### PR TITLE
fix(cmux): preserve automatic workspace titles and explicit user names

### DIFF
--- a/local_operator/multiplexer/cmux.py
+++ b/local_operator/multiplexer/cmux.py
@@ -99,10 +99,6 @@ CALL_TIMEOUT_S = 5.0
 SURFACE_ENV = "CMUX_SURFACE_ID"
 WORKSPACE_ENV = "CMUX_WORKSPACE_ID"
 
-#: Placement vocabulary shared with ``spawn.cmux`` without importing that
-#: package back into the multiplexer layer.
-_FORK_SURFACE_PLACEMENT = "surface"
-
 #: cmux mints these as UUIDs. Validated before use because they are
 #: interpolated into a JSON payload handed to a socket that acts on them, and
 #: an inherited-but-stale value (a container, an ssh hop) should read as "no
@@ -264,47 +260,6 @@ def _rpc(binary: str, method: str, params: dict[str, object]) -> dict[str, objec
 # They DELEGATE to the underscore functions rather than replacing them: those
 # are the definitions the existing tests monkeypatch, and a promotion that moved
 # the body would silently make every one of those patches a no-op.
-
-
-def rename_fork_target(env: EnvMap, title: str, *, placement: str) -> bool:
-    """Best-effort rename of the cmux target owned by this fork process.
-
-    cmux 0.64.22+ exposes ``workspace rename <id> --title`` and
-    ``rename-tab --surface <id> <title>``. Target explicit ids from THIS
-    process's environment: defaults could rename whichever workspace the user
-    selected meanwhile. Callers additionally gate on fork provenance, which is
-    what prevents an ordinary/parent session from ever reaching this mutation.
-    """
-    target = _surface_target(env)
-    binary = _cmux_binary()
-    clean = " ".join(str(title).split()).strip()
-    if target is None or binary is None or not clean:
-        return False
-    if placement == _FORK_SURFACE_PLACEMENT:
-        argv = [binary, "rename-tab", "--surface", target["surface_id"], clean]
-    else:
-        argv = [
-            binary,
-            "workspace",
-            "rename",
-            target["workspace_id"],
-            "--title",
-            clean,
-        ]
-    try:
-        completed = subprocess.run(  # noqa: S603 — fixed argv, no shell
-            argv,
-            capture_output=True,
-            text=True,
-            timeout=CALL_TIMEOUT_S,
-        )
-    except (OSError, subprocess.SubprocessError):
-        logger.debug("cmux fork rename failed to spawn", exc_info=True)
-        return False
-    if completed.returncode != 0:
-        logger.debug("cmux fork rename exited %s: %s", completed.returncode, completed.stderr[:200])
-        return False
-    return True
 
 
 def cmux_binary() -> str | None:

--- a/local_operator/spawn/cmux.py
+++ b/local_operator/spawn/cmux.py
@@ -64,12 +64,15 @@ def workspace_argv(binary: str, launch: ForkLaunch) -> list[str]:
     the argv is joined with ``shlex.join`` and not ``" ".join``: a launcher path
     containing a space (``/Applications/My Tools/lop``) would otherwise arrive as
     two arguments and start nothing.
+
+    Do not pass ``--name``: cmux treats it as a persistent USER override, so it
+    masks every later OSC title. The resumed app already owns the automatic
+    title (including fork provenance and run state); explicit user renames must
+    remain free to override it without a competing socket writer.
     """
     return [
         binary,
         "new-workspace",
-        "--name",
-        launch.title,
         "--cwd",
         launch.cwd,
         "--command",

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2590,10 +2590,6 @@ class OperatorApp(App[None]):
         # next substantive message retries, which is bounded by the user's own
         # sends and only ever fires while no name exists to displace.
         self._name_requested: bool = False
-        #: Last cmux label dispatched for THIS fork process. Name updates can
-        #: arrive provisionally, generated, and manually within seconds; exact
-        #: coalescing avoids three socket calls for an unchanged stored title.
-        self._fork_cmux_name: str = ""
         #: A receipt that must survive a session transition, as
         #: ``(fork_id, text)``. `fork.mode=switch` reboots onto the fork, which
         #: wipes the ledger about half a second after the notice is written, so
@@ -12645,68 +12641,11 @@ class OperatorApp(App[None]):
             return
         self._provisional_name = label
         self._status.update(conversation_name=label)
-        self._sync_fork_cmux_name(label)
         # The band is DISPLAY-only; the phone reads the session store, which
         # is still empty. Push the stand-in so the list and header name the
         # conversation the same frame the tab does, instead of "untitled"
         # until a generated title lands (or forever, if naming 429s).
         self._notify_mobile_title(label)
-
-    def _sync_fork_cmux_name(self, title: str) -> None:
-        """Rename only the cmux target this fork process owns, best-effort.
-
-        Terminal OSC titles identify the live surface but cmux workspace labels
-        do not follow them. Provenance is the safety gate: a parent/ordinary
-        session never calls the mutating cmux command, even when it happens to
-        run in the workspace from which a fork was created.
-        """
-        session = self._session
-        session_id = str(getattr(session, "session_id", "") or "") if session else ""
-        clean = " ".join(str(title).split()).strip()
-        if not session_id or not clean or clean == getattr(self, "_fork_cmux_name", ""):
-            return
-        try:
-            from local_operator.fork import fork_parent
-            from local_operator.paths import config_dir
-
-            if not fork_parent(config_dir() / "sessions" / session_id):
-                return
-        except Exception:
-            return
-        self._fork_cmux_name = clean
-
-        if getattr(self, "_fork_cmux_name_worker_running", False):
-            return
-        self._fork_cmux_name_worker_running = True
-
-        async def rename() -> None:
-            from local_operator.multiplexer.cmux import rename_fork_target
-            from local_operator.spawn.policy import fork_cmux_placement
-
-            applied = ""
-            try:
-                # One serial drain owns the subprocess boundary. A newer title
-                # arriving during a slow rename replaces the pending value; the
-                # old call may finish, but the drain always applies the newest
-                # value afterwards, making the externally visible result latest-wins.
-                while applied != getattr(self, "_fork_cmux_name", ""):
-                    pending = self._fork_cmux_name
-                    try:
-                        await asyncio.to_thread(
-                            rename_fork_target,
-                            dict(os.environ),
-                            pending,
-                            placement=fork_cmux_placement(self._config_values()),
-                        )
-                    except Exception:
-                        # A label is decoration; cmux restart/closure must never
-                        # disturb the conversation or roll back the stored title.
-                        logger.debug("fork cmux rename failed", exc_info=True)
-                    applied = pending
-            finally:
-                self._fork_cmux_name_worker_running = False
-
-        self.run_worker(rename(), group="fork-cmux-name", exclusive=False, exit_on_error=False)
 
     def _clock(self) -> float:
         """Monotonic seconds, as one overridable seam.
@@ -13003,7 +12942,6 @@ class OperatorApp(App[None]):
                 conversation_name=stored,
                 forked=bool(getattr(session, "wears_inherited_title", False)),
             )
