### PR TITLE
chore(release): bump version to 0.49.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.48.0"
+version = "0.49.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Release window lock

**Owner session pid:** 95033 (`Fix Incorrect cmux Session Names`, manager of lopdev).

This PR is the observable lock for the current combined-release window (see AGENTS.md "One release owner per window", PR #655). Peers with a merged PR: reply to pid 95033 via `send` with PR#, merge SHA, one-line impact, bump argument.

### PRs in this window (merged since v0.48.0)
- [x] #648 — cmux workspace titles no longer overwritten by headless forks (patch)
- [x] #652 — first-class local model servers (LM Studio, Ollama, vLLM, llama.cpp) via /login (**minor**)
- [x] #655 — AGENTS.md combined-release protocol (docs) — 6277fbef
- [x] #647 — Codex OAuth cache affinity (patch) — 804dd6dd
- [x] #640 — OSWorld pinned task helpers + evaluator evidence (patch) — 55da4724
- [x] #651 — Unicode paste_text evaluation action (patch) — a583d17b
- [x] #646 — complete subagent tool cards, plans, nested children (patch) — be921de2
- [x] #657 — security advisory runbook + Dependabot (docs) — f4e9613a
- [ ] #653 — rides the next window

**Bump decided:** minor → **0.49.0** (#652 clears the step-function bar on its own).

Amended: the single commit is now the 0.49.0 bump. Review round: one-file scope check by an independent reviewer.
