### PR TITLE
fix(tui): hold a follower's working title until the owner's outcome lands

### DIFF
--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -1545,6 +1545,10 @@ class RemoteSession:
         if not self._ready_for_events or not self._handlers:
             self._buffered_events.append(event)
             return
+        self._deliver(event)
+
+    def _deliver(self, event: AgentEvent[Any]) -> None:
+        """Hand ``event`` to every subscribed handler now, buffering nothing."""
         for handler in list(self._handlers):
             result = handler(event)
             if inspect.isawaitable(result):
@@ -1690,18 +1694,36 @@ class RemoteSession:
         self._end_turn_locally()
         self._recovery_task = asyncio.create_task(self._recover_owner())
 
-    def _end_turn_locally(self) -> None:
+    def _end_turn_locally(self, *, direct: bool = False) -> None:
         """End an in-flight turn the owner can no longer end itself.
 
-        Both terminal outcomes need it and neither can get it from the owner:
-        a killed owner factually aborted the turn, and a stopped one ended the
-        whole session under it. Marked through the normal event path so no
+        All three terminal outcomes need it and none can get it from the
+        owner: a killed owner factually aborted the turn, a stopped one ended
+        the whole session under it, and a viewer going cold has no runtime
+        left to hear from. Marked through the normal event path so no
         card/banner or attach vocabulary appears — the transcript reads as an
         ordinary aborted turn, which is what it is.
+
+        ``direct`` bypasses the sync buffer and hands the end straight to the
+        subscribed handlers (dropping it when there are none). The go-cold
+        caller needs this: a failed successor ``_dial`` leaves
+        ``_ready_for_events`` False, so a BUFFERED end would sit until the
+        NEXT bind's ``_finish_sync`` drained it — behind that bind's seeded
+        ``AgentStartEvent``, and stamped with a generation the fresh runtime
+        does not necessarily exceed (the controller drops only ``gen <
+        current``). Delivered late it would tear down the new turn it never
+        belonged to; delivered now it ends the one it does. A handler-less
+        drop is correct on that path too: with nobody subscribed there is no
+        spinner to stop, and parking the end for a later subscriber recreates
+        the same stale-end hazard one seam over.
         """
         if not self._streaming:
             return
-        self._emit_or_buffer(AgentEndEvent(aborted=True, generation=self._generation, error=None))
+        end = AgentEndEvent(aborted=True, generation=self._generation, error=None)
+        if direct:
+            self._deliver(end)
+        else:
+            self._emit_or_buffer(end)
         self._streaming = False
 
     async def _session_was_stopped(self) -> bool:
@@ -1753,6 +1775,22 @@ class RemoteSession:
         ``_owner_ready`` is SET rather than left clear because a cold viewer is
         ready — the next prompt engages a runtime through ``_ensure_bound``
         instead of waiting for one that is never coming back.