-        self._sync_fork_cmux_name(stored)
         # The title lands on a detached worker AFTER the last turn event, so
         # the mobile fold never re-reads it on its own. Push now so the
         # phone's header and list update the same moment the band does.
@@ -13068,7 +13006,6 @@ class OperatorApp(App[None]):
                 conversation_name=stored,
                 forked=bool(getattr(session, "wears_inherited_title", False)),
             )
-        self._sync_fork_cmux_name(stored)
         self._notify_mobile_title(stored)
         # `stored`, not `arg`: the store collapses whitespace and caps the length
         # (`MAX_TITLE_CHARS`), and the receipt's whole job is to show the title

--- a/local_operator/tui/terminal_title.py
+++ b/local_operator/tui/terminal_title.py
@@ -27,6 +27,12 @@ Three things are deliberate.
   ASCII ``>``. It is the mark this UI already uses to point at what follows,
   and "the user's turn" is exactly a prompt pointing at the user.
 
+Forks use this same title channel. cmux follows it unless a user explicitly
+named the workspace or surface; socket renames would pin that override and
+freeze the sidebar while this title continues updating. A forked transcript is
+not proof of native workspace ownership: it can be resumed in any surface,
+including a headless test inheriting the developer's cmux environment.
+
 Everything here is either a pure function or a small state holder with an
 injected sink, because the alternative — writing to ``sys.stdout`` — is a
 correctness bug and not a style choice: Textual serialises terminal output

