### PR TITLE
feat(config): apply approvals, web-tool and model settings live on the watcher poll

### DIFF
--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -1781,6 +1781,11 @@ async def _construct_child_session(
         cleanup.push_async_callback(child_stream.close)
     child = Session(
         model=model_spec if model_spec is not None else parent_session.model,
+        # A child's model was chosen HERE (tier or parent), never by the
+        # ``hosting``/``model_name`` keys, so a later edit to those must not
+        # switch it — ``_job_id`` already guards that path, this makes the
+        # provenance honest too.
+        model_source="child",
         stream_fn=child_stream,
         tools=tools,
         transcript=transcript,
@@ -1921,6 +1926,14 @@ async def _construct_child_session(
     # Unsubscribed by ``_dispose_child`` through the dispose hook, exactly as
     # the parent's is. Degrades silently: a child that cannot follow config is
     # a child built the way every child was before this seam.
+    #
+    # What a child does NOT follow, by design (``Session._apply_config_change``
+    # guards each on ``_job_id``): a ``hosting``/``model_name`` edit (its spec
+    # was picked above and a mid-task switch costs its cache prefix), and the
+    # ``web_*.enabled`` INVENTORY reconcile (re-adding would re-run the
+    # allowlist and network-floor filtering for a short-lived run). The web
+    # tools' per-call gate still refuses inside the child after a disable, and
+    # the approval MODE reaches it through the parent's gate closure.
     try:
         from local_operator.config_watch import process_watcher
 

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -778,15 +778,17 @@ class ToolContext(BaseModel):
     # single values on demand. ``None`` degrades those tools to the process
     # environment only.
     variables: VariableStoreProtocol | None = None
-    # Startup snapshot used only by the web_search createIf gate. Execution
-    # re-reads config so provider toggles apply to the next call without
-    # rebuilding the session; the master on/off switch removes the advertised
-    # tool on reload.
+    # Snapshot used only by the web_search createIf gate: it decides whether
+    # the tool is IN the inventory being built. Execution re-reads config per
+    # call — provider toggles AND the master ``enabled`` switch — so a
+    # disabled tool refuses at once even while still advertised. A top-level
+    # session rebuilds this from the config watcher's last-good values and
+    # reconciles its inventory at the next turn boundary
+    # (``Session._reconcile_web_tools``); a subagent keeps its spawn snapshot.
     web_search_settings: dict[str, Any] | None = None
-    # Startup snapshot used only by the web_fetch createIf gate, mirroring
-    # web_search: execution re-reads config so knobs (TTL, allow_private) apply
-    # to the next call without rebuilding the session, while the master on/off
-    # switch removes the advertised tool on reload.
+    # Same contract as ``web_search_settings`` for the fetch tool. The per-call
+    # ``enabled`` check lives in ``run_fetch``, so it also covers the
+    # ``read <url>`` sugar, which has no createIf gate of its own.
     web_fetch_settings: dict[str, Any] | None = None
     # Session-owned capability tools that built-ins may delegate to. This is
     # deliberately a mapping rather than a second MCP client: OAuth transports

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -1237,6 +1237,23 @@ class NoticeEvent(AgentEvent[Literal["notice"]]):
     type: Literal["notice"] = "notice"
     text: str
     kind: Literal["info", "warning", "error"] = "info"
+    #: A SHORT glance for the boot toast, when the emitter knows the state.
+    #:
+    #: While the splash is up a notice is shown twice — as a durable splash row
+    #: carrying the full sentence, and as a toast, which is one clause with no
+    #: wrap. A toast with no headline falls through to a blind 35-cell cut
+    #: (``tui/app.py:_splash_toast_headline``), which lands mid-phrase:
+    #: ``tool approvals: auto — config.yml c…``. That fallback has already
+    #: regressed once when a sibling message was added without a headline, and
+    #: the fix recorded there is that callers which KNOW the state pass one
+    #: rather than have prose re-parsed for a magic phrase.
+    #:
+    #: On the event rather than at the terminal because these notices are
+    #: emitted by the RUNTIME, one process away: a headline derived at the
+    #: viewer could only be derived by matching on the sentence, which is the
+    #: fragile thing this field exists to replace. Empty means "no opinion" and
+    #: the existing fallback applies, so every other emitter is unaffected.
+    headline: str = ""
 
 
 class WakeDeliveredEvent(AgentEvent[Literal["wake_delivered"]]):

--- a/local_operator/session/runtime/exec_control.py
+++ b/local_operator/session/runtime/exec_control.py
@@ -150,7 +150,10 @@ async def start_exec_control(
     ``yolo`` maps to the handle's ``auto_approve``, so ``exec --control --yolo``
     keeps approving every tier inline instead of parking a card no supervisor
     may be watching. Without it the gates park for an attached supervisor —
-    the behavioural difference this module's header calls out.
+    the behavioural difference this module's header calls out. The flag is
+    also the handle's ``approval_pinned``: an explicit ``--yolo`` on this run
+    outranks a later ``tool_approval_mode`` edit, while an un-flagged run
+    follows the file like every other runtime gate.
 
     Imports are function-local by contract, not by habit: ``owned`` pulls the
     composition root and ``server`` pulls asyncio, and this package sits on the
@@ -160,11 +163,15 @@ async def start_exec_control(
 
     from local_operator.paths import config_dir
     from local_operator.session.runtime import registry
-    from local_operator.session.runtime.owned import OwnedSessionHandle
+    from local_operator.session.runtime.owned import (
+        OwnedSessionHandle,
+        attach_gate_config_watch,
+    )
     from local_operator.session.runtime.server import RuntimeServer
 
     loop = asyncio.get_running_loop()
-    handle = OwnedSessionHandle(session, loop, cwd=cwd, auto_approve=yolo)
+    handle = OwnedSessionHandle(session, loop, cwd=cwd, auto_approve=yolo, approval_pinned=yolo)
+    attach_gate_config_watch(handle, config_dir())
     # The ``stop`` control op (and therefore `lop stop`, which can now see this
     # run because it publishes a record) reaches ``request_stop`` -> this hook.
     # Without one the handle falls back to disposing in place, UNDER the prompt

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -166,6 +166,14 @@ class OwnedSessionHandle(SessionHandle):
         # CONFIG-derived value — the same ``True`` that must keep following
         # the file.
         self._approval_pinned = approval_pinned
+        #: True once a human has made a deliberate ``/approvals`` choice in
+        #: THIS session. Deliberately the same shape as
+        #: ``Session._explicit_model_choice``, and the symmetry is the point:
+        #: the model half of this change already protects an explicit ``/model``
+        #: pick from a ``config.yml`` default, and approvals is the more
+        #: dangerous key of the two. Read only by :meth:`follow_config`, which
+        #: consults it in the LOOSENING direction alone \u2014 see the rule there.
+        self._explicit_approvals_choice = False
         self._unsubscribe_config_watch: Callable[[], None] | None = None
         #: The (kind, title, detail) of the gate currently parked, or None.
         #: Kept so the announcement can be re-run when the last viewer
@@ -380,24 +388,52 @@ class OwnedSessionHandle(SessionHandle):
         """Move the gate to the mode on disk; the next DECISION sees it.
 
         A ``config.yml`` write is the operator's machine-wide intent ("if I
-        change a setting I want it to go into effect for all my agents"), so
-        it overrides a per-session ``/approvals`` toggle in either direction.
-        ``source`` is ignored on purpose: the runtime is never the process
-        that wrote, so every delivery is another process's edit.
+        change a setting I want it to go into effect for all my agents"), so a
+        session that never made a choice of its own follows the file in BOTH
+        directions. ``source`` is ignored on purpose: the runtime is never the
+        process that wrote, so every delivery is another process's edit.
 
-        Two deliberate limits. ``--yolo`` (``_approval_pinned``) outranks the
-        key — an explicit flag on this run is narrower and newer than a
-        default in a file. And a prompt already PARKED (``_pending_futures``)
-        is left alone: the gate reads ``_auto_approve`` when a decision is
-        made, so a card on screen keeps waiting for the human — never
-        auto-answered on a loosening, never auto-denied on a tightening.
+        **The rule is asymmetric, and only for a session that chose** (review
+        round 1 R1, UX round 1 U1):
+
+        * **Tightening (``auto`` → ``ask``) always follows the file**,
+          unconditionally, in every session. Safety propagates without
+          exception; a user ends up safer than they asked, which is never the
+          wrong surprise.
+        * **Loosening (``ask`` → ``auto``) does not move a session whose human
+          typed ``/approvals ask`` in it.** That session keeps its gate and
+          reads a keep notice naming the way to adopt the file instead.
+
+        The asymmetry is the whole point. The operator asked for settings to
+        REACH running sessions, which was broken and is what this change fixes;
+        they did not ask for a file write to revoke a hardening a human typed
+        into a specific pane thirty seconds earlier. The parked-prompt rule
+        below already encodes that principle — a card on screen is not
+        auto-answered *because the human's presence outranks the file* — and it
+        applies one step earlier to a human who typed the mode. This mirrors
+        the model half of the same change exactly (``Session.
+        _on_configured_model_changed``, ``_explicit_model_choice``, and its
+        ``keeping …`` notice), and approvals is the more dangerous of the two
+        keys: an explicit ``/model`` pick was already protected while an
+        explicit ``/approvals ask`` was not, which reversed the safer default
+        on the key where it matters more.
+
+        Two further limits, unchanged. ``--yolo`` (``_approval_pinned``)
+        outranks the key entirely — an explicit flag on this run is narrower
+        and newer than a default in a file — and a prompt already PARKED
+        (``_pending_futures``) is left alone: the gate reads ``_auto_approve``
+        when a decision is made, so a card on screen keeps waiting for the
+        human, never auto-answered on a loosening and never auto-denied on a
+        tightening.
 
         The receipt goes out as a :class:`NoticeEvent` from THIS process, the
         one that owns the gate, so every attached viewer and the phone see
-        the effect ("every tool runs without asking") rather than only the
-        TUI's own "config.yml changed" line, which fires even when no runtime
-        is attached. Two lines in the common case is accepted over losing
-        either. Subagents inherit this gate closure, so they follow too.
+        the effect ("every tool runs without asking"). It is now the ONLY
+        receipt for the event: the TUI no longer prints a value clause when a
+        runtime is attached (design round 1, D1), on the same "the process that
+        decided is the one the user should read" rule the ``model`` section
+        already follows. Subagents inherit this gate closure, so they follow
+        too.
         """
         if self._disposing or "tool_approval_mode" not in getattr(change, "changed_keys", ()):
             return
@@ -414,6 +450,18 @@ class OwnedSessionHandle(SessionHandle):
         wanted_auto = mode == "auto"
         if wanted_auto == self._auto_approve:
             return
+        if wanted_auto and self._explicit_approvals_choice:
+            # LOOSENING against a human's explicit hardening: keep the gate and
+            # say so. Shaped like the model half's keep notice — what is kept,
+            # why, and the exact command that adopts the file — so the two
+            # conflicts read as one rule rather than two behaviours.
+            self._emit_notice(
+                "keeping tool approvals: ask — set with /approvals in this session; "
+                "config.yml now says auto, /approvals auto adopts it",
+                "info",
+                headline="Approvals unchanged",
+            )
+            return
         self._auto_approve = wanted_auto
         self._notify()
         self._emit_notice(
@@ -424,15 +472,20 @@ class OwnedSessionHandle(SessionHandle):
                 "prompt again"
             ),
             "warning" if wanted_auto else "info",
+            headline=f"Approvals: {mode}",
         )
 
-    def _emit_notice(self, text: str, kind: str) -> None:
+    def _emit_notice(self, text: str, kind: str, headline: str = "") -> None:
         """Fire-and-forget a ``NoticeEvent`` through the session's emit seam.
 
         Same shape as :meth:`_grant_notice`: the channel every attached
         terminal and the phone already listen on. Held on
         ``_mcp_reload_tasks`` because it is the same class of sub-second
         best-effort work, and ``dispose`` cancels that set.
+
+        ``headline`` is the SHORT glance a boot toast shows instead of a blind
+        cell cut of ``text`` (design round 1, D3; see ``NoticeEvent.headline``).
+        Passed by callers that know the state; "" keeps the existing fallback.
         """
         from local_operator.harness.types import NoticeEvent
 
@@ -445,7 +498,7 @@ class OwnedSessionHandle(SessionHandle):
 
         async def _emit_notice() -> None:
             try:
-                await typed_emit(NoticeEvent(text=text, kind=event_kind))
+                await typed_emit(NoticeEvent(text=text, kind=event_kind, headline=headline))
             except Exception:  # noqa: BLE001 — a failed notice must not kill the loop
                 logger.debug("runtime notice failed", exc_info=True)
 
@@ -2462,6 +2515,21 @@ class OwnedSessionHandle(SessionHandle):
                 if self._auto_approve
                 else "write and command tools prompt before running"
             )
+            # Compared against the FILE, not against a cached default (UX round
+            # 1, U1/U2). This is the surface whose job is "what is in effect and
+            # why", and a session that kept its own mode against a config edit
+            # has to be able to learn that here — otherwise the one place a user
+            # asks reports a matched pair while the two genuinely disagree.
+            on_disk = self._configured_approval_mode()
+            if on_disk is not None and on_disk != live:
+                return SlashResult(
+                    kind="notice",
+                    text=(
+                        f"tool approvals: {live} (this session) — {effect}; "
+                        f"config.yml says {on_disk}"
+                    ),
+                    style="warning" if self._auto_approve else "info",
+                )
             return SlashResult(
                 kind="notice",
                 text=f"tool approvals: {live} — {effect}",
@@ -2478,6 +2546,13 @@ class OwnedSessionHandle(SessionHandle):
                 style="warning",
             )
         self._auto_approve = wanted_auto
+        # A human typed the mode in this session, so a later LOOSENING disk
+        # write leaves this gate alone (see :meth:`follow_config`). Recorded on
+        # both directions, not only on the hardening: the flag means "this
+        # session has an owner's opinion", and a user who typed `/approvals
+        # auto` here has one just as much — what differs is that only the
+        # loosening direction consults it.
+        self._explicit_approvals_choice = True
         self._notify()
         return SlashResult(
             kind="notice",
@@ -2488,6 +2563,30 @@ class OwnedSessionHandle(SessionHandle):
             ),
             style="warning" if wanted_auto else "info",
         )
+
+    def _configured_approval_mode(self) -> str | None:
+        """``tool_approval_mode`` as the WATCHER last read it, or ``None``.
+
+        Read off ``existing_watcher().values`` — the last-good snapshot — and
+        never from a fresh ``ConfigManager``. Constructing one here would give
+        a report path the power to MOVE A MALFORMED FILE ASIDE (the module
+        docstring of ``config_watch`` explains why), so asking "what does the
+        file say?" could rewrite the user's config as a side effect. ``None``
+        when no watcher is running (a headless embed, a test host): the caller
+        then reports the live mode alone rather than inventing a comparison.
+        """
+        try:
+            from local_operator.config_watch import existing_watcher
+            from local_operator.paths import config_dir
+
+            watcher = existing_watcher(config_dir())
+            if watcher is None:
+                return None
+            mode = str(watcher.values.get("tool_approval_mode", "")).strip().lower()
+            return mode if mode in ("ask", "auto") else None
+        except Exception:  # noqa: BLE001 — a report must never take down the session
+            logger.debug("tool_approval_mode could not be read for the report", exc_info=True)
+            return None
 
     def _compact_slash(self, session: Any, SlashResult: Any) -> Any:
         """Kick the real pass; the ACCEPT receipt is the answer.

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -147,14 +147,26 @@ class OwnedSessionHandle(SessionHandle):
         *,
         cwd: str,
         auto_approve: bool = False,
+        approval_pinned: bool = False,
     ) -> None:
         self._session = session
         self._loop = loop
         # When the owner's saved default is full-auto (``tool_approval_mode:
         # auto``), the phone must not park a card the TUI would never show —
-        # the gate is answered ``True`` inline instead. Stored so a future
-        # per-session toggle can flip it without reconstructing the handle.
+        # the gate is answered ``True`` inline instead. Read PER DECISION by
+        # the gate closure, which is what lets ``/approvals`` and a
+        # ``config.yml`` change (:meth:`follow_config`) move it without
+        # reconstructing the handle.
         self._auto_approve = auto_approve
+        # ``approval_pinned`` marks the value as an explicit FLAG (``lop exec
+        # --yolo``), which outranks the config key: a ``tool_approval_mode``
+        # edit must not re-arm a gate the operator disabled on the command
+        # line for this run. A separate kwarg rather than inferred from
+        # ``auto_approve`` because ``spawn_owned_session`` passes the
+        # CONFIG-derived value — the same ``True`` that must keep following
+        # the file.
+        self._approval_pinned = approval_pinned
+        self._unsubscribe_config_watch: Callable[[], None] | None = None
         #: The (kind, title, detail) of the gate currently parked, or None.
         #: Kept so the announcement can be re-run when the last viewer
         #: detaches — the routing decision is made when the gate opens, and
@@ -347,6 +359,100 @@ class OwnedSessionHandle(SessionHandle):
         self._session.set_approval_handler(approval_gate)
         self._session.set_ask_handler(ask_gate)
 
+    # -- live config -------------------------------------------------------------
+
+    def follow_config(self, watcher: Any) -> None:
+        """Subscribe the gate to ``tool_approval_mode`` changes on ``watcher``.
+
+        The handle, not the session, owns the approval mode the RUNTIME's
+        tools consult (``_auto_approve``), so it needs its own listener on the
+        process :class:`~local_operator.config_watch.ConfigWatcher` beside the
+        session's. Wired by the spawn sites (``spawn_owned_session``,
+        ``start_exec_control``) rather than in ``__init__`` so a handle built
+        around a test double never touches the real config directory.
+        Idempotent; unsubscribed in :meth:`dispose`.
+        """
+        if self._unsubscribe_config_watch is not None:
+            return
+        self._unsubscribe_config_watch = watcher.subscribe(self._on_config_change)
+
+    def _on_config_change(self, change: Any) -> None:
+        """Move the gate to the mode on disk; the next DECISION sees it.
+
+        A ``config.yml`` write is the operator's machine-wide intent ("if I
+        change a setting I want it to go into effect for all my agents"), so
+        it overrides a per-session ``/approvals`` toggle in either direction.
+        ``source`` is ignored on purpose: the runtime is never the process
+        that wrote, so every delivery is another process's edit.
+
+        Two deliberate limits. ``--yolo`` (``_approval_pinned``) outranks the
+        key — an explicit flag on this run is narrower and newer than a
+        default in a file. And a prompt already PARKED (``_pending_futures``)
+        is left alone: the gate reads ``_auto_approve`` when a decision is
+        made, so a card on screen keeps waiting for the human — never
+        auto-answered on a loosening, never auto-denied on a tightening.
+
+        The receipt goes out as a :class:`NoticeEvent` from THIS process, the
+        one that owns the gate, so every attached viewer and the phone see
+        the effect ("every tool runs without asking") rather than only the
+        TUI's own "config.yml changed" line, which fires even when no runtime
+        is attached. Two lines in the common case is accepted over losing
+        either. Subagents inherit this gate closure, so they follow too.
+        """
+        if self._disposing or "tool_approval_mode" not in getattr(change, "changed_keys", ()):
+            return
+        if self._approval_pinned:
+            return
+        values = getattr(change, "values", {})
+        mode = str(values.get("tool_approval_mode", "ask")).strip().lower()
+        if mode not in ("ask", "auto"):
+            # An unknown spelling is not "ask" by accident: the watcher only
+            # delivers parseable files, so this is a typo, and the safe answer
+            # is to keep the mode in force rather than guess.
+            logger.warning("tool_approval_mode=%r ignored; use ask or auto", mode)
+            return
+        wanted_auto = mode == "auto"
+        if wanted_auto == self._auto_approve:
+            return
+        self._auto_approve = wanted_auto
+        self._notify()
+        self._emit_notice(
+            (
+                "tool approvals: auto — config.yml changed; every tool runs without asking"
+                if wanted_auto
+                else "tool approvals: ask — config.yml changed; write and command tools "
+                "prompt again"
+            ),
+            "warning" if wanted_auto else "info",
+        )
+
+    def _emit_notice(self, text: str, kind: str) -> None:
+        """Fire-and-forget a ``NoticeEvent`` through the session's emit seam.
+
+        Same shape as :meth:`_grant_notice`: the channel every attached
+        terminal and the phone already listen on. Held on
+        ``_mcp_reload_tasks`` because it is the same class of sub-second
+        best-effort work, and ``dispose`` cancels that set.
+        """
+        from local_operator.harness.types import NoticeEvent
+
+        emit = getattr(self._session, "_emit", None)
+        if not callable(emit):
+            logger.info("notice: %s", text)
+            return
+        event_kind = kind if kind in ("info", "warning", "error") else "info"
+        typed_emit = cast("Callable[[Any], Awaitable[Any]]", emit)
+
+        async def _emit_notice() -> None:
+            try:
+                await typed_emit(NoticeEvent(text=text, kind=event_kind))
+            except Exception:  # noqa: BLE001 — a failed notice must not kill the loop
+                logger.debug("runtime notice failed", exc_info=True)
+
+        task = self._loop.create_task(_emit_notice())
+        self._mcp_reload_tasks.add(task)
+        task.add_done_callback(self._mcp_reload_tasks.discard)
+
     async def dispose(self) -> None:
         """Dispose the underlying session (release the claim, flush, abort).
 
@@ -354,6 +460,9 @@ class OwnedSessionHandle(SessionHandle):
         to ``self._session`` so the ordering (deny gates first) stays in one
         place and hosts cannot forget the claim release."""
         self._disposing = True
+        if self._unsubscribe_config_watch is not None:
+            self._unsubscribe_config_watch()
+            self._unsubscribe_config_watch = None
         drain = self._prompt_drain_task
         if drain is not None and not drain.done():
             drain.cancel()
@@ -2730,6 +2839,8 @@ async def spawn_owned_session(
     # device set to full-auto still pops an approval card the desktop would
     # not. ``yolo`` stays False so the gate is INSTALLED (a per-session toggle
     # can still switch to asking); the handle short-circuits it when auto.
+    # This is only the BOOT value: ``follow_config`` below keeps the gate on
+    # the file for the session's life.
     try:
         approval_mode = (
             str(config_manager.get_config_value("tool_approval_mode", "ask")).strip().lower()
@@ -2756,4 +2867,31 @@ async def spawn_owned_session(
         has_ui=False,
         cwd=cwd,
     )
-    return OwnedSessionHandle(session, loop, cwd=cwd, auto_approve=auto_approve)
+    # NOT pinned: this value came from config, so it must keep following
+    # config. ``create_session`` has already started the process watcher for
+    # this directory (``attach_config_watch``), so ``process_watcher`` returns
+    # the running one; the guard mirrors that seam's "boot must not depend on
+    # the watcher" degrade.
+    handle = OwnedSessionHandle(
+        session, loop, cwd=cwd, auto_approve=auto_approve, approval_pinned=False
+    )
+    attach_gate_config_watch(handle, config_directory)
+    return handle
+
+
+def attach_gate_config_watch(handle: OwnedSessionHandle, config_directory: Path) -> None:
+    """Hang the handle's approval listener on the process watcher, or degrade.
+
+    Shared by the phone/TUI runtime spawn and ``exec --control`` so the two
+    cannot drift on how the gate follows config. Degrades to "this gate does
+    not follow config" rather than failing the spawn, the same policy as
+    ``session_factory.attach_config_watch``.
+    """
+    try:
+        from local_operator.config_watch import process_watcher
+
+        watcher = process_watcher(config_directory)
+        watcher.start(asyncio.get_running_loop())
+        handle.follow_config(watcher)
+    except Exception:  # noqa: BLE001 — the gate keeps its boot value
+        logger.warning("config watcher could not be attached to the runtime gate", exc_info=True)

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -166,14 +166,27 @@ class OwnedSessionHandle(SessionHandle):
         # CONFIG-derived value — the same ``True`` that must keep following
         # the file.
         self._approval_pinned = approval_pinned
-        #: True once a human has made a deliberate ``/approvals`` choice in
-        #: THIS session. Deliberately the same shape as
+        #: The mode a human typed with ``/approvals`` in THIS session, or
+        #: ``None``. Deliberately the same shape as
         #: ``Session._explicit_model_choice``, and the symmetry is the point:
         #: the model half of this change already protects an explicit ``/model``
         #: pick from a ``config.yml`` default, and approvals is the more
-        #: dangerous key of the two. Read only by :meth:`follow_config`, which
-        #: consults it in the LOOSENING direction alone \u2014 see the rule there.
-        self._explicit_approvals_choice = False
+        #: dangerous key of the two.
+        #:
+        #: It records WHICH mode was chosen, not merely THAT one was (review
+        #: round 2, R6). A boolean conflated the two and the loosening guard
+        #: read it as "the human chose ask", so a session whose human typed
+        #: ``/approvals auto`` was pinned to ``ask`` forever by one file
+        #: tightening \u2014 the operator's originating complaint ("if I change a
+        #: setting I want it to go into effect for all my agents") reappearing
+        #: on the very key this change is centred on.
+        #:
+        #: INVARIANT: non-``None`` only while the gate in force is the mode a
+        #: human typed here. :meth:`_on_config_change` clears it whenever a
+        #: file write MOVES the gate, because at that moment the file, not the
+        #: human, owns the value \u2014 which is also what keeps the keep notice's
+        #: "set with /approvals in this session" a true statement.
+        self._explicit_approvals_mode: str | None = None
         self._unsubscribe_config_watch: Callable[[], None] | None = None
         #: The (kind, title, detail) of the gate currently parked, or None.
         #: Kept so the announcement can be re-run when the last viewer
@@ -402,7 +415,10 @@ class OwnedSessionHandle(SessionHandle):
           wrong surprise.
         * **Loosening (``ask`` → ``auto``) does not move a session whose human
           typed ``/approvals ask`` in it.** That session keeps its gate and
-          reads a keep notice naming the way to adopt the file instead.
+          reads a keep notice naming the way to adopt the file instead. It is
+          the CHOSEN MODE that is consulted, not merely the fact of a choice:
+          a session whose human chose ``auto`` has no hardening to protect and
+          follows the file in both directions like any other.
 
         The asymmetry is the whole point. The operator asked for settings to
         REACH running sessions, which was broken and is what this change fixes;
@@ -450,11 +466,16 @@ class OwnedSessionHandle(SessionHandle):
         wanted_auto = mode == "auto"
         if wanted_auto == self._auto_approve:
             return
-        if wanted_auto and self._explicit_approvals_choice:
+        if wanted_auto and self._explicit_approvals_mode == "ask":
             # LOOSENING against a human's explicit hardening: keep the gate and
             # say so. Shaped like the model half's keep notice — what is kept,
             # why, and the exact command that adopts the file — so the two
             # conflicts read as one rule rather than two behaviours.
+            #
+            # `== "ask"` and not a bare truth test: only a typed `ask` is a
+            # hardening this may refuse a file for. A typed `auto` is an
+            # opinion about the same key, but refusing a loosening on its
+            # behalf would pin a session to a mode its human never asked for.
             self._emit_notice(
                 "keeping tool approvals: ask — set with /approvals in this session; "
                 "config.yml now says auto, /approvals auto adopts it",
@@ -463,6 +484,13 @@ class OwnedSessionHandle(SessionHandle):
             )
             return
         self._auto_approve = wanted_auto
+        # The FILE now owns the value in force, so a mode the human typed here
+        # earlier no longer describes this gate. Clearing keeps the invariant on
+        # `_explicit_approvals_mode` exact (review round 2, R6): without it, a
+        # session tightened off a typed `auto` would still be carrying that
+        # `auto`, and the keep notice's "set with /approvals in this session"
+        # would be describing a choice the file, not the human, had made.
+        self._explicit_approvals_mode = None
         self._notify()
         self._emit_notice(
             (
@@ -2355,7 +2383,9 @@ class OwnedSessionHandle(SessionHandle):
 
         The persist half is declined for the machine-locality reason
         `/approvals default` gives: a default belongs to the terminal whose
-        launches it governs, not to a runtime that outlives it.
+        launches it governs, not to a runtime that outlives it. ``saved`` is
+        NOT declined on those grounds — it only READS that default and switches
+        this session, which is this handle's own mutation (QA round 2, Q49).
         """
         target = (arg or "").strip()
         lowered = target.lower()
@@ -2376,14 +2406,55 @@ class OwnedSessionHandle(SessionHandle):
                 "switches the shared session now",
                 style="warning",
             )
