### PR TITLE
feat(evaluation): add explicit capability-gated Unicode paste

### DIFF
--- a/benchmarks/osworld_v2_adapter/README.md
+++ b/benchmarks/osworld_v2_adapter/README.md
@@ -17,6 +17,16 @@ of the installed wheel — so it must be a *separate* distribution, or every
 harness release would invalidate the adapter pin. Isolation comes from the
 wheel + digest + isolated worker, not from the source's location.
 
+## Computer input capability
+
+Adapter 0.1.2 uses RPC 1.5 and explicitly advertises clipboard `paste_text`
+with caller-chosen keys and overwrite policy. Native `type` remains ASCII-only
+on this backend; Unicode requires the explicit paste action, never an automatic
+fallback. See [the negotiated computer-input contract](../../docs/benchmarks/computer-input.md)
+for limits, clipboard ownership, application semantics and frozen-environment
+compatibility. Historical 0.1.1 environment examples below are not migration
+instructions: new proofs need a newly built wheel and exact selector pins.
+
 ## Prerequisite: the gated inputs, in a DURABLE root
 
 OSWorld 2.0's 108 task classes and its 4.2 GB of assets are **gated** Hugging

--- a/benchmarks/osworld_v2_adapter/pyproject.toml
+++ b/benchmarks/osworld_v2_adapter/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lop-osworld-v2-adapter"
-version = "0.1.1"
+version = "0.1.2"
 description = "OSWorld 2.0 evaluation adapter for local-operator"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/actions.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/actions.py
@@ -20,6 +20,8 @@ not be silently repaired.
 
 from __future__ import annotations
 
