### PR TITLE
fix(tui): lazy-load subagent transcript history on attached viewers

### DIFF
--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -1439,11 +1439,24 @@ class SnapshotSubagentComms:
 #: transcript's presence, which the view deliberately re-probes because it can
 #: appear later.
 #:
-#: Only NEGATIVE-able facts are cached: an ``OSError`` (a transient EMFILE, a
-#: volume blip) yields no entry, so a moment's failure cannot pin a wrong
+#: Only facts about well-formed CONTENT are cached. A read that failed
+#: (``OSError`` — a transient EMFILE, a volume blip) or a marker that did not
+#: parse (the truncate-then-write window of ``mark_session_origin``, reachable
+#: while a child is still starting) is a fact about the MOMENT and yields no
+#: entry, so it is re-asked on the next frame instead of pinning a wrong
 #: verdict for the life of the process — the same distinction
 #: ``resume._session_origin_read`` draws with its ``readable`` flag.
+#:
+#: A node that never resolves therefore re-reads once per frame. That is the
+#: honest cost of not deciding early, it is bounded by one stat, and it is not
+#: a regression: before this check the same node simply resolved to ``None``
+#: without reading at all.
 _DERIVED_OWNERSHIP: dict[tuple[str, str, str], bool] = {}
+
+#: Cap on the memo above. Generous beside the 256 live records a roster may
+#: hold, because the point is only to stop unbounded growth across a long
+#: session, never to keep the working set small.
+_DERIVED_OWNERSHIP_MAX = 2048
 
 
 def _derived_dir_belongs_to(directory: Path, label: str, agent_role: str) -> bool:
@@ -1460,18 +1473,32 @@ def _derived_dir_belongs_to(directory: Path, label: str, agent_role: str) -> boo
 
     ``origin.json`` is the proof already on disk: ``run_subagent`` stamps it
     with ``{"origin": "subagent", "label": ..., "agent": ...}`` at creation.
-    The predicate is therefore "this is a subagent session AND it is the one
-    the node describes": origin must be ``subagent``, and whichever of
-    label/agent the marker recorded must match the node. Matching only the
-    fields present keeps a marker written by an older release (which may
-    predate one of the details) usable, while still refusing a directory that
-    positively disagrees.
+    The predicate is "this is a subagent session AND the marker POSITIVELY
+    identifies the child the node describes": origin must be ``subagent``, and
+    the marker's label and agent must both be present and both equal the
+    node's.
 
-    A missing or unreadable marker is NOT ownership. That is the safe
-    direction and costs nothing real: failing closed degrades to the existing
-    "no saved transcript" note, which is exactly what a follower saw before
-    the derivation existed, whereas failing open renders another session's
-    conversation under this child's name.
+    **An absent identity field means NOT PROVEN, never proven** (review round
+    2, R2-1). The earlier "match only the fields present" rule degenerated to
+    ``True`` for a marker carrying neither, and such markers are real rather
+    than hypothetical: ``resume.backfill_session_origins`` stamps
+    ``{"origin": "subagent", "backfilled": true}`` — no label, no agent — over
+    the operator's existing store at startup, so one of those would have
+    authorised ANY child's derived path. The same hole let a label-only marker
+    ignore an agent mismatch, and let a node with no identity of its own match
+    every marker.
+
+    That refuses genuinely backfilled OLD sessions, and refusing them is the
+    right trade: a marker that cannot say WHICH child it belongs to cannot
+    discharge the only question being asked. Those sessions degrade to the
+    existing "no saved transcript" note — exactly what a follower saw before
+    this derivation existed — whereas trusting them renders somebody else's
+    conversation under this child's name. Nothing is lost that the wire path
+    does not already cover: an owner that stamps ``session_dir`` never reaches
+    this check at all.
+
+    Neither is a missing, unreadable, or malformed marker ownership, and the
+    two failure kinds are cached differently — see the call below.
     """
     from local_operator.resume import ORIGIN_NAME, ORIGIN_SUBAGENT
 
@@ -1484,17 +1511,47 @@ def _derived_dir_belongs_to(directory: Path, label: str, agent_role: str) -> boo
     except OSError:
         # A fact about this MOMENT, not about the file: do not memoise it.
         return False
-    verdict = False
     try:
         payload = json.loads(raw)
     except ValueError:
-        payload = None
+        # Also a fact about the moment, for a reason that is easy to miss:
+        # ``mark_session_origin`` writes with ``write_text``, which TRUNCATES
+        # and then writes, so a reader that lands between the two sees an
+        # empty or half-written file. That window is reachable for a child
+        # that is still starting — between ``claim_session`` and the stamp —
+        # which is precisely the case the memo must not decide early. Caching
+        # this ``False`` pinned a starting child as unusable for the life of
+        # the process (review round 2, R2-2). Same distinction the ``OSError``
+        # arm above draws, and the one ``resume._session_origin_read`` draws
+        # with its ``readable`` flag: only facts about CONTENT are memoised.
+        return False
+    verdict = False
     if isinstance(payload, dict) and payload.get("origin") == ORIGIN_SUBAGENT:
         marked_label = payload.get("label")
         marked_agent = payload.get("agent")
-        verdict = (not isinstance(marked_label, str) or not label or marked_label == label) and (
-            not isinstance(marked_agent, str) or not agent_role or marked_agent == agent_role
+        # Both sides must be non-empty and equal. A node missing its own
+        # identity cannot be proven to own anything either, so it is refused
+        # by the same conjunction rather than by a separate branch.
+        verdict = bool(
+            label
+            and agent_role
+            and isinstance(marked_label, str)
+            and isinstance(marked_agent, str)
+            and marked_label == label
+            and marked_agent == agent_role
         )
+    # Only a decided verdict about well-formed CONTENT reaches the memo.
+    #
+    # Bounded explicitly rather than leaning on the roster's own cap. The live
+    # roster is capped (``SubagentComms.MAX_RECORDS`` = 256) but that bounds it
+    # at an INSTANT: eviction there does not clear entries here, so over a long
+    # session the key space is the number of distinct (directory, label, agent)
+    # triples ever SEEN, which keeps growing. The cap is generous next to 256
+    # live records — a session would have to churn through eight full rosters
+    # to evict anything — and re-deciding an evicted entry costs one stat.
+    if len(_DERIVED_OWNERSHIP) >= _DERIVED_OWNERSHIP_MAX:
+        # First-seen insertion order, so the oldest verdict goes first.
+        _DERIVED_OWNERSHIP.pop(next(iter(_DERIVED_OWNERSHIP)))
     _DERIVED_OWNERSHIP[key] = verdict
     return verdict
 

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -1427,13 +1427,86 @@ class SnapshotSubagentComms:
         return getattr(node, "session_dir", None) if node is not None else None
 
 
+#: Memoised ownership verdicts for DERIVED child directories, keyed by
+#: ``(path, label, agent_role)`` — the exact question asked, so a second job
+#: cannot reuse a first job's answer. The value is the verdict alone.
+#:
+#: A cache rather than a per-call read because ``session_dir_of`` sits on the
+#: page's 1 Hz refresh: QA measured this path at 1.08 stats/s and 0 page reads
+#: over 5.6 s idle, and an ``origin.json`` read per tick would regress exactly
+#: that. Safe to memoise because the marker is written ONCE by whoever creates
+#: the directory (``mark_session_origin``) and never rewritten — unlike the
+#: transcript's presence, which the view deliberately re-probes because it can
+#: appear later.
+#:
+#: Only NEGATIVE-able facts are cached: an ``OSError`` (a transient EMFILE, a
+#: volume blip) yields no entry, so a moment's failure cannot pin a wrong
+#: verdict for the life of the process — the same distinction
+#: ``resume._session_origin_read`` draws with its ``readable`` flag.
+_DERIVED_OWNERSHIP: dict[tuple[str, str, str], bool] = {}
+
+
+def _derived_dir_belongs_to(directory: Path, label: str, agent_role: str) -> bool:
+    """Whether a DERIVED directory really is this child's session.
+
+    The derivation below turns a ``session_id`` into a path by construction,
+    and a 48-bit truncated uuid is not an ownership proof: any local session
+    with that id answers to it. Worse, the id space is per-config-root while
+    the derivation reads the PROCESS-GLOBAL ``config_dir()`` — so a follower
+    attached with a different ``config_dir`` still resolves against this
+    process's root, and an unrelated local session's transcript could render
+    under a remote child's page (review round 1, M2; QA reproduced the
+    config-root half of it directly).
+
+    ``origin.json`` is the proof already on disk: ``run_subagent`` stamps it
+    with ``{"origin": "subagent", "label": ..., "agent": ...}`` at creation.
+    The predicate is therefore "this is a subagent session AND it is the one
+    the node describes": origin must be ``subagent``, and whichever of
+    label/agent the marker recorded must match the node. Matching only the
+    fields present keeps a marker written by an older release (which may
+    predate one of the details) usable, while still refusing a directory that
+    positively disagrees.
+
+    A missing or unreadable marker is NOT ownership. That is the safe
+    direction and costs nothing real: failing closed degrades to the existing
+    "no saved transcript" note, which is exactly what a follower saw before
+    the derivation existed, whereas failing open renders another session's
+    conversation under this child's name.
+    """
+    from local_operator.resume import ORIGIN_NAME, ORIGIN_SUBAGENT
+
+    key = (str(directory), label, agent_role)
+    cached = _DERIVED_OWNERSHIP.get(key)
+    if cached is not None:
+        return cached
+    try:
+        raw = (directory / ORIGIN_NAME).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        # A fact about this MOMENT, not about the file: do not memoise it.
+        return False
+    verdict = False
+    try:
+        payload = json.loads(raw)
+    except ValueError:
+        payload = None
+    if isinstance(payload, dict) and payload.get("origin") == ORIGIN_SUBAGENT:
+        marked_label = payload.get("label")
+        marked_agent = payload.get("agent")
+        verdict = (not isinstance(marked_label, str) or not label or marked_label == label) and (
+            not isinstance(marked_agent, str) or not agent_role or marked_agent == agent_role
+        )
+    _DERIVED_OWNERSHIP[key] = verdict
+    return verdict
+
+
 def _snapshot_session_dir(job: JobState) -> Path | None:
     """Resolve a projected job's child session directory on a follower.
 
     Two sources, in order of authority:
 
     1. The wire ``session_dir`` the owner stamped (``_with_lineage``). This is
