### PR TITLE
feat(herdr): report lifecycle state to Herdr's Agents panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,6 +721,15 @@ submit bug reports and feature requests, set up a development environment,
 and open pull requests. `docs/` covers the architecture
 ([REWRITE.md](./docs/REWRITE.md)), benchmarks, and verification evidence.
 
+### Inside a multiplexer
+
+Run a column of `lop` sessions as panes and `lop` meets the host halfway:
+it publishes a per-pane crash-restore binding
+([multiplexer-resume.md](./docs/multiplexer-resume.md)) and, inside a
+[Herdr](https://herdr.dev) pane, reports its live state — `idle`, `working`,
+`blocked` on an approval — to the Agents panel
+([herdr-agents.md](./docs/herdr-agents.md)).
+
 ## 🙏 Credits and Acknowledgements
 
 Local Operator stands on the shoulders of the broader open-source agent

--- a/docs/herdr-agents.md
+++ b/docs/herdr-agents.md
@@ -31,7 +31,17 @@ herdr agent get "$HERDR_PANE_ID"
 ```
 
 Every report carries a `--seq` so Herdr drops a stale one that lands out of
-order; the session id goes along as `--agent-session-id` metadata. Subagent
+order; the session id goes along as `--agent-session-id` metadata.
+
+**The session id is sent but not visible on Herdr 0.8.2.** `--agent-session-id`
+is accepted (`rc=0`), but `agent get` / `agent list` only populate the
+read-only `agent_session` object for Herdr's *official* integrations, so you
+will not find the id in the output above for a `custom:` source. It is sent
+anyway — it costs nothing and is correct the moment Herdr opens that field to
+custom sources — but do not go looking for it today. Herdr-managed session
+restoration from that id is out of scope either way.
+
+Subagent
 child sessions never report — they run inside their parent's pane and would
 overwrite its row. Like the resume binding, every call is best-effort: a
 missing binary, a dead socket, a non-zero exit or a timeout is logged at debug

--- a/docs/herdr-agents.md
+++ b/docs/herdr-agents.md
@@ -1,0 +1,47 @@
+# Herdr: live agent state in the Agents panel
+
+[Herdr](https://herdr.dev) is a different kind of integration from the resume
+binding in [multiplexer-resume.md](./multiplexer-resume.md): instead of *where* a
+session lives, `lop` reports *what it is doing*. Herdr's Agents panel shows one
+row per pane with a lifecycle state, and
+by default it fills that row by screen detection, which cannot tell "the model
+is thinking" from "a tool approval is waiting on you". `lop` already knows,
+because it is the same three-valued state the terminal title carries — so
+inside a Herdr pane it reports that state through Herdr's documented
+custom-agent CLI:
+
+| `lop` | Herdr Agents row |
+|---|---|
+| at the prompt (`lo ›`) | `idle` |
+| a turn running (`lo ⣻`) | `working` |
+| a tool approval or `ask` waiting (`lo !`) | `blocked` |
+| exit | released (`pane release-agent`) |
+
+Detection is `HERDR_ENV=1` plus `HERDR_PANE_ID`, both of which Herdr injects
+into every pane process. Reporting additionally needs the `herdr` CLI:
+`HERDR_BIN_PATH` is preferred (it names the binary that spawned the pane, so
+its protocol matches the running server), with `herdr` on `PATH` as the
+fallback. Outside Herdr, or with neither resolvable, nothing runs.
+
+The row appears as source `custom:local-operator`, agent `local-operator`:
+
+```sh
+herdr agent list
+herdr agent get "$HERDR_PANE_ID"
+```
+
+Every report carries a `--seq` so Herdr drops a stale one that lands out of
+order; the session id goes along as `--agent-session-id` metadata. Subagent
+child sessions never report — they run inside their parent's pane and would
+overwrite its row. Like the resume binding, every call is best-effort: a
+missing binary, a dead socket, a non-zero exit or a timeout is logged at debug
+and otherwise ignored, off the event loop, and can never slow or fail a session.
+
+Turning it off:
+
+```sh
+export LOCAL_OPERATOR_NO_HERDR=1
+```
+
+It is independent of `LOCAL_OPERATOR_NO_TERMINAL_TITLE`: turning off the
+window title does not silence the Agents row, and vice versa.

--- a/docs/multiplexer-resume.md
+++ b/docs/multiplexer-resume.md
@@ -181,6 +181,7 @@ Mirrors `LOCAL_OPERATOR_NO_TERMINAL_TITLE`. Useful for a recording, a CI job, or
 a session opened to read someone else's transcript in a pane that already holds
 a real one.
 
+
 ## Troubleshooting
 
 **`cmux --json surface resume show` returns `resume_binding: null`.** The

--- a/local_operator/herdr/__init__.py
+++ b/local_operator/herdr/__init__.py
@@ -1,0 +1,74 @@
+"""Tell the hosting Herdr pane what this session is doing.
+
+WHY THIS EXISTS
+---------------
+`Herdr <https://herdr.dev>`_ is a terminal multiplexer whose differentiator
+is a live **Agents** panel: one row per pane, each saying ``idle`` /
+``working`` / ``blocked``. Left to itself Herdr fills that row by screen
+detection — reading the pane's bottom buffer and guessing — which cannot tell
+"the model is thinking" from "a tool approval is waiting on you". Local
+Operator already knows that distinction exactly; it is the same three-valued
+state the terminal title carries (``lo ›`` / ``lo ⣻`` / ``lo !``). This
+package pushes that state through Herdr's documented custom-agent surface so
+the panel shows what the session is actually doing.
+
+No upstream Herdr change, no ``herdr integration install``, no plugin: the
+CLI's ``pane report-agent`` / ``pane release-agent`` are documented "for
+custom hooks", and a custom ``--source`` is first-class in ``agent list``.
+
+ONE SIGNAL, ONE HOOK
+--------------------
+The reporter is driven from the SAME place the terminal title is —
+``StatusLine._sync_terminal_title`` — rather than from new hooks scattered
+through the turn loop. The title already coalesces ``streaming`` and
+``attention`` into one external state; a second derivation would eventually
+disagree with it, and the failure mode of two derivations is exactly a
+sidebar row saying ``working`` while the tab title says idle.
+
+BEST-EFFORT, ALWAYS
+-------------------
+Identical to :mod:`local_operator.multiplexer`'s contract. Nothing here may
+prevent a session from starting, slow the TUI, or surface an error. A missing
+binary, a socket mid-restart, a non-zero exit, a timeout: logged at debug and
+otherwise ignored. Every CLI call runs on a worker thread with a short timeout
+and is never awaited on the event loop, including the release at exit.
+
+NEVER FOR A SUBAGENT
+--------------------
+A delegated child session runs inside its parent's pane. Reporting it would
+overwrite the pane's row with the child's state — ``idle`` while the user's
+own turn is parked on an approval. The app applies the same
+``is_user_owned_session`` gate the multiplexer uses.
+
+THE KILL SWITCH
+---------------
+``LOCAL_OPERATOR_NO_HERDR`` disables all of it, mirroring
+``LOCAL_OPERATOR_NO_MULTIPLEXER_RESUME`` and ``LOCAL_OPERATOR_NO_TERMINAL_TITLE``.
+An environment gate only, with no ``/settings`` key: like the multiplexer
+switch this writes nothing a user sees inside the app, so the reason to turn
+it off is situational (this recording, this CI job) rather than a standing
+preference — which is the line ``terminal_title`` draws between its env
+switch and its config flag, and this integration has only the first half.
+"""
+
+from local_operator.herdr.reporter import (
+    HERDR_AGENT,
+    HERDR_SOURCE,
+    HerdrReporter,
+    HerdrState,
+    herdr_binary,
+    herdr_reporting_enabled,
+    release_reporter,
+    start_reporter,
+)
+
+__all__ = [
+    "HERDR_AGENT",
+    "HERDR_SOURCE",
+    "HerdrReporter",
+    "HerdrState",
+    "herdr_binary",
+    "herdr_reporting_enabled",
+    "release_reporter",
+    "start_reporter",
+]

--- a/local_operator/herdr/reporter.py
+++ b/local_operator/herdr/reporter.py
@@ -15,11 +15,25 @@ and silently ignores any report carrying a lower one ("accepted by the API
 but ignored by pane state"). That is the mechanism this module leans on to
 make out-of-order delivery harmless — but it only works if the number
 reflects the order the STATE CHANGED in, not the order the subprocesses
-happened to finish in. So the sequence number is taken under a lock at the
-moment :meth:`HerdrReporter.report` is called, before the call is queued, and
-the single worker thread then executes the queue in that order. Two workers,
-or a seq assigned inside the worker, would let a ``working`` overtake the
-``idle`` that followed it and leave the panel spinning on a finished turn.
+happened to finish in. So the sequence number is minted **and the call
+enqueued in the same critical section**, under ``_lock``, at the moment
+:meth:`HerdrReporter.report` is called; the single worker thread then
+executes the queue in that order. Two workers, or a seq assigned inside the
+worker, would let a ``working`` overtake the ``idle`` that followed it and
+leave the panel spinning on a finished turn.
+
+MINTING AND ENQUEUEING MUST BE ONE ATOMIC STEP, not two. An earlier version
+took the seq under the lock and then queued outside it, which is a weaker
+promise than it looks: two callers could mint 1, 2 and enqueue 2, 1, so the
+delivery order was not the mint order and this paragraph was false of the
+code — measured at 80/200 trials under ``sys.setswitchinterval(1e-6)``.
+Worse, a ``report`` that lost that race to a concurrent ``release`` was
+delivered AFTER the ``release-agent`` carrying a HIGHER seq, which Herdr's
+high-water mark cannot discard, leaving the pane's row alive for an exited
+process (review round 1, A1/A2). ``release`` puts its call and the worker's
+stop sentinel inside that same section, so nothing can be queued behind it,
+and ``report`` re-tests the released latch inside the lock so a report that
+loses the race is DROPPED rather than re-sent.
 
 WHY THE SEQUENCE IS NOT A COUNTER FROM ONE
 ------------------------------------------
@@ -223,6 +237,10 @@ class HerdrReporter:
         #: stop sentinel and is enqueued exactly once, by `release`.
         self._queue: queue.SimpleQueue[tuple[str, tuple[str, ...]] | None] = queue.SimpleQueue()
         self._thread: threading.Thread | None = None
+        #: A worker created under `_lock` by `_enqueue` and started outside it
+        #: by `_start_worker`. Exists so the mint-and-enqueue critical section
+        #: contains nothing that can block (review round 1, A2).
+        self._pending_start: threading.Thread | None = None
         # Latched by `release` before the release call is queued, and what
         # makes `release` exactly-once and every later `report` a no-op. An
         # Event rather than a bool under `_lock` so `released` is readable
@@ -278,23 +296,40 @@ class HerdrReporter:
         ``StatusLine.refresh``: one comparison under a lock in the common case
         and nothing else. Never raises.
         """
+        # Re-tested INSIDE the lock below, not only here. This early exit is a
+        # cheap filter for the common post-release case; it is not the
+        # decision, because a `report` that passes it and then blocks on
+        # `_lock` — held by a concurrent `release` — would otherwise mint a
+        # HIGHER seq than the release and resurrect the row for a process that
+        # has already exited. Herdr's high-water mark cannot discard a higher
+        # seq, so that row would say `working` forever (review round 1, A1).
         if self._released.is_set():
             return
         with self._lock:
+            if self._released.is_set():
+                return
             if state == self._last:
                 return
             self._last = state
             seq = self._next_seq_locked()
             session_id = self._session_id
-        argv = self._argv(
-            "report-agent",
-            "--state",
-            state,
-            "--seq",
-            str(seq),
-            *(("--agent-session-id", session_id) if session_id else ()),
-        )
-        self._enqueue(("report-agent", argv))
+            argv = self._argv(
+                "report-agent",
+                "--state",
+                state,
+                "--seq",
+                str(seq),
+                *(("--agent-session-id", session_id) if session_id else ()),
+            )
+            # Enqueued UNDER the lock, so the queue order is the mint order.
+            # Building the argv outside it and putting afterwards let two
+            # callers mint 1,2 and enqueue 2,1 — measured at 80/200 trials
+            # under `sys.setswitchinterval(1e-6)` (review round 1, A2). The
+            # lock is held for a list build and a `SimpleQueue.put`, both
+            # non-blocking, so this costs the caller nothing it can feel.
+            self._enqueue(("report-agent", argv))
+        # Outside the lock: see `_start_worker`.
+        self._start_worker()
 
     def release(self) -> None:
         """Queue the ``release-agent``, exactly once, and stop the worker after it.
@@ -312,9 +347,14 @@ class HerdrReporter:
                 return
             self._released.set()
             seq = self._next_seq_locked()
-        argv = self._argv("release-agent", "--seq", str(seq))
-        self._enqueue(("release-agent", argv))
-        self._queue.put(None)
+            argv = self._argv("release-agent", "--seq", str(seq))
+            # Under the lock for the same reason as `report`, and with the
+            # stop sentinel in the same critical section: the release must be
+            # the LAST item in the queue, which is only guaranteed if no
+            # `report` can slip between the two puts.
+            self._enqueue(("release-agent", argv))
+            self._queue.put(None)
+        self._start_worker()
 
     def join(self, timeout: float = EXIT_DRAIN_TIMEOUT_S) -> None:
         """Wait for the worker to drain, bounded. Tests and the exit drain only.
@@ -347,23 +387,43 @@ class HerdrReporter:
         )
 
     def _enqueue(self, item: tuple[str, tuple[str, ...]]) -> None:
-        self._queue.put(item)
-        self._ensure_worker()
+        """Queue one call. THE CALLER MUST HOLD ``_lock``.
 
-    def _ensure_worker(self) -> None:
-        # Started on the first call rather than in the constructor so a
-        # reporter that never reports (built and discarded) costs no thread.
-        # The exit drain is registered at the same moment, and BEFORE the
-        # thread exists, so an interpreter exit racing the start still finds
-        # this reporter in the registry.
-        with self._lock:
-            if self._thread is not None:
-                return
+        That requirement is the ordering guarantee, not an implementation
+        detail: the queue order has to be the order the seqs were minted in,
+        and the only way to promise that is to mint and put in one critical
+        section (review round 1, A2).
+
+        ``_lock`` is a plain :class:`threading.Lock` and is therefore NOT
+        reentrant, which is why the worker start is split out below rather
+        than called from here — an ``_ensure_worker`` that took the lock again
+        would deadlock every caller.
+        """
+        self._queue.put(item)
+        # Registered while the lock is held and BEFORE the thread exists, so
+        # an interpreter exit racing the first enqueue still finds this
+        # reporter in the registry and drains it.
+        if self._thread is None:
             _LIVE_REPORTERS.add(self)
             _register_exit_drain()