-        provider, sep, model_id = target.partition("/")
-        if not sep or not model_id:
-            return SlashResult(
-                kind="notice",
-                text="usage: /model <provider>/<model-id> "
-                "(e.g. openrouter/deepseek/deepseek-chat)",
-                style="warning",
-            )
+        if lowered == "saved":
+            # ``/model saved`` — adopt the CONFIGURED default (#369). Handled
+            # here because this method is what serves a DETACHED runtime's
+            # `/model`: `OperatorApp` intercepts `saved` before routing, so a
+            # local pane always worked while the phone and any viewer on a
+            # runtime-owned session fell through to the `<provider>/<model-id>`
+            # usage error — `saved` has no `/` (QA round 2, Q49). That made the
+            # keep notice this same change emits (`session.py`, "/model saved
+            # adopts it") a dead end on the one surface that prints it from a
+            # runtime, and contradicted the `/help` text round 1's U5 added.
+            #
+            # UNLIKE `/model default`, this is a READ of config, not a write, so
+            # the machine-locality reason that declines the persist above does
+            # not apply: adopting a value is a switch on this session, which is
+            # exactly what this handle owns. The read is direct rather than a
+            # cached boot value, matching `OperatorApp._cmd_model_saved`, so a
+            # default written during this session is what gets adopted.
+            try:
+                from local_operator.config import ConfigManager
+                from local_operator.paths import config_dir
+
+                manager = ConfigManager(config_dir())
+                saved_provider = str(manager.get_config_value("hosting", "") or "").strip().lower()
+                saved_model = str(manager.get_config_value("model_name", "") or "").strip()
+            except Exception as error:  # noqa: BLE001 — reported, never fatal
+                return SlashResult(
+                    kind="notice",
+                    text=f"could not read the saved default: {error}",
+                    style="error",
+                )
+            if not saved_provider or not saved_model:
+                # Honest "there is nothing to go back to", in the app's own
+                # words so both surfaces answer an empty config identically.
+                return SlashResult(
+                    kind="notice",
+                    text="no boot default saved yet — /model default <provider>/<model-id> "
+                    "sets one",
+                    style="warning",
+                )
+            provider, model_id = saved_provider, saved_model
+        else:
+            provider, sep, model_id = target.partition("/")
+            if not sep or not model_id:
+                return SlashResult(
+                    kind="notice",
+                    text="usage: /model <provider>/<model-id> "
+                    "(e.g. openrouter/deepseek/deepseek-chat)",
+                    style="warning",
+                )
         old_label = getattr(session, "model_label", "")
         try:
             await self.set_model(provider.lower(), model_id)
@@ -2547,12 +2618,11 @@ class OwnedSessionHandle(SessionHandle):
             )
         self._auto_approve = wanted_auto
         # A human typed the mode in this session, so a later LOOSENING disk
