### PR TITLE
fix(tools): run the bash tool through real bash, configurable via bash.shell (#629)

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,7 +659,11 @@ lop config open        # open it in your editor
 Commonly set values: `hosting` and `model_name` (skip the CLI flags),
 `conversation_length` / `detail_length` (history kept verbatim vs
 summarized), and `tui.theme` (any registered theme name — easier to set with
-`/theme`, which previews live).
+`/theme`, which previews live). `bash.shell` picks the interpreter the `bash`
+tool spawns: unset, it runs the first `bash` on `PATH` (Homebrew bash 5 when
+installed, else the system one) and falls back to `/bin/sh` only on a host
+with no bash — so process substitution and other bash syntax work as the
+tool's name promises. Every option is browsable in `/settings`.
 
 Credentials are stored in `~/.local-operator/credentials.env` and never
 echoed:

--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -367,6 +367,18 @@ SECTIONS: tuple[Section, ...] = (
         Scope.LIVE,
         "Limits and rendering for the fetch tool.",
     ),
+    # LIVE for the same reason as the two web sections: ``execute_bash`` reads
+    # ``bash.shell`` through a fresh ``ConfigManager(config_dir())`` on EVERY
+    # call (``tools/builtin.py::_configured_bash_shell``), so an edit lands on
+    # the very next command. Its own section rather than a row under "Session"
+    # or "Runtime": scope is uniform within a section by construction, and
+    # this is about how a tool executes, not how sessions behave.
+    Section(
+        "tools",
+        "Tools",
+        Scope.LIVE,
+        "How the built-in tools execute.",
+    ),
     Section(
         "local_providers",
         "Local servers",
@@ -1202,6 +1214,21 @@ SETTINGS: tuple[Setting, ...] = (
         default=True,
         help="Try .md, llms.txt and content negotiation before scraping HTML.",
         choices=_bool_choices("try cleaner sources first", "scrape HTML directly"),
+    ),
+    # -- tools --------------------------------------------------------------
+    # ``path`` mirrors ``tools.builtin.BASH_SHELL_PATH``; the two are pinned
+    # together by ``test_bash_shell_row_shares_the_consumer_path`` rather than
+    # imported, because this module must stay cheap for the CLI and
+    # ``tools.builtin`` is not (see the module docstring on Textual).
+    Setting(
+        key="bash.shell",
+        path=("bash", "shell"),
+        section="tools",
+        label="Bash interpreter",
+        kind=Kind.TEXT,
+        default="",
+        help="Path the bash tool runs commands with. Empty: bash on PATH, else /bin/sh.",
+        empty_unsets=True,
     ),
     *[
         setting

--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -1227,7 +1227,7 @@ SETTINGS: tuple[Setting, ...] = (
         label="Bash interpreter",
         kind=Kind.TEXT,
         default="",
-        help="Path the bash tool runs commands with. Empty: bash on PATH, else /bin/sh.",
+        help="Interpreter for the bash tool. Empty uses bash on PATH, else /bin/sh.",
         empty_unsets=True,
     ),
     *[

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -51,6 +51,7 @@ import logging
 import mimetypes
 import os
 import re
+import shutil
 import signal as signal_module
 import threading
 import time
@@ -73,6 +74,7 @@ from pydantic import (
 )
 from rich.cells import cell_len
 
+from local_operator.config import ConfigManager
 from local_operator.harness.approval import ask_approval
 from local_operator.harness.types import (
     AbortSignal,
@@ -102,6 +104,7 @@ from local_operator.imaging import (
     bound_image_for_model,
 )
 from local_operator.media import ImageInfo, sniff_image_file
+from local_operator.paths import config_dir
 from local_operator.tools import group_reaper
 from local_operator.tools.spill import (
     SPILL_ENTRY_LIMIT_BYTES,
@@ -149,6 +152,17 @@ BASH_DEFAULT_TIMEOUT_SECONDS = 120.0
 #: Hard cap on the per-command timeout; longer runs are a session bug, not a
 #: tool feature.
 BASH_MAX_TIMEOUT_SECONDS = 3600.0
+#: Where ``bash.shell`` lives under ``values``, spelled ONCE and shared with
+#: the ``settings_io`` row so the reader and the writer cannot disagree about
+#: the path (the flat-vs-nested mismatch that silenced the #576 opt-out).
+BASH_SHELL_PATH: tuple[str, ...] = ("bash", "shell")
+#: The registry default for ``bash.shell``: empty means "auto-resolve" via
+#: :func:`resolve_bash_shell`, never a literal interpreter, so a config that
+#: says nothing tracks whatever bash the host has rather than freezing a path.
+BASH_SHELL_DEFAULT = ""
+#: Last-resort interpreter when the host has no ``bash`` on PATH at all. The
+#: tool keeps working (POSIX syntax only) instead of failing every call.
+BASH_SHELL_FALLBACK = "/bin/sh"
 #: Number of trailing traceback characters kept in an error result.
 TRACEBACK_TAIL_CHARS = 2000
 
@@ -1146,10 +1160,49 @@ async def _run_with_abort(
 # ---------------------------------------------------------------------------
 
 
+def resolve_bash_shell(configured: str | None) -> str:
+    """Pick the interpreter the ``bash`` tool spawns (#629).
+
+    Order: the ``bash.shell`` config value when set and non-blank; else the
+    first ``bash`` on PATH (Homebrew's bash 5 when installed, else
+    ``/bin/bash`` on macOS or ``/usr/bin/bash`` on Linux); else ``/bin/sh`` so a
+    host with no bash still runs POSIX commands rather than nothing.
+
+    Deliberately NOT ``$SHELL``: the login shell is zsh on macOS, and zsh's
+    word-splitting and globbing differ from what a tool named ``bash``
+    promises, so a model writing bash would get a third dialect. Pure and
+    cheap (one ``which`` per call) so the config edit is LIVE and the order is
+    unit-testable without spawning anything.
+    """
+    chosen = (configured or "").strip() or shutil.which("bash") or BASH_SHELL_FALLBACK
+    logger.debug("bash tool interpreter: %s", chosen)
+    return chosen
+
+
+def _configured_bash_shell() -> str | None:
+    """Read ``bash.shell`` from config at CALL time, the way web_fetch does.
+
+    A fresh ``ConfigManager(config_dir())`` per call is what makes the key
+    honestly LIVE in ``/settings``: an edit takes effect on the very next
+    command with no session rebuild. Any read failure means "unset" — the
+    command must run even when config.yml is unreadable.
+    """
+    try:
+        value = ConfigManager(config_dir()).get_nested_value(BASH_SHELL_PATH, None)
+    except Exception:  # noqa: BLE001 — config trouble must never block a command
+        return None
+    return value if isinstance(value, str) else None
+
+
 class BashParams(BaseModel):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
-    command: str = Field(description="Shell command to run (executed via /bin/sh -c).")
+    command: str = Field(
+        description=(
+            "Shell command to run, executed via `bash -c` (falls back to /bin/sh only "
+            "when no bash exists), so bash syntax such as <(...), arrays and [[ ]] works."
+        )
+    )
     timeout: float = Field(
         default=BASH_DEFAULT_TIMEOUT_SECONDS,
         gt=0,
@@ -1422,8 +1475,15 @@ async def execute_bash(
         extra = {str(name): str(value) for name, value in extra.items()}
         env.update(extra)
 
+    # Real bash, not /bin/sh (#629). On macOS /bin/sh is bash 3.2 in POSIX
+    # mode, which rejects process substitution and other bashisms at parse
+    # time — and because this tool is NAMED bash, models write bash: 37 of 43
+    # `<(...)` commands in a week of transcripts died on `syntax error near
+    # unexpected token '('`. Resolution order: the configured `bash.shell`,
+    # then `bash` on PATH, then /bin/sh as the no-bash last resort. Never
+    # $SHELL — see resolve_bash_shell for why zsh is the wrong answer.
     process = await asyncio.create_subprocess_exec(
-        "/bin/sh",
+        resolve_bash_shell(_configured_bash_shell()),
         "-c",
         params.command,
         stdout=asyncio.subprocess.PIPE,
@@ -1973,7 +2033,7 @@ def build_bash_tool() -> AgentTool:
         name="bash",
         label="Shell",
         describe_approval=_describe_shell_approval,
-        description=("Run a shell command and return its exit code, stdout and stderr."),
+        description=("Run a bash command and return its exit code, stdout and stderr."),
         parameters=BashParams.model_json_schema(),
         approval_tier="exec",
         # bash runs shared when non-pty; models batch independent

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -1173,8 +1173,16 @@ def resolve_bash_shell(configured: str | None) -> str:
     promises, so a model writing bash would get a third dialect. Pure and
     cheap (one ``which`` per call) so the config edit is LIVE and the order is
     unit-testable without spawning anything.
+
+    ``~`` is expanded because the key is a ``Kind.TEXT`` row in ``/settings``
+    and ``~/bin/bash`` is a plausible thing to type there; nothing else in the
+    settings registry or the reader expands it, so an unexpanded value would
+    reach ``execve`` verbatim and fail every call.
     """
-    chosen = (configured or "").strip() or shutil.which("bash") or BASH_SHELL_FALLBACK
+    stripped = (configured or "").strip()
+    chosen = (
+        os.path.expanduser(stripped) if stripped else shutil.which("bash") or BASH_SHELL_FALLBACK
+    )
     logger.debug("bash tool interpreter: %s", chosen)
     return chosen
 
@@ -1188,7 +1196,7 @@ def _configured_bash_shell() -> str | None:
     command must run even when config.yml is unreadable.
     """
     try:
-        value = ConfigManager(config_dir()).get_nested_value(BASH_SHELL_PATH, None)
+        value = ConfigManager(config_dir()).get_nested_value(BASH_SHELL_PATH, BASH_SHELL_DEFAULT)
     except Exception:  # noqa: BLE001 — config trouble must never block a command
         return None
     return value if isinstance(value, str) else None
@@ -1197,10 +1205,14 @@ def _configured_bash_shell() -> str | None:
 class BashParams(BaseModel):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
+    # Kept terse on purpose: a schema rides EVERY request in every session and
+    # subagent. The bash-syntax claim is model-actionable (it tells the model
+    # which dialect to write); the /bin/sh fallback is not — the model cannot
+    # detect or change which host it runs on.
     command: str = Field(
         description=(
-            "Shell command to run, executed via `bash -c` (falls back to /bin/sh only "
-            "when no bash exists), so bash syntax such as <(...), arrays and [[ ]] works."
+            "Bash command to run (via `bash -c`; bash syntax such as <(...), "
+            "arrays and [[ ]] works)."
         )
     )
     timeout: float = Field(
@@ -1482,16 +1494,36 @@ async def execute_bash(
     # unexpected token '('`. Resolution order: the configured `bash.shell`,
     # then `bash` on PATH, then /bin/sh as the no-bash last resort. Never
     # $SHELL — see resolve_bash_shell for why zsh is the wrong answer.
-    process = await asyncio.create_subprocess_exec(
-        resolve_bash_shell(_configured_bash_shell()),
-        "-c",
-        params.command,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        cwd=_safe_cwd(context),
-        env=env,
-        start_new_session=True,
-    )
+    shell = resolve_bash_shell(_configured_bash_shell())
+    try:
+        process = await asyncio.create_subprocess_exec(
+            shell,
+            "-c",
+            params.command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=_safe_cwd(context),
+            env=env,
+            start_new_session=True,
+        )
+    except OSError as exc:
+        # A `bash.shell` pointing at a missing or non-executable file made the
+        # spawn raise out of the tool, and the generic tool boundary rendered
+        # `Tool 'bash' failed unexpectedly:` plus a 2000-char traceback tail —
+        # so EVERY call failed with a stack dump that never named the key that
+        # caused it. OSError (not just FileNotFoundError) because the same
+        # misconfiguration also arrives as PermissionError for a non-executable
+        # path, and ENOTDIR/ELOOP for a malformed one. A normal error result
+        # keeps the loop alive and tells the model exactly what to say to the
+        # operator.
+        return _error(
+            tool_call_id,
+            "bash",
+            f"bash.shell: cannot execute {shell!r} ({exc.strerror or exc}). "
+            "Point it at a real interpreter with "
+            "`lop config edit bash.shell <path>`, or clear it with "
+            "`lop config edit bash.shell ''` to auto-resolve bash on PATH.",
+        )
 
     # Record this group in the owner's process-group ledger so a HARD death of
     # THIS lop process (SIGKILL from cmux, OOM, crash) — the one stop path with

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -1495,6 +1495,7 @@ async def execute_bash(
     # then `bash` on PATH, then /bin/sh as the no-bash last resort. Never
     # $SHELL — see resolve_bash_shell for why zsh is the wrong answer.
     shell = resolve_bash_shell(_configured_bash_shell())
+    cwd = _safe_cwd(context)
     try:
         process = await asyncio.create_subprocess_exec(
             shell,
@@ -1502,7 +1503,7 @@ async def execute_bash(
             params.command,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            cwd=_safe_cwd(context),
+            cwd=cwd,
             env=env,
             start_new_session=True,
         )
@@ -1513,16 +1514,51 @@ async def execute_bash(
         # so EVERY call failed with a stack dump that never named the key that
         # caused it. OSError (not just FileNotFoundError) because the same
         # misconfiguration also arrives as PermissionError for a non-executable
-        # path, and ENOTDIR/ELOOP for a malformed one. A normal error result
-        # keeps the loop alive and tells the model exactly what to say to the
-        # operator.
+        # path, and ENOTDIR/ELOOP for a malformed one.
+        #
+        # But the SAME OSError family covers two distinct arguments, and only
+        # one of them is `bash.shell`: argv[0] (the interpreter) and `cwd=`
+        # (the session directory, which is routinely deleted under us — a
+        # removed worktree, a reclaimed tmpdir). Blaming `bash.shell`
+        # unconditionally named a key the operator may never have set and
+        # prescribed two commands that cannot fix a missing directory.
+        # `exc.filename` is the discriminator: CPython sets it to the path that
+        # actually failed, and the child chdirs BEFORE execve, so a bad cwd
+        # correctly wins even when both are bad. It is None only for errors
+        # that carry no path at all, which must not be attributed to either.
+        #
+        # Each message is split across short lines and carries no backticks:
+        # the tool card truncates per line and paints Text rather than
+        # markdown, so a single long sentence loses its own recovery half and
+        # backticks land literally inside the command the operator must type.
+        if exc.filename is None:
+            return _error(
+                tool_call_id,
+                "bash",
+                f"cannot start the command ({exc.strerror or exc}).\n"
+                f"Interpreter: {shell}\n"
+                f"Working directory: {cwd}",
+            )
+        if exc.filename != shell:
+            # The offending path IS the cwd in the case this branch exists for,
+            # so repeating it on its own line would spend a scarce card line on
+            # a duplicate; it is named separately only when the two differ.
+            where = "" if exc.filename == cwd else f"Working directory: {cwd}\n"
+            return _error(
+                tool_call_id,
+                "bash",
+                f"cannot start the command in {exc.filename!r} "
+                f"({exc.strerror or exc}).\n"
+                f"{where}"
+                "That directory is gone or unreadable. Recreate it, or work "
+                "from a directory that exists.",
+            )
         return _error(
             tool_call_id,
             "bash",
-            f"bash.shell: cannot execute {shell!r} ({exc.strerror or exc}). "
-            "Point it at a real interpreter with "
-            "`lop config edit bash.shell <path>`, or clear it with "
-            "`lop config edit bash.shell ''` to auto-resolve bash on PATH.",
+            f"bash.shell: cannot execute {shell!r} ({exc.strerror or exc}).\n"
+            "Point it at a real interpreter: lop config edit bash.shell <path>\n"
+            "Or clear it to auto-resolve bash on PATH: lop config edit bash.shell ''",
         )
 
     # Record this group in the owner's process-group ledger so a HARD death of

--- a/tests/unit/session/test_config_live.py
+++ b/tests/unit/session/test_config_live.py
@@ -142,6 +142,14 @@ def _fetch_settings(watcher: ConfigWatcher):
     return load_fetch_settings(ConfigManager(watcher.config_dir))
 
 
+def _bash_shell(watcher: ConfigWatcher) -> str:
+    """What `execute_bash` resolves per call (it reads through `paths.config_dir()`,
+    which the probe points at the watcher's directory)."""
+    from local_operator.tools.builtin import _configured_bash_shell, resolve_bash_shell
+
+    return resolve_bash_shell(_configured_bash_shell())
+
+
 def _spawn_model(session: Session, tier: str, watcher: ConfigWatcher | None = None) -> str:
     """The subagent ModelSpec the session resolves for an effort tier.
 
@@ -289,6 +297,7 @@ LIVE_KEY_PROBES: dict[str, tuple[Any, Any]] = {
     "web_fetch.allow_private": (True, lambda s, w: _fetch_settings(w).allow_private),
     "web_fetch.render_backend": ("stdlib", lambda s, w: _fetch_settings(w).render_backend),
     "web_fetch.enrich": (False, lambda s, w: _fetch_settings(w).enrich),
+    "bash.shell": ("/opt/probe/bash", lambda s, w: _bash_shell(w)),
 }
 
 #: LIVE sections whose keys have no session-side apply because the TUI owns

--- a/tests/unit/test_settings_io.py
+++ b/tests/unit/test_settings_io.py
@@ -61,6 +61,7 @@ def _consumer_defaults() -> dict[str, object]:
         DEFAULT_FORK_CMUX_PLACEMENT,
         DEFAULT_FORK_MODE,
     )
+    from local_operator.tools.builtin import BASH_SHELL_DEFAULT
     from local_operator.tui.theme import DEFAULT_THEME
     from local_operator.web_fetch.models import DEFAULT_WEB_FETCH_CONFIG
     from local_operator.web_search.models import DEFAULT_WEB_SEARCH_CONFIG
@@ -84,6 +85,9 @@ def _consumer_defaults() -> dict[str, object]:
         "retry.usageReservePercent": retry.usage_reserve_percent,
         "retry.usageAwareAccountPick": retry.usage_aware_account_pick,
         "retry.fallbackChains": dict(retry.fallback_chains),
+        # Empty means "auto-resolve" (bash on PATH, else /bin/sh) rather than
+        # an interpreter, so the consumer's constant is the empty string too.
+        "bash.shell": BASH_SHELL_DEFAULT,
         "runtime.background_on_resume": DEFAULT_BACKGROUND_ON_RESUME,
         "runtime.unattended_gate_timeout": DEFAULT_UNATTENDED_GATE_TIMEOUT_H,
         "session.cleanup.enabled": DEFAULT_ENABLED,
@@ -338,6 +342,23 @@ def test_no_consumer_reads_a_nested_setting_through_the_flat_accessor() -> None:
                         f"{path.relative_to(package.parent)}:{number}: {match.group(0)}"
                     )
     assert not offenders, "\n".join(offenders)
+
+
+def test_bash_shell_row_shares_the_consumer_path(manager: ConfigManager) -> None:
+    """The ``bash.shell`` row is pinned to ``builtin.BASH_SHELL_PATH`` and a
+    write lands as a nested ``bash: {shell: ...}`` block the tool reads back.
+    Pinned by test rather than import because ``settings_io`` must stay cheap
+    for the CLI and ``tools.builtin`` is not."""
+    from local_operator.tools.builtin import BASH_SHELL_PATH, _configured_bash_shell
+
+    assert settings_io.BY_KEY["bash.shell"].path == BASH_SHELL_PATH
+    settings_io.write_setting(manager, settings_io.BY_KEY["bash.shell"], "/opt/x/bash")
+    stored = yaml.safe_load((manager.config_dir / "config.yml").read_text())["values"]
+    assert stored["bash"]["shell"] == "/opt/x/bash"
+    assert "bash.shell" not in stored
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(manager.config_dir))
+        assert _configured_bash_shell() == "/opt/x/bash"
 
 
 def test_cleanup_settings_are_nested_under_session_cleanup(manager: ConfigManager) -> None:

--- a/tests/unit/tools/test_builtin_tools.py
+++ b/tests/unit/tools/test_builtin_tools.py
@@ -361,6 +361,62 @@ def test_resolve_bash_shell_last_resort_is_sh(monkeypatch) -> None:
     assert builtin.resolve_bash_shell(None) == builtin.BASH_SHELL_FALLBACK == "/bin/sh"
 
 
+def test_resolve_bash_shell_expands_a_tilde(monkeypatch) -> None:
+    """`~/bin/bash` is a plausible thing to type into the Kind.TEXT settings
+    row, and nothing else on the read path expands it — unexpanded it would
+    reach execve verbatim and fail every call."""
+    monkeypatch.setenv("HOME", "/home/tester")
+    assert builtin.resolve_bash_shell("~/bin/bash") == "/home/tester/bin/bash"
+    assert builtin.resolve_bash_shell("  ~/bin/bash  ") == "/home/tester/bin/bash"
+
+
+def _set_configured_shell(monkeypatch, tmp_path, value: str):
+    """Point `bash.shell` at `value` in an isolated config dir."""
+    from local_operator.config import ConfigManager
+
+    config_home = tmp_path / "config"
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_home))
+    ConfigManager(config_home).set_config_value("bash", {"shell": value})
+
+
+@pytest.mark.asyncio
+async def test_bash_reports_a_missing_configured_shell_as_a_tool_error(
+    tools, context, tmp_path, monkeypatch
+) -> None:
+    """A `bash.shell` that does not exist must be a normal error result naming
+    the path and the key — not the generic boundary's `failed unexpectedly`
+    plus a traceback tail, which never said which key broke every call."""
+    _set_configured_shell(monkeypatch, tmp_path, "/nonexistent/qa-shell")
+
+    result = await _call(tools, "bash", {"command": "echo hi"}, context)
+
+    assert result.is_error is True
+    assert "bash.shell" in result.text
+    assert "/nonexistent/qa-shell" in result.text
+    assert "failed unexpectedly" not in result.text
+    assert "Traceback" not in result.text
+
+
+@pytest.mark.asyncio
+async def test_bash_reports_a_non_executable_configured_shell_as_a_tool_error(
+    tools, context, tmp_path, monkeypatch
+) -> None:
+    """The same misconfiguration arrives as PermissionError rather than
+    FileNotFoundError when the path exists but has no exec bit, which is why
+    the handler catches OSError rather than one subclass."""
+    not_executable = tmp_path / "not-executable"
+    not_executable.write_text("#!/bin/sh\necho nope\n")
+    not_executable.chmod(0o644)
+    _set_configured_shell(monkeypatch, tmp_path, str(not_executable))
+
+    result = await _call(tools, "bash", {"command": "echo hi"}, context)
+
+    assert result.is_error is True
+    assert "bash.shell" in result.text
+    assert str(not_executable) in result.text
+    assert "Traceback" not in result.text
+
+
 _HOST_BASH = builtin.shutil.which("bash")
 
 

--- a/tests/unit/tools/test_builtin_tools.py
+++ b/tests/unit/tools/test_builtin_tools.py
@@ -333,6 +333,76 @@ async def test_bash_empty_command_is_error(tools, context) -> None:
     assert result.is_error is True
 
 
+# -- interpreter resolution (#629) ------------------------------------------
+#
+# The tool is NAMED bash, so models write bash; /bin/sh on macOS is bash 3.2 in
+# POSIX mode and rejects `<(...)` at parse time. These pin the resolution order
+# and prove the real spawn path runs bash syntax.
+
+
+def test_resolve_bash_shell_prefers_the_configured_value(monkeypatch) -> None:
+    monkeypatch.setattr(builtin.shutil, "which", lambda name: "/path/which/bash")
+    assert builtin.resolve_bash_shell("/opt/custom/bash") == "/opt/custom/bash"
+    # Surrounding whitespace is a typo, not an interpreter.
+    assert builtin.resolve_bash_shell("  /opt/custom/bash \n") == "/opt/custom/bash"
+
+
+def test_resolve_bash_shell_falls_back_to_bash_on_path(monkeypatch) -> None:
+    monkeypatch.setattr(builtin.shutil, "which", lambda name: "/path/which/bash")
+    assert builtin.resolve_bash_shell(None) == "/path/which/bash"
+    # Empty and blank both mean "unset": the registry's empty_unsets row and a
+    # hand-edited `shell: "  "` must resolve the same way.
+    assert builtin.resolve_bash_shell("") == "/path/which/bash"
+    assert builtin.resolve_bash_shell("   ") == "/path/which/bash"
+
+
+def test_resolve_bash_shell_last_resort_is_sh(monkeypatch) -> None:
+    monkeypatch.setattr(builtin.shutil, "which", lambda name: None)
+    assert builtin.resolve_bash_shell(None) == builtin.BASH_SHELL_FALLBACK == "/bin/sh"
+
+
+_HOST_BASH = builtin.shutil.which("bash")
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(_HOST_BASH is None, reason="no bash on this host")
+async def test_bash_runs_process_substitution(tools, context) -> None:
+    """The issue's own reproduction: `comm -12 <(echo a) <(echo a)` must print
+    `a` and exit 0 under the default (auto-resolved) interpreter."""
+    result = await _call(tools, "bash", {"command": "comm -12 <(echo a) <(echo a)"}, context)
+    assert result.is_error is False
+    assert "exit code: 0" in result.text
+    assert "--- stdout ---\na\n" in result.text
+    assert "syntax error" not in result.text
+
+
+@pytest.mark.asyncio
+async def test_bash_honours_configured_shell(tools, context, tmp_path, monkeypatch) -> None:
+    """`bash.shell` from config is what gets spawned, read at CALL time.
+
+    Pointed at a tiny script rather than /bin/sh so the assertion is a
+    positive marker rather than "process substitution failed", which would
+    also be true of a broken default."""
+    from local_operator.config import ConfigManager
+
+    marker = tmp_path / "marker-shell"
+    marker.write_text('#!/bin/sh\necho MARKER-SHELL "$@"\n')
+    marker.chmod(0o755)
+    config_home = tmp_path / "config"
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_home))
+    ConfigManager(config_home).set_config_value("bash", {"shell": str(marker)})
+
+    result = await _call(tools, "bash", {"command": "ignored"}, context)
+    assert result.is_error is False
+    assert "MARKER-SHELL -c ignored" in result.text
+
+    # Clearing the key on disk takes effect on the very next call: no cache.
+    ConfigManager(config_home).set_config_value("bash", {"shell": ""})
+    result = await _call(tools, "bash", {"command": "echo plain"}, context)
+    assert "MARKER-SHELL" not in result.text
+    assert "plain" in result.text
+
+
 @pytest.mark.asyncio
 async def test_bash_executes_without_tool_level_prompt(tmp_path) -> None:
     # The write/exec approval gate is the LOOP's (it fires after

--- a/tests/unit/tools/test_builtin_tools.py
+++ b/tests/unit/tools/test_builtin_tools.py
@@ -394,7 +394,6 @@ async def test_bash_reports_a_missing_configured_shell_as_a_tool_error(
     assert "bash.shell" in result.text
     assert "/nonexistent/qa-shell" in result.text
     assert "failed unexpectedly" not in result.text
-    assert "Traceback" not in result.text
 
 
 @pytest.mark.asyncio
@@ -414,7 +413,33 @@ async def test_bash_reports_a_non_executable_configured_shell_as_a_tool_error(
     assert result.is_error is True
     assert "bash.shell" in result.text
     assert str(not_executable) in result.text
-    assert "Traceback" not in result.text
+    # `Traceback` cannot discriminate here: the boundary emits only the last
+    # 2000 chars of the formatted traceback, which cuts the header off, so the
+    # literal string is absent from the pre-fix output too.
+    assert "failed unexpectedly" not in result.text
+
+
+@pytest.mark.asyncio
+async def test_bash_blames_the_working_directory_not_bash_shell(tmp_path, monkeypatch) -> None:
+    """`create_subprocess_exec` raises the same OSError family for a deleted
+    `cwd=` as for a bad argv[0], so the handler must discriminate on
+    `exc.filename`. With `bash.shell` unset and the session directory gone —
+    an ordinary condition after a removed worktree or a reclaimed tmpdir — the
+    error must name the directory and never mention a key the operator never
+    set, whose two prescribed fixes cannot repair a missing directory."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "empty-config"))
+    gone = tmp_path / "deleted-cwd"
+    gone.mkdir()
+    gone_context = ToolContext(cwd=str(gone), session_id="unit-test")
+    gone_tools = {tool.name: tool for tool in create_tools(gone_context)}
+    gone.rmdir()
+
+    result = await _call(gone_tools, "bash", {"command": "echo hi"}, gone_context)
+
+    assert result.is_error is True
+    assert str(gone) in result.text
+    assert "bash.shell" not in result.text
+    assert "failed unexpectedly" not in result.text
 
 
 _HOST_BASH = builtin.shutil.which("bash")


### PR DESCRIPTION
## Summary of Changes

The `bash` tool spawned every command through `/bin/sh -c`. On macOS `/bin/sh` is bash 3.2 in POSIX mode, which rejects process substitution and other bashisms at parse time — and because the tool is *named* `bash`, models write bash: the issue measured 37 of 43 `<(...)` commands failing (86%) over a week of transcripts. Closes #629.

**C1 — standard/pre-authorized.** Bug fix in one tool plus one new config key; no contract change for callers, no dependency or schema migration, no version bump (releases are owned per window).

- `execute_bash` resolves its interpreter **per call** through a pure helper, `resolve_bash_shell(configured)`: the configured `bash.shell` when set and non-blank → `shutil.which("bash")` (Homebrew bash 5 when installed, else `/bin/bash` on macOS / `/usr/bin/bash` on Linux) → `/bin/sh` as the last resort so a host with no bash keeps working. Never `$SHELL`: the login shell is zsh on macOS and its word-splitting/globbing is a third dialect. The chosen shell is logged at debug.
- New **`bash.shell`** config key (`Kind.TEXT`, `empty_unsets`, default `""` = auto-resolve) in a new **`tools` / "Tools"** section of `/settings`, scope **LIVE** — `_configured_bash_shell` builds `ConfigManager(config_dir())` on every call exactly as `web_fetch/tool.py` does, so an edit lands on the very next command. Its own section rather than a row under Session/Runtime because scope is uniform within a section and this is about how a tool executes, not how sessions behave. `BASH_SHELL_PATH` / `BASH_SHELL_DEFAULT` live beside the reader and are pinned by `test_every_default_matches_its_consumer` and a new path-pin test (pinned by test, not import, so `settings_io` stays cheap for the CLI).
- Schema text tells the truth: `command` is "executed via `bash -c` (falls back to /bin/sh only when no bash exists), so bash syntax such as <(...), arrays and [[ ]] works"; the tool description reads "Run a bash command…". Kept short — schemas ride every call. No prompt template mentioned `/bin/sh` (grepped `prompts_md/`, `prompts_api.py`).
- The spawn site comments the why: the issue, the macOS POSIX-mode failure, why not `$SHELL`, and the fallback order.
- README documents the key under Configuration.

### Delivery contract

- A bash-idiomatic command (`comm -12 <(…) <(…)`, arrays, `[[ ]]`) run through the `bash` tool exits 0 with its output on a macOS host with any bash installed.
- `bash.shell` set to a path spawns that path with `-c <command>`; cleared, the tool auto-resolves again on the next call with no session rebuild.
- Existing bash behaviour (timeouts, abort/process-group kill, background jobs, non-interactive env, credential env injection, output budgets) is unchanged — only argv[0] moved.

**Non-goals:** consulting `$SHELL`; a per-call `shell` parameter on the tool (schema footprint); changing the `eval`/`group_reaper` `/bin/sh` uses, which are not model-facing.

## Testing Details

Worktree `/private/tmp/lop-629` on its own editable venv (`.venv/bin/python -c "import local_operator; print(local_operator.__file__)"` → `/private/tmp/lop-629/local_operator/__init__.py`).

Whole-tree gates, as CI: `flake8` exit 0 · `black==26.1.0 --check` 925 unchanged · `isort==5.13.2 --check` clean · `pyright` 0 errors/0 warnings.

```text
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
14280 passed, 17 skipped, 708 warnings in 544.28s (0:09:04)
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q   # every CMUX_* unset
29 passed, 2 warnings in 22.06s
```

New tests (`tests/unit/tools/test_builtin_tools.py`, `tests/unit/test_settings_io.py`, `tests/unit/session/test_config_live.py`): resolver order with `shutil.which` monkeypatched (configured wins, blank = unset, `which` fallback, `/bin/sh` last resort); the issue's own `comm -12 <(echo a) <(echo a)` through `execute_bash` asserting exit 0 and stdout `a` (skipped when no bash); `bash.shell` pointed at a marker script that echoes its argv, then cleared on disk and observed to stop applying on the next call; the LIVE-section cross-process probe for `bash.shell`; and the `settings_io` path ↔ `BASH_SHELL_PATH` pin with a nested `bash: {shell: …}` write read back by the consumer.

### End-to-end evidence

Full captures on the data-only branch [`evidence/629-bash-shell`](https://github.com/damianvtran/local-operator/tree/ab4b447147f3e6028fbac11361cb1ff75b633e63/docs/evidence/bash-shell-629).

**1. Reproduction on `origin/main`** — the shell itself, then `execute_bash` called from the main checkout's own venv (`~/local-operator/.venv/bin/python`, importing `~/local-operator/local_operator` at `0f2e02322`, an ancestor of `origin/main`; `builtin.py:1287` there still spawns `"/bin/sh"`), isolated `HOME`/config dir:

```text
$ /bin/sh -c 'comm -12 <(echo a) <(echo a)'; echo "exit $?"
/bin/sh: -c: line 0: syntax error near unexpected token `('
/bin/sh: -c: line 0: `comm -12 <(echo a) <(echo a)'
exit 2
$ /bin/bash -c 'comm -12 <(echo a) <(echo a)'; echo "exit $?"
a
exit 0
$ /bin/sh -c 'echo $BASH_VERSION'
3.2.57(1)-release

# execute_bash("comm -12 <(echo a) <(echo a)") on main
tree: /Users/damian/local-operator/local_operator
is_error: False
exit code: 2
--- stdout ---
(empty)
--- stderr ---
/bin/sh: -c: line 0: syntax error near unexpected token `('
/bin/sh: -c: line 0: `comm -12 <(echo a) <(echo a)'
```

**2. Same call on the branch:**

```text
tree: /private/tmp/lop-629/local_operator
is_error: False
exit code: 0
--- stdout ---
a
--- stderr ---
(empty)

# execute_bash('arr=(x y z); [[ ${#arr[@]} -eq 3 ]] && echo "arrays+[[ ]] ok: ${arr[*]}"; echo "BASH_VERSION=$BASH_VERSION"')
exit code: 0
--- stdout ---
arrays+[[ ]] ok: x y z
BASH_VERSION=5.3.9(1)-release
```

**3. Configured override**, via the real CLI in an isolated config dir (`env HOME=/tmp/…/iso-override LOCAL_OPERATOR_CONFIG_DIR=…/.local-operator`, never the operator's config):

```text
$ lop config edit bash.shell /bin/sh
Successfully updated bash.shell to /bin/sh
$ grep -A1 "^  bash:" config.yml
  bash:
    shell: /bin/sh
# execute_bash("comm -12 <(echo a) <(echo a)")  → the override is honoured: POSIX-mode failure again
exit code: 2
--- stderr ---
/bin/sh: -c: line 0: syntax error near unexpected token `('

$ lop config edit bash.shell /bin/bash
# execute_bash('echo "BASH_VERSION=$BASH_VERSION"; comm -12 <(echo a) <(echo a)')  → system bash, not Homebrew
exit code: 0
--- stdout ---
BASH_VERSION=3.2.57(1)-release
a

$ lop config edit bash.shell ""            # unset → auto-resolve on the very next call
BASH_VERSION=5.3.9(1)-release
$ lop config list | grep -A1 bash.shell
│ bash.shell:
│   Description: Path the bash tool runs commands with. Empty: bash on PATH, else /bin/sh.
```

(The `config migration: session.reap_unused` warning that appeared once during this run is the pre-existing #645 first-touch migration on a fresh config file, unrelated to this change.)

**4. Assembled app:** `tests/e2e -m e2e -n0` — 29 passed (includes `test_viewer_attach_e2e`, which runs a real `execute_bash` in the assembled app).

**5. `/settings` before/after** — real `OperatorApp` with the stylesheet, 110×36, headless pilot with every `CMUX_*` unset and an isolated `HOME`; cursor paged to the last section before "Local servers". Geometry identical in both frames: `virtual_size == size == (108, 34)`, `show_vertical_scrollbar == False`, so the new section adds no scroll or width loss.

| Before (`origin/main`) | After |
| --- | --- |
| ![settings before](https://raw.githubusercontent.com/damianvtran/local-operator/ab4b447147f3e6028fbac11361cb1ff75b633e63/docs/evidence/bash-shell-629/settings-before.png) | ![settings after](https://raw.githubusercontent.com/damianvtran/local-operator/ab4b447147f3e6028fbac11361cb1ff75b633e63/docs/evidence/bash-shell-629/settings-after.png) |

## Rollout / rollback

No migration, no dependency change, no version bump. Behavioural delta is argv[0] of the bash tool's child process; any host that has no `bash` on PATH behaves exactly as before (`/bin/sh`). Rollback is a revert of the single commit; a `bash.shell` key left in `config.yml` by a user is ignored by the previous code (unknown nested keys are preserved and unread).
