### PR TITLE
fix(fork): serve a fork's own session_id so its viewer binds, /model lands and followers attach

### DIFF
--- a/local_operator/mobile/attach_client.py
+++ b/local_operator/mobile/attach_client.py
@@ -74,6 +74,13 @@ OVERSIZED_FRAME_REASON = "owner sent a frame too large to read"
 logger = logging.getLogger(__name__)
 
 
+class _OversizedFrame(Exception):
+    """A readline overrun, re-raised under its own type so the pump's outer
+    handler cannot confuse it with a ``ValueError`` a frame CALLBACK raised —
+    the two mean opposite things (owner sent too much vs. this side refused
+    what it sent) and were logged as the same overrun before this existed."""
+
+
 def find_owner_record(config_dir: Path, session_id: str) -> tuple[SessionRecord | None, int | None]:
     """Locate the discovery record of the live process hosting ``session_id``.
 
@@ -239,7 +246,33 @@ class AttachClient:
         reason = "owner exited"
         try:
             while True:
-                line = await reader.readline()
+                try:
+                    line = await reader.readline()
+                except ValueError as exc:
+                    # ``StreamReader.readline`` raises ValueError (via
+                    # LimitOverrunError) when one frame exceeds the connection's
+                    # ``limit``. It is NOT a transport failure and it is not
+                    # recoverable by reading on: the oversized line stays in the
+                    # buffer, so every subsequent read raises the same way.
+                    #
+                    # Before this it fell through as an unhandled task exception
+                    # that killed the pump silently, and the host — which only
+                    # ever learns about a dead connection through
+                    # ``on_disconnected`` — kept waiting for a sync that could
+                    # never arrive, timed out after 15 s, and degraded to a
+                    # runtime-less cold session. A hard bug that presented as a
+                    # slow owner. Report it as its own reason so the host can
+                    # say what actually happened instead of blaming the owner's
+                    # liveness.
+                    #
+                    # Caught HERE, around the read alone, and not around the
+                    # whole loop: the frame callbacks below raise ValueError
+                    # too (a follower store refusing an update as "not the next
+                    # state sequence", pydantic validation of a frame), and
+                    # when the outer handler owned every ValueError those were
+                    # logged as "owner sent a frame larger than the limit" — a
+                    # 104 KB frame reported as an overrun (#573's viewer).
+                    raise _OversizedFrame() from exc
                 if not line:
                     break
                 try:
@@ -322,28 +355,35 @@ class AttachClient:
                     future = self._pending.pop(frame.get("req"), None)
                     if future is not None and not future.done():
                         future.set_result(frame)
-        except (ConnectionResetError, BrokenPipeError, OSError):
-            reason = "owner connection reset"
-        except ValueError:
-            # ``StreamReader.readline`` raises ValueError (via LimitOverrunError)
-            # when one frame exceeds the connection's ``limit``. It is NOT a
-            # transport failure and it is not recoverable by reading on: the
-            # oversized line stays in the buffer, so every subsequent read
-            # raises the same way.
-            #
-            # Before this it fell through as an unhandled task exception that
-            # killed the pump silently, and the host — which only ever learns
-            # about a dead connection through ``on_disconnected`` — kept waiting
-            # for a sync that could never arrive, timed out after 15 s, and
-            # degraded to a runtime-less cold session. A hard bug that presented
-            # as a slow owner. Report it as its own reason so the host can say
-            # what actually happened instead of blaming the owner's liveness.
+        except _OversizedFrame:
             reason = OVERSIZED_FRAME_REASON
             logger.error(
                 "attach client: owner sent a frame larger than the %d-byte line limit; "
                 "the connection cannot continue",
                 _READ_LIMIT_BYTES,
             )
+        except (ConnectionResetError, BrokenPipeError):
+            reason = "owner connection reset"
+        except ConnectionError as exc:
+            # A frame the owner sent was refused by this side — malformed, a
+            # sequence gap, or a sync a host callback rejected. The socket is
+            # healthy; the STATE is not, and the host's disconnect handler is
+            # the one place that can decide between redialling for a fresh
+            # snapshot and giving up. Named so the log says which. Ordered
+            # BEFORE the bare ``OSError`` clause below because
+            # ``ConnectionError`` is one, and the two resets above are
+            # ``ConnectionError`` subclasses in turn.
+            reason = str(exc) or "owner sent a frame this client refused"
+            logger.warning("attach client: %s; the connection cannot continue", reason)
+        except OSError:
+            reason = "owner connection reset"
+        except Exception as exc:  # noqa: BLE001 — a callback failure must still report
+            # A host callback raised something else (a store rejecting an
+            # update, a validation error). Same treatment: the pump cannot
+            # continue past a frame it could not apply, and silence here is
+            # the "slow owner" bug shape above wearing a different exception.
+            reason = f"owner frame could not be applied: {exc}"
+            logger.warning("attach client: %s; the connection cannot continue", reason)
         finally:
             self._connected = False
             for future in self._pending.values():
@@ -634,6 +674,20 @@ class AttachClient:
                 self._writer.close()
             except Exception:  # noqa: BLE001
                 pass
+
+    def abandon(self) -> None:
+        """Close WITHOUT reporting the closure as a disconnect.
+
+        Both ``detach`` and ``close`` still end in ``on_disconnected`` (the
+        pump observes EOF or its cancellation) — right for a host that is
+        exiting or leaving, whose teardown runs one path, and wrong for a host
+        that is ABANDONING a connection it judged unusable and intends to keep
+        running: there the callback reads as owner loss and starts a recovery
+        that redials the same runtime. The refused-sync path in
+        ``RemoteSession`` is that case.
+        """
+        self._on_disconnected = lambda _reason: None
+        self.close()
 
     def close(self) -> None:
         """Synchronous teardown for hosts without a loop (app exit paths)."""

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -290,6 +290,42 @@ def _capped_components(components: Sequence[Any]) -> list[Any]:
     return values[len(values) - USAGE_COMPONENT_CAP :]
 
 
+def _inherited_identity_fixups(state: Any, session_id: str) -> dict[str, Any]:
+    """Fields a restored checkpoint must NOT be allowed to carry across a fork.
+
+    A fork copies ``transcript.jsonl`` verbatim (``fork.py``), and every
+    ``frontend_state_checkpoint_v1`` row in it was written by the PARENT — so
+    the newest checkpoint a fork restores is stamped with the parent's
+    identity, and down a fork chain with whatever the previous hop was
+    already serving (the grandparent's, observed in #573). The directory a
+    session runs in is authoritative for who it is; a status row it inherited
+    is not. Without this the fork's runtime served the parent's ``session_id``
+    in every ``frontend_sync``, ``RemoteSession._install_frontend`` refused
+    the frame ("frontend state belongs to another session"), and the fork was
+    permanently un-attachable: the switched-to fork's own viewer never got a
+    state install, so ``/model`` appeared to do nothing and the band never
+    painted its context (#573).
+
+    ``session_id`` is always re-stamped. The other two are corrected only when
+    the checkpoint is provably someone else's — a same-session resume keeps
+    them, because they are then this session's own history:
+
+    * ``checkpoint_id`` names the parent's last status row. It self-heals on
+      the fork's first turn end, but until then a reconciling reader would
+      match it against a row this transcript did write for the parent.
+    * ``jobs`` are the parent's children. ``subagent-roster.v1.json`` is on
+      ``fork.EXCLUDED_SIDECARS`` precisely so a fork does not list children it
+      cannot address (their comms registry belongs to the parent's process),
+      and the checkpoint smuggled equivalent rows past that exclusion.
+    """
+    fixups: dict[str, Any] = {"session_id": session_id}
+    inherited = str(getattr(state, "session_id", "") or "")
+    if inherited and inherited != session_id:
+        fixups["checkpoint_id"] = None
+        fixups["jobs"] = []
+    return fixups
+
+
 # Commands whose effect belongs to the process drawing the widgets. Every other
 # advertised slash is routed to the authoritative session owner; keeping this a
 # complement means adding a command without classification fails the test rather
@@ -1708,7 +1744,8 @@ class FrontendStateStore:
             except Exception:
                 restored = None
         epoch = uuid.uuid4().hex
-        state = restored or FrontendSessionState(session_id=str(session.session_id), epoch=epoch)
+        session_id = str(session.session_id)
+        state = restored or FrontendSessionState(session_id=session_id, epoch=epoch)
         # A new owner epoch invalidates stale wire updates while preserving the
         # durable checkpoint identity used to reconcile takeover without addition.
         #
@@ -1723,6 +1760,7 @@ class FrontendStateStore:
                 "epoch": epoch,
                 "sequence": 0,
                 "usage_components": _capped_components(state.usage_components),
+                **_inherited_identity_fixups(state, session_id),
             }
         )
 

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -1814,6 +1814,24 @@ class RemoteSession:
                     try:
                         await self._dial(record)
                     except (ConnectionError, OSError, TimeoutError):
+                        # ``_dial`` closes the client it built on every raise
+                        # path and installs ``self._client`` only as its last
+                        # statement, so a failed redial leaks no socket. What it
+                        # DOES leave is the identity it stamped on entry:
+                        # ``_runtime_pid = record.pid`` (and a pending
+                        # ``_frontend_future``) for a runtime this viewer never
+                        # attached to. That outlives the pass — ``_go_cold``
+                        # does not clear it either — so a viewer that never
+                        # bound reports ``runtime_pid`` as a live pid where the
+                        # property promises None while cold, and
+                        # ``take_unannounced_cleanup`` reads that pid to decide
+                        # whether THIS viewer owns the cleanup notice: a stale
+                        # match claims another runtime's notice and blanks the
+                        # terminal that should have shown it (review round 1,
+                        # F3). Discarding here keeps the whole loop on one
+                        # rule — a pass that did not bind leaves no trace of
+                        # the runtime it tried.
+                        self._discard_rejected_client()
                         await asyncio.sleep(delay)
                         delay = min(delay * 1.7, 0.5)
                         continue

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -474,9 +474,16 @@ class RemoteSession:
             takeover_factory=takeover_factory,
         )
         await self._dial(record)
-        frontend = await self._await_frontend()
-        self._install_frontend(frontend.snapshot)
-        await self._load_history(frontend.live_cursor)
+        try:
+            frontend = await self._await_frontend()
+            self._install_frontend(frontend.snapshot)
+            await self._load_history(frontend.live_cursor)
+        except BaseException:
+            # The caller gets the error and no facade — so nothing would ever
+            # close the connection ``_dial`` just opened. See
+            # ``_discard_rejected_client`` for the leak this closes.
+            self._discard_rejected_client()
+            raise
         self._finish_sync()
         return self
 
@@ -592,12 +599,19 @@ class RemoteSession:
                 "todo panels start empty"
             )
             return self._restore_cold_subagents(state)
+        # A fork's transcript carries the PARENT's checkpoints verbatim (#573),
+        # and the parent's children are not this session's to list — the same
+        # reason ``fork.EXCLUDED_SIDECARS`` leaves the roster behind. The
+        # runtime applies the identical rule when it restores
+        # (``frontend_state._inherited_identity_fixups``), so the cold frame
+        # and the attached frame agree on what the fork has.
+        inherited = durable.session_id != self._session_id
         restored = state.model_copy(
             update={
                 # Everything the last runtime knew and this process cannot
                 # derive. The panel reads these directly, so restoring them is
                 # what puts the session's details on the FIRST frame.
-                "jobs": list(durable.jobs),
+                "jobs": [] if inherited else list(durable.jobs),
                 "todos": list(durable.todos),
                 "conversation_title": durable.conversation_title,
                 "conversation_title_user_set": durable.conversation_title_user_set,
@@ -1008,13 +1022,58 @@ class RemoteSession:
         a second time.
         """
         await self._dial(record)
-        frontend = await self._await_frontend()
-        self._install_frontend(frontend.snapshot, publish=True)
-        await self._load_history(frontend.live_cursor)
+        try:
+            frontend = await self._await_frontend()
+            self._install_frontend(frontend.snapshot, publish=True)
+            await self._load_history(frontend.live_cursor)
+        except BaseException:
+            self._discard_rejected_client()
+            raise
         self._finish_sync()
         self._deliberate_stop = False
         self._stopped_announced = False
         self._owner_ready.set()
+
+    def _discard_rejected_client(self) -> None:
+        """Drop a client whose runtime dialled fine but whose state was refused.
+
+        ``_dial`` installs ``self._client`` the moment the socket authenticates,
+        BEFORE the canonical sync is awaited and checked — so when the sync is
+        rejected (``_install_frontend``'s identity guard, a malformed frame, the
+        15 s sync timeout) the facade was left half-bound: ``is_cold`` said
+        False because a connected client existed, every RPC still reached the
+        owner, yet no state had been installed and none ever would be. That is
+        the exact shape #573 produced on a switched-to fork: ``/model`` landed
+        on the owner's journal while the band never repainted and the context
+        segment stayed blank, so the switch read as "nothing happened".
+
+        Closing the client makes ``is_cold`` honest again — the next
+        ``_ensure_bound`` retries the whole engage and the TUI's own failure
+        path can say why — and it releases the runtime's attach slot. Without
+        the release each retry of ``_recover_owner`` opened another connection
+        on top of the last, and the runtime's LRU cap evicted them in a burst
+        (272 evictions logged in the minutes after one fork booted).
+
+        ``close()`` also cancels the pump, which is the one thing that must not
+        run on: with no state installed, the owner's next ``frontend_update``
+        would land on a store at the wrong epoch and fail as a sequence gap.
+        Cleared directly rather than through ``_on_disconnected`` because the
+        socket did not fail — the state did — and the recovery loop that hook
+        starts would redial the same runtime and be refused the same way.
+        """
+        client, self._client = self._client, None
+        self._frontend_future = None
+        self._runtime_pid = None
+        if client is None:
+            return
+        # ``abandon`` rather than ``close``: this closure is ours, not the
+        # owner's, so it must not read as owner loss — a bind that was refused
+        # would otherwise start a recovery that redials the same runtime and
+        # is refused again.
+        try:
+            client.abandon()
+        except Exception:  # noqa: BLE001 - teardown of a connection being abandoned
+            logger.debug("closing a rejected owner connection failed", exc_info=True)
 
     async def _dial(self, record: SessionRecord) -> None:
         # Freeze relay delivery until the canonical sync is installed ahead of
@@ -1754,6 +1813,11 @@ class RemoteSession:
                 ):
                     try:
                         await self._dial(record)
+                    except (ConnectionError, OSError, TimeoutError):
+                        await asyncio.sleep(delay)
+                        delay = min(delay * 1.7, 0.5)
+                        continue
+                    try:
                         frontend = await self._await_frontend()
                         self._install_frontend(frontend.snapshot, publish=True)
                         # ONE threaded parse feeds both the gap replay and the
@@ -1781,7 +1845,13 @@ class RemoteSession:
                         self._finish_sync()
                         return
                     except (ConnectionError, OSError, TimeoutError):
-                        pass
+                        # The runtime answered but its state was refused (or
+                        # the sync never came). The dialled client must not
+                        # survive into the next pass: it would sit connected
+                        # on the runtime, make ``is_cold`` lie, and be joined
+                        # by another on every retry. See
+                        # ``_discard_rejected_client``.
+                        self._discard_rejected_client()
                 else:
                     try:
                         local = await self._takeover_factory()

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -15907,6 +15907,18 @@ class OperatorApp(App[None]):
         notice: NoticeFn,
     ) -> None:
         old_label = session.model_label
+        # The DESTINATION is derived from the spec this command resolved, never
+        # re-read from ``session.model_label`` after ``set_model``. On a local
+        # ``Session`` the two agree — ``set_model`` assigns synchronously — but
+        # on a ``RemoteSession`` (a terminal attached to another owner's
+        # session) ``set_model`` only schedules the request as a task and
+        # ``model_label`` keeps reading the owner's frontend-state sync, which
+        # lands on a later tick. Re-reading there printed
+        # ``model: X → X (this session)`` for a switch that DID happen: the
+        # band and the incident were right and the receipt named the old
+        # model. The effort/fast-mode copies below change neither half of the
+        # identity, so this is the same pair ``set_model`` is asked for.
+        new_label = f"{spec.provider}/{spec.model_id}"
         # WRITE-ONLY when the default being saved is the model already in force
         # (review round 1, R3/Q1). This is the whole of the bare form, and it is
         # what makes "switches nothing" a true statement rather than a summary
@@ -15919,7 +15931,7 @@ class OperatorApp(App[None]):
         # has the plain `/model <p>/<id>` spelling for exactly that gesture.
         # Compared on the joined label because that is what the elided form was
         # derived from, so the two halves cannot disagree by case or spacing.
-        write_only = persist_default and f"{provider}/{model_id}" == old_label
+        write_only = persist_default and new_label == old_label
         if not write_only:
             # The chosen effort rides along when the new model accepts it: a
             # user who dropped to `low` for cost did not mean "until I switch
@@ -16043,10 +16055,7 @@ class OperatorApp(App[None]):
             # run-on. "(this session)" is the half that answers "for how long";
             # "from the next turn" answered "starting when", which nothing had
             # asked and which the very next receipt demonstrates anyway.
-            notice(
-                f"model: {old_label} → {session.model_label} "
-                f"(this session){suffix} — {PERSIST_HINT}"
-            )
+            notice(f"model: {old_label} → {new_label} (this session){suffix} — {PERSIST_HINT}")
         # MID-TURN is the one moment "starting when" is a live question, and the
         # next receipt cannot answer it because the answer is visible before
         # then: the agent goes on working on the old model until the step in
@@ -16061,12 +16070,16 @@ class OperatorApp(App[None]):
         # new model. Every spelling that switches the session owes the same
         # answer to "starting when".
         #
-        # ``old_label != session.model_label`` because re-selecting the model
-        # already in force is a no-op, and promising that "this one finishes on
-        # the old model" describes a handover that will not happen (D4). The
-        # session layer already declines to re-derive anything for a same-model
-        # write; this is the UI half of that rule.
-        if session.is_streaming and old_label != session.model_label:
+        # ``old_label != new_label`` because re-selecting the model already in
+        # force is a no-op, and promising that "this one finishes on the old
+        # model" describes a handover that will not happen (D4). The session
+        # layer already declines to re-derive anything for a same-model write;
+        # this is the UI half of that rule. Compared against the RESOLVED
+        # label, not a re-read of ``session.model_label``: on a remote session
+        # the re-read still equals ``old_label`` (see ``new_label`` above), so
+        # the mid-turn row never printed for exactly the switches it exists to
+        # qualify.
+        if session.is_streaming and old_label != new_label:
             # ``info``, matching the receipt it qualifies, NOT ``note`` (design
             # review D3). Both rows answer one action, and at ``note`` the
             # subordinate half measured 8.62:1 against the receipt's 4.55:1 —
@@ -21542,6 +21555,10 @@ class OperatorApp(App[None]):
                 kind="notice", text=f"cannot resolve {provider}: {error}", style="error"
             )
         old_label = session.model_label