+from local_operator.computer_input import paste_text_source
+from local_operator.evaluation.action_surface import ActionSurface
 from local_operator.evaluation.protocol import (
     ActionBatch,
     AskUserAction,
@@ -29,10 +31,16 @@ from local_operator.evaluation.protocol import (
     FinishAction,
     FrameGeometry,
     KeyAction,
+    PasteTextAction,
     ScrollAction,
     TypeAction,
     WaitAction,
 )
+
+# Admission is independent of neutral data parsing and runs for the ENTIRE
+# batch before a provider sees any statement, so a click cannot precede a
+# silently lossy Unicode TypeAction. The adapter metadata uses this same surface.
+ACTION_SURFACE = ActionSurface(paste_text=True, type_text_mode="ascii", ask_user=True)
 
 # Our named keys (protocol._NAMED_KEYS) -> pyautogui key names. pyautogui
 # uses lowercase single words; the two that differ structurally are META
@@ -112,7 +120,14 @@ def compile_action(action: ComputerAction, geometry: FrameGeometry | None = None
         # needed, and emitting it explicitly documents the closure.
         return f"pyautogui.click(x={nx}, y={ny}, clicks=2, interval=0.1, button='left')"
 
+    if isinstance(action, PasteTextAction):
+        return paste_text_source(action.text, [_key_name(key) for key in action.keys])
+
     if isinstance(action, TypeAction):
+        if not action.text.isascii():
+            raise CompilationError(
+                "type supports only ASCII; use paste_text with an explicit chord"
+            )
         # repr(), NEVER f-string interpolation: the text is model output and
         # may contain quotes, backslashes, or newlines. repr() produces a
         # Python literal that re-parses to exactly the same string.
@@ -160,6 +175,7 @@ def compile_batch(batch: ActionBatch, geometry: FrameGeometry) -> list[str]:
     observation at the end.
     """
 
+    ACTION_SURFACE.validate_batch(batch)
     statements: list[str] = []
     for action in batch.actions:
         statement = compile_action(action, geometry)

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
@@ -88,7 +88,7 @@ from local_operator.evaluation.adapters.discovery import (
 
 _DISTRIBUTION = "lop-osworld-v2-adapter"
 _ADAPTER_ID = "osworld-v2"
-_VERSION = "0.1.1"
+_VERSION = "0.1.2"
 _ENTRY_POINT = "lop_osworld_v2_adapter:create"
 
 
@@ -287,8 +287,10 @@ class OSWorldV2Adapter:
             schema_version=ADAPTER_SCHEMA_VERSION,
             capabilities=AdapterCapabilities(
                 routes=("computer",),
-                ask_user=True,  # honest ONLY because V2 has user_simulator
+                ask_user=actions.ACTION_SURFACE.ask_user,  # V2 has user_simulator
                 scoring=True,
+                paste_text=actions.ACTION_SURFACE.paste_text,
+                type_text_mode=actions.ACTION_SURFACE.type_text_mode,
             ),
         )
         # Per-episode state. None until the corresponding method runs.

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/aws.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/aws.py
@@ -113,6 +113,10 @@ class AllocationError(RuntimeError):
     """``allocate`` could not reach a fully-leased, ready guest."""
 
 
+class GuestExecutionError(RuntimeError):
+    """Input may have partially committed; never replay the failed batch."""
+
+
 class ReadinessTimeout(AllocationError):
     """The instance ran but the guest service never answered in time."""
 
@@ -425,7 +429,7 @@ class AwsProvider:
         )
         returncode = body.get("returncode")
         return guest_disk.CommandResult(
-            returncode=returncode if isinstance(returncode, int) else 1,
+            returncode=returncode if type(returncode) is int else 1,
             stdout=str(body.get("output") or ""),
             stderr=str(body.get("error") or ""),
         )
@@ -765,8 +769,24 @@ class AwsProvider:
         env = self._require_env()
 
         def run() -> None:
-            for statement in statements:
-                env.controller.execute_python_command(statement)
+            for index, statement in enumerate(statements):
+                # Upstream retries failed HTTP requests and logs their full body.
+                # A lost response can already have typed text, so reuse our
+                # single-shot transport, preserving the controller's input patch.
+                script = env.controller.pkgs_prefix.format(command=statement)
+                try:
+                    result = self._run_guest_command(["python", "-c", script], timeout=90)
+                except Exception:
+                    # Neither transport exceptions nor guest stderr are safe to
+                    # expose: they may echo the command, credentials or UI text.
+                    raise GuestExecutionError(
+                        f"guest action {index + 1} outcome is unknown; batch not retried"
+                    ) from None
+                if result.returncode != 0:
+                    raise GuestExecutionError(
+                        f"guest action {index + 1} failed (exit {result.returncode}); "
+                        "input may be partial; batch not retried"
+                    )
             # Let the desktop settle after the batch, exactly as OSWorld's
             # own ``step(pause=...)`` does. An empty batch still settles so a
             # pure WAIT advances the guest clock.

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/aws.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/aws.py
@@ -775,7 +775,9 @@ class AwsProvider:
                 # single-shot transport, preserving the controller's input patch.
                 script = env.controller.pkgs_prefix.format(command=statement)
                 try:
-                    result = self._run_guest_command(["python", "-c", script], timeout=90)
+                    from local_operator.computer_input import python_source_argv
+
+                    result = self._run_guest_command(python_source_argv(script), timeout=90)
                 except Exception:
                     # Neither transport exceptions nor guest stderr are safe to
                     # expose: they may echo the command, credentials or UI text.

--- a/docs/benchmarks/computer-input.md
+++ b/docs/benchmarks/computer-input.md
@@ -1,0 +1,96 @@
+# Negotiated computer text input
+
+`type` and `paste_text` are different actions, not fallback strategies. The
+neutral protocol continues to parse and canonically serialize historical
+`TypeAction` records, including Unicode. An adapter's execution restriction
+(`type_text_mode`) is applied to the entire batch before mutating dispatch.
+The OSWorld X11 backend declares `ascii`: non-ASCII native typing is rejected,
+not silently dropped or automatically replaced with clipboard input. Native
+ASCII controls keep their existing keyboard semantics.
+
+An adapter advertising `paste_text: true` admits this additional action:
+
+```json
+{
+  "kind": "paste_text",
+  "observation_id": "<current observation id>",
+  "text": "café 東京🙂\tsecond column\nnext line",
+  "keys": ["ctrl", "v"],
+  "clipboard_policy": "overwrite"
+}
+```
+
+All four data fields are required. The chord uses the same validation as
+`key`; there is no default chord. The caller must first focus the intended
+application and choose its shortcut (a terminal commonly uses Ctrl+Shift+V).
+There is no focus/window-title inference, automatic Enter, restore policy,
+retry, or native-typing fallback. A wrong chord can do nothing or invoke
+another application command. Read the next observation before claiming text
+insertion or task completion.
+
+Text accepts 1–100,000 Unicode characters, including whitespace-only input.
+Lone surrogates and Unicode control characters are rejected, except tab, CR
+and LF. Those three remain clipboard data, not separately generated key
+presses. The receiving application may normalize them, remove a trailing
+newline, or submit on a newline; transport equality is not a guarantee of
+application storage semantics.
+
+## X11 execution and ownership
+
+The generic stdlib host helper `local_operator.computer_input` generates guest
+source; only execution in the guest imports pyautogui. It requires the guest's
+existing `xclip`. UTF-8 is transferred without shell interpolation and checked
+against bounded readback before the explicit chord. Readiness polling has a
+five-second deadline and never replays the chord. The readback buffer cannot
+exceed the new payload by more than one byte; mismatching/oversized old selection
+contents are discarded, never retained as evidence.
+
+`xclip -quiet -selection clipboard -in -target UTF8_STRING -loops 0` runs as a
+tracked foreground child in its own session. A successful action leaves that
+owner serving the new CLIPBOARD until another application replaces it; PRIMARY
+is never selected. An ownership replacement causes xclip to exit (an active
+selection transfer may need to finish first). Each payload is at most 400 KB
+UTF-8 plus xclip's transfer buffers; there are no durable payload files. The
+helper closes its unnamed temporary source and reaps transient readback
+processes. On failure it also kills/reaps its new owner; it never restores the
+old clipboard, so a failed action can leave the clipboard changed or empty.
+Episode/guest teardown remains the final process-lifetime bound. Native proof
+must check repeated ownership replacement, not merely one successful paste.
+
+The generated helper is one `exec` statement, compatible with controllers that
+prepend imports with semicolons. Large Python programs use a fixed bootstrap
+and bounded argv chunks to avoid Linux's per-argument limit, but remain **one**
+guest request through the existing adapter/provider single-shot transport.
+Small legacy command argv is unchanged. A timeout/nonzero/ambiguous response
+uses existing mutation-failure policy; only a separately declared observation
+phase can be re-read, without reapplying input.
+
+## Negotiation, evidence, and compatibility
+
+Adapter RPC **1.5** explicitly negotiates clipboard support and native text
+restrictions. Exact version checks refuse mixed workers before allocation.
+Supervisor admission and adapter compilation independently enforce the surface;
+known model admission failures use existing bounded corrective decisions and do
+not enter ambiguous-mutation poisoning.
+
+`ActionSurface` is the shared source for admitted action models, model prompt,
+and schema identity. The runner passes the negotiated surface explicitly to
+`EpisodeModelClient.decide(action_surface=...)`, records its canonical JSON in
+manifest metadata `action_surface`, and hashes that same schema with the
+`runner-tool-schema-v1` domain for `tool_schema_digest`. The digest is independent
+of the episode ID; capability changes alter it. Unsupported kinds are not
+advertised in the generated prompt.
+
+Adapter 0.1.2 is a new artifact identity, not a replacement of frozen 0.1.1
+wheels. Build/pin a new worker environment and selector for RPC 1.5. Keep frozen
+older environments and their rescue launch paths intact until their episodes
+and descriptors are settled; do not rewrite historical bundles, selectors,
+attestations or rescue descriptors to make them look compatible. Root harness
+release version assignment happens at PR/release preparation; private proofs
+pin the committed source and built wheel digest.
+
+Local tests execute generated source against fake clipboard/keyboard boundaries
+and exercise the real local HTTP command transport. They are not native X11 or
+rendered UI proof. Native validation runs separately through the actual
+runner → worker → compiler → provider pipeline, with independently read saved
+text and screenshots; no model call or scored benchmark claim is implied.

--- a/local_operator/computer_input.py
+++ b/local_operator/computer_input.py
@@ -1,0 +1,179 @@
+"""Source generation for explicit X11 clipboard input, independent of benchmarks.
+
+Only the guest imports GUI dependencies. The host can validate/compile without a
+DISPLAY, xclip or pyautogui. This is deliberately not the composer's best-effort
+clipboard helper: failure after ownership changes is an ambiguous mutation and
+must escape to the caller's existing no-replay policy.
+"""
+
+from __future__ import annotations
+
+import base64
+import inspect
+import textwrap
+import unicodedata
+from collections.abc import Sequence
+
+MAX_PASTE_CHARACTERS = 100_000
+
+
+def validate_paste_text(text: str) -> None:
+    """Reject unrepresentable/control payloads without exposing their contents."""
+    if not 1 <= len(text) <= MAX_PASTE_CHARACTERS:
+        raise ValueError("paste text must contain 1 to 100000 characters")
+    if any(unicodedata.category(char) in ("Cc", "Cs") and char not in "\t\r\n" for char in text):
+        raise ValueError("paste text contains unsupported controls or invalid Unicode")
+    text.encode("utf-8", errors="strict")
+
+
+def _paste_x11(encoded: str, keys: tuple[str, ...]) -> None:
+    # This function is shipped as source into a guest that need not have this
+    # package installed. Keep its imports and dependencies local and stdlib-only
+    # until the explicit keyboard dispatch at the very end.
+    import base64
+    import importlib
+    import os
+    import selectors
+    import shutil
+    import subprocess
+    import tempfile
+    import time
+
+    # The host intentionally has no GUI dependency; resolve it only in the
+    # generated guest program, where the adapter already requires it.
+    pyautogui = importlib.import_module("pyautogui")
+
+    payload = base64.b64decode(encoded, validate=True)
+    executable = shutil.which("xclip")
+    if executable is None:
+        raise RuntimeError("clipboard transport unavailable: xclip is required")
+    deadline = time.monotonic() + 5.0
+    owner = None
+    success = False
+
+    def read_new_payload() -> bytes:
+        # communicate()/capture_output can accumulate an unbounded selection if
+        # another application replaces CLIPBOARD during readiness. Limit BOTH
+        # the bytes read and the time; never include those bytes in diagnostics.
+        reader = subprocess.Popen(
+            [executable, "-selection", "clipboard", "-out", "-target", "UTF8_STRING"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            assert reader.stdout is not None
+            data = bytearray()
+            with selectors.DefaultSelector() as selector:
+                selector.register(reader.stdout, selectors.EVENT_READ)
+                while True:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0 or not selector.select(remaining):
+                        raise RuntimeError("clipboard readiness timed out")
+                    part = os.read(reader.stdout.fileno(), min(65536, len(payload) + 1 - len(data)))
+                    if not part:
+                        break
+                    data.extend(part)
+                    if len(data) > len(payload):
+                        # The old owner may still be visible while xclip takes
+                        # ownership. Discard at the bound and poll readiness;
+                        # never retain a larger old selection or dispatch keys.
+                        return b""
+            if reader.wait(timeout=max(0.001, deadline - time.monotonic())) != 0:
+                return b""
+            return bytes(data)
+        finally:
+            if reader.poll() is None:
+                reader.kill()
+            reader.wait(timeout=1)
+            if reader.stdout is not None:
+                reader.stdout.close()
+
+    try:
+        # A regular, unnamed file avoids a full stdin pipe blocking a 400KB
+        # UTF-8 payload before the timeout machinery gets a chance to run.
+        with tempfile.TemporaryFile() as source:
+            source.write(payload)
+            source.seek(0)
+            owner = subprocess.Popen(
+                [
+                    executable,
+                    "-selection",
+                    "clipboard",
+                    "-in",
+                    "-target",
+                    "UTF8_STRING",
+                    "-quiet",
+                    "-loops",
+                    "0",
+                ],
+                stdin=source,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+        # -quiet keeps xclip in the foreground (no untracked fork). X11 holds
+        # exactly one CLIPBOARD owner: this process exits when the next owner
+        # replaces it. Do not use -loops 1: readiness itself is a selection
+        # request, and consuming that quota would erase the paste's source.
+        while True:
+            if owner.poll() is not None:
+                raise RuntimeError("clipboard owner exited before readiness")
+            if time.monotonic() >= deadline:
+                raise RuntimeError("clipboard readiness timed out")
+            if read_new_payload() == payload:
+                break
+            time.sleep(0.01)
+        # There is deliberately no focus/title heuristic, default chord, Enter,
+        # clipboard restoration, native fallback, or replay. A successful chord
+        # is not proof the receiving application inserted the requested text.
+        if len(keys) == 1:
+            pyautogui.press(keys[0])
+        else:
+            pyautogui.hotkey(*keys)
+        success = True
+    except Exception:
+        # Third-party errors can contain commands or clipboard contents. The
+        # outer transport must see failure, but never an echo of the payload.
+        raise RuntimeError("clipboard paste failed; input may have partially applied") from None
+    finally:
+        if not success and owner is not None:
+            if owner.poll() is None:
+                owner.kill()
+            owner.wait(timeout=1)
+
+
+def paste_text_source(text: str, keys: Sequence[str]) -> str:
+    """Compile one explicit clipboard replacement and keyboard dispatch.
+
+    ``keys`` are backend key names supplied by the caller's validated key
+    vocabulary. Python literals, never shell interpolation, carry them into the
+    guest. CLIPBOARD remains the new text; PRIMARY is never selected or read.
+    """
+    validate_paste_text(text)
+    if not keys or len(keys) > 8 or any(not isinstance(key, str) or not key for key in keys):
+        raise ValueError("paste requires an explicit bounded key chord")
+    encoded = base64.b64encode(text.encode("utf-8")).decode("ascii")
+    source = textwrap.dedent(inspect.getsource(_paste_x11))
+    source += f"\n_paste_x11({encoded!r}, {tuple(keys)!r})"
+    # Controllers commonly prepend imports with a semicolon, after which a
+    # compound `def` statement is illegal. exec keeps this one simple statement.
+    return f"exec({source!r})"
+
+
+def python_source_argv(source: str) -> list[str]:
+    """Keep one guest exec without exceeding Linux's per-argument byte limit.
+
+    The clipboard accepts 100k Unicode characters (up to 400KB UTF-8), so even
+    one base64 payload exceeds MAX_ARG_STRLEN. Splitting *source*, not actions,
+    preserves the single-shot mutation boundary. Small legacy commands retain
+    their exact argv; each large-source chunk is at most 64KB in UTF-8.
+    """
+    if len(source.encode("utf-8")) <= 64_000:
+        return ["python", "-c", source]
+    return [
+        "python",
+        "-c",
+        "import sys; exec(''.join(sys.argv[1:]))",
+        *(source[offset : offset + 16_000] for offset in range(0, len(source), 16_000)),
+    ]

--- a/local_operator/evaluation/action_surface.py
+++ b/local_operator/evaluation/action_surface.py
@@ -1,0 +1,69 @@
+"""One negotiated source for action admission, model instructions and evidence.
+
+The neutral protocol still parses historic Unicode TypeAction records. Execution
+restrictions belong here, not on that data model: an ASCII keyboard backend must
+reject a lossy batch before its first click, while a Unicode backend may accept it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, get_args
+
+from local_operator.evaluation.protocol import (
+    NAMED_KEYS,
+    ActionBatch,
+    AskUserAction,
+    ComputerAction,
+    PasteTextAction,
+    TypeAction,
+)
+
+
+class ActionAdmissionError(ValueError):
+    """Known pre-dispatch invalid input; no environment mutation was attempted."""
+
+
+@dataclass(frozen=True)
+class ActionSurface:
+    paste_text: bool = False
+    type_text_mode: Literal["unicode", "ascii"] = "unicode"
+    ask_user: bool = True
+
+    @property
+    def models(self) -> tuple[Any, ...]:
+        return tuple(
+            model
+            for model in get_args(get_args(ComputerAction)[0])
+            if (model is not PasteTextAction or self.paste_text)
+            and (model is not AskUserAction or self.ask_user)
+        )
+
+    @property
+    def named_keys(self) -> tuple[str, ...]:
+        return tuple(sorted(NAMED_KEYS))
+
+    def schema(self) -> dict[str, Any]:
+        # Include the execution restriction in the identity: the same neutral
+        # field schema on a lossy keyboard is not the same admitted action surface.
+        return {
+            "actions": [model.model_json_schema() for model in self.models],
+            "type_text_mode": self.type_text_mode,
+            "named_keys": list(self.named_keys),
+        }
+
+    def validate_batch(self, batch: ActionBatch) -> None:
+        for action in batch.actions:
+            if type(action) not in self.models:
+                raise ActionAdmissionError("action kind is not supported by this adapter")
+            if isinstance(action, TypeAction) and self.type_text_mode == "ascii":
+                if not action.text.isascii():
+                    raise ActionAdmissionError(
+                        "type supports only ASCII on this adapter; "
+                        "use paste_text with an explicit chord"
+                        if self.paste_text
+                        else "type supports only ASCII on this adapter"
+                    )
+
+
+LEGACY_ACTION_SURFACE = ActionSurface()

--- a/local_operator/evaluation/adapters/api.py
+++ b/local_operator/evaluation/adapters/api.py
@@ -16,6 +16,7 @@ from typing import Annotated, Any, Literal, Protocol, TypeAlias, runtime_checkab
 
 from pydantic import AfterValidator, Field, field_validator, model_validator
 
+from local_operator.evaluation.action_surface import ActionSurface
 from local_operator.evaluation.evidence.models import ScoreArtifact, canonical_digest
 from local_operator.evaluation.lifecycle import CleanupPlan
 from local_operator.evaluation.protocol import ActionBatch, Observation, ProtocolModel
@@ -78,10 +79,13 @@ from local_operator.evaluation.receipts import (
 # canonicality check, and a 1.4 worker's ``"phase":"unknown"`` fails a 1.3
 # parent's ``extra="forbid"``. ``resume_observation`` is the same story on the
 # request side.
-ADAPTER_SCHEMA_VERSION = "1.4"
+# 1.5 advertises clipboard paste and the native text execution restriction.
+# Exact negotiation rejects old workers before prepare/reset can allocate, rather
+# than discovering an unknown action after a preceding click has already applied.
+ADAPTER_SCHEMA_VERSION = "1.5"
 # One alias for the three models that pin the version, so a future bump cannot
 # move the constant while leaving a model silently accepting the older literal.
-SchemaVersion: TypeAlias = Literal["1.4"]
+SchemaVersion: TypeAlias = Literal["1.5"]
 ADAPTER_ENTRY_POINT_GROUP = "local_operator.evaluation_adapters.v1"
 MAX_RESCUE_REFS = 256
 MAX_REQUIREMENTS = 256
@@ -189,6 +193,15 @@ class AdapterCapabilities(ProtocolModel):
     routes: tuple[RouteCapability, ...] = Field(min_length=1, max_length=3)
     ask_user: bool
     scoring: bool
+    paste_text: bool = False
+    type_text_mode: Literal["unicode", "ascii"] = "unicode"
+
+    def action_surface(self) -> "ActionSurface":
+        return ActionSurface(
+            paste_text=self.paste_text,
+            type_text_mode=self.type_text_mode,
+            ask_user=self.ask_user,
+        )
 
     @field_validator("routes", mode="before")
     @classmethod

--- a/local_operator/evaluation/adapters/supervisor.py
+++ b/local_operator/evaluation/adapters/supervisor.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from pydantic import field_validator, model_validator
 
+from local_operator.evaluation.action_surface import LEGACY_ACTION_SURFACE
 from local_operator.evaluation.adapters.api import (
     AckResult,
     AdapterResult,
@@ -269,6 +270,7 @@ class AdapterSupervisor:
 
     def __init__(self, selector: AdapterSelector, process: subprocess.Popen[bytes]) -> None:
         self.selector = selector
+        self.action_surface = LEGACY_ACTION_SURFACE
         self.process = process
         self.pgid = process.pid
         self.stdout_tail = _Tail()
@@ -399,6 +401,7 @@ class AdapterSupervisor:
         if result.selector != self.selector:
             await self.terminate()
             raise SupervisionError("adapter handshake selector differs")
+        self.action_surface = result.metadata.capabilities.action_surface()
         return result
 
     async def terminate(self) -> None:
@@ -748,6 +751,11 @@ class VerifiedAdapterSession:
         if current is None:
             raise SupervisionError("execute has no current observation")
         params.action_batch.validate_for(current)
+        # Known unsupported input has not touched the worker and must not enter
+        # the ambiguous-mutation poison path. Legacy/fake supervisors fail closed
+        # for the new action until their handshake explicitly advertises it.
+        surface = getattr(self._supervisor, "action_surface", LEGACY_ACTION_SURFACE)
+        surface.validate_batch(params.action_batch)
         self._ensure_usable()
         result = await self._mutating_call(
             "execute",

--- a/local_operator/evaluation/protocol.py
+++ b/local_operator/evaluation/protocol.py
@@ -447,8 +447,7 @@ NAMED_KEYS = frozenset(
 _PRINTABLE_KEYS = frozenset(string.ascii_letters + string.digits + string.punctuation)
 
 
-class KeyAction(_Action):
-    kind: Literal["key"] = "key"
+class _KeyChordAction(_Action):
     keys: tuple[str, ...] = Field(min_length=1, max_length=8)
 
     @field_validator("keys", mode="before")
@@ -468,6 +467,31 @@ class KeyAction(_Action):
         if len(normalized) != len(set(normalized)):
             raise ValueError("a key chord cannot contain duplicate keys")
         return tuple(normalized)
+
+
+class KeyAction(_KeyChordAction):
+    kind: Literal["key"] = "key"
+
+
+class PasteTextAction(_KeyChordAction):
+    """Replace CLIPBOARD and send an explicit chord, without claiming insertion.
+
+    Inheriting the key validation prevents paste from growing a second key
+    vocabulary. Tabs/newlines remain data; the receiving application may still
+    normalize them or submit a field. No focus inference or restoration is implied.
+    """
+
+    kind: Literal["paste_text"] = "paste_text"
+    text: str = Field(min_length=1, max_length=MAX_TEXT_LENGTH)
+    clipboard_policy: Literal["overwrite"]
+
+    @field_validator("text")
+    @classmethod
+    def _clipboard_text(cls, text: str) -> str:
+        from local_operator.computer_input import validate_paste_text
+
+        validate_paste_text(text)
+        return text
 
 
 class ScrollAction(_FrameAction):
@@ -510,6 +534,7 @@ ComputerAction: TypeAlias = Annotated[
     | DoubleClickAction
     | TypeAction
     | KeyAction
+    | PasteTextAction
     | ScrollAction
     | WaitAction
     | FinishAction

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -87,6 +87,7 @@ from local_operator.evaluation.evidence.models import (
     ScoringResultPayload,
     UsageCostPayload,
     UserSimulatorExchangePayload,
+    canonical_bytes,
     canonical_digest,
 )
 from local_operator.evaluation.evidence.store import EvidenceError, EvidenceWriter
@@ -457,6 +458,7 @@ class EpisodeRunner:
         supervisor = self._launch(self._selector)
         self._supervisor = supervisor
         handshake = await supervisor.handshake(timeout=self._config.handshake_timeout)
+        self._action_surface = handshake.metadata.capabilities.action_surface()
         verifier = HostVerifier(
             self._spec.task_id,
             self._spec.episode_id,
@@ -791,7 +793,9 @@ class EpisodeRunner:
         # so recording it eagerly would make the failure path unsealable.
         rejected: DecisionRejected | None = None
         try:
-            decision = await self._model.decide(observation, tuple(self._turns))
+            decision = await self._model.decide(
+                observation, tuple(self._turns), action_surface=self._action_surface
+            )
         except _EvidenceFailure:
             raise
         except DecisionRejected as error:
@@ -860,7 +864,7 @@ class EpisodeRunner:
                 request_id=request_id,
                 requested_route=self._spec.requested_route,
                 tool_schema_digest=canonical_digest(
-                    "runner-tool-schema-v1", {"episode_id": self._spec.episode_id}
+                    "runner-tool-schema-v1", self._action_surface.schema()
                 ),
                 input_tokens=decision.usage.input_tokens,
                 message_count=message_count,
@@ -1607,7 +1611,13 @@ class EpisodeRunner:
             cleanup_plan_id=plan.cleanup_plan_id,
             config_digest=spec.config_digest,
             created_wall_time_ms=self._started_ms,
-            metadata=dict(spec.metadata),
+            # The same negotiated schema builds the prompt and gates admission.
+            # Publish it, not merely a digest with no reproducible preimage; old
+            # sealed bundles retain their original metadata and canonical bytes.
+            metadata={
+                **dict(spec.metadata),
+                "action_surface": canonical_bytes(self._action_surface.schema()).decode("utf-8"),
+            },
         )
 
     def _append(self, kind: Any, payload: Any) -> None:

--- a/local_operator/evaluation/runner/model.py
+++ b/local_operator/evaluation/runner/model.py
@@ -18,6 +18,7 @@ from typing import Protocol, Sequence, runtime_checkable
 
 from pydantic import Field
 
+from local_operator.evaluation.action_surface import ActionSurface
 from local_operator.evaluation.evidence.models import RouteIdentity
 from local_operator.evaluation.protocol import ActionBatch, Observation, ProtocolModel
 from local_operator.evaluation.receipts import SafeCount, StrictIdentifier
@@ -194,4 +195,6 @@ class EpisodeModelClient(Protocol):
         self,
         observation: Observation,
         history: Sequence[EpisodeTurn],
+        *,
+        action_surface: ActionSurface,
     ) -> ModelDecision: ...

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -31,14 +31,13 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Mapping, Sequence, get_args, get_origin
 
+from local_operator.evaluation.action_surface import (
+    LEGACY_ACTION_SURFACE,
+    ActionSurface,
+)
 from local_operator.evaluation.adapters.supervisor import verify_artifact
 from local_operator.evaluation.evidence.models import RouteIdentity
-from local_operator.evaluation.protocol import (
-    NAMED_KEYS,
-    ActionBatch,
-    ComputerAction,
-    Observation,
-)
+from local_operator.evaluation.protocol import ActionBatch, Observation
 from local_operator.evaluation.runner.model import (
     CompactionRecord,
     DecisionRejected,
@@ -127,7 +126,7 @@ _FUNCTION_KEY = re.compile(r"F\d+")
 _IDENTIFIER = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]*")
 
 
-def _action_schema_lines() -> list[str]:
+def _action_schema_lines(surface: ActionSurface = LEGACY_ACTION_SURFACE) -> list[str]:
     """Describe every action kind by reading the protocol models themselves.
 
     A parse failure costs a billed corrective re-prompt at best and the
@@ -139,7 +138,7 @@ def _action_schema_lines() -> list[str]:
     """
 
     lines: list[str] = []
-    for action in get_args(get_args(ComputerAction)[0]):
+    for action in surface.models:
         fields: list[str] = []
         for name, field in action.model_fields.items():
             if name in ("kind", "observation_id"):
@@ -161,7 +160,7 @@ def _action_schema_lines() -> list[str]:
     return lines
 
 
-def _named_keys_line() -> str:
+def _named_keys_line(surface: ActionSurface) -> str:
     """The key vocabulary, wrapped, derived from the set the validator enforces.
 
     Stated rather than implied. ``KeyAction`` accepts a closed set and rejects
@@ -172,7 +171,7 @@ def _named_keys_line() -> str:
     spends prompt budget on a pattern one phrase conveys.
     """
 
-    named = sorted(key.lower() for key in NAMED_KEYS if not _FUNCTION_KEY.fullmatch(key))
+    named = sorted(key.lower() for key in surface.named_keys if not _FUNCTION_KEY.fullmatch(key))
     wrapped = textwrap.wrap(", ".join(named) + ", and f1 through f24", width=68)
     return textwrap.indent("\n".join(wrapped), "  ")
 
@@ -200,9 +199,39 @@ def _type_name(annotation: Any) -> str:
     return "value"
 
 
-def build_system_prompt() -> str:
+def _paste_instructions(surface: ActionSurface) -> str:
+    if not surface.paste_text:
+        return ""
+    return """* "paste_text" is the supported Unicode path: replace CLIPBOARD with text,
+  then send exactly the REQUIRED "keys" chord. Choose the chord for the focused
+  application (for example ["ctrl", "v"] or ["ctrl", "shift", "v"]); there is
+  NO default chord, focus change, automatic Enter, retry, or keyboard fallback.
+  REQUIRED "clipboard_policy" must be "overwrite". The new text remains on
+  CLIPBOARD; the old clipboard is not restored and PRIMARY is untouched.
+  Text must be valid Unicode, 1 to 100000 characters; whitespace-only text is
+  allowed. Tabs, CR and newlines are data; other control characters are refused.
+  The receiving application may normalize text or submit on a newline. A wrong
+  chord can do something else or nothing: inspect the next observation; success
+  of the action does NOT prove insertion or task completion.
+"""
+
+
+def build_system_prompt(surface: ActionSurface = LEGACY_ACTION_SURFACE) -> str:
     """Compose the episode system prompt around the live protocol schema."""
 
+    native_text = (
+        "Only ASCII text is supported by this adapter; "
+        "non-ASCII is rejected before any batch action."
+        if surface.type_text_mode == "ascii"
+        else "This adapter supports Unicode native text input."
+    )
+    ask_text = (
+        '* "ask_user" -- you need a human answer. '
+        "THE EPISODE PAUSES until the answer is delivered. "
+        "Do not ask a question you can resolve by acting."
+        if surface.ask_user
+        else ""
+    )
     return f"""You are operating a computer to complete one task.
 
 Each user message is one observation of the screen: its text, and a screenshot
@@ -244,7 +273,7 @@ Every action is an object whose type is given by the key "kind" (NOT "type"),
 and every action must carry the "observation_id" of the observation you are
 looking at right now. These are the only permitted shapes:
 
-{chr(10).join(_action_schema_lines())}
+{chr(10).join(_action_schema_lines(surface))}
 
 Field names are JSON keys spelled exactly as quoted above -- "keys" is not
 "key", "text" is not "value". Where a field lists alternatives separated by
@@ -256,8 +285,10 @@ name all require typing.
 
 * "type" enters literal text wherever the keyboard focus already is. It does
   NOT click first, so focus the field with a click (or Tab) in an earlier
-  action, then type. It sends exactly the characters given and does not press
-  Enter for you.
+  action, then type. It uses native keyboard input, not the clipboard.
+  {native_text}
+  It does not press Enter for you.
+{_paste_instructions(surface)}
 * "key" presses named keys, and presses the ones in a single action TOGETHER
   as one chord: ["ctrl", "s"] is Ctrl+S, ["enter"] commits a field or dialog,
   ["tab"] moves focus, ["esc"] dismisses, and ["ctrl", "a"] followed by a
@@ -267,7 +298,7 @@ name all require typing.
   synonym is rejected -- "ctrl" not "control", "esc" not "escape", "enter"
   not "return":
 
-{_named_keys_line()}
+{_named_keys_line(surface)}
 
 A batch may contain SEVERAL actions and they execute in order against the
 screen you are looking at, with one new observation at the end. That is how a
@@ -275,14 +306,12 @@ click-then-type-then-Enter sequence is done in one step rather than three.
 Batch only what you can predict without seeing the screen in between; when the
 result of an action decides the next one, end the batch and look.
 
-Two actions end your turn in a special way, and each must be the ONLY action in
+Terminal actions end your turn in a special way, and each must be the ONLY action in
 its batch. Their fields are listed above; what the list cannot tell you is what
 they MEAN:
 
 * "finish" -- you believe the task is done. The episode is then scored.
-* "ask_user" -- you need a human answer. THE EPISODE PAUSES: a person answers
-  your question, and the next observation you see is the state after that
-  answer was delivered. Do not ask a question you can resolve by acting.
+{ask_text}
 """
 
 
@@ -445,6 +474,7 @@ def parse_decision(
     prompt_cache_key: str | None = None,
     context_tokens: int | None = None,
     compaction: CompactionRecord | None = None,
+    action_surface: ActionSurface = LEGACY_ACTION_SURFACE,
 ) -> ModelDecision:
     """Parse one strict JSON decision and bind it to the current observation.
 
@@ -500,6 +530,7 @@ def parse_decision(
         raise DecisionParseError(f"decision is not a valid action batch: {error}") from error
     try:
         batch.validate_for(observation)
+        action_surface.validate_batch(batch)
     except Exception as error:
         raise DecisionParseError(f"decision does not match this observation: {error}") from error
     return ModelDecision(
@@ -755,6 +786,8 @@ class ProviderModelClient:
         self,
         observation: Observation,
         history: Sequence[EpisodeTurn],
+        *,
+        action_surface: ActionSurface = LEGACY_ACTION_SURFACE,
     ) -> ModelDecision:
         from local_operator.harness.types import ChatRequest
 
@@ -767,7 +800,13 @@ class ProviderModelClient:
         messages = self._context.messages
         request = ChatRequest(
             model=self._model_spec,
-            system_blocks=[self._system_prompt],
+            system_blocks=[
+                (
+                    build_system_prompt(action_surface)
+                    if self._system_prompt == _SYSTEM_PROMPT
+                    else self._system_prompt + "\n\n" + build_system_prompt(action_surface)
+                )
+            ],
             messages=list(messages),
             tool_choice="none",
             prompt_cache_key=self._prompt_cache_key,
@@ -800,6 +839,7 @@ class ProviderModelClient:
                 prompt_cache_key=self._prompt_cache_key,
                 context_tokens=_estimate_context(messages),
                 compaction=compaction,
+                action_surface=action_surface,
             )
         except DecisionParseError as error:
             # The call happened and was billed; only the reply is unusable.

--- a/scripts/run_episode.py
+++ b/scripts/run_episode.py
@@ -566,7 +566,7 @@ class _ScriptedFinish:
     def __init__(self, route: RouteIdentity) -> None:
         self._route = route
 
-    async def decide(self, observation: Any, history: Sequence[Any]) -> Any:
+    async def decide(self, observation: Any, history: Sequence[Any], *, action_surface: Any) -> Any:
         from local_operator.evaluation.protocol import ActionBatch
         from local_operator.evaluation.runner.model import ModelDecision
 

--- a/tests/unit/evaluation/adapters/osworld/spawn_helpers.py
+++ b/tests/unit/evaluation/adapters/osworld/spawn_helpers.py
@@ -39,7 +39,7 @@ from tests.unit.evaluation.copied_interpreter import (
 # tests/unit/evaluation/adapters/osworld/spawn_helpers.py -> repo root is 5
 # parents up (osworld -> adapters -> evaluation -> unit -> tests -> root).
 ADAPTER_SRC = Path(__file__).resolve().parents[5] / "benchmarks" / "osworld_v2_adapter"
-WHEEL_NAME = "lop_osworld_v2_adapter-0.1.1-py3-none-any.whl"
+WHEEL_NAME = "lop_osworld_v2_adapter-0.1.2-py3-none-any.whl"
 
 
 def build_adapter_wheel(out_dir: Path) -> Path:
@@ -134,7 +134,7 @@ def install_adapter_into_site(site: Path, wheel: Path) -> str:
 
     from local_operator.evaluation.adapters.discovery import distribution_digest
 
-    info = site / "lop_osworld_v2_adapter-0.1.1.dist-info"
+    info = site / "lop_osworld_v2_adapter-0.1.2.dist-info"
     return distribution_digest(PathDistribution(info))
 
 
@@ -207,7 +207,7 @@ def build_spawnable_adapter(
         schema_version=ADAPTER_SCHEMA_VERSION,
         adapter_id="osworld-v2",
         distribution="lop-osworld-v2-adapter",
-        version="0.1.1",
+        version="0.1.2",
         entry_point="lop_osworld_v2_adapter:create",
         package_digest=package_digest,
         release_digest=release_digest,
@@ -248,5 +248,5 @@ def release_digest_for(package_digest: str, tasks: dict[str, str]) -> str:
     workspace manifest and the selector agree on the same attestation."""
 
     manifest = hashlib.sha256("".join(tasks[k] for k in sorted(tasks)).encode()).hexdigest()
-    payload = f"lop-osworld-v2-adapter|0.1.1|{package_digest}|osworld-v2-2026.08.08|{manifest}"
+    payload = f"lop-osworld-v2-adapter|0.1.2|{package_digest}|osworld-v2-2026.08.08|{manifest}"
     return hashlib.sha256(payload.encode()).hexdigest()

--- a/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
+++ b/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
@@ -1188,7 +1188,7 @@ async def test_execute_over_real_http_reports_partial_subprocess_failure(
     requests_seen: list[dict[str, Any]] = []
 
     class Handler(BaseHTTPRequestHandler):
-        def log_message(self, *_args: Any) -> None:
+        def log_message(self, format: str, *args: Any) -> None:
             pass
 
         def do_POST(self) -> None:
@@ -1223,7 +1223,11 @@ async def test_execute_over_real_http_reports_partial_subprocess_failure(
             # with fixture credentials and are never invoked by execute().
             stubs.clients.http_post_json = aws.build_clients(CREDS, REGION).http_post_json
             provider = AwsProvider(
-                CREDS, region=REGION, lease_ref="lop-ttl-x", clients=stubs.clients, sleep=stubs.sleep
+                CREDS,
+                region=REGION,
+                lease_ref="lop-ttl-x",
+                clients=stubs.clients,
+                sleep=stubs.sleep,
             )
             env = _FakeEnv()
             env.pkgs_prefix = "{command}"
@@ -1236,6 +1240,15 @@ async def test_execute_over_real_http_reports_partial_subprocess_failure(
             assert marker.read_text() == "once\nonce\n"
             assert len(requests_seen) == 2
             assert stubs.slept == [3.0]
+            # Exercise the actual HTTP -> subprocess path, not just a source
+            # string assertion: 100k Unicode cannot fit Linux's single-arg cap.
+            large_marker = tmp_path / "large-text"
+            text = "🙂" * 100_000
+            large = f"from pathlib import Path; Path({str(large_marker)!r}).write_text({text!r})"
+            await provider.execute([large])
+            assert large_marker.read_text() == text
+            assert len(requests_seen) == 3
+            assert all(len(arg.encode("utf-8")) <= 64_000 for arg in requests_seen[-1]["command"])
     finally:
         server.shutdown()
         thread.join(timeout=5)

--- a/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
+++ b/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
@@ -1,6 +1,7 @@
 """AwsProvider against botocore's Stubber: the boto3 call shapes, in order.
 
-Nothing here touches the network. Every EC2 / Scheduler call is answered by a
+No cloud calls are made; one control-boundary test uses loopback HTTP.
+Every EC2 / Scheduler call is answered by a
 ``Stubber`` that ALSO asserts the request parameters, so these tests pin the
 exact ``run_instances`` shape (ClientToken, both TagSpecifications, the
 adapter tag the TTL role's condition requires), the schedule shape, and the
@@ -30,6 +31,7 @@ from lop_osworld_v2_adapter.providers.aws import (
     AllocationError,
     AwsCredentials,
     AwsProvider,
+    GuestExecutionError,
     ReadinessTimeout,
     _Clients,
     ttl_seconds_for,
@@ -341,6 +343,7 @@ class _FakeEnv:
         self.reset_calls: list[Any] = []
         self.user_simulator = None
         self.controller = self
+        self.pkgs_prefix = "import pyautogui; {command}"
         self.provider = _UpstreamProviderShape()
         self.manager = self.provider
         self.is_environment_used = False
@@ -1170,6 +1173,108 @@ async def test_evaluate_returns_raw_when_the_judge_is_quiet() -> None:
 
 
 @pytest.mark.asyncio
+async def test_execute_over_real_http_reports_partial_subprocess_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Exercise the control boundary, not X11: no guest display exists on CI."""
+    import subprocess
+    import sys
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+    from threading import Thread
+
+    from lop_osworld_v2_adapter.providers import aws
+
+    marker = tmp_path / "committed.txt"
+    requests_seen: list[dict[str, Any]] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *_args: Any) -> None:
+            pass
+
+        def do_POST(self) -> None:
+            payload = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            requests_seen.append(payload)
+            assert self.path == "/execute"
+            assert payload["shell"] is False
+            # The guest resolves `python` in its own environment. Use this test
+            # environment's interpreter, but execute the received source intact.
+            completed = subprocess.run(
+                [sys.executable, *payload["command"][1:]], capture_output=True, text=True
+            )
+            body = json.dumps(
+                {
+                    "returncode": completed.returncode,
+                    "output": completed.stdout,
+                    "error": completed.stderr,
+                }
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    monkeypatch.setattr(aws, "GUEST_PORT", server.server_port)
+    try:
+        with _Stubs() as stubs:
+            # The real HTTP closure makes requests; boto clients are constructed
+            # with fixture credentials and are never invoked by execute().
+            stubs.clients.http_post_json = aws.build_clients(CREDS, REGION).http_post_json
+            provider = AwsProvider(
+                CREDS, region=REGION, lease_ref="lop-ttl-x", clients=stubs.clients, sleep=stubs.sleep
+            )
+            env = _FakeEnv()
+            env.pkgs_prefix = "{command}"
+            provider._env = env
+            provider._public_ip = "127.0.0.1"
+            write = f"from pathlib import Path; Path({str(marker)!r}).open('a').write('once\\n')"
+            await provider.execute([write])
+            with pytest.raises(GuestExecutionError, match=r"exit 7"):
+                await provider.execute([write + "; raise SystemExit(7)", write])
+            assert marker.read_text() == "once\nonce\n"
+            assert len(requests_seen) == 2
+            assert stubs.slept == [3.0]
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "response",
+    [
+        {"returncode": 7, "error": "PRIVATE_PAYLOAD"},
+        {"error": "PRIVATE_PAYLOAD"},
+        {"returncode": False},
+        {"returncode": "0"},
+        RuntimeError("PRIVATE_PAYLOAD"),
+        TimeoutError("PRIVATE_PAYLOAD"),
+    ],
+)
+async def test_execute_failure_stops_batch_without_retry_or_payload_leak(
+    response: dict[str, Any] | Exception,
+) -> None:
+    with _Stubs() as stubs:
+        provider = AwsProvider(
+            CREDS, region=REGION, lease_ref="lop-ttl-x", clients=stubs.clients, sleep=stubs.sleep
+        )
+        env = _FakeEnv()
+        provider._env = env
+        provider._public_ip = "127.0.0.1"
+        stubs.guest_default = response
+        with pytest.raises(GuestExecutionError) as raised:
+            await provider.execute(["first()", "must_not_run()"])
+        assert "PRIVATE_PAYLOAD" not in str(raised.value)
+        assert "batch not retried" in str(raised.value)
+        assert len(stubs.guest_posts) == 1
+        assert stubs.slept == []
+        assert "executed" not in env.kwargs
+
+
+@pytest.mark.asyncio
 async def test_execute_settles_after_the_batch_and_respond_without_simulator_is_none() -> None:
     with _Stubs() as stubs:
         provider = AwsProvider(
@@ -1177,9 +1282,16 @@ async def test_execute_settles_after_the_batch_and_respond_without_simulator_is_
         )
         env = _FakeEnv()
         provider._env = env
+        provider._public_ip = "127.0.0.1"
         await provider.execute(["pyautogui.click(1, 2)"])
         await provider.execute([])
-        assert env.kwargs["executed"] == ["pyautogui.click(1, 2)"]
+        assert stubs.guest_posts == [
+            {
+                "command": ["python", "-c", "import pyautogui; pyautogui.click(1, 2)"],
+                "shell": False,
+            }
+        ]
+        assert "executed" not in env.kwargs
         assert stubs.slept == [3.0, 3.0]
         assert await provider.respond("?") is None
         assert (await provider.observe())["screenshot"] == b"png"

--- a/tests/unit/evaluation/adapters/osworld/test_build_and_scripts.py
+++ b/tests/unit/evaluation/adapters/osworld/test_build_and_scripts.py
@@ -91,7 +91,7 @@ def runner_descriptor(tmp_path: Path, episode_id: str, *, secret_refs: Any = ())
 
     tmp_path.mkdir(parents=True, exist_ok=True)
     return RescueDescriptor(
-        schema_version="1.4",
+        schema_version="1.5",
         selector=selector(tmp_path),
         handshake=handshake(tmp_path),
         episode_id=episode_id,
@@ -443,17 +443,13 @@ def test_a_version_that_cannot_be_determined_refuses_to_build(
 
 
 def test_the_staged_pilot_release_digest_is_reproduced_from_committed_values() -> None:
-    """The pinned attestation of the staged pilot, through the REAL resolution.
+    """The frozen pilot attestation remains reproducible after adapter upgrades.
 
-    This is the regression test the original defect needed: it fails outright
-    on the bug (the stale ``0.1.0`` version yields ``a15961b1...``) rather than
-    only on a guard's error message.
-
-    It routes through ``resolve_attested_version`` -- the same call ``main``
-    makes -- rather than recomputing the rule. Calling ``_adapter_version()``
-    and passing the result straight to ``_release_digest`` would re-implement
-    the resolution, and a mutation to it would leave this test green: exactly
-    the bypass the original defect exploited, one level up.
+    The historical declaration still routes through ``resolve_attested_version``
+    and the real digest function. Current-source version selection is exercised
+    separately by ``test_main_takes_its_attested_version_from_the_resolver``:
+    passing today's adapter version beside an old wheel digest would relabel
+    the pilot rather than test its original attestation.
 
     Hermetic because every input is committed or supplied here -- the release
     name and task-hash manifest sha from ``config/release-v2026.08.08.json``,
@@ -466,11 +462,13 @@ def test_the_staged_pilot_release_digest_is_reproduced_from_committed_values() -
     """
 
     pin = json.loads(build._DEFAULT_PIN.read_text())
-    # Exactly what main does: nothing requested, so the tree's own declaration
-    # is what gets attested.
+    # This attestation belongs to the frozen 0.1.1 wheel, not the current
+    # source's declaration. Keep that historical preimage intact when a new
+    # adapter is published; the current-version resolver path has its own
+    # regression below and must not relabel this old package digest.
     version, advisory = build.resolve_attested_version(
         requested=None,
-        declared=build._adapter_version(),
+        declared="0.1.1",
         allow_mismatch=False,
     )
     assert advisory is None

--- a/tests/unit/evaluation/adapters/osworld/test_cache_dir.py
+++ b/tests/unit/evaluation/adapters/osworld/test_cache_dir.py
@@ -147,7 +147,7 @@ def _selector(workspace: Path, adapter: OSWorldV2Adapter, digest: str) -> Adapte
         schema_version=ADAPTER_SCHEMA_VERSION,
         adapter_id="osworld-v2",
         distribution="lop-osworld-v2-adapter",
-        version="0.1.1",
+        version="0.1.2",
         entry_point="lop_osworld_v2_adapter:create",
         package_digest=metadata.package_digest,
         release_digest=metadata.release_digest,

--- a/tests/unit/evaluation/adapters/osworld/test_discovery.py
+++ b/tests/unit/evaluation/adapters/osworld/test_discovery.py
@@ -38,7 +38,7 @@ def _selector(
         schema_version=ADAPTER_SCHEMA_VERSION,
         adapter_id="osworld-v2",
         distribution="lop-osworld-v2-adapter",
-        version="0.1.1",
+        version="0.1.2",
         entry_point="lop_osworld_v2_adapter:create",
         package_digest=package_digest,
         release_digest=release_digest,
@@ -54,7 +54,7 @@ def test_wheel_has_no_console_scripts(adapter_wheel: Path, tmp_path: Path) -> No
     import zipfile
 
     with zipfile.ZipFile(adapter_wheel) as archive:
-        record = archive.read("lop_osworld_v2_adapter-0.1.1.dist-info/RECORD").decode()
+        record = archive.read("lop_osworld_v2_adapter-0.1.2.dist-info/RECORD").decode()
     for line in record.splitlines():
         path = line.split(",")[0]
         assert not path.startswith(".."), f"RECORD path escapes the root: {path}"

--- a/tests/unit/evaluation/adapters/osworld/test_fake_end_to_end.py
+++ b/tests/unit/evaluation/adapters/osworld/test_fake_end_to_end.py
@@ -131,7 +131,7 @@ def _selector(tmp_path: Path, workspace: Path, adapter: OSWorldV2Adapter) -> Ada
         schema_version=ADAPTER_SCHEMA_VERSION,
         adapter_id="osworld-v2",
         distribution="lop-osworld-v2-adapter",
-        version="0.1.1",
+        version="0.1.2",
         entry_point="lop_osworld_v2_adapter:create",
         package_digest=metadata.package_digest,
         release_digest=metadata.release_digest,

--- a/tests/unit/evaluation/adapters/osworld/test_paste.py
+++ b/tests/unit/evaluation/adapters/osworld/test_paste.py
@@ -1,0 +1,73 @@
+"""The compiler independently gates loss and emits one explicit paste statement."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from lop_osworld_v2_adapter import actions
+from lop_osworld_v2_adapter.adapter import OSWorldV2Adapter
+
+from local_operator.evaluation.action_surface import ActionAdmissionError
+from local_operator.evaluation.protocol import (
+    ActionBatch,
+    ClickAction,
+    PasteTextAction,
+    TypeAction,
+)
+from tests.unit.evaluation.adapters.osworld.test_actions import _geo
+
+
+def test_whole_batch_rejected_before_any_compilation(monkeypatch: pytest.MonkeyPatch) -> None:
+    batch = ActionBatch(
+        protocol_version="1.0",
+        task_id="task",
+        episode_id="episode",
+        observation_id="obs",
+        actions=(
+            ClickAction(observation_id="obs", frame_id="screen", x=1, y=1),
+            TypeAction(observation_id="obs", text="café 東京🙂"),
+        ),
+    )
+    called: list[Any] = []
+    monkeypatch.setattr(actions, "compile_action", lambda *args: called.append(args))
+    with pytest.raises(ActionAdmissionError, match="use paste_text"):
+        actions.compile_batch(batch, _geo())
+    assert not called
+
+
+@pytest.mark.parametrize(
+    "keys,expected",
+    [
+        (("CTRL", "v"), ("ctrl", "v")),
+        (("CTRL", "SHIFT", "v"), ("ctrl", "shift", "v")),
+        (("SHIFT", "INSERT"), ("shift", "insert")),
+        (("META", "v"), ("win", "v")),
+    ],
+)
+def test_paste_uses_native_key_mapping_without_default_chord(
+    monkeypatch: pytest.MonkeyPatch,
+    keys: tuple[str, ...],
+    expected: tuple[str, ...],
+) -> None:
+    captured: list[Any] = []
+    monkeypatch.setattr(
+        actions,
+        "paste_text_source",
+        lambda text, chord: captured.append((text, tuple(chord))) or "paste",
+    )
+    action = PasteTextAction(
+        observation_id="obs", text="東京🙂", keys=keys, clipboard_policy="overwrite"
+    )
+    assert actions.compile_action(action) == "paste"
+    assert captured == [("東京🙂", expected)]
+
+
+def test_adapter_metadata_matches_compiler_admission() -> None:
+    assert OSWorldV2Adapter().metadata.capabilities.action_surface() == actions.ACTION_SURFACE
+
+
+def test_native_type_control_and_small_transport_are_unchanged() -> None:
+    assert actions.compile_action(TypeAction(observation_id="obs", text="a\t\n\r")) == (
+        "pyautogui.typewrite('a\\t\\n\\r', interval=0.01)"
+    )

--- a/tests/unit/evaluation/adapters/osworld/test_secrets_and_rescue.py
+++ b/tests/unit/evaluation/adapters/osworld/test_secrets_and_rescue.py
@@ -419,7 +419,7 @@ async def test_rescue_without_aws_secrets_fails_closed(
 
 
 def test_schema_is_1_2_and_secrets_live_only_on_reset_and_rescue() -> None:
-    assert ADAPTER_SCHEMA_VERSION == "1.4"
+    assert ADAPTER_SCHEMA_VERSION == "1.5"
     assert "secrets" in ResetStartParams.model_fields
     assert "secrets" in BeginRescueParams.model_fields
     assert "secrets" not in PrepareParams.model_fields

--- a/tests/unit/evaluation/adapters/test_api.py
+++ b/tests/unit/evaluation/adapters/test_api.py
@@ -27,7 +27,7 @@ def selector(tmp_path: Path) -> AdapterSelector:
     workspace = tmp_path / "workspace"
     workspace.mkdir(exist_ok=True)
     return AdapterSelector(
-        schema_version="1.4",
+        schema_version="1.5",
         adapter_id="tiny",
         distribution="tiny-adapter",
         version="1.2.3",
@@ -49,7 +49,7 @@ def metadata() -> AdapterMetadata:
         entry_point="tiny_adapter:create",
         package_digest=DIGEST,
         release_digest="b" * 64,
-        schema_version="1.4",
+        schema_version="1.5",
         capabilities=AdapterCapabilities(routes=("computer",), ask_user=True, scoring=True),
     )
 
@@ -133,7 +133,7 @@ def test_scoped_infra_has_no_provider_or_model_purpose() -> None:
 def test_rescue_descriptor_is_content_bound_and_has_refs_not_secrets(tmp_path: Path) -> None:
     selected = selector(tmp_path)
     descriptor = RescueDescriptor(
-        schema_version="1.4",
+        schema_version="1.5",
         selector=selected,
         handshake=handshake(tmp_path),
         episode_id="episode",

--- a/tests/unit/evaluation/adapters/test_discovery.py
+++ b/tests/unit/evaluation/adapters/test_discovery.py
@@ -101,7 +101,7 @@ def selected(tmp_path: Path, digest: str) -> AdapterSelector:
         shutil.copy2(Path(sys.executable).resolve(), executable)
         executable.chmod(0o755)
     return AdapterSelector(
-        schema_version="1.4",
+        schema_version="1.5",
         adapter_id="tiny",
         distribution="tiny-adapter",
         version="1.0",

--- a/tests/unit/evaluation/adapters/test_launch.py
+++ b/tests/unit/evaluation/adapters/test_launch.py
@@ -75,7 +75,7 @@ def create():
             entry_point="tiny_e2e_adapter:create",
             package_digest=distribution_digest(installed),
             release_digest="%s",
-            schema_version="1.4",
+            schema_version="1.5",
             capabilities=AdapterCapabilities(
                 routes=("computer",), ask_user=False, scoring=False
             ),
@@ -170,7 +170,7 @@ def create():
             entry_point="rescue_e2e_adapter:create",
             package_digest=distribution_digest(installed),
             release_digest="{release}",
-            schema_version="1.4",
+            schema_version="1.5",
             capabilities=AdapterCapabilities(
                 routes=("computer",), ask_user=False, scoring=False
             ),
@@ -272,7 +272,7 @@ async def test_supervisor_launch_completes_real_handshake_and_reaps(tmp_path: Pa
         json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
     )
     selector = AdapterSelector(
-        schema_version="1.4",
+        schema_version="1.5",
         adapter_id="tiny-e2e",
         distribution="tiny-e2e-adapter",
         version="1.0",
@@ -317,7 +317,7 @@ def _rescue_selector(tmp_path: Path) -> AdapterSelector:
         json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
     )
     return AdapterSelector(
-        schema_version="1.4",
+        schema_version="1.5",
         adapter_id="rescue-e2e",
         distribution="rescue-e2e-adapter",
         version="1.0",
@@ -348,7 +348,7 @@ def _rescue_descriptor(selector: AdapterSelector, handshake: Handshake, root: Pa
         ),
     )
     return RescueDescriptor(
-        schema_version="1.4",
+        schema_version="1.5",
         selector=selector,
         handshake=handshake,
         episode_id="episode",
@@ -422,7 +422,7 @@ async def test_spawned_rescue_worker_refuses_an_adapter_without_begin_rescue(
         json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
     )
     selector = AdapterSelector(
-        schema_version="1.4",
+        schema_version="1.5",
         adapter_id="tiny-e2e",
         distribution="tiny-e2e-adapter",
         version="1.0",
@@ -513,7 +513,7 @@ def create():
             entry_point="failing_e2e_adapter:create",
             package_digest=distribution_digest(installed),
             release_digest="{release}",
-            schema_version="1.4",
+            schema_version="1.5",
             capabilities=AdapterCapabilities(
                 routes=("computer",), ask_user=False, scoring=False
             ),
@@ -540,7 +540,7 @@ def _failing_selector(tmp_path: Path) -> AdapterSelector:
         json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
     )
     return AdapterSelector(
-        schema_version="1.4",
+        schema_version="1.5",
         adapter_id="failing-e2e",
         distribution="failing-e2e-adapter",
         version="1.0",
@@ -697,7 +697,7 @@ def create():
             entry_point="leaky_e2e_adapter:create",
             package_digest=distribution_digest(installed),
             release_digest="{release}",
-            schema_version="1.4",
+            schema_version="1.5",
             capabilities=AdapterCapabilities(
                 routes=("computer",), ask_user=False, scoring=False
             ),
@@ -724,7 +724,7 @@ def _leaky_selector(tmp_path: Path) -> AdapterSelector:
         json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
     )
     return AdapterSelector(
-        schema_version="1.4",
+        schema_version="1.5",
         adapter_id="leaky-e2e",
         distribution="leaky-e2e-adapter",
         version="1.0",

--- a/tests/unit/evaluation/adapters/test_supervisor.py
+++ b/tests/unit/evaluation/adapters/test_supervisor.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import pytest
 
+from local_operator.evaluation.action_surface import LEGACY_ACTION_SURFACE
 from local_operator.evaluation.adapters.api import (
     AckResult,
     AdapterCapabilities,
@@ -67,7 +68,7 @@ def selector(tmp_path: Path) -> AdapterSelector:
     workspace = tmp_path / "workspace"
     workspace.mkdir(exist_ok=True)
     return AdapterSelector(
-        schema_version="1.4",
+        schema_version="1.5",
         adapter_id="tiny",
         distribution="tiny-adapter",
         version="1.0",
@@ -89,7 +90,7 @@ def metadata() -> AdapterMetadata:
         entry_point="tiny_adapter:create",
         package_digest="a" * 64,
         release_digest="b" * 64,
-        schema_version="1.4",
+        schema_version="1.5",
         capabilities=AdapterCapabilities(routes=("computer",), ask_user=False, scoring=True),
     )
 
@@ -121,7 +122,7 @@ def plan() -> CleanupPlan:
 
 def descriptor(tmp_path: Path) -> RescueDescriptor:
     return RescueDescriptor(
-        schema_version="1.4",
+        schema_version="1.5",
         selector=selector(tmp_path),
         handshake=handshake(tmp_path),
         episode_id="episode",
@@ -220,6 +221,8 @@ def test_ask_exchange_requires_expected_episode_and_preserves_pending_on_error(
 
 
 class RawSupervisor:
+    action_surface = LEGACY_ACTION_SURFACE
+
     def __init__(self, responses: list[Any]) -> None:
         self.responses = responses
         self.terminated = False
@@ -553,6 +556,61 @@ def _execute_params(current: Any) -> ExecuteParams:
         action_batch=batch,
         action_batch_id=canonical_digest("adapter-action-batch-v1", batch),
     )
+
+
+@pytest.mark.parametrize("kind", ["paste_text", "type"])
+def test_action_admission_rejects_before_mutating_call_without_poison(
+    tmp_path: Path, kind: str
+) -> None:
+    import asyncio
+
+    from local_operator.evaluation.action_surface import (
+        ActionAdmissionError,
+        ActionSurface,
+    )
+
+    current = observation("task", "episode", 0)
+    verifier = HostVerifier("task", "episode", tmp_path)
+    verifier.accept_initial(current)
+    raw = RawSupervisor([])
+    # This is the surface installed by a successful handshake, independently
+    # of what the model client was told it could emit.
+    raw.action_surface = ActionSurface(type_text_mode="ascii")
+    session = VerifiedAdapterSession(raw, verifier)  # type: ignore[arg-type]
+    batch = ActionBatch.model_validate(
+        {
+            "protocol_version": "1.0",
+            "task_id": "task",
+            "episode_id": "episode",
+            "observation_id": current.observation_id,
+            "actions": [
+                {
+                    "kind": kind,
+                    "observation_id": current.observation_id,
+                    "text": "東京",
+                    **(
+                        {"keys": ["ctrl", "v"], "clipboard_policy": "overwrite"}
+                        if kind == "paste_text"
+                        else {}
+                    ),
+                }
+            ],
+        }
+    )
+    params = ExecuteParams(
+        operation_id="exec-paste",
+        action_batch=batch,
+        action_batch_id=canonical_digest("adapter-action-batch-v1", batch),
+    )
+
+    async def run() -> None:
+        with pytest.raises(ActionAdmissionError):
+            await session.execute(params, timeout=1)
+        session._ensure_usable()
+
+    asyncio.run(run())
+    assert raw.calls == []
+    assert not raw.terminated
 
 
 def _adapter_error(phase: str) -> RpcRemoteError:

--- a/tests/unit/evaluation/adapters/test_worker.py
+++ b/tests/unit/evaluation/adapters/test_worker.py
@@ -279,7 +279,7 @@ def rescue_selector(tmp_path: Path) -> AdapterSelector:
     release_digest = "b" * 64
     (workspace / "adapter-release.json").write_text(f'{{"release_digest":"{release_digest}"}}')
     return AdapterSelector(
-        schema_version="1.4",
+        schema_version="1.5",
         adapter_id="rescue",
         distribution="rescue-adapter",
         version="1.0",
@@ -301,7 +301,7 @@ def rescue_metadata() -> AdapterMetadata:
         entry_point="rescue_adapter:create",
         package_digest="a" * 64,
         release_digest="b" * 64,
-        schema_version="1.4",
+        schema_version="1.5",
         capabilities=AdapterCapabilities(routes=("computer",), ask_user=False, scoring=False),
     )
 
@@ -348,7 +348,7 @@ async def test_real_worker_rescue_invokes_each_cleanup_once_and_blocks_normal_fl
             ),
         )
         descriptor = RescueDescriptor(
-            schema_version="1.4",
+            schema_version="1.5",
             selector=selected,
             handshake=handshake,
             episode_id="episode",
@@ -470,7 +470,7 @@ def test_rescue_cleanup_rejects_forged_episode_and_action_without_losing_pin(
         selected_route="computer",
     )
     descriptor = RescueDescriptor(
-        schema_version="1.4",
+        schema_version="1.5",
         selector=selected,
         handshake=pinned_handshake,
         episode_id="episode",

--- a/tests/unit/evaluation/runner/conftest.py
+++ b/tests/unit/evaluation/runner/conftest.py
@@ -73,7 +73,7 @@ def selector(tmp_path: Path) -> AdapterSelector:
     workspace = tmp_path / "workspace"
     workspace.mkdir(exist_ok=True)
     return AdapterSelector(
-        schema_version="1.4",
+        schema_version="1.5",
         adapter_id="tiny",
         distribution="tiny-adapter",
         version="1.0",
@@ -97,7 +97,7 @@ def handshake(tmp_path: Path) -> Handshake:
             entry_point="tiny_adapter:create",
             package_digest="a" * 64,
             release_digest="b" * 64,
-            schema_version="1.4",
+            schema_version="1.5",
             capabilities=AdapterCapabilities(routes=("computer",), ask_user=True, scoring=True),
         ),
         python=PythonRuntime.current(),
@@ -334,7 +334,7 @@ class ScriptedModel:
         self.route = ROUTE
 
     async def decide(
-        self, observation: Observation, history: Sequence[EpisodeTurn]
+        self, observation: Observation, history: Sequence[EpisodeTurn], **kwargs: Any
     ) -> ModelDecision:
         self.histories.append(tuple(history))
         if self.error is not None:

--- a/tests/unit/evaluation/runner/test_action_negotiation.py
+++ b/tests/unit/evaluation/runner/test_action_negotiation.py
@@ -1,0 +1,95 @@
+"""Exercise the existing provider/runner paths with negotiated capabilities."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.evaluation.action_surface import ActionSurface
+from local_operator.evaluation.evidence.models import (
+    ModelRequestPayload,
+    canonical_digest,
+)
+from local_operator.evaluation.runner.model import DecisionRejected
+from tests.unit.evaluation.runner.conftest import FakeAdapter, ScriptedModel, payloads
+from tests.unit.evaluation.runner.test_episode import _runner
+from tests.unit.evaluation.runner.test_provider_client import (
+    ScriptedStream,
+    _client,
+    _turns,
+    observation,
+)
+
+
+def _payload(kind: str) -> str:
+    return json.dumps(
+        {
+            "actions": [
+                {
+                    "kind": kind,
+                    "observation_id": observation().observation_id,
+                    "text": "café 東京🙂",
+                    **(
+                        {"keys": ["ctrl", "v"], "clipboard_policy": "overwrite"}
+                        if kind == "paste_text"
+                        else {}
+                    ),
+                }
+            ]
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_provider_sees_supported_unicode_path_and_rejects_lossy_type() -> None:
+    surface = ActionSurface(paste_text=True, type_text_mode="ascii")
+    stream = ScriptedStream(_payload("type"))
+    client = _client(stream)
+    with pytest.raises(DecisionRejected, match="use paste_text"):
+        await client.decide(observation(), _turns(observation()), action_surface=surface)
+    assert '"paste_text"' in stream.requests[0].system_blocks[0]
+    stream.text = _payload("paste_text")
+    decision = await client.decide(observation(), _turns(observation()), action_surface=surface)
+    assert decision.action_batch.actions[0].kind == "paste_text"
+    assert len(stream.requests) == 2
+
+
+@pytest.mark.asyncio
+async def test_unsupported_paste_is_a_correctable_decision_not_dispatch() -> None:
+    stream = ScriptedStream(_payload("paste_text"))
+    client = _client(stream)
+    with pytest.raises(DecisionRejected, match="not supported"):
+        await client.decide(observation(), _turns(observation()), action_surface=ActionSurface())
+    assert '"paste_text"' not in stream.requests[0].system_blocks[0]
+
+
+@pytest.mark.asyncio
+async def test_runner_records_the_same_negotiated_schema_it_passes_to_model(
+    tmp_path: Path, episode_id: str
+) -> None:
+    seen: list[ActionSurface] = []
+
+    class CapturingModel(ScriptedModel):
+        async def decide(self, observation: Any, history: Any, **kwargs: Any) -> Any:
+            seen.append(kwargs["action_surface"])
+            return await super().decide(observation, history, **kwargs)
+
+    outcome = await _runner(
+        tmp_path,
+        episode_id,
+        adapter=FakeAdapter(tmp_path, episode_id),
+        model=CapturingModel(["finish"]),
+    ).run()
+    assert outcome.status == "completed"
+    assert outcome.bundle_root is not None
+    manifest = json.loads((outcome.bundle_root / "manifest.json").read_text())
+    recorded = json.loads(manifest["metadata"]["action_surface"])
+    assert recorded == seen[0].schema()
+    requests = payloads(outcome.bundle_root, ModelRequestPayload)
+    assert requests[0].tool_schema_digest == canonical_digest("runner-tool-schema-v1", recorded)
+    assert requests[0].tool_schema_digest != canonical_digest(
+        "runner-tool-schema-v1", {"episode_id": episode_id}
+    )

--- a/tests/unit/evaluation/runner/test_episode.py
+++ b/tests/unit/evaluation/runner/test_episode.py
@@ -717,7 +717,7 @@ async def test_context_unrecoverable_seals_as_a_harness_error_not_a_provider_one
     )
 
     class RefusingModel:
-        async def decide(self, observation: Any, history: Any) -> Any:
+        async def decide(self, observation: Any, history: Any, **kwargs: Any) -> Any:
             raise ContextUnrecoverableError("context cannot fit the window")
 
     adapter = FakeAdapter(tmp_path, episode_id)
@@ -964,11 +964,11 @@ async def test_provider_failure_after_a_step_still_seals(tmp_path: Path, episode
     original = model.decide
     calls = {"n": 0}
 
-    async def decide(observation: Any, history: Any) -> Any:
+    async def decide(observation: Any, history: Any, **kwargs: Any) -> Any:
         calls["n"] += 1
         if calls["n"] > 1:
             raise RuntimeError("provider exhausted retries")
-        return await original(observation, history)
+        return await original(observation, history, **kwargs)
 
     model.decide = decide  # type: ignore[method-assign]
     runner = _runner(tmp_path, episode_id, adapter=adapter, model=model)

--- a/tests/unit/evaluation/runner/test_episode_subprocess.py
+++ b/tests/unit/evaluation/runner/test_episode_subprocess.py
@@ -408,7 +408,7 @@ def create():
             entry_point="tiny_runner_adapter:create",
             package_digest=distribution_digest(installed),
             release_digest="%s",
-            schema_version="1.4",
+            schema_version="1.5",
             capabilities=AdapterCapabilities(
                 routes=("computer",), ask_user=False, scoring=True
             ),
@@ -479,7 +479,7 @@ def real_selector(tmp_path: Path, adapter_site: Path) -> AdapterSelector:
     (workspace / "tasks" / "pkg").mkdir(exist_ok=True)
     (workspace / "tasks" / "pkg" / "mod.py").write_text("MARK = 'nested'\n")
     return AdapterSelector(
-        schema_version="1.4",
+        schema_version="1.5",
         adapter_id="tiny-runner",
         distribution="tiny-runner-adapter",
         version="1.0",

--- a/tests/unit/evaluation/runner/test_secrets.py
+++ b/tests/unit/evaluation/runner/test_secrets.py
@@ -337,8 +337,8 @@ async def test_value_reaching_the_bundle_is_refused_by_the_canaried_writer(
     class _Leaky(ScriptedModel):
         """Smuggles the value into a model_response through ``stop_reason``."""
 
-        async def decide(self, observation: Any, history: Any) -> Any:
-            decision = await super().decide(observation, history)
+        async def decide(self, observation: Any, history: Any, **kwargs: Any) -> Any:
+            decision = await super().decide(observation, history, **kwargs)
             return decision.model_copy(update={"stop_reason": SHORT_CANARY})
 
     adapter = FakeAdapter(tmp_path, episode_id)

--- a/tests/unit/evaluation/test_action_surface.py
+++ b/tests/unit/evaluation/test_action_surface.py
@@ -1,0 +1,134 @@
+"""Negotiated admission is stricter than historic action-data parsing."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from local_operator.evaluation.action_surface import ActionAdmissionError, ActionSurface
+from local_operator.evaluation.adapters.api import AdapterCapabilities, AdapterSelector
+from local_operator.evaluation.evidence.models import canonical_bytes, canonical_digest
+from local_operator.evaluation.protocol import (
+    ActionBatch,
+    KeyAction,
+    PasteTextAction,
+    TypeAction,
+)
+from local_operator.evaluation.runner.provider_client import build_system_prompt
+
+
+def batch(action: object) -> ActionBatch:
+    return ActionBatch.model_validate(
+        {
+            "protocol_version": "1.0",
+            "task_id": "task",
+            "episode_id": "episode",
+            "observation_id": "obs",
+            "actions": [action],
+        }
+    )
+
+
+def paste(**changes: object) -> PasteTextAction:
+    return PasteTextAction.model_validate(
+        {
+            "observation_id": "obs",
+            "text": "café 東京🙂",
+            "keys": ["ctrl", "v"],
+            "clipboard_policy": "overwrite",
+            **changes,
+        }
+    )
+
+
+@pytest.mark.parametrize("text", [" ", "\t\n\r", "e\u0301", "東京🙂", "🙂" * 100_000])
+def test_unicode_and_whitespace_are_paste_data(text: str) -> None:
+    action = paste(text=text)
+    assert action.text == text
+    assert action.keys == ("CTRL", "v")
+    assert ActionBatch.from_canonical_json(batch(action).to_canonical_json()) == batch(action)
+
+
+@pytest.mark.parametrize("text", ["", "x" * 100_001, "\0", "\x1b", "\x7f", "\x85", "\ud800"])
+def test_invalid_paste_rejected_before_dispatch(text: str) -> None:
+    with pytest.raises(ValidationError):
+        paste(text=text)
+
+
+@pytest.mark.parametrize("field", ["text", "keys", "clipboard_policy", "observation_id"])
+def test_paste_has_no_implicit_policy_or_chord(field: str) -> None:
+    payload = paste().model_dump(mode="json")
+    del payload[field]
+    with pytest.raises(ValidationError):
+        PasteTextAction.model_validate(payload)
+
+
+@pytest.mark.parametrize("keys", [[], ["control", "v"], ["CTRL", "ctrl"], ["a"] * 9, "ctrl+v"])
+def test_paste_uses_the_same_key_validator(keys: object) -> None:
+    for model, extra in [
+        (KeyAction, {}),
+        (PasteTextAction, {"text": "x", "clipboard_policy": "overwrite"}),
+    ]:
+        with pytest.raises(ValidationError):
+            model.model_validate({"observation_id": "obs", "keys": keys, **extra})
+
+
+def test_no_restore_policy() -> None:
+    with pytest.raises(ValidationError):
+        paste(clipboard_policy="restore")
+
+
+def test_old_type_and_key_bytes_are_frozen() -> None:
+    # Captured with the 743b014f frozen baseline interpreter/source, not derived
+    # from the implementation under test. Adding paste must not rehash old input.
+    old = [
+        (
+            TypeAction(observation_id="obs", text="café 東京🙂\t\n"),
+            "5a469102f4362cb1af551110f4e2c560d6c785829e2a2a7b96922bdf8cccecfd",
+        ),
+        (
+            KeyAction(observation_id="obs", keys=("ctrl", "v")),
+            "d0d97bafcca4f751006d1a2f7928b4c0eb0b5858a2ee32c9d3808dea557fe689",
+        ),
+    ]
+    for action, expected in old:
+        encoded = batch(action).to_canonical_json()
+        assert hashlib.sha256(encoded).hexdigest() == expected
+        assert ActionBatch.from_canonical_json(encoded).to_canonical_json() == encoded
+
+
+def test_negotiation_controls_admission_prompt_and_schema_identity() -> None:
+    legacy = AdapterCapabilities(routes=("computer",), ask_user=True, scoring=True).action_surface()
+    enabled = AdapterCapabilities(
+        routes=("computer",), ask_user=False, scoring=True, paste_text=True, type_text_mode="ascii"
+    ).action_surface()
+    assert '"paste_text"' not in build_system_prompt(legacy)
+    assert '"paste_text"' in build_system_prompt(enabled)
+    assert '"ask_user"' not in build_system_prompt(enabled)
+    assert '"keys": [str, ...]' in build_system_prompt(enabled)
+    assert '"clipboard_policy": overwrite' in build_system_prompt(enabled)
+    with pytest.raises(ActionAdmissionError):
+        legacy.validate_batch(batch(paste()))
+    enabled.validate_batch(batch(paste()))
+    unicode_type = batch(TypeAction(observation_id="obs", text="東京"))
+    legacy.validate_batch(unicode_type)
+    with pytest.raises(ActionAdmissionError, match="use paste_text"):
+        enabled.validate_batch(unicode_type)
+    assert canonical_digest("runner-tool-schema-v1", enabled.schema()) != canonical_digest(
+        "runner-tool-schema-v1", legacy.schema()
+    )
+    assert json.loads(canonical_bytes(enabled.schema())) == enabled.schema()
+
+
+def test_old_rpc_refused_before_allocation() -> None:
+    with pytest.raises(ValidationError, match="1.5"):
+        AdapterSelector.model_validate({"schema_version": "1.4"})
+
+
+def test_ascii_native_controls_are_not_reinterpreted_as_paste() -> None:
+    ActionSurface(type_text_mode="ascii").validate_batch(
+        batch(TypeAction(observation_id="obs", text="x\t\n\r"))
+    )

--- a/tests/unit/test_computer_input.py
+++ b/tests/unit/test_computer_input.py
@@ -1,0 +1,167 @@
+"""Real subprocesses around a fake X11 boundary; not native desktop proof.
+
+The guest's generated source is executed intact, with tiny stand-ins for xclip
+and pyautogui. This catches quoting, argv limits, pipe hangs and owned-child
+cleanup without importing or installing GUI libraries on the host.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from local_operator.computer_input import paste_text_source, python_source_argv
+
+
+@pytest.fixture
+def guest(tmp_path: Path) -> Iterator[dict[str, str]]:
+    xclip = tmp_path / "xclip"
+    xclip.write_text(f"#!{sys.executable}\n" + """
+import os, pathlib, sys, time
+root = pathlib.Path(os.environ["PASTE_TEST_ROOT"])
+assert sys.argv[1:3] == ["-selection", "clipboard"]
+assert sys.argv[4:6] == ["-target", "UTF8_STRING"]
+if "-in" in sys.argv:
+    assert sys.argv[6:] == ["-quiet", "-loops", "0"]
+    root.joinpath("owner.pid").write_text(str(os.getpid()))
+    data = sys.stdin.buffer.read()
+    if os.environ.get("PASTE_FAILURE") == "owner":
+        sys.exit(7)
+    root.joinpath("payload").write_bytes(data)
+    while True:
+        time.sleep(0.1)
+else:
+    failure = os.environ.get("PASTE_FAILURE")
+    if failure == "hang":
+        root.joinpath("reader.pid").write_text(str(os.getpid()))
+        time.sleep(30)
+    elif failure == "overflow":
+        sys.stdout.buffer.write(b"x" * 1_000_000)
+    elif failure == "read":
+        sys.stderr.write("PRIVATE_PAYLOAD")
+        sys.exit(4)
+    else:
+        try:
+            sys.stdout.buffer.write(root.joinpath("payload").read_bytes())
+        except FileNotFoundError:
+            sys.exit(1)
+""")
+    xclip.chmod(0o700)
+    (tmp_path / "pyautogui.py").write_text("""
+import json, os, pathlib
+root = pathlib.Path(os.environ["PASTE_TEST_ROOT"])
+def hotkey(*keys):
+    root.joinpath("keys").write_text(json.dumps(keys))
+    if os.environ.get("PASTE_FAILURE") == "key":
+        raise ValueError("PRIVATE_PAYLOAD")
+def press(key):
+    hotkey(key)
+""")
+    environment = {
+        **os.environ,
+        "PATH": str(tmp_path),
+        "PYTHONPATH": str(tmp_path),
+        "PASTE_TEST_ROOT": str(tmp_path),
+    }
+    yield environment
+    # Only children whose PID was written by this test's executable are owned
+    # here. Production ownership ends on selection replacement, tested natively
+    # by the parent proof rather than claimed by this fake X11 service.
+    for name in ("owner.pid", "reader.pid"):
+        path = tmp_path / name
+        if path.exists():
+            try:
+                os.kill(int(path.read_text()), signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+
+def run_source(source: str, environment: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    argv = python_source_argv(source)
+    assert all(len(arg.encode("utf-8")) <= 64_000 for arg in argv[1:])
+    return subprocess.run(
+        [sys.executable, *argv[1:]],
+        env=environment,
+        text=True,
+        capture_output=True,
+        timeout=12,
+    )
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "café 東京🙂",
+        "a\tb\nnext\r\n",
+        " \t\n",
+        "'; __import__('os').abort(); #",
+        "🙂" * 100_000,
+    ],
+    ids=["unicode", "tabs-newlines", "whitespace", "injection", "100k-unicode"],
+)
+def test_generated_source_transfers_exact_utf8_and_only_explicit_chord(
+    guest: dict[str, str],
+    tmp_path: Path,
+    text: str,
+) -> None:
+    import json
+
+    # The actual controller prefixes a semicolon, so do not test a more
+    # permissive multiline-only script host than production uses.
+    source = "import pyautogui; " + paste_text_source(text, ["ctrl", "shift", "v"])
+    result = run_source(source, guest)
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "payload").read_bytes() == text.encode("utf-8")
+    assert json.loads((tmp_path / "keys").read_text()) == ["ctrl", "shift", "v"]
+    assert result.stdout == ""
+    assert text not in result.stderr
+
+
+@pytest.mark.parametrize("failure", ["owner", "overflow", "hang", "read", "key"])
+def test_failure_is_bounded_redacted_and_does_not_retry(
+    guest: dict[str, str],
+    tmp_path: Path,
+    failure: str,
+) -> None:
+    guest["PASTE_FAILURE"] = failure
+    result = run_source(paste_text_source("PRIVATE_PAYLOAD", ["ctrl", "v"]), guest)
+    assert result.returncode != 0
+    assert "PRIVATE_PAYLOAD" not in result.stderr
+    assert "clipboard paste failed" in result.stderr
+    assert (tmp_path / "keys").exists() == (failure == "key")
+    # The generated helper reaps the owned foreground owner before it exits.
+    owner = int((tmp_path / "owner.pid").read_text())
+    with pytest.raises(ProcessLookupError):
+        os.kill(owner, 0)
+
+
+def test_source_arguments_are_literals_not_caller_injection(
+    guest: dict[str, str], tmp_path: Path
+) -> None:
+    import json
+
+    key = "v'); __import__('os').abort(); #"
+    result = run_source(paste_text_source("x", [key]), guest)
+    assert result.returncode == 0, result.stderr
+    assert json.loads((tmp_path / "keys").read_text()) == [key]
+
+
+def test_small_python_commands_keep_legacy_bytes() -> None:
+    source = "pyautogui.typewrite('abc', interval=0.01)"
+    assert python_source_argv(source) == ["python", "-c", source]
+
+
+def test_large_argv_reconstruction_executes_once(tmp_path: Path) -> None:
+    marker = tmp_path / "marker"
+    source = (
+        f"from pathlib import Path; Path({str(marker)!r}).write_text('once')\n#" + "🙂" * 100_000
+    )
+    result = run_source(source, os.environ.copy())
+    assert result.returncode == 0, result.stderr
+    assert marker.read_text() == "once"


### PR DESCRIPTION
## Summary of Changes

Add an explicit, capability-gated `paste_text` computer action for reliable Unicode transfer. The caller supplies a chord and acknowledges `clipboard_policy: overwrite`; this is not a silent fallback inside native `type`.

**C2, standard/pre-authorized. Draft, not ready to merge.** Stacked on #640 (`743b014f`); the additional source is `743b014f..0aa8960c`. Root release version is deferred until integration. Adapter version is 0.1.2 and adapter RPC is 1.5.

## Delivery contract

- Preserve existing action canonical bytes and historical evidence. Add paste as a new discriminated action, not new defaults on existing `TypeAction`.
- Advertise and enforce the negotiated action surface in the shared model prompt, runner, supervisor and adapter. Unsupported native text is rejected before batch mutation rather than silently dropped.
- Supply unchanged Unicode clipboard data, dispatch the caller's chord to existing focus, add no Enter, and explicitly overwrite CLIPBOARD without pretending to restore its previous formats. PRIMARY is not intentionally modified. Application-specific paste/save behavior remains the application's.
- Bound data and subprocess I/O, preserve single-shot execution on ambiguous failures, and support the declared 100,000-character ceiling without violating Linux argv limits.
- Record the actual negotiated schema and its digest, replacing the previous episode-ID-derived placeholder.
- Keep normal TUI/mobile/CLI startup and default tools unchanged. The reusable execution utility is outside the OSWorld adapter and imported only by consumers that need it.

## Non-goals

No task-ID hints, benchmark solution tuning, evaluator changes, automatic chord or window-title detection, rich-clipboard restoration, screenshot-backend patch, new normal-interface tool, or leaderboard claim.

## Why

A retained real task trajectory lost all 18 non-ASCII characters in its typed document. A subsequent zero-delay xdotool candidate also silently lost Unicode in a live guest despite exit status zero. That candidate is excluded from this branch. Explicit paste makes the clipboard side effect and keyboard intent inspectable instead of changing native Tab/Return semantics covertly.

## Testing Details

- Implementer: 284 focused protocol/API/supervisor/compiler/provider/prompt/episode/import-isolation tests passed.
- Corrected artifact and native-boundary regression files: 119 passed, including real wheel workers, synthetic no-inference `run_episode`, rescue/score evidence, and generated subprocess execution through local HTTP. These runs overlap; their counts are not summed.
- The first evaluation-only sweep had 943 passes and 40 version-fixture failures/errors following the intentional adapter version change. The affected files were corrected and re-run; this is not a claim that the entire repository suite has completed.
- All four whole-tree static gates passed. The first whole-tree Pyright run also scanned completed wheel-build caches and found duplicate-module type identities; removing those regenerable build directories and re-running the unchanged source produced zero errors/warnings. No exclusions or suppressions were added.
- Offline-built, non-editable private proof artifacts: harness wheel SHA-256 `95e41054d072094a0da3c269ba62f36fc9d8bc550f5f0f927702bbb5ae63929b`; adapter wheel SHA-256 `60cfa0f1555652626a769a8c9aff0d736a47fc98767175978f7ce7048f07431c`. The harness wheel retains development metadata 0.46.22 and is **not** asserted to be the published 0.46.22 artifact.
- Installed selector validation passed against the unchanged 108-task benchmark release, adapter 0.1.2 and RPC 1.5.
- First real action-pipeline run rendered and saved every supplied Unicode character, but its byte assertion failed because Gedit's default implicit-trailing-newline save policy added one LF. That failed run is retained. The repeat verified Gedit 41.0's starting setting `true`, disabled it **only for the synthetic byte-oracle fixture**, and verified `false` before input. All four exact checks passed: editor 32 codepoints/47 bytes, editor 1,000/1,471 bytes, editor 100,000/220,000 bytes, and terminal 24/35 bytes. Each post-check xclip process count was 1. The full evidence bundle verifies, the VM terminated, and the final tagged-resource audit was empty. No stripping or normalization was applied to readbacks.
- Separate capture diagnostics established a fixture-occlusion confound. The visibility-controlled real `/screenshot` frames correctly show the before/after ASCII state. No production screenshot change is proposed.

Native diagnostics make no model inference calls and are excluded from benchmark results. Normal runtime installation is untouched.

## Published native evidence

[Apparatus, procedure, raw-result hashes and coverage limits](https://github.com/damianvtran/local-operator/blob/a7b76ffac958f77f48c878ff7ffa9ba44caac17a/docs/benchmarks/osworld_2/evidence/paste-651/README.md). This data-only evidence branch does not move the reviewed implementation head.

| Before | After |
| --- | --- |
| ![Empty editor](https://raw.githubusercontent.com/damianvtran/local-operator/a7b76ffac958f77f48c878ff7ffa9ba44caac17a/docs/benchmarks/osworld_2/evidence/paste-651/editor-before.png) | ![Saved Unicode](https://raw.githubusercontent.com/damianvtran/local-operator/a7b76ffac958f77f48c878ff7ffa9ba44caac17a/docs/benchmarks/osworld_2/evidence/paste-651/editor-after.png) |
| ![Terminal before](https://raw.githubusercontent.com/damianvtran/local-operator/a7b76ffac958f77f48c878ff7ffa9ba44caac17a/docs/benchmarks/osworld_2/evidence/paste-651/terminal-before.png) | ![Terminal after](https://raw.githubusercontent.com/damianvtran/local-operator/a7b76ffac958f77f48c878ff7ffa9ba44caac17a/docs/benchmarks/osworld_2/evidence/paste-651/terminal-after.png) |

These are cropped native frames; original frame hashes and crop rectangles are recorded in the evidence package.

## Review and integration gates

Independent code and design round 1 are **clean and TERMINAL** on `0aa8960c`; both implementing-agent acknowledgements are recorded. Native proof is complete. Current-head CI remains the readiness gate. Publication/merging is explicitly held for the coordinated #643 security release window; neither this PR nor prerequisite #640 will move main during that hold. Keep the old frozen runtime available for version-pinned rescue descriptors; never rewrite historical bundles.
