### PR TITLE
chore(release): bump version to 0.47.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.47.1"
+version = "0.47.2"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Summary of Changes

Version-only bump `0.47.1` -> `0.47.2`.

## Why

#619 and #644 both claimed `0.47.1` while in review in parallel. #619 merged and released first ([v0.47.1](https://github.com/damianvtran/local-operator/releases/tag/v0.47.1), target `ec9ebbda`), so the published 0.47.1 wheel does **not** carry #644's model-catalogue-flap retry, while `origin/main` (`290b73bd`, #644 merged) still reads `0.47.1`. `gh release create v0.47.1` against the #644 merge was correctly refused (tag exists). Main needs a version PyPI does not have before #644 can ship.

## Testing evidence

`git diff origin/main` is exactly the one version line. No code change; CI on this branch is the proof it still builds.

## Review

Version-only, one line, mechanical; per the standing rules this still gets an agent review round before merge.
