### PR TITLE
fix(tui): restore scoped subagent tool details, plans, and child navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,24 @@ addressable: peek at its transcript, send it a note, ask it a question, steer
 it onto a different course, pause it, or resume it later — all without
 burning its attention on status meetings.
 
+Opening a worker shows its own live todo list and its direct children, not the
+root session's plan or unrelated workers. Click a child to inspect it; `Esc`
+returns one parent at a time, `[` / `]` cycle peers, and `c` opens the first
+child. The reader stays read-only. At shorter terminal heights the disabled
+composer is collapsed so the transcript, child controls, and plan remain useful;
+`ctrl+t` and `ctrl+g` expose the scrollable full plan and child list.
+
+Attached terminals fetch child details only while that worker is open. A plan
+that has not arrived is labeled **Loading todos**; an empty fetched plan says
+**No todos**. Older owners, unavailable history, or a child plan exceeding
+128 KiB of serialized JSON show **Todos unavailable** rather than a partial
+list. The full plan stays on the owner; this limit does not truncate the todo
+store or prevent attaching to the root session. Child plans are not copied into
+the root's durable frontend checkpoint. After an owner restart, saved child
+plans and the recorded child hierarchy/status remain inspectable, but the
+in-memory tool-event window is gone; attached child pages do not yet page the
+full saved transcript and continue to report that history limitation.
+
 **Roles are capability boundaries, not just prompts.** A subagent launched as
 `reviewer` carries vetted review guidance *and loses the tools to edit code*
 — it can read and run tests but cannot alter what it reviews, which is what

