### PR TITLE
chore(release): bump version to 0.49.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.49.0"
+version = "0.49.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Release window: v0.49.0 → v0.49.1

Version bump only — `pyproject.toml`, one line. No functional change.

I am the owner of this release window under the combined-release protocol
(AGENTS.md "One release owner per window"). Ownership was confirmed before
claiming: no open claim PR existed, pid 4237 explicitly declined ownership,
and pid 3894 (the other contributor in this window) confirmed its merges.

### PRs in this window (merged since the v0.49.0 tag)

| PR | SHA | Impact |
|---|---|---|
| #670 | `028bf760f` | usage panel dead-grant follow-ups (R10-R12, Q6, D6-D7) |
| #675 | `5b5f71b81` | evaluation: guard against stopping repeated actions that make progress |
| #653 | `299ec72d8` | evaluation: bounded public-observation retention in shared memory |
| #663 | `547136ee8` | chore(deps): actions/setup-python 5 → 7 |
| #662 | `83371bfbb` | chore(deps): actions/setup-node 4 → 7 |
| #661 | `c5a93eba0` | chore(deps): actions/download-artifact 4 → 8 |
| #660 | `583140370` | chore(deps): actions/checkout 4 → 7 |
| #659 | `56a2555f9` | chore(deps): softprops/action-gh-release 2 → 3 |
| #658 | `aeb4374fe` | chore(deps-dev): flake8 7.1.0 → 7.3.0 |

**Note on #653.** It is in this window rather than the last one despite its
number: it merged at 11:50 EDT, two minutes *after* the `v0.49.0` bump commit
`4d3ce1d1a` (11:48 EDT) that the tag points at, so it never shipped. Verified
by ancestry rather than by merge order —
`git merge-base --is-ancestor 299ec72d8 v0.49.0` returns false.

### Bump class: patch

Per AGENTS.md "Versioning: choose the bump by materiality, not commit type".
The window is bug fixes plus dependabot CI/action bumps. Nothing here is a new
surface or subsystem a user would notice and adopt — there is no step-function
capability to name in a release title, which is the stated test for a minor.
Both evaluation contributors independently argued patch class for their own
changes. **Patch.**

### Scope check

`git diff origin/main` is one line in `pyproject.toml`. No source, no tests,
no workflows. C0 one-file scope-check round.