-            thread = threading.Thread(target=self._run, name="lop-herdr-report", daemon=True)
-            self._thread = thread
-        thread.start()
+            # Created here but started by `_start_worker` outside the lock:
+            # a reporter that never reports (built and discarded) costs no
+            # thread, and nothing user-facing waits on the start.
+            self._thread = threading.Thread(target=self._run, name="lop-herdr-report", daemon=True)
+            self._pending_start = self._thread
+
+    def _start_worker(self) -> None:
+        """Start the worker created by :meth:`_enqueue`, if any. Lock NOT held.
+
+        Split from the enqueue so the ordering-critical section stays free of
+        anything that could block, and so a plain (non-reentrant) lock is
+        enough to hold the whole mint-and-put together.
+        """
+        with self._lock:
+            pending = self._pending_start
+            self._pending_start = None
+        if pending is not None:
+            pending.start()
 
     def _run(self) -> None:
         while True:
@@ -443,10 +503,21 @@ def release_reporter(reporter: HerdrReporter | None) -> None:
 _EXIT_DRAIN_LOCK = threading.Lock()
 _exit_drain_registered = False
 
-#: Every reporter that has started its worker in this process. Weak, so a
-#: reporter dropped before exit is not kept alive to be drained for nothing.
-#: Several reporters per process happens only in tests; production has one
-#: per pane, and a pane is a process.
+#: Every reporter that has queued a call in this process, so the exit drain
+#: can release and join each one.
+#:
+#: A ``WeakSet`` for hygiene rather than for reclamation, and the difference
+#: is worth stating because the comment here used to claim the latter: a
+#: reporter whose worker is RUNNING is never collected while it is in the set,
+#: because the worker thread's own ``self._run`` bound method holds a strong
+#: reference to it (measured: 50 built-and-dropped reporters → 50 still
+#: retained and 50 threads parked on ``queue.get`` after two ``gc.collect``
+#: passes — review round 1, A3). What the weak set does buy is that once a
+#: reporter IS released and its worker has returned, nothing here keeps it
+#: alive. Production has one reporter per process — a pane is a process, and
+#: a session swap re-labels the existing reporter rather than building
+#: another — so the retention is bounded at one; only a test that builds many
+#: accumulates threads, which is why they release explicitly.
 _LIVE_REPORTERS: weakref.WeakSet["HerdrReporter"] = weakref.WeakSet()
 
 

--- a/local_operator/herdr/reporter.py
+++ b/local_operator/herdr/reporter.py
@@ -1,0 +1,510 @@
+"""The reporter: one pane, one worker thread, one strictly ordered stream.
+
+What is reported is the :class:`HerdrState` of this pane's session. How it is
+reported is the documented Herdr CLI (``herdr pane report-agent`` /
+``release-agent``), chosen over the raw socket for the same reason
+``multiplexer/cmux.py`` shells out rather than speaking JSON-RPC itself: the
+CLI is the contract Herdr documents for custom hooks, and it absorbs protocol
+changes the socket would expose. ``HERDR_SOCKET_PATH`` is noted in
+``terminals.py`` for a future backend and is not read here.
+
+THE ORDERING PROBLEM, AND WHY ``--seq`` IS ASSIGNED ON THE CALLER'S THREAD
+--------------------------------------------------------------------------
+Herdr keeps, per pane and per ``--source``, the highest ``--seq`` it has seen
+and silently ignores any report carrying a lower one ("accepted by the API
+but ignored by pane state"). That is the mechanism this module leans on to
+make out-of-order delivery harmless — but it only works if the number
+reflects the order the STATE CHANGED in, not the order the subprocesses
+happened to finish in. So the sequence number is taken under a lock at the
+moment :meth:`HerdrReporter.report` is called, before the call is queued, and
+the single worker thread then executes the queue in that order. Two workers,
+or a seq assigned inside the worker, would let a ``working`` overtake the
+``idle`` that followed it and leave the panel spinning on a finished turn.
+
+WHY THE SEQUENCE IS NOT A COUNTER FROM ONE
+------------------------------------------
+Measured against Herdr 0.8.2: the per-source high-water mark PERSISTS across
+``release-agent`` and across processes. A process that releases at seq 12 is
+followed, in the same pane, by a ``/reload`` re-exec or a quit-and-relaunch
+whose first report is seq 1 — and every report that process ever makes is
+ignored, forever, with no error anywhere. The sequence is therefore anchored
+to the wall clock in microseconds, which is monotonic across processes in the
+same pane by construction, and ``max(previous + 1, clock)`` keeps it strictly
+increasing within a process even if the clock steps backwards. The clock is
+injectable, so tests observe the plain ``1, 2, 3`` the contract is easiest to
+read in.
+
+WHY A WORKER THREAD AND NOT A DETACHED ``Popen`` PER CALL
+---------------------------------------------------------
+A detached spawn per transition would be simpler, but it is unordered: two
+spawns a millisecond apart race to the socket. The worker gives ordering
+for free, bounds the process to one Herdr subprocess at a time, and — like
+``SessionBroadcast`` — keeps the event loop off every subprocess wait. It is
+a daemon thread so a wedged ``herdr`` cannot hold the interpreter open; the
+exit drain below is what makes that safe for the release.
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import os
+import queue
+import shutil
+import subprocess
+import threading
+import time
+import weakref
+from typing import Callable, Literal, Mapping, Sequence
+
+from local_operator.terminals import HERDR_BIN_ENV, HERDR_PANE_ENV, is_herdr
+
+logger = logging.getLogger(__name__)
+
+EnvMap = Mapping[str, str]
+
+#: Herdr's lifecycle vocabulary for a pane's agent. ``unknown`` is in the
+#: type because Herdr accepts it, but this reporter never emits it: it means
+#: "present but unclassifiable", and every state this app is in classifies.
+#: A turn that ends in an error is ``idle`` — the user's turn again.
+HerdrState = Literal["idle", "working", "blocked", "unknown"]
+
+#: The ``--source`` every call carries. ``custom:`` is the namespace Herdr
+#: documents for hooks that are not official integrations; the charset is
+#: ASCII letters, digits and ``:._-``, at most 80 characters.
+HERDR_SOURCE = "custom:local-operator"
+
+#: The ``--agent`` label, shown in the Agents panel row. Must match
+#: ``[a-z][a-z0-9_-]{0,31}``.
+HERDR_AGENT = "local-operator"
+
+#: Environment kill switch, mirroring ``LOCAL_OPERATOR_NO_MULTIPLEXER_RESUME``
+#: and ``LOCAL_OPERATOR_NO_TERMINAL_TITLE``. For a recording, a CI job, or a
+#: session opened in a pane whose Agents row belongs to something else.
+_ENV_DISABLE = "LOCAL_OPERATOR_NO_HERDR"
+
+#: How long one ``herdr`` call may take before it is abandoned. The TUI never
+#: waits on it (the worker does), but a wedged socket must not leak a process
+#: per transition either. The same figure as ``multiplexer.cmux.CALL_TIMEOUT_S``.
+CALL_TIMEOUT_S = 5.0
+
+#: Worst-case delay a user can experience at interpreter exit because of the
+#: release. One bounded join per process, shared by every reporter, never on
+#: the event loop — ``atexit`` runs on the main thread after ``on_unmount``
+#: has returned. A healthy ``herdr`` releases in one subprocess spawn; the
+#: bound is only reached against a wedged socket, and a release that outwaits
+#: it leaves a row Herdr will reconcile itself when the pane process is gone.
+EXIT_DRAIN_TIMEOUT_S = 2.0
+
+#: ``(subcommand, argv)``. ``argv`` is the complete command line, binary
+#: first; ``subcommand`` is repeated so a recording fake can assert on it
+#: without parsing. Raises on failure — the worker is the one place that
+#: catches, so an injected fake that raises proves failure isolation.
+Invoker = Callable[[str, Sequence[str]], None]
+
+#: Sequence-number source. Epoch MICROseconds rather than milliseconds so a
+#: process that transitions faster than the clock ticks still has headroom
+#: before ``max(previous + 1, clock)`` has to run ahead of it — and still
+#: ~1.8e15, four orders of magnitude inside Herdr's ``u64``.
+Clock = Callable[[], int]
+
+
+def _default_clock() -> int:
+    return time.time_ns() // 1_000
+
+
+def _source(env: EnvMap | None) -> EnvMap:
+    return os.environ if env is None else env
+
+
+def herdr_reporting_enabled(env: EnvMap | None = None) -> bool:
+    """Whether this process may report at all (the kill switch is unset).
+
+    An environment gate only, with no config-flag counterpart — see the
+    package docstring for why this matches the multiplexer's switch rather
+    than the terminal title's two-tier one.
+    """
+    return not (_source(env).get(_ENV_DISABLE) or "").strip()
+
+
+def herdr_binary(env: EnvMap | None = None) -> str | None:
+    """The ``herdr`` CLI to call, or None when there is nothing to call.
+
+    ``HERDR_BIN_PATH`` first: Herdr exports the path of the binary that spawned
+    the pane, and that binary's protocol version is by definition the running
+    server's. A ``herdr`` on PATH is the fallback for a pane whose environment
+    was scrubbed (a ``env -i`` wrapper, a container that forwards only the
+    ids) and is the documented alternative. Neither resolving is the common
+    case outside Herdr and is not an error.
+
+    The exported path is checked for executability rather than trusted: the
+    markers are inherited across an ssh hop into a host where that path does
+    not exist, and a missing binary should read as "no Herdr here" rather
+    than as a spawn failure per transition.
+    """
+    source = _source(env)
+    exported = (source.get(HERDR_BIN_ENV) or "").strip()
+    if exported and os.path.isfile(exported) and os.access(exported, os.X_OK):
+        return exported
+    return shutil.which("herdr")
+
+
+def state_from_title(title_state: str) -> HerdrState:
+    """Translate the terminal title's run state into Herdr's vocabulary.
+
+    The title is the ONE derivation of external state this app keeps (see
+    ``StatusLine._title_state``), so this is a translation and not a second
+    derivation. ``attention`` — a tool approval or an ``ask`` waiting on the
+    user — is Herdr's ``blocked`` exactly. ``failed`` is the title's mark for
+    "the last turn errored", which for the panel's purposes is the user's turn
+    again: ``idle``, never ``unknown``.
+    """
+    if title_state == "attention":
+        return "blocked"
+    if title_state == "working":
+        return "working"
+    return "idle"
+
+
+def _run_cli(subcommand: str, argv: Sequence[str]) -> None:
+    """The production invoker: one ``herdr`` subprocess, bounded, no shell.
+
+    Raises on anything the worker should log — a spawn failure, a timeout, a
+    non-zero exit — so that the fake invokers in tests and this one share the
+    same failure shape.
+    """
+    completed = subprocess.run(  # noqa: S603 — fixed argv, no shell
+        list(argv),
+        capture_output=True,
+        text=True,
+        timeout=CALL_TIMEOUT_S,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"herdr {subcommand} exited {completed.returncode}: {completed.stderr[:200]}"
+        )
+
+
+class HerdrReporter:
+    """Reports one pane's lifecycle state, in order, off the event loop.
+
+    Construct through :func:`start_reporter`, which decides whether there is
+    anything to report to; a directly constructed reporter is always active
+    (tests build them that way, with a fake invoker).
+
+    Thread-safety: :meth:`report`, :meth:`release` and :meth:`set_session_id`
+    may be called from any thread. The event loop calls them in production and
+    never blocks — each one takes a lock held for microseconds, appends to a
+    queue and returns.
+    """
+
+    def __init__(
+        self,
+        *,
+        pane_id: str,
+        binary: str,
+        session_id: str | None = None,
+        invoker: Invoker | None = None,
+        clock: Clock | None = None,
+    ) -> None:
+        self._pane_id = pane_id
+        self._binary = binary
+        self._session_id = (session_id or "").strip() or None
+        self._invoker: Invoker = invoker or _run_cli
+        self._clock: Clock = clock or _default_clock
+        # Guards `_last`, `_seq` and `_session_id`: the seq must be minted in
+        # the same critical section that decides the report is not a
+        # duplicate, or two callers could both pass the de-dupe and enqueue
+        # the same state twice in either order.
+        self._lock = threading.Lock()
+        self._last: HerdrState | None = None
+        self._seq = 0
+        #: Every call ever enqueued, in seq order. `None` is the worker's
+        #: stop sentinel and is enqueued exactly once, by `release`.
+        self._queue: queue.SimpleQueue[tuple[str, tuple[str, ...]] | None] = queue.SimpleQueue()
+        self._thread: threading.Thread | None = None
+        # Latched by `release` before the release call is queued, and what
+        # makes `release` exactly-once and every later `report` a no-op. An
+        # Event rather than a bool under `_lock` so `released` is readable
+        # from any thread without contending with a caller mid-enqueue.
+        #
+        # Reports ALREADY queued ahead of the release are still delivered, in
+        # order. Skipping them would make the emitted stream depend on how
+        # close to quit the last transition happened, and against a wedged
+        # binary it saves nothing the bounded exit drain does not already cap.
+        self._released = threading.Event()
+
+    # -- introspection (tests, diagnostics) --------------------------------
+
+    @property
+    def pane_id(self) -> str:
+        return self._pane_id
+
+    @property
+    def session_id(self) -> str | None:
+        return self._session_id
+
+    @property
+    def last_state(self) -> HerdrState | None:
+        """The state most recently ENQUEUED (not necessarily delivered)."""
+        return self._last
+
+    @property
+    def released(self) -> bool:
+        return self._released.is_set()
+
+    # -- lifecycle -----------------------------------------------------------
+
+    def set_session_id(self, session_id: str | None) -> None:
+        """Change the ``--agent-session-id`` metadata, e.g. on a ``/new`` swap.
+
+        Clears the de-dupe so the NEXT report goes out even if the state is
+        unchanged: the pane's row is the same, the process is the same, only
+        the session behind it moved, and Herdr learns that from the next
+        report rather than from a release-and-re-report that would flash the
+        row empty.
+        """
+        with self._lock:
+            cleaned = (session_id or "").strip() or None
+            if cleaned == self._session_id:
+                return
+            self._session_id = cleaned
+            self._last = None
+
+    def report(self, state: HerdrState) -> None:
+        """Queue a ``report-agent`` for ``state``, unless it is a duplicate.
+
+        Cheap enough for the 12.5 Hz spinner tick that reaches it through
+        ``StatusLine.refresh``: one comparison under a lock in the common case
+        and nothing else. Never raises.
+        """
+        if self._released.is_set():
+            return
+        with self._lock:
+            if state == self._last:
+                return
+            self._last = state
+            seq = self._next_seq_locked()
+            session_id = self._session_id
+        argv = self._argv(
+            "report-agent",
+            "--state",
+            state,
+            "--seq",
+            str(seq),
+            *(("--agent-session-id", session_id) if session_id else ()),
+        )
+        self._enqueue(("report-agent", argv))
+
+    def release(self) -> None:
+        """Queue the ``release-agent``, exactly once, and stop the worker after it.
+
+        Idempotent and safe from any thread — the event loop on ``on_unmount``,
+        and the exit drain from ``atexit``. Returns immediately: the call runs
+        on the worker, and the exit drain is what guarantees it lands before
+        the interpreter is gone.
+        """
+        # `Event.set` is not test-and-set, so the once-only decision needs the
+        # lock; the latch is still an Event so the worker can read it without
+        # contending for that lock mid-subprocess.
+        with self._lock:
+            if self._released.is_set():
+                return
+            self._released.set()
+            seq = self._next_seq_locked()
+        argv = self._argv("release-agent", "--seq", str(seq))
+        self._enqueue(("release-agent", argv))
+        self._queue.put(None)
+
+    def join(self, timeout: float = EXIT_DRAIN_TIMEOUT_S) -> None:
+        """Wait for the worker to drain, bounded. Tests and the exit drain only.
+
+        Never called from the event loop: a call parked in a subprocess
+        timeout would stall the TUI for exactly as long as this waits.
+        """
+        thread = self._thread
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=timeout)
+
+    # -- internals -----------------------------------------------------------
+
+    def _next_seq_locked(self) -> int:
+        # See the module docstring for why this is not `+= 1` alone.
+        self._seq = max(self._seq + 1, self._clock())
+        return self._seq
+
+    def _argv(self, subcommand: str, *rest: str) -> tuple[str, ...]:
+        return (
+            self._binary,
+            "pane",
+            subcommand,
+            self._pane_id,
+            "--source",
+            HERDR_SOURCE,
+            "--agent",
+            HERDR_AGENT,
+            *rest,
+        )
+
+    def _enqueue(self, item: tuple[str, tuple[str, ...]]) -> None:
+        self._queue.put(item)
+        self._ensure_worker()
+
+    def _ensure_worker(self) -> None:
+        # Started on the first call rather than in the constructor so a
+        # reporter that never reports (built and discarded) costs no thread.
+        # The exit drain is registered at the same moment, and BEFORE the
+        # thread exists, so an interpreter exit racing the start still finds
+        # this reporter in the registry.
+        with self._lock:
+            if self._thread is not None:
+                return
+            _LIVE_REPORTERS.add(self)
+            _register_exit_drain()
+            thread = threading.Thread(target=self._run, name="lop-herdr-report", daemon=True)
+            self._thread = thread
+        thread.start()
+
+    def _run(self) -> None:
+        while True:
+            item = self._queue.get()
+            if item is None:
+                return
+            subcommand, argv = item
+            try:
+                self._invoker(subcommand, argv)
+            except Exception:  # noqa: BLE001 — best-effort by contract
+                logger.debug("herdr %s failed", subcommand, exc_info=True)
+
+
+def start_reporter(
+    session_id: str | None = None,
+    *,
+    env: EnvMap | None = None,
+    invoker: Invoker | None = None,
+    clock: Clock | None = None,
+) -> HerdrReporter | None:
+    """A reporter for this pane, or None when there is nothing to report to.
+
+    None is the common case and not an error: not inside Herdr, the kill
+    switch, or no resolvable ``herdr`` binary. The caller is expected to hand
+    the result to ``StatusLine.set_herdr_reporter``, which emits the initial
+    state — this function itself sends nothing, so the first report carries
+    whatever the band's state actually is rather than an assumed ``idle``.
+
+    Never raises: this runs at session adoption, where an exception would cost
+    the user their session for the sake of a sidebar row.
+    """
+    try:
+        source = _source(env)
+        if not herdr_reporting_enabled(source):
+            return None
+        if not is_herdr(source):
+            return None
+        binary = herdr_binary(source)
+        if binary is None:
+            logger.debug("inside Herdr but no herdr binary is resolvable; not reporting")
+            return None
+        pane_id = (source.get(HERDR_PANE_ENV) or "").strip()
+        reporter = HerdrReporter(
+            pane_id=pane_id,
+            binary=binary,
+            session_id=session_id,
+            invoker=invoker,
+            clock=clock,
+        )
+        logger.debug("reporting lifecycle state to Herdr pane %s", pane_id)
+        return reporter
+    except Exception:  # noqa: BLE001 — must never break session startup
+        logger.debug("herdr reporter failed to start", exc_info=True)
+        return None
+
+
+def release_reporter(reporter: HerdrReporter | None) -> None:
+    """Release the pane's row on a clean exit. Safe with None, never raises.
+
+    The release itself runs on the reporter's worker, and the exit drain
+    guarantees it lands before the interpreter is gone — see
+    :func:`_register_exit_drain` for why that is ``atexit`` and not a join
+    here. A join here would be on the Textual event loop.
+    """
+    if reporter is None:
+        return
+    try:
+        reporter.release()
+    except Exception:  # noqa: BLE001 — best-effort by contract
+        logger.debug("herdr release failed", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Exit drain
+# ---------------------------------------------------------------------------
+
+_EXIT_DRAIN_LOCK = threading.Lock()
+_exit_drain_registered = False
+
+#: Every reporter that has started its worker in this process. Weak, so a
+#: reporter dropped before exit is not kept alive to be drained for nothing.
+#: Several reporters per process happens only in tests; production has one
+#: per pane, and a pane is a process.
+_LIVE_REPORTERS: weakref.WeakSet["HerdrReporter"] = weakref.WeakSet()
+
+
+def _register_exit_drain() -> None:
+    """Make sure the release survives interpreter exit — and is issued at all.
+
+    WHY THIS EXISTS
+    ---------------
+    The worker is a daemon thread, and daemon threads are killed at
+    interpreter exit without running what is left of their target. Without
+    this, ``release()`` on quit would return in microseconds having only
+    QUEUED the call; the interpreter then exits and the pane's row keeps
+    saying ``idle`` for a process that no longer exists. And an exit that
+    never reached ``on_unmount`` at all (an exception unwinding out of Textual)
+    would never even queue it — so this drain also ISSUES the release for any
+    reporter still unreleased, which is the "abrupt exit still releases" half
+    of the contract.
+
+    WHY ``atexit`` AND NOT A JOIN IN ``release``
+    --------------------------------------------
+    A join in ``release`` would sit on the Textual event loop (``on_unmount``
+    is a coroutine) for as long as a wedged ``herdr`` takes to time out —
+    the exact freeze ``SessionBroadcast.stop`` documents removing.
+    ``atexit`` runs on the main thread after the loop is gone.
+
+    EVERY exec-shaped exit skips ``atexit``: a hard crash, ``os._exit``, and
+    the POSIX re-exec behind ``/reload`` and ``/update`` (``reexec.py``
+    replaces the image with ``os.execvpe``). That is harmless here for the
+    same reason it is for the multiplexer: the re-exec has already queued its
+    release in ``on_unmount`` before ``cli.py`` calls ``replace_self``, and
+    whether or not that subprocess lands before or after the successor's
+    first report, the clock-anchored ``--seq`` makes Herdr keep the newer
+    one. A crash leaves the row for Herdr's own process-exit reconciliation.
+
+    Registered once per process, not once per reporter.
+    """
+    global _exit_drain_registered
+    with _EXIT_DRAIN_LOCK:
+        if _exit_drain_registered:
+            return
+        _exit_drain_registered = True
+    atexit.register(_drain_at_exit)
+
+
+def _drain_at_exit() -> None:
+    """Release every live reporter and join its worker, bounded. Never raises."""
+    reporters = tuple(_LIVE_REPORTERS)
+    for reporter in reporters:
+        try:
+            reporter.release()
+        except Exception:  # noqa: BLE001 — an exit path must never raise
+            logger.debug("exit release failed", exc_info=True)
+    deadline = time.monotonic() + EXIT_DRAIN_TIMEOUT_S
+    for reporter in reporters:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        try:
+            reporter.join(timeout=remaining)
+        except Exception:  # noqa: BLE001 — an exit path must never raise
+            logger.debug("exit release drain failed", exc_info=True)

--- a/local_operator/terminals.py
+++ b/local_operator/terminals.py
@@ -69,6 +69,21 @@ TERM_PROGRAM_APPLE = "apple_terminal"
 CMUX_SURFACE_ENV = "CMUX_SURFACE_ID"
 CMUX_WORKSPACE_ENV = "CMUX_WORKSPACE_ID"
 
+#: Herdr (https://herdr.dev) injects these into every pane process. ``HERDR_ENV``
+#: is the "inside Herdr" flag and ``HERDR_PANE_ID`` names the pane holding this
+#: session — BOTH gate :func:`is_herdr`, because the pane id is what every
+#: report is addressed to and a flag with no pane is nothing to report to.
+#: ``HERDR_BIN_PATH`` is the ``herdr`` CLI the reporter prefers over PATH (the
+#: binary that started the pane is by definition the one whose socket protocol
+#: matches the running server). The socket path and the tab/workspace ids are
+#: recorded for completeness; nothing here reads them yet.
+HERDR_ENV = "HERDR_ENV"
+HERDR_PANE_ENV = "HERDR_PANE_ID"
+HERDR_BIN_ENV = "HERDR_BIN_PATH"
+HERDR_SOCKET_ENV = "HERDR_SOCKET_PATH"
+HERDR_TAB_ENV = "HERDR_TAB_ID"
+HERDR_WORKSPACE_ENV = "HERDR_WORKSPACE_ID"
+
 #: Set by sshd in a remote session. Used to say "no window server here" in a
 #: fork's fallback receipt, which reads as competent rather than broken.
 SSH_CONNECTION_ENV = "SSH_CONNECTION"
@@ -148,6 +163,22 @@ def is_cmux(env: EnvMap | None = None) -> bool:
     """
     source = _source(env)
     return bool(source.get(CMUX_SURFACE_ENV) and source.get(CMUX_WORKSPACE_ENV))
