### PR TITLE
feat(tui): cycle the dock's subagent panel full → summary → hidden

### DIFF
--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -742,9 +742,14 @@ SETTINGS: tuple[Setting, ...] = (
         default="full",
         help="How much room the subagent panel takes when a session starts; ctrl+g cycles it.",
         choices=(
+            # Parallel descriptions: each names WHAT IS SHOWN and nothing
+            # else. `hidden` used to append "; ctrl+g brings it back", which
+            # made it the only choice explaining its own exit and left the
+            # list reading unevenly — and the help line above already names
+            # `ctrl+g` for all three (round 1, D5).
             Choice("full", "full", "one row per child, newest first"),
             Choice("summary", "summary", "a one-line count"),
-            Choice("hidden", "hidden", "not shown; ctrl+g brings it back"),
+            Choice("hidden", "hidden", "not shown"),
         ),
     ),
     # -- session ------------------------------------------------------------

--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -726,6 +726,27 @@ SETTINGS: tuple[Setting, ...] = (
         help="Fires only while the terminal is unfocused.",
         choices=_bool_choices("notify when unfocused", "never notify"),
     ),
+    Setting(
+        # The session's INITIAL dock density, not a hard override: `ctrl+g`
+        # cycles freely from it and never writes it back (the same split as
+        # `tool_approval_mode` vs `/approvals`). A hard override would make
+        # the key a no-op again, which is the defect #525 fixed. LIVE by
+        # section: a write applies to the mounted panel unless the user has
+        # already cycled it this session. Named `display.dock` rather than
+        # `display.subagent_dock` so a later todo-panel extension can share it.
+        key="display.dock",
+        path=("display.dock",),
+        section="appearance",
+        label="Subagent dock",
+        kind=Kind.ENUM,
+        default="full",
+        help="How much room the subagent panel takes when a session starts; ctrl+g cycles it.",
+        choices=(
+            Choice("full", "full", "one row per child, newest first"),
+            Choice("summary", "summary", "a one-line count"),
+            Choice("hidden", "hidden", "not shown; ctrl+g brings it back"),
+        ),
+    ),
     # -- session ------------------------------------------------------------
     Setting(
         key="tool_approval_mode",

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -215,6 +215,7 @@ from local_operator.tui.widgets.status_line import (
     format_window,
 )
 from local_operator.tui.widgets.subagent_panel import (
+    Density,
     JobStats,
     SubagentPanel,
     SubagentRow,
@@ -2004,9 +2005,10 @@ class OperatorApp(App[None]):
         # ctrl+a/e/w/d/x/k/f/u but not ctrl+t, so the composer keeps every
         # editing key it had.
         Binding("ctrl+t", "toggle_todos", "Expand/collapse todos", show=False),
-        # The subagent roster's matching disclosure. `ctrl+g` is free in the
-        # app and TextArea, and bubbles so an active picker keeps first refusal.
-        Binding("ctrl+g", "toggle_subagents", "Expand/collapse subagents", show=False),
+        # The subagent dock's density cycle (full → summary → hidden, with the
+        # overflow roster as a stop inside full). `ctrl+g` is free in the app
+        # and TextArea, and bubbles so an active picker keeps first refusal.
+        Binding("ctrl+g", "toggle_subagents", "Cycle the subagent panel", show=False),
         Binding("p", "subagent_parent", "Parent subagent", show=False),
         Binding("left_square_bracket", "subagent_peer(-1)", "Previous peer", show=False),
         Binding("right_square_bracket", "subagent_peer(1)", "Next peer", show=False),
@@ -5416,6 +5418,12 @@ class OperatorApp(App[None]):
             # first turn ended.
             cost="",
         )
+        # The dock density chosen for the dead conversation goes with it: the
+        # replacement session re-reads `display.dock` on its first roster and
+        # a `ctrl+g` pressed against the old children does not pin the new
+        # ones (#525 design §2).
+        if self._subagent_panel is not None:
+            self._subagent_panel.reset_density()
         return (*carried_spend, was_floor)
 
     def _conversation_id(self) -> str:
@@ -13965,6 +13973,8 @@ class OperatorApp(App[None]):
                 # and every block already on screen re-lays out with it. A
                 # repaint would re-ink content that has not changed colour.
                 self._sync_row_density_class()
+            elif message.key == "display.dock":
+                self._apply_dock_density()
             elif message.key.startswith("display."):
                 # The display flags are read through the cached fast path, which
                 # `settings_io` already invalidated; the widgets that resolved a
@@ -14590,6 +14600,8 @@ class OperatorApp(App[None]):
                 settings_reload()
             except Exception:  # noqa: BLE001 — the cache drop is best-effort
                 logger.debug("display settings cache could not be dropped", exc_info=True)
+        if "display.dock" in changed:
+            self._apply_dock_density()
         if "tui.theme" in changed:
             values = getattr(change, "values", {})
             tui_block = values.get("tui") if isinstance(values, Mapping) else None
@@ -16826,10 +16838,49 @@ class OperatorApp(App[None]):
                 self._repaint_themed_widgets()
 
     def action_toggle_subagents(self) -> None:
-        """``ctrl+g`` — flip the dock roster between recent and complete."""
-        if self._subagent_panel is not None and self._subagent_panel.display:
-            self._subagent_panel.toggle_expanded(enter_navigation=True)
+        """``ctrl+g`` — cycle the dock subagent panel: full, summary, hidden.
+
+        With overflow the full state has two stops (preview, then the expanded
+        roster with keyboard navigation) before it shrinks; without it the
+        first press goes straight to the summary row — which is the change
+        #525 asked for, since that press used to be a silent no-op at ≤6
+        children. ``_refresh_band`` settles the band inset and the todo budget
+        in the same frame the density changed, so the dock never paints one
+        frame at the old height.
+
+        Gated on ``_panel_holds_children`` rather than ``display``: a HIDDEN
+        panel is not displayed by definition, and the key is the only way
+        back from it.
+        """
+        panel = self._subagent_panel
+        if panel is not None and (panel.display or self._panel_holds_children(panel)):
+            panel.toggle_expanded(enter_navigation=True)
             self._refresh_band()
+
+    @staticmethod
+    def _panel_holds_children(panel: SubagentPanel) -> bool:
+        """Whether a hidden panel would show rows if brought back."""
+        return panel.density is Density.HIDDEN and bool(panel._rows)
+
+    def _apply_dock_density(self) -> None:
+        """Live-apply a changed ``display.dock`` to the mounted panel.
+
+        Honest LIVE scope for the Appearance section (#525 design §5): the
+        page's write and another process's edit both land here. The panel
+        applies it only while the user has not pressed ``ctrl+g`` this
+        session — an explicit choice outranks a file edit, the same rule the
+        todo panel's ``_expanded`` follows — so the apply cannot fight the
+        user, and the band is settled in the same frame either way.
+        """
+        panel = self._subagent_panel
+        if panel is None:
+            return
+        try:
+            panel.seed_density(panel._configured_density())
+        except Exception:  # noqa: BLE001 — the write landed; the apply is a bonus
+            logger.debug("display.dock live apply failed", exc_info=True)
+            return
+        self._refresh_band()
 
     def action_toggle_todos(self) -> None:
         """``ctrl+t`` — flip the dock todo list between collapsed and expanded.
@@ -20671,7 +20722,10 @@ class OperatorApp(App[None]):
         lines.append(_key_row("shift+tab", "cycle reasoning effort"))
         lines.append(_key_row("ctrl+l", "clear the transcript (history stays)"))
         lines.append(_key_row("ctrl+t", "expand or collapse the todo panel"))
-        lines.append(_key_row("ctrl+g", "expand or collapse the subagent panel"))
+        # 46 cells (66 composed) against the 74-cell ceiling: names the three
+        # stops so a user who only ever saw "expand/collapse" learns the panel
+        # can now shrink to a row or go away (#525).
+        lines.append(_key_row("ctrl+g", "cycle the subagent panel: full, summary, hidden"))
         lines.append(_key_row("ctrl+b", "open an aside; ctrl+f forks it in"))
         # Directly under `ctrl+b`, because it is only meaningful once an aside
         # is open. ONE row for the pair rather than two: the partner chord fits
@@ -24033,6 +24087,13 @@ class OperatorApp(App[None]):
         pass
 
     def on_subagent_ended(self, message: SubagentEnded) -> None:
+        # BEFORE the refresh, so the re-emerged summary row paints in the same
+        # band pass that reads the failure — a hidden panel that came back one
+        # frame later would be a dock height jump (#525 design §2/§8). Only a
+        # FAILURE breaks through a hidden dock; cancelled and interrupted are
+        # not failures and leave the user's choice alone.
+        if message.status == "failed" and self._subagent_panel is not None:
+            self._subagent_panel.note_child_failed()
         self._refresh_band()
         # The last child settling is the moment a deferred completion becomes
         # true: the parent stopped talking earlier, and now the delegated work

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3453,7 +3453,10 @@ class OperatorApp(App[None]):
             # is the answer that leaves such a host exactly as it was.
             forked=bool(getattr(state, "conversation_title_forked", False)),
             streaming=bool(getattr(state, "streaming", False)),
-            subagents=sum(1 for j in task_jobs if j.status == "running" and not j.queued),
+            # Queued children counted, matching `_job_count("task")`: the band
+            # is the hidden dock's only liveness cue, so a follower's band must
+            # not go silent where the owner's would not (round 1, U2).
+            subagents=sum(1 for j in task_jobs if j.status == "running"),
             jobs=sum(1 for j in bash_jobs if j.status == "running" and not j.queued),
             mcp=McpStatus(
                 configured=len(mcp_servers),
@@ -14233,31 +14236,39 @@ class OperatorApp(App[None]):
             self.screen.set_focus(None)
 
     def _job_count(self, kind: str) -> int:
-        """Running jobs of one ``kind`` — ``task`` (subagents) or ``bash``.
+        """Jobs of one ``kind`` the band counts — ``task`` (subagents) or ``bash``.
 
         The two are counted separately because they are different things an
         operator tracks: a subagent is delegated reasoning with no other
         representation on screen, while a backgrounded shell command already has
         a tool card. Summing them would hide which kind is running.
 
-        ``queued`` is excluded to match ``AsyncJobManager``'s own running count
-        (``harness/jobs.py``): a job admitted to the ledger but held behind the
-        capacity gate carries ``status == "running"`` and has not started, so
-        counting it would report work that is not yet happening — and disagree
-        with the number the harness itself reports.
+        ``task`` INCLUDES children still queued behind the capacity gate;
+        ``bash`` does not. The asymmetry is the point. This counter is the
+        stated fallback for a dock the user has hidden with `ctrl+g` — the
+        justification for letting a live panel disappear is that the band
+        still says children exist — and excluding queued children made that
+        fallback empty for exactly the state the panel had been showing: a
+        hidden dock whose children were all queued reported nothing anywhere
+        (round 1, U2). A queued child is delegated work the user is waiting
+        on, which is the question this segment answers, whereas a queued
+        shell command still has its tool card on screen and the ``bash``
+        count stays aligned with ``AsyncJobManager``'s own running total
+        (``harness/jobs.py``).
 
         Never raises: a status segment must not be able to take the app down.
         """
         manager = getattr(self._session, "jobs", None)
         if manager is None:
             return 0
+        counts_queued = kind == "task"
         try:
             return sum(
                 1
                 for job in manager.list()
                 if job.status == "running"
                 and job.type == kind
-                and not getattr(job, "queued", False)
+                and (counts_queued or not getattr(job, "queued", False))
             )
         except Exception:
             return 0
@@ -16859,8 +16870,14 @@ class OperatorApp(App[None]):
 
     @staticmethod
     def _panel_holds_children(panel: SubagentPanel) -> bool:
-        """Whether a hidden panel would show rows if brought back."""
-        return panel.density is Density.HIDDEN and bool(panel._rows)
+        """Whether a hidden panel would show rows if brought back.
+
+        Through the panel's own ``has_children`` rather than its private
+        ``_rows``: every other app→panel call here goes through a public
+        member, and the accessor is what the todo panel's band budget needs
+        anyway (round 1, F5).
+        """
+        return panel.density is Density.HIDDEN and panel.has_children
 
     def _apply_dock_density(self) -> None:
         """Live-apply a changed ``display.dock`` to the mounted panel.

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -1242,9 +1242,18 @@ KeyPromptBlock:focus {
     padding: 0 1;
 }
 
+/* Clickable in every density (issue 525): the caption is the one widget the panel
+ * paints in full AND summary, so it is the pointer's way to cycle the dock
+ * where the affordance row (overflow only) does not exist. Same hover ground
+ * as `#subagent-affordance` so the two controls read as one kind of thing. */
 #subagent-header {
     height: auto;
     color: $lo-dim;
+    pointer: pointer;
+}
+
+#subagent-header:hover {
+    background: $lo-overlay;
 }
 
 /* The rows container must SIZE TO ITS CONTENT, never stretch to fill the

--- a/local_operator/tui/settings.py
+++ b/local_operator/tui/settings.py
@@ -82,6 +82,15 @@ _DEFAULT_NOTES: dict[str, Any] = {
     # UNFOCUSED, so a user watching the session is never interrupted; the env
     # kill switch is `LOCAL_OPERATOR_NO_NOTIFICATIONS`.
     "display.notifications": True,
+    # The dock subagent panel's density when a session STARTS: `full` (one
+    # row per child), `summary` (one row of counts) or `hidden`. Defaults to
+    # full, today's shape. It seeds the panel and nothing more — `ctrl+g`
+    # cycles from it and never writes it back, because a setting that pinned
+    # the density would make the key a no-op again, the exact defect #525
+    # fixed. Read by `widgets/subagent_panel.py` on the first non-empty
+    # roster and on a live edit (applied only if the user has not cycled it
+    # this session). Unknown strings read as full.
+    "display.dock": "full",
 }
 
 _cache: dict[str, Any] | None = None

--- a/local_operator/tui/widgets/subagent_panel.py
+++ b/local_operator/tui/widgets/subagent_panel.py
@@ -1502,8 +1502,10 @@ class SubagentPanel(Container):
         #: were derived from, and the counts themselves. Keyed rather than
         #: invalidated because the caption is reached from every tick, and
         #: re-deriving every job's facts there is the cheap state costing more
-        #: than the expensive one (round 1, F3).
-        self._summary_counts_key: tuple[tuple[int, str], ...] | None = None
+        #: than the expensive one (round 1, F3). One entry per job of
+        #: ``(identity, status, queued)`` — see the method for why the flag is
+        #: a term and not redundant with the status (round 2, Q2/F7).
+        self._summary_counts_key: tuple[tuple[int, str, bool], ...] | None = None
         self._summary_counts_value: SummaryCounts = SummaryCounts()
         # Logical focus within the full roster. The expanded DOM displays only
         # one screenful around it; every job remains keyboard-reachable without
@@ -2358,15 +2360,36 @@ class SubagentPanel(Container):
 
         ``summary_counts`` calls :func:`row_facts` once per job and is reached
         from every ``sync`` AND every tick — 956 µs/call at 60 children, on
-        the state that is supposed to be the CHEAP one (round 1, F3). The
-        memo is keyed on the same ledger identity ``sync`` already maintains,
-        so it needs no invalidation of its own: ``_sync_rows`` replaces
-        ``_jobs_by_id`` wholesale when the roster moves, and a job object
-        mutating in place is picked up because the key carries each job's
-        identity, not just the dict's.
+        the state that is supposed to be the CHEAP one (round 1, F3).
+
+        THE KEY MUST NAME EVERY FIELD THE COUNTS ARE DERIVED FROM. ``id(job)``
+        catches the roster changing shape, but it is stable ACROSS a mutation
+        of the job it identifies, so it detects nothing about a job that is
+        edited in place — only the fields spelled out beside it do. This
+        docstring previously claimed the opposite ("a job object mutating in
+        place is picked up because the key carries each job's identity"),
+        which was wrong in exactly one reachable way and shipped a caption
+        that lied (round 2, Q2/F7).
+
+        ``queued`` is that second field, and it is not a redundant one:
+        :func:`summary_counts` buckets on ``facts.queued`` BEFORE it looks at
+        the status, and a queued child already carries
+        ``status == "running"``. So when the capacity gate admits it,
+        ``AsyncJobManager.start_queued`` clears ``job.queued`` in place and
+        leaves ``status`` untouched — the one ledger move that changes
+        neither the identity nor the status while changing the counts. With
+        ``status`` alone the memo returned the pre-admission numbers
+        indefinitely, until an unrelated job happened to settle and move the
+        key. In `summary` the caption is the panel's ONLY representation, so
+        that stale tuple was the whole surface.
+
+        Anything added to :func:`summary_counts`' bucketing belongs here too.
         """
         jobs = list(self._jobs_by_id.values())
-        key = tuple((id(job), getattr(job, "status", "")) for job in jobs)
+        key = tuple(
+            (id(job), getattr(job, "status", ""), bool(getattr(job, "queued", False)))
+            for job in jobs
+        )
         if self._summary_counts_key != key:
             self._summary_counts_key = key
             self._summary_counts_value = summary_counts(jobs)

--- a/local_operator/tui/widgets/subagent_panel.py
+++ b/local_operator/tui/widgets/subagent_panel.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import time
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Callable, NamedTuple
 
 from rich.cells import cell_len
@@ -154,6 +155,63 @@ _MIN_PREVIEW_JOB_ROWS = 0
 #: Expanded means every child is reachable, not that the dock may push the
 #: composer off-screen; overflow therefore scrolls inside the roster.
 _EXPANDED_DOCK_ROWS = 14
+
+
+class Density(str, Enum):
+    """How much of the dock the panel takes; ``ctrl+g`` cycles it (#525).
+
+    A SECOND axis beside ``_expanded``, not a replacement for it. ``full`` is
+    everything the panel did before: the budgeted preview, and inside it the
+    expanded roster the overflow disclosure opens. ``summary`` is one row of
+    counts in the caption; ``hidden`` paints nothing. Kept orthogonal so the
+    overflow contract (``+N earlier``, navigation, ``collapse_for_child_view``)
+    is untouched — the density only decides whether that machinery is shown.
+
+    Before this the key was an OVERFLOW disclosure and nothing else: with six
+    or fewer children — the common fan-out — ``toggle_expanded`` returned at
+    its budget gate and the press did nothing, so the panel was a fixed claim
+    on 2-8 rows above the composer for the rest of the session (#525). The
+    only zero-row shape was the height-forced compact fallback, which the user
+    could not ask for.
+
+    Values are the ``display.dock`` setting's vocabulary: ``compact`` already
+    names the height-forced state in this module and ``off`` would read as
+    "the feature is disabled", so the setting, the enum, the ``/help`` row and
+    the tests all say ``full | summary | hidden``.
+    """
+
+    FULL = "full"
+    SUMMARY = "summary"
+    HIDDEN = "hidden"
+
+
+#: The density a session starts at when ``display.dock`` is unset. Read via
+#: ``tui/settings.settings_get`` — whose defaults derive from the ``settings_io``
+#: registry, so the registry row is the guarded source and this constant is
+#: the panel's own fallback for a reader that cannot reach it.
+DEFAULT_DOCK_DENSITY = Density.FULL
+
+#: Order the summary row sheds its segments at a narrow width, first to go
+#: first. Whole segments, never a truncation into the hotkey: the ``ctrl+g``
+#: token is the one thing on the row that must always survive, because it is
+#: the ONLY cue the panel can be brought back (``todo_panel._footer`` rule).
+#: Counts of settled-quietly states go before the running count, and the
+#: failed count goes last because it is the reason the row re-emerged from
+#: ``hidden`` at all. The ``Subagents`` word goes before the numbers: on a
+#: 50-column terminal the reader can tell a row of ✗/⣾ counts from the todo
+#: list without the label, and cannot tell ``1 failed`` from nothing.
+_SUMMARY_SHED_ORDER = ("cancelled", "interrupted", "queued", "done", "label", "running", "failed")
+
+#: Eviction rank for the collapsed preview, lowest kept first. Running and
+#: queued children are the ones the user is waiting on; a failure is the one
+#: outcome that needs acting on; an interrupted child may be resumable; a
+#: completed or cancelled one has said everything a row can say. Ties break
+#: by start order, newest kept, which is the rule the slice had before.
+_EVICTION_RANK: dict[str, int] = {
+    "running": 0,
+    "failed": 1,
+    "interrupted": 2,
+}
 
 #: Seam between the numbers on a row. The same ` · ` the full-page view's
 #: title uses between its own facts, one tone under them — a row and the page
@@ -1016,6 +1074,139 @@ def compose_row(
     return row
 
 
+class SummaryCounts(NamedTuple):
+    """Per-state child counts the summary row paints.
+
+    A tuple rather than a dict so it can be the paint-once guard's key: the
+    summary caption repaints only when one of these moves or the spinner
+    frame advances, the same equality gate every other coalesced paint on
+    this panel sits behind.
+    """
+
+    running: int = 0
+    queued: int = 0
+    done: int = 0
+    failed: int = 0
+    cancelled: int = 0
+    interrupted: int = 0
+
+    @property
+    def total(self) -> int:
+        return sum(self)
+
+
+def summary_counts(jobs: Sequence[Any]) -> SummaryCounts:
+    """Bucket task jobs by the state the row vocabulary already names.
+
+    Reads through :func:`row_facts` rather than ``job.status`` directly so a
+    queued child counts as queued here exactly as its row would glyph it (a
+    queued job's ``status`` is still ``running``; see :func:`status_glyph`).
+    Restored rows arrive as ``interrupted``/``completed`` and bucket there.
+    """
+    counts = dict.fromkeys(SummaryCounts._fields, 0)
+    for job in jobs:
+        facts = row_facts(job, fallback_id="", current=False)
+        if facts.queued:
+            counts["queued"] += 1
+        elif facts.status == "running":
+            counts["running"] += 1
+        elif facts.status == "failed":
+            counts["failed"] += 1
+        elif facts.status == "cancelled":
+            counts["cancelled"] += 1
+        elif facts.status == "interrupted":
+            counts["interrupted"] += 1
+        else:
+            counts["done"] += 1
+    return SummaryCounts(**counts)
+
+
+def _summary_segments(
+    counts: SummaryCounts, spinner_glyph: str, *, dropped: frozenset[str]
+) -> list[tuple[str, str, str]]:
+    """``(name, text, semantic ink)`` for every segment that survives ``dropped``.
+
+    Zero-count segments are omitted outright (``format_agents`` says nothing
+    at zero, and ``0 failed`` would spend the danger ink on good news). The
+    spinner frame follows the running count so the count is what the eye
+    reads first and the motion is what says it is still moving. When the
+    running COUNT is shed but children are still running, the frame stays as
+    a bare glyph: at the width that sheds it, the reader still needs to know
+    the panel is not describing a finished session. A count that is shed
+    while nonzero compresses to its glyph (``✗2``) for the same reason the
+    label is shed before it: the number carries the meaning, the word only
+    spells it.
+    """
+    segments: list[tuple[str, str, str]] = []
+    if "label" not in dropped:
+        segments.append(("label", "Subagents", "dim"))
+    if counts.running:
+        if "running" in dropped:
+            segments.append(("running", spinner_glyph, "muted"))
+        else:
+            segments.append(("running", f"{counts.running} running {spinner_glyph}", "muted"))
+    if counts.done and "done" not in dropped:
+        segments.append(("done", f"{counts.done} done", "dim"))
+    if counts.failed:
+        if "failed" in dropped:
+            segments.append(("failed", f"{GLYPH_FAILED}{counts.failed}", "danger"))
+        else:
+            segments.append(("failed", f"{counts.failed} failed", "danger"))
+    if counts.queued and "queued" not in dropped:
+        segments.append(("queued", f"{counts.queued} queued", "dim"))
+    if counts.cancelled and "cancelled" not in dropped:
+        segments.append(("cancelled", f"{counts.cancelled} cancelled", "dim"))
+    if counts.interrupted and "interrupted" not in dropped:
+        segments.append(("interrupted", f"{counts.interrupted} interrupted", "dim"))
+    segments.append(("hotkey", "ctrl+g", "muted"))
+    return segments
+
+
+def compose_summary(counts: SummaryCounts, *, spinner_glyph: str, width: int) -> Text:
+    """The one-row summary the panel paints in :attr:`Density.SUMMARY`.
+
+    ``Subagents · 1 running ⣾ · 3 done · 1 failed · ctrl+g``
+
+    Ink follows the row law: ``failed`` is the only coloured segment, matching
+    the ``✗`` a full row would carry; everything else is ``dim`` chrome except
+    the running count and the hotkey at ``muted``, because the hotkey is the
+    only signal the panel can grow again and has to be the loudest token
+    (``todo_panel`` D3/U3).
+
+    Fit is decided against the WIDEST rendering the roster can produce (every
+    count at its current digit width, spinner present) rather than the string
+    being painted, so a segment does not flicker in and out as the spinner
+    frame or a count's last digit changes (``todo_panel`` U1). Segments are
+    shed whole in :data:`_SUMMARY_SHED_ORDER`; the row is never truncated into
+    the hotkey, and if even ``✗N · ctrl+g`` cannot fit the hotkey alone is
+    painted and clipped by the renderer, which is the one case with nothing
+    left to shed.
+    """
+    inks = {
+        name: Style(color=theme_mod.semantic_color(name)) for name in ("dim", "muted", "danger")
+    }
+    dropped: set[str] = set()
+    # The widest frame is the reference so the choice is stable across frames.
+    widest = max(SPINNER_FRAMES, key=cell_len)
+    for _ in range(len(_SUMMARY_SHED_ORDER) + 1):
+        segments = _summary_segments(counts, widest, dropped=frozenset(dropped))
+        needed = sum(cell_len(text) for _name, text, _ink in segments)
+        needed += cell_len(STATS_SEAM) * (len(segments) - 1)
+        if needed <= width:
+            break
+        remaining = [name for name in _SUMMARY_SHED_ORDER if name not in dropped]
+        if not remaining:
+            break
+        dropped.add(remaining[0])
+    segments = _summary_segments(counts, spinner_glyph, dropped=frozenset(dropped))
+    row = Text(no_wrap=True, overflow="ellipsis")
+    for index, (_name, text, ink) in enumerate(segments):
+        if index:
+            row.append(STATS_SEAM, style=inks["dim"])
+        row.append(text, style=inks[ink])
+    return row
+
+
 class SubagentRow(Static):
     """One task job: bullet, label, state glyph, elapsed, numbers, activity.
 
@@ -1186,6 +1377,28 @@ class SubagentAffordance(Static):
             panel.request_toggle()
 
 
+class SubagentHeader(Static):
+    """The caption, clickable in every density (#525 design §3).
+
+    The affordance row only exists with overflow, so before this a pointer
+    user had no target at all in the common ≤ 6-child case — the same gap
+    the key had. The caption is the one widget painted in every non-hidden
+    density (it IS the summary row), so it is the one that can carry the
+    click. Same contract as the affordance: stop the event so the transcript
+    behind the dock does not also scroll, and cycle through the pointer path
+    so the composer keeps focus.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(id="subagent-header", classes="band-body")
+
+    def on_click(self, event) -> None:  # type: ignore[no-untyped-def]
+        event.stop()
+        panel = self.parent
+        if isinstance(panel, SubagentPanel):
+            panel.request_toggle()
+
+
 class SubagentPanel(Container):
     """The task-job list in the dock band.
 
@@ -1233,7 +1446,7 @@ class SubagentPanel(Container):
     def __init__(self, on_open: Callable[[str], None]) -> None:
         super().__init__(id="subagent-panel", classes="band-slot")
         self._on_open = on_open
-        self._header = Static(id="subagent-header", classes="band-body")
+        self._header = SubagentHeader()
         # `.band-body`, the same class the header carries and the todo panel's
         # single body carries: the panel's ROWS are the panel, so they take the
         # dock's fill and the dock's one-cell inset rather than sitting on bare
@@ -1248,6 +1461,26 @@ class SubagentPanel(Container):
         self._affordance = SubagentAffordance()
         self._rows: dict[str, SubagentRow] = {}
         self._expanded = False
+        #: How much of the dock the panel takes (#525). VIEW state, like
+        #: `_expanded`: `ctrl+g` and the header click cycle it, the setting
+        #: only seeds it, and nothing writes it back to disk — a hard override
+        #: would make the key a no-op again, the exact defect being fixed.
+        self._density: Density = DEFAULT_DOCK_DENSITY
+        #: Whether the user chose the current density THIS session (plandex's
+        #: `userToggledBuild`). An explicit choice holds against a live edit of
+        #: `display.dock` and against new children starting; only a child
+        #: FAILING breaks through, and that clears it so the next press reads
+        #: naturally (summary → hidden re-hides what the failure surfaced).
+        self._user_density: bool = False
+        #: Whether the seed from `display.dock` has been read. Deferred to the
+        #: first non-empty `sync` rather than `__init__` because the panel is
+        #: built at compose time, before the config watcher the reader prefers
+        #: exists, and a session swap (`/new`, `/resume`) re-seeds through
+        #: `reset_density` anyway.
+        self._density_seeded: bool = False
+        #: What the summary caption last painted, for its paint-once guard
+        #: (counts + spinner frame). None until the summary has painted once.
+        self._summary_key: tuple[SummaryCounts, str] | None = None
         # Logical focus within the full roster. The expanded DOM displays only
         # one screenful around it; every job remains keyboard-reachable without
         # making Textual reflow 100 hidden/off-screen widgets per arrow press.
@@ -1272,6 +1505,10 @@ class SubagentPanel(Container):
         #: paint-once guard can still repaint when the state flips (a resize
         #: across the threshold), without repainting on every unrelated tick.
         self._header_compact: bool = False
+        #: Whether the full-density caption is carrying the `ctrl+g` hint (no
+        #: overflow, so no affordance row to say it). Same guard purpose as
+        #: `_header_compact`: repaint when the hint moves, not per tick.
+        self._header_hint: bool = False
         #: The ledger moved since the last paint. Set by `sync`, cleared by
         #: the tick that acts on it — the coalescing buffer, one bit wide,
         #: because "something changed" is all a full repaint needs to know.
@@ -1305,22 +1542,50 @@ class SubagentPanel(Container):
         yield self._list
         yield self._affordance
 
+    @property
+    def density(self) -> Density:
+        """The panel's current :class:`Density` (view state; see `_density`)."""
+        return self._density
+
+    @property
+    def has_overflow(self) -> bool:
+        """Whether the collapsed preview hides rows, i.e. expanding is a step.
+
+        Gated on the BUDGET, not the flat ceiling: on a short terminal the
+        preview shows fewer rows than `_PREVIEW_JOB_ROWS`, so a roster of
+        four children can already have rows hidden. Keying the refusal on the
+        constant would make `ctrl+g` a silent no-op on exactly the screens
+        where it is the only way to reach them (UX round 2, U7).
+        """
+        return len(self._rows) > self._preview_job_rows()
+
     def toggle_expanded(self, *, enter_navigation: bool = False) -> None:
-        """Flip the roster, optionally entering its explicit keyboard mode."""
-        # Gated on the BUDGET, not the flat ceiling: on a short terminal the
-        # preview shows fewer rows than `_PREVIEW_JOB_ROWS`, so a roster of
-        # four children can already have rows hidden. Keying the refusal on the
-        # constant would make `ctrl+g` a silent no-op on exactly the screens
-        # where it is the only way to reach them (UX round 2, U7).
-        if len(self._rows) <= self._preview_job_rows():
-            return
-        self._expanded = not self._expanded
-        self._apply_visibility()
-        # Existing row content remains valid across disclosure/navigation. A
-        # full 100-row repaint here delayed the key's visible focus feedback;
-        # the ordinary spinner tick may refresh changing facts afterwards.
-        if enter_navigation:
-            if self._expanded:
+        """Advance the density cycle one step, optionally entering navigation.
+
+        The name predates the cycle and is kept because both callers (the
+        ``ctrl+g`` action and the header/affordance click) already go through
+        it; what it does is now the ``ctrl+g`` table from the #525 design:
+
+        * full, no overflow → summary (was a silent no-op: the bug)
+        * full, overflow, collapsed → expanded roster, as before
+        * full, overflow, expanded → collapse AND shrink to summary in one
+          press — the roster's own collapse is folded into the forward cycle
+          rather than being a fourth stop the user has to press through
+        * summary → hidden
+        * hidden → full, collapsed
+
+        Any press is the USER's choice, so it pins `_user_density` (decision
+        2): from here a live `display.dock` edit and new children starting
+        leave the density alone; only a failure moves it, and that unpins.
+        """
+        self._user_density = True
+        if self._density is Density.FULL and self.has_overflow and not self._expanded:
+            self._expanded = True
+            self._apply_visibility()
+            # Existing row content remains valid across disclosure/navigation.
+            # A full 100-row repaint here delayed the key's visible focus
+            # feedback; the ordinary spinner tick refreshes facts afterwards.
+            if enter_navigation:
                 # ``ctrl+g`` is the explicit keyboard-navigation gesture: start
                 # at the oldest row so arrows can traverse every retained child.
                 # Pointer disclosure only changes visibility and must leave the
@@ -1328,8 +1593,115 @@ class SubagentPanel(Container):
                 self._navigation_index = 0
                 self._apply_visibility()
                 self.call_after_refresh(self._focus_navigation_row)
-            else:
-                self.exit_navigation()
+            return
+        if self._density is Density.FULL:
+            next_density = Density.SUMMARY
+        elif self._density is Density.SUMMARY:
+            next_density = Density.HIDDEN
+        else:
+            next_density = Density.FULL
+        # Leaving the expanded roster from the keyboard hands focus back to
+        # the composer exactly as the old collapse did; the pointer path never
+        # took it. Unconditional on `_expanded` because navigation may have
+        # been entered by the key and the collapse by the click.
+        if self._expanded and enter_navigation:
+            self.exit_navigation()
+        self._set_density(next_density)
+
+    def _set_density(self, density: Density) -> None:
+        """Apply ``density`` and settle the panel's own geometry for it.
+
+        Every density change funnels through here so the three things that
+        must move together always do: the expanded flag (only meaningful in
+        `full`, and a hidden roster that came back expanded would re-take the
+        screen), the row visibility and the caption. The band inset and the
+        todo budget are the app's to settle — callers go through
+        `request_toggle`/`action_toggle_subagents`, which `_refresh_band` in
+        the same frame (design §8, dock height jumps).
+        """
+        if density is not Density.FULL:
+            self._expanded = False
+        changed = density is not self._density
+        self._density = density
+        # `display` is settled HERE and re-asserted by `sync`, not only there:
+        # the key press must change the frame it lands on, and `sync` only
+        # runs on the following band refresh.
+        if self._rows:
+            self.display = density is not Density.HIDDEN
+        self._apply_visibility()
+        if changed:
+            # A caption keyed on the old density would stand for a repaint.
+            self._header_shown = False
+            self._summary_key = None
+            self._paint_header()
+            self._sync_spinner_for_density()
+
+    def _sync_spinner_for_density(self) -> None:
+        """Stop the spinner while hidden; let `sync_animation_rate` restart it.
+
+        A hidden panel has nothing to animate, and without this it would keep
+        ticking at 12.5 fps for the rest of the session (design §8). The
+        restart is not done here: `_tick`'s own start/stop already answers to
+        whether any row is running, and it is called from the sync that paints
+        the re-emerged panel.
+        """
+        if self._density is Density.HIDDEN:
+            self._stop_spinner()
+        elif any(row.running for row in self._rows.values()):
+            self._start_spinner()
+
+    def seed_density(self, density: Density, *, force: bool = False) -> None:
+        """Take the configured initial density without claiming it as a choice.
+
+        The setting's job (decision 5): it is where a session STARTS, so a
+        `ctrl+g` afterwards still cycles from it and never writes it back. The
+        live-apply path uses the same entry with the same rule — a file edit
+        applies only while the user has not chosen a density this session
+        (`force` is for the session swap, where the previous choice belonged to
+        a conversation that is gone).
+        """
+        if force:
+            self._user_density = False
+        if self._user_density:
+            return
+        self._set_density(density)
+
+    def reset_density(self) -> None:
+        """Session swap: forget the user's choice and re-read `display.dock`."""
+        self._density_seeded = False
+        self._user_density = False
+
+    def note_child_failed(self) -> None:
+        """A child failed: a hidden panel re-emerges as ONE row, never more.
+
+        The clig.dev rule the issue quotes ("if there is an error, print the
+        logs") scaled to a row: a failure should not re-take 2-8 rows of the
+        user's screen, it should make one row appear that says ``1 failed``.
+        Regardless of `_user_density` — a failure outranks the preference —
+        and it CLEARS the pin so the user's next press re-hides it rather than
+        stepping to `full` (decision 2). Cancelled and interrupted children
+        are not failures and do not come through here; neither do restored
+        rows, which never end in this process.
+        """
+        if self._density is not Density.HIDDEN:
+            return
+        self._user_density = False
+        self._set_density(Density.SUMMARY)
+
+    def _configured_density(self) -> Density:
+        """The `display.dock` value, mapped to the enum; unknown strings are full.
+
+        Function-local import for the reason `tui/settings.py` gives: this
+        module is on the band paint path and the reader is cheap, but the
+        registry it consults on first read is not, so it is not paid at import.
+        """
+        try:
+            from local_operator.tui.settings import settings_get
+
+            raw = settings_get("display.dock", DEFAULT_DOCK_DENSITY.value)
+            return Density(str(raw).strip().lower())
+        except Exception:
+            return DEFAULT_DOCK_DENSITY
 
     def _focus_navigation_row(self) -> None:
         rows = list(self._rows.values())
@@ -1352,7 +1724,11 @@ class SubagentPanel(Container):
         self._focus_navigation_row()
 
     def collapse_for_child_view(self) -> None:
-        """Give the child page the rows the expanded roster was temporarily using."""
+        """Give the child page the rows the expanded roster was temporarily using.
+
+        Touches `_expanded` only: the density is the user's and survives opening
+        a child page and coming back (design §8).
+        """
         if not self._expanded:
             return
         self._expanded = False
@@ -1367,7 +1743,12 @@ class SubagentPanel(Container):
             pass
 
     def request_toggle(self) -> None:
-        """Toggle from the pointer path and settle the dock in the same frame."""
+        """Cycle from the pointer path and settle the dock in the same frame.
+
+        The SAME cycle as ``ctrl+g`` (the header and the affordance both land
+        here) but with ``enter_navigation=False``: a click is a visibility
+        gesture and must never take focus from a draft-bearing composer.
+        """
         self.toggle_expanded()
         app = getattr(self, "app", None)
         refresh = getattr(app, "_refresh_band", None)
@@ -1375,8 +1756,23 @@ class SubagentPanel(Container):
             refresh()
 
     def _apply_visibility(self) -> None:
-        """Show the newest preview slice, or make every start-ordered row reachable."""
+        """Show the preview slice, or make every start-ordered row reachable.
+
+        In `summary` and `hidden` the list and the affordance are switched off
+        and the panel is header-only (one row, or nothing); the row budget
+        arithmetic already counts the caption, so `_painted_rows` is
+        ``_HEADER_ROWS`` and the app's inset and todo budget follow from it.
+        """
         job_ids = list(self._rows)
+        if self._density is not Density.FULL:
+            for row in self._rows.values():
+                row.display = False
+            self._list.display = False
+            self._affordance.display = False
+            self._painted_rows = _HEADER_ROWS if self._density is Density.SUMMARY else 0
+            self._paint_header()
+            return
+        self._list.display = True
         # The COLLAPSED budget is computed in both states: the expanded branch
         # sizes its own viewport, but the affordance below is keyed on this one
         # so the way back stays on screen (see `has_overflow`).
@@ -1398,7 +1794,7 @@ class SubagentPanel(Container):
             # A zero budget is the COMPACT state, and the slice has to be
             # written as a guard rather than `job_ids[-0:]` — which is the whole
             # list, the exact inversion of what a zero budget asks for.
-            visible_ids = set(job_ids[-budget:]) if budget > 0 else set()
+            visible_ids = self._priority_slice(job_ids, budget) if budget > 0 else set()
         for job_id, row in self._rows.items():
             row.display = job_id in visible_ids
         visible_count = len(visible_ids)
@@ -1412,7 +1808,15 @@ class SubagentPanel(Container):
         self._list.styles.max_height = budget
         self._painted_rows = _HEADER_ROWS + list_rows + int(has_overflow)
         if has_overflow:
-            self._paint_affordance(len(job_ids) - visible_count)
+            # `+N earlier` is only TRUE when the hidden set is the roster's
+            # prefix, which the collapsed priority pick no longer guarantees:
+            # a failed child from the first batch can outrank a completed one
+            # from the last. `+N more` when the hidden rows are mixed in. The
+            # expanded roster keeps the wording it had: its window scrolls and
+            # the count there is "not in view", the same as before.
+            hidden_ids = [job_id for job_id in job_ids if job_id not in visible_ids]
+            prefix = job_ids[: len(hidden_ids)]
+            self._paint_affordance(len(hidden_ids), earlier=self._expanded or hidden_ids == prefix)
         # The caption changes shape with the compact state, and that flips on a
         # RESIZE — which moves no row content, so `_paint_all` does not run.
         # Repainting here keeps the count truthful across a resize; the guard
@@ -1481,12 +1885,49 @@ class SubagentPanel(Container):
         except Exception:
             return 0
 
-    def _paint_affordance(self, hidden: int) -> None:
+    def _priority_slice(self, job_ids: list[str], budget: int) -> set[str]:
+        """The ``budget`` rows the collapsed preview shows, by what needs attention.
+
+        Was ``job_ids[-budget:]`` — newest by start order — which evicted a
+        failed child the moment enough later ones completed, so the one row
+        that asked for action was the one the preview dropped (#525 design
+        §4). Rank by :data:`_EVICTION_RANK` (running/queued, then failed, then
+        interrupted, then everything settled quietly), ties to the newest, and
+        the picked set keeps its start order because `_sync_rows` owns the DOM
+        order and this only decides which rows are displayed.
+
+        Only the collapsed preview: the expanded roster shows every row, so
+        there is nothing to pick.
+        """
+        if len(job_ids) <= budget:
+            return set(job_ids)
+
+        def rank(item: tuple[int, str]) -> tuple[int, int]:
+            index, job_id = item
+            row = self._rows.get(job_id)
+            # The row's `running` flag is the last-painted state, not the job's
+            # — a row mounted this sync has not been painted yet, so reading it
+            # here would rank a failed child as running and lose it to the
+            # budget. Fall back to the job's own status, which `_sync_rows`
+            # has just refreshed.
+            if row is not None and row.running:
+                status = "running"
+            else:
+                facts = row_facts(self._jobs_by_id.get(job_id), fallback_id=job_id, current=False)
+                status = "running" if facts.queued else facts.status
+            # Newest first within a rank: a negative index sorts later starts
+            # ahead, which is the `[-budget:]` rule the slice had before.
+            return (_EVICTION_RANK.get(status, 3), -index)
+
+        picked = sorted(enumerate(job_ids), key=rank)[:budget]
+        return {job_id for _index, job_id in picked}
+
+    def _paint_affordance(self, hidden: int, *, earlier: bool = True) -> None:
         dim = Style(color=theme_mod.semantic_color("dim"))
         muted = Style(color=theme_mod.semantic_color("muted"))
         row = Text(no_wrap=True, overflow="ellipsis")
         if hidden:
-            row.append(f"+{hidden} earlier · ", style=dim)
+            row.append(f"+{hidden} {'earlier' if earlier else 'more'} · ", style=dim)
         row.append("ctrl+g to collapse" if self._expanded else "ctrl+g to expand", style=muted)
         self._affordance.update(row)
 
@@ -1502,7 +1943,8 @@ class SubagentPanel(Container):
 
         Never raises and never returns less than one: a displayed panel is at
         least a row, and under-counting hands the transcript a row the dock is
-        about to take.
+        about to take. In `summary` that row IS the panel; a hidden panel is
+        not displayed, so the app never asks.
         """
         return max(1, self._painted_rows)
 
@@ -1547,12 +1989,26 @@ class SubagentPanel(Container):
             self._dirty = False
             self._stop_spinner()
             return
-        self.display = True
+        if not self._density_seeded:
+            # First non-empty sync of this session: the setting is the INITIAL
+            # density (decision 5). Read here rather than at construction so
+            # the config watcher's snapshot, which the reader prefers, exists.
+            self._density_seeded = True
+            self.seed_density(self._configured_density())
+        # NOT an unconditional `True`: the 1 Hz poll lands here every second,
+        # and un-hiding on each tick would make `hidden` last one second.
+        self.display = self._density is not Density.HIDDEN
         self._jobs_by_id = {str(getattr(job, "id", "") or ""): job for job in task_jobs}
         changed = self._sync_rows(task_jobs)
         self._apply_visibility()
         if changed:
             self._paint_all()
+        if self._density is Density.HIDDEN:
+            # Nothing is painted, so nothing should animate; the rows keep
+            # their facts through `_sync_rows` for the frame the panel returns.
+            self._dirty = False
+            self._stop_spinner()
+            return
         # Dirty AFTER the arrival paint, not before it. That paint happens the
         # instant a row is mounted, which is before the layout has measured
         # anything, so it necessarily lays out against the guessed width — it
@@ -1812,19 +2268,56 @@ class SubagentPanel(Container):
         # not a second copy of the band's RUNNING tally (the D-04 objection):
         # this counts every child the session HAS, which on a resumed session
         # with nothing running is precisely the number the band cannot show.
+        #
+        # The SUMMARY density is the same zero-row shape asked for by the user
+        # rather than forced by the height, so it paints the same row (design
+        # §8: one vocabulary, not two) — the counts caption replaced the bare
+        # `Subagents · 19` when the summary row arrived (#525).
         compact = self._painted_rows > 0 and not self._list_shows_any_row()
-        if self._header_shown and compact == self._header_compact:
+        if compact:
+            self._paint_summary()
+            return
+        # In full with no overflow the affordance row is not painted, so the
+        # hint moves into the caption: a `ctrl+g` the user only ever saw with
+        # seven or more children was the discoverability half of #525, and
+        # the caption already has the row. With overflow the affordance says
+        # it and the caption does not repeat it.
+        hint = not self._affordance.display
+        if self._header_shown and not self._header_compact and hint == self._header_hint:
             return
         self._header_shown = True
-        self._header_compact = compact
+        self._header_compact = False
+        self._header_hint = hint
+        self._summary_key = None
         muted = Style(color=theme_mod.semantic_color("muted"))
         dim = Style(color=theme_mod.semantic_color("dim"))
         header = Text(no_wrap=True, overflow="ellipsis")
         header.append("Subagents", style=muted)
-        if compact:
-            header.append(" · ", style=dim)
-            header.append(str(len(self._rows)), style=muted)
+        if hint:
+            header.append(STATS_SEAM, style=dim)
+            header.append("ctrl+g", style=muted)
         self._header.update(header)
+
+    def _paint_summary(self) -> None:
+        """Paint the one-row summary, once per (counts, spinner frame).
+
+        The guard is keyed on the counts tuple and the glyph, not on the
+        density flag the old caption keyed on: a summary keyed on the flag
+        alone painted once and then froze while children settled (design §8).
+        """
+        counts = summary_counts(list(self._jobs_by_id.values()))
+        glyph = SPINNER_FRAMES[self._spinner_index] if counts.running else ""
+        key = (counts, glyph)
+        if self._header_shown and self._header_compact and self._summary_key == key:
+            return
+        self._header_shown = True
+        self._header_compact = True
+        self._summary_key = key
+        self._header.update(compose_summary(counts, spinner_glyph=glyph, width=self._row_width()))
+
+    def summary_text(self) -> str:
+        """The plain string the caption reads right now, for a test to assert."""
+        return str(self._header.content)
 
     def _list_shows_any_row(self) -> bool:
         """Whether the roster is painting a job row right now."""
@@ -1898,6 +2391,17 @@ class SubagentPanel(Container):
         self._tick_count += 1
         self._spinner_index = (self._spinner_index + 1) % len(SPINNER_FRAMES)
         due = self._tick_count % self.STATS_EVERY_TICKS == 0
+        if self._density is not Density.FULL:
+            # Header-only: the rows are not displayed, so the cheap path is the
+            # caption — its own guard keeps a settled roster from repainting.
+            # `_dirty` is consumed here too, or the first tick after the panel
+            # returns to `full` would still owe a full paint (which it does,
+            # from the sync that un-hid it).
+            self._paint_header()
+            self._dirty = False
+            if not any(row.running for row in self._rows.values()):
+                self._stop_spinner()
+            return
         if self._dirty or due:
             self._paint_all(reread_stats=self._dirty or due)
         elif any(row.running for row in self._rows.values()):

--- a/local_operator/tui/widgets/subagent_panel.py
+++ b/local_operator/tui/widgets/subagent_panel.py
@@ -207,8 +207,15 @@ _SUMMARY_SHED_ORDER = ("cancelled", "interrupted", "queued", "done", "label", "r
 #: outcome that needs acting on; an interrupted child may be resumable; a
 #: completed or cancelled one has said everything a row can say. Ties break
 #: by start order, newest kept, which is the rule the slice had before.
+#: ``queued`` is spelled out rather than folded onto ``running`` by the
+#: caller: it shares rank 0, but reaching that through a string substitution
+#: meant "completed", "cancelled" and "queued" all landed on the default
+#: together, so adding a queued rank later — the obvious edit, since the
+#: design names queued explicitly — would have silently changed behaviour for
+#: a state this table appears to describe (round 1, F4).
 _EVICTION_RANK: dict[str, int] = {
     "running": 0,
+    "queued": 0,
     "failed": 1,
     "interrupted": 2,
 }
@@ -217,6 +224,16 @@ _EVICTION_RANK: dict[str, int] = {
 #: title uses between its own facts, one tone under them — a row and the page
 #: it opens must punctuate the same way.
 STATS_SEAM = " · "
+
+#: Break between the FULL header's label and its `ctrl+g` hint. Deliberately
+#: not :data:`STATS_SEAM`: that seam separates COUNTS, so borrowing it here
+#: made the hotkey scan as one more statistic beside the label rather than as
+#: a hint about it (round 1, D3). Same reasoning and same shape as
+#: :data:`ACTIVITY_GAP` below — a break between two KINDS of thing is wider
+#: than the separator used within one kind, so proximity groups them
+#: correctly. Three spaces, one under the 4-cell activity gap, because this
+#: header carries two short tokens rather than a row of numbers.
+HINT_GAP = "   "
 
 #: Cells between the numbers and the activity. FOUR, and wider than the
 #: 3-cell seam on purpose: this is the break between the row's numbers and its
@@ -1481,6 +1498,13 @@ class SubagentPanel(Container):
         #: What the summary caption last painted, for its paint-once guard
         #: (counts + spinner frame). None until the summary has painted once.
         self._summary_key: tuple[SummaryCounts, str] | None = None
+        #: Memo for `_summary_counts_cached`: the ledger identity the counts
+        #: were derived from, and the counts themselves. Keyed rather than
+        #: invalidated because the caption is reached from every tick, and
+        #: re-deriving every job's facts there is the cheap state costing more
+        #: than the expensive one (round 1, F3).
+        self._summary_counts_key: tuple[tuple[int, str], ...] | None = None
+        self._summary_counts_value: SummaryCounts = SummaryCounts()
         # Logical focus within the full roster. The expanded DOM displays only
         # one screenful around it; every job remains keyboard-reachable without
         # making Textual reflow 100 hidden/off-screen widgets per arrow press.
@@ -1546,6 +1570,20 @@ class SubagentPanel(Container):
     def density(self) -> Density:
         """The panel's current :class:`Density` (view state; see `_density`)."""
         return self._density
+
+    @property
+    def has_children(self) -> bool:
+        """Whether the panel holds any child rows, PAINTED OR NOT.
+
+        Deliberately independent of ``display``: in `Density.HIDDEN` the panel
+        is out of the layout but the roster is still docked and still owns its
+        share of the band. The todo panel's shared transcript floor and the
+        app's re-emergence check both need "is a roster present", which is not
+        the same question as "is a roster on screen" — keying either on
+        ``display`` is how hiding the panel came to hand its rows to the todo
+        panel instead of the conversation (review round 1, F1/D1/Q1).
+        """
+        return bool(self._rows)
 
     @property
     def has_overflow(self) -> bool:
@@ -1647,7 +1685,11 @@ class SubagentPanel(Container):
         """
         if self._density is Density.HIDDEN:
             self._stop_spinner()
-        elif any(row.running for row in self._rows.values()):
+        elif self._ledger_has_running():
+            # Same stale-flag trap as `_tick`'s: coming back from `summary`
+            # the rows have not painted since the density changed, so their
+            # own flags would start a timer for a roster with nothing left
+            # running (round 1, F2).
             self._start_spinner()
 
     def seed_density(self, density: Density, *, force: bool = False) -> None:
@@ -1800,7 +1842,7 @@ class SubagentPanel(Container):
         visible_count = len(visible_ids)
         # Overflow is measured against the COLLAPSED budget in both states, so
         # an expanded roster showing every child still carries the row that says
-        # `ctrl+g to collapse`. Keying it on what is hidden RIGHT NOW would hide
+        # `ctrl+g to shrink`. Keying it on what is hidden RIGHT NOW would hide
         # the affordance exactly when the user needs it to get back.
         has_overflow = len(job_ids) > preview_budget
         self._affordance.display = has_overflow
@@ -1904,17 +1946,18 @@ class SubagentPanel(Container):
 
         def rank(item: tuple[int, str]) -> tuple[int, int]:
             index, job_id = item
-            row = self._rows.get(job_id)
-            # The row's `running` flag is the last-painted state, not the job's
-            # — a row mounted this sync has not been painted yet, so reading it
-            # here would rank a failed child as running and lose it to the
-            # budget. Fall back to the job's own status, which `_sync_rows`
-            # has just refreshed.
-            if row is not None and row.running:
-                status = "running"
-            else:
-                facts = row_facts(self._jobs_by_id.get(job_id), fallback_id=job_id, current=False)
-                status = "running" if facts.queued else facts.status
+            # Always the LEDGER, never `row.running`. That flag is written
+            # only in `SubagentRow.paint`, so it reports the last frame the
+            # row was painted in, not the job's state now: a child that
+            # painted while running and has since failed still reads
+            # "running" and outranks the failures this slice exists to keep —
+            # non-deterministically, since whether the row got a paint before
+            # this sync depends on tick timing (it failed ~50% of runs in
+            # isolation). It is the same staleness as F2, one function over.
+            facts = row_facts(self._jobs_by_id.get(job_id), fallback_id=job_id, current=False)
+            # `queued` by its own name: the table ranks it explicitly, so
+            # there is no longer a substitution here to keep in step.
+            status = "queued" if facts.queued else facts.status
             # Newest first within a rank: a negative index sorts later starts
             # ahead, which is the `[-budget:]` rule the slice had before.
             return (_EVICTION_RANK.get(status, 3), -index)
@@ -1928,7 +1971,13 @@ class SubagentPanel(Container):
         row = Text(no_wrap=True, overflow="ellipsis")
         if hidden:
             row.append(f"+{hidden} {'earlier' if earlier else 'more'} · ", style=dim)
-        row.append("ctrl+g to collapse" if self._expanded else "ctrl+g to expand", style=muted)
+        # "shrink", not "collapse": from the expanded roster the key goes to
+        # the one-row SUMMARY, skipping the collapsed preview entirely, so
+        # "collapse" promised a state the press does not reach — on the very
+        # frame where the panel is largest and the user is most deliberately
+        # trying to get back to a known shape (round 1, U1/D2). "Shrink" is
+        # true of every forward step and names no destination.
+        row.append("ctrl+g to shrink" if self._expanded else "ctrl+g to expand", style=muted)
         self._affordance.update(row)
 
     def predicted_rows(self) -> int:
@@ -2294,9 +2343,49 @@ class SubagentPanel(Container):
         header = Text(no_wrap=True, overflow="ellipsis")
         header.append("Subagents", style=muted)
         if hint:
-            header.append(STATS_SEAM, style=dim)
+            # A GAP, not `STATS_SEAM`. That ` · ` is the separator between
+            # counts, so in the summary row the hotkey genuinely is the last
+            # item of a list and the seam is right. The FULL header has no
+            # list, and borrowing the seam put `ctrl+g` in the slot the eye
+            # has learned holds a statistic — it read as "Subagents, and also
+            # ctrl+g" rather than "Subagents (press ctrl+g)" (round 1, D3).
+            header.append(HINT_GAP, style=dim)
             header.append("ctrl+g", style=muted)
         self._header.update(header)
+
+    def _summary_counts_cached(self) -> SummaryCounts:
+        """This frame's counts, re-derived only when the ledger has moved.
+
+        ``summary_counts`` calls :func:`row_facts` once per job and is reached
+        from every ``sync`` AND every tick — 956 µs/call at 60 children, on
+        the state that is supposed to be the CHEAP one (round 1, F3). The
+        memo is keyed on the same ledger identity ``sync`` already maintains,
+        so it needs no invalidation of its own: ``_sync_rows`` replaces
+        ``_jobs_by_id`` wholesale when the roster moves, and a job object
+        mutating in place is picked up because the key carries each job's
+        identity, not just the dict's.
+        """
+        jobs = list(self._jobs_by_id.values())
+        key = tuple((id(job), getattr(job, "status", "")) for job in jobs)
+        if self._summary_counts_key != key:
+            self._summary_counts_key = key
+            self._summary_counts_value = summary_counts(jobs)
+        return self._summary_counts_value
+
+    def _ledger_has_running(self) -> bool:
+        """Whether any child is live, read from the LEDGER not the rows.
+
+        ``row.running`` is written only in ``SubagentRow.paint``, which never
+        runs in `summary` (no row is displayed) — so both the tick's stop
+        condition and the spinner's restart were reading a flag frozen at the
+        last `full` frame. A user who summarised a running fan-out and walked
+        away kept a 12.5 fps timer on the keyboard thread for the rest of the
+        session, on a dock where every child had finished (round 1, F2;
+        measured 12.7 ticks/sec settled, against 1.0/sec in `full`). The
+        counts are already computed for the caption, so this is free.
+        """
+        counts = self._summary_counts_cached()
+        return bool(counts.running or counts.queued)
 
     def _paint_summary(self) -> None:
         """Paint the one-row summary, once per (counts, spinner frame).
@@ -2305,7 +2394,7 @@ class SubagentPanel(Container):
         density flag the old caption keyed on: a summary keyed on the flag
         alone painted once and then froze while children settled (design §8).
         """
-        counts = summary_counts(list(self._jobs_by_id.values()))
+        counts = self._summary_counts_cached()
         glyph = SPINNER_FRAMES[self._spinner_index] if counts.running else ""
         key = (counts, glyph)
         if self._header_shown and self._header_compact and self._summary_key == key:
@@ -2399,7 +2488,11 @@ class SubagentPanel(Container):
             # from the sync that un-hid it).
             self._paint_header()
             self._dirty = False
-            if not any(row.running for row in self._rows.values()):
+            # Liveness from the LEDGER, not from `row.running`: no row is
+            # displayed here, so nothing repaints them and their flags stay
+            # frozen at the last `full` frame — which kept this timer alive at
+            # 12.5 fps on a fully settled dock (round 1, F2).
+            if not self._ledger_has_running():
                 self._stop_spinner()
             return
         if self._dirty or due:

--- a/local_operator/tui/widgets/todo_panel.py
+++ b/local_operator/tui/widgets/todo_panel.py
@@ -144,6 +144,20 @@ _EXPANDED_TRANSCRIPT_FLOOR = 3
 #:   shared floor 6   3   5   5   5   5   6   6   8  12  22
 _COLLAPSED_SHARED_TRANSCRIPT_FLOOR = 6
 
+#: Rows this panel keeps reserved for a sibling that is DOCKED BUT HIDDEN.
+#:
+#: A subagent roster in ``Density.HIDDEN`` paints nothing, so measuring it
+#: gives zero and this panel would grow into rows the user just freed for the
+#: TRANSCRIPT — the dock ending taller than before the keypress (round 1,
+#: F1/D1/Q1). Valued at what the roster costs the instant it comes back —
+#: `Density.SUMMARY`'s one caption row plus the slot's own rhythm row, i.e.
+#: exactly what ``app.slot_rows`` reports for a summarised sibling — which is
+#: also the state a hidden roster is promoted into when a child fails, so the
+#: reservation is already correct when that happens. Charging the roster's
+#: full FULL height instead would leave the band visibly short for the whole
+#: time it is hidden, which is the opposite complaint.
+_HIDDEN_SIBLING_RESERVED_ROWS = 2
+
 #: Hard ceiling on the expanded body's own painted rows, above which the body
 #: SCROLLS instead of growing further (``#todo-body`` gains ``overflow-y: auto``
 #: in expanded mode — see :meth:`TodoPanel._body_rows`). A list longer than the
@@ -1605,7 +1619,10 @@ class TodoPanel(Container):
         dock = _DOCK_ROWS + self._band_inset_rows() + sibling_rows
         # The collapsed budget is the floor for BOTH states (see the
         # expanded-floor rule above): expanded may only ever GROW the panel.
-        # Only charged when a sibling is actually docked — see the constant.
+        # Only charged when a sibling SHARES THE BAND — see the constant. That
+        # is now `sibling_rows > 0` again by construction, because the helper
+        # counts a docked-but-unpainted roster's reserved claim rather than its
+        # painted height (round 1, F1/D1/Q1).
         shared_floor = _COLLAPSED_SHARED_TRANSCRIPT_FLOOR if sibling_rows else 0
         detail_view = self.screen.has_class("subagent")
         if detail_view:
@@ -1690,7 +1707,31 @@ class TodoPanel(Container):
             return 0
         from local_operator.tui.app import slot_rows
 
-        return sum(slot_rows(slot) for slot in parent.children if slot is not self and slot.display)
+        rows = 0
+        for slot in parent.children:
+            if slot is self:
+                continue
+            if slot.display:
+                rows += slot_rows(slot)
+            elif getattr(slot, "has_children", False):
+                # DOCKED BUT NOT PAINTING — a roster the user has hidden with
+                # `ctrl+g` (`Density.HIDDEN`). It measures zero rows this
+                # frame, but the rows it gave up belong to the CONVERSATION,
+                # not to this panel: the gesture's whole promise is handing
+                # them back, and one keypress restores the roster, so growing
+                # into them means paying them straight back the moment it
+                # returns. Counting its reserved claim keeps this budget
+                # steady across the hide, which is what makes the transcript
+                # non-decreasing across full → summary → hidden (round 1,
+                # F1/D1/Q1; before: transcript 8 → 11 → 5 at 100x24).
+                #
+                # A roster with NO children is not counted: the panel is
+                # mounted for the session's whole life and empty for most of
+                # it, so charging for it would shrink every solo todo list and
+                # break the single-panel contract the shared floor's sweep
+                # pins.
+                rows += _HIDDEN_SIBLING_RESERVED_ROWS
+        return rows
 
     def _item_row(self, text: str, status: str, reason: str = "") -> Text:
         """One ``- [ ]``/``- [x]``/``- [~]``/``- [-]`` row — the tool's own

--- a/tests/unit/test_settings_io.py
+++ b/tests/unit/test_settings_io.py
@@ -144,6 +144,7 @@ _NO_SINGLE_VALUE_CONSUMER: dict[str, str] = {
     "display.terminal_title": "tui/settings.py derives its defaults from this registry",
     "display.images": "tui/settings.py derives its defaults from this registry",
     "display.notifications": "tui/settings.py derives its defaults from this registry",
+    "display.dock": "tui/settings.py derives its defaults from this registry",
     "subagents.models.lo": "free text; empty means 'keep the parent's model', no constant",
     "subagents.models.med": "free text; empty means 'keep the parent's model', no constant",
     "subagents.models.hi": "free text; empty means 'keep the parent's model', no constant",
@@ -194,6 +195,7 @@ def test_display_keys_are_flat_dotted() -> None:
         "display.terminal_title",
         "display.images",
         "display.notifications",
+        "display.dock",
     }
 
 
@@ -690,6 +692,38 @@ def test_display_defaults_matches_the_tui_reader() -> None:
     from local_operator.tui import settings as tui_settings
 
     assert settings_io.display_defaults() == tui_settings._DEFAULT_NOTES
+
+
+def test_display_dock_is_a_closed_enum_whose_default_is_the_panels(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#525 case 8: the dock density key.
+
+    Its default is the panel's own constant (the registry is the guarded
+    source, the constant is the panel's fallback — they must agree), its
+    value space is exactly the enum's, and a write round-trips through the
+    flat-dotted reader the panel uses.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    from local_operator.tui.settings import settings_get, settings_reload
+    from local_operator.tui.widgets.subagent_panel import DEFAULT_DOCK_DENSITY, Density
+
+    settings_reload()
+    setting = settings_io.BY_KEY["display.dock"]
+    assert setting.section == "appearance"
+    assert setting.kind is settings_io.Kind.ENUM
+    assert setting.default == DEFAULT_DOCK_DENSITY.value == "full"
+    assert [choice.value for choice in setting.choices] == [d.value for d in Density]
+    assert settings_io.display_defaults()["display.dock"] == "full"
+
+    manager = ConfigManager(tmp_path)
+    settings_io.write_setting(manager, setting, "summary")
+    raw = yaml.safe_load((tmp_path / "config.yml").read_text())
+    assert raw["values"]["display.dock"] == "summary", raw
+    assert "display" not in raw["values"], "split into a nested mapping nothing reads"
+    # The facade dropped the cache, so the panel's reader sees it at once.
+    assert settings_get("display.dock", "full") == "summary"
+    settings_reload()
 
 
 def test_write_is_atomic_and_leaves_no_temp_file(tmp_path: Path) -> None:

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -10504,6 +10504,15 @@ async def test_help_documents_shell_mode_and_the_composer_chords() -> None:
         for row in keyed:
             assert len(row) <= 74, f"{row!r} is {len(row)} cells and wraps at 80 columns"
 
+        # #525 case 9: the `ctrl+g` row names the three stops. A user who only
+        # ever read "expand or collapse" would not learn the panel can shrink
+        # to a row or go away; the description is 46 cells against the
+        # 47-cell budget this block's ceiling leaves a key row.
+        ctrl_g = next(row for row in keyed if row[:20].strip() == "ctrl+g")
+        description = ctrl_g[20:].strip()
+        assert description == "cycle the subagent panel: full, summary, hidden", ctrl_g
+        assert len(description) <= 47, (len(description), description)
+
 
 # -- the aside's keyboard scroll chord (D3) --------------------------------
 #

--- a/tests/unit/tui/test_band_panels.py
+++ b/tests/unit/tui/test_band_panels.py
@@ -1888,3 +1888,50 @@ async def test_the_band_counts_queued_children_so_a_hidden_dock_is_never_silent(
         # The fallback the design leans on is present rather than empty.
         assert app._job_count("task") == 3
         assert format_agents(app._job_count("task")) == "3 agents"
+
+
+@pytest.mark.asyncio
+async def test_the_gate_admitting_a_queued_child_updates_the_summary_caption() -> None:
+    """Round 2 Q2/F7: the counts memo must see a queued→running promotion.
+
+    The one ledger move that changes NEITHER the job's identity nor its
+    status. A queued child already carries ``status == "running"``
+    (`summary_counts` buckets on ``facts.queued`` first), and
+    ``AsyncJobManager.start_queued`` clears ``job.queued`` in place when the
+    capacity gate opens — so a memo keyed on ``(id, status)`` alone returns
+    the pre-admission counts and the caption reports children as queued
+    while they are actually running, indefinitely, until some unrelated job
+    happens to move its status.
+
+    In `summary` that caption is the panel's ONLY representation, which is
+    what made a cheap-path optimisation into a user-visible wrong number.
+    """
+    session = FakeSession()
+    jobs = [_Job(f"sub-{n}", f"child task {n}") for n in range(1, 4)]
+    # One running, two parked behind the gate — `queued` set without touching
+    # `status`, exactly as the manager holds them.
+    jobs[1].queued = True
+    jobs[2].queued = True
+    session.jobs = _fake_jobs(*jobs)
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        panel = await _boot_with_jobs(app, pilot)
+        await pilot.press("ctrl+g")
+        await pilot.pause()
+        assert panel.density is Density.SUMMARY
+        assert "2 queued" in panel.summary_text(), panel.summary_text()
+        assert "1 running" in panel.summary_text(), panel.summary_text()
+
+        # The gate opens: `start_queued` flips this flag in place and leaves
+        # `status` alone (`harness/jobs.py`, which even guards on the status
+        # already being "running").
+        jobs[1].queued = False
+        jobs[2].queued = False
+        session.jobs = _fake_jobs(*jobs)
+        app._refresh_band()
+        for _ in range(8):
+            await pilot.pause()
+
+        caption = panel.summary_text()
+        assert "3 running" in caption, caption
+        assert "queued" not in caption, caption

--- a/tests/unit/tui/test_band_panels.py
+++ b/tests/unit/tui/test_band_panels.py
@@ -26,6 +26,7 @@ from local_operator.tui import theme as theme_mod
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.events import SubagentEnded, SubagentStarted
 from local_operator.tui.widgets.editor import Editor
+from local_operator.tui.widgets.status_line import format_agents
 from local_operator.tui.widgets.subagent_panel import (
     MAX_SUBAGENT_ROWS,
     Density,
@@ -267,6 +268,11 @@ class _Job:
         # does not think about it says "never ran" — the same default the real
         # model carries, and the discriminator ``cancel()`` stamps on.
         self.started_at: float | None = None
+        # Mirrors ``AsyncJob.queued``: admitted to the ledger but held behind
+        # the capacity gate, which carries ``status == "running"`` while not
+        # actually running. Declared so a test can set it without inventing an
+        # attribute the real model has.
+        self.queued: bool = False
         self.result_text: str | None = None
         self.error_text: str | None = None
         self.settled_at: float | None = None
@@ -369,7 +375,7 @@ async def test_subagent_panel_bounds_to_newest_slice_and_expands_in_start_order(
         assert [row.job_id for row in panel.query(SubagentRow) if row.display] == [
             f"sub-{index:02d}" for index in range(1, 13)
         ]
-        assert str(panel._affordance.content) == "ctrl+g to collapse"
+        assert str(panel._affordance.content) == "ctrl+g to shrink"
 
         await pilot.press("ctrl+g")
         await pilot.pause()
@@ -1383,7 +1389,9 @@ async def test_ctrl_g_cycles_full_summary_hidden_with_three_children() -> None:
         assert panel.density is Density.FULL
         assert panel.predicted_rows() == 4
         # No overflow, so the hint lives in the caption (design §3).
-        assert panel.summary_text() == "Subagents · ctrl+g"
+        # A gap, not the counts' ` · ` seam, so the hint does not scan as a
+        # statistic beside the label (round 1, D3).
+        assert panel.summary_text() == "Subagents   ctrl+g"
         assert panel._affordance.display is False
 
         await pilot.press("ctrl+g")
@@ -1539,10 +1547,16 @@ async def test_summary_row_at_fifty_columns_keeps_the_hotkey() -> None:
         while panel.density is not Density.SUMMARY:
             await pilot.press("ctrl+g")
             await pilot.pause()
+        from rich.cells import cell_len
+
         text = panel.summary_text()
         assert text.endswith("ctrl+g"), text
         assert "3 running" in text and "1 failed" in text, text
-        assert len(text) <= panel._row_width(), (text, panel._row_width())
+        # `cell_len`, not `len`: `compose_summary` budgets in CELLS because
+        # the spinner and `✗` are width-sensitive, so a character count
+        # asserts a different quantity than the code guarantees and passes
+        # only while the glyphs happen to be single-width (round 1, F6).
+        assert cell_len(text) <= panel._row_width(), (text, panel._row_width())
         assert tuple(app.screen.virtual_size) == tuple(app.screen.size)
 
 
@@ -1709,3 +1723,168 @@ async def test_display_dock_seeds_the_initial_density_and_live_applies_unless_pi
             assert panel._user_density is False
     finally:
         settings_reload()
+
+
+@pytest.mark.asyncio
+async def test_hiding_the_roster_beside_a_todo_list_never_shrinks_the_transcript() -> None:
+    """Round 1 F1/D1/Q1: the rows a hidden roster frees go to the CONVERSATION.
+
+    The coverage gap the whole round turned on. Every other density test docks
+    the roster alone, where the arithmetic is trivially right; with a todo
+    panel sharing the band each panel sizes against the other's CURRENT
+    height, so `display = False` made the roster contribute zero rows, the
+    shared transcript floor evaporated, and the todo panel absorbed the rows
+    the user had just asked for — the dock ending TALLER than in `full`
+    (measured 100x24: transcript 8 → 11 → 5, dock 14 → 11 → 17).
+
+    Asserts the invariant rather than three fixed numbers: the exact heights
+    depend on the todo panel's own budget ladder, but "pressing ctrl+g never
+    costs the transcript rows" is the promise the feature makes.
+    """
+    from local_operator.tools import builtin
+
+    session = FakeSession()
+    session.jobs = _fake_jobs(*[_Job(f"sub-{n}", f"child task {n}") for n in range(1, 4)])
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        panel = await _boot_with_jobs(app, pilot)
+        todo = app.query_one(TodoPanel)
+        builtin.TODO_STORE["sess"] = [
+            {"text": f"step {n} of the plan", "status": "pending"} for n in range(1, 13)
+        ]
+        # Let the BAND settle before measuring anything. The todo panel walks
+        # to its own budget over a couple of polls, and a baseline captured
+        # mid-walk attributes that panel's convergence to the keypress —
+        # which is a measurement artifact, not the defect under test.
+        for _ in range(3):
+            app._refresh_band()
+            for _ in range(6):
+                await pilot.pause()
+        assert todo.display, "this test is meaningless without a todo panel docked"
+
+        transcript = app.query_one("#transcript")
+
+        async def settled_height() -> int:
+            """The transcript once the band has stopped moving.
+
+            Both panels re-budget against each other over a couple of polls,
+            so every reading here is taken the SAME way — settled — or the
+            comparison measures pump depth rather than the density change.
+            """
+            for _ in range(3):
+                app._refresh_band()
+                for _ in range(6):
+                    await pilot.pause()
+            return transcript.size.height
+
+        heights = [await settled_height()]
+        densities = [panel.density]
+        for _ in range(2):
+            await pilot.press("ctrl+g")
+            for _ in range(4):
+                await pilot.pause()
+            heights.append(await settled_height())
+            densities.append(panel.density)
+
+        assert densities == [Density.FULL, Density.SUMMARY, Density.HIDDEN], densities
+        # The invariant. `>=` rather than `>`: on a short screen a density step
+        # may be absorbed entirely by the floor, which is fine — what must
+        # never happen is the conversation paying for the user's own request
+        # for more room.
+        assert heights[1] >= heights[0], f"summary took transcript rows: {heights}"
+        assert heights[2] >= heights[1], f"hiding took transcript rows: {heights}"
+        # And the dock must not grow across the same presses.
+        assert app.query_one("#input-dock").size.height <= 24, heights
+
+
+@pytest.mark.asyncio
+async def test_children_settling_while_summarised_return_the_dock_to_idle() -> None:
+    """Round 1 F2: a settled dock in `summary` must stop animating.
+
+    `row.running` is written only in `SubagentRow.paint`, which never runs in
+    `summary` because no row is displayed — so the tick's stop condition read
+    a flag frozen at the last `full` frame and kept a 12.5 fps timer on the
+    keyboard thread for the rest of the session (measured 12.7 ticks/sec on a
+    fully settled dock against 1.0/sec in `full`). The children settle AFTER
+    the press here, which is precisely the ordering every existing summary
+    test misses.
+    """
+    session = FakeSession()
+    jobs = [_Job(f"sub-{n}", f"child task {n}") for n in range(1, 4)]
+    session.jobs = _fake_jobs(*jobs)
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        panel = await _boot_with_jobs(app, pilot)
+        await pilot.press("ctrl+g")
+        await pilot.pause()
+        assert panel.density is Density.SUMMARY
+        assert panel._spinner_timer is not None, "a running roster should animate"
+
+        # Settle every child WHILE summarised: no row repaints, so the rows'
+        # own flags stay stale and only the ledger knows.
+        for job in jobs:
+            job.status = "completed"
+        session.jobs = _fake_jobs(*jobs)
+        app._refresh_band()
+        for _ in range(8):
+            await pilot.pause()
+
+        assert all(
+            row.running for row in panel._rows.values()
+        ), "precondition: the stale row flags are exactly what made this a bug"
+        assert "3 done" in panel.summary_text(), panel.summary_text()
+
+        # The timer stops itself from INSIDE `_tick`, so wait for that tick to
+        # happen rather than for a pump count: at a 0.08 s interval a fixed
+        # number of `pause()` calls bets on how much wall time a loaded xdist
+        # worker gets, which is the clock-dependence AGENTS.md warns about (it
+        # failed 2 runs in 3 under `-n2` while passing alone every time).
+        for _ in range(60):
+            if panel._spinner_timer is None:
+                break
+            await asyncio.sleep(0.05)
+            await pilot.pause()
+        assert panel._spinner_timer is None, "settled summary is still animating (F2)"
+
+        # And it comes back when work does, rather than being stopped for good.
+        jobs.append(_Job("sub-4", "child task 4"))
+        session.jobs = _fake_jobs(*jobs)
+        app._refresh_band()
+        for _ in range(8):
+            await pilot.pause()
+        assert panel._spinner_timer is not None, "a new child did not restart the spinner"
+
+
+@pytest.mark.asyncio
+async def test_the_band_counts_queued_children_so_a_hidden_dock_is_never_silent() -> None:
+    """Round 1 U2: hiding is justified by the band, so the band must speak.
+
+    The design lets a LIVE panel disappear because `◍ N agents` still reports
+    the children. That counter excluded queued children, so a hidden dock
+    whose children were all queued reported nothing anywhere — the panel's
+    own stated fallback, empty for exactly the state the panel was showing.
+    """
+    session = FakeSession()
+    jobs = [_Job(f"sub-{n}", f"child task {n}") for n in range(1, 4)]
+    for job in jobs:
+        job.queued = True
+    session.jobs = _fake_jobs(*jobs)
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        panel = await _boot_with_jobs(app, pilot)
+        assert app._job_count("task") == 3, "queued children are still delegated work"
+
+        await pilot.press("ctrl+g")
+        for _ in range(4):
+            await pilot.pause()
+        # Summary names them as queued, which is the state the band must not
+        # then contradict by falling silent.
+        assert "3 queued" in panel.summary_text(), panel.summary_text()
+
+        await pilot.press("ctrl+g")
+        for _ in range(4):
+            await pilot.pause()
+        assert panel.density is Density.HIDDEN
+        # The fallback the design leans on is present rather than empty.
+        assert app._job_count("task") == 3
+        assert format_agents(app._job_count("task")) == "3 agents"

--- a/tests/unit/tui/test_band_panels.py
+++ b/tests/unit/tui/test_band_panels.py
@@ -24,11 +24,15 @@ from local_operator.session.naming import ConversationName
 from local_operator.session.protocol import CompactionOutcome
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.app import OperatorApp
+from local_operator.tui.events import SubagentEnded, SubagentStarted
 from local_operator.tui.widgets.editor import Editor
 from local_operator.tui.widgets.subagent_panel import (
     MAX_SUBAGENT_ROWS,
+    Density,
     SubagentPanel,
     SubagentRow,
+    SummaryCounts,
+    compose_summary,
 )
 from local_operator.tui.widgets.todo_panel import MAX_TODO_ROWS, TodoPanel
 
@@ -337,7 +341,11 @@ async def test_band_panels_hidden_when_empty_and_shown_when_populated() -> None:
 @pytest.mark.asyncio
 async def test_subagent_panel_bounds_to_newest_slice_and_expands_in_start_order() -> None:
     """The default roster preserves the relevant tail without reversing it;
-    its keyboard disclosure reveals every retained child and collapses back."""
+    its keyboard disclosure reveals every retained child, and the press after
+    that collapses the roster AND shrinks the panel to the summary row in one
+    step (#525 design §1: the roster's collapse is folded into the forward
+    cycle rather than being a fourth stop). The press after that hides it,
+    and the one after brings the preview back exactly as it was."""
     session = FakeSession()
     jobs = [_Job(f"sub-{index:02d}", f"task {index:02d}") for index in range(1, 13)]
     session.jobs = _fake_jobs(*jobs)
@@ -365,7 +373,21 @@ async def test_subagent_panel_bounds_to_newest_slice_and_expands_in_start_order(
 
         await pilot.press("ctrl+g")
         await pilot.pause()
+        assert panel.density is Density.SUMMARY
+        assert panel._expanded is False
+        assert [row.job_id for row in panel.query(SubagentRow) if row.display] == []
+        assert app.focused is app.query_one(Editor)
+
+        await pilot.press("ctrl+g")
+        await pilot.pause()
+        assert panel.density is Density.HIDDEN
+        assert panel.display is False
+
+        await pilot.press("ctrl+g")
+        await pilot.pause()
+        assert panel.density is Density.FULL
         assert [row.job_id for row in panel.query(SubagentRow) if row.display] == visible
+        assert str(panel._affordance.content) == "+6 earlier · ctrl+g to expand"
 
 
 @pytest.mark.asyncio
@@ -397,12 +419,39 @@ async def test_clicking_subagent_disclosure_preserves_composer_focus_and_input()
         await pilot.press("x")
         assert editor.text == "draftx"
 
+        # The second click on the affordance is the forward cycle: collapse
+        # AND shrink to the summary row, with the composer still focused.
         await pilot.click("#subagent-affordance")
         await pilot.pause()
         assert app.focused is editor
-        assert app.query_one(SubagentPanel)._expanded is False
+        panel = app.query_one(SubagentPanel)
+        assert panel._expanded is False
+        assert panel.density is Density.SUMMARY
         await pilot.press("y")
         assert editor.text == "draftxy"
+
+        # The header is the pointer target in every density (#525 design §3):
+        # in summary the affordance row is gone, so the caption is what the
+        # user has to click to keep cycling, and it too leaves the draft alone.
+        await pilot.click("#subagent-header")
+        await pilot.pause()
+        assert panel.density is Density.HIDDEN
+        assert app.focused is editor
+        await pilot.press("z")
+        assert editor.text == "draftxyz"
+        # Hidden has no header to click; the key is the way back.
+        await pilot.press("ctrl+g")
+        await pilot.pause()
+        assert panel.density is Density.FULL
+        assert panel._expanded is False
+        await pilot.click("#subagent-header")
+        await pilot.pause()
+        # With overflow the header click is the expand step, same as the key
+        # would be, and still does not enter navigation.
+        assert panel._expanded is True
+        assert app.focused is editor
+        await pilot.press("w")
+        assert editor.text == "draftxyzw"
 
 
 @pytest.mark.asyncio
@@ -1273,10 +1322,390 @@ async def test_ctrl_g_still_reaches_every_child_from_the_compact_roster() -> Non
         # the transcript — but it must still leave the composer on screen.
         assert tuple(app.screen.virtual_size) == tuple(app.screen.size)
 
+        # The press after the expanded roster collapses it AND shrinks the
+        # panel to the summary row (#525 cycle), which on this short screen
+        # is the strongest form of "gives the conversation its rows back".
         await pilot.press("ctrl+g")
         for _ in range(8):
             await pilot.pause()
-        assert sum(1 for row in panel._rows.values() if row.display) == collapsed_visible
+        assert panel.density is Density.SUMMARY
+        assert sum(1 for row in panel._rows.values() if row.display) == 0
         assert (
             app.query_one("#transcript").size.height > 0
         ), "collapsing did not give the conversation its rows back"
+        # Two more presses round the cycle: hidden, then the preview as it was.
+        await pilot.press("ctrl+g")
+        await pilot.press("ctrl+g")
+        for _ in range(8):
+            await pilot.pause()
+        assert panel.density is Density.FULL
+        assert tuple(app.screen.virtual_size) == tuple(app.screen.size)
+        # Coming back from hidden is the ARRIVAL path — the todo list grew into
+        # the rows while the panel was gone, and the two slots re-divide the
+        # band over the next polls exactly as they do on `main` when a roster
+        # first appears beside a docked plan (`slot_rows` keeps the larger of
+        # measured and predicted, so the todo's stale height withholds rows
+        # for a frame). Converge through the poll rather than asserting the
+        # first frame; the settled preview must be the one the session began on.
+        for _ in range(4):
+            app._refresh_band()
+            for _ in range(4):
+                await pilot.pause()
+        assert sum(1 for row in panel._rows.values() if row.display) == collapsed_visible
+
+
+async def _boot_with_jobs(app: OperatorApp, pilot: Any) -> SubagentPanel:
+    """Wait for the session, paint the band, and return the panel."""
+    for _ in range(80):
+        await pilot.pause()
+        if app._session is not None:
+            break
+    app._refresh_band()
+    for _ in range(4):
+        await pilot.pause()
+    return app.query_one(SubagentPanel)
+
+
+@pytest.mark.asyncio
+async def test_ctrl_g_cycles_full_summary_hidden_with_three_children() -> None:
+    """#525 case 1: the common ≤6-child roster, where the key used to no-op.
+
+    Every stop is checked against the geometry the app budgets from
+    (``predicted_rows``: header+3 → 1 → not displayed → header+3) and against
+    the screen never becoming scrollable, the invariant the band tests share.
+    """
+    session = FakeSession()
+    session.jobs = _fake_jobs(*[_Job(f"sub-{n}", f"child task {n}") for n in range(1, 4)])
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        panel = await _boot_with_jobs(app, pilot)
+        editor = app.query_one(Editor)
+        assert panel.density is Density.FULL
+        assert panel.predicted_rows() == 4
+        # No overflow, so the hint lives in the caption (design §3).
+        assert panel.summary_text() == "Subagents · ctrl+g"
+        assert panel._affordance.display is False
+
+        await pilot.press("ctrl+g")
+        await pilot.pause()
+        assert panel.density is Density.SUMMARY
+        assert panel.display is True
+        assert panel.predicted_rows() == 1
+        assert panel._list.display is False
+        assert panel.summary_text().startswith("Subagents · 3 running ")
+        assert panel.summary_text().endswith(" · ctrl+g")
+        assert tuple(app.screen.virtual_size) == tuple(app.screen.size)
+        assert app.focused is editor
+
+        await pilot.press("ctrl+g")
+        await pilot.pause()
+        assert panel.density is Density.HIDDEN
+        assert panel.display is False
+        assert tuple(app.screen.virtual_size) == tuple(app.screen.size)
+        # The 1 Hz poll must not un-hide it (design §8).
+        app._refresh_band()
+        await pilot.pause()
+        assert panel.display is False
+        assert panel._spinner_timer is None, "a hidden panel must not keep ticking"
+
+        await pilot.press("ctrl+g")
+        await pilot.pause()
+        assert panel.density is Density.FULL
+        assert panel.display is True
+        assert panel._expanded is False
+        assert panel.predicted_rows() == 4
+        assert sum(1 for row in panel._rows.values() if row.display) == 3
+        assert tuple(app.screen.virtual_size) == tuple(app.screen.size)
+        assert panel._spinner_timer is not None, "running rows must animate again"
+
+
+@pytest.mark.asyncio
+async def test_ctrl_g_with_overflow_expands_then_summarises_then_hides() -> None:
+    """#525 case 2: with 30 children the full state has two stops.
+
+    Expanded enters navigation (focus on a row, as before); the NEXT press
+    leaves navigation, collapses the roster and shrinks to summary in one
+    step; then hidden; then the preview.
+    """
+    session = FakeSession()
+    session.jobs = _fake_jobs(*[_Job(f"sub-{n:02d}", f"task {n:02d}") for n in range(1, 31)])
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        panel = await _boot_with_jobs(app, pilot)
+        editor = app.query_one(Editor)
+        # With overflow the affordance says the hint; the caption does not
+        # repeat it.
+        assert panel.summary_text() == "Subagents"
+        assert str(panel._affordance.content) == "+24 earlier · ctrl+g to expand"
+
+        await pilot.press("ctrl+g")
+        await pilot.pause()
+        assert panel._expanded is True
+        assert isinstance(app.focused, SubagentRow)
+
+        await pilot.press("ctrl+g")
+        await pilot.pause()
+        assert panel.density is Density.SUMMARY
+        assert panel._expanded is False
+        assert app.focused is editor
+        assert panel.predicted_rows() == 1
+        # The spinner frame between the count and the hotkey varies per tick.
+        text = panel.summary_text()
+        assert text.startswith("Subagents · 30 running ") and text.endswith(" · ctrl+g")
+
+        await pilot.press("ctrl+g")
+        await pilot.pause()
+        assert panel.density is Density.HIDDEN
+        assert panel.display is False
+
+        await pilot.press("ctrl+g")
+        await pilot.pause()
+        assert panel.density is Density.FULL
+        assert panel._expanded is False
+        assert sum(1 for row in panel._rows.values() if row.display) == 6
+        assert str(panel._affordance.content) == "+24 earlier · ctrl+g to expand"
+        assert tuple(app.screen.virtual_size) == tuple(app.screen.size)
+
+
+def test_summary_row_counts_each_state_and_sheds_segments_in_order() -> None:
+    """#525 case 3: the summary row's content and its width ladder.
+
+    Zero segments are omitted, the spinner is present iff something is
+    running, and shedding drops whole segments in the documented order
+    without ever truncating into ``ctrl+g``.
+    """
+    counts = SummaryCounts(running=1, queued=2, done=3, failed=1, cancelled=1, interrupted=1)
+    wide = compose_summary(counts, spinner_glyph="⣾", width=200).plain
+    assert wide == (
+        "Subagents · 1 running ⣾ · 3 done · 1 failed · 2 queued · 1 cancelled · 1 interrupted"
+        " · ctrl+g"
+    )
+    # Ink: `failed` is the only danger segment; the hotkey is muted.
+    row = compose_summary(counts, spinner_glyph="⣾", width=200)
+    assert _ink(_style_at(row, "1 failed")) == theme_mod.semantic_color("danger")
+    assert _ink(_style_at(row, "ctrl+g")) == theme_mod.semantic_color("muted")
+    assert _ink(_style_at(row, "3 done")) == theme_mod.semantic_color("dim")
+
+    # Zero counts are omitted, and no spinner when nothing runs.
+    settled = compose_summary(SummaryCounts(done=4, failed=1), spinner_glyph="", width=200).plain
+    assert settled == "Subagents · 4 done · 1 failed · ctrl+g"
+    assert "⣾" not in settled and "running" not in settled
+
+    # The ladder, from a width that fits everything down to one that fits
+    # only the compressed failed glyph and the hotkey. Each step is a strict
+    # subset of the segments before it and the hotkey is always intact.
+    floor = "⣾ · ✗1 · ctrl+g"
+    seen: list[str] = []
+    for width in range(len(wide), 8, -1):
+        text = compose_summary(counts, spinner_glyph="⣾", width=width).plain
+        assert text.endswith("ctrl+g"), (width, text)
+        # Below the floor there is nothing left to shed; the renderer clips.
+        assert len(text) <= width or text == floor, (width, text)
+        if not seen or seen[-1] != text:
+            seen.append(text)
+    # The documented order: cancelled, interrupted, queued, done, label,
+    # running count (glyph stays), failed count (glyph stays).
+    assert seen[0] == wide
+    assert (
+        seen[1] == "Subagents · 1 running ⣾ · 3 done · 1 failed · 2 queued · 1 interrupted · ctrl+g"
+    )
+    assert seen[2] == "Subagents · 1 running ⣾ · 3 done · 1 failed · 2 queued · ctrl+g"
+    assert seen[3] == "Subagents · 1 running ⣾ · 3 done · 1 failed · ctrl+g"
+    assert seen[4] == "Subagents · 1 running ⣾ · 1 failed · ctrl+g"
+    assert seen[5] == "1 running ⣾ · 1 failed · ctrl+g"
+    assert seen[6] == "⣾ · 1 failed · ctrl+g"
+    assert seen[7] == floor
+    assert seen[-1] == floor
+
+
+@pytest.mark.asyncio
+async def test_summary_row_at_fifty_columns_keeps_the_hotkey() -> None:
+    """#525 case 3, on the real panel: 50x16 sheds segments, never ctrl+g."""
+    session = FakeSession()
+    session.jobs = _fake_jobs(
+        _Job("sub-1", "child one"),
+        _Job("sub-2", "child two"),
+        _Job("sub-3", "child three"),
+        _Job("sub-4", "child four", status="completed"),
+        _Job("sub-5", "child five", status="completed"),
+        _Job("sub-6", "child six", status="failed"),
+    )
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(50, 16)) as pilot:
+        panel = await _boot_with_jobs(app, pilot)
+        # Height-forced compact on this screen paints the SAME summary row
+        # (design §8: one vocabulary for the two zero-row shapes) — so go to
+        # summary explicitly and assert the row either way.
+        while panel.density is not Density.SUMMARY:
+            await pilot.press("ctrl+g")
+            await pilot.pause()
+        text = panel.summary_text()
+        assert text.endswith("ctrl+g"), text
+        assert "3 running" in text and "1 failed" in text, text
+        assert len(text) <= panel._row_width(), (text, panel._row_width())
+        assert tuple(app.screen.virtual_size) == tuple(app.screen.size)
+
+
+@pytest.mark.asyncio
+async def test_a_failure_promotes_hidden_to_summary_and_a_start_does_not() -> None:
+    """#525 case 4: re-emergence rules.
+
+    Hidden + a child STARTING stays hidden (a preference for a small dock is
+    a preference; the band's counter says children run). Hidden + a child
+    FAILING becomes summary — one row, never full — and clears the user pin
+    so the next press re-hides. Summary + failure stays summary with the
+    count moved.
+    """
+    session = FakeSession()
+    jobs = [_Job(f"sub-{n}", f"child task {n}") for n in range(1, 4)]
+    session.jobs = _fake_jobs(*jobs)
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        panel = await _boot_with_jobs(app, pilot)
+        await pilot.press("ctrl+g")
+        await pilot.press("ctrl+g")
+        await pilot.pause()
+        assert panel.density is Density.HIDDEN
+        assert panel._user_density is True
+
+        # A fourth child starts: still hidden.
+        jobs.append(_Job("sub-4", "child task 4"))
+        session.jobs = _fake_jobs(*jobs)
+        app.post_message(SubagentStarted("sub-4", "child task 4"))
+        await pilot.pause()
+        await pilot.pause()
+        assert panel.density is Density.HIDDEN
+        assert panel.display is False
+
+        # A cancel is not a failure: still hidden.
+        jobs[1].status = "cancelled"
+        app.post_message(SubagentEnded("sub-2", "child task 2", "cancelled"))
+        await pilot.pause()
+        await pilot.pause()
+        assert panel.density is Density.HIDDEN
+
+        # A failure breaks through, to ONE row, and unpins.
+        jobs[0].status = "failed"
+        app.post_message(SubagentEnded("sub-1", "child task 1", "failed"))
+        await pilot.pause()
+        await pilot.pause()
+        assert panel.density is Density.SUMMARY
+        assert panel.display is True
+        assert panel.predicted_rows() == 1
+        assert panel._user_density is False
+        text = panel.summary_text()
+        assert "1 failed" in text and "2 running" in text and "1 cancelled" in text, text
+        assert tuple(app.screen.virtual_size) == tuple(app.screen.size)
+
+        # Summary + another failure: still summary, count moves.
+        jobs[2].status = "failed"
+        app.post_message(SubagentEnded("sub-3", "child task 3", "failed"))
+        await pilot.pause()
+        await pilot.pause()
+        assert panel.density is Density.SUMMARY
+        assert "2 failed" in panel.summary_text(), panel.summary_text()
+
+        # The next press reads naturally: summary → hidden.
+        await pilot.press("ctrl+g")
+        await pilot.pause()
+        assert panel.density is Density.HIDDEN
+
+
+@pytest.mark.asyncio
+async def test_collapsed_preview_keeps_failed_children_over_completed_ones() -> None:
+    """#525 case 6: the budgeted slice is a priority pick, not the newest tail.
+
+    Eight children, budget six, the two OLDEST failed and the two NEWEST
+    completed: the failed pair is shown, the affordance says ``+2 more``
+    (the hidden set is no longer the roster's prefix), and DOM order is
+    unchanged.
+    """
+    session = FakeSession()
+    jobs = [_Job(f"sub-{n:02d}", f"task {n:02d}") for n in range(1, 9)]
+    jobs[0].status = "failed"
+    jobs[1].status = "failed"
+    jobs[6].status = "completed"
+    jobs[7].status = "completed"
+    session.jobs = _fake_jobs(*jobs)
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        panel = await _boot_with_jobs(app, pilot)
+        assert panel._preview_job_rows() == 6
+        visible = [row.job_id for row in panel.query(SubagentRow) if row.display]
+        assert visible == ["sub-01", "sub-02", "sub-03", "sub-04", "sub-05", "sub-06"]
+        assert str(panel._affordance.content) == "+2 more · ctrl+g to expand"
+
+        # When the hidden set IS the prefix the old wording stands.
+        for job in jobs:
+            job.status = "running"
+        session.jobs = _fake_jobs(*jobs)
+        app._refresh_band()
+        await pilot.pause()
+        visible = [row.job_id for row in panel.query(SubagentRow) if row.display]
+        assert visible == [f"sub-{n:02d}" for n in range(3, 9)]
+        assert str(panel._affordance.content) == "+2 earlier · ctrl+g to expand"
+
+
+@pytest.mark.asyncio
+async def test_display_dock_seeds_the_initial_density_and_live_applies_unless_pinned(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#525 case 7: the setting is where a session STARTS, never an override.
+
+    ``display.dock: summary`` in an isolated config paints summary on the
+    first non-empty sync; ``ctrl+g`` still cycles from it; a live write
+    applies while the user has not chosen, and is ignored once they have.
+    """
+    import yaml
+
+    from local_operator import settings_io
+    from local_operator.config import ConfigManager
+    from local_operator.tui.settings import settings_reload
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "config.yml").write_text(yaml.safe_dump({"values": {"display.dock": "summary"}}))
+    settings_reload()
+    # Writes go through the facade the `/settings` page uses, so the process
+    # watcher's snapshot (which the fast-path reader prefers once the app has
+    # started one) and the display cache both move, exactly as a page edit
+    # would move them. A bare file write would be read by nobody until the
+    # watcher's next poll.
+    manager = ConfigManager(tmp_path)
+    dock = settings_io.BY_KEY["display.dock"]
+    try:
+        session = FakeSession()
+        session.jobs = _fake_jobs(*[_Job(f"sub-{n}", f"child task {n}") for n in range(1, 4)])
+        app = OperatorApp(_async_factory(session))
+        async with app.run_test(size=(100, 30)) as pilot:
+            panel = await _boot_with_jobs(app, pilot)
+            assert panel.density is Density.SUMMARY
+            assert panel._user_density is False
+            assert panel.predicted_rows() == 1
+
+            # A live write with no user choice applies.
+            settings_io.write_setting(manager, dock, "hidden")
+            app._apply_dock_density()
+            await pilot.pause()
+            assert panel.density is Density.HIDDEN
+            assert panel.display is False
+
+            # ctrl+g cycles from wherever the setting put it.
+            await pilot.press("ctrl+g")
+            await pilot.pause()
+            assert panel.density is Density.FULL
+            assert panel._user_density is True
+
+            # Now pinned: a live write does not fight the user.
+            settings_io.write_setting(manager, dock, "summary")
+            app._apply_dock_density()
+            await pilot.pause()
+            assert panel.density is Density.FULL
+
+            # A session swap forgets the pin and re-reads the setting.
+            panel.reset_density()
+            app._refresh_band()
+            await pilot.pause()
+            assert panel.density is Density.SUMMARY
+            assert panel._user_density is False
+    finally:
+        settings_reload()

--- a/tests/unit/tui/test_settings_view.py
+++ b/tests/unit/tui/test_settings_view.py
@@ -4954,3 +4954,45 @@ async def test_page_reads_a_garbage_master_switch_the_way_the_policy_does(tmp_pa
             theme_mod.semantic_color("dim").lower()
         )
         assert "inert: Session cleanup is off" in view.render_lines_for_test()[-1]
+
+
+@pytest.mark.asyncio
+async def test_subagent_dock_row_renders_in_appearance_with_its_three_choices(
+    tmp_path: Path,
+) -> None:
+    """#525 case 8: the ``display.dock`` row is on the page, in Appearance, and
+    expanding it offers exactly ``full | summary | hidden`` — the enum's own
+    vocabulary, not the issue's ``compact``/``off``. Committing a choice writes
+    the FLAT-DOTTED key, which is the trap the registry's path guards."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 32)) as pilot:
+        await pilot.pause()
+        app._open_settings_view()
+        view = app.query_one(SettingsView)
+        await pilot.pause()
+        index = _select(view, "display.dock")
+        lines = view.render_lines_for_test()
+        row = lines[index + 2]
+        assert "Subagent dock" in row and "full" in row, row
+        # The row sits under the Appearance header, not Session.
+        headers = [
+            (offset, line)
+            for offset, line in enumerate(lines[: index + 2])
+            if line.strip().lower().startswith("appearance") or line.strip().lower() == "session"
+        ]
+        assert headers and headers[-1][1].strip().lower().startswith("appearance"), headers
+
+        view.action_activate()
+        await pilot.pause()
+        assert view._expanded == "display.dock"
+        choices = [row.choice.value for row in view._rows if row.kind == "choice"]
+        assert choices == ["full", "summary", "hidden"], choices
+
+        for offset, row in enumerate(view._rows[index + 1 :], start=index + 1):
+            if row.kind == "choice" and row.choice.value == "hidden":
+                view._selected = offset
+                break
+        view.action_activate()
+        await pilot.pause()
+        assert _values(tmp_path)["display.dock"] == "hidden"
+        assert "display" not in _values(tmp_path)


### PR DESCRIPTION
## Summary

**C2 standard / pre-authorized.** Give the dock's subagent panel a three-state
density cycle on `ctrl+g` — **full → summary → hidden** — that works while
children are running, collapse it to a one-line summary instead of a fixed
row-per-job list, and stop the collapsed preview from evicting the children that
need attention.

Closes #525.

**Relation to #524 — separate.** `_sweep_due` has three call sites, all on a
job's own settle path; nothing is timer-driven, and no open or merged PR
addresses it. #524 is a manager-side timer with no UI. Coupling them would put a
harness change under a design/UX round it does not need. "Hidden" is the user's
answer to a crowded dock; #524 is the system's, and they land independently.

### The defect

`ctrl+g` was an *overflow disclosure*: `toggle_expanded` returned early when
`len(rows) <= _preview_job_rows()`, so with six or fewer children — the common
fan-out — **the key did nothing and the affordance row was not painted**. The
states were "preview (≤6 newest)" and "expanded roster": no small state, no off
state. The only zero-row shape was the height-forced compact fallback, which the
user cannot ask for. The panel was an unshrinkable 2–8 row claim above the
composer for the whole session.

## Design decisions

Pasted inline from the architecture note (the file lives outside the repo).

**1. Three states, one direction.** `Density.FULL | SUMMARY | HIDDEN` on the
panel as view state, beside `_expanded`. Forward-only, matching lazygit's `+`
convention; no reverse key (none free, and the cycle is length ≤ 4). The
`ctrl+g` table:

| from | to |
| --- | --- |
| full, no overflow | summary *(was the silent no-op — the bug)* |
| full, overflow, collapsed | expanded roster, as before |
| full, overflow, expanded | collapse **and** shrink to summary, one press |
| summary | hidden |
| hidden | full, collapsed |

The expanded roster's collapse folds into the forward cycle rather than becoming
a fourth stop the user presses through.

**2. Re-emergence: sticky choice, failure breaks through.** Any press sets
`_user_density`, and the chosen density then holds against everything below.
A **new child starting never reopens the dock** — a preference for a small dock
is a preference for a small dock, the summary row's spinner is the liveness cue,
and the status band's `◍ N agents` counter already says children are running,
so nothing is silently invisible. A child **failing** while hidden promotes to
**summary — never to full**: a failure should not re-take 2–8 rows, it should
make one row appear that says `1 failed`. That happens regardless of the pin and
*clears* it, so the next `ctrl+g` reads naturally (summary → hidden re-hides).
Restored/cancelled rows do not trigger it.

**3. Summary row and the `ctrl+g` hint.** One row carrying the counts the rows
would have shown, in the compact caption's existing vocabulary so the two
zero-row shapes read the same:

```
Subagents · 1 running ⣾ · 3 done · 1 failed · 2 queued · 1 cancelled · 1 interrupted · ctrl+g
```

Zero counts are omitted; the spinner appears iff something runs; `failed` is the
only coloured segment. As width runs out it sheds **whole segments** in a fixed
order — cancelled, interrupted, queued, done, the label, then the running and
failed words compress to glyphs — and **never truncates into `ctrl+g`**, so the
way back is always on screen. Measured against the widest rendering, not the
current string. In *full with no overflow* the hint moves into the header
(`Subagents · ctrl+g`) at zero row cost, fixing discoverability without adding a
row to the common case; with overflow the affordance row keeps its wording and
the header does not duplicate it. The header is clickable in every state and
routes through the same cycle with `enter_navigation=False`, so the pointer path
never steals composer focus.

**4. Eviction priority; row cap deferred.** `_apply_visibility` sliced
`job_ids[-budget:]` — newest by start order — which dropped a failed child as
soon as enough later ones completed, losing the one row that asked for action.
The collapsed slice becomes a **priority pick, then a start-order re-sort**:
running/queued (0) < failed (1) < interrupted (2) < settled (3), ties to newest.
DOM order is unchanged because `_sync_rows` owns it. **No new row cap** — the
existing height-aware budget already bounds the panel.

**5–8.** `display.dock` (`full|summary|hidden`, Appearance/LIVE) seeds where a
session *starts* and is deliberately **not** an override: a setting that pinned
the density would make the key a no-op again, the exact defect being fixed. It
applies live only while `_user_density` is False. Risks handled explicitly:
`predicted_rows` returns 1 in summary and the panel sets `display=False` inside
`sync` so the band inset and todo budget read a settled count in one pass;
`sync`'s "re-show whenever there are jobs" short-circuits on hidden or the 1 Hz
poll un-hides it every second; the paint-once header guard is keyed on
`(density, counts, spinner frame)` so summary cannot freeze; the spinner stops
when hidden and restarts on re-emergence; density survives `collapse_for_child_view`;
no new key bindings. Mobile web shares no state with the panel — out of scope.

## Testing evidence

### Gates (whole tree, exactly as CI)

```
$ .venv/bin/python -m flake8 .
(exit 0, no output)

$ uvx --from black==26.1.0 black --check .
All done! ✨ 🍰 ✨
928 files would be left unchanged.

$ uvx isort==5.13.2 --check .
Skipped 2 files
(exit 0)

$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .
0 errors, 0 warnings, 0 informations

$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q -n2
14327 passed, 17 skipped, 673 warnings in 2471.08s (0:41:11)

$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q
29 passed, 2 warnings in 29.22s
```

Re-run on the round-1 remediation head `064b483d3`. The whole tree is green
now, including `test_phone_watchers_do_not_change_idle_timing` — the
wall-clock flake reported below at round 0, which passed on this run.

The single unit failure is **`test_process_reaper.py::test_phone_watchers_do_not_change_idle_timing`**,
a pre-existing wall-clock flake unrelated to this diff (which touches no
`session/` file). Reproduced on **clean `origin/main` with this branch absent**,
in a throwaway worktree: 5 isolated runs gave *fail, pass, fail, pass, pass*.
Not fixed here — out of slice, and reported rather than papered over.

```
$ .venv/bin/python -m pytest .../test_phone_watchers_do_not_change_idle_timing -q   # on origin/main
1 failed / 1 passed / 1 failed / 1 passed / 1 passed
```

Also fixed en route: my `.tcss` comment originally cited the issue as `#525`,
which `test_tcss_has_no_literal_hex` and `test_stylesheet_region_has_no_literal_hex`
correctly match as a literal hex colour. Switched to the sheet's existing
`issue NNN` convention.

### Unit and pilot cases added (design §7, all nine)

`tests/unit/tui/test_band_panels.py` — the `ctrl+g` cycle with 3 children
(the case that used to no-op), the overflow cycle with 30, the summary row's
content plus its full shedding ladder, the 50×16 truncation floor, failure
re-emergence (start does *not* reopen, cancel does not, failure does and unpins),
the priority slice keeping failed children over completed ones, and
`display.dock` seeding plus live-apply-unless-pinned. `tests/unit/test_settings_io.py`
— flat-dotted write, allow-list, `display_defaults()`, closed enum whose default
is the panel's own constant. `tests/unit/tui/test_settings_view.py` — the
Appearance row renders and committing a choice writes the flat key.
`tests/unit/tui/test_app_pilot.py` — the `/help` row text and its ≤47-cell budget.

### Rendered stills and geometry

Captured from the real `OperatorApp` via `run_test` + `save_screenshot`, with
every inherited `CMUX_*` variable unset and an isolated config dir. **Before**
frames come from a throwaway `origin/main` worktree, since deleted. Every frame
was rendered to PNG and looked at, not merely produced.

**Three children — the common fan-out where `ctrl+g` did nothing.**

| before (`origin/main`) | after — full | after — summary | after — hidden |
| --- | --- | --- | --- |
| <img src="https://raw.githubusercontent.com/damianvtran/local-operator/b93264fa61eb631d36e2145f5ab7e3ac9820f3fe/before-three-full.png" width="380"> | <img src="https://raw.githubusercontent.com/damianvtran/local-operator/b93264fa61eb631d36e2145f5ab7e3ac9820f3fe/after-three-full.png" width="380"> | <img src="https://raw.githubusercontent.com/damianvtran/local-operator/b93264fa61eb631d36e2145f5ab7e3ac9820f3fe/after-three-summary.png" width="380"> | <img src="https://raw.githubusercontent.com/damianvtran/local-operator/b93264fa61eb631d36e2145f5ab7e3ac9820f3fe/after-three-hidden.png" width="380"> |

On `main` all four presses produce an identical frame. After: 4 rows → 1 row →
gone, and the transcript grows 14 → 17 → 20 rows. Hidden restores the boot
splash's logo; `◍ 3 agents` on the status band still reports the running children.

**Thirty children — the overflow path keeps its expanded stop.**

| preview | expanded | summary | hidden |
| --- | --- | --- | --- |
| <img src="https://raw.githubusercontent.com/damianvtran/local-operator/b93264fa61eb631d36e2145f5ab7e3ac9820f3fe/after-thirty-preview.png" width="380"> | <img src="https://raw.githubusercontent.com/damianvtran/local-operator/b93264fa61eb631d36e2145f5ab7e3ac9820f3fe/after-thirty-expanded.png" width="380"> | <img src="https://raw.githubusercontent.com/damianvtran/local-operator/b93264fa61eb631d36e2145f5ab7e3ac9820f3fe/after-thirty-summary.png" width="380"> | <img src="https://raw.githubusercontent.com/damianvtran/local-operator/b93264fa61eb631d36e2145f5ab7e3ac9820f3fe/after-thirty-hidden.png" width="380"> |

**Hidden → a child fails → summary, two consecutive frames.** Proves there is no
intermediate full frame: the first frame after the failure is already the
one-row summary, and the second differs only in the spinner glyph.

| hidden | frame 1 (failure lands) | frame 2 (next tick) |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/damianvtran/local-operator/b93264fa61eb631d36e2145f5ab7e3ac9820f3fe/after-failure-hidden.png" width="380"> | <img src="https://raw.githubusercontent.com/damianvtran/local-operator/b93264fa61eb631d36e2145f5ab7e3ac9820f3fe/after-failure-frame1.png" width="380"> | <img src="https://raw.githubusercontent.com/damianvtran/local-operator/b93264fa61eb631d36e2145f5ab7e3ac9820f3fe/after-failure-frame2.png" width="380"> |

**100×24 with a 12-item todo docked (the U7 case)** — the short screen where the
dock used to take the conversation, and where review round 1 found the blocker
(F1/D1/Q1). Hiding the roster now returns its rows to the **transcript**; the
todo panel keeps the height its own `ctrl+t` state chose.

| full | summary | hidden |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/damianvtran/local-operator/b93264fa61eb631d36e2145f5ab7e3ac9820f3fe/after-todo-full.png" width="380"> | <img src="https://raw.githubusercontent.com/damianvtran/local-operator/b93264fa61eb631d36e2145f5ab7e3ac9820f3fe/after-todo-summary.png" width="380"> | <img src="https://raw.githubusercontent.com/damianvtran/local-operator/b93264fa61eb631d36e2145f5ab7e3ac9820f3fe/after-todo-hidden.png" width="380"> |

Transcript rows across the cycle, from the frame JSON these stills are captured
with — the same measurement the three reviewers used to file the defect:

| | full | summary | hidden | verdict |
| --- | --- | --- | --- | --- |
| round 0 (defect) | 8 | 11 | **3** | conversation lost 5 rows; dock 3 rows taller |
| round 1 (fixed) | 8 | 8 | **10** | non-decreasing; hiding returns 2 rows |

The todo panel no longer balloons to 10 rows, which is what the stills show
directly.

> **Correction (round 2).** An earlier version of this paragraph and the round-1
> remediation comment claimed the todo panel "keeps the height its own `ctrl+t`
> state chose across all three densities", at 3 rows throughout. That was
> **inaccurate**: QA re-measured it as **3 → 6 → 6**, and the settled numbers
> confirm it — the panel does grow 3 rows at the `summary` step. QA A/B'd the
> growth as **pre-existing and identical under the round-1 implementation**, and
> harmless, because it comes out of the roster's own shed rows rather than the
> transcript's. The finding this evidence supports is genuinely fixed; the
> sentence describing it was wrong. Settled geometry at 100x24:
>
> | state | transcript | todo_outer | subagent | band |
> |---|---|---|---|---|
> | full | 8 | 3 | 5 | 8 |
> | summary | 8 | 6 | 2 | 8 |
> | hidden | 10 | 6 | 0 | 6 |
>
> (Q3, round 3: the `hidden` row previously read `2` for the subagent column. The
> panel is `display: False` there and contributes 0 to the band; the 2 was a stale
> `outer_size` Textual does not zero on an undisplayed widget. Corrected so the
> table's own arithmetic — band = todo + subagent — holds on every row.)

**50×16 summary truncation** and **`/settings` Appearance row** with its three choices.

| 50×16 summary | /settings row | /settings expanded |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/damianvtran/local-operator/b93264fa61eb631d36e2145f5ab7e3ac9820f3fe/after-narrow-summary.png" width="380"> | <img src="https://raw.githubusercontent.com/damianvtran/local-operator/b93264fa61eb631d36e2145f5ab7e3ac9820f3fe/after-settings-settings.png" width="380"> | <img src="https://raw.githubusercontent.com/damianvtran/local-operator/b93264fa61eb631d36e2145f5ab7e3ac9820f3fe/after-settings-settings-expanded.png" width="380"> |

At 50 columns the row sheds down to `Subagents · 3 running ⣻ · 1 failed · ctrl+g`
and the hotkey survives. The shedding ladder, printed from the real function:

```
46  'Subagents · 3 running ⣾ · 1 failed · ctrl+g'
40  '3 running ⣾ · 1 failed · ctrl+g'
30  '⣾ · 1 failed · ctrl+g'
18  '⣾ · ✗1 · ctrl+g'
```

**Geometry behind the frames.** `virtual_size == size` on every one, i.e. no
state introduces a scrollable screen:

| frame | screen | virtual==size | predicted_rows | panel height | displayed |
| --- | --- | --- | --- | --- | --- |
| `failure-frame1` | 98x28 | True | 1 | 1 | True |
| `failure-frame2` | 98x28 | True | 1 | 1 | True |
| `failure-hidden` | 98x28 | True | 1 | 0 | False |
| `narrow-summary` | 48x14 | True | 1 | 1 | True |
| `settings-settings-expanded` | 98x28 | True | - | - | - |
| `settings-settings` | 98x28 | True | - | - | - |
| `thirty-expanded` | 98x28 | True | 16 | 16 | True |
| `thirty-hidden` | 98x28 | True | 1 | 0 | False |
| `thirty-preview` | 98x28 | True | 8 | 8 | True |
| `thirty-summary` | 98x28 | True | 1 | 1 | True |
| `three-full-again` | 98x28 | True | 4 | 4 | True |
| `three-full` | 98x28 | True | 4 | 4 | True |
| `three-hidden` | 98x28 | True | 1 | 0 | False |
| `three-summary` | 98x28 | True | 1 | 1 | True |
| `todo-full` | 98x22 | True | 4 | 4 | True |
| `todo-hidden` | 98x22 | True | 1 | 0 | False |
| `todo-summary` | 98x22 | True | 1 | 1 | True |

One geometry note for reviewers: the boot splash re-measures asynchronously
(`WelcomeView._poll` fires when the model label resolves) and lifts the dock two
rows on **both** trees. A frame captured before it lands differs from the settled
one, so the capture script forces `_sync_boot_layout()` and waits for the region
to stop moving. This is pre-existing behaviour, verified identical on
`origin/main`, not something this PR introduces.

## How to reach it locally

```sh
git fetch origin feat/525-dock-density
git worktree add /tmp/lop-525-review origin/feat/525-dock-density
cd /tmp/lop-525-review
uv venv --python 3.12 .venv && uv pip install -e ".[all,dev]" --python .venv/bin/python
```

Drive it headlessly against a scripted fan-out (no live sessions touched, every
inherited `CMUX_*` unset):

```sh
env -u NO_COLOR TERM=xterm-256color .venv/bin/python - <<'PY'
import asyncio, os, sys
sys.path.insert(0, os.getcwd())
for k in [k for k in os.environ if k.startswith("CMUX_")]: os.environ.pop(k)
import scripts.probe_isolation  # isolated HOME + LOCAL_OPERATOR_CONFIG_DIR
from local_operator.tui.app import OperatorApp
from local_operator.tui.widgets.subagent_panel import SubagentPanel
from tests.unit.tui.test_band_panels import FakeSession, _async_factory, _fake_jobs, _Job

async def main():
    session = FakeSession()
    session.jobs = _fake_jobs(*[_Job(f"sub-{n}", f"child task {n}") for n in range(1, 4)])
    app = OperatorApp(_async_factory(session))
    async with app.run_test(size=(100, 30)) as pilot:
        for _ in range(80):
            await pilot.pause()
            if app._session is not None: break
        app._refresh_band(); await pilot.pause()
        panel = app.query_one(SubagentPanel)
        for label in ("start", "1x", "2x", "3x"):
            if label != "start":
                await pilot.press("ctrl+g"); await pilot.pause()
            print(f"{label:6s} density={panel.density.value:8s} display={panel.display!s:5s} "
                  f"rows={panel.predicted_rows()} header={panel.summary_text()!r}")
asyncio.run(main())
PY
```

Expected — the three-child case that used to be a no-op:

```
start  density=full     display=True  rows=4 header='Subagents · ctrl+g'
1x     density=summary  display=True  rows=1 header='Subagents · 3 running ⣾ · ctrl+g'
2x     density=hidden   display=False rows=1 header='Subagents · ctrl+g'
3x     density=full     display=True  rows=4 header='Subagents · ctrl+g'
```

To see it in a real terminal with an isolated config, and the `/settings` row:

```sh
LOCAL_OPERATOR_CONFIG_DIR=/tmp/lop-525-cfg .venv/bin/local-operator
#   then: /settings → Appearance → "Subagent dock"; or press ctrl+g with children running
```

To re-capture any still: `dock_shot.py` takes an output dir, a prefix and a
scenario (`three | thirty | failure | todo | narrow | settings`).

## Not in this PR

- **#524** (sweep/retention timer) — separate, per the design; no dependency.
- **The todo panel's own density** — out of scope; `ctrl+t` is unchanged.
- **A reverse-direction key** — no free binding was found and the cycle is short.
- **A new row cap** — the existing height-aware budget already bounds the panel.
- **`test_phone_watchers_do_not_change_idle_timing`** — pre-existing flake on
  `main`, evidence above; not touched.
- **pyproject.toml is not bumped** — per the release policy, versioning is the
  window owner's.



---

## Review round 1 — remediation summary

Head `064b483d3`. All four streams (code, QA, design, UX) were worked as **one
batched commit**; per-stream disposition comments are on the PR.

| ID | Severity | Disposition |
| --- | --- | --- |
| F1 / D1 / Q1 | blocker | **fixed** — hidden roster's rows go to the transcript; regression test added |
| F2 | major | **fixed** — liveness read from the ledger; 12.7 → 1.0 ticks/sec |
| F3 | minor | **fixed** — counts memoised, 309 → 73 µs/call |
| F4 | minor | **fixed** — `queued` ranked by name; surfaced and fixed a latent race |
| F5, F6 | nit | **fixed** — `has_children` accessor; `cell_len` assertion |
| U1 / D2 | minor | **fixed** — `ctrl+g to shrink` |
| U2 | minor | **fixed** — band counts queued children |
| D3, D5 | nit | **fixed** — header hint gap; parallel choice descriptions |
| D4 | nit | accepted, no change requested by the reviewer |
| U3 | minor | **deferred** — the `_DROP_LADDER` is a swept contract outside this diff's surface |
| U4 | nit | accepted, no action needed |

Both coverage gaps the round turned on now have regression tests, each verified
to **fail against the unfixed code**:

```
$ pytest -k hiding_the_roster_beside_a_todo_list   # F1 fix reverted
FAILED — AssertionError: hiding took transcript rows: [5, 5, 2]; assert 2 >= 5
$ pytest -k settling_while_summarised              # F2 fix reverted
FAILED — AssertionError: settled summary is still animating (F2)
```

#### Follow-up observations (recorded, not fixed, no issue opened)

- **`tests/conftest.py::_AMBIENT_VARS` clears only 5 of the 24 inherited
  `CMUX_*` variables** (`CMUX_WORKSPACE_ID`, `SURFACE_ID`, `PANEL_ID`, `TAB_ID`,
  `SOCKET`), found by QA. An inherited `CMUX_WORKSPACE_ID` previously let
  headless tests rename real cmux workspaces, so the gap has bitten before; the
  reviewers' harnesses scrub the rest themselves. Outside this diff's surface —
  raising it here so it reaches the operator rather than dying in a thread.
- **A hidden, pinned panel keeps its pin across an emptying roster** (reviewer's
  lifecycle note). Correct per design §2 as written; recorded so the choice
  stays deliberate.
- **Pre-existing order-dependence in `test_band_panels.py`** from the
  module-global `builtin.TODO_STORE`, reproducible at the merge base. Not this
  PR's, and not touched.
- **D6 — the `summary` step reflows visibly (~450 ms)**, the todo panel growing
  3 rows and the transcript shrinking 3 about a third of a second after the
  keypress. Real motion, but the designer reproduced the identical two-stage
  settle at `1d4e10505`, so it **predates this PR** and is the todo panel's own
  budget recompute rather than anything in this delta. Non-gating, recorded at
  the designer's request; worth a look if the band's budget is ever touched for
  its own sake.
- **`dock_shot.py` samples a pre-settle transient at the `summary` step** —
  `transcript=11` at ~110 ms, reflowing to the settled `8` at ~450 ms. That
  transient is what produced the round-1 "8 → 11 → 3" table (one transient mixed
  with two settled numbers) and it cost a full review round. **Any future
  evidence from that script must be settled before it is trusted**; both the
  regression test and the reviewers' instruments now settle before reading.



---

## Review round 2 — remediation summary

Head `5f19473ad`. Code review and design were **TERMINAL** on `064b483d3`; one
defect remained, found independently by QA (Q2, major) and the code reviewer
(F7, minor). Fixed in one commit.

| ID | Severity | Disposition |
| --- | --- | --- |
| Q2 / F7 | major / minor | **fixed** — counts memo keys on `queued` as well as `status` |

The round-1 counts memo keyed on `(id(job), status)`, but `summary_counts`
buckets on `facts.queued` **before** the status and a queued child already
carries `status == "running"`. `AsyncJobManager.start_queued` clears
`job.queued` in place without touching `status` — it guards on the status
already being `"running"` — so neither key term moved and the caption reported
running children as queued, indefinitely. Measured in `summary` with 1 running
+ 2 queued:

```
before:  caption 'Subagents · 1 running ⢿ · 2 queued · ctrl+g'
         cached running=1 queued=2   direct running=3 queued=0   AGREE=False
after:   caption 'Subagents · 3 running ⣯ · ctrl+g'
         cached running=3 queued=0   direct running=3 queued=0   AGREE=True
```

The memo's docstring is corrected with it: it had asserted that in-place
mutation was caught "because the key carries each job's identity", which is
false — `id(job)` is stable across a mutation of that job, so only the fields
named beside it detect anything. That sentence is what the next person would
have trusted.

Regression test `test_the_gate_admitting_a_queued_child_updates_the_summary_caption`
moves `queued` without moving `status`, the gap no existing test covered, and is
verified to fail against the old key.

**Gates on `5f19473ad`:** flake8 clean · black 928 unchanged · isort clean ·
pyright 0 errors · touched suites `777 passed` at `-n2`. No frames re-captured —
this fix changes no rendered surface, so the design round stays fresh on its own
terms.

