### PR TITLE
fix(subagent): fail a pinned effort tier loudly instead of inheriting the parent

### DIFF
--- a/local_operator/harness/comms.py
+++ b/local_operator/harness/comms.py
@@ -1699,7 +1699,19 @@ class SubagentComms:
         model_spec: ModelSpec | None = None
         resolve = getattr(self._session, "_resolve_subagent_model", None)
         if callable(resolve):
-            resolved = resolve(agent, effort)
+            # Strict, exactly like the first launch: a tier that broke between
+            # launch and resume must fail the resume with the reason, not
+            # bring the child back on the parent's model while the panel still
+            # says ``hi`` — the same silent substitution the launch path
+            # refuses. ``SubagentModelUnavailable`` is the only expected raise;
+            # it lands in the ``(None, reason)`` slot every other refusal here
+            # already uses.
+            from local_operator.harness.subagent import SubagentModelUnavailable
+
+            try:
+                resolved = resolve(agent, effort, strict=True)
+            except SubagentModelUnavailable as exc:
+                return None, f"cannot resume {record.label}: {exc}"
             if isinstance(resolved, ModelSpec):
                 model_spec = resolved
         new_job_id = run_subagent(

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -143,6 +143,28 @@ from local_operator.harness.types import (
 from local_operator.paths import config_dir
 from local_operator.resume import ORIGIN_SUBAGENT, mark_session_origin
 
+
+class SubagentModelUnavailable(RuntimeError):
+    """A launch asked for an effort tier that cannot be honoured.
+
+    Raised BEFORE a child is registered, so the ``task`` tool reports it as
+    "could not launch" with the tier and the reason, and no job row ever
+    exists for a child that would have run on the wrong model. Deliberately
+    not a subclass of ``ValueError``: the tool's argument validation has its
+    own error shape, and this is a configuration/availability fact about the
+    machine, not a malformed call.
+
+    ``tier`` and ``reason`` are attributes as well as message text so a
+    caller that wants to react (retry on another tier, tell the operator
+    which key to fix) does not have to parse the string.
+    """
+
+    def __init__(self, tier: str, reason: str) -> None:
+        super().__init__(f"effort tier {tier!r} is unavailable: {reason}")
+        self.tier = tier
+        self.reason = reason
+
+
 if TYPE_CHECKING:
     from local_operator.agent_profiles import AgentProfile
     from local_operator.harness.comms import SubagentComms
@@ -521,7 +543,20 @@ def _make_runner(
                         schedule_persist()
                     except Exception:  # noqa: BLE001 - persistence is not load-bearing here
                         logger.warning("could not persist roster after attach", exc_info=True)
-            await emit(SubagentStartEvent(job_id=job_id, label=label, agent_id=child.agent_id))
+            # ``model`` is the child's EFFECTIVE selector, read off the built
+            # child exactly as ``job.model_label`` is above. A consumer of the
+            # event stream (the Axis runner, a UI) can then state which model
+            # a review actually ran on without cross-referencing the job row —
+            # the fact that was missing when a pinned reviewer silently ran on
+            # the author's model.
+            await emit(
+                SubagentStartEvent(
+                    job_id=job_id,
+                    label=label,
+                    agent_id=child.agent_id,
+                    model=str(getattr(child, "effective_model_label", "") or child.model_label),
+                )
+            )
             unsubscribe = child.subscribe(
                 _make_relay(
                     job_id,
@@ -548,7 +583,7 @@ def _make_runner(
                 # The child's loop reported a provider/turn error; the job
                 # must settle failed with it, not completed with the partial
                 # text.
-                raise RuntimeError(str(final["error"]))
+                raise RuntimeError(_describe_child_failure(str(final["error"]), child, model_spec))
             result_text = final["text"]
             # Recorded on the comms record, not just the job row: the manager
             # sweeps settled rows after its retention window while comms
@@ -633,6 +668,47 @@ def _make_runner(
                             job.child_jobs = None
 
     return runner
+
+
+def _describe_child_failure(
+    error: str, child: "Session | None", model_spec: ModelSpec | None
+) -> str:
+    """The error a failed child settles with, naming the model when that is the point.
+
+    A pinned child (``model_spec`` given) that dies on an auth/availability
+    error is not a generic failure: the operator chose that model for this
+    child, and the only correct responses are to fix the model's access or to
+    consciously run the child elsewhere. Left as the provider's bare text
+    (``authentication failed (HTTP 403): ...``), the parent model read it as
+    a transient launch problem and retried on another tier \u2014 the observed
+    path to a self-review. Naming the pinned model and saying what NOT to do
+    is the cheapest intervention that changes that decision.
+
+    Only the auth kind gets the suffix: a pinned child that fails on a
+    transient 5xx should be retried on the SAME model, and the suffix would
+    argue against exactly that.
+    """
+    if model_spec is None:
+        return error
+    from local_operator.providers.failover import is_rendered_auth_error
+
+    # ``final["error"]`` is the loop's RENDERED text, not an exception, so the
+    # kind is read the way the display layer reads it (``with_auth_hint``):
+    # by the stable "authentication failed" label the failover module puts in
+    # front of every auth-kind error. ``classify_provider_error`` is
+    # deliberately not used here — it refuses to read kinds out of text, and
+    # this text is the harness's own rendering, which is the one case where
+    # the prefix is authoritative.
+    if not is_rendered_auth_error(error):
+        return error
+    pinned = f"{model_spec.provider}/{model_spec.model_id}"
+    return (
+        f"{error} [pinned model {pinned} is unavailable to this credential. This "
+        f"child was pinned to it on purpose; do not re-run it at another effort "
+        f"tier, which would silently substitute a different model. Fix access to "
+        f"{pinned} or launch without 'effort' and disclose that the child inherits "
+        f"the parent's model.]"
+    )
 
 
 async def _abort_bridge(signal: Any, child: "Session") -> None:

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -583,7 +583,7 @@ def _make_runner(
                 # The child's loop reported a provider/turn error; the job
                 # must settle failed with it, not completed with the partial
                 # text.
-                raise RuntimeError(_describe_child_failure(str(final["error"]), child, model_spec))
+                raise RuntimeError(_describe_child_failure(str(final["error"]), model_spec))
             result_text = final["text"]
             # Recorded on the comms record, not just the job row: the manager
             # sweeps settled rows after its retention window while comms
@@ -670,9 +670,7 @@ def _make_runner(
     return runner
 
 
-def _describe_child_failure(
-    error: str, child: "Session | None", model_spec: ModelSpec | None
-) -> str:
+def _describe_child_failure(error: str, model_spec: ModelSpec | None) -> str:
     """The error a failed child settles with, naming the model when that is the point.
 
     A pinned child (``model_spec`` given) that dies on an auth/availability
@@ -693,7 +691,7 @@ def _describe_child_failure(
     from local_operator.providers.failover import is_rendered_auth_error
 
     # ``final["error"]`` is the loop's RENDERED text, not an exception, so the
-    # kind is read the way the display layer reads it (``with_auth_hint``):
+    # kind is read the way the display layer reads it (``append_auth_recovery``):
     # by the stable "authentication failed" label the failover module puts in
     # front of every auth-kind error. ``classify_provider_error`` is
     # deliberately not used here — it refuses to read kinds out of text, and

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -1320,6 +1320,14 @@ class SubagentStartEvent(AgentEvent[Literal["subagent_start"]]):
     job_id: str
     label: str
     agent_id: str | None = None
+    #: The ``provider/model-id`` the child actually runs on, once known. Set
+    #: by the runner from the BUILT child (its effective label, so a resumed
+    #: child restored onto a fallback reports that fallback). ``None`` only
+    #: for emitters that predate the field. It exists so a consumer can name
+    #: the model behind a delegated review from the event alone, which is the
+    #: fact that was missing when a pinned reviewer silently ran on the
+    #: author's model and nothing on the stream said so.
+    model: str | None = None
 
 
 class SubagentProgressEvent(AgentEvent[Literal["subagent_progress"]]):

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -770,8 +770,8 @@ def is_rendered_auth_error(rendered_error: str) -> bool:
     The one sanctioned way to read a kind back out of text: the failover
     module itself put ``_KIND_LABELS["auth"]`` at the front of every auth-kind
     error it rendered, so the prefix is its own statement rather than a guess
-    about a provider's wording. This is the predicate :func:`with_auth_hint`
-    already applies inline; it is named so a second caller (the subagent
+    about a provider's wording. This is the predicate :func:`append_auth_recovery`
+    already applied inline; it is named so a second caller (the subagent
     runner, deciding whether a pinned child died of access) shares it instead
     of re-deriving the prefix and drifting from it.
     """

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -759,11 +759,23 @@ def append_auth_recovery(rendered_error: str, provider: str | None) -> str:
     ``is_image_rejection`` string-form convention rather than requiring the
     original exception at the display site.
     """
-    if not rendered_error:
-        return rendered_error
-    if not rendered_error.lower().startswith(_KIND_LABELS["auth"]):
+    if not is_rendered_auth_error(rendered_error):
         return rendered_error
     return f"{rendered_error}\n{auth_recovery_hint(provider)}"
+
+
+def is_rendered_auth_error(rendered_error: str) -> bool:
+    """Whether a RENDERED error string is the auth kind.
+
+    The one sanctioned way to read a kind back out of text: the failover
+    module itself put ``_KIND_LABELS["auth"]`` at the front of every auth-kind
+    error it rendered, so the prefix is its own statement rather than a guess
+    about a provider's wording. This is the predicate :func:`with_auth_hint`
+    already applies inline; it is named so a second caller (the subagent
+    runner, deciding whether a pinned child died of access) shares it instead
+    of re-deriving the prefix and drifting from it.
+    """
+    return bool(rendered_error) and rendered_error.lower().startswith(_KIND_LABELS["auth"])
 
 
 def is_usage_limit_error(error: BaseException) -> bool:

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -70,7 +70,7 @@ from local_operator.harness.jobs import (
     AsyncJobManager,
 )
 from local_operator.harness.loop import AgentLoop, LoopContext, _materialize_asides
-from local_operator.harness.subagent import run_subagent
+from local_operator.harness.subagent import SubagentModelUnavailable, run_subagent
 from local_operator.harness.types import (
     AbortSignal,
     AgentEndEvent,
@@ -5985,10 +5985,25 @@ class Session:
         effort resolves through ``values.subagents.models`` (``lo``/``med``/
         ``hi`` -> ``provider/model-id``), so a scout or a cheap bulk task runs
         on the model the operator picked for that job, not the session's
-        default. An unresolvable tier falls back to the parent's model with a
-        warning — a delegation must not fail because a config key is stale.
+        default.
+
+        A tier that was ASKED FOR and cannot be honoured fails the launch
+        (``SubagentModelUnavailable``) rather than silently inheriting the
+        parent's model. The failure mode this closes was observed live: a
+        reviewer role pinned to a cross-family model via its ``effort`` tier
+        launched, the pinned model 403'd, the author retried at a DIFFERENT
+        tier that resolved to nothing, and the "independent" review ran on
+        the author's own model and approved a wrong fix. Independence that
+        can silently collapse into self-review is not independence. The
+        parent gets the reason in the tool result, and
+        :class:`SubagentStartEvent` names the model the child really runs on,
+        so nothing downstream has to infer it.
+
+        Only an EXPLICIT tier is strict. ``effort=None`` on a plain ``task``
+        child still means "inherit the parent", which is the ordinary case
+        and must keep working with no config at all.
         """
-        model_spec = self._resolve_subagent_model(agent, effort)
+        model_spec = self._resolve_subagent_model(agent, effort, strict=True)
         return run_subagent(
             label=label,
             prompt=prompt,
@@ -6002,7 +6017,9 @@ class Session:
             effort=effort,
         )
 
-    def _resolve_subagent_model(self, agent: str, effort: str | None) -> ModelSpec | None:
+    def _resolve_subagent_model(
+        self, agent: str, effort: str | None, *, strict: bool = False
+    ) -> ModelSpec | None:
         """Effort tier -> ModelSpec via config; None keeps the parent's model.
 
         Precedence: an explicit ``effort`` on the launch beats the role's own
@@ -6013,6 +6030,13 @@ class Session:
         inherits the session's model unless the OPERATOR chose a tier — a
         shipped default that silently downgraded review quality could not be
         traced to anything the operator decided.
+
+        ``strict`` (the launch path) turns "tier named but unresolvable" from a
+        warning-and-inherit into :class:`SubagentModelUnavailable`. The
+        lenient default stays for callers that merely PREFER a tier and have
+        a sound fallback of their own — session naming on ``lo`` is one — and
+        for whom failing would be worse than inheriting. See
+        :meth:`_launch_subagent` for the incident that made the launch strict.
         """
         wanted = effort
         if wanted is None and agent and agent != "task":
@@ -6026,6 +6050,15 @@ class Session:
                 wanted = profile.effort
         if wanted is None:
             return None
+
+        def _unavailable(reason: str) -> ModelSpec | None:
+            # One exit for every "asked for a tier, cannot honour it" branch so
+            # strict and lenient callers differ in exactly one place.
+            if strict:
+                raise SubagentModelUnavailable(wanted, reason)
+            logger.warning("subagent model tier %r: %s; using session model", wanted, reason)
+            return None
+
         try:
             from local_operator.config import ConfigManager
             from local_operator.paths import config_dir
@@ -6033,20 +6066,19 @@ class Session:
             raw = ConfigManager(config_dir()).get_config_value("subagents", None)
             models = raw.get("models", {}) if isinstance(raw, dict) else {}
             selector = models.get(wanted)
-            if not selector:
-                return None
-            provider, _, model_id = str(selector).partition("/")
-            if not model_id:
-                logger.warning("subagents.models.%s=%r lacks provider/model", wanted, selector)
-                return None
+        except Exception as exc:  # noqa: BLE001 — a config read error is a reason, not a crash
+            return _unavailable(f"config could not be read ({exc})")
+        if not selector:
+            return _unavailable(f"no model configured at subagents.models.{wanted}")
+        provider, _, model_id = str(selector).partition("/")
+        if not model_id:
+            return _unavailable(f"subagents.models.{wanted}={selector!r} lacks provider/model")
+        try:
             from local_operator.model.configure import build_model_spec
 
             return build_model_spec(provider, model_id)
-        except Exception:  # noqa: BLE001 — stale config must not fail a spawn
-            logger.warning(
-                "subagent model tier %r could not be resolved; using session model", wanted
-            )
-            return None
+        except Exception as exc:  # noqa: BLE001 — an unbuildable selector is a reason, not a crash
+            return _unavailable(f"{selector!r} could not be resolved ({exc})")
 
     def _append_or_park_journal(self, message: CustomMessage) -> None:
         """Put a journal notice on the live context, or park it for a boundary.

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -6051,12 +6051,18 @@ class Session:
         if wanted is None:
             return None
 
-        def _unavailable(reason: str) -> ModelSpec | None:
+        def _unavailable(reason: str, *, quiet: bool = False) -> ModelSpec | None:
             # One exit for every "asked for a tier, cannot honour it" branch so
-            # strict and lenient callers differ in exactly one place.
+            # strict and lenient callers differ in exactly one place. ``quiet``
+            # is for the ordinary unconfigured case on the lenient path: a
+            # session with no ``subagents.models`` at all names itself on the
+            # parent model by design, and a warning on every naming call for
+            # that would be noise about a default (the pre-strict code was
+            # silent there too). Malformed or unreadable config still warns.
             if strict:
                 raise SubagentModelUnavailable(wanted, reason)
-            logger.warning("subagent model tier %r: %s; using session model", wanted, reason)
+            if not quiet:
+                logger.warning("subagent model tier %r: %s; using session model", wanted, reason)
             return None
 
         try:
@@ -6069,7 +6075,7 @@ class Session:
         except Exception as exc:  # noqa: BLE001 — a config read error is a reason, not a crash
             return _unavailable(f"config could not be read ({exc})")
         if not selector:
-            return _unavailable(f"no model configured at subagents.models.{wanted}")
+            return _unavailable(f"no model configured at subagents.models.{wanted}", quiet=True)
         provider, _, model_id = str(selector).partition("/")
         if not model_id:
             return _unavailable(f"subagents.models.{wanted}={selector!r} lacks provider/model")

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -7965,8 +7965,21 @@ class JobsParams(BaseModel):
 #: payload.  A child report can dwarf an ordinary tool result, so it uses the
 #: same bounded, lossless spill path as every other verbose tool.
 def _job_summary(job: Any, context: ToolContext | None = None) -> tuple[str, dict[str, Any] | None]:
-    """Return a context-bounded handoff while keeping the full report readable."""
+    """Return a context-bounded handoff while keeping the full report readable.
+
+    A task job's header names the model the child ran on, as recorded by the
+    harness (``job.model_label``, set from the child's own model-change event),
+    so the parent can STATE which model produced a delegated result rather
+    than assume it. This is the parent-visible half of the pinned-tier work:
+    ``subagent_start.model`` tells a stream consumer, this tells the model
+    that launched the child. It is deliberately the harness's record and not
+    anything the child said about itself, which is what makes it evidence
+    when the question is whether a review was independent.
+    """
     text = f"job {job.id} ({job.label}) [{job.status}]"
+    model_label = str(getattr(job, "model_label", "") or "").strip()
+    if getattr(job, "type", None) == "task" and model_label:
+        text += f" model={model_label}"
     if job.status == "completed" and job.result_text:
         text += f"\n{job.result_text}"
     if job.status == "failed" and job.error_text:

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -8028,7 +8028,24 @@ async def execute_task(
         try:
             job_id = launcher(item.label, _full_prompt(item), agent=item.agent, effort=item.effort)
         except Exception as exc:  # noqa: BLE001 — engine failure surfaces as an error result
-            failures.append(f"{item.label}: {exc}")
+            # An unavailable tier is the one launch failure the model is
+            # tempted to "fix" by retrying at another tier, which is how a
+            # pinned reviewer ends up running on the author's own model. Say
+            # so in the result, so the correct next step (report the tier as
+            # broken, or launch with NO effort and disclose that the child
+            # inherits the parent's model) is in front of it rather than
+            # something it has to infer from a bare exception string.
+            tier = getattr(exc, "tier", None)
+            if tier is not None:
+                failures.append(
+                    f"{item.label}: {exc}. Do NOT retry at a different effort tier — "
+                    f"that runs the child on a different model than {tier!r} was "
+                    f"chosen for. Either fix subagents.models.{tier} or launch "
+                    f"without 'effort' and state that the child inherits this "
+                    f"session's model."
+                )
+            else:
+                failures.append(f"{item.label}: {exc}")
             continue
         launched.append({"job_id": job_id, "label": item.label, "agent": item.agent})
     if not launched:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.46.22"
+version = "0.46.23"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -1217,7 +1217,11 @@ def test_a_resume_carries_the_childs_role_and_tier_forward(tmp_path, monkeypatch
     # a second launch and has to perform the same resolution, or the child
     # comes back on the parent's model while the panel still says `hi`.
     resolved = comms_mod.ModelSpec(provider="anthropic", model_id="claude-opus-5")
-    parent._resolve_subagent_model = lambda agent, effort: resolved  # type: ignore[attr-defined]
+    # ``strict`` is what the resume passes now: a tier that broke since launch
+    # refuses the resume rather than inheriting (test_pinned_subagent_model).
+    parent._resolve_subagent_model = (  # type: ignore[attr-defined]
+        lambda agent, effort, strict=False: resolved
+    )
     comms = SubagentComms(parent)  # type: ignore[arg-type]
     jobs.add("job-1", status="cancelled")
     comms.record_launch("job-1", "review-301-r2", agent_role="reviewer", effort="hi")

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -2055,8 +2055,19 @@ async def test_the_launch_role_and_effort_are_recorded_on_the_job(tmp_path, monk
     both. Effort is recorded here rather than derived from the resolved model
     spec because a tier does not survive that resolution — two tiers can point
     at one model, and a child on the parent's own model still ran at a chosen
-    level the band should name."""
+    level the band should name.
+
+    The tier is CONFIGURED here because a launch that names a tier now fails
+    closed when nothing is configured for it (see
+    ``test_pinned_subagent_model``): an ``effort="hi"`` that silently ran on
+    the parent's model is the incident that rule exists to prevent, so this
+    test can no longer rely on it. The parent's own selector is used so the
+    child still runs through the same ``OneShotStream``."""
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    (tmp_path / "config").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "config" / "config.yml").write_text(
+        f"values:\n  subagents:\n    models:\n      hi: {MODEL.provider}/{MODEL.model_id}\n"
+    )
     parent = make_session(tmp_path, OneShotStream())
 
     job_id = parent._launch_subagent(

--- a/tests/unit/session/test_pinned_subagent_model.py
+++ b/tests/unit/session/test_pinned_subagent_model.py
@@ -197,6 +197,26 @@ async def test_start_event_names_the_model_the_child_runs_on(tmp_path, monkeypat
 
 
 @pytest.mark.asyncio
+async def test_wait_names_the_model_a_task_child_ran_on(tmp_path, monkeypatch):
+    """The parent model's own view: ``wait`` reports the harness-recorded
+    model of a settled task child in its header, so a launcher can state
+    which model produced a delegated verdict instead of assuming it."""
+    from local_operator.tools.builtin import execute_wait
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    write_tiers(tmp_path / "config", hi=f"{MODEL.provider}/{MODEL.model_id}")
+    session = make_session(tmp_path)
+    job_id = session._launch_subagent(label="review", prompt="review it", effort="hi")
+    await wait_for(lambda: (j := session.jobs.get(job_id)) is not None and j.status == "completed")
+
+    context = ToolContext(jobs=session.jobs, subagent_comms=session.subagent_comms)
+    result = await execute_wait("call-1", {"job_id": job_id, "wait_ms": 1000}, None, None, context)
+    text = "".join(block.text for block in result.content if isinstance(block, TextContent))
+    assert f"[completed] model={MODEL.provider}/{MODEL.model_id}" in text
+    await session.dispose()
+
+
+@pytest.mark.asyncio
 async def test_task_tool_tells_the_model_not_to_retry_on_another_tier():
     def launcher(label, prompt, *, agent="task", effort=None):
         raise SubagentModelUnavailable("hi", "no model configured at subagents.models.hi")

--- a/tests/unit/session/test_pinned_subagent_model.py
+++ b/tests/unit/session/test_pinned_subagent_model.py
@@ -1,0 +1,215 @@
+"""A pinned subagent tier fails the launch loudly instead of inheriting.
+
+The incident these pin: a reviewer role bound to a cross-family model through
+its ``effort`` tier launched, the model 403'd, the author retried at a
+different tier that resolved to nothing, and the "independent" review ran on
+the author's own model and approved a wrong fix. Three seams close it:
+
+* ``_resolve_subagent_model(strict=True)`` raises ``SubagentModelUnavailable``
+  for a tier that is named but unresolvable — the launch path is strict, the
+  session-naming path is not.
+* the ``task`` tool names the tier and says not to retry elsewhere;
+* ``SubagentStartEvent.model`` states the model a child really runs on, and a
+  pinned child that dies of access names its pinned model in the error.
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from local_operator.harness.subagent import (
+    SubagentModelUnavailable,
+    _describe_child_failure,
+)
+from local_operator.harness.types import (
+    AbortSignal,
+    AgentEvent,
+    ChatRequest,
+    ModelSpec,
+    StreamEndEvent,
+    StreamTextDelta,
+    SubagentStartEvent,
+    TextContent,
+    ToolContext,
+)
+from local_operator.session.session import Session
+from local_operator.session.transcript import Transcript
+from local_operator.tools.builtin import execute_task
+
+MODEL = ModelSpec(
+    provider="openrouter",
+    model_id="qwen/qwen3.8-max",
+    context_window=100_000,
+    max_output_tokens=4_096,
+)
+
+
+class OneShotStream:
+    def __init__(self) -> None:
+        self.requests: list[ChatRequest] = []
+
+    def __call__(self, request: ChatRequest, signal: AbortSignal | None):
+        self.requests.append(request)
+
+        async def gen():
+            yield StreamTextDelta(delta="child did the work")
+            yield StreamEndEvent(stop_reason="stop")
+
+        return gen()
+
+
+def make_session(tmp_path) -> Session:
+    return Session(
+        model=MODEL,
+        stream_fn=OneShotStream(),
+        tools=[],
+        transcript=Transcript(tmp_path / "sess"),
+        system_blocks_provider=lambda: ["stable", "env"],
+    )
+
+
+def write_tiers(config_dir, **tiers: str) -> None:
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "config.yml").write_text(
+        yaml.safe_dump({"values": {"subagents": {"models": tiers}}})
+    )
+
+
+async def wait_for(predicate, timeout: float = 5.0) -> None:
+    import asyncio
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while not predicate():
+        if loop.time() > deadline:
+            raise AssertionError("condition not met in time")
+        await asyncio.sleep(0.01)
+
+
+# ---------------------------------------------------------------------------
+# strict resolution
+# ---------------------------------------------------------------------------
+
+
+def test_strict_launch_fails_on_a_tier_with_no_model(tmp_path, monkeypatch):
+    """The exact shape of the incident: ``effort='hi'`` is asked for, nothing
+    is configured at ``subagents.models.hi``. The launch must raise, not
+    inherit the parent's model."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    write_tiers(tmp_path / "config", lo="openrouter/moonshotai/kimi-k3")
+    session = make_session(tmp_path)
+
+    with pytest.raises(SubagentModelUnavailable) as caught:
+        session._launch_subagent(label="review", prompt="review it", effort="hi")
+    assert caught.value.tier == "hi"
+    assert "no model configured at subagents.models.hi" in caught.value.reason
+    # No job row for a child that would have run on the wrong model.
+    assert not session.jobs.list()
+
+
+def test_strict_launch_fails_on_a_malformed_selector(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    write_tiers(tmp_path / "config", hi="just-a-model-no-provider")
+    session = make_session(tmp_path)
+
+    with pytest.raises(SubagentModelUnavailable) as caught:
+        session._launch_subagent(label="review", prompt="review it", effort="hi")
+    assert caught.value.tier == "hi"
+    assert "lacks provider/model" in caught.value.reason
+
+
+@pytest.mark.asyncio
+async def test_no_effort_still_inherits_the_parent(tmp_path, monkeypatch):
+    """The ordinary case must be untouched: a plain child with no tier and no
+    config at all launches on the parent's model."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    session = make_session(tmp_path)
+
+    job_id = session._launch_subagent(label="sub", prompt="go")
+    assert session.jobs.get(job_id) is not None
+    await session.dispose()
+
+
+def test_lenient_resolution_still_inherits_for_naming(tmp_path, monkeypatch):
+    """Session naming prefers ``lo`` but has a sound fallback of its own; it
+    must keep getting ``None`` (inherit) rather than an exception when the
+    tier is unset."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    session = make_session(tmp_path)
+    assert session._resolve_subagent_model("task", "lo") is None
+    assert session._resolve_subagent_model("task", "lo", strict=False) is None
+
+
+@pytest.mark.asyncio
+async def test_start_event_names_the_model_the_child_runs_on(tmp_path, monkeypatch):
+    """A consumer of the stream (the Axis runner) can state which model a
+    delegated review ran on from ``subagent_start`` alone."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    write_tiers(tmp_path / "config", hi="openrouter/moonshotai/kimi-k3")
+    session = make_session(tmp_path)
+    events: list[AgentEvent] = []
+    session.subscribe(events.append)
+
+    session._launch_subagent(label="review", prompt="review it", effort="hi")
+    await wait_for(lambda: any(isinstance(e, SubagentStartEvent) for e in events))
+    [start] = [e for e in events if isinstance(e, SubagentStartEvent)]
+    assert start.model == "openrouter/moonshotai/kimi-k3"
+    # And the wire form carries it, since exec --json is model_dump.
+    assert start.model_dump(mode="json")["model"] == "openrouter/moonshotai/kimi-k3"
+    await session.dispose()
+
+
+# ---------------------------------------------------------------------------
+# the task tool's wording
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_task_tool_tells_the_model_not_to_retry_on_another_tier():
+    def launcher(label, prompt, *, agent="task", effort=None):
+        raise SubagentModelUnavailable("hi", "no model configured at subagents.models.hi")
+
+    context = ToolContext(subagent_launcher=launcher)
+    result = await execute_task(
+        "call-1", {"label": "review", "prompt": "review it", "effort": "hi"}, None, None, context
+    )
+    text = "".join(block.text for block in result.content if isinstance(block, TextContent))
+    assert result.is_error
+    assert "effort tier 'hi' is unavailable" in text
+    assert "Do NOT retry at a different effort tier" in text
+    assert "subagents.models.hi" in text
+
+
+# ---------------------------------------------------------------------------
+# a pinned child that dies of access
+# ---------------------------------------------------------------------------
+
+
+def test_pinned_child_auth_failure_names_the_pinned_model():
+    spec = ModelSpec(
+        provider="openrouter", model_id="meta/muse-spark-1.2", context_window=1, max_output_tokens=1
+    )
+    rendered = (
+        "authentication failed (HTTP 403): This model requires you to complete "
+        "18+ age confirmation."
+    )
+    out = _describe_child_failure(rendered, None, spec)
+    assert out.startswith(rendered)
+    assert "pinned model openrouter/meta/muse-spark-1.2 is unavailable" in out
+    assert "do not re-run it at another effort tier" in out
+
+
+def test_pinned_child_transient_failure_is_left_alone():
+    """A 5xx on a pinned child should be retried on the SAME model; the
+    suffix would argue against that, so it must not appear."""
+    spec = ModelSpec(
+        provider="openrouter", model_id="moonshotai/kimi-k3", context_window=1, max_output_tokens=1
+    )
+    rendered = "transient provider error (HTTP 502): upstream unavailable"
+    assert _describe_child_failure(rendered, None, spec) == rendered
+
+
+def test_unpinned_child_failure_is_left_alone():
+    rendered = "authentication failed (HTTP 401): bad key"
+    assert _describe_child_failure(rendered, None, None) == rendered

--- a/tests/unit/session/test_pinned_subagent_model.py
+++ b/tests/unit/session/test_pinned_subagent_model.py
@@ -131,14 +131,45 @@ async def test_no_effort_still_inherits_the_parent(tmp_path, monkeypatch):
     await session.dispose()
 
 
-def test_lenient_resolution_still_inherits_for_naming(tmp_path, monkeypatch):
+def test_lenient_resolution_still_inherits_for_naming(tmp_path, monkeypatch, caplog):
     """Session naming prefers ``lo`` but has a sound fallback of its own; it
     must keep getting ``None`` (inherit) rather than an exception when the
-    tier is unset."""
+    tier is unset -- and SILENTLY, because "no subagents.models at all" is the
+    default configuration and a warning on every naming call for a default
+    is noise (review R1). A malformed selector still warns."""
+    import logging
+
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
     session = make_session(tmp_path)
-    assert session._resolve_subagent_model("task", "lo") is None
-    assert session._resolve_subagent_model("task", "lo", strict=False) is None
+    with caplog.at_level(logging.WARNING):
+        assert session._resolve_subagent_model("task", "lo") is None
+        assert session._resolve_subagent_model("task", "lo", strict=False) is None
+    assert not [r for r in caplog.records if "subagent model tier" in r.getMessage()]
+
+    write_tiers(tmp_path / "config", lo="no-provider-here")
+    with caplog.at_level(logging.WARNING):
+        assert session._resolve_subagent_model("task", "lo") is None
+    assert [r for r in caplog.records if "lacks provider/model" in r.getMessage()]
+
+
+@pytest.mark.asyncio
+async def test_resume_refuses_a_tier_that_broke_since_launch(tmp_path, monkeypatch):
+    """A resume is a second launch (review R2): a child launched on ``hi``
+    whose tier has since been removed must NOT come back on the parent's
+    model with the panel still saying ``hi``. The refusal lands in the same
+    ``(None, reason)`` slot every other resume refusal uses."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    write_tiers(tmp_path / "config", hi=f"{MODEL.provider}/{MODEL.model_id}")
+    session = make_session(tmp_path)
+    job_id = session._launch_subagent(label="review", prompt="review it", effort="hi")
+    await wait_for(lambda: (j := session.jobs.get(job_id)) is not None and j.status == "completed")
+
+    # The tier disappears between launch and resume.
+    (tmp_path / "config" / "config.yml").write_text("values: {}\n")
+    new_id, reason = session.subagent_comms.resume(job_id, "carry on")
+    assert new_id is None
+    assert reason is not None and "effort tier 'hi' is unavailable" in reason
+    await session.dispose()
 
 
 @pytest.mark.asyncio
@@ -194,7 +225,7 @@ def test_pinned_child_auth_failure_names_the_pinned_model():
         "authentication failed (HTTP 403): This model requires you to complete "
         "18+ age confirmation."
     )
-    out = _describe_child_failure(rendered, None, spec)
+    out = _describe_child_failure(rendered, spec)
     assert out.startswith(rendered)
     assert "pinned model openrouter/meta/muse-spark-1.2 is unavailable" in out
     assert "do not re-run it at another effort tier" in out
@@ -207,9 +238,9 @@ def test_pinned_child_transient_failure_is_left_alone():
         provider="openrouter", model_id="moonshotai/kimi-k3", context_window=1, max_output_tokens=1
     )
     rendered = "transient provider error (HTTP 502): upstream unavailable"
-    assert _describe_child_failure(rendered, None, spec) == rendered
+    assert _describe_child_failure(rendered, spec) == rendered
 
 
 def test_unpinned_child_failure_is_left_alone():
     rendered = "authentication failed (HTTP 401): bad key"
-    assert _describe_child_failure(rendered, None, None) == rendered
+    assert _describe_child_failure(rendered, None) == rendered

--- a/tests/unit/session/test_resume_subagents_todos.py
+++ b/tests/unit/session/test_resume_subagents_todos.py
@@ -467,6 +467,13 @@ async def test_role_and_effort_survive_a_resume(tmp_path, monkeypatch):
     process launched must come back saying what kind it was and at what effort —
     exactly what the panel/model/usage fields already promise."""
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    # An explicit tier now fails the launch when nothing is configured for it
+    # (``test_pinned_subagent_model``), so the tier under test is configured —
+    # to the parent's own selector, so the child still runs on OneShotStream.
+    (tmp_path / "config").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "config" / "config.yml").write_text(
+        f"values:\n  subagents:\n    models:\n      hi: {MODEL.provider}/{MODEL.model_id}\n"
+    )
 
     parent = _session(tmp_path, OneShotStream())
     await parent.async_init()


### PR DESCRIPTION
## Summary of Changes

A subagent launch that names an effort tier which cannot be honoured now **fails the launch** (`SubagentModelUnavailable`) instead of warning and running the child on the parent's model. The `task` tool result names the tier and tells the model not to retry at another tier; `SubagentStartEvent` carries the model the child really runs on; a pinned child that dies of access names its pinned model in the error. Patch version: **0.46.23** (0.46.18–0.46.22 released from parallel branches while this was in review; rebased twice, diff identical modulo the version line).

### Root cause, observed live

On a Minerva sentinel pass (core-svc !199) the `diff-reviewer` role was bound to a cross-family model through its `effort: hi` tier. The model 403'd on the credential. The author relaunched at `effort: lo`, which resolved to nothing, so the "independent" review ran on the author's own model and approved a fix for a mechanism the codebase could not exhibit. From the sentinel's stream:

```
subagent_end  review-info4c-http1        failed   authentication failed (HTTP 403): This model requires…
subagent_end  review-info4c-http1-retry  failed   authentication failed (HTTP 403): …
subagent_end  review-info4c-http1-lo     completed {"verdict":"approve","confidence":"medium",…}
```

Every step was individually reasonable; the sum was a self-review with a different label. Nothing on the stream said which model the third launch actually used.

## Related Issue(s) / delivery contract

**C1 standard / pre-authorized reliability bugfix.** Operator-requested after the incident above; this PR is the record.

Acceptance criteria:
- A launch with an explicit `effort` whose tier is unset, malformed, unbuildable, or whose config is unreadable raises before any job is registered, with tier and reason as attributes.
- `effort=None` on a plain child still inherits the parent's model with no config at all (the ordinary case).
- Session naming's lenient preference for `lo` is unchanged.
- The `task` tool's error names the tier and says not to retry at a different tier.
- `subagent_start` carries `model` and it reaches `exec --json`.
- A pinned child's auth-kind failure names the pinned model with the same guidance; a transient failure on a pinned child is left alone.

Non-goals: no change to tier configuration keys, role seeds, or the child's tool surface; no retry policy; no change to how a resolvable tier is built.

## Impact / risk / rollback

**Behaviour change for operators with roles that pin an `effort` but have not configured that tier** — those launches used to inherit silently and now fail with the key to fix. That is the intended change: a shipped default that silently downgraded review quality is the defect. Two existing tests that launched `effort="hi"` against an empty config configured the tier they ask for. Rollback is a revert; no persisted state changes.

## Testing evidence

**Unit** (`tests/unit/session/test_pinned_subagent_model.py`, 9 tests): strict failure on unset and malformed tiers, no job row left behind, `effort=None` still launches, lenient naming path still returns `None`, `subagent_start.model` carries the selector and survives `model_dump`, the task tool's wording, the auth suffix on a pinned child, no suffix on a transient failure, no suffix on an unpinned child. Affected neighbouring suites (launch/resume/role/comms/failover/tools): green.

**Full unit run**: 13074 passed. Six failures on this branch, five of which reproduce identically on `origin/main` (`test_eval_tool::test_eval_tool_bridge_uses_this_calls_dispatch` and four `test_efficiency` bridge cases — a local-environment issue, not touched here). The sixth was `test_role_and_effort_survive_a_resume`, which launched `effort="hi"` against an empty config; now configures the tier.

**Gates** (exactly as CI): flake8 0, black clean, isort clean, pyright 0 errors.

**Live, in-cluster, on the sentinel's real OpenRouter key**, running this branch's source through `lop exec --json` with `subagents.models.hi` pinned to `meta/muse-spark-1.2` (which 403s on that key):

```
SUBAGENT_START model= openrouter/meta/muse-spark-1.2
SUBAGENT_END status= failed error= authentication failed (HTTP 403): This model requires you to
  complete the following before use: 18+ age confirmation. […] [pinned model
  openrouter/meta/muse-spark-1.2 is unavailable to this credential. This child was pinned to it
  on purpose; do not re-run it at another effort tier, which would silently substitute a
  different model. Fix access to openrouter/meta/muse-spark-1.2 or launch without 'effort'
  and disclose that the child inherits the parent's model.]
```

And with an unconfigured tier (`effort: lo`, nothing at `subagents.models.lo`), the launch is refused at the tool with no child created:

```
TOOL task -> is_error= True
could not launch subagent(s): r: effort tier 'lo' is unavailable: no model configured at
  subagents.models.lo. Do NOT retry at a different effort tier — that runs the child on a
  different model than 'lo' was chosen for. Either fix subagents.models.lo or launch
  without 'effort' and state that the child inherits this session's model.
```

Both are the exact situations from the incident, and both now end differently.