+
+
+def is_herdr(env: EnvMap | None = None) -> bool:
+    """True when this process is a Herdr pane, by MARKERS ALONE.
+
+    The same caveat as :func:`is_cmux`: the markers are inherited across a
+    container or an ssh hop into a host with no ``herdr`` CLI, so this is
+    sufficient for "was this started by Herdr" and NOT for shelling out.
+    ``herdr.reporter`` additionally gates on a resolvable binary.
+
+    ``HERDR_ENV`` is compared to ``"1"`` exactly, as documented, rather than
+    tested for truthiness: a stray ``HERDR_ENV=0`` exported to switch the
+    integration off by hand should read as "not Herdr".
+    """
+    source = _source(env)
+    return source.get(HERDR_ENV) == "1" and bool(source.get(HERDR_PANE_ENV))
 
 
 def is_ssh(env: EnvMap | None = None) -> bool:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -257,6 +257,7 @@ from local_operator.tui.widgets.welcome import (
 if TYPE_CHECKING:  # keeps the provider graph off the TUI's runtime import path
     from pathlib import Path
 
+    from local_operator.herdr import HerdrReporter
     from local_operator.multiplexer import SessionBroadcast
     from local_operator.providers.controller import CatalogueEntry
     from local_operator.providers.oauth.callback_server import LoginCallbacks
@@ -2217,6 +2218,13 @@ class OperatorApp(App[None]):
         #: — all ordinary, none an error. Rebound on every session swap, since
         #: the pane's binding must name the conversation currently in it.
         self._multiplexer_broadcast: SessionBroadcast | None = None
+        #: Reports idle/working/blocked to the hosting Herdr pane's Agents row
+        #: (see :mod:`local_operator.herdr`). ``None`` outside Herdr, headless,
+        #: for a subagent's session, or under the kill switch — all ordinary.
+        #: Unlike the multiplexer binding this is NOT rebuilt on a session
+        #: swap: the row belongs to the PANE and the process, and a ``/new``
+        #: only changes the session-id metadata it carries.
+        self._herdr_reporter: HerdrReporter | None = None
         #: Desktop notifications for the user who is looking at another app —
         #: the surface one step beyond the window title (see `tui/notify.py`).
         #: Held by the app rather than by the band because, unlike the title,
@@ -3188,6 +3196,9 @@ class OperatorApp(App[None]):
         # to name the conversation now in it, and a swap (`/new`, `/resume`)
         # is exactly when the old one becomes wrong.
         self._start_multiplexer_broadcast()
+        # Same moment, same reason: the Herdr row's session-id metadata has to
+        # name the conversation now in the pane.
+        self._start_herdr_reporter()
         # A remote follower must never publish a second discovery record for
         # the shared session, and it must be ready to replace this facade with
         # the lease-winning real Session after owner death. The callback uses
@@ -11475,6 +11486,90 @@ class OperatorApp(App[None]):
         # withdraw simply lands whenever its worker finishes and the exit
         # drain still guarantees it lands at all.
 
+    def _start_herdr_reporter(self) -> None:
+        """Report this pane's lifecycle state to Herdr's Agents panel.
+
+        Called on every session adoption, like the multiplexer broadcast, but
+        the reporter is built ONCE per process and only re-labelled on a swap:
+        the Agents row is a property of the pane, and a ``/new`` that released
+        and re-reported would flash the row empty for one round trip. Only the
+        ``--agent-session-id`` metadata changes, and the reporter re-sends the
+        current state under the new id.
+
+        Everything below is best-effort and returns on the ordinary paths —
+        no Herdr, the kill switch, headless, a subagent's session — see
+        :mod:`local_operator.herdr`. Nothing here can raise into the boot
+        path, and no subprocess runs on this thread: the reporter owns a
+        worker thread so the event loop never waits on the ``herdr`` CLI.
+        """
+        # Headless means no pane, and this gate is what keeps the test suite
+        # off a developer's own Herdr pane: `tests/conftest.py` does not scrub
+        # `HERDR_*` (only `CMUX_*`), so without it every pilot test run from
+        # inside Herdr would overwrite the Agents row of the session running
+        # the tests. Same hazard `_start_multiplexer_broadcast` documents.
+        if self.is_headless:
+            return
+        session = self._session
+        if session is None:
+            return
+        session_id = getattr(session, "session_id", "") or ""
+        if not session_id:
+            return
+        # Guarded even though `start_reporter` guards itself: the IMPORT is
+        # part of this path, and the feature can never be the reason a
+        # session fails to open.
+        try:
+            from local_operator.multiplexer.broadcast import is_user_owned_session
+
+            # A subagent's child session runs INSIDE its parent's pane, so
+            # reporting it would overwrite the user's own row with the
+            # child's state — `idle` while the parent is parked on an
+            # approval. The same gate as the resume binding, deliberately:
+            # one definition of "the user's own session".
+            if not is_user_owned_session(session_id):
+                return
+            reporter = self._herdr_reporter
+            if reporter is not None:
+                reporter.set_session_id(session_id)
+                if self._status is not None:
+                    # Re-attach so the current state goes out under the
+                    # new session id (the reporter cleared its de-dupe).
+                    self._status.set_herdr_reporter(reporter)
+                return
+            from local_operator.herdr import start_reporter
+
+            reporter = start_reporter(session_id)
+        except Exception:  # noqa: BLE001 — bookkeeping must not break a session
+            logger.debug("herdr reporter failed to start", exc_info=True)
+            reporter = None
+        self._herdr_reporter = reporter
+        if reporter is not None and self._status is not None:
+            # Attaching is what sends the initial report, with the band's
+            # actual state rather than an assumed `idle`.
+            self._status.set_herdr_reporter(reporter)
+
+    def _stop_herdr_reporter(self) -> None:
+        """Release the pane's Agents row (idempotent). Never blocks.
+
+        The release runs on the reporter's worker and the exit drain lands it
+        before the interpreter is gone; see ``herdr.reporter`` for why that is
+        ``atexit`` and not a join here (a join here would be on the loop).
+        """
+        reporter = self._herdr_reporter
+        if reporter is None:
+            return
+        # Cleared FIRST, so a failure below cannot leave the app holding a
+        # handle it believes is still reporting.
+        self._herdr_reporter = None
+        try:
+            if self._status is not None:
+                self._status.set_herdr_reporter(None)
+            from local_operator.herdr import release_reporter
+
+            release_reporter(reporter)
+        except Exception:  # noqa: BLE001 — never block an exit path
+            logger.debug("herdr reporter failed to stop", exc_info=True)
+
     def _stop_multiplexer_broadcast(self, *, retire: bool = True) -> "SessionBroadcast | None":
         """Withdraw this pane's binding (idempotent), returning the handle.
 
@@ -11925,6 +12020,11 @@ class OperatorApp(App[None]):
         # closed. A crash never reaches this line, which is what leaves the
         # binding standing for the restore to find.
         self._stop_multiplexer_broadcast()
+        # And the Herdr row, for the same reason: a clean exit must not leave
+        # the Agents panel showing a session that is gone. Before the approval
+        # settling below so the release is queued ahead of anything that can
+        # await — the exit drain then lands it even if teardown throws.
+        self._stop_herdr_reporter()
         # Before disposing the session: dispose awaits teardown, and a turn
         # parked on an unanswered approval would never reach it.
         self._deny_queued_approvals()

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -11502,11 +11502,15 @@ class OperatorApp(App[None]):
         path, and no subprocess runs on this thread: the reporter owns a
         worker thread so the event loop never waits on the ``herdr`` CLI.
         """
-        # Headless means no pane, and this gate is what keeps the test suite
-        # off a developer's own Herdr pane: `tests/conftest.py` does not scrub
-        # `HERDR_*` (only `CMUX_*`), so without it every pilot test run from
-        # inside Herdr would overwrite the Agents row of the session running
-        # the tests. Same hazard `_start_multiplexer_broadcast` documents.
+        # Headless means no pane, and this is the SECOND of two independent
+        # guards keeping the test suite off a developer's own Herdr pane: a
+        # pilot test run from inside Herdr would otherwise overwrite the Agents
+        # row of the session running the tests. `tests/conftest.py` scrubs
+        # `HERDR_*` (alongside `CMUX_*`, for the same reason and after the same
+        # class of incident), so detection already fails there — this gate is
+        # what holds if that scrub is ever narrowed, and it is verified on its
+        # own by `test_a_headless_app_reports_nothing` plus its lifted-gate
+        # control. Same hazard `_start_multiplexer_broadcast` documents.
         if self.is_headless:
             return
         session = self._session

--- a/local_operator/tui/widgets/status_line.py
+++ b/local_operator/tui/widgets/status_line.py
@@ -38,6 +38,7 @@ from rich.style import Style
 from rich.text import Text
 from textual.widgets import Static
 
+from local_operator.herdr.reporter import HerdrReporter, state_from_title
 from local_operator.model.naming import model_label as model_label_forms
 from local_operator.session.frontend_state import (
     format_context_tokens as _format_context_tokens,
@@ -1048,6 +1049,24 @@ class StatusLine:
         #: attaches one, which keeps the band usable by the lightweight test
         #: hosts that have no terminal to write to.
         self._title: TerminalTitle | None = None
+        #: The Herdr Agents-panel reporter, driven from the same place as the
+        #: title and for the same reason: the band is the one object that
+        #: already coalesces ``streaming`` and ``attention`` into ONE external
+        #: run state, and a second derivation is a second thing to disagree.
+        #: ``None`` outside Herdr (the common case) and for every test host.
+        self._herdr: HerdrReporter | None = None
+
+    def set_herdr_reporter(self, reporter: HerdrReporter | None) -> None:
+        """Attach (or detach) the Herdr reporter and report the current state once.
+
+        Mirrors :meth:`set_terminal_title`. The immediate sync is what emits
+        the INITIAL report: the reporter itself sends nothing on construction,
+        so the first thing Herdr hears is the band's actual state — ``idle``
+        at a prompt, but ``working`` if the app attached it mid-turn (a
+        ``/resume`` that adopts a session whose turn is already running).
+        """
+        self._herdr = reporter
+        self._sync_terminal_title()
 
     def set_terminal_title(self, title: TerminalTitle | None) -> None:
         """Attach (or detach) the window-title writer and paint it once.
@@ -1152,6 +1171,14 @@ class StatusLine:
         rendered string, so a redundant sync costs three comparisons and
         writes nothing.
         """
+        # BEFORE the title's own early-return, deliberately. The title is
+        # gated by `LOCAL_OPERATOR_NO_TERMINAL_TITLE` / `display.terminal_title`
+        # and is never attached headless; the Herdr row must not go silent
+        # because a user turned off a different feature. The state is the
+        # title's derivation either way — only the sink differs.
+        herdr = self._herdr
+        if herdr is not None:
+            herdr.report(state_from_title(self._title_state()))
         title = self._title
         if title is None:
             return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,15 @@ _AMBIENT_VARS = (
     "CMUX_PANEL_ID",
     "CMUX_TAB_ID",
     "CMUX_SOCKET",
+    # The calling Herdr pane: the identical hazard as CMUX_* — a test run from
+    # inside a Herdr pane would take over that pane's Agents row and then
+    # RELEASE it on exit. Nothing in a test may address a real Herdr pane.
+    "HERDR_ENV",
+    "HERDR_PANE_ID",
+    "HERDR_BIN_PATH",
+    "HERDR_SOCKET_PATH",
+    "HERDR_TAB_ID",
+    "HERDR_WORKSPACE_ID",
     "OPENAI_API_KEY",
     "ANTHROPIC_API_KEY",
     # The provider registry's ONLY callable ``env_keys`` resolver prefers this

--- a/tests/unit/test_ambient_env_isolation.py
+++ b/tests/unit/test_ambient_env_isolation.py
@@ -72,6 +72,7 @@ _HARMLESS: dict[str, str] = {
     "LOCAL_OPERATOR_NO_SHIMMER": "animation switch; the visual harness sets it",
     "LOCAL_OPERATOR_NO_TERMINAL_TITLE": "title-escape switch",
     "LOCAL_OPERATOR_NO_MULTIPLEXER_RESUME": "kill switch for the pane resume marker; safer ON",
+    "LOCAL_OPERATOR_NO_HERDR": "kill switch for the Herdr Agents-panel reporter; safer ON",
     "LOCAL_OPERATOR_NO_NOTIFICATIONS": "desktop-notification kill switch (safer ON)",
     "LOCAL_OPERATOR_IMAGES": "inline-image protocol switch",
     "LOCAL_OPERATOR_GREP_ENGINE": "rg vs python grep",

--- a/tests/unit/test_fork.py
+++ b/tests/unit/test_fork.py
@@ -1470,6 +1470,8 @@ def _band():
     band._spinner_index = 0
     band._subagent = None
     band._title = None
+    # The Herdr reporter, which `_sync_terminal_title` consults on every call.
+    band._herdr = None
     return band
 
 

--- a/tests/unit/test_herdr_reporter.py
+++ b/tests/unit/test_herdr_reporter.py
@@ -277,13 +277,27 @@ def test_the_production_clock_is_epoch_microseconds() -> None:
     assert seq < 2**63
 
 
-def test_reports_are_ordered_by_enqueue_not_by_completion() -> None:
-    """The seq is minted on the caller's thread, so it reflects state order.
+def test_delivery_order_is_mint_order_under_contention() -> None:
+    """Two threads racing `report`: the delivered seqs are strictly ascending.
 
-    Two threads racing `report` still produce seqs in the order the reports
-    were queued: the call at position N in the invoker's log carries the Nth
-    seq. A seq minted inside the worker could not be wrong here — it is
-    single-threaded — but a seq minted OUTSIDE the lock could.
+    This is the module's central ordering claim, and it is a real one only
+    because the seq is minted and the call enqueued in ONE critical section.
+    An earlier version minted under the lock and queued outside it, so two
+    callers could mint 1, 2 and deliver 2, 1 — and the test that pinned it
+    asserted the same `sorted` property this one does while passing purely
+    because the default 5 ms GIL switch interval hid the window (review round
+    1, A2: 80/200 inverted at 1e-6, 0/400 at the default).
+
+    So the window is FORCED open rather than hoped shut: `setswitchinterval`
+    is dropped to 1 µs for the duration, which makes the interleaving that
+    used to fail the common case instead of a rare one. That is what makes
+    this a test rather than a bet on machine load (AGENTS.md "Timing,
+    flakes") — there is no sleep and no deadline anywhere in it; the wait is
+    on the threads' own completion.
+
+    `test_the_mint_and_enqueue_are_one_critical_section` below is the
+    can-it-still-fail control: it reintroduces the split and shows this
+    property breaking.
     """
     recorder = Recorder()
     reporter = _reporter(recorder)
@@ -294,26 +308,183 @@ def test_reports_are_ordered_by_enqueue_not_by_completion() -> None:
         for state in states:
             reporter.report(state)
 
-    threads = [
-        threading.Thread(
-            target=hammer, args=(cast(Sequence[HerdrState], ("working", "idle") * 20),)
-        ),
-        threading.Thread(
-            target=hammer, args=(cast(Sequence[HerdrState], ("blocked", "idle") * 20),)
-        ),
-    ]
-    for thread in threads:
-        thread.start()
-    start.set()
-    for thread in threads:
-        thread.join(WAIT_S)
-    reporter.release()
-    reporter.join()
+    previous = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    try:
+        threads = [
+            threading.Thread(
+                target=hammer, args=(cast(Sequence[HerdrState], ("working", "idle") * 20),)
+            ),
+            threading.Thread(
+                target=hammer, args=(cast(Sequence[HerdrState], ("blocked", "idle") * 20),)
+            ),
+        ]
+        for thread in threads:
+            thread.start()
+        start.set()
+        for thread in threads:
+            thread.join(WAIT_S)
+        reporter.release()
+        reporter.join()
+    finally:
+        sys.setswitchinterval(previous)
+
     seqs = recorder.seqs()
-    assert seqs == sorted(seqs) and len(set(seqs)) == len(seqs)
+    assert seqs == sorted(seqs), f"delivered out of mint order: {seqs}"
+    assert len(set(seqs)) == len(seqs), f"duplicate seq: {seqs}"
     # De-dupe held under contention: no two consecutive reports share a state.
     states = recorder.states()
     assert all(a != b for a, b in zip(states, states[1:]))
+    # The release is last, and no report was delivered behind it.
+    assert [sub for sub, _ in recorder.calls][-1] == "release-agent"
+
+
+def test_the_mint_and_enqueue_are_one_critical_section() -> None:
+    """Prove the test above can still fail: reintroduce the split, see it break.
+
+    AGENTS.md requires a guard to be shown catching the bug it exists for
+    rather than passing vacuously. A subclass restores the OLD shape — mint
+    under the lock, enqueue after releasing it — and the same hammering then
+    produces an inverted delivery log. Asserting that the inversion HAPPENS
+    would itself be a race, so the assertion is one-sided: the real reporter
+    is run in the identical arrangement and must be ordered every time, while
+    the broken one is merely reported on. That keeps this test deterministic
+    while still exercising the exact code path that used to fail.
+    """
+
+    class SplitMintAndEnqueue(HerdrReporter):
+        """The PRE-FIX shape, and nothing else: mint under the lock, put after it.
+
+        Deliberately a thin override rather than a copy of the real method —
+        what is being reintroduced is exactly one thing, the gap between the
+        mint and the put, so that is all this changes.
+        """
+
+        def report(self, state: HerdrState) -> None:  # type: ignore[override]
+            if self._released.is_set():
+                return
+            with self._lock:
+                if state == self._last:
+                    return
+                self._last = state
+                seq = self._next_seq_locked()
+                argv = self._argv("report-agent", "--state", state, "--seq", str(seq))
+            # THE DEFECT: the lock is dropped before the put, so two callers
+            # that minted in one order can enqueue in the other.
+            self._queue.put(("report-agent", argv))
+            with self._lock:
+                self._enqueue_started = getattr(self, "_enqueue_started", False)
+                if not self._enqueue_started:
+                    self._enqueue_started = True
+                    self._thread = threading.Thread(
+                        target=self._run, name="lop-herdr-report", daemon=True
+                    )
+                    pending = self._thread
+                else:
+                    pending = None
+            if pending is not None:
+                pending.start()
+
+    def hammer_seqs(reporter: HerdrReporter, recorder: Recorder) -> list[int]:
+        start = threading.Event()
+
+        def hammer(states: Sequence[HerdrState]) -> None:
+            start.wait()
+            for state in states:
+                reporter.report(state)
+
+        threads = [
+            threading.Thread(
+                target=hammer, args=(cast(Sequence[HerdrState], ("working", "idle") * 30),)
+            ),
+            threading.Thread(
+                target=hammer, args=(cast(Sequence[HerdrState], ("blocked", "idle") * 30),)
+            ),
+        ]
+        for thread in threads:
+            thread.start()
+        start.set()
+        for thread in threads:
+            thread.join(WAIT_S)
+        reporter.release()
+        reporter.join()
+        return recorder.seqs()
+
+    previous = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    inversions = 0
+    try:
+        # Several trials, because the defect is probabilistic even with the
+        # window forced open. Nothing is asserted about the count.
+        for _ in range(12):
+            recorder = Recorder()
+            counter = itertools.count(1)
+            broken = SplitMintAndEnqueue(
+                pane_id="w1:p1",
+                binary="/opt/herdr",
+                invoker=recorder,
+                clock=lambda: next(counter),
+            )
+            seqs = hammer_seqs(broken, recorder)
+            if seqs != sorted(seqs):
+                inversions += 1
+
+        # The FIXED reporter, in the identical arrangement, every trial.
+        for _ in range(12):
+            recorder = Recorder()
+            fixed = _reporter(recorder)
+            seqs = hammer_seqs(fixed, recorder)
+            assert seqs == sorted(seqs), f"the fix regressed: {seqs}"
+    finally:
+        sys.setswitchinterval(previous)
+
+    # Recorded for the reader, not asserted: on the machine this was written
+    # on the split shape inverted in most trials. A zero here would mean the
+    # control did not exercise the window, not that the fix is wrong, so it
+    # must never fail the suite.
+    print(f"[control] split-mint/enqueue inverted {inversions}/12 trials")
+
+
+def test_a_report_racing_a_release_is_dropped_not_resent() -> None:
+    """A1: nothing may be delivered after `release-agent` with a higher seq.
+
+    That is the failure `release-agent` exists to prevent — Herdr's high-water
+    mark cannot discard a HIGHER seq, so the row would keep describing an
+    exited process. The pre-fix code tested the released latch outside the
+    lock, so a report could pass the check, block on the lock the release
+    held, then mint a later seq and be delivered behind it (reproduced at
+    3/6000). The window is forced open here the same way, and the invariant is
+    checked over many trials rather than one.
+    """
+    previous = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    try:
+        for trial in range(400):
+            recorder = Recorder()
+            reporter = _reporter(recorder)
+            reporter.report("idle")
+            ready = threading.Event()
+
+            def racer(rep: HerdrReporter = reporter, gate: threading.Event = ready) -> None:
+                gate.wait()
+                rep.report("working")
+
+            thread = threading.Thread(target=racer)
+            thread.start()
+            ready.set()
+            reporter.release()
+            thread.join(WAIT_S)
+            reporter.join()
+
+            subs = [sub for sub, _ in recorder.calls]
+            assert subs.count("release-agent") == 1, f"trial {trial}: {subs}"
+            assert (
+                subs[-1] == "release-agent"
+            ), f"trial {trial}: a report was delivered after the release: {subs}"
+            seqs = recorder.seqs()
+            assert seqs == sorted(seqs), f"trial {trial}: {seqs}"
+    finally:
+        sys.setswitchinterval(previous)
 
 
 def test_the_invoker_runs_off_the_calling_thread() -> None:

--- a/tests/unit/test_herdr_reporter.py
+++ b/tests/unit/test_herdr_reporter.py
@@ -1,0 +1,556 @@
+"""The Herdr reporter: detection, ordering, de-dupe, release, failure isolation.
+
+Every test drives the reporter through an INJECTED invoker that records
+``(subcommand, argv)`` and never spawns anything, the same shape
+``test_multiplexer_broadcast`` uses with its fake backend. The one property
+that cannot be observed in-process — the release landing before interpreter
+exit — runs in a subprocess, exactly as the multiplexer's F8 test does.
+
+Waits are on events the code under test publishes (a ``threading.Event`` set
+by the invoker), never on the clock — see AGENTS.md "Timing, flakes".
+"""
+
+from __future__ import annotations
+
+import itertools
+import subprocess
+import sys
+import textwrap
+import threading
+from pathlib import Path
+from typing import Sequence, cast
+
+import pytest
+
+from local_operator import terminals
+from local_operator.herdr import reporter as reporter_mod
+from local_operator.herdr.reporter import (
+    HERDR_AGENT,
+    HERDR_SOURCE,
+    HerdrReporter,
+    HerdrState,
+    herdr_binary,
+    herdr_reporting_enabled,
+    release_reporter,
+    start_reporter,
+    state_from_title,
+)
+
+#: Generous backstop for a wait on a worker thread. Not an expectation: the
+#: worker runs a fake invoker that returns in microseconds, so a wait that
+#: reaches this is a wedge, not slowness.
+WAIT_S = 10.0
+
+
+class Recorder:
+    """An invoker that records every call and publishes each arrival.
+
+    ``fail`` makes every call raise, which is how the failure-isolation tests
+    prove the worker swallows exceptions. ``calls`` is appended BEFORE the
+    raise so a test can still see the call was attempted.
+    """
+
+    def __init__(self, *, fail: bool = False) -> None:
+        self.calls: list[tuple[str, tuple[str, ...]]] = []
+        self.fail = fail
+        self._lock = threading.Lock()
+        self._arrived = threading.Condition(self._lock)
+        self.threads: list[int] = []
+
+    def __call__(self, subcommand: str, argv: Sequence[str]) -> None:
+        with self._arrived:
+            self.calls.append((subcommand, tuple(argv)))
+            self.threads.append(threading.get_ident())
+            self._arrived.notify_all()
+        if self.fail:
+            raise RuntimeError("herdr exploded")
+
+    def wait_for_calls(self, count: int) -> list[tuple[str, tuple[str, ...]]]:
+        with self._arrived:
+            if not self._arrived.wait_for(lambda: len(self.calls) >= count, timeout=WAIT_S):
+                pytest.fail(f"expected {count} herdr calls, saw {self.calls}")
+            return list(self.calls)
+
+    def states(self) -> list[str]:
+        return [_flag(argv, "--state") for sub, argv in self.calls if sub == "report-agent"]
+
+    def seqs(self) -> list[int]:
+        return [int(_flag(argv, "--seq")) for _, argv in self.calls]
+
+
+def _flag(argv: Sequence[str], name: str) -> str:
+    return argv[list(argv).index(name) + 1]
+
+
+def _reporter(recorder: Recorder, *, session_id: str | None = "sess-1") -> HerdrReporter:
+    # `clock` counts from one so the seqs read as the contract's `1, 2, 3`
+    # rather than as epoch microseconds; the production clock is covered by
+    # `test_the_sequence_is_anchored_to_the_clock`.
+    counter = itertools.count(1)
+    return HerdrReporter(
+        pane_id="w1:p1",
+        binary="/opt/herdr",
+        session_id=session_id,
+        invoker=recorder,
+        clock=lambda: next(counter),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Detection and gating
+# ---------------------------------------------------------------------------
+
+
+def test_is_herdr_needs_both_markers() -> None:
+    assert terminals.is_herdr({"HERDR_ENV": "1", "HERDR_PANE_ID": "w1:p1"})
+    assert not terminals.is_herdr({"HERDR_ENV": "1"})
+    assert not terminals.is_herdr({"HERDR_PANE_ID": "w1:p1"})
+    assert not terminals.is_herdr({})
+    # Exact match, as documented: a hand-exported `0` reads as "not Herdr".
+    assert not terminals.is_herdr({"HERDR_ENV": "0", "HERDR_PANE_ID": "w1:p1"})
+
+
+def test_the_binary_prefers_the_exported_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    exported = tmp_path / "herdr"
+    exported.write_text("#!/bin/sh\n")
+    exported.chmod(0o755)
+    monkeypatch.setattr(reporter_mod.shutil, "which", lambda name: "/usr/local/bin/herdr")
+    assert herdr_binary({"HERDR_BIN_PATH": str(exported)}) == str(exported)
+
+
+def test_the_binary_falls_back_to_path_when_the_export_is_dead(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An inherited `HERDR_BIN_PATH` across an ssh hop names nothing here."""
+    monkeypatch.setattr(reporter_mod.shutil, "which", lambda name: "/usr/local/bin/herdr")
+    assert herdr_binary({"HERDR_BIN_PATH": str(tmp_path / "missing")}) == "/usr/local/bin/herdr"
+    monkeypatch.setattr(reporter_mod.shutil, "which", lambda name: None)
+    assert herdr_binary({"HERDR_BIN_PATH": str(tmp_path / "missing")}) is None
+    assert herdr_binary({}) is None
+
+
+def test_the_kill_switch() -> None:
+    assert herdr_reporting_enabled({})
+    assert not herdr_reporting_enabled({"LOCAL_OPERATOR_NO_HERDR": "1"})
+    # Whitespace-only is "unset", matching the multiplexer switch.
+    assert herdr_reporting_enabled({"LOCAL_OPERATOR_NO_HERDR": "  "})
+
+
+def test_start_reporter_is_none_outside_herdr(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(reporter_mod.shutil, "which", lambda name: "/usr/local/bin/herdr")
+    assert start_reporter("sess", env={}) is None
+
+
+def test_start_reporter_is_none_without_a_binary(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Markers alone are not enough: they are inherited into hosts with no CLI."""
+    monkeypatch.setattr(reporter_mod.shutil, "which", lambda name: None)
+    assert start_reporter("sess", env={"HERDR_ENV": "1", "HERDR_PANE_ID": "w1:p1"}) is None
+
+
+def test_start_reporter_is_none_under_the_kill_switch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(reporter_mod.shutil, "which", lambda name: "/usr/local/bin/herdr")
+    env = {"HERDR_ENV": "1", "HERDR_PANE_ID": "w1:p1", "LOCAL_OPERATOR_NO_HERDR": "1"}
+    assert start_reporter("sess", env=env) is None
+
+
+def test_start_reporter_inside_herdr(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(reporter_mod.shutil, "which", lambda name: "/usr/local/bin/herdr")
+    recorder = Recorder()
+    reporter = start_reporter(
+        "sess-9", env={"HERDR_ENV": "1", "HERDR_PANE_ID": "w1:p1"}, invoker=recorder
+    )
+    assert reporter is not None
+    assert reporter.pane_id == "w1:p1"
+    assert reporter.session_id == "sess-9"
+    # Construction reports nothing: the band's attach sends the first state.
+    assert recorder.calls == []
+
+
+def test_start_reporter_never_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(env=None):  # noqa: ANN001, ANN202
+        raise RuntimeError("detection exploded")
+
+    monkeypatch.setattr(reporter_mod, "is_herdr", boom)
+    assert start_reporter("sess", env={"HERDR_ENV": "1", "HERDR_PANE_ID": "w1:p1"}) is None
+
+
+def test_the_state_translation() -> None:
+    assert state_from_title("idle") == "idle"
+    assert state_from_title("working") == "working"
+    assert state_from_title("attention") == "blocked"
+    # An errored turn is the user's turn again — never `unknown`.
+    assert state_from_title("failed") == "idle"
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def test_the_first_report_carries_the_session_id_and_seq_one() -> None:
+    recorder = Recorder()
+    reporter = _reporter(recorder)
+    reporter.report("idle")
+    (call,) = recorder.wait_for_calls(1)
+    assert call == (
+        "report-agent",
+        (
+            "/opt/herdr",
+            "pane",
+            "report-agent",
+            "w1:p1",
+            "--source",
+            HERDR_SOURCE,
+            "--agent",
+            HERDR_AGENT,
+            "--state",
+            "idle",
+            "--seq",
+            "1",
+            "--agent-session-id",
+            "sess-1",
+        ),
+    )
+
+
+def test_the_session_id_is_absent_when_unknown() -> None:
+    recorder = Recorder()
+    reporter = _reporter(recorder, session_id=None)
+    reporter.report("idle")
+    ((_, argv),) = recorder.wait_for_calls(1)
+    assert "--agent-session-id" not in argv
+
+
+def test_transitions_and_recovery_from_blocked() -> None:
+    """working → blocked → working (answered mid-turn), then idle at turn end."""
+    recorder = Recorder()
+    reporter = _reporter(recorder)
+    for state in ("idle", "working", "blocked", "working", "idle"):
+        reporter.report(state)
+    recorder.wait_for_calls(5)
+    assert recorder.states() == ["idle", "working", "blocked", "working", "idle"]
+
+
+def test_identical_consecutive_states_are_deduped_and_seq_strictly_increases() -> None:
+    recorder = Recorder()
+    reporter = _reporter(recorder)
+    for state in ("idle", "idle", "idle", "working", "working", "idle"):
+        reporter.report(state)
+    reporter.release()
+    recorder.wait_for_calls(4)
+    reporter.join()
+    assert recorder.states() == ["idle", "working", "idle"]
+    seqs = recorder.seqs()
+    assert seqs == sorted(seqs) and len(set(seqs)) == len(seqs)
+    assert seqs == [1, 2, 3, 4]
+
+
+def test_the_sequence_is_anchored_to_the_clock() -> None:
+    """A fresh process must out-sequence the one that released before it.
+
+    Herdr keeps the per-source high-water mark across `release-agent`, so a
+    counter from one would be ignored forever after any relaunch in the same
+    pane. Pinned: the seq is `max(previous + 1, clock)` — clock-anchored, and
+    still strictly increasing when the clock stalls or steps back.
+    """
+    recorder = Recorder()
+    ticks = iter([1_000, 1_000, 900, 5_000])
+    reporter = HerdrReporter(
+        pane_id="w1:p1", binary="/opt/herdr", invoker=recorder, clock=lambda: next(ticks)
+    )
+    for state in ("idle", "working", "blocked", "idle"):
+        reporter.report(state)
+    recorder.wait_for_calls(4)
+    assert recorder.seqs() == [1_000, 1_001, 1_002, 5_000]
+
+
+def test_the_production_clock_is_epoch_microseconds() -> None:
+    import time
+
+    before = time.time_ns() // 1_000
+    seq = reporter_mod._default_clock()
+    assert before <= seq <= time.time_ns() // 1_000
+    # Inside Herdr's u64 with headroom: the probe against 0.8.2 accepted
+    # 2**64 - 1 and rejected 2**64.
+    assert seq < 2**63
+
+
+def test_reports_are_ordered_by_enqueue_not_by_completion() -> None:
+    """The seq is minted on the caller's thread, so it reflects state order.
+
+    Two threads racing `report` still produce seqs in the order the reports
+    were queued: the call at position N in the invoker's log carries the Nth
+    seq. A seq minted inside the worker could not be wrong here — it is
+    single-threaded — but a seq minted OUTSIDE the lock could.
+    """
+    recorder = Recorder()
+    reporter = _reporter(recorder)
+    start = threading.Event()
+
+    def hammer(states: Sequence[HerdrState]) -> None:
+        start.wait()
+        for state in states:
+            reporter.report(state)
+
+    threads = [
+        threading.Thread(
+            target=hammer, args=(cast(Sequence[HerdrState], ("working", "idle") * 20),)
+        ),
+        threading.Thread(
+            target=hammer, args=(cast(Sequence[HerdrState], ("blocked", "idle") * 20),)
+        ),
+    ]
+    for thread in threads:
+        thread.start()
+    start.set()
+    for thread in threads:
+        thread.join(WAIT_S)
+    reporter.release()
+    reporter.join()
+    seqs = recorder.seqs()
+    assert seqs == sorted(seqs) and len(set(seqs)) == len(seqs)
+    # De-dupe held under contention: no two consecutive reports share a state.
+    states = recorder.states()
+    assert all(a != b for a, b in zip(states, states[1:]))
+
+
+def test_the_invoker_runs_off_the_calling_thread() -> None:
+    """Structural, not timed: the subprocess never runs where `report` was called."""
+    recorder = Recorder()
+    reporter = _reporter(recorder)
+    reporter.report("idle")
+    reporter.release()
+    reporter.join()
+    assert recorder.threads and all(t != threading.get_ident() for t in recorder.threads)
+
+
+# ---------------------------------------------------------------------------
+# Release
+# ---------------------------------------------------------------------------
+
+
+def test_release_is_exactly_once_and_last() -> None:
+    recorder = Recorder()
+    reporter = _reporter(recorder)
+    reporter.report("idle")
+    reporter.release()
+    reporter.release()
+    release_reporter(reporter)
+    # A report after release is dropped: the row is gone.
+    reporter.report("working")
+    reporter.join()
+    assert [sub for sub, _ in recorder.calls] == ["report-agent", "release-agent"]
+    _, argv = recorder.calls[-1]
+    assert argv[:4] == ("/opt/herdr", "pane", "release-agent", "w1:p1")
+    assert "--state" not in argv and "--agent-session-id" not in argv
+    assert recorder.seqs() == [1, 2]
+    assert reporter.released
+
+
+def test_release_before_any_report_still_releases() -> None:
+    recorder = Recorder()
+    reporter = _reporter(recorder)
+    reporter.release()
+    reporter.join()
+    assert [sub for sub, _ in recorder.calls] == ["release-agent"]
+
+
+def test_reports_queued_ahead_of_a_release_still_land_in_order() -> None:
+    """The stream is a function of the transitions, not of how busy the worker was.
+
+    The worker is parked inside the first call while three more are queued;
+    every one of them is delivered, in order, and the release is last. What
+    is pinned is that `release()` on the caller's thread does not depend on
+    the worker being idle — it queues and returns.
+    """
+    gate = threading.Event()
+    recorder = Recorder()
+
+    def slow_first_call(subcommand: str, argv: Sequence[str]) -> None:
+        recorder(subcommand, argv)
+        if len(recorder.calls) == 1:
+            gate.wait(WAIT_S)
+
+    reporter = HerdrReporter(
+        pane_id="w1:p1", binary="/opt/herdr", invoker=slow_first_call, clock=None
+    )
+    reporter.report("idle")
+    recorder.wait_for_calls(1)
+    reporter.report("working")
+    reporter.report("blocked")
+    # Returns while the worker is still parked in the first call: the release
+    # is queued, not performed, on the caller's thread.
+    reporter.release()
+    assert reporter.released
+    gate.set()
+    reporter.join()
+    assert [sub for sub, _ in recorder.calls] == [
+        "report-agent",
+        "report-agent",
+        "report-agent",
+        "release-agent",
+    ]
+    assert recorder.states() == ["idle", "working", "blocked"]
+
+
+def test_release_reporter_tolerates_none_and_errors() -> None:
+    release_reporter(None)
+
+    class Broken:
+        def release(self) -> None:
+            raise RuntimeError("no")
+
+    release_reporter(Broken())  # type: ignore[arg-type]
+
+
+def test_set_session_id_resends_the_current_state_under_the_new_id() -> None:
+    """A `/new` swap changes only the metadata; the row is not released."""
+    recorder = Recorder()
+    reporter = _reporter(recorder)
+    reporter.report("idle")
+    reporter.set_session_id("sess-2")
+    reporter.report("idle")
+    reporter.set_session_id("sess-2")  # unchanged: no re-send
+    reporter.report("idle")
+    reporter.release()
+    reporter.join()
+    subs = [sub for sub, _ in recorder.calls]
+    assert subs == ["report-agent", "report-agent", "release-agent"]
+    assert _flag(recorder.calls[0][1], "--agent-session-id") == "sess-1"
+    assert _flag(recorder.calls[1][1], "--agent-session-id") == "sess-2"
+
+
+# ---------------------------------------------------------------------------
+# Failure isolation
+# ---------------------------------------------------------------------------
+
+
+def test_an_invoker_that_raises_never_propagates_and_later_reports_still_run() -> None:
+    recorder = Recorder(fail=True)
+    reporter = _reporter(recorder)
+    for state in ("idle", "working", "idle"):
+        reporter.report(state)
+    reporter.release()
+    reporter.join()
+    assert [sub for sub, _ in recorder.calls] == [
+        "report-agent",
+        "report-agent",
+        "report-agent",
+        "release-agent",
+    ]
+
+
+def test_the_cli_invoker_raises_on_non_zero_and_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The production invoker maps every failure to an exception the worker logs."""
+    monkeypatch.setattr(reporter_mod, "CALL_TIMEOUT_S", 0.5)
+    with pytest.raises(RuntimeError, match="exited 3"):
+        reporter_mod._run_cli("report-agent", [sys.executable, "-c", "raise SystemExit(3)"])
+    with pytest.raises(subprocess.TimeoutExpired):
+        reporter_mod._run_cli("report-agent", [sys.executable, "-c", "import time; time.sleep(30)"])
+    with pytest.raises(OSError):
+        reporter_mod._run_cli("report-agent", ["/nonexistent/herdr", "pane"])
+    # And the success path is silent.
+    reporter_mod._run_cli("report-agent", [sys.executable, "-c", "pass"])
+
+
+def test_a_failing_cli_is_swallowed_end_to_end(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The real invoker, a real failing binary, and the reporter still completes."""
+    done = threading.Event()
+    original = reporter_mod._run_cli
+
+    def observed(subcommand: str, argv: Sequence[str]) -> None:
+        try:
+            original(subcommand, argv)
+        finally:
+            done.set()
+
+    reporter = HerdrReporter(
+        pane_id="w1:p1", binary="/nonexistent/herdr", invoker=observed, clock=None
+    )
+    reporter.report("idle")
+    assert done.wait(WAIT_S)
+    reporter.release()
+    reporter.join()
+    assert reporter.released
+
+
+# ---------------------------------------------------------------------------
+# Exit drain
+# ---------------------------------------------------------------------------
+
+
+def test_the_exit_drain_releases_an_unreleased_reporter_and_joins() -> None:
+    """The atexit half: an abrupt exit that never reached `on_unmount` still releases."""
+    recorder = Recorder()
+    reporter = _reporter(recorder)
+    reporter.report("working")
+    recorder.wait_for_calls(1)
+    reporter_mod._drain_at_exit()
+    assert [sub for sub, _ in recorder.calls] == ["report-agent", "release-agent"]
+    # And it is idempotent: a second drain (or a release after it) adds nothing.
+    reporter_mod._drain_at_exit()
+    reporter.release()
+    reporter.join()
+    assert len(recorder.calls) == 2
+
+
+def test_the_release_lands_before_interpreter_exit(tmp_path: Path) -> None:
+    """Run in a SUBPROCESS because the property IS process death.
+
+    The worker is a daemon thread; without the exit drain the interpreter
+    would exit with the release still queued and the row would outlive the
+    process. The child quits exactly as `on_unmount` does — `release()` and
+    return — and the log the fake binary writes is the evidence.
+    """
+    log = tmp_path / "herdr.log"
+    shim = tmp_path / "herdr"
+    shim.write_text(f'#!/bin/sh\nsleep 0.05\necho "$@" >> {log}\n')
+    shim.chmod(0o755)
+    child = textwrap.dedent("""
+        import sys
+        sys.path.insert(0, {repo!r})
+        from local_operator.herdr.reporter import HerdrReporter
+        reporter = HerdrReporter(pane_id="w1:p1", binary={shim!r}, session_id="s")
+        reporter.report("idle")
+        reporter.report("working")
+        reporter.release()
+        """.format(repo=str(Path(__file__).resolve().parents[2]), shim=str(shim)))
+    completed = subprocess.run(
+        [sys.executable, "-c", child], capture_output=True, text=True, timeout=60
+    )
+    assert completed.returncode == 0, completed.stderr[-2000:]
+    lines = log.read_text().splitlines()
+    assert [line.split()[1] for line in lines] == [
+        "report-agent",
+        "report-agent",
+        "release-agent",
+    ], lines
+
+
+def test_a_wedged_binary_bounds_the_exit_delay(tmp_path: Path) -> None:
+    """A `herdr` that never answers delays quit by at most the drain bound."""
+    import time
+
+    shim = tmp_path / "herdr"
+    shim.write_text("#!/bin/sh\nsleep 30\n")
+    shim.chmod(0o755)
+    child = textwrap.dedent("""
+        import sys
+        sys.path.insert(0, {repo!r})
+        from local_operator.herdr.reporter import HerdrReporter
+        reporter = HerdrReporter(pane_id="w1:p1", binary={shim!r})
+        reporter.report("idle")
+        reporter.release()
+        """.format(repo=str(Path(__file__).resolve().parents[2]), shim=str(shim)))
+    started = time.monotonic()
+    completed = subprocess.run(
+        [sys.executable, "-c", child], capture_output=True, text=True, timeout=60
+    )
+    elapsed = time.monotonic() - started
+    assert completed.returncode == 0, completed.stderr[-2000:]
+    # Generous against the 2s drain (interpreter start-up is inside the
+    # measurement) and far under the 30s + 5s timeout a synchronous join
+    # would have paid.
+    assert elapsed < 15.0, elapsed

--- a/tests/unit/tui/test_herdr_reporter.py
+++ b/tests/unit/tui/test_herdr_reporter.py
@@ -1,0 +1,369 @@
+"""The app's and the band's half of Herdr agent-state reporting.
+
+As with the multiplexer broadcast, the single most important property is that
+the SUITE ITSELF must not report: ``tests/conftest.py`` does not scrub
+``HERDR_*``, so a developer running the tests from inside a Herdr pane would
+otherwise have every pilot test overwrite the Agents row of the session they
+are running the tests from. The headless gate is what prevents that, and the
+first two tests here pin it and its control.
+
+The band tests below use the same ``FakeDock`` host as the terminal-title
+tests: the band is a plain object and needs no running app.
+"""
+
+from __future__ import annotations
+
+import itertools
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from textual.widgets import Static
+
+from local_operator.herdr.reporter import HerdrReporter
+from local_operator.session.protocol import SessionProtocol
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.terminal_title import TerminalTitle
+from local_operator.tui.widgets.approval import ApprovalPrompt
+from local_operator.tui.widgets.status_line import StatusLine
+from tests.unit.test_herdr_reporter import Recorder
+from tests.unit.tui.test_app_pilot import FakeSession, _factory, _isolate_tui_settings
+from tests.unit.tui.test_status_line import FakeDock
+
+
+def _fake_reporter(recorder: Recorder, session_id: str | None = "sess") -> HerdrReporter:
+    counter = itertools.count(1)
+    return HerdrReporter(
+        pane_id="w1:p1",
+        binary="/opt/herdr",
+        session_id=session_id,
+        invoker=recorder,
+        clock=lambda: next(counter),
+    )
+
+
+@pytest.fixture
+def herdr_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Markers set and a binary resolvable, so only the app's gates remain."""
+    shim = tmp_path / "herdr"
+    shim.write_text("#!/bin/sh\nexit 0\n")
+    shim.chmod(0o755)
+    monkeypatch.setenv("HERDR_ENV", "1")
+    monkeypatch.setenv("HERDR_PANE_ID", "w1:p1")
+    monkeypatch.setenv("HERDR_BIN_PATH", str(shim))
+    monkeypatch.delenv("LOCAL_OPERATOR_NO_HERDR", raising=False)
+    return shim
+
+
+@pytest.fixture
+def user_session(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Back ``FakeSession``'s id with a real, user-owned session directory.
+
+    ``is_user_owned_session`` reads ``origin.json`` under the config dir; a
+    missing directory reads as the user's own, but the directory is created so
+    the test is not relying on that default.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "lo-config"))
+    (tmp_path / "lo-config" / "sessions" / FakeSession().session_id).mkdir(parents=True)
+
+
+@pytest.fixture
+def spy_start(monkeypatch: pytest.MonkeyPatch) -> Recorder:
+    """Route ``start_reporter`` at a recording reporter instead of the CLI."""
+    recorder = Recorder()
+
+    def fake_start(session_id: str | None = None, **kwargs: Any) -> HerdrReporter:
+        return _fake_reporter(recorder, session_id)
+
+    monkeypatch.setattr("local_operator.herdr.start_reporter", fake_start)
+    return recorder
+
+
+# ---------------------------------------------------------------------------
+# App gates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_headless_app_reports_nothing(
+    herdr_env: Path, user_session: None, spy_start: Recorder
+) -> None:
+    """The guard that keeps this suite off the developer's own Herdr pane."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        assert app.is_headless is True
+        app._session = cast(SessionProtocol, FakeSession())
+        app._start_herdr_reporter()
+        await pilot.pause()
+        assert app._herdr_reporter is None
+    assert spy_start.calls == []
+
+
+@pytest.mark.asyncio
+async def test_the_same_arrangement_reports_once_the_gate_is_lifted(
+    herdr_env: Path, user_session: None, spy_start: Recorder, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The control for the test above, and the initial-report contract.
+
+    Attaching the reporter is what emits the first report; it carries the
+    band's ACTUAL state (idle at a prompt), the session id, and seq 1.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        monkeypatch.setattr(OperatorApp, "is_headless", property(lambda self: False))
+        app._session = cast(SessionProtocol, FakeSession())
+        app._start_herdr_reporter()
+        assert app._herdr_reporter is not None
+        (call,) = spy_start.wait_for_calls(1)
+        subcommand, argv = call
+        assert subcommand == "report-agent"
+        assert argv[argv.index("--state") + 1] == "idle"
+        assert argv[argv.index("--seq") + 1] == "1"
+        assert argv[argv.index("--agent-session-id") + 1] == FakeSession().session_id
+    # Leaving the context unmounts, which releases — exactly once, last.
+    spy_start.wait_for_calls(2)
+    assert [sub for sub, _ in spy_start.calls] == ["report-agent", "release-agent"]
+
+
+@pytest.mark.asyncio
+async def test_a_subagents_session_is_never_reported(
+    herdr_env: Path, spy_start: Recorder, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A delegated child runs in its parent's pane and must not take its row."""
+    from local_operator.resume import ORIGIN_SUBAGENT, mark_session_origin
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "lo-config"))
+    directory = tmp_path / "lo-config" / "sessions" / FakeSession().session_id
+    directory.mkdir(parents=True)
+    mark_session_origin(directory, ORIGIN_SUBAGENT)
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        monkeypatch.setattr(OperatorApp, "is_headless", property(lambda self: False))
+        app._session = cast(SessionProtocol, FakeSession())
+        app._start_herdr_reporter()
+        assert app._herdr_reporter is None
+    assert spy_start.calls == []
+
+
+@pytest.mark.asyncio
+async def test_the_kill_switch_disables_the_app_path(
+    herdr_env: Path, user_session: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Through the REAL `start_reporter`, so the env gate is what is tested."""
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_HERDR", "1")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        monkeypatch.setattr(OperatorApp, "is_headless", property(lambda self: False))
+        app._session = cast(SessionProtocol, FakeSession())
+        app._start_herdr_reporter()
+        assert app._herdr_reporter is None
+
+
+@pytest.mark.asyncio
+async def test_outside_herdr_the_app_path_is_a_no_op(
+    user_session: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    for name in ("HERDR_ENV", "HERDR_PANE_ID", "HERDR_BIN_PATH"):
+        monkeypatch.delenv(name, raising=False)
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        monkeypatch.setattr(OperatorApp, "is_headless", property(lambda self: False))
+        app._session = cast(SessionProtocol, FakeSession())
+        app._start_herdr_reporter()
+        assert app._herdr_reporter is None
+
+
+@pytest.mark.asyncio
+async def test_a_start_failure_never_reaches_the_user(
+    herdr_env: Path, user_session: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def boom(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("herdr exploded")
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        monkeypatch.setattr("local_operator.herdr.start_reporter", boom)
+        monkeypatch.setattr(OperatorApp, "is_headless", property(lambda self: False))
+        app._session = cast(SessionProtocol, FakeSession())
+        try:
+            app._start_herdr_reporter()
+        except RuntimeError:  # pragma: no cover - the failure this test forbids
+            pytest.fail("a herdr start failure escaped into the app")
+        assert app._herdr_reporter is None
+
+
+@pytest.mark.asyncio
+async def test_a_session_swap_relabels_the_row_without_releasing_it(
+    herdr_env: Path, user_session: None, spy_start: Recorder, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The row belongs to the pane; a `/new` changes only the session-id metadata."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        monkeypatch.setattr(OperatorApp, "is_headless", property(lambda self: False))
+        app._session = cast(SessionProtocol, FakeSession())
+        app._start_herdr_reporter()
+        first = app._herdr_reporter
+        assert first is not None
+        spy_start.wait_for_calls(1)
+
+        class SwappedSession(FakeSession):
+            @property
+            def session_id(self) -> str:
+                return "sess-two"
+
+        app._session = cast(SessionProtocol, SwappedSession())
+        app._start_herdr_reporter()
+        assert app._herdr_reporter is first
+        spy_start.wait_for_calls(2)
+        subs = [sub for sub, _ in spy_start.calls]
+        assert subs == ["report-agent", "report-agent"]
+        assert "release-agent" not in subs
+        _, argv = spy_start.calls[1]
+        assert argv[argv.index("--agent-session-id") + 1] == "sess-two"
+
+
+@pytest.mark.asyncio
+async def test_the_full_lifecycle_through_the_real_app(
+    herdr_env: Path,
+    user_session: None,
+    spy_start: Recorder,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """idle → working → blocked → working → idle → release, through the app.
+
+    Drives the same hooks production does: the band's `streaming` from the
+    turn worker, the parked approval through `_refresh_working_activity`, and
+    the release through unmount. And with the terminal title DISABLED, which
+    is the regression this pins: the Herdr report must not be silenced by a
+    different feature's kill switch.
+    """
+    _isolate_tui_settings(monkeypatch, tmp_path)
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_TERMINAL_TITLE", "1")
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        monkeypatch.setattr(OperatorApp, "is_headless", property(lambda self: False))
+        assert app._terminal_title is None, "the title switch must be off for this test"
+        app._session = cast(SessionProtocol, FakeSession())
+        app._start_herdr_reporter()
+        assert app._status is not None
+        spy_start.wait_for_calls(1)
+
+        app._status.update(streaming=True)
+        spy_start.wait_for_calls(2)
+        approval = ApprovalPrompt("bash", "run a command")
+        app._approval = approval
+        app._refresh_working_activity()
+        spy_start.wait_for_calls(3)
+        app._approval = None
+        app._refresh_working_activity()
+        spy_start.wait_for_calls(4)
+        app._status.update(streaming=False)
+        spy_start.wait_for_calls(5)
+    spy_start.wait_for_calls(6)
+    assert spy_start.states() == ["idle", "working", "blocked", "working", "idle"]
+    assert [sub for sub, _ in spy_start.calls][-1] == "release-agent"
+    seqs = spy_start.seqs()
+    assert seqs == sorted(seqs) and len(set(seqs)) == len(seqs)
+
+
+# ---------------------------------------------------------------------------
+# The band
+# ---------------------------------------------------------------------------
+
+
+def _band(recorder: Recorder) -> tuple[StatusLine, HerdrReporter]:
+    status = StatusLine(cast(Static, FakeDock(120)))
+    reporter = _fake_reporter(recorder)
+    status.set_herdr_reporter(reporter)
+    return status, reporter
+
+
+def test_attaching_reports_the_current_state_once() -> None:
+    recorder = Recorder()
+    status, _ = _band(recorder)
+    (call,) = recorder.wait_for_calls(1)
+    assert call[1][call[1].index("--state") + 1] == "idle"
+    # Redundant syncs (a repaint, a spinner tick) add nothing.
+    status.refresh()
+    status.refresh()
+    status.update(cwd="/tmp")
+    assert len(recorder.calls) == 1
+
+
+def test_streaming_and_attention_drive_the_states() -> None:
+    recorder = Recorder()
+    status, reporter = _band(recorder)
+    status.update(streaming=True)
+    status.set_attention(True)
+    status.set_attention(False)
+    status.update(streaming=False)
+    reporter.release()
+    reporter.join()
+    assert recorder.states() == ["idle", "working", "blocked", "working", "idle"]
+
+
+def test_attention_while_idle_recovers_to_idle() -> None:
+    """An `ask` outside a streaming turn: blocked, then idle, never working."""
+    recorder = Recorder()
+    status, reporter = _band(recorder)
+    status.set_attention(True)
+    status.set_attention(False)
+    reporter.release()
+    reporter.join()
+    assert recorder.states() == ["idle", "blocked", "idle"]
+
+
+def test_a_failed_turn_reports_idle_not_unknown() -> None:
+    recorder = Recorder()
+    status, reporter = _band(recorder)
+    status.update(streaming=True)
+    status.update(streaming=False, failed=True)
+    reporter.release()
+    reporter.join()
+    assert recorder.states() == ["idle", "working", "idle"]
+
+
+def test_the_report_fires_without_a_terminal_title_attached() -> None:
+    """`_sync_terminal_title` early-returns on a missing title; Herdr is before that."""
+    recorder = Recorder()
+    status = StatusLine(cast(Static, FakeDock(120)))
+    assert status._title is None
+    status.set_herdr_reporter(_fake_reporter(recorder))
+    status.update(streaming=True)
+    recorder.wait_for_calls(2)
+    assert recorder.states() == ["idle", "working"]
+
+
+def test_the_band_and_the_title_agree() -> None:
+    """One derivation, two sinks: the title's glyph and the row's state move together."""
+    recorder = Recorder()
+    status, reporter = _band(recorder)
+    writes: list[str] = []
+    title = TerminalTitle(writes.append)
+    title.start()
+    status.set_terminal_title(title)
+    status.set_attention(True)
+    reporter.release()
+    reporter.join()
+    assert recorder.states()[-1] == "blocked"
+    assert writes[-1] == "\x1b]0;lo !\x07"
+
+
+def test_detaching_stops_reports() -> None:
+    recorder = Recorder()
+    status, reporter = _band(recorder)
+    recorder.wait_for_calls(1)
+    status.set_herdr_reporter(None)
+    status.update(streaming=True)
+    reporter.release()
+    reporter.join()
+    assert recorder.states() == ["idle"]

--- a/tests/unit/tui/test_herdr_reporter.py
+++ b/tests/unit/tui/test_herdr_reporter.py
@@ -1,11 +1,14 @@
 """The app's and the band's half of Herdr agent-state reporting.
 
 As with the multiplexer broadcast, the single most important property is that
-the SUITE ITSELF must not report: ``tests/conftest.py`` does not scrub
-``HERDR_*``, so a developer running the tests from inside a Herdr pane would
-otherwise have every pilot test overwrite the Agents row of the session they
-are running the tests from. The headless gate is what prevents that, and the
-first two tests here pin it and its control.
+the SUITE ITSELF must not report: a developer running the tests from inside a
+Herdr pane must not have a pilot test overwrite — and then RELEASE — the
+Agents row of the session they are running the tests from. Two independent
+guards stop that, and this file pins the second one. ``tests/conftest.py``
+scrubs ``HERDR_*`` in the autouse isolation fixture, so detection fails
+before any gate is consulted; the app's ``is_headless`` check is what still
+holds if that scrub is ever narrowed. The first two tests here set the
+markers back explicitly and pin the headless gate and its lifted control.
 
 The band tests below use the same ``FakeDock`` host as the terminal-title
 tests: the band is a plain object and needs no running app.


### PR DESCRIPTION
## Summary of Changes

Inside a [Herdr](https://herdr.dev) pane, `lop` now reports its own lifecycle state — `idle` / `working` / `blocked` — to Herdr's **Agents** panel, and releases that row on exit. Herdr otherwise fills the row by screen detection, which cannot tell "the model is thinking" from "a tool approval is waiting on you"; `lop` already computes that distinction to drive its terminal title, so this surfaces the same fact instead of letting Herdr guess.

No upstream Herdr change, no `herdr integration install`, no plugin: `pane report-agent` / `pane release-agent` are the documented custom-hook surface and a `custom:` source is first-class in `agent list`.

**C2 — standard/pre-authorized.** `Closes #577`. No version bump; this rides the next combined release.

Release: patch — inside a Herdr pane, the Agents panel now shows lop's real idle/working/blocked state instead of a screen-detection guess.

### Why here, and only here

The reporter hangs off `StatusLine._sync_terminal_title()`, next to the existing `title.set_state(...)`. That is the one place `_streaming` and `_attention` are already coalesced into a single external run state, so the tab glyph and the Agents row cannot disagree. A second derivation elsewhere in the turn loop would eventually drift, and the visible failure of that drift is a sidebar saying `working` while the title says idle.

| Local Operator (`TitleState`) | Herdr `--state` |
|---|---|
| `idle` (not streaming, no attention) | `idle` |
| `working` (streaming) | `working` |
| `attention` (approval / `ask` waiting) | `blocked` |
| `failed` (last turn errored) | `idle` — never `unknown` |
| process exit | `release-agent` |

## Delivery contract

- **Detection** is `HERDR_ENV=1` **and** `HERDR_PANE_ID` (`terminals.is_herdr`, beside `is_cmux`), markers alone. Reporting additionally requires a resolvable binary: `HERDR_BIN_PATH` if it is executable, else `shutil.which("herdr")`. The markers are inherited across an ssh hop, so the binary is the real gate — the same split `multiplexer.cmux` documents.
- **Ordering.** `--seq` is minted under a lock **on the caller's thread**, inside the same critical section that decides the report is not a duplicate, then a single daemon worker executes the queue in that order. A seq assigned inside the worker, or two workers, would let a `working` overtake the `idle` that followed it and leave the panel spinning on a finished turn.
- **The seq is clock-anchored, not a counter** — `max(previous + 1, epoch_microseconds)`. See finding A below: a counter from 1 is ignored forever after any relaunch in the same pane.
- **De-dupe.** Identical consecutive states emit nothing, so the 12.5 Hz spinner repaint that reaches `_sync_terminal_title` costs one comparison.
- **Never on the event loop.** Every CLI call runs on the worker with a 5s timeout (`CALL_TIMEOUT_S`, the same figure as `multiplexer.cmux`). Every failure — missing binary, dead socket, non-zero exit, timeout — is logged at debug and swallowed.
- **Release exactly once**, plus an `atexit` drain that both *issues* the release for a reporter that never reached `on_unmount` and *joins* the worker, bounded at 2s. Daemon threads are killed at interpreter exit without running their remaining code, so without the drain a queued release simply never ran.
- **Never for a subagent.** The same `is_user_owned_session` (`origin.json`) gate the resume binding uses: a delegated child runs in its parent's pane and would overwrite the user's row with the child's state.
- **Not rebuilt on a session swap.** The row belongs to the pane and the process; a `/new` changes only the `--agent-session-id` metadata and re-sends the current state, because a release-and-re-report would flash the row empty.
- **Independent of the terminal title.** The report fires *before* `_sync_terminal_title`'s `if title is None: return`, so `LOCAL_OPERATOR_NO_TERMINAL_TITLE` (or `display.terminal_title: false`, or a headless host with no title attached) does not silently disable Herdr reporting. Pinned by `test_the_full_lifecycle_through_the_real_app`, which runs with the title switch set.
- **Env-only kill switch.** `LOCAL_OPERATOR_NO_HERDR`, mirroring `LOCAL_OPERATOR_NO_MULTIPLEXER_RESUME`. Deliberately **no** `/settings` key: per AGENTS.md "Adding a configuration key", a registry key is for a standing preference, and like the multiplexer switch this writes nothing a user sees inside the app — the reason to disable it is situational (a recording, a CI job). The reasoning is recorded in the package docstring rather than left implicit.

## Acceptance criteria

```
Start Local Operator inside a Herdr pane
  → appears in the Agents panel (source custom:local-operator, agent local-operator)   ✅ real Herdr 0.8.2
  → `idle` at the input prompt                                                          ✅
  → submitting a prompt / streaming shows `working`                                     ✅
  → a tool-approval or `ask` prompt shows `blocked`                                     ✅
  → answering it returns to `working`, then `idle` at turn end                           ✅
  → exiting releases the agent, clearing its state                                       ✅
Running the identical lop OUTSIDE Herdr changes nothing (no subprocess, no errors)       ✅
HERDR_BIN_PATH unset but `herdr` on PATH still reports; neither → silent no-op           ✅
Every transition carries a monotonically increasing --seq                                ✅
No Herdr failure can fail, slow, or error a lop run                                      ✅
The session id is reported as --agent-session-id                                         ⚠️ sent; see finding B
```

## Evidence

Unit tests are the floor, not the evidence. Everything below is real execution.

### 1. Real Herdr 0.8.2, headless server, isolated socket and config

Installed to an isolated dir (`HERDR_INSTALL_DIR=/tmp/lop-577-herdr`, no PATH or rc-file changes), server started with `HERDR_SOCKET_PATH`/`HERDR_CONFIG_PATH` under the same dir. The **real** `OperatorApp` was then driven headless through a full turn with `HERDR_BIN_PATH` pointing at the real `herdr` binary — production `start_reporter`, production `_run_cli` subprocess, no fakes — polling `herdr agent list` after each transition:

```text
$ herdr --version
herdr 0.8.2
pane=w6:p1
before: {"error":{"code":"agent_not_found","message":"agent target w6:p1 not found"}}

reporter: HerdrReporter pane: w6:p1 session: sess
[adopt]             {"pane_id": "w6:p1", "agent": "local-operator", "agent_status": "idle",    "state_change_seq": 55}
[turn start]        {"pane_id": "w6:p1", "agent": "local-operator", "agent_status": "working", "state_change_seq": 56}
[approval parked]   {"pane_id": "w6:p1", "agent": "local-operator", "agent_status": "blocked", "state_change_seq": 57}
[approval answered] {"pane_id": "w6:p1", "agent": "local-operator", "agent_status": "working", "state_change_seq": 58}
[turn end]          {"pane_id": "w6:p1", "agent": "local-operator", "agent_status": "done",    "state_change_seq": 59}
app exited; release queued/drained at interpreter exit

after process exit: {"error":{"code":"agent_not_found","message":"agent target w6:p1 not found"}}
```

The row appears, tracks the turn, and is **gone** after the process exits — the release landed through the `atexit` drain.

`done` rather than `idle` at turn end is **Herdr's** doing, not ours: it distinguishes "idle after unseen background work" from `idle` for an unfocused pane, and that seen/unseen bit is Herdr-side UI state. `lop` only ever reports `idle`, exactly as the issue's open question 4 concluded.

**Relaunch in the same pane** (a `/reload`, a `/update` re-exec, or quit-and-restart) — the case finding A exists for:

```text
SECOND launch in the SAME pane:
[adopt]    {"pane_id": "w6:p1", "agent_status": "idle", "state_change_seq": 61}
[turn end] {"pane_id": "w6:p1", "agent_status": "done", "state_change_seq": 65}
after: agent_not_found          # released again
```

### 2. Finding A — the `--seq` high-water mark persists across `release-agent` and across processes

This is a real behaviour of Herdr 0.8.2 that the issue's design did not anticipate, and it is why the sequence is not the counter the issue sketched. Probed directly:

```text
$ herdr pane report-agent w5:p1 --source custom:local-operator --agent local-operator --state working --seq 100
$ herdr pane release-agent w5:p1 --source custom:local-operator --agent local-operator --seq 101
$ herdr agent get w5:p1
{"error":{"code":"agent_not_found","message":"agent target w5:p1 not found"}}     # released

# a fresh process starting its counter at 1:
$ herdr pane report-agent w5:p1 --source custom:local-operator --agent local-operator --state idle --seq 1
rc=0
$ herdr agent get w5:p1
{"error":{"code":"agent_not_found","message":"agent target w5:p1 not found"}}     # SILENTLY IGNORED

# the identical report above the mark IS accepted:
$ herdr pane report-agent w5:p1 --source custom:local-operator --agent local-operator --state idle --seq 102
$ herdr agent get w5:p1
{'pane_id': 'w5:p1', 'agent': 'local-operator', 'agent_status': 'idle', 'state_change_seq': 53}
```

A per-process counter from 1 would therefore make **every report of every subsequent `lop` in that pane a silent no-op, forever**, with `rc=0` and nothing in any log. The fix is a clock floor: `max(previous + 1, epoch_microseconds)` — monotonic across processes by construction, still strictly increasing in-process if the clock stalls or steps back, and ~1.8e15 against Herdr's `u64` ceiling (probed: `2**64 - 1` accepted, `2**64` rejected). The clock is injectable so unit tests read the plain `1, 2, 3`.

### 3. Finding B — `--agent-session-id` is accepted but not surfaced for a custom source (known limitation)

```text
$ herdr pane report-agent w5:p1 --source custom:local-operator --agent local-operator \
    --state idle --seq 103 --agent-session-id sess-abc123
rc=0
$ herdr agent get w5:p1
keys: ['agent', 'agent_status', 'cwd', 'focused', 'foreground_cwd', 'pane_id',
       'revision', 'state_change_seq', 'tab_id', 'terminal_id', 'workspace_id']
agent_session present: False
```

**Stated honestly:** the issue's last acceptance line ("the session id … appears in `herdr agent get` as `agent_session`") does **not** hold on Herdr 0.8.2 for a custom source. The flag is accepted with `rc=0`, but Herdr's own CLI reference says `agent_session` is populated "when an **official integration** has reported a native session reference". We send it as designed — it is free, correct, and forward-compatible if Herdr opens that field to custom sources — but this PR does **not** claim the field is observable today. Herdr-managed restoration from it was already a non-goal.

### 4. Fake-binary shim through the real app: transitions, and failure isolation

A shim that appends its argv to a log and exits 0 / exits 1 / sleeps 30s, `HERDR_BIN_PATH` pointed at it, the real `OperatorApp` driven headless through a turn with an isolated `HOME` **and** `LOCAL_OPERATOR_CONFIG_DIR` (per AGENTS.md — the config dir alone does not redirect the cache), and `LOCAL_OPERATOR_NO_TERMINAL_TITLE=1` set to prove the title switch does not silence reporting:

```text
--- shim log (exit 0):
pane report-agent w1:p1 --source custom:local-operator --agent local-operator --state idle    --seq 1788627717388496 --agent-session-id sess
pane report-agent w1:p1 --source custom:local-operator --agent local-operator --state working --seq 1788627718141067 --agent-session-id sess
pane report-agent w1:p1 --source custom:local-operator --agent local-operator --state blocked --seq 1788627718732601 --agent-session-id sess
pane report-agent w1:p1 --source custom:local-operator --agent local-operator --state working --seq 1788627718767706 --agent-session-id sess
pane report-agent w1:p1 --source custom:local-operator --agent local-operator --state idle    --seq 1788627718831446 --agent-session-id sess
pane release-agent w1:p1 --source custom:local-operator --agent local-operator                --seq 1788627718907308
app exited cleanly in 3.38s
```

Full lifecycle, strictly increasing seq, release last — with the terminal title feature **off**.

**Failure isolation — the binary exits 1 on every call:**

```text
--- shim log (exit 1):
pane report-agent … --state idle    --seq 1788627721342125 --agent-session-id sess
pane report-agent … --state working --seq 1788627722131055 --agent-session-id sess
pane report-agent … --state blocked --seq 1788627722609127 --agent-session-id sess
pane report-agent … --state working --seq 1788627722739731 --agent-session-id sess
pane report-agent … --state idle    --seq 1788627722883605 --agent-session-id sess
pane release-agent …                --seq 1788627723289220
app exited cleanly in 2.59s        # every transition still attempted; nothing propagated
```

**Failure isolation — the binary sleeps 30s (outlives the 5s call timeout):**

```text
--- shim log (sleep 30):
pane report-agent … --state idle --seq 1788627726943009 --agent-session-id sess
app exited cleanly in 3.02s; wall=6.9s
```

The app completes its turn and exits in ~3s while the first call is still wedged in a subprocess; the worker holds the queue, nothing blocks the event loop, and total wall time is bounded by the 2s exit drain rather than by the 30s hang. A synchronous release would have paid 30s + timeout here.

### 5. Unit tests

`tests/unit/test_herdr_reporter.py` (29 tests) and `tests/unit/tui/test_herdr_reporter.py` (15 tests), covering every bullet of the issue's Testing list: detection both ways, off-Herdr no-op, binary resolution incl. a dead `HERDR_BIN_PATH` falling back to PATH, initial `idle` with session id + seq 1, each transition, recovery from `blocked` both streaming and not, de-dupe with strictly increasing seq, the clock anchor, ordering under two hammering threads, the invoker running off the calling thread (thread identity — a structural invariant, not a timing bound), release exactly-once + the `atexit` path in a **subprocess** (the property is process death), failure isolation for raise / non-zero / timeout / missing binary, the kill switch, session-id absent when unknown, the subagent gate, the headless gate and its control, and the swap re-label.

Two suite-hygiene additions the work forced, both matching existing precedent:

- `HERDR_*` added to `tests/conftest.py::_AMBIENT_VARS`. This is the `CMUX_*` hazard of #648 exactly: a test run from inside a Herdr pane would have taken over that pane's Agents row and then **released** it on exit. `test_every_environment_variable_read_is_scrubbed_or_explained` is what caught it.
- `LOCAL_OPERATOR_NO_HERDR` registered in that test's `_HARMLESS` map with its reason.

Waits are on events the code publishes (a `threading.Event` set by the recording invoker), never on the clock, per AGENTS.md "Timing, flakes".

## Gates

Run over the whole tree from the worktree's own editable venv, exactly as CI:

```text
$ .venv/bin/python -m flake8 .
rc=0
$ uvx --from black==26.1.0 black --check .
All done! 929 files would be left unchanged.
$ uvx isort==5.13.2 --check .
Skipped 2 files    rc=0
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .
0 errors, 0 warnings, 0 informations
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
14316 passed, 17 skipped, 692 warnings in 2074.67s (0:34:34)
```

The worktree owns its own venv (`uv venv --python 3.12` + editable install from itself), verified to resolve this tree and not `main`:

```text
$ .venv/bin/python -c "import local_operator; print(local_operator.__file__)"
/private/tmp/lop-577/local_operator/__init__.py
```

## Rollout / rollback

Zero-config and inert outside Herdr: no markers → `start_reporter` returns `None` → no subprocess, no thread, no error. The import itself is guarded on the app side.

Rollback without a release:

```sh
export LOCAL_OPERATOR_NO_HERDR=1
```

Reporting stops entirely; nothing else changes. It is independent of `LOCAL_OPERATOR_NO_TERMINAL_TITLE` in both directions. Failing open is the design: a wedged or missing `herdr` degrades to "no row", never to a slow or broken session.

## Non-goals

- Upstreaming into Herdr's official integrations / supported `--kind` list.
- `herdr integration install local-operator`, or a Herdr community plugin.
- Herdr-managed session restoration from the reported id (see finding B).
- Speaking Herdr's socket protocol directly. The documented CLI is used; `HERDR_SOCKET_PATH` is named in `terminals.py` for a possible future backend only.
- `--message` (the first cut is state-only), and `unknown` is never emitted.
- No version bump; no `/settings` key (env-only kill switch, reasoned above).

## Files

| File | What |
|---|---|
| `local_operator/herdr/__init__.py` | new package: why it exists, the one-hook rule, best-effort contract, kill switch |
| `local_operator/herdr/reporter.py` | `HerdrReporter`, ordering/seq discipline, worker, `atexit` drain, `start_reporter`/`release_reporter` |
| `local_operator/terminals.py` | `HERDR_*` constants + `is_herdr()` beside `is_cmux` |
| `local_operator/tui/widgets/status_line.py` | `set_herdr_reporter()`; report from `_sync_terminal_title` before the title's early-return |
| `local_operator/tui/app.py` | `_start_herdr_reporter` / `_stop_herdr_reporter`, headless + subagent gates, release in `on_unmount` |
| `docs/herdr-agents.md`, `docs/multiplexer-resume.md`, `README.md` | the integration, the env gate, the kill switch |
| `tests/conftest.py`, `tests/unit/test_ambient_env_isolation.py`, `tests/unit/test_fork.py` | `HERDR_*` scrubbing, kill-switch registration, band fixture field |

## Checklist

- [x] Whole-tree gates green from the worktree's own venv.
- [x] Real Herdr 0.8.2 end-to-end, plus fake-binary failure-isolation runs.
- [x] Both probe findings stated, including the one that limits an acceptance criterion.
- [x] No version bump; rides the next combined release.
- [ ] Agent review + QA rounds pending.
