### PR TITLE
feat(benchmarks): reclaim the OSWorld guest's disk before an episode starts

### DIFF
--- a/benchmarks/osworld_v2_adapter/README.md
+++ b/benchmarks/osworld_v2_adapter/README.md
@@ -416,6 +416,19 @@ it must print `[]`.**
   reads the instruction text (OSWorld's live object supplies the real one at
   `reset`). `id` and `user_simulator` must resolve completely or the task is
   refused with the field named.
+- **Guest disk reclamation runs before every episode's first observation.**
+  The released AMI ships ~93% full and the guest's own snapd fills the rest from
+  boot (a 9.7 GB `/var/lib/snapd/cache` plus an `Auto-refresh 9 snaps`), which
+  took the root filesystem to 0 bytes at ~t+383s and destroyed 7 of 8 episodes
+  in a 424-466s window. `allocate` therefore holds snap auto-refresh, aborts
+  in-flight snap changes, and clears the snapd download cache between guest
+  readiness and upstream's `reset`. It is conditional (below 12 GiB free), it
+  fails soft step by step, it never removes an installed snap or anything a task
+  could need, and it writes `guest-preparation.json` — free space before and
+  after, the disk geometry, every step's outcome — into the episode's cache
+  root. See "Guest disk reclamation at episode start" in
+  `docs/benchmarks/osworld_2/README.md`, which also records that the earlier
+  `x11grab`/ffmpeg diagnosis was wrong.
 - **Screenshot-only observations.** The a11y tree is not shipped as a frame
   (a geometry for an XML document is a fiction). Its presence is recorded in
   observation metadata; shipping it is a protocol addition, not a fake frame.

--- a/benchmarks/osworld_v2_adapter/README.md
+++ b/benchmarks/osworld_v2_adapter/README.md
@@ -420,9 +420,11 @@ it must print `[]`.**
   The released AMI ships ~93% full and the guest's own snapd fills the rest from
   boot (a 9.7 GB `/var/lib/snapd/cache` plus an `Auto-refresh 9 snaps`), which
   took the root filesystem to 0 bytes at ~t+383s and destroyed 7 of 8 episodes
