### PR TITLE
fix(providers): re-ask a model id the gateway has served when it says the id is unknown

### DIFF
--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -269,7 +269,11 @@ _MODEL_ROUTING_FLAP_MARKERS = (
     "is not a valid model id",
     "is not a valid model",
     "model not found",
-    "no endpoints found",
+    # OpenRouter's routing 404. Anchored with "for" so the deterministic
+    # per-request variants ("No endpoints found that support tool use",
+    # "...matching your data policy") — which describe OUR request and will
+    # 404 identically on every re-ask — stay request defects (review R3).
+    "no endpoints found for",
     "model is not available",
     "the model does not exist",
 )
@@ -2809,6 +2813,11 @@ async def stream_with_failover(
                     continue
                 if (
                     retry.enabled
+                    # Only the request KIND: a relayed 404 that clients.py has
+                    # already reclassified transient owns the transport retry
+                    # ladder below, and letting it through here as well would
+                    # spend both budgets on one failure (review R2).
+                    and exc.kind == "request"
                     and is_model_routing_flap(exc, spec)
                     and model_flap_retries < MAX_MODEL_FLAP_RETRIES
                 ):

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -250,6 +250,80 @@ _FAST_MODE_REFUSAL_MARKERS = (
 )
 
 
+#: Bodies a gateway sends when its model ROUTING table momentarily lacks an
+#: id it serves — observed as OpenRouter answering ``400: qwen/qwen3.8-max is
+#: not a valid model ID`` on the 97th request of a session whose previous 96
+#: it had served on that exact id, and serving it again seconds later. By
+#: status alone this is ``kind="request"``: deterministic, abort the turn, do
+#: not walk the chain — and ``_relayed_upstream_failure`` deliberately leaves
+#: the aggregator's own FLAT refusals there, on the reasoning that a body
+#: naming the problem is actionable. That reasoning holds for an id that has
+#: never worked; it does not hold for an id that served a moment ago, which
+#: is the evidence the driver has and the aggregator's wording lacks. So the
+#: words select the CANDIDATE and :data:`_SERVED_SELECTORS` supplies the
+#: proof; neither alone reclassifies anything. Anchored on unknown-model
+#: phrasing, never on a bare "invalid"/"not found" (a 400 about an invalid
+#: PARAMETER must stay a request defect). omp carries the same reroll for the
+#: same reason (``isCopilotTransientModelError``).
+_MODEL_ROUTING_FLAP_MARKERS = (
+    "is not a valid model id",
+    "is not a valid model",
+    "model not found",
+    "no endpoints found",
+    "model is not available",
+    "the model does not exist",
+)
+
+#: In-place re-asks a model-routing flap earns on the SAME credential before
+#: the turn takes the ordinary request-defect path. A flap clears in seconds
+#: (it did live: three probes 200'd within a minute of the 400), and a
+#: catalogue that has genuinely dropped the id fails identically on every
+#: retry, so the budget is small and flat: the cost of being wrong is
+#: ``MAX_MODEL_FLAP_RETRIES`` cheap 400s, the cost of not trying was a
+#: 75-minute sentinel pass dying with its root cause established and nothing
+#: written.
+MAX_MODEL_FLAP_RETRIES = 3
+MODEL_FLAP_RETRY_DELAY_MS = 2_000
+
+#: ``provider/model-id`` selectors that have served at least one request in
+#: THIS process. The evidence that turns an unknown-model 4xx from "your id
+#: is wrong" into "the catalogue blinked": an id that answered 200 earlier
+#: cannot have been invalid, so a later refusal of the same id is the
+#: gateway's state, not our bytes. Process-wide rather than per session on
+#: purpose — a child session's success is as much proof as the parent's, and
+#: the naming/compaction errands ride the same clients. Never cleared: an id
+#: that once existed and was truly retired earns at most
+#: ``MAX_MODEL_FLAP_RETRIES`` cheap re-asks before the ordinary path
+#: surfaces the provider's words, which is the accepted cost.
+_SERVED_SELECTORS: set[str] = set()
+
+
+def note_selector_served(spec: "ModelSpec") -> None:
+    """Record that ``spec`` answered a request; see :data:`_SERVED_SELECTORS`."""
+    _SERVED_SELECTORS.add(f"{spec.provider}/{spec.model_id}")
+
+
+def is_model_routing_flap(exc: "ProviderError", spec: "ModelSpec") -> bool:
+    """Whether a 4xx is the gateway momentarily not knowing a model it HAS served.
+
+    Two conditions, both required: a 400/404 whose body carries the
+    unknown-model wording, AND a selector this process has already seen
+    answer a request. A never-served id with the same body is the actionable
+    refusal the aggregator means it to be and must still abort at once (the
+    "flat unknown model" contract in ``_relayed_upstream_failure``); a 5xx
+    already takes the transient path; 401/403/429 have their own kinds; any
+    other 4xx text is a request the provider read and refused. Narrow on
+    purpose: a false negative costs one more marker, a false positive costs
+    three cheap 400s on a request that was going to fail anyway.
+    """
+    if exc.status not in (400, 404):
+        return False
+    if f"{spec.provider}/{spec.model_id}" not in _SERVED_SELECTORS:
+        return False
+    lowered = (exc.message or "").lower()
+    return any(marker in lowered for marker in _MODEL_ROUTING_FLAP_MARKERS)
+
+
 def is_fast_mode_refusal(status: int | None, message: str) -> bool:
     """Whether this failure is the provider refusing FAST MODE specifically.
 
@@ -2416,6 +2490,10 @@ async def stream_with_failover(
         # back (or the patient budget is spent), never rotating on the strength
         # of a failure the credential did not cause.
         connectivity_retries = 0
+        # Per-target, like the connectivity budget: a flap is a fact about
+        # this gateway's catalogue, so the allowance belongs to the target, not
+        # the credential (rotation does not reset it) and not the turn.
+        model_flap_retries = 0
         retry_same_key = False
         # Requests aimed at THIS target's provider that came back a server-side
         # fault, counted across every credential it rotates through.
@@ -2644,6 +2722,11 @@ async def stream_with_failover(
                     if not isinstance(event, StreamStartEvent):
                         forwarded_any = True
                     yield stamped
+                # This selector just answered: from here on an unknown-model
+                # 4xx on it is a catalogue flap, not a bad id (see
+                # ``is_model_routing_flap``). Recorded for isolated errands too;
+                # a naming call's 200 is exactly as much proof the id exists.
+                note_selector_served(spec)
                 if route_state is not None and target == primary_target:
                     # Settled, not silent: while a fallback was pinned the front
                     # end has been displaying THAT model, so the primary serving
@@ -2722,6 +2805,37 @@ async def stream_with_failover(
                         # are the turn's to record. An errand that hits the
                         # refusal simply retries at standard speed silently.
                         await route_state.record_fast_refusal(refused_selector, exc.message)
+                    retry_same_key = True
+                    continue
+                if (
+                    retry.enabled
+                    and is_model_routing_flap(exc, spec)
+                    and model_flap_retries < MAX_MODEL_FLAP_RETRIES
+                ):
+                    # The gateway's routing table blinked on an id it serves.
+                    # Re-ask the SAME credential after a short flat delay
+                    # rather than (a) aborting the turn as a request defect,
+                    # which is what a bare 400 earns below, or (b) rotating,
+                    # which buys nothing — the catalogue is per gateway, not
+                    # per bearer. BEFORE `record()`, like the fast-mode
+                    # refusal above: a flap being recovered from must not
+                    # occupy the reported-error slot. Flat delay on purpose: a
+                    # ramp only adds dead time to a coin flip the next attempt
+                    # is equally likely to win. Budget spent, the error falls
+                    # through to the ordinary request-kind handling and is
+                    # surfaced with the provider's own words.
+                    model_flap_retries += 1
+                    logger.warning(
+                        "model routing flap from %s/%s (%s: %s); re-asking in %dms (%d/%d)",
+                        spec.provider,
+                        spec.model_id,
+                        exc.status,
+                        exc.message,
+                        MODEL_FLAP_RETRY_DELAY_MS,
+                        model_flap_retries,
+                        MAX_MODEL_FLAP_RETRIES,
+                    )
+                    await _abortable_sleep(MODEL_FLAP_RETRY_DELAY_MS, signal)
                     retry_same_key = True
                     continue
                 record(exc, primary=is_primary)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.47.0"
+version = "0.47.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -263,3 +263,21 @@ def terminal_output(tmp_path) -> Iterator[Path]:
         os.dup2(saved, 2)
         os.close(saved)
         sink.close()
+
+
+@pytest.fixture(autouse=True)
+def fresh_served_selectors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start every test with no model selector recorded as served.
+
+    ``failover._SERVED_SELECTORS`` is process-wide by design — a served id is
+    proof the id exists for every session in the process — which makes it
+    cross-test state: any test that streams a success on ``openai/gpt-4o``
+    would turn a later test's flat unknown-model 400 on that id into a
+    catalogue flap and re-ask it three times instead of aborting at once.
+    Several suites drive ``stream_with_failover``, so the reset lives here
+    rather than in one test module. Tests that need served evidence set it
+    explicitly, which is also the honest way to state that precondition.
+    """
+    import local_operator.providers.failover as failover
+
+    monkeypatch.setattr(failover, "_SERVED_SELECTORS", set())

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -1066,6 +1066,42 @@ def test_model_routing_flap_predicate_is_narrow(monkeypatch) -> None:
     assert not is_model_routing_flap(ProviderError(400, "bad request"), served)
     assert not is_model_routing_flap(ProviderError(502, "model not found"), served)
     assert not is_model_routing_flap(ProviderError(429, "model not found"), served)
+    # OpenRouter's per-request routing 404s describe OUR request (review R3).
+    assert not is_model_routing_flap(
+        ProviderError(404, "No endpoints found that support tool use"), served
+    )
+    assert is_model_routing_flap(ProviderError(404, "No endpoints found for qwen/x"), served)
+
+
+async def test_relayed_transient_404_does_not_also_spend_the_flap_budget(monkeypatch) -> None:
+    """A 404 already classified ``transient`` (clients.py's relayed-upstream
+    reclassification) owns the transport retry ladder; the flap arm must not
+    add its own three re-asks in front of it (review R2). The body is chosen
+    to MATCH a flap marker on a served id, so the only thing keeping the arm
+    off is the ``kind == "request"`` gate. The ladder gets ``maxRetries: 1``
+    (two attempts); the arm firing would add up to three more."""
+    import local_operator.providers.failover as fo
+
+    monkeypatch.setattr(fo, "MODEL_FLAP_RETRY_DELAY_MS", 1)
+    monkeypatch.setattr(fo, "_SERVED_SELECTORS", {"openai/gpt-4o"})
+    calls = {"n": 0}
+
+    def relayed(
+        request: ChatRequest, api_key: str | None, oauth_access: Any = None
+    ) -> AsyncIterator[Any]:
+        calls["n"] += 1
+        raise ProviderError(404, "model not found", retryable=True, kind="transient")
+
+    async def client_for(spec: ModelSpec) -> Any:
+        return _FnClient(relayed)
+
+    settings = {"retry": {"baseDelayMs": 1, "maxRetries": 1, "fallbackChains": {}}}
+    with pytest.raises(ProviderError):
+        async for _ in stream_with_failover(
+            _request(), FakeAuth({"openai": ["k"]}), settings, client_for
+        ):
+            pass
+    assert calls["n"] == 2, "transient ladder only: one attempt plus one retry, no flap re-asks"
 
 
 async def test_fallback_request_400_still_walks() -> None:

--- a/tests/unit/providers/test_failover.py
+++ b/tests/unit/providers/test_failover.py
@@ -957,6 +957,117 @@ async def test_primary_request_400_aborts_without_walking_chain() -> None:
     assert anthropic.calls == 0  # the fallback chain was never walked
 
 
+async def test_model_routing_flap_is_reasked_in_place(monkeypatch) -> None:
+    """A 400 that SAYS the gateway does not know the model is a routing flap,
+    not a request defect: it is re-asked on the same credential after a flat
+    delay, and the turn is served when the catalogue comes back.
+
+    Observed live: OpenRouter answered ``qwen/qwen3.8-max is not a valid
+    model ID`` on the 97th request of a session it had served 96 times on
+    that id, and served it again seconds later; by status alone the driver
+    aborted a 75-minute sentinel pass. The fallback must NOT be walked (the
+    catalogue is per gateway, not per bearer) and the flap must not occupy
+    the reported-error slot."""
+    import local_operator.providers.failover as fo
+
+    monkeypatch.setattr(fo, "MODEL_FLAP_RETRY_DELAY_MS", 1)
+    # The id has served before in this process: that is what makes the
+    # refusal a flap rather than a bad id.
+    monkeypatch.setattr(fo, "_SERVED_SELECTORS", {"openai/gpt-4o"})
+    calls = {"n": 0}
+    anthropic = ScriptedClient([StreamTextDelta(delta="b"), StreamEndEvent(stop_reason="stop")])
+
+    def flap_then_serve(
+        request: ChatRequest, api_key: str | None, oauth_access: Any = None
+    ) -> AsyncIterator[Any]:
+        calls["n"] += 1
+        if calls["n"] <= 2:
+            raise ProviderError(400, "qwen/qwen3.8-max is not a valid model ID", retryable=False)
+
+        async def gen():
+            yield StreamTextDelta(delta="served")
+            yield StreamEndEvent(stop_reason="stop")
+
+        return gen()
+
+    async def client_for(spec: ModelSpec) -> Any:
+        if spec.provider == "anthropic":
+            return anthropic
+        return _FnClient(flap_then_serve)
+
+    settings = {"retry": {"baseDelayMs": 1, "fallbackChains": {"default": ["anthropic/claude-x"]}}}
+    got = [
+        e
+        async for e in stream_with_failover(
+            _request(), FakeAuth({"openai": ["k"]}), settings, client_for
+        )
+    ]
+    assert any(isinstance(e, StreamTextDelta) and e.delta == "served" for e in got)
+    assert calls["n"] == 3  # two flaps re-asked in place, third served
+    assert anthropic.calls == 0  # never walked the chain
+
+
+async def test_model_routing_flap_budget_then_request_defect(monkeypatch) -> None:
+    """A flap that never clears spends its small budget and then takes the
+    ordinary request-defect path: the primary's own 400 surfaces, with the
+    provider's words, and the chain is still not walked."""
+    import local_operator.providers.failover as fo
+
+    monkeypatch.setattr(fo, "MODEL_FLAP_RETRY_DELAY_MS", 1)
+    monkeypatch.setattr(fo, "_SERVED_SELECTORS", {"openai/gpt-4o"})
+    calls = {"n": 0}
+    anthropic = ScriptedClient([StreamTextDelta(delta="b"), StreamEndEvent(stop_reason="stop")])
+
+    def always_flap(
+        request: ChatRequest, api_key: str | None, oauth_access: Any = None
+    ) -> AsyncIterator[Any]:
+        calls["n"] += 1
+        raise ProviderError(404, "model not found", retryable=False)
+
+    async def client_for(spec: ModelSpec) -> Any:
+        if spec.provider == "anthropic":
+            return anthropic
+        return _FnClient(always_flap)
+
+    settings = {"retry": {"baseDelayMs": 1, "fallbackChains": {"default": ["anthropic/claude-x"]}}}
+    with pytest.raises(ProviderError) as excinfo:
+        async for _ in stream_with_failover(
+            _request(), FakeAuth({"openai": ["k"], "anthropic": ["k2"]}), settings, client_for
+        ):
+            pass
+    assert "model not found" in str(excinfo.value)
+    assert calls["n"] == 1 + fo.MAX_MODEL_FLAP_RETRIES
+    assert anthropic.calls == 0
+
+
+def test_model_routing_flap_predicate_is_narrow(monkeypatch) -> None:
+    """A flap needs BOTH the unknown-model wording on a 400/404 AND a selector
+    this process has seen serve. A never-served id with the same body is the
+    actionable refusal it reads as (``test_flat_unknown_model_404_still_aborts
+    _immediately`` pins that end to end); a 400 about a parameter, and a 5xx
+    or 429 with the same words, are never flaps."""
+    import local_operator.providers.failover as fo
+    from local_operator.providers.failover import is_model_routing_flap
+
+    served = ModelSpec(provider="openrouter", model_id="qwen/qwen3.8-max", context_window=1)
+    fresh = ModelSpec(provider="openrouter", model_id="openai/nope-9.9", context_window=1)
+    monkeypatch.setattr(fo, "_SERVED_SELECTORS", set())
+    fo.note_selector_served(served)
+
+    assert is_model_routing_flap(
+        ProviderError(400, "qwen/qwen3.8-max is not a valid model ID"), served
+    )
+    assert is_model_routing_flap(ProviderError(404, "Model not found"), served)
+    # Same words, never served: not a flap.
+    assert not is_model_routing_flap(
+        ProviderError(400, "openai/nope-9.9 is not a valid model ID"), fresh
+    )
+    assert not is_model_routing_flap(ProviderError(400, "invalid value for 'temperature'"), served)
+    assert not is_model_routing_flap(ProviderError(400, "bad request"), served)
+    assert not is_model_routing_flap(ProviderError(502, "model not found"), served)
+    assert not is_model_routing_flap(ProviderError(429, "model not found"), served)
+
+
 async def test_fallback_request_400_still_walks() -> None:
     """A request-shape 400 on a FALLBACK target still walks to the next target.
 


### PR DESCRIPTION
## Summary of Changes

A 400/404 whose body says the model id is unknown, **on a selector this process has already served**, is now treated as a gateway catalogue flap: re-asked in place on the same credential (flat 2 s delay, at most 3 per target) before falling through to the ordinary request-defect path. A never-served id with the same body still aborts at once. Patch version: **0.47.1** (main moved to 0.47.0 while this was in review; rebased).

### Root cause, observed live

A Minerva sentinel pass on OpenRouter (`qwen/qwen3.8-max`) died at 75 minutes with its root cause established and nothing written:

```
agent_end error: invalid request (HTTP 400): qwen/qwen3.8-max is not a valid model ID
```

It was the 97th request of the session; the previous 96 had been served on that exact id. Three probes within a minute afterwards all returned 200 (`qwen/qwen3.8-max-0902`). By status alone the driver classified it `kind="request"` — deterministic, abort, do not walk the chain — which is the correct verdict for a malformed body and a wrong one for a routing table that blinked. The words are identical in both cases; the evidence that separates them is whether the id has answered before, and the driver has that and the body does not.

## Related Issue(s) / delivery contract

**C1 standard / pre-authorized reliability bugfix.** Operator-visible as a dead turn on a long autonomous run; this PR is the record.

Acceptance criteria:
- A 400/404 with unknown-model wording on a **served** selector is re-asked in place ≤3 times, on the same credential, without walking the fallback chain, and the turn is served when the catalogue returns.
- The same body on a **never-served** selector aborts immediately (unchanged contract; `test_flat_unknown_model_404_still_aborts_immediately` still passes).
- Budget spent, the primary's own error surfaces with the provider's words; the flap never occupies the reported-error slot.
- 5xx, 429, 401/403, and 4xx bodies about parameters are not flaps.

Non-goals: no change to the fallback walk, rotation, or `_relayed_upstream_failure`'s envelope logic; no persisted state; no user-facing setting.

## Impact / risk / rollback

Adds one process-wide set (`_SERVED_SELECTORS`) and one narrow retry arm ahead of `record()`, mirroring the fast-mode-refusal arm. Cost of a false positive: three cheap 4xx on a request that was going to fail anyway. The served set is deliberately cross-session (a child's success is proof) and therefore cross-test state; a shared autouse fixture in `tests/conftest.py` resets it. Rollback is a revert.

## Testing evidence

- `test_model_routing_flap_is_reasked_in_place`: two flaps then a 200 → served, 3 calls, fallback never touched.
- `test_model_routing_flap_budget_then_request_defect`: flap never clears → `1 + MAX_MODEL_FLAP_RETRIES` calls, primary's own words surface, fallback never touched.
- `test_model_routing_flap_predicate_is_narrow`: served vs never-served with identical bodies; parameter 400, 502, 429 rejected.
- **Mutation-tested**: with the retry arm disabled both flap tests fail (`assert 1 == 4`; the 400 propagates); with the served gate removed the flat-unknown-model test and the narrow-predicate test both fail. Each guard is load-bearing.
- Providers + adjacent suites (`tests/unit/providers`, effort classifier, openai context, stream recording): **1086 passed**.
- Gates exactly as CI: flake8 0, black clean, isort clean, pyright 0.

The live confirmation is the next sentinel pass on QA once this is released (the pass that died has been re-fired on the current release for the reviewer-shell/kimi-k3 verification and is running now).