--- a/local_operator/harness/comms.py
+++ b/local_operator/harness/comms.py
@@ -46,7 +46,7 @@ import logging
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Literal, Protocol
+from typing import TYPE_CHECKING, Any, Callable, Literal, Protocol, cast
 
 from local_operator.harness.types import (
     AgentEvent,
@@ -342,6 +342,11 @@ class SubagentNode:
     #: superseded attempts here it could only reconcile the newest launch and
     #: would leak every earlier attempt's full role/team/system preamble.
     launch_prompts: dict[str, str] = field(default_factory=dict)
+    attempt_aliases: tuple[str, ...] = ()
+    live: bool = False
+    status: str = "gone"
+    result_text: str = ""
+    error_text: str = ""
 
 
 class ChildSession(Protocol):
@@ -398,6 +403,11 @@ class _ChildRecord:
     #: resume, and the reason a record outlives the job row.
     session_dir: Path | None = None
     child: ChildSession | None = None
+    # A nested manager's ledger dies with its session. Keep only the job row,
+    # bounded by this registry's retention, so its completed children remain
+    # inspectable without retaining the disposed session or reading disk.
+    job_ref: Any | None = None
+    unsubscribe_jobs: Callable[[], None] | None = None
     unsubscribe: Callable[[], None] | None = None
     #: Notes addressed to this child before its session existed.
     pending: list[CustomMessage] = field(default_factory=list)
@@ -482,7 +492,20 @@ class SubagentComms:
         self._session = session
         self._records: dict[str, _ChildRecord] = {}
         self._detail_listeners: set[Callable[[str], None]] = set()
+        self._change_listeners: set[Callable[[], None]] = set()
         self._aliases: dict[str, str] = {}
+
+    def subscribe_changes(self, listener: Callable[[], None]) -> Callable[[], None]:
+        """Observe graph/state changes without triggering durable history reads."""
+        self._change_listeners.add(listener)
+        return lambda: self._change_listeners.discard(listener)
+
+    def _notify_change(self) -> None:
+        for listener in tuple(self._change_listeners):
+            try:
+                listener()
+            except Exception:
+                logger.debug("subagent state listener failed", exc_info=True)
 
     def subscribe_detail_changes(self, listener: Callable[[str], None]) -> Callable[[], None]:
         """Observe child transcript mutations through the shared root registry."""
@@ -498,6 +521,7 @@ class SubagentComms:
         self._notify_detail_change(job_id)
 
     def _notify_detail_change(self, job_id: str) -> None:
+        self._notify_change()
         for listener in tuple(self._detail_listeners):
             try:
                 listener(job_id)
@@ -554,6 +578,8 @@ class SubagentComms:
             existing.launch_message_id = launch_message_id
             existing.agent_role = agent_role
             existing.effort = effort
+            existing.job_ref = self.job(job_id)
+            self._notify_change()
             return
         self._records[job_id] = _ChildRecord(
             job_id=job_id,
@@ -565,7 +591,9 @@ class SubagentComms:
             agent_role=agent_role,
             effort=effort,
         )
+        self._records[job_id].job_ref = self.job(job_id)
         self._evict_overflow()
+        self._notify_change()
 
     def attach(self, job_id: str, child: ChildSession, session_dir: Path) -> None:
         """Bind the live child session to its record and flush buffered notes."""
@@ -619,6 +647,15 @@ class SubagentComms:
             self._aliases[alias] = job_id
         record.child = child
         record.session_dir = session_dir
+        record.job_ref = self.job(job_id)
+        if record.unsubscribe_jobs is not None:
+            record.unsubscribe_jobs()
+        subscribe_jobs = getattr(getattr(child, "jobs", None), "subscribe_changes", None)
+        if callable(subscribe_jobs):
+            # Nested jobs need their final status as well as streamed events.
+            # These notifications feed only the root's existing coalescer.
+            record.unsubscribe_jobs = cast(Callable[[], None], subscribe_jobs(self._notify_change))
+        self._notify_change()
         # Imported here, not at module scope: ``subagent`` imports this module
         # for its comms types, so a top-level import closes the cycle. Same
         # reason ``resume`` imports ``run_subagent`` locally.
@@ -667,6 +704,10 @@ class SubagentComms:
         record.settled = True
         record.settled_at = time.time()
         record.child = None
+        if record.unsubscribe_jobs is not None:
+            record.unsubscribe_jobs()
+            record.unsubscribe_jobs = None
+        self._notify_change()
         record.armed = False
         # Wake anyone parked in ``_await_child``: the child is gone, so the
         # attach they are waiting for is never coming. They re-check
@@ -718,10 +759,11 @@ class SubagentComms:
         launch_prompts = dict(record.prior_launch_prompts)
         if record.launch_message_id and record.prompt:
             launch_prompts[record.launch_message_id] = record.prompt
+        parent = self._record(record.parent_job_id) if record.parent_job_id else None
         return SubagentNode(
             job_id=record.job_id,
             label=record.label,
-            parent_job_id=record.parent_job_id,
+            parent_job_id=parent.job_id if parent is not None else record.parent_job_id,
             session_id=session_id,
             session_dir=record.session_dir,
             prompt=record.prompt,
@@ -730,10 +772,40 @@ class SubagentComms:
             agent_role=record.agent_role,
             effort=record.effort,
             launch_prompts=launch_prompts,
+            attempt_aliases=tuple(record.attempt_aliases),
+            live=record.child is not None,
+            status=(
+                "paused"
+                if record.paused
+                else record.outcome or ("cancelled" if record.settled else "gone")
+            ),
+            result_text=record.result_text or "",
+            error_text=record.error_text or "",
         )
+
+    def job_rows(self) -> list[Any]:
+        """Snapshot the shared graph's ledgers once, without moving execution."""
+        sessions: list[Any] = [self._session]
+        sessions.extend(
+            record.child for record in self._records.values() if record.child is not None
+        )
+        rows: dict[str, Any] = {}
+        for session in sessions:
+            manager = getattr(session, "jobs", None)
+            if manager is not None:
+                rows.update((job.id, job) for job in manager.list())
+        for record in self._records.values():
+            if record.job_ref is not None:
+                rows.setdefault(record.job_id, record.job_ref)
+        # Resumed attempts have one current identity, even while a predecessor
+        # row has not yet aged out of its original execution ledger.
+        return [job for key, job in rows.items() if key not in self._aliases]
 
     def job(self, job_id: str) -> Any | None:
         """Find a node's job without centralizing its execution manager."""
+        record = self._record(job_id)
+        if record is not None:
+            job_id = record.job_id
         sessions: list[Any] = [self._session]
         sessions.extend(
             record.child for record in self._records.values() if record.child is not None
@@ -746,21 +818,16 @@ class SubagentComms:
                 job = None
             if job is not None:
                 return job
-        return None
+        return record.job_ref if record is not None else None
 
     def parent(self, job_id: str) -> SubagentNode | None:
         node = self.node(job_id)
         return self.node(node.parent_job_id) if node is not None and node.parent_job_id else None
 
     def children(self, job_id: str | None) -> list[SubagentNode]:
-        rows: list[SubagentNode] = []
-        for record in self._records.values():
-            if record.parent_job_id != job_id:
-                continue
-            node = self.node(record.job_id)
-            if node is not None:
-                rows.append(node)
-        return rows
+        selected = self._record(job_id) if job_id else None
+        parent_id = selected.job_id if selected is not None else job_id
+        return [node for node in self.nodes() if node.parent_job_id == parent_id]
 
     def peers(self, job_id: str) -> list[SubagentNode]:
         node = self.node(job_id)

--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -352,6 +352,7 @@ class AsyncJobManager:
         # single call site guards it.
         self._on_roster_change = on_roster_change
         self._on_job_change = on_job_change
+        self._job_listeners: set[Callable[[], None]] = set()
         self._jobs: dict[str, AsyncJob] = {}
         # Historical attempt ids remain valid after a resume replaces the
         # visible row. Values point directly at the current attempt; flattening
@@ -599,9 +600,18 @@ class AsyncJobManager:
         """
         self._notify_job_change(persist_roster=False)
 
+    def subscribe_changes(self, listener: Callable[[], None]) -> Callable[[], None]:
+        """Observe descendant lifecycle/progress without taking over its ledger."""
+        self._job_listeners.add(listener)
+        return lambda: self._job_listeners.discard(listener)
+
     def _notify_job_change(self, *, persist_roster: bool) -> None:
         """Publish every job mutation and persist only durable task fields."""
-        callbacks = ([self._on_roster_change] if persist_roster else []) + [self._on_job_change]
+        callbacks = (
+            ([self._on_roster_change] if persist_roster else [])
+            + [self._on_job_change]
+            + list(self._job_listeners)
+        )
         for callback in callbacks:
             if callback is None:
                 continue

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -645,7 +645,9 @@ def _wire_value(value: Any) -> Any:
 def _job_summary(job: "JobState") -> dict[str, Any]:
     """Serialize one roster row without visiting its retained trajectory."""
     values = {
-        name: _wire_value(value) for name, value in job.__dict__.items() if name != "trajectory"
+        name: _wire_value(value)
+        for name, value in job.__dict__.items()
+        if name not in {"trajectory", "todos"}
     }
     values.update({name: _wire_value(value) for name, value in (job.model_extra or {}).items()})
     return to_jsonable_python(values)
@@ -732,6 +734,10 @@ class JobState(BaseModel):
     # than silently doing nothing.
     parent_job_id: str | None = None
     session_id: str | None = None
+    attempt_aliases: list[str] = Field(default_factory=list)
+    # Child plans are detail payloads, not roster metadata. None is unavailable;
+    # an empty list is an authoritative clear and must never restore a stale plan.
+    todos: list[dict[str, Any]] | None = None
 
     @model_validator(mode="before")
     @classmethod
@@ -1064,6 +1070,22 @@ class FrontendUpdate(BaseModel):
     # without this marker a follower would extend forever (500 → 1000 → 1500…)
     # while duplicating rows in its click-through view.
     job_trajectory_replacements: list[str] = Field(default_factory=list)
+    job_todo_updates: dict[str, list[dict[str, Any]] | None] = Field(default_factory=dict)
+
+
+# One watched plan must not take down the 1 MiB control stream. Larger plans
+# remain authoritative on the owner and are explicitly unavailable on a follower,
+# never silently truncated into what looks like a complete task list.
+JOB_TODOS_WIRE_BYTES = 128 * 1024
+
+
+def job_todos_wire_value(todos: Any) -> list[dict[str, Any]] | None:
+    if todos is None:
+        return None
+    value = _wire_value(todos)
+    if len(json.dumps(value).encode("utf-8")) > JOB_TODOS_WIRE_BYTES:
+        return None
+    return value
 
 
 def sync_wire_payload(sync: FrontendSync) -> dict[str, Any]:
@@ -1122,6 +1144,7 @@ def sync_wire_payload(sync: FrontendSync) -> dict[str, Any]:
                     # construction, see JobState), so dropping the rows here
                     # loses nothing the viewer needs to describe the job.
                     job["trajectory"] = []
+                job["todos"] = None
                 _fold_job_usage_in_place(job)
                 _bound_job_text_in_place(job, share=text_share)
     return payload
@@ -1234,9 +1257,11 @@ def filter_update_trajectories(
     """
     appends = payload.get("job_trajectory_appends")
     replacements = payload.get("job_trajectory_replacements")
+    todos = payload.get("job_todo_updates")
+    has_todos = isinstance(todos, dict) and todos
     has_appends = isinstance(appends, dict) and appends
     has_replacements = isinstance(replacements, list) and replacements
-    if not has_appends and not has_replacements:
+    if not has_appends and not has_replacements and not has_todos:
         return payload
     kept_appends = (
         {job_id: rows for job_id, rows in appends.items() if watched(str(job_id))}
@@ -1248,13 +1273,21 @@ def filter_update_trajectories(
         if isinstance(replacements, list)
         else []
     )
-    if len(kept_appends) == (len(appends) if isinstance(appends, dict) else 0) and len(
-        kept_replacements
-    ) == (len(replacements) if isinstance(replacements, list) else 0):
+    kept_todos = (
+        {job_id: rows for job_id, rows in todos.items() if watched(str(job_id))}
+        if isinstance(todos, dict)
+        else {}
+    )
+    if (
+        len(kept_appends) == (len(appends) if isinstance(appends, dict) else 0)
+        and len(kept_replacements) == (len(replacements) if isinstance(replacements, list) else 0)
+        and len(kept_todos) == (len(todos) if isinstance(todos, dict) else 0)
+    ):
         return payload
     filtered = dict(payload)
     filtered["job_trajectory_appends"] = kept_appends
     filtered["job_trajectory_replacements"] = kept_replacements
+    filtered["job_todo_updates"] = kept_todos
     return filtered
 
 
@@ -1308,7 +1341,9 @@ class SnapshotSubagentComms:
         self.replace(jobs)
 
     def replace(self, jobs: Iterable[JobState]) -> None:
-        self._nodes = {job.id: self._node_for(job) for job in jobs}
+        rows = list(jobs)
+        self._nodes = {job.id: self._node_for(job) for job in rows}
+        self._aliases = {alias: job.id for job in rows for alias in job.attempt_aliases}
 
     @staticmethod
     def _node_for(job: JobState) -> Any:
@@ -1324,7 +1359,7 @@ class SnapshotSubagentComms:
         )
 
     def node(self, job_id: str) -> Any | None:
-        return self._nodes.get(job_id)
+        return self._nodes.get(self._aliases.get(job_id, job_id))
 
     def job(self, job_id: str) -> Any | None:
         # The page reads live job fields from the jobs facade, not here; the
@@ -1333,13 +1368,14 @@ class SnapshotSubagentComms:
         return None
 
     def parent(self, job_id: str) -> Any | None:
-        node = self._nodes.get(job_id)
+        node = self.node(job_id)
         if node is None or not node.parent_job_id:
             return None
-        return self._nodes.get(node.parent_job_id)
+        return self.node(node.parent_job_id)
 
     def children(self, job_id: str | None) -> list[Any]:
-        return [node for node in self._nodes.values() if node.parent_job_id == job_id]
+        parent_id = self._aliases.get(job_id, job_id) if job_id else None
+        return [node for node in self._nodes.values() if node.parent_job_id == parent_id]
 
     def peers(self, job_id: str) -> list[Any]:
         node = self._nodes.get(job_id)
@@ -1401,6 +1437,8 @@ class FrontendStateStore:
     def __init__(self, state: FrontendSessionState) -> None:
         self._state = _freeze_state_jobs(state.model_copy(deep=True))
         self._subscribers: list[Callable[[FrontendUpdate], None]] = []
+        self._todo_sequences: dict[str, int] = {}
+        self._todo_seed_floor = state.sequence
 
     @property
     def state(self) -> FrontendSessionState:
@@ -1417,10 +1455,12 @@ class FrontendStateStore:
 
     def replace(self, state: FrontendSessionState) -> None:
         self._state = _freeze_state_jobs(state.model_copy(deep=True))
+        self._todo_sequences.clear()
+        self._todo_seed_floor = state.sequence
 
     def replace_and_notify(self, state: FrontendSessionState) -> None:
         """Install a proven wire snapshot without reaching into subscribers."""
-        self._state = _freeze_state_jobs(state.model_copy(deep=True))
+        self.replace(state)
         update = FrontendUpdate(
             epoch=state.epoch,
             sequence=state.sequence,
@@ -1451,8 +1491,19 @@ class FrontendStateStore:
                 if len(trajectory) > _TRAJECTORY_CAP:
                     del trajectory[: len(trajectory) - _TRAJECTORY_CAP]
                 raw["trajectory"] = trajectory
+                raw["todos"] = _wire_value(prior.todos) if prior is not None else None
+                if (
+                    job_id in update.job_todo_updates
+                    and update.sequence > self._todo_sequences.get(job_id, -1)
+                ):
+                    raw["todos"] = update.job_todo_updates[job_id]
+                    self._todo_sequences[job_id] = update.sequence
                 rebuilt.append(raw)
             changes["jobs"] = rebuilt
+            retained = {str(row["id"]) for row in rebuilt}
+            self._todo_sequences = {
+                key: seq for key, seq in self._todo_sequences.items() if key in retained
+            }
         payload = self._state.model_dump()
         payload.update(changes)
         payload["epoch"] = update.epoch
@@ -1494,11 +1545,41 @@ class FrontendStateStore:
             return True
         return False
 
+    def seed_job_todos(
+        self,
+        job_id: str,
+        todos: list[dict[str, Any]] | None,
+        *,
+        epoch: str,
+        sequence: int,
+        session_id: str | None,
+    ) -> bool:
+        """Join an on-demand snapshot with deltas without rolling a plan back.
+
+        The request reply and the ordered stream race in both directions. Keep a
+        per-job watermark: a newer fetched snapshot also fences older deltas
+        still queued on the wire, without consuming their global sequence.
+        """
+        if epoch != self._state.epoch or sequence < max(
+            self._todo_seed_floor, self._todo_sequences.get(job_id, -1)
+        ):
+            return False
+        jobs = list(self._state.jobs)
+        for index, job in enumerate(jobs):
+            if job.id != job_id or job.session_id != session_id:
+                continue
+            jobs[index] = _freeze_job(job.model_copy(update={"todos": todos}))
+            self._state = self._state.model_copy(update={"jobs": _FrozenSequence(jobs)})
+            self._todo_sequences[job_id] = sequence
+            return True
+        return False
+
     def mutate(self, **changes: Any) -> FrontendUpdate | None:
         normalized: dict[str, Any] = {}
         wire_changes: dict[str, Any] = {}
         trajectory_appends: dict[str, list[dict[str, Any]]] = {}
         trajectory_replacements: list[str] = []
+        todo_updates: dict[str, list[dict[str, Any]] | None] = {}
         for key, value in changes.items():
             if key == "jobs":
                 # JobState equality walks the bounded trajectories without first
@@ -1529,6 +1610,8 @@ class FrontendStateStore:
                 job_id = job.id
                 trajectory = job.trajectory
                 prior = previous.get(job_id)
+                if prior is None or prior.todos != job.todos:
+                    todo_updates[job_id] = job_todos_wire_value(job.todos)
                 old = prior.trajectory if prior is not None else []
                 if trajectory[: len(old)] == old:
                     appended = trajectory[len(old) :]
@@ -1564,6 +1647,7 @@ class FrontendStateStore:
             changes=wire_changes,
             job_trajectory_appends=trajectory_appends,
             job_trajectory_replacements=trajectory_replacements,
+            job_todo_updates=todo_updates,
         )
         for subscriber in list(self._subscribers):
             subscriber(update.model_copy(deep=True))
@@ -1654,14 +1738,6 @@ class FrontendStateStore:
             except Exception:
                 last_usage = None
         jobs = self._jobs(session)
-        if initial:
-            # The atomic join snapshot folds canonical lineage in once so a
-            # follower's job graph is complete from its first frame; steady-
-            # state updates re-fold on the 50 ms jobs coalesce (see
-            # ``refresh_jobs``), never on the per-event session-loop refresh.
-            comms = getattr(session, "_subagent_comms", None)
-            if comms is not None:
-                jobs = [_with_lineage(job, comms) for job in jobs]
         child_costs: dict[str, float] = dict(current.child_costs)
         for job in jobs:
             cost = _job_subtree_cost(job, default_model_label=_label(selected))
@@ -1855,9 +1931,6 @@ class FrontendStateStore:
         the cost.
         """
         jobs = self._jobs(session)
-        comms = getattr(session, "_subagent_comms", None)
-        if comms is not None:
-            jobs = [_with_lineage(job, comms) for job in jobs]
         child_costs = dict(self._state.child_costs)
         selected = getattr(session, "model", None)
         for job in jobs:
@@ -2081,6 +2154,7 @@ class FrontendStateStore:
                     job.model_copy(
                         update={
                             "trajectory": [],
+                            "todos": None,
                             "usage": (
                                 job.usage.model_copy(
                                     update={
@@ -2111,13 +2185,45 @@ class FrontendStateStore:
             rows = manager.list() if manager else []
         except Exception:
             return []
+        # Execution stays local to each manager; presentation follows the shared
+        # graph. Snapshot its ledgers once, without per-node scans or disk reads.
+        comms = getattr(session, "_subagent_comms", None)
+        graph_jobs = getattr(comms, "job_rows", None)
+        if callable(graph_jobs):
+            graph_rows = graph_jobs()
+            if isinstance(graph_rows, Sequence):
+                rows = graph_rows
         values: list[JobState] = []
         for job in rows:
             try:
-                values.append(JobState.from_job(job))
+                value = JobState.from_job(job)
+                values.append(_with_lineage(value, comms) if comms is not None else value)
             except Exception:
                 # One malformed extension row cannot erase unrelated jobs.
                 continue
+        nodes = getattr(comms, "nodes", None)
+        if callable(nodes):
+            known = {job.id for job in values}
+            graph_nodes = nodes()
+            for node in graph_nodes if isinstance(graph_nodes, Sequence) else []:
+                if node.job_id in known:
+                    continue
+                # After a cold restart nested execution ledgers no longer exist,
+                # but the shared durable graph still does. These are reader rows
+                # only: never register a fake runnable job or invent a trajectory.
+                row = JobState(
+                    id=node.job_id,
+                    type="task",
+                    label=node.label,
+                    status=getattr(node, "status", "gone"),
+                    restored=True,
+                    prompt=getattr(node, "prompt", ""),
+                    agent_role=getattr(node, "agent_role", ""),
+                    effort=getattr(node, "effort", ""),
+                    result_text=getattr(node, "result_text", ""),
+                    error_text=getattr(node, "error_text", ""),
+                )
+                values.append(_with_lineage(row, comms))
         return values
 
 
@@ -2199,10 +2305,20 @@ def _with_lineage(job: JobState, comms: Any) -> JobState:
         node = None
     if node is None:
         return job
+    from local_operator.tools.builtin import TODO_STORE
+
+    child_id = getattr(node, "session_id", None)
+    has_plan = bool(child_id) and (bool(getattr(node, "live", False)) or child_id in TODO_STORE)
     return job.model_copy(
         update={
             "parent_job_id": getattr(node, "parent_job_id", None),
             "session_id": getattr(node, "session_id", None),
+            "attempt_aliases": list(getattr(node, "attempt_aliases", ())),
+            "todos": (
+                [phase.model_dump(mode="json") for phase in _todo_state(node.session_id)]
+                if has_plan
+                else None
+            ),
         }
     )
 

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -1539,7 +1539,13 @@ class FrontendStateStore:
                     appended = trajectory
                     trajectory_replacements.append(job_id)
                 if appended:
-                    trajectory_appends[job_id] = appended
+                    # Unlike the job snapshot, this delta does not pass through
+                    # JobState's serializer. Pydantic validates the outer event
+                    # dict but leaves its Any-valued args/message/result frozen;
+                    # JSON then turns their tuple-backed mappings into arrays of
+                    # pairs. The viewer loses tool details until a fresh history
+                    # fetch. Thaw at this wire boundary, just as snapshots do.
+                    trajectory_appends[job_id] = [_wire_value(event) for event in appended]
                 summaries.append(_job_summary(job))
             wire_changes["jobs"] = summaries
         if not normalized:

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -1826,7 +1826,12 @@ class RemoteSession:
         the page can say so instead of rendering the child as empty.
         """
         client = self._client
-        if client is None:
+        store = self._frontend_store
+        if client is None or store is None:
+            return False
+        epoch = store.state.epoch
+        identity = next((job for job in store.state.jobs if job.id == job_id), None)
+        if identity is None:
             return False
         try:
             await client.watch_job(job_id)
@@ -1837,11 +1842,14 @@ class RemoteSession:
         rows: list[dict[str, Any]] = []
         offset = 0
         base_seq: int | None = None
+        details: Mapping[str, Any] = {}
         try:
             while True:
                 payload = await client.job_trajectory(job_id, offset=offset)
                 if not isinstance(payload, Mapping):
                     return False
+                if offset == 0:
+                    details = payload
                 page = [row for row in (payload.get("rows") or []) if isinstance(row, dict)]
                 page_base = payload.get("base_seq")
                 page_base = page_base if isinstance(page_base, int) else None
@@ -1859,13 +1867,35 @@ class RemoteSession:
                     break
         except (ConnectionError, RuntimeError):
             return False
-        store = self._frontend_store
-        if store is None:
-            return False
+        current = next((job for job in store.state.jobs if job.id == job_id), None)
+        if (
+            self._client is not client
+            or self._frontend_store is not store
+            or store.state.epoch != epoch
+            or current is None
+            or current.session_id != identity.session_id
+        ):
+            return False  # detached/reconnected/resumed while the request was in flight
         # Into the canonical state, where the live append stream will extend it
         # from here; see ``FrontendStateStore.seed_job_trajectory``.
         if not store.seed_job_trajectory(job_id, rows):
             return False
+        detail_sequence = details.get("detail_sequence")
+        if (
+            details.get("detail_job_id") == job_id
+            and details.get("detail_epoch") == epoch
+            and isinstance(detail_sequence, int)
+            and "todos" in details
+        ):
+            todos = details["todos"]
+            if todos is None or isinstance(todos, list):
+                store.seed_job_todos(
+                    job_id,
+                    todos,
+                    epoch=epoch,
+                    sequence=detail_sequence,
+                    session_id=details.get("detail_session_id"),
+                )
         self._apply_frontend_facades(store.state)
         return True
 

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -2492,6 +2492,7 @@ class OwnedSessionHandle(SessionHandle):
             and node is not None
             and node.session_id
             and node.session_dir is not None
+            and not getattr(node, "live", False)
         ):
             from local_operator.tools.builtin import TODO_STORE, restore_todos
 

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -104,6 +104,32 @@ class _PromptCommand:
         yield self.images
 
 
+def _read_child_todo_snapshot(directory: Any) -> list[dict[str, Any]] | None:
+    """Read one historical plan without materializing or rewriting its files."""
+    from local_operator.session.frontend_state import TodoItemState, TodoPhaseState
+    from local_operator.session.transcript import Transcript
+
+    try:
+        transcript = Transcript(directory, defer_materialise=True)
+        if not transcript.path.is_file():
+            return None
+        payload = transcript.latest_custom("todo_snapshot") or {}
+        raw = payload.get("items", [])
+        if not isinstance(raw, list):
+            return None
+        phases = [
+            (
+                TodoPhaseState.model_validate(row)
+                if "items" in row
+                else TodoPhaseState(name="Todos", items=[TodoItemState.model_validate(row)])
+            )
+            for row in raw
+        ]
+        return [phase.model_dump(mode="json") for phase in phases]
+    except (OSError, ValueError, TypeError):
+        return None
+
+
 class OwnedSessionHandle(SessionHandle):
     """SessionHandle over an in-process Session living on ``loop``.
 
@@ -2451,8 +2477,55 @@ class OwnedSessionHandle(SessionHandle):
         which is the same eviction problem ``job_trajectory_replacements``
         solves for the delta stream.
         """
-        job = self._session.jobs.get(job_id)
+        comms = getattr(self._session, "_subagent_comms", None)
+        node = comms.node(job_id) if comms is not None else None
+        lookup = getattr(comms, "job", None)
+        job = lookup(job_id) if callable(lookup) else None
+        if job is None:
+            job = self._session.jobs.get(job_id)
         rows = list(getattr(job, "trajectory", None) or []) if job is not None else []
+        details: dict[str, Any] = {}
+        store = getattr(self._session, "_frontend_state_store", None)
+        if (
+            offset == 0
+            and comms is not None
+            and node is not None
+            and node.session_id
+            and node.session_dir is not None
+        ):
+            from local_operator.tools.builtin import TODO_STORE, restore_todos
+
+            if node.session_id not in TODO_STORE:
+                # A cold owner's roster must not read every child transcript.
+                # Hydrate only this selected plan, off-loop, then join the newest
+                # canonical snapshot. A live update or resumed identity wins.
+                phases = await asyncio.to_thread(_read_child_todo_snapshot, node.session_dir)
+                current_node = comms.node(job_id)
+                if (
+                    phases is not None
+                    and current_node is not None
+                    and current_node.job_id == node.job_id
+                    and current_node.session_id == node.session_id
+                ):
+                    restore_todos(node.session_id, phases)
+        if offset == 0 and store is not None:
+            from local_operator.session.frontend_state import job_todos_wire_value
+
+            # Publish the flush before capturing its sequence, with no await in
+            # between. A delayed reply can then be joined safely with newer live
+            # todo replacements on the follower. Only the first page pays for it.
+            store.refresh_jobs(self._session)
+            state = store.state
+            canonical_id = node.job_id if node is not None else str(getattr(job, "id", job_id))
+            row = next((row for row in state.jobs if row.id == canonical_id), None)
+            if row is not None:
+                details = {
+                    "detail_job_id": canonical_id,
+                    "detail_session_id": row.session_id,
+                    "detail_epoch": state.epoch,
+                    "detail_sequence": state.sequence,
+                    "todos": job_todos_wire_value(row.todos),
+                }
         total = len(rows)
         page = rows[offset : offset + limit]
         first = rows[0] if rows else None
@@ -2466,7 +2539,8 @@ class OwnedSessionHandle(SessionHandle):
             # A job swept from the ledger is distinguishable from one with no
             # events yet: the page renders "no longer on the ledger" for the
             # first and "no activity" for the second.
-            "known": job is not None,
+            "known": job is not None or node is not None,
+            **details,
         }
 
     async def refresh(self) -> None:

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -2051,31 +2051,12 @@ class Session:
         # concurrent children than a hosted one. An unset or unusable config
         # contributes NO kwarg, so the manager's own default stands and the
         # behaviour is exactly what it was before this was configurable.