-        # write leaves this gate alone (see :meth:`follow_config`). Recorded on
-        # both directions, not only on the hardening: the flag means "this
-        # session has an owner's opinion", and a user who typed `/approvals
-        # auto` here has one just as much — what differs is that only the
-        # loosening direction consults it.
-        self._explicit_approvals_choice = True
+        # write leaves this gate alone (see :meth:`_on_config_change`). The MODE
+        # is recorded, not merely the fact of a choice (review round 2, R6):
+        # both directions are worth recording, but only a recorded `ask` is a
+        # hardening a file loosening must not revoke.
+        self._explicit_approvals_mode = "auto" if wanted_auto else "ask"
         self._notify()
         return SlashResult(
             kind="notice",

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -10164,7 +10164,7 @@ class Session:
         listener per session that fans out to the session's own consumers, so
         the order in which they see a change is deterministic.
 
-        Three groups are live, each for a reason that makes the apply trivial:
+        These groups are live, each for a reason that makes the apply trivial:
 
         * ``compaction.*`` — re-coerced into a fresh ``CompactionSettings``.
           All three trigger checks read ``self._compaction_settings`` at check
@@ -10201,7 +10201,6 @@ class Session:
           keeps its spawn inventory: re-adding would mean re-running the
           role allowlist and network-floor filtering for a short-lived run,
           and the per-call gate already makes "disabled" true for it.
-
         * ``subagents.models.*`` — the launch path reads these per spawn, but
           the ``task``/``agent`` tool SCHEMAS bake the configured tiers in at
           build time (the enum the model picks from, and the description

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1560,6 +1560,16 @@ class Session:
         #: tool is not advertised.
         team_registry: Any | None = None,
         conversation_name: ConversationName | None = None,
+        #: Where the BOOT model came from: ``"config"`` (the ``hosting`` /
+        #: ``model_name`` keys), ``"agent"`` (a profile), ``"flag"``
+        #: (``--hosting``/``--model``) or ``"child"`` (a subagent, whose spec
+        #: was picked at spawn). Decides whether a later ``config.yml`` edit
+        #: to those keys SWITCHES this session: only a config-sourced session
+        #: follows the file, because for the others the file was never what
+        #: chose the model. Defaults to ``"config"`` because that is the
+        #: composition root's common case and what every caller predating
+        #: this kwarg meant.
+        model_source: str = "config",
         # Called each turn with the session's live ``model_label`` so the env
         # block names the running model; accepts it positionally (``...``) and
         # may return sync or async. A provider that ignores the argument is
@@ -1687,6 +1697,22 @@ class Session:
         #: adopt that row (the changed default/flag/profile is the newer
         #: choice). See :data:`SELECTED_MODEL_CUSTOM_TYPE`.
         self._boot_selector = f"{model.provider}/{model.model_id}"
+        self._model_source = model_source
+        #: True once the user has made a deliberate model CHOICE in this
+        #: session (``/model p/id``, the phone's switch, or a restored
+        #: ``selected_model`` row). A ``hosting``/``model_name`` edit on disk
+        #: then leaves this session alone and prints a keep notice instead —
+        #: the user's explicit pick outranks the default it replaced. Cleared
+        #: only by :meth:`_adopt_configured_model` itself, so a session that
+        #: is following config keeps following it across successive edits.
+        self._explicit_model_choice = False
+        #: Set by :meth:`_apply_config_change` when ``web_search.enabled`` /
+        #: ``web_fetch.enabled`` moved; consumed at the next TURN boundary by
+        #: :meth:`_reconcile_web_tools`. Deferred rather than applied on the
+        #: tick because a call the model already emitted against a
+        #: just-removed tool would come back "Tool not found" mid-turn; the
+        #: per-call gate inside the tools already refuses immediately.
+        self._web_tools_dirty = False
         #: True while a mid-session model selection has not reached the
         #: transcript yet; the same dispose-flush contract as the title (the
         #: write is a background task, and dispose cancels background tasks,
@@ -3265,6 +3291,13 @@ class Session:
         # and the journal stays one row per switch, not one per keystroke.
         self._selected_model_dirty = True
         self._spawn_selected_model_write()
+        if explicit:
+            # The user chose: from here a ``hosting``/``model_name`` edit on
+            # disk keeps its hands off this session (see
+            # ``_apply_config_change``). ``_adopt_configured_model`` passes
+            # ``explicit=True`` too — for the fallback-pin withdrawal below —
+            # and resets this flag itself afterwards.
+            self._explicit_model_choice = True
         # The measured byte cap belonged to the provider that demonstrated it,
         # and that provider is gone. Keeping it would pin a session to a
         # departed connection's limit — shedding screenshots a laxer provider
@@ -5652,6 +5685,11 @@ class Session:
                 ):
                     await self._emit(MessageStartEvent(message=message))
 
+            # Inventory changes deferred from a `web_*.enabled` edit land HERE,
+            # before the tool context and the loop config are built for this
+            # turn, so the schema the model sees is consistent for the whole
+            # turn (see ``_reconcile_web_tools`` for why not on the tick).
+            self._reconcile_web_tools()
             blocks = await self._prepare_system_blocks(commit_state=False)
             self._context.system_blocks = list(blocks)
             self._context.tool_context = self._build_tool_context()
@@ -9840,6 +9878,9 @@ class Session:
             logger.warning("dropping unresolvable persisted model selection: %r", selector)
             return
         self._model = spec
+        # A restored row IS the user's earlier explicit choice, so a config
+        # default edited after the resume must not override it either.
+        self._explicit_model_choice = True
         # Same synchronous re-fit hook `set_model` ends on. Nothing is frozen
         # this early, but a stream fn that keys caches by selector must start
         # keyed to the model that will actually serve, not the boot default.
@@ -10094,6 +10135,25 @@ class Session:
           the same validation the constructor applied; an unset or invalid
           value restores the manager's built-in default rather than freezing
           the last explicit one, so "reset to default" on the page means it.
+        * ``hosting`` / ``model_name`` — the running model FOLLOWS the file
+          iff it came from the file: ``_model_source == "config"`` and no
+          explicit ``/model`` choice since boot. Otherwise a keep notice says
+          so and names ``/model saved`` as the way to adopt the default. A
+          CHILD (``_job_id`` set) never follows: its spec was chosen at spawn
+          (tier or parent) and a review child losing its cache prefix
+          mid-task is pure cost. The switch itself is :meth:`set_model` — the
+          same operation ``/model`` performs, landing at the next provider
+          call and never splitting a response. Either key alone triggers it
+          (a bare ``model_name`` edit is the common case); the pair is
+          re-read from ``values`` as a whole.
+        * ``web_search.enabled`` / ``web_fetch.enabled`` — marked dirty here
+          and reconciled into the inventory at the next TURN boundary
+          (:meth:`_reconcile_web_tools`), top-level sessions only. The tools
+          themselves re-check ``enabled`` per call, so a disable refuses at
+          once; the inventory catching up a turn later is cosmetic. A child
+          keeps its spawn inventory: re-adding would mean re-running the
+          role allowlist and network-floor filtering for a short-lived run,
+          and the per-call gate already makes "disabled" true for it.
 
         * ``subagents.models.*`` — the launch path reads these per spawn, but
           the ``task``/``agent`` tool SCHEMAS bake the configured tiers in at
@@ -10103,8 +10163,11 @@ class Session:
           who removes a tier gets a tool that stops offering it.
 
         Everything else the registry calls LIVE is already read per use
-        (``fork.*``, ``web_*`` knobs) and needs no apply here. Everything it
-        calls NEW_SESSIONS is deliberately ignored.
+        (``fork.*``, ``web_*`` knobs, ``bash.shell``) and needs no apply here.
+        ``tool_approval_mode`` is LIVE but owned by the HOST's gate
+        (``OwnedSessionHandle`` / ``OperatorApp``), not the session.
+        Everything the registry calls NEW_LAUNCH or NEW_SESSIONS is
+        deliberately ignored.
 
         Guards on ``_disposed`` because the unsubscribe runs as a dispose
         HOOK, after the session's own teardown, and a tick can land between.
@@ -10172,6 +10235,11 @@ class Session:
                 logger.warning("subagents.max_running=%r rejected by the job manager", cap)
         if any(key.startswith("subagents.models.") for key in changed):
             self._rebuild_effort_tier_tools()
+        if "web_search.enabled" in changed or "web_fetch.enabled" in changed:
+            if self._job_id is None:
+                self._web_tools_dirty = True
+        if "hosting" in changed or "model_name" in changed:
+            self._on_configured_model_changed(values)
 
     def _rebuild_effort_tier_tools(self) -> None:
         """Re-render the tools whose schema advertises the configured effort tiers.
@@ -10202,6 +10270,183 @@ class Session:
         if not rebuilt:
             return
         self.refresh_tools([rebuilt.get(tool.name, tool) for tool in self._tools])
+
+    def _on_configured_model_changed(self, values: Mapping[str, Any]) -> None:
+        """Decide whether a ``hosting``/``model_name`` edit moves THIS session.
+
+        Sync and cheap: the decision is made here, the switch (which resolves
+        model metadata, possibly over the network) runs in the background.
+        The keep notice is emitted from here too, so a session that declines
+        still tells the user why the pane did not move — the TUI prints no
+        clause of its own for the ``model`` section precisely because only
+        this process knows the answer.
+        """
+        if self._job_id is not None:
+            return
+        if self._model_source != "config" or self._explicit_model_choice:
+            label = self.model_label
+            if self._explicit_model_choice:
+                reason = "chosen with /model"
+            elif self._model_source == "agent":
+                reason = "chosen by an agent profile"
+            else:
+                reason = "chosen by a flag"
+            self._spawn_background(
+                self._emit(
+                    NoticeEvent(
+                        text=(
+                            f"keeping {label} — {reason}; config.yml default changed, "
+                            "/model saved adopts it"
+                        ),
+                        kind="info",
+                    )
+                )
+            )
+            return
+        self._spawn_background(self._adopt_configured_model(values))
+
+    async def _adopt_configured_model(self, values: Mapping[str, Any]) -> None:
+        """Switch onto the ``hosting``/``model_name`` pair in ``values``.
+
+        Mirrors ``resolve_hosting_model``'s config arm (an empty model falls
+        back to the provider's default) and ``_restore_selected_model``'s
+        validation (an unknown provider is a warning, never a switch onto a
+        spec that cannot serve). ``build_model_spec`` may fetch a provider
+        listing over a blocking client, so it runs on a thread exactly as the
+        runtime's ``/model`` op does. The chosen effort rides along when the
+        new model's ladder has it, as the TUI's ``/model`` carries it.
+
+        Goes through :meth:`set_model` with ``explicit=True`` so a pinned
+        fallback is withdrawn (the default the fallback was rescuing is gone),
+        then clears ``_explicit_model_choice`` again: adopting the file is not
+        the user choosing, and the next edit must keep applying. The boot
+        selector is re-based too, so a ``selected_model`` journal row written
+        for this switch is skipped on resume (the new default IS the boot).
+        Reads ``values`` — the watcher's validated snapshot — never a fresh
+        ``ConfigManager`` (the module docstring of ``config_watch`` explains
+        why a listener must not construct one).
+        """
+        hosting = str(values.get("hosting") or "").strip().lower()
+        model_name = str(values.get("model_name") or "").strip()
+        if not hosting:
+            return
+        from local_operator.providers.registry import get_provider_definition
+
+        if get_provider_definition(hosting) is None:
+            await self._emit(
+                NoticeEvent(
+                    text=(
+                        f"config.yml names unknown provider {hosting!r}; "
+                        f"keeping {self.model_label}"
+                    ),
+                    kind="warning",
+                )
+            )
+            return
+        if not model_name:
+            from local_operator.model.defaults import default_model_for
+
+            model_name = default_model_for(hosting) or ""
+            if not model_name:
+                await self._emit(
+                    NoticeEvent(
+                        text=(
+                            f"config.yml sets hosting {hosting} with no model_name and "
+                            f"{hosting} has no default; keeping {self.model_label}"
+                        ),
+                        kind="warning",
+                    )
+                )
+                return
+        current = self._model
+        if (current.provider, current.model_id) == (hosting, model_name):
+            # The writer's own pane: `/model default` already switched it (or
+            # it was already there). Nothing to do, and no receipt owed.
+            return
+        from local_operator.model.configure import build_model_spec
+
+        try:
+            spec = await asyncio.to_thread(build_model_spec, hosting, model_name)
+        except Exception as error:  # noqa: BLE001 — reported, never a broken session
+            await self._emit(
+                NoticeEvent(
+                    text=f"could not resolve {hosting}/{model_name} from config.yml: {error}",
+                    kind="warning",
+                )
+            )
+            return
+        if self._disposed:
+            return
+        chosen_effort = current.reasoning_effort
+        if chosen_effort and chosen_effort in tuple(spec.reasoning_efforts or ()):
+            spec = spec.model_copy(update={"reasoning_effort": chosen_effort})
+        previous_label = self.model_label
+        self.set_model(spec, explicit=True)
+        self._explicit_model_choice = False
+        self._boot_selector = f"{spec.provider}/{spec.model_id}"
+        await self._emit(
+            NoticeEvent(
+                text=f"model: {previous_label} → {self.model_label} — config.yml default changed",
+                kind="info",
+            )
+        )
+
+    def _reconcile_web_tools(self) -> None:
+        """Bring the advertised web tools in line with ``web_*.enabled``.
+
+        Runs at the TURN boundary, only when :meth:`_apply_config_change`
+        marked the flags dirty, and only on a top-level session. Rebuilds the
+        two tools through the same createIf builders the factory used, with
+        ``web_search_settings``/``web_fetch_settings`` taken from the config
+        watcher's last-good snapshot (``existing_watcher().values``) — the
+        one source a config-driven path may read without risking the
+        move-aside a fresh ``ConfigManager`` performs on a malformed file.
+        Missing tools are merged in through :meth:`_merge_capability_tools`
+        (same-name replacement, stable order); disabled ones are dropped
+        through :meth:`refresh_tools`, the committed inventory-swap hook.
+
+        Never mid-turn: the loop reads ``context.tools`` per model call, and a
+        tool removed between a model's call and its dispatch comes back "Tool
+        not found" — the per-call gate in the tool gives a better answer.
+        """
+        if not self._web_tools_dirty or self._job_id is not None:
+            return
+        self._web_tools_dirty = False
+        try:
+            from local_operator.config_watch import existing_watcher
+            from local_operator.paths import config_dir
+            from local_operator.tools.registry import create_tools
+            from local_operator.web_fetch.service import coerce_fetch_settings
+            from local_operator.web_search.service import coerce_search_settings
+
+            watcher = existing_watcher(config_dir())
+            if watcher is None:
+                return
+            values = watcher.values
+            search_raw = values.get("web_search")
+            fetch_raw = values.get("web_fetch")
+            wanted = {
+                "web_search": coerce_search_settings(search_raw).enabled,
+                "web_fetch": coerce_fetch_settings(fetch_raw).enabled,
+            }
+            have = {tool.name for tool in self._tools}
+            to_add = [name for name, on in wanted.items() if on and name not in have]
+            to_drop = {name for name, on in wanted.items() if not on and name in have}
+            if to_drop:
+                self.refresh_tools([t for t in self._tools if t.name not in to_drop])
+            if to_add:
+                context = self._build_tool_context()
+                context.web_search_settings = (
+                    dict(search_raw) if isinstance(search_raw, Mapping) else None
+                )
+                context.web_fetch_settings = (
+                    dict(fetch_raw) if isinstance(fetch_raw, Mapping) else None
+                )
+                fresh = create_tools(context, enabled=to_add)
+                if fresh:
+                    self.refresh_tools(list(self._tools) + fresh)
+        except Exception:  # noqa: BLE001 — the inventory is never worth a broken turn
+            logger.warning("web tool inventory could not be reconciled", exc_info=True)
 
     def add_dispose_hook(self, hook: Callable[[], Awaitable[None] | None]) -> None:
         """Register teardown that runs after the session's own dispose.

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -255,6 +255,45 @@ _MAX_CONTINUATIONS = 8
 SESSION_CAPABILITY_TOOLS: tuple[str, ...] = ("task", "wait", "jobs", "wake", "hub", "ask")
 
 
+def _splice_in_registry_order(existing: Sequence[Any], fresh: Sequence[Any]) -> list[Any]:
+    """Insert ``fresh`` tools at their ``DEFAULT_TOOL_NAMES`` positions.
+
+    The tools array rides in the same prompt-cache prefix as the system prompt,
+    and ``tools/registry.py`` builds it in a stable order precisely so that
+    prefix stays cache-stable (AGENTS.md, "the tool-surface footprint ladder").
+    Appending a re-enabled tool therefore costs a prefix miss on every
+    remaining call of the session, which is why a live ``web_search.enabled``
+    flip has to put the tool BACK where it was rather than merely put it back
+    (review round 1, R4).
+
+    Each fresh tool is placed before the first existing tool that ranks after
+    it in the registry order; anything the registry does not name (an MCP tool,
+    a host extension) sorts last and is never reordered relative to its
+    neighbours, so a session whose inventory was customised keeps that shape.
+    Same-name replacement is NOT this function's job \u2014 the caller has already
+    established that these names are absent.
+    """
+    from local_operator.tools.registry import DEFAULT_TOOL_NAMES
+
+    # Unknown names rank past every known one, and stably among themselves, so
+    # the merge cannot shuffle tools the registry has no opinion about.
+    last = len(DEFAULT_TOOL_NAMES)
+
+    def rank(tool: Any) -> int:
+        name = getattr(tool, "name", "")
+        return DEFAULT_TOOL_NAMES.index(name) if name in DEFAULT_TOOL_NAMES else last
+
+    merged = list(existing)
+    for tool in sorted(fresh, key=rank):
+        position = len(merged)
+        for index, present in enumerate(merged):
+            if rank(present) > rank(tool):
+                position = index
+                break
+        merged.insert(position, tool)
+    return merged
+
+
 class _PeerArrival:
     """Session-owned :class:`PeerArrivalProtocol` behind ``ToolContext``.
 
@@ -1706,6 +1745,14 @@ class Session:
         #: only by :meth:`_adopt_configured_model` itself, so a session that
         #: is following config keeps following it across successive edits.
         self._explicit_model_choice = False
+        #: Bumped by :meth:`_on_configured_model_changed` on every dispatch, and
+        #: captured by :meth:`_adopt_configured_model` before its thread hop.
+        #: An adopt whose generation is stale when it returns has been
+        #: superseded by a newer ``hosting``/``model_name`` edit and abandons,
+        #: so two edits arriving inside one ``build_model_spec`` resolve in
+        #: EDIT order rather than in whichever-thread-finished-first order
+        #: (review round 1, R2).
+        self._configured_model_generation = 0
         #: Set by :meth:`_apply_config_change` when ``web_search.enabled`` /
         #: ``web_fetch.enabled`` moved; consumed at the next TURN boundary by
         #: :meth:`_reconcile_web_tools`. Deferred rather than applied on the
@@ -10299,10 +10346,17 @@ class Session:
                             "/model saved adopts it"
                         ),
                         kind="info",
+                        # A glance for the boot toast, so it does not fall
+                        # through to a blind cut landing mid-phrase (design
+                        # round 1, D3). See ``NoticeEvent.headline``.
+                        headline="Model unchanged",
                     )
                 )
             )
             return
+        # Bumped BEFORE the spawn so an adopt already parked on its thread hop
+        # sees a generation newer than the one it captured and stands down.
+        self._configured_model_generation += 1
         self._spawn_background(self._adopt_configured_model(values))
 
     async def _adopt_configured_model(self, values: Mapping[str, Any]) -> None:
@@ -10318,14 +10372,40 @@ class Session:
 
         Goes through :meth:`set_model` with ``explicit=True`` so a pinned
         fallback is withdrawn (the default the fallback was rescuing is gone),
-        then clears ``_explicit_model_choice`` again: adopting the file is not
-        the user choosing, and the next edit must keep applying. The boot
-        selector is re-based too, so a ``selected_model`` journal row written
-        for this switch is skipped on resume (the new default IS the boot).
+        then RESTORES ``_explicit_model_choice`` to what it was before the
+        call rather than assigning ``False``: adopting the file is not the user
+        choosing, so a session that was following config keeps following it —
+        but a session that had already recorded a real ``/model`` choice must
+        not have that record erased by an adopt (review round 1, R2, second
+        half). The boot selector is re-based too, so a ``selected_model``
+        journal row written for this switch is skipped on resume (the new
+        default IS the boot).
+
+        **The apply is guarded against the await.** ``build_model_spec`` may
+        fetch a provider listing, so the thread hop below is a real window in
+        which the user can type ``/model`` and a second config edit can land.
+        Reproduced in review: a ``/model`` choice made during a parked adopt
+        was silently undone AND its ``_explicit_model_choice`` reset, which
+        disabled the keep rule for every later edit. Two guards close it, both
+        re-checked AFTER the await:
+
+        * ``_explicit_model_choice`` — a user choice that landed while this was
+          in flight outranks the file, the same rule
+          :meth:`_on_configured_model_changed` applies before spawning; and
+        * ``_configured_model_generation`` — bumped by every dispatch, so a
+          NEWER adopt (a second edit while the first was resolving) wins and
+          the older task abandons rather than last-writer-wins between two
+          tasks with no ordering.
+
+        Both abandon silently: the newer decision emits its own receipt, and a
+        second line about a switch that did not happen is noise.
+
         Reads ``values`` — the watcher's validated snapshot — never a fresh
         ``ConfigManager`` (the module docstring of ``config_watch`` explains
         why a listener must not construct one).
         """
+        generation = self._configured_model_generation
+        explicit_before = self._explicit_model_choice
         hosting = str(values.get("hosting") or "").strip().lower()
         model_name = str(values.get("model_name") or "").strip()
         if not hosting:
@@ -10377,17 +10457,30 @@ class Session:
             return
         if self._disposed:
             return
+        if self._explicit_model_choice and not explicit_before:
+            # The user chose while this adopt was resolving. Their pick is
+            # newer and explicit; applying the file's spec now would undo it.
+            return
+        if self._configured_model_generation != generation:
+            # A newer config edit has already been dispatched. It resolves
+            # against the newer values and owns the receipt.
+            return
         chosen_effort = current.reasoning_effort
         if chosen_effort and chosen_effort in tuple(spec.reasoning_efforts or ()):
             spec = spec.model_copy(update={"reasoning_effort": chosen_effort})
         previous_label = self.model_label
         self.set_model(spec, explicit=True)
-        self._explicit_model_choice = False
+        # RESTORED, not cleared: see the docstring. ``set_model(explicit=True)``
+        # sets the flag as a side effect of withdrawing a pinned fallback, and
+        # this call is the file's decision rather than the user's — so the flag
+        # goes back to whatever the user's own history had made it.
+        self._explicit_model_choice = explicit_before
         self._boot_selector = f"{spec.provider}/{spec.model_id}"
         await self._emit(
             NoticeEvent(
                 text=f"model: {previous_label} → {self.model_label} — config.yml default changed",
                 kind="info",
+                headline=f"model: {self.model_label}",
             )
         )
 
@@ -10401,17 +10494,28 @@ class Session:
         watcher's last-good snapshot (``existing_watcher().values``) — the
         one source a config-driven path may read without risking the
         move-aside a fresh ``ConfigManager`` performs on a malformed file.
-        Missing tools are merged in through :meth:`_merge_capability_tools`
-        (same-name replacement, stable order); disabled ones are dropped
-        through :meth:`refresh_tools`, the committed inventory-swap hook.
+        Disabled tools are dropped through :meth:`refresh_tools`, the committed
+        inventory-swap hook; a re-enabled one is spliced back at its
+        ``DEFAULT_TOOL_NAMES`` POSITION rather than appended (review round 1,
+        R4). Order is not cosmetic here: ``tools/registry.py`` builds the array
+        in a stable order precisely so the tools array — which rides in the
+        same cache prefix as the system prompt — stays cache-stable, and an
+        appended tool costs a prompt-cache prefix miss on every later call of
+        the session (AGENTS.md, "the tool-surface footprint ladder").
 
         Never mid-turn: the loop reads ``context.tools`` per model call, and a
         tool removed between a model's call and its dispatch comes back "Tool
         not found" — the per-call gate in the tool gives a better answer.
+
+        The dirty flag is cleared only once the reconcile has actually HAPPENED
+        (review round 1, R5). Cleared up front, a pass that returned early
+        (``watcher is None``) or was swallowed by the ``except`` dropped the
+        pending work, and the inventory then stayed out of line with a file
+        that had already changed until the operator edited the key a second
+        time. Left set, the next turn boundary simply tries again.
         """
         if not self._web_tools_dirty or self._job_id is not None:
             return
-        self._web_tools_dirty = False
         try:
             from local_operator.config_watch import existing_watcher
             from local_operator.paths import config_dir
@@ -10444,7 +10548,8 @@ class Session:
                 )
                 fresh = create_tools(context, enabled=to_add)
                 if fresh:
-                    self.refresh_tools(list(self._tools) + fresh)
+                    self.refresh_tools(_splice_in_registry_order(self._tools, fresh))
+            self._web_tools_dirty = False
         except Exception:  # noqa: BLE001 — the inventory is never worth a broken turn
             logger.warning("web tool inventory could not be reconciled", exc_info=True)
 

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -409,6 +409,26 @@ def resolve_hosting_model(
 
     Raises ``ValueError`` with the legacy message shapes when either value is
     missing, so the CLI's red-banner handler reports it exactly like before.
+    The pair-only shape every existing caller expects; the composition root
+    uses :func:`resolve_hosting_model_with_source` because the SOURCE decides
+    whether the session later follows a ``hosting``/``model_name`` edit.
+    """
+    hosting, model_name, _source = resolve_hosting_model_with_source(agent, args, config_manager)
+    return hosting, model_name
+
+
+def resolve_hosting_model_with_source(
+    agent: AgentData | None, args: argparse.Namespace, config_manager: ConfigManager
+) -> tuple[str, str, str]:
+    """``resolve_hosting_model`` plus WHERE the hosting came from.
+
+    The third element is ``"agent"``, ``"flag"`` or ``"config"`` — the same
+    classification ``HostingUnknownError.source`` carries for the repair
+    prompt. The session stores it as ``model_source``: only a
+    ``"config"``-sourced session switches when the file's default changes,
+    because for the other two the file never chose the model (see
+    ``Session._apply_config_change``). Keyed on the HOSTING's source: a model
+    name from config under a flagged hosting is still a flag-chosen run.
     """
     # The SOURCE is tracked alongside the value, not just the value: the repair
     # offered when this turns out to be unusable writes the config file, which
@@ -465,7 +485,7 @@ def resolve_hosting_model(
             # repaired. The message is unchanged -- it names concrete model ids,
             # and the fail-fast paths still print exactly it.
             raise ModelNotConfiguredError(_no_model_message(hosting), hosting)
-    return hosting, model_name
+    return hosting, model_name, hosting_source
 
 
 def default_convert_to_llm(messages: list[AgentMessage]) -> list[Message]:
@@ -1491,7 +1511,9 @@ async def _prepare(
     ``cwd`` (default: process cwd) is the single working-directory source for
     the tool context, the session and MCP discovery."""
     agent = resolve_agent(args, agent_registry)
-    hosting, model_name = resolve_hosting_model(agent, args, config_manager)
+    hosting, model_name, model_source = resolve_hosting_model_with_source(
+        agent, args, config_manager
+    )
     yolo = bool(getattr(args, "yolo", False))
 
     transcript_dir, agent_id = _transcript_dir_and_agent_id(agent, args, agent_registry)
@@ -1751,6 +1773,9 @@ async def _prepare(
         variables=variable_store,
         agent_registry=agent_registry,
         team_registry=team_registry,
+        # Whether a later ``hosting``/``model_name`` edit switches this session
+        # (config-sourced) or only prints a keep notice (agent/flag).
+        model_source=model_source,
     )
     return _SessionPlan(
         session_kwargs=session_kwargs,

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -420,15 +420,30 @@ def resolve_hosting_model(
 def resolve_hosting_model_with_source(
     agent: AgentData | None, args: argparse.Namespace, config_manager: ConfigManager
 ) -> tuple[str, str, str]:
-    """``resolve_hosting_model`` plus WHERE the hosting came from.
+    """``resolve_hosting_model`` plus WHERE the model SELECTION came from.
 
-    The third element is ``"agent"``, ``"flag"`` or ``"config"`` — the same
-    classification ``HostingUnknownError.source`` carries for the repair
-    prompt. The session stores it as ``model_source``: only a
-    ``"config"``-sourced session switches when the file's default changes,
-    because for the other two the file never chose the model (see
-    ``Session._apply_config_change``). Keyed on the HOSTING's source: a model
-    name from config under a flagged hosting is still a flag-chosen run.
+    The third element is ``"agent"``, ``"flag"`` or ``"config"``. The session
+    stores it as ``model_source``: only a ``"config"``-sourced session switches
+    when the file's default changes, because for the other two the file never
+    chose the model (see ``Session._apply_config_change``).
+
+    Keyed on EITHER field of the pair, not on the hosting alone (review round
+    1, R3). Both directions have to classify as chosen: a model name from
+    config under a flagged hosting is a flag-chosen run, and — the harmful
+    direction — ``--model X`` with no ``--hosting`` is equally chosen, because
+    ``cli.py`` registers the two flags independently and ``lop exec --model
+    <pinned>`` is the spelling a user reaches for to pin a run. Keyed on
+    hosting only, that run classified ``"config"`` and another pane's ``/model
+    default`` moved it off the model the flag named — a file default silently
+    overriding an explicit flag, which is the converse of the rule this source
+    exists to enforce.
+
+    The HOSTING's own origin stays separate and narrower, because
+    :class:`HostingUnknownError` uses it to name the place the bad value came
+    from ("passed with --hosting", "on the agent record"). Widening that one
+    would have ``--model gpt-5`` under a config hosting report the config's
+    typo as having been passed on a flag the user never typed — a repair
+    instruction pointing at the wrong file.
     """
     # The SOURCE is tracked alongside the value, not just the value: the repair
     # offered when this turns out to be unusable writes the config file, which
@@ -436,10 +451,21 @@ def resolve_hosting_model_with_source(
     agent_hosting: str | None = getattr(agent, "hosting", None) if agent is not None else None
     flag_hosting: str | None = getattr(args, "hosting", None)
     hosting = agent_hosting or flag_hosting or config_manager.get_config_value("hosting")
+    agent_model: str | None = getattr(agent, "model", None) if agent is not None else None
+    flag_model: str | None = getattr(args, "model", None)
+    # WHERE THE HOSTING VALUE CAME FROM — the repair prompt's subject, so it
+    # stays keyed on the hosting fields alone.
     hosting_source = "agent" if agent_hosting else "flag" if flag_hosting else "config"
-    model_name: str | None = getattr(agent, "model", None) if agent is not None else None
-    model_name = (
-        model_name or getattr(args, "model", None) or config_manager.get_config_value("model_name")
+    # WHAT CHOSE THE RUN — the returned source, and the one the live-config
+    # rule reads. An agent profile outranks a flag outranks the file, exactly
+    # as for the values: naming EITHER field is choosing.
+    model_source = (
+        "agent"
+        if (agent_hosting or agent_model)
+        else "flag" if (flag_hosting or flag_model) else "config"
+    )
+    model_name: str | None = (
+        agent_model or flag_model or config_manager.get_config_value("model_name")
     )
     if not hosting:
         raise HostingNotConfiguredError("Hosting platform is not configured.")
@@ -485,7 +511,7 @@ def resolve_hosting_model_with_source(
             # repaired. The message is unchanged -- it names concrete model ids,
             # and the fail-fast paths still print exactly it.
             raise ModelNotConfiguredError(_no_model_message(hosting), hosting)
-    return hosting, model_name, hosting_source
+    return hosting, model_name, model_source
 
 
 def default_convert_to_llm(messages: list[AgentMessage]) -> list[Message]:

--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -342,7 +342,10 @@ SECTIONS: tuple[Section, ...] = (
         "session",
         "Session storage",
         Scope.NEW_LAUNCH,
-        "Autosave and the cleanup policy — read once at launch.",
+        # The scope tag one column away already says "takes effect: new
+        # launch", so restating "read once at launch" here said "launch" twice
+        # within one row (design round 1, D7).
+        "Autosave and the cleanup policy.",
     ),
     # LIVE: ``max_running`` is pushed into the running ``AsyncJobManager`` by
     # ``Session._apply_config_change`` (raising it lets the next launch through;
@@ -502,7 +505,12 @@ SETTINGS: tuple[Setting, ...] = (
         label="Default provider",
         kind=Kind.TEXT,
         default="",
-        help="Provider sessions run on unless chosen with /model. Set here or by /model default.",
+        # 72 cells. Every help string on this page has to clear the ~76-cell
+        # footer budget at 80 columns: past it the shed ladder drops the YAML
+        # key path (the thing a user maps a row to the file by) and then the
+        # sentence itself is clipped mid-clause with no ellipsis (design round
+        # 1, D2). Measure any edit to these four before landing it.
+        help="Provider sessions run on unless chosen with /model. Also /model default.",
         empty_unsets=True,
     ),
     Setting(
@@ -512,7 +520,8 @@ SETTINGS: tuple[Setting, ...] = (
         label="Default model",
         kind=Kind.TEXT,
         default="",
-        help="Model id sessions run on unless chosen with /model. Set here or by /model default.",
+        # 72 cells — see the note on `hosting` above.
+        help="Model id sessions run on unless chosen with /model. Also /model default.",
         empty_unsets=True,
     ),
     # -- providers ----------------------------------------------------------
@@ -819,7 +828,8 @@ SETTINGS: tuple[Setting, ...] = (
         label="Tool approval mode",
         kind=Kind.ENUM,
         default="ask",
-        help="How every running session treats write and exec tools, from its next decision.",
+        # 74 cells — see the note on `hosting`.
+        help="How every running session treats write and exec tools, from its next call.",
         choices=(
             Choice("ask", "ask", "prompt before write/exec tools"),
             Choice("auto", "auto", "run them without asking"),
@@ -1213,7 +1223,10 @@ SETTINGS: tuple[Setting, ...] = (
         label="Web fetch",
         kind=Kind.BOOL,
         default=True,
-        help="Offer the fetch tool (and `read <url>`) and let it run; off refuses every call.",
+        # 60 cells — see the note on `hosting`. No BACKTICKS: the footer is a
+        # plain `Text`, so they render as literal characters, and this was the
+        # only one of 57 help strings carrying any (design round 1, D5).
+        help="Offer the fetch tool and read <url>; off refuses every call.",
         choices=_bool_choices("fetch available", "fetch disabled"),
     ),
     Setting(

--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -120,9 +120,16 @@ class Scope(enum.Enum):
     #: Takes effect immediately in every running session on this machine —
     #: on the same call stack in the process that wrote it, and within
     #: ``ConfigWatcher.POLL_INTERVAL_S`` for sessions in other processes (see
-    #: :mod:`local_operator.config_watch`).
+    #: :mod:`local_operator.config_watch`). Per-key caveats live on the
+    #: SECTION description (``model``: a session that chose with ``/model``
+    #: keeps its choice; ``web_tools``: the inventory catches up at the next
+    #: turn while execution refuses at once) — the scope says WHEN, the
+    #: description says what "applied" means for that key.
     LIVE = "live"
     #: Read when a session is built — a ``/new`` or ``/reload`` picks it up.
+    #: Only ``local_providers`` carries it now: ``approvals``, ``model`` and
+    #: ``web_tools`` went LIVE, and ``session`` (autosave + cleanup) turned out
+    #: to be launch-time all along.
     NEW_SESSIONS = "new sessions"
     #: Read once at process start; needs a relaunch.
     NEW_LAUNCH = "new launch"
@@ -246,11 +253,22 @@ class Section:
 # retired keys are last.
 
 SECTIONS: tuple[Section, ...] = (
+    # LIVE with a rule, not unconditionally: ``Session._apply_config_change``
+    # switches a running session onto the new pair iff its model CAME from
+    # config (not an agent profile, not ``--hosting``/``--model``) and no
+    # explicit ``/model`` choice has been made since boot. A session the user
+    # pointed somewhere deliberately keeps its choice and prints a keep
+    # notice — ``/model saved`` re-adopts the default on demand. Children
+    # (subagents) never follow; their spec was picked at spawn. Before this
+    # the section was NEW_LAUNCH and the operator's report was exactly the
+    # painted lie: `/model default` in one pane told every other pane
+    # "model_name needs a relaunch" while "all my agents" was the intent.
     Section(
         "model",
         "Model",
-        Scope.NEW_LAUNCH,
-        "The provider and model new launches boot on.",
+        Scope.LIVE,
+        "The provider and model sessions run on. Sessions that chose a model "
+        "with /model keep it (/model saved adopts the default).",
     ),
     # Split out of ``model`` (review round 1, M3). The design left this key in
     # ``model`` and proposed documenting the discrepancy, which was defensible
@@ -260,8 +278,9 @@ SECTIONS: tuple[Section, ...] = (
     # ``configure._openai_api_mode`` reads the rebound mapping when it builds
     # the next client. Scope is uniform within a section by construction, so
     # saying something true here means a section of its own, exactly as ``fork``
-    # and ``web_tools`` are. ``hosting``/``model_name`` genuinely stay
-    # NEW_LAUNCH: they are the session's identity, not a knob it re-reads.
+    # and ``web_tools`` are. ``model`` has since gone LIVE too, but by a
+    # DIFFERENT mechanism (a guarded model switch rather than a mapping
+    # rebind), so the two stay separate sections with separate descriptions.
     Section(
         "providers",
         # Titled for the WIRE FORMAT, not the word "provider" (design review
@@ -293,16 +312,37 @@ SECTIONS: tuple[Section, ...] = (
         Scope.LIVE,
         "Theme and the terminal features the TUI is allowed to use.",
     ),
-    # Deliberately NOT live, and split from ``subagents`` for that reason (scope
-    # is uniform within a section by construction). A tool-approval mode that
-    # flipped under a running turn would be a security-relevant surprise; the
-    # per-session ``/approvals`` toggle is the live control, and it WRITES this
-    # default rather than following it.
+    # LIVE — a reversal of the original design, which kept the approval mode
+    # build-time on the theory that a gate flipping under a running turn is a
+    # security-relevant surprise. The operator's actual request ("if I change
+    # a setting I want it to go into effect for all my agents") is the
+    # opposite: a disk write IS the machine-wide intent, and it overrides any
+    # per-session ``/approvals`` toggle. Two rules keep it safe: the new mode
+    # applies at the next approval DECISION (``OwnedSessionHandle`` reads its
+    # flag per gate call), so a prompt already parked on screen is left for
+    # the human — never auto-answered, never auto-denied; and every viewer
+    # prints the amber "tool approvals now auto" notice. ``--yolo`` is an
+    # explicit pin that outranks the key. Its own section because ``session``
+    # (autosave + cleanup) is launch-time and scope is uniform per section.
+    Section(
+        "approvals",
+        "Approvals",
+        Scope.LIVE,
+        "Whether write and command tools prompt, in every running session.",
+    ),
+    # NEW_LAUNCH, honestly: ``auto_save_conversation`` is read ONCE by the CLI
+    # at process start (``cli.py`` sets ``args.train``) to pick the transcript
+    # DIRECTORY, and a transcript cannot move mid-session; the TUI's runtime
+    # child never reads it at all. ``session.cleanup.*`` is consumed by the
+    # once-per-process store-maintenance pass (``session_factory
+    # ._STORE_MAINTENANCE_TASK``), so a ``/new`` does not re-run it either.
+    # The former "new sessions" label promised a `/new` would adopt these,
+    # which nothing did.
     Section(
         "session",
-        "Session",
-        Scope.NEW_SESSIONS,
-        "Approvals and autosave for sessions started from now on.",
+        "Session storage",
+        Scope.NEW_LAUNCH,
+        "Autosave and the cleanup policy — read once at launch.",
     ),
     # LIVE: ``max_running`` is pushed into the running ``AsyncJobManager`` by
     # ``Session._apply_config_change`` (raising it lets the next launch through;
@@ -316,9 +356,10 @@ SECTIONS: tuple[Section, ...] = (
     ),
     # Its own section rather than a row under "Session", and the reason is the
     # SCOPE: scope is uniform within a section by construction, "Session" is
-    # NEW_SESSIONS, and these keys take effect on the very next /resume in this
-    # same terminal. Filing a live key under a section labelled "new sessions"
-    # is exactly the painted lie AGENTS.md warns about — split the section.
+    # launch-time (autosave and the cleanup policy), and these keys take
+    # effect on the very next /resume in this same terminal. Filing a live key
+    # under a section labelled for launch is exactly the painted lie AGENTS.md
+    # warns about — split the section.
     Section(
         "runtime",
         "Runtime",
@@ -342,16 +383,22 @@ SECTIONS: tuple[Section, ...] = (
         "Where /fork opens the branched conversation.",
     ),
     # The GATE comes first, then the knobs it gates (design review round 1,
-    # D3). Whether each tool is offered at all is decided when the tool
-    # inventory is built, so these two flags cannot be LIVE — but reading order
-    # is the hierarchy the user sees, and putting the master switches after
-    # four tuning knobs left someone scanning for "is web search on?" finding
-    # the answer next to the retired-keys graveyard.
+    # D3): reading order is the hierarchy the user sees, and putting the
+    # master switches after four tuning knobs left someone scanning for "is
+    # web search on?" finding the answer next to the retired-keys graveyard.
+    # LIVE by two mechanisms that together make "applied" true: execution
+    # re-checks ``enabled`` on EVERY call (``execute_web_search`` /
+    # ``run_fetch`` — which also covers the ``read <url>`` sugar), so a
+    # disable refuses at once even mid-turn; and a top-level session
+    # reconciles its advertised inventory at the next TURN boundary (never
+    # mid-turn — a call the model already emitted against a just-removed tool
+    # would come back "Tool not found"). Subagents keep their spawn inventory
+    # and rely on the per-call gate alone.
     Section(
         "web_tools",
         "Web tools",
-        Scope.NEW_SESSIONS,
-        "Whether the search and fetch tools are offered to the model.",
+        Scope.LIVE,
+        "Whether the search and fetch tools are offered and allowed to run.",
     ),
     # LIVE: both tools build their settings from config on EVERY call
     # (``web_search/tool.py``, ``web_fetch/tool.py``).
@@ -455,7 +502,7 @@ SETTINGS: tuple[Setting, ...] = (
         label="Default provider",
         kind=Kind.TEXT,
         default="",
-        help="Provider new launches boot on. Set here or by /model default.",
+        help="Provider sessions run on unless chosen with /model. Set here or by /model default.",
         empty_unsets=True,
     ),
     Setting(
@@ -465,7 +512,7 @@ SETTINGS: tuple[Setting, ...] = (
         label="Default model",
         kind=Kind.TEXT,
         default="",
-        help="Model id new launches boot on. Set here or by /model default.",
+        help="Model id sessions run on unless chosen with /model. Set here or by /model default.",
         empty_unsets=True,
     ),
     # -- providers ----------------------------------------------------------
@@ -764,20 +811,21 @@ SETTINGS: tuple[Setting, ...] = (
             Choice("hidden", "hidden", "not shown"),
         ),
     ),
-    # -- session ------------------------------------------------------------
+    # -- approvals ----------------------------------------------------------
     Setting(
         key="tool_approval_mode",
         path=("tool_approval_mode",),
-        section="session",
+        section="approvals",
         label="Tool approval mode",
         kind=Kind.ENUM,
         default="ask",
-        help="How a new interactive session treats write and exec tools.",
+        help="How every running session treats write and exec tools, from its next decision.",
         choices=(
             Choice("ask", "ask", "prompt before write/exec tools"),
             Choice("auto", "auto", "run them without asking"),
         ),
     ),
+    # -- session storage ----------------------------------------------------
     Setting(
         key="auto_save_conversation",
         path=("auto_save_conversation",),
@@ -785,7 +833,7 @@ SETTINGS: tuple[Setting, ...] = (
         label="Auto-save conversation",
         kind=Kind.BOOL,
         default=False,
-        help="Write the conversation to disk as it goes.",
+        help="Headless REPL launches only; the TUI's runtime does not read it.",
         choices=_bool_choices("save automatically", "save on request"),
     ),
     # -- runtime ------------------------------------------------------------
@@ -796,7 +844,7 @@ SETTINGS: tuple[Setting, ...] = (
         # stays in the Session section, so a user reading the Runtime page
         # could not predict which YAML key they were editing. The scope
         # argument for keeping it out of the Session SECTION (that section is
-        # NEW_SESSIONS, this key is LIVE) is sound and unaffected: the section
+        # NEW_LAUNCH, this key is LIVE) is sound and unaffected: the section
         # is the scope boundary, the namespace is the section's name. New in
         # this release, so there is no migration cost to settling it now.
         key="runtime.background_on_resume",
@@ -1091,9 +1139,11 @@ SETTINGS: tuple[Setting, ...] = (
         minimum=0,
     ),
     # -- web search ---------------------------------------------------------
-    # The two ``enabled`` flags sit in ``web_tools`` (NEW_SESSIONS), apart from
-    # the knobs that share their YAML block: they gate whether the tool exists
-    # in the inventory, which is decided once at build.
+    # The two ``enabled`` flags sit in ``web_tools``, apart from the knobs that
+    # share their YAML block, for reading order (the gate before what it
+    # gates). The startup snapshot decides the BOOT inventory; execution
+    # re-checks ``enabled`` per call; a flip is reconciled into a top-level
+    # session's inventory at its next turn.
     Setting(
         key="web_search.enabled",
         path=("web_search", "enabled"),
@@ -1101,7 +1151,7 @@ SETTINGS: tuple[Setting, ...] = (
         label="Web search",
         kind=Kind.BOOL,
         default=True,
-        help="Expose the search tool to the agent.",
+        help="Offer the search tool and let it run; off refuses every call.",
         choices=_bool_choices("search available", "search disabled"),
     ),
     Setting(
@@ -1163,7 +1213,7 @@ SETTINGS: tuple[Setting, ...] = (
         label="Web fetch",
         kind=Kind.BOOL,
         default=True,
-        help="Expose the fetch tool to the agent.",
+        help="Offer the fetch tool (and `read <url>`) and let it run; off refuses every call.",
         choices=_bool_choices("fetch available", "fetch disabled"),
     ),
     Setting(

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1331,6 +1331,27 @@ class _ProviderRows(NamedTuple):
     problem: str
 
 
+class _ApprovalsFollow(NamedTuple):
+    """What ``_follow_configured_approvals`` did, for a caller that must report it.
+
+    Two fields rather than the bare clause string it used to return, because
+    "the gate moved and another process is announcing it" and "the gate did NOT
+    move" both produce an empty clause and are not the same news (design round
+    2, D8). Only the caller knows about the ``applied:`` key list, and only this
+    method knows whether the write was refused, so the verdict has to cross that
+    boundary explicitly — read as a bare string it printed ``applied:
+    tool_approval_mode`` one row under a notice saying the gate was kept.
+
+    ``kept`` is specifically the KEEP path (a loosening refused on behalf of a
+    mode a human typed here), not "nothing to say": a mode that failed to parse
+    and a value the gate already held both leave ``kept`` False, because in
+    neither case did this listener refuse a change the file asked for.
+    """
+
+    clause: str
+    kept: bool
+
+
 #: Tag for the toast the COMPOSER's copy raises, so a later edit can withdraw
 #: that card and no other. One `Toast` slot serves every caller, and a receipt
 #: may be SHOWING or HELD behind an actionable notice; the tag rides the card
@@ -14510,6 +14531,23 @@ class OperatorApp(App[None]):
                 relaunch.append(key)
             else:
                 new_sessions.append(key)
+        # The gate decision is taken BEFORE the `applied:` list is assembled,
+        # because on the keep path the key must not appear in it (design round
+        # 2, D8). Read after assembly — which is how it used to run — the keep
+        # notice was followed one row later by `applied: tool_approval_mode`,
+        # two dim rows stating opposite facts about the same key, and a user
+        # scanning for "did my hardening survive?" could not tell which won.
+        #
+        # The refusing MODEL section is the standard this follows: it `continue`s
+        # above, prints no `config.yml changed:` line at all, and leaves the
+        # session's own receipt to speak. An `applied:` clause is a claim about
+        # keys that MOVED, so a key this listener just refused to move has no
+        # place in it.
+        follow = _ApprovalsFollow("", False)
+        if "tool_approval_mode" in changed:
+            follow = self._follow_configured_approvals(change, announce=True)
+            if follow.kept:
+                live = [key for key in live if key != "tool_approval_mode"]
         parts: list[str] = []
         if live:
             # "applied:" leads rather than trailing as "— applied" (design
@@ -14536,9 +14574,12 @@ class OperatorApp(App[None]):
                 "is retired and does nothing" if len(retired) == 1 else "are retired and do nothing"
             )
             parts.append(f"{', '.join(retired)} {tail}")
-        if not parts:
-            # Only ``model`` keys moved: nothing this process can truthfully
-            # say, and the session's receipt is already on its way.
+        if not parts and not follow.clause:
+            # Only ``model`` keys moved, or the sole live key was the approval
+            # mode this listener just REFUSED to move: nothing this process can
+            # truthfully say, and the receipt that matters (the session's, or the
+            # keep notice) is already on its way. `follow.clause` is checked too
+            # so a lone loosening that DID apply still prints its value clause.
             return
         # The approval mode names its VALUE and raises the severity (design
         # review round 1, D2). "changed" is not actionable for a two-valued
@@ -14560,10 +14601,11 @@ class OperatorApp(App[None]):
             # the `model` section already follows above, and for the same
             # stated reason.
             #
-            # `tool_approval_mode` stays in the `applied:` key list either way:
-            # that clause is about WHICH KEYS moved, not about what the gate
-            # now does, so it does not duplicate the runtime's line.
-            spoken = self._follow_configured_approvals(change, announce=True)
+            # `tool_approval_mode` stays in the `applied:` key list whenever the
+            # gate MOVED — that clause is about WHICH KEYS moved, not about what
+            # the gate now does, so it does not duplicate the runtime's line. On
+            # the keep path it moved nothing and was dropped from `live` above.
+            spoken = follow.clause
             if spoken:
                 parts.append(spoken)
                 # Amber on the LOOSENING only (design round 1, D6). The house
@@ -14619,13 +14661,19 @@ class OperatorApp(App[None]):
                 except KeyError:
                     self._system_notice(f"theme: unknown theme {wanted!r} in config.yml", "warning")
 
-    def _follow_configured_approvals(self, change: Any, *, announce: bool) -> str:
+    def _follow_configured_approvals(self, change: Any, *, announce: bool) -> _ApprovalsFollow:
         """Move this app's gate to ``tool_approval_mode``. THE one apply path.
 
-        Returns the value clause the caller should add to its line, or ``""``
-        when this process has nothing to say — either because the mode did not
-        parse, or because the gate did not move, or because another process
-        owns the gate and its own receipt is already on its way.
+        Returns an :class:`_ApprovalsFollow`: the value clause the caller should
+        add to its line (``""`` when this process has nothing to say — the mode
+        did not parse, the gate did not move, or another process owns the gate
+        and its own receipt is already on its way), plus ``kept``, which is True
+        only on the KEEP path below.
+
+        The caller needs ``kept`` separately from the clause because both a
+        refusal and a silent success return no clause, and only the refusal must
+        strike ``tool_approval_mode`` from the ``applied:`` key list (design
+        round 2, D8).
 
         **The rule is asymmetric** (review round 1 R1, UX round 1 U1), and it
         is the same rule ``OwnedSessionHandle.follow_config`` applies, stated
@@ -14663,7 +14711,11 @@ class OperatorApp(App[None]):
             # A typo on disk is not "ask" by accident: the watcher only
             # delivers parseable files, so the safe answer is to keep the mode
             # in force rather than guess. Same policy as the runtime's.
-            return ""
+            #
+            # `kept=False`: nothing was refused on a human's behalf here, so the
+            # caller's `applied:` list is not this method's business — an
+            # unparseable value never reached the point of moving anything.
+            return _ApprovalsFollow("", False)
         wanted_auto = mode == "auto"
         # The SAVED default follows the file in every case, including the one
         # where the live gate does not: the file IS the saved default, and
@@ -14671,7 +14723,7 @@ class OperatorApp(App[None]):
         self._approvals_default_auto = wanted_auto
         if wanted_auto == self._approve_all:
             self._set_approve_all(self._approve_all)  # re-assert the band's `always` marker
-            return ""
+            return _ApprovalsFollow("", False)
         if announce and wanted_auto and self._explicit_approvals_mode == "ask":
             # Loosening against this pane's own deliberate hardening: keep the
             # gate. Shaped like the model half's keep notice — what is kept,
@@ -14679,13 +14731,23 @@ class OperatorApp(App[None]):
             #
             # `== "ask"` rather than a bare truth test (review round 2, R6):
             # only a typed `ask` is a hardening worth refusing the file for.
-            self._system_notice(
-                "keeping tool approvals: ask — set with /approvals in this session; "
-                "config.yml now says auto, /approvals auto adopts it",
-                "info",
-            )
+            #
+            # The NOTICE is gated on ownership for the same reason the value
+            # clause below is (design round 1 D1, extended to this branch by
+            # round 2 D8): with a runtime attached, both carriers hold the typed
+            # `ask`, both keep-branches fire on one poll, and the identical
+            # 118-character sentence printed twice in one viewport. The runtime
+            # owns the gate, so the runtime's keep notice is the one that speaks;
+            # this branch still returns `kept=True` because the local `applied:`
+            # list is this process's to correct either way.
+            if not self._gate_is_owned_elsewhere():
+                self._system_notice(
+                    "keeping tool approvals: ask — set with /approvals in this session; "
+                    "config.yml now says auto, /approvals auto adopts it",
+                    "info",
+                )
             self._set_approve_all(self._approve_all)
-            return ""
+            return _ApprovalsFollow("", True)
         if not announce:
             # A page write in this pane is a choice made here, so it REPLACES
             # whatever `/approvals` had recorded rather than being refused by
@@ -14705,11 +14767,11 @@ class OperatorApp(App[None]):
         if wanted_auto:
             self._note_approvals_on_parked_prompt()
         if not announce or self._gate_is_owned_elsewhere():
-            return ""
+            return _ApprovalsFollow("", False)
         return (
-            "tool approvals now auto — every tool runs without asking"
+            _ApprovalsFollow("tool approvals now auto — every tool runs without asking", False)
             if wanted_auto
-            else "tool approvals now ask — tools prompt before running"
+            else _ApprovalsFollow("tool approvals now ask — tools prompt before running", False)
         )
 
     def _gate_is_owned_elsewhere(self) -> bool:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2423,14 +2423,23 @@ class OperatorApp(App[None]):
         # gate armed, and will it still be tomorrow" — and the list, the band
         # and the bare report all have to answer both halves from the same pair.
         self._approvals_default_auto: bool = False
-        # True once the user has made a deliberate `/approvals` choice in THIS
-        # pane. Deliberately the same shape as `Session._explicit_model_choice`
-        # (and `OwnedSessionHandle._explicit_approvals_choice`, which is the
-        # authority whenever a runtime is attached), and the symmetry is the
-        # point: a config edit may not revoke a hardening a human typed here,
-        # exactly as it may not revoke an explicit `/model` pick. Consulted in
-        # the LOOSENING direction only — see `_follow_configured_approvals`.
-        self._explicit_approvals_choice: bool = False
+        # The mode the user typed with `/approvals` in THIS pane, or None.
+        # Deliberately the same shape as `Session._explicit_model_choice` (and
+        # `OwnedSessionHandle._explicit_approvals_mode`, which is the authority
+        # whenever a runtime is attached), and the symmetry is the point: a
+        # config edit may not revoke a hardening a human typed here, exactly as
+        # it may not revoke an explicit `/model` pick.
+        #
+        # Records WHICH mode, not merely THAT one was chosen (review round 2,
+        # R6): as a boolean, a pane whose human typed `/approvals auto` was
+        # pinned to `ask` permanently by a single file tightening, since the
+        # loosening guard read the flag as "the human chose ask".
+        #
+        # INVARIANT: non-None only while the gate in force is the mode a human
+        # typed here — `_follow_configured_approvals` clears it when a file
+        # write moves the gate, which is what keeps the keep notice's "set with
+        # /approvals in this session" true.
+        self._explicit_approvals_mode: str | None = None
         # Which TURN a stop belongs to, rather than a flag someone has to clear.
         # `_turn_epoch` counts turn boundaries; `_approvals_denied_epoch` records
         # the epoch a stop/teardown armed the deny latch in. An asker captures the
@@ -10763,10 +10772,10 @@ class OperatorApp(App[None]):
             if not problem:
                 self._approvals_default_auto = wanted_auto
         # The user typed the mode in this pane, so a later LOOSENING disk write
-        # leaves this gate alone (see `_follow_configured_approvals`). Recorded
-        # on both directions: the flag means "this pane has an owner's
-        # opinion", and only the loosening direction consults it.
-        self._explicit_approvals_choice = True
+        # leaves this gate alone (see `_follow_configured_approvals`). The MODE
+        # is recorded, not merely the fact of a choice (review round 2, R6):
+        # both directions are recorded, but only a recorded `ask` refuses a file.
+        self._explicit_approvals_mode = "auto" if wanted_auto else "ask"
         self._set_approve_all(wanted_auto)
         if problem:
             notice(problem, "warning")
@@ -14624,7 +14633,9 @@ class OperatorApp(App[None]):
 
         * tightening (``auto`` → ``ask``) follows the file unconditionally;
         * loosening (``ask`` → ``auto``) does not move a pane whose human typed
-          ``/approvals ask`` in it, and prints a keep notice instead;
+          ``/approvals ask`` in it, and prints a keep notice instead — the
+          CHOSEN MODE is what is consulted, so a pane whose human chose ``auto``
+          has no hardening to protect and still follows the file both ways;
         * a pane that never chose follows the file in both directions, which is
           the operator's "goes into effect for all my agents" case and is what
           this change exists to deliver.
@@ -14661,10 +14672,13 @@ class OperatorApp(App[None]):
         if wanted_auto == self._approve_all:
             self._set_approve_all(self._approve_all)  # re-assert the band's `always` marker
             return ""
-        if announce and wanted_auto and self._explicit_approvals_choice:
+        if announce and wanted_auto and self._explicit_approvals_mode == "ask":
             # Loosening against this pane's own deliberate hardening: keep the
             # gate. Shaped like the model half's keep notice — what is kept,
             # why, and the command that adopts the file.
+            #
+            # `== "ask"` rather than a bare truth test (review round 2, R6):
+            # only a typed `ask` is a hardening worth refusing the file for.
             self._system_notice(
                 "keeping tool approvals: ask — set with /approvals in this session; "
                 "config.yml now says auto, /approvals auto adopts it",
@@ -14677,7 +14691,14 @@ class OperatorApp(App[None]):
             # whatever `/approvals` had recorded rather than being refused by
             # it. Without this a pane that had typed `/approvals ask` could
             # never loosen itself from its own settings page.
-            self._explicit_approvals_choice = True
+            self._explicit_approvals_mode = "auto" if wanted_auto else "ask"
+        else:
+            # An ANOTHER-PROCESS write that reaches here is one that moves the
+            # gate, so the file now owns the value in force and a mode typed
+            # here earlier no longer describes it. Clearing is what makes the
+            # keep notice's "set with /approvals in this session" true rather
+            # than a claim about a value the file chose (review round 2, R6).
+            self._explicit_approvals_mode = None
         if not wanted_auto:
             self._allow_approvals_again()
         self._set_approve_all(wanted_auto)
@@ -22260,8 +22281,10 @@ class OperatorApp(App[None]):
         else:
             self._allow_approvals_again()
         # The user typed the mode here, so a later LOOSENING disk write leaves
-        # this pane's gate alone (see `_follow_configured_approvals`).
-        self._explicit_approvals_choice = True
+        # this pane's gate alone (see `_follow_configured_approvals`). The mode
+        # itself is recorded, so only a typed `ask` refuses a file loosening
+        # (review round 2, R6).
+        self._explicit_approvals_mode = "auto" if wanted_auto else "ask"
         self._set_approve_all(wanted_auto)
         if wanted_auto:
             return SlashResult(

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -5901,11 +5901,13 @@ class OperatorApp(App[None]):
         # Design review round 1 (D1) / QA round 2 (Q1) drove the real path and
         # proved the gap: an out-of-process write to `hosting` followed by
         # `/new` built with the OLD value. That was survivable while nothing
-        # said otherwise, but the config-change notice now tells the user in so
-        # many words that a NEW_SESSIONS key "takes effect on /new" — including
-        # `tool_approval_mode`, where believing it and being wrong is a safety
-        # problem. Making the promise true is the honest fix; wording around it
-        # would leave `/new` quietly serving stale settings.
+        # said otherwise, but the config-change notice tells the user in so
+        # many words that a NEW_SESSIONS key "takes effect on /new"
+        # (`local_providers` today; `tool_approval_mode` at the time, before
+        # it went LIVE). Making the promise true is the honest fix; wording
+        # around it would leave `/new` quietly serving stale settings — and the
+        # LIVE keys the factory also reads (`hosting`, `web_*.enabled`) must
+        # boot the new session on the current file too.
         # GUARDED, because that reload is destructive on a malformed file
         # (review round 3, B1). In production `_on_config_changed` is
         # `ConfigManager.reload` → `_load_config`, which RAISES on a non-mapping
@@ -5941,19 +5943,20 @@ class OperatorApp(App[None]):
     def _reload_config_for_new_session(self, notice: NoticeFn) -> None:
         """Adopt on-disk config for the session `/new` is about to build.
 
-        Two consumers, both of which `/new` must reach for its own notice to be
-        true, and neither of which the other covers:
+        Two consumers, neither of which the other covers:
 
         * the launch-time ``ConfigManager`` the session factory closed over —
-          `hosting`, `model_name`, `auto_save_conversation`, `web_*.enabled`;
+          `hosting`, `model_name`, `web_*.enabled` and the `local_providers`
+          block. The first three are LIVE now (a running session follows them
+          on the watcher poll), but the factory still reads them at build, so
+          a stale manager would boot the NEW session on values the old one
+          had already moved past;
         * the TUI's own approval gate, which is process state rather than
-          session state and is otherwise written only by
-          ``_load_approvals_default`` at mount (review round 3, Q3). Missing it
-          meant `tool_approval_mode` was the ONE key of the four whose "takes
-          effect on /new" promise was not kept — and the one where believing it
-          and being wrong is a safety problem, in both directions: a tightened
-          `auto → ask` left the new session auto-approving writes with no
-          prompt.
+          session state. ``_on_config_change`` now moves it on every disk
+          change (`tool_approval_mode` is LIVE), so this re-read is the
+          belt-and-braces for a write the watcher never delivered — a file
+          that was unreadable at the tick and fixed since (review round 3,
+          Q3 first found the gap, when the key was still build-time).
 
         Refuses the reload outright when the file on disk is not parseable,
         because `ConfigManager._load_config` would move it aside and continue
@@ -14368,15 +14371,24 @@ class OperatorApp(App[None]):
 
         For a change from another process, ONE notice per change listing the
         registry keys compactly, with the keys whose section is not LIVE named
-        separately as taking effect on ``/new`` — the honest answer for
-        ``tool_approval_mode``, which the design deliberately keeps
-        build-time. ``changed_keys`` is per registry key, so a write that only
-        bumped ``metadata.last_modified`` never reaches here and produces no
-        line. Then the two TUI-owned groups are applied: the display cache is
-        dropped so the next paint re-reads, and the theme is switched through
-        the same orchestrator ``/theme`` uses. An unknown theme name on disk is
-        reported rather than raised — a config bug should not take down the
-        listener.
+        separately as taking effect on ``/new`` or needing a relaunch.
+        ``changed_keys`` is per registry key, so a write that only bumped
+        ``metadata.last_modified`` never reaches here and produces no line.
+        Then the TUI-owned groups are applied: the display cache is dropped so
+        the next paint re-reads, the theme is switched through the same
+        orchestrator ``/theme`` uses, and the approval gate follows
+        ``tool_approval_mode`` through :meth:`_set_approve_all`. An unknown
+        theme name on disk is reported rather than raised — a config bug
+        should not take down the listener.
+
+        The ``model`` section is deliberately LEFT OUT of the line even though
+        it is LIVE. Whether ``hosting``/``model_name`` applied depends on a
+        rule only the SESSION can evaluate (config-sourced and no explicit
+        ``/model`` since boot — see ``Session._apply_config_change``), so an
+        "applied: model_name" printed here would be a claim this process
+        cannot back. The session's own receipt — the model-change repaint plus
+        its notice, or the keep notice — comes from the process that decided
+        and is the one the user should read.
         """
         if getattr(change, "source", "disk") == "local":
             return
@@ -14406,6 +14418,9 @@ class OperatorApp(App[None]):
             scope = scope_of.get(section) if section is not None else None
             if section == "retired":
                 retired.append(key)
+            elif section == "model":
+                # The session's receipt is the receipt (docstring above).
+                continue
             elif scope is settings_io.Scope.LIVE:
                 live.append(key)
             elif scope is settings_io.Scope.NEW_LAUNCH:
@@ -14438,6 +14453,10 @@ class OperatorApp(App[None]):
                 "is retired and does nothing" if len(retired) == 1 else "are retired and do nothing"
             )
             parts.append(f"{', '.join(retired)} {tail}")
+        if not parts:
+            # Only ``model`` keys moved: nothing this process can truthfully
+            # say, and the session's receipt is already on its way.
+            return
         # The approval mode names its VALUE and raises the severity (design
         # review round 1, D2). "changed" is not actionable for a two-valued
         # safety switch: the user in the other pane cannot tell whether
@@ -14456,13 +14475,25 @@ class OperatorApp(App[None]):
             elif mode == "ask":
                 parts.append("tool approvals now ask — tools prompt before running")
                 kind = "warning"
-            # The running session's gate deliberately does NOT move here: the
-            # key is NEW_SESSIONS and cell A4 of QA round 2 pins that. Only the
-            # cached default is refreshed, so a later bare `/approvals` reports
-            # what a new session would actually boot with instead of the value
-            # this process read at mount.
+            # The running gate FOLLOWS the disk (the key is LIVE): a disk
+            # write is the operator's machine-wide intent and overrides a
+            # per-session `/approvals` toggle — this reverses the A4 pin of QA
+            # round 2, which kept the gate build-time. Through
+            # `_set_approve_all`, the one writer of gate + band, so the band
+            # cannot say something the gate does not do. The cached default
+            # moves first so the band's `always` marker is computed against
+            # the new default. A prompt already on screen is NOT answered
+            # here: `_answer_live_approval_as_allowed` is the `/approvals
+            # auto` COMMAND's gesture, where the human typed the loosening in
+            # this very pane; a write from another process leaves the parked
+            # card for the human to decide. The deny latch IS released on a
+            # tightening, since "tools prompt again" is the promise printed.
             if mode in ("auto", "ask"):
-                self._approvals_default_auto = mode == "auto"
+                wanted_auto = mode == "auto"
+                self._approvals_default_auto = wanted_auto
+                if not wanted_auto:
+                    self._allow_approvals_again()
+                self._set_approve_all(wanted_auto)
         self._system_notice("config.yml changed: " + "; ".join(parts), kind)
 
         if any(key.startswith("display.") for key in changed):

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2423,6 +2423,14 @@ class OperatorApp(App[None]):
         # gate armed, and will it still be tomorrow" — and the list, the band
         # and the bare report all have to answer both halves from the same pair.
         self._approvals_default_auto: bool = False
+        # True once the user has made a deliberate `/approvals` choice in THIS
+        # pane. Deliberately the same shape as `Session._explicit_model_choice`
+        # (and `OwnedSessionHandle._explicit_approvals_choice`, which is the
+        # authority whenever a runtime is attached), and the symmetry is the
+        # point: a config edit may not revoke a hardening a human typed here,
+        # exactly as it may not revoke an explicit `/model` pick. Consulted in
+        # the LOOSENING direction only — see `_follow_configured_approvals`.
+        self._explicit_approvals_choice: bool = False
         # Which TURN a stop belongs to, rather than a flag someone has to clear.
         # `_turn_epoch` counts turn boundaries; `_approvals_denied_epoch` records
         # the epoch a stop/teardown armed the deny latch in. An asker captures the
@@ -10754,6 +10762,11 @@ class OperatorApp(App[None]):
             saved_to, problem = self._save_approvals_default(wanted_auto)
             if not problem:
                 self._approvals_default_auto = wanted_auto
+        # The user typed the mode in this pane, so a later LOOSENING disk write
+        # leaves this gate alone (see `_follow_configured_approvals`). Recorded
+        # on both directions: the flag means "this pane has an owner's
+        # opinion", and only the loosening direction consults it.
+        self._explicit_approvals_choice = True
         self._set_approve_all(wanted_auto)
         if problem:
             notice(problem, "warning")
@@ -10787,11 +10800,29 @@ class OperatorApp(App[None]):
         from a mode they last chose days ago, and nothing else on the screen
         would ever mention it.
 
+        The saved half is read from the FILE at report time, not from the
+        cached ``_approvals_default_auto`` (UX round 1, U1/U2). This is the one
+        surface whose job is "what is in effect and why", and with the
+        asymmetric rule a pane can now legitimately hold a mode the file
+        disagrees with — a ``/approvals ask`` this pane kept against a
+        machine-wide ``auto``. Comparing against a cache that had been moved in
+        the same tick as the gate made this function report a MATCHED PAIR for
+        exactly the state it exists to disclose, so the user had no surface
+        anywhere in the app that would admit the divergence.
+
+        The read goes through the watcher's last-good snapshot and never
+        constructs a ``ConfigManager``: doing that in a report path would give
+        printing a line the power to move a malformed config file aside (the
+        module docstring of ``config_watch``). With no watcher running the
+        cached default stands in — it is what this process last saw of the file
+        and is right in every case but the one this comment is about.
+
         The `warning` tint follows the LIVE mode, not the saved one: the tint
         answers "is the gate disarmed right now".
         """
         live = mode_word(self._approve_all)
-        saved = mode_word(self._approvals_default_auto)
+        on_disk = self._configured_approvals_mode()
+        saved = on_disk if on_disk is not None else mode_word(self._approvals_default_auto)
         effect = (
             "every tool runs without asking"
             if self._approve_all
@@ -10805,9 +10836,32 @@ class OperatorApp(App[None]):
             return
         notice(
             f"tool approvals: {live} (this session) — {effect}; "
-            f"new sessions open in {saved} — /approvals default {live} changes that",
+            f"config.yml says {saved} — /approvals default {live} changes that",
             "warning" if self._approve_all else "info",
         )
+
+    def _configured_approvals_mode(self) -> str | None:
+        """``tool_approval_mode`` as the WATCHER last read it, or ``None``.
+
+        The read-only half of the report above. ``None`` means "no watcher on
+        this process" (a test host, an embed) rather than "no value": the
+        caller falls back to its own cached default instead of inventing a
+        comparison against a file nobody is reading. Never constructs a
+        ``ConfigManager`` — see :meth:`_report_approvals` for why a report path
+        must not.
+        """
+        try:
+            from local_operator.config_watch import existing_watcher
+            from local_operator.paths import config_dir
+
+            watcher = existing_watcher(config_dir())
+            if watcher is None:
+                return None
+            mode = str(watcher.values.get("tool_approval_mode", "")).strip().lower()
+            return mode if mode in ("ask", "auto") else None
+        except Exception:  # noqa: BLE001 — a report must never take down the app
+            logger.debug("tool_approval_mode could not be read for the report", exc_info=True)
+            return None
 
     def _save_approvals_default(self, auto: bool) -> tuple[str, str]:
         """Write the boot default to config: ``(saved_to, problem)``.
@@ -14363,11 +14417,23 @@ class OperatorApp(App[None]):
         loop it was started on, and ``notify_local`` hops there), so widgets
         are touched directly without ``call_from_thread``.
 
-        ``source == "local"`` is silent and applies nothing: the page or the
-        command in THIS process already showed its own result and already
-        repainted (``_persist_theme`` follows ``_apply_theme``;
-        ``settings_io`` already dropped the display cache). Announcing it
-        again would be the line the user just read, twice.
+        ``source == "local"`` is SILENT but no longer inert (review round 1,
+        R1). The page or the command in THIS process already showed its own
+        result and already repainted (``_persist_theme`` follows
+        ``_apply_theme``; ``settings_io`` already dropped the display cache),
+        so announcing it again would be the line the user just read, twice —
+        that is what the local return was for, and the notice stays suppressed.
+        What it must NOT suppress is the APPLY. ``SettingsView._write`` goes
+        through ``settings_io.write_setting``, which notifies the watcher
+        locally, so a ``tool_approval_mode`` written on the ``/settings`` page
+        arrived here as the one delivery that moved nothing: the section is
+        labelled LIVE and its help promises every running session follows from
+        its next decision, and the page painted that claim while this pane's
+        own gate stayed where it was. Reproduced in review in the UNSAFE
+        direction — page set to ``ask``, ``request_tool_approval`` still
+        auto-approving a command tool with no prompt. A page write is also an
+        explicit user action in this pane, so it moves the gate in BOTH
+        directions.
 
         For a change from another process, ONE notice per change listing the
         registry keys compactly, with the keys whose section is not LIVE named
@@ -14390,10 +14456,18 @@ class OperatorApp(App[None]):
         its notice, or the keep notice — comes from the process that decided
         and is the one the user should read.
         """
-        if getattr(change, "source", "disk") == "local":
-            return
         changed = sorted(getattr(change, "changed_keys", ()))
         if not changed:
+            return
+        local = getattr(change, "source", "disk") == "local"
+        if local:
+            # Apply, do not announce. The only group whose apply this process
+            # owns and has not already performed is the approval gate: the
+            # theme and display caches are written by the same handlers that
+            # repainted, while `tool_approval_mode` reaches the gate through
+            # nothing but this listener.
+            if "tool_approval_mode" in changed:
+                self._follow_configured_approvals(change, announce=False)
             return
         from local_operator import settings_io
 
@@ -14467,33 +14541,54 @@ class OperatorApp(App[None]):
         # grey inverted the priority.
         kind = "info"
         if "tool_approval_mode" in changed:
-            values = getattr(change, "values", {})
-            mode = str(values.get("tool_approval_mode", "")).strip().lower()
-            if mode == "auto":
-                parts.append("tool approvals now auto — every tool runs without asking")
-                kind = "warning"
-            elif mode == "ask":
-                parts.append("tool approvals now ask — tools prompt before running")
-                kind = "warning"
-            # The running gate FOLLOWS the disk (the key is LIVE): a disk
-            # write is the operator's machine-wide intent and overrides a
-            # per-session `/approvals` toggle — this reverses the A4 pin of QA
-            # round 2, which kept the gate build-time. Through
-            # `_set_approve_all`, the one writer of gate + band, so the band
-            # cannot say something the gate does not do. The cached default
-            # moves first so the band's `always` marker is computed against
-            # the new default. A prompt already on screen is NOT answered
-            # here: `_answer_live_approval_as_allowed` is the `/approvals
-            # auto` COMMAND's gesture, where the human typed the loosening in
-            # this very pane; a write from another process leaves the parked
-            # card for the human to decide. The deny latch IS released on a
-            # tightening, since "tools prompt again" is the promise printed.
-            if mode in ("auto", "ask"):
-                wanted_auto = mode == "auto"
-                self._approvals_default_auto = wanted_auto
-                if not wanted_auto:
-                    self._allow_approvals_again()
-                self._set_approve_all(wanted_auto)
+            # ONE receipt per event, from the process that owns the gate
+            # (design round 1, D1). When a runtime is attached the gate lives
+            # there, `OwnedSessionHandle.follow_config` moves it and emits the
+            # accurate line, and a value clause here was a second sentence
+            # about one fact in a second vocabulary ("tool approvals now auto"
+            # over "tool approvals: auto") — read as two events, with the
+            # accurate one second and looking like an echo. Exactly the rule
+            # the `model` section already follows above, and for the same
+            # stated reason.
+            #
+            # `tool_approval_mode` stays in the `applied:` key list either way:
+            # that clause is about WHICH KEYS moved, not about what the gate
+            # now does, so it does not duplicate the runtime's line.
+            spoken = self._follow_configured_approvals(change, announce=True)
+            if spoken:
+                parts.append(spoken)
+                # Amber on the LOOSENING only (design round 1, D6). The house
+                # rule is `_report_approvals`' — "the tint answers 'is the gate
+                # disarmed right now'" — so `ask` is `info` and only `auto`
+                # earns the interrupt. A gate disarmed by a file the user did
+                # not touch, in a pane they were not looking at, is exactly the
+                # case that does. Painting `ask` amber here while the runtime
+                # sent `info` for the same transition put one event on screen
+                # with two urgency signals.
+                if "auto" in spoken:
+                    kind = "warning"
+        # The web switches name their VALUE too (UX round 1, U4). Both
+        # directions produced a byte-identical `applied: web_search.enabled`,
+        # so a user in another pane could not tell whether their agent had just
+        # lost web access or just gained it — the same reasoning that already
+        # made `tool_approval_mode` name its value, applied to another
+        # two-valued switch. "from your next turn" is the other half: the
+        # inventory reconciles at the turn boundary (`_reconcile_web_tools`),
+        # and nothing on screen mentioned that lag.
+        values = getattr(change, "values", {})
+        for key, label in (
+            ("web_search.enabled", "web search"),
+            ("web_fetch.enabled", "web fetch"),
+        ):
+            if key not in changed:
+                continue
+            block = values.get(key.split(".")[0])
+            enabled = bool(block.get("enabled", True)) if isinstance(block, Mapping) else True
+            parts.append(
+                f"{label} on — takes effect from your next turn"
+                if enabled
+                else f"{label} off — calls will be refused until it is turned back on"
+            )
         self._system_notice("config.yml changed: " + "; ".join(parts), kind)
 
         if any(key.startswith("display.") for key in changed):
@@ -14514,6 +14609,124 @@ class OperatorApp(App[None]):
                     self._apply_theme(wanted)
                 except KeyError:
                     self._system_notice(f"theme: unknown theme {wanted!r} in config.yml", "warning")
+
+    def _follow_configured_approvals(self, change: Any, *, announce: bool) -> str:
+        """Move this app's gate to ``tool_approval_mode``. THE one apply path.
+
+        Returns the value clause the caller should add to its line, or ``""``
+        when this process has nothing to say — either because the mode did not
+        parse, or because the gate did not move, or because another process
+        owns the gate and its own receipt is already on its way.
+
+        **The rule is asymmetric** (review round 1 R1, UX round 1 U1), and it
+        is the same rule ``OwnedSessionHandle.follow_config`` applies, stated
+        once there in full:
+
+        * tightening (``auto`` → ``ask``) follows the file unconditionally;
+        * loosening (``ask`` → ``auto``) does not move a pane whose human typed
+          ``/approvals ask`` in it, and prints a keep notice instead;
+        * a pane that never chose follows the file in both directions, which is
+          the operator's "goes into effect for all my agents" case and is what
+          this change exists to deliver.
+
+        A write from THIS process (``announce=False``, the ``/settings`` page)
+        applies with no notice at all: the page is its own receipt, and it is
+        also an explicit action IN this pane, so it moves the gate in both
+        directions and re-bases the explicit-choice flag rather than being
+        blocked by it.
+
+        Written through :meth:`_set_approve_all`, the one writer of gate and
+        band, so the band cannot say something the gate does not do; the cached
+        default moves FIRST so the band's ``always`` marker is computed against
+        the new default. A prompt already on screen is deliberately NOT answered
+        here — ``_answer_live_approval_as_allowed`` is the ``/approvals auto``
+        COMMAND's gesture, where the human typed the loosening in this very pane
+        — but it IS repainted with a note, so the frame stops saying "every tool
+        runs without asking" two lines above "the agent needs your approval"
+        (UX round 1, U6). The deny latch is released on a tightening, since
+        "tools prompt again" is the promise being printed.
+        """
+        values = getattr(change, "values", {})
+        mode = str(values.get("tool_approval_mode", "")).strip().lower()
+        if mode not in ("auto", "ask"):
+            # A typo on disk is not "ask" by accident: the watcher only
+            # delivers parseable files, so the safe answer is to keep the mode
+            # in force rather than guess. Same policy as the runtime's.
+            return ""
+        wanted_auto = mode == "auto"
+        # The SAVED default follows the file in every case, including the one
+        # where the live gate does not: the file IS the saved default, and
+        # `_report_approvals` needs the pair to be able to disagree.
+        self._approvals_default_auto = wanted_auto
+        if wanted_auto == self._approve_all:
+            self._set_approve_all(self._approve_all)  # re-assert the band's `always` marker
+            return ""
+        if announce and wanted_auto and self._explicit_approvals_choice:
+            # Loosening against this pane's own deliberate hardening: keep the
+            # gate. Shaped like the model half's keep notice — what is kept,
+            # why, and the command that adopts the file.
+            self._system_notice(
+                "keeping tool approvals: ask — set with /approvals in this session; "
+                "config.yml now says auto, /approvals auto adopts it",
+                "info",
+            )
+            self._set_approve_all(self._approve_all)
+            return ""
+        if not announce:
+            # A page write in this pane is a choice made here, so it REPLACES
+            # whatever `/approvals` had recorded rather than being refused by
+            # it. Without this a pane that had typed `/approvals ask` could
+            # never loosen itself from its own settings page.
+            self._explicit_approvals_choice = True
+        if not wanted_auto:
+            self._allow_approvals_again()
+        self._set_approve_all(wanted_auto)
+        if wanted_auto:
+            self._note_approvals_on_parked_prompt()
+        if not announce or self._gate_is_owned_elsewhere():
+            return ""
+        return (
+            "tool approvals now auto — every tool runs without asking"
+            if wanted_auto
+            else "tool approvals now ask — tools prompt before running"
+        )
+
+    def _gate_is_owned_elsewhere(self) -> bool:
+        """Whether an attached RUNTIME, not this app, owns the approval gate.
+
+        When it does, ``OwnedSessionHandle.follow_config`` moves the real gate
+        and emits the receipt every attached viewer and the phone already see,
+        so a second value clause from here is one event told twice (design
+        round 1, D1). This app's own ``_approve_all`` still tracks the mode —
+        it governs this process's widgets and the band — but it is not the
+        thing the engine consults, so it is not the thing that gets to speak.
+        """
+        return bool(getattr(self._session, "is_remote", False))
+
+    def _note_approvals_on_parked_prompt(self) -> None:
+        """Tell a card already on screen why it still asks (UX round 1, U6).
+
+        A loosening that lands while a prompt is parked leaves a frame that
+        contradicts itself: "every tool runs without asking" two lines above
+        "the agent needs your approval", with a visible ``Allow all — stop
+        asking for this session`` row describing a state the session is already
+        in. The card is deliberately not auto-answered (the human did not type
+        this loosening in this pane), so the fix is that the card SAYS so.
+
+        Best-effort by construction: a repaint is cosmetic, and a card that has
+        already settled or unmounted between the config tick and this call is
+        the ordinary race, not an error.
+        """
+        prompt = self._approval
+        if prompt is None or prompt.answered or not prompt.is_attached:
+            return
+        try:
+            prompt.set_note(
+                "config.yml set approvals to auto; this call still needs your "
+                "answer, later calls will not"
+            )
+        except Exception:  # noqa: BLE001 — a note is never worth a broken prompt
+            logger.debug("the parked approval card could not be annotated", exc_info=True)
 
     def _system_notice(self, body: str, kind: NoticeKind = "info") -> None:
         """A notice about the HARNESS that leaves the empty state intact.
@@ -20901,6 +21114,29 @@ class OperatorApp(App[None]):
         skill_note = Text()
         skill_note.append("$<skill>".ljust(name_width), style=muted)
         skill_note.append("runs a named skill on the rest of the line", style=dim)
+        # `/model saved` is documented here for the same reason as the rows
+        # above: nothing else durable advertises it. The command table's
+        # `/model` row is sized to 49 cells to stay whole at 80 columns and
+        # already spends its description on `PERSIST_HINT`, and the picker
+        # footer's budget is 43 cells against a 42-cell hint — so neither
+        # surface has room for a third verb.
+        #
+        # That was tolerable while the only mention was the bare-`/model`
+        # notice a user reads because they asked. It stopped being tolerable
+        # when the live-config keep notice started INSTRUCTING a user to type
+        # `/model saved` from a pane where they asked nothing: measured, the
+        # `/model` picker offers no `saved` row, `/model sav` completes to
+        # nothing, and `/help` did not name it either — so the instruction and
+        # every discovery surface disagreed (UX round 1, U5). `/help` is the
+        # surface reachable at any width and still there an hour in.
+        #
+        # MEASURED against the 74-cell ceiling this block documents above:
+        # `name_width` is 16 on the current registry and the description is 45,
+        # composing to 61.
+        model_saved_note = Text()
+        model_saved_note.append("/model saved".ljust(name_width), style=muted)
+        model_saved_note.append("switches back to the config.yml default", style=dim)
+        lines.append(model_saved_note)
         lines.append(copy_note)
         lines.append(copy_note_more)
         lines.append(paste_note)
@@ -21995,8 +22231,13 @@ class OperatorApp(App[None]):
                 style="warning",
             )
         else:
+            # Compared against the FILE, exactly as `_report_approvals` is and
+            # for the same reason (UX round 1, U1/U2): with the asymmetric rule
+            # a session can hold a mode the file disagrees with, and this is
+            # the surface a user asks.
             live = mode_word(self._approve_all)
-            saved = mode_word(self._approvals_default_auto)
+            on_disk = self._configured_approvals_mode()
+            saved = on_disk if on_disk is not None else mode_word(self._approvals_default_auto)
             effect = (
                 "every tool runs without asking"
                 if self._approve_all
@@ -22011,13 +22252,16 @@ class OperatorApp(App[None]):
             return SlashResult(
                 kind="notice",
                 text=f"tool approvals: {live} (this session) — {effect}; "
-                f"new sessions open in {saved} — /approvals default {live} changes that",
+                f"config.yml says {saved} — /approvals default {live} changes that",
                 style="warning" if self._approve_all else "info",
             )
         if wanted_auto:
             self._answer_live_approval_as_allowed()
         else:
             self._allow_approvals_again()
+        # The user typed the mode here, so a later LOOSENING disk write leaves
+        # this pane's gate alone (see `_follow_configured_approvals`).
+        self._explicit_approvals_choice = True
         self._set_approve_all(wanted_auto)
         if wanted_auto:
             return SlashResult(
@@ -23866,7 +24110,12 @@ class OperatorApp(App[None]):
         # empty and the splash is about to come back, so a preflight notice
         # must not land as a transcript row that the splash then sits on.
         if self._welcome_visible or self._welcome_pending:
-            self._announce_on_splash(message.text, message.kind)
+            # The emitter's own headline when it has one, rather than a blind
+            # 35-cell cut of the sentence (design round 1, D3). See
+            # `NoticeEvent.headline`.
+            self._announce_on_splash(
+                message.text, message.kind, headline=getattr(message, "headline", "") or None
+            )
             return
         self._append_block(NoticeBlock(message.text, message.kind))
 

--- a/local_operator/tui/events.py
+++ b/local_operator/tui/events.py
@@ -309,13 +309,19 @@ class PeerMessageDelivered(Message):
 class NoticePosted(Message):
     """A notice to surface in the transcript."""
 
-    def __init__(self, text: str, kind: NoticeKind) -> None:
+    def __init__(self, text: str, kind: NoticeKind, headline: str = "") -> None:
         super().__init__()
         self.text = text
         # Annotated, not inferred: pyright WIDENS a literal to ``str`` when it
         # infers an attribute's type from an assignment, which silently undid the
         # typing at the one hop that carries a kind across a thread boundary.
         self.kind: NoticeKind = kind
+        #: The emitter's SHORT glance for the boot toast, or "" for none. See
+        #: ``NoticeEvent.headline``: a toast with no headline falls through to a
+        #: blind cell cut that lands mid-phrase, and these notices are emitted
+        #: one process away, where the viewer could only recover a headline by
+        #: matching on prose.
+        self.headline = headline
 
 
 class CompactionStarted(Message):
@@ -715,7 +721,7 @@ class EventController:
             self._pending_tool_ends[event.tool_call_id] = event
 
     def _handle_notice(self, event: NoticeEvent) -> None:
-        self._post(NoticePosted(event.text, event.kind))
+        self._post(NoticePosted(event.text, event.kind, getattr(event, "headline", "") or ""))
 
     def _handle_wake_delivered(self, event: WakeDeliveredEvent) -> None:
         # No generation guard: a wake receipt is a state fact about the

--- a/local_operator/tui/widgets/approval.py
+++ b/local_operator/tui/widgets/approval.py
@@ -1088,6 +1088,49 @@ class ApprovalPrompt(AskPickerScreen):
         """The future the engine awaits. Resolved exactly once."""
         return self._future
 
+    def set_note(self, note: str) -> None:
+        """Append a one-line note to the QUESTION of a still-parked card.
+
+        Written into the question rather than as a new row (UX round 1, U6).
+        The card's row budget is allocated in a strict priority order
+        (``AskPickerScreen._allocate``) in which the question ranks above the
+        option rows and below only the footer, so a note carried there can
+        never be the line that sheds at a tight size — and a note that is the
+        first thing to disappear on a 16-row terminal is a note that is not
+        there. A new chrome row would also have to be bought from that same
+        budget, which is how the footer went missing in the first place.
+
+        The case this exists for: a ``config.yml`` loosening lands while this
+        card is parked. The card is deliberately NOT auto-answered — the human
+        did not type that loosening in this pane — but the frame then said
+        "every tool runs without asking" two lines above "the agent needs your
+        approval", with a visible ``Allow all — stop asking for this session``
+        row describing a state the session was already in. The note is what
+        makes the frame stop contradicting itself.
+
+        Joined with ``·`` on ONE logical line rather than with a newline:
+        ``wrap_cells`` splits on spaces alone, so an embedded newline would
+        travel inside a "word" and reach the terminal as a literal break the
+        row budget never counted. The separator is the one this card already
+        uses between a fact and its qualifier.
+
+        Idempotent on the same note, so a second config tick delivering the
+        same transition does not stack the sentence; a settled card is left
+        alone, since its question is a historical record by then.
+        """
+        if self._answer is not None or not note:
+            return
+        question = self._questions[0]
+        if question.question.endswith(note):
+            return
+        self._questions[0] = question.model_copy(
+            update={"question": f"{question.question}  ·  {strip_control_sequences(note)}"}
+        )
+        # The wrap cache is keyed on (row, width) and the question is not in the
+        # key, so the question's own wrap has to be invalidated by repainting.
+        self._invalidate_description_wraps()
+        self._repaint()
+
     @property
     def answered(self) -> bool:
         return self._answer is not None

--- a/local_operator/tui/widgets/settings_view.py
+++ b/local_operator/tui/widgets/settings_view.py
@@ -3247,8 +3247,24 @@ class SettingsView(Vertical):
             )
             for rung in rungs:
                 rendered = self._join_detail(rung)
-                if cell_len(rendered.plain) <= width or rung is rungs[-1]:
+                if cell_len(rendered.plain) <= width:
                     text.append_text(rendered)
+                    break
+                if rung is rungs[-1]:
+                    # THE LAST RUNG IS CUT, NOT EMITTED WHOLE (design round 1,
+                    # D2). The ladder sheds until only the help remains, and
+                    # there is nothing below that to shed — so a help string
+                    # longer than the footer used to be handed over intact for
+                    # `.settings-view-detail` (`height: 2`, no wrap) to clip.
+                    # That clip leaves NO mark: the Web fetch footer painted 73
+                    # cells of a 79-cell sentence and stopped dead on the word
+                    # "every", which is exactly the "half of a sentence cut
+                    # mid-clause reads as a rendering fault" this ladder exists
+                    # to prevent. Truncating here degrades the next overlong
+                    # string to a visible `…` instead. The copy fix is still
+                    # the real fix — this is the floor under it, so a future
+                    # long string is ugly rather than silently broken.
+                    text.append(truncate_cells(rendered.plain, width), style=rung[0][1])
                     break
         self._detail_text = text
         self._detail.update(text)

--- a/local_operator/web_fetch/tool.py
+++ b/local_operator/web_fetch/tool.py
@@ -320,9 +320,14 @@ async def _fetch_or_abort(coro, signal: AbortSignal | None):
 #: The refusal a call gets while ``web_fetch.enabled`` is false. Returned
 #: through ``run_fetch`` so ``web_fetch`` and ``read <url>`` refuse with one
 #: sentence, naming the key and the page that flips it.
+#
+# Names the KEY without its VALUE (design round 1, D4). The key is what the
+# user greps for in ``config.yml`` and it is what distinguishes a policy
+# refusal from a provider outage; ``: false`` only restates the condition the
+# user is already living through, and being hardcoded rather than read from the
+# value that triggered the refusal, it is the one fragment that can go stale.
 WEB_FETCH_DISABLED_MESSAGE = (
-    "web_fetch is disabled by config (web_fetch.enabled: false) — "
-    "turn it on in /settings › Web tools"
+    "web_fetch is disabled by config (web_fetch.enabled) — " "turn it on in /settings › Web tools"
 )
 
 
@@ -354,7 +359,17 @@ async def run_fetch(
     # with no createIf gate in front of them. "Disabled" now means no fetching
     # through any spelling; before, ``read https://…`` fetched regardless.
     if not settings.enabled:
-        return WEB_FETCH_DISABLED_MESSAGE, {"url": url, "cache": "miss"}, True
+        # NO details mapping (UX round 1, U3). ``tool_card`` turns any details
+        # carrying a ``url`` into a row reading ``Fetched: <url> · cache miss``,
+        # so the refusal card told the user a request had gone out and
+        # something downstream had refused it — for a call that never opened a
+        # connection. That misreport matters most on exactly this key:
+        # ``web_fetch.enabled: false`` is the switch a privacy- or
+        # airgap-minded user flips, and the card claimed the URL was fetched.
+        # ``web_search``'s refusal already returns no details and reads
+        # correctly; this matches it, so the card shows the refusal sentence
+        # and nothing else.
+        return WEB_FETCH_DISABLED_MESSAGE, {}, True
 
     try:
         normalized = normalize_url(url)

--- a/local_operator/web_fetch/tool.py
+++ b/local_operator/web_fetch/tool.py
@@ -317,6 +317,15 @@ async def _fetch_or_abort(coro, signal: AbortSignal | None):
         await asyncio.gather(fetch_task, abort_task, return_exceptions=True)
 
 
+#: The refusal a call gets while ``web_fetch.enabled`` is false. Returned
+#: through ``run_fetch`` so ``web_fetch`` and ``read <url>`` refuse with one
+#: sentence, naming the key and the page that flips it.
+WEB_FETCH_DISABLED_MESSAGE = (
+    "web_fetch is disabled by config (web_fetch.enabled: false) — "
+    "turn it on in /settings › Web tools"
+)
+
+
 async def run_fetch(
     url: str,
     *,
@@ -337,6 +346,15 @@ async def run_fetch(
     """
     manager = ConfigManager(config_dir())
     settings = load_fetch_settings(manager)
+    # The master switch is re-checked PER CALL, not only at inventory build.
+    # ``web_fetch.enabled`` is LIVE: a top-level session drops the tool from
+    # its schema at the next turn boundary, but a call the model already
+    # emitted, a subagent's spawn-time inventory, and — the case that made
+    # this line necessary — the ``read <url>`` sugar all reach this engine
+    # with no createIf gate in front of them. "Disabled" now means no fetching
+    # through any spelling; before, ``read https://…`` fetched regardless.
+    if not settings.enabled:
+        return WEB_FETCH_DISABLED_MESSAGE, {"url": url, "cache": "miss"}, True
 
     try:
         normalized = normalize_url(url)

--- a/local_operator/web_search/tool.py
+++ b/local_operator/web_search/tool.py
@@ -302,9 +302,14 @@ def _tavily_oauth_delegate(
 #: The refusal a call gets while ``web_search.enabled`` is false. Names the
 #: key and the page that flips it, so the model (and the human reading the
 #: card) can tell a policy refusal from a provider outage.
+#:
+#: The KEY without its VALUE (design round 1, D4). The key is the thing the
+#: user greps for in ``config.yml``; ``: false`` only restates the condition
+#: they are already living through, and being hardcoded rather than read from
+#: the value that triggered the refusal, it is the one fragment that can go
+#: stale. Kept byte-parallel with ``WEB_FETCH_DISABLED_MESSAGE``.
 WEB_SEARCH_DISABLED_MESSAGE = (
-    "web_search is disabled by config (web_search.enabled: false) — "
-    "turn it on in /settings › Web tools"
+    "web_search is disabled by config (web_search.enabled) — " "turn it on in /settings › Web tools"
 )
 
 

--- a/local_operator/web_search/tool.py
+++ b/local_operator/web_search/tool.py
@@ -299,6 +299,15 @@ def _tavily_oauth_delegate(
     return search
 
 
+#: The refusal a call gets while ``web_search.enabled`` is false. Names the
+#: key and the page that flips it, so the model (and the human reading the
+#: card) can tell a policy refusal from a provider outage.
+WEB_SEARCH_DISABLED_MESSAGE = (
+    "web_search is disabled by config (web_search.enabled: false) — "
+    "turn it on in /settings › Web tools"
+)
+
+
 async def execute_web_search(
     tool_call_id: str,
     args: dict[str, Any],
@@ -314,6 +323,15 @@ async def execute_web_search(
 
     manager = ConfigManager(config_dir())
     settings = load_search_settings(manager)
+    # The master switch is re-checked PER CALL, not only at inventory build.
+    # ``web_search.enabled`` is LIVE: a top-level session drops the tool from
+    # its schema at the next turn boundary, but the model may already hold a
+    # call against the old schema, and a subagent keeps its spawn inventory
+    # for its whole life — so this line is what makes "disabled" true from the
+    # moment the file changes. Same per-call manager the other knobs already
+    # use, so no new parse cost and no new malformed-file exposure.
+    if not settings.enabled:
+        return _result(tool_call_id, WEB_SEARCH_DISABLED_MESSAGE, error=True)
     credentials = CredentialManager(config_dir())
     service = WebSearchService(
         settings,

--- a/tests/unit/session/runtime/test_owned.py
+++ b/tests/unit/session/runtime/test_owned.py
@@ -1297,3 +1297,60 @@ async def test_dispose_cancels_a_grant_parked_on_a_browser(
     await handle.dispose()
     await asyncio.gather(*tasks, return_exceptions=True)
     assert tasks[0].cancelled() or tasks[0].done()
+
+
+@pytest.mark.asyncio
+async def test_model_saved_adopts_the_configured_default_on_a_runtime(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """``/model saved`` WORKS on a detached runtime (QA round 2, Q49).
+
+    ``OperatorApp`` intercepts ``saved`` before routing, so a local pane always
+    honoured it while this handler — the one serving a DETACHED runtime's
+    ``/model`` — saw a bare word with no ``/`` and answered the
+    ``<provider>/<model-id>`` usage error. That made the keep notice emitted by
+    this same change ("config.yml default changed, /model saved adopts it")
+    a dead end on the phone and on any viewer of a runtime-owned session, and
+    contradicted the ``/help`` text round 1's U5 added.
+    """
+    from local_operator.config import ConfigManager
+    from local_operator.session.frontend_state import SlashResult
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    manager = ConfigManager(tmp_path)
+    manager.set_config_value("hosting", "openai")
+    manager.set_config_value("model_name", "gpt-5")
+
+    handle, session = make_handle()
+    switched: list[tuple[str, str]] = []
+
+    async def _set_model(provider: str, model_id: str) -> str:
+        switched.append((provider, model_id))
+        session.model_label = f"{provider}/{model_id}"
+        return f"model: {session.model_label}"
+
+    # Substituted rather than run for real: `set_model` resolves provider
+    # metadata over the network, and what this pins is the ROUTING — that
+    # `saved` reaches the same mutation a `<provider>/<id>` switch does.
+    monkeypatch.setattr(handle, "set_model", _set_model)
+
+    result = await handle._model_slash(session, "saved", SlashResult)
+
+    assert switched == [("openai", "gpt-5")], result.text
+    assert "usage:" not in result.text
+    assert "openai/gpt-5" in result.text
+
+
+@pytest.mark.asyncio
+async def test_model_saved_with_no_configured_default_says_so(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """An empty config gets the app's own words, not a usage error: the two
+    surfaces must answer "there is nothing to go back to" identically."""
+    from local_operator.session.frontend_state import SlashResult
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    handle, session = make_handle()
+    result = await handle._model_slash(session, "saved", SlashResult)
+    assert "no boot default saved yet" in result.text
+    assert "/model default <provider>/<model-id>" in result.text

--- a/tests/unit/session/runtime/test_owned_approvals_live.py
+++ b/tests/unit/session/runtime/test_owned_approvals_live.py
@@ -162,7 +162,7 @@ async def test_a_tightening_follows_the_file_even_over_an_explicit_choice(tmp_pa
 
     handle._approvals_slash(session, "auto", SlashResult)
     assert handle._auto_approve is True
-    assert handle._explicit_approvals_choice is True
+    assert handle._explicit_approvals_mode == "auto"
     emitted.clear()
 
     _write_elsewhere(watcher.config_dir, "tool_approval_mode", "ask")
@@ -171,6 +171,27 @@ async def test_a_tightening_follows_the_file_even_over_an_explicit_choice(tmp_pa
     assert handle._auto_approve is False, "a tightening was refused; safety must always propagate"
     texts = [getattr(e, "text", "") for e in emitted]
     assert any("tool approvals: ask" in t and "config.yml changed" in t for t in texts), texts
+
+    # ...AND THE SESSION CAN STILL FOLLOW THE FILE BACK (review round 2, R6).
+    # The runtime half of the same regression: the only mode this human ever
+    # typed is `auto`, so there is no hardening for the loosening guard to
+    # protect, and a guard that read merely "this session chose something"
+    # pinned it to `ask` permanently. The FILE owns the value once it moves the
+    # gate, which is why the recorded mode is cleared — that is also what keeps
+    # the keep notice's "set with /approvals in this session" a true statement.
+    assert (
+        handle._explicit_approvals_mode is None
+    ), "a file write left the session claiming the human had typed the mode"
+    emitted.clear()
+    _write_elsewhere(watcher.config_dir, "tool_approval_mode", "auto")
+    watcher.poll_now()
+    await asyncio.sleep(0)
+    assert handle._auto_approve is True, (
+        "a session whose human only ever chose `auto` stayed pinned to `ask` after a "
+        "file tightening; no later file write could ever move it back (R6)"
+    )
+    texts = [getattr(e, "text", "") for e in emitted]
+    assert not any("keeping tool approvals" in t for t in texts), texts
     await handle.dispose()
 
 

--- a/tests/unit/session/runtime/test_owned_approvals_live.py
+++ b/tests/unit/session/runtime/test_owned_approvals_live.py
@@ -106,26 +106,123 @@ async def test_a_disk_write_tightens_the_gate_and_the_next_decision_parks(tmp_pa
 
 
 @pytest.mark.asyncio
-async def test_the_disk_overrides_a_per_session_approvals_toggle(tmp_path) -> None:
-    """A pane the operator put in ``ask`` with ``/approvals ask`` flips to
-    ``auto`` when the FILE says auto: the disk write is the machine-wide
-    intent, and the alternative makes "all my agents" false in exactly the
-    case the operator described. ``/approvals ask`` restores it in one step."""
-    handle, session, watcher, _emitted = _handle(tmp_path, auto_approve=False)
+async def test_a_loosening_does_not_revoke_an_explicit_per_session_ask(tmp_path) -> None:
+    """THE ASYMMETRIC RULE, loosening half (review R1, UX U1).
+
+    A human who typed ``/approvals ask`` in this session keeps that gate when
+    the FILE later says ``auto``, and reads a keep notice naming the way to
+    adopt the file. The operator asked for settings to REACH running sessions;
+    they did not ask for a file write to revoke a hardening a human typed into
+    a specific pane. This mirrors the model half of the same change
+    (``Session._explicit_model_choice`` and its ``keeping …`` notice) on the
+    more dangerous of the two keys.
+    """
+    handle, session, watcher, emitted = _handle(tmp_path, auto_approve=False)
 
     from local_operator.session.frontend_state import SlashResult
 
-    # /approvals auto in this session, then /approvals ask again — per-session.
-    handle._approvals_slash(session, "auto", SlashResult)
-    assert handle._auto_approve is True
     handle._approvals_slash(session, "ask", SlashResult)
     assert handle._auto_approve is False
+    emitted.clear()
+
+    _write_elsewhere(watcher.config_dir, "tool_approval_mode", "auto")
+    watcher.poll_now()
+    await asyncio.sleep(0)
+
+    assert handle._auto_approve is False, "a file write revoked a hardening the human typed"
+    # The gate really is still armed, not merely flagged: a decision parks.
+    parked = asyncio.ensure_future(handle._approval_gate("bash", "rm -rf build/"))
+    await asyncio.sleep(0)
+    assert handle._fold.projection.pending is not None
+    await handle.approval_answer(handle._fold.projection.pending.request_id, False, False)
+    assert await parked is False
+
+    texts = [getattr(e, "text", "") for e in emitted]
+    assert any(
+        "keeping tool approvals: ask" in t and "/approvals auto adopts it" in t for t in texts
+    ), texts
+    # And the named way out works in one step.
+    handle._approvals_slash(session, "auto", SlashResult)
+    assert handle._auto_approve is True
+    await handle.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_tightening_follows_the_file_even_over_an_explicit_choice(tmp_path) -> None:
+    """THE ASYMMETRIC RULE, tightening half. Safety propagates without
+    exception: a session that explicitly chose ``auto`` still follows the file
+    to ``ask``, because a user who ends up safer than they asked is never the
+    wrong surprise. This is the direction the rule does NOT make conditional."""
+    # File AND gate start at `auto`, so the disk write below is a real
+    # transition; the session's own `/approvals auto` is what records the
+    # explicit choice the tightening then has to override.
+    handle, session, watcher, emitted = _handle(tmp_path, auto_approve=True)
+
+    from local_operator.session.frontend_state import SlashResult
+
+    handle._approvals_slash(session, "auto", SlashResult)
+    assert handle._auto_approve is True
+    assert handle._explicit_approvals_choice is True
+    emitted.clear()
+
+    _write_elsewhere(watcher.config_dir, "tool_approval_mode", "ask")
+    watcher.poll_now()
+    await asyncio.sleep(0)
+    assert handle._auto_approve is False, "a tightening was refused; safety must always propagate"
+    texts = [getattr(e, "text", "") for e in emitted]
+    assert any("tool approvals: ask" in t and "config.yml changed" in t for t in texts), texts
+    await handle.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_session_that_never_chose_follows_the_file_in_both_directions(tmp_path) -> None:
+    """The operator's own case, unchanged: a pane nobody typed ``/approvals``
+    into is exactly the "goes into effect for all my agents" pane, and it
+    follows the file loosening AND tightening. The keep rule is scoped to a
+    deliberate in-session choice and must not leak into this path."""
+    handle, _session, watcher, _emitted = _handle(tmp_path, auto_approve=False)
 
     _write_elsewhere(watcher.config_dir, "tool_approval_mode", "auto")
     watcher.poll_now()
     assert handle._auto_approve is True
-    handle._approvals_slash(session, "ask", SlashResult)
+
+    _write_elsewhere(watcher.config_dir, "tool_approval_mode", "ask")
+    watcher.poll_now()
     assert handle._auto_approve is False
+    await handle.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_bare_approvals_reports_a_divergence_against_the_file(
+    tmp_path, monkeypatch
+) -> None:
+    """The reporting half (UX U1 step 3 / U2). With the asymmetric rule a
+    session can legitimately hold a mode the file disagrees with, so the one
+    surface whose job is "what is in effect and why" compares against the FILE
+    rather than a cached default — otherwise it reports a matched pair for
+    exactly the state it exists to disclose."""
+    handle, session, watcher, _emitted = _handle(tmp_path, auto_approve=False)
+
+    from local_operator.config_watch import process_watcher
+    from local_operator.session.frontend_state import SlashResult
+
+    # The report reads the REGISTERED watcher's last-good snapshot (never a
+    # fresh `ConfigManager`, which could move a malformed file aside from a
+    # print path) and resolves it through `paths.config_dir()`, so the env var
+    # has to name this scratch dir. `_handle`'s own bare watcher stays the one
+    # driving the gate; this one is what the REPORT reads.
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(watcher.config_dir))
+    registered = process_watcher(watcher.config_dir)
+
+    handle._approvals_slash(session, "ask", SlashResult)
+    _write_elsewhere(watcher.config_dir, "tool_approval_mode", "auto")
+    registered.poll_now()
+    watcher.poll_now()  # the gate's own watcher; the keep rule holds `ask`
+
+    reported = handle._approvals_slash(session, "", SlashResult)
+    text = getattr(reported, "text", "")
+    assert "tool approvals: ask (this session)" in text, text
+    assert "config.yml says auto" in text, text
     await handle.dispose()
 
 

--- a/tests/unit/session/runtime/test_owned_approvals_live.py
+++ b/tests/unit/session/runtime/test_owned_approvals_live.py
@@ -1,0 +1,194 @@
+"""``OwnedSessionHandle``'s approval gate follows ``tool_approval_mode`` live.
+
+The gate the RUNTIME's tools actually consult is ``_auto_approve`` on the
+handle (``_install_gates``), read per decision. ``follow_config`` hangs a
+listener on the process ``ConfigWatcher`` so a ``config.yml`` write from any
+process moves it within a poll — in both directions, overriding a per-session
+``/approvals`` toggle — while two limits hold: a card already PARKED is never
+auto-answered or auto-denied, and an explicit ``--yolo`` pin ignores the key.
+
+``poll_now()`` is the tick; nothing here waits on the clock.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from local_operator import settings_io
+from local_operator.config import ConfigManager
+from local_operator.config_watch import ConfigWatcher, _reset_for_tests
+from local_operator.session.runtime.owned import OwnedSessionHandle
+from tests.unit.session.runtime.test_owned import FakeSession
+
+
+@pytest.fixture(autouse=True)
+def _fresh_registry():
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+def _write_elsewhere(config_dir, key: str, value: Any) -> None:
+    """A write shaped like another process's: below the notify hook."""
+    setting = settings_io.resolve_key(key)
+    assert setting is not None, key
+    settings_io._store(ConfigManager(config_dir), setting.path, value)
+
+
+def _handle(
+    tmp_path, *, auto_approve: bool, pinned: bool = False
+) -> tuple[OwnedSessionHandle, FakeSession, ConfigWatcher, list[Any]]:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    ConfigManager(config_dir).set_config_value(
+        "tool_approval_mode", "auto" if auto_approve else "ask"
+    )
+    session = FakeSession()
+    emitted: list[Any] = []
+
+    async def _emit(event: object) -> None:
+        emitted.append(event)
+
+    session._emit = _emit
+    handle = OwnedSessionHandle(
+        session,
+        asyncio.get_running_loop(),
+        cwd=str(tmp_path),
+        auto_approve=auto_approve,
+        approval_pinned=pinned,
+    )
+    watcher = ConfigWatcher(config_dir)
+    handle.follow_config(watcher)
+    return handle, session, watcher, emitted
+
+
+@pytest.mark.asyncio
+async def test_a_disk_write_loosens_the_gate_at_the_next_decision(tmp_path) -> None:
+    handle, _session, watcher, emitted = _handle(tmp_path, auto_approve=False)
+    _write_elsewhere(watcher.config_dir, "tool_approval_mode", "auto")
+    change = watcher.poll_now()
+    assert change is not None and "tool_approval_mode" in change.changed_keys
+
+    assert handle._auto_approve is True
+    # The NEXT decision answers inline — no card parked.
+    assert await handle._approval_gate("bash", "rm -rf build/") is True
+    assert handle._fold.projection.pending is None
+    # The receipt comes from the process that owns the gate.
+    await asyncio.sleep(0)
+    texts = [getattr(e, "text", "") for e in emitted]
+    assert any("tool approvals: auto" in t and "config.yml changed" in t for t in texts), texts
+    assert [getattr(e, "kind", "") for e in emitted if "auto" in getattr(e, "text", "")] == [
+        "warning"
+    ]
+    await handle.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_disk_write_tightens_the_gate_and_the_next_decision_parks(tmp_path) -> None:
+    handle, _session, watcher, emitted = _handle(tmp_path, auto_approve=True)
+    _write_elsewhere(watcher.config_dir, "tool_approval_mode", "ask")
+    watcher.poll_now()
+
+    assert handle._auto_approve is False
+    pending = asyncio.ensure_future(handle._approval_gate("write", "a file"))
+    await asyncio.sleep(0)
+    assert handle._fold.projection.pending is not None, "the tightened gate did not park a card"
+    request_id = handle._fold.projection.pending.request_id
+    await handle.approval_answer(request_id, False, False)
+    assert await pending is False
+    await asyncio.sleep(0)
+    texts = [getattr(e, "text", "") for e in emitted]
+    assert any("tool approvals: ask" in t and "prompt again" in t for t in texts), texts
+    await handle.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_disk_overrides_a_per_session_approvals_toggle(tmp_path) -> None:
+    """A pane the operator put in ``ask`` with ``/approvals ask`` flips to
+    ``auto`` when the FILE says auto: the disk write is the machine-wide
+    intent, and the alternative makes "all my agents" false in exactly the
+    case the operator described. ``/approvals ask`` restores it in one step."""
+    handle, session, watcher, _emitted = _handle(tmp_path, auto_approve=False)
+
+    from local_operator.session.frontend_state import SlashResult
+
+    # /approvals auto in this session, then /approvals ask again — per-session.
+    handle._approvals_slash(session, "auto", SlashResult)
+    assert handle._auto_approve is True
+    handle._approvals_slash(session, "ask", SlashResult)
+    assert handle._auto_approve is False
+
+    _write_elsewhere(watcher.config_dir, "tool_approval_mode", "auto")
+    watcher.poll_now()
+    assert handle._auto_approve is True
+    handle._approvals_slash(session, "ask", SlashResult)
+    assert handle._auto_approve is False
+    await handle.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_parked_prompt_is_left_for_the_human(tmp_path) -> None:
+    """The gate reads the flag when a DECISION is made. A card already on
+    screen when the file loosens is neither auto-approved nor dismissed; a
+    card on screen when it tightens is not auto-denied. The human answers."""
+    handle, _session, watcher, _emitted = _handle(tmp_path, auto_approve=False)
+    parked = asyncio.ensure_future(handle._approval_gate("bash", "touch /tmp/x"))
+    await asyncio.sleep(0)
+    pending = handle._fold.projection.pending
+    assert pending is not None
+
+    _write_elsewhere(watcher.config_dir, "tool_approval_mode", "auto")
+    watcher.poll_now()
+    await asyncio.sleep(0)
+    assert handle._auto_approve is True
+    assert not parked.done(), "a loosening auto-answered a card the human was looking at"
+    assert handle._fold.projection.pending is not None
+    assert handle._fold.projection.pending.request_id == pending.request_id
+
+    # The human decides, and only then does the future settle.
+    await handle.approval_answer(pending.request_id, False, False)
+    assert await parked is False
+    # A brand-new decision after the human's answer follows the file.
+    assert await handle._approval_gate("bash", "next") is True
+    await handle.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_yolo_pin_ignores_the_key(tmp_path) -> None:
+    """``lop exec --control --yolo``: an explicit flag on this run outranks a
+    default in a file. Nothing moves, nothing is announced."""
+    handle, _session, watcher, emitted = _handle(tmp_path, auto_approve=True, pinned=True)
+    _write_elsewhere(watcher.config_dir, "tool_approval_mode", "ask")
+    watcher.poll_now()
+    assert handle._auto_approve is True
+    assert await handle._approval_gate("bash", "anything") is True
+    await asyncio.sleep(0)
+    assert emitted == []
+    await handle.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_no_op_write_and_an_unknown_mode_leave_the_gate_alone(tmp_path) -> None:
+    handle, _session, watcher, emitted = _handle(tmp_path, auto_approve=False)
+    _write_elsewhere(watcher.config_dir, "tool_approval_mode", "sometimes")
+    watcher.poll_now()
+    assert handle._auto_approve is False
+    await asyncio.sleep(0)
+    assert emitted == []
+    await handle.dispose()
+
+
+@pytest.mark.asyncio
+async def test_dispose_unsubscribes_and_follow_config_is_idempotent(tmp_path) -> None:
+    handle, _session, watcher, _emitted = _handle(tmp_path, auto_approve=False)
+    handle.follow_config(watcher)
+    assert len(watcher._listeners) == 1
+    await handle.dispose()
+    assert watcher._listeners == []
+    # A tick after dispose reaches nothing.
+    _write_elsewhere(watcher.config_dir, "tool_approval_mode", "auto")
+    watcher.poll_now()
+    assert handle._auto_approve is False

--- a/tests/unit/session/test_config_live.py
+++ b/tests/unit/session/test_config_live.py
@@ -17,6 +17,7 @@ Nothing here waits on the clock: ``poll_now()`` is the tick.
 
 from __future__ import annotations
 
+import inspect
 from typing import Any, cast
 
 import pytest
@@ -104,10 +105,27 @@ class RebindableStream:
 
 
 def make_session(tmp_path, stream, **kwargs) -> Session:
+    # Both web tools OFFERED at build, the way the factory builds a session on
+    # default config, so the ``web_*.enabled`` probes can observe a disable as
+    # the tool leaving the inventory at the next turn boundary.
+    from local_operator.harness.types import ToolContext
+    from local_operator.tools.registry import create_tools
+
+    tools = kwargs.pop(
+        "tools",
+        create_tools(
+            ToolContext(
+                cwd=str(tmp_path),
+                web_search_settings={"enabled": True},
+                web_fetch_settings={"enabled": True},
+            ),
+            enabled=("web_search", "web_fetch"),
+        ),
+    )
     return Session(
         model=MODEL,
         stream_fn=stream,
-        tools=[],
+        tools=tools,
         transcript=Transcript(tmp_path / "sess"),
         system_blocks_provider=lambda: ["stable"],
         **kwargs,
@@ -171,6 +189,38 @@ def compaction_of(session: Session) -> CompactionSettings:
     settings = session._compaction_settings
     assert isinstance(settings, CompactionSettings)
     return settings
+
+
+async def _settled_model(session: Session) -> ModelSpec:
+    """``session.model`` after the background model adopt has landed.
+
+    ``_apply_config_change`` spawns the switch (``build_model_spec`` may hit
+    the network for a real provider), so the observer AWAITS the session's
+    background tasks rather than the clock. The probe table's other observers
+    are sync; the live-apply test awaits whatever an observer returns.
+    """
+    import asyncio
+
+    pending = [task for task in session._background_tasks if not task.done()]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+    return session.model
+
+
+async def _settled_model_attr(session: Session, attr: str) -> Any:
+    return getattr(await _settled_model(session), attr)
+
+
+def _web_tool_offered(session: Session, name: str) -> bool:
+    """Whether ``name`` is in the inventory after the next turn-boundary reconcile.
+
+    Calls the same hook ``_run_turn`` calls, so the probe measures the real
+    path rather than the dirty flag. The probe value is ``False`` (disabled),
+    so the session under test must START with the tool offered — see
+    ``_web_session`` for how the table's session is built.
+    """
+    session._reconcile_web_tools()
+    return any(tool.name == name for tool in session._tools)
 
 
 # ---------------------------------------------------------------------------
@@ -298,11 +348,33 @@ LIVE_KEY_PROBES: dict[str, tuple[Any, Any]] = {
     "web_fetch.render_backend": ("stdlib", lambda s, w: _fetch_settings(w).render_backend),
     "web_fetch.enrich": (False, lambda s, w: _fetch_settings(w).enrich),
     "bash.shell": ("/opt/probe/bash", lambda s, w: _bash_shell(w)),
+    # -- model: the session's OWN spec, after the background adopt settles -----
+    # Observed on ``session.model``, not the snapshot: what makes these keys
+    # live is that a config-sourced session SWITCHES. ``model_name`` probes
+    # against the ``test`` provider the session boots on; ``hosting`` moves to
+    # ``openai`` with no ``model_name`` set, which exercises the
+    # default-model fallback and resolves from the static registry (verified
+    # with sockets blocked: ~4 ms, no network). The observer awaits the
+    # background adopt so the switch has landed before it reads.
+    "hosting": ("openai", lambda s, w: _settled_model_attr(s, "provider")),
+    "model_name": ("probe-model", lambda s, w: _settled_model_attr(s, "model_id")),
+    # -- web_tools: the inventory after the next turn boundary -----------------
+    # Observed through the SAME reconcile the turn start runs, on a session
+    # whose inventory starts with both tools, so a disable is seen as the tool
+    # leaving. The per-call gate inside the tools is covered separately.
+    "web_search.enabled": (False, lambda s, w: _web_tool_offered(s, "web_search")),
+    "web_fetch.enabled": (False, lambda s, w: _web_tool_offered(s, "web_fetch")),
 }
 
-#: LIVE sections whose keys have no session-side apply because the TUI owns
+#: LIVE sections whose keys have no session-side apply because a HOST owns
 #: them (``appearance``: ``OperatorApp._on_config_change`` applies
 #: ``display.*``/``tui.theme``; covered in the TUI suite).
+#:
+#: ``approvals`` is here because the approval MODE lives in the host's gate,
+#: not in the ``Session``: the runtime's ``OwnedSessionHandle._auto_approve``
+#: (``tests/unit/session/runtime/test_owned_approvals_live.py``) and the
+#: TUI's ``_approve_all`` (``tests/unit/tui/test_config_change_notice.py``).
+#: The session only holds whatever gate closure the host installed.
 #:
 #: ``runtime`` is here for the same reason and a sharper one: its keys are
 #: read at COMMAND time by the surface that acts on them, so there is no
@@ -313,7 +385,7 @@ LIVE_KEY_PROBES: dict[str, tuple[Any, Any]] = {
 #: moment a question parks — a different process from the ``Session`` this
 #: file drives. Both are covered where they live: the resume behaviour in the
 #: TUI suite, the gate policy in ``tests/unit/session/runtime/test_parked_gates.py``.
-TUI_OWNED_LIVE_SECTIONS = {"appearance", "runtime"}
+HOST_OWNED_LIVE_SECTIONS = {"appearance", "runtime", "approvals"}
 
 
 def _live_sections() -> set[str]:
@@ -336,21 +408,33 @@ async def test_a_write_from_another_process_reaches_the_running_session(
     # `ConfigManager`). Pointing the env at the watched directory is what makes
     # those probes read the file under test instead of the operator's real one.
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
-    ConfigManager(config_dir).set_config_value("hosting", "")  # a real file to diff against
+    # A real file to diff against. ``hosting`` is seeded to the session's own
+    # provider (``MODEL`` is ``test/m``) so the ``model_name`` probe exercises
+    # the common case — a bare ``model_name`` edit with ``hosting`` unchanged —
+    # and resolves to a provider that needs no network.
+    ConfigManager(config_dir).set_config_value("hosting", MODEL.provider)
 
     stream = RebindableStream(dict(ConfigManager(config_dir).get_config().values))
     session = make_session(tmp_path, stream, compaction_settings=CompactionSettings())
-    watcher = ConfigWatcher(config_dir)
+    # Through the process registry, not a bare ``ConfigWatcher``: the web-tool
+    # reconcile reads ``existing_watcher()`` for its snapshot, which is the
+    # contract the module docstring imposes on every listener-side consumer.
+    watcher = process_watcher(config_dir)
     subscribe(session, watcher)
+
+    async def observed() -> Any:
+        result = observe(session, watcher)
+        return await result if inspect.isawaitable(result) else result
+
     try:
-        before = observe(session, watcher)
+        before = await observed()
         assert before != value, f"{key}: the session already held the probe value"
 
         write_from_another_process(config_dir, key, value)
         change = watcher.poll_now()
 
         assert change is not None and key in change.changed_keys
-        assert observe(session, watcher) == value
+        assert await observed() == value
     finally:
         await session.dispose()
 
@@ -366,7 +450,7 @@ def test_every_live_section_is_exercised_and_every_probe_is_live() -> None:
     probed_sections = {
         cast(settings_io.Setting, settings_io.resolve_key(k)).section for k in LIVE_KEY_PROBES
     }
-    unprobed = live - probed_sections - TUI_OWNED_LIVE_SECTIONS
+    unprobed = live - probed_sections - HOST_OWNED_LIVE_SECTIONS
     assert not unprobed, f"LIVE sections with no live-apply probe: {sorted(unprobed)}"
     mislabelled = {
         k
@@ -386,9 +470,8 @@ def test_every_live_section_is_exercised_and_every_probe_is_live() -> None:
 #: legitimate. Kept explicit so the guard below fails by name on a new one
 #: rather than being widened silently.
 #:
-#: ``subagents.*`` cannot appear here — it is LIVE. ``web_*.enabled`` cannot
-#: either: the session must NOT react to them (the tool surface is build-time),
-#: which is the whole reason they were split into ``web_tools``.
+#: ``subagents.*`` and ``web_*.enabled`` cannot appear here — both are LIVE
+#: now, so the honesty test above covers them from the other direction.
 _NON_LIVE_KEYS_ALLOWED_TO_APPLY: dict[str, str] = {}
 
 
@@ -508,19 +591,34 @@ async def test_a_non_live_key_does_not_quietly_apply_to_a_running_session(tmp_pa
         await session.dispose()
 
 
-def test_the_deliberately_build_time_keys_stay_new_sessions() -> None:
-    """The design keeps these OUT of live on purpose; a future relabel must be
-    a decision, not a side effect of the section split."""
+def test_the_scope_of_every_reclassified_key_is_the_one_its_consumer_earns() -> None:
+    """The reversal of the original build-time design, pinned as a DECISION.
+
+    ``tool_approval_mode``, ``hosting``/``model_name`` and ``web_*.enabled``
+    were kept out of LIVE on purpose and are now IN it on purpose: the gate,
+    the model and the web tools all follow the file in a running session. A
+    future relabel in either direction must be a decision, not a side effect
+    of a section split. ``auto_save_conversation`` and ``session.cleanup.*``
+    go the other way — nothing reads them after process start, so the honest
+    label is NEW_LAUNCH, not the "new sessions" the old section claimed.
+    """
     scope_of = {s.name: s.scope for s in settings_io.SECTIONS}
-    for key in ("tool_approval_mode", "auto_save_conversation"):
+    for key, section in (
+        ("tool_approval_mode", "approvals"),
+        ("hosting", "model"),
+        ("model_name", "model"),
+        ("web_search.enabled", "web_tools"),
+        ("web_fetch.enabled", "web_tools"),
+    ):
         setting = settings_io.resolve_key(key)
         assert setting is not None
-        assert scope_of[setting.section] is settings_io.Scope.NEW_SESSIONS, key
-    for key in ("web_search.enabled", "web_fetch.enabled"):
+        assert setting.section == section, key
+        assert scope_of[section] is settings_io.Scope.LIVE, key
+    for key in ("auto_save_conversation", "session.cleanup.enabled"):
         setting = settings_io.resolve_key(key)
         assert setting is not None
-        assert setting.section == "web_tools"
-        assert scope_of["web_tools"] is settings_io.Scope.NEW_SESSIONS
+        assert setting.section == "session", key
+        assert scope_of["session"] is settings_io.Scope.NEW_LAUNCH, key
 
 
 # ---------------------------------------------------------------------------
@@ -711,3 +809,278 @@ async def test_a_subagent_follows_config_and_does_not_alias_its_parents_seed(
         await parent.dispose()
         assert watcher._listeners == []
         await watcher.stop()
+
+
+# ---------------------------------------------------------------------------
+# 9. The model rule: follow the file iff the file chose the model
+# ---------------------------------------------------------------------------
+
+
+#: Events captured per session by ``_capture_events``, keyed by id.
+_EVENTS: dict[int, list[Any]] = {}
+
+
+def _notices(session: Session) -> list[str]:
+    """Texts of every ``NoticeEvent`` the session emitted, via a real subscriber."""
+    return [getattr(e, "text", "") for e in _EVENTS[id(session)] if e.type == "notice"]
+
+
+def _capture_events(session: Session) -> None:
+    events: list[Any] = []
+    _EVENTS[id(session)] = events
+    session.subscribe(events.append)
+
+
+async def _settle(session: Session) -> None:
+    import asyncio
+
+    for _ in range(3):
+        pending = [t for t in session._background_tasks if not t.done()]
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_a_model_name_edit_alone_switches_a_config_sourced_session(
+    tmp_path, monkeypatch
+) -> None:
+    """The operator's exact report: ``/model default`` (or ``lop config edit
+    model_name``) in one pane printed "model_name needs a relaunch" in every
+    other. A bare ``model_name`` diff, ``hosting`` untouched, is the common
+    shape and must switch on its own — the pair is re-read as a whole."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+    ConfigManager(config_dir).set_config_value("hosting", MODEL.provider)
+    session = make_session(tmp_path, RebindableStream({}), compaction_settings=CompactionSettings())
+    _capture_events(session)
+    watcher = process_watcher(config_dir)
+    subscribe(session, watcher)
+    try:
+        write_from_another_process(config_dir, "model_name", "m-next")
+        change = watcher.poll_now()
+        assert change is not None and change.changed_keys == {"model_name"}
+        await _settle(session)
+        assert (session.model.provider, session.model.model_id) == ("test", "m-next")
+        # The receipt names both ends and the cause, and comes from the session.
+        assert any("test/m → test/m-next" in n and "config.yml" in n for n in _notices(session))
+        # Adopting the file is not the user choosing: a SECOND edit applies too.
+        write_from_another_process(config_dir, "model_name", "m-after")
+        watcher.poll_now()
+        await _settle(session)
+        assert session.model.model_id == "m-after"
+        # And the boot selector re-based, so the journal row for this switch is
+        # skipped on resume (the new default IS the boot).
+        assert session._boot_selector == "test/m-after"
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_an_explicit_model_choice_keeps_its_model_and_says_so(tmp_path, monkeypatch) -> None:
+    """A session the user pointed somewhere with ``/model`` is not moved by a
+    default edit; it prints the keep notice naming ``/model saved``."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+    ConfigManager(config_dir).set_config_value("hosting", MODEL.provider)
+    session = make_session(tmp_path, RebindableStream({}), compaction_settings=CompactionSettings())
+    _capture_events(session)
+    watcher = process_watcher(config_dir)
+    subscribe(session, watcher)
+    try:
+        session.set_model(MODEL.model_copy(update={"model_id": "chosen"}), explicit=True)
+        assert session._explicit_model_choice is True
+
+        write_from_another_process(config_dir, "model_name", "m-next")
+        watcher.poll_now()
+        await _settle(session)
+        assert session.model.model_id == "chosen"
+        keep = [n for n in _notices(session) if "keeping test/chosen" in n]
+        assert keep and "chosen with /model" in keep[0] and "/model saved" in keep[0], _notices(
+            session
+        )
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("source, phrase", [("agent", "an agent profile"), ("flag", "a flag")])
+async def test_an_agent_or_flag_sourced_session_gets_a_notice_only(
+    tmp_path, monkeypatch, source: str, phrase: str
+) -> None:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+    ConfigManager(config_dir).set_config_value("hosting", MODEL.provider)
+    session = make_session(
+        tmp_path,
+        RebindableStream({}),
+        compaction_settings=CompactionSettings(),
+        model_source=source,
+    )
+    _capture_events(session)
+    watcher = process_watcher(config_dir)
+    subscribe(session, watcher)
+    try:
+        write_from_another_process(config_dir, "model_name", "m-next")
+        watcher.poll_now()
+        await _settle(session)
+        assert session.model.model_id == "m"
+        assert any(phrase in n and "keeping test/m" in n for n in _notices(session)), _notices(
+            session
+        )
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_child_session_never_follows_the_default_model(tmp_path, monkeypatch) -> None:
+    """Silent, not even a notice: the child's spec was chosen at spawn and a
+    review child losing its cache prefix mid-task is pure cost."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+    ConfigManager(config_dir).set_config_value("hosting", MODEL.provider)
+    session = make_session(
+        tmp_path,
+        RebindableStream({}),
+        compaction_settings=CompactionSettings(),
+        job_id="job-1",
+        model_source="child",
+    )
+    _capture_events(session)
+    watcher = process_watcher(config_dir)
+    subscribe(session, watcher)
+    try:
+        write_from_another_process(config_dir, "model_name", "m-next")
+        watcher.poll_now()
+        await _settle(session)
+        assert session.model.model_id == "m"
+        assert _notices(session) == []
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_provider_in_config_warns_and_does_not_switch(
+    tmp_path, monkeypatch
+) -> None:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+    ConfigManager(config_dir).set_config_value("hosting", MODEL.provider)
+    session = make_session(tmp_path, RebindableStream({}), compaction_settings=CompactionSettings())
+    _capture_events(session)
+    watcher = process_watcher(config_dir)
+    subscribe(session, watcher)
+    try:
+        write_from_another_process(config_dir, "hosting", "no-such-provider")
+        watcher.poll_now()
+        await _settle(session)
+        assert (session.model.provider, session.model.model_id) == ("test", "m")
+        warnings = [
+            e
+            for e in _EVENTS[id(session)]
+            if e.type == "notice" and getattr(e, "kind", "") == "warning"
+        ]
+        assert warnings and "unknown provider 'no-such-provider'" in warnings[0].text
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_writing_pane_is_a_no_op(tmp_path, monkeypatch) -> None:
+    """``/model default p/id`` in THIS session: the runtime already switched
+    (explicit) and the disk change names the model it is on. No receipt owed
+    — the `/model default` receipt was it — and no journal churn."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+    ConfigManager(config_dir).set_config_value("hosting", MODEL.provider)
+    session = make_session(tmp_path, RebindableStream({}), compaction_settings=CompactionSettings())
+    _capture_events(session)
+    watcher = process_watcher(config_dir)
+    subscribe(session, watcher)
+    try:
+        write_from_another_process(config_dir, "model_name", "m")
+        change = watcher.poll_now()
+        assert change is not None
+        await _settle(session)
+        assert session.model.model_id == "m"
+        assert _notices(session) == []
+    finally:
+        await session.dispose()
+
+
+# ---------------------------------------------------------------------------
+# 10. Web tools: inventory at the turn boundary, never mid-turn
+# ---------------------------------------------------------------------------
+
+
+def _offered(session: Session) -> set[str]:
+    return {t.name for t in session._tools}
+
+
+@pytest.mark.asyncio
+async def test_web_tools_leave_and_return_at_the_turn_boundary(tmp_path, monkeypatch) -> None:
+    """The tick only marks dirty; the inventory moves when the next turn
+    starts (``_reconcile_web_tools`` is what ``_run_turn`` calls). Both
+    directions, and a re-enabled tool comes back through the same createIf
+    builder the factory used."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+    ConfigManager(config_dir).set_config_value("hosting", "")
+    session = make_session(tmp_path, RebindableStream({}), compaction_settings=CompactionSettings())
+    watcher = process_watcher(config_dir)
+    subscribe(session, watcher)
+    try:
+        assert {"web_search", "web_fetch"} <= _offered(session)
+
+        write_from_another_process(config_dir, "web_search.enabled", False)
+        watcher.poll_now()
+        # Mid-turn view: still offered (a call already emitted must not 404).
+        assert "web_search" in _offered(session)
+        assert session._web_tools_dirty is True
+
+        session._reconcile_web_tools()
+        assert "web_search" not in _offered(session)
+        assert "web_fetch" in _offered(session)
+        assert session._web_tools_dirty is False
+
+        write_from_another_process(config_dir, "web_search.enabled", True)
+        write_from_another_process(config_dir, "web_fetch.enabled", False)
+        watcher.poll_now()
+        session._reconcile_web_tools()
+        assert "web_search" in _offered(session)
+        assert "web_fetch" not in _offered(session)
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_child_keeps_its_spawn_inventory(tmp_path, monkeypatch) -> None:
+    """Per-call gate only for a child: no dirty mark, no reconcile."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+    ConfigManager(config_dir).set_config_value("hosting", "")
+    session = make_session(
+        tmp_path,
+        RebindableStream({}),
+        compaction_settings=CompactionSettings(),
+        job_id="job-1",
+        model_source="child",
+    )
+    watcher = process_watcher(config_dir)
+    subscribe(session, watcher)
+    try:
+        write_from_another_process(config_dir, "web_search.enabled", False)
+        watcher.poll_now()
+        assert session._web_tools_dirty is False
+        session._reconcile_web_tools()
+        assert "web_search" in _offered(session)
+    finally:
+        await session.dispose()

--- a/tests/unit/session/test_config_live.py
+++ b/tests/unit/session/test_config_live.py
@@ -1084,3 +1084,219 @@ async def test_a_child_keeps_its_spawn_inventory(tmp_path, monkeypatch) -> None:
         assert "web_search" in _offered(session)
     finally:
         await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_model_choice_during_a_parked_adopt_is_not_undone(tmp_path, monkeypatch) -> None:
+    """Review round 1, R2 — the race, reproduced and closed.
+
+    ``_adopt_configured_model`` awaits ``build_model_spec`` on a thread (it may
+    fetch a provider listing), and on return re-checked only ``_disposed``. A
+    ``/model`` choice made inside that window was silently undone AND
+    ``_explicit_model_choice`` was reset to ``False``, which disabled the keep
+    rule for every LATER edit — so one race cost the user their pick and their
+    protection from the next edit too.
+
+    The spec build is held open here so the window is deterministic rather than
+    timing-dependent.
+    """
+    import asyncio
+
+    from local_operator.model import configure as configure_mod
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+    ConfigManager(config_dir).set_config_value("hosting", MODEL.provider)
+    session = make_session(tmp_path, RebindableStream({}), compaction_settings=CompactionSettings())
+    _capture_events(session)
+    watcher = process_watcher(config_dir)
+    subscribe(session, watcher)
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    def _slow_build(hosting: str, model_id: str, *a, **k):
+        # Runs on the thread `to_thread` put it on; hop back to signal.
+        loop.call_soon_threadsafe(entered.set)
+        asyncio.run_coroutine_threadsafe(_wait_release(), loop).result(timeout=5)
+        return MODEL.model_copy(update={"provider": hosting, "model_id": model_id})
+
+    async def _wait_release() -> None:
+        await release.wait()
+
+    monkeypatch.setattr(configure_mod, "build_model_spec", _slow_build)
+    try:
+        write_from_another_process(config_dir, "model_name", "m-from-config")
+        watcher.poll_now()
+        await asyncio.wait_for(entered.wait(), timeout=5)
+
+        # The user chooses WHILE the adopt is parked on its thread hop.
+        session.set_model(MODEL.model_copy(update={"model_id": "m-user-chose"}), explicit=True)
+        assert session._explicit_model_choice is True
+
+        release.set()
+        await _settle(session)
+
+        assert (
+            session.model.model_id == "m-user-chose"
+        ), "a parked adopt landed a stale spec over a newer explicit /model choice"
+        assert session._explicit_model_choice is True, (
+            "the adopt cleared _explicit_model_choice, disabling the keep rule "
+            "for every later config edit"
+        )
+        # The abandon is silent: no receipt for a switch that did not happen.
+        assert not [n for n in _notices(session) if "m-from-config" in n], _notices(session)
+
+        # And the keep rule really is still in force for the NEXT edit.
+        write_from_another_process(config_dir, "model_name", "m-later")
+        watcher.poll_now()
+        await _settle(session)
+        assert session.model.model_id == "m-user-chose"
+    finally:
+        release.set()
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_newer_config_edit_wins_over_an_in_flight_adopt(tmp_path, monkeypatch) -> None:
+    """R2, second half. Two edits arriving inside one ``build_model_spec``
+    used to be two tasks with no ordering — last writer wins, which is
+    whichever thread happened to finish, not whichever edit the operator made
+    last. The generation guard makes the NEWER edit the one that lands."""
+    import asyncio
+
+    from local_operator.model import configure as configure_mod
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+    ConfigManager(config_dir).set_config_value("hosting", MODEL.provider)
+    session = make_session(tmp_path, RebindableStream({}), compaction_settings=CompactionSettings())
+    _capture_events(session)
+    watcher = process_watcher(config_dir)
+    subscribe(session, watcher)
+
+    entered_first = asyncio.Event()
+    release = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    seen: list[str] = []
+
+    def _build(hosting: str, model_id: str, *a, **k):
+        seen.append(model_id)
+        if model_id == "m-first":
+            loop.call_soon_threadsafe(entered_first.set)
+            asyncio.run_coroutine_threadsafe(_wait_release(), loop).result(timeout=5)
+        return MODEL.model_copy(update={"provider": hosting, "model_id": model_id})
+
+    async def _wait_release() -> None:
+        await release.wait()
+
+    monkeypatch.setattr(configure_mod, "build_model_spec", _build)
+    try:
+        write_from_another_process(config_dir, "model_name", "m-first")
+        watcher.poll_now()
+        await asyncio.wait_for(entered_first.wait(), timeout=5)
+
+        # A SECOND edit lands while the first is still resolving.
+        write_from_another_process(config_dir, "model_name", "m-second")
+        watcher.poll_now()
+        release.set()
+        await _settle(session)
+
+        assert "m-second" in seen, seen
+        assert (
+            session.model.model_id == "m-second"
+        ), "the older in-flight adopt overwrote the newer edit"
+    finally:
+        release.set()
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_lost_reconcile_is_retried_at_the_next_turn_boundary(tmp_path, monkeypatch) -> None:
+    """Review round 1, R5. The dirty flag was cleared BEFORE the work, so a
+    pass that returned early (no watcher) or raised dropped the pending
+    reconcile — leaving the inventory out of line with a file that had already
+    changed until the operator edited the key a second time."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+    session = make_session(tmp_path, RebindableStream({}), compaction_settings=CompactionSettings())
+    watcher = process_watcher(config_dir)
+    subscribe(session, watcher)
+    try:
+        write_from_another_process(config_dir, "web_search.enabled", False)
+        watcher.poll_now()
+        assert session._web_tools_dirty is True
+
+        # A pass that cannot do the work must not consume the flag. Patched
+        # and restored by hand rather than through `monkeypatch.undo()`, which
+        # would also revert the LOCAL_OPERATOR_CONFIG_DIR this test runs in.
+        import local_operator.config_watch as watch_mod
+
+        real_existing = watch_mod.existing_watcher
+        watch_mod.existing_watcher = lambda *_a, **_k: None  # type: ignore[assignment]
+        try:
+            session._reconcile_web_tools()
+        finally:
+            watch_mod.existing_watcher = real_existing  # type: ignore[assignment]
+        assert session._web_tools_dirty is True, (
+            "an early return consumed the dirty flag; the reconcile is lost until "
+            "the operator edits the key again"
+        )
+
+        # The next boundary, with the watcher reachable, does the work and
+        # only then clears it.
+        session._reconcile_web_tools()
+        assert session._web_tools_dirty is False
+        assert "web_search" not in {t.name for t in session._tools}
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_re_enabled_web_tool_returns_to_its_registry_position(
+    tmp_path, monkeypatch
+) -> None:
+    """Review round 1, R4. The tools array rides in the same prompt-cache
+    prefix as the system prompt and ``tools/registry.py`` builds it in a stable
+    order precisely so that prefix stays cache-stable (AGENTS.md, "the
+    tool-surface footprint ladder"). A re-enabled tool appended to the END
+    costs a prefix miss on every later call of the session."""
+    from local_operator.tools.registry import DEFAULT_TOOL_NAMES
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+    session = make_session(tmp_path, RebindableStream({}), compaction_settings=CompactionSettings())
+    watcher = process_watcher(config_dir)
+    subscribe(session, watcher)
+    try:
+        before = [t.name for t in session._tools]
+        assert "web_search" in before
+
+        write_from_another_process(config_dir, "web_search.enabled", False)
+        watcher.poll_now()
+        session._reconcile_web_tools()
+        assert "web_search" not in {t.name for t in session._tools}
+
+        write_from_another_process(config_dir, "web_search.enabled", True)
+        watcher.poll_now()
+        session._reconcile_web_tools()
+
+        after = [t.name for t in session._tools]
+        assert after == before, f"the cycle reordered the inventory: {before} -> {after}"
+        # And specifically at its REGISTRY position relative to its web sibling
+        # — measured in review, the append landed it dead last:
+        # `['web_fetch','task',…,'web_search']`. Compared against `web_fetch`
+        # rather than against the whole array because a session's inventory is
+        # not globally registry-ordered to begin with (the capability tools are
+        # merged in afterwards by `_merge_capability_tools`), so a whole-array
+        # sortedness assertion would pin something this code never promised.
+        assert DEFAULT_TOOL_NAMES.index("web_search") < DEFAULT_TOOL_NAMES.index("web_fetch")
+        assert after.index("web_search") < after.index("web_fetch"), after
+        assert after[-1] != "web_search", "the re-enabled tool was appended"
+    finally:
+        await session.dispose()

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -178,11 +178,16 @@ def test_resolve_precedence_config_fallback() -> None:
     assert resolve_hosting_model(None, _args(), config) == ("kimi", "moonshot-v1-8k")
 
 
-def test_resolve_with_source_names_where_the_hosting_came_from() -> None:
+def test_resolve_with_source_names_what_chose_the_run() -> None:
     """The third element decides whether a running session later FOLLOWS a
-    ``hosting``/``model_name`` edit (config-sourced only). Keyed on the hosting's
-    source: a model name from config under a flagged hosting is still a flag
-    run, and a model name from a flag under a config hosting is still config."""
+    ``hosting``/``model_name`` edit (config-sourced only).
+
+    Keyed on EITHER field of the pair (review round 1, R3). Naming the model is
+    choosing just as much as naming the hosting is: ``cli.py`` registers
+    ``--model`` independently of ``--hosting``, so ``lop exec --model <pinned>``
+    is a reachable spelling, and keyed on the hosting alone it classified
+    ``config`` — letting another pane's ``/model default`` move a run off the
+    model a flag had explicitly pinned."""
     from local_operator.session_factory import resolve_hosting_model_with_source
 
     agent = cast("AgentData", SimpleNamespace(hosting="anthropic", model="claude"))
@@ -200,16 +205,46 @@ def test_resolve_with_source_names_where_the_hosting_came_from() -> None:
         "moonshot-v1-8k",
         "flag",
     )
+    # The R3 case: `--model` with no `--hosting` is flag-chosen, not config.
     assert resolve_hosting_model_with_source(None, _args(model="other"), config) == (
         "kimi",
         "other",
-        "config",
+        "flag",
+    )
+    # An agent record naming only the model is agent-chosen, for the same
+    # reason and by the same precedence.
+    model_only_agent = cast("AgentData", SimpleNamespace(hosting=None, model="claude"))
+    assert resolve_hosting_model_with_source(model_only_agent, _args(), config) == (
+        "kimi",
+        "claude",
+        "agent",
     )
     assert resolve_hosting_model_with_source(None, _args(), config) == (
         "kimi",
         "moonshot-v1-8k",
         "config",
     )
+
+
+def test_an_unknown_hosting_still_names_where_the_HOSTING_came_from() -> None:
+    """The returned source widened for R3; the REPAIR PROMPT's did not.
+
+    ``HostingUnknownError.source`` picks the sentence that tells the user where
+    the bad value lives ("in your configuration" / "passed with --hosting"), so
+    it stays keyed on the hosting fields alone. Widened along with the model
+    source, ``--model gpt-5`` over a config hosting with a typo in it would
+    report that typo as having been passed on a flag the user never typed —
+    pointing the repair at the wrong file."""
+    from local_operator.session_factory import (
+        HostingUnknownError,
+        resolve_hosting_model_with_source,
+    )
+
+    config = cast("ConfigManager", FakeConfigManager({"hosting": "nosuchprovider"}))
+    with pytest.raises(HostingUnknownError) as caught:
+        resolve_hosting_model_with_source(None, _args(model="gpt-5"), config)
+    assert caught.value.source == "config"
+    assert "in your configuration" in str(caught.value)
 
 
 def test_resolve_missing_values_raise_legacy_messages() -> None:

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -178,6 +178,40 @@ def test_resolve_precedence_config_fallback() -> None:
     assert resolve_hosting_model(None, _args(), config) == ("kimi", "moonshot-v1-8k")
 
 
+def test_resolve_with_source_names_where_the_hosting_came_from() -> None:
+    """The third element decides whether a running session later FOLLOWS a
+    ``hosting``/``model_name`` edit (config-sourced only). Keyed on the hosting's
+    source: a model name from config under a flagged hosting is still a flag
+    run, and a model name from a flag under a config hosting is still config."""
+    from local_operator.session_factory import resolve_hosting_model_with_source
+
+    agent = cast("AgentData", SimpleNamespace(hosting="anthropic", model="claude"))
+    config = cast(
+        "ConfigManager",
+        FakeConfigManager({"hosting": "kimi", "model_name": "moonshot-v1-8k"}),
+    )
+    assert resolve_hosting_model_with_source(agent, _args(), config) == (
+        "anthropic",
+        "claude",
+        "agent",
+    )
+    assert resolve_hosting_model_with_source(None, _args(hosting="openai"), config) == (
+        "openai",
+        "moonshot-v1-8k",
+        "flag",
+    )
+    assert resolve_hosting_model_with_source(None, _args(model="other"), config) == (
+        "kimi",
+        "other",
+        "config",
+    )
+    assert resolve_hosting_model_with_source(None, _args(), config) == (
+        "kimi",
+        "moonshot-v1-8k",
+        "config",
+    )
+
+
 def test_resolve_missing_values_raise_legacy_messages() -> None:
     from local_operator.session_factory import HostingNotConfiguredError
 

--- a/tests/unit/tui/test_approvals_ux.py
+++ b/tests/unit/tui/test_approvals_ux.py
@@ -272,6 +272,16 @@ async def test_a_session_switched_away_from_its_default_says_both(config_dir: Pa
     one relaunch away from a mode they last chose days ago. Nothing else on the
     frame would ever mention it: the band goes quiet when the gate is armed,
     which is correct, and correct is not the same as complete.
+
+    The saved half names ``config.yml`` and is read from the FILE at report
+    time rather than from the cached default (UX round 1, U1/U2). Two reasons,
+    both from the live-config change: the cached value now MOVES on a config
+    tick, so comparing against it reported a matched pair for exactly the
+    divergence this sentence exists to disclose; and with the asymmetric
+    approvals rule a session can legitimately hold a mode the file disagrees
+    with, which makes "what does the file say" the question a user is actually
+    asking here. Naming the file also makes the claim checkable without
+    quitting, which "new sessions" never was.
     """
     first = OperatorApp(lambda: _factory(GatedSession()))
     async with first.run_test(size=(120, 40)) as pilot:
@@ -286,7 +296,7 @@ async def test_a_session_switched_away_from_its_default_says_both(config_dir: Pa
 
         report = _notices(app)[-1]
         assert "ask (this session)" in report
-        assert "new sessions open in auto" in report
+        assert "config.yml says auto" in report
         assert "/approvals default ask" in report
 
 

--- a/tests/unit/tui/test_config_change_notice.py
+++ b/tests/unit/tui/test_config_change_notice.py
@@ -666,3 +666,235 @@ async def test_no_config_watch_listener_path_constructs_a_config_manager(
         "the B1/B3 defect class reopening. Read the watcher's validated snapshot "
         "(existing_watcher().values) instead."
     )
+
+
+@pytest.mark.asyncio
+async def test_a_page_write_in_this_pane_moves_this_pane_own_gate(monkeypatch, tmp_path) -> None:
+    """Review round 1, R1 — the BLOCKER, in its unsafe direction.
+
+    ``SettingsView._write`` goes through ``settings_io.write_setting``, which
+    notifies the watcher locally, so a ``tool_approval_mode`` set on the
+    ``/settings`` page arrived as ``source="local"`` — the one delivery the
+    listener blanket-returned on. The approvals section is labelled LIVE and
+    its help promises every running session follows from its next call, so the
+    page painted a claim it did not keep: reproduced with the page set to
+    ``ask`` while ``request_tool_approval`` went on auto-approving a command
+    tool with no prompt.
+
+    The write stays SILENT (the page is its own receipt) but no longer inert.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+    _write_elsewhere(tmp_path, "tool_approval_mode", "auto")
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        assert app._approve_all is True, "the app did not boot on the saved default"
+
+        # EXACTLY what the page does: the facade write, which notifies locally.
+        setting = settings_io.resolve_key("tool_approval_mode")
+        assert setting is not None
+        settings_io.write_setting(ConfigManager(tmp_path), setting, "ask")
+        await pilot.pause()
+
+        assert app._approve_all is False, (
+            "a /settings page write did not move this pane's own gate; the page "
+            "paints a LIVE claim it does not keep"
+        )
+        assert app._status is not None and app._status._approvals_auto is False
+        # Silent: the page already showed the user its result.
+        assert not [n for n in _notices(app) if "config.yml changed" in n]
+
+        # And the page can loosen its own pane back, even though that write
+        # records an explicit choice: a choice made HERE replaces it.
+        settings_io.write_setting(ConfigManager(tmp_path), setting, "auto")
+        await pilot.pause()
+        assert app._approve_all is True
+
+
+@pytest.mark.asyncio
+async def test_a_loosening_does_not_revoke_an_explicit_approvals_ask(monkeypatch, tmp_path) -> None:
+    """THE ASYMMETRIC RULE, loosening half (review R1, UX U1).
+
+    A human who typed ``/approvals ask`` in this pane keeps that gate when the
+    FILE later says ``auto``, and reads a keep notice naming the way to adopt
+    it. The operator asked for settings to REACH running sessions; they did not
+    ask for a file write to revoke a hardening a human typed into a specific
+    pane thirty seconds earlier. Mirrors the model half of this same change
+    (``_explicit_model_choice`` and its ``keeping …`` notice) on the more
+    dangerous of the two keys.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+    _write_elsewhere(tmp_path, "tool_approval_mode", "ask")
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        app._cmd_approvals("ask", app._notice)
+        assert app._approve_all is False
+        assert app._explicit_approvals_choice is True
+
+        _write_elsewhere(tmp_path, "tool_approval_mode", "auto")
+        process_watcher(tmp_path).poll_now()
+        await pilot.pause()
+
+        assert app._approve_all is False, "a file write revoked a hardening the human typed"
+        keep = [n for n in _notices(app) if "keeping tool approvals" in n]
+        assert keep and "/approvals auto adopts it" in keep[-1], _notices(app)
+        # The saved default DID follow the file — the pair is allowed to
+        # disagree, which is what `/approvals` now reports.
+        assert app._approvals_default_auto is True
+
+
+@pytest.mark.asyncio
+async def test_a_tightening_follows_the_file_over_an_explicit_choice(monkeypatch, tmp_path) -> None:
+    """THE ASYMMETRIC RULE, tightening half. Safety propagates without
+    exception: a pane that explicitly chose ``auto`` still follows the file to
+    ``ask``. This is the direction the rule does NOT make conditional, because
+    a user who ends up safer than they asked is never the wrong surprise."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+    _write_elsewhere(tmp_path, "tool_approval_mode", "auto")
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        app._cmd_approvals("auto", app._notice)
+        assert app._approve_all is True and app._explicit_approvals_choice is True
+
+        _write_elsewhere(tmp_path, "tool_approval_mode", "ask")
+        process_watcher(tmp_path).poll_now()
+        await pilot.pause()
+        assert app._approve_all is False, "a tightening was refused; safety must always propagate"
+
+
+@pytest.mark.asyncio
+async def test_a_bare_approvals_reports_the_divergence_against_the_file(
+    monkeypatch, tmp_path
+) -> None:
+    """The reporting half (UX U1 step 3, U2).
+
+    With the asymmetric rule a pane can legitimately hold a mode the file
+    disagrees with. Compared against the cached default — which the same tick
+    moves — ``_report_approvals`` reported a MATCHED PAIR for exactly the state
+    it exists to disclose, so no surface in the app would admit that a
+    deliberate `ask` had been kept. It compares against the FILE now.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+    _write_elsewhere(tmp_path, "tool_approval_mode", "ask")
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        app._cmd_approvals("ask", app._notice)
+        _write_elsewhere(tmp_path, "tool_approval_mode", "auto")
+        process_watcher(tmp_path).poll_now()
+        await pilot.pause()
+
+        reported: list[str] = []
+        app._report_approvals(lambda body, kind="info": reported.append(body))
+        assert reported, "the bare report printed nothing"
+        assert "tool approvals: ask (this session)" in reported[-1], reported
+        assert "config.yml says auto" in reported[-1], reported
+
+
+@pytest.mark.asyncio
+async def test_the_web_tool_notice_says_which_way_the_switch_went(monkeypatch, tmp_path) -> None:
+    """UX round 1, U4. Both directions produced a byte-identical
+    ``applied: web_search.enabled``, so a user in another pane could not tell
+    whether their agent had just lost web access or just gained it — the same
+    reasoning that already made ``tool_approval_mode`` name its value."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        _write_elsewhere(tmp_path, "web_search.enabled", False)
+        process_watcher(tmp_path).poll_now()
+        await pilot.pause()
+        off = [n for n in _notices(app) if "config.yml changed" in n][-1]
+        assert "web search off" in off and "refused" in off, off
+
+        _write_elsewhere(tmp_path, "web_search.enabled", True)
+        process_watcher(tmp_path).poll_now()
+        await pilot.pause()
+        on = [n for n in _notices(app) if "config.yml changed" in n][-1]
+        assert "web search on" in on and "next turn" in on, on
+        assert on != off, "both directions still print the same line"
+
+
+@pytest.mark.asyncio
+async def test_only_the_process_that_owns_the_gate_prints_the_value(monkeypatch, tmp_path) -> None:
+    """Design round 1, D1 — one receipt per event.
+
+    With a runtime attached, ``OwnedSessionHandle.follow_config`` moves the
+    real gate and emits the accurate line every attached viewer and the phone
+    see. The TUI's own value clause then made one fact into two sentences in
+    two vocabularies ("tool approvals now auto" over "tool approvals: auto"),
+    which reads as two separate events with the accurate one second, looking
+    like an echo. Exactly the rule the ``model`` section already follows.
+
+    ``tool_approval_mode`` stays in the ``applied:`` key list either way: that
+    clause is about WHICH KEYS moved, not what the gate now does.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+
+    class AttachedSession(FakeSession):
+        is_remote = True
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        _write_elsewhere(tmp_path, "tool_approval_mode", "auto")
+        process_watcher(tmp_path).poll_now()
+        await pilot.pause()
+
+        notices = [n for n in _notices(app) if "config.yml changed" in n]
+        assert notices == ["config.yml changed: applied: tool_approval_mode"], notices
+        assert "every tool runs without asking" not in notices[-1]
+        # The apply still happened here — this pane's widgets and band track
+        # the mode even though the engine's gate lives in the runtime.
+        assert app._approve_all is True
+
+
+@pytest.mark.asyncio
+async def test_a_parked_approval_card_says_why_it_still_asks(monkeypatch, tmp_path) -> None:
+    """UX round 1, U6. The card is deliberately NOT auto-answered — the human
+    did not type this loosening in this pane — but nothing told the card, so
+    the frame said "every tool runs without asking" two lines above "the agent
+    needs your approval", with a visible ``Allow all — stop asking for this
+    session`` row describing a state the session was already in."""
+    import asyncio
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+    _write_elsewhere(tmp_path, "tool_approval_mode", "ask")
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _adopted(app, pilot)
+        assert app._approve_all is False
+
+        parked = asyncio.ensure_future(app.request_tool_approval("bash", "rm -rf build/"))
+        for _ in range(50):
+            await pilot.pause()
+            if app._approval is not None:
+                break
+        assert app._approval is not None, "no card was parked"
+
+        _write_elsewhere(tmp_path, "tool_approval_mode", "auto")
+        process_watcher(tmp_path).poll_now()
+        await pilot.pause()
+
+        question = app._approval.question.question
+        assert "this call still needs your answer" in question, question
+        assert "later calls will not" in question, question
+        # Still parked, still the human's to answer.
+        assert not parked.done(), "a loosening auto-answered a card on screen"
+        app._approval.resolve(False, answer="n")
+        assert await parked is False

--- a/tests/unit/tui/test_config_change_notice.py
+++ b/tests/unit/tui/test_config_change_notice.py
@@ -746,6 +746,89 @@ async def test_a_loosening_does_not_revoke_an_explicit_approvals_ask(monkeypatch
         # The saved default DID follow the file — the pair is allowed to
         # disagree, which is what `/approvals` now reports.
         assert app._approvals_default_auto is True
+        # ...AND THE KEY IS NOT REPORTED AS APPLIED (design round 2, D8).
+        # `applied:` is a claim about which keys MOVED, and the whole point of
+        # the row above is that this one did not. Printed anyway, the keep
+        # notice was followed one row later by `config.yml changed: applied:
+        # tool_approval_mode` — two adjacent dim rows stating opposite facts
+        # about one key, leaving a user scanning for "did my hardening survive?"
+        # unable to tell which won without running `/approvals`. Since it was
+        # the only live key here, the generic line must not print at all, which
+        # is exactly what the refusing `model` section already does.
+        assert not [n for n in _notices(app) if "config.yml changed" in n], _notices(app)
+
+
+@pytest.mark.asyncio
+async def test_a_refused_loosening_drops_only_its_own_key_from_applied(
+    monkeypatch, tmp_path
+) -> None:
+    """Design round 2, D8 — the keep path inside a BATCHED edit.
+
+    The sibling test covers the lone-key case, where the whole line disappears.
+    This is the other half of the same rule and the one a naive fix breaks: a
+    poll carrying a refused ``tool_approval_mode`` beside a live key that DID
+    apply must still print, naming the applied key and only that key. Dropping
+    the whole line would lose a true receipt for ``compaction.enabled``;
+    keeping the key would restore the contradiction the round found.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+    _write_elsewhere(tmp_path, "tool_approval_mode", "ask")
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        app._cmd_approvals("ask", app._notice)
+        assert app._explicit_approvals_mode == "ask"
+
+        _write_elsewhere(tmp_path, "tool_approval_mode", "auto")
+        _write_elsewhere(tmp_path, "compaction.enabled", False)
+        process_watcher(tmp_path).poll_now()
+        await pilot.pause()
+
+        assert app._approve_all is False, "a file write revoked a hardening the human typed"
+        notices = [n for n in _notices(app) if "config.yml changed" in n]
+        assert notices == ["config.yml changed: applied: compaction.enabled"], notices
+        assert [n for n in _notices(app) if "keeping tool approvals" in n], _notices(app)
+
+
+@pytest.mark.asyncio
+async def test_only_the_owning_process_prints_the_keep_notice(monkeypatch, tmp_path) -> None:
+    """Design round 2, D8, second half — one keep receipt, like every other event.
+
+    The keep branch returned before ``_gate_is_owned_elsewhere()``, so the D1
+    single-receipt fix did not cover it. With a runtime attached both carriers
+    legitimately hold ``"ask"`` — ``/approvals`` routes to the runtime, which
+    records its own, while the viewer records one for its ``/settings`` page —
+    so both keep-branches fired on one poll and the same 118-character sentence
+    printed twice, with the (then also wrong) ``applied:`` line wedged between:
+    five visual rows for one non-event. The runtime owns the gate, so its notice
+    is the one that speaks, exactly as with the value clause.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+    _write_elsewhere(tmp_path, "tool_approval_mode", "ask")
+
+    class AttachedSession(FakeSession):
+        is_remote = True
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        app._cmd_approvals("ask", app._notice)
+        assert app._explicit_approvals_mode == "ask"
+
+        _write_elsewhere(tmp_path, "tool_approval_mode", "auto")
+        process_watcher(tmp_path).poll_now()
+        await pilot.pause()
+
+        # Silent HERE: the runtime's own keep notice reaches this transcript as
+        # a NoticeEvent, and printing a local copy is the one event told twice.
+        assert not [n for n in _notices(app) if "keeping tool approvals" in n], _notices(app)
+        # The refusal still happened — this pane's gate did not follow the file.
+        assert app._approve_all is False
+        # ...and it is still not claimed as applied.
+        assert not [n for n in _notices(app) if "config.yml changed" in n], _notices(app)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_config_change_notice.py
+++ b/tests/unit/tui/test_config_change_notice.py
@@ -734,7 +734,7 @@ async def test_a_loosening_does_not_revoke_an_explicit_approvals_ask(monkeypatch
         await _adopted(app, pilot)
         app._cmd_approvals("ask", app._notice)
         assert app._approve_all is False
-        assert app._explicit_approvals_choice is True
+        assert app._explicit_approvals_mode == "ask"
 
         _write_elsewhere(tmp_path, "tool_approval_mode", "auto")
         process_watcher(tmp_path).poll_now()
@@ -762,12 +762,33 @@ async def test_a_tightening_follows_the_file_over_an_explicit_choice(monkeypatch
     async with app.run_test(size=(100, 24)) as pilot:
         await _adopted(app, pilot)
         app._cmd_approvals("auto", app._notice)
-        assert app._approve_all is True and app._explicit_approvals_choice is True
+        assert app._approve_all is True and app._explicit_approvals_mode == "auto"
 
         _write_elsewhere(tmp_path, "tool_approval_mode", "ask")
         process_watcher(tmp_path).poll_now()
         await pilot.pause()
         assert app._approve_all is False, "a tightening was refused; safety must always propagate"
+
+        # ...AND THE PANE CAN STILL FOLLOW THE FILE BACK (review round 2, R6).
+        # The human's only explicit act was choosing `auto`; the file tightened
+        # them off it, and a loosening guard that read merely "this pane chose
+        # something" pinned the pane to `ask` for the rest of its life. Nothing
+        # here is a hardening to protect: the only mode this human ever typed is
+        # the one the file is now returning them to. Reading the FILE's write as
+        # the human's own choice is precisely the operator's originating
+        # complaint reappearing on this change's central key.
+        assert app._explicit_approvals_mode is None, (
+            "a file write left the pane claiming the human had typed the mode; "
+            "the keep notice would then misattribute the file's value"
+        )
+        _write_elsewhere(tmp_path, "tool_approval_mode", "auto")
+        process_watcher(tmp_path).poll_now()
+        await pilot.pause()
+        assert app._approve_all is True, (
+            "a pane whose human only ever chose `auto` stayed pinned to `ask` after "
+            "a file tightening; the file can never move it again (R6)"
+        )
+        assert not [n for n in _notices(app) if "keeping tool approvals" in n], _notices(app)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_config_change_notice.py
+++ b/tests/unit/tui/test_config_change_notice.py
@@ -72,9 +72,11 @@ async def test_a_change_from_another_process_is_announced_once_with_its_keys(
 
 
 @pytest.mark.asyncio
-async def test_a_non_live_key_is_named_as_taking_effect_on_new(monkeypatch, tmp_path) -> None:
-    """``tool_approval_mode`` is deliberately build-time; the notice must not
-    claim it applied."""
+async def test_the_approval_mode_is_applied_and_named_in_the_applied_clause(
+    monkeypatch, tmp_path
+) -> None:
+    """``tool_approval_mode`` is LIVE: it lands in ``applied:`` beside the
+    other live keys, and the amber value clause still follows."""
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
     ConfigManager(tmp_path).set_config_value("hosting", "")
     app = OperatorApp(lambda: _factory(FakeSession()))
@@ -86,10 +88,31 @@ async def test_a_non_live_key_is_named_as_taking_effect_on_new(monkeypatch, tmp_
         await pilot.pause()
         notices = [n for n in _notices(app) if "config.yml changed" in n]
         assert notices == [
-            "config.yml changed: applied: compaction.enabled; "
-            "tool_approval_mode takes effect on /new; "
+            "config.yml changed: applied: compaction.enabled, tool_approval_mode; "
             "tool approvals now auto — every tool runs without asking"
         ]
+        assert app._approve_all is True
+
+
+@pytest.mark.asyncio
+async def test_a_new_sessions_key_is_named_as_taking_effect_on_new(monkeypatch, tmp_path) -> None:
+    """The one remaining NEW_SESSIONS section is ``local_providers``; the
+    clause survives for it and reads in the singular."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+    key = next(
+        s.key
+        for s in settings_io.SETTINGS
+        if s.section == "local_providers" and s.key.endswith(".base_url")
+    )
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        _write_elsewhere(tmp_path, key, "http://127.0.0.1:9999/v1")
+        process_watcher(tmp_path).poll_now()
+        await pilot.pause()
+        notices = [n for n in _notices(app) if "config.yml changed" in n]
+        assert notices == [f"config.yml changed: {key} takes effect on /new"]
 
 
 @pytest.mark.asyncio
@@ -120,7 +143,7 @@ async def test_a_lone_approval_mode_change_from_another_pane_is_announced(
         await pilot.pause()
         notices = [n for n in _notices(app) if "config.yml changed" in n]
         assert notices == [
-            "config.yml changed: tool_approval_mode takes effect on /new; "
+            "config.yml changed: applied: tool_approval_mode; "
             "tool approvals now auto — every tool runs without asking"
         ]
 
@@ -264,11 +287,37 @@ async def test_a_new_launch_key_asks_for_a_relaunch_not_a_new(monkeypatch, tmp_p
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 24)) as pilot:
         await _adopted(app, pilot)
-        _write_elsewhere(tmp_path, "hosting", "openrouter")
+        _write_elsewhere(tmp_path, "auto_save_conversation", True)
         process_watcher(tmp_path).poll_now()
         await pilot.pause()
         notices = [n for n in _notices(app) if "config.yml changed" in n]
-        assert notices == ["config.yml changed: hosting needs a relaunch"]
+        assert notices == ["config.yml changed: auto_save_conversation needs a relaunch"]
+
+
+@pytest.mark.asyncio
+async def test_a_model_key_change_prints_no_tui_clause(monkeypatch, tmp_path) -> None:
+    """``hosting``/``model_name`` are LIVE, but whether they APPLIED to this
+    session is a rule only the session can evaluate (config-sourced and no
+    explicit ``/model`` since boot). The TUI therefore prints nothing for
+    them — not "applied", not "needs a relaunch" (the operator's reported
+    line) — and the session's own receipt is the receipt."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    ConfigManager(tmp_path).set_config_value("hosting", "")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _adopted(app, pilot)
+        _write_elsewhere(tmp_path, "model_name", "some/model")
+        process_watcher(tmp_path).poll_now()
+        await pilot.pause()
+        assert [n for n in _notices(app) if "config.yml changed" in n] == []
+
+        # Alongside a live key: the model key is simply absent from the line.
+        _write_elsewhere(tmp_path, "hosting", "openrouter")
+        _write_elsewhere(tmp_path, "compaction.enabled", False)
+        process_watcher(tmp_path).poll_now()
+        await pilot.pause()
+        notices = [n for n in _notices(app) if "config.yml changed" in n]
+        assert notices == ["config.yml changed: applied: compaction.enabled"]
 
 
 @pytest.mark.asyncio
@@ -435,50 +484,44 @@ async def test_new_survives_a_malformed_config_without_touching_the_file(
 
 
 @pytest.mark.asyncio
-async def test_new_adopts_the_approval_mode_into_the_real_gate(monkeypatch, tmp_path) -> None:
-    """The fourth NEW_SESSIONS key, which the round-2 fix could not reach.
+@pytest.mark.parametrize("direction", ["tighten", "loosen"])
+async def test_a_disk_write_moves_the_running_gate_without_new(
+    monkeypatch, tmp_path, direction: str
+) -> None:
+    """The reversal of QA round 2's A4 pin: ``tool_approval_mode`` is LIVE.
 
-    QA round 3, Q3. `_cmd_new` → `_on_config_changed` repairs the session
-    FACTORY path, but the TUI's approval gate is process state written only by
-    `_load_approvals_default` at mount — so `tool_approval_mode` was the one
-    key of four whose "takes effect on /new" promise was not kept, and the one
-    where being wrong is a safety problem.
-
-    Driven in the tightening direction (`auto → ask`), which is the dangerous
-    one: the notice promises prompts and the old behaviour kept auto-approving.
+    The pin kept the running gate build-time and required a ``/new``. The
+    operator's request ("if I change a setting I want it to go into effect
+    for all my agents") is the opposite, so a disk write now moves
+    ``_approve_all`` on the tick, in BOTH directions, through
+    ``_set_approve_all`` so the band's glyph agrees with the gate. Driven
+    both ways because each is the dangerous one for a different reader: a
+    tightening that did not land keeps auto-approving writes; a loosening
+    that did not land leaves a pane the operator meant to free still asking.
     """
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
     launch_manager = ConfigManager(tmp_path)
     launch_manager.set_config_value("hosting", "anthropic")
-    _write_elsewhere(tmp_path, "tool_approval_mode", "auto")
+    before, after = ("auto", "ask") if direction == "tighten" else ("ask", "auto")
+    _write_elsewhere(tmp_path, "tool_approval_mode", before)
 
-    async def resume_factory(resume_id):
-        return await _factory(FakeSession())
-
-    app = OperatorApp(
-        lambda: _factory(FakeSession()),
-        resume_factory=resume_factory,
-        on_config_changed=launch_manager.reload,
-    )
+    app = OperatorApp(lambda: _factory(FakeSession()), on_config_changed=launch_manager.reload)
     async with app.run_test(size=(100, 24)) as pilot:
         await _adopted(app, pilot)
-        assert app._approve_all is True, "the app did not boot on the saved auto default"
+        assert app._approve_all is (before == "auto"), "the app did not boot on the saved default"
 
-        _write_elsewhere(tmp_path, "tool_approval_mode", "ask")
+        _write_elsewhere(tmp_path, "tool_approval_mode", after)
         process_watcher(tmp_path).poll_now()
         await pilot.pause()
-        # The RUNNING session's gate must not move — the key is NEW_SESSIONS.
-        assert app._approve_all is True
-
-        app._cmd_new(lambda body, kind="info": None)
-        for _ in range(400):
-            await pilot.pause()
-            if app._approve_all is False:
-                break
-        assert app._approve_all is False, (
-            "the notice promised tool_approval_mode takes effect on /new, but the "
-            "approval gate still auto-approves"
+        assert app._approve_all is (after == "auto"), (
+            f"the notice said tool_approval_mode applied, but the gate still reads "
+            f"{'auto' if app._approve_all else 'ask'} without a /new"
         )
+        # The band is an assertion about the gate; the two moved together.
+        assert app._status is not None
+        assert app._status._approvals_auto is (after == "auto")
+        # And the cached default followed, so `always` is computed against it.
+        assert app._approvals_default_auto is (after == "auto")
 
 
 @pytest.mark.asyncio
@@ -488,9 +531,10 @@ async def test_multi_key_clauses_agree_in_number(monkeypatch, tmp_path) -> None:
     Pinned with MULTIPLE keys per clause on purpose: every other pin in this
     file asserts a single-key string, which is exactly why three ungrammatical
     clauses shipped — `hosting, model_name needs a relaunch` and, worse,
-    `a, b, c is retired and does nothing`. The two-key relaunch form is the
-    common case, not an edge: those are the keys a user changes together when
-    switching models.
+    `a, b, c is retired and does nothing`. The relaunch clause now names the
+    launch-time ``session`` keys (the model pair went LIVE and prints no TUI
+    clause at all), but the plural form is still the shape a settings-page
+    save of several keys produces.
     """
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
     ConfigManager(tmp_path).set_config_value("hosting", "")
@@ -500,8 +544,8 @@ async def test_multi_key_clauses_agree_in_number(monkeypatch, tmp_path) -> None:
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(200, 24)) as pilot:
         await _adopted(app, pilot)
-        _write_elsewhere(tmp_path, "hosting", "openrouter")
-        _write_elsewhere(tmp_path, "model_name", "some/model")
+        _write_elsewhere(tmp_path, "auto_save_conversation", True)
+        _write_elsewhere(tmp_path, "session.cleanup.enabled", True)
         for key in retired:
             _write_elsewhere(tmp_path, key, 4321)
         process_watcher(tmp_path).poll_now()
@@ -509,7 +553,7 @@ async def test_multi_key_clauses_agree_in_number(monkeypatch, tmp_path) -> None:
 
         notice = [n for n in _notices(app) if "config.yml changed" in n][-1]
 
-    assert "hosting, model_name need a relaunch" in notice, notice
+    assert "auto_save_conversation, session.cleanup.enabled need a relaunch" in notice, notice
     assert f"{', '.join(sorted(retired))} are retired and do nothing" in notice, notice
     # And the singular forms must survive the change.
     assert " needs a relaunch" not in notice

--- a/tests/unit/web_fetch/test_read_sugar.py
+++ b/tests/unit/web_fetch/test_read_sugar.py
@@ -158,3 +158,30 @@ async def test_read_skill_url_still_resolves(context: ToolContext) -> None:
     assert result.is_error is False
     assert "skill body content" in result.text
     assert resolved["target"] == "skill://demo"
+
+
+@pytest.mark.asyncio
+async def test_read_url_is_refused_when_web_fetch_is_disabled(
+    context: ToolContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The sugar has no createIf gate of its own, so before the per-call check
+    in ``run_fetch`` a user who turned fetching OFF still had every URL
+    fetched through ``read``. "Disabled" now means no fetching through any
+    spelling, and the refusal is the same sentence ``web_fetch`` gives."""
+    from local_operator.config import ConfigManager
+    from local_operator.paths import config_dir
+
+    service.set_fetch_enabled(ConfigManager(config_dir()), False)
+    transport = httpx.MockTransport(
+        lambda req: httpx.Response(200, text="<p>never</p>", headers={"content-type": "text/html"})
+    )
+    orig = tool.run_fetch
+
+    async def _run_with_transport(url: str, **kwargs):
+        kwargs.setdefault("transport", transport)
+        return await orig(url, **kwargs)
+
+    monkeypatch.setattr(tool, "run_fetch", _run_with_transport)
+    result = await execute_read("t1", {"path": "https://example.com"}, None, None, context)
+    assert result.is_error is True
+    assert result.text == tool.WEB_FETCH_DISABLED_MESSAGE

--- a/tests/unit/web_fetch/test_tool.py
+++ b/tests/unit/web_fetch/test_tool.py
@@ -558,7 +558,16 @@ async def test_a_disabled_fetch_refuses_per_call_without_touching_the_network(
     )
     assert is_error is True
     assert preview == tool.WEB_FETCH_DISABLED_MESSAGE
-    assert "web_fetch.enabled: false" in preview
+    # The KEY, without its value: the key is what the user greps for, while
+    # `: false` restates the condition they are living through and is the one
+    # fragment that can go stale (design round 1, D4).
+    assert "web_fetch.enabled" in preview
+    assert "false" not in preview
+    # NO details mapping (UX round 1, U3). `tool_card` renders any details
+    # carrying a `url` as `Fetched: <url> · cache miss`, which told the user a
+    # request had gone out for a call that never opened a connection — on
+    # exactly the key a privacy- or airgap-minded user flips.
+    assert not details
     assert transport.calls == 0
 
     # Flip it back on and the very next call fetches — no rebuild, no restart.

--- a/tests/unit/web_fetch/test_tool.py
+++ b/tests/unit/web_fetch/test_tool.py
@@ -536,3 +536,35 @@ async def test_llms_txt_used_for_site_root(context: ToolContext, monkeypatch) ->
         transport=transport,
     )
     assert "Example Site" in preview
+
+
+@pytest.mark.asyncio
+async def test_a_disabled_fetch_refuses_per_call_without_touching_the_network(
+    context: ToolContext,
+) -> None:
+    """``web_fetch.enabled`` is LIVE: the file is re-read on EVERY call, so a
+    tool still advertised (mid-turn, or in a subagent whose inventory is
+    fixed at spawn) refuses the moment the switch is off. The transport
+    counter is the proof no request left the process."""
+    from local_operator.config import ConfigManager
+    from local_operator.paths import config_dir
+
+    service.set_fetch_enabled(ConfigManager(config_dir()), False)
+    transport = _CountingTransport(
+        lambda req: httpx.Response(200, text="<p>x</p>", headers={"content-type": "text/html"})
+    )
+    preview, details, is_error = await run_fetch(
+        "https://example.com/", tool_name="web_fetch", context=context, transport=transport
+    )
+    assert is_error is True
+    assert preview == tool.WEB_FETCH_DISABLED_MESSAGE
+    assert "web_fetch.enabled: false" in preview
+    assert transport.calls == 0
+
+    # Flip it back on and the very next call fetches — no rebuild, no restart.
+    service.set_fetch_enabled(ConfigManager(config_dir()), True)
+    _p, _d, is_error = await run_fetch(
+        "https://example.com/", tool_name="web_fetch", context=context, transport=transport
+    )
+    assert is_error is False
+    assert transport.calls >= 1

--- a/tests/unit/web_search/test_tool.py
+++ b/tests/unit/web_search/test_tool.py
@@ -274,4 +274,10 @@ async def test_a_disabled_search_refuses_per_call(tmp_path, monkeypatch) -> None
     result = await search_tool.execute_web_search("t1", {"query": "anything"}, None, None, None)
     assert result.is_error is True
     assert result.text == search_tool.WEB_SEARCH_DISABLED_MESSAGE
-    assert "web_search.enabled: false" in result.text
+    # The KEY, without its value (design round 1, D4) — see the twin assertion
+    # in `tests/unit/web_fetch/test_tool.py`.
+    assert "web_search.enabled" in result.text
+    assert "false" not in result.text
+    # Already correct before this round, and pinned so it stays the shape
+    # `web_fetch`'s refusal was brought into line with (UX round 1, U3).
+    assert result.details is None

--- a/tests/unit/web_search/test_tool.py
+++ b/tests/unit/web_search/test_tool.py
@@ -250,3 +250,28 @@ async def test_search_wrapper_closes_call_when_signal_is_already_aborted() -> No
     with pytest.raises(asyncio.CancelledError):
         await _search_or_abort(call, signal)
     assert call.cr_frame is None
+
+
+@pytest.mark.asyncio
+async def test_a_disabled_search_refuses_per_call(tmp_path, monkeypatch) -> None:
+    """``web_search.enabled`` is LIVE: the switch is re-read on EVERY call, so
+    a tool still advertised (mid-turn, or in a subagent whose inventory is
+    fixed at spawn) refuses the moment the file says off — before any
+    provider or credential is consulted."""
+    from local_operator.config import ConfigManager
+    from local_operator.web_search import tool as search_tool
+    from local_operator.web_search.service import set_search_enabled
+
+    config_dir = tmp_path / "cfg"
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+    set_search_enabled(ConfigManager(config_dir), False)
+
+    class _NoService:
+        def __init__(self, *a, **k):
+            raise AssertionError("a disabled search must not build a service")
+
+    monkeypatch.setattr(search_tool, "WebSearchService", _NoService)
+    result = await search_tool.execute_web_search("t1", {"query": "anything"}, None, None, None)
+    assert result.is_error is True
+    assert result.text == search_tool.WEB_SEARCH_DISABLED_MESSAGE
+    assert "web_search.enabled: false" in result.text


### PR DESCRIPTION
## Summary of Changes

A `config.yml` edit now reaches every **running** session within one `ConfigWatcher` poll (~2 s) instead of printing `takes effect on /new` or `needs a relaunch`. The operator's report: "if I change a setting I want it to go into effect for all my agents" — today `/model default` in one pane tells every other pane `model_name needs a relaunch` and nothing moves.

**Change class: C2, standard / pre-authorized.** No version bump; rides the next combined release per AGENTS.md.

Release: patch — settings live on the watcher poll: approvals, web tools, and the default model apply to every running session without /new.

### Per-key behaviour

| key | before | after |
|---|---|---|
| `tool_approval_mode` | "takes effect on /new"; only the cached default refreshed | **LIVE.** Runtime gate (`OwnedSessionHandle._auto_approve`, read per decision) and TUI gate (`_approve_all` via `_set_approve_all`) both flip on the poll; the amber "tool approvals now auto/ask" notice lands in every viewer. A prompt already parked is never auto-answered (and now says so on the card); `--yolo` is an explicit pin that ignores the key. **The disk-vs-session rule is ASYMMETRIC** (review round 1 R1, UX round 1 U1): a **tightening** (`auto`→`ask`) follows the file **unconditionally in every session** — safety propagates without exception; a **loosening** (`ask`→`auto`) does **not** move a session whose human typed `/approvals ask` in it, which instead reads `keeping tool approvals: ask — set with /approvals in this session; config.yml now says auto, /approvals auto adopts it`. A session that never made an explicit `/approvals` choice follows the file **in both directions** — the operator's "goes into effect for all my agents" case, intact. The explicit choice is tracked with the same shape `Session._explicit_model_choice` uses, and **the symmetry is the point**: the model half of this same PR already protects an explicit `/model` pick from a config default, and approvals is the more dangerous of the two keys — the operator asked for settings to *reach* running sessions, not for a file write to revoke a hardening a human typed into a specific pane thirty seconds earlier. A `/settings` page write in a pane is an explicit action **in that pane**, so it moves that pane's own gate in both directions (silently — the page is its own receipt). One receipt per event: when a runtime is attached the TUI prints no value clause, because the process that owns the gate is the one that speaks. |
| `web_search.enabled` / `web_fetch.enabled` | "takes effect on /new"; createIf decided at inventory build only | **LIVE.** `execute_web_search`/`run_fetch` re-check `enabled` per call, so a disable refuses at once even mid-turn and in children — and `read <url>` (which has no createIf gate) is refused too, closing a real bypass. Top-level sessions reconcile the advertised inventory at the next turn boundary (never mid-turn, so a call already emitted never comes back "Tool not found"). Children keep their spawn inventory; the per-call gate still refuses. |
| `hosting` / `model_name` | "needs a relaunch" | **LIVE with a rule.** A session switches iff its model came from config AND no explicit `/model` choice has been made since boot. Otherwise a keep notice: `keeping X — chosen with /model; config.yml default changed, /model saved adopts it`. Unknown provider warns and does not switch. Children never follow (their spec was chosen at spawn). `model_name` alone triggers it (a bare model edit is the common case); the pair is re-read from the watcher's snapshot as a whole. The TUI prints **no clause** for the `model` section — the session's own receipt is the receipt, from the process that decided. |
| `auto_save_conversation` | NEW_SESSIONS | Relabelled honestly **NEW_LAUNCH** (read once by the CLI at process start to pick the transcript directory; the TUI's runtime child never reads it). Help text now says so. |

Section taxonomy after: `model` LIVE; new `approvals` section LIVE; `session` → NEW_LAUNCH "Session storage"; `web_tools` LIVE; `retired` unchanged. Only `local_providers` still carries NEW_SESSIONS.

### VERIFY items from the plan, all confirmed

- `exec_control.py:167` and `spawn_owned_session` are the only handle constructors; `--yolo` is passed as a separate `approval_pinned` kwarg (the config-derived value from `spawn_owned_session` must keep following the file — inference from the bool would conflate them).
- `NoticeEvent` reaches the TUI as a `NoticeBlock` via `tui/events.py:717`.
- The headless REPL / `lop exec` gate never consults `tool_approval_mode` (`session_factory.py:504-560`) — noted below, not changed.
- `session.cleanup.*` is genuinely once-per-process (the `_STORE_MAINTENANCE_TASK` guard at `session_factory.py:1467`), so `session` becomes NEW_LAUNCH as the plan intended — no section split needed.
- `--hosting/--model` never reach the TUI runtime child (`launch.py` passes only cwd/resume; only the mobile daemon sets `LOP_MOBILE_CHILD_*`), so the flag branch of the model rule matters only for `lop exec`/headless, where it behaves as designed (notice only).
- `_build_tool_context` is rebuilt at turn start (`session.py:5651`), the reconcile hook's home.

### Testing details

Static gates on this head, whole tree exactly as CI: `flake8 .` exit 0 · `black==26.1.0 --check` 929 files unchanged · `isort==5.13.2 --check` clean · `pyright` 0 errors. Unit suite: **14095 passed**, 17 skipped. e2e stage (`tests/e2e -m e2e -n0`): **29 passed**.

Focused new/updated tests:

- `tests/unit/session/runtime/test_owned_approvals_live.py` (7 cases): gate follows the disk flip **both directions** at the next decision, overrides a per-session `/approvals` toggle, parked prompt left for the human, `--yolo` pin ignores the key, no-op/unknown mode inert, dispose unsubscribes.
- `tests/unit/session/test_config_live.py`: probe entries for `hosting`/`model_name`/`web_search.enabled`/`web_fetch.enabled` (every LIVE section has a probe; `approvals` is host-owned with its own suite), plus the model rule — explicit `/model` choice keeps + keep notice, agent/flag source keeps + notice, child silent, unknown provider warns and does not switch, writing pane is a no-op, and the web inventory leave/return at the turn boundary with the child's inventory unchanged.
- `tests/unit/tui/test_config_change_notice.py`: the A4 pin **reversed** (disk write moves `_approve_all` + band + cached default without `/new`, both directions, parametrized), the `model` section prints no TUI clause, the relaunch clause now names `auto_save_conversation`, and the plural-verb pin moves to the launch-time session keys.
- `tests/unit/web_fetch|web_search`: per-call refusal while disabled with the transport counter proving no request left the process, re-enable works on the very next call, and `read <url>` refuses with the same sentence.

### End-to-end evidence (real running sessions, no /new)

Two REAL runtime processes (`python -m local_operator.session.runtime.process`, the exact child `lop` spawns) from the worktree venv share one isolated config dir (`HOME=/tmp/iso-live`); this driver attaches to each over the production `RemoteSession` client and a third process edits the file with the worktree's `local-operator config edit` CLI. Driver + probe + full log on the evidence branch:

https://raw.githubusercontent.com/damianvtran/local-operator/evidence/live-settings/live-settings/e2e-two-runtimes.log

```
== cell 1: tool_approval_mode ask -> auto (both runtimes, no /new) ==
  $ lop config edit tool_approval_mode auto
  [A notice/warning] tool approvals: auto — config.yml changed; every tool runs without asking
  [B notice/warning] tool approvals: auto — config.yml changed; every tool runs without asking
  both runtimes announced auto 0.05s after the write
  A /approvals -> tool approvals: auto — every tool runs without asking

== cell 2: auto -> ask, overriding a per-session /approvals (B was /approvals auto; disk wins) ==
  $ lop config edit tool_approval_mode ask
  [A|B notice/info] tool approvals: ask — config.yml changed; write and command tools prompt again   (0.05s)

== cell 3: model_name edit alone (the operator's reported case) ==
  before: A=test/m-boot B=test/m-boot
  $ lop config edit model_name m-live
  [A|B notice/info] model: test/m-boot → test/m-live — config.yml default changed
  after:  A=test/m-live B=test/m-live  (0.05s after the write)

== cell 4: B made an explicit /model choice; the default edit keeps it ==
  $ lop config edit model_name m-live-2
  [B notice/info] keeping test/m-chosen — chosen with /model; config.yml default changed, /model saved adopts it
  after:  A=test/m-live-2 (0.05s)  B=test/m-chosen (kept)

== cell 5: hosting -> unknown provider: warning, no switch ==
  $ lop config edit hosting no-such-provider
  [A notice/warning] config.yml names unknown provider 'no-such-provider'; keeping test/m-live-2

== cell 6: web_fetch/web_search disabled -> refused per call, read <url> included ==
  $ lop config edit web_fetch.enabled false / web_search.enabled false
  read <url>   : error web_fetch is disabled by config (web_fetch.enabled: false) — turn it on in /settings › Web tools
  web_search   : error web_search is disabled by config (web_search.enabled: false) — ...
  after re-enable: read <url>: ok [200] https://example.com …; web_search: ok Provider: duckduckgo …

== cell 7: web tool INVENTORY follows at the next turn boundary ==
  runtime A /context tool schemas: 10.0k -> 9.3k after disable + one turn -> 10.0k after re-enable + one turn
```

Rendered stills, real `OperatorApp` via `run_test` + `save_screenshot` per AGENTS.md "Visual validation":

| | before | after |
|---|---|---|
| `tool_approval_mode: auto` written elsewhere | ![before](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/live-settings/live-settings/before-approvals.png) "takes effect on /new", gate unmoved | ![after](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/live-settings/live-settings/after-approvals.png) "applied: tool_approval_mode", band `!` on, gate moved |
| `model_name` written elsewhere | ![before](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/live-settings/live-settings/before-model.png) "needs a relaunch" (the reported line) | no TUI clause; the session's receipt is the receipt → |
| config-sourced session on a real Session in the TUI | — | ![after](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/live-settings/live-settings/after-model-config.png) band repaints `test/m-next`, receipt "model: … → test/m-next — config.yml default changed" |
| explicit-/model session | — | ![after](https://raw.githubusercontent.com/damianvtran/local-operator/evidence/live-settings/live-settings/after-model-explicit.png) band stays `test/chosen`, keep notice names `/model saved` |

### Non-goals

- Children never re-add web tools on enable and never follow a model change (spawn inventory; per-call gate still refuses).
- `auto_save_conversation` stays launch-time; nothing is retired.
- The headless REPL / `lop exec` approval gate never consulted `tool_approval_mode` (it prompts per call or auto-approves under `--yolo`); making it read the key is a separate decision, noted rather than smuggled in.
- No dispatch-time gate in `loop.py` (a second gating convention beside createIf is the footprint ladder's forbidden shape).
- **The `ask`→`auto` loosening deliberately does NOT converge a session that chose.** Two panes on one `config.yml` can therefore hold different gates, and that is the intended outcome rather than a gap: the asymmetry only ever leaves a session SAFER than the file. `/approvals` discloses the divergence (it compares against the file's last-good snapshot at report time, so a bare `/approvals` says `tool approvals: ask (this session) — …; config.yml says auto`), and `/approvals auto` adopts it in one step.
- **The override is edge-triggered on the value, not level-asserted** (QA Q1). Re-writing a value already on disk produces no change event and so moves nothing; the next real transition does. This is what makes "no-op write → no notice" work, and QA explicitly did not ask for it to change.
- No version bump — rides the next combined release.

## Checklist

- [x] Conventional commit; why/constraints/context comments on all new code.
- [x] flake8 / black==26.1.0 / isort==5.13.2 / pyright / unit suite / e2e stage all green on this head.
- [x] Real-process end-to-end evidence for every key, both directions where applicable, with timings.
- [x] Rendered before/after stills viewed, band geometry cross-checked in the driver output.

