### PR TITLE
chore(release): 0.46.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.46.18"
+version = "0.46.19"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Summary

Cuts the release carrying `/fast` (#627), merged as `ccfd6f84` on top of `v0.46.18` (`fc80a967` + #622).

## Version choice

**Patch, per the materiality rule in `AGENTS.md`** ("Versioning: choose the bump by materiality, not commit type"):

> if you cannot name the step-function capability in the release title (`X.Y.0: <the new thing>`), it is a patch, not a minor

`/fast` is a new slash command on an existing surface — a dial beside `/effort`, session-scoped, sent as one extra request field where the provider sells the tier. It is not a new subsystem a user adopts (the browser extension, the mobile relay); "a single small `feat:` commit is a patch". Err toward patch.

## What is being released

`feat(tui): /fast toggles the provider's fast tier for the current model` (#627) — six code review rounds and three design rounds on the PR; the round-5 blocker (an unbounded retry spin introduced by rebasing over #631's OpenAI context rebind) is fixed and regression-tested there.

## Evidence

The only change is the version string:

```
$ git diff origin/main..HEAD
-version = "0.46.18"
+version = "0.46.19"
```

No dependency pin, script, or entry point moved; no pipeline consumes this field as a deploy input (publishing is triggered by the GitHub release, not by this file). No runtime path — nothing to exercise beyond the bump itself.