--- a/tests/e2e/test_fork_e2e.py
+++ b/tests/e2e/test_fork_e2e.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import subprocess
 import time
 from pathlib import Path
 from typing import Any
@@ -90,6 +91,22 @@ async def test_fork_keeps_original_tool_and_gate_then_returns_without_restart(
         raise AssertionError("default switch must never open a native terminal")
 
     monkeypatch.setattr(registry, "active_backend", forbid_window)
+    # HOME isolation does not remove inherited native terminal targets. Exercise
+    # that environment deliberately, but intercept the subprocess boundary so a
+    # regression fails here instead of pinning a developer's real sidebar title.
+    monkeypatch.setenv("CMUX_WORKSPACE_ID", "11111111-1111-4111-8111-111111111111")
+    monkeypatch.setenv("CMUX_SURFACE_ID", "22222222-2222-4222-8222-222222222222")
+    monkeypatch.setattr("local_operator.multiplexer.cmux._cmux_binary", lambda: "/bin/cmux")
+    native_calls = []
+    run = subprocess.run
+
+    def intercept_native(argv, *args, **kwargs):
+        if isinstance(argv, list) and Path(str(argv[0])).name == "cmux":
+            native_calls.append(argv)
+            return subprocess.CompletedProcess(argv, 0, stdout="{}", stderr="")
+        return run(argv, *args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", intercept_native)
     # Naming is a separate provider call and would consume this finite model
     # script before the actual tool turn. It is not part of fork admission.
     monkeypatch.setattr(OwnedSessionHandle, "_maybe_name_conversation", lambda *_: None)
@@ -194,6 +211,15 @@ async def test_fork_keeps_original_tool_and_gate_then_returns_without_restart(
                 await wait_for_adoption(app, pilot)
                 app._set_approve_all(not approval)
                 assert app._session is not None
+                from local_operator.tui.terminal_title import TerminalTitle, osc_title
+
+                # Capture the production OSC writer without enabling the headless
+                # driver's output. The same status band survives each adoption.
+                title_wire: list[str] = []
+                title = TerminalTitle(title_wire.append)
+                assert app._status is not None
+                app._status.set_terminal_title(title)
+                title.start()
                 pending: tuple[str, ...] = ()
                 pending_id = ""
                 await app._session.prompt("continue original")
@@ -229,6 +255,18 @@ async def test_fork_keeps_original_tool_and_gate_then_returns_without_restart(
                 assert "Return to original: /resume forkparent01" in painted
                 assert "Work still in progress was not copied" in painted
                 await _capture(app, pilot, f"after-{'approval' if approval else 'tool'}-{size[0]}")
+                assert "Original question" in title.current
+                assert osc_title(title.current) in title_wire
+                assert native_calls == [], "headless fork leaked a native cmux mutation"
+                app._run_slash_command("/rename Divergent work")
+                await _pump(
+                    pilot,
+                    lambda: runtimes[fork_id][0].conversation_name == "Divergent work"
+                    and "Divergent work" in title.current,
+                )
+                assert "Divergent work" in title.current
+                assert osc_title(title.current) in title_wire
+                assert native_calls == [], "fork rename must use OSC, not a user override"
                 assert (
                     "original-write"
                     not in (config / "sessions" / fork_id / "transcript.jsonl").read_text()
@@ -243,6 +281,8 @@ async def test_fork_keeps_original_tool_and_gate_then_returns_without_restart(
                     and app._session.session_id == owner.session_id,
                 )
                 assert runtimes[owner.session_id][0] is owner
+                assert "Divergent work" not in title.current
+                assert osc_title(title.current) in title_wire
                 assert len(runtimes) == 2
                 if approval:
                     await _pump(pilot, lambda: app._approval is not None)
@@ -281,6 +321,22 @@ async def test_fork_keeps_original_tool_and_gate_then_returns_without_restart(
                     pilot, lambda: app._session is not None and app._session.session_id == fork_id
                 )
                 assert len(branch_stream.requests) == 1
+                assert "Divergent work" in title.current
+                assert osc_title(title.current) in title_wire
+                assert native_calls == [], "resuming a fork must not pin a native title"
+                await _capture(
+                    app, pilot, f"renamed-{'approval' if approval else 'tool'}-{size[0]}"
+                )
+                print(
+                    json.dumps(
+                        {
+                            "terminal_title": title.current,
+                            "osc": title_wire[-1],
+                            "native_calls": native_calls,
+                        }
+                    )
+                )
+                title.stop()
                 assert (
                     sum(
                         m.text == "try another route"

--- a/tests/unit/test_fork.py
+++ b/tests/unit/test_fork.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import Any, cast
+from typing import cast
 
 import pytest
 from textual.widgets import Static
@@ -477,114 +477,6 @@ class TestForkRuntimeOwnership:
             "child-descendant"
         )
         assert descendant_resume.subagent_comms.session_dir_of("fork-job") is None
-
-
-class TestForkCmuxOwnership:
-    def test_parent_never_schedules_a_cmux_rename(self, tmp_path: Path, monkeypatch) -> None:
-        from local_operator.tui.app import OperatorApp
-
-        parent = _seed_parent(tmp_path)
-        scheduled: list[Any] = []
-        app = cast(
-            OperatorApp,
-            type(
-                "ForkNameHarness",
-                (),
-                {
-                    "_session": type("SessionStub", (), {"session_id": parent.name})(),
-                    "_fork_cmux_name": "",
-                    "run_worker": lambda self, awaitable, **kwargs: scheduled.append(awaitable),
-                },
-            )(),
-        )
-        monkeypatch.setattr("local_operator.paths.config_dir", lambda: tmp_path)
-
-        OperatorApp._sync_fork_cmux_name(app, "Parent work")
-
-        assert scheduled == []
-        assert app._fork_cmux_name == ""
-
-    def test_fork_schedules_only_its_owned_target_rename(self, tmp_path: Path, monkeypatch) -> None:
-        from local_operator.tui.app import OperatorApp
-
-        _seed_parent(tmp_path)
-        fork_id = fork_session(tmp_path, PARENT_ID)
-        scheduled: list[Any] = []
-        app = cast(
-            OperatorApp,
-            type(
-                "ForkNameHarness",
-                (),
-                {
-                    "_session": type("SessionStub", (), {"session_id": fork_id})(),
-                    "_fork_cmux_name": "",
-                    "_fork_cmux_name_worker_running": False,
-                    "run_worker": lambda self, awaitable, **kwargs: scheduled.append(awaitable),
-                },
-            )(),
-        )
-        monkeypatch.setattr("local_operator.paths.config_dir", lambda: tmp_path)
-
-        OperatorApp._sync_fork_cmux_name(app, "  Divergent   work ")
-
-        assert app._fork_cmux_name == "Divergent work"
-        assert len(scheduled) == 1
-        # The harness deliberately does not run the worker: argv construction is
-        # covered separately, and closing avoids a false un-awaited warning.
-        scheduled[0].close()
-
-    @pytest.mark.asyncio
-    async def test_out_of_order_requests_converge_on_the_latest_title(
-        self, tmp_path: Path, monkeypatch
-    ) -> None:
-        import asyncio
-
-        from local_operator.tui.app import OperatorApp
-
-        _seed_parent(tmp_path)
-        fork_id = fork_session(tmp_path, PARENT_ID)
-        started = asyncio.Event()
-        release = asyncio.Event()
-        applied: list[str] = []
-        tasks: list[asyncio.Task[None]] = []
-
-        async def to_thread(func, env, title, **kwargs):
-            if title == "Old title":
-                started.set()
-                await release.wait()
-            applied.append(title)
-            return True
-
-        app = cast(
-            OperatorApp,
-            type(
-                "ForkNameHarness",
-                (),
-                {
-                    "_session": type("SessionStub", (), {"session_id": fork_id})(),
-                    "_fork_cmux_name": "",
-                    "_fork_cmux_name_worker_running": False,
-                    "_config_values": lambda self: {},
-                    "run_worker": lambda self, awaitable, **kwargs: tasks.append(
-                        asyncio.create_task(awaitable)
-                    ),
-                },
-            )(),
-        )
-        monkeypatch.setattr("local_operator.paths.config_dir", lambda: tmp_path)
-        monkeypatch.setattr("local_operator.tui.app.asyncio.to_thread", to_thread)
-
-        OperatorApp._sync_fork_cmux_name(app, "Old title")
-        await started.wait()
-        OperatorApp._sync_fork_cmux_name(app, "Newest title")
-        OperatorApp._sync_fork_cmux_name(app, "Newest title")
-        assert len(tasks) == 1
-        release.set()
-        await tasks[0]
-
-        assert applied == ["Old title", "Newest title"]
-        assert app._fork_cmux_name == "Newest title"
-        assert app._fork_cmux_name_worker_running is False
 
 
 class TestTheClonedTranscriptIsLegalOnTheWire:

--- a/tests/unit/test_multiplexer.py
+++ b/tests/unit/test_multiplexer.py
@@ -41,11 +41,7 @@ from local_operator.multiplexer.broadcast import (
     resume_executable,
     retire_session,
 )
-from local_operator.multiplexer.cmux import (
-    REASSERT_INTERVAL_S,
-    CmuxBackend,
-    rename_fork_target,
-)
+from local_operator.multiplexer.cmux import REASSERT_INTERVAL_S, CmuxBackend
 from local_operator.multiplexer.markers import (
     COMMAND_OPTION,
     SESSION_OPTION,
@@ -1041,51 +1037,6 @@ class TestCmuxPayload:
         monkeypatch.setattr("local_operator.multiplexer.cmux._cmux_binary", lambda: "/bin/cmux")
         assert CmuxBackend().detect(env) is False
         assert CmuxBackend().publish(_binding(), env) is False
-
-
-class TestForkTargetRename:
-    @pytest.mark.parametrize(
-        ("placement", "expected"),
-        [
-            (
-                "workspace",
-                ["/bin/cmux", "workspace", "rename", WORKSPACE, "--title", "Divergent work"],
-            ),
-            (
-                "surface",
-                ["/bin/cmux", "rename-tab", "--surface", SURFACE, "Divergent work"],
-            ),
-        ],
-    )
-    def test_renames_the_owned_target_for_each_placement(
-        self, monkeypatch, placement: str, expected: list[str]
-    ) -> None:
-        calls: list[list[str]] = []
-        monkeypatch.setattr("local_operator.multiplexer.cmux._cmux_binary", lambda: "/bin/cmux")
-
-        class Completed:
-            returncode = 0
-            stderr = ""
-
-        monkeypatch.setattr(
-            "local_operator.multiplexer.cmux.subprocess.run",
-            lambda argv, **kwargs: calls.append(list(argv)) or Completed(),
-        )
-        env = {"CMUX_WORKSPACE_ID": WORKSPACE, "CMUX_SURFACE_ID": SURFACE}
-
-        assert rename_fork_target(env, "  Divergent   work ", placement=placement) is True
-        assert calls == [expected]
-        if placement == "surface":
-            assert "workspace" not in calls[0]
-
-    def test_failure_is_nonfatal(self, monkeypatch) -> None:
-        monkeypatch.setattr("local_operator.multiplexer.cmux._cmux_binary", lambda: "/bin/cmux")
-        monkeypatch.setattr(
-            "local_operator.multiplexer.cmux.subprocess.run",
-            lambda *args, **kwargs: (_ for _ in ()).throw(OSError("gone")),
-        )
-        env = {"CMUX_WORKSPACE_ID": WORKSPACE, "CMUX_SURFACE_ID": SURFACE}
-        assert rename_fork_target(env, "name", placement="workspace") is False
 
 
 class TestMarkerBackends:

--- a/tests/unit/test_spawn.py
+++ b/tests/unit/test_spawn.py
@@ -170,8 +170,6 @@ class TestCmuxArgv:
         assert workspace_argv("/opt/bin/cmux", launch) == [
             "/opt/bin/cmux",
             "new-workspace",
-            "--name",
-            "fork · Refactor the loader",
             "--cwd",
             "/Users/x/projects/thing",
             "--command",


### PR DESCRIPTION
## Summary of Changes

Fix cmux workspace names getting stuck at **Original question** while the terminal surface continues showing the correct Local Operator session title.

**C1 standard / pre-authorized bug fix.** Operator-requested; this PR is the delivery record. No tracker was requested. Manager owns reviews, merge, version coordination and release.

### Root cause, reproduced before editing

The original tree (`c1e8db90`) had two competing title owners:
- `tui/terminal_title.py` writes the normal OSC 0 title through Textual's serialized driver, including session name and run state.
- `tui/app.py:12416-12470` treated **fork transcript provenance** as proof of native workspace ownership, then called `multiplexer/cmux.py:269-307` to run `cmux workspace rename` / `rename-tab`. Those commands install persistent **user overrides**, which mask later automatic titles. This path ignored headless-driver and terminal-title opt-out gates.

`tests/e2e/test_fork_e2e.py:100` seeded `original question`; provisional naming capitalized it to `Original question`. A real same-terminal fork E2E run inherited cmux target variables and reached the native rename subprocess. The safe reproduction intercepted that subprocess and used synthetic target UUIDs; it did not mutate any user's workspace:

```text
$ .venv/bin/python /tmp/lop-cmux-repro.py
1 passed, 4 deselected
NATIVE_CMUX_CALLS=[["/opt/homebrew/bin/cmux", "workspace", "rename",
 "11111111-1111-4111-8111-111111111111", "--title", "Original question"]]
```

This was not an OSC/control-character injection or a special meaning of that string. The observed live workspaces had `custom_title="Original question"`, `has_custom_title=true`; their terminal surface titles were already correct.

### Fix

- Remove the redundant fork-specific socket rename pipeline and its helper. Ordinary, forked and resumed sessions all use the existing OSC title channel.
- Stop passing `--name` when creating an automatic cmux fork workspace: that also establishes a persistent override rather than a temporary launch label.
- Replace tests that required the unsafe behavior with real fork/rename/resume regression coverage, including inherited synthetic cmux targets, a native subprocess interception, and actual OSC bytes from the production status band/title writer.
- Document why transcript provenance cannot establish ownership of a native workspace and why explicit user names must win.

## Delivery contract / non-goals

Acceptance criteria:
1. A headless same-window fork with inherited cmux variables never installs a native title override.
2. Fork adoption, owner-routed `/rename`, return to the original, and resume of the renamed fork update the normal OSC title correctly.
3. Automatic cmux workspace creation does not pin the seed name; terminal placement, launch command, cwd and non-focus behavior remain unchanged.
4. Explicit user workspace/surface names remain untouched: no unconditional startup clearing, repair heuristic, string special case, or competing rename worker.

Non-goals: no terminal layout, naming-model, transcript sanitation, generic cmux client, notification, resume-binding, or fork-lifecycle redesign. No automatic repair of existing custom titles: legitimate user names cannot be distinguished safely from prior unintended overrides.

## Impact / risk / rollback

Blast radius is fork title publication and cmux fork workspace creation. A new workspace may briefly display its shell/default title until the resumed app emits OSC; this is preferable to a permanently pinned seed title. Disabling terminal titles continues to mean the app does not own automatic terminal naming. Explicit cmux user names remain authoritative. No dependency changes, migrations, or persisted session-format changes. Revert the fix to roll back; existing custom-title repair is a separate operator action, never a startup mutation.

## Testing Details

### Actual assembled path and side effects

```sh
LO_FORK_EVIDENCE_DIR=/tmp/lop-cmux-evidence/after \
 env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
 tests/e2e/test_fork_e2e.py -m e2e -n0 -q -s -k 'size0 and False'
```

Actual output on the fixed tree:
```json
{"original_owner_reused":true,"parent_cancelled":[],"writes":["original completed"],"fork_model_calls":1}
{"terminal_title":"lo › Divergent work","osc":"\^[]0;lo › Divergent work\^G","native_calls":[]}
```
`1 passed, 4 deselected`. The test drives real RuntimeServer sockets, RemoteSession adoption, OperatorApp, `/fork`, routed `/rename`, return/resume, real tool output, status band and title writer. Only the model is scripted; title output goes to an in-memory sink instead of the user's terminal. The regression matrix additionally covers pending approval and narrow width; independent QA results follow in its review comment.

### Real native cmux contract check

Manager read back the three affected live workspace records, cleared **only those proven accidental overrides**, and read them again. All three changed from `custom_title="Original question"` to `null`; their existing automatic titles immediately became visible:
- `lo ⣯ Address Local Operator Security Advisories`
- `lo ⣯ Remove d key default model shortcut`
- `lo ⣟ Fix subagent status showing responding vs thinking`

The selected workspace stayed unchanged. This confirms the native override/automatic-title distinction without opening a new workspace or touching unrelated user names. Local readback evidence: `/tmp/lop-cmux-title-repair.json`.

### Rendered evidence and limitations

Before/after real OperatorApp captures were exported using `scripts.visual_capture.save_capture`, rasterized with `rsvg-convert`, and actually viewed. Native 100×30 grid = **800×510 px** (8×17 px cells). The TUI is intentionally unchanged; only external naming ownership changes. Before/after fork content/virtual boxes are both **98×28**, no outer scrollbar; editor **92×1**. Consecutive settled after frames are pixel-identical. A separate renamed/resumed still displays `Divergent work` in the status band.

Screenshots are attached separately to this PR, not committed. **These are TUI captures, not native cmux sidebar screenshots.** No approved native sidebar screenshot tool is available here; native behavior is evidenced by the actual cmux API readback above. Explicit user-name preservation is proven by removing native mutations and by regression guards, not by renaming a user's workspace for a GUI experiment. No unrelated sessions were manipulated by the implementing agent.

### Gates

**Head / scope:** `0f2e02322`..`7feebc825` — the round-1 candidate `42c14637` rebased unchanged onto `origin/main` v0.48.0 (`git range-diff` `=`, +/- line sets byte-identical, 340 lines). Whole-tree static commands on `7feebc825` and actual results:

| Command | Result |
| --- | --- |
| `.venv/bin/python -m flake8 .` | Exit 0 |
| `uvx --from black==26.1.0 black --check .` | Exit 0, 908 files unchanged |
| `uvx isort==5.13.2 --check .` | Exit 0 |
| `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | Exit 0, 0 errors / warnings |

Focused and end-to-end (isolated HOME/config, real `CMUX_*` unset, synthetic CMUX IDs):

| Command | Result |
| --- | --- |
| `pytest tests/unit/test_fork.py tests/unit/test_spawn.py tests/unit/test_multiplexer.py tests/unit/tui/test_terminal_title.py tests/unit/tui/test_conversation_naming.py -n0` | 247 passed |
| `pytest tests/e2e -m e2e -n0` | 29 passed |

Complete unit gate:
```sh
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
```
**13984 passed, 17 skipped, 691 warnings in 903.76s**, exit 0. CI: [run 33971549772](https://github.com/damianvtran/local-operator/actions/runs/33971549772) success on `7feebc825`. Independent QA runs the focused title/fork suites and complete assembled E2E suite; its results are recorded in its own review comments.

## Checklist

- [x] Focused self-review and existing conventions followed.
- [x] Bug reproduced before the source change, with actual subprocess argv.
- [x] Real assembled behavior, title bytes, side effects and rendered frames verified.
- [x] Explicit user naming and non-focus constraints preserved.
- [x] Final full-unit/static gate results recorded above.
- [x] Independent code/QA/design rounds 1 (`42c14637`) and 2 (`7feebc825`, rebase convergence onto v0.48.0) and implementing acknowledgements complete; all rounds are terminal with no findings.
- [x] Final-base integration onto `0f2e02322` with delta-only convergence reviewed.
- [ ] Version bump and publication. Held for the manager's release slot.
