### PR TITLE
fix(evaluation): avoid stopping repeated actions that make progress

### DIFF
--- a/docs/benchmarks/osworld_2/PILOT_AUDIT_2026_09_05.md
+++ b/docs/benchmarks/osworld_2/PILOT_AUDIT_2026_09_05.md
@@ -1,0 +1,162 @@
+# Pilot audit: 2026-09-05
+
+This is an apparatus incident and exploratory-run report, **not a leaderboard
+score or a model ranking**. Original sealed outcomes must remain unchanged.
+An internally `comparable`/`reportable` receipt does not certify compliance with
+an external benchmark protocol.
+
+## Observed runs
+
+The inspected runs used the clean source checkout at `299ec72d8`, an isolated
+Python 3.12.13 wheel installation, and adapter 0.1.2 with explicit `paste_text`
+and ASCII-only `type`. The launch snapshot specified 150 action batches,
+$3 per-episode model admission budget, 2400-second episode wall budget,
+2700-second cloud lease, and three recent frames. Exact package, workspace,
+and environment identities remain in each original bundle.
+Do not confuse `harness_git_revision` with a raw Git SHA: this launcher hashes
+its source checkout's HEAD (falling back to a version digest outside Git).
+That field alone does not attest every byte of the installed harness wheel.
+
+| Route via OpenRouter | Task | Binary | Model requests | Recorded model USD | Stop |
+| --- | --- | ---: | ---: | ---: | --- |
+| `meta/muse-spark-1.3` | 010 | 0 | 101 | 2.307911 | budget-cap |
+| `google/gemini-3.8-flash` | 010 | 0 | 157 | 2.860948 | max-steps |
+| `google/gemini-3.8-flash` | 080 | 0 | 80 | 1.041983 | repeated-batch |
+| `google/gemini-3.8-flash` | 103 | unscored | 0 | 0 recorded | outer process killed during setup |
+
+Costs are sums of `usage_cost.cost_microusd`, not retail-price estimates, and
+exclude infrastructure. A budget reservation can stop before the allowance is
+fully spent. `completed` is the runner lifecycle, not task success. The empty
+outcome file for the interrupted task is not JSON and must not be converted to
+score zero. Gemini's completed attempts cost $3.902931 in total; with no accepted
+completion, cost per successful task and full-suite competitiveness are unknown.
+
+Local raw evidence locations (not public redistribution of gated task assets):
+
+- `~/worktrees/osworld/runs/batch-spark-m1-010/task_010/evidence/ep-0a52bce248bd/`
+- `~/worktrees/osworld/runs/batch-gem38-3t/task_010/evidence/ep-290e1c3f86b7/`
+- `~/worktrees/osworld/runs/batch-gem38-3t/task_080/evidence/ep-a3bd6e25062f/`
+- `~/worktrees/osworld/runs/batch-gem38-3t/task_103/evidence/ep-ee26a47e0bf6/`
+
+## Repeated input was mistaken for lack of progress
+
+Gemini task 080 ended with four consecutive Right-arrow batches. Inspection of
+stored screenshots shows the image viewer advancing through document pages;
+its last two observations display `view_3.png` and `view_4.png` with different
+content. The old `RepeatedBatchGuard` compared only action bodies (excluding
+observation IDs). It stopped legitimate pagination even though observations
+changed. This is a benchmark-neutral false positive, not evidence the model
+was stuck at that point.
+
+The last viewed screenshot is artifact
+`4de4c87e80223993f58e34a05966a289c59571b047b29fc699d757c2bc90b1c7`.
+The sealed `environment_step` records `truncation_reason: repeated-batch`.
+A correction must require evidence of unchanged observable state, not merely
+repeated input, and must inspect the post-action observation. Text progress,
+multiple displays, and intervening waits matter too. Reuse the existing guard
+boundary rather than introducing task IDs, benchmark answers, a second agent
+loop, or an image-processing service. Pixel-identical state is a conservative
+signal, not a proof of semantic stagnation; animations may defeat it. Existing
+step, wall, and spend budgets remain the backstop.
+
+Correcting this decision cannot retroactively turn the historical zero into a
+success. An offline replay proves only the corrected stop decision. A fresh,
+separately identified run is needed to measure task completion.
+
+### Offline replay actually performed
+
+The parent replay reconstructed guard-relevant state from retained observations
+75–79 and the four corresponding ActionBatch artifacts, verifying each consumed
+artifact's byte count and SHA-256. It used real `GuardInput`/`EpisodeTurn`
+objects and the production guard, with the old guard loaded from base
+`547136ee8` for comparison. No task setup, evaluator, VM, or model was called.
+The observed sequence was not replaced with invented identical frames.
+
+```text
+observation sequence: 75, 76, 77, 78, 79
+old RepeatedBatchGuard: truncate / repeated-batch
+new RepeatedBatchGuard: continue / ok
+new NoChangeGuard: continue / ok
+```
+
+Consumed frame digests, in order:
+
+```text
+3073980d95e5a6141465680c07f4d8498beec8a56dec6d7c4b62937fd0a5ea9f
+8514cde4b0ce80942e30764f02ca73c79643b2019f83a601a4366028f1ca1376
+45e377e4b494b6be5dcec048272e9557ca9a402891ec4562748c1d6958cf66d8
+05218df81995a7dcd56816318f1a82f1e9552a3691529e2061b4277275ca6f7d
+4de4c87e80223993f58e34a05966a289c59571b047b29fc699d757c2bc90b1c7
+```
+
+This is a real-data decision replay, not re-execution of the task. Synthetic
+regression fixtures complement it with stationary loops, text-only progress,
+changed secondary frames, missing observable state, and intervening waits.
+
+## Memory and interpretation corrections
+
+All 327 retained parseable accepted replies across these three scored attempts
+have empty `public_observations` (98 Spark, 150 Gemini task 010, 79 Gemini task
+080). Their 34 context-compaction events are not evidence that useful public
+facts survived compaction. The memory mechanism being installed is different
+from the model supplying facts to it. Do not claim proven efficiency gains from
+these unsuccessful runs or silently turn private reasoning into public notes.
+
+Terminal commands entered through permitted computer I/O are not inherently a
+wrong application surface. The [OSWorld 2.0 paper](https://arxiv.org/html/2606.29537v1)
+analyzes terminal use. This does not authorize direct host filesystem/API access
+or exposing evaluator internals to the evaluated agent. The agent must remain
+separate from the setup/evaluation controller. No hidden task solutions were
+used to design the guard correction.
+
+## Outer-timeout incident and future admission
+
+A single tool invocation wrapped three sequential episodes in a 3600-second
+outer timeout. Tasks 010 and 080 took approximately 2321 and 1168 seconds,
+respectively; the third was killed during setup. Per-episode wall limits do not
+bound the sum of setup, all episodes, scoring, rescue and cloud deletion.
+
+Before future paid work:
+
+1. Launch one episode per outer command unless a campaign supervisor explicitly
+   budgets the entire lifecycle. Never wrap several 2400-second episode budgets
+   in one 3600-second process timeout.
+2. Leave time for setup, scoring, and cleanup; an outer SIGKILL is not graceful
+   cancellation. Verify actual resource deletion rather than treating a cleanup
+   request or a terminated local process as success.
+3. If interrupted, inspect persisted rescue descriptors before any next launch.
+   The existing same-selector rescue sweep requested termination and schedule
+   deletion here. A follow-up AWS read confirmed the instance terminated, its
+   attached volume absent, and the benchmark tag audit `[]` in `us-east-1`,
+   account `212841448981`. Do not rewrite the interrupted bundle as complete.
+4. Do not run independent batch scripts concurrently while their safety check
+   requires a globally empty audit: another owned live episode will appear as
+   dirty. Use sequential pilots until ownership-aware orchestration is verified.
+5. Enforce the existing free-disk admission threshold (21 GiB for these pilots),
+   not a lowered threshold to get a run started. The host fell below it during
+   this audit; no further paid episodes were started.
+6. Check costs, stop reasons and rendered progress after each pilot. Expand only
+   after apparatus defects are resolved and completed-task evidence improves.
+
+## Recovery and evidence retention
+
+Earlier cleanup treated an absent remote ref as zero commits ahead of main and
+deleted local branches/worktrees. That is not a merge check. Local recovery refs
+now preserve `8afbba9fe`, `d173ef6cd`, and `6c8470285`; no unrelated work was
+changed during this recovery. A missing ref or failed Git command means unknown,
+not permission to delete. Verify local commit identity, the all-state PR record,
+patch equivalence where squash merging applies, cleanliness including untracked
+work, and active ownership before removing a worktree.
+
+The native-X11 candidate `8afbba9fe` is unmerged and intentionally rejected:
+retained records report silent Unicode loss with zero-delay xdotool. It is not
+part of the installed runtime. The reviewed replacement is the explicit paste
+path merged in [PR #651](https://github.com/damianvtran/local-operator/pull/651).
+Do not revive the rejected candidate merely because its branch was recovered.
+
+Some original native-input/capture diagnostic run directories were deleted.
+Surviving scripts, hashes, audit summaries and published #651 evidence are not
+a replacement for missing raw reports/PNGs; no claim of full raw retention is
+made. The separately retained capture audit found no demonstrated production
+screenshot defect. Do not repeat paid native experiments solely to reconstruct
+lost evidence or change screenshot code without a current reproduction.

--- a/local_operator/evaluation/runner/guards.py
+++ b/local_operator/evaluation/runner/guards.py
@@ -256,15 +256,58 @@ def _acted(turns: Sequence[EpisodeTurn]) -> list[EpisodeTurn]:
     ]
 
 
-class RepeatedBatchGuard:
-    """Truncate when the last ``repeats`` batches are canonically identical.
+def _action_span(turns: Sequence[EpisodeTurn], repeats: int) -> Sequence[EpisodeTurn]:
+    """Include the result of every counted action, including intervening waits.
 
-    Identical bytes, not "similar": the model issuing the exact same action
-    list on consecutive turns is doing nothing new. Batches are compared by
-    their canonical JSON with the observation id removed -- the id changes
-    every turn by construction, so with it every batch is unique. Wait-only
-    batches are transparent (see :func:`_is_waiting`): they neither count as
-    a repeat nor break a run of repeats around them.
+    Turn i's batch produces turn i+1's observation. Without that final,
+    undecided observation, a guard could stop on the very action that moved
+    the screen. Waits do not count as attempts, but progress during a wait
+    still disproves a stationary loop.
+    """
+    if not turns or turns[-1].batch is not None:
+        return ()
+    acting = 0
+    for index in range(len(turns) - 2, -1, -1):
+        turn = turns[index]
+        if turn.batch is None:
+            return ()
+        if turn.batch.actions and not _is_waiting(turn):
+            acting += 1
+            if acting == repeats:
+                return turns[index:]
+    return ()
+
+
+def _unchanged_observations(turns: Sequence[EpisodeTurn]) -> bool:
+    """Exact public text and ordered frame digests, never capture IDs or sequence.
+
+    Digests are already verified by the runner, so equality needs no image I/O
+    or visual-similarity threshold. Preserve every frame's order and count:
+    an unchanged first frame cannot hide progress in a later one. Missing
+    both text and frames is unknown state, not evidence of no progress.
+    """
+    if not turns:
+        return False
+    keys = []
+    for turn in turns:
+        observation = turn.observation
+        if observation.text is None and not observation.frames:
+            return False
+        keys.append(
+            (observation.text, tuple(frame.artifact.sha256 for frame in observation.frames))
+        )
+    return len(set(keys)) == 1
+
+
+class RepeatedBatchGuard:
+    """Truncate when ``repeats`` identical batches leave observable state unchanged.
+
+    Repeated input can legitimately advance pages or move through a view, so
+    action identity alone proves nothing. Compare canonical actions without
+    observation IDs, and require exact public text and frame equality across
+    the entire span including the last result. Wait-only batches are
+    transparent (see :func:`_is_waiting`), but their observations still count
+    as evidence of progress.
     """
 
     def __init__(self, repeats: int = 4) -> None:
@@ -275,16 +318,16 @@ class RepeatedBatchGuard:
         self._repeats = repeats
 
     def evaluate(self, snapshot: GuardInput) -> GuardVerdict:
-        decided = _acted(snapshot.recent_turns)
-        if len(decided) < self._repeats:
-            return CONTINUE
-        tail = decided[-self._repeats :]
-        keys = {_batch_key(turn) for turn in tail}
-        if len(keys) == 1:
+        span = _action_span(snapshot.recent_turns, self._repeats)
+        keys = {_batch_key(turn) for turn in _acted(span)}
+        if len(keys) == 1 and _unchanged_observations(span):
             return GuardVerdict(
                 kind="truncate",
                 code="repeated-batch",
-                detail=f"the same action batch was issued {self._repeats} times in a row",
+                detail=(
+                    f"the same action batch was issued {self._repeats} times "
+                    "without observable change"
+                ),
             )
         return CONTINUE
 
@@ -300,14 +343,12 @@ def _batch_key(turn: EpisodeTurn) -> str:
 
 
 class NoChangeGuard:
-    """Truncate when ``repeats`` consecutive NON-EMPTY batches produced
-    byte-identical frames -- the model keeps acting and the screen does not
-    move.
+    """Truncate when ``repeats`` NON-EMPTY batches leave frames AND text unchanged.
 
-    Frames are compared by their content digest (``artifact.sha256``), which
-    the adapter already computed and the runner already verified, so this
-    costs no bytes. An observation with no frames cannot be judged and does
-    not count; a text-only benchmark never trips this guard.
+    Share exact observation equality with :class:`RepeatedBatchGuard` so text
+    progress beside a static image cannot trigger a conflicting stop. This
+    guard still requires frames throughout; a text-only benchmark never trips
+    it, since different actions can legitimately produce the same text.
 
     Wait-only batches are not actions (see :func:`_is_waiting`): a model
     waiting on a static screen is loading, not floundering. Waits interleaved
@@ -326,34 +367,14 @@ class NoChangeGuard:
         self._repeats = repeats
 
     def evaluate(self, snapshot: GuardInput) -> GuardVerdict:
-        turns = list(snapshot.recent_turns)
-        # Walk back from the newest observation until ``repeats`` acting turns
-        # are in the span. The frame produced by turn i's batch is turn i+1's
-        # observation, so the span always includes one observation beyond the
-        # last acting turn (the current, undecided one at the end).
-        start = None
-        acting = 0
-        for index in range(len(turns) - 2, -1, -1):
-            turn = turns[index]
-            if turn.batch is None:
-                return CONTINUE
-            if turn.batch.actions and not _is_waiting(turn):
-                acting += 1
-                if acting == self._repeats:
-                    start = index
-                    break
-        if start is None:
+        span = _action_span(snapshot.recent_turns, self._repeats)
+        if any(not turn.observation.frames for turn in span):
             return CONTINUE
-        digests: list[tuple[str, ...]] = []
-        for turn in turns[start:]:
-            if not turn.observation.frames:
-                return CONTINUE
-            digests.append(tuple(frame.artifact.sha256 for frame in turn.observation.frames))
-        if len(set(digests)) == 1:
+        if _unchanged_observations(span):
             return GuardVerdict(
                 kind="truncate",
                 code="no-change",
-                detail=f"{self._repeats} consecutive actions left the screen byte-identical",
+                detail=f"{self._repeats} consecutive actions left frames and text unchanged",
             )
         return CONTINUE
 

--- a/tests/unit/evaluation/runner/test_episode.py
+++ b/tests/unit/evaluation/runner/test_episode.py
@@ -568,17 +568,35 @@ async def test_context_compaction_event_is_recorded_and_verifies(
 
 
 @pytest.mark.asyncio
-async def test_guard_truncation_seals_scored_with_reason(tmp_path: Path, episode_id: str) -> None:
-    """A floundering guard stops the episode the way ``max_steps`` does: the
-    last step is truncated with the guard's code, the episode is SCORED on the
-    state reached, and the bundle verifies."""
+@pytest.mark.parametrize("stationary", [True, False])
+async def test_guard_truncation_seals_scored_with_reason(
+    tmp_path: Path, episode_id: str, monkeypatch: pytest.MonkeyPatch, stationary: bool
+) -> None:
+    """A stationary loop stops early, but repeated input with text progress
+    reaches the step cap. Both paths score and seal a verifiable bundle."""
 
+    from local_operator.evaluation.adapters.api import observation_content_id
+    from local_operator.evaluation.protocol import Observation
     from local_operator.evaluation.runner.guards import RepeatedBatchGuard
+    from tests.unit.evaluation.runner import conftest
+
+    if stationary:
+        original_observation = conftest.observation
+
+        def observation(episode_id: str, sequence: int, *, text: str = "state") -> Observation:
+            # Keep real sequence/identity validation while removing visible
+            # progress; the normal fixture's changing text is not a loop.
+            current = original_observation(episode_id, sequence, text=text).model_copy(
+                update={"text": text}
+            )
+            return current.model_copy(update={"observation_id": observation_content_id(current)})
+
+        monkeypatch.setattr(conftest, "observation", observation)
 
     adapter = FakeAdapter(tmp_path, episode_id)
     runner = EpisodeRunner(
         build_spec(episode_id),
-        build_config(tmp_path, max_steps=10, guards=(RepeatedBatchGuard(repeats=2),)),
+        build_config(tmp_path, max_steps=4, guards=(RepeatedBatchGuard(repeats=2),)),
         selector=selector(tmp_path),
         model=ScriptedModel(["type"] * 8),
         launch=lambda _: adapter,
@@ -594,9 +612,13 @@ async def test_guard_truncation_seals_scored_with_reason(tmp_path: Path, episode
     report = verify_bundle(root)
     assert report.valid, [issue.code for issue in report.issues]
     steps = payloads(root, EnvironmentStepPayload)
-    assert len(steps) == 2
-    assert [step.truncated for step in steps] == [False, True]
-    assert [step.truncation_reason for step in steps] == [None, "repeated-batch"]
+    expected_steps = 2 if stationary else 4
+    expected_reason = "repeated-batch" if stationary else "max-steps"
+    assert len(steps) == expected_steps
+    assert [step.truncated for step in steps] == [False] * (expected_steps - 1) + [True]
+    assert [step.truncation_reason for step in steps] == [None] * (expected_steps - 1) + [
+        expected_reason
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/evaluation/runner/test_guards.py
+++ b/tests/unit/evaluation/runner/test_guards.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Any, Sequence
 
 import pytest
+from pydantic import ValidationError
 
 from local_operator.evaluation.adapters.api import observation_content_id
 from local_operator.evaluation.protocol import (
@@ -51,25 +52,27 @@ def _budget(**caps: int) -> BudgetAuthorization:
     )
 
 
-def _observation(sequence: int, *, frame_digest: str | None = None) -> Observation:
-    frames: tuple[FrameRef, ...] = ()
-    if frame_digest is not None:
-        frames = (
-            FrameRef(
-                frame_id=f"frame-{sequence}",
-                artifact=ArtifactRef(sha256=frame_digest, media_type="image/png", byte_count=8),
-                geometry=FrameGeometry(
-                    native=FrameSize(width=1, height=1),
-                    model_visible=FrameSize(width=1, height=1),
-                ),
+def _observation(
+    sequence: int, *, frame_digest: str | tuple[str, ...] | None = None, text: str | None = "state"
+) -> Observation:
+    digests = (frame_digest,) if isinstance(frame_digest, str) else (frame_digest or ())
+    frames = tuple(
+        FrameRef(
+            frame_id=f"frame-{sequence}-{index}",
+            artifact=ArtifactRef(sha256=digest, media_type="image/png", byte_count=8),
+            geometry=FrameGeometry(
+                native=FrameSize(width=1, height=1),
+                model_visible=FrameSize(width=1, height=1),
             ),
         )
+        for index, digest in enumerate(digests)
+    )
     provisional = Observation(
         task_id="task-1",
         episode_id="episode-1",
         sequence=sequence,
         observation_id="provisional",
-        text=f"state-{sequence}",
+        text=text,
         frames=frames,
     )
     return provisional.model_copy(update={"observation_id": observation_content_id(provisional)})
@@ -91,18 +94,24 @@ def _batch(current: Observation, actions: Sequence[dict[str, Any]]) -> ActionBat
 WAIT = {"kind": "wait", "duration_ms": 5000}
 CLICK = {"kind": "click", "frame_id": "frame-0", "x": 1, "y": 1}
 TYPE = {"kind": "type", "text": "hello"}
+FORWARD = {"kind": "key", "keys": ["RIGHT"]}
 ASK = {"kind": "ask_user", "request_id": "ask-1", "question": "what?"}
 
 
 def _turns(
-    kinds: Sequence[Sequence[dict[str, Any]] | None], *, digests: Sequence[str] | None = None
-):
+    kinds: Sequence[Sequence[dict[str, Any]] | None],
+    *,
+    digests: Sequence[str | tuple[str, ...] | None] | None = None,
+    texts: Sequence[str | None] | None = None,
+) -> tuple[EpisodeTurn, ...]:
     """Turns oldest-first; ``None`` is the undecided current turn."""
 
     turns: list[EpisodeTurn] = []
     for index, actions in enumerate(kinds):
         digest = digests[index] if digests is not None else None
-        observation = _observation(index, frame_digest=digest)
+        observation = _observation(
+            index, frame_digest=digest, text=texts[index] if texts is not None else "state"
+        )
         batch = _batch(observation, actions) if actions is not None else None
         turns.append(EpisodeTurn(observation=observation, batch=batch))
     return tuple(turns)
@@ -166,7 +175,7 @@ def test_cost_rate_absolute_cap_fires_on_one_expensive_cycle() -> None:
     assert verdict.kind == "truncate" and verdict.code == "cost-spike"
 
 
-def test_repeated_batch_ignores_the_observation_id_and_the_undecided_turn() -> None:
+def test_repeated_batch_ignores_observation_ids_but_requires_unchanged_state() -> None:
     guard = RepeatedBatchGuard(repeats=3)
     same = _turns([[CLICK], [CLICK], [CLICK], None])
     verdict = guard.evaluate(_snapshot(recent_turns=same))
@@ -175,6 +184,13 @@ def test_repeated_batch_ignores_the_observation_id_and_the_undecided_turn() -> N
     assert guard.evaluate(_snapshot(recent_turns=varied)).kind == "continue"
     short = _turns([[CLICK], [CLICK], None])
     assert guard.evaluate(_snapshot(recent_turns=short)).kind == "continue"
+
+
+@pytest.mark.parametrize("digests", [["a", "b", "c", "d", "e"], ["a"] * 4 + ["b"]])
+def test_repeated_forward_input_with_visible_progress_continues(digests: list[str]) -> None:
+    # The newest, undecided observation contains the final forward input's result.
+    turns = _turns([[FORWARD]] * 4 + [None], digests=[digest * 64 for digest in digests])
+    assert RepeatedBatchGuard().evaluate(_snapshot(recent_turns=turns)).kind == "continue"
 
 
 def test_no_change_needs_identical_frames_after_non_empty_batches() -> None:
@@ -220,6 +236,90 @@ def test_waits_are_transparent_to_a_run_of_real_actions() -> None:
     # Two real actions plus waits is below a repeats=3 span.
     fewer = _turns([[CLICK], [WAIT], [WAIT], [CLICK], None], digests=static[:5])
     assert NoChangeGuard(repeats=3).evaluate(_snapshot(recent_turns=fewer)).kind == "continue"
+
+
+@pytest.mark.parametrize("guard_type", [RepeatedBatchGuard, NoChangeGuard])
+def test_loop_guards_allow_changed_text_beside_identical_frames(guard_type: Any) -> None:
+    turns = _turns(
+        [[FORWARD], [FORWARD], None],
+        digests=["a" * 64] * 3,
+        texts=["page 1", "page 1", "page 2"],
+    )
+    assert guard_type(repeats=2).evaluate(_snapshot(recent_turns=turns)).kind == "continue"
+
+
+@pytest.mark.parametrize("guard_type", [RepeatedBatchGuard, NoChangeGuard])
+@pytest.mark.parametrize("missing_index", [0, 1, 2])
+def test_loop_guards_need_observable_state_throughout(guard_type: Any, missing_index: int) -> None:
+    digests: list[str | None] = ["a" * 64] * 3
+    texts: list[str | None] = ["state"] * 3
+    digests[missing_index] = None
+    texts[missing_index] = None
+    turns = _turns([[TYPE], [TYPE], None], digests=digests, texts=texts)
+    assert guard_type(repeats=2).evaluate(_snapshot(recent_turns=turns)).kind == "continue"
+    blind = _turns([[TYPE], [TYPE], None], texts=[None] * 3)
+    assert guard_type(repeats=2).evaluate(_snapshot(recent_turns=blind)).kind == "continue"
+
+
+@pytest.mark.parametrize("guard_type", [RepeatedBatchGuard, NoChangeGuard])
+@pytest.mark.parametrize("final_frames", [("a", "c"), ("b", "a"), ("a",)])
+def test_loop_guards_compare_every_frame_in_order(
+    guard_type: Any, final_frames: tuple[str, ...]
+) -> None:
+    frames = ("a" * 64, "b" * 64)
+    turns = _turns(
+        [[TYPE], [TYPE], None],
+        digests=[frames, frames, tuple(digest * 64 for digest in final_frames)],
+    )
+    assert guard_type(repeats=2).evaluate(_snapshot(recent_turns=turns)).kind == "continue"
+
+
+@pytest.mark.parametrize("guard_type", [RepeatedBatchGuard, NoChangeGuard])
+def test_loop_guards_ignore_capture_ids_but_stop_real_stationary_loops(guard_type: Any) -> None:
+    frames = ("a" * 64, "b" * 64)
+    turns = _turns([[FORWARD], [FORWARD], None], digests=[frames] * 3, texts=[None] * 3)
+    assert len({turn.observation.observation_id for turn in turns}) == 3
+    assert len({turn.observation.frames[0].frame_id for turn in turns}) == 3
+    assert guard_type(repeats=2).evaluate(_snapshot(recent_turns=turns)).kind == "truncate"
+
+
+@pytest.mark.parametrize("guard_type", [RepeatedBatchGuard, NoChangeGuard])
+@pytest.mark.parametrize("progress_index", [1, 2, 3])
+def test_waits_do_not_hide_observation_progress(guard_type: Any, progress_index: int) -> None:
+    # The view may move during a wait then return before the next action.
+    digests = ["a" * 64] * 4
+    digests[progress_index] = "b" * 64
+    turns = _turns([[TYPE], [WAIT], [TYPE], None], digests=digests)
+    assert guard_type(repeats=2).evaluate(_snapshot(recent_turns=turns)).kind == "continue"
+
+
+@pytest.mark.parametrize("guard_type", [RepeatedBatchGuard, NoChangeGuard])
+def test_last_action_needs_its_result_observation(guard_type: Any) -> None:
+    turns = _turns([[TYPE]] * 3, digests=["a" * 64] * 3)
+    assert guard_type(repeats=2).evaluate(_snapshot(recent_turns=turns)).kind == "continue"
+
+
+@pytest.mark.parametrize("texts", [["state"] * 3, ["state", "state", None]])
+def test_repeated_batch_handles_text_only_state_conservatively(texts: list[str | None]) -> None:
+    turns = _turns([[TYPE], [TYPE], None], texts=texts)
+    verdict = RepeatedBatchGuard(repeats=2).evaluate(_snapshot(recent_turns=turns))
+    assert verdict.kind == ("truncate" if texts[-1] is not None else "continue")
+    assert NoChangeGuard(repeats=2).evaluate(_snapshot(recent_turns=turns)).kind == "continue"
+
+
+def test_repeated_batch_maximum_fits_completed_turns_plus_latest_observation() -> None:
+    # EpisodeRunner supplies the full completed-turn window PLUS the new result.
+    turns = _turns([[TYPE]] * RECENT_TURNS_WINDOW + [None])
+    verdict = RepeatedBatchGuard(repeats=RECENT_TURNS_WINDOW).evaluate(
+        _snapshot(recent_turns=turns)
+    )
+    assert verdict.code == "repeated-batch"
+
+
+@pytest.mark.parametrize("text", ["", " "])
+def test_empty_text_is_rejected_by_observation_contract(text: str) -> None:
+    with pytest.raises(ValidationError):
+        _observation(0, text=text)
 
 
 def test_ask_loop_counts_consecutive_ask_batches_only() -> None:


### PR DESCRIPTION
## Summary of Changes

**C1, standard/pre-authorized bug fix.** Repeated computer input is not proof of stagnation: Right-arrow can advance document pages. An actual Gemini pilot was truncated while its image viewer was progressing.

Change the existing benchmark-neutral RepeatedBatchGuard to require identical action bodies AND unchanged public observed state across the entire action/result span. Share the observation/span comparison with NoChangeGuard so textual progress cannot be ignored by that guard either. No task IDs, task-specific strategy, extra inference calls, pixel-processing service, or second execution loop.

## Delivery contract

- Advancing pages/repeated inputs with changed public text or frame content continue.
- Actual repeated stationary actions still truncate with the same stable reason code.
- Include the last action's result and intervening wait observations; waits do not count as failed attempts.
- Treat missing observations as unknown, not proof of stagnation. Check every ordered frame, not only the first.
- Preserve the reachable 16-action boundary (runner supplies 16 completed turns plus the current observation).
- Keep normal Session/TUI/mobile/exec defaults, imports, provider caching and prompt contracts unchanged. This fixes the optional evaluation guard surface, not a claimed normal-interface performance gain.

## Testing evidence

Before change: two targeted pagination regressions fail with `truncate != continue`.

After change (explicit worktree imports verified in the pytest process):
- Full evaluation runner directory: **295 passed** before three final contract-only tests.
- Final focused guard + episode tests: **96 passed**.
- Focused Flake8, pinned Black26.1.0/isort5.13.2, Pyright: clean.
- Whole-tree Flake8, pinned Black26.1.0 (928 files unchanged), isort5.13.2, and Pyright: all exit0; Pyright0 errors/warnings. Default notebook exclusions unchanged.
- Independent agent review round1 is clean and TERMINAL on0352dd359; parent acknowledgement posted. Reviewer independently repeated96 focused tests and the retained-trajectory replay. Current-head CI remains required.

### Actual retained-trajectory replay (zero new model/VM calls)

The parent reconstructed guard-relevant state from Gemini task080 observations75–79 and recorded ActionBatch artifacts, verifying consumed byte counts and SHA-256s. The production guard was called against those actual recorded values, compared with the base guard loaded from547136ee8:

```text
old RepeatedBatchGuard: truncate / repeated-batch
new RepeatedBatchGuard: continue / ok
new NoChangeGuard: continue / ok
```

The last two screenshots were actually viewed and show `view_3.png` then `view_4.png` with different content. Digests and detailed apparatus limitations are in `docs/benchmarks/osworld_2/PILOT_AUDIT_2026_09_05.md`. No gated task/evaluator solutions were used in this fix; no screenshots containing benchmark assets are uploaded in this PR.

The EpisodeRunner integration checks also exercise real scoring/finalization/evidence sealing with the controlled in-process adapter: stationary inputs stop after2 actions; progressing text reaches4-step limit; both bundles independently verify. These are controlled offline adapter tests, not a claim of rerunning the live OSWorld task.

## Non-goals and limits

- No new full benchmark score or successful-task claim. Historical zero scores remain unchanged; fresh separately identified pilots are required to measure completion.
- Exact content equality is conservative: clocks/animations may conceal semantic stagnation. Existing step/wall/spend caps remain the backstop.
- No native Unicode candidate revival; reviewed explicit paste from#651 stays unchanged.
- No memory/prompt overhaul. Audit found all327 accepted Spark/Gemini replies had empty public notes; presence of retention plumbing is not proof of effective fact retention.
- No runtime/UI/default-tool change; no rendered visual surface altered, so no design round is applicable.

## Rollout and rollback

No dependency, migration, version bump, or installed runtime mutation. Review/CI gate before merge. Rollback is a normal revert of this guard change; do not rewrite old sealed results. Further paid pilots remain paused until the fix is reviewed and disk headroom meets the existing admission threshold. A single outer3600s invocation must not wrap three2400s episodes; future pilot launches run one episode per lifecycle budget with cleanup headroom.