-       the owner's own ``Path`` and is right by construction.
+       the owner's own ``Path`` and is right by construction, so it is trusted
+       as-is — the owner knows where it put the child.
     2. ``config_dir() / "sessions" / session_id`` when the owner sent only a
        ``session_id``. Children are always created there
        (``harness/subagent.py``: ``session_id`` IS ``session_dir.name``), and a
@@ -1441,14 +1514,21 @@ def _snapshot_session_dir(job: JobState) -> Path | None:
        root. The derivation exists so an already-running daemon from before
        ``session_dir`` rode the wire — the exact situation an operator is in
        when they upgrade the viewer under a long-lived owner — gets history
-       without a restart, rather than only after the owner is relaunched.
+       without a restart, rather than only after the owner is relaunched. It
+       is also what rescues a child rebuilt from the comms graph after a
+       restart, which carries a ``session_id`` and never had a wire directory.
+
+    Only the GUESS is verified (:func:`_derived_dir_belongs_to`): a path this
+    function invented must prove it is the right child's session before the
+    page reads it, because the id alone is not an ownership proof.
 
     A follower on ANOTHER machine (the mobile daemon relaying a remote
-    session) derives a path that does not exist locally. That is accepted on
-    purpose: the view treats a directory with no transcript as "no saved
-    transcript" and keeps painting the live trajectory, which is exactly the
-    behaviour every follower had before this field existed, so the fallback
-    can only add history, never take a page away.
+    session) derives a path that does not exist locally, and now also one that
+    cannot prove ownership. Both degrade to ``None``: the view treats that as
+    "no saved transcript" and keeps painting the live trajectory, which is
+    exactly the behaviour every follower had before this field existed, so the
+    fallback can only add history, never take a page away or show the wrong
+    one.
     """
     wire = job.session_dir
     if wire:
@@ -1456,7 +1536,9 @@ def _snapshot_session_dir(job: JobState) -> Path | None:
     if job.session_id:
         from local_operator.paths import config_dir
 
-        return config_dir() / "sessions" / str(job.session_id)
+        derived = config_dir() / "sessions" / str(job.session_id)
+        if _derived_dir_belongs_to(derived, job.label or job.agent or "", job.agent_role or ""):
+            return derived
     return None
 
 

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -26,6 +26,7 @@ from collections.abc import (
 )
 from dataclasses import dataclass
 from enum import StrEnum
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -734,6 +735,16 @@ class JobState(BaseModel):
     # than silently doing nothing.
     parent_job_id: str | None = None
     session_id: str | None = None
+    #: The child's durable session directory, as a string (``Path`` is not
+    #: JSON-native). Projected here for the same reason ``session_id`` is:
+    #: the owner's ``SubagentComms`` registry never crosses the socket, and
+    #: the full-page view lazy-loads the child's ``transcript.jsonl`` through
+    #: ``comms.session_dir_of(job_id)``. A follower with no directory treated
+    #: every child as "no saved transcript" and could show only the 500-event
+    #: in-memory trajectory window of a child that had hours of history on
+    #: disk. ``None`` from an owner that predates this field is tolerated —
+    #: ``SnapshotSubagentComms`` derives the path from ``session_id`` then.
+    session_dir: str | None = None
     attempt_aliases: list[str] = Field(default_factory=list)
     # Child plans are detail payloads, not roster metadata. None is unavailable;
     # an empty list is an authoritative clear and must never restore a stale plan.
@@ -1335,6 +1346,13 @@ class SnapshotSubagentComms:
     all of which ``JobState`` now carries. This facade answers the SAME methods
     the app calls on ``_subagent_comms`` from ``state.jobs``, so the hierarchy
     keys work identically on a follower (U5) with no attach-specific code path.
+
+    ``session_dir_of`` is the one method whose answer is not pure graph: it is
+    a filesystem path the view reads durable history from. It is answered
+    from the projected ``session_dir``/``session_id`` (see
+    :func:`_snapshot_session_dir`) because the alternative — fetching the
+    child's history over the socket — would put an hour-long transcript on
+    the wire that a same-machine follower can page straight off disk.
     """
 
     def __init__(self, jobs: Iterable[JobState] = ()) -> None:
@@ -1352,7 +1370,7 @@ class SnapshotSubagentComms:
             label=job.label or job.agent or job.id,
             parent_job_id=job.parent_job_id,
             session_id=job.session_id,
-            session_dir=None,
+            session_dir=_snapshot_session_dir(job),
             prompt=job.prompt or "",
             agent_role=job.agent_role or "",
             effort=job.effort or "",
@@ -1394,8 +1412,52 @@ class SnapshotSubagentComms:
         rows.reverse()
         return rows
 
-    def session_dir_of(self, job_id: str) -> Any | None:
-        return None
+    def session_dir_of(self, job_id: str) -> Path | None:
+        """Where the child's durable transcript lives, for lazy history paging.
+
+        The owner answers this from its live registry; a follower answers it
+        from the projected job (see :func:`_snapshot_session_dir`). Existence
+        is deliberately NOT checked here: the view already re-probes a
+        directory whose ``transcript.jsonl`` is missing on every refresh
+        (``SubagentView._reconsider_missing_history``), and a path that never
+        materialises on this machine degrades to the same "no saved
+        transcript" note a missing file does.
+        """
+        node = self.node(job_id)
+        return getattr(node, "session_dir", None) if node is not None else None
+
+
+def _snapshot_session_dir(job: JobState) -> Path | None:
+    """Resolve a projected job's child session directory on a follower.
+
+    Two sources, in order of authority:
+
+    1. The wire ``session_dir`` the owner stamped (``_with_lineage``). This is
+       the owner's own ``Path`` and is right by construction.
+    2. ``config_dir() / "sessions" / session_id`` when the owner sent only a
+       ``session_id``. Children are always created there
+       (``harness/subagent.py``: ``session_id`` IS ``session_dir.name``), and a
+       TUI attached to a daemon on the same machine reads the same config
+       root. The derivation exists so an already-running daemon from before
+       ``session_dir`` rode the wire — the exact situation an operator is in
+       when they upgrade the viewer under a long-lived owner — gets history
+       without a restart, rather than only after the owner is relaunched.
+
+    A follower on ANOTHER machine (the mobile daemon relaying a remote
+    session) derives a path that does not exist locally. That is accepted on
+    purpose: the view treats a directory with no transcript as "no saved
+    transcript" and keeps painting the live trajectory, which is exactly the
+    behaviour every follower had before this field existed, so the fallback
+    can only add history, never take a page away.
+    """
+    wire = job.session_dir
+    if wire:
+        return Path(str(wire))
+    if job.session_id:
+        from local_operator.paths import config_dir
+
+        return config_dir() / "sessions" / str(job.session_id)
+    return None
 
 
 class SnapshotMcpManager:
@@ -2309,10 +2371,15 @@ def _with_lineage(job: JobState, comms: Any) -> JobState:
 
     child_id = getattr(node, "session_id", None)
     has_plan = bool(child_id) and (bool(getattr(node, "live", False)) or child_id in TODO_STORE)
