### PR TITLE
fix(tui): preserve aside question spines and answer separation

### DIFF
--- a/local_operator/tui/widgets/aside_panel.py
+++ b/local_operator/tui/widgets/aside_panel.py
@@ -761,7 +761,13 @@ class AsidePanel(Static):
             head_start = len(flat.lines) + len(rows)
             rows.extend(question)
             flat.heads.append((head_start, head_start + len(question)))
-            rows.extend(self._answer_rows(turn, width, dim, danger))
+            # Status/error rows are answer-side too. Keep the separator in the
+            # measured body so it consumes scroll budget instead of extra height.
+            # Markdown lists/code may already supply that breathing row.
+            answer = self._answer_rows(turn, width, dim, danger)
+            if not answer or answer[0].plain.strip():
+                rows.append(Text())
+            rows.extend(answer)
             flat.lines.extend(rows)
             flat.owners.extend([index] * len(rows))
         self._flat_memo = (key, flat)
@@ -818,6 +824,11 @@ class AsidePanel(Static):
         back = min(offset, max(0, total - budget))
         end = total - back
         first = max(0, end - budget)
+        # A separator alone is not a readable one-row window. Show its owning
+        # question instead; the next scroll step still reaches the answer.
+        if budget == 1 and first == flat.heads[flat.owners[first]][1]:
+            first -= 1
+            end = first + 1
 
         owner = flat.owners[first]
         head_start, head_end = flat.heads[owner]
@@ -878,6 +889,20 @@ class AsidePanel(Static):
         if len(marker) >= budget:
             marker = []
         pinned = pinned[: max(0, budget - len(marker) - 1)]
+        # A pinned question needs the same breathing row as an uncut turn. It
+        # costs overlay budget, never height: shorten a wrapped pin first, but
+        # at tiny budgets retain the existing question/content priority. Do not
+        # insert a second gap when the window still shows the question or its
+        # original separator (head_end), or cover the next turn's question.
+        if pinned and budget - len(marker) >= 3:
+            pinned = pinned[: budget - len(marker) - 2]
+            content_start = first + len(marker) + len(pinned)
+            if (
+                content_start > head_end
+                and flat.owners[content_start] == owner
+                and flat.lines[content_start].plain.strip()
+            ):
+                pinned.append(Text())
         # Pinned UNCONDITIONALLY while the window opens inside a turn, even at
         # the offsets where the overlay then covers the last of that turn's own
         # rows and the question is left with nothing under it. That frame is
@@ -961,10 +986,12 @@ class AsidePanel(Static):
         wrapped = _wrap(question, body) or [""]
         gutter = QUESTION_MARK + " " * (len(ANSWER_INDENT) - cell_len(QUESTION_MARK))
         rows: list[Text] = []
-        head = Text(gutter, style=mark_style)
-        head.append(wrapped[0], style=text_style)
-        rows.append(head)
-        rows.extend(Text(f"{ANSWER_INDENT}{line}", style=text_style) for line in wrapped[1:])
+        # Extent, not colour, makes this the same sent-question spine as
+        # UserBlock; continuation rows must keep the mark and prose styles apart.
+        for line in wrapped:
+            row = Text(gutter, style=mark_style)
+            row.append(line, style=text_style)
+            rows.append(row)
         return rows
 
     def _answer_rows(self, turn: AsideTurn, width: int, dim: Style, danger: Style) -> list[Text]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.46.23"
+version = "0.46.24"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/tui/test_aside.py
+++ b/tests/unit/tui/test_aside.py
@@ -727,7 +727,8 @@ def test_a_long_exchange_pins_the_owning_question_and_counts_questions() -> None
     panel._scroll_by(8)
     rendered = panel.render_lines_for_test()
     assert rendered[3].startswith("▌ question 4?")
-    assert rendered[4].strip() == "• line"
+    assert rendered[4].strip() == ""
+    assert rendered[5].strip() == "• line"
 
 
 def test_one_long_answer_states_the_rows_it_withheld() -> None:
@@ -1110,6 +1111,54 @@ def test_the_question_is_never_markdown_rendered() -> None:
 
     assert "**kwargs" in body
     assert "`f(**kwargs)`" in body
+
+
+@pytest.mark.parametrize("width", [12, 26, 46])
+def test_every_wrapped_question_row_keeps_the_transcript_spine(width: int) -> None:
+    from rich.console import Console
+    from rich.style import Style
+
+    panel = AsidePanel()
+    console = Console()
+    mark = Style(color="red", dim=True)
+    prose = Style(color="white", dim=False)
+    question = "What does **kwargs mean in `f(**kwargs)` when the question wraps?"
+    rows = panel._question_rows(question, width, mark, prose)
+
+    assert len(rows) > 1
+    for row in rows:
+        assert row.plain.startswith("▌ ")
+        assert row.cell_len <= width
+        assert row.get_style_at_offset(console, 0) == mark
+        assert row.get_style_at_offset(console, 2) == prose
+    assert "".join(row.plain[2:] for row in rows).replace(" ", "") == question.replace(" ", "")
+
+
+@pytest.mark.parametrize(
+    "turn, expected",
+    [
+        (AsideTurn("question", answer="Short answer.", state="done"), "Short answer."),
+        (AsideTurn("question", state="running"), "thinking…"),
+        (AsideTurn("question", error="Failure.", state="error"), "! Failure."),
+        (AsideTurn("question", state="cancelled"), "no answer"),
+        (AsideTurn("question", answer="Partial answer.", state="cancelled"), "Partial answer."),
+    ],
+)
+def test_each_turn_separates_its_question_from_answer_side_rows(
+    turn: AsideTurn, expected: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    panel = AsidePanel()
+    panel.display = True
+    monkeypatch.setattr(panel, "_content_width", lambda: 26)
+    turn.question = "This question needs several wrapped rows to finish"
+    panel._turns = [turn, AsideTurn("Next question?", answer="Next answer.", state="done")]
+    flat = panel._flat_body()
+    for start, end in flat.heads:
+        assert all(row.plain.startswith("▌ ") for row in flat.lines[start:end])
+        assert flat.lines[end].plain == ""
+        assert flat.lines[end + 1].plain.strip(), "exactly one question/answer separator"
+    assert flat.lines[flat.heads[0][1] + 1].plain.strip() == expected
+    assert len(flat.lines) == len(flat.owners), "separators participate in row windowing"
 
 
 def test_an_error_is_shown_verbatim_rather_than_parsed() -> None:

--- a/tests/unit/tui/test_aside_reachability.py
+++ b/tests/unit/tui/test_aside_reachability.py
@@ -613,6 +613,34 @@ def test_a_settle_that_shrinks_the_answer_does_not_strand_the_window(
     assert _rows_present(_exhaust_the_wheel(panel), 10) == set(range(10))
 
 
+@pytest.mark.parametrize("budget", [1, 2, 3, 4, 5, 9, 25])
+def test_question_separation_fits_the_row_window(
+    budget: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pinned separator consumes overlay rows without hiding answer content.
+
+    Below four rows the existing marker/question/content priority has no spare
+    row for the pin's gap. The flat turn still owns a separator; at budget one
+    the separator must not become an otherwise empty frame.
+    """
+    panel = _panel(
+        [AsideTurn("This question wraps across several narrow rows", _long_answer(30), "done")],
+        budget + 8,
+        monkeypatch,
+    )
+    monkeypatch.setattr(panel, "_fit", lambda: (budget + 8, 2, budget))
+    monkeypatch.setattr(panel, "_content_width", lambda: 26)
+    for offset in range(panel._max_scroll_back() + 1):
+        panel._scroll_back_rows = offset
+        rows = [row.plain for row in panel._visible_rows().lines]
+        assert len(rows) <= budget
+        if budget >= 4:
+            for question, following in zip(rows, rows[1:]):
+                if question.startswith("▌") and not following.startswith("▌"):
+                    assert not following.strip(), (budget, offset, rows)
+    assert _rows_present(_exhaust_the_wheel(panel), 30) == set(range(30))
+
+
 # -- the smallest budgets, and each direction on its own -------------------
 @pytest.mark.parametrize("rows_above_dock", [4, 5, 6, 7, 8, 9, 10])
 def test_the_smallest_budgets_still_show_the_answer(


### PR DESCRIPTION
## Fix wrapped aside question rows

**C1 — standard/pre-authorized.** Bounded TUI bug fix requested for patch release.
Relates to #570. The issue intentionally remains open until the release is verified.

### Delivery contract

The aside should echo a wrapped question with the same continuous `▌` spine as the transcript, then clearly separate the answer-side block. This changes rendering only, not commands or conversation behavior.

- [x] Every wrapped question row gets the same gutter style; literal question prose stays plain, not Markdown.
- [x] One blank row separates each question from its answer/thinking/error block; partial answers and their superseded status stay grouped.
- [x] Markdown's existing leading blank is reused instead of doubling the gap.
- [x] Pinned questions in scrolled windows get the same separation when the body can fit it. The separator consumes existing row budget, never extra overlay height, and cannot cover the next turn's question.
- [x] Preserve all answer-row reachability, steady window height, wheel/keyboard navigation, and composer/outer-screen geometry.
- [x] Preserve existing fallback at tiny body budgets: with fewer than four rows, marker/question/content priority can leave no row for a *pinned* gap; with one row, an otherwise separator-only frame shows its owning question. No overflow, no unreachable answer rows.
- [x] Real CSS-loaded app captures before editing and after the fix, including narrow/multi-turn, thinking, error, superseded, empty, scrolling, tight height, and consecutive settled frames.

**Non-goals:** new shortcuts or interaction flows; changing conversation persistence/fork/copy semantics; Markdown rendering changes; live provider/auth calls; redesigning the existing tiny-terminal fallback.

**Contracts/blast radius:** `AsidePanel._question_rows`, `_flat_body`, `_window` only, plus regressions and patch version. Added separators are owned/cached/measured alongside their turn. Existing row overlay, height clamp, scroll offset and answer reachability remain the governing constraints. No API/schema, dependency, credentials, auth, external-service, or data-migration changes.

### Implementation

The issue's old `_turn_group` has since become a flat row window with pinned questions. Fix both the uncut body and the current pinned overlay, rather than applying the issue's old method names. A one-row guard prevents the new separator from becoming a blank-only frame. Reserve a pinned gap only when it fits without displacing content, and never overwrite the next turn's question with it.

Patch version **0.46.24**, coordinated after concurrent release v0.46.23; integration base `e0c27ea94e918b831bc2429ebfb7804a447a502a`.

## Actual verification

Own real editable Python 3.12 venv resolves `local_operator` to this worktree; no shared/symlinked venv and no writes to the unrelated dirty main checkout/index.

```text
$ cd /tmp && /tmp/lop-aside-570/.venv/bin/local-operator --version
v0.46.24
# Import resolution from outside the checkout:
/private/tmp/lop-aside-570/local_operator/__init__.py

$ cd /tmp/lop-aside-570
$ .venv/bin/python -m flake8 .
exit=0
$ uvx --from black==26.1.0 black --check .
873 files would be left unchanged. exit=0
$ uvx isort==5.13.2 --check .
Skipped 1 files. exit=0
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .
0 errors, 0 warnings, 0 informations. exit=0

$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui/test_aside.py tests/unit/tui/test_aside_reachability.py -n0 -q
130 passed, 2 warnings in 31.19s

$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q
10 passed, 3 warnings in 20.19s

$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
13330 passed, 15 skipped, 668 warnings in 968.28s (0:16:08)
```

Regression sensitivity: ran the 15 new parameterized checks after loading the unmodified baseline `aside_panel.py` from `git show` in an isolated Python process, without changing working files. **12 failed, 3 passed**, including missing continuation spines and question/answer gaps. The new narrow budgets are swept across every scroll offset and every answer row remains reachable. Existing tests also cover multi-turn answers, wrapped prose, todos squeezing the dock, forward/backward paging, stream updates, resizing, copy and fork refusal.

### Rendered real-app evidence (beyond units)

[Durable synthetic evidence gist: SVGs, native geometry and reproducible probe](https://gist.github.com/damianvtran/f5b57ab65b5505bc08e5a375d243a72b).

| State | Before | After |
| --- | --- | --- |
| 60x30 narrow/two turns | [Native SVG](https://gist.github.com/damianvtran/f5b57ab65b5505bc08e5a375d243a72b#file-before-narrow-multi-settled-svg) | [Native SVG](https://gist.github.com/damianvtran/f5b57ab65b5505bc08e5a375d243a72b#file-after-narrow-multi-settled-svg) |
| 80x24 pinned window | [Native SVG](https://gist.github.com/damianvtran/f5b57ab65b5505bc08e5a375d243a72b#file-before-windowed-settled-svg) | [Native SVG](https://gist.github.com/damianvtran/f5b57ab65b5505bc08e5a375d243a72b#file-after-windowed-settled-svg) |

The gist includes after thinking/error/superseded/tight frames and the consecutive narrow first frame. Use **Raw** to download SVG; rasterize with `rsvg-convert frame.svg -o frame.png`. Source previews are not visual evidence. Implementer rendered and actually viewed native PNGs; independent reviewers receive the full native PNG matrix locally at `/tmp/lop-aside-570-evidence/{before,after}`. Generated evidence is deliberately **not committed**, following current AGENTS.md.

Capture: `env -u NO_COLOR TERM=xterm-256color .venv/bin/python probe.py /tmp/aside-capture`. `isolate_capture()` runs before app imports; synthetic `FakeSession`, **real OperatorApp and production CSS**, actual `ask`/`append_answer`/`settle_answer`/`fail_answer`/supersession methods. No credentials or live provider claims. Default native preset: 8x17 cells, 13px system Menlo, regular/bold/italic resolved by fontconfig/librsvg with 8px i/W/0/1 advances. Native images are 480x510 (60x30), 640x408 (80x24), 480x272 (60x16); no rescaling to suggest different terminal proportions.

| Measurement | Before → after |
| --- | --- |
| Narrow/two-turn card height | 12 → 14 rows; both wrapped question rows marked, each answer separated |
| Thinking/error card height | 9 → 10 rows |
| Superseded/next-question card height | 13 → 15 rows |
| Empty card height | 7 → 7 rows |
| 80x24 window card/body budget | 15/9 → 15/9 rows; one fewer answer row visible, all reachable |
| 60x16 tight card/body budget | 7/3 → 7/3 rows; existing tiny-budget fallback preserved |
| All 14 before/after cases | Screen virtual size = content size, outer scrollbars false |
| All 14 first/settled PNG pairs | Pixel-identical; no geometry movement across captured interval |

Baseline captures were taken/viewed on `bce85796` before editing; after frames use current head `38970ad2` over `e0c27ea94`. The intervening release changed subagent model/effort handling, not aside rendering.

## Rollout / rollback

After fresh independent code, QA and design rounds are clean and answered, the coordinating manager can merge, publish v0.46.24 through the existing GitHub release/PyPI workflow, then install the committed release with `lop-update` and smoke-test from outside the checkout. Recheck version availability before publication because releases are concurrent. Do not close #570 until publication and installed-runtime verification finish.

Rollback: reinstall prior release `lop-update v0.46.23` if needed, verify its source marker and runtime version, and revert the rendering change through a reviewed corrective PR. No data migration or cleanup is required. No human reviewers have been added; no merge or release has been performed by the implementing agent.