+        # Destination from the RESOLVED spec, not a re-read of the session's
+        # label — same reason as in ``_cmd_model``: a ``RemoteSession`` applies
+        # ``set_model`` asynchronously and its label follows the owner's sync.
+        new_label = f"{spec.provider}/{spec.model_id}"
         session.set_model(
             self._spec_with_chosen_fast_mode(self._spec_with_chosen_effort(spec)),
             explicit=True,
@@ -21554,10 +21571,7 @@ class OperatorApp(App[None]):
         # repaints from the canonical update — the receipt below only has to
         # reach the invoker. Mid-turn timing is stated by the owner-side
         # notice path (the streamed turn's own events carry it).
-        text = (
-            f"model: {old_label} → {session.model_label} "
-            f"(this session){suffix} — {PERSIST_HINT}"
-        )
+        text = f"model: {old_label} → {new_label} (this session){suffix} — {PERSIST_HINT}"
         if warning:
             text = f"{text}\n{warning}"
         return SlashResult(kind="notice", text=text, style="info")

--- a/tests/e2e/test_fork_checkpoint_e2e.py
+++ b/tests/e2e/test_fork_checkpoint_e2e.py
@@ -1,0 +1,305 @@
+"""A fork whose transcript carries the PARENT's checkpoint still binds and switches.
+
+The fork e2e in ``test_fork_e2e.py`` seeds a parent with messages only, so its
+fork inherits no ``frontend_state_checkpoint_v1`` row and the runtime restores
+a fresh state stamped with the right id. Every real fork of a session that has
+run a turn inherits the parent's checkpoint, and until #573 that checkpoint's
+``session_id`` rode through the restore untouched: the fork's runtime served
+the parent's id in ``frontend_sync``, the viewer refused it, and the fork was
+un-attachable — its own switched-to viewer half-bound (RPCs landed, no state
+ever painted), every second terminal refused outright. This stage drives that
+exact shape against REAL runtime subprocesses, the way ``lop`` does:
+
+* the TUI's viewer factory (cold ``RemoteSession`` engaged into a
+  ``local_operator.session.runtime.process`` child by ``engage_runtime``);
+* a parent transcript whose newest checkpoint names the parent and carries a
+  measured context reading;
+* ``/fork`` in switch mode, then ``/model`` on the fork;
+* a second follower ``RemoteSession.connect``-ing to the live fork.
+
+Only the provider is a mock (the ``test`` hosting). Everything else — the fork
+copy, the lease, the spawn, the socket, the sync, the band — is production.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.session.remote import RemoteSession
+from local_operator.tui.app import OperatorApp
+from tests.e2e.harness import wait_for_adoption
+from tests.e2e.test_fork_e2e import _never_take_over, _pump
+from tests.e2e.watchdog import bounded
+
+PARENT_ID = "ckptparent01"
+
+
+def _seed_parent_with_checkpoint(config: Path) -> None:
+    """A parent that has run a turn: messages plus the checkpoint it wrote."""
+    from local_operator.session.frontend_state import (
+        FRONTEND_CHECKPOINT_CUSTOM_TYPE,
+        FrontendModelSpec,
+        FrontendSessionState,
+        JobState,
+    )
+
+    directory = config / "sessions" / PARENT_ID
+    directory.mkdir(parents=True)
+    model = FrontendModelSpec(provider="test", model_id="mock", context_window=128_000)
+    checkpoint = FrontendSessionState(
+        session_id=PARENT_ID,
+        epoch="parent-owner",
+        conversation_title="Checkpointed parent",
+        # The parent's child: a fork must not list it (#573, and the reason
+        # the roster sidecar is on ``fork.EXCLUDED_SIDECARS``).
+        jobs=[JobState(id="parent-child", type="task", label="auditor", status="succeeded")],
+        selected_model=model,
+        effective_model=model,
+        context_tokens=42_000,
+        context_is_estimate=False,
+        context_window=128_000,
+    )
+    rows = [
+        {
+            "id": "u1",
+            "ts": 1.0,
+            "type": "message",
+            "payload": {
+                "kind": "message",
+                "role": "user",
+                "content": [{"type": "text", "text": "original question"}],
+            },
+        },
+        {
+            "id": "a1",
+            "ts": 2.0,
+            "type": "message",
+            "payload": {
+                "kind": "message",
+                "role": "assistant",
+                "content": [{"type": "text", "text": "saved answer"}],
+                "stop_reason": "stop",
+            },
+        },
+        {
+            "id": "c1",
+            "ts": 3.0,
+            "type": "custom",
+            "payload": {
+                "custom_type": FRONTEND_CHECKPOINT_CUSTOM_TYPE,
+                "details": {
+                    "checkpoint_id": "cp-parent",
+                    "state": checkpoint.model_dump(mode="json"),
+                },
+            },
+        },
+    ]
+    (directory / "transcript.jsonl").write_text(
+        "".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8"
+    )
+
+
+def _kill_runtime_children(config: Path) -> None:
+    """Reap the runtime subprocesses this test's engages spawned.
+
+    They are started in their own session group and would otherwise live
+    until their idle drain; a killed child never writes anything the
+    assertions read, and the tmp config dir is removed with the test.
+    """
+    try:
+        out = subprocess.run(
+            ["pgrep", "-f", "local_operator.session.runtime.process"],
+            capture_output=True,
+            text=True,
+            check=False,
+        ).stdout.split()
+    except OSError:
+        return
+    for pid in out:
+        try:
+            environ = subprocess.run(
+                ["ps", "-o", "command=", "-p", pid], capture_output=True, text=True, check=False
+            )
+            # ``ps`` cannot show the child's environment portably; match on the
+            # record it published instead.
+            del environ
+            for record_path in (config / "run" / "mobile").glob("*.json"):
+                if json.loads(record_path.read_text()).get("pid") == int(pid):
+                    os.kill(int(pid), 9)
+        except (OSError, ValueError):
+            continue
+
+
+@pytest.mark.asyncio
+async def test_a_fork_with_an_inherited_checkpoint_binds_switches_and_admits_followers(
+    headless_tui_env: Path, workspace: Path, monkeypatch
+) -> None:
+    from local_operator.mobile.attach_client import find_owner_record
+    from local_operator.providers.auth_store import AuthStore
+    from local_operator.providers.controller import ProviderController
+    from local_operator.spawn import registry as spawn_registry
+
+    config = headless_tui_env
+    monkeypatch.setattr(
+        spawn_registry,
+        "active_backend",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("switch must not open a window")),
+    )
+    # The runtime children must resolve the SAME source tree as this test.
+    monkeypatch.setenv("PYTHONPATH", str(Path(__file__).resolve().parents[2]))
+    monkeypatch.setenv("HOME", str(config.parent))
+    (config / "config.yml").write_text(
+        "version: 0.0.0\nvalues:\n  hosting: test\n  model_name: mock\n  fork:\n    mode: switch\n",
+        encoding="utf-8",
+    )
+    _seed_parent_with_checkpoint(config)
+
+    async def take_over() -> Any:
+        raise RuntimeError("a viewer never takes over a session")
+
+    async def viewer_factory(resume_id: str | None) -> RemoteSession:
+        # ``cli.viewer_factory`` in miniature: attach when a live record
+        # exists, else open cold and let the mount engage start a runtime.
+        session_id = resume_id or "newsession01"
+        record = None
+        if resume_id:
+            record, _ = await asyncio.to_thread(find_owner_record, config, session_id)
+        if record is not None:
+            return await RemoteSession.connect(
+                record, session_id, config_dir=config, takeover_factory=take_over
+            )
+        return await RemoteSession.cold(
+            session_id, config_dir=config, cwd=str(workspace), takeover_factory=take_over
+        )
+
+    controller = ProviderController(AuthStore(config / "auth.db"))
+    OperatorApp._check_for_update = lambda self: None  # type: ignore[method-assign]
+    app = OperatorApp(
+        lambda: viewer_factory(PARENT_ID),
+        provider_controller=controller,
+        resume_factory=viewer_factory,
+    )
+    follower: RemoteSession | None = None
+    try:
+        with bounded(150, "fork with inherited checkpoint binds, switches, admits a follower"):
+            async with app.run_test(size=(100, 30)) as pilot:
+                await wait_for_adoption(app, pilot)
+                # The parent's own engage: a real runtime child comes up and
+                # the band paints the checkpoint's context reading.
+                await _pump(pilot, lambda: not getattr(app._session, "is_cold", True))
+                await _pump(pilot, lambda: app._status is not None and app._status.context_tokens)
+                assert app._status is not None
+                assert app._status.context_tokens == 42_000
+
+                app._run_slash_command("/fork")
+                await _pump(
+                    pilot,
+                    lambda: app._session is not None and app._session.session_id != PARENT_ID,
+                )
+                fork = app._session
+                assert isinstance(fork, RemoteSession)
+                fork_id = fork.session_id
+                status = app._status
+                # THE regression: the fork's runtime must bind. Before #573
+                # this engage failed with "frontend state belongs to another
+                # session" and the viewer sat half-bound forever.
+                await _pump(pilot, lambda: not fork.is_cold)
+                await _pump(pilot, lambda: status.context_tokens == 42_000)
+                state = fork.frontend_state
+                assert state.session_id == fork_id
+                assert state.jobs == (), "a fork must not list its parent's children"
+                assert status._context_window == 128_000
+                assert status._model_label == "test/mock"
+
+                # /model on the fork lands on the owner and repaints the band
+                # from the owner's sync.
+                app._run_slash_command("/model test/other")
+                await _pump(pilot, lambda: fork.model_label == "test/other")
+                await _pump(pilot, lambda: status._model_label == "test/other")
+                assert status.context_tokens == 42_000
+                journal = (config / "sessions" / fork_id / "transcript.jsonl").read_text()
+                # The owner journals a genuine switch (``Session.set_model``):
+                # the durable proof it landed on the runtime, not just the band.
+                assert '"new_label":"test/other"' in journal.replace(
+                    " ", ""
+                ), "the switch never reached the owner"
+
+                # A SECOND terminal attaches as a follower (#573's report).
+                record, _ = await asyncio.to_thread(find_owner_record, config, fork_id)
+                assert record is not None
+                follower = await RemoteSession.connect(
+                    record, fork_id, config_dir=config, takeover_factory=_never_take_over
+                )
+                assert follower.frontend_state.session_id == fork_id
+                assert follower.model_label == "test/other"
+                assert follower.frontend_state.context_tokens == 42_000
+                app.exit()
+    finally:
+        if follower is not None:
+            await follower.dispose()
+        _kill_runtime_children(config)
+
+
+@pytest.mark.asyncio
+async def test_a_fork_of_a_fork_serves_its_own_id(headless_tui_env: Path, workspace: Path) -> None:
+    """#573 observed the GRANDPARENT's id two hops down. Chain two forks on
+    disk and boot a real runtime for the second: its sync names itself."""
+    from local_operator.fork import fork_session
+    from local_operator.mobile.attach_client import find_owner_record
+    from local_operator.session.runtime import registry
+
+    config = headless_tui_env
+    (config / "config.yml").write_text(
+        "version: 0.0.0\nvalues:\n  hosting: test\n  model_name: mock\n", encoding="utf-8"
+    )
+    _seed_parent_with_checkpoint(config)
+    first = fork_session(config, PARENT_ID)
+    second = fork_session(config, first)
+    env = {
+        **os.environ,
+        "HOME": str(config.parent),
+        "LOCAL_OPERATOR_CONFIG_DIR": str(config),
+        "PYTHONPATH": str(Path(__file__).resolve().parents[2]),
+        "LOP_MOBILE_CHILD_CWD": str(workspace),
+        "LOP_MOBILE_CHILD_RESUME": second,
+    }
+    child = subprocess.Popen(
+        [sys.executable, "-m", "local_operator.session.runtime.process"],
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    viewer: RemoteSession | None = None
+    try:
+        with bounded(90, "fork-of-a-fork runtime serves its own id"):
+            record = None
+            deadline = time.monotonic() + 60
+            while time.monotonic() < deadline and record is None:
+                for candidate, state in registry.scan(config):
+                    if candidate.session_id == second and state == "live":
+                        record = candidate
+                await asyncio.sleep(0.1)
+            assert record is not None, "the fork-of-a-fork runtime never published"
+            # ``find_owner_record`` needs the liveness marker the child wrote.
+            found, _ = await asyncio.to_thread(find_owner_record, config, second)
+            assert found is not None
+            viewer = await RemoteSession.connect(
+                found, second, config_dir=config, takeover_factory=_never_take_over
+            )
+            assert viewer.frontend_state.session_id == second
+            assert viewer.frontend_state.jobs == ()
+    finally:
+        if viewer is not None:
+            await viewer.dispose()
+        child.kill()
+        child.wait(timeout=10)

--- a/tests/unit/mobile/test_attach_client.py
+++ b/tests/unit/mobile/test_attach_client.py
@@ -329,3 +329,40 @@ async def test_abandon_closes_without_reporting_owner_loss(config: Path) -> None
         assert r.attach_clients() == 0
     finally:
         r.close()
+
+
+@pytest.mark.asyncio
+async def test_a_connection_reset_keeps_the_reset_reason_not_the_generic_one(
+    config: Path,
+) -> None:
+    """Locks the pump's clause ORDER, which is load-bearing and invisible.
+
+    ``ConnectionResetError`` and ``BrokenPipeError`` are ``ConnectionError``
+    subclasses, and ``ConnectionError`` is an ``OSError``. So the pump's three
+    handlers are ordered reset -> ConnectionError -> OSError, and every one of
+    them is reachable only because of that order: hoisting the bare
+    ``ConnectionError`` clause above the reset clause would silently retag a
+    dead transport as "a frame this client refused", which is the opposite
+    diagnosis — the host redials for a fresh snapshot instead of reporting the
+    owner as gone. Nothing about the source says that, so this pins it
+    (review round 1, F4).
+    """
+    handle = FakeHandle("sess-a")
+    r = RuntimeServer(handle, kind="tui")
+    r.start()
+    try:
+        record = await _wait_record()
+        disconnected: list[str] = []
+        client = AttachClient(lambda p: None, disconnected.append)
+        await client.connect(record, "sess-a")
+        # A transport death, raised out of the pump's read exactly as a peer
+        # RST would surface it.
+        assert client._reader is not None
+        client._reader.set_exception(ConnectionResetError("peer reset"))
+        deadline = asyncio.get_running_loop().time() + 5
+        while asyncio.get_running_loop().time() < deadline and not disconnected:
+            await asyncio.sleep(0.05)
+        assert disconnected == ["owner connection reset"]
+        assert not client.connected
+    finally:
+        r.close()

--- a/tests/unit/mobile/test_attach_client.py
+++ b/tests/unit/mobile/test_attach_client.py
@@ -252,3 +252,80 @@ async def test_request_error_raises_runtime_error(config: Path) -> None:
         await client.detach()
     finally:
         r.close()
+
+
+@pytest.mark.asyncio
+async def test_a_refused_frame_is_not_reported_as_an_oversized_one(config: Path) -> None:
+    """The pump's disconnect reason names what actually happened.
+
+    ``StreamReader.readline`` raises ``ValueError`` on a line overrun, and the
+    pump's ``except ValueError`` was written for that. But the frame callbacks
+    raise ``ValueError`` too — a follower store refusing an update as "not the
+    next state sequence", pydantic validating a frame — and every one of those
+    was logged as "owner sent a frame larger than the 1048576-byte line
+    limit" for a frame of a few hundred bytes (#573's viewer, whose store was
+    still the cold one because the sync had been refused). Only the READ can
+    be oversized; a callback failure carries its own reason.
+    """
+    from local_operator.mobile.attach_client import OVERSIZED_FRAME_REASON
+    from tests.unit.session.runtime.test_server import FakeHandle as RelayHandle
+
+    # The relay-capable fake (session_id "s1"): this test needs an owner that
+    # actually pushes an event frame at the client.
+    handle = RelayHandle()
+    r = RuntimeServer(handle, kind="tui")
+    r.start()
+    try:
+        record = await _wait_record()
+        disconnected: list[str] = []
+
+        def refuse(_data):  # noqa: ANN001, ANN202
+            raise ValueError("frontend update is not the next state sequence")
+
+        # The real shape: the sync installs, then the follower's store refuses
+        # the next ordered update (a viewer left at the wrong epoch).
+        client = AttachClient(
+            lambda p: None,
+            disconnected.append,
+            frontend_state=True,
+            on_frontend_sync=lambda _data: None,
+            on_frontend_update=refuse,
+        )
+        await client.connect(record, "s1")
+        handle._frontend.mutate(goal="anything that publishes an update")
+        deadline = asyncio.get_running_loop().time() + 5
+        while asyncio.get_running_loop().time() < deadline and not disconnected:
+            await asyncio.sleep(0.05)
+        assert len(disconnected) == 1
+        assert disconnected[0] != OVERSIZED_FRAME_REASON
+        assert "not the next state sequence" in disconnected[0]
+        assert not client.connected
+    finally:
+        r.close()
+
+
+@pytest.mark.asyncio
+async def test_abandon_closes_without_reporting_owner_loss(config: Path) -> None:
+    """``abandon`` is the close for a host that is abandoning a connection it
+    judged unusable and intends to keep running: the pump's ``finally`` must
+    not report it as a disconnect, or the host's recovery loop would redial
+    the very runtime it just gave up on."""
+    handle = FakeHandle("sess-a")
+    r = RuntimeServer(handle, kind="tui")
+    r.start()
+    try:
+        record = await _wait_record()
+        disconnected: list[str] = []
+        client = AttachClient(lambda p: None, disconnected.append)
+        await client.connect(record, "sess-a")
+        client.abandon()
+        await asyncio.sleep(0.2)
+        assert disconnected == []
+        assert not client.connected
+        for _ in range(50):
+            if r.attach_clients() == 0:
+                break
+            await asyncio.sleep(0.02)
+        assert r.attach_clients() == 0
+    finally:
+        r.close()

--- a/tests/unit/mobile/test_attach_client.py
+++ b/tests/unit/mobile/test_attach_client.py
@@ -284,14 +284,21 @@ async def test_a_refused_frame_is_not_reported_as_an_oversized_one(config: Path)
 
         # The real shape: the sync installs, then the follower's store refuses
         # the next ordered update (a viewer left at the wrong epoch).
+        synced = asyncio.Event()
         client = AttachClient(
             lambda p: None,
             disconnected.append,
             frontend_state=True,
-            on_frontend_sync=lambda _data: None,
+            on_frontend_sync=lambda _data: synced.set(),
             on_frontend_update=refuse,
         )
         await client.connect(record, "s1")
+        # ``connect()`` returns at the WELCOME frame, but the server subscribes
+        # this connection to the frontend only afterwards. A mutation landing in
+        # that gap is folded into the sync snapshot instead of being relayed as
+        # an update, so ``refuse`` never fires and no amount of waiting on the
+        # deadline below can produce the frame. Gate on the sync itself.
+        await asyncio.wait_for(synced.wait(), timeout=5)
         handle._frontend.mutate(goal="anything that publishes an update")
         deadline = asyncio.get_running_loop().time() + 5
         while asyncio.get_running_loop().time() < deadline and not disconnected:

--- a/tests/unit/session/test_frontend_state.py
+++ b/tests/unit/session/test_frontend_state.py
@@ -899,3 +899,116 @@ def test_queued_custom_steers_project_their_human_text() -> None:
     ]
     assert [entry["id"] for entry in state.queued_steering] == [peer.id, wake.id, typed.id]
     assert all(entry["image_count"] == 0 for entry in state.queued_steering)
+
+
+class _CheckpointTranscript:
+    """The one method ``FrontendStateStore._restored_state`` reads."""
+
+    def __init__(self, state: FrontendSessionState | None, checkpoint_id: str = "cp-parent"):
+        self._state = state
+        self._checkpoint_id = checkpoint_id
+
+    def latest_custom(self, custom_type: str) -> dict[str, Any] | None:
+        if self._state is None:
+            return None
+        return {
+            "checkpoint_id": self._checkpoint_id,
+            "state": self._state.model_dump(mode="json"),
+        }
+
+
+def _owner_over(session_id: str, checkpoint: FrontendSessionState | None) -> SimpleNamespace:
+    return SimpleNamespace(session_id=session_id, _transcript=_CheckpointTranscript(checkpoint))
+
+
+def test_a_fork_restores_its_own_session_id_not_the_parents(tmp_path) -> None:
+    """#573: the directory a session runs in is authoritative for who it is.
+
+    A fork copies ``transcript.jsonl`` verbatim, so the newest checkpoint it
+    restores was written BY THE PARENT and carries the parent's ``session_id``.
+    The runtime then served that id in every ``frontend_sync`` and
+    ``RemoteSession._install_frontend`` refused the frame — a fork nobody could
+    attach to, and (in switch mode) a fork whose own viewer never got a state
+    install, so ``/model`` looked inert and the band never painted its context.
+    The same shape as the ``COPIED_SIDECARS`` set-equality test in
+    ``tests/unit/test_fork.py``: fork with a checkpoint present, assert the
+    restored identity equals the new directory name.
+    """
+    from local_operator.fork import fork_session
+
+    parent = _state(session_id="parent000001", checkpoint_id="cp-parent")
+    parent_dir = tmp_path / "sessions" / "parent000001"
+    parent_dir.mkdir(parents=True)
+    row = {
+        "id": "r1",
+        "ts": 1.0,
+        "type": "custom",
+        "payload": {
+            "custom_type": "frontend_state_checkpoint_v1",
+            "details": {"checkpoint_id": "cp-parent", "state": parent.model_dump(mode="json")},
+        },
+    }
+    import json
+
+    (parent_dir / "transcript.jsonl").write_text(json.dumps(row) + "\n", encoding="utf-8")
+    fork_id = fork_session(tmp_path, "parent000001")
+
+    from local_operator.session.transcript import Transcript
+
+    owner = SimpleNamespace(
+        session_id=fork_id, _transcript=Transcript(tmp_path / "sessions" / fork_id)
+    )
+    restored = FrontendStateStore.from_checkpoint(owner).state
+    assert restored.session_id == fork_id
+    # Everything that is genuinely the conversation's carries over: spend,
+    # title, occupancy against the window it was measured on.
+    assert restored.conversation_title == parent.conversation_title
+    assert restored.cumulative_parent_cost == parent.cumulative_parent_cost
+    assert restored.context_tokens == parent.context_tokens
+    assert restored.context_window == parent.context_window
+
+
+def test_a_same_session_resume_keeps_its_checkpoint_id_and_jobs() -> None:
+    """The fixup is scoped to INHERITED checkpoints. A resume of the session
+    that wrote the row keeps its own bookkeeping: the checkpoint id names a row
+    this transcript wrote for itself, and the jobs are its own children."""
+    own = _state(session_id="s1", checkpoint_id="cp-own")
+    restored = FrontendStateStore.from_checkpoint(_owner_over("s1", own)).state
+    assert restored.session_id == "s1"
+    assert restored.checkpoint_id == "cp-own"
+    assert [job.id for job in restored.jobs] == ["j1"]
+
+
+def test_an_inherited_checkpoint_drops_the_parents_checkpoint_id_and_jobs() -> None:
+    """The two identity-bearing fields #573 flagged beside ``session_id``.
+
+    ``checkpoint_id`` would otherwise name the parent's last row until the
+    fork's first turn end; ``jobs`` are the parent's children, which
+    ``fork.EXCLUDED_SIDECARS`` already keeps out of the roster sidecar — the
+    checkpoint was the one door left open.
+    """
+    inherited = _state(session_id="parent000001", checkpoint_id="cp-parent")
+    restored = FrontendStateStore.from_checkpoint(_owner_over("fork00000001", inherited)).state
+    assert restored.session_id == "fork00000001"
+    assert restored.checkpoint_id is None
+    assert restored.jobs == ()
+    # ``from_session`` (the TUI-hosted construction) restores through the same
+    # helper, so the two hosts cannot disagree about the fork's identity.
+    assert FrontendStateStore._restored_state(
+        _owner_over("fork00000001", inherited)
+    ).session_id == ("fork00000001")
+
+
+def test_a_fork_of_a_fork_is_stamped_with_its_own_id_at_every_hop() -> None:
+    """#573 observed the GRANDPARENT's id two hops down: each hop inherited
+    whatever the previous one was already serving. With the re-stamp on
+    restore, a checkpoint written by the first fork names the first fork, and
+    the second fork corrects it again to itself."""
+    grandparent = _state(session_id="grand0000001")
+    first_fork = FrontendStateStore.from_checkpoint(_owner_over("fork10000001", grandparent)).state
+    assert first_fork.session_id == "fork10000001"
+    # The first fork writes ITS checkpoint (now correctly stamped); the second
+    # fork inherits that row.
+    second_fork = FrontendStateStore.from_checkpoint(_owner_over("fork20000001", first_fork)).state
+    assert second_fork.session_id == "fork20000001"
+    assert second_fork.jobs == ()

--- a/tests/unit/session/test_remote.py
+++ b/tests/unit/session/test_remote.py
@@ -333,3 +333,57 @@ async def test_remote_adopt_aside_and_cancel_route_to_owner(tmp_path: Path, monk
         if remote is not None:
             await remote.dispose()
         registrant.close()
+
+
+@pytest.mark.asyncio
+async def test_a_refused_sync_leaves_the_viewer_cold_and_holds_no_connection(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """#573's viewer half: a rejected bind must not leave a connected client.
+
+    An owner whose canonical state names ANOTHER session (a fork serving its
+    parent's checkpoint before the restore re-stamped it) is refused by
+    ``_install_frontend``. Before this, ``_dial`` had already installed the
+    client, so the facade stayed "bound": ``is_cold`` said False, RPCs still
+    reached the owner, no state was ever installed, and every recovery pass
+    dialled ANOTHER connection on top — the runtime's attach cap evicted them
+    in bursts. The refusal must leave exactly what a failed engage leaves:
+    a cold viewer and zero attach clients on the runtime.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions" / "s1").mkdir(parents=True)
+    handle = FakeHandle()
+    # The owner is hosting "s1" (welcome identity passes) but its canonical
+    # state was restored from a checkpoint stamped with another session.
+    handle._frontend.mutate(session_id="parent000001")
+    registrant = RuntimeServer(handle, kind="tui")
+    registrant.start()
+    try:
+        record = await _wait_record(tmp_path)
+        with pytest.raises(ConnectionError, match="belongs to another session"):
+            await RemoteSession.connect(
+                record, "s1", config_dir=tmp_path, takeover_factory=_never_take_over
+            )
+        # Cold path: the same refusal through ``_ensure_bound`` on a viewer
+        # that will keep living (the TUI's mount engage).
+        viewer = await RemoteSession.cold(
+            "s1", config_dir=tmp_path, cwd=str(tmp_path), takeover_factory=_never_take_over
+        )
+        try:
+            with pytest.raises(ConnectionError, match="belongs to another session"):
+                await viewer._bind_to(record)
+            assert viewer.is_cold is True, "a refused bind must not leave the facade bound"
+            # Two refusals, zero leaked sockets: give the server a few ticks
+            # to observe the closes.
+            for _ in range(50):
+                if registrant.attach_clients() == 0:
+                    break
+                await asyncio.sleep(0.02)
+            assert registrant.attach_clients() == 0
+            # And no recovery loop was started by our own close.
+            await asyncio.sleep(0.1)
+            assert viewer._recovery_task is None
+        finally:
+            await viewer.dispose()
+    finally:
+        registrant.close()

--- a/tests/unit/session/test_remote.py
+++ b/tests/unit/session/test_remote.py
@@ -14,6 +14,7 @@ from local_operator.harness.types import (
     ToolExecutionStartEvent,
 )
 from local_operator.mobile.types import AskOptionWire, PendingRequest
+from local_operator.session.frontend_state import FRONTEND_CAPABILITY
 from local_operator.session.remote import RemoteSession
 from local_operator.session.runtime import registry
 from local_operator.session.runtime.server import RuntimeServer
@@ -387,3 +388,64 @@ async def test_a_refused_sync_leaves_the_viewer_cold_and_holds_no_connection(
             await viewer.dispose()
     finally:
         registrant.close()
+
+
+@pytest.mark.asyncio
+async def test_a_failed_redial_in_recovery_leaves_no_stale_runtime_identity(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The recovery loop's dial-failure branch must leave no trace of the try.
+
+    ``_dial`` stamps ``_runtime_pid`` from the record on ENTRY, before it can
+    know the dial will fail, and installs ``self._client`` only as its LAST
+    statement (it closes the client it built on every raise path). So what a
+    failed redial leaks is not a socket — it is the IDENTITY: the branch
+    ``continue``d straight to the next pass, so a viewer that never bound kept
+    reporting ``runtime_pid`` as the pid it merely tried, where the property
+    promises None while cold, and ``_go_cold`` does not clear it either.
+
+    That pid is not cosmetic. ``take_unannounced_cleanup`` compares it against
+    the pid that wrote the cleanup record to decide WHICH terminal announces a
+    cleanup, so a stale match makes this viewer claim a notice belonging to a
+    runtime it never attached to, and the terminal that should have printed it
+    stays blank (review round 1, F3).
+
+    Driven through the real loop: a live-looking record whose control port
+    refuses is exactly what recovery sees while a runtime is going away.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions" / "s1").mkdir(parents=True)
+    viewer = await RemoteSession.cold(
+        "s1", config_dir=tmp_path, cwd=str(tmp_path), takeover_factory=_never_take_over
+    )
+    try:
+        dead = registry.SessionRecord(
+            pid=424242,
+            kind="tui",
+            session_id="s1",
+            conversation_name="gone",
+            cwd=str(tmp_path),
+            model_label="test/model",
+            control_port=1,  # nothing listens here, so `_dial` raises
+            control_key="k",
+            protocol=5,
+            capabilities=[FRONTEND_CAPABILITY],
+        )
+
+        # Feed the loop that unreachable record instead of the registry, then
+        # let it take a few passes and go cold on its own deadline.
+        monkeypatch.setattr(
+            "local_operator.session.remote.find_owner_record",
+            lambda *_a, **_k: (dead, None),
+        )
+        monkeypatch.setattr("local_operator.session.remote.COLD_FALLBACK_S", 0.4)
+        await viewer._recover_owner()
+
+        assert viewer._client is None, "a failed dial installs no client"
+        assert viewer.is_cold is True
+        assert (
+            viewer.runtime_pid is None
+        ), "a viewer that never bound must not report the pid it failed to dial"
+        assert viewer._frontend_future is None, "the abandoned sync wait must not survive"
+    finally:
+        await viewer.dispose()

--- a/tests/unit/session/test_remote_cold.py
+++ b/tests/unit/session/test_remote_cold.py
@@ -953,3 +953,52 @@ async def test_the_restored_roster_unions_the_sidecar_and_the_checkpoint(
         assert jobs["shared"].status == "failed"
     finally:
         await viewer.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_cold_fork_does_not_list_its_parents_children(tmp_path: Path, monkeypatch) -> None:
+    """#573 on the cold path: the checkpoint a fork inherits is the parent's.
+
+    ``fork.EXCLUDED_SIDECARS`` keeps the roster sidecar out of a fork precisely
+    so it does not list children it cannot address, and the checkpoint was
+    smuggling equivalent rows past that exclusion. The rest of the durable
+    state — title, spend, occupancy — IS the conversation's and still restores,
+    and the identity the viewer reports is its own directory's.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    directory = _seed_transcript(tmp_path, SESSION_ID)
+
+    from local_operator.harness.types import Message
+    from local_operator.session.frontend_state import (
+        FRONTEND_CHECKPOINT_CUSTOM_TYPE,
+        FrontendModelSpec,
+        FrontendSessionState,
+        JobState,
+    )
+    from local_operator.session.transcript import Transcript
+
+    transcript = Transcript(directory)
+    await transcript.append_message(Message.user("go"))
+    inherited = FrontendSessionState(
+        session_id="parent000001",
+        epoch="parent-owner",
+        conversation_title="Parent's title",
+        jobs=[JobState(id="parent-child", type="task", label="auditor", status="succeeded")],
+        cumulative_parent_cost=4.5,
+        selected_model=FrontendModelSpec(provider="", model_id=""),
+    )
+    await transcript.append_custom(
+        FRONTEND_CHECKPOINT_CUSTOM_TYPE,
+        {"checkpoint_id": "cp-parent", "state": inherited.model_dump(mode="json")},
+    )
+    viewer = await RemoteSession.cold(
+        SESSION_ID, config_dir=tmp_path, cwd=str(tmp_path), takeover_factory=_never
+    )
+    try:
+        state = viewer.frontend_state
+        assert state.session_id == SESSION_ID
+        assert state.jobs == ()
+        assert state.conversation_title == "Parent's title"
+        assert state.cumulative_parent_cost == 4.5
+    finally:
+        await viewer.dispose()

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -9021,6 +9021,91 @@ async def test_a_mid_turn_switch_says_when_it_starts_applying() -> None:
     assert qualifier._token == receipt._token, (qualifier._token, receipt._token)
 
 
+class _AsyncLabelSession(FakeSession):
+    """A session whose label follows ``set_model`` only LATER, as ``RemoteSession``'s
+    does: there ``set_model`` schedules the owner request as a task and
+    ``model_label`` reads the frontend-state sync that lands on a later tick.
+    The label here never moves on its own, which is the sharpest form of that
+    gap — a receipt that re-reads the label after the call sees the old model.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._label = "anthropic/claude-opus-5"
+        self.requested: list[tuple[str, str]] = []
+
+    @property
+    def model_label(self) -> str:
+        return self._label
+
+    def set_model(self, model, *, explicit: bool = False) -> None:
+        self.requested.append((model.provider, model.model_id))
+
+
+@pytest.mark.asyncio
+async def test_switch_receipt_names_the_destination_before_a_remote_label_lands() -> None:
+    """The arrow's right-hand side is the model the user ASKED for, even when the
+    session's own label has not caught up yet.
+
+    Operator report: on a terminal attached to another owner's session,
+    ``/model anthropic/claude-fable-5-1`` printed ``model: anthropic/claude-opus-5
+    → anthropic/claude-opus-5 (this session)`` while the band and the
+    model-switch incident correctly showed the new model. The receipt re-read
+    ``session.model_label`` after ``set_model``, which on a ``RemoteSession`` is
+    still the pre-switch value; the destination has to come from the spec the
+    command resolved.
+    """
+    session = _AsyncLabelSession()
+    ctrl = _AccessController(stored=("openrouter", "anthropic"))
+    app = OperatorApp(lambda: _factory(session), provider_controller=ctrl)
+    async with app.run_test(size=(110, 24)) as pilot:
+        await _await_session(app, pilot)
+        app._run_slash_command("/model anthropic/claude-fable-5-1")
+        await pilot.pause()
+        text = _unwrapped(_transcript_text(app))
+    assert session.requested == [("anthropic", "claude-fable-5-1")], session.requested
+    assert session.model_label == "anthropic/claude-opus-5", "the fake's label must not have moved"
+    assert (
+        _unwrapped("model: anthropic/claude-opus-5 → anthropic/claude-fable-5-1 (this session)")
+        in text
+    ), text
+    assert _unwrapped("claude-opus-5 → anthropic/claude-opus-5") not in text, text
+
+
+@pytest.mark.asyncio
+async def test_mid_turn_switch_row_prints_before_a_remote_label_lands() -> None:
+    """The mid-turn qualifier fires on a real change of model, judged against the
+    RESOLVED destination — not against a re-read label that, on a remote
+    session, still equals the old one and made the guard read as "no change".
+    """
+    session = _AsyncLabelSession()
+    session.streaming = True
+    ctrl = _AccessController(stored=("openrouter", "anthropic"))
+    app = OperatorApp(lambda: _factory(session), provider_controller=ctrl)
+    async with app.run_test(size=(110, 24)) as pilot:
+        await _await_session(app, pilot)
+        app._run_slash_command("/model anthropic/claude-fable-5-1")
+        await pilot.pause()
+        text = _unwrapped(_transcript_text(app))
+    assert _unwrapped(MODEL_SWITCH_MID_TURN_NOTICE) in text, text
+
+
+@pytest.mark.asyncio
+async def test_routed_switch_receipt_names_the_destination_before_a_remote_label_lands() -> None:
+    """The routed ``/model`` (the owner-loop path a phone or a peer terminal
+    resolves through) formats the same receipt and had the same re-read."""
+    session = _AsyncLabelSession()
+    ctrl = _AccessController(stored=("openrouter", "anthropic"))
+    app = OperatorApp(lambda: _factory(session), provider_controller=ctrl)
+    async with app.run_test(size=(110, 24)) as pilot:
+        await _await_session(app, pilot)
+        result = await app.run_slash_authoritative("model", "anthropic/claude-fable-5-1")
+    assert session.requested == [("anthropic", "claude-fable-5-1")], session.requested
+    assert "model: anthropic/claude-opus-5 → anthropic/claude-fable-5-1 (this session)" in (
+        result["text"]
+    ), result
+
+
 @pytest.mark.asyncio
 async def test_model_default_mid_turn_also_says_when_it_applies(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## What this does

Closes #573. A forked session now serves its **own** `session_id` in `frontend_sync`, so a fork's viewer binds, `/model` on a switched-to fork visibly lands, the status band paints the fork's real context reading, and a second terminal can `/resume <fork-id>` as a follower.

**Change class: C1, standard bugfix.** Operator screenshot report + #573; this PR is the record. No merge, no release by the implementing agent. Version stays at main's `0.49.0`.

Stacked on #654 (`9e115e1a` is its receipt commit, cherry-picked so the `/model` receipt tests do not collide). Rebase onto main once #654 lands and that commit drops out.

## Root cause, established on real runtimes

`fork.py` copies `transcript.jsonl` verbatim, so every `frontend_state_checkpoint_v1` row in a fork was written by the **parent**. `FrontendStateStore._restored_state` re-stamped only `epoch`/`sequence`; `session_id` (the parent's — the *grandparent's* two hops down) rode through, and the fork's runtime served it in every `frontend_sync`. `RemoteSession._install_frontend` correctly refused the frame:

```
ConnectionError: frontend state belongs to another session
```

Three user-visible symptoms came from that one refusal:

1. **`/model` "does nothing" on the switched-to fork.** `_dial` had already installed the client before the sync was checked, so the viewer was left *half-bound*: `is_cold` read False, RPCs reached the owner (the switch **did** land in the fork's journal — `selected_model` + `session_model_switch` rows), but no state was ever installed, so the band never repainted the model or the context segment. The receipt's `X → X` text is #654's half of the same picture.
2. **No follower can attach to a fork** (#573's report): `RemoteSession.connect` raised the same error for a second terminal.
3. **A dial leaked per retry.** `_recover_owner` redialled every ~0.5 s and swallowed the refusal without closing the client; the runtime's LRU attach cap evicted the pile-up in bursts — the operator's `~/Library/Logs/local-operator/mobile.log` shows **272** `evicting attach client … (cap)` lines starting the second the fork `e83bf1a52cc5` built its projection fold at 10:12:20. The leaked clients' pumps then took a `ValueError` from the follower store (an update at the owner's epoch against the never-replaced cold store) and logged it as `owner sent a frame larger than the 1048576-byte line limit` — the frame was 104 KB.

Reproduced with the TUI's real `viewer_factory` shape, real `local_operator.session.runtime.process` children, and the operator's actual 7.9 MB fork transcript (models rewritten to the offline `test` provider). The existing fork e2e seeds a parent with no checkpoint, which is why it stayed green.

## The fix

- **`session/frontend_state.py`** — `_restored_state` always re-stamps `session_id` from the owning session (the directory is authoritative). When the checkpoint provably belonged to another session it also clears `checkpoint_id` (names the parent's last row) and drops the inherited `jobs` (the parent's children — `fork.EXCLUDED_SIDECARS` already keeps them out of the roster sidecar; the checkpoint was the door left open). A same-session resume keeps both. `history_cursor`/`attachment_root` were already re-derived from the live transcript and need nothing.
- **`session/remote.py`** — the cold restore (`_restore_cold_details`) applies the same inherited-jobs rule so the cold and attached frames agree. `connect`, `_bind_to` and `_recover_owner` discard a dialled client whose sync was refused (`_discard_rejected_client` → `AttachClient.abandon`) so `is_cold` is honest, nothing leaks per retry, and the deliberate close is not reported as owner loss (which would start a recovery that redials the same runtime).
- **`mobile/attach_client.py`** — `abandon()` (close without a disconnect report; `detach()`/`close()` still report, by design). The pump attributes only a readline overrun to "oversized"; a callback that refuses a frame carries its own reason. Except clauses reordered so `ConnectionError` is no longer swallowed by the `OSError` clause.

## Non-goals

- **The `X → X` receipt text** — #654's fix, cherry-picked here, not re-done.
- **The two-row `/model` output** (`model: X — /model default saves … · /model saved switches back … · or set it in /settings` above the receipt). Row 1 is the picker's persist hint printed by `on_model_query_opened` the moment `/model ` opens the list; row 2 is the receipt. UX review round 2 **U10** recorded this as intended ("one hint for the opening and none for the keystrokes after it") and `test_a_fully_typed_selector_prints_the_hint_once_above_its_receipt` pins exactly two rows. Left alone.
- A frame-size bound for `frontend_sync`: the measured frame is 104 KB (usage_components 66 KB, model_catalogue 23 KB); the "larger than 1 MiB" log was misattribution, fixed above, not an oversized frame.

## Validation

Everything below ran in this worktree's own venv against an isolated `HOME`/`LOCAL_OPERATOR_CONFIG_DIR`; the operator's `~/.local-operator` was read once (read-only) to confirm the fork's checkpoint carries the parent id `0a08dc6d7624`, and never modified.

### Reproduction: `/fork` (switch) → `/model` on the fork, real runtime children

`repro.py` boots `OperatorApp` over the CLI's cold-viewer factory, seeds the operator-shaped parent (`REPRO_BIG_PARENT`, 7.9 MB, checkpoint with `session_id = parent`, `context_tokens 298149`), forks in switch mode, runs `/model test/other`, and dumps band geometry + a per-frame wire tap.

| step | before (`origin/main`) | after (this head) |
|---|---|---|
| fork engaged: `is_cold` / band model / ctx | False (half-bound) / `test/mock` / **0 / 128000** | False / `test/switched` / **298149 / 128000** |
| `/model test/other` settled: band model | `test/mock` (never repainted) | `test/other` |
| `session.model_label` after switch | `test/mock` | `test/other` |
| owner journal | switch row present (it landed, silently) | switch row present |
| viewer-debug.log | `runtime engage failed (mount)` … `frontend state belongs to another session` ×2, `owner sent a frame larger than the 1048576-byte line limit`, `no runtime … viewer is going cold` ×2 | none of these |
| wire tap: `frontend_sync` frames in one run | **41** (one per leaked dial) | **2** (one per runtime) |
| sandbox `mobile.log` evictions | present | 0 |

### Follower attach to a live fork (#573's exact steps) + dial leak

`follower_attach.py`: fork a checkpointed parent on disk, boot a real runtime child for the fork, `RemoteSession.connect` as a second terminal, then five `_bind_to` attempts from a cold viewer (the recovery loop's shape):

```
BEFORE (origin/main 299ec72d8):
{"follower_attach": "REFUSED: frontend state belongs to another session",
 "bind_attempts": ["ConnectionError"×5], "is_cold_after": false, "evictions_logged": 3}
AFTER:
{"follower_attach": "ok", "sync_session_id": "<fork id>", "jobs": [],
 "context": [42000, 128000], "bind_attempts": ["bound"], "is_cold_after": false, "evictions_logged": 0}
```

(5 refused dials against a cap of 4 → 3 evictions; after the fix one bind, none.)

### Tests, each proven to fail on the pre-fix tree

- `tests/unit/session/test_frontend_state.py` — fork with a checkpoint restores `session_id == new dir` (via real `fork_session`); same-session resume keeps `checkpoint_id`/`jobs`; inherited checkpoint drops them; fork-of-a-fork chain. Pre-fix: `'parent000001' == '23f901d7…'`, `'grand0000001' == 'fork10000001'`.
- `tests/unit/session/test_remote.py::test_a_refused_sync_leaves_the_viewer_cold_and_holds_no_connection` — pre-fix: `is_cold` False.
- `tests/unit/mobile/test_attach_client.py` — refused-frame attribution (pre-fix reason was the OVERSIZED string), `abandon()` reports no disconnect and leaves 0 attach clients.
- `tests/unit/session/test_remote_cold.py::test_a_cold_fork_does_not_list_its_parents_children`.
- `tests/e2e/test_fork_checkpoint_e2e.py` (new stage, real runtime subprocesses): fork with an inherited checkpoint binds on mount, `/model` repaints from the owner's sync and lands in the journal, a follower attaches with the fork's id and `context 42000/128000`; fork-of-a-fork serves its own id. Pre-fix both fail with `frontend state belongs to another session`.

### Gates (whole tree, as CI)

```
.venv/bin/python -m flake8 .                                  clean
uvx --from black==26.1.0 black --check .                      929 files would be left unchanged
uvx isort==5.13.2 --check .                                   clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .   0 errors
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
                                                              14324 passed, 17 skipped in 9:22
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q
                                                              31 passed
```

### Frames

Before/after stills (120×32, `scripts.visual_capture.save_capture` → `rsvg-convert`) of the fork after `/model test/other` are attached in the first comment. Before: band `◆ test/mock`, no context segment. After: band `◆ test/other … 232.9%/128k`, and the parent frame paints `test/switched · high … 232.9%/128k` (the reading is the operator's real 298k measured against the offline model's 128k window — the point is that it paints at all and against the model actually serving).

Evidence dir on the build machine: `/tmp/lop-fork-model-evidence/` (`NOTES.md`, `repro.py`, `follower_attach.py`, `before-big/`, `after-big/`, `unit.log`).