+    # Stringified: the wire is JSON and ``Path`` is not. A follower's
+    # ``SnapshotSubagentComms`` turns it back into a ``Path``; the owner-side
+    # view never reads this field, it asks the live registry directly.
+    session_dir = getattr(node, "session_dir", None)
     return job.model_copy(
         update={
             "parent_job_id": getattr(node, "parent_job_id", None),
             "session_id": getattr(node, "session_id", None),
+            "session_dir": str(session_dir) if session_dir is not None else None,
             "attempt_aliases": list(getattr(node, "attempt_aliases", ())),
             "todos": (
                 [phase.model_dump(mode="json") for phase in _todo_state(node.session_id)]

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -1855,6 +1855,13 @@ class SubagentView(Vertical):
             if self._body.is_mounted:
                 self._body.clear_blocks()
         elif transcript_directory != self._history_directory:
+            # Same job, different answer about where its transcript lives.
+            # Load-bearing on a FOLLOWER: the directory arrives on a wire
+            # frame (``JobState.session_dir``), and a page opened off a frame
+            # that had none must not stay "no saved transcript" forever.
+            # ``_reset_history`` un-finalises the absence and issues the
+            # initial tail read itself, because ``on_mount`` — the other
+            # place that read starts — has already run for this page.
             self._reset_history(transcript_directory)
         self._label = strip_control_sequences(label or job_id)
         self._status = status
@@ -1965,6 +1972,14 @@ class SubagentView(Vertical):
         # durable session has nothing to read now and nothing to read later,
         # and no refresh will change that. A directory that exists is a
         # question the page re-asks (``_reconsider_missing_history``).
+        #
+        # "Final" is scoped to THIS directory answer, not to the page: a
+        # follower may open the page off a frame with no directory and learn
+        # it on a later one, and ``show()`` routes that through here again,
+        # which is what un-finalises the absence. It used to be genuinely
+        # permanent on every follower — ``SnapshotSubagentComms`` answered
+        # ``None`` for every child — so an hour-long child showed only its
+        # 500-event live window with the transcript fully on disk.
         self._history_absent_final = not bool(directory)
         # Re-armed on retarget (see ``_history_at_top``): a new job is a new
         # reader at the tail whose first scroll to the top owes a page.

--- a/local_operator/tui/widgets/todo_panel.py
+++ b/local_operator/tui/widgets/todo_panel.py
@@ -241,10 +241,23 @@ def todo_items(
 
 
 def _read_restored_todos(transcript_directory: str) -> list[dict[str, Any]]:
-    """Read a historical child snapshot; callers must run this in a worker."""
+    """Read a historical child snapshot; callers must run this in a worker.
+
+    ``defer_materialise`` because this is a pure READ of somebody else's
+    session and must leave nothing behind. ``Transcript`` otherwise mkdirs its
+    directory on construction, so merely opening a child's page created an
+    empty session directory in the real store whenever the path did not exist
+    — and the path can now be DERIVED from a ``session_id`` (see
+    ``frontend_state._snapshot_session_dir``), so a remote follower whose
+    children live on another machine would litter this one with a phantom
+    directory per page open (review round 1, M1).
+    """
     from local_operator.session.transcript import Transcript
 
-    details = Transcript(transcript_directory).latest_custom("todo_snapshot") or {}
+    details = (
+        Transcript(transcript_directory, defer_materialise=True).latest_custom("todo_snapshot")
+        or {}
+    )
     candidate = details.get("items") or []
     return candidate if isinstance(candidate, list) else []
 

--- a/tests/unit/session/test_launch_subagent.py
+++ b/tests/unit/session/test_launch_subagent.py
@@ -2627,3 +2627,92 @@ async def test_the_parent_name_resolver_holds_its_parent_weakly(tmp_path, monkey
     # The resolver alone never kept it alive, and a dead parent lends no name.
     assert parent_ref() is None
     assert resolve() == ""
+
+
+@pytest.mark.asyncio
+async def test_a_swept_child_keeps_its_durable_identity_on_the_roster(tmp_path, monkeypatch):
+    """The retention sweep releases execution evidence, never identity.
+
+    ``AsyncJobManager._sweep_due`` deletes a settled row from ``_jobs`` five
+    minutes after it settles (``DEFAULT_RETENTION_MS``), which is what makes a
+    long session's memory bounded. The row must nevertheless keep riding
+    ``state.jobs``, because that projection is the ONLY thing a follower sees:
+    the comms registry cannot cross the socket, so a child whose row vanished
+    would lose the ``session_id``/``session_dir`` its page needs to reach a
+    ``transcript.jsonl`` that outlives the process forever.
+
+    It survives through ``_ChildRecord.job_ref`` — the registry holds a live
+    reference the sweep's ``del`` cannot free — which ``comms.job_rows()``
+    re-adds to the roster. Pinned here because that is a load-bearing
+    consequence of an unrelated-looking field, and a future sweep that also
+    dropped the comms record would silently reintroduce the defect (a settled
+    child rendering "no saved transcript" over a fully intact transcript).
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    parent = make_session(tmp_path, OneShotStream())
+    try:
+        job_id = parent._launch_subagent(label="swept", prompt="go do a thing")
+        await asyncio.wait_for(parent.jobs.settled_event(job_id).wait(), timeout=10)
+        child_dir = parent.subagent_comms.session_dir_of(job_id)
+        assert child_dir is not None and (child_dir / "transcript.jsonl").exists()
+
+        # Exactly what the five-minute retention does, without waiting for it.
+        parent.jobs._retention_ms = 0
+        parent.jobs._sweep_due()
+        assert parent.jobs.get(job_id) is None, "the execution row must be swept"
+
+        parent.refresh_frontend_state()
+        row = next((row for row in parent.frontend_state.jobs if row.id == job_id), None)
+        assert row is not None, "a swept child must not vanish from the roster"
+        assert row.session_id == child_dir.name
+        assert row.session_dir == str(child_dir)
+        assert row.status == "completed"
+        # The owner's own page reads the live registry, which also survives.
+        assert parent.subagent_comms.session_dir_of(job_id) == child_dir
+    finally:
+        await parent.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_restored_swept_child_still_points_at_its_transcript(tmp_path, monkeypatch):
+    """The state the operator's machine was actually in.
+
+    A session that is RESTARTED after a child was swept persists an asymmetric
+    roster: ``_persist_subagent_roster`` writes ``jobs`` from ``jobs.list()``
+    (the swept row is gone) but ``records`` from the comms snapshot (kept, so
+    resume works). Restore therefore rebuilds those children from the comms
+    graph alone, as ``restored`` rows with an EMPTY trajectory — the honest
+    result, since in-memory execution evidence is precisely what the sweep
+    released.
+
+    What must NOT be lost is the way back to the durable transcript. Observed
+    live on a nine-child session that persisted one job row: the eight
+    reconstructed children carried ``session_id`` but no directory, so the
+    follower's page painted "no saved transcript" over a 1153-row file.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    parent = make_session(tmp_path, OneShotStream())
+    try:
+        job_id = parent._launch_subagent(label="swept", prompt="go do a thing")
+        await asyncio.wait_for(parent.jobs.settled_event(job_id).wait(), timeout=10)
+        child_dir = parent.subagent_comms.session_dir_of(job_id)
+        snapshot = parent.subagent_comms.snapshot()
+    finally:
+        await parent.dispose()
+
+    # The restart: comms records survive to disk, the swept job row does not.
+    resumed = make_session(tmp_path / "resumed", OneShotStream())
+    try:
+        resumed.subagent_comms.restore(snapshot)
+        assert resumed.jobs.get(job_id) is None, "no execution row survives a restart"
+
+        resumed.refresh_frontend_state()
+        row = next((row for row in resumed.frontend_state.jobs if row.id == job_id), None)
+        assert row is not None, "the comms graph must still reconstruct the child"
+        assert row.restored is True
+        assert not row.trajectory, "a swept child has no in-memory trajectory to serve"
+        # The one fact the page cannot do without.
+        assert row.session_id == child_dir.name
+        assert row.session_dir == str(child_dir)
+    finally:
+        await resumed.dispose()

--- a/tests/unit/session/test_subagent_view_state.py
+++ b/tests/unit/session/test_subagent_view_state.py
@@ -143,6 +143,16 @@ def test_follower_comms_answers_session_dir_from_wire_then_derives_it(
     through ``comms.session_dir_of``, and a ``None`` there is treated as a
     PERMANENT absence by the view, so every answer below is load-bearing."""
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    # The derived answer is only trusted once the directory proves it is this
+    # child's session (see ``_derived_dir_belongs_to``), so stamp the marker
+    # ``run_subagent`` writes at creation. Written BEFORE the facade is built:
+    # ``replace()`` resolves every node's directory eagerly.
+    derived_dir = tmp_path / "sessions" / "def456"
+    derived_dir.mkdir(parents=True)
+    (derived_dir / "origin.json").write_text(
+        json.dumps({"origin": "subagent", "label": "worker", "agent": "coder"}),
+        encoding="utf-8",
+    )
     comms = SnapshotSubagentComms(
         [
             # A current owner stamps the directory on the wire; it wins even
@@ -156,18 +166,120 @@ def test_follower_comms_answers_session_dir_from_wire_then_derives_it(
             # A pre-fix owner sends only the session_id: derive the path the
             # child was created at so the operator's already-running daemon
             # gains history without a restart.
-            JobState(id="derived", type="task", session_id="def456"),
+            JobState(
+                id="derived",
+                type="task",
+                session_id="def456",
+                label="worker",
+                agent_role="coder",
+            ),
             # A job with neither (a bash job, a swept child) has nothing to read.
             JobState(id="bare", type="task"),
         ]
     )
     assert comms.session_dir_of("wired") == tmp_path / "elsewhere" / "abc123"
-    assert comms.session_dir_of("derived") == tmp_path / "sessions" / "def456"
+    assert comms.session_dir_of("derived") == derived_dir
     assert comms.session_dir_of("bare") is None
     assert comms.session_dir_of("unknown") is None
     # The node carries the same answer, which is what the todo panel reads.
     node = comms.node("derived")
-    assert node is not None and node.session_dir == tmp_path / "sessions" / "def456"
+    assert node is not None and node.session_dir == derived_dir
+
+
+def test_a_derived_path_is_refused_unless_the_directory_proves_ownership(
+    tmp_path, monkeypatch
+) -> None:
+    """The guess must prove itself; the wire value never has to.
+
+    ``session_id`` is a 48-bit truncated uuid and carries no ownership proof,
+    and the derivation reads the PROCESS-GLOBAL ``config_dir()`` rather than
+    whichever root a follower attached against — so an unrelated local session
+    is directly reachable, no collision required (review round 1, M2; QA hit
+    the config-root half of this with a "wrong config root" cell that resolved
+    anyway).
+
+    Every case below degrades to ``None``, which the view already renders as
+    the "no saved transcript" note — the behaviour followers had before the
+    derivation existed. Failing closed can only withhold history; failing open
+    renders somebody else's conversation under this child's name.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    sessions = tmp_path / "sessions"
+
+    # 1. Nothing on disk at all: a remote/mobile follower whose children live
+    #    on another machine. Must NOT be trusted, and must not create anything.
+    absent = JobState(id="absent", type="task", session_id="aaaaaaaaaaaa", label="w")
+    assert SnapshotSubagentComms([absent]).session_dir_of("absent") is None
+    assert not (sessions / "aaaaaaaaaaaa").exists(), "resolution must not touch disk"
+
+    # 2. A real local session that is the USER'S OWN, not anyone's child. It
+    #    has no origin marker, which is precisely how a user session looks.
+    user_dir = sessions / "bbbbbbbbbbbb"
+    user_dir.mkdir(parents=True)
+    (user_dir / "transcript.jsonl").write_text("{}\n", encoding="utf-8")
+    stranger = JobState(id="stranger", type="task", session_id="bbbbbbbbbbbb", label="w")
+    assert SnapshotSubagentComms([stranger]).session_dir_of("stranger") is None
+
+    # 3. A subagent session, but a DIFFERENT child's: the id matched, the
+    #    identity does not.
+    other_dir = sessions / "cccccccccccc"
+    other_dir.mkdir(parents=True)
+    (other_dir / "origin.json").write_text(
+        json.dumps({"origin": "subagent", "label": "someone-else", "agent": "reviewer"}),
+        encoding="utf-8",
+    )
+    mismatched = JobState(
+        id="mismatched", type="task", session_id="cccccccccccc", label="w", agent_role="coder"
+    )
+    assert SnapshotSubagentComms([mismatched]).session_dir_of("mismatched") is None
+
+    # 4. The real thing: same id, and the marker agrees about who it is.
+    mine_dir = sessions / "dddddddddddd"
+    mine_dir.mkdir(parents=True)
+    (mine_dir / "origin.json").write_text(
+        json.dumps({"origin": "subagent", "label": "w", "agent": "coder"}),
+        encoding="utf-8",
+    )
+    mine = JobState(
+        id="mine", type="task", session_id="dddddddddddd", label="w", agent_role="coder"
+    )
+    assert SnapshotSubagentComms([mine]).session_dir_of("mine") == mine_dir
+
+    # 5. A WIRE-supplied directory is the owner's own answer and is trusted
+    #    without a marker — the owner knows where it put the child.
+    bare = sessions / "eeeeeeeeeeee"
+    wired = JobState(
+        id="wired", type="task", session_id="ffffffffffff", session_dir=str(bare), label="w"
+    )
+    assert SnapshotSubagentComms([wired]).session_dir_of("wired") == bare
+
+
+def test_a_missing_marker_is_not_memoised_as_a_verdict(tmp_path, monkeypatch) -> None:
+    """The ownership verdict is cached, so a child that is still STARTING
+    must not be pinned as unusable.
+
+    ``session_dir_of`` rides the page's 1 Hz refresh and QA measured this path
+    at 1.08 stats/s with 0 page reads, so the marker read is memoised. The
+    memo may only hold facts about CONTENT: a directory whose marker is not
+    there yet (or briefly unreadable) has to be re-asked, exactly as
+    ``resume._session_origin_read`` declines to cache an ``OSError``.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    job = JobState(
+        id="starting", type="task", session_id="abcabcabcabc", label="w", agent_role="coder"
+    )
+    comms = SnapshotSubagentComms([job])
+    assert comms.session_dir_of("starting") is None
+
+    directory = tmp_path / "sessions" / "abcabcabcabc"
+    directory.mkdir(parents=True)
+    (directory / "origin.json").write_text(
+        json.dumps({"origin": "subagent", "label": "w", "agent": "coder"}),
+        encoding="utf-8",
+    )
+    # A later frame re-projects the node; the answer must now be the directory.
+    comms.replace([job])
+    assert comms.session_dir_of("starting") == directory
 
 
 def test_lineage_stamps_the_child_session_dir_as_a_string() -> None:

--- a/tests/unit/session/test_subagent_view_state.py
+++ b/tests/unit/session/test_subagent_view_state.py
@@ -136,6 +136,74 @@ def test_resumed_manager_alias_resolves_to_one_current_node() -> None:
     assert parent is not None and parent.job_id == "manager"
 
 
+def test_follower_comms_answers_session_dir_from_wire_then_derives_it(
+    tmp_path, monkeypatch
+) -> None:
+    """The follower's history seam: the full-page view pages durable history
+    through ``comms.session_dir_of``, and a ``None`` there is treated as a
+    PERMANENT absence by the view, so every answer below is load-bearing."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    comms = SnapshotSubagentComms(
+        [
+            # A current owner stamps the directory on the wire; it wins even
+            # when it disagrees with where the session_id would derive to.
+            JobState(
+                id="wired",
+                type="task",
+                session_id="abc123",
+                session_dir=str(tmp_path / "elsewhere" / "abc123"),
+            ),
+            # A pre-fix owner sends only the session_id: derive the path the
+            # child was created at so the operator's already-running daemon
+            # gains history without a restart.
+            JobState(id="derived", type="task", session_id="def456"),
+            # A job with neither (a bash job, a swept child) has nothing to read.
+            JobState(id="bare", type="task"),
+        ]
+    )
+    assert comms.session_dir_of("wired") == tmp_path / "elsewhere" / "abc123"
+    assert comms.session_dir_of("derived") == tmp_path / "sessions" / "def456"
+    assert comms.session_dir_of("bare") is None
+    assert comms.session_dir_of("unknown") is None
+    # The node carries the same answer, which is what the todo panel reads.
+    node = comms.node("derived")
+    assert node is not None and node.session_dir == tmp_path / "sessions" / "def456"
+
+
+def test_lineage_stamps_the_child_session_dir_as_a_string() -> None:
+    """``_with_lineage`` is where an owner projects its registry onto the
+    wire; ``Path`` is not JSON-native so the projection is a string, and a
+    node without a directory projects ``None`` rather than ``"None"``."""
+    from pathlib import Path
+    from types import SimpleNamespace
+
+    from local_operator.session.frontend_state import _with_lineage
+
+    def comms_with(session_dir):  # noqa: ANN001, ANN202
+        node = SimpleNamespace(
+            job_id="child",
+            parent_job_id="root",
+            session_id="abc123",
+            session_dir=session_dir,
+            attempt_aliases=(),
+            live=False,
+        )
+        return SimpleNamespace(node=lambda _job_id: node)
+
+    job = JobState(id="child", type="task")
+    stamped = _with_lineage(job, comms_with(Path("/tmp/sessions/abc123")))
+    assert stamped.session_dir == "/tmp/sessions/abc123"
+    assert stamped.session_id == "abc123"
+    # Survives a JSON round trip, which is how a follower receives it.
+    wire = JobState.model_validate_json(stamped.model_dump_json())
+    assert wire.session_dir == "/tmp/sessions/abc123"
+    assert _with_lineage(job, comms_with(None)).session_dir is None
+    # An owner from before the field existed sends no key at all; the model
+    # must default it rather than reject the frame.
+    old = JobState.model_validate({"id": "child", "type": "task", "session_id": "abc123"})
+    assert old.session_dir is None
+
+
 @pytest.mark.parametrize("saved", [[], _todos("Previously saved child task")])
 @pytest.mark.asyncio
 async def test_cold_owner_hydrates_selected_child_plan_and_reconstructs_nested_rows(

--- a/tests/unit/session/test_subagent_view_state.py
+++ b/tests/unit/session/test_subagent_view_state.py
@@ -273,6 +273,22 @@ def test_a_missing_marker_is_not_memoised_as_a_verdict(tmp_path, monkeypatch) ->
 
     directory = tmp_path / "sessions" / "abcabcabcabc"
     directory.mkdir(parents=True)
+
+    # The PARTIAL state, which a plain absent->complete step walks straight
+    # past: ``mark_session_origin`` writes with ``write_text``, which truncates
+    # and then writes, so a reader landing between the two sees an empty or
+    # half-written file. That window is reachable for a child between
+    # ``claim_session`` and its stamp, and caching the parse failure pinned
+    # such a child as unusable for the life of the process (round 2, R2-2).
+    (directory / "origin.json").write_text("", encoding="utf-8")
+    comms.replace([job])
+    assert comms.session_dir_of("starting") is None
+
+    # Half-written JSON is the same class of transient, not a decided answer.
+    (directory / "origin.json").write_text('{"origin": "suba', encoding="utf-8")
+    comms.replace([job])
+    assert comms.session_dir_of("starting") is None
+
     (directory / "origin.json").write_text(
         json.dumps({"origin": "subagent", "label": "w", "agent": "coder"}),
         encoding="utf-8",
@@ -280,6 +296,88 @@ def test_a_missing_marker_is_not_memoised_as_a_verdict(tmp_path, monkeypatch) ->
     # A later frame re-projects the node; the answer must now be the directory.
     comms.replace([job])
     assert comms.session_dir_of("starting") == directory
+
+
+def test_a_marker_that_cannot_name_its_child_authorises_nobody(tmp_path, monkeypatch) -> None:
+    """Absent identity in the marker means NOT PROVEN, never proven.
+
+    ``resume.backfill_session_origins`` stamps
+    ``{"origin": "subagent", "backfilled": true}`` — no label, no agent — over
+    the operator's existing store at startup (``cli.py`` calls it on boot), so
+    these markers are real rather than hypothetical. Under a "match only the
+    fields present" rule such a marker satisfied every node, which handed any
+    child a directory it had not earned (round 2, R2-1).
+
+    Refusing genuinely backfilled old sessions is the deliberate trade: a
+    marker that cannot say WHICH child it belongs to cannot answer the only
+    question being asked, and those sessions degrade to the existing
+    "no saved transcript" note rather than showing the wrong conversation.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    sessions = tmp_path / "sessions"
+
+    def resolve(session_id: str, marker: dict[str, Any], label: str, agent_role: str):
+        directory = sessions / session_id
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "origin.json").write_text(json.dumps(marker), encoding="utf-8")
+        job = JobState(
+            id=f"j-{session_id}",
+            type="task",
+            session_id=session_id,
+            label=label,
+            agent_role=agent_role,
+        )
+        return SnapshotSubagentComms([job]).session_dir_of(f"j-{session_id}")
+
+    backfilled = {"origin": "subagent", "backfilled": True}
+    assert resolve("aaaaaaaaaaaa", backfilled, "any-child", "reviewer") is None
+
+    # Label-only: the agent mismatch must still be fatal.
+    assert resolve("bbbbbbbbbbbb", {"origin": "subagent", "label": "w"}, "w", "coder") is None
+    # Agent-only, mirrored.
+    assert resolve("cccccccccccc", {"origin": "subagent", "agent": "coder"}, "w", "coder") is None
+
+    # A node carrying no identity of its own cannot be proven to own anything.
+    full = {"origin": "subagent", "label": "w", "agent": "coder"}
+    assert resolve("dddddddddddd", full, "", "") is None
+    assert resolve("eeeeeeeeeeee", full, "w", "") is None
+
+    # The genuine article still resolves.
+    assert resolve("ffffffffffff", full, "w", "coder") == sessions / "ffffffffffff"
+
+
+def test_the_ownership_memo_is_bounded(tmp_path, monkeypatch) -> None:
+    """The memo outlives any single roster, so it needs its own cap.
+
+    ``SubagentComms._records`` is capped at ``MAX_RECORDS``, but that bounds
+    the roster at an INSTANT: eviction there does not clear entries here, so
+    the key space is every distinct (directory, label, agent) triple the
+    process has ever seen. Bounded first-seen-first-out; re-deciding an
+    evicted entry costs one stat.
+    """
+    from local_operator.session import frontend_state as module
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(module, "_DERIVED_OWNERSHIP", {})
+    monkeypatch.setattr(module, "_DERIVED_OWNERSHIP_MAX", 8)
+    sessions = tmp_path / "sessions"
+    for index in range(20):
+        session_id = f"s{index:011d}"
+        directory = sessions / session_id
+        directory.mkdir(parents=True)
+        (directory / "origin.json").write_text(
+            json.dumps({"origin": "subagent", "label": f"L{index}", "agent": "coder"}),
+            encoding="utf-8",
+        )
+        job = JobState(
+            id=f"j{index}",
+            type="task",
+            session_id=session_id,
+            label=f"L{index}",
+            agent_role="coder",
+        )
+        assert SnapshotSubagentComms([job]).session_dir_of(f"j{index}") == directory
+    assert len(module._DERIVED_OWNERSHIP) <= 8
 
 
 def test_lineage_stamps_the_child_session_dir_as_a_string() -> None:

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import json
 from collections.abc import Mapping, Sequence
 from types import SimpleNamespace
 from typing import Any, cast
@@ -4756,11 +4757,19 @@ async def test_follower_pages_durable_history_from_the_projected_session_dir(
         transcript = Transcript(directory)
         for index in range(120):
             await transcript.append_message(Message.assistant(f"{shape} durable {index}"))
+        # The ownership marker ``run_subagent`` stamps at creation. A DERIVED
+        # path is refused without it (review round 1, M2); the wire shape does
+        # not need it, and carries it here only because a real child has one.
+        (directory / "origin.json").write_text(
+            json.dumps({"origin": "subagent", "label": "audit the ingest path", "agent": "coder"}),
+            encoding="utf-8",
+        )
         row = JobState(
             id=f"sub-{shape}",
             type="task",
             status="completed",
             label="audit the ingest path",
+            agent_role="coder",
             start_time=1_700_000_000.0,
             settled_at=1_700_000_042.0,
             trajectory=[],
@@ -4838,3 +4847,157 @@ async def test_a_follower_page_that_gains_a_directory_re_arms_history(tmp_path) 
         assert "durable 29" in page
         # The live trajectory rows the first frame painted are still there.
         assert "Reading the ingest path." in page
+
+
+@pytest.mark.asyncio
+async def test_a_restored_swept_child_pages_its_transcript_on_a_follower(
+    tmp_path, monkeypatch
+) -> None:
+    """The operator's reported case, as a regression guard.
+
+    A child swept by retention and then restored across a restart reaches a
+    follower as a ``restored`` reader row: ``session_id`` but NO trajectory
+    and no wire ``session_dir`` (the pre-fix owner never sent one). The page
+    must still reach its transcript, because the file outlives the process —
+    observed live as a 1153-row transcript rendered as "no saved transcript".
+
+    The empty trajectory is deliberate and stays empty: in-memory execution
+    evidence is exactly what the sweep releases, and the durable transcript is
+    its replacement. The assertion is therefore about HISTORY, not rows.
+    """
+    from local_operator.session.frontend_state import (
+        JobState,
+        SnapshotJobs,
+        SnapshotSubagentComms,
+    )
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    session_id = "e72882c37267"
+    transcript = Transcript(tmp_path / "sessions" / session_id)
+    for index in range(140):
+        await transcript.append_message(Message.assistant(f"durable {index}"))
+    # The real marker for this child, copied from the operator's own machine:
+    # {"origin": "subagent", "label": "desktop-ui-implementation", "agent": "coder"}.
+    # A derived path is only trusted once it proves ownership (round 1, M2).
+    (transcript.directory / "origin.json").write_text(
+        json.dumps({"origin": "subagent", "label": "desktop-ui-implementation", "agent": "coder"}),
+        encoding="utf-8",
+    )
+    row = JobState(
+        id="b76f9293544d",
+        type="task",
+        status="completed",
+        label="desktop-ui-implementation",
+        agent_role="coder",
+        start_time=1_700_000_000.0,
+        settled_at=1_700_000_042.0,
+        # The shape the comms-node fallback builds: identity, no trajectory,
+        # and no wire directory — the derivation is the only way home.
+        restored=True,
+        trajectory=[],
+        session_id=session_id,
+    )
+    session = FakeSession()
+    session.is_remote = True  # type: ignore[attr-defined]
+    session.jobs = SnapshotJobs([row])
+    session._subagent_comms = SnapshotSubagentComms([row])
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(90, 28)) as pilot:
+        view = await _open(pilot, app, row)
+        await _wait_history(pilot, view)
+        assert not view._history_absent_final
+        assert HISTORY_UNAVAILABLE_NOTE not in view._history_state_text()
+        assert "durable 139" in " ".join(view.rendered_rows())
+
+        while not view._history_exhausted:
+            view.action_home()
+            await _wait_history(pilot, view)
+        assert len(view._history_ids) == 140
+        assert "durable 0" in " ".join(view.rendered_rows())
+        settled = f"{HISTORY_START_NOTE} · {READ_ONLY_NOTE}"
+        for _ in range(50):
+            if view._state_hint.rendered().endswith(settled):
+                break
+            await pilot.pause()
+        assert view._state_hint.rendered().endswith(settled)
+
+
+@pytest.mark.asyncio
+async def test_an_owner_page_survives_the_sweep_of_its_own_job_row(tmp_path) -> None:
+    """Owner-side parity, and the case where the sweep lands mid-read.
+
+    An owner reads the LIVE comms registry rather than the wire, so its page
+    keeps the transcript directory when retention deletes the execution row
+    underneath it (``_ChildRecord.job_ref`` is what carries the row itself).
+    The page then reports the ledger loss — ``LEDGER_GONE_NOTE``, which is
+    true — while the durable history stays readable, which is the whole point
+    of the distinction between execution evidence and the transcript.
+    """
+    transcript = Transcript(tmp_path / "child")
+    for index in range(30):
+        await transcript.append_message(Message.assistant(f"durable {index}"))
+    job = _job_with(TRAJECTORY, status="completed")
+    session = FakeSession()
+    session.jobs = _fake_jobs(job)
+    session._subagent_comms = type(
+        "Comms", (), {"session_dir_of": lambda self, _job_id: transcript.directory}
+    )()
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(90, 28)) as pilot:
+        view = await _open(pilot, app, job)
+        await _wait_history(pilot, view)
+        assert len(view._history_ids) == 30
+
+        # Retention removes the row while the page is open: the ledger lookup
+        # now misses, but the registry (and so the directory) is untouched.
+        session.jobs = _fake_jobs()
+        app._refresh_subagent_view(view.job_id)
+        await _wait_history(pilot, view)
+
+        assert view._status == "gone"
+        page = " ".join(view.rendered_rows())
+        assert LEDGER_GONE_NOTE in page
+        # The durable half is unaffected — identity outlived the sweep.
+        assert HISTORY_UNAVAILABLE_NOTE not in view._history_state_text()
+        assert len(view._history_ids) == 30
+        assert "durable 29" in page
+
+
+@pytest.mark.asyncio
+async def test_a_swept_child_with_no_directory_anywhere_keeps_the_note(tmp_path) -> None:
+    """The other half: no directory is still a genuine, permanent absence.
+
+    A swept row carrying neither a wire ``session_dir`` nor a ``session_id``
+    (a job that never started a durable session) has nothing to derive from
+    and nothing to read. The note is the truth, and the derivation must not
+    invent a path for it — an invented path would send the page reading a
+    directory that describes some other session.
+    """
+    from local_operator.session.frontend_state import (
+        JobState,
+        SnapshotJobs,
+        SnapshotSubagentComms,
+    )
+
+    row = JobState(
+        id="never-started",
+        type="task",
+        status="cancelled",
+        label="parked",
+        start_time=1_700_000_000.0,
+        settled_at=1_700_000_002.0,
+        restored=True,
+        trajectory=[],
+    )
+    session = FakeSession()
+    session.is_remote = True  # type: ignore[attr-defined]
+    session.jobs = SnapshotJobs([row])
+    comms = SnapshotSubagentComms([row])
+    assert comms.session_dir_of("never-started") is None
+    session._subagent_comms = comms
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(90, 28)) as pilot:
+        view = await _open(pilot, app, row)
+        await _wait_history(pilot, view)
+        assert view._history_absent_final
+        assert HISTORY_UNAVAILABLE_NOTE in view._history_state_text()

--- a/tests/unit/tui/test_subagent_view.py
+++ b/tests/unit/tui/test_subagent_view.py
@@ -70,6 +70,7 @@ from local_operator.tui.widgets.subagent_view import (
     COLLAPSE_AFFORDANCE,
     EXPAND_HINT,
     HISTORY_ERROR_NOTE,
+    HISTORY_PAGE_ROWS,
     HISTORY_START_NOTE,
     HISTORY_UNAVAILABLE_NOTE,
     INSTRUCTION_ROWS,
@@ -4720,3 +4721,120 @@ async def test_a_persistently_failing_probe_costs_no_extra_reads_per_refresh(
         # And the reader sees one stable, truthful note throughout — no blink
         # between the absence and an error nobody asked to hear about.
         assert footers == {f"{HISTORY_UNAVAILABLE_NOTE} · {READ_ONLY_NOTE}"}, footers
+
+
+@pytest.mark.asyncio
+async def test_follower_pages_durable_history_from_the_projected_session_dir(
+    tmp_path, monkeypatch
+) -> None:
+    """An ATTACHED viewer must lazy-load the child's transcript off disk.
+
+    A follower has no live comms registry — ``_subagent_comms`` is a
+    ``SnapshotSubagentComms`` rebuilt from the wire ``JobState`` rows — and its
+    ``session_dir_of`` answered ``None`` for every child. The view treats a
+    ``None`` directory as a PERMANENT absence, so a subagent running for an
+    hour showed only the in-memory 500-event window under "earlier activity
+    dropped", with "no saved transcript" in the footer, while the child's
+    ``transcript.jsonl`` sat fully on disk.
+
+    Built from the production facades rather than a lambda-comms double, so
+    the test fails if the projection stops carrying a directory. Both wire
+    shapes are covered: an owner that stamps ``session_dir`` and an older one
+    that sends only ``session_id`` (derived under the isolated config dir).
+    """
+    from local_operator.session.frontend_state import (
+        JobState,
+        SnapshotJobs,
+        SnapshotSubagentComms,
+    )
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    # 120 durable rows: more than one HISTORY_PAGE_ROWS page, so the initial
+    # tail page and a Home page-back are both distinguishable.
+    for shape, session_id in (("wired", "aaaaaaaaaaaa"), ("derived", "bbbbbbbbbbbb")):
+        directory = tmp_path / "sessions" / session_id
+        transcript = Transcript(directory)
+        for index in range(120):
+            await transcript.append_message(Message.assistant(f"{shape} durable {index}"))
+        row = JobState(
+            id=f"sub-{shape}",
+            type="task",
+            status="completed",
+            label="audit the ingest path",
+            start_time=1_700_000_000.0,
+            settled_at=1_700_000_042.0,
+            trajectory=[],
+            session_id=session_id,
+            session_dir=str(directory) if shape == "wired" else None,
+        )
+        session = FakeSession()
+        # What the production ``RemoteSession`` says of itself; it keeps the
+        # app from standing up an owner-side mobile registrant over a fake.
+        session.is_remote = True  # type: ignore[attr-defined]
+        session.jobs = SnapshotJobs([row])
+        session._subagent_comms = SnapshotSubagentComms([row])
+        app = OperatorApp(_async_factory(session))
+        async with app.run_test(size=(90, 28)) as pilot:
+            view = await _open(pilot, app, row)
+            await _wait_history(pilot, view)
+            assert not view._history_absent_final, shape
+            assert HISTORY_UNAVAILABLE_NOTE not in view._history_state_text(), shape
+            page = " ".join(view.rendered_rows())
+            assert f"{shape} durable 119" in page, shape
+            assert len(view._history_ids) == HISTORY_PAGE_ROWS, shape
+
+            while not view._history_exhausted:
+                view.action_home()
+                await _wait_history(pilot, view)
+            assert len(view._history_ids) == 120, shape
+            assert f"{shape} durable 0" in " ".join(view.rendered_rows()), shape
+            settled = f"{HISTORY_START_NOTE} · {READ_ONLY_NOTE}"
+            for _ in range(50):
+                if view._state_hint.rendered().endswith(settled):
+                    break
+                await pilot.pause()
+            assert view._state_hint.rendered().endswith(settled), shape
+
+
+@pytest.mark.asyncio
+async def test_a_follower_page_that_gains_a_directory_re_arms_history(tmp_path) -> None:
+    """None → path on the SAME job must un-finalise the absence and load.
+
+    A follower can open a child's page off a frame that carried no directory
+    (a job registered before ``attach`` bound its session, or a frame from an
+    owner that only later learned it) and receive the path on a later frame.
+    ``_history_absent_final`` is correct for the first frame — nothing to
+    read — but it must be a fact about that frame, not about the page: the
+    retarget branch in ``show()`` has to reset history and issue the initial
+    tail read itself, because ``on_mount`` (the other place the first read
+    starts) has already run.
+    """
+    transcript = Transcript(tmp_path / "child")
+    for index in range(30):
+        await transcript.append_message(Message.assistant(f"durable {index}"))
+    job = _job_with(TRAJECTORY, status="running")
+    session = FakeSession()
+    session.jobs = _fake_jobs(job)
+    answer: dict[str, Any] = {"dir": None}
+    session._subagent_comms = type(
+        "Comms", (), {"session_dir_of": lambda self, _job_id: answer["dir"]}
+    )()
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(90, 28)) as pilot:
+        view = await _open(pilot, app, job)
+        await _wait_history(pilot, view)
+        assert view._history_absent_final
+        assert HISTORY_UNAVAILABLE_NOTE in view._history_state_text()
+        assert "durable 29" not in " ".join(view.rendered_rows())
+
+        # The later frame: same job, now with a directory.
+        answer["dir"] = transcript.directory
+        app._refresh_subagent_view(view.job_id)
+        await _wait_history(pilot, view)
+        assert not view._history_absent_final
+        assert HISTORY_UNAVAILABLE_NOTE not in view._history_state_text()
+        assert len(view._history_ids) == 30
+        page = " ".join(view.rendered_rows())
+        assert "durable 29" in page
+        # The live trajectory rows the first frame painted are still there.
+        assert "Reading the ingest path." in page

--- a/tests/unit/tui/test_todo_panel_phases.py
+++ b/tests/unit/tui/test_todo_panel_phases.py
@@ -1547,3 +1547,24 @@ async def test_expanded_footer_recomposes_when_only_the_width_changes() -> None:
             painted = resized[:cells] if cells else resized
             assert "ctrl+t" in painted, f"w={width}: ctrl+t cropped away from {painted!r}"
         builtin.TODO_STORE.clear()
+
+
+def test_reading_a_childs_todo_snapshot_never_creates_its_directory(tmp_path) -> None:
+    """A pure read of somebody else's session must leave nothing behind.
+
+    ``Transcript`` mkdirs its directory on construction, so this read created
+    an empty session directory whenever the path did not exist. That was
+    harmless while the directory always came from the owner's live registry,
+    and stopped being harmless once a follower can DERIVE one from a
+    ``session_id``: a remote follower would then litter the real store with a
+    phantom directory per page open (review round 1, M1).
+
+    Pinned here rather than at the derivation because the materialising call
+    is the actual defect — any future caller that reads a child's snapshot
+    inherits it.
+    """
+    from local_operator.tui.widgets.todo_panel import _read_restored_todos
+
+    absent = tmp_path / "sessions" / "ffffffffffff"
+    assert _read_restored_todos(str(absent)) == []
+    assert not absent.exists(), "reading a child's snapshot must not create its directory"


### PR DESCRIPTION
## Summary of Changes

The full-page subagent view could not lazy-load a child's durable transcript when the TUI is an **attached follower** of a daemon session. Two separately-reported symptoms turn out to be **the same defect**: the wire carried no `session_dir`, so `SnapshotSubagentComms.session_dir_of` returned `None`, which the view treats as a *permanent* absence.

1. **A long-running child** showed only the in-memory 500-event window under "earlier activity dropped — last 500 events kept", footer "no saved transcript · read-only".
2. **A settled child ~30 min after settle** (`desktop-ui-implementation`, 1153 durable rows on disk) showed "no activity was retained for this subagent" and the same footer.

The owner-mode TUI was unaffected in both cases, which is why this only surfaced under `lop` daemon attach.

**The durable transcript was never lost.** `session/retention.py` documents an absolute never-delete rule and only reaps empty directories; the operator's real 1153-row `transcript.jsonl` was intact throughout, and is exactly what the fixed page now renders end to end (evidence below).

**C1, standard fix. No version bump** — `pyproject.toml` is untouched per the combined-release rule.

### Root cause (verified on `origin/main` @ `299ec72d8`)

- `SnapshotSubagentComms._node_for()` set `session_dir=None` and `session_dir_of()` returned `None` unconditionally. `JobState` carried `session_id` but not the child's session directory, and the owner's live `SubagentComms` registry never crosses the socket.
- `OperatorApp._refresh_subagent_view` passes `comms.session_dir_of(job_id)` → `None` on a follower.
- `SubagentView._reset_history(None)` sets `_history_absent_final = True`: a `None` directory is treated as a *permanent* absence, so no `read_transcript_page` is ever issued (open, Home, scroll-to-top) and `_reconsider_missing_history` refuses to re-probe.

**Symptom 2 shares that cause — it is not a retention bug.** A hypothesis that the 5-minute job sweep (`DEFAULT_RETENTION_MS`) removes the row from `state.jobs`, leaving followers with no `session_id`, was investigated and **disproved** ([full write-up with measurements](https://github.com/damianvtran/local-operator/pull/669#issuecomment-5553447760)):

- `SubagentComms._ChildRecord.job_ref` holds a live reference to the `AsyncJob`, so the sweep's `del self._jobs[job_id]` cannot free it, and `job_rows()` (`harness/comms.py:786`) re-adds it via `rows.setdefault(record.job_id, record.job_ref)` — which `_jobs()` prefers over `manager.list()`. Measured across a forced sweep: `manager_get=False, manager_list=[]`, but `state_job_present=True` with `session_id`, `session_dir` and an 8-row trajectory intact. A live follower against a swept child loaded 83/83 rows and reached "start of transcript". **The sweep alone does not reproduce the symptom.**
- What produced the operator's screenshot is a **restart** after a sweep: `_persist_subagent_roster` writes `jobs` from `jobs.list()` (swept ⇒ absent) but `records` from the comms snapshot (kept, so resume works). Their sidecar for parent `94868d212048` shows 9 comms records against 1 job row. On restore those children return through the comms-node fallback in `_jobs()` as `restored=True` reader rows with `session_id` and no trajectory — and with no wire directory they hit exactly the `None` above.

The derivation fallback in this PR is what rescues them: they carry `session_id`, so `config_dir()/sessions/<session_id>` resolves.

### Why "trajectory unavailable" is not a bug

The in-memory trajectory is **execution evidence the 5-minute sweep exists to release** — that is what bounds a long session's memory, and the comms-node fallback deliberately refuses to "invent a trajectory" for a reconstructed row. The durable transcript is its replacement, and after this fix it actually loads. Retaining job rows indefinitely to keep a trajectory alive would trade a bounded ledger for an unbounded one and buy nothing the transcript does not already give. Please do not "fix" that note by extending retention.

### Fix

- **`local_operator/session/frontend_state.py`**
  - `JobState.session_dir: str | None = None` (string — `Path` is not JSON-native; `extra="allow"` model so old owners are tolerated).
  - `_with_lineage` stamps it from the owner's comms node alongside `session_id`.
  - `SnapshotSubagentComms._node_for` / `session_dir_of` resolve a `Path` via new `_snapshot_session_dir(job)`: the wire `session_dir` when present, else **derived** `config_dir() / "sessions" / session_id` — the location every child is created at (`harness/subagent.py`: `session_id` *is* `session_dir.name`). The derivation is what makes an already-running pre-fix daemon (the operator's current situation) gain history without a restart, and what rescues restored swept rows. Existence is deliberately not checked here: the view already re-probes a directory whose transcript is missing, so a derived path that does not exist locally (remote/mobile follower) degrades to the pre-existing "no saved transcript" behaviour rather than erroring.
- **`local_operator/tui/widgets/subagent_view.py`** — comments only. Confirmed `show()`'s `transcript_directory != self._history_directory` branch calls `_reset_history`, which un-finalises the absence and issues the initial tail read itself (`call_after_refresh(_maybe_load_history, initial=True)`) since `on_mount` has already run.

**No new retention mechanism and no subagent-disk sweep.** A `_swept` identity ledger in `harness/jobs.py` was started on the strength of the original hypothesis and **dropped**: it would have been a second mechanism beside `job_ref`/`job_rows()` for the same job, and it fixed nothing measurable.

## Testing Details

### Unit tests (new)

- `tests/unit/session/test_subagent_view_state.py`
  - `test_follower_comms_answers_session_dir_from_wire_then_derives_it` — wire value wins; `session_id`-only derives under the isolated config dir; no `session_id` → `None`; unknown job → `None`; node carries the same answer (todo panel reads it).
  - `test_lineage_stamps_the_child_session_dir_as_a_string` — `_with_lineage` stringifies a `Path`, survives a JSON round trip, projects `None` (not `"None"`), and an old-owner frame without the key validates.
- `tests/unit/tui/test_subagent_view.py`
  - `test_follower_pages_durable_history_from_the_projected_session_dir` — built from the **production** `SnapshotJobs` + `SnapshotSubagentComms` (not a lambda double), both wire shapes, 120 durable rows: initial tail page = `HISTORY_PAGE_ROWS` (100), Home pages back to 120 with `HISTORY_START_NOTE`, never paints `HISTORY_UNAVAILABLE_NOTE`.
  - `test_a_follower_page_that_gains_a_directory_re_arms_history` — same job, `None` → path on a later refresh re-arms history.
  - `test_a_restored_swept_child_pages_its_transcript_on_a_follower` — the operator's reported shape (`restored=True`, `session_id` only, empty trajectory) pages to "transcript start".
  - `test_an_owner_page_survives_the_sweep_of_its_own_job_row` — owner parity: the row is swept while the page is open; the page reports `LEDGER_GONE_NOTE` (true) *and* keeps readable durable history.
  - `test_a_swept_child_with_no_directory_anywhere_keeps_the_note` — no directory and no `session_id` → unavailable note unchanged, no invented path.
- `tests/unit/session/test_launch_subagent.py`
  - `test_a_swept_child_keeps_its_durable_identity_on_the_roster` — the sweep-survival invariant: after `_sweep_due()` the execution row is gone but `state.jobs` keeps identity, `session_id` and `session_dir`.
  - `test_a_restored_swept_child_still_points_at_its_transcript` — the restart shape: `restored=True`, no trajectory, directory still resolvable.

Every assertion that describes the fix **fails on the unfixed tree** (checked in a throwaway `origin/main` worktree, never `git stash`): 3 of the swept guards fail there (`assert not True`, and `'JobState' object has no attribute 'session_dir'` ×2) plus the original three; the remaining two pin invariants that were already true (owner-side `job_ref` survival, the no-directory note), which is their purpose.

### Whole-tree gates (exactly as `AGENTS.md`/CI)

```sh
.venv/bin/python -m flake8 .                                   # rc=0
uvx --from black==26.1.0 black --check .                       # 928 files would be left unchanged
uvx isort==5.13.2 --check .                                    # rc=0 (2 files skipped by repo config)
.venv/bin/python -m pyright --pythonpath .venv/bin/python .   # 0 errors, 0 warnings, 0 informations
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
# 14317 passed, 17 skipped, 708 warnings in 694.37s   (whole-tree, earlier head this branch)
```

The four static gates above were re-run on the current head `9615997f4` and are green there. The **whole-tree unit run named above is the earlier one on this branch**; the final round-1 remediation was verified with targeted suites over every file it touched — `113 passed` (session + todo panel) and `180 passed` (TUI, `env -u NO_COLOR TERM=xterm-256color`). The local full suite was deliberately not re-run on the final SHA while this machine was at 99% disk; CI's `test (3.12, N)` shards on the pushed head are the whole-tree evidence for it, and no local full-suite pass is claimed for `9615997f4`.

Worktree `~/workspace/repos/lo-subagent-history` with its own editable venv (`local_operator.__file__` verified to resolve to this checkout).

> **CI note:** on `2ffafbec8c` every check was green except `server-sanity`, which failed on an upstream provider 429 (`qwen3.7-flash` rate-limited via OpenRouter) — an infra flake unrelated to this diff. It should pass on the re-run this commit triggers.

### Evidence 1 — synthetic: real daemon + attached follower, 523-row child

A production `Session` behind `OwnedSessionHandle` + `RuntimeServer(kind="daemon")` in an **isolated** config dir (`scripts.probe_isolation` imported first; every `CMUX_*` var unset), one child issuing 260 real `bash` calls (523 durable rows; retained trajectory capped at exactly 500), then the production `OperatorApp` over `RemoteSession.connect`.

| | before (`origin/main`) | after (this PR) |
|---|---|---|
| wire `JobState.session_dir` | `<no field>` | `<config>/sessions/7937123affef` |
| `comms.session_dir_of(job)` | `None` | the child's dir |
| at open: `_history_absent_final` / `_history_ids` | `True` / **0** | `False` / **100** |
| at open: footer | `· no saved transcript · read-only` | `· read-only` |
| Home presses to exhaust | 40 (never exhausted) | **5** |
| after Home: `_history_ids` / rows on disk | **0** / 523 | **523** / 523 |
| after Home: footer | `· no saved transcript · read-only` | `· start of transcript · read-only` |
| rendered entries / unique row keys | 126 / 126 | **523 / 523** (no duplicates) |

Frames: [before/after at open, and after at transcript start](https://github.com/damianvtran/local-operator/pull/669#issuecomment-5553260207).

### Evidence 2 — the operator's REAL swept child (1153 rows)

Their actual roster sidecar (parent `94868d212048`) and the real `transcript.jsonl` of `desktop-ui-implementation` (`e72882c37267`, 1153 rows), copied **read-only** into an isolated sandbox with `session_dir` paths rewritten into it, restored through the production `Session`, served by the production daemon runtime, and opened on an `OperatorApp` follower over `RemoteSession.connect`. `~/.local-operator` was never written to.

| | origin/main | this branch |
|---|---|---|
| wire `session_dir` | `<no field>` | populated |
| `comms.session_dir_of` | `None` | the child's dir |
| history rows at open | **0** | 100 (one page) |
| after Home | 0, never exhausted | **1153**, exhausted |
| footer | `· no saved transcript · read-only` | `· start of transcript · read-only` |

**Before — `origin/main`** ("no activity was retained for this subagent", footer "no saved transcript", over an intact 1153-row transcript):

![before-live](https://github.com/user-attachments/assets/a4b7a238-3fb9-4203-bd6e-c024f29cd47f)

**After — this branch** (full durable history, footer "start of transcript", title `561 tools · 11 failed`):

![after-live](https://github.com/user-attachments/assets/5222ea48-9065-4719-9f19-2337cef572dd)

Not proven here: a follower on a *different* machine (mobile relay) — asserted only by unit test that a derived non-existent path yields the "no saved transcript" note rather than an error.

## Related Changes

None. Adjacent gap noticed and **not** addressed in this slice: `launch_message_id`/`launch_prompts` also do not ride the wire, so a follower cannot reconcile the durable launch turn with the synthetic prompt head — visible in the synthetic after/Home frame as the launch prompt appearing twice at the top. Pre-existing on followers; only observable now that history loads. Worth its own small follow-up.

A bounded, user-invoked cleanup tool for subagent transcripts is **deferred — the operator's ask is "store and inspect", which the existing never-delete store plus this fix delivers**; adding a disk sweep would work against `session/retention.py`'s documented rule.

## Review round 1

Two MAJOR findings, both in the derived-path fallback introduced by this PR, both fixed in `9615997f4` ([per-finding remediation](https://github.com/damianvtran/local-operator/pull/669#issuecomment-5554179513)):

- **M1 — phantom session directory.** `Transcript` mkdirs on construction, so the todo panel's snapshot read created an empty session directory whenever the derived path did not exist — a remote follower would litter the real store with one per page open. Now read with `defer_materialise=True`; a pure read of another session leaves nothing behind.
- **M2 — wrong session's transcript.** A derived path must now prove ownership via the `origin.json` marker `run_subagent` already writes (`origin == "subagent"` and the recorded label/agent matching the node) before it is trusted. A wire-supplied `session_dir` stays authoritative without a check. Failing closed degrades to the existing "no saved transcript" note, so the check can only withhold history, never render another session under this child's name. The verdict is memoised per `(dir, label, agent)` — measured 0 `origin.json` reads across 600 `session_dir_of` calls — so QA's 1.08 stats/s idle cost is unregressed.

QA round 1 **PASSed** on `2ffafbec8c` (12 cells, 0 FAIL), reproducing the bug on base (0/523 rows after 60 Home presses) and the fix on head (523/523, 0 duplicates).

Deferred, recorded in the PR thread: the doubled launch prompt (follow-up PR this session — the wire gap predates this PR but the *visible* duplicate is its consequence), the truncation note beside "start of transcript" (cosmetic), and a bounded transcript cleanup tool (against `session/retention.py`'s documented never-delete rule).

## Checklist

- [x] Conventional-commit title
- [x] No version bump
- [x] Unit tests fail on the unfixed tree and pass on head
- [x] Whole-tree gates green
- [x] Real-path evidence with before/after frames, including the operator's own data
- [x] Agent review round 1 — 2 MAJOR, both fixed in `9615997f4`
- [x] QA round 1 — PASS on `2ffafbec8c`, 12 cells, 0 FAIL
- [ ] Round 2 scoped to `2ffafbec8c..9615997f4` (delta: M1/M2 fixes + regression tests)