-        def on_job_change() -> None:
-            store = getattr(self, "_frontend_state_store", None)
-            # No terminal or attach subscriber can observe these snapshots yet.
-            # Avoid serializing large child trajectories solely for an unused
-            # in-process state object; the first subscription snapshots live data.
-            if store is None or not store.has_subscribers:
-                return
-            if getattr(self, "_frontend_jobs_refresh_scheduled", False):
-                return
-            self._frontend_jobs_refresh_scheduled = True
-            try:
-                # Child trajectory events arrive in bursts. A 50 ms coalesce
-                # keeps progress perceptibly live without serializing six full
-                # rosters on every shared-loop event.
-                asyncio.get_running_loop().call_later(0.05, self._flush_frontend_jobs)
-            except RuntimeError:
-                self._frontend_jobs_refresh_scheduled = False
-                store.refresh_jobs(self)
-
         self.jobs = AsyncJobManager(
             on_job_complete=self._on_job_completed,
             # One mutation seam persists resumability and publishes the live
             # canonical roster, including progress/cost/status changes.
             on_roster_change=self._schedule_subagent_persist,
-            on_job_change=on_job_change,
+            on_job_change=self._schedule_frontend_jobs,
             **_configured_max_running(),
         )
         self._wake = WakeScheduler(
@@ -2900,6 +2881,11 @@ class Session:
         """
         if self._subagent_comms is None:
             self._subagent_comms = SubagentComms(self)
+            # Only the root creates the registry. Children inherit it and must
+            # not each subscribe a second projector to the same graph.
+            self._unsubscribe_subagent_state = self._subagent_comms.subscribe_changes(
+                self._schedule_frontend_jobs
+            )
         return self._subagent_comms
 
     @property
@@ -5251,6 +5237,22 @@ class Session:
         return await asyncio.to_thread(count)
 
     # -- events ---------------------------------------------------------------
+
+    def _schedule_frontend_jobs(self) -> None:
+        """Share one subscriber-aware coalescer across root and descendant jobs."""
+        store = getattr(self, "_frontend_state_store", None)
+        # Fresh subscriptions take a full graph snapshot. Unobserved sessions
+        # need no eager projection, particularly while a manager is waiting.
+        if store is None or not store.has_subscribers:
+            return
+        if getattr(self, "_frontend_jobs_refresh_scheduled", False):
+            return
+        self._frontend_jobs_refresh_scheduled = True
+        try:
+            asyncio.get_running_loop().call_later(0.05, self._flush_frontend_jobs)
+        except RuntimeError:
+            self._frontend_jobs_refresh_scheduled = False
+            store.refresh_jobs(self)
 
     def _flush_frontend_jobs(self) -> None:
         """Coalesce a burst of child trajectory/progress mutations per loop tick."""
@@ -10193,6 +10195,10 @@ class Session:
         if self._disposed:
             return
         self._disposed = True
+        unsubscribe_state = getattr(self, "_unsubscribe_subagent_state", None)
+        if unsubscribe_state is not None:
+            unsubscribe_state()
+            self._unsubscribe_subagent_state = None
         # No later boundary can drain producer steers once disposal starts.
         # Reject them while owner callbacks and viewers are still attached so
         # capacity is released and the producer can safely reuse the same ID.

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -4282,14 +4282,15 @@ def restore_todos(session_id: str, phases: list[dict[str, Any]]) -> None:
     mirrors :func:`todo_snapshot`: each phase gets a fresh ``items`` list of
     copied item dicts so the store never aliases the caller's structure.
 
-    A no-op when there is nothing to restore or the id is empty, and it REFUSES
-    to overwrite a list the current session already has: restore runs once at
-    construction, before any turn, so a populated slot means a live list that
-    must win over a stale snapshot.
+    An empty snapshot is authoritative too: keeping its empty slot distinguishes
+    a restored clear from a child whose plan has not been loaded yet. Existing
+    slots, including empty ones, win over a stale on-demand read that raced a
+    live tool call. An empty session id is never a store identity.
     """
-    if not session_id or not phases:
+    if not session_id or session_id in TODO_STORE:
         return
-    if TODO_STORE.get(session_id):
+    if not phases:
+        TODO_STORE[session_id] = []
         return
     TODO_STORE[session_id] = [
         {"name": phase["name"], "items": [dict(item) for item in phase["items"]]}

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -13267,7 +13267,10 @@ class OperatorApp(App[None]):
                 return jobs, job_for(view.job_id) if view is not None else None
             # Old/local hosts without lineage can still show their root ledger,
             # but a child must never inherit its parent's roster by default.
-            return (manager.list() if manager is not None and view is None else []), None
+            return (
+                manager.list() if manager is not None and view is None else [],
+                self._subagent_job(view.job_id) if view is not None else None,
+            )
         except Exception:
             return [], None
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1384,9 +1384,9 @@ COMFORTABLE_ROWS_CLASS = "comfortable-rows"
 #: recede rather than disappear, or the page stops reading as the same app.
 #: Flipped in exactly two places, ``_open_subagent_view``/``_close_subagent_view``.
 SUBAGENT_LAYOUT_CLASS = "subagent"
-#: At phone-height terminals the live roster and todos can consume nearly the
-#: entire detail page. The compact mode keeps the selected transcript primary;
-#: secondary context remains one ``Esc`` away in the parent conversation.
+#: At phone-height terminals the scoped roster and todos still need to be
+#: reachable. Compact mode reclaims the disabled composer and decorative rows,
+#: keeping the selected transcript primary without hiding the owner's controls.
 SUBAGENT_COMPACT_LAYOUT_CLASS = "subagent-compact"
 SUBAGENT_COMPACT_MAX_ROWS = 24
 
@@ -13233,6 +13233,44 @@ class OperatorApp(App[None]):
                 wake_rows = 0
         return rows + wake_rows + _SUBAGENT_DOCK_ROWS < screen_height
 
+    def _subagent_job(self, job_id: str) -> Any:
+        session = self._session
+        comms = getattr(session, "_subagent_comms", None)
+        lookup = getattr(comms, "job", None)
+        job = lookup(job_id) if callable(lookup) else None
+        manager = getattr(session, "jobs", None)
+        if job is None and manager is not None:
+            job = manager.get(job_id)
+        if job is None:
+            # Restored descendants have reader DTOs, not local execution rows.
+            frontend = getattr(session, "frontend_state", None)
+            job = next((row for row in getattr(frontend, "jobs", ()) if row.id == job_id), None)
+        return job
+
+    def _subagent_roster(self) -> tuple[list[Any], Any]:
+        """Resolve one direct-child scope for open, retarget, tick and close.
+
+        The execution ledger is local on an owner and flattened on a follower.
+        The comms graph is the common ownership contract, never the current row
+        selection or a best-effort label match.
+        """
+        session = self._session
+        comms = getattr(session, "_subagent_comms", None)
+        manager = getattr(session, "jobs", None)
+        view = self._subagent_view
+        try:
+            job_for = self._subagent_job
+
+            if comms is not None and callable(getattr(comms, "children", None)):
+                nodes = comms.children(view.job_id if view is not None else None)
+                jobs = [job for node in nodes if (job := job_for(node.job_id)) is not None]
+                return jobs, job_for(view.job_id) if view is not None else None
+            # Old/local hosts without lineage can still show their root ledger,
+            # but a child must never inherit its parent's roster by default.
+            return (manager.list() if manager is not None and view is None else []), None
+        except Exception:
+            return [], None
+
     def _refresh_band(self) -> None:
         """Repaint the dock band (subagent + todo) from live session state.
 
@@ -13245,11 +13283,7 @@ class OperatorApp(App[None]):
         # The settle loop deliberately runs several panel passes, but the job
         # ledger cannot change synchronously inside one refresh. Snapshot once
         # so 100-child sessions do not copy and sort the same roster per pass.
-        try:
-            manager = getattr(session, "jobs", None)
-            jobs = manager.list() if manager is not None else []
-        except Exception:
-            jobs = []
+        jobs, selected_job = self._subagent_roster()
         # Three steps, and the order is load-bearing rather than tidy.
         #
         # A panel's own `sync` is what decides whether it is displayed at all
@@ -13284,7 +13318,7 @@ class OperatorApp(App[None]):
         # first frame that does not move.
         for _ in range(_BAND_SETTLE_PASSES):
             if self._subagent_panel is not None:
-                self._subagent_panel.sync(session, jobs=jobs)
+                self._subagent_panel.sync(session, jobs=jobs, selected_job=selected_job)
             if self._wake_panel is not None:
                 self._wake_panel.sync(session)
             if self._todo_panel is not None:
@@ -13309,6 +13343,10 @@ class OperatorApp(App[None]):
                     session,
                     session_id=selected_session_id,
                     transcript_directory=selected_directory,
+                    loading=(
+                        self._subagent_view is not None
+                        and self._trajectory_state.get(self._subagent_view.job_id) == "loading"
+                    ),
                 )
             self._sync_band_inset()
         # The open subagent page rides the SAME tick, for the same reason: a
@@ -13477,7 +13515,23 @@ class OperatorApp(App[None]):
         un-dimmed under the view precisely so a reader can hop between
         subagents without going back up a level to do it.
         """
+        comms = getattr(self._session, "_subagent_comms", None)
+        node_lookup = getattr(comms, "node", None)
+        node = node_lookup(job_id) if callable(node_lookup) else None
+        canonical_id = getattr(node, "job_id", None)
+        if isinstance(canonical_id, str) and canonical_id:
+            job_id = canonical_id
         if self._subagent_view is not None:
+            previous_id = self._subagent_view.job_id
+            if previous_id != job_id:
+                unload = getattr(self._session, "unload_job_trajectory", None)
+                if callable(unload):
+                    self._trajectory_loads.discard(previous_id)
+                    self.run_worker(
+                        cast(Callable[[str], Awaitable[None]], unload)(previous_id),
+                        group="subagent-trajectory",
+                        exclusive=False,
+                    )
             # Retargeting is opening another child's page; it owes the same
             # fetch a first open does.
             self._load_subagent_trajectory(job_id)
@@ -13575,6 +13629,9 @@ class OperatorApp(App[None]):
             )
         self._subagent_view = None
         view.remove()
+        if self._subagent_panel is not None:
+            scoped_jobs, _ = self._subagent_roster()
+            self._subagent_panel.sync(self._session, jobs=scoped_jobs)
         if self._subagent_panel is not None:
             self._subagent_panel.mark_current(None)
         self.screen.remove_class(SUBAGENT_LAYOUT_CLASS)
@@ -13974,16 +14031,17 @@ class OperatorApp(App[None]):
         session = self._session
         manager = getattr(session, "jobs", None) if session is not None else None
         comms = getattr(session, "_subagent_comms", None) if session is not None else None
+        node_lookup = getattr(comms, "node", None)
+        node = node_lookup(job_id) if callable(node_lookup) else None
+        canonical_id = getattr(node, "job_id", None)
+        if isinstance(canonical_id, str) and canonical_id and canonical_id != job_id:
+            # Resume may replace the attempt while its page is open. Resolve
+            # before reading the ledger, and use the normal navigation path to
+            # move the watch/fetch rather than painting a phantom missing job.
+            self._open_subagent_view(canonical_id)
+            return
         try:
-            lookup = getattr(comms, "job", None) if comms is not None else None
-            job = lookup(job_id) if callable(lookup) else None
-            # Owner comms resolves durable attempt aliases to a live job. The
-            # follower graph facade deliberately has no job objects of its own;
-            # its canonical SnapshotJobs ledger is authoritative instead. A
-            # callable lookup returning None must therefore fall through, not
-            # turn every follower child page into a false "no longer on ledger".
-            if job is None and manager is not None:
-                job = manager.get(job_id)
+            job = self._subagent_job(job_id)
         except Exception:
             job = manager.get(job_id) if manager is not None else None
         # Comms accepts durable predecessor IDs, but the panel contains only the
@@ -14067,6 +14125,9 @@ class OperatorApp(App[None]):
         if self._subagent_panel is not None:
             self._subagent_panel.mark_current(job_id)
         self._point_band_at(job)
+        if self._subagent_panel is not None:
+            scoped_jobs, selected_job = self._subagent_roster()
+            self._subagent_panel.sync(session, jobs=scoped_jobs, selected_job=selected_job)
         if self._todo_panel is not None and session is not None:
             self._todo_panel.sync(
                 session,
@@ -14076,6 +14137,7 @@ class OperatorApp(App[None]):
                     if node is not None and getattr(node, "session_dir", None) is not None
                     else None
                 ),
+                loading=self._trajectory_state.get(job_id) == "loading",
             )
 
     def _point_band_at(self, job: Any) -> None:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -13566,6 +13566,17 @@ class OperatorApp(App[None]):
         # limit. Started before the first paint so the fetch overlaps the
         # mount, and the page shows its loading row meanwhile.
         self._load_subagent_trajectory(job_id)
+        # The dock is re-scoped to THIS child's direct children the moment the
+        # page exists, in the same handler, and through `_refresh_band` rather
+        # than a bare panel `sync`. A leaf child has no roster, so the panel
+        # hides; only `_refresh_band` also re-decides the band's `has-slot`
+        # inset from that visibility. Leaving either half to the deferred
+        # refresh below (or to the 1 Hz poll, which is where the inset used to
+        # catch up) posts a four-widget `messages.Layout` cascade on whichever
+        # later frame happens to run it — a reflow the reader sees as the dock
+        # jumping after the page has already painted, and one the spinner-tick
+        # budget test caught only under xdist contention.
+        self._refresh_band()
         # Enter paints the new mode first; folding and mounting a retained
         # 500-event trajectory on the same key handler made the key appear lost
         # for about a second. The next refresh fills the already-visible page.

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -1339,12 +1339,31 @@ Screen.subagent SubagentRow.current {
     background: $lo-tint-select;
 }
 