+
+        A turn still in flight is ENDED through the event path, not merely
+        flagged off (#642, UX U11). Clearing ``_streaming`` alone told the
+        facade the turn was over while the app — which holds its working line,
+        band and title open until an ``AgentEndEvent`` reaches it — was never
+        told anything, so a viewer that went cold mid-turn held a spinner
+        forever with no toast and no notice. On the common path this is a
+        no-op: ``_on_disconnected`` already ended the turn before
+        ``_recover_owner`` started. The case it exists for is a SUCCESSOR
+        dying mid-reattach — ``_on_disconnected`` returns early while
+        ``_recovering``, and ``_apply_frontend_facades`` has just re-marked
+        the turn live from the successor's snapshot — which leaves
+        ``_streaming`` True with nothing else on the way to clear it.
+        Delivered ``direct`` for the reason on ``_end_turn_locally``: the
+        failed dial left the sync buffer closed, and a buffered end would land
+        on the NEXT runtime's turn instead of this one.
         """
         client, self._client = self._client, None
         if client is not None:
@@ -1760,7 +1798,7 @@ class RemoteSession:
                 client.close()
             except Exception:  # noqa: BLE001 — teardown of a dead socket
                 logger.debug("closing the lost owner connection failed", exc_info=True)
-        self._streaming = False
+        self._end_turn_locally(direct=True)
         self._owner_ready.set()
         callback = self._went_cold_callback
         if callback is None:

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -1740,11 +1740,27 @@ class RemoteSession:
         if not self._streaming:
             return
         end = AgentEndEvent(aborted=True, generation=0, error=None)
-        if direct:
-            self._deliver(end)
-        else:
-            self._emit_or_buffer(end)
-        self._streaming = False
+        # THE STATE CHANGE IS THE CONTRACT; ONLY THE NOTIFICATION IS
+        # BEST-EFFORT (review round 2, MAJOR-2). `_deliver` calls handlers
+        # synchronously with no guard of its own, and
+        # `EventController._handle_agent_end` does real work on this path —
+        # flush, usage pricing, cost summation. When one of those raises, a
+        # trailing assignment never runs and the facade reports `is_streaming`
+        # True on a session that is now cold with no runtime left to clear it.
+        # The caller's `try/except` cannot cover that: it catches the exception
+        # OUTSIDE this method, by which point the clear has already been
+        # skipped. That strands `_retire_turn_band`'s hold — the band and tab
+        # title assert `working` for the rest of the process's life, with no
+        # wall-clock timeout by design — and mis-routes the next message into
+        # the steer branch, which is the round-4 MAJOR-3/D4-1 failure the
+        # deliberate-stop comment above records.
+        try:
+            if direct:
+                self._deliver(end)
+            else:
+                self._emit_or_buffer(end)
+        finally:
+            self._streaming = False
 
     async def _session_was_stopped(self) -> bool:
         """True when the disconnect's cause is a DELIBERATE stop, not owner death.

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -1548,7 +1548,14 @@ class RemoteSession:
         self._deliver(event)
 
     def _deliver(self, event: AgentEvent[Any]) -> None:
-        """Hand ``event`` to every subscribed handler now, buffering nothing."""
+        """Hand ``event`` to every subscribed handler now, buffering nothing.
+
+        With NO subscriber the event is DROPPED, not parked — that is the
+        contract, not an omission. Callers reach for this instead of
+        ``_emit_or_buffer`` precisely when a deferred delivery would land on a
+        LATER runtime's turn (see ``_end_turn_locally``), and parking the event
+        for a future subscriber recreates exactly that hazard one seam over.
+        """
         for handler in list(self._handlers):
             result = handler(event)
             if inspect.isawaitable(result):
@@ -1709,17 +1716,30 @@ class RemoteSession:
         caller needs this: a failed successor ``_dial`` leaves
         ``_ready_for_events`` False, so a BUFFERED end would sit until the
         NEXT bind's ``_finish_sync`` drained it — behind that bind's seeded
-        ``AgentStartEvent``, and stamped with a generation the fresh runtime
-        does not necessarily exceed (the controller drops only ``gen <
-        current``). Delivered late it would tear down the new turn it never
-        belonged to; delivered now it ends the one it does. A handler-less
-        drop is correct on that path too: with nobody subscribed there is no
-        spinner to stop, and parking the end for a later subscriber recreates
-        the same stale-end hazard one seam over.
+        ``AgentStartEvent`` — and would tear down the new turn it never
+        belonged to. Delivered now it ends the one it does.
+
+        UNSTAMPED (``generation=0``), never ``self._generation`` — review
+        round 1, BLOCKER-1. That field is not this viewer's own turn counter:
+        ``_apply_frontend_facades`` overwrites it from whatever snapshot last
+        arrived, and a SUCCESSOR is a fresh runtime whose counter restarts
+        (``Session.__init__`` sets 0, so its first turn is 1) while the app's
+        ``EventController`` has adopted the PREVIOUS owner's generation — 6,
+        or any long session's turn count. Stamping the synthesised end with
+        the successor's number therefore made ``_handle_agent_end`` drop it as
+        ``gen < current`` (``tui/events.py``), so the end reached the handler
+        and died one layer below it: no ``TurnEnded``, and — with edit 1's
+        hold in place and no wall-clock timeout by design — a band and tab
+        title asserting ``working`` for the rest of the process's life. ``0``
+        is the field's default and the established "unstamped: belongs to
+        whatever turn is open" encoding that the controller's ``if gen:``
+        branch reads, which is exactly the semantics a locally synthesised end
+        wants. It applies to the buffered path for the same reason: neither
+        delivery has standing to speak for the successor's numbering.
         """
         if not self._streaming:
             return
-        end = AgentEndEvent(aborted=True, generation=self._generation, error=None)
+        end = AgentEndEvent(aborted=True, generation=0, error=None)
         if direct:
             self._deliver(end)
         else:
@@ -1798,7 +1818,16 @@ class RemoteSession:
                 client.close()
             except Exception:  # noqa: BLE001 — teardown of a dead socket
                 logger.debug("closing the lost owner connection failed", exc_info=True)
-        self._end_turn_locally(direct=True)
+        # Guarded like the two teardown steps that bracket it (the client
+        # close above, the went-cold callback below): a handler that raises —
+        # `EventController._handle_agent_end` flushes, prices usage and sums
+        # cost — must not propagate out of teardown and skip `_owner_ready`,
+        # which would leave the prompt path waiting on an event nothing else
+        # will set (review round 1, MINOR-1).
+        try:
+            self._end_turn_locally(direct=True)
+        except Exception:  # noqa: BLE001 — a viewer notice must not break teardown
+            logger.debug("ending the in-flight turn on go-cold failed", exc_info=True)
         self._owner_ready.set()
         callback = self._went_cold_callback
         if callback is None:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -12277,27 +12277,65 @@ class OperatorApp(App[None]):
                 # `streaming=True` above and no `TurnStarted` ever arrived, so
                 # `_turn_open` is False and nothing else would clear the band.
                 #
-                # CARRIES THE OUTCOME, and that is what closes the title flash
-                # structurally. This is the EARLIER of the two writes that retire
-                # a turn's band — `_finalize_turn`'s is the other — so writing
-                # only `streaming=False` here published `lo ›` ("finished
-                # cleanly") for a turn this very `except` had just caught, and
-                # `lo ✗` landed one write later (review D6/U8). The fact is
-                # already in hand; sending it with the write that needs it means
-                # there is no interval in which the title is wrong, rather than a
-                # short one. `_finalize_turn` then writes the same pair and the
-                # title dedupes on the rendered string.
+                # IN-PROCESS, CARRIES THE OUTCOME, and that is what closes the
+                # title flash structurally on that path. This is the EARLIER of
+                # the two writes that retire a turn's band — `_finalize_turn`'s
+                # is the other — so writing only `streaming=False` here
+                # published `lo ›` ("finished cleanly") for a turn this very
+                # `except` had just caught, and `lo ✗` landed one write later
+                # (review D6/U8). The fact is already in hand; sending it with
+                # the write that needs it means there is no interval in which
+                # the title is wrong. `_finalize_turn` then writes the same pair
+                # and the title dedupes on the rendered string.
                 #
-                # `None` (leave alone) when this worker cannot know the outcome —
-                # a FOLLOWER's `prompt()` returns on the owner's ACK, mid-turn,
-                # so its `error_text` is None because nothing was reported here,
-                # not because the turn succeeded. Same reasoning as
-                # `_post_turn_abandoned`'s `outcome_known`.
+                # ON A FOLLOWER, WITHHELD WHILE THE OWNER IS LIVE (#642). A
+                # follower's `prompt()` returns on the owner's ACK, mid-turn, so
+                # this worker cannot know the outcome: its `error_text` is None
+                # because nothing was reported here, not because the turn
+                # succeeded (same reasoning as `_post_turn_abandoned`'s
+                # `outcome_known`). Carrying the fact into this write — the fix
+                # that worked in-process — is therefore unavailable, and writing
+                # `streaming=False` with `failed=None` resolved the title to
+                # `idle`: `lo ›` for exactly the owner's relay latency (measured
+                # 501.7 ms at a 0.5 s relay, 2011 ms at 2 s — the window IS the
+                # relay), then `lo ✗`. "Ignorant" must not render as "finished
+                # cleanly": `idle` is a positive claim that the turn is over and
+                # the user's attention is free, and a viewer that has not been
+                # told has no standing to make it. So while `is_streaming` is
+                # still True the band HOLDS `working` — honest, because the turn
+                # IS still running as far as this viewer knows — and the
+                # outcome lands through `_finalize_turn` when the owner's end
+                # arrives. This is the same predicate `on_turn_abandoned`'s
+                # guard 2 applies at dispatch, read here at worker time.
+                #
+                # A follower whose `prompt()` refused BEFORE any `agent_start`
+                # has `is_streaming` False and still takes the write: that is
+                # the "KEPT" case above, and it survives unchanged.
+                #
+                # NO WALL-CLOCK TIMEOUT ON THE HOLD, deliberately. Every way the
+                # outcome can fail to arrive is a socket event that ends the
+                # turn locally: the relayed `agent_end`; EOF/reset →
+                # `_on_disconnected` → `_end_turn_locally`; a slow-follower drop
+                # (the owner's `_send_to` timeout closes the socket → EOF); and
+                # the cold fallback (`_go_cold` → `_end_turn_locally`). A timer
+                # could only fire while the socket is alive and silent — i.e.
+                # while the owner IS still working, and turns legitimately run
+                # for hours — and every terminal it could pick (`›`, `✗`,
+                # "interrupted") would be a false claim. The bound is
+                # event-driven, not timed.
+                #
+                # Accepted residual: the owner ACKs on the durable append BEFORE
+                # `agent_start` (`runtime/owned.py` `prompt` vs `harness/loop.py`
+                # `_run_turn`), so a `finally` that runs inside that gap reads
+                # `is_streaming` False and clears the band — a working→idle→
+                # working blip bounded by the owner's prompt preparation, not by
+                # the relay of the OUTCOME. That is not the flash this closes.
                 knows_outcome = not bool(getattr(session, "is_remote", False))
-                self._status.update(
-                    streaming=False,
-                    failed=(bool(error_text) and not aborted) if knows_outcome else None,
-                )
+                if knows_outcome or not bool(getattr(session, "is_streaming", False)):
+                    self._status.update(
+                        streaming=False,
+                        failed=(bool(error_text) and not aborted) if knows_outcome else None,
+                    )
                 # POSTED, NEVER CALLED INLINE. For an in-process `Session`,
                 # `prompt()` returns only after the pipeline's `finally` has
                 # flushed the held end, which `_emit`s `agent_end`
@@ -22551,8 +22589,11 @@ class OperatorApp(App[None]):
         #    in-process `Session` this is already False when `prompt()` returns
         #    (`_run_turn`'s finally clears it before the pipeline flushes the
         #    held end), so it never suppresses a genuine fallback — and a
-        #    follower needs none, since an owner death or a `/stop` synthesises
-        #    a real aborted `AgentEndEvent` locally.
+        #    follower needs none, since an owner death, a `/stop`, or the
+        #    viewer going cold (`_go_cold`, #642) each synthesise a real
+        #    aborted `AgentEndEvent` locally. The turn worker's own band write
+        #    applies this SAME predicate at worker time, so the band holds
+        #    `working` exactly as long as this guard keeps the turn open.
         if self._session is not None and getattr(self._session, "is_streaming", False):
             return
         # 3. NOTHING TO FALL BACK FOR. A fallback is only meaningful for a turn
@@ -22839,8 +22880,9 @@ class OperatorApp(App[None]):
         # same turn (review R4). The turn is fully retired by the work above;
         # only the announcement waits for the route that knows.
         #
-        # NOT a silence hole: a follower whose owner dies or is stopped gets a
-        # real aborted `AgentEndEvent` synthesised locally
+        # NOT a silence hole: a follower whose owner dies, is stopped, or whose
+        # viewer goes cold with no successor (`_go_cold`, #642) gets a real
+        # aborted `AgentEndEvent` synthesised locally
         # (`RemoteSession._end_turn_locally`), which reaches this method through
         # `on_turn_ended` and settles the ladder. The abandoned route is the
         # fallback for a turn NOBODY ends, and on a follower that is precisely

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -12331,11 +12331,10 @@ class OperatorApp(App[None]):
                 # working blip bounded by the owner's prompt preparation, not by
                 # the relay of the OUTCOME. That is not the flash this closes.
                 knows_outcome = not bool(getattr(session, "is_remote", False))
-                if knows_outcome or not bool(getattr(session, "is_streaming", False)):
-                    self._status.update(
-                        streaming=False,
-                        failed=(bool(error_text) and not aborted) if knows_outcome else None,
-                    )
+                self._retire_turn_band(
+                    session,
+                    failed=(bool(error_text) and not aborted) if knows_outcome else None,
+                )
                 # POSTED, NEVER CALLED INLINE. For an in-process `Session`,
                 # `prompt()` returns only after the pipeline's `finally` has
                 # flushed the held end, which `_emit`s `agent_end`
@@ -12349,6 +12348,42 @@ class OperatorApp(App[None]):
                 self._post_turn_abandoned(aborted=aborted, error=error_text)
 
         self.run_worker(run_prompt(), thread=False, group="turns")
+
+    def _retire_turn_band(self, session: Any, *, failed: bool | None = None) -> None:
+        """Clear the status band for a turn whose worker is done with it.
+
+        ONE helper for the same reason `_post_turn_abandoned` is one: THREE
+        places drive `session.prompt()` — `_start_turn` and both `/loop`
+        workers — and "a follower never publishes an outcome it was not told"
+        has to hold at all of them. It did not: the loop workers wrote a bare
+        `update(streaming=False)`, so a `/loop` on a follower reproduced D-1
+        verbatim, `⣾ → › → ⣾ → ›` with the owner live throughout, on the most
+        unattended surface in the app (review round 1, MAJOR-1/U1). The gate
+        was originally inlined at the composer's path only, on the incorrect
+        premise that `/loop` always routes to the owner; it does not on a COLD
+        viewer, whose `_synthesise_cold_state` advertises no
+        `slash_capabilities`, so the `route_shared_slash` branch is not taken
+        and the LOCAL worker drives the `RemoteSession` (see the corrected
+        note in `_run_slash_command`'s routing branch).
+
+        WITHHELD on a follower whose owner is still streaming: that worker
+        returned on the owner's ACK, mid-turn, so `streaming=False` there
+        resolves the title to `idle` — "finished cleanly" — for a turn whose
+        outcome this viewer has not been told. The band is released by the
+        relayed `agent_end` through `_finalize_turn`, or by a locally
+        synthesised one (owner death, `/stop`, go-cold). In-process
+        (`is_remote` False) the write is unconditional and unchanged.
+
+        ``failed`` carries the outcome where the caller HAS it (the composer's
+        worker does, in-process); `None` means "leave the mark alone".
+        """
+        if self._status is None:
+            return
+        if bool(getattr(session, "is_remote", False)) and bool(
+            getattr(session, "is_streaming", False)
+        ):
+            return
+        self._status.update(streaming=False, failed=failed)
 
     def _post_turn_abandoned(self, *, aborted: bool, error: str | None) -> None:
         """Offer the fallback retirement for the turn this worker just left.
@@ -17722,8 +17757,11 @@ class OperatorApp(App[None]):
                     crashed = True
                     break
                 finally:
-                    if self._status is not None:
-                        self._status.update(streaming=False)
+                    # Through the shared gate, not a bare write: on a follower
+                    # this `finally` runs on the owner's ACK, mid-turn, and the
+                    # bare write published `lo ›` for a turn still running (see
+                    # `_retire_turn_band`).
+                    self._retire_turn_band(session)
                     # The SAME retirement the composer's turn gets. A loop
                     # iteration is an ordinary turn as far as the transcript is
                     # concerned — it mounts a working line and opens the latch —
@@ -17840,8 +17878,7 @@ class OperatorApp(App[None]):
                 try:
                     await session.prompt(prompt, **echo.prompt_kwargs())
                 except Exception as error:  # surface and stop; never spin
-                    if self._status is not None:
-                        self._status.update(streaming=False)
+                    self._retire_turn_band(session)
                     # Same helper, same reason as the numeric worker: a held
                     # goal loop is the MOST unattended surface in the app, and
                     # it was printing a bare `str(error)` (review U6).
@@ -17866,8 +17903,7 @@ class OperatorApp(App[None]):
                 completed += 1
                 # --- yield boundary reached: judge the settled turn ---
                 if self._loop_cancelled or session is not self._session:
-                    if self._status is not None:
-                        self._status.update(streaming=False)
+                    self._retire_turn_band(session)
                     break
                 # Keep the status in a working state ACROSS the judge call. The
                 # judge is a real `complete_aside` network round-trip that can
@@ -17875,8 +17911,7 @@ class OperatorApp(App[None]):
                 # `loop N` and `loop N+1` while it is in fact spending tokens on
                 # the verdict. Cleared once the verdict is in hand (below).
                 achieved, reason = await self._judge_goal(session, goal)
-                if self._status is not None:
-                    self._status.update(streaming=False)
+                self._retire_turn_band(session)
                 if achieved is True:
                     released = True
                     break

--- a/tests/unit/session/test_remote_takeover.py
+++ b/tests/unit/session/test_remote_takeover.py
@@ -577,6 +577,16 @@ async def test_going_cold_does_not_let_a_raising_handler_break_teardown(
     now sits between them and takes the same guard: without it a raising
     handler skips ``_owner_ready.set()``, and the prompt path waits forever on
     an event nothing else will set.
+
+    BOTH HALVES OF THE INVARIANT, deliberately (review round 2, MAJOR-2). The
+    caller's guard alone is not enough: the exception escapes from INSIDE
+    ``_end_turn_locally``, where the ``_streaming`` clear used to be the line
+    after the delivery, so it was skipped and the facade reported a live turn
+    forever on a cold session. Asserting only that teardown finished pinned
+    half of what the guard exists to protect and let that through — the flag
+    is what ``_retire_turn_band`` reads to decide whether to withhold the band
+    write, so a stuck True is a tab title asserting ``working`` for the life
+    of the process.
     """
     monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
     remote = RemoteSession(
@@ -597,3 +607,4 @@ async def test_going_cold_does_not_let_a_raising_handler_break_teardown(
 
     assert remote._owner_ready.is_set(), "teardown was stranded by a raising handler"
     assert remote.is_cold
+    assert remote.is_streaming is False, "the facade reports a live turn forever on a cold session"

--- a/tests/unit/session/test_remote_takeover.py
+++ b/tests/unit/session/test_remote_takeover.py
@@ -495,3 +495,105 @@ async def test_a_disconnect_followed_by_going_cold_ends_the_turn_once(
     assert len(ends) == 1, f"one owner loss produced {len(ends)} aborted ends"
     assert remote._buffered_events == []
     assert remote.is_streaming is False
+
+
+@pytest.mark.asyncio
+async def test_going_cold_survives_a_controllers_higher_adopted_generation(
+    tmp_path, monkeypatch
+) -> None:
+    """Review round 1, BLOCKER-1: the go-cold end must reach the APP, not just
+    the handler list.
+
+    The sibling test above asserts the event is delivered, and that stayed true
+    while the defect was live — the ``EventController`` sitting one layer below
+    dropped it, so no ``TurnEnded`` was ever posted. This drives the REAL
+    controller for that reason: the drop happens where the event is consumed,
+    which is the only layer that can pin it.
+
+    The scenario is the one ``_go_cold``'s direct delivery exists for. Owner A
+    stamps its turn with a long-lived session's generation (6 here); the
+    controller adopts it. A successor binds and ``_apply_frontend_facades``
+    re-marks the turn live from ITS snapshot — a fresh runtime, so generation
+    1. Stamping the synthesised end with that number made
+    ``_handle_agent_end`` drop it as ``gen < current`` and, with the follower
+    band held by design and no wall-clock timeout, left the tab title asserting
+    ``working`` permanently. An unstamped end (``generation=0``) is the
+    controller's "belongs to whatever turn is open" encoding.
+    """
+    from local_operator.harness.types import AgentStartEvent
+    from local_operator.session.frontend_state import FrontendSessionState
+    from local_operator.tui.events import EventController, TurnEnded, TurnStarted
+    from tests.unit.tui.test_events import FakeApp
+
+    previous_owner_generation = 6
+    successor_first_turn_generation = 1  # Session.__init__ starts a fresh count
+
+    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    remote = RemoteSession(
+        config_dir=tmp_path,
+        session_id="s1",
+        takeover_factory=lambda: asyncio.sleep(0, result=None),
+    )
+    remote._can_go_cold = True
+    remote._ready_for_events = True
+
+    app = FakeApp()
+    controller = EventController(remote, app)  # type: ignore[arg-type]
+    app.controller = controller
+    controller.subscribe()
+
+    remote._on_wire_event(
+        AgentStartEvent(generation=previous_owner_generation).model_dump(mode="json")
+    )
+    assert controller.generation == previous_owner_generation
+    assert sum(isinstance(m, TurnStarted) for m in app.posted) == 1
+
+    remote._apply_frontend_facades(
+        FrontendSessionState(
+            session_id="s1",
+            epoch="e1",
+            streaming=True,
+            generation=successor_first_turn_generation,
+        )
+    )
+    assert remote.is_streaming is True
+
+    remote._go_cold()
+
+    ends = [m for m in app.posted if isinstance(m, TurnEnded)]
+    assert len(ends) == 1, "the synthesised end never reached the app"
+    assert ends[0].aborted is True
+    assert remote.is_streaming is False
+
+
+@pytest.mark.asyncio
+async def test_going_cold_does_not_let_a_raising_handler_break_teardown(
+    tmp_path, monkeypatch
+) -> None:
+    """Review round 1, MINOR-1: a handler that raises must not strand teardown.
+
+    ``_go_cold`` already guards the client close and the went-cold callback
+    because "a viewer notice must not break teardown". The end-the-turn call
+    now sits between them and takes the same guard: without it a raising
+    handler skips ``_owner_ready.set()``, and the prompt path waits forever on
+    an event nothing else will set.
+    """
+    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    remote = RemoteSession(
+        config_dir=tmp_path,
+        session_id="s1",
+        takeover_factory=lambda: asyncio.sleep(0, result=None),
+    )
+    remote._can_go_cold = True
+    remote._streaming = True
+    remote._ready_for_events = True
+
+    def explode(event: Any) -> None:
+        raise RuntimeError("handler blew up while pricing the turn")
+
+    remote.subscribe(explode)
+
+    remote._go_cold()
+
+    assert remote._owner_ready.is_set(), "teardown was stranded by a raising handler"
+    assert remote.is_cold

--- a/tests/unit/session/test_remote_takeover.py
+++ b/tests/unit/session/test_remote_takeover.py
@@ -416,3 +416,82 @@ async def test_a_deliberate_stop_ends_the_turn_in_both_states(
     # lets a message reach it instead of the silent steer queue.
     with pytest.raises(ConnectionError, match="stopped"):
         await remote.prompt("the message typed after the stop")
+
+
+@pytest.mark.asyncio
+async def test_going_cold_ends_an_in_flight_turn_directly(tmp_path, monkeypatch) -> None:
+    """#642 (UX U11 from #619): a viewer going cold mid-turn gets a terminal state.
+
+    ``_go_cold`` cleared ``_streaming`` without emitting an ``AgentEndEvent``,
+    so the app — which keeps its working line, band and title open until an
+    end reaches it — held a spinner forever with the toast suppressed too.
+
+    The end must be delivered DIRECTLY, not buffered: a failed successor
+    ``_dial`` leaves ``_ready_for_events`` False, and a buffered end would be
+    drained by the NEXT bind's ``_finish_sync`` behind that bind's seeded
+    ``AgentStartEvent``, where the controller (which drops only ``gen <
+    current``) would let it tear down the fresh turn. So the assertion is on
+    both sides: exactly one aborted end reached the handler, and nothing was
+    left in the buffer for a later runtime to inherit.
+    """
+    from local_operator.harness.types import AgentEndEvent
+
+    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    remote = RemoteSession(
+        config_dir=tmp_path,
+        session_id="s1",
+        takeover_factory=lambda: asyncio.sleep(0, result=None),
+    )
+    remote._can_go_cold = True
+    remote._streaming = True
+    remote._ready_for_events = False
+    received: list[Any] = []
+    remote.subscribe(received.append)
+
+    remote._go_cold()
+
+    ends = [event for event in received if isinstance(event, AgentEndEvent)]
+    assert len(ends) == 1 and ends[0].aborted is True and ends[0].error is None
+    assert remote._buffered_events == []
+    assert remote.is_streaming is False
+    assert remote.is_cold
+
+
+@pytest.mark.asyncio
+async def test_a_disconnect_followed_by_going_cold_ends_the_turn_once(
+    tmp_path, monkeypatch
+) -> None:
+    """The common path: ``_on_disconnected`` already ended the turn, so the
+    go-cold end is a no-op rather than a second "interrupted" notice.
+
+    ``_end_turn_locally`` returns on ``not self._streaming``, which is what
+    makes the two callers safe to stack — pinned here so a later rewrite of
+    either does not turn one owner loss into two aborted ends on the app.
+    """
+    from local_operator.harness.types import AgentEndEvent
+
+    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    remote = RemoteSession(
+        config_dir=tmp_path,
+        session_id="s1",
+        takeover_factory=lambda: asyncio.sleep(0, result=None),
+    )
+    remote._can_go_cold = True
+    remote._streaming = True
+    remote._ready_for_events = True
+    received: list[Any] = []
+    remote.subscribe(received.append)
+
+    remote._on_disconnected("owner exited")
+    if remote._recovery_task is not None:
+        remote._recovery_task.cancel()
+        try:
+            await remote._recovery_task
+        except (asyncio.CancelledError, Exception):  # noqa: BLE001 — teardown only
+            pass
+    remote._go_cold()
+
+    ends = [event for event in received if isinstance(event, AgentEndEvent)]
+    assert len(ends) == 1, f"one owner loss produced {len(ends)} aborted ends"
+    assert remote._buffered_events == []
+    assert remote.is_streaming is False

--- a/tests/unit/tui/test_turn_abandoned.py
+++ b/tests/unit/tui/test_turn_abandoned.py
@@ -1542,3 +1542,63 @@ async def test_a_followers_held_turn_settles_when_the_owner_dies() -> None:
         assert "interrupted" in notices, notices
     assert _titles(writes)[-1].startswith("lo ›"), _titles(writes)
     assert notifier.kinds == [], "an owner-death abort is not announced"
+
+
+@pytest.mark.asyncio
+async def test_a_followers_loop_turn_holds_working_between_iterations() -> None:
+    """Review round 1, MAJOR-1/U1: the `/loop` surface takes the same gate.
+
+    The band gate first shipped inlined at the composer's worker only, on the
+    premise that `/loop` always routes to the owner. It does not on a COLD
+    viewer: `_synthesise_cold_state` advertises no `slash_capabilities`, so
+    `_run_slash_command`'s routing branch (which needs a matching capability)
+    is not taken, `/loop` is not in `_needs_runtime_first`, and the LOCAL loop
+    worker drives the `RemoteSession` — whose `prompt()` returns on the
+    owner's ACK, mid-turn. The loop workers' bare `update(streaming=False)`
+    then wrote `lo ›` between every iteration with the owner still live:
+    `⣾ → › → ⣾ → ›`, D-1 verbatim on the one surface the issue calls out as
+    unattended (`/loop 20` overnight).
+
+    Driven through the real slash dispatch rather than by calling the worker,
+    because the dispatch is half of what the finding is about.
+    """
+
+    class CapabilitylessFollowerSession(JobsSession):
+        """A follower whose owner advertised nothing — every cold viewer."""
+
+        is_remote = True
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.local_prompts: list[str] = []
+
+        async def prompt(self, text: str, images: Any = None, **kwargs: Any) -> None:
+            self.local_prompts.append(text)
+            self.streaming = True
+            return None
+
+    session = CapabilitylessFollowerSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _armed(pilot, app, RecordingNotifier())
+        writes = await _spy_title(pilot, app)
+
+        app._run_slash_command("/goal ship the audit")
+        await pilot.pause()
+        app._run_slash_command("/loop 2")
+        for _ in range(30):
+            await pilot.pause()
+            await asyncio.sleep(0.02)
+
+        # The premise of the finding: this really is the LOCAL worker driving a
+        # follower, not a routed command. Without this the test could pass by
+        # never running a loop at all.
+        assert session.local_prompts, "the local loop worker never drove the session"
+        assert session.is_streaming is True, "the owner is no longer live; nothing to hold"
+        assert app._status is not None and app._status._streaming is True
+
+    titles = _titles(writes)
+    assert not any(
+        t.startswith("lo ›") for t in titles
+    ), f"flashed 'finished cleanly' between loop iterations: {titles}"

--- a/tests/unit/tui/test_turn_abandoned.py
+++ b/tests/unit/tui/test_turn_abandoned.py
@@ -1086,6 +1086,10 @@ async def test_a_follower_whose_owner_never_reports_still_retires_the_turn() -> 
         # turn stays open for the owner's end — the pre-existing contract.
         assert app._turn_open is True
         assert _working(app) is not None
+        # And the BAND holds with it (#642): the worker's own write applies the
+        # same predicate, so a live owner keeps the title on `working` rather
+        # than dropping it to `idle` for a turn this viewer was never told about.
+        assert app._status is not None and app._status._streaming is True
     assert notifier.kinds == [], "a mid-turn follower ACK was read as a finish"
 
 
@@ -1356,3 +1360,185 @@ async def test_the_toast_kind_and_the_title_agree_on_one_turn(
         [expected_kind],
         expected_title,
     ), f"the toast said {notifier.kinds} while the title said {title!r}"
+
+
+def _titles(writes: list[str]) -> list[str]:
+    """The rendered title strings, in write order, from a `TerminalTitle` spy."""
+    return [w.split("\x07")[0].split(";", 1)[1] for w in writes if "]0;" in w]
+
+
+async def _spy_title(pilot: Any, app: OperatorApp) -> list[str]:
+    """Attach a write-recording `TerminalTitle` and drop the attach-time idle write."""
+    from local_operator.tui.terminal_title import TerminalTitle
+
+    assert app._status is not None
+    writes: list[str] = []
+    title = TerminalTitle(writes.append, enabled=True)
+    title.start()
+    app._status.set_terminal_title(title)
+    await pilot.pause()
+    # The band writes an ordinary `lo ›` while wiring up, and that one is
+    # correct — there is no turn yet. The window under test is the TURN.
+    writes.clear()
+    return writes
+
+
+async def _hold(pilot: Any, seconds: float) -> None:
+    """Keep the pump running for ``seconds`` — the owner's relay latency."""
+    deadline = asyncio.get_running_loop().time() + seconds
+    while asyncio.get_running_loop().time() < deadline:
+        await pilot.pause()
+        await asyncio.sleep(0.02)
+
+
+@pytest.mark.parametrize("relay_delay", [0.05, 0.3])
+@pytest.mark.asyncio
+async def test_a_followers_failed_turn_holds_working_until_the_owner_reports(
+    relay_delay: float,
+) -> None:
+    """#642 (D-1 from #619). "Ignorant" must not render as "finished cleanly".
+
+    On a follower, `prompt()` returns on the owner's ACK — mid-turn — so the
+    worker's `finally` runs with the outcome genuinely unknown. It used to
+    write `streaming=False, failed=None` anyway, and with no failure mark set
+    the title resolved to `idle`: `lo ›` for exactly the owner's relay latency
+    (measured 501.7 ms at a 0.5 s relay, 2011 ms at 2 s), then `lo ✗`. A user
+    glancing at the tab strip in that window read success on a failed turn.
+
+    The band now HOLDS `working` while `is_streaming` is still True, and the
+    outcome lands through `_finalize_turn` when the relayed end arrives. The
+    delay is parametrized because the window WAS the relay: a fix that merely
+    shrank it would pass at one delay and fail at the other. Asserted on the
+    emitted bytes, as the sibling flash tests are, because that is where the
+    defect lived.
+    """
+    session = HangingFollowerSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _armed(pilot, app, RecordingNotifier())
+        writes = await _spy_title(pilot, app)
+
+        app._start_turn("Run the audit")
+        await _hold(pilot, relay_delay)
+        assert app._status is not None
+        assert app._status._title_state() == "working", "the hold dropped while the owner was live"
+
+        # The owner's relayed end: the turn FAILED.
+        session.streaming = False
+        app.post_message(TurnEnded(aborted=False, error="MCP authorization failed"))
+        for _ in range(5):
+            await pilot.pause()
+            await asyncio.sleep(0.02)
+
+    titles = _titles(writes)
+    assert titles, "the turn wrote no title at all"
+    assert titles[-1].startswith("lo ✗"), titles
+    assert not any(
+        t.startswith("lo ›") for t in titles
+    ), f"flashed 'finished cleanly' on a failed follower turn: {titles}"
+
+
+@pytest.mark.asyncio
+async def test_a_followers_clean_turn_settles_idle_once_the_owner_reports() -> None:
+    """The other half of #642: the hold releases to `›` on a clean relay.
+
+    A hold that never let go would trade a false `idle` for a permanent
+    `working`. The clean relay lands `lo ›`, and the completion toast fires
+    exactly once — the hold changes WHEN the band settles, not whether the
+    owner's end is announced.
+    """
+    session = HangingFollowerSession()
+    app = OperatorApp(lambda: _factory(session))
+    notifier = RecordingNotifier()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _armed(pilot, app, notifier)
+        writes = await _spy_title(pilot, app)
+
+        app._start_turn("Run the audit")
+        await _hold(pilot, 0.1)
+        assert app._status is not None
+        assert app._status._title_state() == "working"
+        assert not any(t.startswith("lo ›") for t in _titles(writes)), _titles(writes)
+
+        session.streaming = False
+        app.post_message(TurnEnded(aborted=False, error=None))
+        for _ in range(5):
+            await pilot.pause()
+            await asyncio.sleep(0.02)
+
+        assert app._status._title_state() == "idle"
+        assert _working(app) is None
+    assert _titles(writes)[-1].startswith("lo ›"), _titles(writes)
+    assert notifier.kinds == ["complete"], "the held clean turn went unannounced or doubled"
+
+
+@pytest.mark.asyncio
+async def test_a_follower_whose_prompt_is_refused_before_start_still_clears_the_band() -> None:
+    """The hold is scoped to a LIVE owner, not to every follower.
+
+    A follower's `prompt()` can refuse before any `agent_start` reaches the
+    owner (disposed session, queue full, owner reconnecting). `is_streaming`
+    is False, no `TurnStarted` ever arrives, and the worker's `finally` is the
+    only thing that clears the band `_start_turn` lit — exactly the "KEPT"
+    case the in-process refusal test pins. Gating the write on `is_remote`
+    alone would have left THIS band lit forever.
+    """
+
+    class RefusingFollowerSession(JobsSession):
+        is_remote = True
+
+        async def prompt(self, text: str, images: Any = None, **kwargs: Any) -> None:
+            raise RuntimeError("session owner is reconnecting")
+
+    app = OperatorApp(lambda: _factory(RefusingFollowerSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+
+        app._start_turn("do the thing")
+        for _ in range(10):
+            await pilot.pause()
+            await asyncio.sleep(0.02)
+
+        assert app._turn_open is False
+        assert app._status is not None and not app._status._streaming
+        assert _working(app) is None
+
+
+@pytest.mark.asyncio
+async def test_a_followers_held_turn_settles_when_the_owner_dies() -> None:
+    """Owner death releases the hold: `›`, an "interrupted" notice, no toast.
+
+    `RemoteSession._end_turn_locally` synthesises an aborted `AgentEndEvent`
+    on EOF, which reaches the app as `TurnEnded(aborted=True)`. The held band
+    must read that as the terminal state it is — not a failure (the owner did
+    not report one) and not a completion (nothing completed).
+    """
+    session = HangingFollowerSession()
+    app = OperatorApp(lambda: _factory(session))
+    notifier = RecordingNotifier()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _armed(pilot, app, notifier)
+        writes = await _spy_title(pilot, app)
+
+        app._start_turn("Run the audit")
+        await _hold(pilot, 0.1)
+        assert app._status is not None
+        assert app._status._title_state() == "working"
+
+        session.streaming = False
+        app.post_message(TurnEnded(aborted=True, error=None))
+        for _ in range(5):
+            await pilot.pause()
+            await asyncio.sleep(0.02)
+
+        assert app._status._title_state() == "idle"
+        assert _working(app) is None
+        notices = [
+            b.text() for b in app.query_one(TranscriptView).blocks() if isinstance(b, NoticeBlock)
+        ]
+        assert "interrupted" in notices, notices
+    assert _titles(writes)[-1].startswith("lo ›"), _titles(writes)
+    assert notifier.kinds == [], "an owner-death abort is not announced"


### PR DESCRIPTION
## What this does

On a **follower** (`lop attach` viewer) a turn that ends in failure first rendered the tab/terminal title as `lo › <label>` — the `idle`, "finished cleanly" state — and only then settled on `lo ✗ <label>`. The width of that window was exactly the owner's relay latency, so a user glancing at the tab strip during it read success on a failed turn. Deferred out of #619 as design finding **D-1**; this PR is the state-machine change that closes it, together with **U11** from the same round (`_go_cold` leaving a spinner forever), which is the same missing concept: a follower's turn state when the owner's outcome arrives late or never.

**C1, standard/pre-authorized.** No version bump — `pyproject.toml` stays at `0.49.0`; the window's release owner picks the bump.

Closes #642

## Delivery contract

**Acceptance criteria**

- A follower whose owner is still streaming when the turn worker's `finally` runs **holds `working`** in the band and title; it never writes `lo ›` until the owner's outcome (or a local terminal event) arrives.
- The held band settles to the outcome the owner relays: `✗` on error, `›` on a clean end (with exactly one completion toast), `›` + "interrupted" on an aborted end (no toast).
- A follower whose `prompt()` refuses before any `agent_start` (`is_streaming` False) still clears the band — the load-bearing "KEPT" case from #619 is unchanged.
- The in-process path (`knows_outcome` True) is byte-identical to #619's behaviour.
- `_go_cold()` on a viewer with an in-flight turn delivers exactly one `AgentEndEvent(aborted=True)` to subscribed handlers and leaves nothing in the sync buffer; the app renders `›` + "interrupted".
- `_on_disconnected` followed by `_go_cold` produces one end event, not two.

**Non-goals**

- **No wall-clock timeout on the hold.** Every "outcome never arrives" case is a socket event that ends the turn locally: the relayed `agent_end`; EOF/reset → `_on_disconnected` → `_end_turn_locally`; a slow-follower drop (the owner's `_send_to` timeout closes the socket → EOF); and the cold fallback (this PR's edit 2). A timer could only fire while the socket is alive and silent — i.e. while the owner IS still working, and turns legitimately run for hours — and every terminal it could pick (`›`, `✗`, "interrupted") would be a false claim. The bound is event-driven. Stated in the code comment at the write site.
- No change to how the in-process `Session` retires a turn.
- ~~No change to the `/loop` workers' unconditional `update(streaming=False)` writes: verified **not reachable on a follower**.~~ **CORRECTED in round 1 (reviewer MAJOR-1, ux U1) — the original claim was wrong and the writes are now fixed here.** `loop` not being in `_FRONTEND_LOCAL_SLASHES` makes the `route_shared_slash` branch the *intended* path, but that branch requires a matching entry in the viewer's `slash_capabilities`, and a **cold** viewer has none: `_synthesise_cold_state` constructs `FrontendSessionState` without them (`default_factory=list`), the unadvertised-command refusal is gated on `and remote_capabilities` (an empty dict is falsy), and (at the base this was found on) `/loop` was not in `_needs_runtime_first`, so nothing bound first. Dispatch therefore falls through to the **local** `_cmd_loop` → loop worker driving the `RemoteSession`.

  **Updated after the rebase onto `ff9b16b5c`:** #654 rewrote `_needs_runtime_first` to a census-based rule, and a *genuinely cold* viewer (`is_cold` True) now returns True for `/loop` — so that viewer binds before dispatch and no longer reaches the local worker by that route. The gate this PR adds is **still load-bearing and still exercised**: a viewer that is bound but whose owner advertises no matching capability (`slash_capabilities` empty, `is_cold` False) takes the local worker exactly as before, which is the shape the regression test drives and the shape both reproductions use. Re-verified by execution on the new base — zero `lo ›` writes with the owner live, against 2 before the fix. The four loop-worker band writes now go through the same gate as the composer's worker (see "Round 1 remediation").

Both reproduction scripts (`repro_flash.py`, `repro_go_cold.py`) are in the evidence gist below.

## Root cause

Two separate writes retire a turn's title, and on the follower path they are ordered by the wire rather than by construction:

1. the turn worker's `finally` writes `self._status.update(streaming=False, failed=None)` — `failed=None` because `knows_outcome = not session.is_remote` and a follower's `prompt()` returns on the owner's ACK, mid-turn;
2. `_finalize_turn` writes the real `failed=` when the owner's `agent_end` arrives.

`failed=None` means "leave alone", but `streaming=False` in the same write drops the title out of `working`, and with no failure mark the renderer resolves to `idle`. In-process the ordering is structural (the real `TurnEnded` is already in the FIFO at write 1, which is why #619 could fix the local path by carrying the outcome into write 1). On a follower the outcome is genuinely unknown at write 1, so that fix is unavailable — the write has to be **withheld**, not enriched.

## The change

### Edit 1 — `local_operator/tui/app.py`, `_start_turn.run_prompt` `finally`

```python
knows_outcome = not bool(getattr(session, "is_remote", False))
if knows_outcome or not bool(getattr(session, "is_streaming", False)):
    self._status.update(
        streaming=False,
        failed=(bool(error_text) and not aborted) if knows_outcome else None,
    )
```

This is the predicate `on_turn_abandoned`'s guard 2 already applies at dispatch, now read at worker time, so the band holds `working` exactly as long as that guard keeps the turn open. The surrounding comment block is rewritten: the write carries the outcome in-process and is withheld on a follower whose owner is live; the "closes the flash structurally" claim is scoped to the in-process path; the no-timeout reasoning and the accepted residual are recorded at the site. The "NOT a silence hole" notes at guard 2 and in `_finalize_turn` now list the go-cold path.

### Edit 2 — `local_operator/session/remote.py`, `_go_cold`

`self._streaming = False` → `self._end_turn_locally(direct=True)`. `_end_turn_locally` gains a `direct` keyword that hands the `AgentEndEvent(aborted=True, generation=self._generation)` straight to subscribed handlers via a new `_deliver` helper (factored out of `_emit_or_buffer`, which now calls it) instead of going through the sync buffer.

**Why direct rather than setting `_ready_for_events = True`:** a failed successor `_dial` leaves `_ready_for_events` False. A buffered end would be drained by the NEXT bind's `_finish_sync` behind that bind's seeded `AgentStartEvent`; the controller drops only `gen < current`, so the stale end would tear down the fresh turn. Flipping `_ready_for_events` to True from go-cold would also release whatever else is sitting in the buffer out of order, and would misstate the facade's sync state for the next dial. Delivering the one event directly changes nothing else. A handler-less drop is correct on that path: with nobody subscribed there is no spinner to stop.

**Double-end safety:** `_end_turn_locally` returns on `not self._streaming`, and `_on_disconnected` already ended the turn before `_recover_owner` runs, so on the common path the go-cold call is a no-op. The case it exists for is a successor dying mid-reattach: `_on_disconnected` returns early while `_recovering`, and `_apply_frontend_facades` has just re-marked the turn live from the successor's snapshot, leaving `_streaming` True with nothing else on the way to clear it.

### Terminal-state table (follower, after this change)

| path | title | transcript | toast |
|---|---|---|---|
| owner end clean / failed / aborted | `›` / `✗` / `›` | — / error + hint / "interrupted" | complete / error / none |
| owner death (EOF) | `›` | "interrupted" | none |
| deliberate stop | `›` | stopped notice | none |
| go cold (**new**) | `›` | "interrupted" | none |
| prompt refused pre-start | `›` (`failed=None`) | error / stopped notice | none |
| owner live, still working | spinner held | — | — |

### Accepted residual

The owner ACKs on the durable append **before** `agent_start` (`runtime/owned.py` `prompt` awaits `admitted`; `harness/loop.py` yields `AgentStartEvent` later in `_run_turn`). If the follower worker's `finally` runs inside that gap, `is_streaming` is still False and the band clears — a working→idle→working blip bounded by the owner's prompt preparation, not by the outcome relay. This is not the D-1 window (which is the relay of the *outcome*) and is accepted as a residual rather than papered over with a timer.

## Evidence

All runs from the worktree venv (`/tmp/lop-642/.venv`, verified `local_operator.__file__` resolves inside the worktree) with every inherited `CMUX_*` variable unset.

### The reproduction, before and after

Headless `run_test()` pilot driving the real `OperatorApp` with a follower fake (`is_remote=True`, `prompt()` returns with `is_streaming=True`) and a `TerminalTitle` write spy; the owner's `TurnEnded(error=...)` is relayed after the stated delay. Script: `repro_flash.py` (in the evidence gist below).

**Before** (`origin/main` @ `aeb4374fe`):

```
relay delay = 0.5s; band state while relay pending = idle
  t=     1.0ms  ›
  t=   512.1ms  ✗
IDLE WINDOW on a failed turn: 511.1 ms  (FLASH)
relay delay = 2.0s; band state while relay pending = idle
  t=     1.1ms  ›
  t=  2015.4ms  ✗
IDLE WINDOW on a failed turn: 2014.3 ms  (FLASH)
```

**After** (this head):

```
relay delay = 0.5s; band state while relay pending = working
  t=    26.5ms  working
  t=   528.1ms  ✗
no `›` write between start and the relayed end (no flash)
relay delay = 2.0s; band state while relay pending = working
  t=    33.0ms  working
  t=  2077.2ms  ✗
no `›` write between start and the relayed end (no flash)
```

### The go-cold path, before and after

Session level: `RemoteSession` with `_streaming=True`, `_can_go_cold=True`, `_ready_for_events=False`, one subscribed handler, then `_go_cold()`. App level: the same facade under the real `OperatorApp` with a synthetic in-flight turn.

**Before:**

```
[session] after _go_cold: end events delivered=0 aborted=[] buffered=0 is_streaming=False
[app] title before go-cold=idle; after go-cold=idle; working line=present; turn_open=True; notices=[]
```

(The `title before go-cold=idle` there is D-1 itself — the band had already dropped to idle on the ACK — and `working line=present; turn_open=True` with no notice is U11: the spinner that never stops.)

**After:**

```
[session] after _go_cold: end events delivered=1 aborted=[True] buffered=0 is_streaming=False
[app] title before go-cold=working; after go-cold=idle; working line=gone; turn_open=False; notices=['interrupted']
```

### Rendered frames

Captured per AGENTS.md "Visual validation" from the real `OperatorApp` (stylesheet loaded), 100×30, while the owner's relay is pending at a 2 s delay.

SVG stills (render with any browser): https://gist.github.com/damianvtran/b2911d4c4928ae27bb7cc4206c475636 — `before_2s.svg` shows the band **idle** (no spinner, elapsed frozen at `0s`) while the working line says `thinking`; `after_2s.svg` shows the spinner alive and the clock running (`2s`); `gocold_after_post.svg` shows `! interrupted` with the band idle and the working line gone (versus the old spinner-forever).

Before: the band reads idle (no spinner, elapsed frozen at `0s`) while the working line says `thinking`. After: the spinner is alive in the band and the clock is running (`2s`) — band and working line agree. Go-cold after: `! interrupted` in the transcript, band idle, working line gone.

### Tests, and proof each one can fail

New (`tests/unit/tui/test_turn_abandoned.py`):

- `test_a_followers_failed_turn_holds_working_until_the_owner_reports[0.05|0.3]` — TerminalTitle spy; asserts no `lo ›` write between turn start and the relayed failed end, and that the last write is `lo ✗`. Parametrized over the relay delay because the window WAS the relay.
- `test_a_followers_clean_turn_settles_idle_once_the_owner_reports` — held, then `›` on a clean relay, exactly one completion toast.
- `test_a_follower_whose_prompt_is_refused_before_start_still_clears_the_band` — `is_remote=True`, `is_streaming` False, `prompt()` raises → band cleared, no working line.
- `test_a_followers_held_turn_settles_when_the_owner_dies` — relayed `TurnEnded(aborted=True)` → `›`, "interrupted" notice, no toast.
- `test_a_follower_whose_owner_never_reports_still_retires_the_turn` — **extended** to assert `_status._streaming is True` while the owner is live.

- `test_a_followers_loop_turn_holds_working_between_iterations` — **round 1**: real slash dispatch, capability-less follower, `/goal` then `/loop 2`; asserts the local worker really drove the session, the owner is still live, and no `lo ›` was written between iterations.

New (`tests/unit/session/test_remote_takeover.py`):

- `test_going_cold_ends_an_in_flight_turn_directly` — `_ready_for_events=False`, subscribed handler → exactly one `AgentEndEvent(aborted=True)` delivered, `_buffered_events == []`.
- `test_a_disconnect_followed_by_going_cold_ends_the_turn_once` — one end event total.
- `test_going_cold_survives_a_controllers_higher_adopted_generation` — **round 1**: drives the REAL `EventController` (the layer where the drop happened), controller adopted generation 6, successor snapshot at generation 1, asserts exactly one `TurnEnded` is posted to the app.
- `test_going_cold_does_not_let_a_raising_handler_break_teardown` — **round 1**: a handler that raises leaves `_owner_ready` set and the viewer cold.

Run against the **pre-fix tree** (detached worktree at `origin/main`, the new test files copied in, `PYTHONPATH` pointed at it and verified):

```
FAILED test_turn_abandoned.py::test_a_follower_whose_owner_never_reports_still_retires_the_turn - assert (... False is True)
FAILED test_turn_abandoned.py::test_a_followers_failed_turn_holds_working_until_the_owner_reports[0.05] - AssertionError: the hold dropped while the owner was live
FAILED test_turn_abandoned.py::test_a_followers_failed_turn_holds_working_until_the_owner_reports[0.3] - AssertionError: the hold dropped while the owner was live
FAILED test_turn_abandoned.py::test_a_followers_clean_turn_settles_idle_once_the_owner_reports - AssertionError: assert 'idle' == 'working'
FAILED test_turn_abandoned.py::test_a_followers_held_turn_settles_when_the_owner_dies - AssertionError: assert 'idle' == 'working'
FAILED test_remote_takeover.py::test_going_cold_ends_an_in_flight_turn_directly - assert (0 == 1)
6 failed, 2 passed, 50 deselected
```

The two that pass on both trees are the refusal test and the double-end test: they pin behaviour this change must **not** alter, so passing before is the point.

Existing `test_an_abandoned_failing_turn_never_flashes_idle_in_the_title` and `test_a_turn_that_never_started_leaves_the_band_idle` are untouched and green.

## Round 1 remediation

Four review streams ran on `3dbd7baa5`. Design signed off; QA passed with no findings; the reviewer raised 1 BLOCKER + 1 MAJOR and UX raised the same MAJOR independently. All fixed in one commit, `5563bd30ee190a4697d76a6f2cf48a2d815dac1d`.

### BLOCKER-1 — the go-cold end was dropped by the controller's generation guard

`_end_turn_locally` stamped the synthesised end with `self._generation`, but `_apply_frontend_facades` overwrites that field from whatever snapshot last arrived — and a **successor is a fresh runtime** (`Session.__init__` starts at 0, so its first turn is 1) while the app's `EventController` has adopted the **previous** owner's generation. `_handle_agent_end` then dropped the end as `gen < current`. The event reached the handler (which is why the round-1 test passed) and died one layer below it.

That made this head strictly **worse than `origin/main`** on the one path edit 2 exists for: `main` reached a wrong terminal state (`idle`), this head reached **none** — band and tab title holding `working` for the life of the process, with no timeout by design.

Fixed by stamping the synthesised end `generation=0`. Verified against `events.py` first: `_handle_agent_end`'s `if gen:` branch treats an unstamped end as belonging to the current turn, `0` is the field's default and the documented "older producer" encoding — an existing convention, not a new one. The buffered path takes the same fix for the same reason.

Reproduced with the real `RemoteSession` + real `EventController` (`repro_blocker1.py` in the gist), the reviewer's exact scenario:

```
                        BEFORE (3dbd7baa5)                AFTER
after A's agent_start : remote.gen=6 ctrl.gen=6 …    remote.gen=6 ctrl.gen=6 …
TurnStarted posted    : 1                            1
after B's snapshot    : remote.gen=1 streaming=True  remote.gen=1 streaming=True
after _go_cold        : TurnEnded=0  buffered=[]     TurnEnded=1  buffered=[]

RESULT: the app's turn is retired = False            = True
```

### MAJOR-1 / U1 — the D-1 flash survived on the `/loop` surface

Fix (a): the four loop-worker `update(streaming=False)` writes now go through a shared `_retire_turn_band(session, failed=...)` helper carrying the same predicate as the composer's worker. A helper rather than four copies of the gate, matching the existing `_post_turn_abandoned` pattern that exists for exactly the same "three prompt drivers, one promise" problem.

Reproduced through the real slash dispatch on a capability-less (cold-shaped) follower, `/goal` then `/loop 2` (`repro_loop_flash.py` in the gist):

```
BEFORE (3dbd7baa5)                          AFTER
caps=0  is_remote=True                      caps=0  is_remote=True
LOCAL prompt() calls by the worker: 2       LOCAL prompt() calls by the worker: 2
session.is_streaming=True                   session.is_streaming=True
band_streaming=False title_state=idle       band_streaming=True title_state=working
title sequence: working → › → working → ›   title sequence: working
`lo ›` writes while the owner is live: 2    `lo ›` writes while the owner is live: 0
```

The Non-goals paragraph above has been corrected: it recorded a verification that did not cover the cold-viewer case.

### Non-gating dispositions

- **MINOR-1** (reviewer) — fixed: the `_end_turn_locally(direct=True)` call in `_go_cold` is now wrapped in `try/except`, matching the client close and the went-cold callback that bracket it. Pinned by `test_going_cold_does_not_let_a_raising_handler_break_teardown`.
- **MINOR-2** (reviewer) — fixed by the BLOCKER-1 test, which drives the real controller instead of asserting on the handler list.
- **NIT-1** (reviewer) — fixed: `_deliver`'s docstring now states the handler-less **drop** as the contract, where a future caller reads it.
- **D2** (designer) — fixed in evidence only: the go-cold pre-frame is re-captured after a 3 s hold, so it shows `thinking 3s` with a live spinner instead of a frozen `0s`. No code change.
- **D1** (designer) — **deferred**. The go-cold title (`lo ›`) is byte-identical to a clean finish, but `_on_disconnected`, `/stop` and relayed aborts all already land on `›`; this PR makes go-cold *consistent with its siblings* rather than introducing an inconsistency. A real fix is a new title state applied across all four abort paths together, which is its own PR.
- **U2** (ux) — **deferred**: `set_went_cold_callback` is a dead seam with zero callers. Wiring or deleting it is out of scope for this PR.
- **U3** (ux) — no change requested by the reviewer; none made.
- **QA** — no findings. QA's one unit failure (`test_a_deliberately_slow_double_click_is_still_a_double_click`) is a host-load flake at load average 208 in a file this diff does not touch; QA verified it 5/5 and 218/218 in isolation. Noted, not chased.

## Gates

Whole tree, exactly as CI:

At the round-1 head `5563bd30e`, whole tree, exactly as CI:

```
$ .venv/bin/python -m flake8 .                              # rc=0
$ uvx --from black==26.1.0 black --check .                  # 928 files would be left unchanged
$ uvx isort==5.13.2 --check .                               # rc=0
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .   # 0 errors, 0 warnings, 0 informations
```

Unit suite at the round-1 head: **the full 14k-test tree was NOT re-run locally.** The host is under severe shared pressure (load average ~300 across sibling worktrees, ~7 GiB free disk) and an earlier full run at this head was killed by an xdist worker crash (`OSError: cannot send`) caused by that load, not by a test. Locally I ran the touched areas serially instead:

```
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/session -n0 -q
1320 passed in 146.86s
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui -q
5378 passed, 12 skipped in 770.35s   # capped xdist per AGENTS.md; -n0 exceeded a sane budget at load ~180
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q
29 passed in 30.13s
```

**CI's full matrix on this head is the authoritative full-tree signal** (5 shards + tui-e2e on both platforms), and it is green — see the checks on this PR. The pre-remediation head's full local run (14320 passed, 17 skipped in 934s) is recorded above for the original commit only.

At the ORIGINAL head `3dbd7baa5`, whole tree:

```
$ .venv/bin/python -m flake8 .                              # rc=0
$ uvx --from black==26.1.0 black --check .                  # 928 files would be left unchanged
$ uvx isort==5.13.2 --check .                               # rc=0
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .   # 0 errors, 0 warnings
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
14320 passed, 17 skipped in 934s (host under heavy shared load; capped workers per AGENTS.md)
```




