### PR TITLE
fix(evaluation): bounded public-observation retention

### DIFF
--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -788,7 +788,10 @@ class EpisodeRunner:
         nothing -- a missing usage record leaves an unclosed operation and the
         bundle cannot reach a terminal.
         """
-        from local_operator.evaluation.runner.model import DecisionRejected, ModelDecision
+        from local_operator.evaluation.runner.model import (
+            DecisionRejected,
+            ModelDecision,
+        )
 
         request_id = f"req-{self._model_cycles}-{uuid.uuid4().hex[:12]}"
         message_count = len(self._turns)
@@ -867,7 +870,9 @@ class EpisodeRunner:
         served_route = decision.route or self._spec.requested_route
         response_artifact = None
         if isinstance(decision, ModelDecision) and decision.public_reply is not None:
-            from local_operator.evaluation.runner.public_reply import redact_public_reply
+            from local_operator.evaluation.runner.public_reply import (
+                redact_public_reply,
+            )
 
             public_reply = redact_public_reply(decision.public_reply, self._redactions)
             decision = decision.model_copy(update={"public_reply": public_reply})

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -730,6 +730,13 @@ class EpisodeRunner:
                 return
             decision = await self._decide(current)
             batch = decision.action_batch
+            if decision.public_reply is not None:
+                # _decide_once has already redacted and published this reply.
+                # Keep it on the current observation through _close_turn so
+                # accepted replay cannot silently collapse back to actions.
+                self._turns[-1] = self._turns[-1].model_copy(
+                    update={"public_reply": decision.public_reply}
+                )
             terminal = _terminal_kind(batch)
             if terminal == "finish":
                 self._append_batch(batch, terminal="finish")
@@ -781,7 +788,7 @@ class EpisodeRunner:
         nothing -- a missing usage record leaves an unclosed operation and the
         bundle cannot reach a terminal.
         """
-        from local_operator.evaluation.runner.model import DecisionRejected
+        from local_operator.evaluation.runner.model import DecisionRejected, ModelDecision
 
         request_id = f"req-{self._model_cycles}-{uuid.uuid4().hex[:12]}"
         message_count = len(self._turns)
@@ -858,6 +865,15 @@ class EpisodeRunner:
         # not know one); the requested route is the honest stand-in because
         # nothing served was accepted.
         served_route = decision.route or self._spec.requested_route
+        response_artifact = None
+        if isinstance(decision, ModelDecision) and decision.public_reply is not None:
+            from local_operator.evaluation.runner.public_reply import redact_public_reply
+
+            public_reply = redact_public_reply(decision.public_reply, self._redactions)
+            decision = decision.model_copy(update={"public_reply": public_reply})
+            response_artifact = self._publish(
+                public_reply.encode("utf-8"), media_type="application/json"
+            )
         self._append(
             "model_request",
             ModelRequestPayload(
@@ -886,6 +902,7 @@ class EpisodeRunner:
                 cache_read_tokens=decision.usage.cache_read_tokens,
                 cache_write_tokens=decision.usage.cache_write_tokens,
                 tool_call_count=decision.tool_call_count,
+                redacted_response=response_artifact,
             ),
         )
         self._append(
@@ -1617,6 +1634,9 @@ class EpisodeRunner:
             metadata={
                 **dict(spec.metadata),
                 "action_surface": canonical_bytes(self._action_surface.schema()).decode("utf-8"),
+                # Reply fields are NOT tools. Keep their advertised schema and
+                # identity separate, and absent for clients that never used it.
+                **getattr(self._model, "model_reply_metadata", {}),
             },
         )
 

--- a/local_operator/evaluation/runner/model.py
+++ b/local_operator/evaluation/runner/model.py
@@ -74,6 +74,9 @@ class ModelDecision(ProtocolModel):
     """
 
     action_batch: ActionBatch
+    # Only validated visible model output, never provider reasoning. None keeps
+    # old clients/history on their byte-identical canonical-action replay path.
+    public_reply: str | None = None
     route: RouteIdentity
     usage: ModelUsage = Field(default_factory=ModelUsage)
     cost_micros: SafeCount = 0
@@ -99,6 +102,9 @@ class EpisodeTurn(ProtocolModel):
 
     observation: Observation
     batch: ActionBatch | None = None
+    # The runner attaches the evidence-redacted reply to this same observation;
+    # the context builder must not reconstruct it as actions and lose its facts.
+    public_reply: str | None = None
     ask_answer: str | None = None
 
 

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -46,6 +46,7 @@ from local_operator.evaluation.runner.model import (
     ModelUsage,
 )
 from local_operator.evaluation.runner.public_reply import (
+    MAX_PUBLIC_OBSERVATIONS_CHARS,
     REJECTED_PUBLIC_REPLY,
     REPLY_VERSION,
     decode_public_reply,
@@ -280,7 +281,8 @@ fence:
 
 This is a MODEL-REPLY envelope, not the adapter protocol. Use exactly these
 three keys; action_batch contains only actions. public_observations is a string
-of at most 2000 characters; empty is valid. Record only concise NEW factual data
+of at most {MAX_PUBLIC_OBSERVATIONS_CHARS} characters; empty is valid.
+Record only concise NEW factual data
 or visible progress observed on the CURRENT screen that may be needed later,
 because old screenshots are removed before text summarization. Do not repeat
 prior notes, invent facts, record credentials/secrets, or provide deliberation,

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -655,10 +655,15 @@ class _ContextBuilder:
                 self._messages.append(
                     Message(
                         role="assistant",
-                        content=[TextContent(
-                            text=(turn.public_reply if turn.public_reply is not None
-                                  else turn.batch.to_canonical_json().decode("utf-8"))
-                        )],
+                        content=[
+                            TextContent(
+                                text=(
+                                    turn.public_reply
+                                    if turn.public_reply is not None
+                                    else turn.batch.to_canonical_json().decode("utf-8")
+                                )
+                            )
+                        ],
                     )
                 )
                 self._closed_turns.add(index)

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -51,6 +51,7 @@ from local_operator.evaluation.runner.public_reply import (
     REPLY_VERSION,
     decode_public_reply,
     is_public_reply,
+    looks_like_public_reply,
     public_reply_contract,
 )
 from local_operator.logger import get_logger
@@ -900,16 +901,17 @@ class ProviderModelClient:
             diagnostic = _rejection_prompt(str(error), observation)
             # Invalid notes are not factual memory. For envelope failures do
             # not quote their unvalidated (possibly secret) text on retries or
-            # in evidence. Legacy rejection evidence remains unchanged.
+            # in evidence. Classification cannot rely on successful decoding
+            # (a truncated reply fails) or literal keys (JSON Unicode escapes
+            # bypass the substring test), so the reserved-key scan is
+            # escape-aware and fails closed (F1, review round 1). Raw legacy
+            # rejection text is retained only where no reserved key appears.
             shown = text
             try:
                 rejected_value, _ = json.JSONDecoder().raw_decode(text.lstrip())
             except (ValueError, RecursionError):
                 rejected_value = None
-            if is_public_reply(rejected_value) or any(
-                key in text
-                for key in ('"reply_version"', '"public_observations"', '"action_batch"')
-            ):
+            if is_public_reply(rejected_value) or looks_like_public_reply(text):
                 shown = REJECTED_PUBLIC_REPLY
             self._context.append_rejection(shown, diagnostic)
             raise DecisionRejected(

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -45,6 +45,13 @@ from local_operator.evaluation.runner.model import (
     ModelDecision,
     ModelUsage,
 )
+from local_operator.evaluation.runner.public_reply import (
+    REJECTED_PUBLIC_REPLY,
+    REPLY_VERSION,
+    decode_public_reply,
+    is_public_reply,
+    public_reply_contract,
+)
 from local_operator.logger import get_logger
 
 if TYPE_CHECKING:
@@ -235,8 +242,9 @@ def build_system_prompt(surface: ActionSurface = LEGACY_ACTION_SURFACE) -> str:
     return f"""You are operating a computer to complete one task.
 
 Each user message is one observation of the screen: its text, and a screenshot
-when one is attached. Your own earlier replies are the actions you already
-took. "{UNCHANGED_OBSERVATION}" means the observation's TEXT repeats the
+when one is attached. Your own earlier replies contain the actions you already
+took and any public factual observations you recorded.
+"{UNCHANGED_OBSERVATION}" means the observation's TEXT repeats the
 previous one's; "{NO_TEXTUAL_STATE}" means the adapter published no text for
 this step, which is normal for a screenshot-only benchmark and means the
 screenshot is the whole state; "[screenshot omitted ...]" marks an older
@@ -267,7 +275,18 @@ observation with a corrected batch; nothing was executed.
 Reply with a single JSON object and nothing else, with no prose and no code
 fence:
 
-  {{"actions": [ ... ]}}
+  {{"reply_version": "{REPLY_VERSION}", "action_batch": {{"actions": [ ... ]}},
+   "public_observations": ""}}
+
+This is a MODEL-REPLY envelope, not the adapter protocol. Use exactly these
+three keys; action_batch contains only actions. public_observations is a string
+of at most 2000 characters; empty is valid. Record only concise NEW factual data
+or visible progress observed on the CURRENT screen that may be needed later,
+because old screenshots are removed before text summarization. Do not repeat
+prior notes, invent facts, record credentials/secrets, or provide deliberation,
+plans, explanations of your decision, or private reasoning. Do not claim the
+chosen actions succeeded until a later observation shows their result.
+Legacy replies containing only {{"actions": [ ... ]}} are also accepted.
 
 Every action is an object whose type is given by the key "kind" (NOT "type"),
 and every action must carry the "observation_id" of the observation you are
@@ -451,6 +470,10 @@ def _batch_observation_ids(value: Any) -> set[str]:
 
     if not isinstance(value, Mapping):
         return set()