-/* A 24-row terminal cannot carry the selected transcript plus an unbounded
- * live roster and selected todos without reducing the conversation to a
- * single row. In compact detail mode the conversation is the primary surface;
- * the hidden parent-session context returns unchanged when the reader leaves. */
-Screen.subagent-compact #band {
+/* The detail dock now contains only this owner's bounded child preview and
+ * plan, not the root's whole roster. Hiding it at 24 rows made nested children
+ * unclickable and hid the selected plan. Keep those controls, reclaiming only
+ * the decorative inset; each panel still owns its compact/expanded row budget. */
+Screen.subagent-compact #band.has-slot {
+    padding-top: 0;
+}
+
+/* This mode cannot accept a draft: its footer already explains read-only/Esc.
+ * Keep the owner's status row but reclaim the disabled input and vertical
+ * padding, so exposing its own controls does not reduce the transcript to a
+ * single row. Removing the mode restores the parent's untouched draft. */
+Screen.subagent-compact #input-row {
     display: none;
+}
+
+Screen.subagent-compact #input-shell {
+    /* The docked status row does not contribute to an auto-height shell. */
+    min-height: 1;
+    padding: 0 1;
+}
+
+Screen.subagent-compact #status-band {
+    height: 1;
+    padding: 0;
 }
 
 /* ── full-page subagent view ───────────────────────────────────────────── *

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -1203,7 +1203,7 @@ DEFAULT_PLACEHOLDER = "Message Local Operator…"
 #: What the composer says while it refuses input. It names the state AND the
 #: consequence, because the only useful thing to tell someone whose keys are
 #: being ignored is how to get a composer that accepts them.
-READ_ONLY_PLACEHOLDER = "Read-only — press esc to reply"
+READ_ONLY_PLACEHOLDER = "Read-only · esc back"
 
 #: What the composer says while the `/btw` aside card owns it — what the FIELD
 #: does, in ``DEFAULT_PLACEHOLDER``'s shape, and nothing about how to leave.

--- a/local_operator/tui/widgets/subagent_panel.py
+++ b/local_operator/tui/widgets/subagent_panel.py
@@ -1257,6 +1257,7 @@ class SubagentPanel(Container):
         #: spinner tick repaints from it between refreshes rather than
         #: re-querying the manager eight times a second.
         self._jobs_by_id: dict[str, Any] = {}
+        self._selected_job_id = ""
         self._spinner_index = 0
         self._spinner_timer = None
         #: Interval the live timer was created with; a focus change compares
@@ -1533,6 +1534,7 @@ class SubagentPanel(Container):
         self._model_label = str(getattr(session, "model_label", "") or "")
         task_jobs = [job for job in job_rows if getattr(job, "type", "") == "task"]
         selected_id = str(getattr(selected_job, "id", "") or "")
+        self._selected_job_id = selected_id
         if selected_id:
             # The viewed manager is not its own child row, but its status band
             # still needs the same off-thread stats cache as visible children.
@@ -1626,7 +1628,10 @@ class SubagentPanel(Container):
             if job_id not in seen:
                 changed = True
                 self._rows.pop(job_id).remove()
-                self._stats.pop(job_id, None)
+                # The selected reader still consumes its owner's band stats
+                # after that job stops being a visible child-list row.
+                if job_id != self._selected_job_id:
+                    self._stats.pop(job_id, None)
         # The manager hands jobs back in start order; keep the DOM in the
         # same order so a stable ledger paints a stable list.
         #

--- a/local_operator/tui/widgets/subagent_panel.py
+++ b/local_operator/tui/widgets/subagent_panel.py
@@ -273,6 +273,8 @@ def job_seconds(job: Any) -> float:
     """
     try:
         start = float(getattr(job, "start_time", 0.0) or 0.0)
+        if start <= 0:
+            return 0.0
         settled = getattr(job, "settled_at", None)
         end = float(settled) if settled else time.time()
         return max(end - start, 0.0)
@@ -287,6 +289,10 @@ def job_elapsed(job: Any) -> str:
     NUMBER — its duration segment does its own formatting and compares against
     zero to decide whether the segment exists at all.
     """
+    # Cold presentation-only rows have identity/outcome but no trustworthy
+    # clock. Epoch zero is not a launch time, and "0s" would invent a duration.
+    if not getattr(job, "start_time", None):
+        return ""
     return format_duration(job_seconds(job))
 
 

--- a/local_operator/tui/widgets/subagent_panel.py
+++ b/local_operator/tui/widgets/subagent_panel.py
@@ -1376,7 +1376,11 @@ class SubagentPanel(Container):
         preview_budget = self._preview_job_rows()
         if self._expanded:
             try:
-                budget = max(1, int(self.screen.size.height) - _EXPANDED_DOCK_ROWS)
+                budget = (
+                    max(1, preview_budget)
+                    if self.screen.has_class("subagent")
+                    else max(1, int(self.screen.size.height) - _EXPANDED_DOCK_ROWS)
+                )
             except Exception:
                 budget = len(job_ids)
             self._navigation_index = max(0, min(len(job_ids) - 1, self._navigation_index))
@@ -1437,12 +1441,13 @@ class SubagentPanel(Container):
             return _PREVIEW_JOB_ROWS
         if screen_height <= 0:
             return _PREVIEW_JOB_ROWS
-        available = (
-            screen_height
-            - _COLLAPSED_DOCK_ROWS
-            - _TRANSCRIPT_FLOOR_ROWS
-            - self._band_sibling_rows()
-        )
+        floor = _TRANSCRIPT_FLOOR_ROWS
+        if self.screen.has_class("subagent") and not self.screen.has_class("subagent-compact"):
+            # The detail page has title/breadcrumb/footer rows the root transcript
+            # does not. Compact mode recovers those from its disabled composer;
+            # normal mode must reserve them before allocating auxiliary rows.
+            floor += 6
+        available = screen_height - _COLLAPSED_DOCK_ROWS - floor - self._band_sibling_rows()
         return max(_MIN_PREVIEW_JOB_ROWS, min(_PREVIEW_JOB_ROWS, available))
 
     def _band_sibling_rows(self) -> int:
@@ -1498,7 +1503,9 @@ class SubagentPanel(Container):
         self._stop_spinner()
 
     # -- sync -------------------------------------------------------------
-    def sync(self, session: Any, *, jobs: Sequence[Any] | None = None) -> None:
+    def sync(
+        self, session: Any, *, jobs: Sequence[Any] | None = None, selected_job: Any = None
+    ) -> None:
         """Re-read ``session.jobs`` and schedule a repaint.
 
         Called on every Subagent* event (immediate) and on the 1 Hz poll (the
@@ -1519,9 +1526,14 @@ class SubagentPanel(Container):
         job_rows = jobs or []
         self._model_label = str(getattr(session, "model_label", "") or "")
         task_jobs = [job for job in job_rows if getattr(job, "type", "") == "task"]
+        selected_id = str(getattr(selected_job, "id", "") or "")
+        if selected_id:
+            # The viewed manager is not its own child row, but its status band
+            # still needs the same off-thread stats cache as visible children.
+            self._stats_for(selected_id, selected_job, True)
         if not task_jobs:
             self._jobs_by_id = {}
-            self._stats = {}
+            self._stats = {key: value for key, value in self._stats.items() if key == selected_id}
             self._sync_rows([])
             self.display = False
             self._dirty = False

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -3307,11 +3307,12 @@ class SubagentView(Vertical):
         # (visible hints, esc label, state label) per rung, widest first.
         arrows = (self._up_hint, self._down_hint, self._scroll_label)
         relations = (self._parent_hint, self._peer_hint, self._child_hint, self._root_hint)
+        back_label = "back to parent" if self._ancestors else "back to conversation"
         rungs: tuple[tuple[tuple[HintButton, ...], str], ...] = (
-            ((*relations, *arrows, self._exit_hint, self._state_hint), "back to conversation"),
-            ((*arrows, self._exit_hint, self._state_hint), "back to conversation"),
-            ((*relations, *arrows, self._exit_hint), "back to conversation"),
-            ((*arrows, self._exit_hint), "back to conversation"),
+            ((*relations, *arrows, self._exit_hint, self._state_hint), back_label),
+            ((*arrows, self._exit_hint, self._state_hint), back_label),
+            ((*relations, *arrows, self._exit_hint), back_label),
+            ((*arrows, self._exit_hint), back_label),
             ((*arrows, self._exit_hint), "back"),
             ((self._exit_hint,), "back"),
             ((self._exit_hint,), ""),

--- a/local_operator/tui/widgets/todo_panel.py
+++ b/local_operator/tui/widgets/todo_panel.py
@@ -421,6 +421,7 @@ class TodoPanel(Container):
                 int,
                 bool,
                 frozenset[str],
+                str,
             ]
             | None
         ) = None
@@ -452,6 +453,7 @@ class TodoPanel(Container):
         self._expanded_body_lines: int = 0
         self._restored_todos: dict[str, list[dict[str, Any]]] = {}
         self._todo_loads: dict[str, asyncio.Task[None]] = {}
+        self._selection: tuple[str, str | None] | None = None
         # Hidden until the first todo exists: an empty panel is not content.
         self.display = False
 
@@ -542,11 +544,14 @@ class TodoPanel(Container):
         try:
             phases = await asyncio.to_thread(_read_restored_todos, transcript_directory)
             self._restored_todos[transcript_directory] = phases
-            self.sync(
-                session,
-                session_id=session_id,
-                transcript_directory=transcript_directory,
-            )
+            # A read may finish after navigation. Cache it without ever
+            # retargeting the visible panel to the child that started it.
+            if self._selection == (session_id, transcript_directory):
+                self.sync(
+                    session,
+                    session_id=session_id,
+                    transcript_directory=transcript_directory,
+                )
         except asyncio.CancelledError:
             raise
         except Exception:
@@ -560,6 +565,7 @@ class TodoPanel(Container):
         *,
         session_id: str | None = None,
         transcript_directory: str | None = None,
+        loading: bool = False,
     ) -> None:
         """Re-read the selected session's store and repaint only on change.
 
@@ -573,11 +579,40 @@ class TodoPanel(Container):
             selected_id = (
                 session_id if session_id is not None else getattr(session, "session_id", "")
             )
-            if frontend is not None and selected_id == getattr(session, "session_id", ""):
-                # The live owner/follower session reads canonical state;
-                # historical child pages fall through to their own durable
-                # transcript below.
-                phases = [phase.model_dump(mode="json") for phase in frontend.todos]
+            selection = (selected_id, transcript_directory)
+            if selection != self._selection:
+                self._selection = selection
+                self._settled_since.clear()
+                if self._scroll.is_mounted:
+                    self._scroll.scroll_home(animate=False)
+            empty_state = ""
+            if frontend is not None:
+                if selected_id == getattr(session, "session_id", ""):
+                    phases = [phase.model_dump(mode="json") for phase in frontend.todos]
+                else:
+                    job = next(
+                        (row for row in frontend.jobs if row.session_id == selected_id), None
+                    )
+                    # A selected detail snapshot owns this list. Never borrow
+                    # root/process-local todos while an attached child's plan
+                    # is loading or unavailable; [] is an authoritative clear.
+                    canonical = getattr(job, "todos", None)
+                    phases = (
+                        [
+                            {
+                                "name": phase.get("name", _IMPLICIT_PHASE),
+                                "items": [dict(item) for item in phase.get("items", [])],
+                            }
+                            for phase in canonical
+                        ]
+                        if canonical is not None
+                        else []
+                    )
+                    empty_state = (
+                        ("Loading todos" if loading else "Todos unavailable")
+                        if canonical is None
+                        else "No todos"
+                    )
             else:
                 restored = None
                 if transcript_directory is not None:
@@ -644,12 +679,22 @@ class TodoPanel(Container):
                 cells,
                 self._expanded,
                 hidden,
+                empty_state,
             )
             if state == self._shown:
                 return  # equality guard — nothing that affects the paint moved
             self._shown = state
             if not fingerprint:
-                self.display = False
+                self.display = bool(empty_state)
+                self._painted_rows = 1 if empty_state else 0
+                self._affordance.display = False
+                self._expanded_item_rows = []
+                self._expanded_body_lines = 0
+                if empty_state:
+                    self._body.update(
+                        Text(empty_state, style=Style(color=theme_mod.semantic_color("muted")))
+                    )
+                    self._scroll.styles.max_height = 1
                 return
             self.display = True
             body, affordance = self._build(phases, hidden)
@@ -1562,11 +1607,26 @@ class TodoPanel(Container):
         # expanded-floor rule above): expanded may only ever GROW the panel.
         # Only charged when a sibling is actually docked — see the constant.
         shared_floor = _COLLAPSED_SHARED_TRANSCRIPT_FLOOR if sibling_rows else 0
+        detail_view = self.screen.has_class("subagent")
+        if detail_view:
+            # A child page spends six rows on title/breadcrumb/footer chrome
+            # before its transcript gets a single row. The root's six-row floor
+            # alone was consumed by that chrome, leaving one or two body rows.
+            # Keep the same useful body floor, even with no roster beside us.
+            shared_floor = _COLLAPSED_SHARED_TRANSCRIPT_FLOOR + 6
         collapsed_budget = max(
             _MIN_BODY_ROWS, min(collapsed_ceiling, screen_height - dock - shared_floor)
         )
+        if detail_view:
+            # Phase/header, one scrollable item and the disclosure need four
+            # rows. Below that the normal root-page fitting ladder sacrifices
+            # the hint, which made a compact child's full plan undiscoverable.
+            # Still degrade on genuinely tiny terminals rather than overflow.
+            control_floor = max(_MIN_BODY_ROWS, min(4, screen_height - dock - 6))
+            collapsed_budget = max(control_floor, collapsed_budget)
         if self._expanded:
-            grown = screen_height - dock - _EXPANDED_TRANSCRIPT_FLOOR
+            floor = shared_floor if detail_view else _EXPANDED_TRANSCRIPT_FLOOR
+            grown = screen_height - dock - floor
             grown = max(_MIN_BODY_ROWS, min(_MAX_EXPANDED_ROWS, grown))
             return max(collapsed_budget, grown)
         return collapsed_budget
@@ -1599,6 +1659,8 @@ class TodoPanel(Container):
         if parent is None:
             return 0
         try:
+            if self.screen.has_class("subagent-compact"):
+                return 0
             return 1 if parent.has_class("has-slot") else 0
         except Exception:  # not a band (reduced test hosts); charge nothing
             return 0

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -88,6 +88,7 @@ import json
 import os
 import re
 import time
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 from rich.cells import cell_len
@@ -571,7 +572,7 @@ def _diff_counts(details: dict[str, Any] | None) -> tuple[int, int]:
     ``bool`` is excluded explicitly — it is an ``int`` subclass in Python and
     ``details={"added": True}`` must not print ``+1``.
     """
-    if not isinstance(details, dict):
+    if not isinstance(details, Mapping):
         return (0, 0)
 
     def _count(value: object) -> int:
@@ -584,17 +585,17 @@ def _diff_counts(details: dict[str, Any] | None) -> tuple[int, int]:
 
 def _search_result_output(details: dict[str, Any] | None) -> list[str]:
     """Structured web-search rows: provider, page name, URL, and short snippet."""
-    if not isinstance(details, dict):
+    if not isinstance(details, Mapping):
         return []
     sources = details.get("sources")
-    if not isinstance(sources, list) or not sources:
+    if not isinstance(sources, Sequence) or isinstance(sources, (str, bytes)) or not sources:
         return []
 
     provider = _strip_control_sequences(str(details.get("provider") or "search"))
     auth_mode = _strip_control_sequences(str(details.get("auth_mode") or ""))
     lines = [f"Provider: {provider}" + (f" ({auth_mode})" if auth_mode else ""), "Sources:"]
     for index, source in enumerate(sources, start=1):
-        if not isinstance(source, dict):
+        if not isinstance(source, Mapping):
             continue
         title = _strip_control_sequences(
             " ".join(str(source.get("title") or "Untitled result").split())
@@ -622,7 +623,7 @@ def _is_fetch_details(tool_name: str, details: dict[str, Any] | None) -> bool:
     """
     if tool_name == "web_fetch":
         return True
-    if tool_name != "read" or not isinstance(details, dict):
+    if tool_name != "read" or not isinstance(details, Mapping):
         return False
     return "render_method" in details and "final_url" in details
 
@@ -637,7 +638,7 @@ def _fetch_result_output(details: dict[str, Any] | None) -> list[str]:
     itself is appended by the body painter from the result text; this helper owns
     only the header rows, mirroring ``_search_result_output``'s split of duties.
     """
-    if not isinstance(details, dict):
+    if not isinstance(details, Mapping):
         return []
     url = _strip_control_sequences(str(details.get("url") or ""))
     final = _strip_control_sequences(str(details.get("final_url") or url))
@@ -1469,8 +1470,10 @@ class ToolCard(ExpandableActionBlock):
         # the fetch presentation without re-inspecting details every repaint.
         self._is_fetch_card = bool(fetch_output)
         self._output = search_output or fetch_output or self._clean_output(result_text)
-        diff = details.get("diff") if isinstance(details, dict) else None
-        if isinstance(diff, list) and diff:
+        diff = details.get("diff") if isinstance(details, Mapping) else None
+        # Canonical follower details are immutable sequences, not concrete
+        # lists. They still carry the same unified diff as the live executor.
+        if isinstance(diff, Sequence) and not isinstance(diff, (str, bytes)) and diff:
             self._diff = [str(line) for line in diff]
         else:
             self._diff = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.48.1"
+version = "0.48.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.48.0"
+version = "0.48.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]
@@ -60,9 +60,6 @@ dependencies = [
     "starlette",
     "uvicorn",
     "python-multipart",
-    # The personal tunnel gateway verifies the edge's RSA proof locally;
-    # declare this directly rather than relying on the MCP transitive copy.
-    "pyjwt[crypto]>=2.10,<3",
     "websockets>=15.0.1",
     "apscheduler",
     "dill",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ dependencies = [
     "starlette",
     "uvicorn",
     "python-multipart",
+    # The personal tunnel gateway verifies the edge's RSA proof locally;
+    # declare this directly rather than relying on the MCP transitive copy.
+    "pyjwt[crypto]>=2.10,<3",
     "websockets>=15.0.1",
     "apscheduler",
     "dill",

--- a/tests/unit/harness/test_comms.py
+++ b/tests/unit/harness/test_comms.py
@@ -1729,6 +1729,62 @@ def make_parent(tmp_path, provider) -> Session:
 
 
 @pytest.mark.asyncio
+async def test_completed_nested_job_survives_manager_disposal_without_retaining_session(
+    tmp_path, monkeypatch
+):
+    import gc
+    import weakref
+
+    from local_operator.harness.jobs import AsyncJob
+    from local_operator.session.frontend_state import FrontendStateStore
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    root = make_parent(tmp_path, ScriptedProvider())
+    manager = Session(
+        model=MODEL,
+        stream_fn=ScriptedProvider(),
+        tools=[],
+        system_blocks_provider=lambda: [],
+        transcript=Transcript(tmp_path / "manager"),
+        cwd=str(tmp_path),
+    )
+    comms = root.subagent_comms
+    manager_job = AsyncJob(id="manager", type="task", label="synthetic manager", start_time=1.0)
+    leaf_job = AsyncJob(id="leaf", type="task", label="synthetic leaf", start_time=1.0)
+    root.jobs._jobs[manager_job.id] = manager_job
+    manager.jobs._jobs[leaf_job.id] = leaf_job
+    comms.record_launch("manager", "Manager")
+    comms.attach("manager", manager, tmp_path / "manager")
+    root.jobs.attach_child_manager("manager", manager.jobs)
+    comms.record_launch("leaf", "Leaf", parent_job_id="manager")
+    notices = []
+    unsubscribe = comms.subscribe_changes(lambda: notices.append(True))
+    manager.jobs._notify_transient_job_change()
+    assert notices  # independent of the manager having a frontend subscriber
+    unsubscribe()
+    ref = weakref.ref(manager)
+    comms.detach("manager")
+    # Detach precedes the runner's terminal assignment. Retaining a value copy
+    # here would preserve a permanently running child on the root's viewer.
+    manager_job.status = "completed"
+    leaf_job.status = "completed"
+    leaf_job.result_text = "Nested work completed"
+    root.jobs.detach_child_manager("manager", [])
+    await manager.dispose()
+    del manager
+    gc.collect()
+    assert ref() is None
+    assert manager_job.child_jobs is None
+    assert comms.job("leaf") is leaf_job
+    rows = FrontendStateStore._jobs(root)
+    leaf = next(row for row in rows if row.id == "leaf")
+    assert leaf.parent_job_id == "manager"
+    assert leaf.status == "completed"
+    assert leaf.result_text == "Nested work completed"
+    await root.dispose()
+
+
+@pytest.mark.asyncio
 async def test_a_question_reaches_a_busy_child_and_its_answer_comes_back(tmp_path, monkeypatch):
     """The end-to-end claim: an aside injected into a child that is mid tool
     loop reaches its context, and the child's own hub call answers the

--- a/tests/unit/session/test_attach_frame_size.py
+++ b/tests/unit/session/test_attach_frame_size.py
@@ -575,6 +575,98 @@ async def test_attach_succeeds_against_a_session_that_exceeded_the_old_limit(
         registrant.close()
 
 
+@pytest.mark.parametrize("invalidate", ["", "epoch", "removed", "identity"])
+@pytest.mark.asyncio
+async def test_watched_todo_fetch_cannot_roll_back_newer_state(tmp_path, monkeypatch, invalidate):
+    import threading
+
+    entered, release = threading.Event(), threading.Event()
+
+    def plan(text):  # noqa: ANN001, ANN202
+        return [{"name": "Work", "items": [{"text": text, "status": "pending", "reason": ""}]}]
+
+    class DetailHandle(FakeHandle):
+        async def job_trajectory(self, job_id, offset, limit):  # noqa: ANN001, ANN202
+            page = await super().job_trajectory(job_id, offset, limit)
+            snapshot = self._frontend.state
+            job = next(row for row in snapshot.jobs if row.id == job_id)
+            page.update(
+                detail_job_id=job_id,
+                detail_session_id=job.session_id,
+                detail_epoch=snapshot.epoch,
+                detail_sequence=snapshot.sequence,
+                todos=job.model_dump(mode="json")["todos"],
+            )
+            entered.set()
+            await asyncio.to_thread(release.wait, 10)
+            return page
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions" / "s1").mkdir(parents=True)
+    handle = DetailHandle()
+    jobs = [
+        row.model_copy(update={"session_id": f"child-{i}", "todos": plan("Earlier")})
+        for i, row in enumerate(_jobs(2, 1))
+    ]
+    handle._frontend.mutate(jobs=jobs)
+    registrant = RuntimeServer(handle, kind="tui")
+    registrant.start()
+    remote = None
+    try:
+        remote = await RemoteSession.connect(
+            await _record(tmp_path), "s1", config_dir=tmp_path, takeover_factory=_never
+        )
+
+        def todos_for(job_id: str):  # noqa: ANN202
+            assert remote is not None
+            job = remote.jobs.get(job_id)
+            assert job is not None
+            return job.todos
+
+        assert todos_for("job0") is None
+        loading = asyncio.create_task(remote.load_job_trajectory("job0"))
+        assert await asyncio.to_thread(entered.wait, 10)
+        changed = asyncio.Event()
+        subscription = remote.subscribe_frontend(lambda _: changed.set())
+        try:
+            updated = [job.model_copy(update={"todos": plan("Newer")}) for job in jobs]
+            handle._frontend.mutate(jobs=updated)
+            await asyncio.wait_for(changed.wait(), 10)
+            assert todos_for("job0") == plan("Newer")
+            assert todos_for("job1") is None
+            state = remote.frontend_state
+            if invalidate == "epoch":
+                remote._install_frontend(state.model_copy(update={"epoch": "new-owner"}))
+            elif invalidate == "removed":
+                remote._install_frontend(state.model_copy(update={"jobs": []}))
+            elif invalidate == "identity":
+                remote._install_frontend(
+                    state.model_copy(
+                        update={
+                            "jobs": [
+                                row.model_copy(update={"session_id": "resumed-child"})
+                                for row in state.jobs
+                            ]
+                        }
+                    )
+                )
+            release.set()
+            assert await loading is (not bool(invalidate))
+            if not invalidate:
+                assert todos_for("job0") == plan("Newer")
+                changed.clear()
+                handle._frontend.mutate(jobs=[job.model_copy(update={"todos": []}) for job in jobs])
+                await asyncio.wait_for(changed.wait(), 10)
+                assert todos_for("job0") == []
+        finally:
+            subscription.unsubscribe()
+    finally:
+        release.set()
+        if remote is not None:
+            await remote.dispose()
+        registrant.close()
+
+
 @pytest.mark.asyncio
 async def test_live_appends_reach_only_the_watched_job(tmp_path: Path, monkeypatch) -> None:
     """``watch_job`` is what makes the delta stream affordable."""

--- a/tests/unit/session/test_frontend_state.py
+++ b/tests/unit/session/test_frontend_state.py
@@ -653,6 +653,53 @@ def test_rejected_snapshot_mutation_cannot_diverge_owner_and_follower() -> None:
     assert follower.state.jobs[0].trajectory == owner.state.jobs[0].trajectory
 
 
+@pytest.mark.parametrize("replacement", [False, True])
+def test_trajectory_delta_preserves_nested_json_objects(replacement: bool) -> None:
+    """Exercise JSON, not an in-process delta that still recognizes frozen maps."""
+    earlier = {"type": "notice", "text": "Earlier activity"}
+    initial = _state(jobs=[JobState(id="child", type="task", trajectory=[earlier])])
+    owner = FrontendStateStore(initial)
+    follower = FrontendStateStore(initial)
+    events = [
+        {
+            "type": "tool_execution_start",
+            "tool_call_id": "call",
+            "tool_name": "read",
+            "intent": "Reading documentation",
+            "args": {"path": "README.md", "options": {"ranges": [{"start": 1}]}},
+        },
+        {
+            "type": "tool_execution_end",
+            "tool_call_id": "call",
+            "tool_name": "read",
+            "result": {
+                "content": [{"type": "text", "text": "Synthetic documentation"}],
+                "details": {"count": 1, "rows": [{"ok": True, "extra": None}]},
+            },
+        },
+        {
+            "type": "message_end",
+            "message": {
+                "id": "message",
+                "role": "assistant",
+                "content": [{"type": "text", "text": "Finished reading."}],
+            },
+        },
+    ]
+    trajectory = events if replacement else [earlier, *events]
+    update = owner.mutate(jobs=[JobState(id="child", type="task", trajectory=trajectory)])
+    assert update is not None
+    wire = FrontendUpdate.model_validate_json(update.model_dump_json())
+    assert wire.job_trajectory_appends == {"child": events}
+    assert wire.job_trajectory_replacements == (["child"] if replacement else [])
+    assert follower.apply_update(wire)
+    assert follower.state.jobs[0].trajectory == owner.state.jobs[0].trajectory
+    assert follower.state.jobs[0].model_dump(mode="json")["trajectory"] == trajectory
+    # Thawing the emitted payload must not expose canonical state to a consumer.
+    update.job_trajectory_appends["child"][0]["args"]["options"]["ranges"][0]["start"] = 99
+    assert owner.state.jobs[0].model_dump(mode="json")["trajectory"] == trajectory
+
+
 def test_one_large_roster_progress_update_sends_only_the_new_event() -> None:
     """A one-child append must not serialize 50,000 unchanged events."""
     jobs = [

--- a/tests/unit/session/test_no_session_deletion.py
+++ b/tests/unit/session/test_no_session_deletion.py
@@ -504,6 +504,11 @@ _ALLOWED_ROWS: tuple[tuple[str | int, ...], ...] = (
         "in-memory .replace",
     ),
     (
+        "local_operator/session/frontend_state.py::FrontendStateStore.replace_and_notify",
+        "<path>.replace",
+        "self.replace(state): FrontendStateStore.replace, an in-memory snapshot swap",
+    ),
+    (
         "local_operator/session/frontend_state.py::SnapshotSubagentComms.__init__",
         "<path>.replace",
         "in-memory .replace",
@@ -772,6 +777,8 @@ _NEAR_DISPLACERS: frozenset[str] = frozenset(
         "local_operator/session/frontend_state.py::SnapshotWakeScheduler.__init__",
         "local_operator/session/frontend_state.py::SnapshotSubagentComms.__init__",
         "local_operator/session/frontend_state.py::SnapshotMcpManager.__init__",
+        # self.replace(state) = in-memory snapshot swap
+        "local_operator/session/frontend_state.py::FrontendStateStore.replace_and_notify",
         "local_operator/session/frontend_state.py::FrontendStateStore.checkpoint",  # tmp -> FILE
         "local_operator/session/remote.py::RemoteSession._install_frontend",  # facade
         "local_operator/session/remote.py::RemoteSession._apply_frontend_facades",  # facade

--- a/tests/unit/session/test_subagent_view_state.py
+++ b/tests/unit/session/test_subagent_view_state.py
@@ -195,6 +195,40 @@ async def test_cold_owner_hydrates_selected_child_plan_and_reconstructs_nested_r
 
 
 @pytest.mark.asyncio
+async def test_live_empty_child_plan_fetch_never_reads_transcript(tmp_path, monkeypatch) -> None:
+    import asyncio
+
+    from local_operator.harness.jobs import AsyncJob
+    from local_operator.session.runtime import owned
+    from local_operator.tools.builtin import TODO_STORE
+    from tests.unit.harness.test_comms import ScriptedProvider, make_parent
+
+    root = make_parent(tmp_path / "root", ScriptedProvider())
+    child = make_parent(tmp_path / "child", ScriptedProvider())
+    job = AsyncJob(id="live-child", type="task", label="Live child", start_time=1.0)
+    root.jobs._jobs[job.id] = job
+    root.subagent_comms.record_launch(job.id, job.label)
+    root.subagent_comms.attach(job.id, child, child._transcript.directory)
+    monkeypatch.delitem(TODO_STORE, child.session_id, raising=False)
+
+    def forbid_read(*args):  # noqa: ANN002, ANN202
+        raise AssertionError("a live empty plan must not trigger historical disk I/O")
+
+    monkeypatch.setattr(owned, "_read_child_todo_snapshot", forbid_read)
+    handle = owned.OwnedSessionHandle(root, asyncio.get_running_loop(), cwd=str(tmp_path))
+    try:
+        page = await handle.job_trajectory(job.id, 0, 100)
+        assert page["known"] is True
+        assert page["todos"] == []
+        assert child.session_id not in TODO_STORE
+    finally:
+        root.subagent_comms.detach(job.id)
+        job.status = "completed"
+        await child.dispose()
+        await root.dispose()
+
+
+@pytest.mark.asyncio
 async def test_parent_checkpoint_does_not_duplicate_child_plans() -> None:
     saved = []
 

--- a/tests/unit/session/test_subagent_view_state.py
+++ b/tests/unit/session/test_subagent_view_state.py
@@ -1,0 +1,206 @@
+"""Child detail ownership across canonical snapshots, deltas and fetch races."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from local_operator.session.frontend_state import (
+    JOB_TODOS_WIRE_BYTES,
+    FrontendSessionState,
+    FrontendStateStore,
+    FrontendUpdate,
+    JobState,
+    SnapshotSubagentComms,
+    filter_update_trajectories,
+    job_todos_wire_value,
+    sync_wire_payload,
+)
+
+
+def _todos(text: str) -> list[dict[str, Any]]:
+    return [{"name": "Work", "items": [{"text": text, "status": "pending", "reason": ""}]}]
+
+
+def _job(todos=None, **changes) -> JobState:  # noqa: ANN001, ANN003
+    return JobState(id="manager", type="task", session_id="child-session", todos=todos, **changes)
+
+
+def _state(*jobs: JobState) -> FrontendSessionState:
+    return FrontendSessionState(session_id="root", epoch="epoch", jobs=list(jobs))
+
+
+def test_todo_delta_is_watched_and_does_not_ride_roster_or_attach() -> None:
+    owner = FrontendStateStore(_state(_job()))
+    follower = FrontendStateStore(owner.state)
+    update = owner.mutate(jobs=[_job(_todos("Child work"))])
+    assert update is not None
+    payload = update.model_dump(mode="json")
+    assert "todos" not in payload["changes"]["jobs"][0]
+    assert filter_update_trajectories(payload, lambda _: False)["job_todo_updates"] == {}
+    watched = filter_update_trajectories(payload, lambda _: True)
+    follower.apply_update(FrontendUpdate.model_validate_json(json.dumps(watched)))
+    assert follower.state.jobs[0].todos == _todos("Child work")
+    snapshot = sync_wire_payload(owner.subscribe(lambda _: None).sync)
+    assert snapshot["snapshot"]["jobs"][0]["todos"] is None
+    # A status-only roster delta must preserve the already-hydrated plan.
+    later = owner.mutate(jobs=[_job(_todos("Child work"), status="completed")])
+    assert later is not None and not later.job_todo_updates
+    follower.apply_update(FrontendUpdate.model_validate_json(later.model_dump_json()))
+    assert follower.state.jobs[0].todos == _todos("Child work")
+
+
+def test_fetched_todos_and_stream_replacements_have_two_way_watermarks() -> None:
+    owner = FrontendStateStore(_state(_job()))
+    follower = FrontendStateStore(owner.state)
+    older = owner.mutate(jobs=[_job(_todos("Earlier"))])
+    newer = owner.mutate(jobs=[_job(_todos("Newer"))])
+    assert older is not None and newer is not None
+    assert follower.seed_job_todos(
+        "manager",
+        _todos("Newer"),
+        epoch="epoch",
+        sequence=newer.sequence,
+        session_id="child-session",
+    )
+    follower.apply_update(FrontendUpdate.model_validate_json(older.model_dump_json()))
+    assert follower.state.jobs[0].todos == _todos("Newer")
+    follower.apply_update(FrontendUpdate.model_validate_json(newer.model_dump_json()))
+    assert not follower.seed_job_todos(
+        "manager",
+        _todos("Earlier"),
+        epoch="epoch",
+        sequence=older.sequence,
+        session_id="child-session",
+    )
+    clear = owner.mutate(jobs=[_job([])])
+    assert clear is not None
+    follower.apply_update(FrontendUpdate.model_validate_json(clear.model_dump_json()))
+    assert follower.state.jobs[0].todos == []
+    assert not follower.seed_job_todos(
+        "manager",
+        _todos("Wrong session"),
+        epoch="epoch",
+        sequence=100,
+        session_id="another-session",
+    )
+    follower.replace(_state(_job()).model_copy(update={"epoch": "new-owner"}))
+    assert not follower.seed_job_todos(
+        "manager",
+        _todos("Old owner"),
+        epoch="epoch",
+        sequence=100,
+        session_id="child-session",
+    )
+    assert follower.seed_job_todos(
+        "manager",
+        [],
+        epoch="new-owner",
+        sequence=0,
+        session_id="child-session",
+    )
+
+
+def test_large_child_plans_cannot_amplify_attach_or_selected_frames() -> None:
+    large = _todos("x" * (JOB_TODOS_WIRE_BYTES + 1))
+    assert job_todos_wire_value(large) is None  # unavailable, never a partial task
+    assert job_todos_wire_value([]) == []
+    jobs = [JobState(id=f"child-{i}", type="task", todos=large) for i in range(12)]
+    owner = FrontendStateStore(_state())
+    update = owner.mutate(jobs=jobs)
+    assert update is not None
+    snapshot = sync_wire_payload(owner.subscribe(lambda _: None).sync)
+    assert len(json.dumps(snapshot).encode()) < 1_048_576
+    assert all(job["todos"] is None for job in snapshot["snapshot"]["jobs"])
+    selected = filter_update_trajectories(
+        update.model_dump(mode="json"), lambda key: key == "child-1"
+    )
+    assert selected["job_todo_updates"] == {"child-1": None}
+    assert len(json.dumps(selected).encode()) < 1_048_576
+    assert owner.state.jobs[1].todos == large
+
+
+def test_resumed_manager_alias_resolves_to_one_current_node() -> None:
+    comms = SnapshotSubagentComms(
+        [
+            _job([], attempt_aliases=["old-manager"]),
+            JobState(id="leaf", type="task", parent_job_id="manager", session_id="leaf-session"),
+        ]
+    )
+    node = comms.node("old-manager")
+    assert node is not None and node.job_id == "manager"
+    assert [node.job_id for node in comms.children("old-manager")] == ["leaf"]
+    parent = comms.parent("leaf")
+    assert parent is not None and parent.job_id == "manager"
+
+
+@pytest.mark.parametrize("saved", [[], _todos("Previously saved child task")])
+@pytest.mark.asyncio
+async def test_cold_owner_hydrates_selected_child_plan_and_reconstructs_nested_rows(
+    tmp_path, monkeypatch, saved
+) -> None:
+    import asyncio
+
+    from local_operator.session.runtime.owned import OwnedSessionHandle
+    from local_operator.session.transcript import Transcript
+    from local_operator.tools.builtin import TODO_STORE
+    from tests.unit.harness.test_comms import ScriptedProvider, make_parent
+
+    root = make_parent(tmp_path, ScriptedProvider())
+    child = Transcript(tmp_path / "cold-manager")
+    await child.append_custom("todo_snapshot", {"items": saved})
+    leaf = Transcript(tmp_path / "cold-leaf")
+    root.subagent_comms.restore(
+        [
+            {
+                "job_id": "manager",
+                "label": "Manager",
+                "session_dir": str(child.directory),
+                "outcome": "completed",
+            },
+            {
+                "job_id": "leaf",
+                "label": "Leaf",
+                "parent_job_id": "manager",
+                "session_dir": str(leaf.directory),
+                "outcome": "completed",
+            },
+        ]
+    )
+    monkeypatch.delitem(TODO_STORE, "cold-manager", raising=False)
+    root._frontend_state_store.refresh_jobs(root)
+    manager = next(job for job in root.frontend_state.jobs if job.id == "manager")
+    assert manager.todos is None  # absent process store is not an empty saved plan
+    assert (
+        next(job for job in root.frontend_state.jobs if job.id == "leaf").parent_job_id == "manager"
+    )
+    handle = OwnedSessionHandle(root, asyncio.get_running_loop(), cwd=str(tmp_path))
+    try:
+        page = await handle.job_trajectory("manager", 0, 100)
+        assert page["known"] is True
+        assert page["todos"] == saved
+        assert page["detail_epoch"] == root.frontend_state.epoch
+        assert page["detail_sequence"] == root.frontend_state.sequence
+        assert "cold-manager" in TODO_STORE
+        root._frontend_state_store.refresh_jobs(root)
+        assert next(job for job in root.frontend_state.jobs if job.id == "manager").todos == saved
+    finally:
+        TODO_STORE.pop("cold-manager", None)
+        await root.dispose()
+
+
+@pytest.mark.asyncio
+async def test_parent_checkpoint_does_not_duplicate_child_plans() -> None:
+    saved = []
+
+    class Transcript:
+        async def append_custom(self, kind, payload, **kwargs):  # noqa: ANN001, ANN003, ANN202
+            saved.append(payload)
+
+    store = FrontendStateStore(_state(_job(_todos("Private child plan"))))
+    await store.checkpoint(Transcript())
+    assert saved
+    assert saved[-1]["state"]["jobs"][0]["todos"] is None
+    assert store.state.jobs[0].todos == _todos("Private child plan")

--- a/tests/unit/session/test_subagent_view_state.py
+++ b/tests/unit/session/test_subagent_view_state.py
@@ -146,6 +146,7 @@ async def test_cold_owner_hydrates_selected_child_plan_and_reconstructs_nested_r
     from local_operator.session.runtime.owned import OwnedSessionHandle
     from local_operator.session.transcript import Transcript
     from local_operator.tools.builtin import TODO_STORE
+    from local_operator.tui.widgets.subagent_panel import job_elapsed, job_seconds
     from tests.unit.harness.test_comms import ScriptedProvider, make_parent
 
     root = make_parent(tmp_path, ScriptedProvider())
@@ -173,6 +174,8 @@ async def test_cold_owner_hydrates_selected_child_plan_and_reconstructs_nested_r
     root._frontend_state_store.refresh_jobs(root)
     manager = next(job for job in root.frontend_state.jobs if job.id == "manager")
     assert manager.todos is None  # absent process store is not an empty saved plan
+    assert job_seconds(manager) == 0.0
+    assert job_elapsed(manager) == ""  # no invented multi-day age or zero-second receipt
     assert (
         next(job for job in root.frontend_state.jobs if job.id == "leaf").parent_job_id == "manager"
     )

--- a/tests/unit/tui/test_subagent_scope.py
+++ b/tests/unit/tui/test_subagent_scope.py
@@ -329,3 +329,72 @@ async def test_late_durable_todo_read_cannot_retarget_selected_owner(monkeypatch
     await asyncio.gather(*pending)
     assert panel._selection == ("child-b", None)
     assert "Old child" not in str(panel._body.content)
+
+
+def _dock_state(app: OperatorApp) -> tuple[bool, bool, bool]:
+    band = app.query_one("#band")
+    panel = app.query_one(SubagentPanel)
+    todos = app.query_one(TodoPanel)
+    return (panel.display, todos.display, band.has_class("has-slot"))
+
+
+@pytest.mark.parametrize("leaf_has_plan", [True, False])
+@pytest.mark.asyncio
+async def test_opening_a_leaf_settles_the_dock_in_the_same_handler(leaf_has_plan: bool) -> None:
+    """Re-scoping the dock to a leaf's (empty) roster must not straddle frames.
+
+    Opening a leaf hides the child panel and re-decides the band's
+    ``has-slot`` inset from whatever is STILL docked (the leaf's todo panel:
+    a plan, or the authoritative "No todos" of an empty one). Both are decided
+    inside ``_open_subagent_view`` itself, through ``_refresh_band``. A bare panel
+    ``sync`` deferred to the next refresh left the inset to the 1 Hz poll, so
+    the dock reflowed twice (panel hides; poll drops the inset a frame or a
+    second later) and posted a four-widget ``messages.Layout`` cascade on
+    whichever later frame ran it. That is what made a spinner tick "post
+    layout" under xdist contention and the dock visibly jump after the page
+    had painted.
+
+    The invariant is stated as "what ``open`` returns with is what every later
+    refresh reaches", read on the frame ``open`` returns on: that is the only
+    place where "settled in the handler" is distinguishable from "settled
+    eventually". Parametrised on the leaf's plan so both todo-panel branches
+    (a rendered list, and the one-row empty state) are shown to settle with
+    the roster in the same handler.
+    """
+    state = scoped_state()
+    if not leaf_has_plan:
+        state = state.model_copy(
+            update={
+                "jobs": [
+                    job.model_copy(update={"todos": []}) if job.id == "leaf" else job
+                    for job in state.jobs
+                ]
+            }
+        )
+    session = FakeSession()
+    install(session, state)
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(80):
+            await pilot.pause()
+            if app._session is not None:
+                break
+        app._refresh_band()
+        await pilot.pause()
+        panel_shown, _, inset = _dock_state(app)
+        assert panel_shown and inset, "fixture must start with a docked roster"
+
+        app._open_subagent_view("leaf")
+        # No pause: the dock has to be right on the frame that opened the page.
+        settled = _dock_state(app)
+        panel_shown, todos_shown, inset = settled
+        assert panel_shown is False, "a leaf has no children to dock"
+        assert inset is (panel_shown or todos_shown), "the inset follows what is still docked"
+
+        # Nothing left over for a later frame to flip: the handler's answer is
+        # the answer the deferred refresh and the poll both arrive at.
+        for _ in range(3):
+            await pilot.pause()
+            assert _dock_state(app) == settled
+        app._refresh_band()
+        assert _dock_state(app) == settled

--- a/tests/unit/tui/test_subagent_scope.py
+++ b/tests/unit/tui/test_subagent_scope.py
@@ -1,0 +1,331 @@
+"""The viewed owner, not the root process, owns docked plans and children."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from local_operator.session.frontend_state import (
+    FrontendModelSpec,
+    FrontendSessionState,
+    FrontendStateStore,
+    FrontendUpdate,
+    JobState,
+    SnapshotJobs,
+    SnapshotSubagentComms,
+    TodoPhaseState,
+)
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.subagent_panel import SubagentPanel
+from local_operator.tui.widgets.subagent_view import entry_block, fold_trajectory
+from local_operator.tui.widgets.todo_panel import TodoPanel
+from local_operator.tui.widgets.tool_card import ToolCard
+from tests.unit.tui.test_subagent_view import (
+    FakeSession,
+    _async_factory,
+    _call,
+    _open,
+    _result,
+)
+
+
+def plan(text: str, status: str = "pending") -> list[dict[str, Any]]:
+    return [{"name": "Work", "items": [{"text": text, "status": status, "reason": ""}]}]
+
+
+def scoped_state() -> FrontendSessionState:
+    return FrontendSessionState(
+        session_id="sess",
+        epoch="owner",
+        selected_model=FrontendModelSpec(
+            provider="test", model_id="model", display_name="test/model"
+        ),
+        todos=[TodoPhaseState.model_validate(row) for row in plan("Root plan")],
+        jobs=[
+            JobState(
+                id="manager",
+                type="task",
+                session_id="manager-session",
+                label="Coordinate review",
+                todos=plan("Manager plan"),
+                trajectory=[_call("wait", "jobs", op="peek")],
+            ),
+            JobState(
+                id="sibling",
+                type="task",
+                session_id="sibling-session",
+                label="Independent work",
+                todos=plan("Sibling plan"),
+            ),
+            JobState(
+                id="leaf",
+                type="task",
+                session_id="leaf-session",
+                parent_job_id="manager",
+                label="Inspect documentation",
+                todos=plan("Leaf plan"),
+                trajectory=[
+                    _call("read", "read", path="README.md"),
+                    _result("read", "read", "Synthetic documentation"),
+                ],
+            ),
+        ],
+    )
+
+
+def install(session: Any, state: FrontendSessionState) -> None:
+    session.is_remote = True
+    session.frontend_state = state
+    session.jobs = SnapshotJobs(state.jobs)
+    session._subagent_comms = SnapshotSubagentComms(state.jobs)
+
+
+@pytest.mark.parametrize("size", [(100, 30), (80, 24)])
+@pytest.mark.asyncio
+async def test_manager_children_and_plans_follow_navigation_and_live_updates(size) -> None:
+    state = scoped_state()
+    session = FakeSession()
+    install(session, state)
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=size) as pilot:
+        view = await _open(pilot, app, session.jobs.get("manager"))
+        panel = app.query_one(SubagentPanel)
+        todos = app.query_one(TodoPanel)
+        assert set(panel._rows) == {"leaf"}
+        assert "Manager plan" in str(todos._body.content)
+        assert "Root plan" not in str(todos._body.content)
+        await pilot.click(panel._rows["leaf"])
+        await pilot.pause()
+        assert view.job_id == "leaf"
+        assert not panel.display
+        assert "Leaf plan" in str(todos._body.content)
+        assert "Manager plan" not in str(todos._body.content)
+        card = view.query_one(ToolCard)
+        await pilot.click(card)
+        await pilot.pause()
+        assert card._expanded
+        await pilot.press("escape")
+        await pilot.pause()
+        assert view.job_id == "manager"
+        assert set(panel._rows) == {"leaf"}
+        owner = FrontendStateStore(state)
+        follower = FrontendStateStore(state)
+        updated = [
+            (
+                job.model_copy(update={"todos": plan("Manager updated"), "status": "running"})
+                if job.id == "manager"
+                else job
+            )
+            for job in state.jobs
+        ]
+        delta = owner.mutate(jobs=updated)
+        assert delta is not None
+        follower.apply_update(FrontendUpdate.model_validate_json(delta.model_dump_json()))
+        install(session, follower.state)
+        app._apply_frontend_state(follower.state)
+        await pilot.pause()
+        assert "Manager updated" in str(todos._body.content)
+        assert "Manager plan" not in str(todos._body.content)
+        await pilot.press("right_square_bracket")
+        await pilot.pause()
+        assert view.job_id == "sibling"
+        assert "Sibling plan" in str(todos._body.content)
+        assert not panel.display
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app._subagent_view is None
+        assert set(panel._rows) == {"manager", "sibling"}
+        assert "Root plan" in str(todos._body.content)
+        assert app.screen.size == app.screen.virtual_size
+        assert not app.screen.show_vertical_scrollbar
+
+
+@pytest.mark.parametrize("size", [(100, 30), (80, 24)])
+@pytest.mark.asyncio
+async def test_scoped_overflow_preserves_body_status_and_disclosure(size) -> None:
+    state = scoped_state()
+    long_plan = [
+        {
+            "name": "Implementation",
+            "items": [
+                {"text": f"Task {index}", "status": "pending", "reason": ""} for index in range(30)
+            ],
+        }
+    ]
+    state = state.model_copy(
+        update={
+            "jobs": [
+                job.model_copy(update={"todos": long_plan}) if job.id == "manager" else job
+                for job in state.jobs
+            ]
+        }
+    )
+    session = FakeSession()
+    install(session, state)
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=size) as pilot:
+        view = await _open(pilot, app, session.jobs.get("manager"))
+        todos = app.query_one(TodoPanel)
+        for key in (None, "ctrl+t", "ctrl+down", "ctrl+t"):
+            if key:
+                await pilot.press(key)
+            await pilot.pause()
+            assert view._body.size.height >= 5
+            assert todos._affordance.display
+            assert "ctrl+t" in str(todos._affordance.content)
+            status = app.query_one("#status-band")
+            shell = app.query_one("#input-shell")
+            assert shell.size.height >= 1
+            assert status.region.bottom <= app.screen.region.bottom
+            assert shell.region.contains_region(status.region)
+            assert not app.screen.show_vertical_scrollbar
+        await pilot.press("escape")
+        await pilot.pause()
+        assert app.query_one("#input-row").display
+
+
+@pytest.mark.asyncio
+async def test_open_manager_tracks_resumed_attempt_without_reentry() -> None:
+    state = scoped_state()
+    session: Any = FakeSession()
+    install(session, state)
+    loaded, unloaded = [], []
+
+    async def load(job_id):  # noqa: ANN001, ANN202
+        loaded.append(job_id)
+        return True
+
+    async def unload(job_id):  # noqa: ANN001, ANN202
+        unloaded.append(job_id)
+
+    session.load_job_trajectory = load
+    session.unload_job_trajectory = unload
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        view = await _open(pilot, app, session.jobs.get("manager"))
+        resumed = state.model_copy(
+            update={
+                "jobs": [
+                    (
+                        row.model_copy(
+                            update={
+                                "id": "manager-new",
+                                "attempt_aliases": ["manager"],
+                                "todos": plan("Resumed manager plan"),
+                            }
+                        )
+                        if row.id == "manager"
+                        else (
+                            row.model_copy(update={"parent_job_id": "manager-new"})
+                            if row.id == "leaf"
+                            else row
+                        )
+                    )
+                    for row in state.jobs
+                ]
+            }
+        )
+        install(session, resumed)
+        app._apply_frontend_state(resumed)
+        await pilot.pause()
+        await app.workers.wait_for_complete(
+            [worker for worker in app.workers if worker.group == "subagent-trajectory"]
+        )
+        await pilot.pause()
+        assert view.job_id == "manager-new"
+        assert "manager" in unloaded and "manager-new" in loaded
+        assert "no longer on" not in " ".join(view.rendered_rows())
+        assert "Resumed manager plan" in str(app.query_one(TodoPanel)._body.content)
+        assert set(app.query_one(SubagentPanel)._rows) == {"leaf"}
+        await pilot.click(app.query_one(SubagentPanel)._rows["leaf"])
+        await pilot.pause()
+        assert "back to parent" in " ".join(view.rendered_rows())
+        await pilot.press("escape")
+        await pilot.pause()
+        assert view.job_id == "manager-new"
+
+
+@pytest.mark.asyncio
+async def test_child_todo_loading_unavailable_and_authoritative_clear_are_distinct() -> None:
+    state = scoped_state()
+    session = FakeSession()
+    install(session, state)
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _open(pilot, app, session.jobs.get("manager"))
+        todos = app.query_one(TodoPanel)
+        for phases, loading, expected in [
+            (None, True, "Loading todos"),
+            (None, False, "Todos unavailable"),
+            ([], False, "No todos"),
+        ]:
+            state = state.model_copy(
+                update={
+                    "jobs": [
+                        row.model_copy(update={"todos": phases}) if row.id == "manager" else row
+                        for row in state.jobs
+                    ]
+                }
+            )
+            install(session, state)
+            app._trajectory_state["manager"] = "loading" if loading else ""
+            app._refresh_subagent_view()
+            await pilot.pause()
+            assert expected in str(todos._body.content)
+            assert "Root plan" not in str(todos._body.content)
+            assert "Manager plan" not in str(todos._body.content)
+
+
+def test_canonical_edit_result_keeps_unified_diff() -> None:
+    end = _result("edit", "edit", "Edited synthetic file")
+    end["result"]["details"] = {
+        "diff": ["--- before", "+++ after", "-old", "+new"],
+        "added": 1,
+        "removed": 1,
+    }
+    owner = FrontendStateStore(FrontendSessionState(session_id="root", epoch="owner"))
+    delta = owner.mutate(
+        jobs=[
+            JobState(
+                id="leaf",
+                type="task",
+                trajectory=[
+                    _call("edit", "edit", path="synthetic.txt", old_text="old", new_text="new"),
+                    end,
+                ],
+            )
+        ]
+    )
+    assert delta is not None
+    follower = FrontendStateStore(FrontendSessionState(session_id="root", epoch="owner"))
+    follower.apply_update(FrontendUpdate.model_validate_json(delta.model_dump_json()))
+    card = entry_block(fold_trajectory(follower.state.jobs[0].trajectory)[0])
+    assert isinstance(card, ToolCard)
+    assert card._diff == ["--- before", "+++ after", "-old", "+new"]
+    assert card.can_expand()
+
+
+@pytest.mark.asyncio
+async def test_late_durable_todo_read_cannot_retarget_selected_owner(monkeypatch) -> None:
+    from local_operator.tui.widgets import todo_panel
+
+    entered, release = asyncio.Event(), asyncio.Event()
+
+    async def delayed_read(*args):  # noqa: ANN002, ANN202
+        entered.set()
+        await release.wait()
+        return plan("Old child")
+
+    monkeypatch.setattr(todo_panel.asyncio, "to_thread", delayed_read)
+    session = FakeSession()
+    panel = TodoPanel()
+    panel.sync(session, session_id="child-a", transcript_directory="synthetic-child-a")
+    await entered.wait()
+    pending = list(panel._todo_loads.values())
+    panel.sync(session, session_id="child-b")
+    release.set()
+    await asyncio.gather(*pending)
+    assert panel._selection == ("child-b", None)
+    assert "Old child" not in str(panel._body.content)

--- a/tests/unit/tui/test_subagent_stats.py
+++ b/tests/unit/tui/test_subagent_stats.py
@@ -1219,15 +1219,23 @@ async def test_an_open_page_does_not_reinstate_the_per_event_repaint() -> None:
         Job("j2", "docs sweep", progress="running 3 tools"),
         Job("j3", "flaky test triage", progress="thinking"),
     ]
+    from local_operator.harness.comms import SubagentComms
+
     session = FakeSession()
-    session.jobs = _fake_jobs(*jobs)
+    owner = Job("owner", "manager")
+    session.jobs = _fake_jobs(owner, *jobs)
+    comms = SubagentComms(session)  # type: ignore[arg-type]
+    comms.record_launch("owner", "manager")
+    for job in jobs:
+        comms.record_launch(job.id, job.label, parent_job_id="owner")
+    session._subagent_comms = comms
     app = OperatorApp(_async_factory(session))
     async with app.run_test(size=(120, 40)) as pilot:
         await _booted(app)
         panel = app.query_one(SubagentPanel)
         panel.sync(session)
         panel._tick()
-        app._open_subagent_view("j1")
+        app._open_subagent_view("owner")
         await pilot.pause()
         panel._tick()
 
@@ -1237,9 +1245,9 @@ async def test_an_open_page_does_not_reinstate_the_per_event_repaint() -> None:
             app._refresh_band()  # what on_subagent_progress does
         assert painted == [], "an open page repainted rows per relayed event"
         panel._tick()
-        # All three, once each — the burst of twelve collapsed into one paint
-        # per row. j1 is the current row and repaints too, because a RUNNING
-        # child keeps its activity even while its page is open.
+        # All three direct children, once each: the viewed manager is not a
+        # child row, but its whole visible roster must stay fresh without a
+        # per-event repaint while the manager's transcript is being read.
         assert sorted(painted) == ["j1", "j2", "j3"]
 
 

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -1137,7 +1137,8 @@ async def test_narrow_subagent_mode_preserves_a_useful_transcript_viewport() -> 
         for _ in range(3):
             await pilot.pause()
         assert app.screen.has_class("subagent-compact")
-        assert app.query_one("#band").display is False
+        assert app.query_one("#input-row").display is False
+        assert app.query_one("#input-shell").size.height >= 1
         assert view._body.size.height >= 8, view._body.size
         assert app.screen.virtual_size.height <= app.screen.size.height
 

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -983,6 +983,59 @@ async def _open(pilot: Any, app: OperatorApp, job: Any) -> SubagentView:
     return app.query_one(SubagentView)
 
 
+@pytest.mark.asyncio
+async def test_live_wire_tool_details_match_reentered_history() -> None:
+    """A JSON delta and a later owner fetch must paint the same tool receipt."""
+    from local_operator.session.frontend_state import (
+        FrontendSessionState,
+        FrontendStateStore,
+        FrontendUpdate,
+        JobState,
+    )
+
+    state = FrontendSessionState(session_id="synthetic", epoch="test")
+    owner, follower = FrontendStateStore(state), FrontendStateStore(state)
+    job = _job_with([], status="running")
+    session = FakeSession()
+    session.jobs = _fake_jobs(job)
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        view = await _open(pilot, app, job)
+        rows = [
+            _call("wire-call", "read", path="README.md"),
+            _result("wire-call", "read", "Synthetic documentation"),
+        ]
+        for end in (1, 2):
+            update = owner.mutate(
+                jobs=[JobState(id=job.id, type="subagent", trajectory=rows[:end])]
+            )
+            assert update is not None
+            assert follower.apply_update(
+                FrontendUpdate.model_validate_json(update.model_dump_json())
+            )
+            job.trajectory = follower.state.jobs[0].trajectory
+            app._refresh_subagent_view(job.id)
+            await pilot.pause()
+            card = view.query_one(ToolCard)
+            assert card._args == {"path": "README.md"}
+            assert "README.md" in card._summary
+        assert card._output == ["Synthetic documentation"]
+        assert card.can_expand()
+        await pilot.click(card)
+        await pilot.pause()
+        assert card._expanded
+        assert card.size.height > 1
+        await pilot.press("escape")
+        assert app._subagent_view is None
+        job.trajectory = rows
+        app._open_subagent_view(job.id)
+        await pilot.pause()
+        restored = app.query_one(SubagentView).query_one(ToolCard)
+        assert restored._args == card._args
+        assert restored._output == card._output
+        assert restored.can_expand()
+
+
 @pytest.mark.parametrize("size", [(100, 30), (140, 40)])
 @pytest.mark.asyncio
 async def test_the_page_takes_the_whole_view_when_opened_from_the_splash(

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -2378,7 +2378,7 @@ async def test_the_page_renders_the_childs_messages_and_tool_calls() -> None:
 
 
 @pytest.mark.asyncio
-async def test_historical_attempt_opens_and_selects_the_current_visible_row() -> None:
+async def test_historical_attempt_opens_current_identity_and_restores_root_row() -> None:
     session = FakeSession()
     manager = AsyncJobManager()
     current = AsyncJob(
@@ -2421,8 +2421,11 @@ async def test_historical_attempt_opens_and_selects_the_current_visible_row() ->
         panel = app._subagent_panel
         assert view.job_id == "current"
         assert panel is not None
+        assert not panel._rows  # a viewed child is not its own descendant
+        await pilot.press("escape")
+        await pilot.pause()
         assert list(panel._rows) == ["current"]
-        assert panel._rows["current"].current is True
+        assert panel._rows["current"].current is False
 
 
 @pytest.mark.asyncio
@@ -4040,7 +4043,7 @@ async def test_a_history_page_lands_in_order_when_the_cap_is_crossed_mid_read(tm
 
 
 def _long_error_notice() -> dict[str, Any]:
-    """An error that wraps past a 62x24 body's viewport.
+    """An error that wraps past a 62x22 body's viewport.
 
     A two-line wrap still fits above the working line on a 9-row body, so
     sticky-tail following never bisects it. The glyph only sits above the
@@ -4088,7 +4091,7 @@ async def test_the_truncation_note_stays_in_the_viewport_when_the_body_scrolls()
     session = FakeSession()
     session.jobs = _fake_jobs(job)
     app = OperatorApp(_async_factory(session))
-    async with app.run_test(size=(62, 24)) as pilot:
+    async with app.run_test(size=(62, 22)) as pilot:
         view = await _open(pilot, app, job)
         for _ in range(8):
             await pilot.pause()
@@ -4139,7 +4142,11 @@ async def test_a_narrow_viewport_opens_on_a_row_head_not_a_wrap_fragment(
     monkeypatch: pytest.MonkeyPatch,
     late_batch_landing: bool,
 ) -> None:
-    """At 62x24 the first visible transcript line must be a row HEAD.
+    """At 62x22 the first visible transcript line must be a row HEAD.
+
+    Compact detail mode reclaims the disabled composer. At the former 24-row
+    fixture its larger viewport lands on the deliberate gap before the notice,
+    so use 22 rows to keep exercising a bisected notice rather than that gap.
 
     Sticky-tail following can bisect a wrapping notice so the glyph sits
     above the fold and the first glance is a hanging-indented continuation
@@ -4196,7 +4203,7 @@ async def test_a_narrow_viewport_opens_on_a_row_head_not_a_wrap_fragment(
         "Comms", (), {"session_dir_of": lambda self, _job_id: transcript.directory}
     )()
     app = OperatorApp(_async_factory(session))
-    async with app.run_test(size=(62, 24)) as pilot:
+    async with app.run_test(size=(62, 22)) as pilot:
         view = await _open(pilot, app, job)
         await _wait_history(pilot, view)
         await _wait_landing_settled(pilot, view)
@@ -4243,7 +4250,7 @@ async def test_the_landing_survives_the_next_extent_change(tmp_path) -> None:
     ``main``, because the sibling test above asserts the landing and then stops
     looking.
 
-    This is that missing half. It opens the same 62x24 page, waits for the same
+    This is that missing half. It opens the same 62x22 page, waits for the same
     landing, then appends one live row — the ordinary thing a running child
     does — and requires the first visible line to still be a row head.
 
@@ -4275,7 +4282,7 @@ async def test_the_landing_survives_the_next_extent_change(tmp_path) -> None:
         "Comms", (), {"session_dir_of": lambda self, _job_id: transcript.directory}
     )()
     app = OperatorApp(_async_factory(session))
-    async with app.run_test(size=(62, 24)) as pilot:
+    async with app.run_test(size=(62, 22)) as pilot:
         view = await _open(pilot, app, job)
         await _wait_history(pilot, view)
         await _wait_landing_settled(pilot, view)

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -4043,7 +4043,7 @@ async def test_a_history_page_lands_in_order_when_the_cap_is_crossed_mid_read(tm
 
 
 def _long_error_notice() -> dict[str, Any]:
-    """An error that wraps past a 62x22 body's viewport.
+    """An error that wraps past a 62x20 body's viewport.
 
     A two-line wrap still fits above the working line on a 9-row body, so
     sticky-tail following never bisects it. The glyph only sits above the
@@ -4142,11 +4142,18 @@ async def test_a_narrow_viewport_opens_on_a_row_head_not_a_wrap_fragment(
     monkeypatch: pytest.MonkeyPatch,
     late_batch_landing: bool,
 ) -> None:
-    """At 62x22 the first visible transcript line must be a row HEAD.
+    """At 62x20 the first visible transcript line must be a row HEAD.
 
     Compact detail mode reclaims the disabled composer. At the former 24-row
     fixture its larger viewport lands on the deliberate gap before the notice,
-    so use 22 rows to keep exercising a bisected notice rather than that gap.
+    and after #625 pinned ``NoticeBlock`` to its authored height (8 rows here,
+    not the 10 a stale box-model measurement reserved) the 22-row fixture does
+    the same: the followed tail sits on the unowned gap row above the notice,
+    where there is no block head to snap to and the one-shot rightly stays
+    armed. 20 rows puts the tail one row INSIDE the notice again, which is
+    the bisected first glance this test exists to reject. Mutation: skip the
+    snap's ``scroll_to`` and this fails with ``landing sits 1 rows into a
+    block``.
 
     Sticky-tail following can bisect a wrapping notice so the glyph sits
     above the fold and the first glance is a hanging-indented continuation
@@ -4203,7 +4210,7 @@ async def test_a_narrow_viewport_opens_on_a_row_head_not_a_wrap_fragment(
         "Comms", (), {"session_dir_of": lambda self, _job_id: transcript.directory}
     )()
     app = OperatorApp(_async_factory(session))
-    async with app.run_test(size=(62, 22)) as pilot:
+    async with app.run_test(size=(62, 20)) as pilot:
         view = await _open(pilot, app, job)
         await _wait_history(pilot, view)
         await _wait_landing_settled(pilot, view)
@@ -4250,7 +4257,7 @@ async def test_the_landing_survives_the_next_extent_change(tmp_path) -> None:
     ``main``, because the sibling test above asserts the landing and then stops
     looking.
 
-    This is that missing half. It opens the same 62x22 page, waits for the same
+    This is that missing half. It opens the same 62x20 page, waits for the same
     landing, then appends one live row — the ordinary thing a running child
     does — and requires the first visible line to still be a row head.
 
@@ -4282,7 +4289,7 @@ async def test_the_landing_survives_the_next_extent_change(tmp_path) -> None:
         "Comms", (), {"session_dir_of": lambda self, _job_id: transcript.directory}
     )()
     app = OperatorApp(_async_factory(session))
-    async with app.run_test(size=(62, 22)) as pilot:
+    async with app.run_test(size=(62, 20)) as pilot:
         view = await _open(pilot, app, job)
         await _wait_history(pilot, view)
         await _wait_landing_settled(pilot, view)


### PR DESCRIPTION
## Summary

**C2 standard / pre-authorized.** Restore complete live subagent tool cards, show the viewed worker's own plan, and make its direct children visible and navigable. No ticket or RFC was requested; this PR is the delivery record.

### Root causes and changes

- Canonical job trajectories freeze nested dictionaries into immutable tuple-backed mappings. The live-delta path bypassed the snapshot serializer, so JSON changed tool `args`, result objects, and message objects into arrays of pairs. Cards lost arguments/output and could not expand; exit/re-entry fetched a correctly shaped snapshot. Thaw only emitted event deltas at the existing wire boundary. Accept immutable mapping/sequence contracts when rendering structured tool results, including edit diffs.
- Attached terminals previously received only the root execution ledger and root todos. Project the shared child graph without relocating execution, retain bounded references to settled child job rows, and restore presentation-only descendant rows from the existing persisted graph after an owner restart.
- Child plans use the existing watched-detail fetch/subscription: they do **not** ride every roster or attach frame. Per-job sequence watermarks join delayed fetches with newer deltas in both directions; epoch, identity, and removal guards reject stale seeds. Empty plans are authoritative clears, distinct from unavailable plans. Cold child plans load only on demand, off the UI/owner event loop.
- Scope the dock to the viewed worker's own todos and direct children. Keep existing click, parent, peer, child, root, and Esc navigation, including an already-open manager whose attempt is replaced by resume. Preserve sufficient transcript space at 100×30 and 80×24, with accessible full-list/disclosure controls and the owner's status row.

## Acceptance criteria

- [x] Live and fetched tool receipts retain arguments, output, and structured edit diffs; result-bearing cards expand without exit/re-entry.
- [x] Root, manager, leaf, and peer plans never bleed into one another; live updates, empty clears, loading, and unavailable states are distinct.
- [x] A manager's direct children are clickable; nested Esc returns to the manager and then root. Root lists exclude grandchildren and a worker never lists itself as its child.
- [x] Resume canonicalizes an already-open attempt and moves its detail subscription without a phantom missing-job state.
- [x] Completed nested rows remain visible after manager disposal; a real disposed manager Session is garbage-collected and its retained job's child-manager link is cleared.
- [x] A cold owner can recover a selected saved child plan and its persisted child hierarchy/status without per-roster disk reads or copying child plans into root checkpoints.
- [x] Normal/overflow/expanded/scrolled views preserve useful transcript space, owner status, and disclosure controls at 100×30 and 80×24. Returning to root restores its composer.

## Non-goals and limits

No changes to delegation permissions/depth, scheduling, cancellation authority, the independent thinking/responding activity change, or public APIs. No new history storage system or full cold child transcript paging. After an owner restart, the runtime-only retained tool-event window is gone; attached child pages honestly retain the existing saved-history limitation while saved plans and hierarchy/status remain available. Unknown historical durations are omitted, not fabricated from epoch zero.

A selected plan over **128 KiB of actual socket JSON** is shown as **Todos unavailable**, never truncated. Its owner-side plan is unchanged and the root remains attachable. Smaller later updates recover normally. This is an explicit limit, not arbitrary-size support.

## Contracts and blast radius

The additive `JobState.todos`/attempt-alias metadata and watched `FrontendUpdate.job_todo_updates` path affect canonical owner/follower state, selected-job detail hydration, and the TUI dock. Older owners degrade to unavailable child plans. Existing socket authentication/authorization and the global ordered frontend stream remain unchanged. The original tree, live sessions, and private security advisory transcripts were not modified or used as evidence.

## Verification

**All fixtures and attached captures are synthetic. No private transcript or security advisory content is published.**

### Real path and reproduced failure

The original real `OperatorApp.run_test` capture went through a serialized owner delta and follower state: both settled tool cards had `{}` arguments, `can_expand=False`, and clicking did nothing. Esc plus re-entry through retained owner rows restored their full details. On the patch, the same delta emits JSON objects, cards hold the path/command and output, clicking expands, and re-entry is equivalent.

Independent QA also exercised a real owner in a **separate process** and an attached terminal over the actual control socket, so the viewer could not accidentally read a shared process todo store. It covered actual manager/leaf todo calls, direct-child clicks, live completion, parent/root return, cold owner restart, live resume while inspecting, delayed detail replies, newer plan replacement, empty clear, oversize unavailable/recovery, unauthorized socket access, and 80×24/100×30 geometry.

### Rendered evidence

| Original failure | Fixed live receipt |
| --- | --- |
| ![Live delta lost tool arguments and expansion](https://github.com/user-attachments/assets/1495b4d8-057f-4235-9ab5-cf3b8a34b2ee) | ![Live delta retains arguments and expanded output](https://github.com/user-attachments/assets/3f0308a7-c198-46c7-bf71-9380663ad236) |

| Missing manager plan/children | Scoped manager plan and child |
| --- | --- |
| ![Original manager reader hid own todos and nested child](https://github.com/user-attachments/assets/6a7006d0-32b2-4e92-b85a-bede5181be64) | ![Manager reader shows own plan and clickable direct child](https://github.com/user-attachments/assets/ed4e23a8-8088-419a-8021-70dba5fa78bd) |

<details><summary>Compact overflow, loading, empty, unavailable, and cold-clock states</summary>

![80×24 expanded plan retains transcript, collapse control, and owner status](https://github.com/user-attachments/assets/b50b8e1f-d7cc-4fe9-81d9-70f66283022c)
![100×30 expanded plan retains transcript and controls](https://github.com/user-attachments/assets/a6f19dde-be0e-44b3-b5b6-bb065acbe882)
![Selected child plan loading](https://github.com/user-attachments/assets/9bc7fca6-0e2f-4b83-9ac1-e497dfeae115)
![Authoritatively empty selected child plan](https://github.com/user-attachments/assets/083ffc49-cfe7-4327-9836-706876eeb54c)
![Unavailable selected child plan does not borrow root data](https://github.com/user-attachments/assets/153487bd-f91c-47c9-bf98-a313cdd1b147)
![Cold completed child omits unknown elapsed time](https://github.com/user-attachments/assets/0eb903a5-8251-4e54-960d-5dd6b8f40042)

</details>

Native SVG exports were rendered to PNG and visually inspected. At 100×30 overflow/expanded/scrolled states, the transcript body retains **6 rows**; at 80×24 it retains **5 rows**, with the owner status row and `ctrl+t` collapse control visible. Outer screen actual/virtual sizes match (98×28 and 78×22 content boxes), with no outer scrollbar. First/settled geometry is unchanged. Parent/child/back and live/empty/error-state captures accompany the independent QA review.

### Automated and assembled checks

- Full local unit run, exactly frozen `73e7572d028472d838bd92f8b7b7c13a33003d06`: **13,336 passed, 15 skipped, 2 failed in 1,278.24 s**. This is deliberately not called green. Both failures were in selected subagent stats: the owner cache was dropped with its no-longer-visible row, and an older repaint fixture still expected root peers in a child-scoped view.
- Both findings were fixed together: preserve the selected reader's stats even when it is not a child row; use the selected job in legacy/no-graph mode; re-scope the repaint fixture to a manager with three actual children. The **entire subagent stats file plus child detail-state tests: 57 passed in 7.12 s** after the fixes. This also exercises the real `OperatorApp` stats cache path.
- Full-tree static gates on the combined candidate: flake8, Black 26.1.0, isort 5.13.2, pyright. **All passed**; Black checked 875 files, pyright reported **0 errors / 0 warnings**. The subsequent metadata-only reservation is `0.47.4`; editable reinstall and the actual entry point returned `v0.47.4`, with imports resolving to this worktree.
- Final focused regression surface (state transport, socket sizing/races, graph persistence, reader, plans, stats, and band geometry): **449 passed in 98.81 s**, exit 0, after both full-suite fixes and the cold-only hydration guard. This includes an explicit live empty-plan request that fails if historical disk I/O is attempted.
- Assembled `tests/e2e -m e2e -n0 -q`: **10 passed in 15.39 s** on the earlier combined candidate; final delta checks and current-head CI are required before merge.
- Subsequent validation removes **all `CMUX_*` environment variables** as well as isolating `HOME`/config, so no test can inherit a real sidebar identity.
- The complete local suite was not repeated for each narrow follow-up or moving peer base. Final-head full CI remains a hard merge gate; the PR records this local evidence gap explicitly rather than implying coverage it does not have.

Commands use a real worktree-owned editable venv. Import provenance was checked from outside the worktree and resolves to this worktree, not the dirty primary checkout. App runs isolate both `HOME` and `LOCAL_OPERATOR_CONFIG_DIR` before imports. No dependency-tree copies or browser engines were created.

## Rollout / rollback

Prebase candidate: `e0c27ea9..4a2281206c7016ecb730b764f4b93b5823d8aa14`, reserved patch version **0.47.4**. The target branch has moved through independently reviewed peer work; integrate the coordinated 0.47.2/0.47.3 prerequisites once, validate the overlap, and re-review that narrow final delta before release. This draft is not a claim that the moving-base integration has passed.

No migration or feature-flag change. Hold merge/release for clean independent code, design, UX, and QA rounds and current-head CI. Release sequencing/version is coordinated by the manager after the earlier security release; this implementing agent does not merge or release. Roll back by reverting this PR; persisted child transcripts and existing root todo snapshots remain intact.
