### PR TITLE
fix(osworld): restore expanded pilot packaging and score evidence

### DIFF
--- a/benchmarks/osworld_v2_adapter/OSWORLD-LICENSE
+++ b/benchmarks/osworld_v2_adapter/OSWORLD-LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 XLANG NLP Lab
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/benchmarks/osworld_v2_adapter/README.md
+++ b/benchmarks/osworld_v2_adapter/README.md
@@ -78,8 +78,11 @@ run setup/evaluate, or scan anything on normal CLI/TUI startup. Stdlib imports
 are admitted; `TYPE_CHECKING` bodies are skipped; imports guarded by an import
 error handler are optional by upstream's contract. Third-party dynamic aliases
 (such as `requests.packages`) are checked by distribution import root, not as
-on-disk submodules. This cheap static presence check is not a general Python
-execution or evaluator-correctness proof.
+on-disk submodules. For pinned upstream package `from` imports, initializer
+source declarations distinguish required child modules from ordinary exported
+values; explicit re-exports also require their providing module. Initializers
+are parsed, never executed. This cheap static presence check is not a general
+Python execution or evaluator-correctness proof.
 
 The release census has 94 mandatory module paths with no missing dependency in
 the locked environment. Task 057 alone names absent `lpips`/`torch`, inside an

--- a/benchmarks/osworld_v2_adapter/README.md
+++ b/benchmarks/osworld_v2_adapter/README.md
@@ -48,6 +48,46 @@ sha, every task file sha, task count, prepared checkout commit — and refuses
 records their manifest sha in `inputs.json`, and the adapter re-verifies the
 live root against it at every `reset_start`.
 