-  in a 424-466s window. `allocate` therefore holds snap auto-refresh, aborts
-  in-flight snap changes, and clears the snapd download cache between guest
-  readiness and upstream's `reset`. It is conditional (below 12 GiB free), it
+  in a 424-466s window. `allocate` therefore aborts the in-flight auto-refresh,
+  holds snap auto-refresh, and clears the snapd download cache between guest
+  readiness and upstream's `reset` — each privileged step as one
+  `sudo -S bash -c '<fragment>'`, because the guest's control server is not
+  root and anything the outer shell does itself happens unprivileged. It is conditional (below 12 GiB free), it
   fails soft step by step, it never removes an installed snap or anything a task
   could need, and it writes `guest-preparation.json` — free space before and
   after, the disk geometry, every step's outcome — into the episode's cache

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/guest_disk.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/guest_disk.py
@@ -1,0 +1,390 @@
+"""Reclaim the guest's root filesystem before the episode's first observation.
+
+WHY THIS EXISTS -- and the wrong answer that came first, so nobody re-derives it.
+
+Every OSWorld episode died at roughly the same WALL-CLOCK time: 7 of 8 runs
+first failed in a 424-466s window, at 16-32 steps, on both ``t3.xlarge`` and
+``m5.xlarge``. Probing the guest's own control server showed the root
+filesystem going 93% used / 2.2 GB free (stable from t+54s to t+342s) -> 95% at
+t+363s -> **100% used, 0 bytes free at t+383s**, with the first
+``ObservationPhaseError: environment returned no screenshot frame`` at t+424s. A
+disk at 0 bytes cannot write a screenshot, so the observation failure is the
+symptom and the full disk is the cause.
+
+**THE FIRST DIAGNOSIS BLAMED OSWORLD'S x11grab SCREEN RECORDER. THAT WAS WRONG.**
+``pgrep -af ffmpeg`` on the failing guest showed **no ffmpeg process at all**;
+the only match was the probe's own ``pgrep`` command line, which is what made
+the theory look confirmed from outside. The measured consumer is **snapd**:
+
+* ``/var`` is 15G of a 29G disk, and ``/var/lib/snapd/cache`` **alone is 9.7 GB**
+* ``snap changes`` shows ``Auto-refresh 9 snaps`` and ``Pre-download novnc``,
+  both fired at boot
+* the AMI ships ~93% full, so a few GB of snap downloads exhausts it
+
+That is exactly why the failure looked like a clock rather than a workload:
+snapd's auto-refresh starts at boot and downloads at its own pace, entirely
+independent of what the agent is doing. It is also why ``AWS_INSTANCE_TYPE``
+changed nothing, and why ``AWS_ROOT_VOLUME_SIZE`` (0.46.11) helped but did not
+fix it -- a 100 GiB volume moved the first failure from t+424s to t+1936s, yet
+the root PARTITION stays 29.5G with ~70 GiB unallocated, because the AMI carries
+no ``growpart`` and ``apt-get install cloud-guest-utils`` cannot run on a disk
+with no free space to download into.
+
+WHAT THIS MODULE DOES, AND THE LINE IT WILL NOT CROSS. This is guest
+ENVIRONMENT PREPARATION, not benchmark semantics. It clears a package manager's
+**download scratch** and stops that download from restarting; it does not
+uninstall an application, change a task, alter scoring, or touch anything the
+model observes. ``/var/lib/snapd/cache`` is documented as "the working cache,
+used to minimise download size and speed up refreshes" -- deleting it costs a
+re-download and nothing else. Nothing here uninstalls a snap or stops
+``snapd`` itself, because a task may legitimately launch a snap-packaged
+application and removing one would change the benchmark.
+
+FAIL SOFT, ALWAYS. Every step is best-effort and every failure mode -- a missing
+binary, a denied sudo, an unreachable control server, a wedged guest -- is
+recorded and stepped over. An episode that would otherwise have succeeded must
+never be destroyed by a hygiene step, so ``prepare_guest_disk`` raises nothing
+and the caller ignores nothing: it writes the report either way.
+
+CONDITIONAL, AND WHY THE THRESHOLD IS WHERE IT IS. Free space is measured on
+every episode (that measurement is the point -- see "observability" below), but
+the reclamation only runs when the guest has less than
+``RECLAIM_BELOW_FREE_BYTES`` free. The threshold is set ABOVE the largest
+measured consumer: snapd's cache was 9.7 GB, so a guest with more than 12 GiB
+free can absorb snapd's entire measured appetite and still have room for the
+episode's own writes, and touching it would be housekeeping nobody needs. Below
+that, the guest is on the trajectory the measurements above describe.
+
+OBSERVABILITY. "The guest had N MB free at the start" is the single fact needed
+to interpret a later environment failure, so the report is written to the
+episode's own cache root as ``guest-preparation.json`` -- beside the artifact
+root, under the durable run root, in the same episode-owned directory the
+adapter already routes upstream's writes to. It deliberately does NOT ride on
+the observation: ``AckResult`` carries no fields, ``ObservationPayload`` carries
+no metadata, and ``Observation.metadata`` feeds ``observation_content_id``, so
+putting guest disk state there would make a content-addressed observation id a
+function of the guest's filesystem rather than of what the model saw.
+
+WHAT IS DELIBERATELY NOT DONE: growing the partition. See
+``docs/benchmarks/osworld_2/README.md`` for the evidence; briefly, ``growpart``
+is absent, the in-place ``sfdisk`` alternative rewrites the root partition table
+and a wrong start sector destroys the guest -- a hygiene step that can fail HARD
+is precisely what this module must not contain -- and once snapd is held and its
+cache cleared the 29.5G partition has ample room for an episode. The disk vs
+partition geometry is REPORTED instead, read-only, because that is the number
+telling the next reader whether ``AWS_ROOT_VOLUME_SIZE`` bought anything.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Callable, Literal, Sequence
+
+# Reclaim only below this much free space. Set above the largest measured
+# consumer (``/var/lib/snapd/cache`` at 9.7 GB) plus room for the episode's own
+# writes, so a guest that can already absorb a full auto-refresh is left alone.
+RECLAIM_BELOW_FREE_BYTES = 12 * 1024**3
+
+# Per-command and whole-preparation ceilings. The runner allows 900s for the
+# whole ``reset_start`` (scripts/run_episode.py), most of which is instance
+# readiness and upstream's own task setup, so hygiene gets a small fixed slice
+# and a wedged guest cannot eat the reset budget: once the budget is spent the
+# remaining steps are recorded as skipped rather than attempted.
+COMMAND_TIMEOUT_S = 60.0
+TOTAL_BUDGET_S = 180.0
+
+# The snapd cache is pure download scratch (snapcraft "Data locations": "the
+# working cache ... used to minimise download size and speed-up refreshes").
+# The contents are removed, never the directory: snapd recreates files in it but
+# does not recreate the directory itself on every path.
+_SNAPD_CACHE = "/var/lib/snapd/cache"
+
+# A hold far enough out that no episode can outlive it. Used only as the
+# fallback for snapd older than 2.58 (which has no ``snap refresh --hold``);
+# newer snapd caps ``refresh.hold`` at 90 days, which is still four orders of
+# magnitude longer than the 2-hour lease, so the cap is harmless here.
+_FALLBACK_HOLD_UNTIL = "2100-01-01T00:00:00Z"
+
+StepStatus = Literal["ok", "failed", "unreachable", "skipped"]
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    """One command's result as the guest's control server reported it."""
+
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+#: Runs ONE command in the guest and returns its result, or raises if the guest
+#: could not be reached at all. Injected so the whole module is testable against
+#: a stub and the AWS provider owns the HTTP details.
+GuestCommand = Callable[[Sequence[str], float], CommandResult]
+
+#: Monotonic clock, injected so tests need no wall time (AGENTS.md "Timing").
+Clock = Callable[[], float]
+
+
+@dataclass(frozen=True)
+class StepOutcome:
+    """What one preparation step did, in terms a later reader can act on.
+
+    ``detail`` is bounded and carries the guest's own stderr/stdout tail. The
+    COMMAND is never recorded: holding and clearing run through
+    ``echo <password> | sudo -S`` (upstream's own pattern, setup.py:609), so the
+    verbatim argv would put the client password in a file on the operator's
+    disk for no diagnostic gain.
+    """
+
+    name: str
+    status: StepStatus
+    returncode: int | None = None
+    detail: str = ""
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "returncode": self.returncode,
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
+class GuestDiskReport:
+    """Free space before and after, the geometry, and every step's outcome.
+
+    ``free_bytes_before`` is the load-bearing field: an episode that later fails
+    with "environment returned no screenshot frame" is read completely
+    differently depending on whether the guest started with 2 GB or 12 GB free,
+    and that question must not depend on anyone having probed by hand.
+    """
+
+    free_bytes_before: int | None
+    free_bytes_after: int | None
+    filesystem_bytes: int | None
+    disk_bytes: int | None
+    threshold_bytes: int
+    # ATTEMPTED, not achieved. A report that said "reclaimed" while every step
+    # came back unreachable would be a false statement sealed beside the
+    # episode's evidence; whether it WORKED is the steps plus the two free-space
+    # measurements, which cannot claim something that did not happen.
+    reclamation_attempted: bool
+    reason: str
+    steps: tuple[StepOutcome, ...] = ()
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "free_bytes_before": self.free_bytes_before,
+            "free_bytes_after": self.free_bytes_after,
+            "filesystem_bytes": self.filesystem_bytes,
+            # The whole block device. When it exceeds ``filesystem_bytes`` the
+            # root partition was never grown into an AWS_ROOT_VOLUME_SIZE
+            # override -- the measured 29.5G-in-100GiB case.
+            "disk_bytes": self.disk_bytes,
+            "threshold_bytes": self.threshold_bytes,
+            "reclamation_attempted": self.reclamation_attempted,
+            "reason": self.reason,
+            "steps": [step.to_json() for step in self.steps],
+        }
+
+    def to_json_bytes(self) -> bytes:
+        return json.dumps(self.to_json(), indent=2, sort_keys=True).encode("utf-8")
+
+
+def _bash(script: str) -> list[str]:
+    # ``shell: false`` on the guest endpoint means the server execs argv
+    # directly, so a pipeline has to be an explicit ``bash -c``. This is the
+    # same shape upstream's own SetupController uses (setup.py:609).
+    return ["bash", "-c", script]
+
+
+def _first_int(text: str) -> int | None:
+    """The first bare integer in a command's output, or None.
+
+    ``df --output`` prints a header line; a busy guest may prepend a warning.
+    Scanning for the first integer token is what makes the parse survive both
+    without a format assumption that a different coreutils would break.
+    """
+
+    for line in text.splitlines():
+        token = line.strip()
+        if token.isdigit():
+            return int(token)
+    return None
+
+
+class _Session:
+    """One preparation pass: runs steps, records them, and honours the budget."""
+
+    def __init__(self, run: GuestCommand, clock: Clock) -> None:
+        self._run = run
+        self._clock = clock
+        self._deadline = clock() + TOTAL_BUDGET_S
+        self.steps: list[StepOutcome] = []
+
+    def step(self, name: str, script: str) -> CommandResult | None:
+        """Run one step, record it, and return its result or None on failure.
+
+        Never raises: a step that cannot run is a recorded fact, not an
+        episode-ending error. That is the whole fail-soft contract.
+        """
+
+        remaining = self._deadline - self._clock()
+        if remaining <= 0:
+            self.steps.append(StepOutcome(name=name, status="skipped", detail="budget exhausted"))
+            return None
+        try:
+            result = self._run(_bash(script), min(COMMAND_TIMEOUT_S, remaining))
+        except Exception as error:
+            # A transport failure (control server down, timeout, malformed
+            # response) is indistinguishable from a guest that never answered,
+            # and both mean the same thing to a reader: the guest was not
+            # prepared. The TYPE is recorded; the message is not, because a
+            # requests exception echoes the URL and query it was given.
+            self.steps.append(
+                StepOutcome(name=name, status="unreachable", detail=type(error).__name__)
+            )
+            return None
+        detail = (result.stderr or result.stdout or "").strip()[:200]
+        self.steps.append(
+            StepOutcome(
+                name=name,
+                status="ok" if result.returncode == 0 else "failed",
+                returncode=result.returncode,
+                detail=detail,
+            )
+        )
+        return result
+
+
+def _measure_free_bytes(session: _Session, name: str) -> int | None:
+    result = session.step(name, "df -B1 --output=avail / | tail -1")
+    if result is None or result.returncode != 0:
+        return None
+    return _first_int(result.stdout)
+
+
+def prepare_guest_disk(
+    run: GuestCommand,
+    *,
+    client_password: str,
+    clock: Clock,
+) -> GuestDiskReport:
+    """Measure the guest's root filesystem and, if it is tight, reclaim it.
+
+    Returns a report in every case, including the cases where nothing could be
+    measured or nothing could be run. It raises nothing by construction: see the
+    module docstring for why an unreachable guest must not cost an episode that
+    would otherwise have worked.
+    """
+
+    session = _Session(run, clock)
+    free_before = _measure_free_bytes(session, "measure-free-before")
+    filesystem_bytes = None
+    disk_bytes = None
+
+    size_result = session.step("measure-geometry", _GEOMETRY_SCRIPT)
+    if size_result is not None and size_result.returncode == 0:
+        numbers = [int(line) for line in size_result.stdout.split() if line.strip().isdigit()]
+        # The script prints filesystem size then whole-disk size, so a partial
+        # answer (an image without lsblk) still yields the first number.
+        if numbers:
+            filesystem_bytes = numbers[0]
+        if len(numbers) > 1:
+            disk_bytes = numbers[1]
+
+    if free_before is not None and free_before >= RECLAIM_BELOW_FREE_BYTES:
+        return GuestDiskReport(
+            free_bytes_before=free_before,
+            free_bytes_after=free_before,
+            filesystem_bytes=filesystem_bytes,
+            disk_bytes=disk_bytes,
+            threshold_bytes=RECLAIM_BELOW_FREE_BYTES,
+            reclamation_attempted=False,
+            reason="above-threshold",
+            steps=tuple(session.steps),
+        )
+
+    # An unmeasurable guest is reclaimed anyway. The steps are safe and
+    # reversible; the failure they prevent destroys a paid episode. Choosing to
+    # skip on a failed measurement would make the protection absent exactly when
+    # the guest is least healthy.
+    reason = "below-threshold" if free_before is not None else "unmeasured"
+    _reclaim(session, client_password)
+    free_after = _measure_free_bytes(session, "measure-free-after")
+    return GuestDiskReport(
+        free_bytes_before=free_before,
+        free_bytes_after=free_after,
+        filesystem_bytes=filesystem_bytes,
+        disk_bytes=disk_bytes,
+        threshold_bytes=RECLAIM_BELOW_FREE_BYTES,
+        reclamation_attempted=True,
+        reason=reason,
+        steps=tuple(session.steps),
+    )
+
+
+# Filesystem size, then the size of the whole block device the root filesystem
+# sits on. Read-only: nothing here alters the partition table (see the module
+# docstring for why growing it is deliberately out of scope). Each half is
+# independently allowed to fail, so an image without ``lsblk`` still reports the
+# filesystem size rather than nothing.
+_GEOMETRY_SCRIPT = (
+    "df -B1 --output=size / | tail -1; "
+    'source=$(findmnt -no SOURCE / 2>/dev/null) && parent=$(lsblk -no PKNAME "$source" '
+    '2>/dev/null | head -1) && lsblk -bdno SIZE "/dev/$parent" 2>/dev/null'
+)
+
+
+def _reclaim(session: _Session, client_password: str) -> None:
+    """Stop snapd re-filling the disk, then delete what it already downloaded.
+
+    ORDER IS LOAD-BEARING. Holding first stops a NEW auto-refresh from starting;
+    aborting second stops the one that ``snap changes`` showed already running
+    at boot -- a hold does not touch a change that is already in flight;
+    clearing last means the abort has stopped writing before the delete runs.
+    Clearing first would race a live download and reclaim nothing.
+    """
+
+    sudo = f"echo {_shell_quote(client_password)} | sudo -S"
+    # ``snap refresh --hold`` needs snapd 2.58+. On anything older it exits
+    # non-zero with an unknown-flag error, which is recorded and then covered by
+    # the ``refresh.hold`` fallback below -- the pre-2.58 way of saying the same
+    # thing. Running the fallback unconditionally would be a second write to the
+    # same setting on every modern guest, so it is conditional on the first
+    # failing.
+    held = session.step("hold-snap-auto-refresh", f"{sudo} snap refresh --hold=forever 2>&1")
+    if held is None or held.returncode != 0:
+        session.step(
+            "hold-snap-auto-refresh-fallback",
+            f"{sudo} snap set system refresh.hold={_FALLBACK_HOLD_UNTIL} 2>&1",
+        )
+
+    # ``snap changes`` lists in-flight changes as ``Doing``; the boot-time
+    # "Auto-refresh 9 snaps" is one of them. Aborting cancels the download and
+    # leaves every INSTALLED snap exactly as it was -- it is not an uninstall,
+    # which is the line this module does not cross. No ``Doing`` row means the
+    # awk prints nothing and xargs runs nothing, so the step is a clean no-op.
+    session.step(
+        "abort-in-flight-snap-changes",
+        f"{sudo} snap changes 2>/dev/null | awk '$2==\"Doing\"{{print $1}}' "
+        f"| xargs -r -n1 {sudo} snap abort 2>&1 || true",
+    )
+
+    # The contents, not the directory: snapd expects the directory to exist.
+    session.step("clear-snapd-cache", f'{sudo} rm -rf -- "{_SNAPD_CACHE}"/* 2>&1')
+
+
+def _shell_quote(value: str) -> str:
+    """POSIX single-quote one value for the ``bash -c`` script.
+
+    The client password is operator-supplied infra and reaches the guest through
+    a shell pipeline (the only way to feed ``sudo -S`` through an endpoint with
+    no stdin). Quoting it here means a password containing a space, a quote, or
+    a ``$`` cannot terminate the command or expand into something else.
+    """
+
+    return "'" + value.replace("'", "'\"'\"'") + "'"

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/guest_disk.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/guest_disk.py
@@ -287,10 +287,14 @@ def prepare_guest_disk(
     disk_bytes = None
 
     size_result = session.step("measure-geometry", _GEOMETRY_SCRIPT)
-    if size_result is not None and size_result.returncode == 0:
+    # Parsed whenever a number is present, NOT only on exit 0: the script
+    # prints the filesystem size first and the whole-disk size second, so a
+    # partial answer (an image without ``lsblk``, a ``df`` that printed and
+    # then something else failed) still yields what was measured. Gating on the
+    # exit code discarded a real ``df`` figure over a missing block-device
+    # tool, which is observability lost for no safety gained.
+    if size_result is not None:
         numbers = [int(line) for line in size_result.stdout.split() if line.strip().isdigit()]
-        # The script prints filesystem size then whole-disk size, so a partial
-        # answer (an image without lsblk) still yields the first number.
         if numbers:
             filesystem_bytes = numbers[0]
         if len(numbers) > 1:
@@ -329,53 +333,112 @@ def prepare_guest_disk(
 
 # Filesystem size, then the size of the whole block device the root filesystem
 # sits on. Read-only: nothing here alters the partition table (see the module
-# docstring for why growing it is deliberately out of scope). Each half is
-# independently allowed to fail, so an image without ``lsblk`` still reports the
-# filesystem size rather than nothing.
+# docstring for why growing it is deliberately out of scope). The block-device
+# half is best-effort (``|| true``): without it a guest lacking ``findmnt`` or
+# ``lsblk`` exits 127 from the ``&&`` chain and the ``df`` figure that WAS
+# printed arrives under a non-zero status. Its own stderr is dropped so the
+# step's detail is the numbers, not a tool's usage text.
 _GEOMETRY_SCRIPT = (
     "df -B1 --output=size / | tail -1; "
-    'source=$(findmnt -no SOURCE / 2>/dev/null) && parent=$(lsblk -no PKNAME "$source" '
-    '2>/dev/null | head -1) && lsblk -bdno SIZE "/dev/$parent" 2>/dev/null'
+    '{ source=$(findmnt -no SOURCE /) && parent=$(lsblk -no PKNAME "$source" | head -1) '
+    '&& lsblk -bdno SIZE "/dev/$parent"; } 2>/dev/null || true'
+)
+
+# Everything privileged runs INSIDE ``sudo -S bash -c '<fragment>'``, and the
+# fragments below are what that inner shell executes. Two hard-won rules:
+#
+# * Nothing that depends on privilege may happen in the outer shell. The guest's
+#   control server runs as an unprivileged user, so a glob like
+#   ``"/var/lib/snapd/cache"/*`` expanded OUT there matches nothing -- the
+#   directory is ``drwx------ root:root`` -- and ``rm -rf`` of the literal,
+#   non-existent name exits 0. That was a reclaim that deleted nothing and
+#   reported ``ok``. ``find -mindepth 1 -delete`` inside the privileged shell
+#   has no glob to expand anywhere.
+# * Nothing may be exec'd through ``xargs`` (or any other splitter) with the
+#   password pipeline as its command: ``xargs ... echo 'pw' | sudo -S snap abort``
+#   parses as ``xargs echo 'pw'`` PIPED INTO one ``sudo -S snap abort`` -- the
+#   password line becomes ``pw <id>`` (rejected), abort receives no id, and the
+#   exec'd ``/bin/echo pw`` is visible in ``ps``. The loop lives inside the
+#   privileged shell instead, and the fragments avoid single quotes so the one
+#   quoting layer (``_shell_quote``) stays readable.
+
+# Only the two change kinds that fill the disk are aborted (snapd's own
+# summaries are ``Auto-refresh ...`` and ``Pre-download ... for auto-refresh``),
+# matched CASE-SENSITIVELY so this module's own ``Hold auto-refreshes for all
+# snaps`` change is never a candidate, and so a seeding change or a hook that
+# happens to be ``Doing`` is left alone. ``snap changes`` failing (no snapd,
+# denied) is surfaced as the step's exit status rather than read as "nothing
+# in flight"; a failed abort of any one change fails the step, with the
+# remaining ids still attempted.
+_ABORT_REFRESH_FRAGMENT = (
+    "changes=$(snap changes) || exit $?; rc=0; "
+    "while read -r id status rest; do "
+    'case "$status $rest" in "Doing "*Auto-refresh*|"Doing "*Pre-download*) '
+    'snap abort "$id" || rc=1;; esac; '
+    'done <<<"$changes"; exit $rc'
 )
 
 
 def _reclaim(session: _Session, client_password: str) -> None:
-    """Stop snapd re-filling the disk, then delete what it already downloaded.
+    """Stop snapd filling the disk, then delete what it already downloaded.
 
-    ORDER IS LOAD-BEARING. Holding first stops a NEW auto-refresh from starting;
-    aborting second stops the one that ``snap changes`` showed already running
-    at boot -- a hold does not touch a change that is already in flight;
-    clearing last means the abort has stopped writing before the delete runs.
-    Clearing first would race a live download and reclaim nothing.
+    ORDER IS LOAD-BEARING: abort, then hold, then clear.
+
+    Abort FIRST because it is the only step that is immediate. ``snap abort``
+    flips the change's state and returns. ``snap refresh --hold`` is a
+    ``configure core`` hook change that the CLI WAITS on (``cmd_snap_op.go``
+    ``holdRefreshes``), and snapd runs one hook task per snap at a time
+    (``hookmgr.go`` ``snapIsRunningHook``), so while the boot-time auto-refresh
+    is still ``Doing`` a core/snapd hook of its own the hold queues behind it --
+    long enough to outlast the per-command ceiling and be recorded as
+    unreachable, after which the fallback joins the same queue. With nothing in
+    flight, the hold completes at once. Snapd cannot launch a fresh auto-refresh
+    in the gap: it enforces a 20-minute ``refreshRetryDelay`` between launches
+    (``autorefresh.go``), so the hold lands long before a retry is considered.
+
+    Hold SECOND so no NEW refresh starts once the in-flight one is gone.
+
+    Clear LAST so nothing is still writing into the directory being emptied;
+    clearing first would race a live download and reclaim nothing.
+
+    What abort does to installed snaps, stated accurately: a change that had
+    already finished refreshing some of its snaps has those tasks UNDONE, which
+    returns each such snap to the revision the AMI shipped -- the benchmark's
+    own baseline, and the state every other episode starts from. It is not an
+    uninstall, which is the line this module does not cross.
     """
 
-    sudo = f"echo {_shell_quote(client_password)} | sudo -S"
+    def privileged(fragment: str) -> str:
+        # ONE ``sudo -S`` per step, the password appearing exactly once, as the
+        # stdin of that one sudo. ``echo`` is a bash builtin in the outer shell,
+        # so nothing is exec'd with the password in its argv; the outer
+        # ``bash -c`` script itself necessarily carries it, which is the
+        # endpoint's contract (argv only, no stdin, no env) and upstream's own
+        # pattern (setup.py:609).
+        return (
+            f"echo {_shell_quote(client_password)} | sudo -S bash -c "
+            f"{_shell_quote(fragment)} 2>&1"
+        )
+
+    session.step("abort-in-flight-snap-changes", privileged(_ABORT_REFRESH_FRAGMENT))
+
     # ``snap refresh --hold`` needs snapd 2.58+. On anything older it exits
     # non-zero with an unknown-flag error, which is recorded and then covered by
     # the ``refresh.hold`` fallback below -- the pre-2.58 way of saying the same
     # thing. Running the fallback unconditionally would be a second write to the
     # same setting on every modern guest, so it is conditional on the first
     # failing.
-    held = session.step("hold-snap-auto-refresh", f"{sudo} snap refresh --hold=forever 2>&1")
+    held = session.step("hold-snap-auto-refresh", privileged("snap refresh --hold=forever"))
     if held is None or held.returncode != 0:
         session.step(
             "hold-snap-auto-refresh-fallback",
-            f"{sudo} snap set system refresh.hold={_FALLBACK_HOLD_UNTIL} 2>&1",
+            privileged(f"snap set system refresh.hold={_FALLBACK_HOLD_UNTIL}"),
         )
 
-    # ``snap changes`` lists in-flight changes as ``Doing``; the boot-time
-    # "Auto-refresh 9 snaps" is one of them. Aborting cancels the download and
-    # leaves every INSTALLED snap exactly as it was -- it is not an uninstall,
-    # which is the line this module does not cross. No ``Doing`` row means the
-    # awk prints nothing and xargs runs nothing, so the step is a clean no-op.
-    session.step(
-        "abort-in-flight-snap-changes",
-        f"{sudo} snap changes 2>/dev/null | awk '$2==\"Doing\"{{print $1}}' "
-        f"| xargs -r -n1 {sudo} snap abort 2>&1 || true",
-    )
-
     # The contents, not the directory: snapd expects the directory to exist.
-    session.step("clear-snapd-cache", f'{sudo} rm -rf -- "{_SNAPD_CACHE}"/* 2>&1')
+    # ``-mindepth 1`` is what keeps the directory; ``-delete`` implies
+    # depth-first so nested entries go before their parents.
+    session.step("clear-snapd-cache", privileged(f"find {_SNAPD_CACHE} -mindepth 1 -delete"))
 
 
 def _shell_quote(value: str) -> str:

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/aws.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/aws.py
@@ -36,6 +36,12 @@ release-pinned AMI in a region where it does not exist.
 
 Every boto3 / HTTP call is blocking and runs under ``asyncio.to_thread`` so the
 worker's event loop keeps answering the parent's RPC while a waiter sleeps.
+
+``allocate`` also runs one GUEST PREPARATION step between readiness and
+upstream's reset: the released AMI ships ~93% full and its own snapd fills the
+remainder on a clock, which destroyed 7 of 8 episodes in a 424-466s window. See
+``guest_disk`` for the measurements, for why ffmpeg was NOT the cause, and for
+why that step can never fail an allocation.
 """
 
 from __future__ import annotations
@@ -45,12 +51,13 @@ import json
 import logging
 import os
 import time
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable
 
-from lop_osworld_v2_adapter import scoring
+from lop_osworld_v2_adapter import guest_disk, scoring
 from lop_osworld_v2_adapter.cleanup import (
     EVIDENCE_INSTANCE_ABSENT,
     EVIDENCE_INSTANCE_TERMINATED,
@@ -90,6 +97,16 @@ _TERMINATE_TARGET_ARN = "arn:aws:scheduler:::aws-sdk:ec2:terminateInstances"
 # ``SetupController.ensure_ready`` probes (setup.py:58-70).
 GUEST_PORT = 5000
 _READY_PATH = "/terminal"
+# The guest's command endpoint. ``shell: false`` means the server execs the argv
+# directly, so a pipeline arrives as an explicit ``bash -c`` -- the same shape
+# upstream's own SetupController posts (setup.py:418).
+_EXECUTE_PATH = "/execute"
+
+# Where the episode's guest-preparation evidence is written, inside the
+# episode-owned cache root the adapter mints in ``reset_start``. It sits there
+# rather than in the artifact root because the bundle verifier refuses any entry
+# in the artifact root that is not a digest-named artifact.
+GUEST_PREPARATION_FILENAME = "guest-preparation.json"
 
 
 class AllocationError(RuntimeError):
@@ -117,14 +134,21 @@ class _Clients:
     """The injectable I/O surface, so tests use botocore's Stubber.
 
     ``ec2`` and ``scheduler`` are boto3 clients; ``http_get`` takes a URL and
-    a timeout and returns the HTTP status code (or raises). Production builds
-    all three from the credentials; tests hand in stubbed clients and a fake
-    prober.
+    a timeout and returns the HTTP status code (or raises); ``http_post_json``
+    posts a JSON body and returns the decoded response (or raises). Production
+    builds all four from the credentials; tests hand in stubbed clients and
+    fake probers.
+
+    ``http_post_json`` is REQUIRED rather than optional-with-a-default: it is
+    what drives the guest's control server for pre-episode disk reclamation
+    (``guest_disk``), and a default that quietly did nothing would make that
+    preparation silently absent in exactly the builds nobody checked.
     """
 
     ec2: Any
     scheduler: Any
     http_get: Callable[[str, float], int]
+    http_post_json: Callable[[str, dict[str, Any], float], dict[str, Any]]
 
 
 def build_clients(credentials: AwsCredentials, region: str) -> _Clients:
@@ -149,10 +173,24 @@ def build_clients(credentials: AwsCredentials, region: str) -> _Clients:
     def http_get(url: str, timeout: float) -> int:
         return int(requests.get(url, timeout=timeout).status_code)
 
+    def http_post_json(url: str, payload: dict[str, Any], timeout: float) -> dict[str, Any]:
+        response = requests.post(
+            url,
+            json=payload,
+            timeout=timeout,
+            headers={"Content-Type": "application/json"},
+        )
+        response.raise_for_status()
+        decoded = response.json()
+        if not isinstance(decoded, dict):
+            raise ValueError("guest control server returned a non-object body")
+        return decoded
+
     return _Clients(
         ec2=session.client("ec2", region_name=region),
         scheduler=session.client("scheduler", region_name=region),
         http_get=http_get,
+        http_post_json=http_post_json,
     )
 
 
@@ -361,7 +399,69 @@ class AwsProvider:
             ) from error
         self._schedule_created = True
         self._public_ip = await asyncio.to_thread(self._wait_ready, instance_id)
+        # BEFORE upstream's reset, and therefore before the episode's first
+        # observation: the guest ships ~93% full and its own snapd fills the
+        # rest on a clock, which killed 7 of 8 episodes in a 424-466s window.
+        # See ``guest_disk`` for the measurements and for why this cannot fail
+        # the allocation.
+        await asyncio.to_thread(self._prepare_guest_disk, plan)
         await asyncio.to_thread(self._start_desktop_env, plan, task)
+
+    def _run_guest_command(
+        self, command: Sequence[str], timeout: float
+    ) -> guest_disk.CommandResult:
+        """One command in the guest, through its own control server.
+
+        Raises on any transport failure; ``guest_disk`` catches that and records
+        the guest as unreachable. The response shape is upstream's own
+        (``{"status", "output", "error", "returncode"}``, setup.py:425-441), and
+        a missing ``returncode`` reads as a failure rather than a success: a
+        server that did not say the command succeeded did not say it succeeded.
+        """
+
+        url = f"http://{self._public_ip}:{GUEST_PORT}{_EXECUTE_PATH}"
+        body = self._clients.http_post_json(
+            url, {"command": list(command), "shell": False}, timeout
+        )
+        returncode = body.get("returncode")
+        return guest_disk.CommandResult(
+            returncode=returncode if isinstance(returncode, int) else 1,
+            stdout=str(body.get("output") or ""),
+            stderr=str(body.get("error") or ""),
+        )
+
+    def _prepare_guest_disk(self, plan: ProvisioningPlan) -> None:
+        """Reclaim the guest's root filesystem and record what happened.
+
+        Wrapped in a blanket ``except`` on purpose, on top of ``guest_disk``'s
+        own per-step fail-soft: this is a hygiene step, and the one outcome that
+        must be impossible is a housekeeping defect destroying an episode that
+        would otherwise have run. The report is still written when the
+        reclamation itself achieved nothing -- "the guest had N bytes free at the
+        start" is the fact a later environment failure is read against.
+        """
+
+        report: guest_disk.GuestDiskReport | None = None
+        try:
+            report = guest_disk.prepare_guest_disk(
+                self._run_guest_command,
+                client_password=plan.client_password,
+                clock=time.monotonic,
+            )
+        except Exception:
+            # ``prepare_guest_disk`` raises nothing by contract; this catches a
+            # contract violation (or an injected runner that misbehaves) rather
+            # than a normal failure mode, so there is no report to write.
+            return
+        if self._cache_root is None:
+            return
+        try:
+            (self._cache_root / GUEST_PREPARATION_FILENAME).write_bytes(report.to_json_bytes())
+        except OSError:
+            # An unwritable cache root is the adapter's problem to surface
+            # elsewhere (upstream writes there too); losing the hygiene report
+            # must not be the thing that ends the episode.
+            pass
 
     def _run_instance(self, plan: ProvisioningPlan) -> str:
         ec2 = self._clients.ec2

--- a/docs/benchmarks/osworld_2/README.md
+++ b/docs/benchmarks/osworld_2/README.md
@@ -332,14 +332,33 @@ It drives the guest's own HTTP control server (`POST /execute`, argv with
 `shell: false` — the same endpoint and contract upstream's `SetupController`
 uses), and does three things, in an order that is load-bearing:
 
-1. **Hold snap auto-refresh** (`snap refresh --hold=forever`, falling back to
+1. **Abort the in-flight auto-refresh** — `snap changes` showed
+   `Auto-refresh 9 snaps` and `Pre-download novnc` already running at boot.
+   Only `Doing` changes with those two summaries are aborted; a seeding hook or
+   any other change is left alone. Abort goes first because it is immediate,
+   whereas a hold is a `configure core` hook change the CLI waits on, and snapd
+   runs one hook per snap at a time — behind a live refresh of core/snapd the
+   hold could queue past the per-command ceiling. Snapd's 20-minute retry delay
+   means no new refresh can start in the gap before the hold lands. Aborting a
+   partly-done change undoes its completed tasks, which returns those snaps to
+   the revision the AMI shipped — the benchmark's own baseline.
+2. **Hold snap auto-refresh** (`snap refresh --hold=forever`, falling back to
    `snap set system refresh.hold=<far future>` on snapd older than 2.58). This
    stops a *new* refresh starting.
-2. **Abort in-flight snap changes** — a hold does not touch a change that is
-   already running, and `snap changes` showed one already running at boot.
 3. **Clear `/var/lib/snapd/cache`** — pure download scratch, documented by
    Canonical as "the working cache … used to minimise download size and speed-up
    refreshes". Deleting it costs a re-download and nothing else.
+
+Every privileged step is exactly one `echo <password> | sudo -S bash -c
+'<fragment>'`, with all of the work — the `snap changes` loop, the
+`find /var/lib/snapd/cache -mindepth 1 -delete` — inside the privileged inner
+shell. That shape is not cosmetic: the control server runs as an unprivileged
+user, so a glob like `/var/lib/snapd/cache/*` expanded by the *outer* shell
+matches nothing against a `drwx------ root:root` directory and `rm -rf` of the
+literal name exits 0, and an `xargs … echo pw | sudo -S snap abort` pipeline
+parses as `xargs echo` piped into one id-less `sudo`. Both were real defects
+that reported `ok` while doing nothing, caught only by re-running the E2E with
+the cache directory genuinely owned by root.
 
 The design constraints are worth stating explicitly, because each is a line a
 future change could cross without noticing:

--- a/docs/benchmarks/osworld_2/README.md
+++ b/docs/benchmarks/osworld_2/README.md
@@ -229,7 +229,7 @@ Seeing that error means the workspace and selector need rebuilding against the
 current adapter source (§ the build recipe in
 `benchmarks/osworld_v2_adapter/README.md`), not that the flag is wrong.
 
-### Disk exhaustion by the screen recorder, and `AWS_ROOT_VOLUME_SIZE`
+### Disk exhaustion by the guest's own snapd, and `AWS_ROOT_VOLUME_SIZE`
 
 `AWS_INSTANCE_TYPE` fixed a *starved* guest. A second failure presents
 **identically** — `ObservationPhaseError: environment returned no screenshot
@@ -248,13 +248,26 @@ filling on a clock rather than on workload:
 | t+383s | **100% used, 0 bytes free** |
 | t+424s | first `ObservationPhaseError` |
 
-OSWorld starts an `x11grab` **ffmpeg screen recorder** in the guest on reset.
-Its measured fill rate is **~6.8 MB/s (~410 MB/min)** against only ~2.2 GB free
-at launch, so the disk exhausts in **~330s on every run**. A disk at 0 bytes
-cannot write a screenshot, which is exactly the observed failure — and the rate
-is constant regardless of agent activity, which is why the wall is a clock
-rather than a workload. The volume is identical on either instance type, which
-is why changing the hardware family did not move it.
+> **Correction.** This was first diagnosed as OSWorld's `x11grab` **ffmpeg
+> screen recorder**, and that was **wrong**. `pgrep -af ffmpeg` on a failing
+> guest showed **no ffmpeg process at all** — the only match was the probe's own
+> `pgrep` command line, which is what made the theory look confirmed from
+> outside. The `~6.8 MB/s` fill rate quoted in the 0.46.11 release notes was
+> inferred from the disk series, not measured at a process. Do not re-derive it.
+
+The measured consumer is **snapd**, inside the guest:
+
+- `/var` is 15G of the 29G disk, and `/var/lib/snapd/cache` **alone is 9.7 GB**
+- `snap changes` shows `Auto-refresh 9 snaps` and `Pre-download novnc`, both
+  fired at boot
+- the AMI ships ~93% full, so a few GB of snap downloads exhausts it
+
+A disk at 0 bytes cannot write a screenshot, which is exactly the observed
+failure. Snapd's auto-refresh starts at boot and downloads at its own pace,
+entirely independent of what the agent is doing — which is precisely why the
+wall looked like a clock rather than a workload, and why the volume being
+identical on either instance type meant changing the hardware family did not
+move it.
 
 The escape hatch is the optional infra value `AWS_ROOT_VOLUME_SIZE`, a whole
 number of GiB:
@@ -263,8 +276,17 @@ number of GiB:
 --infra AWS_ROOT_VOLUME_SIZE=120
 ```
 
-At ~410 MB/min, each extra GiB buys roughly 2.5 minutes of recording, so size
-it against the wall budget rather than against disk cost.
+Measured effect: a 100 GiB volume moved the first failure from t+424s to
+**t+1936s**. It does not fully fix the problem, and the reason is geometry —
+the root **partition** stays 29.5G inside that 100 GiB disk, with ~70 GiB
+unallocated, because the AMI carries no `growpart` and
+`apt-get install cloud-guest-utils` cannot run on a disk with no free space to
+download into. The extra GiB bought time only because a larger volume's
+filesystem happens to start with more slack, not because the partition grew.
+
+Since 0.46.12 the adapter reclaims the space itself at episode start, which
+addresses the cause rather than the symptom — see below. `AWS_ROOT_VOLUME_SIZE`
+remains available as an independent lever.
 
 It is infra rather than a task field for the same reason as the instance type:
 task files are **content-hash verified**, so editing `volume_size` invalidates
@@ -297,6 +319,65 @@ disclosure is a false statement sealed in a `verify_bundle`-valid bundle. Both
 the gate and the stamp derive from a single table
 (`DISCLOSED_INFRA_METADATA_KEYS` in `local_operator/evaluation/runner/episode.py`),
 so a future third value cannot be gated without being disclosed or vice versa.
+
+### Guest disk reclamation at episode start
+
+Growing the volume treats the symptom; the cause is that snapd downloads
+gigabytes into a disk that ships ~93% full. So `AwsProvider.allocate` runs one
+**guest preparation** step between guest readiness and upstream's `reset` —
+before the episode's first observation, because hygiene that ran after the
+reset would be too late for the frame that reset captures.
+
+It drives the guest's own HTTP control server (`POST /execute`, argv with
+`shell: false` — the same endpoint and contract upstream's `SetupController`
+uses), and does three things, in an order that is load-bearing:
+
+1. **Hold snap auto-refresh** (`snap refresh --hold=forever`, falling back to
+   `snap set system refresh.hold=<far future>` on snapd older than 2.58). This
+   stops a *new* refresh starting.
+2. **Abort in-flight snap changes** — a hold does not touch a change that is
+   already running, and `snap changes` showed one already running at boot.
+3. **Clear `/var/lib/snapd/cache`** — pure download scratch, documented by
+   Canonical as "the working cache … used to minimise download size and speed-up
+   refreshes". Deleting it costs a re-download and nothing else.
+
+The design constraints are worth stating explicitly, because each is a line a
+future change could cross without noticing:
+
+- **It is environment preparation, not benchmark semantics.** Nothing here
+  changes the task, the scoring, the applications available, or anything the
+  model observes. Clearing a package manager's download cache is housekeeping;
+  **uninstalling** an application a task might need is not, so no command may
+  ever `snap remove` or `apt-get purge` anything. A test asserts that.
+- **It fails soft, per step.** A missing binary, a denied `sudo`, an
+  unreachable control server, or a guest that answers slowly are each recorded
+  and stepped over. An episode that would otherwise have worked must never be
+  destroyed by a hygiene step, and a whole-pass budget keeps a wedged guest from
+  eating the reset timeout.
+- **It is conditional.** Free space is measured on every episode, but the
+  reclamation only runs below **12 GiB free** — set above snapd's largest
+  measured appetite (the 9.7 GB cache), so a guest that can already absorb a
+  full auto-refresh is left untouched. A guest whose free space cannot be
+  measured *is* reclaimed: the protection must not go missing exactly when the
+  guest is least healthy.
+- **It is observable.** Free space before and after, the filesystem and
+  whole-disk sizes, and every step's outcome are written to
+  `<run-root>/osworld-cache/<episode-id>/guest-preparation.json`. "The guest had
+  N bytes free at the start" is the fact a later
+  `environment returned no screenshot frame` has to be read against, and it must
+  not depend on anyone having probed the guest by hand. It sits in the episode's
+  own cache root rather than the artifact root because the bundle verifier
+  refuses any artifact-root entry that is not a digest-named artifact; it is not
+  on the observation because `Observation.metadata` feeds
+  `observation_content_id`, and a content-addressed observation id must be a
+  function of what the model saw, not of the guest's filesystem.
+
+**Growing the partition is deliberately not done.** `growpart` is absent, and
+the in-place `sfdisk` alternative rewrites the root partition table where a
+wrong start sector destroys the guest. A hygiene step that can fail *hard* is
+exactly what this must not be. The disk-vs-filesystem geometry is **reported**
+instead, read-only, since that pair of numbers is what tells the next reader
+whether `AWS_ROOT_VOLUME_SIZE` bought anything.
 
 ### Upstream is sealed after the first reset
 

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -172,10 +172,12 @@ _PROVISIONAL_CLEANUP_ACTION = "close-session"
 DISCLOSED_INFRA_METADATA_KEYS: Mapping[str, str] = MappingProxyType(
     {
         "AWS_INSTANCE_TYPE": "aws_instance_type_override",
-        # The root volume the guest's x11grab recorder fills at ~6.8 MB/s. A
-        # score run on a larger disk survives past the ~t+383s exhaustion wall
-        # that truncated earlier runs, so it is not comparable to one that hit
-        # it, and the bundle has to say so on its own.
+        # The root volume the guest's own snapd fills from boot (a 9.7 GB
+        # download cache plus an auto-refresh; NOT the x11grab recorder an
+        # earlier revision named -- no ffmpeg process was ever found on a
+        # failing guest). A score run on a larger disk survives past the
+        # ~t+383s exhaustion wall that truncated earlier runs, so it is not
+        # comparable to one that hit it, and the bundle has to say so on its own.
         "AWS_ROOT_VOLUME_SIZE": "aws_root_volume_size_override",
     }
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.46.19"
+version = "0.46.21"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/scripts/osworld_tag_audit.py
+++ b/scripts/osworld_tag_audit.py
@@ -46,11 +46,19 @@ def profile_clients(region: str) -> Any:
     from boto3.session import Session  # type: ignore[import-not-found]
     from lop_osworld_v2_adapter.providers.aws import _Clients
 
+    def _no_guest(_url: str, _payload: dict[str, Any], _timeout: float) -> dict[str, Any]:
+        # The audit is teardown-only: it resolves tagged resources through EC2
+        # and never talks to a guest. Raising rather than returning an empty
+        # body means a future audit path that DID reach for the guest fails
+        # here, where it is obvious, rather than silently reading a stub.
+        raise RuntimeError("the tag audit does not talk to a guest control server")
+
     session = Session(region_name=region)
     return _Clients(
         ec2=session.client("ec2", region_name=region),
         scheduler=session.client("scheduler", region_name=region),
         http_get=lambda _url, _timeout: 0,
+        http_post_json=_no_guest,
     )
 
 

--- a/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
+++ b/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
@@ -101,7 +101,14 @@ def _cache_root(tmp_path: Path) -> Path:
 
 
 class _Stubs:
-    """Two stubbed clients plus a scripted HTTP prober and a virtual clock."""
+    """Two stubbed clients plus scripted HTTP probers and a virtual clock.
+
+    ``guest_posts`` records every ``/execute`` body the provider sent, which is
+    how the disk-preparation tests assert on what ran in the guest without a
+    network. ``guest_responses`` scripts the replies: a mapping from a substring
+    of the posted command to the body to return, so a test names only the step
+    it cares about and every other step gets the benign default.
+    """
 
     def __init__(self, *, http_codes: list[int] | None = None) -> None:
         self.ec2 = boto3.client(
@@ -121,7 +128,34 @@ class _Stubs:
             self.http_calls.append(url)
             return self._http_codes.pop(0) if len(self._http_codes) > 1 else self._http_codes[0]
 
-        self.clients = _Clients(ec2=self.ec2, scheduler=self.scheduler, http_get=http_get)
+        self.guest_posts: list[dict[str, Any]] = []
+        self.guest_responses: list[tuple[str, dict[str, Any] | Exception]] = []
+        # Enough free space that preparation is a no-op unless a test says
+        # otherwise: every pre-existing allocate test wants the old behaviour.
+        self.guest_default: dict[str, Any] | Exception = {
+            "returncode": 0,
+            "output": str(64 * 1024**3),
+            "error": "",
+        }
+
+        def http_post_json(url: str, payload: dict[str, Any], timeout: float) -> dict[str, Any]:
+            self.guest_posts.append(payload)
+            script = " ".join(payload.get("command", []))
+            for needle, response in self.guest_responses:
+                if needle in script:
+                    if isinstance(response, Exception):
+                        raise response
+                    return response
+            if isinstance(self.guest_default, Exception):
+                raise self.guest_default
+            return self.guest_default
+
+        self.clients = _Clients(
+            ec2=self.ec2,
+            scheduler=self.scheduler,
+            http_get=http_get,
+            http_post_json=http_post_json,
+        )
 
     def sleep(self, seconds: float) -> None:
         self.slept.append(seconds)
@@ -476,6 +510,179 @@ async def test_allocate_refuses_without_a_cache_root(monkeypatch: pytest.MonkeyP
         provider = _provider(stubs, monkeypatch, desktop_env_factory=_FakeEnv)
         with pytest.raises(AllocationError, match="cache root"):
             await provider.allocate(_plan(), _task(), cache_root=None)  # type: ignore[arg-type]
+
+
+# ----------------------------------------------------------------------
+# Guest disk preparation (see ``guest_disk`` for the measurements)
+# ----------------------------------------------------------------------
+
+
+async def _allocate_with_guest(
+    stubs: _Stubs, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> Path:
+    """Drive a full allocate and return the episode cache root it wrote into."""
+
+    _expect_describe_images(stubs)
+    _expect_run_instances(stubs)
+    _expect_create_schedule(stubs)
+    _expect_running(stubs)
+    provider = _provider(
+        stubs,
+        monkeypatch,
+        desktop_env_factory=_FakeEnv,
+        task_factory=lambda t: {"id": t.task_id},
+    )
+    root = _cache_root(tmp_path)
+    await provider.allocate(_plan(), _task(), cache_root=root)
+    return root
+
+
+class _ResetRecordingEnv(_FakeEnv):
+    """A ``_FakeEnv`` that records how many guest posts preceded its reset.
+
+    Ordering is only assertable against a shared timeline, so the env samples
+    the guest's post log at the moment upstream's ``reset`` runs. Comparing that
+    count with the final one is what distinguishes "prepared the disk, then
+    reset" from "reset, then prepared" -- two orderings that otherwise produce
+    identical reports and identical call sets.
+    """
+
+    posts_at_reset: int | None = None
+    stubs: _Stubs | None = None
+
+    def reset(self, task_config: Any) -> None:
+        assert _ResetRecordingEnv.stubs is not None
+        _ResetRecordingEnv.posts_at_reset = len(_ResetRecordingEnv.stubs.guest_posts)
+        super().reset(task_config)
+
+
+@pytest.mark.asyncio
+async def test_allocate_reclaims_a_tight_guest_before_upstream_resets(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The disk is reclaimed BEFORE the first observation, and it is recorded.
+
+    Ordering is the whole point: the released AMI ships ~93% full and its own
+    snapd fills the rest on a clock (100% used / 0 bytes free at t+383s, first
+    ``ObservationPhaseError`` at t+424s), so hygiene that ran after upstream's
+    reset would already be too late for the frame that reset captures.
+    """
+
+    _ResetRecordingEnv.posts_at_reset = None
+    with _Stubs() as stubs:
+        _ResetRecordingEnv.stubs = stubs
+        stubs.guest_default = {"returncode": 0, "output": str(2_200_000_000), "error": ""}
+        _expect_describe_images(stubs)
+        _expect_run_instances(stubs)
+        _expect_create_schedule(stubs)
+        _expect_running(stubs)
+        provider = _provider(
+            stubs,
+            monkeypatch,
+            desktop_env_factory=_ResetRecordingEnv,
+            task_factory=lambda t: {"id": t.task_id},
+        )
+        root = _cache_root(tmp_path)
+        await provider.allocate(_plan(), _task(), cache_root=root)
+
+    scripts = [" ".join(post["command"]) for post in stubs.guest_posts]
+    assert any("snap refresh --hold=forever" in script for script in scripts)
+    assert any("/var/lib/snapd/cache" in script for script in scripts)
+
+    # EVERY hygiene post landed before upstream's reset captured the first
+    # frame. Preparation that ran afterwards would leave that frame -- and the
+    # setup writes preceding it -- on the disk this step exists to protect.
+    posts_at_reset = _ResetRecordingEnv.posts_at_reset
+    assert posts_at_reset is not None, "upstream reset never ran"
+    assert posts_at_reset == len(stubs.guest_posts)
+    assert posts_at_reset > 0
+    # Every post uses the endpoint contract upstream itself uses: an argv list
+    # with ``shell: false``, so the server execs it directly.
+    assert all(post["shell"] is False for post in stubs.guest_posts)
+    assert all(isinstance(post["command"], list) for post in stubs.guest_posts)
+
+    report = json.loads((root / "guest-preparation.json").read_bytes())
+    assert report["reclamation_attempted"] is True
+    assert report["free_bytes_before"] == 2_200_000_000
+
+
+@pytest.mark.asyncio
+async def test_allocate_leaves_a_roomy_guest_alone_but_still_records_it(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    with _Stubs() as stubs:
+        root = await _allocate_with_guest(stubs, monkeypatch, tmp_path)
+
+    scripts = [" ".join(post["command"]) for post in stubs.guest_posts]
+    assert not any("snap refresh" in script for script in scripts)
+    report = json.loads((root / "guest-preparation.json").read_bytes())
+    assert report["reclamation_attempted"] is False
+    assert report["reason"] == "above-threshold"
+
+
+@pytest.mark.asyncio
+async def test_an_unreachable_guest_control_server_does_not_fail_the_allocation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """FAIL SOFT, at the provider boundary this time.
+
+    The readiness probe already passed, so the guest is up; a control server
+    that then refuses the hygiene posts must cost the episode nothing. An
+    allocation that raised here would destroy an episode that would have run.
+    """
+
+    with _Stubs() as stubs:
+        stubs.guest_default = ConnectionError("connection refused")
+        root = await _allocate_with_guest(stubs, monkeypatch, tmp_path)
+        stubs.ec2_stub.assert_no_pending_responses()
+        stubs.sched_stub.assert_no_pending_responses()
+
+    report = json.loads((root / "guest-preparation.json").read_bytes())
+    assert report["free_bytes_before"] is None
+    assert all(step["status"] == "unreachable" for step in report["steps"])
+
+
+@pytest.mark.asyncio
+async def test_a_guest_returning_a_body_without_a_returncode_reads_as_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A server that did not say the command succeeded did not say it succeeded.
+
+    Defaulting a missing ``returncode`` to 0 would let a malformed reply be
+    recorded as a successful reclamation, which is the one thing the evidence
+    must not be able to claim falsely.
+    """
+
+    with _Stubs() as stubs:
+        stubs.guest_default = {"output": "", "error": "no returncode field"}
+        root = await _allocate_with_guest(stubs, monkeypatch, tmp_path)
+
+    report = json.loads((root / "guest-preparation.json").read_bytes())
+    assert report["free_bytes_before"] is None
+    assert all(step["status"] == "failed" for step in report["steps"])
+
+
+@pytest.mark.asyncio
+async def test_the_preparation_report_never_carries_the_client_password(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The password reaches the guest through ``sudo -S`` and stops there.
+
+    Same discipline as every other secret on this boundary: it may cross the
+    wire to the guest, and it may not be written to the operator's disk.
+    """
+
+    with _Stubs() as stubs:
+        stubs.guest_default = {"returncode": 0, "output": str(2_200_000_000), "error": ""}
+        root = await _allocate_with_guest(stubs, monkeypatch, tmp_path)
+
+    # ``_plan()``'s OSWORLD_CLIENT_PASSWORD is "pw" -- too short to search for
+    # without false positives, so assert on the pipeline shape that carries it.
+    scripts = [" ".join(post["command"]) for post in stubs.guest_posts]
+    assert any("| sudo -S" in script for script in scripts)
+    report = (root / "guest-preparation.json").read_text()
+    assert "sudo -S" not in report
+    assert "snap refresh" not in report
 
 
 @pytest.mark.asyncio

--- a/tests/unit/evaluation/adapters/osworld/test_build_and_scripts.py
+++ b/tests/unit/evaluation/adapters/osworld/test_build_and_scripts.py
@@ -564,7 +564,19 @@ def stubbed_clients(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Any:
         "scheduler", region_name="us-east-1", aws_access_key_id="x", aws_secret_access_key="y"
     )
     with Stubber(ec2) as ec2_stub, Stubber(scheduler) as sched_stub:
-        yield _Clients(ec2=ec2, scheduler=scheduler, http_get=lambda u, t: 0), ec2_stub, sched_stub
+        # ``audit`` is a teardown-only surface and never posts to a guest; the
+        # poster raises so a test that unexpectedly reached it fails loudly
+        # rather than silently exercising a no-op.
+        def _no_guest(url: str, payload: dict[str, Any], timeout: float) -> dict[str, Any]:
+            raise AssertionError("the audit path must not talk to a guest")
+
+        yield (
+            _Clients(
+                ec2=ec2, scheduler=scheduler, http_get=lambda u, t: 0, http_post_json=_no_guest
+            ),
+            ec2_stub,
+            sched_stub,
+        )
 
 
 def test_audit_prints_empty_list_and_exits_zero_when_clean(

--- a/tests/unit/evaluation/adapters/osworld/test_guest_disk.py
+++ b/tests/unit/evaluation/adapters/osworld/test_guest_disk.py
@@ -1,0 +1,511 @@
+"""Guest disk reclamation: the threshold, the fail-soft paths, the evidence.
+
+Nothing here touches the network or AWS. ``guest_disk`` takes its guest-command
+runner and its clock as arguments precisely so the whole module is exercisable
+against a stub, and the provider integration is covered separately in
+``test_aws_provider.py`` against botocore's Stubber.
+
+WHAT THESE TESTS ARE PROTECTING. The measured failure is that the released AMI
+ships ~93% full and its own snapd fills the rest on a clock: root going 93% ->
+100% used / 0 bytes free at t+383s, first ``ObservationPhaseError`` at t+424s,
+across 7 of 8 runs and both instance types. ``pgrep -af ffmpeg`` showed NO
+ffmpeg, which is why the screen-recorder theory in the 0.46.11 notes is wrong
+and why these tests pin snapd's cache and auto-refresh specifically.
+
+Each failure mode is exercised on its OWN, because "fails soft" is a claim about
+every mode independently: a runner that raises, a step whose command exits
+non-zero, an unparseable measurement, and a budget that runs out mid-pass must
+each leave a usable report rather than an exception.
+
+The clock is virtual (a list-backed counter), so no assertion depends on wall
+time (AGENTS.md "Timing, flakes").
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Sequence
+
+import pytest
+from lop_osworld_v2_adapter import guest_disk
+from lop_osworld_v2_adapter.guest_disk import (
+    COMMAND_TIMEOUT_S,
+    RECLAIM_BELOW_FREE_BYTES,
+    TOTAL_BUDGET_S,
+    CommandResult,
+    prepare_guest_disk,
+)
+
+# A guest below the threshold (the measured 2.2 GB) and one comfortably above.
+TIGHT_FREE = 2_200_000_000
+ROOMY_FREE = 40 * 1024**3
+
+
+class _Guest:
+    """A scripted guest control server.
+
+    ``script`` maps a substring of the posted command to the reply. The first
+    match wins, so a test names only the step it is about; everything else gets
+    ``default``. Every command is recorded, which is what lets a test assert
+    that a step ran WITHOUT asserting on a brittle verbatim string.
+    """
+
+    def __init__(
+        self,
+        *,
+        free_bytes: int = TIGHT_FREE,
+        script: dict[str, Any] | None = None,
+        default: Any = None,
+    ) -> None:
+        self.commands: list[str] = []
+        self.timeouts: list[float] = []
+        self._script = script or {}
+        self._free = free_bytes
+        self._default = default if default is not None else CommandResult(0, "", "")
+
+    def __call__(self, command: Sequence[str], timeout: float) -> CommandResult:
+        script = " ".join(command)
+        self.commands.append(script)
+        self.timeouts.append(timeout)
+        for needle, response in self._script.items():
+            if needle in script:
+                if isinstance(response, Exception):
+                    raise response
+                if isinstance(response, CommandResult):
+                    return response
+                # Anything else is a callable computing the reply from the
+                # guest's current state -- used to model a cache clear that
+                # actually frees space between the two measurements.
+                result = response(self)
+                assert isinstance(result, CommandResult)
+                return result
+        # A raising DEFAULT models a guest that answers nothing at all, so it
+        # has to pre-empt the convenience replies below -- otherwise an
+        # "unreachable guest" test would still get its measurements answered.
+        if isinstance(self._default, Exception):
+            raise self._default
+        if "--output=avail" in script:
+            return CommandResult(0, f"{self._free}\n", "")
+        if "--output=size" in script:
+            return CommandResult(0, "31138512896\n107374182400\n", "")
+        return self._default
+
+    def ran(self, needle: str) -> bool:
+        return any(needle in command for command in self.commands)
+
+
+class _Clock:
+    """A virtual monotonic clock that advances only when a test says so."""
+
+    def __init__(self, step: float = 0.0) -> None:
+        self.now = 0.0
+        self._step = step
+
+    def __call__(self) -> float:
+        value = self.now
+        self.now += self._step
+        return value
+
+
+def _prepare(guest: _Guest, clock: Any = None) -> guest_disk.GuestDiskReport:
+    return prepare_guest_disk(guest, client_password="pw", clock=clock or _Clock())
+
+
+def _status(report: guest_disk.GuestDiskReport, name: str) -> str | None:
+    for step in report.steps:
+        if step.name == name:
+            return step.status
+    return None
+
+
+# ----------------------------------------------------------------------
+# The reclamation itself
+# ----------------------------------------------------------------------
+
+
+def test_a_tight_guest_holds_snap_refresh_aborts_downloads_and_clears_the_cache() -> None:
+    """The three measured consumers, in the order that makes them stick.
+
+    Holding first stops a NEW auto-refresh; aborting second stops the one
+    ``snap changes`` showed already running at boot (a hold does not touch an
+    in-flight change); clearing last means nothing is still writing into the
+    directory being emptied.
+    """
+
+    guest = _Guest(free_bytes=TIGHT_FREE)
+    report = _prepare(guest)
+
+    assert report.reclamation_attempted is True
+    assert report.reason == "below-threshold"
+    assert guest.ran("snap refresh --hold=forever")
+    assert guest.ran("snap abort")
+    assert guest.ran("/var/lib/snapd/cache")
+
+    order = [
+        index
+        for index, command in enumerate(guest.commands)
+        if any(
+            needle in command for needle in ("--hold=forever", "snap abort", "/var/lib/snapd/cache")
+        )
+    ]
+    assert order == sorted(order)
+    hold = next(i for i, c in enumerate(guest.commands) if "--hold=forever" in c)
+    abort = next(i for i, c in enumerate(guest.commands) if "snap abort" in c)
+    clear = next(i for i, c in enumerate(guest.commands) if "/var/lib/snapd/cache" in c)
+    assert hold < abort < clear
+
+
+def test_a_roomy_guest_is_measured_and_left_alone() -> None:
+    """Above the threshold nothing is touched, but the measurement still happens.
+
+    The threshold sits above snapd's largest measured appetite (a 9.7 GB cache),
+    so a guest with this much free can absorb a full auto-refresh; running the
+    hygiene there would be a write to a guest that does not need one.
+    """
+
+    guest = _Guest(free_bytes=ROOMY_FREE)
+    report = _prepare(guest)
+
+    assert report.reclamation_attempted is False
+    assert report.reason == "above-threshold"
+    assert report.free_bytes_before == ROOMY_FREE
+    assert not guest.ran("snap refresh")
+    assert not guest.ran("/var/lib/snapd/cache")
+
+
+def test_the_threshold_is_the_boundary_between_the_two_behaviours() -> None:
+    """Exactly at the threshold is 'enough': the guard is ``>=``.
+
+    Pinned because an off-by-one here is invisible in production -- it only
+    changes behaviour for a guest sitting on the exact byte count.
+    """
+
+    assert _prepare(_Guest(free_bytes=RECLAIM_BELOW_FREE_BYTES)).reclamation_attempted is False
+    assert _prepare(_Guest(free_bytes=RECLAIM_BELOW_FREE_BYTES - 1)).reclamation_attempted is True
+
+
+def test_the_snapd_cache_is_emptied_but_no_snap_is_ever_removed() -> None:
+    """The line between housekeeping and changing the benchmark.
+
+    Clearing a download cache costs a re-download. Uninstalling a snap would
+    remove an application a task may legitimately need, which would change what
+    the benchmark measures -- so no command may ever do it.
+    """
+
+    guest = _Guest(free_bytes=TIGHT_FREE)
+    _prepare(guest)
+
+    for command in guest.commands:
+        assert "snap remove" not in command
+        assert "apt-get remove" not in command
+        assert "apt-get purge" not in command
+    # The cache CONTENTS, never the directory itself: snapd expects it to exist.
+    clear = next(c for c in guest.commands if "/var/lib/snapd/cache" in c)
+    assert '"/var/lib/snapd/cache"/*' in clear
+
+
+def test_an_old_snapd_without_hold_falls_back_to_the_refresh_hold_setting() -> None:
+    """``snap refresh --hold`` needs snapd 2.58+; older guests get the setting.
+
+    The fallback is CONDITIONAL on the first failing, so a modern guest is not
+    written to twice for the same effect.
+    """
+
+    guest = _Guest(
+        free_bytes=TIGHT_FREE,
+        script={"--hold=forever": CommandResult(1, "", "unknown flag `hold'")},
+    )
+    report = _prepare(guest)
+
+    assert _status(report, "hold-snap-auto-refresh") == "failed"
+    assert _status(report, "hold-snap-auto-refresh-fallback") == "ok"
+    assert guest.ran("snap set system refresh.hold=")
+
+
+def test_a_modern_snapd_does_not_run_the_fallback() -> None:
+    guest = _Guest(free_bytes=TIGHT_FREE)
+    report = _prepare(guest)
+
+    assert _status(report, "hold-snap-auto-refresh") == "ok"
+    assert _status(report, "hold-snap-auto-refresh-fallback") is None
+    assert not guest.ran("refresh.hold=")
+
+
+@pytest.mark.parametrize(
+    "password",
+    [
+        "osworld-public-evaluation",
+        "pw'; touch /tmp/pwned; echo '",
+        'pw"$(id)`id`\\',
+        "pw with spaces",
+    ],
+)
+def test_the_client_password_survives_a_real_shell_as_exactly_one_word(
+    password: str, tmp_path: Path
+) -> None:
+    """A password with shell metacharacters must not be able to escape the quote.
+
+    ``sudo -S`` needs the password on stdin and the guest endpoint has no stdin,
+    so it arrives through a pipeline (upstream's own pattern, setup.py:609).
+    That makes quoting a correctness requirement rather than a style choice.
+
+    Verified against a REAL ``bash``, not by matching the quoted string: the
+    property that matters is what a shell does with it, and a string assertion
+    would pass just as happily on a quoting scheme that a shell mis-parses.
+    The command's echo half is replayed with the ``sudo`` half replaced, so the
+    injection would land here if it landed anywhere.
+    """
+
+    guest = _Guest(free_bytes=TIGHT_FREE)
+    prepare_guest_disk(guest, client_password=password, clock=_Clock())
+    hold = next(c for c in guest.commands if "--hold=forever" in c)
+
+    # The generated script is ``bash -c <script>``; take the script and cut the
+    # pipeline at the pipe, leaving exactly the ``echo <quoted-password>`` the
+    # module built.
+    script = hold.split("bash -c ", 1)[1]
+    echo_half = script.split(" | ", 1)[0]
+    canary = tmp_path / "pwned"
+    completed = subprocess.run(
+        ["bash", "-c", echo_half],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        check=False,
+    )
+
+    assert completed.returncode == 0
+    # Exactly the password, nothing expanded, nothing split off, nothing run.
+    assert completed.stdout == password + "\n"
+    assert completed.stderr == ""
+    assert not canary.exists()
+
+
+# ----------------------------------------------------------------------
+# Fail-soft: each mode on its own
+# ----------------------------------------------------------------------
+
+
+def test_an_unreachable_guest_returns_a_report_instead_of_raising() -> None:
+    """The whole fail-soft contract in one case: nothing propagates.
+
+    An episode that would have worked must not be destroyed by a hygiene step,
+    so a control server that answers nothing produces a report saying so.
+    """
+
+    guest = _Guest(default=ConnectionError("connection refused"))
+    report = _prepare(guest)
+
+    assert report.free_bytes_before is None
+    # Unmeasurable means reclaim ANYWAY: the protection must not go missing
+    # exactly when the guest is least healthy. Asserted on the ATTEMPTED steps,
+    # not only on the flag -- a flag alone would still be set by an
+    # implementation that skipped the work.
+    assert report.reclamation_attempted is True
+    assert report.reason == "unmeasured"
+    assert guest.ran("snap refresh --hold=forever")
+    assert guest.ran("/var/lib/snapd/cache")
+    assert all(step.status == "unreachable" for step in report.steps)
+    # The exception TYPE is recorded; its message is not, because a transport
+    # error echoes the URL it was given.
+    assert all(step.detail == "ConnectionError" for step in report.steps)
+
+
+def test_a_denied_sudo_is_recorded_and_the_remaining_steps_still_run() -> None:
+    """One failing step must not abort the pass: the others may still help."""
+
+    guest = _Guest(
+        free_bytes=TIGHT_FREE,
+        script={"snap refresh": CommandResult(1, "", "sudo: a password is required")},
+    )
+    report = _prepare(guest)
+
+    assert _status(report, "hold-snap-auto-refresh") == "failed"
+    assert _status(report, "clear-snapd-cache") == "ok"
+    assert guest.ran("/var/lib/snapd/cache")
+
+
+def test_a_missing_binary_is_recorded_as_a_failed_step_not_an_error() -> None:
+    guest = _Guest(
+        free_bytes=TIGHT_FREE,
+        script={"snap changes": CommandResult(127, "", "snap: command not found")},
+    )
+    report = _prepare(guest)
+
+    assert _status(report, "abort-in-flight-snap-changes") == "failed"
+    detail = next(s.detail for s in report.steps if s.name == "abort-in-flight-snap-changes")
+    assert "not found" in detail
+
+
+def test_an_unparseable_measurement_reads_as_unknown_rather_than_zero() -> None:
+    """A garbled ``df`` must never be read as "0 bytes free".
+
+    Inventing a number would be worse than reporting none: a later reader would
+    take it as measured fact.
+    """
+
+    guest = _Guest(script={"--output=avail": CommandResult(0, "Filesystem\n", "")})
+    report = _prepare(guest)
+
+    assert report.free_bytes_before is None
+    assert report.reason == "unmeasured"
+    # An unmeasurable guest is still reclaimed: skipping would make the
+    # protection absent exactly when the guest is least healthy, and this guest
+    # ANSWERS -- only its measurement is unparseable.
+    assert report.reclamation_attempted is True
+    assert guest.ran("snap refresh --hold=forever")
+
+
+def test_a_transport_failure_on_one_step_alone_does_not_stop_the_others() -> None:
+    guest = _Guest(
+        free_bytes=TIGHT_FREE,
+        script={"snap abort": TimeoutError("read timed out")},
+    )
+    report = _prepare(guest)
+
+    assert _status(report, "abort-in-flight-snap-changes") == "unreachable"
+    assert _status(report, "clear-snapd-cache") == "ok"
+
+
+def test_an_exhausted_budget_skips_the_remaining_steps_rather_than_hanging() -> None:
+    """A wedged guest must not eat the reset budget.
+
+    Each command already has its own timeout; the whole-pass budget is what
+    bounds a guest that answers every call slowly rather than not at all.
+    """
+
+    clock = _Clock(step=TOTAL_BUDGET_S)
+    guest = _Guest(free_bytes=TIGHT_FREE)
+    report = _prepare(guest, clock=clock)
+
+    skipped = [step for step in report.steps if step.status == "skipped"]
+    assert skipped, "a spent budget must skip, not run"
+    assert all(step.detail == "budget exhausted" for step in skipped)
+
+
+def test_a_command_timeout_never_exceeds_the_remaining_budget() -> None:
+    """The per-command ceiling is the smaller of its own and what is left."""
+
+    guest = _Guest(free_bytes=TIGHT_FREE)
+    _prepare(guest)
+    assert guest.timeouts
+    assert max(guest.timeouts) <= COMMAND_TIMEOUT_S
+    assert all(timeout > 0 for timeout in guest.timeouts)
+
+
+# ----------------------------------------------------------------------
+# Observability
+# ----------------------------------------------------------------------
+
+
+def test_the_report_records_free_space_before_and_after_reclamation() -> None:
+    """ "The guest had N bytes free at the start" is the point of the whole step.
+
+    It is the fact a later "environment returned no screenshot frame" is read
+    against, and it must not depend on anyone having probed the guest by hand.
+    """
+
+    freed = {"value": TIGHT_FREE}
+
+    def measure(guest: _Guest) -> CommandResult:
+        return CommandResult(0, f"{freed['value']}\n", "")
+
+    def clear(guest: _Guest) -> CommandResult:
+        freed["value"] = 12_000_000_000
+        return CommandResult(0, "", "")
+
+    guest = _Guest(
+        script={"--output=avail": measure, "/var/lib/snapd/cache": clear},
+    )
+    report = _prepare(guest)
+
+    assert report.free_bytes_before == TIGHT_FREE
+    assert report.free_bytes_after == 12_000_000_000
+    assert report.free_bytes_after > report.free_bytes_before
+
+
+def test_the_report_records_the_partition_and_whole_disk_geometry() -> None:
+    """A 29.5G filesystem inside a 100 GiB disk is the AWS_ROOT_VOLUME_SIZE story.
+
+    Reported read-only: nothing here repartitions (``growpart`` is absent from
+    the AMI and an ``sfdisk`` rewrite can fail HARD, which a hygiene step must
+    never do), but the two numbers are what tell the next reader whether the
+    volume override bought anything.
+    """
+
+    report = _prepare(_Guest(free_bytes=TIGHT_FREE))
+
+    assert report.filesystem_bytes == 31138512896
+    assert report.disk_bytes == 107374182400
+    assert report.disk_bytes > report.filesystem_bytes
+
+
+def test_a_partial_geometry_answer_still_reports_the_filesystem_size() -> None:
+    """An image without ``lsblk`` must still yield the first number."""
+
+    guest = _Guest(
+        free_bytes=TIGHT_FREE,
+        script={"--output=size": CommandResult(0, "31138512896\n", "")},
+    )
+    report = _prepare(guest)
+
+    assert report.filesystem_bytes == 31138512896
+    assert report.disk_bytes is None
+
+
+def test_the_report_serialises_to_portable_json_with_every_step() -> None:
+    """The report is written to a file, so it has to round-trip as JSON."""
+
+    report = _prepare(_Guest(free_bytes=TIGHT_FREE))
+    decoded = json.loads(report.to_json_bytes())
+
+    assert decoded["free_bytes_before"] == TIGHT_FREE
+    assert decoded["threshold_bytes"] == RECLAIM_BELOW_FREE_BYTES
+    # ATTEMPTED, never "achieved": whether it worked is the steps plus the two
+    # measurements, which cannot claim something that did not happen.
+    assert decoded["reclamation_attempted"] is True
+    assert "reclaimed" not in decoded
+    assert decoded["reason"] == "below-threshold"
+    names = [step["name"] for step in decoded["steps"]]
+    assert "measure-free-before" in names
+    assert "clear-snapd-cache" in names
+    assert "measure-free-after" in names
+    for step in decoded["steps"]:
+        assert step["status"] in {"ok", "failed", "unreachable", "skipped"}
+
+
+def test_the_report_never_carries_the_client_password() -> None:
+    """The commands are not recorded, and that is why.
+
+    Every privileged step runs through ``echo <password> | sudo -S``, so a
+    verbatim argv in the report would put the password in a file on the
+    operator's disk for no diagnostic gain.
+    """
+
+    marker = "marker-client-password"
+    guest = _Guest(
+        free_bytes=TIGHT_FREE,
+        script={"snap refresh": CommandResult(1, "", "sudo: 1 incorrect password attempt")},
+    )
+    report = prepare_guest_disk(guest, client_password=marker, clock=_Clock())
+
+    assert marker not in report.to_json_bytes().decode()
+    assert marker in " ".join(guest.commands), "the password must reach the guest"
+
+
+@pytest.mark.parametrize("free", [TIGHT_FREE, ROOMY_FREE, None])
+def test_a_report_is_produced_on_every_path(free: int | None) -> None:
+    """Above, below, and unmeasurable all produce a usable report.
+
+    There is no path on which the episode's evidence loses the disk facts.
+    """
+
+    guest = _Guest(default=ConnectionError("refused")) if free is None else _Guest(free_bytes=free)
+    report = _prepare(guest)
+
+    assert report.threshold_bytes == RECLAIM_BELOW_FREE_BYTES
+    assert report.reason in {"above-threshold", "below-threshold", "unmeasured"}
+    assert report.steps
+    json.loads(report.to_json_bytes())

--- a/tests/unit/evaluation/adapters/osworld/test_guest_disk.py
+++ b/tests/unit/evaluation/adapters/osworld/test_guest_disk.py
@@ -125,13 +125,15 @@ def _status(report: guest_disk.GuestDiskReport, name: str) -> str | None:
 # ----------------------------------------------------------------------
 
 
-def test_a_tight_guest_holds_snap_refresh_aborts_downloads_and_clears_the_cache() -> None:
+def test_a_tight_guest_aborts_downloads_holds_snap_refresh_and_clears_the_cache() -> None:
     """The three measured consumers, in the order that makes them stick.
 
-    Holding first stops a NEW auto-refresh; aborting second stops the one
-    ``snap changes`` showed already running at boot (a hold does not touch an
-    in-flight change); clearing last means nothing is still writing into the
-    directory being emptied.
+    Aborting FIRST because it is immediate, while ``snap refresh --hold`` is a
+    hook change the CLI waits on and that queues behind an in-flight refresh's
+    own hooks -- long enough to outlast the per-command ceiling. Holding second
+    stops a NEW auto-refresh (snapd's 20-minute retry delay covers the gap).
+    Clearing last means nothing is still writing into the directory being
+    emptied.
     """
 
     guest = _Guest(free_bytes=TIGHT_FREE)
@@ -143,18 +145,10 @@ def test_a_tight_guest_holds_snap_refresh_aborts_downloads_and_clears_the_cache(
     assert guest.ran("snap abort")
     assert guest.ran("/var/lib/snapd/cache")
 
-    order = [
-        index
-        for index, command in enumerate(guest.commands)
-        if any(
-            needle in command for needle in ("--hold=forever", "snap abort", "/var/lib/snapd/cache")
-        )
-    ]
-    assert order == sorted(order)
-    hold = next(i for i, c in enumerate(guest.commands) if "--hold=forever" in c)
     abort = next(i for i, c in enumerate(guest.commands) if "snap abort" in c)
+    hold = next(i for i, c in enumerate(guest.commands) if "--hold=forever" in c)
     clear = next(i for i, c in enumerate(guest.commands) if "/var/lib/snapd/cache" in c)
-    assert hold < abort < clear
+    assert abort < hold < clear
 
 
 def test_a_roomy_guest_is_measured_and_left_alone() -> None:
@@ -203,7 +197,188 @@ def test_the_snapd_cache_is_emptied_but_no_snap_is_ever_removed() -> None:
         assert "apt-get purge" not in command
     # The cache CONTENTS, never the directory itself: snapd expects it to exist.
     clear = next(c for c in guest.commands if "/var/lib/snapd/cache" in c)
-    assert '"/var/lib/snapd/cache"/*' in clear
+    assert "find /var/lib/snapd/cache -mindepth 1 -delete" in clear
+    # And no glob anywhere near it: a ``/*`` is expanded by whichever shell
+    # holds it, and the OUTER shell is unprivileged (see the real-shell test
+    # below for what that did).
+    assert "*" not in clear
+
+
+def _privileged_scripts(guest: _Guest) -> list[str]:
+    """The ``bash -c`` scripts that reach ``sudo``, as the guest received them."""
+
+    return [c.split("bash -c ", 1)[1] for c in guest.commands if "sudo -S" in c]
+
+
+def test_every_privileged_step_is_one_sudo_running_one_inner_shell() -> None:
+    """The shape that keeps the work on the privileged side of the boundary.
+
+    The guest's control server is NOT root (upstream's server runs ``sudo -S``
+    for everything, setup.py:661), so anything the outer shell does itself --
+    expanding a glob, feeding ``xargs`` -- happens without privilege. Two real
+    defects had that shape: ``rm -rf -- /var/lib/snapd/cache/*`` expanded to
+    nothing against a ``drwx------ root:root`` directory and exited 0, and
+    ``xargs -r -n1 echo 'pw' | sudo -S snap abort`` parsed as ``xargs echo``
+    PIPED INTO one id-less ``snap abort``. Each step is therefore exactly one
+    ``echo <pw> | sudo -S bash -c '<fragment>'`` with the password appearing
+    once, and nothing else on the outer command line.
+    """
+
+    guest = _Guest(free_bytes=TIGHT_FREE)
+    _prepare(guest)
+    scripts = _privileged_scripts(guest)
+
+    assert len(scripts) == 3  # abort, hold, clear
+    for script in scripts:
+        assert script.count("sudo") == 1
+        assert script.count("'pw'") == 1
+        assert script.startswith("echo 'pw' | sudo -S bash -c '")
+        assert "xargs" not in script
+        # No PATHNAME glob (a ``case`` pattern is matched, never expanded).
+        assert "/*" not in script
+
+
+def _install_fake_sudo(bin_dir: Path, *, password: str, marker: Path) -> None:
+    """A ``sudo -S`` that regains access the way root would.
+
+    It reads the password from stdin like the real one, refuses anything else,
+    then runs the command with ``marker``'s parent tree made readable -- the
+    model for "root can see what the unprivileged shell cannot". Whatever the
+    command's stdin was is consumed by the password read, exactly as sudo's.
+    """
+
+    script = f"""#!/bin/bash
+[ "$1" = "-S" ] && shift
+IFS= read -r pw
+if [ "$pw" != {guest_disk._shell_quote(password)} ]; then
+  echo 'sudo: 1 incorrect password attempt' >&2; exit 1
+fi
+chmod -R u+rwx {guest_disk._shell_quote(str(marker))}
+"$@"
+rc=$?
+chmod 000 {guest_disk._shell_quote(str(marker))} 2>/dev/null
+exit $rc
+"""
+    (bin_dir / "sudo").write_text(script)
+    (bin_dir / "sudo").chmod(0o755)
+
+
+def test_the_cache_is_emptied_through_a_real_shell_when_only_root_can_read_it(
+    tmp_path: Path,
+) -> None:
+    """B1, replayed against a real ``bash``: the delete must run as root.
+
+    The cache directory is ``chmod 000`` -- the ``drwx------ root:root`` that
+    snapd creates, as seen from a user who is not root. The fake ``sudo``
+    restores access only for the command it runs. A glob expanded outside it
+    matches nothing, ``rm -rf`` of the literal name exits 0, and the bytes
+    stay; ``find -mindepth 1 -delete`` INSIDE it empties the directory.
+    """
+
+    cache = tmp_path / "var/lib/snapd/cache"
+    (cache / "nested").mkdir(parents=True)
+    (cache / "blob-1").write_bytes(b"x" * 4096)
+    (cache / "nested" / "inner").write_bytes(b"y" * 4096)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _install_fake_sudo(bin_dir, password="pw", marker=cache)
+
+    guest = _Guest(free_bytes=TIGHT_FREE)
+    _prepare(guest)
+    clear = next(s for s in _privileged_scripts(guest) if "/var/lib/snapd/cache" in s)
+    # The production path is absolute; the fixture relocates it under tmp_path.
+    clear = clear.replace("/var/lib/snapd/cache", str(cache))
+
+    cache.chmod(0o000)
+    try:
+        completed = subprocess.run(
+            ["bash", "-c", clear],
+            capture_output=True,
+            text=True,
+            env={"PATH": f"{bin_dir}:/usr/bin:/bin"},
+            check=False,
+        )
+    finally:
+        cache.chmod(0o700)
+
+    assert completed.returncode == 0, completed.stdout
+    assert cache.is_dir(), "the directory itself must survive"
+    assert list(cache.iterdir()) == [], "bytes must actually be gone"
+
+
+def test_every_in_flight_refresh_is_aborted_by_id_through_a_real_shell(
+    tmp_path: Path,
+) -> None:
+    """M1, replayed against a real ``bash`` and a ``snap`` with the real CLI rules.
+
+    ``snap abort`` REQUIRES a change id ("please provide change ID or type
+    with --last"), and only ``Doing`` rows whose summary is an auto-refresh or
+    its pre-download are candidates: a seeding hook that happens to be running
+    is not the benchmark's to abort, and a COMPLETED auto-refresh must not be
+    touched at all (aborting it is an error in real snapd, and the intent it
+    would express is a revert). The fake ``snap`` records every call it
+    receives, so an id-less abort, an abort of the wrong change, or an abort
+    running as the wrong user is visible rather than masked by ``|| true``.
+    """
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    calls = tmp_path / "snap-calls"
+    guard = tmp_path / "root-only"
+    guard.mkdir()
+    _install_fake_sudo(bin_dir, password="pw", marker=guard)
+    (bin_dir / "snap").write_text(f"""#!/bin/bash
+echo "$*" >> {guest_disk._shell_quote(str(calls))}
+case "$1" in
+  changes)
+    printf 'ID   Status  Spawn  Ready  Summary\\n'
+    printf '10   Done    -      -      Initialize system state\\n'
+    printf '11   Done    -      -      Auto-refresh 3 snaps\\n'
+    printf '12   Doing   -      -      Auto-refresh 9 snaps\\n'
+    printf '13   Doing   -      -      Pre-download "novnc" for auto-refresh\\n'
+    printf '14   Doing   -      -      Run configure hook of "seed-thing" snap\\n'
+    printf '15   Doing   -      -      Hold auto-refreshes for all snaps\\n'
+    ;;
+  abort)
+    [ -r {guest_disk._shell_quote(str(guard))} ] || {{ echo 'error: access denied' >&2; exit 1; }}
+    [ -n "$2" ] || {{ echo 'error: please provide change ID or type with --last' >&2; exit 1; }}
+    ;;
+esac
+""")
+    (bin_dir / "snap").chmod(0o755)
+
+    guest = _Guest(free_bytes=TIGHT_FREE)
+    _prepare(guest)
+    abort = next(s for s in _privileged_scripts(guest) if "snap abort" in s)
+
+    guard.chmod(0o000)
+    try:
+        completed = subprocess.run(
+            ["bash", "-c", abort],
+            capture_output=True,
+            text=True,
+            env={"PATH": f"{bin_dir}:/usr/bin:/bin"},
+            check=False,
+        )
+    finally:
+        guard.chmod(0o700)
+
+    assert completed.returncode == 0, completed.stdout
+    assert calls.read_text().splitlines() == ["changes", "abort 12", "abort 13"]
+
+
+def test_a_failed_abort_is_recorded_as_a_failed_step_rather_than_masked() -> None:
+    """``|| true`` used to turn an abort that did nothing into ``ok``."""
+
+    guest = _Guest(
+        free_bytes=TIGHT_FREE,
+        script={"snap abort": CommandResult(1, "", "error: cannot abort change 12")},
+    )
+    report = _prepare(guest)
+
+    assert _status(report, "abort-in-flight-snap-changes") == "failed"
+    abort = next(s for s in _privileged_scripts(guest) if "snap abort" in s)
+    assert "|| true" not in abort
 
 
 def test_an_old_snapd_without_hold_falls_back_to_the_refresh_hold_setting() -> None:
@@ -266,7 +441,7 @@ def test_the_client_password_survives_a_real_shell_as_exactly_one_word(
     # pipeline at the pipe, leaving exactly the ``echo <quoted-password>`` the
     # module built.
     script = hold.split("bash -c ", 1)[1]
-    echo_half = script.split(" | ", 1)[0]
+    echo_half = script.split(" | sudo -S ", 1)[0]
     canary = tmp_path / "pwned"
     completed = subprocess.run(
         ["bash", "-c", echo_half],
@@ -442,17 +617,54 @@ def test_the_report_records_the_partition_and_whole_disk_geometry() -> None:
     assert report.disk_bytes > report.filesystem_bytes
 
 
-def test_a_partial_geometry_answer_still_reports_the_filesystem_size() -> None:
-    """An image without ``lsblk`` must still yield the first number."""
+@pytest.mark.parametrize("returncode", [0, 127])
+def test_a_partial_geometry_answer_still_reports_the_filesystem_size(returncode: int) -> None:
+    """An image without ``lsblk`` must still yield the first number.
+
+    Parametrised over the exit status because a missing tool is exactly the
+    case where the shell reports failure (127) AFTER ``df`` has already
+    printed: the number that was measured must not be discarded over a tool
+    that was not there.
+    """
 
     guest = _Guest(
         free_bytes=TIGHT_FREE,
-        script={"--output=size": CommandResult(0, "31138512896\n", "")},
+        script={"--output=size": CommandResult(returncode, "31138512896\n", "lsblk: not found")},
     )
     report = _prepare(guest)
 
     assert report.filesystem_bytes == 31138512896
     assert report.disk_bytes is None
+
+
+def test_the_geometry_script_exits_zero_through_a_real_shell_without_lsblk(
+    tmp_path: Path,
+) -> None:
+    """The block-device half is best-effort, so the step itself reports ``ok``.
+
+    Run against a real ``bash`` with a PATH holding ``df`` and nothing else:
+    the ``&&`` chain used to leak its 127 into the step status, which the
+    report then showed as a FAILED measurement beside a perfectly good
+    filesystem figure.
+    """
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    (bin_dir / "df").write_text("#!/bin/bash\nprintf '  1B-blocks\\n31138512896\\n'\n")
+    (bin_dir / "df").chmod(0o755)
+    for tool in ("tail", "head"):
+        (bin_dir / tool).symlink_to(f"/usr/bin/{tool}")
+
+    completed = subprocess.run(
+        ["/bin/bash", "-c", guest_disk._GEOMETRY_SCRIPT],
+        capture_output=True,
+        text=True,
+        env={"PATH": str(bin_dir)},
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout == "31138512896\n"
 
 
 def test_the_report_serialises_to_portable_json_with_every_step() -> None:

--- a/tests/unit/evaluation/adapters/osworld/test_provisioning.py
+++ b/tests/unit/evaluation/adapters/osworld/test_provisioning.py
@@ -188,12 +188,18 @@ def test_proxy_flag_comes_from_the_task() -> None:
 # AWS_ROOT_VOLUME_SIZE: the disk-exhaustion escape hatch
 # ---------------------------------------------------------------------------
 #
-# The failure this knob answers is a CLOCK, not a workload: the guest's x11grab
-# recorder fills the root filesystem at ~6.8 MB/s against ~2.2 GB free, so the
-# disk reaches 0 bytes at ~t+383s and the next screenshot request fails. 7 of 8
-# runs first failed in a 424-466s window regardless of agent activity (16-32
-# steps) and on both t3.xlarge and m5.xlarge -- the volume is identical either
-# way, which is why the instance-type knob changed nothing.
+# The failure this knob answers is a CLOCK, not a workload: the root filesystem
+# reaches 0 bytes at ~t+383s and the next screenshot request fails. 7 of 8 runs
+# first failed in a 424-466s window regardless of agent activity (16-32 steps)
+# and on both t3.xlarge and m5.xlarge -- the volume is identical either way,
+# which is why the instance-type knob changed nothing.
+#
+# The CONSUMER is the guest's own snapd (a 9.7 GB /var/lib/snapd/cache plus a
+# boot-time auto-refresh), NOT the x11grab recorder an earlier revision of this
+# comment named: pgrep found no ffmpeg process on a failing guest. The adapter
+# now reclaims that space itself at episode start (``guest_disk``); this knob
+# remains an independent lever, and cannot fully fix it on its own because the
+# root partition stays 29.5G inside whatever volume is requested.
 
 
 def _with_volume_size(value: str) -> tuple[ScopedInfraValue, ...]:

--- a/tests/unit/evaluation/adapters/osworld/test_run_episode_script.py
+++ b/tests/unit/evaluation/adapters/osworld/test_run_episode_script.py
@@ -442,8 +442,9 @@ def test_a_root_volume_override_is_disclosed_in_the_sealed_manifest(
     """A run on a resized disk must be disclosable from the bundle alone.
 
     Comparability is the whole point. An episode on a larger root volume
-    survives past the ~t+383s exhaustion wall where the guest's x11grab
-    recorder fills the default 2.2 GB of free space, so its score is not
+    survives past the ~t+383s exhaustion wall where the guest's own snapd fills
+    the default 2.2 GB of free space (NOT the x11grab recorder an earlier
+    revision blamed -- no ffmpeg process was ever found), so its score is not
     comparable to a truncated default run -- and a reader has no other way to
     learn that, since ``ObservationPayload`` carries no metadata and nothing
     the worker resolves reaches the bundle except through the manifest the


### PR DESCRIPTION
## What

The OSWorld V2 adapter now **reclaims the guest's root filesystem before an episode's first observation**, so a benchmark run is not destroyed by the guest's own package manager filling its disk.

Between guest readiness and upstream's `reset`, `AwsProvider.allocate` drives the guest's own control server (`POST /execute`, argv with `shell: false` — the same endpoint and contract upstream's `SetupController` uses) to hold snap auto-refresh, abort the in-flight snap change, and clear snapd's download cache. It is conditional, it fails soft per step, and it writes its measurements into the episode's evidence.

## Why — and a correction to #620, which got the cause wrong

Every episode died at roughly the same **wall-clock time**: 7 of 8 runs first failed in a **424–466s window**, regardless of work done (16–32 steps), on **both `t3.xlarge` and `m5.xlarge`**. Measured from inside the guest:

| time | root filesystem |
|------|-----------------|
| t+54s … t+342s | 93% used, 2.2 GB free (stable) |
| t+363s | 95% |
| t+383s | **100% used, 0 bytes free** |
| t+424s | first `ObservationPhaseError` — "environment returned no screenshot frame" |

A disk at 0 bytes cannot write a screenshot.

> ### ⚠️ The ffmpeg diagnosis in #620 / 0.46.11 was WRONG
>
> That PR blamed OSWorld's `x11grab` **ffmpeg screen recorder** at a quoted **~6.8 MB/s**. `pgrep -af ffmpeg` on a failing guest showed **no ffmpeg process at all** — the only match was the probe's own `pgrep` command line, which is what made the theory look confirmed from outside. The fill rate was **inferred from the disk series, never measured at a process**. This PR corrects that claim in the docs, in `episode.py`'s disclosure comment, and in two test comments, so the next person does not re-derive it.

The measured consumer is the guest's own **snapd**:

- `/var` is 15G of a 29G disk, and **`/var/lib/snapd/cache` alone is 9.7 GB**
- `snap changes` shows `Auto-refresh 9 snaps` and `Pre-download novnc`, both fired at boot
- the AMI ships **~93% full**, so a few GB of snap downloads exhausts it

Snapd downloads at its own pace from boot, entirely independent of the agent — which is precisely why the failure looked like a **clock** rather than a workload, and why changing the instance family moved nothing.

### Why `AWS_ROOT_VOLUME_SIZE` (#620) helps but cannot fix it

A 100 GiB volume moved the first failure from **t+424s to t+1936s** — real improvement, not a fix. The root **partition** stays **29.5G inside that 100 GiB disk**, ~70 GiB unallocated, because the AMI carries **no `growpart`** and `apt-get install cloud-guest-utils` cannot run on a disk with no free space to download into. That knob remains available as an independent lever; this PR addresses the cause.

## Design constraints, each pinned by a test

**Environment preparation, not benchmark semantics.** Nothing changes the task, the scoring, the applications available, or anything the model observes. Clearing a package manager's *download scratch* is housekeeping — Canonical documents `/var/lib/snapd/cache` as "the working cache … used to minimise download size and speed-up refreshes", so deleting it costs a re-download and nothing else. **Uninstalling** an application a task might need is the line this does not cross: no command may `snap remove` or `apt-get purge`, and a test asserts it. Nothing stops `snapd` itself, since a task may legitimately launch a snap-packaged app.

**Fails soft, per step.** A missing binary, a denied `sudo`, an unreachable control server, a non-JSON body, and a wedged guest are each recorded and stepped over. An episode that would otherwise have worked must never be destroyed by a hygiene step. A whole-pass budget (180s, 60s per command) keeps a slow guest from eating the 900s reset timeout, and the provider wraps the whole thing so even a contract violation cannot fail the allocation.

**Observable.** Free space before/after, the filesystem-vs-whole-disk geometry, and every step's outcome go to `<run-root>/osworld-cache/<episode-id>/guest-preparation.json`. "The guest had N bytes free at the start" is exactly the fact a later environment failure must be read against, and it must not depend on anyone having probed by hand. It is deliberately **not** on the observation: `Observation.metadata` feeds `observation_content_id`, and a content-addressed observation id must be a function of what the model saw, not of the guest's filesystem. Nor in the artifact root, whose verifier refuses any entry that is not a digest-named artifact.

**Conditional, at 12 GiB free.** Set *above* snapd's largest measured appetite (the 9.7 GB cache) plus room for the episode's own writes, so a guest that can already absorb a full auto-refresh is left untouched. A guest whose free space **cannot be measured is reclaimed anyway** — the protection must not go missing exactly when the guest is least healthy.

**Order is load-bearing.** Abort → hold → clear. Abort goes **first** because it is immediate; `snap refresh --hold` is a `configure core` hook change the CLI *waits on*, and snapd runs one hook per snap at a time, so behind a live core/snapd refresh a hold would queue past the 60 s ceiling (round-1 finding m4). Snapd's 20-minute retry delay means no new refresh can start before the hold lands. Clearing last means nothing is still writing into the directory being emptied. Only `Doing` changes summarised `Auto-refresh …`/`Pre-download …` are aborted; a seeding hook is left alone (m2). Aborting a partly-done change undoes its completed tasks, which returns those snaps to the revision the AMI shipped — the benchmark's own baseline, stated accurately rather than as "exactly as it was".

**Every privileged step is one `echo <pw> | sudo -S bash -c '<fragment>'`, with all of the work inside the privileged inner shell.** This is the shape round 1 found missing (B1, M1): the guest's control server runs as an **unprivileged** user, so a glob like `/var/lib/snapd/cache/*` expanded by the *outer* shell matched nothing against snapd's `drwx------ root:root` cache and `rm -rf` of the literal name exited 0 — the 9.7 GB reclaim was a no-op that reported `ok`. Likewise `xargs -r -n1 echo 'pw' | sudo -S snap abort` parsed as `xargs echo` piped into one id-less `sudo`, aborting nothing behind a `|| true`. Now the delete is `find /var/lib/snapd/cache -mindepth 1 -delete` inside `sudo -S bash -c`, the abort loop runs inside the privileged shell with no `|| true`, and the password appears exactly once per step as the stdin of that one `sudo` (a bash builtin `echo` — nothing is exec'd with it in argv).

**Growing the partition is deliberately not attempted.** `growpart` is absent, and the in-place `sfdisk` alternative rewrites the root partition table where a wrong start sector destroys the guest. A hygiene step that can fail **hard** is exactly what this must not be. The geometry is **reported** read-only instead, since that pair of numbers is what tells the next reader whether `AWS_ROOT_VOLUME_SIZE` bought anything.

**Honesty in the field name.** The report says `reclamation_attempted`, not `reclaimed`: a flag claiming achievement while every step came back `unreachable` would be a false statement sealed beside the episode's evidence. Whether it *worked* is the steps plus the two measurements, which cannot claim something that did not happen. (This was found by a surviving mutant, not by review.)

## Testing evidence

### 1. Real end-to-end execution across a REAL privilege boundary

Round 1 was right that the original E2E never had the privilege boundary in it (it ran as the author's own user over the author's own directories). The re-run is against a Linux guest container (`ubuntu:24.04`) whose control server (`POST /execute`, argv, `shell: false`, upstream's response shape) runs as an **unprivileged `osworld` user**, whose `sudo` is the **real one** with a real password (not `NOPASSWD`), whose `/var/lib/snapd/cache` is **`drwx------ root:root`** holding 902 MB (three blobs plus a nested entry), and whose `find`/`df`/`findmnt`/`lsblk`/`bash` are real. Only `snap` is a double — one that enforces the real CLI's rules (`abort` **requires** an id, privileged verbs refuse a non-root caller) and logs every call with its uid. Driven through the **production** `build_clients(...).http_post_json` → `AwsProvider._run_guest_command` → `prepare_guest_disk` → `guest-preparation.json` writer. The password carries `'`, `"` and `$`.

```
  [PASS] control server runs unprivileged        [PASS] cache dir is root-only 0700
  [PASS] cache had bytes before (944,766,976 B)   [PASS] cache really emptied (bytes)   <- 0 B
  [PASS] cache really emptied (entries)  <- 0     [PASS] cache DIRECTORY survives
  [PASS] clear step recorded ok                   [PASS] abort step recorded ok
  [PASS] Auto-refresh change aborted              [PASS] Pre-download change aborted
  [PASS] unrelated Doing change NOT aborted       [PASS] Done change untouched
  [PASS] every abort carried an id, as root       [PASS] hold ran as root
  [PASS] no snap ever removed                     [PASS] abort BEFORE hold BEFORE clear
  [PASS] free space really rose (+944 MB)         [PASS] geometry reported filesystem_bytes
  [PASS] password absent from report              [PASS] password never in any argv but the outer bash -c
  [PASS] password appears exactly once per privileged post
  [PASS] no exec'd echo ever carried the password [PASS] every post is bash -c argv

snap log (uid + argv, as the guest's snap saw it):
  uid=0 argv=changes
  uid=0 argv=abort 12
  uid=0 argv=abort 13
  uid=0 argv=refresh --hold=forever
RESULT: ALL PASS
```

**Password hygiene, measured rather than asserted:** while each command ran, a sampler read every `/proc/*/cmdline` in the guest and recorded any argv carrying the password (raw or shell-quoted); a shadowing `/usr/local/bin/echo` logged any *exec'd* echo. On the fixed code the only hits are the three outer `bash -c <script>` argvs the adapter itself posts (the endpoint's only input channel — upstream's own pattern); **zero** other processes, zero exec'd echoes.

**Mutants against this harness** (`__pycache__` purged between each):

| mutant | result |
|---|---|
| B1 restored — glob `"/var/lib/snapd/cache"/*` back outside the privileged shell | **FAILS**: step `ok`, `944,766,976 B` / 5 entries still present, free space unchanged |
| M1 restored — `xargs -r -n1 echo 'pw' \| sudo -S snap abort` | **FAILS**: snap log shows `uid=0 argv=abort` with **no id**, neither change aborted, step `ok`; sampler catches `['xargs','-r','-n1','echo','<pw>']` and `['/bin/bash','/usr/local/bin/echo','<pw>','12']` — the password exec'd in argv as an unprivileged process |
| m1 restored — `&&` geometry chain + rc-gated parse, on a guest with `lsblk`/`findmnt` hidden | **FAILS**: `measure-geometry` rc 126 → `failed`, `filesystem_bytes: null` despite `df` having printed it |

Same guest without `lsblk`/`findmnt` on the fixed code: **ALL PASS**, `filesystem_bytes` reported, `disk_bytes: null`, step `ok`.

### 2. Fail-soft on the new command shape, against the real guest

```
wrong password:     abort/hold/hold-fallback/clear all "failed"
                    (detail: "[sudo] password for osworld: Sorry, try again … 1 incorrect password attempt"),
                    measurements ok, cache untouched (902M), no change aborted, 8.0s, password absent from report
connection refused: every step "unreachable", 0.0s, no raise
```

(The HTTP 500 / non-JSON cases from round 0 are transport-level and unchanged by this diff.)

### 3. Password quoting proven against a real shell

The password reaches `sudo -S` through a pipeline (the endpoint has no stdin), so quoting is a correctness requirement. Verified by **running `bash`**, not by string-matching a quoting scheme a shell might still mis-parse — asserting the echo half emits exactly the password, nothing expanded, nothing split, and an injected `touch` canary never fires. Cases: `osworld-public-evaluation`, `pw'; touch /tmp/pwned; echo '`, ``pw"$(id)`id`\``, `pw with spaces`.

### 4. Mutation testing — 24/24 (round 0) + 14/14 (round 1) killed

Round 1 adds unit tests that replay both defects against a **real `bash`**: a `chmod 000` cache directory with a fake `sudo -S` that reads the password from stdin and restores access only for the command it runs, and a fake `snap` that enforces the real CLI's rules (`abort` without an id is an error; only root may abort). New source mutants, `__pycache__` purged between each:

```
KILLED B1: glob back outside the privileged shell     KILLED B1b: rm glob INSIDE sudo bash -c (pins find form)
KILLED B1c: whole directory removed                    KILLED M1: xargs-split abort restored
KILLED M1b: abort failure masked with || true          KILLED M1c: abort without an id
KILLED m2: every Doing row aborted (unscoped)          KILLED m2b: Done auto-refresh rows aborted too
KILLED m4: hold before abort                           KILLED m1: geometry && chain restored
KILLED m1b: geometry parse gated on rc 0               KILLED sec: password unquoted
KILLED sec: fragment unquoted                          (plus the original 24, re-run green)
```

`m2b` **survived** the first pass — the fake `snap changes` table had no `Done` auto-refresh row, so a pattern that dropped the `Doing` guard was indistinguishable. A `Done Auto-refresh 3 snaps` row was added and the mutant now dies.

#### Round-0 mutants

Every new test was mutation-tested, purging `__pycache__` between mutants (stale bytecode has confounded this twice before). Two mutants **survived** the first pass and both were real gaps, now fixed:

- *"unmeasured guest is skipped instead of reclaimed"* — the test asserted the flag but not that the work ran. Now asserts the actual commands.
- *"preparation runs AFTER upstream's reset"* — orderings that produce identical reports and identical call sets. Now pinned by a `_FakeEnv` that samples the guest post-log at the moment `reset` runs.

A third mutant motivated the `reclaimed` → `reclamation_attempted` rename above.

<details><summary>All 24 mutants (each KILLED)</summary>

```
KILLED threshold: >= becomes >                     KILLED threshold: never reclaims
KILLED threshold: always reclaims                  KILLED unmeasured guest is skipped
KILLED fail-soft: transport exception propagates   KILLED fail-soft: error message leaks into report
KILLED fail-soft: a failing step aborts the pass   KILLED fallback runs unconditionally
KILLED budget: exhausted budget runs anyway        KILLED budget: timeout ignores the ceiling
KILLED measurement: garbled df reads as 0 free     KILLED observability: after never re-measured
KILLED observability: geometry not reported        KILLED safety: whole cache DIRECTORY removed
KILLED safety: reclamation uninstalls snaps        KILLED safety: password interpolated unquoted
KILLED safety: report records verbatim command     KILLED order: cache cleared before hold/abort
KILLED honesty: flag claims achievement            KILLED provider: preparation AFTER reset
KILLED provider: preparation not wired in          KILLED provider: missing returncode = success
KILLED provider: report never written              KILLED provider: posts use shell:true
```
</details>

### 5. Whole-tree gates, exactly as CI, each exit code read directly

Round 1 (head `21d5d524`, rebased onto `origin/main` at `a517f229`, version **0.46.18**):

```
flake8   EXIT=0   (first pass FAILED: one W605 in a new docstring — fixed before commit)
black    EXIT=0   (26.1.0 via uvx; first pass reformatted 1 file)
isort    EXIT=0   (5.13.2 via uvx)
pyright  EXIT=0   0 errors, 0 warnings
pytest   see the remediation comment for the final-head run
```

OSWorld adapter suite: **266 passed** (`test_guest_disk.py` now 31, 6 new).

### What is NOT covered

**No AWS writes and no real instance launches** were performed, per the brief. The boto3 half stays on botocore's `Stubber`. The guest half now runs against a real unprivileged control server, real `sudo`, and a real root-only directory; the one thing only a paid run can confirm is a real **snapd's** behaviour (the `snap` binary is a double that enforces the CLI's argument and privilege rules, not snapd's state machine). The commands are snapd's documented interfaces and every failure mode is fail-soft by construction.

## Operator follow-up (not done here)

The harness pins the adapter's package digest, so the wheel, workspace and selector must be rebuilt before this reaches a paid run — the adapter distribution version stays `0.1.1` deliberately (bumping it would falsify `_release_digest` as the attestation of what the pilot ran). Commands are in the review comment below.

