### PR TITLE
fix(tools): advertise only configured effort tiers in task/agent schemas

### DIFF
--- a/local_operator/guides/agents/GUIDE.md
+++ b/local_operator/guides/agents/GUIDE.md
@@ -41,7 +41,7 @@ A registered profile is not automatically a live peer in the current process. In
 
 Use the `task` tool when the current job contains an independent, well-bounded slice that can run concurrently or needs isolated context. A task subagent:
 
-- inherits the parent model unless overridden, working directory, approval gate, and compaction budget
+- inherits the parent model and reasoning effort (unless `effort` names a tier the operator configured under `subagents.models` — the `task` schema lists only those), working directory, approval gate, and compaction budget
 - receives only the prompt passed to `task`; include every requirement and expected output
 - reports through the parent session's jobs/events
 - is one level deep and cannot spawn grandchildren

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -166,23 +166,63 @@ class SubagentModelUnavailable(RuntimeError):
         self.reason = reason
 
 
-#: The tier names the ``/settings`` registry knows, in the order they are
-#: presented. Tiers are NOT limited to these — ``values.subagents.models`` is a
-#: free mapping and a hand-edited key is honoured like any other — this only
-#: fixes the presentation order so the schema stays byte-stable (it rides in
-#: the prompt-cache prefix) rather than following YAML key order.
+#: The tier names the harness supports, in the order they are presented.
+#:
+#: This is the WHOLE set, not merely a presentation order over a free mapping:
+#: :func:`read_effort_tier_selectors` drops every other key in
+#: ``values.subagents.models``, so a hand-added ``xl:`` is inert everywhere
+#: (schema, tool-argument validation, launch) rather than honoured by some
+#: consumers and not others.
+#:
+#: Narrowing to the registry set is what keeps ADVERTISED == REBUILDABLE.
+#: These are the only keys ``lop config edit`` and the ``/settings`` page can
+#: write (``settings_io`` accepts registered keys only), and — the reason this
+#: is a correctness boundary rather than a preference — the only ones the
+#: config watcher's per-registry-key diff can report. A tier outside the set
+#: would be read and advertised, but editing it produces no ``changed_keys``
+#: entry, so ``Session._rebuild_effort_tier_tools`` never fires: the schema
+#: would promise a tier whose edits the live re-render could not reach until
+#: the next session. Widening this tuple therefore means registering the key
+#: in ``settings_io.SETTINGS`` in the same change, which is what makes the
+#: watcher see it.
+#:
+#: The order is load-bearing too: the schema rides in the prompt-cache prefix,
+#: so it follows this tuple rather than YAML key order, and a reordering edit
+#: to ``config.yml`` cannot move the enum.
 CANONICAL_EFFORT_TIERS: tuple[str, ...] = ("lo", "med", "hi")
 
 
 def read_effort_tier_selectors() -> dict[str, Any]:
-    """The raw ``values.subagents.models`` mapping, exactly as configured.
+    """``values.subagents.models``, narrowed to the tiers the harness supports.
 
     The one place the tier mapping is read from ``config.yml``, shared by the
-    strict launch path (``Session._resolve_subagent_model``) and the tool
-    schemas (:func:`configured_effort_tiers`), so the two can never disagree
-    about what is configured. Raw and unfiltered on purpose: the launch path
-    turns a malformed selector into a *named* refusal ("lacks
-    provider/model"), which it cannot do if the read has already dropped it.
+    strict launch path (``Session._resolve_subagent_model``), the tool-argument
+    refusal (:func:`effort_tier_rejection`) and the tool schemas
+    (:func:`configured_effort_tiers`), so no two of them can disagree about
+    what is configured.
+
+    The narrowing to :data:`CANONICAL_EFFORT_TIERS` happens HERE rather than
+    in each consumer, because a key filtered in only one of them is exactly
+    the drift this shared reader exists to prevent: a hand-added ``xl`` left
+    visible to the launch path but hidden from the schema would be
+    unadvertised yet launchable through a role pin, and would draw the
+    "lacks provider/model" refusal (which is false — the selector is
+    well-formed) instead of the accurate "not configured". One filter, one
+    key set, one story. See :data:`CANONICAL_EFFORT_TIERS` for why the
+    registry set is the honest boundary.
+
+    That membership test also disposes of keys YAML silently coerced away
+    from ``str`` (``1:``, ``on:``, ``yes:`` parse as int/bool): they match no
+    canonical name, so they never reach a ``sorted()`` or an enum. Stringifying
+    them instead would advertise an ``effort='1'`` no operator ever typed.
+
+    Selector VALUES are stripped here and nowhere else: ``lop config edit``
+    preserves surrounding whitespace verbatim, and two consumers stripping
+    (or not) independently is how a padded ``'  openai/gpt-5-mini  '`` got
+    advertised, passed the strict launch check, and then failed on the first
+    provider call with ``provider='  openai'`` instead of at launch. A
+    non-string value is passed through raw so the launch path can still turn
+    it into a *named* refusal, which it cannot do if the read dropped it.
 
     Raises whatever the config read raises; callers decide whether that is a
     reason (launch) or nothing (schema).
@@ -191,7 +231,13 @@ def read_effort_tier_selectors() -> dict[str, Any]:
 
     raw = ConfigManager(config_dir()).get_config_value("subagents", None)
     models = raw.get("models") if isinstance(raw, dict) else None
-    return dict(models) if isinstance(models, dict) else {}
+    if not isinstance(models, dict):
+        return {}
+    return {
+        tier: selector.strip() if isinstance(selector, str) else selector
+        for tier, selector in models.items()
+        if tier in CANONICAL_EFFORT_TIERS
+    }
 
 
 def configured_effort_tiers() -> dict[str, str]:
@@ -216,18 +262,26 @@ def configured_effort_tiers() -> dict[str, str]:
         selectors = read_effort_tier_selectors()
     except Exception:  # noqa: BLE001 — schema construction must never fail a turn
         return {}
+    # Iterating CANONICAL_EFFORT_TIERS rather than the config's own keys is
+    # what makes this function's "never raises" contract hold. The previous
+    # shape sorted the non-canonical leftovers, and that ``sorted()`` sat
+    # OUTSIDE the ``try``: one YAML-coerced ``1:`` key beside a ``hi:`` was a
+    # ``TypeError`` through ``create_tools`` (the session could not boot) and
+    # through ``TaskParams(effort=...)`` as a non-ValidationError. There is no
+    # ordering decision left to make here — the canonical tuple IS the order,
+    # which also keeps the schema byte-stable in the prompt-cache prefix.
+    ordered = [tier for tier in CANONICAL_EFFORT_TIERS if selectors.get(tier)]
     tiers: dict[str, str] = {}
-    ordered = [t for t in CANONICAL_EFFORT_TIERS if t in selectors] + sorted(
-        t for t in selectors if t not in CANONICAL_EFFORT_TIERS
-    )
     for tier in ordered:
-        selector = selectors.get(tier)
-        if not isinstance(selector, str) or not selector.strip():
+        selector = selectors[tier]
+        if not isinstance(selector, str):
+            # A non-string VALUE is kept by the read so the launch path can
+            # name it; it is simply not a tier the schema may advertise.
             continue
-        provider, _, model_id = selector.strip().partition("/")
+        provider, _, model_id = selector.partition("/")
         if not provider or not model_id:
             continue
-        tiers[str(tier)] = selector.strip()
+        tiers[tier] = selector
     return tiers
 
 
@@ -1301,10 +1355,26 @@ def _child_mcp_wiring(parent_session: "Session", *, restricted: bool = False) ->
     # may inherit its parent's discovered set but cannot expand it.
     deferred: set[tuple[str, str]] = set(getattr(parent_session, "_mcp_deferred_origins", ()))
     child: Session | None = None
-    base: list[AgentTool] = []
 
     def selected(source: list[AgentTool]) -> list[AgentTool]:
         return [tool for tool in source if origin(tool) in enabled]
+
+    def base() -> list[AgentTool]:
+        # Derived from the LIVE inventory on every activation rather than
+        # snapshotted at ``attach``: the config watcher swaps fresh
+        # ``task``/``agent`` objects into a child mid-run when the effort
+        # tiers change, and a frozen base would silently reinstate the
+        # pre-rebuild objects (with the stale ``effort`` enum) the first time
+        # the child activated an MCP tool. A live tool whose metadata has
+        # been dropped from the manager (``origin`` can no longer answer for
+        # it) keeps its earlier classification from being rewritten to base
+        # here: the cost of a transient misclassification — it stays visible
+        # until the next activation — beats disappearing a tool the child
+        # was already using, and the top-level path accepts the same
+        # trade-off with its ``installed_mcp`` name set.
+        if child is None:
+            return []
+        return [tool for tool in child._tools if origin(tool) is None]
 
     def activate(server_name: str, raw_tool_name: str) -> None:
         # Unreachable for a restricted child: its resolver is built with
@@ -1313,18 +1383,14 @@ def _child_mcp_wiring(parent_session: "Session", *, restricted: bool = False) ->
         # allow-check that could drift from the resolver's.
         enabled.add((server_name, raw_tool_name))
         if child is not None:
-            child.refresh_tools(base + selected(manager.get_tools()))
+            child.refresh_tools(base() + selected(manager.get_tools()))
 
     def defer(server_name: str, raw_tool_name: str) -> None:
         deferred.add((server_name, raw_tool_name))
 
     def attach(session: "Session") -> None:
-        nonlocal child, base
+        nonlocal child
         child = session
-        # The non-MCP base is DERIVED, not remembered: Session.__init__ merges
-        # its own capability tools in and this module prunes some back out, so
-        # the constructor's list is not what the session ended up with.
-        base = [tool for tool in session._tools if origin(tool) is None]
         prior = session._fallback_tool_resolver
 
         def resolve_deferred(name: str) -> AgentTool | None:

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -166,6 +166,124 @@ class SubagentModelUnavailable(RuntimeError):
         self.reason = reason
 
 
+#: The tier names the ``/settings`` registry knows, in the order they are
+#: presented. Tiers are NOT limited to these — ``values.subagents.models`` is a
+#: free mapping and a hand-edited key is honoured like any other — this only
+#: fixes the presentation order so the schema stays byte-stable (it rides in
+#: the prompt-cache prefix) rather than following YAML key order.
+CANONICAL_EFFORT_TIERS: tuple[str, ...] = ("lo", "med", "hi")
+
+
+def read_effort_tier_selectors() -> dict[str, Any]:
+    """The raw ``values.subagents.models`` mapping, exactly as configured.
+
+    The one place the tier mapping is read from ``config.yml``, shared by the
+    strict launch path (``Session._resolve_subagent_model``) and the tool
+    schemas (:func:`configured_effort_tiers`), so the two can never disagree
+    about what is configured. Raw and unfiltered on purpose: the launch path
+    turns a malformed selector into a *named* refusal ("lacks
+    provider/model"), which it cannot do if the read has already dropped it.
+
+    Raises whatever the config read raises; callers decide whether that is a
+    reason (launch) or nothing (schema).
+    """
+    from local_operator.config import ConfigManager
+
+    raw = ConfigManager(config_dir()).get_config_value("subagents", None)
+    models = raw.get("models") if isinstance(raw, dict) else None
+    return dict(models) if isinstance(models, dict) else {}
+
+
+def configured_effort_tiers() -> dict[str, str]:
+    """``{tier: "provider/model"}`` for every tier a launch could honour.
+
+    What the ``task`` and ``agent`` tool schemas advertise. Only a tier whose
+    selector is a non-empty ``provider/model`` string is included, because
+    those are exactly the tiers the strict launch path
+    (:class:`SubagentModelUnavailable`) accepts: the incident behind this was
+    the schema hard-coding ``lo|med|hi`` while the operator had configured
+    NONE, so the delegating model read the enum, picked ``hi``, and the launch
+    refused it — the tool's own schema was steering the model into a
+    guaranteed failure, and nothing told it that omitting ``effort`` was the
+    only working choice.
+
+    Never raises. A config that cannot be read reports no tiers: this runs
+    while the tool inventory is being built, and a corrupt ``config.yml`` must
+    cost the operator a tier picker, not a session. The launch path reads the
+    file again on its own terms and still names the read error there.
+    """
+    try:
+        selectors = read_effort_tier_selectors()
+    except Exception:  # noqa: BLE001 — schema construction must never fail a turn
+        return {}
+    tiers: dict[str, str] = {}
+    ordered = [t for t in CANONICAL_EFFORT_TIERS if t in selectors] + sorted(
+        t for t in selectors if t not in CANONICAL_EFFORT_TIERS
+    )
+    for tier in ordered:
+        selector = selectors.get(tier)
+        if not isinstance(selector, str) or not selector.strip():
+            continue
+        provider, _, model_id = selector.strip().partition("/")
+        if not provider or not model_id:
+            continue
+        tiers[str(tier)] = selector.strip()
+    return tiers
+
+
+def effort_tier_rejection(tier: str) -> str | None:
+    """Why ``tier`` cannot be asked for right now, or ``None`` when it can.
+
+    The tool-argument counterpart of the strict launch check: the ``task``
+    and ``agent`` tools validate ``effort`` against the LIVE config with this
+    (``subagents.models.*`` is a live setting, read at every spawn), so a tier
+    that is not usable is refused with a message that names what IS — before
+    a job row, a role pin, or a launch attempt exists. The launch path keeps
+    its own refusal for the case this cannot see: a pin recorded while the
+    tier existed and read after the operator removed it.
+
+    Always tells the model the working alternative. The failure this guards
+    against was a model that could see tiers and not the fact that omitting
+    the field was the only choice that worked.
+    """
+    tiers = configured_effort_tiers()
+    if tier in tiers:
+        return None
+    inherit = "omit 'effort' to inherit this session's model and reasoning effort"
+    if not tiers:
+        return (
+            f"effort tier {tier!r} is unavailable: no tiers are configured under "
+            f"values.subagents.models; {inherit}"
+        )
+    try:
+        raw = read_effort_tier_selectors().get(tier)
+    except Exception:  # noqa: BLE001 — the tier list above already survived the read
+        raw = None
+    # Same wording as the launch path's refusal for a selector that is present
+    # but unusable, so an operator who set ``lo: gpt-5`` (no provider) learns
+    # that the KEY is there and the VALUE is wrong, not that it is missing.
+    why = (
+        f"subagents.models.{tier}={raw!r} lacks provider/model"
+        if raw not in (None, "")
+        else f"not configured at subagents.models.{tier}"
+    )
+    return (
+        f"effort tier {tier!r} is unavailable: {why} "
+        f"(configured: {describe_effort_tiers(tiers)}); pick one of those or {inherit}"
+    )
+
+
+def describe_effort_tiers(tiers: dict[str, str]) -> str:
+    """One short clause naming what each tier resolves to, for a schema
+    description: ``lo → openai/gpt-5-mini, hi → anthropic/claude-opus-5``.
+
+    The model chooses on this, so it must carry the MODEL and not just the
+    label — "hi" says nothing about cost, family, or capability — while
+    staying short, because a schema description is billed on every turn.
+    """
+    return ", ".join(f"{tier} → {selector}" for tier, selector in tiers.items())
+
+
 if TYPE_CHECKING:
     from local_operator.agent_profiles import AgentProfile
     from local_operator.harness.comms import SubagentComms

--- a/local_operator/prompts_md/system.md
+++ b/local_operator/prompts_md/system.md
@@ -136,7 +136,8 @@ the `agent` tool): it carries vetted guidance and may restrict tools, so your
 prompt states the TASK and the role supplies how that work is done well. Use
 `agent="reviewer"` instead of hand-writing review instructions, and when a
 role's guidance proves wrong, fix it with the `agent` tool rather than