+    if is_public_reply(value):
+        value = value.get("action_batch")
+        if not isinstance(value, Mapping):
+            return set()
     actions = value.get("actions")
     if not isinstance(actions, list) or not actions:
         return set()
@@ -495,6 +518,16 @@ def parse_decision(
     decoded, trailing = _decode_leading_json(payload)
     if not isinstance(decoded, Mapping):
         raise DecisionParseError("decision must be a JSON object")
+    public_reply = None
+    if is_public_reply(decoded):
+        try:
+            envelope = decode_public_reply(payload)
+        except ValueError as error:
+            raise DecisionParseError(str(error)) from error
+        decoded = envelope["action_batch"]
+        # Keep the visible response, not a reconstruction from its actions. It
+        # is redacted at the runner's resolved-secret boundary before replay.
+        public_reply = payload.strip()
     if trailing:
         # Tolerated, but never silent. A model that reliably appends junk is a
         # signal worth seeing -- it may point at a prompt or provider problem
@@ -535,6 +568,7 @@ def parse_decision(
         raise DecisionParseError(f"decision does not match this observation: {error}") from error
     return ModelDecision(
         action_batch=batch,
+        public_reply=public_reply,
         route=route,
         usage=usage or ModelUsage(),
         cost_micros=cost_micros,
@@ -619,7 +653,10 @@ class _ContextBuilder:
                 self._messages.append(
                     Message(
                         role="assistant",
-                        content=[TextContent(text=turn.batch.to_canonical_json().decode("utf-8"))],
+                        content=[TextContent(
+                            text=(turn.public_reply if turn.public_reply is not None
+                                  else turn.batch.to_canonical_json().decode("utf-8"))
+                        )],
                     )
                 )
                 self._closed_turns.add(index)
@@ -782,6 +819,12 @@ class ProviderModelClient:
         self._last_provider_context_tokens: int | None = None
         self._last_request_ms = _now_ms()
 
+    @property
+    def model_reply_metadata(self) -> dict[str, Any]:
+        # Optional client capability: scripted/historic clients must not claim
+        # a prompt contract they never used. The runner stays provider-free.
+        return public_reply_contract()
+
     async def decide(
         self,
         observation: Observation,
@@ -848,12 +891,25 @@ class ProviderModelClient:
             # is corrective by construction. The billing provenance rides on
             # the exception so the runner can write this attempt's triple.
             diagnostic = _rejection_prompt(str(error), observation)
-            self._context.append_rejection(text, diagnostic)
+            # Invalid notes are not factual memory. For envelope failures do
+            # not quote their unvalidated (possibly secret) text on retries or
+            # in evidence. Legacy rejection evidence remains unchanged.
+            shown = text
+            try:
+                rejected_value, _ = json.JSONDecoder().raw_decode(text.lstrip())
+            except (ValueError, RecursionError):
+                rejected_value = None
+            if is_public_reply(rejected_value) or any(
+                key in text
+                for key in ('"reply_version"', '"public_observations"', '"action_batch"')
+            ):
+                shown = REJECTED_PUBLIC_REPLY
+            self._context.append_rejection(shown, diagnostic)
             raise DecisionRejected(
                 diagnostic,
                 # Truncated with the same bound the context replay uses: a
                 # runaway reply must not be able to inflate the bundle either.
-                reply=text[:MAX_REJECTED_REPLY_CHARS],
+                reply=shown[:MAX_REJECTED_REPLY_CHARS],
                 route=self._route,
                 usage=usage,
                 cost_micros=cost_micros,

--- a/local_operator/evaluation/runner/public_reply.py
+++ b/local_operator/evaluation/runner/public_reply.py
@@ -27,6 +27,53 @@ def is_public_reply(value: Any) -> bool:
     return isinstance(value, Mapping) and bool(_ENVELOPE_KEYS.intersection(value))
 
 
+def looks_like_public_reply(payload: str) -> bool:
+    """Whether a REJECTED reply appears to attempt the reserved envelope.
+
+    Used only to withhold unvalidated output from corrective history and
+    rejection evidence; acceptance is unaffected and stays with the strict
+    decoder. A literal substring test is bypassed by legal JSON Unicode escapes
+    (``public_\\u006fbservations``), and full decoding fails on truncated
+    framing — exactly the combination that leaked an encoded known note before
+    review round 1 (F1). So scan the raw string-literal SPANS for reserved
+    keys: fully decodable names are compared after unescaping, and any
+    truncatable prefix (e.g. a malformed ``"public_`` remainder) fails closed.
+    Non-string positions are untouched, so legacy prose and actions-only
+    rejection replay keep their raw text.
+    """
+    in_string = False
+    escaped = False
+    start = 0
+    for index, char in enumerate(payload):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            if in_string:
+                escaped = True
+            continue
+        if char != '"':
+            continue
+        if not in_string:
+            in_string = True
+            start = index + 1
+            continue
+        in_string = False
+        span = payload[start:index]
+        try:
+            decoded = json.loads(payload[start - 1 : index + 1])
+        except ValueError:
+            decoded = None
+        if isinstance(decoded, str) and decoded in _ENVELOPE_KEYS:
+            return True
+        if decoded is None or "\\" in span:
+            # An escaped name decodes above only when complete; an undecodable
+            # or escaped literal is conservatively tested by prefix too.
+            if any(key.startswith(span) for key in _ENVELOPE_KEYS):
+                return True
+    return False
+
+
 def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
     result: dict[str, Any] = {}
     for key, value in pairs:

--- a/local_operator/evaluation/runner/public_reply.py
+++ b/local_operator/evaluation/runner/public_reply.py
@@ -1,0 +1,123 @@
+"""Public model output, not an extension of the adapter action protocol.
+
+Screenshots leave the shared context before text summarization. Concise facts
+from the model's *visible reply* therefore need the same ordinary assistant
+text path as interactive sessions; private reasoning is never an input here.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+from urllib.parse import unquote
+
+from local_operator.evaluation.protocol import ActionBatch
+from local_operator.evaluation.evidence.models import canonical_bytes, canonical_digest
+from local_operator.evaluation.receipts import RedactionSet
+
+REPLY_VERSION = "1.0"
+MAX_PUBLIC_OBSERVATIONS_CHARS = 2_000
+_ENVELOPE_KEYS = {"reply_version", "action_batch", "public_observations"}
+REJECTED_PUBLIC_REPLY = "(model reply rejected; no public observations accepted)"
+
+
+def is_public_reply(value: Any) -> bool:
+    # Reserve every envelope key: a misspelled/missing version must not silently
+    # downgrade a reply with notes to the legacy actions-only interpretation.
+    return isinstance(value, Mapping) and bool(_ENVELOPE_KEYS.intersection(value))
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            # Do not echo arbitrary keys/values into diagnostics or retry text.
+            raise ValueError("model reply contains duplicate JSON keys")
+        result[key] = value
+    return result
+
+
+def decode_public_reply(payload: str) -> dict[str, Any]:
+    """Require one exact envelope; the legacy decoder keeps its own tolerance."""
+    try:
+        value = json.loads(payload, object_pairs_hook=_unique_object)
+    except (ValueError, RecursionError) as error:
+        raise ValueError(
+            "model reply must be one duplicate-free JSON object, with no trailing text"
+        ) from error
+    if not isinstance(value, dict) or set(value) != _ENVELOPE_KEYS:
+        raise ValueError(
+            "model reply requires exactly reply_version, action_batch, public_observations"
+        )
+    if value["reply_version"] != REPLY_VERSION:
+        raise ValueError("unsupported model reply version")
+    notes = value["public_observations"]
+    if not isinstance(notes, str) or len(notes) > MAX_PUBLIC_OBSERVATIONS_CHARS:
+        raise ValueError("public_observations must be a string of at most 2000 characters")
+    try:
+        notes.encode("utf-8")
+    except UnicodeEncodeError as error:
+        raise ValueError("public_observations must be valid Unicode text") from error
+    batch = value["action_batch"]
+    if not isinstance(batch, dict) or set(batch) != {"actions"}:
+        raise ValueError("model reply action_batch requires exactly an actions array")
+    return value
+
+
+def redact_public_reply(payload: str, redactions: RedactionSet) -> str:
+    """Drop an entire unsafe note before either evidence or accepted replay.
+
+    Scan decoded text (including percent escapes) before serializing: scanning
+    raw JSON alone would miss a credential spelt with JSON unicode escapes.
+    This is the existing resolved-secret boundary, not a general secret detector.
+    """
+    value = decode_public_reply(payload)
+    notes = value["public_observations"]
+    try:
+        redactions.assert_clear(notes)
+        redactions.assert_clear(unquote(notes))
+    except ValueError:
+        value["public_observations"] = "[redacted public observations]"
+    return canonical_bytes(value).decode("utf-8")
+
+
+def public_reply_contract() -> dict[str, Any]:
+    """Publish a reproducible reply identity separately from the tool surface.
+
+    The action array schema is borrowed, not copied: its vocabulary and bounds
+    remain owned by ActionBatch. Negotiated execution restrictions are declared
+    by the existing action_surface metadata/tool digest and still gate parsing.
+    """
+    batch_schema = ActionBatch.model_json_schema()
+    schema = {
+        "$defs": batch_schema["$defs"],
+        "type": "object",
+        "additionalProperties": False,
+        "required": sorted(_ENVELOPE_KEYS),
+        "properties": {
+            "reply_version": {"const": REPLY_VERSION},
+            "action_batch": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["actions"],
+                "properties": {"actions": batch_schema["properties"]["actions"]},
+            },
+            "public_observations": {"type": "string", "maxLength": MAX_PUBLIC_OBSERVATIONS_CHARS},
+        },
+    }
+    contract = {
+        "schema": schema,
+        "legacy_plain_action_batch": True,
+        "envelope_framing": "single-json-object-no-duplicate-keys-no-trailing-text",
+        "binding": (
+            "action observation_ids validated against current observation "
+            "and negotiated action_surface"
+        ),
+        "public_observations": (
+            "concise new observed facts/progress only; no deliberation or credentials"
+        ),
+    }
+    return {
+        "model_reply_contract": canonical_bytes(contract).decode("utf-8"),
+        "model_reply_contract_digest": canonical_digest("runner-model-reply-v1", contract),
+    }

--- a/local_operator/evaluation/runner/public_reply.py
+++ b/local_operator/evaluation/runner/public_reply.py
@@ -11,8 +11,8 @@ import json
 from typing import Any, Mapping
 from urllib.parse import unquote
 
-from local_operator.evaluation.protocol import ActionBatch
 from local_operator.evaluation.evidence.models import canonical_bytes, canonical_digest
+from local_operator.evaluation.protocol import ActionBatch
 from local_operator.evaluation.receipts import RedactionSet
 
 REPLY_VERSION = "1.0"

--- a/local_operator/evaluation/runner/public_reply.py
+++ b/local_operator/evaluation/runner/public_reply.py
@@ -53,7 +53,10 @@ def decode_public_reply(payload: str) -> dict[str, Any]:
         raise ValueError("unsupported model reply version")
     notes = value["public_observations"]
     if not isinstance(notes, str) or len(notes) > MAX_PUBLIC_OBSERVATIONS_CHARS:
-        raise ValueError("public_observations must be a string of at most 2000 characters")
+        raise ValueError(
+            "public_observations must be a string of at most "
+            f"{MAX_PUBLIC_OBSERVATIONS_CHARS} characters"
+        )
     try:
         notes.encode("utf-8")
     except UnicodeEncodeError as error:

--- a/tests/unit/evaluation/runner/test_public_reply.py
+++ b/tests/unit/evaluation/runner/test_public_reply.py
@@ -39,6 +39,7 @@ from local_operator.evaluation.runner.public_reply import (
     MAX_PUBLIC_OBSERVATIONS_CHARS,
     REJECTED_PUBLIC_REPLY,
     decode_public_reply,
+    looks_like_public_reply,
     public_reply_contract,
     redact_public_reply,
 )
@@ -185,6 +186,119 @@ async def test_rejected_envelope_notes_are_not_replayed_as_facts(
     assert secret not in replay
     assert REJECTED_PUBLIC_REPLY in replay
     assert not stream.summary_requests
+
+
+def _escaped_envelope(raw: str, secret: str) -> str:
+    """The F1 encoding: reserved keys and the known note in JSON escapes."""
+
+    for key, escaped in (
+        ("public_observations", "public_\\u006fbservations"),
+        ("reply_version", "reply_\\u0076ersion"),
+        ("action_batch", "action_\\u0062atch"),
+    ):
+        raw = raw.replace(key, escaped)
+    return raw.replace(secret, secret.replace("fixture", "\\u0066ixture"))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("variant", ["truncated-end", "truncated-key", "truncated-value"])
+async def test_truncated_escaped_envelope_with_escaped_known_note_fails_closed(
+    tmp_path: Path, variant: str
+) -> None:
+    """F1 (review round 1): a truncated envelope whose reserved keys and known
+    note are JSON Unicode-escaped bypassed literal filters and leaked the note
+    into corrective context, the next provider request and rejection evidence."""
+
+    secret = "fixture-canary-note-653"
+    escaped = secret.replace("fixture", "\\u0066ixture")
+    raw = _escaped_envelope(envelope(type_payload(observation()), secret), secret)
+    if variant == "truncated-end":
+        raw = raw[:-1]  # exact F1 shape: missing the final closing brace
+    elif variant == "truncated-key":
+        raw = raw[: raw.index('"public_') + len('"public_')]  # framing dies mid-key
+    else:
+        raw = raw[: raw.index(escaped) + 6]  # framing dies inside the note
+    stream = RecordingStream(raw)
+    client = _client(stream, tmp_path)
+    turns = [EpisodeTurn(observation=observation())]
+    with pytest.raises(DecisionRejected) as error:
+        await client.decide(observation(), turns)
+    assert error.value.reply == REJECTED_PUBLIC_REPLY
+    stream.reply = finish_payload(observation())
+    await client.decide(observation(), turns)
+    replay = "\n".join(message.text for message in stream.requests[-1].messages)
+    for canary in (secret, escaped):
+        assert canary not in replay
+    assert REJECTED_PUBLIC_REPLY in replay
+
+
+@pytest.mark.asyncio
+async def test_f1_runner_repro_leaves_no_secret_in_bundle_or_replay(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """The exact reviewer reproduction through the real EpisodeRunner: the
+    next request and every retained artifact stay clean, and the bundle still
+    verifies -- the fix removes the leak, it does not hide an invalid bundle."""
+
+    secret = "fixture-canary-runner-653"
+    escaped = secret.replace("fixture", "\\u0066ixture")
+    calls = 0
+
+    def reply(message: Message) -> str:
+        nonlocal calls
+        calls += 1
+        batch = _wait_reply(message)
+        if calls == 1:
+            return _escaped_envelope(envelope(batch, secret), secret)[:-1]
+        oid = json.loads(batch)["actions"][0]["observation_id"]
+        return json.dumps(
+            {
+                "actions": [
+                    {
+                        "kind": "finish",
+                        "observation_id": oid,
+                        "status": "done",
+                        "reason": "complete",
+                    }
+                ]
+            }
+        )
+
+    config = build_config(tmp_path)
+    stream = RecordingStream(reply)
+    client = _client(stream, config.artifact_root)
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        config,
+        selector=selector(tmp_path),
+        model=client,
+        launch=lambda _: FakeAdapter(tmp_path, episode_id),
+        rescue=_rescue_ok,
+        redactions=RedactionSet.from_resolved_values([secret]),
+    )
+    outcome = await runner.run()
+    root = outcome.bundle_root
+    assert root is not None and len(stream.requests) >= 2
+    replay = "\n".join(m.text for m in stream.requests[1].messages)
+    for canary in (secret, escaped):
+        assert canary not in replay
+        assert not any(
+            canary.encode() in path.read_bytes() for path in root.rglob("*") if path.is_file()
+        )
+    assert verify_bundle(root).valid
+
+
+def test_reserved_key_scan_preserves_legacy_rejection_replay() -> None:
+    """No reserved key means legacy raw-text corrective replay is unchanged;
+    escaped or truncated reserved keys fail closed on undecodable output."""
+
+    assert not looks_like_public_reply("x" * 200)
+    assert not looks_like_public_reply('{"actions": [{"kind": "click"}]}')
+    assert not looks_like_public_reply('{"public_note": "not a reserved key"}')
+    assert looks_like_public_reply('{"public_\\u006fbservations": ""}')
+    assert looks_like_public_reply('{"public_observations": "')
+    assert looks_like_public_reply('{"reply_\\u0076ersion": "1.0"}')
+    assert looks_like_public_reply('{"action_batch": {"actions": []}')
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/evaluation/runner/test_public_reply.py
+++ b/tests/unit/evaluation/runner/test_public_reply.py
@@ -64,9 +64,13 @@ from tests.unit.evaluation.runner.test_provider_client import (
 
 
 def envelope(batch: str, notes: Any = "") -> str:
-    return json.dumps({
-        "reply_version": "1.0", "action_batch": json.loads(batch), "public_observations": notes,
-    })
+    return json.dumps(
+        {
+            "reply_version": "1.0",
+            "action_batch": json.loads(batch),
+            "public_observations": notes,
+        }
+    )
 
 
 @pytest.mark.parametrize("notes", ["", "Visible status: ready", "x" * 2000, "東京"])
@@ -90,11 +94,24 @@ def test_invalid_or_oversized_notes_reject_entire_decision(notes: Any) -> None:
         parse_decision(envelope(type_payload(observation()), notes), observation(), route=ROUTE)
 
 
-@pytest.mark.parametrize("change", [
-    "missing-version", "wrong-version", "extra-envelope", "extra-batch", "nested-envelope",
-    "nested-batch", "duplicate-note", "duplicate-action", "duplicate-version",
-    "trailing-prose", "trailing-batch", "leading-prose", "wrong-observation",
-])
+@pytest.mark.parametrize(
+    "change",
+    [
+        "missing-version",
+        "wrong-version",
+        "extra-envelope",
+        "extra-batch",
+        "nested-envelope",
+        "nested-batch",
+        "duplicate-note",
+        "duplicate-action",
+        "duplicate-version",
+        "trailing-prose",
+        "trailing-batch",
+        "leading-prose",
+        "wrong-observation",
+    ],
+)
 def test_envelope_is_single_unambiguous_current_decision(change: str) -> None:
     current = observation()
     value = json.loads(envelope(type_payload(current), "visible fact"))
@@ -147,7 +164,8 @@ def test_legacy_trailing_envelope_cannot_supersede_current_decision() -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("escaped_keys", [False, True])
 async def test_rejected_envelope_notes_are_not_replayed_as_facts(
-    tmp_path: Path, escaped_keys: bool,
+    tmp_path: Path,
+    escaped_keys: bool,
 ) -> None:
     secret = "invalid-note-must-not-enter-memory"
     raw = envelope(type_payload(observation(1)), secret)
@@ -169,9 +187,14 @@ async def test_rejected_envelope_notes_are_not_replayed_as_facts(
     assert not stream.summary_requests
 
 
-@pytest.mark.parametrize("transform", [
-    str, lambda s: quote(s, safe=""), lambda s: base64.b64encode(s.encode()).decode(),
-])
+@pytest.mark.parametrize(
+    "transform",
+    [
+        str,
+        lambda s: quote(s, safe=""),
+        lambda s: base64.b64encode(s.encode()).decode(),
+    ],
+)
 def test_resolved_secret_notes_are_redacted_before_replay(transform: Any) -> None:
     secret = "known-secret/credential-value"
     raw = envelope(type_payload(observation()), transform(secret))
@@ -206,8 +229,12 @@ def test_context_builder_retains_notes_as_append_only_shared_messages(tmp_path: 
     context = _ContextBuilder(artifact_root=tmp_path, keep_recent_frames=3, rebuild_every_frames=12)
     context.append_new_turns([EpisodeTurn(observation=first)])
     prefix = list(context.messages)
-    turns = [EpisodeTurn(observation=first, batch=decision.action_batch,
-                         public_reply=decision.public_reply), EpisodeTurn(observation=second)]
+    turns = [
+        EpisodeTurn(
+            observation=first, batch=decision.action_batch, public_reply=decision.public_reply
+        ),
+        EpisodeTurn(observation=second),
+    ]
     context.append_new_turns(turns)
     assert context.messages[0] is prefix[0]
     assert context.messages[1].role == "assistant"
@@ -223,17 +250,27 @@ def image_history(variant: str, *, notes: bool) -> list[Message]:
     for index in range(12):
         # IDs/text/actions are fixed: only the oldest screenshot's bytes vary.
         pixels = variant if index == 0 else f"unchanged-frame-{index}"
-        history.append(Message.user(f"Observation {index}", [ImageContent(
-            data=base64.b64encode(pixels.encode()).decode(), mime_type="image/png",
-        )]))
+        history.append(
+            Message.user(
+                f"Observation {index}",
+                [
+                    ImageContent(
+                        data=base64.b64encode(pixels.encode()).decode(),
+                        mime_type="image/png",
+                    )
+                ],
+            )
+        )
         batch = type_payload(observation(index))
         fact = f"Visible label: {variant}" if index == 0 else ""
         reply = envelope(batch, fact) if notes else batch
         history.append(Message.assistant(reply))
     # Message IDs default to UUIDs; fix them so the paired controls genuinely
     # differ only in the old image (and, for the treatment, its public note).
-    return [message.model_copy(update={"id": f"message-{index}"})
-            for index, message in enumerate(history)]
+    return [
+        message.model_copy(update={"id": f"message-{index}"})
+        for index, message in enumerate(history)
+    ]
 
 
 @pytest.mark.asyncio
@@ -242,8 +279,12 @@ async def test_twelve_frame_erasure_and_public_facts_after_prune_then_text_compa
 
     async def prune(history: list[Message]) -> Any:
         return await run_compaction_pass(
-            history, model=model, settings=CompactionSettings(keep_recent_frames=3),
-            summarize=None, now_ms=10_000, last_activity_ms=10_000,
+            history,
+            model=model,
+            settings=CompactionSettings(keep_recent_frames=3),
+            summarize=None,
+            now_ms=10_000,
+            last_activity_ms=10_000,
         )
 
     left, right = image_history("violet", notes=False), image_history("amber", notes=False)
@@ -269,13 +310,19 @@ async def test_twelve_frame_erasure_and_public_facts_after_prune_then_text_compa
             prompts.append(prompt)
             # Only extract from the actual serialized request, never inject
             # an external expected fact into the compactor's output.
-            return next(f"Visible label: {v}" for v in ("violet", "amber")
-                        if f"Visible label: {v}" in prompt)
+            return next(
+                f"Visible label: {v}"
+                for v in ("violet", "amber")
+                if f"Visible label: {v}" in prompt
+            )
 
         compacted = await run_compaction_pass(
-            result.messages, model=model,
+            result.messages,
+            model=model,
             settings=CompactionSettings(keep_recent_tokens=100, strategy="context-full"),
-            summarize=summarize, now_ms=10_000, last_activity_ms=10_000,
+            summarize=summarize,
+            now_ms=10_000,
+            last_activity_ms=10_000,
             respect_threshold=False,
         )
         assert compacted.ran and len(prompts) == 1
@@ -287,7 +334,9 @@ async def test_twelve_frame_erasure_and_public_facts_after_prune_then_text_compa
 @pytest.mark.asyncio
 @pytest.mark.parametrize("secret", [False, True])
 async def test_real_provider_runner_records_and_replays_public_evidence(
-    tmp_path: Path, episode_id: str, secret: bool,
+    tmp_path: Path,
+    episode_id: str,
+    secret: bool,
 ) -> None:
     note = "known-secret/credential-value" if secret else "Visible status: ready"
     calls = 0
@@ -298,16 +347,30 @@ async def test_real_provider_runner_records_and_replays_public_evidence(
         raw = _wait_reply(message)
         if calls == 2:
             oid = json.loads(raw)["actions"][0]["observation_id"]
-            raw = json.dumps({"actions": [{"kind": "finish", "observation_id": oid,
-                                          "status": "done", "reason": "complete"}]})
+            raw = json.dumps(
+                {
+                    "actions": [
+                        {
+                            "kind": "finish",
+                            "observation_id": oid,
+                            "status": "done",
+                            "reason": "complete",
+                        }
+                    ]
+                }
+            )
         return envelope(raw, note if calls == 1 else "")
 
     config = build_config(tmp_path)
     stream = RecordingStream(reply)
     client = _client(stream, config.artifact_root)
     runner = EpisodeRunner(
-        build_spec(episode_id), config, selector=selector(tmp_path), model=client,
-        launch=lambda _: FakeAdapter(tmp_path, episode_id), rescue=_rescue_ok,
+        build_spec(episode_id),
+        config,
+        selector=selector(tmp_path),
+        model=client,
+        launch=lambda _: FakeAdapter(tmp_path, episode_id),
+        rescue=_rescue_ok,
         redactions=RedactionSet.from_resolved_values([note] if secret else []),
     )
     outcome = await runner.run()
@@ -343,11 +406,15 @@ async def test_real_provider_runner_records_and_replays_public_evidence(
 
 @pytest.mark.asyncio
 async def test_old_fake_client_does_not_claim_a_new_reply_contract(
-    tmp_path: Path, episode_id: str,
+    tmp_path: Path,
+    episode_id: str,
 ) -> None:
     runner = EpisodeRunner(
-        build_spec(episode_id), build_config(tmp_path), selector=selector(tmp_path),
-        model=ScriptedModel(["finish"]), launch=lambda _: FakeAdapter(tmp_path, episode_id),
+        build_spec(episode_id),
+        build_config(tmp_path),
+        selector=selector(tmp_path),
+        model=ScriptedModel(["finish"]),
+        launch=lambda _: FakeAdapter(tmp_path, episode_id),
         rescue=_rescue_ok,
     )
     outcome = await runner.run()

--- a/tests/unit/evaluation/runner/test_public_reply.py
+++ b/tests/unit/evaluation/runner/test_public_reply.py
@@ -1,0 +1,359 @@
+"""Offline public-memory parity through the real provider and shared compactor.
+
+The erasure test deliberately varies ONLY image bytes first. Different IDs or
+observation text would leak the answer into the control and hide the defect.
+Summary output below is deterministic plumbing evidence, not an LLM quality claim.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+import pytest
+
+from local_operator.compaction.api import serialize_conversation
+from local_operator.compaction.pass_ import run_compaction_pass
+from local_operator.compaction.snapcompact import serialize_for_snapcompact
+from local_operator.compaction.thresholds import CompactionSettings
+from local_operator.evaluation.evidence.models import (
+    ActionBatchPayload,
+    ModelRequestPayload,
+    ModelResponsePayload,
+    canonical_digest,
+)
+from local_operator.evaluation.evidence.verify import verify_bundle
+from local_operator.evaluation.receipts import RedactionSet
+from local_operator.evaluation.runner.episode import EpisodeRunner
+from local_operator.evaluation.runner.model import DecisionRejected, EpisodeTurn
+from local_operator.evaluation.runner.provider_client import (
+    DecisionParseError,
+    _ContextBuilder,
+    build_system_prompt,
+    parse_decision,
+)
+from local_operator.evaluation.runner.public_reply import (
+    MAX_PUBLIC_OBSERVATIONS_CHARS,
+    REJECTED_PUBLIC_REPLY,
+    decode_public_reply,
+    public_reply_contract,
+    redact_public_reply,
+)
+from local_operator.harness.types import ImageContent, Message, ModelSpec, TextContent
+from tests.unit.evaluation.runner.conftest import (
+    FakeAdapter,
+    ScriptedModel,
+    build_config,
+    build_spec,
+    payloads,
+    selector,
+)
+from tests.unit.evaluation.runner.test_episode import _rescue_ok
+from tests.unit.evaluation.runner.test_provider_client import (
+    ROUTE,
+    RecordingStream,
+    _client,
+    _wait_reply,
+    finish_payload,
+    observation,
+    type_payload,
+)
+
+
+def envelope(batch: str, notes: Any = "") -> str:
+    return json.dumps({
+        "reply_version": "1.0", "action_batch": json.loads(batch), "public_observations": notes,
+    })
+
+
+@pytest.mark.parametrize("notes", ["", "Visible status: ready", "x" * 2000, "東京"])
+def test_public_reply_binds_without_changing_legacy_batch_bytes(notes: str) -> None:
+    current = observation()
+    legacy = parse_decision(type_payload(current), current, route=ROUTE)
+    visible = envelope(type_payload(current), notes)
+    decision = parse_decision(visible, current, route=ROUTE)
+    assert decision.public_reply == visible
+    assert legacy.public_reply is None
+    assert decision.action_batch.to_canonical_json() == legacy.action_batch.to_canonical_json()
+    assert canonical_digest("adapter-action-batch-v1", decision.action_batch) == canonical_digest(
+        "adapter-action-batch-v1", legacy.action_batch
+    )
+    assert current == observation()
+
+
+@pytest.mark.parametrize("notes", [None, [], {}, 1, True, "x" * 2001, "\ud800"])
+def test_invalid_or_oversized_notes_reject_entire_decision(notes: Any) -> None:
+    with pytest.raises(DecisionParseError):
+        parse_decision(envelope(type_payload(observation()), notes), observation(), route=ROUTE)
+
+
+@pytest.mark.parametrize("change", [
+    "missing-version", "wrong-version", "extra-envelope", "extra-batch", "nested-envelope",
+    "nested-batch", "duplicate-note", "duplicate-action", "duplicate-version",
+    "trailing-prose", "trailing-batch", "leading-prose", "wrong-observation",
+])
+def test_envelope_is_single_unambiguous_current_decision(change: str) -> None:
+    current = observation()
+    value = json.loads(envelope(type_payload(current), "visible fact"))
+    if change == "missing-version":
+        del value["reply_version"]
+    elif change == "wrong-version":
+        value["reply_version"] = "2.0"
+    elif change == "extra-envelope":
+        value["actions"] = json.loads(type_payload(current))["actions"]
+    elif change == "extra-batch":
+        value["action_batch"]["episode_id"] = "another-episode"
+    elif change == "nested-envelope":
+        value = {"wrapper": value}
+    elif change == "nested-batch":
+        value["action_batch"] = {"wrapper": value["action_batch"]}
+    elif change == "wrong-observation":
+        value["action_batch"] = json.loads(type_payload(observation(1)))
+    raw = json.dumps(value)
+    if change == "duplicate-note":
+        raw = raw.replace(
+            '"public_observations":', '"public_observations":"other", "public_observations":'
+        )
+    elif change == "duplicate-action":
+        raw = raw.replace('"kind":', '"kind":"finish", "kind":')
+    elif change == "duplicate-version":
+        raw = raw.replace('"reply_version":', '"reply_version":"2.0", "reply_version":')
+    elif change == "trailing-prose":
+        raw += " commentary"
+    elif change == "trailing-batch":
+        raw += finish_payload(current)
+    elif change == "leading-prose":
+        raw = "commentary " + raw
+    with pytest.raises(DecisionParseError):
+        parse_decision(raw, current, route=ROUTE)
+
+
+def test_legacy_trailing_envelope_cannot_supersede_current_decision() -> None:
+    current = observation()
+    with pytest.raises(DecisionParseError, match="second action batch"):
+        parse_decision(
+            type_payload(current) + envelope(finish_payload(current)), current, route=ROUTE
+        )
+    # Preserve the original tolerance for old quoted decisions.
+    decision = parse_decision(
+        type_payload(current) + envelope(finish_payload(observation(1))), current, route=ROUTE
+    )
+    assert decision.public_reply is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("escaped_keys", [False, True])
+async def test_rejected_envelope_notes_are_not_replayed_as_facts(
+    tmp_path: Path, escaped_keys: bool,
+) -> None:
+    secret = "invalid-note-must-not-enter-memory"
+    raw = envelope(type_payload(observation(1)), secret)
+    if escaped_keys:
+        raw = raw.replace("public_observations", "public_\\u006fbservations")
+        raw = raw.replace("reply_version", "reply_\\u0076ersion")
+        raw = raw.replace("action_batch", "action_\\u0062atch")
+    stream = RecordingStream(raw)
+    client = _client(stream, tmp_path)
+    turns = [EpisodeTurn(observation=observation())]
+    with pytest.raises(DecisionRejected) as error:
+        await client.decide(observation(), turns)
+    assert error.value.reply == REJECTED_PUBLIC_REPLY
+    stream.reply = finish_payload(observation())
+    await client.decide(observation(), turns)
+    replay = "\n".join(message.text for message in stream.requests[-1].messages)
+    assert secret not in replay
+    assert REJECTED_PUBLIC_REPLY in replay
+    assert not stream.summary_requests
+
+
+@pytest.mark.parametrize("transform", [
+    str, lambda s: quote(s, safe=""), lambda s: base64.b64encode(s.encode()).decode(),
+])
+def test_resolved_secret_notes_are_redacted_before_replay(transform: Any) -> None:
+    secret = "known-secret/credential-value"
+    raw = envelope(type_payload(observation()), transform(secret))
+    # JSON escapes cannot hide decoded credentials from the existing boundary.
+    raw = raw.replace("known", "\\u006bnown")
+    clean = redact_public_reply(raw, RedactionSet.from_resolved_values([secret]))
+    assert json.loads(clean)["public_observations"] == "[redacted public observations]"
+    assert json.loads(clean)["action_batch"] == json.loads(raw)["action_batch"]
+    assert secret not in clean
+
+
+def test_contract_identity_is_separate_from_action_surface() -> None:
+    metadata = public_reply_contract()
+    contract = json.loads(metadata["model_reply_contract"])
+    assert metadata["model_reply_contract_digest"] == canonical_digest(
+        "runner-model-reply-v1", contract
+    )
+    schema = contract["schema"]
+    assert schema["properties"]["public_observations"]["maxLength"] == MAX_PUBLIC_OBSERVATIONS_CHARS
+    assert schema["properties"]["action_batch"]["additionalProperties"] is False
+    prompt = build_system_prompt()
+    assert '"reply_version": "1.0"' in prompt
+    assert "concise NEW factual data" in prompt
+    assert "private reasoning" in prompt and "credentials/secrets" in prompt
+
+
+def test_context_builder_retains_notes_as_append_only_shared_messages(tmp_path: Path) -> None:
+    first, second = observation(), observation(1)
+    decision = parse_decision(
+        envelope(type_payload(first), "Visible status: ready"), first, route=ROUTE
+    )
+    context = _ContextBuilder(artifact_root=tmp_path, keep_recent_frames=3, rebuild_every_frames=12)
+    context.append_new_turns([EpisodeTurn(observation=first)])
+    prefix = list(context.messages)
+    turns = [EpisodeTurn(observation=first, batch=decision.action_batch,
+                         public_reply=decision.public_reply), EpisodeTurn(observation=second)]
+    context.append_new_turns(turns)
+    assert context.messages[0] is prefix[0]
+    assert context.messages[1].role == "assistant"
+    assert all(isinstance(block, TextContent) for block in context.messages[1].content)
+    assert context.messages[1].text == decision.public_reply
+    closed = list(context.messages)
+    context.append_new_turns(turns)
+    assert all(a is b for a, b in zip(closed, context.messages, strict=True))
+
+
+def image_history(variant: str, *, notes: bool) -> list[Message]:
+    history = []
+    for index in range(12):
+        # IDs/text/actions are fixed: only the oldest screenshot's bytes vary.
+        pixels = variant if index == 0 else f"unchanged-frame-{index}"
+        history.append(Message.user(f"Observation {index}", [ImageContent(
+            data=base64.b64encode(pixels.encode()).decode(), mime_type="image/png",
+        )]))
+        batch = type_payload(observation(index))
+        fact = f"Visible label: {variant}" if index == 0 else ""
+        reply = envelope(batch, fact) if notes else batch
+        history.append(Message.assistant(reply))
+    # Message IDs default to UUIDs; fix them so the paired controls genuinely
+    # differ only in the old image (and, for the treatment, its public note).
+    return [message.model_copy(update={"id": f"message-{index}"})
+            for index, message in enumerate(history)]
+
+
+@pytest.mark.asyncio
+async def test_twelve_frame_erasure_and_public_facts_after_prune_then_text_compaction() -> None:
+    model = ModelSpec(provider="provider", model_id="model", context_window=128_000)
+
+    async def prune(history: list[Message]) -> Any:
+        return await run_compaction_pass(
+            history, model=model, settings=CompactionSettings(keep_recent_frames=3),
+            summarize=None, now_ms=10_000, last_activity_ms=10_000,
+        )
+
+    left, right = image_history("violet", notes=False), image_history("amber", notes=False)
+    assert left != right
+    # Neither serializer could rescue pixels simply by running before prune.
+    assert serialize_conversation(left) == serialize_conversation(right)
+    assert serialize_for_snapcompact(left) == serialize_for_snapcompact(right)
+    erased_left, erased_right = await prune(left), await prune(right)
+    assert erased_left.frames_dropped == erased_right.frames_dropped == 9
+    assert not erased_left.ran and not erased_right.ran
+    assert erased_left.messages == erased_right.messages
+
+    summaries = []
+    for variant in ("violet", "amber"):
+        result = await prune(image_history(variant, notes=True))
+        assert result.frames_dropped == 9 and not result.ran
+        fact = f"Visible label: {variant}"
+        assert fact in serialize_conversation(result.messages)
+        assert fact in serialize_for_snapcompact(result.messages)
+        prompts = []
+
+        async def summarize(prompt: str) -> str:
+            prompts.append(prompt)
+            # Only extract from the actual serialized request, never inject
+            # an external expected fact into the compactor's output.
+            return next(f"Visible label: {v}" for v in ("violet", "amber")
+                        if f"Visible label: {v}" in prompt)
+
+        compacted = await run_compaction_pass(
+            result.messages, model=model,
+            settings=CompactionSettings(keep_recent_tokens=100, strategy="context-full"),
+            summarize=summarize, now_ms=10_000, last_activity_ms=10_000,
+            respect_threshold=False,
+        )
+        assert compacted.ran and len(prompts) == 1
+        assert fact in compacted.messages[0].text
+        summaries.append(compacted.messages)
+    assert summaries[0] != summaries[1]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("secret", [False, True])
+async def test_real_provider_runner_records_and_replays_public_evidence(
+    tmp_path: Path, episode_id: str, secret: bool,
+) -> None:
+    note = "known-secret/credential-value" if secret else "Visible status: ready"
+    calls = 0
+
+    def reply(message: Message) -> str:
+        nonlocal calls
+        calls += 1
+        raw = _wait_reply(message)
+        if calls == 2:
+            oid = json.loads(raw)["actions"][0]["observation_id"]
+            raw = json.dumps({"actions": [{"kind": "finish", "observation_id": oid,
+                                          "status": "done", "reason": "complete"}]})
+        return envelope(raw, note if calls == 1 else "")
+
+    config = build_config(tmp_path)
+    stream = RecordingStream(reply)
+    client = _client(stream, config.artifact_root)
+    runner = EpisodeRunner(
+        build_spec(episode_id), config, selector=selector(tmp_path), model=client,
+        launch=lambda _: FakeAdapter(tmp_path, episode_id), rescue=_rescue_ok,
+        redactions=RedactionSet.from_resolved_values([note] if secret else []),
+    )
+    outcome = await runner.run()
+    assert outcome.status == "completed"
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    assert report.valid, [issue.code for issue in report.issues]
+    responses = payloads(root, ModelResponsePayload)
+    assert len(responses) == calls == 2 and not stream.summary_requests
+    ref = responses[0].redacted_response
+    assert ref is not None
+    recorded = (root / "artifacts" / ref.sha256).read_text()
+    expected = "[redacted public observations]" if secret else note
+    assert json.loads(recorded)["public_observations"] == expected
+    replay = next(m.text for m in stream.requests[1].messages if m.role == "assistant")
+    assert replay == recorded
+    batches = payloads(root, ActionBatchPayload)
+    batch = json.loads((root / "artifacts" / batches[0].action_artifact.sha256).read_text())
+    assert batch["actions"] == json.loads(recorded)["action_batch"]["actions"]
+    manifest = json.loads((root / "manifest.json").read_text())
+    assert all(manifest["metadata"][key] == value for key, value in public_reply_contract().items())
+    request = payloads(root, ModelRequestPayload)[0]
+    assert request.tool_schema_digest == canonical_digest(
+        "runner-tool-schema-v1", json.loads(manifest["metadata"]["action_surface"])
+    )
+    if secret:
+        assert note not in "\n".join(m.text for m in stream.requests[1].messages)
+        assert not any(
+            note.encode() in path.read_bytes() for path in root.rglob("*") if path.is_file()
+        )
+
+
+@pytest.mark.asyncio
+async def test_old_fake_client_does_not_claim_a_new_reply_contract(
+    tmp_path: Path, episode_id: str,
+) -> None:
+    runner = EpisodeRunner(
+        build_spec(episode_id), build_config(tmp_path), selector=selector(tmp_path),
+        model=ScriptedModel(["finish"]), launch=lambda _: FakeAdapter(tmp_path, episode_id),
+        rescue=_rescue_ok,
+    )
+    outcome = await runner.run()
+    root = outcome.bundle_root
+    assert root is not None and verify_bundle(root).valid
+    manifest = json.loads((root / "manifest.json").read_text())
+    assert "model_reply_contract" not in manifest["metadata"]
+    assert payloads(root, ModelResponsePayload)[0].redacted_response is None
+    assert decode_public_reply(envelope(type_payload(observation())))

--- a/tests/unit/evaluation/runner/test_public_reply_transport.py
+++ b/tests/unit/evaluation/runner/test_public_reply_transport.py
@@ -1,0 +1,200 @@
+"""Bounded loopback SSE proof, not a vision or model-quality benchmark.
+
+Use the existing stdlib HTTP server pattern and the production client factory:
+only the provider's answers and the adapter boundary are deterministic fixtures.
+No replaced HTTP transport, second client implementation or global provider config.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import replace
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from threading import Thread
+from typing import Any
+
+import pytest
+
+from local_operator.compaction.pass_ import run_compaction_pass
+from local_operator.compaction.thresholds import CompactionSettings
+from local_operator.evaluation.adapters.api import observation_content_id
+from local_operator.evaluation.evidence.models import (
+    ContextCompactionPayload,
+    ModelResponsePayload,
+    RouteIdentity,
+)
+from local_operator.evaluation.evidence.verify import verify_bundle
+from local_operator.evaluation.receipts import RedactionSet
+from local_operator.evaluation.runner.episode import EpisodeRunner
+from local_operator.evaluation.runner.provider_client import create_provider_model_client
+from local_operator.harness.types import ImageContent, ModelSpec
+from local_operator.providers.auth_store import AuthStore
+from tests.unit.evaluation.runner import conftest as fixtures
+from tests.unit.evaluation.runner.test_episode import _rescue_ok
+from tests.unit.evaluation.runner.test_provider_client import _distinct_framed_observation
+from tests.unit.evaluation.runner.test_public_reply import envelope
+
+
+@pytest.mark.asyncio
+async def test_loopback_sse_factory_public_memory_and_secret_retention(
+    tmp_path: Path, episode_id: str, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    public_fact = "Visible status: ready"
+    secret = "fixture-resolved-secret-not-for-memory"
+    requests: list[dict[str, Any]] = []
+    replies: list[str] = []
+    decisions = 0
+    summaries = 0
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, format: str, *args: Any) -> None:
+            pass
+
+        def do_POST(self) -> None:
+            nonlocal decisions, summaries
+            self.connection.settimeout(3)
+            if self.path != "/v1/chat/completions" or len(requests) >= 14:
+                self.send_error(400)
+                return
+            request = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            requests.append(request)
+            rendered = json.dumps(request["messages"], ensure_ascii=False)
+            if "<conversation>" in rendered:
+                summaries += 1
+                # Echo only a fact demonstrably present in the actual summary
+                # request. This validates transport/retention, not understanding.
+                reply = public_fact if public_fact in rendered else "No retained fact"
+            else:
+                decisions += 1
+                content = request["messages"][-1]["content"]
+                text = content if isinstance(content, str) else "\n".join(
+                    block["text"] for block in content if block["type"] == "text"
+                )
+                oid = next(line.split(": ", 1)[1] for line in text.splitlines()
+                           if line.startswith("Observation ID: "))
+                action: dict[str, Any] = {"kind": "wait", "observation_id": oid, "duration_ms": 1}
+                if decisions == 13:
+                    action = {"kind": "finish", "observation_id": oid,
+                              "status": "done", "reason": "fixture complete"}
+                note = public_fact if decisions == 1 else secret if decisions == 2 else ""
+                reply = envelope(json.dumps({"actions": [action]}), note)
+            replies.append(reply)
+            # Two content deltas force the real SSE decoder to assemble the
+            # envelope before decision parsing; usage takes its normal route.
+            chunks = [reply[:len(reply) // 2], reply[len(reply) // 2:]]
+            events = [
+                {"id": f"fixture-{len(requests)}", "choices": [
+                    {"index": 0, "delta": {"content": chunk}, "finish_reason": None}
+                ]} for chunk in chunks
+            ]
+            events.append({"id": f"fixture-{len(requests)}", "choices": [
+                {"index": 0, "delta": {}, "finish_reason": "stop"}
+            ], "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}})
+            body = "".join(f"data: {json.dumps(event)}\n\n" for event in events)
+            data = (body + "data: [DONE]\n\n").encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+            self.wfile.flush()
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = Thread(target=server.serve_forever, kwargs={"poll_interval": 0.05}, daemon=True)
+    # Test-local proxy bypass prevents ambient proxy settings routing loopback
+    # traffic elsewhere; no user's provider configuration is read or changed.
+    monkeypatch.setenv("NO_PROXY", "127.0.0.1")
+    monkeypatch.setenv("no_proxy", "127.0.0.1")
+    store = AuthStore(tmp_path / "fixture-auth.db")
+    store.upsert_credential("openai", {"key": "fixture-local-only", "source": "login"})
+    config = fixtures.build_config(tmp_path, max_steps=13)
+    route = RouteIdentity(provider_id="openai", route_id="loopback", model_id="fixture-model")
+    spec = replace(fixtures.build_spec(episode_id), requested_route=route)
+    model = ModelSpec(
+        provider="openai", model_id="fixture-model", supports_images=True,
+        base_url=f"http://127.0.0.1:{server.server_port}/v1", context_window=128_000,
+    )
+    client = create_provider_model_client(
+        auth_store=store,
+        settings={"providers": {"openai": {"api": "chat_completions"}},
+                  "retry": {"maxRetries": 0}},
+        route=route, model_spec=model, artifact_root=config.artifact_root,
+        episode_id=episode_id, keep_recent_frames=3, rebuild_every_frames=8,
+        compaction=CompactionSettings(strategy="context-full", keep_recent_tokens=100),
+    )
+
+    def framed_observation(episode: str, sequence: int, **kwargs: Any) -> Any:
+        original = _distinct_framed_observation(config.artifact_root, sequence, bytes([sequence]))
+        updated = original.model_copy(update={"episode_id": episode, "text": None})
+        return updated.model_copy(update={"observation_id": observation_content_id(updated)})
+
+    monkeypatch.setattr(fixtures, "observation", framed_observation)
+    thread.start()
+    try:
+        runner = EpisodeRunner(
+            spec, config, selector=fixtures.selector(tmp_path), model=client,
+            launch=lambda _: fixtures.FakeAdapter(tmp_path, episode_id), rescue=_rescue_ok,
+            redactions=RedactionSet.from_resolved_values([secret]),
+        )
+        outcome = await asyncio.wait_for(runner.run(), timeout=30)
+        assert outcome.status == "completed", outcome
+        root = outcome.bundle_root
+        assert root is not None
+        report = verify_bundle(root)
+        assert report.valid, [issue.code for issue in report.issues]
+        assert decisions == 13 and summaries == 0
+        assert secret in replies[1]  # The fixture really emitted the unsafe note.
+        responses = fixtures.payloads(root, ModelResponsePayload)
+        assert len(responses) == 13
+        for index, expected in ((0, public_fact), (1, "[redacted public observations]")):
+            ref = responses[index].redacted_response
+            assert ref is not None
+            recorded = (root / "artifacts" / ref.sha256).read_text()
+            assert json.loads(recorded)["public_observations"] == expected
+            # The next *HTTP request* contains exactly the evidence-redacted
+            # accepted reply, proving the normal Message/provider wire path.
+            assistant = [m["content"] for m in requests[index + 1]["messages"]
+                         if m["role"] == "assistant"]
+            assert recorded in assistant
+        assert all(secret not in json.dumps(request) for request in requests)
+        assert not any(secret.encode() in p.read_bytes() for p in root.rglob("*") if p.is_file())
+        compactions = fixtures.payloads(root, ContextCompactionPayload)
+        assert any(record.frames_dropped == 9 for record in compactions)
+        history = client._context.messages
+        assert sum(isinstance(block, ImageContent) for m in history for block in m.content) < 12
+        assert public_fact in "\n".join(m.text for m in history)
+
+        async def summarize(prompt: str) -> str:
+            text, *_ = await client._stream(client._summary_request(prompt))
+            return text
+
+        compacted = await asyncio.wait_for(run_compaction_pass(
+            history, model=model,
+            settings=CompactionSettings(strategy="context-full", keep_recent_tokens=100),
+            summarize=summarize, now_ms=10_000, last_activity_ms=10_000,
+            respect_threshold=False,
+        ), timeout=10)
+        assert compacted.ran and summaries == 1 and len(requests) == 14
+        assert public_fact in compacted.messages[0].text
+        assert secret not in json.dumps(requests[-1])
+        assert not any(secret in m.text for m in compacted.messages)
+        # Visible under pytest -s for the offline handoff: actual response and
+        # side-effect evidence, without dumping bodies or any credential value.
+        print(json.dumps({
+            "transport": "loopback HTTP/SSE via create_provider_model_client",
+            "http_requests": len(requests), "accepted_decisions": decisions,
+            "response_artifacts": len(responses), "bundle_valid": report.valid,
+            "frames_dropped": [record.frames_dropped for record in compactions],
+            "retained_public_fact": public_fact,
+            "secret_note": "redacted before artifact and next HTTP request",
+            "subsequent_text_summary": compacted.summary_text,
+        }))
+    finally:
+        await client._stream_fn.close()
+        store.close()
+        await asyncio.to_thread(server.shutdown)
+        server.server_close()
+        thread.join(timeout=2)
+        assert not thread.is_alive()

--- a/tests/unit/evaluation/runner/test_public_reply_transport.py
+++ b/tests/unit/evaluation/runner/test_public_reply_transport.py
@@ -28,18 +28,24 @@ from local_operator.evaluation.evidence.models import (
 from local_operator.evaluation.evidence.verify import verify_bundle
 from local_operator.evaluation.receipts import RedactionSet
 from local_operator.evaluation.runner.episode import EpisodeRunner
-from local_operator.evaluation.runner.provider_client import create_provider_model_client
+from local_operator.evaluation.runner.provider_client import (
+    create_provider_model_client,
+)
 from local_operator.harness.types import ImageContent, ModelSpec
 from local_operator.providers.auth_store import AuthStore
 from tests.unit.evaluation.runner import conftest as fixtures
 from tests.unit.evaluation.runner.test_episode import _rescue_ok
-from tests.unit.evaluation.runner.test_provider_client import _distinct_framed_observation
+from tests.unit.evaluation.runner.test_provider_client import (
+    _distinct_framed_observation,
+)
 from tests.unit.evaluation.runner.test_public_reply import envelope
 
 
 @pytest.mark.asyncio
 async def test_loopback_sse_factory_public_memory_and_secret_retention(
-    tmp_path: Path, episode_id: str, monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    episode_id: str,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     public_fact = "Visible status: ready"
     secret = "fixture-resolved-secret-not-for-memory"
@@ -69,29 +75,44 @@ async def test_loopback_sse_factory_public_memory_and_secret_retention(
             else:
                 decisions += 1
                 content = request["messages"][-1]["content"]
-                text = content if isinstance(content, str) else "\n".join(
-                    block["text"] for block in content if block["type"] == "text"
+                text = (
+                    content
+                    if isinstance(content, str)
+                    else "\n".join(block["text"] for block in content if block["type"] == "text")
                 )
-                oid = next(line.split(": ", 1)[1] for line in text.splitlines()
-                           if line.startswith("Observation ID: "))
+                oid = next(
+                    line.split(": ", 1)[1]
+                    for line in text.splitlines()
+                    if line.startswith("Observation ID: ")
+                )
                 action: dict[str, Any] = {"kind": "wait", "observation_id": oid, "duration_ms": 1}
                 if decisions == 13:
-                    action = {"kind": "finish", "observation_id": oid,
-                              "status": "done", "reason": "fixture complete"}
+                    action = {
+                        "kind": "finish",
+                        "observation_id": oid,
+                        "status": "done",
+                        "reason": "fixture complete",
+                    }
                 note = public_fact if decisions == 1 else secret if decisions == 2 else ""
                 reply = envelope(json.dumps({"actions": [action]}), note)
             replies.append(reply)
             # Two content deltas force the real SSE decoder to assemble the
             # envelope before decision parsing; usage takes its normal route.
-            chunks = [reply[:len(reply) // 2], reply[len(reply) // 2:]]
+            chunks = [reply[: len(reply) // 2], reply[len(reply) // 2 :]]
             events = [
-                {"id": f"fixture-{len(requests)}", "choices": [
-                    {"index": 0, "delta": {"content": chunk}, "finish_reason": None}
-                ]} for chunk in chunks
+                {
+                    "id": f"fixture-{len(requests)}",
+                    "choices": [{"index": 0, "delta": {"content": chunk}, "finish_reason": None}],
+                }
+                for chunk in chunks
             ]
-            events.append({"id": f"fixture-{len(requests)}", "choices": [
-                {"index": 0, "delta": {}, "finish_reason": "stop"}
-            ], "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}})
+            events.append(
+                {
+                    "id": f"fixture-{len(requests)}",
+                    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                    "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+                }
+            )
             body = "".join(f"data: {json.dumps(event)}\n\n" for event in events)
             data = (body + "data: [DONE]\n\n").encode()
             self.send_response(200)
@@ -113,15 +134,21 @@ async def test_loopback_sse_factory_public_memory_and_secret_retention(
     route = RouteIdentity(provider_id="openai", route_id="loopback", model_id="fixture-model")
     spec = replace(fixtures.build_spec(episode_id), requested_route=route)
     model = ModelSpec(
-        provider="openai", model_id="fixture-model", supports_images=True,
-        base_url=f"http://127.0.0.1:{server.server_port}/v1", context_window=128_000,
+        provider="openai",
+        model_id="fixture-model",
+        supports_images=True,
+        base_url=f"http://127.0.0.1:{server.server_port}/v1",
+        context_window=128_000,
     )
     client = create_provider_model_client(
         auth_store=store,
-        settings={"providers": {"openai": {"api": "chat_completions"}},
-                  "retry": {"maxRetries": 0}},
-        route=route, model_spec=model, artifact_root=config.artifact_root,
-        episode_id=episode_id, keep_recent_frames=3, rebuild_every_frames=8,
+        settings={"providers": {"openai": {"api": "chat_completions"}}, "retry": {"maxRetries": 0}},
+        route=route,
+        model_spec=model,
+        artifact_root=config.artifact_root,
+        episode_id=episode_id,
+        keep_recent_frames=3,
+        rebuild_every_frames=8,
         compaction=CompactionSettings(strategy="context-full", keep_recent_tokens=100),
     )
 
@@ -134,8 +161,12 @@ async def test_loopback_sse_factory_public_memory_and_secret_retention(
     thread.start()
     try:
         runner = EpisodeRunner(
-            spec, config, selector=fixtures.selector(tmp_path), model=client,
-            launch=lambda _: fixtures.FakeAdapter(tmp_path, episode_id), rescue=_rescue_ok,
+            spec,
+            config,
+            selector=fixtures.selector(tmp_path),
+            model=client,
+            launch=lambda _: fixtures.FakeAdapter(tmp_path, episode_id),
+            rescue=_rescue_ok,
             redactions=RedactionSet.from_resolved_values([secret]),
         )
         outcome = await asyncio.wait_for(runner.run(), timeout=30)
@@ -155,8 +186,9 @@ async def test_loopback_sse_factory_public_memory_and_secret_retention(
             assert json.loads(recorded)["public_observations"] == expected
             # The next *HTTP request* contains exactly the evidence-redacted
             # accepted reply, proving the normal Message/provider wire path.
-            assistant = [m["content"] for m in requests[index + 1]["messages"]
-                         if m["role"] == "assistant"]
+            assistant = [
+                m["content"] for m in requests[index + 1]["messages"] if m["role"] == "assistant"
+            ]
             assert recorded in assistant
         assert all(secret not in json.dumps(request) for request in requests)
         assert not any(secret.encode() in p.read_bytes() for p in root.rglob("*") if p.is_file())
@@ -170,27 +202,39 @@ async def test_loopback_sse_factory_public_memory_and_secret_retention(
             text, *_ = await client._stream(client._summary_request(prompt))
             return text
 
-        compacted = await asyncio.wait_for(run_compaction_pass(
-            history, model=model,
-            settings=CompactionSettings(strategy="context-full", keep_recent_tokens=100),
-            summarize=summarize, now_ms=10_000, last_activity_ms=10_000,
-            respect_threshold=False,
-        ), timeout=10)
+        compacted = await asyncio.wait_for(
+            run_compaction_pass(
+                history,
+                model=model,
+                settings=CompactionSettings(strategy="context-full", keep_recent_tokens=100),
+                summarize=summarize,
+                now_ms=10_000,
+                last_activity_ms=10_000,
+                respect_threshold=False,
+            ),
+            timeout=10,
+        )
         assert compacted.ran and summaries == 1 and len(requests) == 14
         assert public_fact in compacted.messages[0].text
         assert secret not in json.dumps(requests[-1])
         assert not any(secret in m.text for m in compacted.messages)
         # Visible under pytest -s for the offline handoff: actual response and
         # side-effect evidence, without dumping bodies or any credential value.
-        print(json.dumps({
-            "transport": "loopback HTTP/SSE via create_provider_model_client",
-            "http_requests": len(requests), "accepted_decisions": decisions,
-            "response_artifacts": len(responses), "bundle_valid": report.valid,
-            "frames_dropped": [record.frames_dropped for record in compactions],
-            "retained_public_fact": public_fact,
-            "secret_note": "redacted before artifact and next HTTP request",
-            "subsequent_text_summary": compacted.summary_text,
-        }))
+        print(
+            json.dumps(
+                {
+                    "transport": "loopback HTTP/SSE via create_provider_model_client",
+                    "http_requests": len(requests),
+                    "accepted_decisions": decisions,
+                    "response_artifacts": len(responses),
+                    "bundle_valid": report.valid,
+                    "frames_dropped": [record.frames_dropped for record in compactions],
+                    "retained_public_fact": public_fact,
+                    "secret_note": "redacted before artifact and next HTTP request",
+                    "subsequent_text_summary": compacted.summary_text,
+                }
+            )
+        )
     finally:
         await client._stream_fn.close()
         store.close()


### PR DESCRIPTION
## Summary of Changes

Retain bounded public factual observations from the computer model's visible reply through the existing shared transcript and compaction machinery. Normal Session/exec already retains public assistant text; this fixes the computer client's actions-only replay gap using the same ordinary `Message`/`TextContent` path, not a separate memory system.

**C2, standard/pre-authorized. DRAFT, not ready to merge.** Stacked on #651 (`fix/computer-use-paste`), not `main`. Review scope: `0aa8960cc95c5058ab61031b299e5dd7b5d5c00f..89f53dc30fe904cc2c64bd35e97b80ccc061959c`. Root release version remains **unchanged**. Security #643 imposes a global merge/release HOLD; this PR does not authorize moving main or releasing either stack member.

## Delivery contract

- Add an explicitly versioned **model-reply envelope**, outside the adapter protocol: `reply_version: "1.0"`, `action_batch: {actions: [...]}`, and `public_observations: <string>`. Notes are at most 2,000 characters; empty is valid. The actions array remains nonempty and uses the existing action validators.
- Bind notes implicitly to the current observation/episode by accepting them only alongside a batch validated against that observation and the negotiated action surface. Reject unsupported versions, wrong observation IDs, duplicate keys, extra fields, nested substitutes, oversized/non-string notes, and trailing envelope content. Preserve legacy plain ActionBatch replies and their existing framing tolerance.
- Prompt for concise **new observed factual data or visible progress**, not deliberation, plans, credentials, invented facts, or unobserved action success. Do not request, store or replay private chain of thought. Add no extraction LLM call.
- Carry accepted visible replies through optional `ModelDecision.public_reply` and `EpisodeTurn.public_reply`, the existing `redacted_response` evidence artifact, and ordinary assistant `Message`/`TextContent`. Do not collapse accepted notes back into canonical actions when replaying history.
- Redact an entire known-secret note before evidence publication or accepted replay using the existing resolved-secret boundary, including decoded JSON and common encoded forms. Rejected envelope or undecodable envelope-attempt output is not promoted into factual memory: an escape-aware reserved-key scan (legal JSON Unicode escapes defeat literal substring matching, and truncated framing defeats full decoding) replaces it with a safe corrective marker before both corrective history and rejection evidence, while raw legacy rejection replay is preserved where no reserved key appears. This is not a general-purpose secret detector.
- Record the advertised model-reply contract and its domain-separated identity in existing manifest metadata, separately from `action_surface`/`tool_schema_digest`. The reply schema owns the neutral action-array shape; the existing negotiated action surface still owns and enforces execution restrictions. Old fake clients do not claim a reply contract they never used.
- Preserve all legacy ActionBatch canonical bytes/hashes and historical evidence. **Native actions, adapter Action/RPC 1.5, negotiated paste behavior, and adapter execution are unchanged.** Add no normal TUI/mobile/exec startup dependency.

Observable acceptance criteria: two histories differing only in an old screenshot reproduce the existing erasure; public factual text distinguishes the histories after pruning and reaches subsequent text compaction; a real provider HTTP/SSE response survives parsing, evidence/redaction and the next provider request; unchanged action bytes and legacy parser/cache/context invariants remain covered.

## Non-goals and limits

No separate memory database, OSWorld/task-ID hints, benchmark solution examples, image OCR system, screenshot-backend changes, compaction reordering, new adapter action, evaluator change, normal-interface tool, or extra fact-extraction call. No changes to #651's reviewed implementation.

**No claim that vision understanding, task completion or benchmark performance has improved yet.** These deterministic tests prove transport/parsing/retention, not model perception or summary quality. Public notes remain model-authored assertions; the existing text summarizer can still omit or distort facts. Independent code/design review and a later parent-coordinated frozen pilot remain pending. No paid model or native VM pilot was run for this PR.

## Why

The audited computer history reconstructed accepted replies solely as canonical ActionBatch JSON. In the motivating retained trajectory, original observation text was present in only 1 of 41 observations; four compaction events only pruned frames and did not summarize. A deterministic 12-frame control drops nine old frames before summary, making histories differing only in an old image identical.

Both context-full and snapcompact serializers omit image pixels **even before pruning**, so merely moving summary earlier cannot recover those facts. Public assistant fact text already survives the existing text path. This change supplies that missing public channel for computer decisions while leaving private provider reasoning out of the contract.

## Testing Details

### Focused regression coverage

At implementation head `306e1e26a`, **259 focused tests passed in 4.56s** (round 1 remediation head; 254 at the pre-remediation head), serially. This is **not** a full local unit-suite result; full units are left to CI as coordinated.

```sh
.venv/bin/python -m pytest \
  tests/unit/evaluation/runner/test_public_reply.py \
  tests/unit/evaluation/runner/test_public_reply_transport.py \
  tests/unit/evaluation/runner/test_provider_client.py \
  tests/unit/evaluation/runner/test_episode.py \
  tests/unit/evaluation/runner/test_action_negotiation.py \
  tests/unit/evaluation/runner/test_isolation.py \
  tests/unit/evaluation/test_protocol.py \
  tests/unit/compaction/test_pass.py -n0 -q
# 259 passed in 4.56s
```

Coverage includes the original 12-frame erasure control; public facts after prune and subsequent deterministic text summary; both serializers; empty/oversized/invalid/rejected/secret-redacted notes; stale/wrong-observation and ambiguous decisions; legacy bytes/hashes/decoder tolerance; append-only cache prefixes; existing context-budget limits; and import isolation.

### Actual loopback HTTP/SSE path and side effects

Re-exercised after the formatting-only static-gate remediation on the final source, through the **production `create_provider_model_client` factory**, real shared provider HTTP client and SSE decoder, `ModelDecision`, `EpisodeRunner`, existing response artifacts, next assistant-message HTTP replay, frame prune, and subsequent text compaction. The provider answers and adapter boundary are deterministic fixtures; HTTP transport is not replaced with MockTransport, and no global provider configuration is changed.

```sh
.venv/bin/python -m pytest \
  tests/unit/evaluation/runner/test_public_reply_transport.py -n0 -q -s
```

Actual output:
```json
{"transport":"loopback HTTP/SSE via create_provider_model_client","http_requests":14,"accepted_decisions":13,"response_artifacts":13,"bundle_valid":true,"frames_dropped":[9],"retained_public_fact":"Visible status: ready","secret_note":"redacted before artifact and next HTTP request","subsequent_text_summary":"Visible status: ready"}
```

Result: **1 passed in 1.58s**. The test confirms that the server actually emitted the synthetic known-secret note, but no next HTTP request or evidence file retained it; the existing response artifact and next assistant replay contain the redaction marker instead. Thirteen accepted decisions produce thirteen response artifacts; the fourteenth local HTTP request is the existing text-summary path, not a new extraction call. The evidence bundle independently verifies. Server thread, provider stream and local AuthStore are closed afterward. No paid inference occurs.

### Review rounds

- Code review round 1: one MAJOR finding (F1, escaped reserved keys in a truncated envelope bypassing the literal-key rejection filter) — fixed in `89f53dc30` and dispositioned on the PR with the reviewer's exact repro re-run clean (`encoded_known_secret_in_next_request: false`, `encoded_known_secret_in_artifacts: []`, `bundle_valid: true`).
- Design review round 1: clean and TERMINAL; acknowledged on the PR. The remediation touched no prompt strings or rendered surface, so the design round remains fresh.

### Whole-tree static gates

All four exact `AGENTS.md` whole-tree gates passed on the final source:

```sh
.venv/bin/python -m flake8 .
uvx --from black==26.1.0 black --check .
uvx isort==5.13.2 --check .
.venv/bin/python -m pyright --pythonpath .venv/bin/python .
```

- Flake8: exit 0.
- Black: 885 files unchanged. Its standard optional-Jupyter notice was emitted; no exclusions were added.
- isort: exit 0; two files skipped by existing repository configuration.
- Pyright: 0 errors, 0 warnings, 0 informations.
- `git diff --check`: clean.

The first static pass found formatter/import-order issues in this slice; `a2a64a523` applies only the repository formatters to those files. Initial whole-tree Pyright also exposed dependencies missing from the intentionally lightweight venv; those were installed from the offline cache into this worktree's own venv, with no source/config/dependency-manifest changes or suppressions. No completed build directories needed removal. About 25.9 GiB disk headroom remains. Root `pyproject.toml` is byte-unchanged from the stacked base. All four gates were re-run and passed on the round 1 remediation head `89f53dc30`.

## Review and integration gates

Independent code and design rounds will be launched by the parent in parallel against this PR. No human reviewers are requested while those gates are pending. Assignee: `damianvtran`.

Keep this PR **draft and unmerged** pending those rounds, current-head CI and the parent-coordinated pilot gate. Security #643's global HOLD remains in effect regardless of this PR's CI/review status. No merge, release, root version bump, main movement or runtime installation update is authorized. Rollback, if a later integration is approved, is to revert this bounded follow-up while retaining the prerequisite action implementation; no migration or historical-evidence rewrite is required.