+## Runtime helper packaging and pre-allocation checks
+
+Upstream's pinned `osworld` wheel explicitly excludes `evaluation_examples`,
+but 16 of the 108 release tasks import its runtime helper. Task 010 therefore
+failed at `vendor_bridge.instantiate_task` before model spend, but **after** VM
+allocation. A working task 001 was not evidence of complete dependency packaging.
+
+The adapter wheel now owns the exact upstream namespace and three-file runtime
+closure: `evaluation_examples/__init__.py`, `task_class/__init__.py`, and
+`task_class/generated_task_utils.py`. They are byte-identical git objects from
+`d578d2d4e0dc82b43e270fdaa7fa89d9708cd154`, with SHA-256s in the wheel's
+`evaluation_examples/UPSTREAM.json` and the upstream Apache license in
+`OSWORLD-LICENSE` (also included in wheel metadata). The helper SHA-256 is
+`cf0945bc4cd15253631f41dfcd96ca0874116523f07fc34989cce2f23df1bbb0`.
+All three Python files and provenance are covered by the adapter's RECORD and
+`package_digest`. Do not reformat vendored source, install a namespace alias,
+add `PYTHONPATH`, or copy gated task classes into this package. To update the
+closure, audit all pinned task AST imports plus helper imports, copy the exact
+required upstream git objects and package ancestors, update provenance, and
+repeat the isolated import census. A release change is not a wildcard copy of
+`evaluation_examples` (which also contains task classes and setup scripts).
+
+Only when an AWS episode names its task at `reset_start`, before constructing
+or allocating its provider, the adapter parses that task and the packaged helper
+closure. Missing mandatory distributions or upstream runtime modules fail
+locally. This does not execute task code, import dependency package initialisers,
+run setup/evaluate, or scan anything on normal CLI/TUI startup. Stdlib imports
+are admitted; `TYPE_CHECKING` bodies are skipped; imports guarded by an import
+error handler are optional by upstream's contract. Third-party dynamic aliases
+(such as `requests.packages`) are checked by distribution import root, not as
+on-disk submodules. This cheap static presence check is not a general Python
+execution or evaluator-correctness proof.
+
+The release census has 94 mandatory module paths with no missing dependency in
+the locked environment. Task 057 alone names absent `lpips`/`torch`, inside an
+explicit `try/except Exception` fallback; they are **optional**, not grounds to
+exclude that task or install heavyweight packages for tasks 010/080/103. All 108
+task modules loaded in a fresh isolated subprocess with network and process
+execution denied, inert controller settings, and no setup/evaluate calls.
+
 ## Build, lock, install
 
 ```sh
@@ -58,7 +98,8 @@ cd benchmarks/osworld_v2_adapter
 #    schema 1.2 the worker speaks).
 uv lock --upgrade-package local-operator   # writes uv.lock (committed)
 
-# 2. build the wheel
+# 2. build the adapter wheel, including the pinned runtime helper closure.
+#    No harness release/publish is needed for this adapter-only rebuild.
 uv build --wheel --out-dir dist/
 
 # 3. create the dedicated interpreter + install the locked set.
@@ -103,7 +144,9 @@ uv export --frozen --no-emit-project --extra osworld --no-hashes \
     -o "$VENV/build/requirements.locked.txt"
 sed -i '' 's/^local-operator==.*/local-operator==<harness version>/' \
     "$VENV/build/requirements.locked.txt"   # macOS sed; GNU sed wants -i without ''
-uv pip install --python "$VENV/bin/python3.12" -r "$VENV/build/requirements.locked.txt"
+# The export is the full resolved closure. --no-deps preserves those rows and
+# the lock's requests override instead of re-resolving upstream's stale pin.
+uv pip install --no-deps --python "$VENV/bin/python3.12" -r "$VENV/build/requirements.locked.txt"
 
 # The one expected `uv pip check` incompatibility is the documented
 # requests>=2.32 override onto OSWorld's ~=2.31 pin (see [tool.uv] above).

--- a/benchmarks/osworld_v2_adapter/pyproject.toml
+++ b/benchmarks/osworld_v2_adapter/pyproject.toml
@@ -46,11 +46,17 @@ osworld = [
 [project.entry-points."local_operator.evaluation_adapters.v1"]
 osworld-v2 = "lop_osworld_v2_adapter:create"
 
+[tool.setuptools]
+# Preserve the upstream Apache notice with the byte-identical runtime helper
+# package; gated task classes remain exclusively in the pinned workspace.
+license-files = ["OSWORLD-LICENSE"]
+
 [tool.setuptools.packages.find]
 where = ["src"]
 
 [tool.setuptools.package-data]
 lop_osworld_v2_adapter = ["py.typed"]
+evaluation_examples = ["UPSTREAM.json"]
 
 [tool.uv]
 # OSWorld declares ``requests~=2.31.0`` while local-operator requires

--- a/benchmarks/osworld_v2_adapter/src/evaluation_examples/UPSTREAM.json
+++ b/benchmarks/osworld_v2_adapter/src/evaluation_examples/UPSTREAM.json
@@ -1,0 +1,9 @@
+{
+  "repository": "https://github.com/xlang-ai/OSWorld-V2",
+  "commit": "d578d2d4e0dc82b43e270fdaa7fa89d9708cd154",
+  "files": {
+    "evaluation_examples/__init__.py": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "evaluation_examples/task_class/__init__.py": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "evaluation_examples/task_class/generated_task_utils.py": "cf0945bc4cd15253631f41dfcd96ca0874116523f07fc34989cce2f23df1bbb0"
+  }
+}

--- a/benchmarks/osworld_v2_adapter/src/evaluation_examples/task_class/generated_task_utils.py
+++ b/benchmarks/osworld_v2_adapter/src/evaluation_examples/task_class/generated_task_utils.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Sequence
+
+
+def run_postconfig(env: Any, postconfig: Sequence[dict[str, Any]] | None = None) -> None:
+    """Apply evaluator postconfig and mark the environment as used."""
+    if not postconfig:
+        return
+    env.setup_controller.setup(list(postconfig), env.enable_proxy)
+    env.is_environment_used = True
+
+
+def evaluate_infeasible_task(
+    env: Any,
+    *,
+    postconfig: Sequence[dict[str, Any]] | None = None,
+) -> float:
+    """Mirror the runtime behavior for JSON tasks with func='infeasible'."""
+    run_postconfig(env, postconfig)
+    if _last_action_failed(env):
+        return 1.0
+    return 0.0
+
+
+def evaluate_metric(
+    env: Any,
+    *,
+    metric_name: str,
+    result_spec: dict[str, Any] | None = None,
+    expected_spec: dict[str, Any] | None = None,
+    options: dict[str, Any] | None = None,
+    postconfig: Sequence[dict[str, Any]] | None = None,
+) -> float:
+    """Evaluate a single JSON metric using the same semantics as the runtime."""
+    run_postconfig(env, postconfig)
+    if _last_action_failed(env):
+        return 0.0
+
+    try:
+        result_state = get_evaluator_state(env, result_spec) if result_spec else None
+    except FileNotFoundError:
+        return 0.0
+
+    try:
+        expected_state = get_evaluator_state(env, expected_spec) if expected_spec else None
+        return call_metric(
+            metric_name,
+            result_state,
+            expected_state=expected_state,
+            options=options,
+        )
+    except Exception:
+        return 0.0
+
+
+def evaluate_metric_list(
+    env: Any,
+    *,
+    metric_names: Sequence[str],
+    result_specs: Sequence[dict[str, Any] | None],
+    expected_specs: Sequence[dict[str, Any] | None] | None = None,
+    options_list: Sequence[dict[str, Any] | None] | None = None,
+    conj: str = "and",
+    short_circuit: bool = True,
+    postconfig: Sequence[dict[str, Any]] | None = None,
+) -> float:
+    """Evaluate a list-based JSON evaluator using runtime-compatible aggregation."""
+    run_postconfig(env, postconfig)
+    if _last_action_failed(env):
+        return 0.0
+
+    expected_specs = list(expected_specs or [None] * len(metric_names))
+    options_list = list(options_list or [{}] * len(metric_names))
+    scores: list[float] = []
+
+    for metric_name, result_spec, expected_spec, options in zip(
+        metric_names,
+        result_specs,
+        expected_specs,
+        options_list,
+    ):
+        try:
+            result_state = get_evaluator_state(env, result_spec) if result_spec else None
+        except FileNotFoundError:
+            if conj == "and" and short_circuit:
+                return 0.0
+            scores.append(0.0)
+            continue
+
+        try:
+            expected_state = get_evaluator_state(env, expected_spec) if expected_spec else None
+            score = call_metric(
+                metric_name,
+                result_state,
+                expected_state=expected_state,
+                options=options,
+            )
+        except Exception:
+            score = 0.0
+
+        if short_circuit:
+            if conj == "and" and score == 0.0:
+                return 0.0
+            if conj == "or" and score == 1.0:
+                return 1.0
+
+        scores.append(score)
+
+    return aggregate_scores(scores, conj=conj)
+
+
+def get_evaluator_state(env: Any, spec: dict[str, Any]) -> Any:
+    """Resolve a JSON evaluator getter spec into a Python value."""
+    from desktop_env.evaluators import getters
+
+    getter_name = f"get_{spec['type']}"
+    getter = getattr(getters, getter_name)
+    return getter(env, spec)
+
+
+def call_metric(
+    metric_name: str,
+    result_state: Any,
+    *,
+    expected_state: Any = None,
+    options: dict[str, Any] | None = None,
+) -> float:
+    """Resolve and run a metric from desktop_env.evaluators.metrics."""
+    from desktop_env.evaluators import metrics
+
+    metric = getattr(metrics, metric_name)
+    options = dict(options or {})
+    if expected_state is None:
+        return float(metric(result_state, **options))
+    return float(metric(result_state, expected_state, **options))
+
+
+def aggregate_scores(scores: Iterable[float], *, conj: str = "and") -> float:
+    """Aggregate multi-metric scores using the same rules as DesktopEnv."""
+    score_list = list(scores)
+    if not score_list:
+        return 0.0
+    if conj in {"and", "avg"}:
+        return sum(score_list) / len(score_list)
+    if conj == "or":
+        return max(score_list)
+    if conj == "sum":
+        return min(1.0, sum(score_list))
+    return sum(score_list) / len(score_list)
+
+
+def _last_action_failed(env: Any) -> bool:
+    if not getattr(env, "action_history", None):
+        return False
+    last_action = env.action_history[-1]
+    if last_action == "FAIL":
+        return True
+    return isinstance(last_action, dict) and last_action.get("action_type") == "FAIL"

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
@@ -303,6 +303,7 @@ class OSWorldV2Adapter:
         self._secrets: dict[str, str] = {}
         self._provider: EnvironmentProvider | None = None
         self._observation_builder: ObservationBuilder | None = None
+        self._artifact_root: Path | None = None
         self._current_observation: Any = None
         self._sequence = 0
 
@@ -498,7 +499,8 @@ class OSWorldV2Adapter:
         # ambient carries it. The parent creates the directory and refuses a
         # reset whose root differs from the one its verifier reads, so writing
         # exactly here is what makes a frame verifiable rather than a guess.
-        self._observation_builder = ObservationBuilder(Path(params.artifact_root))
+        self._artifact_root = Path(params.artifact_root)
+        self._observation_builder = ObservationBuilder(self._artifact_root)
         raw = await provider.observe()
         self._sequence = 0
         self._current_observation = self._observation_builder.build(
@@ -716,14 +718,14 @@ class OSWorldV2Adapter:
     # ------------------------------------------------------------------
 
     async def score(self, params: ScoreParams) -> ScoreResult:
-        if self._provider is None or self._task is None:
+        if self._provider is None or self._task is None or self._artifact_root is None:
             raise scoring.ScoringUnavailable("score before reset_start")
         if not self._task.has_evaluator():
             # NOT 0.0: a task with no evaluator scored as failed would record
             # a failure the agent did not commit.
             raise scoring.ScoringUnavailable("task declares no evaluator")
         raw = await self._provider.evaluate()
-        return ScoreResult(score=scoring.score_to_artifact(raw))
+        return ScoreResult(score=scoring.score_to_artifact(raw, artifact_root=self._artifact_root))
 
     # ------------------------------------------------------------------
     # cleanup / close / begin_rescue

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
@@ -461,6 +461,15 @@ class OSWorldV2Adapter:
                     f"{missing} were not supplied; OSWorld would return a silent "
                     "0.0, which this adapter refuses to seal"
                 )
+        if self._provider_factory is None and self._read_provider_config().get("provider") in (
+            None,
+            "aws",
+        ):
+            # Tasks are first named here. Check packaging before constructing a
+            # cloud provider; importing the task itself could run arbitrary code.
+            from lop_osworld_v2_adapter.dependencies import validate_task_dependencies
+
+            validate_task_dependencies(self._load_task_source(params.task_id))
         self._plan = provisioning.resolve(
             self._task,
             episode_id=params.episode_id,

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/dependencies.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/dependencies.py
@@ -1,0 +1,119 @@
+"""Static packaging checks, only when an AWS episode names its task.
+
+Never import a task or a dependency to discover dependencies: upstream imports
+can validate service settings, initialise clients or write caches. This is a
+presence check, not a claim that arbitrary Python or every evaluator will run.
+The corpus acceptance check separately exercises module loading without setup.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from importlib.machinery import PathFinder
+from pathlib import Path
+
+# These are real upstream file namespaces, unlike third-party compatibility
+# aliases such as requests.packages. Check their complete module paths so an
+# installed desktop_env alone cannot disguise a missing runtime helper.
+_RUNTIME_ROOTS = frozenset({"desktop_env", "evaluation_examples"})
+_IMPORT_ERRORS = frozenset({"ImportError", "ModuleNotFoundError", "Exception", "BaseException"})
+
+
+class MissingTaskDependencies(RuntimeError):
+    """The isolated interpreter lacks dependencies, before provider allocation."""
+
+
+def import_census(source: str | bytes) -> tuple[set[str], set[str]]:
+    """Return required and guarded-optional imports, including function bodies.
+
+    TYPE_CHECKING bodies are not runtime dependencies. An import in a try body
+    that catches import failure is optional by upstream's own contract; scanning
+    its fallback still finds any mandatory replacement dependency.
+    """
+
+    required: set[str] = set()
+    optional: set[str] = set()
+
+    def walk(node: ast.AST, guarded: bool = False) -> None:
+        if isinstance(node, ast.If) and (
+            isinstance(node.test, ast.Name)
+            and node.test.id == "TYPE_CHECKING"
+            or isinstance(node.test, ast.Attribute)
+            and isinstance(node.test.value, ast.Name)
+            and node.test.value.id == "typing"
+            and node.test.attr == "TYPE_CHECKING"
+        ):
+            for child in node.orelse:
+                walk(child, guarded)
+            return
+        if isinstance(node, ast.Try):
+            catches_import = any(
+                handler.type is None
+                or any(
+                    isinstance(part, ast.Name) and part.id in _IMPORT_ERRORS
+                    for part in ast.walk(handler.type)
+                )
+                for handler in node.handlers
+            )
+            for child in node.body:
+                walk(child, guarded or catches_import)
+            for child in [*node.handlers, *node.orelse, *node.finalbody]:
+                walk(child, guarded)
+            return
+        target = optional if guarded else required
+        if isinstance(node, ast.Import):
+            target.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and not node.level and node.module:
+            target.add(node.module)
+        for child in ast.iter_child_nodes(node):
+            walk(child, guarded)
+
+    walk(ast.parse(source))
+    return required, optional - required
+
+
+def module_present(name: str) -> bool:
+    """Resolve files without executing parent __init__ modules or import hooks.
+
+    Third-party modules may expose submodules dynamically, so only their root
+    is a static packaging contract. Upstream runtime namespaces are file-based
+    and checked down to the leaf. Normal isolated imports remain authoritative
+    for execution (including the worker's RECORD-verified source loader).
+    """
+
+    root = name.split(".", 1)[0]
+    if root in sys.stdlib_module_names:
+        return True
+    parts = name.split(".") if root in _RUNTIME_ROOTS else [root]
+    search = None
+    for index in range(len(parts)):
+        spec = PathFinder.find_spec(".".join(parts[: index + 1]), search)
+        if spec is None:
+            return False
+        if index < len(parts) - 1:
+            if spec.submodule_search_locations is None:
+                return False
+            search = list(spec.submodule_search_locations)
+    return True
+
+
+def validate_task_dependencies(source: str | bytes) -> None:
+    """Fail before spending on a VM; never execute task setup or import code."""
+
+    required, _ = import_census(source)
+    if any(name.split(".", 1)[0] == "evaluation_examples" for name in required):
+        # The wheel owns this entire three-file helper package. Parse its
+        # closure as well, not only the task that imports it; never traverse
+        # third-party source trees or execute their package initialisers.
+        helpers = Path(__file__).parent.parent / "evaluation_examples"
+        for path in helpers.rglob("*.py"):
+            helper_required, _ = import_census(path.read_bytes())
+            required.update(helper_required)
+    missing = sorted(name for name in required if not module_present(name))
+    if missing:
+        raise MissingTaskDependencies(
+            "isolated OSWorld environment is missing task dependencies: "
+            + ", ".join(missing)
+            + "; rebuild/install the pinned adapter wheel and locked OSWorld extra"
+        )

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/dependencies.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/dependencies.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 
 import ast
 import sys
-from importlib.machinery import PathFinder
+from importlib.machinery import ModuleSpec, PathFinder
+from importlib.util import resolve_name
 from pathlib import Path
 
 # These are real upstream file namespaces, unlike third-party compatibility
@@ -24,7 +25,9 @@ class MissingTaskDependencies(RuntimeError):
     """The isolated interpreter lacks dependencies, before provider allocation."""
 
 
-def import_census(source: str | bytes) -> tuple[set[str], set[str]]:
+def import_census(
+    source: str | bytes, *, resolve_runtime_exports: bool = False
+) -> tuple[set[str], set[str]]:
     """Return required and guarded-optional imports, including function bodies.
 
     TYPE_CHECKING bodies are not runtime dependencies. An import in a try body
@@ -66,6 +69,8 @@ def import_census(source: str | bytes) -> tuple[set[str], set[str]]:
             target.update(alias.name for alias in node.names)
         elif isinstance(node, ast.ImportFrom) and not node.level and node.module:
             target.add(node.module)
+            if resolve_runtime_exports and node.module.split(".", 1)[0] in _RUNTIME_ROOTS:
+                target.update(_from_import_modules(node.module, node.names))
         for child in ast.iter_child_nodes(node):
             walk(child, guarded)
 
@@ -85,30 +90,78 @@ def module_present(name: str) -> bool:
     root = name.split(".", 1)[0]
     if root in sys.stdlib_module_names:
         return True
-    parts = name.split(".") if root in _RUNTIME_ROOTS else [root]
+    return _module_spec(name if root in _RUNTIME_ROOTS else root) is not None
+
+
+def _module_spec(name: str) -> ModuleSpec | None:
+    parts = name.split(".")
     search = None
+    spec = None
     for index in range(len(parts)):
         spec = PathFinder.find_spec(".".join(parts[: index + 1]), search)
         if spec is None:
-            return False
+            return None
         if index < len(parts) - 1:
             if spec.submodule_search_locations is None:
-                return False
+                return None
             search = list(spec.submodule_search_locations)
-    return True
+    return spec
+
+
+def _from_import_modules(package: str, names: list[ast.alias]) -> set[str]:
+    """Resolve pinned package exports without executing their initializers.
+
+    ``from evaluators import metrics`` needs a child module even when its file
+    is missing. Conversely, ``from getters import get_vm_file`` is an explicit
+    re-export from ``getters.file``, not a fictional ``getters.get_vm_file``
+    module. Only upstream's file-based namespaces use this rule; dynamic
+    third-party compatibility exports retain the import-root presence check.
+    """
+
+    spec = _module_spec(package)
+    if spec is None or spec.submodule_search_locations is None:
+        return set()
+    exports: dict[str, str | None] = {}
+    if spec.origin is not None and spec.origin.endswith(".py"):
+        for node in ast.parse(Path(spec.origin).read_bytes()).body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                exports[node.name] = None
+            elif isinstance(node, (ast.Assign, ast.AnnAssign)):
+                targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+                for target in targets:
+                    for part in ast.walk(target):
+                        if isinstance(part, ast.Name) and isinstance(part.ctx, ast.Store):
+                            exports[part.id] = None
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    exports[alias.asname or alias.name.split(".")[0]] = alias.name
+            elif isinstance(node, ast.ImportFrom):
+                origin = resolve_name("." * node.level + (node.module or ""), package)
+                for alias in node.names:
+                    exports[alias.asname or alias.name] = (
+                        origin if node.module else f"{origin}.{alias.name}"
+                    )
+    modules: set[str] = set()
+    for alias in names:
+        if alias.name == "*":
+            continue
+        dependency = exports.get(alias.name, f"{package}.{alias.name}")
+        if dependency is not None:
+            modules.add(dependency)
+    return modules
 
 
 def validate_task_dependencies(source: str | bytes) -> None:
     """Fail before spending on a VM; never execute task setup or import code."""
 
-    required, _ = import_census(source)
+    required, _ = import_census(source, resolve_runtime_exports=True)
     if any(name.split(".", 1)[0] == "evaluation_examples" for name in required):
         # The wheel owns this entire three-file helper package. Parse its
         # closure as well, not only the task that imports it; never traverse
         # third-party source trees or execute their package initialisers.
         helpers = Path(__file__).parent.parent / "evaluation_examples"
         for path in helpers.rglob("*.py"):
-            helper_required, _ = import_census(path.read_bytes())
+            helper_required, _ = import_census(path.read_bytes(), resolve_runtime_exports=True)
             required.update(helper_required)
     missing = sorted(name for name in required if not module_present(name))
     if missing:

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/scoring.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/scoring.py
@@ -8,22 +8,33 @@ than raising (desktop_env.py:594-700). Mapping "could not evaluate" to 0.0
 would report a failure the agent did not commit — the exact score-deflation
 error this module exists to prevent.
 
-Mapping rules:
-- exact ``0.0`` -> ``binary=0``; exact ``1.0`` -> ``binary=1`` (the shape a
-  leaderboard expects; ScoreArtifact permits either).
-- any other in-range value -> ``partial_ppm=round(v * 1_000_000)``. The
-  protocol's metadata subset excludes floats, and ``partial_ppm`` is the
-  integer expression of a fractional score. V2's ``conj: "avg"``/``"sum"``
-  evaluators produce genuine fractions, so this path is real.
-- NaN, out-of-range, non-numeric, or a missing evaluator -> raise.
+Binary completion and partial reward are distinct metrics (OSWorld 2.0 paper,
+https://arxiv.org/html/2606.29537v1, sections 2.1.3 and 3.2). Only a full raw
+score is binary completion: the pinned d578d2d4 upstream monitor/static/index.js
+counts fullScoreTasks only when score === 1 (lines 265-270). Rounding partial
+reward must never promote a near miss. The original evaluate() result is retained
+as canonical JSON, including any safety/checkpoint/error fields, not reconstructed
+from its rounded ppm.
+A scalar result cannot supply checkpoint data the upstream evaluator discarded.
+Invalid or over-budget details fail closed rather than claiming full evidence.
 """
 
 from __future__ import annotations
 
+import hashlib
+import json
 import math
+import os
+from pathlib import Path
 from typing import Any
 
-from local_operator.evaluation.evidence.models import ScoreArtifact
+from local_operator.evaluation.evidence.models import EvidenceArtifactRef, ScoreArtifact
+
+# Evaluator summaries are small. Bound traversal as well as encoded bytes before
+# the parent's independent media/redaction checks (whose JSON ceiling is 32 MiB).
+MAX_SCORE_DETAIL_BYTES = 1024 * 1024
+MAX_SCORE_DETAIL_NODES = 100_000
+MAX_SCORE_DETAIL_DEPTH = 64
 
 
 class ScoringUnavailable(RuntimeError):
@@ -31,10 +42,54 @@ class ScoringUnavailable(RuntimeError):
 
 
 class ScoringProtocolError(RuntimeError):
-    """OSWorld returned a value outside its own [0.0, 1.0] contract."""
+    """The evaluator score or its details violate the bounded JSON contract."""
 
 
-def score_to_artifact(raw: Any) -> ScoreArtifact:
+def _detail_bytes(raw: Any) -> bytes:
+    nodes = 0
+    characters = 0
+
+    def validate(value: Any, depth: int) -> None:
+        nonlocal nodes, characters
+        nodes += 1
+        if nodes > MAX_SCORE_DETAIL_NODES or depth > MAX_SCORE_DETAIL_DEPTH:
+            raise ScoringProtocolError("evaluator details exceed structural limits")
+        if type(value) is str:
+            characters += len(value)
+            if characters > MAX_SCORE_DETAIL_BYTES:
+                raise ScoringProtocolError("evaluator details exceed byte limit")
+        elif type(value) is dict:
+            for key, item in value.items():
+                if type(key) is not str:
+                    raise ScoringProtocolError("evaluator details require JSON string keys")
+                validate(key, depth + 1)
+                validate(item, depth + 1)
+        elif type(value) is list:
+            for item in value:
+                validate(item, depth + 1)
+        elif value is not None and type(value) not in (bool, int, float):
+            # No default=str or tuple/key coercions: those would misrepresent the
+            # upstream result while presenting it as preserved JSON evidence.
+            raise ScoringProtocolError("evaluator details contain a non-JSON value")
+
+    validate(raw, 0)
+    data = bytearray()
+    encoder = json.JSONEncoder(
+        allow_nan=False, ensure_ascii=False, separators=(",", ":"), sort_keys=True
+    )
+    try:
+        for chunk in encoder.iterencode(raw):
+            encoded = chunk.encode("utf-8")
+            if len(data) + len(encoded) > MAX_SCORE_DETAIL_BYTES:
+                raise ScoringProtocolError("evaluator details exceed byte limit")
+            data.extend(encoded)
+    except (ValueError, OverflowError, UnicodeError, RecursionError) as error:
+        # Encoder errors can quote raw values; only a fixed diagnostic crosses RPC.
+        raise ScoringProtocolError("evaluator details are not finite UTF-8 JSON") from error
+    return bytes(data)
+
+
+def score_to_artifact(raw: Any, *, artifact_root: Path) -> ScoreArtifact:
     """Map OSWorld's raw ``evaluate()`` return to a SCORED artifact, or raise.
 
     V2 may return a dict carrying ``{"score": float}`` (task_base.py:79-88)
@@ -43,21 +98,37 @@ def score_to_artifact(raw: Any) -> ScoreArtifact:
     a zero.
     """
 
+    value = raw
     if isinstance(raw, dict):
         if "score" not in raw:
             raise ScoringProtocolError("evaluator returned a dict without a 'score' key")
-        raw = raw["score"]
+        value = raw["score"]
 
-    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
-        raise ScoringProtocolError(f"evaluator returned a non-numeric score: {type(raw).__name__}")
-    value = float(raw)
-    if math.isnan(value) or math.isinf(value):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ScoringProtocolError("evaluator returned a non-numeric score")
+    if isinstance(value, float) and not math.isfinite(value):
         raise ScoringProtocolError("evaluator returned NaN or infinite score")
-    if not (0.0 <= value <= 1.0):
-        raise ScoringProtocolError(f"evaluator score {value} is outside [0.0, 1.0]")
-
-    if value == 0.0:
-        return ScoreArtifact(status="scored", binary=0)
-    if value == 1.0:
-        return ScoreArtifact(status="scored", binary=1)
-    return ScoreArtifact(status="scored", partial_ppm=round(value * 1_000_000))
+    if not (0 <= value <= 1):
+        raise ScoringProtocolError("evaluator score is outside [0.0, 1.0]")
+    value = float(value)
+    data = _detail_bytes(raw)
+    details = EvidenceArtifactRef(
+        sha256=hashlib.sha256(data).hexdigest(),
+        media_type="application/json",
+        byte_count=len(data),
+    )
+    # Like observations, these are worker-staged bytes, not trusted evidence.
+    # The parent reopens by digest, verifies, and scans them before its receipt.
+    try:
+        fd = os.open(artifact_root / details.sha256, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        pass  # The parent's verifier rejects conflicting or non-regular entries.
+    else:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(data)
+    return ScoreArtifact(
+        status="scored",
+        binary=1 if value == 1.0 else 0,
+        partial_ppm=round(value * 1_000_000),
+        details=details,
+    )

--- a/docs/benchmarks/osworld_2/MODEL_PILOT.md
+++ b/docs/benchmarks/osworld_2/MODEL_PILOT.md
@@ -1,0 +1,137 @@
+# Matched-model development pilot
+
+This is an exploratory protocol and run ledger, **not a leaderboard submission**.
+The purpose is to separate model limitations from apparatus failures before paying
+for a full 108-task evaluation. A domain-selected pilot cannot establish parity
+with a published full-suite average, even if its percentage is higher.
+
+## Reference selection
+
+Primary sources checked during the September 2026 pilot:
+
+| Model | OpenRouter ID | USD per million input / output tokens | OSWorld 2.0 reference and limitations |
+| --- | --- | --- | --- |
+| GPT-5.6 Luna | `openai/gpt-5.6-luna` | 0.20 / 1.20 | OpenAI reports 45.6; fetched release text does not establish the precise metric, release, reasoning, or repeat protocol. Do not label it binary completion. |
+| MiniMax M3 | `minimax/minimax-m3` | 0.30 / 1.20 | Benchmark-team reference: 4.6% binary, 22.3% partial at 500 steps on the **June 24** release, standard tools, reasoning enabled. |
+| Muse Spark 1.3 | `meta/muse-spark-1.3` | 1.25 / 4.25 | Existing local control. No exact OSWorld 2.0 reference established by this research. |
+| GPT-5.6 Terra | `openai/gpt-5.6-terra` | 2.00 / 12.00 | Optional mid-price follow-up, not in the initial pilot. OpenAI reports 50.2 with the same unresolved protocol qualifications as Luna. |
+
+Prices are catalog rates, not task costs. Cache discounts, service-tier routing,
+long-context premiums, reasoning, retries, and compaction affect actual bills.
+The pilot must report observed usage rather than price-table extrapolations alone.
+
+Sources:
+
+- [Official leaderboard data](https://osworld-v2.xlang.ai/static/data/leaderboard/official-results.json)
+  separates binary accuracy, partial score, step budget, and benchmark release.
+- [OSWorld 2.0 paper](https://arxiv.org/html/2606.29537v1) documents the original
+  benchmark-team runs. MiniMax uses screenshot observations and PyAutoGUI actions;
+  terminal/file workflows are discussed as solution styles, not automatically
+  prohibited because the observation arrives as a screenshot.
+- [OpenAI release](https://openai.com/es-ES/index/gpt-5-6/) and model documentation
+  for [Luna](https://developers.openai.com/api/docs/models/gpt-5.6-luna.md) and
+  [Terra](https://developers.openai.com/api/docs/models/gpt-5.6-terra.md).
+- [MiniMax model card](https://huggingface.co/MiniMaxAI/MiniMax-M3).
+- [OpenRouter catalog](https://openrouter.ai/api/v1/models).
+- [Google evaluation methodology](https://storage.googleapis.com/deepmind-media/gemini/gemini_3-8_flash_model_evaluation.pdf):
+  Gemini 3.8 Flash's reported 59.0 is **partial score**, maximum of three runs,
+  500 steps, screenshots and batched tools, **before the August 8 patch**. It is
+  not a 59% completion target for this apparatus.
+
+For current-release context, the official data checked here lists Opus 5 max at
+31.43% binary / 68.31% partial and GPT-5.6 Sol max at 27.34% / 62.72%, on the
+August release, full scope, 500 steps with batched tools. Those figures are not
+substitutes for a matched-model control on our pilot tasks.
+
+## Frozen initial design
+
+The controller recorded `trend-pilot-a-plan.json` before the first model result.
+The selected tasks are `task_010`, `task_080`, and `task_103`: respectively an
+Office/mail workflow, a local spreadsheet/PDF workflow, and a CAD/image workflow.
+Selection was based on application diversity and available prerequisites, not
+observed success or evaluator answers. These three tasks are not a random sample.
+Previously explored `task_001` is excluded from clean trend evidence.
+
+Initial arms: Luna, MiniMax M3, and Muse Spark 1.3. Every arm has the same:
+
+- 150-step ceiling, $3 provider-spend ceiling, 2,400-second wall ceiling;
+- 2,700-second resource lease and three recent screenshot frames retained;
+- existing generic cost, repeated-action, unchanged-screen, and ask-loop guards;
+- pinned `osworld-v2-2026.08.08` tasks/assets/code and isolated adapter environment;
+- one episode at a time, distinct output root, cleanup audit before and after;
+- no out-of-band controller interaction with the guest during the episode.
+
+The first applicable cap ends the episode. A wall-limited episode is **not** a
+completed 150-step test. Nine episodes would authorize at most $27 in provider
+spend; infrastructure and any evaluator/simulator charges are separate. The
+controller inspects each outcome before launching the next. Infrastructure
+failures and sustained non-progress stop expansion; failed attempts remain in the
+ledger rather than disappearing from the denominator.
+
+Guest preparation holds/aborts snap refreshes and clears download cache. This
+must be disclosed even on otherwise default hardware. The evidence library's
+`comparable` or `reportable` labels attest its internal checks, **not benchmark
+organizer approval or exact equivalence to reference protocols**.
+
+## Apparatus checks and observed attempts
+
+The starting runner is Local Operator 0.46.21 at
+`2f3d7e9470b9b1c35737bdabf9e63e99beeac153`, with explicitly selected adapter
+workspace `selector-0.1.5.json`. Do not use the stale default selector in an older
+operator script. Verify installed library paths, distribution hashes, runner
+source revision, and workspace digests before any run; version strings alone
+previously concealed a checkout/wheel mismatch. Historical hyg1 event timestamps
+fall on September 5 UTC, while the research context supplied September 4; preserve
+the raw timestamps rather than silently asserting a consistent chronology.
+
+The evaluated control loop is not the full interactive session: it deliberately
+has no host shell/file tools, uses a custom JSON action contract, and sends
+`tool_choice="none"`. It does reuse the central model/provider request path and
+compaction engine. This distinction must remain explicit: shared primitives are
+not proof of identical TUI prompts, skills, tools, or overall behavior.
+
+The current action protocol lacks drag and explicit pointer-motion operations.
+That is a capability limitation for the CAD domain, not grounds to remove a task
+after observing failure. Add missing generic capabilities only against measured
+need and independent regression tests.
+
+| Attempt | Model / task | Outcome | Provider spend | Interpretation |
+| --- | --- | --- | ---: | --- |
+| Existing `batch-hyg1` | Spark / `task_001` | 60 steps, scored 0, no environment errors | $1.194133 | Environment endurance evidence only. Information gathering progressed, but the final calendar was byte-identical to its initial fixture. Not a completed task and not a 500-step comparison. |
+| `batch-trend-luna-a01` | Luna / `task_010` | Setup failure before model call: missing `evaluation_examples` import | $0 | Packaging defect, not a Luna failure. Cleanup audit empty; batch expansion paused for repair. |
+
+The expanded-set failure demonstrates why a one-task smoke test is insufficient:
+the isolated wheel supplied `desktop_env` but not a runtime helper namespace
+imported by another task. The fix must cover the pinned dependency graph and be
+validated before cloud allocation, not special-case one task or add the controller
+checkout to `PYTHONPATH`.
+
+The repair's offline census found 16 imports of the omitted helper namespace.
+After packaging the three exact release helper files, all 108 task modules loaded
+in an isolated interpreter with network/process execution denied by an audit hook.
+No task constructors, setup methods, or evaluators ran in that census. Static
+mandatory dependency resolution reported no missing modules; `torch` and `lpips`
+were absent only in a guarded optional path. This proves import coverage, **not**
+that every task's live environment or evaluator works. The original task_010
+`instantiate_task` reproduction separately changed from `ModuleNotFoundError` to
+`Task010`, without allocating a VM.
+
+## Promotion and reporting gates
+
+1. Require observable target-side edits and at least one official-evaluator
+   completion before increasing the sample. Information extraction alone is not
+   completion.
+2. Preserve binary and partial metrics according to the actual evaluator return
+   contract. Do not infer one from an unrelated field or throw away the detailed
+   evaluation artifact needed to interpret a zero.
+3. Compare models on the same task IDs, apparatus revision, and budgets; distinguish
+   setup failures, agent failures, truncations, and completed evaluations.
+4. Generalizable fixes are developed against synthetic or held-out regression
+   cases. Never inject benchmark answers, task-specific click scripts, or evaluator
+   feedback into model context.
+5. After tuning, freeze the harness and evaluate untouched tasks. Report all
+   attempts and any stopping/selection rules. A promising small pilot supports a
+   decision to spend on a full run; it cannot justify claiming equality with the
+   published benchmark.
+6. A leaderboard claim requires the release/protocol-specific full evaluation and
+   the organizers' verification process, not only a successful local bundle seal.

--- a/docs/benchmarks/osworld_2/README.md
+++ b/docs/benchmarks/osworld_2/README.md
@@ -194,6 +194,30 @@ That key records the value **requested** on the command line. It is only
 honest because the runner refuses the one case that would make it a lie — see
 below.
 
+#### Expanded-task dependency packaging
+
+The expanded pilot exposed a packaging failure, not a model failure: task 010
+imports `evaluation_examples.task_class.generated_task_utils`, which the upstream
+`osworld` wheel excludes. The exception occurred after VM allocation with zero
+model spend. Task 001 did not exercise that import subset. Sixteen release tasks
+need the same helper; the adapter now packages the complete three-file runtime
+helper closure under its upstream namespace, with unchanged upstream bytes,
+license and SHA-256 provenance covered by the adapter wheel RECORD. No gated
+task/answer files are added to the wheel or model context.
+
+The pre-allocation static check runs only for the selected AWS task and helper
+closure, without importing tasks or executing setup. The offline acceptance
+census parsed and loaded all 108 task modules in an isolated interpreter, with
+network/process execution prohibited and no setup/evaluate calls. This proves
+import packaging, not environment setup, evaluator behavior or task scores.
+Optional `lpips`/`torch` imports in task 057 retain upstream's guarded fallback.
+
+Rebuild the adapter wheel and a **new** workspace/selector via the
+[adapter setup recipe](../../../benchmarks/osworld_v2_adapter/README.md#runtime-helper-packaging-and-pre-allocation-checks).
+The changed `package_digest`, not the reused `0.1.1` version string, identifies
+this artifact. Existing pilot evidence and installed environments remain intact;
+no harness publication is needed to test this adapter packaging correction.
+
 #### The adapter source and the pinned wheel both call themselves `0.1.1`
 
 **Read this before running with `AWS_INSTANCE_TYPE`.** The adapter source in

--- a/docs/benchmarks/osworld_2/README.md
+++ b/docs/benchmarks/osworld_2/README.md
@@ -10,14 +10,13 @@ which this document cross-references rather than duplicates. For the harness's
 own cost and throughput measurements — a different subject — see
 [`docs/BENCHMARKS.md`](../../BENCHMARKS.md).
 
-**Status at time of writing (2026-09-02): no score exists.** One paid episode
-has been run; it failed on its first decision, and the two suite-wide numbers
-this apparatus is designed to produce (per-task binary completion, aggregate
-completion over the 108 tasks) have never been measured. Everything below
-describes an apparatus that is built and partly exercised, not a result.
-[Status and honest limitations](#status-and-honest-limitations) states exactly
-what has and has not been done, and it is the section to read first if the
-question is "can I trust a number from this?".
+**Historical baseline (2026-09-02):** one paid episode had failed on its first
+decision and no score existed at that point. The dated observations under
+[Status and honest limitations](#status-and-honest-limitations) preserve that
+baseline, not the current episode count. See [the matched-model pilot ledger](MODEL_PILOT.md)
+for subsequent attempts, current apparatus validation and reference caveats.
+Neither an individual score nor the offline checks below establish a full-suite
+benchmark result.
 
 ## 1. The benchmark
 
@@ -63,11 +62,28 @@ disk against the pin above and refuses, naming the path, on any mismatch.
 An episode's score comes from the task's own upstream `evaluate()` and is
 mapped by `scoring.score_to_artifact` on a **scored-or-raise** contract:
 
-- exact `0.0` → `binary=0`; exact `1.0` → `binary=1`;
-- any other in-range value → `partial_ppm = round(v * 1_000_000)` (the
-  protocol's portable-metadata subset excludes floats; V2's `conj: "avg"`
-  and `"sum"` evaluators produce genuine fractions, so this path is real);
-- NaN, infinity, out-of-range, non-numeric, or a missing evaluator → **raise**.
+- every valid score records both metrics: `binary=1` only for exact raw `1.0`,
+  otherwise `binary=0`, and `partial_ppm = round(v * 1_000_000)`;
+- a near miss can round to `partial_ppm=1000000` while remaining `binary=0`;
+  partial reward rounding never promotes binary completion;
+- the full upstream return value is retained as bounded canonical JSON in
+  `score.details`, including any returned checkpoint, safety or error fields.
+  A scalar return cannot recover checkpoint data upstream already discarded;
+- NaN, infinity, out-of-range, non-numeric, missing evaluator, or invalid or
+  over-budget detail data → **raise**.
+
+The worker stages the raw detail bytes. The runner verifies them, then the
+writer publishes them through its existing confinement, redaction, media and
+fsync checks before committing the exactly-once scoring receipt. Ordinary
+artifact publication remains closed during finalization; only the validated
+score receipt authorizes this narrow exception. Publication failure triggers
+resource rescue and leaves the run unsealed, without evaluating a second time.
+No score-detail bytes enter model context.
+
+This evidence-publication correction requires the matching harness **and**
+adapter builds. Development wheels from the same reviewed source commit suffice;
+there is no need to publish or release the harness to test them. The helper
+packaging correction by itself remains adapter-only.
 
 The raise matters. Upstream's `evaluate()` swallows metric exceptions into
 `0.0` and logs a missing evaluator rather than failing. Mapping "could not

--- a/local_operator/evaluation/evidence/store.py
+++ b/local_operator/evaluation/evidence/store.py
@@ -985,13 +985,30 @@ class EvidenceWriter:
         expected_sha256: str | None = None,
         expected_byte_count: int | None = None,
     ) -> EvidenceArtifactRef:
+        return self._publish_artifact(
+            source,
+            media_type=media_type,
+            expected_sha256=expected_sha256,
+            expected_byte_count=expected_byte_count,
+        )
+
+    def _publish_artifact(
+        self,
+        source: bytes | bytearray | memoryview | BinaryIO | Iterable[bytes],
+        *,
+        media_type: str,
+        expected_sha256: str | None = None,
+        expected_byte_count: int | None = None,
+        scoring_details: bool = False,
+    ) -> EvidenceArtifactRef:
         with self._thread_lock:
             self._ensure_open()
             if self._recovery_only:
                 raise EvidenceRecoveryOnly("recovered bundle may only be abandoned")
             marker = StateMarker.from_canonical_json(self._read_regular(self._root_fd, _STATE))
-            if marker.state != "open":
-                raise EvidenceTerminal("artifact publication is closed after finalization begins")
+            expected_state = "finalizing" if scoring_details else "open"
+            if marker.state != expected_state:
+                raise EvidenceTerminal("artifact publication is closed in this phase")
             stream: Iterable[bytes]
             if isinstance(source, (bytes, bytearray, memoryview)):
                 stream = (bytes(source),)
@@ -1274,6 +1291,7 @@ class EvidenceWriter:
         self,
         payload: ScoringResultPayload,
         *,
+        details_source: bytes | None = None,
         monotonic_ns: int | None = None,
         wall_time_ms: int | None = None,
     ) -> EventRecord:
@@ -1299,12 +1317,28 @@ class EvidenceWriter:
                 or starts[0].scoring_operation_id != payload.scoring_operation_id
             ):
                 raise EvidenceBundleInvalid("scoring result does not match scoring start")
-            return self._append_locked(
+            event = self._build_event(
                 "scoring_result",
                 payload,
                 monotonic_ns=monotonic_ns,
                 wall_time_ms=wall_time_ms,
             )
+            if details_source is not None:
+                details = payload.score.details
+                if details is None:
+                    raise EvidenceBundleInvalid("scoring detail bytes require a score detail ref")
+                # The evaluator runs only AFTER durable scoring_start. Ordinary
+                # publication stays closed: this one exception is bound to the
+                # validated, exactly-once scoring receipt and its asserted ref.
+                # Reuse the same confinement, redaction, media and fsync path.
+                self._publish_artifact(
+                    details_source,
+                    media_type=details.media_type,
+                    expected_sha256=details.sha256,
+                    expected_byte_count=details.byte_count,
+                    scoring_details=True,
+                )
+            return self._persist_prevalidated_event(event)
 
     def seal(self, draft: OutcomeDraft) -> OutcomeSeal:
         with self._thread_lock:

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -100,6 +100,7 @@ from local_operator.evaluation.lifecycle import (
 )
 from local_operator.evaluation.protocol import (
     ActionBatch,
+    ArtifactRef,
     AskUserAction,
     FinishAction,
     Observation,
@@ -1229,26 +1230,33 @@ class EpisodeRunner:
                 ),
                 timeout=self._config.score_timeout,
             )
-        except _EvidenceFailure:
-            raise
+            score = result.score
+            details_source = None
+            if score.details is not None:
+                reference = ArtifactRef.model_validate(score.details.model_dump(mode="json"))
+                # Staged worker bytes are not durable evidence. Reopen with the
+                # bounded verifier; the receipt writer scans and publishes before
+                # committing the score. None of these bytes enter model context.
+                details_source = verify_artifact(self._config.artifact_root, reference)
+            self._append_receipt(
+                "scoring_result",
+                ScoringResultPayload(
+                    finalization_id=self._finalization_id,
+                    scoring_operation_id=self._scoring_operation_id,
+                    score=score,
+                ),
+                details_source=details_source,
+            )
         except BaseException as error:
             # ADAPTER CONTRACT: ``score()`` returns a SCORED artifact or raises.
             # "Unscored" is a harness decision expressed through the
             # finalization intent, never an adapter return value.
             #
             # ``scoring_start`` is already durable and a scored-intent
-            # finalization cannot seal unscored, so no legal terminal remains.
-            # Rescue first (the worker may be poisoned), then abandon.
+            # finalization cannot seal unscored, including when its detail bytes
+            # fail verification/publication. Rescue first, then abandon with the
+            # existing finalization authority; ordinary failure intent is too late.
             return await self._abandon_after_scoring_failure(error)
-        score = result.score
-        self._append_receipt(
-            "scoring_result",
-            ScoringResultPayload(
-                finalization_id=self._finalization_id,
-                scoring_operation_id=self._scoring_operation_id,
-                score=score,
-            ),
-        )
         return await self._close_out(score, failure_kind=None, cancelled=False)
 
     async def _finalize_failure(self, error: BaseException) -> EpisodeOutcome:
@@ -1609,7 +1617,9 @@ class EpisodeRunner:
         except EvidenceError as error:
             raise _EvidenceFailure(_diagnostic(error, None)) from error
 
-    def _append_receipt(self, kind: str, payload: Any) -> None:
+    def _append_receipt(
+        self, kind: str, payload: Any, *, details_source: bytes | None = None
+    ) -> None:
         writer = self._require_writer()
         try:
             if kind == "reconciliation":
@@ -1617,7 +1627,7 @@ class EpisodeRunner:
             elif kind == "cleanup":
                 writer.record_cleanup(payload)
             else:
-                writer.record_scoring_result(payload)
+                writer.record_scoring_result(payload, details_source=details_source)
         except EvidenceError as error:
             raise _EvidenceFailure(_diagnostic(error, None)) from error
 
@@ -1724,14 +1734,26 @@ class EpisodeRunner:
         writer = self._require_writer()
         rescue_complete = await self._attempt_rescue()
         await self._emergency_teardown()
-        record = writer.abandon("ambiguous_finalization", _diagnostic_code(error))
+        status: EpisodeStatus = "abandoned"
+        detail = _diagnostic_code(error)
+        try:
+            record = writer.abandon("ambiguous_finalization", detail)
+            detail = record.diagnostic_code
+        except (EvidenceError, OSError) as abandonment_error:
+            # A detail or receipt fsync can poison the writer after evaluation.
+            # Like _abandon_for_evidence, report the actual unsealed disk state;
+            # recovery requires a fresh writer, never a second evaluator call.
+            status = "abandonment_failed"
+            detail = (
+                f"{detail}; abandonment refused: {_diagnostic(abandonment_error, self._redactions)}"
+            )
         return EpisodeOutcome(
-            status="abandoned",
+            status=status,
             episode_id=self._spec.episode_id,
             bundle_root=Path(writer.root),
             rescue_required=True,
             rescue_complete=rescue_complete,
-            diagnostic=record.diagnostic_code,
+            diagnostic=detail,
         )
 
     async def _abandon_for_evidence(self, detail: str) -> EpisodeOutcome:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,7 +249,8 @@ lop = "local_operator.cli:main"
 [tool.black]
 line-length = 100
 target-version = ['py312']
-extend-exclude = "F401"
+# Vendored release helpers stay byte-identical to their recorded upstream SHA.
+extend-exclude = "F401|benchmarks/osworld_v2_adapter/src/evaluation_examples/"
 
 [tool.pylint."messages control"]
 ignore = ["__init__.py"]
@@ -263,6 +264,7 @@ enable = [
 
 [tool.isort]
 profile = "black"
+extend_skip = ["benchmarks/osworld_v2_adapter/src/evaluation_examples"]
 
 [tool.pyright]
 reportMissingTypeArgument = true
@@ -299,7 +301,7 @@ extraPaths = ["benchmarks/osworld_v2_adapter/src"]
 # runtime surface the gate exists to protect. Excluding `docs/` keeps the
 # type-check gate focused on `local_operator/` and `tests/` without weakening it
 # for real code or littering a throwaway generator with per-line ignores.
-exclude = ["**/node_modules", "**/__pycache__", "**/.*", "docs"]
+exclude = ["**/node_modules", "**/__pycache__", "**/.*", "docs", "benchmarks/osworld_v2_adapter/**/evaluation_examples"]
 # NOTE: venvPath/venv are deliberately NOT set here, even though a bare local
 # `pyright` run resolves whatever interpreter it finds and reports spurious
 # "import could not be resolved" errors that bury the real ones.

--- a/tests/unit/evaluation/adapters/osworld/test_dependencies.py
+++ b/tests/unit/evaluation/adapters/osworld/test_dependencies.py
@@ -1,0 +1,136 @@
+"""Packaging failures are caught without executing task or parent packages."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from lop_osworld_v2_adapter import dependencies
+
+_ROOT = Path(__file__).resolve().parents[5] / "benchmarks" / "osworld_v2_adapter"
+
+
+def test_vendored_closure_is_exact_pinned_source() -> None:
+    provenance = json.loads((_ROOT / "src/evaluation_examples/UPSTREAM.json").read_bytes())
+    pin = json.loads((_ROOT / "config/release-v2026.08.08.json").read_bytes())
+    assert provenance["commit"] == pin["osworld"]["commit"]
+    files = provenance["files"]
+    assert len(files) == 3
+    actual = {
+        str(path.relative_to(_ROOT / "src"))
+        for path in (_ROOT / "src/evaluation_examples").rglob("*.py")
+    }
+    assert actual == set(files)
+    for name, digest in files.items():
+        assert hashlib.sha256((_ROOT / "src" / name).read_bytes()).hexdigest() == digest
+    assert not list((_ROOT / "src/evaluation_examples").rglob("task_*.py"))
+    assert "Apache License" in (_ROOT / "OSWORLD-LICENSE").read_text()
+
+
+def test_census_distinguishes_runtime_type_only_and_optional_imports() -> None:
+    required, optional = dependencies.import_census("""
+import json
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    import type_only
+else:
+    import runtime_else
+if typing.TYPE_CHECKING:
+    import another_type_only
+def evaluate():
+    import needed_at_evaluation
+    try:
+        import torch
+        import lpips
+    except Exception:
+        import fallback
+try:
+    import mandatory
+except ValueError:
+    pass
+raise RuntimeError('must not execute')
+""")
+    assert required == {
+        "json",
+        "typing",
+        "runtime_else",
+        "needed_at_evaluation",
+        "fallback",
+        "mandatory",
+    }
+    assert optional == {"torch", "lpips"}
+
+
+def test_presence_never_imports_parent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    package = tmp_path / "evaluation_examples"
+    package.mkdir()
+    (package / "__init__.py").write_text("raise RuntimeError('parent executed')")
+    (package / "helper.py").write_text("raise RuntimeError('helper executed')")
+    monkeypatch.setattr(sys, "path", [str(tmp_path)])
+    before = set(sys.modules)
+    assert dependencies.module_present("evaluation_examples.helper")
+    assert not dependencies.module_present("evaluation_examples.missing")
+    assert not dependencies.module_present("missing_distribution")
+    assert dependencies.module_present("os.path")
+    assert set(sys.modules) == before
+
+
+def test_preflight_reports_missing_without_executing_source() -> None:
+    with pytest.raises(dependencies.MissingTaskDependencies, match="absent_runtime_dependency"):
+        dependencies.validate_task_dependencies(
+            "import absent_runtime_dependency\nraise RuntimeError('task executed')"
+        )
+
+
+def test_preflight_traverses_packaged_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
+    checked: list[str] = []
+
+    def present(name: str) -> bool:
+        checked.append(name)
+        return name != "desktop_env.evaluators"
+
+    monkeypatch.setattr(dependencies, "module_present", present)
+    with pytest.raises(dependencies.MissingTaskDependencies, match="desktop_env.evaluators"):
+        dependencies.validate_task_dependencies(
+            "from evaluation_examples.task_class.generated_task_utils import evaluate_metric"
+        )
+    assert "typing" in checked
+
+
+@pytest.mark.asyncio
+async def test_missing_helper_stops_before_provider_construction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, episode_id: str
+) -> None:
+    from lop_osworld_v2_adapter.adapter import OSWorldV2Adapter
+
+    from tests.unit.evaluation.adapters.osworld import fixtures
+    from tests.unit.evaluation.adapters.osworld.test_secrets_and_rescue import (
+        _AWS_SECRETS,
+        _prepared,
+        _reset,
+        _workspace,
+    )
+
+    workspace = _workspace(
+        tmp_path,
+        {"task_plain": fixtures.PLAIN + "\nimport absent_runtime_dependency\n"},
+        provider={"provider": "aws"},
+    )
+    adapter = OSWorldV2Adapter(workspace_root=workspace)
+    await _prepared(adapter, episode_id)
+
+    def forbidden() -> None:
+        pytest.fail("provider construction reached before packaging preflight")
+
+    monkeypatch.setattr(adapter, "_build_provider", forbidden)
+    with pytest.raises(dependencies.MissingTaskDependencies, match="absent_runtime_dependency"):
+        await adapter.reset_start(_reset(episode_id, "task_plain", tmp_path, _AWS_SECRETS))
+
+
+def test_optional_missing_dependencies_do_not_exclude_task() -> None:
+    dependencies.validate_task_dependencies(
+        "try:\n import absent_optional_dependency\nexcept ImportError:\n pass"
+    )

--- a/tests/unit/evaluation/adapters/osworld/test_dependencies.py
+++ b/tests/unit/evaluation/adapters/osworld/test_dependencies.py
@@ -100,6 +100,44 @@ def test_preflight_traverses_packaged_helpers(monkeypatch: pytest.MonkeyPatch) -
     assert "typing" in checked
 
 
+def _runtime_package(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    package = tmp_path / "desktop_env" / "evaluators"
+    package.mkdir(parents=True)
+    (package.parent / "__init__.py").write_text("raise RuntimeError('parent executed')")
+    (package / "__init__.py").write_text("raise RuntimeError('evaluators executed')")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    return package
+
+
+def test_runtime_from_imports_preserve_exports_and_reexports(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    package = _runtime_package(tmp_path, monkeypatch)
+    (package / "__init__.py").write_text(
+        "CONSTANT = 1\ndef function(): pass\nclass Class: pass\n"
+        "from .existing import exported\nfrom . import missing_module\n"
+        "raise RuntimeError('initializer executed')\n"
+    )
+    (package / "existing.py").write_text("exported = 1\n")
+    dependencies.validate_task_dependencies(
+        "from desktop_env.evaluators import CONSTANT, function, Class, exported"
+    )
+    with pytest.raises(dependencies.MissingTaskDependencies, match="evaluators.missing_module"):
+        dependencies.validate_task_dependencies("from desktop_env.evaluators import missing_module")
+
+
+def test_runtime_from_imports_keep_type_only_and_guarded_leaves_optional(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _runtime_package(tmp_path, monkeypatch)
+    dependencies.validate_task_dependencies(
+        "from typing import TYPE_CHECKING\n"
+        "if TYPE_CHECKING:\n from desktop_env.evaluators import absent_type\n"
+        "try:\n from desktop_env.evaluators import absent_optional\n"
+        "except ImportError:\n pass\n"
+    )
+
+
 @pytest.mark.asyncio
 async def test_missing_helper_stops_before_provider_construction(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, episode_id: str
@@ -114,9 +152,15 @@ async def test_missing_helper_stops_before_provider_construction(
         _workspace,
     )
 
+    package = _runtime_package(tmp_path, monkeypatch)
+    (package / "getters").mkdir()
+    (package / "getters/__init__.py").write_text("raise RuntimeError('getters executed')")
     workspace = _workspace(
         tmp_path,
-        {"task_plain": fixtures.PLAIN + "\nimport absent_runtime_dependency\n"},
+        {
+            "task_plain": fixtures.PLAIN
+            + "\nfrom evaluation_examples.task_class.generated_task_utils import call_metric\n"
+        },
         provider={"provider": "aws"},
     )
     adapter = OSWorldV2Adapter(workspace_root=workspace)
@@ -126,7 +170,9 @@ async def test_missing_helper_stops_before_provider_construction(
         pytest.fail("provider construction reached before packaging preflight")
 
     monkeypatch.setattr(adapter, "_build_provider", forbidden)
-    with pytest.raises(dependencies.MissingTaskDependencies, match="absent_runtime_dependency"):
+    with pytest.raises(
+        dependencies.MissingTaskDependencies, match="desktop_env.evaluators.metrics"
+    ):
         await adapter.reset_start(_reset(episode_id, "task_plain", tmp_path, _AWS_SECRETS))
 
 

--- a/tests/unit/evaluation/adapters/osworld/test_score_evidence.py
+++ b/tests/unit/evaluation/adapters/osworld/test_score_evidence.py
@@ -1,0 +1,245 @@
+"""Installed-wheel score boundary, real runner finalization and bundle verifier.
+
+The fake substitutes only evaluate()'s upstream source. In a copied interpreter
+we import the installed wheel (not the source conftest's path), run the real
+adapter through its normal prepare/reset/score surface, and inspect sealed bytes.
+No task answer or checkpoint fixture is tied to a benchmark task.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.unit.evaluation.adapters.osworld import fixtures, spawn_helpers
+
+
+@pytest.fixture(scope="module")
+def installed_python(tmp_path_factory: pytest.TempPathFactory) -> str:
+    root = tmp_path_factory.mktemp("score-evidence-install")
+    wheel = spawn_helpers.build_adapter_wheel(root / "wheel")
+    selector = spawn_helpers.build_spawnable_adapter(root, wheel, {"task_plain": fixtures.PLAIN})
+    return selector.python_executable
+
+
+def _raw(case: str) -> Any:
+    if case == "dict":
+        return {
+            "score": 0.5,
+            "safety": {"passed": False, "notes": ["synthetic audit"]},
+            "partial_scores": {"first": 1, "second": 0},
+            "evaluation_error": None,
+        }
+    if case == "missing-submission":
+        return {"score": 0, "evaluation_error": "no_submission"}
+    if case == "secret":
+        return {"score": 1, "safety": "score-detail-secret-canary-9827"}
+    if case == "nonfinite-detail":
+        return {"score": 1, "safety": float("nan")}
+    if case == "nonjson":
+        return {"score": 1, "safety": object()}
+    if case == "oversized":
+        return {"score": 1, "notes": "x" * (1024 * 1024 + 1)}
+    if case in {"missing-detail", "invalid-media", "publication-io", "receipt-io"}:
+        return 0.5
+    return {
+        "zero": 0.0,
+        "one": 1.0,
+        "fraction": 1 / 3,
+        "near-one": 0.9999999,
+        "invalid": "1.0",
+        "nonfinite": float("inf"),
+    }[case]
+
+
+async def _exercise(root: Path, case: str) -> dict[str, Any]:
+    # Deliberately local: pytest's source adapter conftest must never be loaded
+    # in this child. The installed package owns every adapter call below.
+    import lop_osworld_v2_adapter
+    from lop_osworld_v2_adapter.providers.fake import FakeProvider
+
+    from local_operator.evaluation.adapters.api import ScoreParams, ScoreResult
+    from local_operator.evaluation.evidence.models import (
+        EvidenceArtifactRef,
+        ScoreArtifact,
+        ScoringResultPayload,
+    )
+    from local_operator.evaluation.evidence.verify import verify_bundle
+    from local_operator.evaluation.receipts import RedactionSet
+    from local_operator.evaluation.runner.episode import EpisodeRunner
+    from tests.unit.evaluation.adapters.osworld.test_fake_end_to_end import (
+        _adapter,
+        _AdapterSupervisorShim,
+        _selector,
+        _spec_with_task,
+    )
+    from tests.unit.evaluation.runner.conftest import ScriptedModel, build_config
+
+    assert "site-packages" in str(lop_osworld_v2_adapter.__file__)
+    raw = _raw(case)
+    provider = FakeProvider(scripted_score=raw)
+    adapter = _adapter(root, provider)
+    selector = _selector(root, adapter._workspace_root, adapter)
+    shim = _AdapterSupervisorShim(adapter, selector)
+    rescued: list[bool] = []
+
+    async def rescue(*args: Any, **kwargs: Any) -> Any:
+        # The production failure path must invoke resource recovery even if
+        # details fail after evaluate(). No cloud resource is created here.
+        rescued.append(True)
+        from types import SimpleNamespace
+
+        return SimpleNamespace(complete=True)
+
+    model = ScriptedModel(["finish"])
+    runner = EpisodeRunner(
+        _spec_with_task("ep-score-evidence"),
+        build_config(root),
+        selector=selector,
+        model=model,
+        launch=lambda _: shim,
+        rescue=rescue,
+        redactions=RedactionSet.from_resolved_values(("score-detail-secret-canary-9827",)),
+    )
+    original_score = adapter.score
+
+    async def damaged_score(params: ScoreParams) -> ScoreResult:
+        result = await original_score(params)
+        ref = result.score.details
+        assert ref is not None and adapter._artifact_root is not None
+        path = adapter._artifact_root / ref.sha256
+        if case == "missing-detail":
+            path.unlink()
+        elif case == "invalid-media":
+            data = b"not-json"
+            path = adapter._artifact_root / hashlib.sha256(data).hexdigest()
+            path.write_bytes(data)
+            result = ScoreResult(
+                score=ScoreArtifact(
+                    status="scored",
+                    binary=0,
+                    details=EvidenceArtifactRef(
+                        sha256=path.name, media_type="application/json", byte_count=len(data)
+                    ),
+                )
+            )
+        elif case in {"publication-io", "receipt-io"}:
+            from tests.unit.evaluation.evidence.test_store import _OSCallsForTest
+
+            class FailingCalls(_OSCallsForTest):
+                calls = 0
+
+                def fsync(self, fd: int) -> None:
+                    self.calls += 1
+                    # Temp file, artifact directory, then the scoring receipt.
+                    if self.calls == (1 if case == "publication-io" else 3):
+                        raise OSError("synthetic-score-detail-io")
+                    super().fsync(fd)
+
+            assert runner._writer is not None
+            runner._writer._calls = FailingCalls()
+        return result
+
+    if case in {"missing-detail", "invalid-media", "publication-io", "receipt-io"}:
+        adapter.score = damaged_score
+    outcome = await runner.run()
+    assert provider.evaluate_calls == 1
+    assert model.calls == 1
+    assert "synthetic audit" not in repr(model.histories)
+    assert "score-detail-secret-canary-9827" not in repr(model.histories)
+    assert shim.terminated
+    assert outcome.bundle_root is not None
+    report = verify_bundle(outcome.bundle_root)
+    accepted = case in {"zero", "one", "fraction", "near-one", "dict", "missing-submission"}
+    if accepted:
+        assert outcome.status == "completed", outcome.diagnostic
+        assert report.valid, [issue.code for issue in report.issues]
+        score = outcome.score
+        assert score is not None and score.details is not None
+        data = (outcome.bundle_root / "artifacts" / score.details.sha256).read_bytes()
+        assert json.loads(data) == raw
+        assert hashlib.sha256(data).hexdigest() == score.details.sha256
+        assert len(data) == score.details.byte_count
+        assert report.outcome is not None and report.outcome.result == score
+        receipts = [e.payload for e in report.events if isinstance(e.payload, ScoringResultPayload)]
+        assert len(receipts) == 1 and receipts[0].score == score
+        value = raw["score"] if isinstance(raw, dict) else raw
+        assert score.binary == int(value == 1)
+        assert score.partial_ppm == round(value * 1_000_000)
+        assert provider.terminated_refs == ["lop-ep-ep-score-evidence"]
+        return {
+            "case": case,
+            "status": outcome.status,
+            "binary": score.binary,
+            "partial_ppm": score.partial_ppm,
+            "details_preserved": True,
+            "verified": report.valid,
+            "evaluate_calls": provider.evaluate_calls,
+        }
+    assert outcome.score is None and outcome.status != "completed"
+    assert rescued, "detail rejection bypassed resource rescue"
+    if case != "receipt-io":
+        assert not any(isinstance(e.payload, ScoringResultPayload) for e in report.events)
+    assert report.outcome is None
+    # Staging is untrusted adapter output, not a sealed artifact. The writer
+    # must not copy a secret into its bundle or expose it in outcome diagnostics.
+    canary = b"score-detail-secret-canary-9827"
+    assert canary not in (outcome.diagnostic or "").encode()
+    for path in outcome.bundle_root.rglob("*"):
+        if path.is_file():
+            assert canary not in path.read_bytes()
+    return {
+        "case": case,
+        "status": outcome.status,
+        "score": None,
+        "rescued": True,
+        "evaluate_calls": provider.evaluate_calls,
+    }
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "zero",
+        "one",
+        "fraction",
+        "near-one",
+        "dict",
+        "missing-submission",
+        "invalid",
+        "nonfinite",
+        "nonfinite-detail",
+        "nonjson",
+        "oversized",
+        "secret",
+        "missing-detail",
+        "invalid-media",
+        "publication-io",
+        "receipt-io",
+    ],
+)
+def test_installed_score_evidence(installed_python: str, tmp_path: Path, case: str) -> None:
+    result = subprocess.run(
+        [
+            installed_python,
+            "-c",
+            "import asyncio,json,sys; from pathlib import Path; "
+            "from tests.unit.evaluation.adapters.osworld.test_score_evidence import _exercise; "
+            "print(json.dumps(asyncio.run(_exercise(Path(sys.argv[1]),sys.argv[2]))))",
+            str(tmp_path),
+            case,
+        ],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    summary = json.loads(result.stdout.splitlines()[-1])
+    assert summary["evaluate_calls"] == 1
+    print(json.dumps(summary, sort_keys=True))

--- a/tests/unit/evaluation/adapters/osworld/test_scoring.py
+++ b/tests/unit/evaluation/adapters/osworld/test_scoring.py
@@ -8,62 +8,112 @@ or zero artifact.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from lop_osworld_v2_adapter import scoring
 from lop_osworld_v2_adapter.scoring import ScoringProtocolError
 
 
-def test_zero_maps_to_binary_zero() -> None:
-    artifact = scoring.score_to_artifact(0.0)
+def test_zero_maps_to_binary_zero(tmp_path: Path) -> None:
+    artifact = scoring.score_to_artifact(0.0, artifact_root=tmp_path)
     assert artifact.status == "scored"
     assert artifact.binary == 0
 
 
-def test_one_maps_to_binary_one() -> None:
-    artifact = scoring.score_to_artifact(1.0)
+def test_one_maps_to_binary_one(tmp_path: Path) -> None:
+    artifact = scoring.score_to_artifact(1.0, artifact_root=tmp_path)
     assert artifact.status == "scored"
     assert artifact.binary == 1
+    assert artifact.partial_ppm == 1_000_000
 
 
-def test_a_fraction_maps_to_partial_ppm() -> None:
-    artifact = scoring.score_to_artifact(0.5)
+def test_a_fraction_maps_to_partial_ppm(tmp_path: Path) -> None:
+    artifact = scoring.score_to_artifact(0.5, artifact_root=tmp_path)
     assert artifact.status == "scored"
     assert artifact.partial_ppm == 500_000
-    assert artifact.binary is None
+    assert artifact.binary == 0
 
 
-def test_partial_ppm_is_an_exact_integer() -> None:
-    artifact = scoring.score_to_artifact(1 / 3)
+def test_partial_ppm_is_an_exact_integer(tmp_path: Path) -> None:
+    artifact = scoring.score_to_artifact(1 / 3, artifact_root=tmp_path)
     assert artifact.partial_ppm == round((1 / 3) * 1_000_000)
 
 
-def test_a_v2_dict_result_is_unwrapped() -> None:
-    artifact = scoring.score_to_artifact({"score": 1.0})
+def test_a_v2_dict_result_is_unwrapped(tmp_path: Path) -> None:
+    artifact = scoring.score_to_artifact({"score": 1.0}, artifact_root=tmp_path)
     assert artifact.binary == 1
 
 
-def test_nan_raises() -> None:
+def test_nan_raises(tmp_path: Path) -> None:
     with pytest.raises(ScoringProtocolError):
-        scoring.score_to_artifact(float("nan"))
+        scoring.score_to_artifact(float("nan"), artifact_root=tmp_path)
 
 
-def test_out_of_range_raises() -> None:
+def test_out_of_range_raises(tmp_path: Path) -> None:
     with pytest.raises(ScoringProtocolError):
-        scoring.score_to_artifact(2.0)
+        scoring.score_to_artifact(2.0, artifact_root=tmp_path)
     with pytest.raises(ScoringProtocolError):
-        scoring.score_to_artifact(-0.1)
+        scoring.score_to_artifact(-0.1, artifact_root=tmp_path)
 
 
-def test_non_numeric_raises() -> None:
+def test_non_numeric_raises(tmp_path: Path) -> None:
     with pytest.raises(ScoringProtocolError):
-        scoring.score_to_artifact("1.0")
+        scoring.score_to_artifact("1.0", artifact_root=tmp_path)
 
 
-def test_a_dict_without_a_score_raises() -> None:
+def test_a_dict_without_a_score_raises(tmp_path: Path) -> None:
     with pytest.raises(ScoringProtocolError):
-        scoring.score_to_artifact({"result": 1.0})
+        scoring.score_to_artifact({"result": 1.0}, artifact_root=tmp_path)
 
 
-def test_none_raises() -> None:
+def test_none_raises(tmp_path: Path) -> None:
     with pytest.raises(ScoringProtocolError):
-        scoring.score_to_artifact(None)
+        scoring.score_to_artifact(None, artifact_root=tmp_path)
+
+
+@pytest.mark.parametrize(
+    "case", ["nodes", "depth", "cycle", "utf8", "unicode-size", "keys", "tuple"]
+)
+def test_details_fail_closed_without_partial_files(tmp_path: Path, case: str) -> None:
+    from typing import Any
+
+    detail: Any = None
+    if case == "nodes":
+        detail = [0] * scoring.MAX_SCORE_DETAIL_NODES
+    elif case in ("depth", "cycle"):
+        detail = []
+        if case == "cycle":
+            detail.append(detail)
+        else:
+            for _ in range(scoring.MAX_SCORE_DETAIL_DEPTH + 1):
+                detail = [detail]
+    elif case == "utf8":
+        detail = "\ud800"
+    elif case == "unicode-size":
+        detail = "é" * (scoring.MAX_SCORE_DETAIL_BYTES // 2)
+    elif case == "keys":
+        detail = {1: "coercion would lose type"}
+    else:
+        detail = (1, 2)
+    with pytest.raises(ScoringProtocolError):
+        scoring.score_to_artifact({"score": 1, "detail": detail}, artifact_root=tmp_path)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_near_completion_is_not_promoted_by_ppm_rounding(tmp_path: Path) -> None:
+    artifact = scoring.score_to_artifact(0.9999999, artifact_root=tmp_path)
+    assert artifact.binary == 0
+    assert artifact.partial_ppm == 1_000_000
+
+
+def test_detail_byte_limit_is_exact_not_truncation(tmp_path: Path) -> None:
+    overhead = len(scoring._detail_bytes({"score": 1, "note": ""}))
+    raw = {"score": 1, "note": "x" * (scoring.MAX_SCORE_DETAIL_BYTES - overhead)}
+    artifact = scoring.score_to_artifact(raw, artifact_root=tmp_path)
+    assert artifact.details is not None
+    assert artifact.details.byte_count == scoring.MAX_SCORE_DETAIL_BYTES
+    raw["note"] += "x"
+    with pytest.raises(ScoringProtocolError):
+        scoring.score_to_artifact(raw, artifact_root=tmp_path)
+    assert len(list(tmp_path.iterdir())) == 1

--- a/tests/unit/evaluation/adapters/osworld/test_spawn.py
+++ b/tests/unit/evaluation/adapters/osworld/test_spawn.py
@@ -72,6 +72,50 @@ def _spec_for_spawn(episode_id: str) -> Any:
     return spec
 
 
+def test_helper_wheel_record_and_lazy_startup(tmp_path: Path, adapter_wheel: Path) -> None:
+    import subprocess
+
+    selector = spawn_helpers.build_spawnable_adapter(tmp_path, adapter_wheel, _TASKS)
+    result = subprocess.run(
+        [
+            selector.python_executable,
+            "-I",
+            "-B",
+            "-c",
+            """
+import sys
+from pathlib import Path
+from importlib.metadata import distribution
+import local_operator.cli
+import lop_osworld_v2_adapter
+assert not any(name.startswith(('desktop_env', 'evaluation_examples')) for name in sys.modules)
+assert 'lop_osworld_v2_adapter.dependencies' not in sys.modules
+from local_operator.evaluation.adapters.discovery import distribution_digest, AdapterDiscoveryError
+dist = distribution('lop-osworld-v2-adapter')
+digest = distribution_digest(dist)
+helper = Path(str(dist.locate_file('evaluation_examples/task_class/generated_task_utils.py')))
+original = helper.read_bytes()
+try:
+    helper.write_bytes(original + b'\\n# tamper\\n')
+    try:
+        distribution_digest(dist)
+    except AdapterDiscoveryError:
+        print('helper mutation refused; startup imported no task/runtime helpers')
+    else:
+        raise AssertionError('unattested helper bytes were accepted')
+finally:
+    helper.write_bytes(original)
+assert distribution_digest(dist) == digest
+""",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "helper mutation refused" in result.stdout
+
+
 @pytest.mark.asyncio
 async def test_real_wheel_handshakes_and_reaps(tmp_path: Path, adapter_wheel: Path) -> None:
     selector = spawn_helpers.build_spawnable_adapter(tmp_path, adapter_wheel, _TASKS)

--- a/tests/unit/evaluation/evidence/test_score_details.py
+++ b/tests/unit/evaluation/evidence/test_score_details.py
@@ -1,0 +1,194 @@
+"""Only the active scoring receipt may publish artifacts during finalization."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from local_operator.evaluation.evidence.models import (
+    EvidenceArtifactRef,
+    FinalizationIntent,
+    LifecycleTransitionPayload,
+    ScoreArtifact,
+    ScoringResultPayload,
+)
+from local_operator.evaluation.evidence.store import (
+    EvidenceBundleInvalid,
+    EvidenceRecoveryOnly,
+    EvidenceTerminal,
+    EvidenceWriter,
+)
+from local_operator.evaluation.evidence.verify import verify_bundle
+from local_operator.evaluation.receipts import RedactionSet
+from tests.unit.evaluation.evidence.test_finalization import (
+    _append_final_receipts,
+    _append_provenance,
+    _draft,
+)
+from tests.unit.evaluation.evidence.test_models import DIGEST, OTHER_DIGEST, manifest
+from tests.unit.evaluation.evidence.test_store import _OSCallsForTest
+
+
+def _payload(data: bytes, *, media_type: str = "application/json") -> ScoringResultPayload:
+    return ScoringResultPayload(
+        finalization_id="final",
+        scoring_operation_id="score-op",
+        score=ScoreArtifact(
+            status="scored",
+            binary=0,
+            partial_ppm=500_000,
+            details=EvidenceArtifactRef(
+                sha256=hashlib.sha256(data).hexdigest(), media_type=media_type, byte_count=len(data)
+            ),
+        ),
+    )
+
+
+def _complete(writer: EvidenceWriter, score: ScoreArtifact) -> None:
+    writer.record_final_lifecycle(
+        LifecycleTransitionPayload(
+            previous_state_id=None,
+            state_id=OTHER_DIGEST,
+            state="completed",
+            finalization_id="final",
+            preflight_seal_id=DIGEST,
+            commitment_id=OTHER_DIGEST,
+            reconciliation_id=DIGEST,
+            reconciliation_reportable=True,
+            score_id=score.score_id,
+            cleanup_result_id=OTHER_DIGEST,
+            rescue_required=False,
+        ),
+        monotonic_ns=7,
+        wall_time_ms=7,
+    )
+
+
+def _begin(writer: EvidenceWriter) -> None:
+    _append_provenance(writer)
+    writer.begin_finalization(
+        "final",
+        "score-op",
+        FinalizationIntent(kind="score", scorer_id="scorer", scorer_version="1"),
+        monotonic_ns=3,
+        wall_time_ms=3,
+    )
+
+
+def test_scoring_detail_seals_unchanged_and_only_once(tmp_path: Path) -> None:
+    root = tmp_path / "bundle"
+    data = b'{"score":0.5,"summary":[true,false]}'
+    payload = _payload(data)
+    with EvidenceWriter.create(root, manifest(), RedactionSet.from_resolved_values(())) as writer:
+        _begin(writer)
+        with pytest.raises(EvidenceTerminal):
+            writer.publish_artifact(data, media_type="application/json")
+        writer.record_scoring_result(payload, details_source=data, monotonic_ns=4, wall_time_ms=4)
+        with pytest.raises(EvidenceTerminal):
+            writer.record_scoring_result(payload, details_source=data)
+        _append_final_receipts(writer, monotonic_ns=5, wall_time_ms=5)
+        _complete(writer, payload.score)
+        writer.seal(_draft(payload.score))
+    report = verify_bundle(root)
+    assert report.valid, [i.code for i in report.issues]
+    assert report.outcome is not None and report.outcome.result == payload.score
+    assert payload.score.details is not None
+    assert (root / "artifacts" / payload.score.details.sha256).read_bytes() == data
+
+
+@pytest.mark.parametrize("case", ["digest", "count", "media", "secret", "operation", "no-ref"])
+def test_detail_rejection_is_nonmutating_and_retryable(tmp_path: Path, case: str) -> None:
+    root = tmp_path / "bundle"
+    data = b'{"score":0.5}'
+    payload = _payload(data)
+    source = data
+    if case == "digest":
+        source = b'{"score":0.6}'
+    elif case == "count":
+        ref = payload.score.details
+        assert ref is not None
+        score = ScoreArtifact(
+            status="scored",
+            binary=0,
+            details=EvidenceArtifactRef(
+                sha256=ref.sha256, media_type=ref.media_type, byte_count=len(data) + 1
+            ),
+        )
+        payload = ScoringResultPayload(
+            finalization_id="final", scoring_operation_id="score-op", score=score
+        )
+    elif case == "media":
+        source = b"not-json"
+        payload = _payload(source)
+    elif case == "secret":
+        source = b'{"secret":"canary-score-evidence-47329"}'
+        payload = _payload(source)
+    elif case == "operation":
+        payload = payload.model_copy(update={"scoring_operation_id": "wrong-op"})
+    elif case == "no-ref":
+        payload = ScoringResultPayload(
+            finalization_id="final",
+            scoring_operation_id="score-op",
+            score=ScoreArtifact(status="scored", binary=0),
+        )
+    redactions = RedactionSet.from_resolved_values(("canary-score-evidence-47329",))
+    with EvidenceWriter.create(root, manifest(), redactions) as writer:
+        _begin(writer)
+        before = (root / "events.jsonl").read_bytes()
+        with pytest.raises(EvidenceBundleInvalid):
+            writer.record_scoring_result(payload, details_source=source)
+        assert (root / "events.jsonl").read_bytes() == before
+        assert list((root / "artifacts").iterdir()) == []
+        # Retrying publication is safe after a deterministic rejection; it does
+        # not rerun the external evaluator or mint a second scoring operation.
+        writer.record_scoring_result(_payload(data), details_source=data)
+        assert verify_bundle(root).valid
+
+
+def test_missing_details_cannot_seal(tmp_path: Path) -> None:
+    root = tmp_path / "bundle"
+    payload = _payload(b'{"score":0.5}')
+    with EvidenceWriter.create(root, manifest(), RedactionSet.from_resolved_values(())) as writer:
+        _begin(writer)
+        # Compatibility: callers may still prepublish while open. A ref alone
+        # is not proof of those bytes, and the independent seal gate catches it.
+        writer.record_scoring_result(payload, monotonic_ns=4, wall_time_ms=4)
+        _append_final_receipts(writer, monotonic_ns=5, wall_time_ms=5)
+        _complete(writer, payload.score)
+        with pytest.raises(EvidenceBundleInvalid):
+            writer.seal(_draft(payload.score))
+    assert not verify_bundle(root).valid
+
+
+@pytest.mark.parametrize("cutpoint", [1, 2, 3])
+def test_score_publication_fsync_cutpoints_are_recovery_only(tmp_path: Path, cutpoint: int) -> None:
+    class CutpointCalls(_OSCallsForTest):
+        armed = False
+        calls = 0
+
+        def fsync(self, fd: int) -> None:
+            if self.armed:
+                self.calls += 1
+                if self.calls == cutpoint:
+                    raise OSError("score-detail-cutpoint")
+            super().fsync(fd)
+
+    calls = CutpointCalls()
+    root = tmp_path / "bundle"
+    data = b'{"score":0.5}'
+    payload = _payload(data)
+    with EvidenceWriter.create(
+        root, manifest(), RedactionSet.from_resolved_values(()), syscalls=calls
+    ) as writer:
+        _begin(writer)
+        calls.armed = True
+        with pytest.raises(OSError, match="score-detail-cutpoint"):
+            writer.record_scoring_result(payload, details_source=data)
+        assert calls.calls == cutpoint
+        with pytest.raises(EvidenceRecoveryOnly):
+            writer.record_scoring_result(payload, details_source=data)
+        with pytest.raises(EvidenceRecoveryOnly):
+            writer.seal(_draft(payload.score))
+    assert not (root / "outcome.json").exists()


### PR DESCRIPTION
## Summary of Changes

Repair the expanded OSWorld pilot apparatus before any more model/cloud spending. This PR does not change models, prompts, task selection, upstream evaluator semantics, or benchmark success claims.

**Draft blocked by one CI test failure. Independent agent review round 2 is clean and TERMINAL on current head `743b014f2c68fe019477c8da09022e9c6605a058`; its author acknowledgement is recorded.** The single local whole-suite run timed out at the controller's 1800-second limit, ending at 91% without a pytest summary. It is not claimed green and was not restarted. No merge or release is requested.

- Package the omitted upstream runtime helper closure under its real `evaluation_examples` namespace inside the adapter wheel. Preserve the three exact pinned git objects, SHA-256 provenance and Apache license; the adapter RECORD/package digest covers them.
- Check mandatory task/helper import presence before constructing or allocating an AWS provider. Parse ASTs and resolve module files without executing tasks or parent-package initializers; skip type-only and guarded optional imports. No normal CLI/TUI startup scans.
- Preserve upstream evaluation returns as bounded canonical JSON in `score.details`, retaining returned safety/checkpoint/error fields; record binary completion separately from rounded partial reward.
- Publish validated score details through the generic runner/writer finalization boundary before the exactly-once scoring receipt. Missing, malformed, secret-bearing, or failed-publication details trigger rescue and remain unsealed; no schema change or second evaluate call.
- Record the frozen matched-model pilot, benchmark reference caveats, pre-model failure and offline coverage in `MODEL_PILOT.md`.

## Related Issue(s) / delivery contract

**C2 standard/pre-authorized** bounded apparatus correction, requested directly; this PR is the change record. No new tracker was requested.

Acceptance:
1. Reproduce the actual task 010 missing-namespace failure in an isolated import subprocess, then make the same real path succeed with a newly built wheel in a separate isolated environment.
2. Audit imports across all 108 pinned tasks plus the runtime helper closure, without calling task setup/evaluate or putting task answers into actor context. Missing mandatory packaged dependencies must be caught before VM allocation.
3. Preserve upstream helper bytes, licensing, RECORD/source hash coverage, copied-interpreter isolation, existing immutable workspaces, inputs and evidence. Do not use ambient `sys.path`/`PYTHONPATH` aliases.
4. Keep normal startup free of task/dependency imports and scans; validate relevant tests and whole-tree static gates at CI pins.
5. Preserve raw scoring output in a hash-verified sealed bundle, with binary completion based only on exact raw 1.0; fractional rounding must never promote completion. Scoring remains exactly-once, details never enter model context, ordinary artifact writes stay closed in finalization, and failed publication is not a valid seal.

Non-goals: paid model/VM runs, changing upstream evaluator semantics, task-specific fixes, new action capabilities, leaderboard claims, cleanup of existing files, human reviewers, merging or releasing.

## Impact / risk / rollback

The adapter gains one upstream helper package that upstream OSWorld intentionally excluded from its wheel even though release tasks depend on it. It contains **no gated task classes**. The adapter version remains 0.1.1; the changed package/workspace digests, not the version string, identify the artifact. Build a new isolated environment and selector; never replace an environment referenced by historical evidence.

The check is deliberately a static presence check, not a Python execution/evaluator correctness guarantee. Third-party dynamic aliases are checked by import root; upstream file namespaces are checked through the module path. `torch` and `lpips` in task 057 retain upstream's explicit optional fallback rather than forcing heavyweight installation or exclusion.

Rollback is selecting the prior immutable environment/workspace; preserve its known expanded-task packaging limitation. Packaging validation used released harness 0.46.21; building the adapter alone did not require publishing Local Operator.

## Testing Details

### Actual failure and same-path success (no AWS or model calls)

Before: the original installed interpreter, `-I -B`, an empty environment plus inert import-time controller facts, calling:

```python
from lop_osworld_v2_adapter.vendor_bridge import instantiate_task
instantiate_task("<existing-workspace>/tasks/task_010.py", "task_010")
```

Actual exit **1**:

```text
vendor_bridge.py:148 -> spec.loader.exec_module(module)
task_010.py:13 -> from evaluation_examples.task_class.generated_task_utils import ...
ModuleNotFoundError: No module named 'evaluation_examples'
```

After: same call in a freshly created copied-interpreter venv, frozen OSWorld dependency rows plus explicitly selected released `local-operator==0.46.21`, newly built adapter wheel: actual exit **0**, class `Task010`. No task setup/evaluate was invoked.

### Complete bounded offline import census

A separate `-I -B` subprocess AST-parsed all 108 pinned task files, validated helper closure, then loaded each module via `spec_from_file_location`/`exec_module`. It did not instantiate task classes or call setup/evaluate. An audit hook denied `socket.connect`, `socket.getaddrinfo`, `subprocess.Popen`, and `os.system`; import-time controller settings were inert and no credentials were supplied.

```json
{"tasks":108,"required_modules":94,"missing_required":[],"missing_optional":{"lpips":["task_057.py"],"torch":["task_057.py"]},"static_seconds":0.981}
{"loaded_modules":108,"total_seconds":6.795,"task_setup_evaluate_calls":0,"network_process_execution":"prohibited"}
```

The helper is required by 16 tasks: 002, 003, 004, 006, 010, 015, 017, 018, 024, 027, 032, 034, 091, 092, 093, 098. Source commit `d578d2d4e0dc82b43e270fdaa7fa89d9708cd154`; helper SHA-256 `cf0945bc4cd15253631f41dfcd96ca0874116523f07fc34989cce2f23df1bbb0`. Both package initializers are the upstream empty files.

### Isolation, integrity and regression evidence

- Real built-wheel regression mutates the installed helper in a test-owned interpreter: `distribution_digest` refuses it; restoring bytes restores the original digest.
- Provider-boundary regression raises `MissingTaskDependencies` before provider construction for a missing mandatory import.
- AST tests cover type-only imports, guarded optional dependencies, mandatory runtime imports, helper-transitive dependencies, stdlib, and a parent package that raises if executed.
- Actual `lop --help` path exited 0; `sys.modules` contained no adapter, dependency census, `desktop_env`, or `evaluation_examples` imports.
- New immutable workspace build verified all 108 task hashes, release manifest, prepared commit and assets manifest revision; installed wheel inspection confirmed three exact helper files and zero gated task files.
- Packaging-stage adapter suite: `python -m pytest tests/unit/evaluation/adapters/osworld -n2 -q` → **276 passed in 58.18s**.
- Whole-tree static checks: flake8; Black **26.1.0**; isort **5.13.2**; pyright **1.1.411** → all direct exit **0**. Vendored source is excluded from rewriting/type inference to preserve exact upstream bytes; its pin/hash contract is tested instead.

### Integrated installed harness + adapter evidence

Both actual development wheels were built and installed non-editably into the private isolated worker. All **16** installed combined runner/adapter scenarios passed with network/process execution denied. Test-support code was also installed as a separate noneditable proof-only wheel, not supplied by ambient source paths.

- Zero/full/fraction/near-one/dictionary/missing-submission results completed with valid verified bundles and byte-preserved raw JSON details. Near-one: `binary=0`, `partial_ppm=1000000`, proving rounding does not promote binary completion.
- Invalid/nonfinite/non-JSON/oversized/secret/missing/invalid-media cases returned no score, abandoned and invoked rescue. Artifact/receipt fsync failure returned `abandonment_failed`, unsealed with rescue attempted.
- Every scenario called the evaluator exactly once; details/secret canaries were absent from model histories and secret-bearing output was absent from bundle bytes and diagnostics.
- The final combined wheels again loaded **108/108** task modules, with no missing mandatory census module paths, in 14.139 seconds under concurrent suite load (static check: 2.296 seconds).
- Integrated whole-tree flake8, Black 26.1.0, isort 5.13.2 and pyright 1.1.411 passed with direct exit 0. Generated root wheel staging initially caused duplicate nominal types in pyright; moving that task-owned generated directory out of the source scan fixed it without changing source or gates.

**One local whole-suite attempt:** `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest -n2 -q` reached its 1800-second controller limit. Its log stops at 91%, without a pytest summary or successful pytest exit code. It is incomplete, not green, and was not restarted.

**Current-head CI is terminal: one failed test shard.** [Run 33942808052](https://github.com/damianvtran/local-operator/actions/runs/33942808052) passed lint, types, pip-audit, all four other test shards, and both macOS/Linux TUI-e2e jobs. Shard 1 exited **1** with:

```text
FAILED tests/unit/tui/test_word_caret.py::test_real_teardown_settles_a_held_escape_and_leaks_no_callback
KeyError: "No 'text-area--gutter' key in COMPONENT_CLASSES"
1 failed, 3506 passed, 1 skipped, 161 warnings in 843.53s
```

The TUI file is not changed by this PR. That is not proof the failure is harmless or flaky: no such claim is made, and no unrelated source fix, local rerun or repeated full suite was performed. The PR remains draft, not green/ready. Coverage/CLI/server follow-on jobs were skipped.

### Review remediation and final artifacts

Round 1 identified one major dependency-check gap: a `from desktop_env.evaluators import metrics` import only checked its parent package. Commit `743b014f` resolves child modules versus ordinary exported values and explicit re-export providers by parsing pinned initializer declarations, never executing them. The exact installed task-010 missing-metrics probe now rejects admission. Synthetic adapter regression proves rejection before provider construction; type-only and optional behavior is preserved. **15 focused remediation tests passed**, all four CI-pinned whole-tree static gates exited **0**, and installed corpus loading again passed **108/108**. The unchanged scoring/finalization surfaces retain round 1's approval.

- [Round 1 and F1](https://github.com/damianvtran/local-operator/pull/640#issuecomment-5549084969)
- [Round 1 remediation](https://github.com/damianvtran/local-operator/pull/640#issuecomment-5549142381)
- [Clean TERMINAL round 2](https://github.com/damianvtran/local-operator/pull/640#issuecomment-5549168677)
- [Round 2 author acknowledgement](https://github.com/damianvtran/local-operator/pull/640#issuecomment-5549181445)

Both final development wheels were built at `743b014f2c68fe019477c8da09022e9c6605a058` and installed in the retained private environment. All **356 committed Python modules** were compared with their installed bytes and matched. No version bump or publication was used.

| Artifact | SHA-256 |
| --- | --- |
| `local_operator-0.46.22-py3-none-any.whl` | `4e3dd7fedbd0e16fefc7ed1b08bc5ef979ae618c0ba03379a8d4dfd3afb12522` |
| `lop_osworld_v2_adapter-0.1.1-py3-none-any.whl` | `3b7a19c1d93d3031c6c319afb14a252abde5749953ccbdec7b1aaf00a97379c3` |

The files, `build-manifest.json`, and complete no-install selector/build recipe are retained under:
`~/worktrees/lop-task-packaging/.venv/pilot-artifacts/743b014f2c68fe019477c8da09022e9c6605a058/` (`USE-EXISTING-RUNTIME.md`).

### Frozen experimental runtime, no new installation

Disk headroom fell below the 20 GiB pilot threshold. The parent selected the already-installed proof environment rather than allocating another dependency venv; it is now frozen and will not be mutated. It additionally contains explicitly installed noneditable proof test support and pytest, not an ambient checkout alias. The original benchmark `venvs/0.1.1` and all prior evidence remain untouched.

```sh
SRC="$HOME/worktrees/lop-task-packaging"
PY="$SRC/.venv/packaging-proof/venv/bin/python3.12"
SEL="$SRC/.venv/packaging-proof/installed-final/selector.json"
PLAN="$SRC/.venv/packaging-proof/installed-final/pilot-plan.json"
test "$(git -C "$SRC" rev-parse HEAD)" = 743b014f2c68fe019477c8da09022e9c6605a058
# Parent supplies frozen arm settings only after review/CI and disk checks:
# "$PY" -I -B "$SRC/scripts/run_episode.py" --selector "$SEL" ...
```

The copied interpreter is regular with nlink=1. The selector, workspace, copied real plan and build-provenance record are immutable. The plan hash is `46fa017a488a02f00cbea4d70b94cc0600dcb686aeba66039e7c1298f7734f2a`; source/wheel/lock/script hashes and all selector digests are recorded in `installed-final/build-provenance.json`. No paid/cloud episode was performed for this change.

## Checklist

- [x] Followed repository conventions and self-reviewed the packaging diff.
- [x] Added regression tests and real isolated failure/success evidence.
- [x] Updated setup and apparatus documentation.
- [x] Preserved existing data, installed benchmark environment and evidence.
- [x] No AWS writes, paid model calls, human reviewers, merge or release.
- [x] Integrated installed-path tests, focused remediation tests and static gates recorded; local whole-suite timeout disclosed.
- [x] Independent agent review rounds recorded and answered, clean on current head.
- [ ] Current-head CI green: **blocked** by the unmodified TUI teardown test failure recorded above.