-patching one prompt. `effort` picks a configured model tier.
+patching one prompt. Omit `effort` to inherit your model and reasoning
+effort; set it only to a tier the tool's schema actually lists.
 `jobs` lists what is running and `wait` blocks for a result — it returns the
 moment work settles, so size ONE `wait_ms` to the whole job as the tool's
 description spells out (up to 60 minutes; an expired wait means check on the

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -6128,7 +6128,14 @@ class Session:
         if not selector:
             return _unavailable(f"no model configured at subagents.models.{wanted}", quiet=True)
         provider, _, model_id = selector.partition("/")
-        if not model_id:
+        # BOTH halves, to the same standard ``configured_effort_tiers`` applies
+        # (review R3-F11). Checking only the model let a leading-slash selector
+        # (``hi: "/kimi"``) through here while the schema surface refused it —
+        # the same schema-vs-launch drift this change exists to close, and the
+        # worse direction of it: the launch built ``ModelSpec(provider='',
+        # model_id='kimi')`` and the child died at its first provider call
+        # instead of at launch, where the tier is still named.
+        if not provider or not model_id:
             return _unavailable(f"subagents.models.{wanted}={selector!r} lacks provider/model")
         try:
             from local_operator.model.configure import build_model_spec

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -6103,14 +6103,20 @@ class Session:
         try:
             # The same read the tool schemas use (``configured_effort_tiers``),
             # so a tier the schema advertises is one this path resolves and
-            # vice versa. Raw on purpose: a malformed selector must reach the
-            # named refusal below, not vanish into "not configured".
+            # vice versa. Unstripped-but-not on purpose: the shared reader
+            # strips selectors once, so the tier it advertises cannot pass
+            # this check and then die on a whitespace-padded provider name at
+            # the first provider call. Malformed selectors are still kept by
+            # the read: they must reach the named refusal below, not vanish
+            # into "not configured".
             selector = read_effort_tier_selectors().get(wanted)
         except Exception as exc:  # noqa: BLE001 — a config read error is a reason, not a crash
             return _unavailable(f"config could not be read ({exc})")
         if not selector:
             return _unavailable(f"no model configured at subagents.models.{wanted}", quiet=True)
-        provider, _, model_id = str(selector).partition("/")
+        if not isinstance(selector, str):
+            return _unavailable(f"subagents.models.{wanted}={selector!r} lacks provider/model")
+        provider, _, model_id = selector.partition("/")
         if not model_id:
             return _unavailable(f"subagents.models.{wanted}={selector!r} lacks provider/model")
         try:

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -70,7 +70,11 @@ from local_operator.harness.jobs import (
     AsyncJobManager,
 )
 from local_operator.harness.loop import AgentLoop, LoopContext, _materialize_asides
-from local_operator.harness.subagent import SubagentModelUnavailable, run_subagent
+from local_operator.harness.subagent import (
+    SubagentModelUnavailable,
+    read_effort_tier_selectors,
+    run_subagent,
+)
 from local_operator.harness.types import (
     AbortSignal,
     AgentEndEvent,
@@ -6097,12 +6101,11 @@ class Session:
             return None
 
         try:
-            from local_operator.config import ConfigManager
-            from local_operator.paths import config_dir
-
-            raw = ConfigManager(config_dir()).get_config_value("subagents", None)
-            models = raw.get("models", {}) if isinstance(raw, dict) else {}
-            selector = models.get(wanted)
+            # The same read the tool schemas use (``configured_effort_tiers``),
+            # so a tier the schema advertises is one this path resolves and
+            # vice versa. Raw on purpose: a malformed selector must reach the
+            # named refusal below, not vanish into "not configured".
+            selector = read_effort_tier_selectors().get(wanted)
         except Exception as exc:  # noqa: BLE001 — a config read error is a reason, not a crash
             return _unavailable(f"config could not be read ({exc})")
         if not selector:
@@ -10066,9 +10069,16 @@ class Session:
           value restores the manager's built-in default rather than freezing
           the last explicit one, so "reset to default" on the page means it.
 
+        * ``subagents.models.*`` — the launch path reads these per spawn, but
+          the ``task``/``agent`` tool SCHEMAS bake the configured tiers in at
+          build time (the enum the model picks from, and the description
+          naming what each tier resolves to). Rebuilt here so an operator who
+          configures a tier mid-session gets a tool that offers it, and one
+          who removes a tier gets a tool that stops offering it.
+
         Everything else the registry calls LIVE is already read per use
-        (``fork.*``, ``web_*`` knobs, ``subagents.models.*``) and needs no
-        apply here. Everything it calls NEW_SESSIONS is deliberately ignored.
+        (``fork.*``, ``web_*`` knobs) and needs no apply here. Everything it
+        calls NEW_SESSIONS is deliberately ignored.
 
         Guards on ``_disposed`` because the unsubscribe runs as a dispose
         HOOK, after the session's own teardown, and a tick can land between.
@@ -10134,6 +10144,38 @@ class Session:
                 self.jobs.set_max_running(cap)
             except ValueError:
                 logger.warning("subagents.max_running=%r rejected by the job manager", cap)
+        if any(key.startswith("subagents.models.") for key in changed):
+            self._rebuild_effort_tier_tools()
+
+    def _rebuild_effort_tier_tools(self) -> None:
+        """Re-render the tools whose schema advertises the configured effort tiers.
+
+        Only ``task`` and ``agent`` carry the field, and only tools ALREADY in
+        the inventory are replaced: a child whose ``task`` was pruned because
+        its role may not delegate must not get it back because the operator
+        edited a model tier, which is why this does not go through
+        :meth:`_merge_capability_tools` (that one appends). Replacement is
+        in place so the provider-visible tool order — part of the prompt-cache
+        prefix — is unchanged; the schema text itself changing is the point.
+        Never raises: a tool rebuild failing must not take the config watcher
+        or the turn with it.
+        """
+        present = {tool.name for tool in self._tools} & {"task", "agent"}
+        if not present:
+            return
+        try:
+            from local_operator.tools.registry import create_tools
+
+            rebuilt = {
+                tool.name: tool
+                for tool in create_tools(self._build_tool_context(), enabled=sorted(present))
+            }
+        except Exception:  # noqa: BLE001 — a schema refresh must never break a live session
+            logger.warning("could not rebuild effort-tier tool schemas", exc_info=True)
+            return
+        if not rebuilt:
+            return
+        self.refresh_tools([rebuilt.get(tool.name, tool) for tool in self._tools])
 
     def add_dispose_hook(self, hook: Callable[[], Awaitable[None] | None]) -> None:
         """Register teardown that runs after the session's own dispose.

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -6112,10 +6112,21 @@ class Session:
             selector = read_effort_tier_selectors().get(wanted)
         except Exception as exc:  # noqa: BLE001 — a config read error is a reason, not a crash
             return _unavailable(f"config could not be read ({exc})")
+        # Type before falsiness, and the ``is not None`` is what makes the two
+        # surfaces agree (review R2-F7). A FALSY non-string (``lo: 0``,
+        # ``lo: []``) is a key the operator DID write, so it must draw the same
+        # "lacks provider/model" refusal that ``effort_tier_rejection`` gives
+        # it — under the old order it fell into the quiet "not configured"
+        # branch and the tool-argument path called the same key malformed,
+        # which is the schema-vs-launch drift this change exists to close,
+        # merely moved into the message text. Only a genuinely absent key
+        # (``None``) or an empty/whitespace-only string (the shared reader
+        # strips) stays quiet: a session with no ``subagents.models`` at all
+        # names itself on the parent model by design and must not warn.
+        if selector is not None and not isinstance(selector, str):
+            return _unavailable(f"subagents.models.{wanted}={selector!r} lacks provider/model")
         if not selector:
             return _unavailable(f"no model configured at subagents.models.{wanted}", quiet=True)
-        if not isinstance(selector, str):
-            return _unavailable(f"subagents.models.{wanted}={selector!r} lacks provider/model")
         provider, _, model_id = selector.partition("/")
         if not model_id:
             return _unavailable(f"subagents.models.{wanted}={selector!r} lacks provider/model")

--- a/local_operator/tools/agent_tool.py
+++ b/local_operator/tools/agent_tool.py
@@ -73,6 +73,10 @@ from local_operator.agent_profiles import (
     seed_origin,
     seed_tags,
 )
+from local_operator.harness.subagent import (
+    configured_effort_tiers,
+    describe_effort_tiers,
+)
 from local_operator.harness.types import (
     AbortSignal,
     AgentTool,
@@ -81,9 +85,11 @@ from local_operator.harness.types import (
     ToolResult,
 )
 from local_operator.tools.builtin import (
+    _advertise_effort_tiers,
     _error,
     _guard,
     _text,
+    _validate_effort_tier,
     _validation_error,
     spill_truncate,
 )
@@ -136,7 +142,12 @@ class AgentParams(BaseModel):
         default=None,
         description="create/update: restrict the profile to these tools. Omit for all.",
     )
-    effort: Literal["lo", "med", "hi", "inherit"] | None = Field(
+    # A free string rather than a Literal for the same reason as the ``task``
+    # tool's field: a role can only be pinned to a tier the operator has
+    # configured, and that set is live config, not something to freeze at
+    # import. ``_advertise_effort_tiers`` rewrites the schema to ``inherit``
+    # plus the configured tiers; ``_effort_is_configured`` refuses the rest.
+    effort: str | None = Field(
         default=None,
         description="create/update: default model tier. 'inherit' clears it.",
     )
@@ -148,11 +159,25 @@ class AgentParams(BaseModel):
 
         Empty enum strings are rejected by Gemini function declarations. Older
         callers may still send ``""`` to clear a pin, so normalize that legacy
-        wire value before the closed Literal validates while exposing the
+        wire value before the tier check validates while exposing the
         explicit ``inherit`` spelling to models and providers.
         """
 
         return "inherit" if value == "" else value
+
+    @field_validator("effort")
+    @classmethod
+    def _effort_is_configured(cls, value: str | None) -> str | None:
+        """A pin must name a tier a launch could honour TODAY.
+
+        Before this, any of ``lo|med|hi`` was accepted and stored, and the pin
+        then failed at every launch of the role once the strict path refused
+        the unconfigured tier. Refusing here keeps a stale pin from ever being
+        written; the launch path still catches one that went stale later.
+        """
+        if value == "inherit":
+            return value
+        return _validate_effort_tier(value)
 
     delegate: bool | None = Field(
         default=None,
@@ -1178,6 +1203,25 @@ async def execute_agent(
     return await _op_write(context, tool_call_id, params, creating=params.op == "create")
 
 
+def _effort_pin_description() -> str:
+    """The ``effort`` description for create/update, matching the live schema.
+
+    With tiers configured it names what each resolves to so a role is pinned
+    on information; with none it says so and that ``inherit`` (the only
+    member left in the enum) is the whole choice. Short: billed every turn.
+    """
+    tiers = configured_effort_tiers()
+    if not tiers:
+        return (
+            "create/update: no model tiers are configured (values.subagents.models); "
+            "'inherit' clears a pin and every role inherits the launching session's model."
+        )
+    return (
+        f"create/update: default model tier ({describe_effort_tiers(tiers)}). "
+        "'inherit' clears it."
+    )
+
+
 def build_agent_tool(context: ToolContext) -> AgentTool | None:
     """createIf: the tool exists only where a registry can back it.
 
@@ -1200,7 +1244,11 @@ def build_agent_tool(context: ToolContext) -> AgentTool | None:
             "specialist is the reusable base a team layers collaboration and "
             "project briefs on top of."
         ),
-        parameters=AgentParams.model_json_schema(),
+        parameters=_advertise_effort_tiers(
+            AgentParams.model_json_schema(),
+            description=_effort_pin_description(),
+            extra=("inherit",),
+        ),
         # Writes land in the user's own configuration directory, never in the
         # workspace, and are trivially reversible by editing the profile back.
         # Gating them behind an approval prompt would make an agent improving

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -74,6 +74,11 @@ from pydantic import (
 from rich.cells import cell_len
 
 from local_operator.harness.approval import ask_approval
+from local_operator.harness.subagent import (
+    configured_effort_tiers,
+    describe_effort_tiers,
+    effort_tier_rejection,
+)
 from local_operator.harness.types import (
     AbortSignal,
     AgentTool,
@@ -7683,12 +7688,142 @@ def build_browser_tool(context: ToolContext | None) -> AgentTool | None:
 # never advertise tools that can only error.
 
 
+def _validate_effort_tier(value: str | None) -> str | None:
+    """Refuse an ``effort`` the live config cannot honour, naming what can be.
+
+    Shared by both ``task`` forms and the ``agent`` tool so the three fields
+    cannot drift. Validation reads the config at CALL time while the schema
+    was rendered at BUILD time (see :func:`_advertise_effort_tiers`); the two
+    agree except across a mid-session edit, and this is the side that must be
+    right — an accepted-but-stale tier would reach the strict launch path and
+    fail there with less context than the message here carries.
+    """
+    if value is None:
+        return None
+    rejection = effort_tier_rejection(value)
+    if rejection is not None:
+        raise ValueError(rejection)
+    return value
+
+
+def _advertise_effort_tiers(
+    schema: dict[str, Any], *, description: str, extra: tuple[str, ...] = ()
+) -> dict[str, Any]:
+    """Rewrite every ``effort`` property in ``schema`` to the CONFIGURED tiers.
+
+    The params models declare ``effort`` as a free string so validation can
+    consult the live config; the schema the model reads is patched here at
+    tool-build time. Before this, ``effort`` was a hard-coded
+    ``Literal["lo", "med", "hi"]`` regardless of what the operator had set
+    under ``values.subagents.models``. Observed live with NO tier configured:
+    the delegating model read the enum, chose ``effort="hi"``, and the strict
+    launch path (correctly) refused it — every value the schema offered was a
+    guaranteed failure, and the schema never said that omitting the field was
+    the one choice that worked.
+
+    With tiers configured, the enum lists exactly those and the description
+    names the ``provider/model`` each resolves to, so the model chooses on
+    information rather than a label. With none configured the property is
+    REMOVED rather than advertised as empty: Gemini function declarations
+    reject ``enum: []``, an always-invalid field is pure schema cost on every
+    turn, and a model that cannot see the field cannot pick it. Validation
+    still refuses a stray ``effort`` with the same guidance (see
+    :func:`_validate_effort_tier`). ``extra`` members (the ``agent`` tool's
+    ``inherit`` sentinel) follow the configured tiers and keep the property
+    alive on their own.
+
+    Patches both the top-level property and every ``$defs`` entry, so the
+    batch form's ``TaskItem`` mirror gets the same treatment as the single
+    form. Tools are built once at session construction; a config edit is
+    picked up by ``Session._apply_config_change``, which rebuilds the two
+    tools that carry this field.
+    """
+    tiers = configured_effort_tiers()
+    members = [*tiers, *extra]
+
+    def patch(properties: Any) -> None:
+        if not isinstance(properties, dict) or "effort" not in properties:
+            return
+        if not members:
+            del properties["effort"]
+            return
+        # The same ``anyOf [enum, null]`` shape pydantic renders for
+        # ``Literal[...] | None``, so providers see a field of the shape they
+        # always did — only the members and the description change.
+        properties["effort"] = {
+            "anyOf": [{"type": "string", "enum": members}, {"type": "null"}],
+            "default": None,
+            "description": description,
+            "title": "Effort",
+        }
+
+    patched = dict(schema)
+    patched["properties"] = dict(patched.get("properties") or {})
+    patch(patched["properties"])
+    defs = patched.get("$defs")
+    if isinstance(defs, dict):
+        patched["$defs"] = {
+            name: (
+                {**entry, "properties": dict(entry.get("properties") or {})}
+                if isinstance(entry, dict)
+                else entry
+            )
+            for name, entry in defs.items()
+        }
+        for entry in patched["$defs"].values():
+            if isinstance(entry, dict):
+                patch(entry.get("properties"))
+    return patched
+
+
+def _effort_tier_field_description() -> str:
+    """The ``task`` ``effort`` description, built from the configured tiers.
+
+    Only ever rendered when at least one tier exists (with none the property
+    is dropped), so it can lead with the tier list. Short on purpose: it is
+    billed on every turn of every session that can delegate.
+    """
+    tiers = configured_effort_tiers()
+    return (
+        f"Model tier for this subagent ({describe_effort_tiers(tiers)}). "
+        "Omit to inherit this session's model and reasoning effort."
+    )
+
+
+def _task_tool_description() -> str:
+    """The ``task`` tool description, with the effort sentence matching the schema.
+
+    A model told "effort picks a configured model tier" while no tier is
+    configured infers that some tier must be pickable; the sentence has to
+    say which state it is in. One sentence either way — prompt text is paid on
+    every turn.
+    """
+    tiers = configured_effort_tiers()
+    if tiers:
+        effort = (
+            "Omit 'effort' to inherit this session's model and reasoning effort, "
+            "or set it to one of the configured tiers the schema lists."
+        )
+    else:
+        effort = (
+            "No effort tiers are configured (values.subagents.models), so every "
+            "child inherits this session's model and reasoning effort; do not pass "
+            "'effort'."
+        )
+    return (
+        "Launch background subagents — one, or a whole concurrent batch "
+        "('tasks' + shared 'context') in a single call. 'agent' names a "
+        "role carrying vetted guidance (reviewer, coder, architect, "
+        f"manager, designer, scout — see the `agent` tool). {effort}"
+    )
+
+
 class TaskItem(BaseModel):
     """One slice of a task batch. ``agent`` names the ROLE the child runs as —
     a registered profile or a packaged starter (reviewer, coder, architect,
     manager, designer, scout); the role supplies standing guidance and may
     restrict the child's tools. ``effort`` routes to a configured model tier
-    (values.subagents.models lo/med/hi)."""
+    (a key of values.subagents.models)."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -7708,10 +7843,20 @@ class TaskItem(BaseModel):
             "carries vetted guidance and may restrict tools."
         ),
     )
-    effort: Literal["lo", "med", "hi"] | None = Field(
+    # A free string, not a Literal: the valid set is whatever the operator has
+    # configured under ``values.subagents.models`` at CALL time, and a Literal
+    # would freeze one guess at import. The schema the model sees is rewritten
+    # to the configured tiers by ``_advertise_effort_tiers``; validation below
+    # is what refuses anything else.
+    effort: str | None = Field(
         default=None,
-        description="Model tier for this subagent (values.subagents.models).",
+        description="Model tier for this subagent (a configured values.subagents.models key).",
     )
+
+    @field_validator("effort")
+    @classmethod
+    def _effort_is_configured(cls, value: str | None) -> str | None:
+        return _validate_effort_tier(value)
 
 
 class TaskParams(BaseModel):
@@ -7735,10 +7880,16 @@ class TaskParams(BaseModel):
         default=None,
         description="Single-task form: role for the subagent (see 'tasks[].agent').",
     )
-    effort: Literal["lo", "med", "hi"] | None = Field(
+    effort: str | None = Field(
         default=None,
         description="Single-task form: model tier for the subagent.",
     )
+
+    @field_validator("effort")
+    @classmethod
+    def _effort_is_configured(cls, value: str | None) -> str | None:
+        return _validate_effort_tier(value)
+
     context: str = Field(
         default="",
         description=(
@@ -8087,14 +8238,11 @@ def build_task_tool(context: ToolContext) -> AgentTool | None:
         name="task",
         label="Subagent task",
         describe_approval=_describe_task_approval,
-        description=(
-            "Launch background subagents — one, or a whole concurrent batch "
-            "('tasks' + shared 'context') in a single call. 'agent' names a "
-            "role carrying vetted guidance (reviewer, coder, architect, "
-            "manager, designer, scout — see the `agent` tool); effort picks a "
-            "configured model tier."
+        description=_task_tool_description(),
+        parameters=_advertise_effort_tiers(
+            TaskParams.model_json_schema(),
+            description=_effort_tier_field_description(),
         ),
-        parameters=TaskParams.model_json_schema(),
         # Spawns autonomous child work, so it rides the write gate just like
         # scheduling a wake: the user approves starting the child.
         approval_tier="write",

--- a/tests/unit/providers/test_clients.py
+++ b/tests/unit/providers/test_clients.py
@@ -1021,6 +1021,22 @@ async def _ask_user(questions: list[Any]) -> dict[str, list[str]] | None:
     return None
 
 
+@pytest.fixture()
+def three_effort_tiers(tmp_path, monkeypatch) -> None:
+    """``lo``/``med``/``hi`` configured for the tests that audit the ``effort``
+    enum on the wire. The ``agent``/``task`` schemas advertise only CONFIGURED
+    tiers (an unconfigured one is a guaranteed launch failure), so with the
+    suite's isolated HOME the enum would otherwise be ``["inherit"]`` alone and
+    these tests would no longer prove that every tier survives the client."""
+    from local_operator.config import ConfigManager
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    ConfigManager(tmp_path / "config").set_config_value(
+        "subagents",
+        {"models": {"lo": "openai/gpt-5-mini", "med": "openai/gpt-5", "hi": "anthropic/opus"}},
+    )
+
+
 def _default_tools_with_agent() -> list[AgentTool]:
     """Build the genuinely COMPLETE inventory, not merely the ungated part.
 
@@ -1058,7 +1074,9 @@ def _default_tools_with_agent() -> list[AgentTool]:
     return tools
 
 
-async def test_openrouter_gemini_full_tool_bundle_has_no_empty_enum_member() -> None:
+async def test_openrouter_gemini_full_tool_bundle_has_no_empty_enum_member(
+    three_effort_tiers,
+) -> None:
     """Exercise the real OpenRouter client and complete registry-built bundle."""
 
     captured: dict[str, Any] = {}
@@ -1095,7 +1113,7 @@ async def test_openrouter_gemini_full_tool_bundle_has_no_empty_enum_member() -> 
     assert effort["anyOf"][0]["enum"] == ["lo", "med", "hi", "inherit"]
 
 
-def test_direct_google_full_tool_bundle_has_no_empty_enum_member() -> None:
+def test_direct_google_full_tool_bundle_has_no_empty_enum_member(three_effort_tiers) -> None:
     tools = _default_tools_with_agent()
     body = GoogleClient()._build_body(
         ChatRequest(
@@ -1116,7 +1134,9 @@ def test_direct_google_full_tool_bundle_has_no_empty_enum_member() -> None:
     ("provider", "model_id"),
     [("openai", "gpt-5.4"), ("openrouter", "qwen/qwen3-coder")],
 )
-def test_openai_compatible_models_keep_agent_effort_semantics(provider: str, model_id: str) -> None:
+def test_openai_compatible_models_keep_agent_effort_semantics(
+    three_effort_tiers, provider: str, model_id: str
+) -> None:
     """Ordinary OpenAI/Qwen routes receive every tier plus the clear sentinel."""
 
     tools = _default_tools_with_agent()

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -1075,6 +1075,45 @@ async def test_child_starts_with_the_tools_the_parent_already_activated(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_child_activation_keeps_the_rebuilt_effort_tier_tools(tmp_path, monkeypatch):
+    """F3: the child's MCP activation used to refresh from a base snapshotted
+    at ``attach`` — so a config-watcher effort-tier rebuild (which swaps in
+    fresh ``task``/``agent`` objects) was silently reverted the first time the
+    child activated an MCP tool. The base is now derived from the live
+    inventory on each activation."""
+    from local_operator.config import ConfigManager
+    from local_operator.config_watch import ConfigWatcher
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    manager = FakeMcpManager({"linear": ["list_teams"]})
+    parent = make_session(tmp_path, OneShotStream())
+    attach_manager(parent, manager)
+
+    child = await build_child(parent)
+    # What the process watcher does when a tier is configured mid-run: swap
+    # the ``task``/``agent`` objects in place with freshly rebuilt schemas.
+    child_watcher = ConfigWatcher(tmp_path / "config")
+    ConfigManager(tmp_path / "config").set_config_value(
+        "subagents", {"models": {"med": "anthropic/claude-sonnet-4-5"}}
+    )
+    change = child_watcher.poll_now()
+    assert change is not None
+    child._apply_config_change(change)
+    rebuilt = next(t for t in child._tools if t.name == "task")
+    assert rebuilt.parameters["properties"]["effort"]["anyOf"][0]["enum"] == ["med"]
+
+    # Activating an MCP tool must refresh AROUND the rebuilt tools, not
+    # reinstate the pre-rebuild objects the attach-time snapshot held.
+    # Driven through the same ``mcp://`` URL the model would read.
+    rendered = resolve(child, "mcp://linear/list_teams")
+    assert rendered is not None and "mcp__linear_list_teams" in rendered
+    assert next(t for t in child._tools if t.name == "task") is rebuilt
+    assert "mcp__linear_list_teams" in {t.name for t in child._tools}
+    await child.dispose()
+    await parent.dispose()
+
+
+@pytest.mark.asyncio
 async def test_child_activation_lands_on_the_child_not_the_parent(tmp_path, monkeypatch):
     """``read mcp://linear/list_issues`` inside a child must enable that schema
     on the CHILD. The parent's own resolver chain ends in an activate() bound to

--- a/tests/unit/session/test_pinned_subagent_model.py
+++ b/tests/unit/session/test_pinned_subagent_model.py
@@ -119,6 +119,39 @@ def test_strict_launch_fails_on_a_malformed_selector(tmp_path, monkeypatch):
     assert "lacks provider/model" in caught.value.reason
 
 
+def test_a_tier_outside_the_registry_set_never_launches(tmp_path, monkeypatch):
+    """The launch half of the reader's narrowing (review R1-F2). A hand-added
+    ``xl:`` is not advertised by the schema because the config watcher's
+    per-registry-key diff could never re-render it; leaving it launchable
+    through a role pin would make the schema and the launch path disagree in
+    exactly the direction this PR exists to close."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    write_tiers(tmp_path / "config", xl="openrouter/moonshotai/kimi-k3")
+    session = make_session(tmp_path)
+
+    with pytest.raises(SubagentModelUnavailable) as caught:
+        session._launch_subagent(label="review", prompt="review it", effort="xl")
+    assert caught.value.tier == "xl"
+    assert "no model configured at subagents.models.xl" in caught.value.reason
+    assert not session.jobs.list()
+
+
+def test_a_padded_selector_resolves_to_a_clean_provider(tmp_path, monkeypatch):
+    """Q-1: ``lop config edit`` preserves surrounding whitespace verbatim, so
+    a padded selector was advertised by the schema (which stripped) but the
+    strict launch path (which did not) built ``ModelSpec(provider='  openai')``
+    and died on the first provider call. The strip now lives once in
+    ``read_effort_tier_selectors``, so both consumers see the same value."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    write_tiers(tmp_path / "config", hi="  openrouter/moonshotai/kimi-k3  ")
+    session = make_session(tmp_path)
+
+    spec = session._resolve_subagent_model("task", "hi")
+    assert spec is not None
+    assert spec.provider == "openrouter"
+    assert spec.model_id == "moonshotai/kimi-k3"
+
+
 @pytest.mark.asyncio
 async def test_no_effort_still_inherits_the_parent(tmp_path, monkeypatch):
     """The ordinary case must be untouched: a plain child with no tier and no

--- a/tests/unit/session/test_pinned_subagent_model.py
+++ b/tests/unit/session/test_pinned_subagent_model.py
@@ -175,6 +175,13 @@ SELECTOR_CLASSIFICATIONS: list[tuple[object, str]] = [
     (["openrouter/kimi"], "malformed"),
     ({"provider": "openrouter", "model": "kimi"}, "malformed"),
     ("no-provider-here", "malformed"),
+    # The two half-selectors, which are the same defect on opposite sides of
+    # the separator and must not be classified differently (review R3-F11).
+    # ``"/kimi"`` is the one that escaped the table's own promise to enumerate
+    # every shape: the launch checked only the model half, so it accepted a
+    # selector the schema refused and built ``ModelSpec(provider='')``.
+    ("/kimi", "malformed"),
+    ("anthropic/", "malformed"),
     (None, "unconfigured"),
     ("", "unconfigured"),
     ("   ", "unconfigured"),

--- a/tests/unit/session/test_pinned_subagent_model.py
+++ b/tests/unit/session/test_pinned_subagent_model.py
@@ -69,7 +69,14 @@ def make_session(tmp_path) -> Session:
     )
 
 
-def write_tiers(config_dir, **tiers: str) -> None:
+def write_tiers(config_dir, **tiers: object) -> None:
+    """Write ``values.subagents.models`` verbatim.
+
+    Values are ``object`` rather than ``str`` on purpose: the guards under test
+    exist for selectors YAML produced as something other than a string
+    (``lo: 0``, ``lo: []``), and a ``str``-only helper is why those guards went
+    untested through round 1 (review R2-F8).
+    """
     config_dir.mkdir(parents=True, exist_ok=True)
     (config_dir / "config.yml").write_text(
         yaml.safe_dump({"values": {"subagents": {"models": tiers}}})
@@ -117,6 +124,108 @@ def test_strict_launch_fails_on_a_malformed_selector(tmp_path, monkeypatch):
         session._launch_subagent(label="review", prompt="review it", effort="hi")
     assert caught.value.tier == "hi"
     assert "lacks provider/model" in caught.value.reason
+
+
+def test_strict_launch_refuses_a_non_string_selector(tmp_path, monkeypatch):
+    """Q-1's regression guard, made deletable-only-with-a-failure (review
+    R2-F8). A truthy non-string selector must be a NAMED refusal: without the
+    ``isinstance`` check the value flows into ``str.partition`` (or a
+    ``str()`` coercion) and a ``ModelSpec`` gets built out of a list."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    write_tiers(tmp_path / "config", hi=["openrouter/moonshotai/kimi-k3"])
+    session = make_session(tmp_path)
+
+    with pytest.raises(SubagentModelUnavailable) as caught:
+        session._launch_subagent(label="review", prompt="review it", effort="hi")
+    assert caught.value.tier == "hi"
+    assert "lacks provider/model" in caught.value.reason
+    # The refusal names the offending VALUE, so an operator can find it.
+    assert "subagents.models.hi=" in caught.value.reason
+    assert not session.jobs.list()
+
+
+def test_a_falsy_non_string_selector_is_malformed_not_unconfigured(tmp_path, monkeypatch):
+    """Review R2-F7. ``hi: 0`` is a key the operator WROTE, so it must draw the
+    same "lacks provider/model" refusal the tool-argument path
+    (``effort_tier_rejection``) gives it -- not the quiet "not configured"
+    branch, which would put the two user-facing surfaces back into
+    disagreement about the same key."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    write_tiers(tmp_path / "config", hi=0)
+    session = make_session(tmp_path)
+
+    with pytest.raises(SubagentModelUnavailable) as caught:
+        session._launch_subagent(label="review", prompt="review it", effort="hi")
+    assert "lacks provider/model" in caught.value.reason
+    assert "no model configured" not in caught.value.reason
+
+
+#: ``(selector, classification)`` -- every shape ``config.yml`` can hand the
+#: two refusal surfaces, and the ONE verdict both must reach for it. Split by
+#: what the operator did rather than by Python truthiness: a key that is absent
+#: or blank is "unconfigured" (and stays quiet on the lenient path), and a key
+#: that is present with an unusable value is "malformed" however falsy it is.
+SELECTOR_CLASSIFICATIONS: list[tuple[object, str]] = [
+    (0, "malformed"),
+    (False, "malformed"),
+    ([], "malformed"),
+    ({}, "malformed"),
+    (5, "malformed"),
+    (True, "malformed"),
+    (["openrouter/kimi"], "malformed"),
+    ({"provider": "openrouter", "model": "kimi"}, "malformed"),
+    ("no-provider-here", "malformed"),
+    (None, "unconfigured"),
+    ("", "unconfigured"),
+    ("   ", "unconfigured"),
+]
+
+
+def _classify(message: str) -> str:
+    """The verdict a refusal carries, independent of its wording.
+
+    The two surfaces phrase the unconfigured case differently on purpose --
+    the launch says "no model configured at ...", the tool-argument path says
+    "not configured at ..." inside a sentence that also names the working
+    tiers -- so this matches on the CLASSIFICATION both must agree on, not on
+    text neither promises the other. ``lacks provider/model`` is checked first
+    because it is the narrower verdict.
+    """
+    if "lacks provider/model" in message:
+        return "malformed"
+    if "configured at subagents.models" in message:
+        return "unconfigured"
+    return f"unrecognised: {message}"
+
+
+@pytest.mark.parametrize("selector,expected", SELECTOR_CLASSIFICATIONS)
+def test_both_refusal_surfaces_classify_a_selector_the_same(
+    tmp_path, monkeypatch, selector, expected
+):
+    """The invariant this PR exists to hold, asserted directly (review R2-F7).
+
+    ``effort_tier_rejection`` refuses a tool ARGUMENT before a launch exists;
+    ``_resolve_subagent_model(strict=True)`` refuses the LAUNCH. They read the
+    same key through the same reader, so for any value ``config.yml`` can
+    carry they must tell the operator the same story about it -- the drift
+    that motivated this change was two surfaces naming one key differently.
+    """
+    from local_operator.harness.subagent import effort_tier_rejection
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    # A second, WORKING tier is load-bearing: with nothing usable configured,
+    # ``effort_tier_rejection`` short-circuits on "no tiers are configured"
+    # and never reaches the per-key verdict this test compares.
+    write_tiers(tmp_path / "config", hi=selector, lo="openrouter/moonshotai/kimi-k3")
+    session = make_session(tmp_path)
+
+    rejection = effort_tier_rejection("hi")
+    assert rejection is not None, "an unusable selector must never validate"
+    with pytest.raises(SubagentModelUnavailable) as caught:
+        session._launch_subagent(label="review", prompt="review it", effort="hi")
+
+    assert _classify(rejection) == expected
+    assert _classify(caught.value.reason) == expected
 
 
 def test_a_tier_outside_the_registry_set_never_launches(tmp_path, monkeypatch):

--- a/tests/unit/session/test_pinned_subagent_model.py
+++ b/tests/unit/session/test_pinned_subagent_model.py
@@ -217,7 +217,13 @@ async def test_wait_names_the_model_a_task_child_ran_on(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_task_tool_tells_the_model_not_to_retry_on_another_tier():
+async def test_task_tool_tells_the_model_not_to_retry_on_another_tier(tmp_path, monkeypatch):
+    """The launch-time backstop. ``hi`` IS configured here, so the tool's own
+    argument validation lets it through, and the launcher's refusal stands in
+    for the case validation cannot see (a selector that no longer builds)."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    write_tiers(tmp_path / "config", hi="anthropic/claude-opus-5")
+
     def launcher(label, prompt, *, agent="task", effort=None):
         raise SubagentModelUnavailable("hi", "no model configured at subagents.models.hi")
 

--- a/tests/unit/tools/test_agent_tool.py
+++ b/tests/unit/tools/test_agent_tool.py
@@ -8,6 +8,7 @@ import pytest
 
 from local_operator.agent_profiles import load_seed, resolve_profile
 from local_operator.agents import AgentEditFields, AgentRegistry
+from local_operator.config import ConfigManager
 from local_operator.harness.types import ToolContext
 from local_operator.tools.agent_tool import AgentParams, build_agent_tool, execute_agent
 
@@ -15,6 +16,22 @@ from local_operator.tools.agent_tool import AgentParams, build_agent_tool, execu
 @pytest.fixture()
 def registry(tmp_path) -> AgentRegistry:
     return AgentRegistry(tmp_path)
+
+
+@pytest.fixture(autouse=True)
+def configured_tiers(tmp_path, monkeypatch) -> dict[str, str]:
+    """``lo`` and ``hi`` configured, ``med`` not.
+
+    ``effort`` is validated against the live ``subagents.models`` mapping and
+    the schema advertises only what is configured, so the tests that pin a
+    role to ``lo`` need it to exist. Autouse so the default state of this file
+    is "an operator who configured two tiers"; the schema tests that need the
+    zero-tier state clear the config themselves.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    tiers = {"lo": "openai/gpt-5-mini", "hi": "anthropic/claude-opus-5"}
+    ConfigManager(tmp_path / "config").set_config_value("subagents", {"models": tiers})
+    return tiers
 
 
 @pytest.fixture()
@@ -254,12 +271,52 @@ async def test_update_keeps_the_allowlist_it_was_not_asked_to_change(context, re
     assert "Read the diff first." in after.instructions
 
 
-def test_agent_schema_exposes_inherit_without_an_empty_enum_member() -> None:
-    effort = AgentParams.model_json_schema()["properties"]["effort"]
+def _effort_schema(context: ToolContext) -> dict[str, Any]:
+    tool = build_agent_tool(context)
+    assert tool is not None
+    return tool.parameters["properties"]["effort"]
+
+
+def test_agent_schema_exposes_inherit_without_an_empty_enum_member(context) -> None:
+    """The schema lists the CONFIGURED tiers plus the sentinel — not the
+    hard-coded ``lo|med|hi`` that used to invite a pin nothing could launch —
+    and names what each tier resolves to so the pin is chosen on information."""
+    effort = _effort_schema(context)
     enum = effort["anyOf"][0]["enum"]
 
-    assert enum == ["lo", "med", "hi", "inherit"]
+    assert enum == ["lo", "hi", "inherit"]
     assert "" not in enum
+    assert "lo → openai/gpt-5-mini" in effort["description"]
+    assert "hi → anthropic/claude-opus-5" in effort["description"]
+    # The raw params model stays permissive; the schema the model sees is the
+    # patched one, and validation is what closes it.
+    assert "enum" not in AgentParams.model_json_schema()["properties"]["effort"]["anyOf"][0]
+
+
+def test_agent_schema_with_no_tiers_offers_only_inherit(tmp_path, context) -> None:
+    """Zero configured tiers: ``inherit`` alone keeps the property alive (never
+    ``enum: []`` — Gemini rejects it) and the description says no tier exists."""
+    ConfigManager(tmp_path / "config").set_config_value("subagents", {})
+
+    effort = _effort_schema(context)
+
+    assert effort["anyOf"][0]["enum"] == ["inherit"]
+    assert "no model tiers are configured" in effort["description"]
+
+
+@pytest.mark.asyncio
+async def test_an_unconfigured_tier_cannot_be_pinned(context) -> None:
+    """``med`` is a perfectly good tier NAME and is not configured, so a pin
+    on it would fail at every launch of the role; refuse it up front and say
+    which tiers would work."""
+    body = await call(
+        context, op="create", name="e2", description="d", instructions="i", effort="med"
+    )
+
+    assert "invalid arguments" in body
+    assert "effort tier 'med' is unavailable" in body
+    assert "lo → openai/gpt-5-mini" in body
+    assert "omit 'effort'" in body
 
 
 @pytest.mark.parametrize("effort", [None, "inherit"])

--- a/tests/unit/tools/test_effort_tier_schema.py
+++ b/tests/unit/tools/test_effort_tier_schema.py
@@ -30,6 +30,7 @@ from local_operator.harness.subagent import (
     configured_effort_tiers,
     describe_effort_tiers,
     effort_tier_rejection,
+    read_effort_tier_selectors,
 )
 from local_operator.harness.types import (
     AbortSignal,
@@ -131,21 +132,88 @@ def test_malformed_selectors_are_excluded(config_dir) -> None:
             "lo": "just-a-model",  # no provider
             "med": "   ",  # blank
             "hi": THREE["hi"],
-            "ultra": "provider/",  # no model
-            "empty": "",
-            "notastring": {"provider": "x", "model": "y"},
-            "custom": "openai/gpt-5",  # a hand-added tier is honoured
         },
     )
-    assert configured_effort_tiers() == {"hi": THREE["hi"], "custom": "openai/gpt-5"}
+    assert configured_effort_tiers() == {"hi": THREE["hi"]}
 
 
-def test_an_unreadable_config_reports_no_tiers_rather_than_raising(config_dir) -> None:
+def test_a_tier_outside_the_registry_set_is_inert_in_every_consumer(config_dir) -> None:
+    """``subagents.models`` is a free mapping in YAML, but the watcher's
+    per-registry-key diff can only report lo/med/hi — a hand-added ``xl``
+    would be read and advertised yet never trigger the live schema re-render,
+    so the schema would promise a tier whose edits the rebuild cannot reach.
+
+    The narrowing therefore lives in the shared reader, and this asserts all
+    three consumers agree: dropping it in the schema alone would leave ``xl``
+    unadvertised but launchable through a role pin, and would refuse it as
+    'lacks provider/model' — false, since the selector is well-formed."""
+    write_tiers(config_dir, {"hi": THREE["hi"], "xl": "openai/gpt-5"})
+
+    assert read_effort_tier_selectors() == {"hi": THREE["hi"]}
+    assert configured_effort_tiers() == {"hi": THREE["hi"]}
+    # Refused as absent, not as malformed — and it names the tier that works.
+    rejection = effort_tier_rejection("xl")
+    assert rejection is not None
+    assert "not configured at subagents.models.xl" in rejection
+    assert "lacks provider/model" not in rejection
+
+
+def test_whitespace_padded_selectors_are_stripped_once(config_dir) -> None:
+    """``lop config edit`` preserves surrounding whitespace verbatim. The
+    strip lives in the shared reader so the schema and the strict launch
+    path see the SAME value: before this, the schema stripped and launch
+    did not, so a padded selector was advertised, passed the strict check,
+    and failed on the first provider call with ``provider='  openai'``."""
+    write_tiers(config_dir, {"lo": "  openai/gpt-5-mini  "})
+    assert configured_effort_tiers() == {"lo": "openai/gpt-5-mini"}
+
+
+def test_yaml_coerced_non_string_tier_keys_cannot_break_the_schema(config_dir, tmp_path) -> None:
+    """The exact F1 repro: YAML parses ``1:``/``on:``/``yes:`` as int/bool
+    keys, and a mixed-type ``sorted()`` on them raised ``TypeError`` OUTSIDE
+    the reader's ``try`` — through ``create_tools`` (a session could not
+    boot) and through ``TaskParams(effort=...)`` as a non-ValidationError.
+    Non-string keys are dropped rather than stringified: ``1: openai/…`` is
+    a YAML accident, not a tier anyone can ask for by name."""
+    config_dir.mkdir(parents=True, exist_ok=True)
+    # Written as YAML text rather than safe_dump: the point is YAML's silent
+    # key coercion (``1:`` → int, ``on:`` → bool True), and a dict literal
+    # with both would trip F601 (``1 == True`` hashes equal).
+    (config_dir / "config.yml").write_text(
+        "values:\n  subagents:\n    models:\n"
+        f"      1: openai/gpt-5-mini\n      on: x/y\n      hi: {THREE['hi']}\n"
+    )
+    assert configured_effort_tiers() == {"hi": THREE["hi"]}
+
+    # Schema construction — the session-boot path — must survive it, and the
+    # surviving tier must still be accepted as a plain ValidationError-checked
+    # argument rather than escaping as a TypeError.
+    from local_operator.tools.builtin import TaskParams
+
+    TaskParams(label="r", prompt="p", effort="hi")
+    task = next(t for t in create_tools(_context(tmp_path), enabled=["task"]))
+    assert _enum(task.parameters["properties"]["effort"]) == ["hi"]
+
+
+def test_an_unreadable_config_reports_no_tiers_rather_than_raising(
+    config_dir, monkeypatch, tmp_path
+) -> None:
     """Schema construction runs while the tool inventory is being built; a
-    corrupt config.yml must cost the operator a tier picker, not a session."""
-    config_dir.mkdir(parents=True)
-    (config_dir / "config.yml").write_text("values: [not, a, mapping")
+    corrupt config.yml must cost the operator a tier picker, not a session.
+    The read failure is SYNTHESIZED here: ``ConfigManager`` on a corrupt
+    file moves it aside and returns defaults rather than raising, so only a
+    monkeypatched reader actually exercises the except branch the docstring
+    promises."""
+    import local_operator.harness.subagent as subagent_mod
+
+    def boom() -> dict[str, Any]:
+        raise OSError("config.yml is on fire")
+
+    monkeypatch.setattr(subagent_mod, "read_effort_tier_selectors", boom)
     assert configured_effort_tiers() == {}
+    # And the failure must not reach the tool inventory either.
+    task = next(t for t in create_tools(_context(tmp_path), enabled=["task"]))
+    assert "effort" not in task.parameters["properties"]
 
 
 def test_describe_names_the_model_behind_each_tier() -> None:

--- a/tests/unit/tools/test_effort_tier_schema.py
+++ b/tests/unit/tools/test_effort_tier_schema.py
@@ -1,0 +1,396 @@
+"""The ``effort`` field of ``task``/``agent`` advertises only CONFIGURED tiers.
+
+The incident: both tools hard-coded ``effort: Literal["lo", "med", "hi"]``
+regardless of ``values.subagents.models``. On a machine with no tier
+configured, the delegating model read the enum, picked ``effort="hi"``, and
+the strict launch path (``SubagentModelUnavailable``) refused it — every value
+the schema offered was a guaranteed failure, and nothing told the model that
+omitting the field was the one working choice.
+
+These tests pin the class of fix: the schema is built from the live config
+(0, 1, 3 tiers; malformed selectors excluded), a zero-tier schema never emits
+``enum: []`` (Gemini rejects it), validation refuses an unconfigured tier with
+a message naming the working alternative, and a mid-session config edit
+re-renders the two tools that carry the field.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from local_operator.agents import AgentRegistry
+from local_operator.config import ConfigManager
+from local_operator.config_watch import ConfigWatcher
+from local_operator.harness.subagent import (
+    configured_effort_tiers,
+    describe_effort_tiers,
+    effort_tier_rejection,
+)
+from local_operator.harness.types import (
+    AbortSignal,
+    ChatRequest,
+    ModelSpec,
+    StreamEndEvent,
+    StreamTextDelta,
+    ToolContext,
+)
+from local_operator.session.session import Session
+from local_operator.session.transcript import Transcript
+from local_operator.tools.registry import create_tools
+
+THREE = {
+    "lo": "openai/gpt-5-mini",
+    "med": "openrouter/moonshotai/kimi-k3",
+    "hi": "anthropic/claude-opus-5",
+}
+
+
+def write_tiers(config_dir: Path, models: dict[str, Any] | None) -> None:
+    """The on-disk shape ``/settings`` writes; ``None`` leaves ``subagents`` unset."""
+    config_dir.mkdir(parents=True, exist_ok=True)
+    values: dict[str, Any] = {} if models is None else {"subagents": {"models": models}}
+    (config_dir / "config.yml").write_text(yaml.safe_dump({"values": values}))
+
+
+@pytest.fixture()
+def config_dir(tmp_path, monkeypatch) -> Path:
+    path = tmp_path / "config"
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(path))
+    return path
+
+
+def _launcher(label, prompt, *, agent="task", effort=None):
+    return f"job:{label}:{effort}"
+
+
+def _context(tmp_path) -> ToolContext:
+    return ToolContext(
+        cwd=str(tmp_path),
+        session_id="s",
+        subagent_launcher=_launcher,
+        agent_registry=AgentRegistry(tmp_path / "agents"),
+    )
+
+
+def _schemas(tmp_path) -> dict[str, dict[str, Any]]:
+    return {
+        t.name: t.parameters for t in create_tools(_context(tmp_path), enabled=["task", "agent"])
+    }
+
+
+def _effort(schema: dict[str, Any], *path: str) -> dict[str, Any] | None:
+    node: Any = schema
+    for part in path:
+        node = node[part]
+    return node.get("effort")
+
+
+def _enum(prop: dict[str, Any]) -> list[str]:
+    return prop["anyOf"][0]["enum"]
+
+
+def _enum_nodes(node: Any) -> list[list[Any]]:
+    found: list[list[Any]] = []
+    if isinstance(node, dict):
+        if "enum" in node:
+            found.append(node["enum"])
+        for child in node.values():
+            found.extend(_enum_nodes(child))
+    elif isinstance(node, list):
+        for child in node:
+            found.extend(_enum_nodes(child))
+    return found
+
+
+# ---------------------------------------------------------------------------
+# the shared reader
+# ---------------------------------------------------------------------------
+
+
+def test_no_config_file_means_no_tiers(config_dir) -> None:
+    assert configured_effort_tiers() == {}
+
+
+def test_three_tiers_come_back_in_canonical_order(config_dir) -> None:
+    # YAML order is hi/lo/med here on purpose: the schema must not follow it,
+    # or a reordering edit would move the enum and bust the prompt cache.
+    write_tiers(config_dir, {"hi": THREE["hi"], "lo": THREE["lo"], "med": THREE["med"]})
+    assert list(configured_effort_tiers()) == ["lo", "med", "hi"]
+    assert configured_effort_tiers() == THREE
+
+
+def test_malformed_selectors_are_excluded(config_dir) -> None:
+    write_tiers(
+        config_dir,
+        {
+            "lo": "just-a-model",  # no provider
+            "med": "   ",  # blank
+            "hi": THREE["hi"],
+            "ultra": "provider/",  # no model
+            "empty": "",
+            "notastring": {"provider": "x", "model": "y"},
+            "custom": "openai/gpt-5",  # a hand-added tier is honoured
+        },
+    )
+    assert configured_effort_tiers() == {"hi": THREE["hi"], "custom": "openai/gpt-5"}
+
+
+def test_an_unreadable_config_reports_no_tiers_rather_than_raising(config_dir) -> None:
+    """Schema construction runs while the tool inventory is being built; a
+    corrupt config.yml must cost the operator a tier picker, not a session."""
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.yml").write_text("values: [not, a, mapping")
+    assert configured_effort_tiers() == {}
+
+
+def test_describe_names_the_model_behind_each_tier() -> None:
+    assert describe_effort_tiers({"lo": "a/b", "hi": "c/d"}) == "lo → a/b, hi → c/d"
+
+
+def test_rejection_names_the_working_alternative(config_dir) -> None:
+    assert effort_tier_rejection("hi") is not None
+    assert "no tiers are configured" in str(effort_tier_rejection("hi"))
+    assert "omit 'effort'" in str(effort_tier_rejection("hi"))
+    write_tiers(config_dir, {"lo": THREE["lo"]})
+    assert effort_tier_rejection("lo") is None
+    message = effort_tier_rejection("hi")
+    assert message is not None
+    assert "not configured at subagents.models.hi" in message
+    assert "lo → openai/gpt-5-mini" in message
+    # Present but unusable is named as such, in the launch path's own words.
+    write_tiers(config_dir, {"lo": THREE["lo"], "hi": "gpt-5"})
+    assert "subagents.models.hi='gpt-5' lacks provider/model" in str(effort_tier_rejection("hi"))
+
+
+# ---------------------------------------------------------------------------
+# the task tool schema
+# ---------------------------------------------------------------------------
+
+
+def test_zero_tiers_drops_the_field_from_both_task_forms(config_dir, tmp_path) -> None:
+    """No tier means no enum to pick from: the property is REMOVED, from the
+    single form and the batch item alike, and no ``enum: []`` exists anywhere
+    in the schema (Gemini function declarations reject an empty enum)."""
+    task = _schemas(tmp_path)["task"]
+
+    assert _effort(task, "properties") is None
+    assert _effort(task, "$defs", "TaskItem", "properties") is None
+    assert all(members for members in _enum_nodes(task)), "an empty enum leaked"
+
+
+def test_zero_tiers_tells_the_model_not_to_pass_effort(config_dir, tmp_path) -> None:
+    (task,) = create_tools(_context(tmp_path), enabled=["task"])
+    assert "No effort tiers are configured" in task.description
+    assert "inherits this session's model and reasoning effort" in task.description
+    assert "do not pass 'effort'" in task.description
+
+
+def test_one_tier_is_the_whole_enum_and_names_its_model(config_dir, tmp_path) -> None:
+    write_tiers(config_dir, {"hi": THREE["hi"]})
+    task = _schemas(tmp_path)["task"]
+
+    single = _effort(task, "properties")
+    item = _effort(task, "$defs", "TaskItem", "properties")
+    assert single is not None and item is not None
+    assert _enum(single) == ["hi"]
+    assert _enum(item) == ["hi"]
+    assert "hi → anthropic/claude-opus-5" in single["description"]
+    assert "Omit to inherit" in single["description"]
+    # The nullable shape pydantic renders for ``Literal | None`` is kept, so
+    # providers see the field they always saw with different members.
+    assert single["anyOf"][1] == {"type": "null"}
+
+
+def test_three_tiers_list_all_three_with_their_models(config_dir, tmp_path) -> None:
+    write_tiers(config_dir, THREE)
+    (task,) = create_tools(_context(tmp_path), enabled=["task"])
+    single = _effort(task.parameters, "properties")
+    assert single is not None
+    assert _enum(single) == ["lo", "med", "hi"]
+    for tier, selector in THREE.items():
+        assert f"{tier} → {selector}" in single["description"]
+    assert "set it to one of the configured tiers" in task.description
+
+
+def test_a_malformed_tier_is_not_advertised(config_dir, tmp_path) -> None:
+    write_tiers(config_dir, {"lo": "no-provider", "hi": THREE["hi"]})
+    single = _effort(_schemas(tmp_path)["task"], "properties")
+    assert single is not None
+    assert _enum(single) == ["hi"]
+
+
+# ---------------------------------------------------------------------------
+# validation: what the schema does not offer, the tool refuses — helpfully
+# ---------------------------------------------------------------------------
+
+
+async def _call(tmp_path, name: str, args: dict[str, Any]):
+    context = _context(tmp_path)
+    (tool,) = create_tools(context, enabled=[name])
+    return await tool.execute("call-1", args, None, None, context)
+
+
+@pytest.mark.asyncio
+async def test_task_refuses_an_unconfigured_tier_with_zero_tiers(config_dir, tmp_path) -> None:
+    result = await _call(tmp_path, "task", {"label": "r", "prompt": "p", "effort": "hi"})
+    assert result.is_error
+    assert "invalid arguments" in result.text
+    assert "effort tier 'hi' is unavailable" in result.text
+    assert "no tiers are configured under values.subagents.models" in result.text
+    assert "omit 'effort' to inherit this session's model and reasoning effort" in result.text
+    # Refused at validation: the launcher was never reached.
+    assert "job:" not in result.text
+
+
+@pytest.mark.asyncio
+async def test_task_batch_item_is_validated_the_same_way(config_dir, tmp_path) -> None:
+    write_tiers(config_dir, {"lo": THREE["lo"]})
+    result = await _call(
+        tmp_path,
+        "task",
+        {"context": "c", "tasks": [{"label": "r", "prompt": "p", "effort": "hi"}]},
+    )
+    assert result.is_error
+    assert "tasks.0.effort" in result.text
+    assert "not configured at subagents.models.hi" in result.text
+    assert "lo → openai/gpt-5-mini" in result.text
+
+
+@pytest.mark.asyncio
+async def test_task_accepts_a_configured_tier_and_omission(config_dir, tmp_path) -> None:
+    write_tiers(config_dir, {"hi": THREE["hi"]})
+    ok = await _call(tmp_path, "task", {"label": "r", "prompt": "p", "effort": "hi"})
+    assert not ok.is_error and "job:r:hi" in ok.text
+    inherit = await _call(tmp_path, "task", {"label": "r", "prompt": "p"})
+    assert not inherit.is_error and "job:r:None" in inherit.text
+
+
+# ---------------------------------------------------------------------------
+# the agent tool mirrors it, keeping ``inherit`` and the legacy "" spelling
+# ---------------------------------------------------------------------------
+
+
+def test_agent_schema_lists_configured_tiers_then_inherit(config_dir, tmp_path) -> None:
+    write_tiers(config_dir, THREE)
+    prop = _effort(_schemas(tmp_path)["agent"], "properties")
+    assert prop is not None
+    assert _enum(prop) == ["lo", "med", "hi", "inherit"]
+    assert "hi → anthropic/claude-opus-5" in prop["description"]
+
+
+def test_agent_schema_with_zero_tiers_keeps_only_inherit(config_dir, tmp_path) -> None:
+    prop = _effort(_schemas(tmp_path)["agent"], "properties")
+    assert prop is not None
+    assert _enum(prop) == ["inherit"]
+    assert "no model tiers are configured" in prop["description"]
+
+
+@pytest.mark.asyncio
+async def test_agent_refuses_an_unconfigured_pin_and_accepts_inherit(config_dir, tmp_path) -> None:
+    write_tiers(config_dir, {"lo": THREE["lo"]})
+    refused = await _call(
+        tmp_path,
+        "agent",
+        {"op": "create", "name": "r1", "description": "d", "instructions": "i", "effort": "hi"},
+    )
+    assert refused.is_error
+    assert "effort tier 'hi' is unavailable" in refused.text
+    for value in ("inherit", ""):
+        ok = await _call(
+            tmp_path,
+            "agent",
+            {
+                "op": "create",
+                "name": f"r-{value or 'legacy'}",
+                "description": "d",
+                "instructions": "i",
+                "effort": value,
+            },
+        )
+        assert not ok.is_error, ok.text
+
+
+# ---------------------------------------------------------------------------
+# a mid-session edit re-renders the schema the model reads
+# ---------------------------------------------------------------------------
+
+
+class _Stream:
+    def __call__(self, request: ChatRequest, signal: AbortSignal | None):
+        async def gen():
+            yield StreamTextDelta(delta="ok")
+            yield StreamEndEvent(stop_reason="stop")
+
+        return gen()
+
+
+def _session_effort_enum(session: Session) -> list[str] | None:
+    task = next(tool for tool in session._tools if tool.name == "task")
+    prop = task.parameters["properties"].get("effort")
+    return None if prop is None else _enum(prop)
+
+
+@pytest.mark.asyncio
+async def test_configuring_a_tier_mid_session_reaches_the_task_schema(config_dir, tmp_path) -> None:
+    """Tools are built once at session construction, so a tier configured
+    afterwards would stay invisible for the life of the session without the
+    live re-render — and a tier removed would stay advertised, which is the
+    original incident with extra steps."""
+    ConfigManager(config_dir).set_config_value("hosting", "")  # a real file to diff against
+    session = Session(
+        model=ModelSpec(provider="test", model_id="m", context_window=1000, max_output_tokens=100),
+        stream_fn=_Stream(),
+        tools=[],
+        transcript=Transcript(tmp_path / "sess"),
+        system_blocks_provider=lambda: ["stable"],
+    )
+    watcher = ConfigWatcher(config_dir)
+    session.add_dispose_hook(watcher.subscribe(session._apply_config_change))
+    try:
+        order_before = [tool.name for tool in session._tools]
+        assert _session_effort_enum(session) is None
+
+        ConfigManager(config_dir).set_config_value("subagents", {"models": {"hi": THREE["hi"]}})
+        change = watcher.poll_now()
+        assert change is not None and "subagents.models.hi" in change.changed_keys
+        assert _session_effort_enum(session) == ["hi"]
+        # Replacement in place: the provider-visible order is part of the
+        # prompt-cache prefix and must not move.
+        assert [tool.name for tool in session._tools] == order_before
+
+        ConfigManager(config_dir).set_config_value("subagents", {})
+        watcher.poll_now()
+        assert _session_effort_enum(session) is None
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_child_whose_task_tool_was_pruned_does_not_get_it_back(
+    config_dir, tmp_path
+) -> None:
+    """The rebuild replaces tools already present and never appends: a
+    non-delegating child had ``task`` pruned on purpose."""
+    ConfigManager(config_dir).set_config_value("hosting", "")
+    session = Session(
+        model=ModelSpec(provider="test", model_id="m", context_window=1000, max_output_tokens=100),
+        stream_fn=_Stream(),
+        tools=[],
+        transcript=Transcript(tmp_path / "sess"),
+        system_blocks_provider=lambda: ["stable"],
+    )
+    watcher = ConfigWatcher(config_dir)
+    session.add_dispose_hook(watcher.subscribe(session._apply_config_change))
+    try:
+        session.refresh_tools([tool for tool in session._tools if tool.name != "task"])
+        ConfigManager(config_dir).set_config_value("subagents", {"models": {"hi": THREE["hi"]}})
+        watcher.poll_now()
+        assert "task" not in {tool.name for tool in session._tools}
+    finally:
+        await session.dispose()
+        await asyncio.sleep(0)

--- a/tests/unit/tools/test_task_wait_jobs.py
+++ b/tests/unit/tools/test_task_wait_jobs.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import pytest
 
+from local_operator.config import ConfigManager
 from local_operator.harness.jobs import OUTPUT_TAIL_CHARS, AsyncJobManager
 from local_operator.harness.types import AgentTool, ToolContext, ToolResult
 from local_operator.tools import builtin
@@ -452,7 +453,13 @@ def test_wait_jobs_not_advertised_without_job_manager(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_task_batch_launches_concurrent_children_with_shared_context(tmp_path):
+async def test_task_batch_launches_concurrent_children_with_shared_context(tmp_path, monkeypatch):
+    # ``effort`` is validated against the live config, so the tier this batch
+    # asks for has to exist; without one, "hi" is refused before launch.
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    ConfigManager(tmp_path / "config").set_config_value(
+        "subagents", {"models": {"hi": "anthropic/claude-opus-5"}}
+    )
     """One call, three jobs: the batch form is the fan-out economics — N
     independent slices cost N round trips when launched one per call and one
     when launched together. The shared context is prepended to every prompt


### PR DESCRIPTION
## Summary of Changes

Fix the `task` tool (both forms) and the `agent` tool's create/update `effort` field advertising a hard-coded `Literal["lo","med","hi"]` enum regardless of what the operator has configured under `values.subagents.models`.

**C1 standard / pre-authorized bug fix.** Operator-requested; this PR is the delivery record. No tracker requested. No version bump (pyproject stays at the last released version; the window's release owner bumps).

### Root cause, reproduced before editing

On the operator's machine `subagents` is `{}` — no tier configured. The delegating model read the schema enum, chose `effort="hi"`, and #635's strict launch path correctly refused it:

```
could not launch subagent(s): fork-model-switch: effort tier 'hi' is unavailable: no model configured at subagents.models.hi. Do NOT retry at a different effort tier…
```

Every value the schema offered was a guaranteed failure, and the schema never said that omitting `effort` (inherit the parent's model and reasoning effort) was the only working choice. Rendered on `origin/main` with an isolated HOME:

```
{"anyOf": [{"enum": ["lo", "med", "hi"], "type": "string"}, {"type": "null"}], "default": null, "description": "Single-task form: model tier for the subagent.", "title": "Effort"}
```

### Fix (the class, not the symptom)

- **One reader of `subagents.models`** (`harness/subagent.py`): `read_effort_tier_selectors()` is now what `Session._resolve_subagent_model` reads too, so launch and schema can never disagree. `configured_effort_tiers()` filters to usable `provider/model` selectors, keeps canonical `lo/med/hi` order (schema stays byte-stable in the prompt-cache prefix regardless of YAML key order), accepts **only** those three registry tiers — a hand-added `xl:` is filtered out by `read_effort_tier_selectors()` before either surface sees it, so it is not merely unadvertised: it is **inert at launch too**. `Session._resolve_subagent_model` refuses it with `SubagentModelUnavailable` (`effort tier 'xl' is unavailable: no model configured at subagents.models.xl`) and no job is created, so an operator who had a hand-added tier working before this PR gets a loud named refusal rather than a silent downgrade to the session model. That is the intended trade: `settings_io` writes only registered keys and the config watcher only diffs registry keys, so a non-registry tier could be advertised but never re-rendered on edit; narrowing here keeps advertised == rebuildable — and swallows config-read errors into "no tiers" so schema construction can never fail a turn.
- **Schema built from live config** (`tools/builtin.py` `_advertise_effort_tiers`): `effort` is a free string on the params models, validated at call time via `effort_tier_rejection`; the rendered schema is patched at build time to exactly the configured tiers, with a description naming what each resolves to (`hi → anthropic/claude-opus-5`). With **zero** tiers the property is **removed** from both the single form and the `$defs.TaskItem` batch form — never `enum: []` (Gemini rejects it) — and the tool description says no tiers exist and not to pass `effort`.
- **Validation refuses what the schema does not offer, helpfully**: `effort tier 'hi' is unavailable: no tiers are configured under values.subagents.models; omit 'effort' to inherit this session's model and reasoning effort` (or, with tiers: names the configured ones; a present-but-malformed selector is called out as `lacks provider/model` in the launch path's own words).
- **`agent` tool mirrors it**: a role can only be pinned to a configured tier; `inherit` stays (and alone keeps the property alive at zero tiers); legacy `""` normalisation kept.
- **Live rebuild**: tools are built once at session construction, so `Session._apply_config_change` now re-renders `task`/`agent` in place on any `subagents.models.*` edit — order preserved, and a `task` that a non-delegating child had pruned is never re-added.
- **Guidance**: `system.md` task paragraph and the `agents` guide now say to omit `effort` unless the schema lists a tier.
- **#635 untouched**: `_resolve_subagent_model(strict=True)`, `SubagentModelUnavailable` and the "Do NOT retry" result text stay as the backstop for a pin that went stale.

## Delivery contract / non-goals

1. With no configured tier, neither `task` form nor `agent` advertises a pickable tier; the description tells the model to omit `effort`.
2. With N configured tiers, the enum is exactly those N (malformed selectors excluded) and each is described by its resolved `provider/model`.
3. A tier not in the configured set is refused at argument validation with the working alternative named — before any launch or role write.
4. A config edit mid-session updates the schema the model sees on the next call.

Non-goals: no change to how tiers resolve to a `ModelSpec`, to the strict launch refusal, to the `/settings` registry, or to the tier names the settings page offers.

## Impact / risk / rollback

Schema-only change to two tools plus a live-rebuild hook; no wire-format change (the `anyOf [enum, null]` shape pydantic rendered for `Literal | None` is preserved). Sessions with tiers configured see the same enum as before minus unconfigured entries. Rollback is a revert.

## Testing Details

### E2E — rendered schema as a real `Session` builds it (isolated `HOME` + `LOCAL_OPERATOR_CONFIG_DIR`)

**(a) no tiers configured** — `env HOME=$(mktemp -d) LOCAL_OPERATOR_CONFIG_DIR=$HOME/.local-operator .venv/bin/python /tmp/effort_e2e.py`

```
config dir: /var/folders/qd/1q2xkcls0tg60vh97jjngxc40000gn/T/tmp.vFt5IIKllE/.local-operator
config.yml: <absent>
== task.description ==
Launch background subagents — one, or a whole concurrent batch ('tasks' + shared 'context') in a single call. 'agent' names a role carrying vetted guidance (reviewer, coder, architect, manager, designer, scout — see the `agent` tool). No effort tiers are configured (values.subagents.models), so every child inherits this session's model and reasoning effort; do not pass 'effort'.
== task.parameters.properties.effort ==
null
== task.parameters.$defs.TaskItem.properties.effort ==
null
== agent.parameters.properties.effort ==
{
 "anyOf": [
  {
   "type": "string",
   "enum": [
    "inherit"
   ]
  },
  {
   "type": "null"
  }
 ],
 "default": null,
 "description": "create/update: no model tiers are configured (values.subagents.models); 'inherit' clears a pin and every role inherits the launching session's model.",
 "title": "Effort"
}
== task(effort='hi') -> is_error=True ==
invalid arguments:
- effort: Value error, effort tier 'hi' is unavailable: no tiers are configured under values.subagents.models; omit 'effort' to inherit this session's model and reasoning effort
== task(tasks=[effort='lo']) -> is_error=True ==
invalid arguments:
== agent(create effort='hi') -> is_error=True ==
invalid arguments:
- effort: Value error, effort tier 'hi' is unavailable: no tiers are configured under values.subagents.models; omit 'effort' to inherit this session's model and reasoning effort
```

**(b) `subagents.models.hi: anthropic/claude-opus-5` plus a malformed `lo: not-a-selector`**

```
config dir: /var/folders/qd/1q2xkcls0tg60vh97jjngxc40000gn/T/tmp.GTpTqC8j7l/.local-operator
config.yml: values:
  subagents:
    models:
      hi: anthropic/claude-opus-5
      lo: not-a-selector
== task.description ==
Launch background subagents — one, or a whole concurrent batch ('tasks' + shared 'context') in a single call. 'agent' names a role carrying vetted guidance (reviewer, coder, architect, manager, designer, scout — see the `agent` tool). Omit 'effort' to inherit this session's model and reasoning effort, or set it to one of the configured tiers the schema lists.
== task.parameters.properties.effort ==
{
 "anyOf": [
  {
   "type": "string",
   "enum": [
    "hi"
   ]
  },
  {
   "type": "null"
  }
 ],
 "default": null,
 "description": "Model tier for this subagent (hi → anthropic/claude-opus-5). Omit to inherit this session's model and reasoning effort.",
 "title": "Effort"
}
== task.parameters.$defs.TaskItem.properties.effort ==
{
 "anyOf": [
  {
   "type": "string",
   "enum": [
    "hi"
   ]
  },
  {
   "type": "null"
  }
 ],
 "default": null,
 "description": "Model tier for this subagent (hi → anthropic/claude-opus-5). Omit to inherit this session's model and reasoning effort.",
 "title": "Effort"
}
== agent.parameters.properties.effort ==
{
 "anyOf": [
  {
   "type": "string",
   "enum": [
    "hi",
    "inherit"
   ]
  },
  {
   "type": "null"
  }
 ],
 "default": null,
 "description": "create/update: default model tier (hi → anthropic/claude-opus-5). 'inherit' clears it.",
 "title": "Effort"
}
== task(effort='hi') -> is_error=False ==
launched 1 subagent(s) as concurrent background jobs:
- review (task): job 06bdae8f178f
use 'wait' (job_id=...) to await one, or 'jobs' to list running work.
== task(tasks=[effort='lo']) -> is_error=True ==
invalid arguments:
== agent(create effort='hi') -> is_error=False ==
created role 'pinned'; launch with task(agent='pinned').
- tasks.0.effort: Value error, effort tier 'lo' is unavailable: subagents.models.lo='not-a-selector' lacks provider/model (configured: hi → anthropic/claude-opus-5); pick one of those or omit 'effort' to inherit this session's model and reasoning effort
```

**(c) live edit via the real CLI + config watcher while a session runs**

```
boot: (None, "No effort tiers are configured (values.subagents.models), so every child inherits this session's model and reasoning effort; do not pass 'effort'.")
$ local-operator config edit subagents.models.hi anthropic/claude-opus-5  # rc=0 Successfully updated subagents.models.hi to anthropic/claude-opus-5
  watcher changed_keys: ['subagents.models.hi']
  task schema -> (['hi'], "Omit 'effort' to inherit this session's model and reasoning effort, or set it to one of the configured tiers the schema lists.")
$ local-operator config edit subagents.models.lo openai/gpt-5-mini  # rc=0 Successfully updated subagents.models.lo to openai/gpt-5-mini
  watcher changed_keys: ['subagents.models.lo']
  task schema -> (['lo', 'hi'], "Omit 'effort' to inherit this session's model and reasoning effort, or set it to one of the configured tiers the schema lists.")
$ local-operator config edit subagents.models.hi   # rc=0 Successfully updated subagents.models.hi to
  watcher changed_keys: ['subagents.models.hi']
  task schema -> (['lo'], "Omit 'effort' to inherit this session's model and reasoning effort, or set it to one of the configured tiers the schema lists.")
```

The rebuilt `agent` tool was also exercised after a live edit (`create effort=med` → `created role 'x1'`, present in the same registry).

### Gates (whole tree, as CI, on `de7daad98`)

| Command | Result |
| --- | --- |
| `.venv/bin/python -m flake8 .` | exit 0 |
| `uvx --from black==26.1.0 black --check .` | exit 0, 909 files unchanged |
| `uvx isort==5.13.2 --check .` | exit 0 |
| `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | 0 errors, 0 warnings |
| `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q` | **14005 passed, 17 skipped** in 548s |

### Tests added / updated

- New `tests/unit/tools/test_effort_tier_schema.py` (19): reader with 0/1/3 tiers, canonical order, malformed selectors excluded, unreadable config → no tiers; task schema at 0/1/3 tiers (both forms), no empty enum anywhere; validation refusals for single and batch form with the helpful message; agent mirror incl. `inherit`/`""`; live rebuild through `ConfigWatcher` incl. order preservation and no re-adding a pruned `task`.
- `test_agent_tool.py`: autouse fixture configures `lo`/`hi`; schema test now asserts configured-only enum + model names; new zero-tier and unconfigured-pin tests.
- `test_task_wait_jobs.py`, `test_pinned_subagent_model.py`, `providers/test_clients.py`: configure the tier they ask for (they were relying on the hard-coded enum).

## Checklist

- [x] Style, self-review, existing conventions followed; why-comments on every new function.
- [x] Bug reproduced on the original tree before the change.
- [x] Real assembled behaviour verified (rendered schema, validation result, live rebuild through the real CLI + watcher).
- [x] Full unit gate + static gates recorded above.
- [ ] Agent review / QA rounds — pending (manager-orchestrated).
- [ ] Version bump — not in this PR; release owner's window.


