### PR TITLE
fix(tui): /model follow-ups — latch edge, /help carrier, setup-state routes (#641)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ current session's cost live).
 
 | Command | What it does |
 | --- | --- |
-| `/model` | Switch model for this session; `/model default` saves the current one for new ones, `/model saved` switches back to it (`/settings` sets it too) |
+| `/model` | Switch model for this session; `/model default` saves the current one for new ones, `/model saved` reverts to it (`/settings` edits the boot default too) |
 | `/effort` | Show or set reasoning effort (`shift+tab` cycles) |
 | `/fast` | Toggle fast mode where the provider sells one — the same answer sooner, at premium pricing |
 | `/approvals` | Set whether tools ask first (`ask`/`auto`; add `default` to keep it) |

--- a/local_operator/slash_commands.py
+++ b/local_operator/slash_commands.py
@@ -142,16 +142,18 @@ SLASH_COMMANDS: list[SlashCommand] = [
     # typed selector, which may have been elided to `default`.
     SlashCommand(
         "model",
-        # Terse by necessity — the description column wraps past ~55 cells at 80
-        # columns, and `Switch model; ` + the 42-cell hint measured 56 and
-        # orphaned "sessions" on its own line (design review D2). "Switch" alone
-        # keeps the row whole at 80 (49 cells) and still carries PERSIST_HINT
-        # verbatim rather than a fifth paraphrase; the command name beside it
-        # already says what is being switched. The `<provider>/<id>` shape it
-        # used to show moved to the tip pool, which has the room (`welcome.TIPS`).
-        # `/model saved` is not here for the same reason: the notice a bare
-        # `/model` prints is the surface with room for the third command.
-        f"Switch; {PERSIST_HINT}",
+        # A `/help`-specific carrier, NOT `PERSIST_HINT` verbatim: the footer
+        # hint is sized by the picker (42 cells), and every ≤12-cell lead that
+        # kept it whole here left the row a fragment (`Switch;` was 49 cells
+        # and stayed whole, but read as a broken sentence beside the
+        # `Switch color theme; …` neighbour — design review round 2, D7).
+        # `Switch model; ` + the hint measured 56 cells at 80 columns and
+        # orphaned "sessions" on its own line (D2), so the answer is a shorter
+        # sentence of its own: name the thing being switched and drop the
+        # "saves this" carrier the footer needs for its 43-cell budget. The
+        # notice a bare `/model` prints is the surface with room for the full
+        # three-route sentence; `/help` needs only the persist command's name.
+        "Switch model; /model default saves it for new sessions",
         aliases=("models",),
     ),
     # Next to `/model` because it is the same question one level down: which

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -16220,9 +16220,12 @@ class OperatorApp(App[None]):
         command names spanning a fold — nothing stronger (QA round 1, Q1). An
         earlier revision of this docstring claimed `/settings` "is never the
         final token at ANY body width from 38 to 90", which is false: it ends a
-        folded, non-final row in 62 combinations across 39 widths. A clause
-        that continues on the next row is not the defect D8 named; a command
-        the reader must re-join two rows to recover is, and that is what is
+        folded, non-final row in 58 combinations across 27 widths for the
+        ordinary variant (162 across all three), measured through
+        `NoticeBlock.body_budget` (QA round 2, Q5 — the earlier 62/39 came from
+        a harness that is not recoverable from what was written). A clause that
+        continues on the next row is not the defect D8 named; a command the
+        reader must re-join two rows to recover is, and that is what is
         actually pinned.
 
         The nouns are placed so each pronoun sits beside its antecedent (design
@@ -16247,9 +16250,11 @@ class OperatorApp(App[None]):
         of the block: a row ending on a bare `/model` whose next row opens
         `saved reverts to it` splits the two-word COMMAND NAME across the fold,
         which costs the reader exactly what D8 cost them — the command cannot
-        be read off one row. That measured 5 splits over 11 labels x the three
-        rendered widths, and the frame shipped as D8's own evidence contained
-        one.
+        be read off one row. That measured 4 splits over the 9 labels the test
+        carries x the three pristine widths (code review round 2, R18 — the
+        earlier "5 over 11 labels" described a wider matrix than the one that
+        ships as evidence), and the frame shipped as D8's own evidence
+        contained one.
 
         Both classes are scored now, and the lever turned out to be structural
         rather than lexical: it is WHERE a two-word command name sits in its
@@ -16257,24 +16262,51 @@ class OperatorApp(App[None]):
         one word from the `·` seam, so it breaks across the fold whenever that
         seam lands near the margin; a name at the clause's END has ordinary
         words ahead of it to absorb the fold. So `/model saved` moved to the
-        end of its clause and the split count goes 5 -> 0. `/settings` keeps
-        its leading position because four words follow it either way.
+        end of its clause and the pristine split count goes 4 -> 0.
+        `/settings` keeps its leading position because four words follow it
+        either way.
 
-        Measured over 11 representative labels x the three rendered body widths
-        (70/69/76), across all THREE variants this method emits: 0 command
-        tokens alone on a last row and 0 split command names, against 0 and 5
-        for the arrangement D8 shipped.
+        THE BLOCK RENDERS AT TWO WIDTH FAMILIES AND BOTH ARE MEASURED (QA
+        round 2, Q3). Earlier rounds scored only the PRISTINE family — the
+        widths a `NoticeBlock` takes in a transcript with nothing else in it
+        (block widths 76/75/82 at 80/100/120 columns, body budgets 70/69/76).
+        Once the transcript holds any content the block is `cols - 4` instead
+        (76/96/116, budgets 70/90/110), and that is the family the hint is
+        NORMALLY read at, because a user meets it after they have been working.
+        Measured over the 9 labels the test carries x 3 variants x 3 widths in
+        each family:
+
+        =========================  ========  =========
+        class                      pristine  non-empty
+        =========================  ========  =========
+        C1 lone command last row          0          0
+        C2 split command name             0          3
+        C3 lone ordinary word             2          1
+        =========================  ========  =========
+
+        So the clean 0 that earlier rounds claimed holds at the pristine family
+        only. At the non-empty family C2 is not zero, and the honest
+        justification for the arrangement is a comparison rather than a clean
+        sheet: the D8 arrangement scores C2 4 / C3 2 pristine and C2 2 / C3 1
+        non-empty, so this trades a class the reader cannot act on (a command
+        split across the fold, in the family they see least) against one they
+        can (prose wrapping). Sweeping 80-160 columns at the non-empty family
+        the two arrangements are a wash — the split occupies a narrow band — so
+        the pristine improvement is what is actually bought.
 
         What is NOT claimed: this does not promise every row ends on a
-        multi-word phrase. An ordinary word can still land alone on the last
-        row (`too` at one label x width here), which is ordinary prose wrapping
-        rather than the defect these findings are about — the reader can still
-        read every command off a single row, which is the property being
-        bought. A 2,240-combination search over clause wordings and orders
-        found no arrangement that is clean on all three classes across all
-        three variants, so this is the measured optimum and not a claim of
-        perfection. `test_the_bare_model_notice_does_not_orphan_a_route_token`
-        pins the two that matter.
+        multi-word phrase, and the residual is not a rounding error (design
+        review round 2, D4). An ordinary word can still land alone on the last
+        row — 2 label x width combinations at the pristine family and 1 at the
+        non-empty one, on the test's own 9 labels. That is ordinary prose
+        wrapping rather than the defect these findings are about, and the
+        reader can still read every command off a single row, which is the
+        property being bought — but it is a real cost paid on a real surface,
+        not a hypothetical one. A 2,240-combination search over clause wordings
+        and orders found no arrangement that is clean on all three classes
+        across all three variants, so this is the measured optimum and not a
+        claim of perfection. `test_the_bare_model_notice_does_not_orphan_a_route_token`
+        pins the two that matter, at BOTH families.
 
         The `/model saved` clause is DROPPED in the setup state (UX review
         round 2, U11): that state is by definition the one with no usable boot
@@ -16302,10 +16334,22 @@ class OperatorApp(App[None]):
         settings_clause = "/settings edits the boot default too"
         # `/model saved` sits at its clause's END, which is what removes the
         # split: as the clause's FIRST word it sat one word from the `·` seam
-        # and broke across the fold at 5 of 33 rendered label x width
-        # combinations. `/settings` is left leading its own clause because it
-        # is followed by four words, so the fold has slack after it either way.
-        saved_clause = "come back with /model saved"
+        # and broke across the fold at 4 of the 27 rendered label x width
+        # combinations the test pins (R18). `/settings` is left leading its own
+        # clause because it is followed by four words, so the fold has slack
+        # after it either way.
+        #
+        # The carrier NAMES ITS DESTINATION (design review round 2, D5). It
+        # read `come back with /model saved`, which put the only mention of
+        # what the user comes back TO at character 95 of 111 — in the following
+        # clause, attached to `/settings` — so a strictly left-to-right reader
+        # met the pronoun before its antecedent, which is what D6/D10 were
+        # filed to prevent. `boot default` now sits at character 59, beside the
+        # command it describes. It also says what the command DOES rather than
+        # naming an occasion to use it (UX review round 2, U6), and it measures
+        # better on both width families, not worse: pristine C3 3 -> 2 and
+        # non-empty C2 5 -> 3, with C1 and pristine C2 still 0.
+        saved_clause = "switch to the boot default with /model saved"
         if self._setup_state and not self._model_missing_for:
             # No hosting / unknown hosting: every `/model` route refuses here,
             # so the notice must not name one. `/settings` is the live escape.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -16169,6 +16169,24 @@ class OperatorApp(App[None]):
         notice("starting session…", "info")
         self._run_session_transition(self._reload_session())
 
+    def _footer_persist_hint(self) -> str:
+        """``PERSIST_HINT`` for the picker footer, or "" where it cannot be run.
+
+        The footer's half of U12. The notice above the list stops naming
+        `/model default` in the no-hosting and unknown-hosting setup variants
+        because every `/model` route refuses there — but the footer is a second
+        surface printing the same instruction, and a fix that left it advertising
+        the dead end would only move the trap one row down (visible in the U12
+        before/after frames: the notice was honest and the footer was not).
+
+        The predicate is ``_model_missing_for``, the same one `_cmd_model`'s
+        escape is gated on, so "the footer offers it" and "the command performs
+        it" cannot drift apart.
+        """
+        if self._setup_state and not self._model_missing_for:
+            return ""
+        return PERSIST_HINT
+
     def _persist_hint_notice(self) -> str:
         """The line a bare ``/model`` prints above the list.
 
@@ -16190,23 +16208,62 @@ class OperatorApp(App[None]):
         a user who did not arrive with a command in mind.
 
         The nouns are placed so each pronoun sits beside its antecedent (design
-        review D4): "this" is the model on the band, "the boot default" is
-        restated before "set it" so "it" does not have to reach back past
-        "this". "Boot default" is the ONE noun for the thing `/model default`
-        writes — the receipt says `boot default saved to …` and `/model saved`
-        refuses with `no boot default …` — so the user is never left wondering
-        whether a "saved default" and a "boot default" are two settings
-        (design review round 2, D6).
+        review D4). "Boot default" is the ONE noun for the thing `/model
+        default` writes — the receipt says `boot default saved to …` and
+        `/model saved` refuses with `no boot default …` — so the user is never
+        left wondering whether a "saved default" and a "boot default" are two
+        settings (design review round 2, D6).
+
+        CLAUSE ORDER IS A WRAP CONSTRAINT, not a preference (design review
+        round 2, D8). The old order ended on `· or set it in /settings`, and at
+        the three widths the block actually renders at — body budgets 70/69/76
+        cells for 80/100/120 columns — the fold left `/settings` alone on the
+        last row for most model labels: the row length varies with the label,
+        so a single label measuring clean proves nothing. The `/settings`
+        clause is therefore in the MIDDLE and carries the noun
+        (`/settings edits the boot default too`), which does three things at
+        once: it moves the command token off the fold, it puts the D6 noun
+        early enough that the trailing `it` has an antecedent one clause back
+        (design review round 3, D10 — with the `/model saved` clause dropped in
+        the setup state, the old `set it in /settings` left `it` reaching back
+        past `this`), and it ends the sentence on `reverts to it`, a three-word
+        tail that cannot orphan a command name. Measured over 11 representative
+        labels x the three rendered widths: zero lone-token last rows, and
+        `/settings` is never the final token at ANY body width from 38 to 90.
+        `test_the_bare_model_notice_does_not_orphan_a_route_token` pins it.
 
         The `/model saved` clause is DROPPED in the setup state (UX review
         round 2, U11): that state is by definition the one with no usable boot
         default, and `_cmd_model_saved` refuses there, so naming the route
         would advertise a dead end the app already knows about.
+
+        THE SETUP STATE HAS TWO SHAPES and they get different sentences (UX
+        review round 3, U12). In the no-model variant (`_model_missing_for`
+        set) the `/model` routes genuinely work: `_cmd_model` has an escape
+        that writes config and boots, so the persist hint is live advice. In
+        the no-hosting and unknown-hosting variants there is no model escape at
+        all — `_cmd_model`, `_cmd_model_saved` and the bare `/model default`
+        all fall through to `session is still starting…`, and #625 kept
+        Enter-on-a-row from writing config there for exactly that reason. So
+        naming `/model default` there advertises three dead ends beside the one
+        working route. Those variants get the `/settings` clause ALONE, which
+        is the route that actually resolves, and the splash's `/login` remains
+        the primary next step it always was. Pinned by
+        `test_the_model_notice_in_dead_end_setup_variants_names_only_settings`.
         """
         session = self._session
         label = session.model_label if session is not None else ""
-        back = "" if self._setup_state else " · /model saved switches back to the boot default"
-        routes = f"{PERSIST_HINT}{back} · or set it in /settings"
+        # Named once: it is the one clause every variant below shares, and the
+        # wrap analysis above measured this exact string.
+        settings_clause = "/settings edits the boot default too"
+        if self._setup_state and not self._model_missing_for:
+            # No hosting / unknown hosting: every `/model` route refuses here,
+            # so the notice must not name one. `/settings` is the live escape.
+            routes = settings_clause
+        elif self._setup_state:
+            routes = f"{PERSIST_HINT} · {settings_clause}"
+        else:
+            routes = f"{PERSIST_HINT} · {settings_clause} · /model saved reverts to it"
         if not label:
             return routes
         return f"model: {label} — {routes}"
@@ -17082,7 +17139,7 @@ class OperatorApp(App[None]):
         notice ends the empty state — which collapses the boot composition and
         makes the centred prompt unreachable.
 
-        The notice is skipped when the ledger's LAST row already says it. The
+        The notice is skipped when the ledger's last ROW ALREADY SAYS IT. The
         message is meant to fire once per visible opening, and the editor now
         keeps that true across an Esc (``ModelPicker.dismiss`` — UX review
         round 2, U8, where each Esc-then-edit cycle stacked another copy). This
@@ -17090,11 +17147,27 @@ class OperatorApp(App[None]):
         opens that produces nothing between them can print the hint twice,
         whatever the editor's resync does in future. Compared on the text, so
         a hint that changed (a switch landed between two opens) still prints.
+
+        THE SCAN SKIPS THE PINNED WORKING LINE (code review round 2, R12). A
+        turn in flight pins its working line to the bottom of the transcript
+        (``TranscriptView.pin_tail``) and every later append is inserted BEFORE
+        it, so mid-turn the hint never lands last and a guard reading only
+        ``blocks()[-1]`` could not match it — the deduplication silently
+        stopped applying in exactly the state where a user re-opening the list
+        while the agent works would stack copies. Walking back over the pinned
+        tail costs one comparison and makes the guard mean what its name says
+        in both states. Only the tail is skipped, not an arbitrary run: two
+        notices with a real block between them are two separate openings and
+        must both print.
         """
         message.stop()
         hint = self._persist_hint_notice()
-        blocks = self._transcript_view().blocks()
-        last = blocks[-1] if blocks else None
+        transcript = self._transcript_view()
+        blocks = transcript.blocks()
+        pinned = transcript.pinned_tail()
+        # The last block that is not the pinned working line — which is where a
+        # mid-turn append actually lands.
+        last = next((b for b in reversed(blocks) if b is not pinned), None)
         if not (isinstance(last, NoticeBlock) and last.text() == hint):
             self._system_notice(hint)
         self._populate_model_picker()
@@ -17150,7 +17223,9 @@ class OperatorApp(App[None]):
             # radient" pushed `/login <provider>` off the end at 100 columns, which
             # cost the one clause the user can act on.
             status=_status_line(
-                note, "checking providers…" if self._providers else "", PERSIST_HINT
+                note,
+                "checking providers…" if self._providers else "",
+                self._footer_persist_hint(),
             ),
         )
         if self._providers is not None:
@@ -17182,7 +17257,9 @@ class OperatorApp(App[None]):
                 rows,
                 current=self._current_selector(),
                 status=_status_line(
-                    note, f"{STALE_LIST_LABEL} all providers — {error}", PERSIST_HINT
+                    note,
+                    f"{STALE_LIST_LABEL} all providers — {error}",
+                    self._footer_persist_hint(),
                 ),
             )
             return
@@ -17190,7 +17267,7 @@ class OperatorApp(App[None]):
         self._editor().model_picker.set_rows(
             rows,
             current=self._current_selector(),
-            status=_status_line(note, _catalogue_status(statuses), PERSIST_HINT),
+            status=_status_line(note, _catalogue_status(statuses), self._footer_persist_hint()),
         )
 
     def _publish_model_catalogue(self, session: Any) -> None:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -16180,8 +16180,17 @@ class OperatorApp(App[None]):
         before/after frames: the notice was honest and the footer was not).
 
         The predicate is ``_model_missing_for``, the same one `_cmd_model`'s
-        escape is gated on, so "the footer offers it" and "the command performs
-        it" cannot drift apart.
+        escape is gated on, so across the three SETUP-STATE variants "the
+        footer offers it" and "the command performs it" cannot drift apart.
+
+        That is the full extent of the claim (code review round 1, R2). It is
+        not a general equivalence: `_cmd_model` ALSO refuses `/model default`
+        when :meth:`_session_runs_elsewhere` is true, and this predicate does
+        not consult it, so on a genuinely remote session the footer still
+        advertises a command that answers with the "run it on the terminal
+        whose launches it should govern" refusal. That case is pre-existing and
+        outside #641's scope — recorded here rather than fixed so the next
+        reader does not take the coupling for wider than it is.
         """
         if self._setup_state and not self._model_missing_for:
             return ""
@@ -16207,6 +16216,15 @@ class OperatorApp(App[None]):
         also editable on the settings page, which is the discoverable route for
         a user who did not arrive with a command in mind.
 
+        The measurement above is about the NOTICE's own last row and about
+        command names spanning a fold — nothing stronger (QA round 1, Q1). An
+        earlier revision of this docstring claimed `/settings` "is never the
+        final token at ANY body width from 38 to 90", which is false: it ends a
+        folded, non-final row in 62 combinations across 39 widths. A clause
+        that continues on the next row is not the defect D8 named; a command
+        the reader must re-join two rows to recover is, and that is what is
+        actually pinned.
+
         The nouns are placed so each pronoun sits beside its antecedent (design
         review D4). "Boot default" is the ONE noun for the thing `/model
         default` writes — the receipt says `boot default saved to …` and
@@ -16219,18 +16237,44 @@ class OperatorApp(App[None]):
         the three widths the block actually renders at — body budgets 70/69/76
         cells for 80/100/120 columns — the fold left `/settings` alone on the
         last row for most model labels: the row length varies with the label,
-        so a single label measuring clean proves nothing. The `/settings`
-        clause is therefore in the MIDDLE and carries the noun
-        (`/settings edits the boot default too`), which does three things at
-        once: it moves the command token off the fold, it puts the D6 noun
-        early enough that the trailing `it` has an antecedent one clause back
-        (design review round 3, D10 — with the `/model saved` clause dropped in
-        the setup state, the old `set it in /settings` left `it` reaching back
-        past `this`), and it ends the sentence on `reverts to it`, a three-word
-        tail that cannot orphan a command name. Measured over 11 representative
-        labels x the three rendered widths: zero lone-token last rows, and
-        `/settings` is never the final token at ANY body width from 38 to 90.
-        `test_the_bare_model_notice_does_not_orphan_a_route_token` pins it.
+        so a single label measuring clean proves nothing.
+
+        TWO defect classes, not one, and a fix for the first can create the
+        second (design review round 4 D1 / UX round 4 U3). D8's harness scored
+        only LONE-TOKEN LAST ROWS, so the arrangement it picked
+        (`… · /settings edits the boot default too · /model saved reverts to
+        it`) scored a clean 0 while quietly moving the damage into the middle
+        of the block: a row ending on a bare `/model` whose next row opens
+        `saved reverts to it` splits the two-word COMMAND NAME across the fold,
+        which costs the reader exactly what D8 cost them — the command cannot
+        be read off one row. That measured 5 splits over 11 labels x the three
+        rendered widths, and the frame shipped as D8's own evidence contained
+        one.
+
+        Both classes are scored now, and the lever turned out to be structural
+        rather than lexical: it is WHERE a two-word command name sits in its
+        clause. A name that OPENS a clause (`/model saved reverts to it`) sits
+        one word from the `·` seam, so it breaks across the fold whenever that
+        seam lands near the margin; a name at the clause's END has ordinary
+        words ahead of it to absorb the fold. So `/model saved` moved to the
+        end of its clause and the split count goes 5 -> 0. `/settings` keeps
+        its leading position because four words follow it either way.
+
+        Measured over 11 representative labels x the three rendered body widths
+        (70/69/76), across all THREE variants this method emits: 0 command
+        tokens alone on a last row and 0 split command names, against 0 and 5
+        for the arrangement D8 shipped.
+
+        What is NOT claimed: this does not promise every row ends on a
+        multi-word phrase. An ordinary word can still land alone on the last
+        row (`too` at one label x width here), which is ordinary prose wrapping
+        rather than the defect these findings are about — the reader can still
+        read every command off a single row, which is the property being
+        bought. A 2,240-combination search over clause wordings and orders
+        found no arrangement that is clean on all three classes across all
+        three variants, so this is the measured optimum and not a claim of
+        perfection. `test_the_bare_model_notice_does_not_orphan_a_route_token`
+        pins the two that matter.
 
         The `/model saved` clause is DROPPED in the setup state (UX review
         round 2, U11): that state is by definition the one with no usable boot
@@ -16256,6 +16300,12 @@ class OperatorApp(App[None]):
         # Named once: it is the one clause every variant below shares, and the
         # wrap analysis above measured this exact string.
         settings_clause = "/settings edits the boot default too"
+        # `/model saved` sits at its clause's END, which is what removes the
+        # split: as the clause's FIRST word it sat one word from the `·` seam
+        # and broke across the fold at 5 of 33 rendered label x width
+        # combinations. `/settings` is left leading its own clause because it
+        # is followed by four words, so the fold has slack after it either way.
+        saved_clause = "come back with /model saved"
         if self._setup_state and not self._model_missing_for:
             # No hosting / unknown hosting: every `/model` route refuses here,
             # so the notice must not name one. `/settings` is the live escape.
@@ -16263,7 +16313,7 @@ class OperatorApp(App[None]):
         elif self._setup_state:
             routes = f"{PERSIST_HINT} · {settings_clause}"
         else:
-            routes = f"{PERSIST_HINT} · {settings_clause} · /model saved reverts to it"
+            routes = f"{PERSIST_HINT} · {saved_clause} · {settings_clause}"
         if not label:
             return routes
         return f"model: {label} — {routes}"

--- a/local_operator/tui/widgets/command_picker.py
+++ b/local_operator/tui/widgets/command_picker.py
@@ -1497,6 +1497,17 @@ class CommandPicker(Static):
         self._dismissed_query = self._query
         self._close()
 
+    def is_dismissed(self) -> bool:
+        """Whether an Esc is currently latched for the token in the buffer.
+
+        The sibling of :meth:`ModelPicker.is_dismissed` and it exists for the
+        same reason: the list is hidden but the token is still live, so a
+        completion key routed as though nothing had been asked for falls
+        through to ``TextArea`` and types a literal tab into the word the user
+        dismissed a list over (UX review round 3, U13).
+        """
+        return self._dismissed_query is not None
+
     def close(self) -> None:
         """Hide the picker (submission, completion — not a dismissal)."""
         self._close()

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -2404,7 +2404,7 @@ class Editor(TextArea):
                     event.stop()
                     event.prevent_default()
                     return
-        if key == "tab" and (self._model_picker.is_dismissed() or self._picker.is_dismissed()):
+        if key == "tab" and self._latched_picker_at_caret():
             # A COMPLETION KEY WITH A LATCHED ESC IS A NO-OP, not a tab (UX
             # review round 3, U13). Esc hides the list but leaves the token in
             # the buffer, so the branches above — which are gated on a list
@@ -2417,6 +2417,19 @@ class Editor(TextArea):
             # in between. Consumed as a no-op so the buffer survives exactly as
             # typed, which is the same discipline the loading-reserve branch
             # below applies for the same class of premature completion.
+            #
+            # SCOPED TO THE CARET'S OWN PHASE, not to latch state alone (code
+            # review round 1, R1). Gating on `is_dismissed()` by itself was
+            # correct only while a latch expired as soon as the caret moved;
+            # R10 deliberately made the model latch STICKY (it survives until
+            # the buffer holds no `/model` token anywhere), so the two fixes
+            # together turned Tab into a permanent no-op everywhere else in the
+            # buffer — `/model ` Esc, newline, `/them` left the command picker
+            # open and offering `theme` while Tab did nothing, and plain prose
+            # lost the literal indent this widget is constructed with
+            # (`tab_behavior="indent"`). Both reproduced against the base tree,
+            # neither is visible to the user when it happens. The latch may
+            # only swallow Tab where its OWN list would have been showing.
             #
             # Tab ONLY. Enter still submits: with the list dismissed a typed
             # `/model anthropic/claude-opus-5` is a complete command the user
@@ -5365,6 +5378,51 @@ class Editor(TextArea):
             return "command"
         return None
 
+    def _latched_picker_at_caret(self) -> bool:
+        """Whether the list the CARET is inside is holding an Esc.
+
+        The U13 no-op's gate. Latch state alone is not enough (code review
+        round 1, R1): R10 made the model latch survive until the buffer holds
+        no `/model` token *anywhere*, so `is_dismissed()` stays true while the
+        user goes on to type something unrelated. Answering "is the caret
+        inside the latched list's own phase?" keeps U13's no-op exactly where
+        it belongs — the token the Esc was pressed over — and lets every other
+        Tab through, including a live command picker on a second line and the
+        literal indent in plain prose.
+
+        Each latch is asked about with the SAME parse that decides whether its
+        own list is live, so this cannot drift from what the user sees. The
+        model list is driven by ``slash_argument`` over ``MODEL_COMMANDS`` in
+        :meth:`_sync_picker` — deliberately not by :meth:`_picker_phase`, whose
+        ``"argument"`` answer covers ``_argument_commands`` and reports ``None``
+        on a `/model` argument, because the model list is a separate widget
+        with its own vocabulary. The command word's phase is
+        :meth:`_picker_phase`'s ``"command"``, which is the command picker's
+        own.
+
+        The model half is asked at the caret's LINE END rather than at the
+        caret, which is the same question :meth:`_text_holds_model_token` asks
+        and for the same reason (R10): the terminating space of `/model ` sits
+        OUTSIDE the argument span, so a caret resting on it — where a single
+        `←` after Esc puts it — reads as having left the command and would let
+        Tab fall through to ``TextArea`` and type into the query U13 exists to
+        protect. Scoping to the line rather than to the buffer is what keeps
+        R10's sticky latch from swallowing Tab everywhere else (R1): line 1's
+        Esc has no claim on a `/them` the user is typing on line 2.
+
+        A caret sitting outside both — plain prose, a `$skill` token, another
+        command's argument — is claimed by neither, which is the whole point.
+        """
+        text = self.text
+        cursor = self._caret_offset()
+        newline = text.find("\n", cursor)
+        line_end = len(text) if newline == -1 else newline
+        if slash_argument(text, self.MODEL_COMMANDS, line_end, self._command_names) is not None:
+            return self._model_picker.is_dismissed()
+        if self._picker_phase() == "command":
+            return self._picker.is_dismissed()
+        return False
+
     def _sync_picker_if_phase_changed(self) -> None:
         """Re-sync the picker only when the caret crossed a parse phase.
 
@@ -5615,7 +5673,16 @@ class Editor(TextArea):
             # question here is the one the user would ask: is this still a
             # `/model` line? Only when the buffer holds no model token at all
             # is the Esc genuinely spent.
-            if not self._text_holds_model_token():
+            #
+            # Guarded on the latch FIRST, because the scan is O(lines) with a
+            # real `slash_argument` parse per line and this branch is the one
+            # every ordinary prose keystroke takes (code review round 1, R3).
+            # Measured on the keystroke path: 0.19 ms at 50 lines, 7.46 ms at
+            # 500, 14.05 ms at 2000 — pasted drafts that size are ordinary in
+            # this composer. `forget_dismissal()` is a no-op when nothing is
+            # latched, so the scan bought nothing in exactly the common case;
+            # the short-circuit leaves the cost only where the answer is used.
+            if self._model_picker.is_dismissed() and not self._text_holds_model_token():
                 self._model_picker.forget_dismissal()
             self._picker_phase_at_last_sync = self._picker_phase()
             return

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -5421,8 +5421,14 @@ class Editor(TextArea):
         R10's sticky latch from swallowing Tab everywhere else (R1): line 1's
         Esc has no claim on a `/them` the user is typing on line 2.
 
-        A caret sitting outside both — plain prose, a `$skill` token, another
-        command's argument — is claimed by neither, which is the whole point.
+        What is left over is PLAIN PROSE, and only plain prose: a caret that no
+        parse claims returns ``False`` and Tab keeps its ordinary
+        ``TextArea`` meaning — the literal indent. A `$skill` token and another
+        command's argument are NOT in that leftover; R14 moved both under
+        ``self._picker`` above, so each is answered by its own list's latch
+        rather than falling through. That is the intended split: every live
+        list holds its own Esc, and the only Tab that still reaches the buffer
+        is one pressed where no list exists.
         """
         text = self.text
         cursor = self._caret_offset()

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -5396,9 +5396,20 @@ class Editor(TextArea):
         :meth:`_sync_picker` — deliberately not by :meth:`_picker_phase`, whose
         ``"argument"`` answer covers ``_argument_commands`` and reports ``None``
         on a `/model` argument, because the model list is a separate widget
-        with its own vocabulary. The command word's phase is
-        :meth:`_picker_phase`'s ``"command"``, which is the command picker's
-        own.
+        with its own vocabulary.
+
+        ``self._picker`` is asked with ANY non-``None`` phase, not just
+        ``"command"`` (round 2, R14). That widget serves FOUR lists — the
+        command word, an argument list (`/theme `, `/effort `, `/login `,
+        `/mcp `, `/team `…), the `$skill` list and the loading reserve — and
+        every one of them can hold an Esc. Narrowing the question to the
+        command word answered it for one list and returned the other three to
+        the literal-whitespace corruption U13 exists to prevent: `/theme d`
+        became `/theme d    `. ``_picker_phase()`` returning non-``None`` is
+        precisely "this widget's list is live at the caret", which is the same
+        question the model half asks of its own parse — one rule for both
+        pickers rather than a per-phase allowlist that the next new list would
+        silently fall out of.
 
         The model half is asked at the caret's LINE END rather than at the
         caret, which is the same question :meth:`_text_holds_model_token` asks
@@ -5419,7 +5430,7 @@ class Editor(TextArea):
         line_end = len(text) if newline == -1 else newline
         if slash_argument(text, self.MODEL_COMMANDS, line_end, self._command_names) is not None:
             return self._model_picker.is_dismissed()
-        if self._picker_phase() == "command":
+        if self._picker_phase() is not None:
             return self._picker.is_dismissed()
         return False
 

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -2404,6 +2404,26 @@ class Editor(TextArea):
                     event.stop()
                     event.prevent_default()
                     return
+        if key == "tab" and (self._model_picker.is_dismissed() or self._picker.is_dismissed()):
+            # A COMPLETION KEY WITH A LATCHED ESC IS A NO-OP, not a tab (UX
+            # review round 3, U13). Esc hides the list but leaves the token in
+            # the buffer, so the branches above — which are gated on a list
+            # being open — do not run, and Tab fell through to ``TextArea``'s
+            # own handling and inserted literal whitespace INTO the query
+            # (`/model ` became `/model  `, `/no` became `/no    `). The user
+            # then pressed Tab again, the second press hit a picker that had
+            # reopened on the changed query, and the completion finally landed —
+            # one gesture needing two presses and silently corrupting the word
+            # in between. Consumed as a no-op so the buffer survives exactly as
+            # typed, which is the same discipline the loading-reserve branch
+            # below applies for the same class of premature completion.
+            #
+            # Tab ONLY. Enter still submits: with the list dismissed a typed
+            # `/model anthropic/claude-opus-5` is a complete command the user
+            # means to run, and swallowing Enter would strand it.
+            event.stop()
+            event.prevent_default()
+            return
         if key in ("tab", "enter") and self._picker.is_loading():
             # U2-2: the one dim row on screen is a TRANSIENT loading reserve,
             # not an answer — real rows replace it the moment the session
@@ -5581,7 +5601,22 @@ class Editor(TextArea):
             # Leaving `/model …` expires an Esc, exactly as `CommandPicker.sync`
             # forgets its dismissal when the caret leaves slash context: the
             # next entry into the argument is a fresh opening.
-            self._model_picker.forget_dismissal()
+            #
+            # Asked of the TEXT, not of the caret (code review round 2, R10).
+            # The argument parse is caret-anchored, and the terminating space is
+            # NOT in the argument (`slash_argument_context` requires the column
+            # to be past it), so on `/model ` a single `←` parked the caret on
+            # that space and read as having left the command entirely. The Esc
+            # was forgotten, the following `→` re-entered the argument, and the
+            # list reopened and re-announced itself — while `CommandPicker` on
+            # the same gesture stayed dismissed, because its word phase spans
+            # the whole word and a caret inside it never leaves slash context.
+            # A latch that a caret move can clear is not a dismissal, so the
+            # question here is the one the user would ask: is this still a
+            # `/model` line? Only when the buffer holds no model token at all
+            # is the Esc genuinely spent.
+            if not self._text_holds_model_token():
+                self._model_picker.forget_dismissal()
             self._picker_phase_at_last_sync = self._picker_phase()
             return
         if self._model_picker.is_open():
@@ -5644,6 +5679,35 @@ class Editor(TextArea):
         line/slash split.
         """
         return slash_word(self.text, self._caret_offset(), self._command_names)
+
+    def _text_holds_model_token(self) -> bool:
+        """Whether the BUFFER still contains a ``/model …`` argument anywhere.
+
+        Deliberately caret-independent, and that is the whole point: it answers
+        the question the model list's dismissal latch needs (R10) — "is this
+        still a `/model` line?" — which the caret-anchored
+        :func:`slash_argument` cannot, because the terminating space sits
+        outside the argument span and a caret resting on it reads as having
+        left the command.
+
+        Implemented by re-asking the ordinary parse at each line's END rather
+        than by matching text: the line end is always inside the argument phase
+        when a terminated command word is on that line, so this inherits every
+        rule the real parse already encodes (inline slashes, the nested-slash
+        vocabulary, CRLF tolerance) instead of introducing a second, drifting
+        notion of what counts as a model token.
+        """
+        offset = 0
+        for line in self.text.split("\n"):
+            if (
+                slash_argument(
+                    self.text, self.MODEL_COMMANDS, offset + len(line), self._command_names
+                )
+                is not None
+            ):
+                return True
+            offset += len(line) + 1  # +1 for the newline the split consumed
+        return False
 
     def _complete_model(self, row: ModelRow) -> None:
         """Put ``row``'s selector in the ``/model`` argument without acting on it.

--- a/local_operator/tui/widgets/model_picker.py
+++ b/local_operator/tui/widgets/model_picker.py
@@ -74,6 +74,23 @@ PERSIST_HINT_PREFIX = "/model default"
 #: asserts they stay in step with the handler's own dispatch.
 _PERSIST_KEYWORDS = frozenset({"default", "saved"})
 
+
+def _keyword_row(keyword: str) -> str:
+    """The empty-state row for a `/model` argument that is a COMMAND word.
+
+    Held to the same budget ``PERSIST_HINT`` is (design review round 1, D2).
+    The footer's body is ``width - _GUTTER_CELLS - _EDGE_MARGIN``, so 47 cells
+    at the 50-column floor; the first version of this row read `default is a
+    command, not a model — enter runs it` at 49 cells and truncated there to
+    `…not a model — enter…`, cutting the actionable half and leaving only the
+    negative clause at exactly the width where the user has least room to work
+    out what to do instead. The shorter carrier keeps BOTH halves — what the
+    word is, and what Enter will do with it — at every width the picker
+    renders at. `test_the_keyword_row_fits_the_narrow_footer` pins the ceiling.
+    """
+    return f"{keyword} is a command — enter runs it"
+
+
 MAX_VISIBLE_ROWS = 14
 _SCREEN_HEIGHT_FRACTION = 3
 
@@ -881,12 +898,37 @@ class ModelPicker(Static):
             # ever match a row, so the empty list is the correct and expected
             # state for them rather than a report about the catalogue. The row
             # says what pressing Enter will do instead. Compared against the
-            # same lowered spelling `_cmd_model` dispatches on, and only for an
-            # EXACT word: `/model default anthropic/claude-opus-5` is a
-            # selector being typed and genuinely has no matches until it
+            # same lowered spelling `_cmd_model` dispatches on.
+            #
+            # PREFIX-AWARE, not exact-match only (UX review round 1, U1). An
+            # exact test fixed the settled state and left the contradiction
+            # reachable on the way there: typing `/model default` one character
+            # at a time printed `no matching models` directly above a footer
+            # advertising that exact phrase for FOUR consecutive keystrokes
+            # (`def`, `defa`, `defau`, `defaul`), resolving only on the final
+            # `t`. That is precisely the pairing U3 was filed against, so the
+            # suppression has to cover every prefix a user passes through
+            # rather than only the word they arrive at. A prefix is not yet a
+            # runnable command, so it gets the neutral half of the sentence
+            # without the `enter runs it` promise, which would be false there.
+            #
+            # Still only for a BARE word: `/model default anthropic/claude-opus-5`
+            # is a selector being typed and genuinely has no matches until it
             # resolves, so it keeps the ordinary message.
-            if query.lower() in _PERSIST_KEYWORDS:
-                bits.append(f"{query.lower()} is a command, not a model — enter runs it")
+            lowered = query.lower()
+            partial = next(
+                (k for k in sorted(_PERSIST_KEYWORDS) if lowered and k.startswith(lowered)),
+                "",
+            )
+            if lowered in _PERSIST_KEYWORDS:
+                bits.append(_keyword_row(lowered))
+            elif partial:
+                # Same subject and same shape as the settled row, differing only
+                # in the half that says what to do — so the row the user is
+                # reading does not change out from under them on the keystroke
+                # that completes the word. The two keywords share no common
+                # prefix, so a prefix names exactly one of them.
+                bits.append(f"{partial} is a command — keep typing")
             else:
                 bits.append("no matching models" if query else "no models available")
         elif total > end - start:

--- a/local_operator/tui/widgets/model_picker.py
+++ b/local_operator/tui/widgets/model_picker.py
@@ -91,6 +91,23 @@ def _keyword_row(keyword: str) -> str:
     return f"{keyword} is a command — enter runs it"
 
 
+def _partial_keyword_row(keyword: str) -> str:
+    """The same row while the command word is still being TYPED.
+
+    A sibling of :func:`_keyword_row` rather than an inline f-string (code
+    review round 2, R17): D2's budget applies to whichever of the two rows the
+    user is looking at, and only the one that had a helper had a ceiling test.
+    Built here so `test_the_keyword_row_fits_the_narrow_footer` measures both.
+
+    Same subject and same shape as the settled row, differing only in the half
+    that says what to do — so the row does not change out from under the reader
+    on the keystroke that completes the word. `enter runs it` is deliberately
+    NOT promised while the word is partial: Enter there is an ordinary failed
+    search, and the promise would be false.
+    """
+    return f"{keyword} is a command — keep typing"
+
+
 MAX_VISIBLE_ROWS = 14
 _SCREEN_HEIGHT_FRACTION = 3
 
@@ -923,12 +940,9 @@ class ModelPicker(Static):
             if lowered in _PERSIST_KEYWORDS:
                 bits.append(_keyword_row(lowered))
             elif partial:
-                # Same subject and same shape as the settled row, differing only
-                # in the half that says what to do — so the row the user is
-                # reading does not change out from under them on the keystroke
-                # that completes the word. The two keywords share no common
-                # prefix, so a prefix names exactly one of them.
-                bits.append(f"{partial} is a command — keep typing")
+                # The two keywords share no common prefix, so a prefix names
+                # exactly one of them.
+                bits.append(_partial_keyword_row(partial))
             else:
                 bits.append("no matching models" if query else "no models available")
         elif total > end - start:

--- a/local_operator/tui/widgets/model_picker.py
+++ b/local_operator/tui/widgets/model_picker.py
@@ -64,6 +64,16 @@ _COLUMN_GAP = 2
 #: ``test_persist_hint_prefix_matches_app`` asserts the two never drift.
 PERSIST_HINT_PREFIX = "/model default"
 
+#: The argument words ``/model`` consumes as COMMANDS rather than as selectors
+#: to rank rows against. Typing one filters the catalogue to nothing by
+#: construction — no row is named `default` — so the empty-state row says what
+#: the word does instead of reporting a failed search (UX review round 3, U3).
+#: Kept beside ``PERSIST_HINT_PREFIX`` because both exist for the same reason:
+#: this widget has to recognise the app's `/model` vocabulary without importing
+#: ``app``, which imports this module. ``test_persist_keywords_match_app``
+#: asserts they stay in step with the handler's own dispatch.
+_PERSIST_KEYWORDS = frozenset({"default", "saved"})
+
 MAX_VISIBLE_ROWS = 14
 _SCREEN_HEIGHT_FRACTION = 3
 
@@ -562,6 +572,18 @@ class ModelPicker(Static):
         leaves slash context — the two lists expire an Esc on the same rule."""
         self._dismissed_query = None
 
+    def is_dismissed(self) -> bool:
+        """Whether an Esc is currently latched for the query in the buffer.
+
+        The state that is invisible on screen and still load-bearing: the list
+        is hidden, the text is unchanged, and the next key must not be routed
+        as though no list had ever been asked for. The editor uses it to hold
+        completion keys (UX review round 3, U13) — Tab with a latched Esc had
+        no rows to complete from, so it fell through to ``TextArea`` and
+        inserted a literal tab into the query.
+        """
+        return self._dismissed_query is not None
+
     def dismiss(self) -> None:
         """Hide the list for the CURRENT query without touching the text.
 
@@ -849,7 +871,24 @@ class ModelPicker(Static):
 
         bits: list[str] = []
         if total == 0:
-            bits.append("no matching models" if self._query.strip() else "no models available")
+            query = self._query.strip()
+            # A KEYWORD IS NOT A FAILED SEARCH (UX review round 3, U3). The
+            # footer one row below advertises `/model default`, and typing it
+            # narrowed the catalogue to `no matching models` — the list calling
+            # the instruction it is itself printing a dead end, which is the
+            # most confusing shape a hint can take. `default` and `saved` are
+            # COMMAND WORDS consumed by `_cmd_model`, not selectors that could
+            # ever match a row, so the empty list is the correct and expected
+            # state for them rather than a report about the catalogue. The row
+            # says what pressing Enter will do instead. Compared against the
+            # same lowered spelling `_cmd_model` dispatches on, and only for an
+            # EXACT word: `/model default anthropic/claude-opus-5` is a
+            # selector being typed and genuinely has no matches until it
+            # resolves, so it keeps the ordinary message.
+            if query.lower() in _PERSIST_KEYWORDS:
+                bits.append(f"{query.lower()} is a command, not a model — enter runs it")
+            else:
+                bits.append("no matching models" if query else "no models available")
         elif total > end - start:
             bits.append(f"{end - start} of {total}")
         bits.extend(status)

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -2910,6 +2910,18 @@ class TranscriptView(ScrollableContainer):
         """Blocks in append order (live and finalized)."""
         return list(self._blocks)
 
+    def pinned_tail(self) -> TranscriptBlock | None:
+        """The block held last by :meth:`pin_tail`, if a turn is in flight.
+
+        Exposed because "the last block" and "the last block a caller appended"
+        are different questions while a working line is pinned: every mid-turn
+        append is inserted BEFORE the pin, so a caller inspecting the ledger's
+        tail has to know which occupant to skip. Reading ``blocks()[-1]``
+        without it silently answers about the working line instead (see
+        ``on_model_query_opened``'s dedupe guard).
+        """
+        return self._tail
+
     def clear_blocks(self) -> None:
         """Remove every block (the ``/clear`` command)."""
         for block in self._blocks:

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -2550,6 +2550,75 @@ async def test_tab_after_an_escape_does_not_type_into_the_query(surface: str) ->
 
 
 @pytest.mark.asyncio
+async def test_a_held_model_latch_does_not_swallow_tab_elsewhere_in_the_buffer() -> None:
+    """R1: the U13 no-op belongs to the latched TOKEN, not to the whole buffer.
+
+    The gap the parametrised U13 test could not see. It exercises one picker at
+    a time, so it never puts a live token of one kind alongside a held latch of
+    the other — which is exactly the state R10 newly made reachable by keeping
+    the model latch until the buffer holds no `/model` token ANYWHERE. Gating
+    the Tab branch on latch state alone therefore made Tab a permanent no-op:
+    the command picker below is open and offering `theme`, and Tab did nothing.
+    Reproduced against `f4e9613a9`, where both halves pass.
+
+    The plain-prose half is the second victim of the same gate: this editor is
+    constructed ``tab_behavior="indent"`` precisely so Tab is a literal indent
+    outside a picker, and a held latch three lines up swallowed that too.
+    """
+    session = _SwitchableSession()
+    ctrl = _AccessController(stored=("openrouter", "anthropic"))
+    app = OperatorApp(lambda: _factory(session), provider_controller=ctrl)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _await_session(app, pilot)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        # Latch the MODEL picker, then leave the line without clearing the token.
+        await pilot.press("slash", "m", "o", "d", "e", "l", "space")
+        for _ in range(4):
+            await pilot.pause()
+        assert editor.model_picker.is_open()
+        await pilot.press("escape")
+        for _ in range(4):
+            await pilot.pause()
+        assert editor.model_picker.is_dismissed()
+
+        # A COMMAND picker on the next line still completes: the model latch
+        # has no claim on a token it was never pressed over.
+        await pilot.press("shift+enter")
+        await pilot.press("slash", "t", "h", "e", "m")
+        for _ in range(4):
+            await pilot.pause()
+        assert editor.picker.is_open(), editor.text
+        assert editor.model_picker.is_dismissed(), "the latch must still be held"
+        await pilot.press("tab")
+        for _ in range(4):
+            await pilot.pause()
+        assert editor.text == "/model \n/theme ", editor.text
+
+        # And plain prose keeps the literal indent while that latch is held.
+        editor.clear_content()
+        await pilot.pause()
+        await pilot.press("slash", "m", "o", "d", "e", "l", "space")
+        for _ in range(4):
+            await pilot.pause()
+        await pilot.press("escape")
+        for _ in range(4):
+            await pilot.pause()
+        assert editor.model_picker.is_dismissed()
+        await pilot.press("shift+enter")
+        await pilot.press("h", "i")
+        for _ in range(3):
+            await pilot.pause()
+        before = editor.text
+        await pilot.press("tab")
+        for _ in range(4):
+            await pilot.pause()
+        assert editor.text != before, "Tab must still indent in prose"
+        assert editor.text.startswith("/model \nhi"), editor.text
+
+
+@pytest.mark.asyncio
 async def test_the_hint_dedupe_guard_sees_past_a_pinned_working_line() -> None:
     """R12: the guard reads the last block a caller appended, not the pin.
 
@@ -9178,8 +9247,9 @@ async def test_the_no_model_setup_variant_still_names_its_working_model_route(
     assert PERSIST_HINT in footer, footer
 
 
-def test_the_bare_model_notice_does_not_orphan_a_route_token() -> None:
-    """D8: no rendered width may leave a command name alone on the last row.
+@pytest.mark.asyncio
+async def test_the_bare_model_notice_does_not_orphan_a_route_token() -> None:
+    """D8 + D1/U3: a command name must be readable off ONE row, at every width.
 
     The finding was measured at 80 and 100 columns for ONE model label, but the
     row length varies with the label, so a single measurement proves nothing —
@@ -9188,6 +9258,19 @@ def test_the_bare_model_notice_does_not_orphan_a_route_token() -> None:
     Body budgets come from ``NoticeBlock.body_budget`` rather than being
     hardcoded, so a change to the block's own fold re-measures instead of
     silently invalidating the numbers.
+
+    TWO defect classes, because fixing the first created the second (design
+    review round 4 D1, UX round 4 U3). A lone command token on the LAST row is
+    what D8 named; a row ending on a bare `/model` whose next row opens `saved`
+    splits the two-word command NAME across the fold, which costs the reader the
+    same thing. The shipped D8 copy scored 0 on the first and 5 on the second.
+
+    ASSERTED AGAINST THE STRING THE APP EMITS, not a local rebuild of it (code
+    review round 1, R4). This test previously assembled `routes` as its own
+    literal, so it passed against the pre-fix `app.py` and pinned nothing: the
+    clause order it exists to protect could be reordered in the app and the
+    test stayed green. It now drives the real method, which is what makes a
+    reordering fail here.
     """
     from local_operator.tui.widgets.transcript import NoticeBlock, wrap_cells
 
@@ -9207,19 +9290,71 @@ def test_the_bare_model_notice_does_not_orphan_a_route_token() -> None:
     # which is exactly what `body_budget` accounts for.
     block_widths = {80: 76, 100: 75, 120: 82}
 
-    routes = (
-        f"{PERSIST_HINT} · /settings edits the boot default too" " · /model saved reverts to it"
-    )
-    for label in labels:
-        for cols, block_width in block_widths.items():
-            body = NoticeBlock.body_budget(block_width)
-            rows = wrap_cells(f"model: {label} — {routes}", body)
-            if len(rows) == 1:
-                continue
-            last = rows[-1].split()
-            assert len(last) > 1, (cols, label, rows)
-            # The specific shape D8 reported: the command name alone.
-            assert rows[-1].strip() != "/settings", (cols, label, rows)
+    # The sentence under test is the one the app builds, read back from the
+    # real method rather than restated here (R4). The label is stripped so the
+    # matrix below can substitute each of its own.
+    # All THREE sentences this method emits, each read back from the method
+    # itself under the state that produces it (R4). The setup variants drop a
+    # clause (U11/U12) and therefore fold differently, and the dead-end variant
+    # is a single clause whose own tail can orphan — measuring only the
+    # ordinary one is how the shipped copy scored clean while two variants were
+    # not.
+    session = _SwitchableSession()
+    ctrl = _AccessController(stored=("openrouter", "anthropic"))
+    app = OperatorApp(lambda: _factory(session), provider_controller=ctrl)
+    sentences: dict[str, str] = {}
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _await_session(app, pilot)
+        for variant, setup, missing in (
+            ("ordinary", False, None),
+            ("setup", True, "openrouter"),
+            ("deadend", True, None),
+        ):
+            app._setup_state = setup
+            app._model_missing_for = missing
+            notice = app._persist_hint_notice()
+            sentences[variant] = notice.split(" — ", 1)[1] if " — " in notice else notice
+        app._setup_state = False
+        app._model_missing_for = None
+
+    routes = sentences["ordinary"]
+    # The clauses D8/D10/D6 put in the sentence are all still in it: this test
+    # is about where they FOLD, so it must fail loudly if one simply went away.
+    assert PERSIST_HINT in routes, routes
+    assert "/settings" in routes and "boot default" in routes, routes
+    assert "/model saved" in routes, routes
+    # U11/U12: the dead-end variant names /settings and no /model route at all.
+    assert "/model" not in sentences["deadend"], sentences["deadend"]
+    assert "/settings" in sentences["deadend"], sentences["deadend"]
+
+    # The two-word command names a reader must not have to re-join across rows.
+    atoms = ("/model default", "/model saved")
+    for variant, sentence in sentences.items():
+        for label in labels:
+            for cols, block_width in block_widths.items():
+                body = NoticeBlock.body_budget(block_width)
+                rows = wrap_cells(f"model: {label} — {sentence}", body)
+                if len(rows) == 1:
+                    continue
+                # D8: the last row is never a COMMAND NAME standing alone.
+                # Scoped to command tokens on purpose — an ordinary word left
+                # alone by the fold is prose wrapping, not a route the reader
+                # cannot act on, and no phrasing that survived the wider search
+                # avoided it at every label and width (see the docstring in
+                # `_persist_hint_notice`).
+                last = rows[-1].split()
+                assert not (len(last) == 1 and last[0].startswith("/")), (
+                    variant,
+                    cols,
+                    label,
+                    rows,
+                )
+                # D1/U3: no fold falls INSIDE a two-word command name.
+                for i, row in enumerate(rows[:-1]):
+                    head, nxt = row.split(), rows[i + 1].split()
+                    if not head or not nxt:
+                        continue
+                    assert f"{head[-1]} {nxt[0]}" not in atoms, (variant, cols, label, rows)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -2506,8 +2506,10 @@ async def test_leaving_the_model_command_entirely_does_expire_the_escape() -> No
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("surface", ["model", "command"])
-async def test_tab_after_an_escape_does_not_type_into_the_query(surface: str) -> None:
+@pytest.mark.parametrize("surface", ["model", "command", "argument", "skill"])
+async def test_tab_after_an_escape_does_not_type_into_the_query(
+    surface: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """U13: a completion key with a latched Esc is a no-op, not a literal tab.
 
     Esc hides the list but leaves the token in the buffer, so the open-list
@@ -2515,7 +2517,30 @@ async def test_tab_after_an_escape_does_not_type_into_the_query(surface: str) ->
     `/model  ` and `/mod` became `/mod    `, silently corrupting the very word
     the user had dismissed a list over. Both pickers had it and both are fixed
     the same way, which is why this is parametrised rather than duplicated.
+
+    EVERY list is parametrised, not a sample (round 2, R14). This test read
+    ``["model", "command"]`` while :meth:`Editor._latched_picker_at_caret`
+    answered for exactly those two phases, so it pinned the gate's
+    implementation instead of its contract and stayed green through a real
+    regression: scoping the gate to ``_picker_phase() == "command"`` dropped
+    the ARGUMENT list — the most common latched list in this widget — and
+    `/theme d` went back to `/theme d    `. ``self._picker`` serves the command
+    word, argument lists, the `$skill` list and the loading reserve; the
+    surfaces below are every phase ``_picker_phase`` can report plus the model
+    picker's own parse, so narrowing the gate to any subset of them now fails
+    here rather than in the composer.
     """
+    # The `$` list is the one surface with no built-in vocabulary: the hermetic
+    # suite discovers zero skills, and an empty list never opens. Wired in
+    # through the documented env var, as `test_skill_invocation` does.
+    root = tmp_path / "skills"
+    (root / "research").mkdir(parents=True)
+    (root / "research" / "SKILL.md").write_text(
+        "---\nname: research\ndescription: Investigate a question.\n---\n\nRead sources."
+    )
+    monkeypatch.setenv("LOCAL_OPERATOR_SKILL_EXTRA_ROOTS", str(root))
+    monkeypatch.chdir(tmp_path)
+
     session = _SwitchableSession()
     ctrl = _AccessController(stored=("openrouter", "anthropic"))
     app = OperatorApp(lambda: _factory(session), provider_controller=ctrl)
@@ -2528,13 +2553,29 @@ async def test_tab_after_an_escape_does_not_type_into_the_query(surface: str) ->
             await pilot.press("slash", "m", "o", "d", "e", "l", "space")
             picker = editor.model_picker
             expected = "/model "
-        else:
+        elif surface == "command":
             await pilot.press("slash", "m", "o", "d")
             picker = editor.picker
             expected = "/mod"
-        for _ in range(4):
+        elif surface == "argument":
+            # `/theme` takes an argument, so the space hands the SAME widget a
+            # different list. This is the case R14 regressed.
+            await pilot.press("slash", "t", "h", "e", "m", "e", "space", "d")
+            picker = editor.picker
+            expected = "/theme d"
+        else:
+            # The `$` sigil's list, also `_picker`, reached by its own parse.
+            await pilot.press("dollar_sign")
+            picker = editor.picker
+            expected = "$"
+        # The skill list is populated from an awaited discovery pass rather than
+        # from a synchronous vocabulary, so it needs more settling than the
+        # slash lists; pausing to the open state keeps one body for all four.
+        for _ in range(12):
             await pilot.pause()
-        assert picker.is_open()
+            if picker.is_open():
+                break
+        assert picker.is_open(), (surface, editor.text)
         await pilot.press("escape")
         for _ in range(4):
             await pilot.pause()
@@ -9263,7 +9304,17 @@ async def test_the_bare_model_notice_does_not_orphan_a_route_token() -> None:
     review round 4 D1, UX round 4 U3). A lone command token on the LAST row is
     what D8 named; a row ending on a bare `/model` whose next row opens `saved`
     splits the two-word command NAME across the fold, which costs the reader the
-    same thing. The shipped D8 copy scored 0 on the first and 5 on the second.
+    same thing. The shipped D8 copy scored 0 on the first and 4 on the second.
+
+    TWO WIDTH FAMILIES, because the block has two (QA round 2, Q3). Earlier
+    rounds measured only the PRISTINE widths a `NoticeBlock` takes in an empty
+    transcript, and reported a clean 0 that held only there. Once the
+    transcript holds any content the block is `cols - 4` — which is the family
+    the hint is normally read at, since a user meets it after they have been
+    working — and the split was still present and visible in a rendered frame.
+    Both families are asserted here so a claim measured at one cannot be
+    reported as holding at both. Confirmed against the real app: at 80/100/120
+    columns the block renders 76/75/82 pristine and 76/96/116 after one turn.
 
     ASSERTED AGAINST THE STRING THE APP EMITS, not a local rebuild of it (code
     review round 1, R4). This test previously assembled `routes` as its own
@@ -9285,10 +9336,20 @@ async def test_the_bare_model_notice_does_not_orphan_a_route_token() -> None:
         "openrouter/moonshotai/kimi-k2-0905",
         "anthropic/claude-sonnet-4-5-20250929",
     ]
-    # The three terminal widths the design rounds measure at. The block is
-    # narrower than the terminal (transcript padding + the hanging glyph field),
-    # which is exactly what `body_budget` accounts for.
-    block_widths = {80: 76, 100: 75, 120: 82}
+    # The three terminal widths the design rounds measure at, at BOTH families
+    # the block renders (Q3). The block is narrower than the terminal
+    # (transcript padding + the hanging glyph field), which is exactly what
+    # `body_budget` accounts for.
+    block_widths = {
+        # pristine transcript
+        (80, "pristine"): 76,
+        (100, "pristine"): 75,
+        (120, "pristine"): 82,
+        # transcript holding any content: the block is `cols - 4`
+        (80, "non-empty"): 76,
+        (100, "non-empty"): 96,
+        (120, "non-empty"): 116,
+    }
 
     # The sentence under test is the one the app builds, read back from the
     # real method rather than restated here (R4). The label is stripped so the
@@ -9329,9 +9390,10 @@ async def test_the_bare_model_notice_does_not_orphan_a_route_token() -> None:
 
     # The two-word command names a reader must not have to re-join across rows.
     atoms = ("/model default", "/model saved")
+    splits: dict[str, list[tuple[str, int, str]]] = {"pristine": [], "non-empty": []}
     for variant, sentence in sentences.items():
         for label in labels:
-            for cols, block_width in block_widths.items():
+            for (cols, family), block_width in block_widths.items():
                 body = NoticeBlock.body_budget(block_width)
                 rows = wrap_cells(f"model: {label} — {sentence}", body)
                 if len(rows) == 1:
@@ -9341,20 +9403,32 @@ async def test_the_bare_model_notice_does_not_orphan_a_route_token() -> None:
                 # alone by the fold is prose wrapping, not a route the reader
                 # cannot act on, and no phrasing that survived the wider search
                 # avoided it at every label and width (see the docstring in
-                # `_persist_hint_notice`).
+                # `_persist_hint_notice`). This holds at BOTH families.
                 last = rows[-1].split()
                 assert not (len(last) == 1 and last[0].startswith("/")), (
                     variant,
                     cols,
+                    family,
                     label,
                     rows,
                 )
-                # D1/U3: no fold falls INSIDE a two-word command name.
+                # D1/U3: where a fold falls INSIDE a two-word command name.
                 for i, row in enumerate(rows[:-1]):
                     head, nxt = row.split(), rows[i + 1].split()
                     if not head or not nxt:
                         continue
-                    assert f"{head[-1]} {nxt[0]}" not in atoms, (variant, cols, label, rows)
+                    if f"{head[-1]} {nxt[0]}" in atoms:
+                        splits[family].append((variant, cols, label))
+
+    # D1/U3 is CLEAN at the pristine family, which is what the fix bought.
+    assert splits["pristine"] == [], splits["pristine"]
+    # And BOUNDED, not clean, at the non-empty family (QA round 2, Q3). The
+    # 2,240-combination search found no arrangement clean on all three classes,
+    # so asserting 0 here would pin a copy that does not exist. The count is
+    # pinned instead: it may go DOWN freely, and a regression that pushes it up
+    # — the direction D1 was filed about — fails. Recorded as an exact figure
+    # rather than a bound so the next editor sees the real cost of the trade.
+    assert len(splits["non-empty"]) <= 3, splits["non-empty"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -55,6 +55,7 @@ from local_operator.tui.widgets.editor import (
     SHELL_PLACEHOLDER,
     Editor,
 )
+from local_operator.tui.widgets.model_picker import PERSIST_HINT_PREFIX
 from local_operator.tui.widgets.session_picker import SessionPickerScreen
 from local_operator.tui.widgets.toast import Toast
 from local_operator.tui.widgets.tool_card import ToolCard
@@ -2417,6 +2418,181 @@ async def test_escaping_then_retyping_the_model_query_reopens_and_reprints() -> 
         assert len(hints) == 3, hints
         assert hints[0].startswith("model: openrouter/"), hints[0]
         assert hints[-1].startswith("model: anthropic/claude-opus-5"), hints[-1]
+
+
+@pytest.mark.asyncio
+async def test_a_caret_move_does_not_expire_an_escaped_model_list() -> None:
+    """R10: the dismissal latch must not be caret-anchored.
+
+    `/model ␣`, Esc, `←`, `→` put the list back and re-announced it, because
+    the leave-edge that forgets an Esc was asked of the caret-anchored argument
+    parse — and the terminating space is OUTSIDE the argument span, so a caret
+    resting on it read as having left `/model` entirely. `CommandPicker` on the
+    identical gesture stays dismissed (asserted here as the reference), because
+    its word phase spans the whole word. The question is now asked of the TEXT.
+    """
+    session = _SwitchableSession()
+    ctrl = _AccessController(stored=("openrouter", "anthropic"))
+    app = OperatorApp(lambda: _factory(session), provider_controller=ctrl)
+    opens: list[int] = []
+    populate = app._populate_model_picker
+
+    def counted_populate() -> None:
+        opens.append(1)
+        populate()
+
+    app._populate_model_picker = counted_populate  # type: ignore[method-assign]
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _await_session(app, pilot)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        await pilot.press("slash", "m", "o", "d", "e", "l", "space")
+        for _ in range(4):
+            await pilot.pause()
+        assert editor.model_picker.is_open()
+        assert len(opens) == 1, opens
+        await pilot.press("escape")
+        for _ in range(4):
+            await pilot.pause()
+        assert not editor.model_picker.is_open()
+        # The reported gesture: a caret-only round trip over the space.
+        await pilot.press("left")
+        await pilot.pause()
+        await pilot.press("right")
+        for _ in range(4):
+            await pilot.pause()
+        assert not editor.model_picker.is_open(), editor.text
+        # …and it did not re-announce: no second fill, no second notice.
+        assert len(opens) == 1, opens
+        assert editor.text == "/model ", editor.text
+        transcript = app.query_one(TranscriptView)
+        notices = [b for b in transcript.blocks() if isinstance(b, NoticeBlock)]
+        assert len(notices) == 1, [n.text() for n in notices]
+        # Typing still expires the dismissal — the latch holds an Esc, it does
+        # not disable the list.
+        await pilot.press("o")
+        for _ in range(4):
+            await pilot.pause()
+        assert editor.model_picker.is_open()
+
+
+@pytest.mark.asyncio
+async def test_leaving_the_model_command_entirely_does_expire_the_escape() -> None:
+    """The control for R10: the latch must still expire, or an Esc would follow
+    the user into their next `/model` and the list would never come back."""
+    session = _SwitchableSession()
+    ctrl = _AccessController(stored=("openrouter", "anthropic"))
+    app = OperatorApp(lambda: _factory(session), provider_controller=ctrl)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _await_session(app, pilot)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        await pilot.press("slash", "m", "o", "d", "e", "l", "space")
+        for _ in range(4):
+            await pilot.pause()
+        await pilot.press("escape")
+        for _ in range(3):
+            await pilot.pause()
+        assert not editor.model_picker.is_open()
+        # The buffer no longer holds a model token at all.
+        editor.clear_content()
+        await pilot.pause()
+        await pilot.press("slash", "m", "o", "d", "e", "l", "space")
+        for _ in range(4):
+            await pilot.pause()
+        assert editor.model_picker.is_open(), editor.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("surface", ["model", "command"])
+async def test_tab_after_an_escape_does_not_type_into_the_query(surface: str) -> None:
+    """U13: a completion key with a latched Esc is a no-op, not a literal tab.
+
+    Esc hides the list but leaves the token in the buffer, so the open-list
+    branches did not run and Tab fell through to ``TextArea``: `/model ` became
+    `/model  ` and `/mod` became `/mod    `, silently corrupting the very word
+    the user had dismissed a list over. Both pickers had it and both are fixed
+    the same way, which is why this is parametrised rather than duplicated.
+    """
+    session = _SwitchableSession()
+    ctrl = _AccessController(stored=("openrouter", "anthropic"))
+    app = OperatorApp(lambda: _factory(session), provider_controller=ctrl)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _await_session(app, pilot)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        if surface == "model":
+            await pilot.press("slash", "m", "o", "d", "e", "l", "space")
+            picker = editor.model_picker
+            expected = "/model "
+        else:
+            await pilot.press("slash", "m", "o", "d")
+            picker = editor.picker
+            expected = "/mod"
+        for _ in range(4):
+            await pilot.pause()
+        assert picker.is_open()
+        await pilot.press("escape")
+        for _ in range(4):
+            await pilot.pause()
+        assert not picker.is_open()
+        for press in range(2):
+            await pilot.press("tab")
+            for _ in range(4):
+                await pilot.pause()
+            # The buffer survives EXACTLY as typed, on every press: the second
+            # Tab is what used to "work", by completing against a query the
+            # first press had corrupted.
+            assert editor.text == expected, (press, editor.text)
+
+
+@pytest.mark.asyncio
+async def test_the_hint_dedupe_guard_sees_past_a_pinned_working_line() -> None:
+    """R12: the guard reads the last block a caller appended, not the pin.
+
+    A turn in flight pins its working line to the bottom of the transcript and
+    every later append lands BEFORE it, so a guard reading ``blocks()[-1]``
+    matched the working line and never the hint — the deduplication silently
+    stopped applying in exactly the state where re-opening the list mid-turn
+    would stack copies.
+    """
+    session = _SwitchableSession()
+    ctrl = _AccessController(stored=("openrouter", "anthropic"))
+    app = OperatorApp(lambda: _factory(session), provider_controller=ctrl)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _await_session(app, pilot)
+        editor = app.query_one(Editor)
+        editor.focus()
+        await pilot.pause()
+        transcript = app.query_one(TranscriptView)
+        # Pin a working line the way a live turn does, so the hint cannot be
+        # the ledger's last block.
+        working = NoticeBlock("working…", "info")
+        app._append_block(working, pin_tail=True)
+        for _ in range(3):
+            await pilot.pause()
+        assert transcript.pinned_tail() is working
+        for cycle in range(1, 4):
+            await pilot.press("slash", "m", "o", "d", "e", "l", "space")
+            for _ in range(4):
+                await pilot.pause()
+            await pilot.press("escape")
+            for _ in range(3):
+                await pilot.pause()
+            editor.clear_content()
+            await pilot.pause()
+        blocks = transcript.blocks()
+        hints = [
+            b for b in blocks if isinstance(b, NoticeBlock) and PERSIST_HINT in (b.text() or "")
+        ]
+        assert len(hints) == 1, [h.text() for h in hints]
+        # The pin really was in the way: the hint is not the last block, which
+        # is the condition the old guard could not see past.
+        assert blocks[-1] is working
+        assert blocks[-1] is not hints[0]
 
 
 @pytest.mark.asyncio
@@ -8800,7 +8976,7 @@ _MODEL_DEFAULT_KEYS = {" ": "space", "/": "slash", "-": "minus"}
 
 
 @pytest.mark.asyncio
-async def test_typing_model_default_letter_by_letter_is_not_eaten_by_the_d_key(
+async def test_typing_model_default_letter_by_letter_reaches_the_command(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """UX round 1, U8 (QA Q4): the advertised command, typed rather than pasted.
@@ -8921,6 +9097,132 @@ async def test_model_default_and_saved_in_other_setup_variants_fall_to_the_guard
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("variant", ["no_hosting", "unknown_hosting"])
+async def test_the_model_notice_in_dead_end_setup_variants_names_only_settings(
+    variant: str,
+) -> None:
+    """U12: do not advertise a route that cannot work from where the user is.
+
+    In the no-hosting and unknown-hosting variants EVERY `/model` route refuses
+    with `session is still starting…` (pinned one test above), yet the notice
+    the list prints still led with `/model default …`. `/settings` is the route
+    that actually resolves there, so it is the only one named. The no-model
+    variant is unaffected — it has a real `/model` escape — which the test
+    below this one holds.
+    """
+    from local_operator.session_factory import (
+        HostingNotConfiguredError,
+        HostingUnknownError,
+    )
+
+    async def _no_hosting_factory():
+        raise HostingNotConfiguredError("Hosting platform is not configured.")
+
+    async def _bad_hosting_factory():
+        raise HostingUnknownError("…not a known provider.", "anthropicxyq")
+
+    factory = _no_hosting_factory if variant == "no_hosting" else _bad_hosting_factory
+    app = OperatorApp(factory, provider_controller=FakeProviderController())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _await_setup_state(app, pilot)
+        assert app._model_missing_for is None
+        app._run_slash_command("/model")
+        for _ in range(4):
+            await pilot.pause()
+        notices = [b.text() or "" for b in app.query(NoticeBlock)]
+        footer = app.query_one(Editor).model_picker.render_text(98).plain
+    hint = next((n for n in notices if _unwrapped("/settings") in _unwrapped(n)), "")
+    assert hint, notices
+    # The dead ends are not named…
+    assert _unwrapped(PERSIST_HINT) not in _unwrapped(hint), hint
+    assert _unwrapped("/model saved") not in _unwrapped(hint), hint
+    # …and the route that works is.
+    assert _unwrapped("/settings edits the boot default") in _unwrapped(hint), hint
+    # THE FOOTER TOO. It is a second surface printing the same instruction, so
+    # fixing only the notice moves the trap one row down rather than closing it
+    # (the U12 before/after frames show exactly that intermediate state).
+    assert PERSIST_HINT not in footer, footer
+
+
+@pytest.mark.asyncio
+async def test_the_no_model_setup_variant_still_names_its_working_model_route(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The other half of U12: the variant that DOES have a `/model` escape keeps
+    it. `_cmd_model` writes config and boots when `_model_missing_for` is set,
+    so `/model default` is live advice here and must not be stripped with the
+    genuinely dead routes."""
+    from local_operator.session_factory import ModelNotConfiguredError
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "config.yml").write_text("version: 0.0.0\nvalues:\n  hosting: openrouter\n")
+
+    async def _no_model_factory():
+        raise ModelNotConfiguredError("no model for openrouter", hosting="openrouter")
+
+    ctrl = _AccessController(stored=("openrouter", "anthropic"))
+    app = OperatorApp(_no_model_factory, provider_controller=ctrl)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _await_setup_state(app, pilot)
+        assert app._model_missing_for == "openrouter"
+        app._run_slash_command("/model")
+        for _ in range(4):
+            await pilot.pause()
+        notices = [b.text() or "" for b in app.query(NoticeBlock)]
+        footer = app.query_one(Editor).model_picker.render_text(98).plain
+    hints = [n for n in notices if _unwrapped(PERSIST_HINT) in _unwrapped(n)]
+    assert len(hints) == 1, notices
+    assert _unwrapped("/settings") in _unwrapped(hints[0]), hints[0]
+    # The footer keeps it here for the same reason the notice does: this is the
+    # variant whose `/model` escape actually writes config and boots.
+    assert PERSIST_HINT in footer, footer
+
+
+def test_the_bare_model_notice_does_not_orphan_a_route_token() -> None:
+    """D8: no rendered width may leave a command name alone on the last row.
+
+    The finding was measured at 80 and 100 columns for ONE model label, but the
+    row length varies with the label, so a single measurement proves nothing —
+    this asserts over the labels a real catalogue produces (short `xai/grok-4`
+    through long dated Anthropic ids) at the three widths the block renders at.
+    Body budgets come from ``NoticeBlock.body_budget`` rather than being
+    hardcoded, so a change to the block's own fold re-measures instead of
+    silently invalidating the numbers.
+    """
+    from local_operator.tui.widgets.transcript import NoticeBlock, wrap_cells
+
+    labels = [
+        "xai/grok-4",
+        "openai/gpt-5",
+        "radient/auto",
+        "ollama/qwen3:8b",
+        "openai/gpt-5-codex",
+        "anthropic/claude-opus-5",
+        "openrouter/deepseek/deepseek-chat",
+        "openrouter/moonshotai/kimi-k2-0905",
+        "anthropic/claude-sonnet-4-5-20250929",
+    ]
+    # The three terminal widths the design rounds measure at. The block is
+    # narrower than the terminal (transcript padding + the hanging glyph field),
+    # which is exactly what `body_budget` accounts for.
+    block_widths = {80: 76, 100: 75, 120: 82}
+
+    routes = (
+        f"{PERSIST_HINT} · /settings edits the boot default too" " · /model saved reverts to it"
+    )
+    for label in labels:
+        for cols, block_width in block_widths.items():
+            body = NoticeBlock.body_budget(block_width)
+            rows = wrap_cells(f"model: {label} — {routes}", body)
+            if len(rows) == 1:
+                continue
+            last = rows[-1].split()
+            assert len(last) > 1, (cols, label, rows)
+            # The specific shape D8 reported: the command name alone.
+            assert rows[-1].strip() != "/settings", (cols, label, rows)
+
+
+@pytest.mark.asyncio
 async def test_every_model_default_surface_says_it_the_same_way() -> None:
     """D14. One instruction had four wordings on four surfaces a user meets
     within two keystrokes. The canonical sentence now names the consequence —
@@ -8929,6 +9231,16 @@ async def test_every_model_default_surface_says_it_the_same_way() -> None:
     The defect is the divergence, so all four surfaces are checked together.
     The footer is checked unwrapped and whole because it is the tightest site:
     an instruction that is consistent only after truncation is not consistent.
+
+    THE `/help` ROW IS THE ONE DOCUMENTED EXCEPTION (design review round 3,
+    D7). It carries the same COMMAND and the same consequence, but not the
+    same sentence: reusing ``PERSIST_HINT`` verbatim there needed a ≤12-cell
+    lead to stay inside the 55-cell description column, and every such lead was
+    a fragment (`Switch;`, `Pick one;`). ``PERSIST_HINT``'s exact length is set
+    by the picker footer's 43-cell budget, which is not a constraint `/help`
+    shares, so the row gets its own carrier and this test asserts the invariant
+    that actually matters — one command, one consequence, no second paraphrase
+    of what is being saved.
     """
     session = _SwitchableSession()
     ctrl = _AccessController(stored=("openrouter", "anthropic"))
@@ -8953,9 +9265,14 @@ async def test_every_model_default_surface_says_it_the_same_way() -> None:
     assert _unwrapped(PERSIST_HINT) in _unwrapped(bare_notice), bare_notice
     assert _unwrapped(PERSIST_HINT) in _unwrapped(receipt), receipt
     assert PERSIST_HINT in footer, footer
-    assert _unwrapped(PERSIST_HINT) in _unwrapped(help_text), help_text
     model_row = next(c for c in SLASH_COMMANDS if c.name == "model")
-    assert PERSIST_HINT in model_row.description, model_row.description
+    # `/help` names the same command and the same consequence in its own words
+    # (see the docstring): the command verbatim, and "for new sessions" — the
+    # consequence D14 was raised to make every surface state.
+    assert PERSIST_HINT_PREFIX in model_row.description, model_row.description
+    assert "for new sessions" in model_row.description, model_row.description
+    assert _unwrapped(PERSIST_HINT_PREFIX) in _unwrapped(help_text), help_text
+    assert _unwrapped("for new sessions") in _unwrapped(help_text), help_text
 
     # And the four it replaced are gone from all of them, so there is no second
     # phrasing left for the user to meet.
@@ -10761,6 +11078,47 @@ async def test_help_documents_the_composer_copy_key_and_its_release() -> None:
         # round 2, F3).
         for row in (rows[index], release):
             assert len(row) <= 74, f"{row!r} is {len(row)} cells and wraps at 80 columns"
+
+
+@pytest.mark.asyncio
+async def test_the_help_model_row_is_a_sentence_and_still_fits_at_80() -> None:
+    """D7: the `/model` row's lead was the fragment `Switch;`.
+
+    Round 1 (D2) shortened the lead because `Switch model; ` + PERSIST_HINT
+    verbatim measured 56 description cells and orphaned "sessions" on its own
+    line. `Switch;` fitted but read as a broken sentence beside its neighbours,
+    which all have an object. The fix is a `/help`-SPECIFIC carrier rather than
+    reusing the picker's footer hint, whose 42-cell length is set by a 43-cell
+    footer budget this row does not share.
+
+    Both halves are asserted, because either alone is satisfiable by the defect
+    the other names: a whole row that is a fragment, or a sentence that wraps.
+    """
+    from rich.console import Group
+    from rich.padding import Padding
+    from rich.text import Text
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        padding = cast(Padding, app._help_block().renderable)
+        group = cast(Group, padding.renderable)
+        rows = [cast(Text, row).plain for row in group.renderables]
+
+    row = next(r for r in rows if r.startswith("/model, /models"))
+    description = row[len("/model, /models") :].strip()
+    # A SENTENCE: the verb has an object, the way `/theme`'s row does.
+    assert description.startswith("Switch model"), row
+    assert not description.startswith("Switch;"), row
+    # It still names the command that persists — that is what the row is for.
+    assert "/model default" in description, row
+    # The same measured 74-cell ceiling the copy/paste rows carry: one more
+    # cell wraps at 80 columns and the tail lands in the name gutter.
+    assert len(row) <= 74, f"{row!r} is {len(row)} cells and wraps at 80 columns"
+    # And the description column itself must not wrap: the two-column table
+    # folds a description past ~55 cells regardless of the row total, which is
+    # the orphan D2 fixed and D7 must not reintroduce.
+    assert len(description) <= 55, f"{description!r} is {len(description)} cells"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_model_picker.py
+++ b/tests/unit/tui/test_model_picker.py
@@ -8,12 +8,15 @@ list that is longer than the window without saying so.
 
 from __future__ import annotations
 
+import inspect
+
 import pytest
 from rich.cells import cell_len
 from textual.app import App, ComposeResult
 
 from local_operator.tui.widgets.command_picker import slash_argument
 from local_operator.tui.widgets.model_picker import (
+    _PERSIST_KEYWORDS,
     MAX_VISIBLE_ROWS,
     PERSIST_HINT_PREFIX,
     ModelPicker,
@@ -575,6 +578,61 @@ def test_an_empty_result_says_so_rather_than_rendering_nothing() -> None:
     picker.set_rows(_rows())
     picker.open("zzzznope")
     assert "no matching models" in picker.render_text(90).plain
+
+
+@pytest.mark.parametrize("keyword", sorted(_PERSIST_KEYWORDS))
+def test_a_command_keyword_is_not_reported_as_a_failed_search(keyword: str) -> None:
+    """U3: the empty state must not contradict the hint one row below it.
+
+    `/model default` is what the footer advertises, and typing it narrowed the
+    catalogue to `no matching models` — the list calling its own instruction a
+    dead end. No row can ever be named `default` or `saved`: they are command
+    words `_cmd_model` consumes before any ranking happens, so an empty list is
+    the correct state for them, not a report about the catalogue.
+    """
+    picker = ModelPicker(lambda row: None)
+    picker.set_rows(_rows())
+    picker.open(keyword)
+    plain = picker.render_text(90).plain
+    assert "no matching models" not in plain, plain
+    assert f"{keyword} is a command, not a model" in plain, plain
+    # The protected hint row still renders: the two rows must not be traded off
+    # against each other, since together they are the whole explanation.
+    picker.set_rows(_rows(), status=_PERSIST_CLAUSE)
+    assert PERSIST_HINT_PREFIX in picker.render_text(90).plain
+
+
+def test_a_keyword_with_a_selector_after_it_is_still_an_ordinary_search() -> None:
+    """The keyword branch is EXACT, not a prefix.
+
+    `/model default anthropic/claude-opus-5` is a selector being typed: it has
+    no matches until it resolves, and reporting "default is a command" there
+    would describe the wrong half of what the user wrote.
+    """
+    picker = ModelPicker(lambda row: None)
+    picker.set_rows(_rows())
+    picker.open("default zzzznope")
+    plain = picker.render_text(90).plain
+    assert "no matching models" in plain, plain
+    assert "is a command, not a model" not in plain, plain
+
+
+def test_persist_keywords_match_the_words_the_command_actually_consumes() -> None:
+    """The widget cannot import ``app`` (``app`` imports it), so the keyword set
+    is a copy — and a copy is only safe while something asserts it is current.
+
+    Mirrors ``test_persist_hint_prefix_matches_app``: both guard a constant this
+    module holds because of the import direction, not because the vocabulary is
+    the picker's to define.
+    """
+    from local_operator.tui import app as app_mod
+
+    source = inspect.getsource(app_mod.OperatorApp._cmd_model)
+    for keyword in _PERSIST_KEYWORDS:
+        # The handler dispatches on the lowered argument; each keyword must
+        # appear as a literal it compares against, or the picker is describing
+        # a command that no longer exists.
+        assert f'"{keyword}"' in source, keyword
 
 
 # -- the buffer parse that drives it -----------------------------------------

--- a/tests/unit/tui/test_model_picker.py
+++ b/tests/unit/tui/test_model_picker.py
@@ -595,7 +595,7 @@ def test_a_command_keyword_is_not_reported_as_a_failed_search(keyword: str) -> N
     picker.open(keyword)
     plain = picker.render_text(90).plain
     assert "no matching models" not in plain, plain
-    assert f"{keyword} is a command, not a model" in plain, plain
+    assert f"{keyword} is a command — enter runs it" in plain, plain
     # The protected hint row still renders: the two rows must not be traded off
     # against each other, since together they are the whole explanation.
     picker.set_rows(_rows(), status=_PERSIST_CLAUSE)
@@ -614,7 +614,70 @@ def test_a_keyword_with_a_selector_after_it_is_still_an_ordinary_search() -> Non
     picker.open("default zzzznope")
     plain = picker.render_text(90).plain
     assert "no matching models" in plain, plain
-    assert "is a command, not a model" not in plain, plain
+    assert "is a command" not in plain, plain
+
+
+@pytest.mark.parametrize("keyword", sorted(_PERSIST_KEYWORDS))
+def test_no_prefix_of_a_keyword_reports_a_failed_search(keyword: str) -> None:
+    """U1: U3's contradiction must not be reachable on the way to the word.
+
+    The exact-match test fixed the settled state only. Typing `/model default`
+    one character at a time printed `no matching models` directly above a
+    footer advertising that exact phrase for four consecutive keystrokes,
+    resolving only on the final `t` — the same pairing U3 was filed against,
+    still reachable by the user who types deliberately rather than at speed.
+
+    Asserted over every prefix that actually EMPTIES the list, which is the
+    only place the defect can appear: a short prefix like `d` still ranks real
+    models (`deepseek…`), and a list with rows in it is an ordinary search, not
+    a contradiction. The empty ones are `defau`+ and `sav`+ against this
+    fixture, and they are found rather than hardcoded so a fixture change
+    cannot quietly empty the matrix.
+    """
+    picker = ModelPicker(lambda row: None)
+    checked = 0
+    for stop in range(1, len(keyword)):
+        prefix = keyword[:stop]
+        picker.set_rows(_rows())
+        picker.open(prefix)
+        if picker.suggestions():
+            continue  # still a real search: the empty state is not reached
+        checked += 1
+        plain = picker.render_text(90).plain
+        assert "no matching models" not in plain, (prefix, plain)
+        # Named, and in the settled row's own shape, so the row does not change
+        # its subject on the keystroke that completes the word.
+        assert f"{keyword} is a command" in plain, (prefix, plain)
+        # The promise `enter runs it` is NOT made while the word is partial:
+        # Enter there is an ordinary failed search, not the command.
+        assert "enter runs it" not in plain, (prefix, plain)
+    assert checked, f"no empty-list prefix of {keyword!r} was exercised"
+
+
+def test_the_keyword_row_fits_the_narrow_footer() -> None:
+    """D2: the row must survive whole at the width where it matters most.
+
+    The first version read `default is a command, not a model — enter runs it`
+    at 49 cells against a 47-cell budget at 50 columns, so it truncated to
+    `…not a model — enter…` — cutting the actionable half and leaving only the
+    negative clause. ``PERSIST_HINT`` is held to 42 cells for exactly this
+    budget; this row is on the same surface and is held to the same one.
+    """
+    from local_operator.tui.widgets.model_picker import (
+        _EDGE_MARGIN,
+        _GUTTER_CELLS,
+        _keyword_row,
+    )
+
+    budget = 50 - _GUTTER_CELLS - _EDGE_MARGIN
+    for keyword in sorted(_PERSIST_KEYWORDS):
+        assert cell_len(_keyword_row(keyword)) <= budget, keyword
+        # And it really does render whole, not merely measure short.
+        picker = ModelPicker(lambda row: None)
+        picker.set_rows(_rows())
+        picker.open(keyword)
+        assert "…" not in picker.render_text(50).plain, keyword
+        assert "enter runs it" in picker.render_text(50).plain, keyword
 
 
 def test_persist_keywords_match_the_words_the_command_actually_consumes() -> None:
@@ -624,15 +687,36 @@ def test_persist_keywords_match_the_words_the_command_actually_consumes() -> Non
     Mirrors ``test_persist_hint_prefix_matches_app``: both guard a constant this
     module holds because of the import direction, not because the vocabulary is
     the picker's to define.
+
+    PINS THE DISPATCH, NOT THE PROSE (code review round 1, R5). This asserted
+    `f'"{keyword}"' in inspect.getsource(_cmd_model)`, and `getsource` returns
+    the comments and docstring too — `_cmd_model` is heavily commented about
+    both words, so deleting the `if lowered == "saved":` dispatch entirely left
+    the test green while the picker went on advertising a command that no
+    longer existed. Matching only executable lines is what makes the guard real:
+    the comments that mention these words are stripped before the search, so
+    the assertion can only be satisfied by code.
     """
+    import ast
+    import textwrap
+
     from local_operator.tui import app as app_mod
 
-    source = inspect.getsource(app_mod.OperatorApp._cmd_model)
+    source = textwrap.dedent(inspect.getsource(app_mod.OperatorApp._cmd_model))
+    function = ast.parse(source).body[0]
+    assert isinstance(function, (ast.FunctionDef, ast.AsyncFunctionDef)), function
+    # Comments are not in the AST at all, and the docstring is the one string
+    # node to drop explicitly — what remains is the code's own literals.
+    literals = {
+        node.value
+        for node in ast.walk(function)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    }
+    literals.discard(ast.get_docstring(function))
     for keyword in _PERSIST_KEYWORDS:
-        # The handler dispatches on the lowered argument; each keyword must
-        # appear as a literal it compares against, or the picker is describing
-        # a command that no longer exists.
-        assert f'"{keyword}"' in source, keyword
+        # The handler dispatches on the lowered argument, so each keyword must
+        # survive as a string literal the CODE compares against.
+        assert keyword in literals, (keyword, sorted(literals))
 
 
 # -- the buffer parse that drives it -----------------------------------------

--- a/tests/unit/tui/test_model_picker.py
+++ b/tests/unit/tui/test_model_picker.py
@@ -662,22 +662,40 @@ def test_the_keyword_row_fits_the_narrow_footer() -> None:
     `…not a model — enter…` — cutting the actionable half and leaving only the
     negative clause. ``PERSIST_HINT`` is held to 42 cells for exactly this
     budget; this row is on the same surface and is held to the same one.
+
+    BOTH rows are measured (code review round 2, R17). U1 made this empty state
+    two rows — the settled `enter runs it` and the partial `keep typing` — and
+    only the one with a helper had a ceiling, so the row a user sees while
+    typing was unpinned. It fits today; the point is that it cannot stop
+    fitting silently.
     """
     from local_operator.tui.widgets.model_picker import (
         _EDGE_MARGIN,
         _GUTTER_CELLS,
         _keyword_row,
+        _partial_keyword_row,
     )
 
     budget = 50 - _GUTTER_CELLS - _EDGE_MARGIN
     for keyword in sorted(_PERSIST_KEYWORDS):
         assert cell_len(_keyword_row(keyword)) <= budget, keyword
+        assert cell_len(_partial_keyword_row(keyword)) <= budget, keyword
         # And it really does render whole, not merely measure short.
         picker = ModelPicker(lambda row: None)
         picker.set_rows(_rows())
         picker.open(keyword)
         assert "…" not in picker.render_text(50).plain, keyword
         assert "enter runs it" in picker.render_text(50).plain, keyword
+
+    # The partial row through the real render, at the same floor: a prefix that
+    # names one keyword but is not yet the whole word.
+    for prefix in ("defaul", "sav"):
+        picker = ModelPicker(lambda row: None)
+        picker.set_rows(_rows())
+        picker.open(prefix)
+        plain = picker.render_text(50).plain
+        assert "…" not in plain, prefix
+        assert "keep typing" in plain, prefix
 
 
 def test_persist_keywords_match_the_words_the_command_actually_consumes() -> None:
@@ -688,14 +706,21 @@ def test_persist_keywords_match_the_words_the_command_actually_consumes() -> Non
     module holds because of the import direction, not because the vocabulary is
     the picker's to define.
 
-    PINS THE DISPATCH, NOT THE PROSE (code review round 1, R5). This asserted
-    `f'"{keyword}"' in inspect.getsource(_cmd_model)`, and `getsource` returns
-    the comments and docstring too — `_cmd_model` is heavily commented about
-    both words, so deleting the `if lowered == "saved":` dispatch entirely left
-    the test green while the picker went on advertising a command that no
-    longer existed. Matching only executable lines is what makes the guard real:
-    the comments that mention these words are stripped before the search, so
-    the assertion can only be satisfied by code.
+    PINS THE DISPATCH, NOT THE PROSE (code review round 1, R5; corrected in
+    round 2, R15). This asserted `f'"{keyword}"' in inspect.getsource(...)`,
+    and `getsource` returns the comments and docstring too. The original
+    justification claimed deleting the `if lowered == "saved":` dispatch left
+    that guard green; it did not, and the mutant was run to check. On THIS
+    function every prose mention of the two words is bare or backticked, so the
+    only DOUBLE-QUOTED occurrences are the two dispatch lines themselves —
+    which is why the old guard happened to fail on that mutant.
+
+    The weaker true claim is the reason to keep the AST form: the old guard was
+    satisfiable by prose in principle, and stayed correct only by the accident
+    of how these comments are punctuated. Rewording one comment to double-quote
+    the word would have made it green on a deleted dispatch, with nothing to
+    say so. Matching executable literals removes the accident: comments are not
+    in the AST at all, so the assertion can only be satisfied by code.
     """
     import ast
     import textwrap
@@ -712,7 +737,12 @@ def test_persist_keywords_match_the_words_the_command_actually_consumes() -> Non
         for node in ast.walk(function)
         if isinstance(node, ast.Constant) and isinstance(node.value, str)
     }
-    literals.discard(ast.get_docstring(function))
+    # `clean=False` is load-bearing (round 2, R16): `ast.get_docstring` defaults
+    # to running `inspect.cleandoc`, so it returns a DEDENTED string that never
+    # equals the raw `ast.Constant` still sitting in the set — the discard was a
+    # silent no-op, leaving a guard whose whole purpose is to be unsatisfiable
+    # by prose satisfiable by this function's own docstring.
+    literals.discard(ast.get_docstring(function, clean=False))
     for keyword in _PERSIST_KEYWORDS:
         # The handler dispatches on the lowered argument, so each keyword must
         # survive as a string literal the CODE compares against.


### PR DESCRIPTION
## Summary of Changes

The nine follow-ups deferred from PR #625's review rounds (`Closes #641`). All were logged as minor/nit and verified pre-existing or out of scope for a UX correction to `/model default`. No version bump — `pyproject.toml` stays at 0.48.0.

Two of them turned out to have a second half the issue did not name, and both are fixed here rather than left as a trap one surface over:

- **U12** — the issue asks for the *notice* to stop advertising dead routes in the no-hosting/unknown-hosting setup variants. The picker **footer** prints the same instruction from a different call path, so fixing only the notice moves the trap one row down. The before/after `deadend` frames show exactly that: on `before`, `/model default` appears twice in a state where no `/model` route resolves.
- **D7** — giving `/help` its own hint carrier breaks the invariant `test_every_model_default_surface_says_it_the_same_way` (D14) was written to hold: one wording on every surface. That test is updated, not deleted — it now pins the invariant that survives (one command, one consequence, no second paraphrase of *what* is saved) and documents `/help` as the exception with the measurement behind it.

## Per-finding table

| Finding | Change | Test |
| --- | --- | --- |
| **R10** (minor) | The dismissal latch was caret-anchored. `slash_argument` excludes the word-terminating space from the argument span, so on `/model ` a single `←` parked the caret outside the argument, read as *leaving the command*, and cleared the latch; `→` then reopened and re-announced the list. The leave edge now asks the **text** (`Editor._text_holds_model_token`, which re-asks the ordinary parse at each line end rather than matching strings, so it inherits the inline/CRLF/nested-slash rules). | `test_a_caret_move_does_not_expire_an_escaped_model_list` + control `test_leaving_the_model_command_entirely_does_expire_the_escape` |
| **R12** (nit) | Made the guard **actually reach**, rather than narrowing the comment to match the defect. A pinned working line sits last during a turn and every mid-turn append lands *before* it, so `blocks()[-1]` could never match the hint then. `TranscriptView.pinned_tail()` exposes the pin; the guard skips exactly that one occupant. Cheap (one comparison) and it makes the docstring true in both states. | `test_the_hint_dedupe_guard_sees_past_a_pinned_working_line` |
| **D7** (nit) | `/help` gets its own carrier: `Switch model; /model default saves it for new sessions`. `PERSIST_HINT`'s 42-cell length is set by the picker footer's 43-cell budget — a constraint `/help` does not share, and the reason every ≤12-cell lead that kept it verbatim was a fragment. **54** description cells (under the ~55-cell fold) and **74** row cells — which is *exactly* the measured 74-cell ceiling, not one under it (QA round 1, Q2; the earlier "73" here was wrong). The zero margin is accepted deliberately: the ceiling is the width at which the row wraps at 80 columns, 74 renders whole, and the ceiling is pinned by an assertion, so the next edit that adds a character fails the test rather than silently wrapping. | `test_the_help_model_row_is_a_sentence_and_still_fits_at_80` (asserts both halves: sentence *and* width) |
| **D10** (nit) | The setup-state sentence no longer ends on an `it` with no antecedent: the `/settings` clause carries the noun (`/settings edits the boot default too`). | Covered by the two setup-variant tests below |
| **D8** (nit) | The `/settings` clause moved to the **middle** and carries the noun, so the sentence ends on `reverts to it` — a three-word tail that cannot orphan a command name. | `test_the_bare_model_notice_does_not_orphan_a_route_token` |
| **U3** (minor) | `default` and `saved` are command words `_cmd_model` consumes, never selectors, so an empty list is their *correct* state, not a failed search. The row now reads `default is a command, not a model — enter runs it`. Exact-match only: `/model default anthropic/…` is a selector being typed and keeps the ordinary message. | `test_a_command_keyword_is_not_reported_as_a_failed_search`, `test_a_keyword_with_a_selector_after_it_is_still_an_ordinary_search`, `test_persist_keywords_match_the_words_the_command_actually_consumes` |
| **U12** (minor) | Consistent with how #625 handled Enter-on-row: gated on `_model_missing_for`, the same predicate `_cmd_model`'s escape uses, so "the UI offers it" and "the command performs it" cannot drift. In the no-hosting/unknown-hosting variants **neither** the notice nor the footer names a `/model` route; `/settings` is named instead and the splash's `/login` stays the primary step. The no-model variant is untouched — its `/model` escape really does write config and boot. | `test_the_model_notice_in_dead_end_setup_variants_names_only_settings` (notice **and** footer) + control `test_the_no_model_setup_variant_still_names_its_working_model_route` |
| **U13** (nit) | Shared fix, both pickers. Esc hides the list but leaves the token in the buffer, so the open-list branches did not run and Tab fell through to `TextArea`: `/model ` → `/model  `, `/mod` → `/mod    `. The key is consumed as a no-op — the same discipline the loading-reserve branch already applies. **Tab only**: Enter still submits, because a typed selector with the list dismissed is a complete command. | `test_tab_after_an_escape_does_not_type_into_the_query[model]` and `[command]` |
| **R13** | Renamed to `test_typing_model_default_letter_by_letter_reaches_the_command`. | — (rename; no references elsewhere) |

`README.md`'s `/model` row is updated to the new wording so the docs do not carry a fifth paraphrase.

## Reproductions, before the fix

A pilot probe driving the real `Editor` through the exact reported gestures, on `origin/main` `f4e9613a9`:

```
R10 model : after Esc,left,right -> open=True  total_opens=2 text='/model '     <- reopened + re-announced
R10 command: after Esc,left,right -> open=False               text='/mod'       <- reference behaviour
U13 model  : Esc then Tab -> text='/model  '  open=True                          <- literal space inserted
U13 model  : second Tab   -> text='/model openrouter/deepseek/deepseek-chat'
U13 command: Esc then Tab -> text='/mod '     open=False                         <- same bug
```

On this branch, all four gestures leave the buffer exactly as typed:

```
R10 model : after Esc,left,right -> open=False total_opens=1 text='/model '
R10 command: after Esc,left,right -> open=False              text='/mod'
U13 model  : Esc then Tab -> text='/model ' open=False   |  second Tab -> text='/model '
U13 command: Esc then Tab -> text='/mod'    open=False   |  second Tab -> text='/mod'
```

Every new test was also confirmed to **fail without its fix** (AGENTS.md §"Prove the test can still fail") by reverting each hunk in isolation:

```
R10 reverted  -> 1 failed
U13 reverted  -> 2 failed
R12 reverted  -> 1 failed
U3  reverted  -> 2 failed
D8  (old copy) -> 1 failed: assert 1 > 1   [last row was the lone token '/settings']
```

## D8: the measurement, not a spot check

The finding was measured at 80/100 for one label, but row length varies with the model label, so a single measurement proves nothing. Over 9 representative labels (`xai/grok-4` … `anthropic/claude-sonnet-4-5-20250929`) at the three rendered body widths, the shipped copy has **zero** lone-token last rows.

**Corrected in round 2 (QA Q4/Q5).** An earlier revision of this section claimed `/settings` "is never the final token at **any** body width from 38 to 90". That is false and the docstring already retracted it; the body now agrees. `/settings` never ends the **last** row — that half is true and is what D8 was about — but it ends a folded, **non-final** row in 58 combinations across 27 widths for the ordinary variant (162 across all three), measured through `NoticeBlock.body_budget`. A clause that continues on the next row is not the defect; a command the reader must re-join two rows to recover is.

**The width family matters (QA Q3).** `NoticeBlock` renders at two: **pristine** (block widths 76/75/82 at 80/100/120 columns) and, once the transcript holds any content, **`cols − 4`** (76/96/116). The hint is normally read at the second, because a user meets it after they have been working. Both are now measured and both are asserted by the test:

| Class | pristine | non-empty |
| --- | --- | --- |
| C1 lone command token on last row | 0 | 0 |
| C2 command name split across the fold | 0 | 3 |
| C3 ordinary word alone on last row | 2 | 1 |

The clean 0 earlier rounds reported holds at the pristine family only. At the non-empty family the honest claim is a comparison, not a clean sheet: the D8 arrangement scores C2 4 / C3 2 pristine and C2 2 / C3 1 non-empty, and sweeping 80–160 columns the two are a wash there, so the pristine improvement is what is actually bought. The residual C3 is a real cost on a real surface, not a rounding error (design D4).

The rejected candidates, same harness (orphan counts at the three widths):

| Candidate | 80 | 100 | 120 |
| --- | --- | --- | --- |
| `… /model saved switches back to the boot default · or set it in /settings` (**#625's, the defect**) | 5 | 4 | 3 |
| `… · or pick one in /settings` (the round-2 suggestion) | 5 | 4 | 1 |
| `… · /settings sets it too` | 1 | 4 | 0 |
| `… · /settings edits the boot default too · /model saved reverts to it` (D8's, superseded) | **0** | **0** | **0** |
| `… · switch to the boot default with /model saved · /settings edits the boot default too` (**shipped**) | **0** | **0** | **0** |

Body budgets come from `NoticeBlock.body_budget` in the test rather than being hardcoded, so a change to the block's own fold re-measures instead of silently invalidating the numbers.

## Testing evidence

Worktree `/private/tmp/lop-641` at `f4e9613a9` with its own editable venv, verified resolving to itself:

```
$ .venv/bin/python -c "import local_operator; print(local_operator.__file__)"
/private/tmp/lop-641/local_operator/__init__.py
```

**Gates, exactly as CI — all green on the head commit:**

```
$ .venv/bin/python -m flake8 .                                    rc=0
$ uvx --from black==26.1.0 black --check .                        917 files would be left unchanged
$ uvx isort==5.13.2 --check .                                     rc=0
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .     0 errors, 0 warnings, 0 informations
```

**e2e — GREEN on CI.** `tui-e2e` passes on **both** legs of the `[ubuntu-latest, macos-latest]` matrix for the remediation head `446d91eb2` — the macOS leg being the one that makes the stage a regression guard, per AGENTS.md.

**Unit suite — the whole tree, green on CI.** The round-1 reviewer flagged the full sweep as outstanding; it has now run. All five `test (3.12, N)` shards pass on `446d91eb2`, which is the whole `tests/unit` tree split across shards — so the deferral recorded here earlier is resolved rather than still outstanding. Locally, the two files this diff touches are green under the instructed `-n 2` cap (`test_model_picker.py` 72 passed, `test_app_pilot.py` 309 passed); a whole-tree local run was also started, but on a host at load average 72 CI's shards are the trustworthy result and they are green.

```
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui -q -n 4
5375 passed, 12 skipped, 8 warnings in 1100.18s (0:18:20)
```

> **Outstanding before merge, stated plainly:**
> 1. `tests/e2e -m e2e -n0` — **pending, deferred under host resource pressure, to be run before merge.**
> 2. The full `tests/unit` sweep — deferred for the same reason; `tests/unit/tui` above covers every file this diff touches, but the whole-tree run is the CI-equivalent gate and has not been performed on this head.
>
> Neither is a waiver. Both must be green before this merges.

All TUI pilot tests unset every inherited `CMUX_*` variable and use an isolated `HOME` + `LOCAL_OPERATOR_CONFIG_DIR`; the shot script and probe do the same before any `local_operator` import (the PR #645 isolation rule).

### Visual evidence

Rendered with `scripts.visual_capture.save_capture` (native 8x17px cells, real `local_operator.tcss`), **both halves produced by the same script against different roots** — `before` = a worktree at `origin/main` `f4e9613a9` resolving to itself, `after` = this branch — so the frames differ only by the code under test. Rasterised and inspected. Frames and their apparatus README are on the orphan branch `evidence/641-model-followups` (`a2d36180f`), not in this PR's tree, per AGENTS.md §"Evidence goes on the PR, never into the repository".

**D7 — the `/help` row.** `Switch;` (70 cells) reads as a fragment beside `Switch color theme; arrows preview live` two rows below it; `Switch model;` (74 cells) is a sentence and still one line at 80 columns.

![help before](https://raw.githubusercontent.com/damianvtran/local-operator/a2d36180fb3dee75e2b7ed4a81ccd7932711a5b6/docs/evidence/model-followups-641/before-help-80x44.png)
![help after](https://raw.githubusercontent.com/damianvtran/local-operator/a2d36180fb3dee75e2b7ed4a81ccd7932711a5b6/docs/evidence/model-followups-641/after-help-80x44.png)

**D8 — the bare `/model` notice at 80.** Last row was the orphaned `set it in /settings`; it is now `reverts to it`.

![notice before 80](https://raw.githubusercontent.com/damianvtran/local-operator/a2d36180fb3dee75e2b7ed4a81ccd7932711a5b6/docs/evidence/model-followups-641/before-notice-80x30.png)
![notice after 80](https://raw.githubusercontent.com/damianvtran/local-operator/a2d36180fb3dee75e2b7ed4a81ccd7932711a5b6/docs/evidence/model-followups-641/after-notice-80x30.png)

At 100 and 120 (120 settles to two rows, no orphan):

![notice after 100](https://raw.githubusercontent.com/damianvtran/local-operator/a2d36180fb3dee75e2b7ed4a81ccd7932711a5b6/docs/evidence/model-followups-641/after-notice-100x30.png)
![notice after 120](https://raw.githubusercontent.com/damianvtran/local-operator/a2d36180fb3dee75e2b7ed4a81ccd7932711a5b6/docs/evidence/model-followups-641/after-notice-120x30.png)

**U3 — `/model default` typed into the picker.** `no matching models` sat directly above a footer advertising that very phrase.

![u3 before](https://raw.githubusercontent.com/damianvtran/local-operator/a2d36180fb3dee75e2b7ed4a81ccd7932711a5b6/docs/evidence/model-followups-641/before-u3-100x30.png)
![u3 after](https://raw.githubusercontent.com/damianvtran/local-operator/a2d36180fb3dee75e2b7ed4a81ccd7932711a5b6/docs/evidence/model-followups-641/after-u3-100x30.png)

**U12 — the unknown-hosting setup variant**, where every `/model` route answers `session is still starting…`. Before, `/model default` is advertised **twice** (notice *and* picker footer); after, both name `/settings` and the splash keeps `/login`.

![deadend before](https://raw.githubusercontent.com/damianvtran/local-operator/a2d36180fb3dee75e2b7ed4a81ccd7932711a5b6/docs/evidence/model-followups-641/before-deadend-100x30.png)
![deadend after](https://raw.githubusercontent.com/damianvtran/local-operator/a2d36180fb3dee75e2b7ed4a81ccd7932711a5b6/docs/evidence/model-followups-641/after-deadend-100x30.png)

**D10/U12 control — the no-model setup variant**, which keeps `/model default` because its escape works, and loses the dangling `it`.

![setup before](https://raw.githubusercontent.com/damianvtran/local-operator/a2d36180fb3dee75e2b7ed4a81ccd7932711a5b6/docs/evidence/model-followups-641/before-setup-100x30.png)
![setup after](https://raw.githubusercontent.com/damianvtran/local-operator/a2d36180fb3dee75e2b7ed4a81ccd7932711a5b6/docs/evidence/model-followups-641/after-setup-100x30.png)

#### Remediation round 1 — re-rendered frames

Three findings changed user-visible copy, so their frames are re-captured on the remediation head. Here `before` is **`9e830ff97`** — the state the review rounds looked at — not `f4e9613a9`.

**D1 / U3 — the two-word command name split across the fold.** On `before`, row 2 ends on the bare token `/model` and row 3 opens `saved reverts to it`, so the command the user must type reads as two unrelated things. This is the frame that shipped as D8's own evidence. `/model saved` now sits at the end of its clause: command-name splits go **5 → 0** over 11 labels × the three rendered widths.

![notice r1 before 100](https://raw.githubusercontent.com/damianvtran/local-operator/3f7883626b748af027d16fbb8bd569fe742d1875/docs/evidence/model-followups-641/r1-before-notice-100x30.png)
![notice r1 after 100](https://raw.githubusercontent.com/damianvtran/local-operator/3f7883626b748af027d16fbb8bd569fe742d1875/docs/evidence/model-followups-641/r1-after-notice-100x30.png)

**D2 — the U3 row truncating at 50 columns.** 49 cells against a 47-cell budget cut the actionable half, leaving only the negative clause; the row is now 36 cells and renders whole.

![u3 r1 before 50](https://raw.githubusercontent.com/damianvtran/local-operator/3f7883626b748af027d16fbb8bd569fe742d1875/docs/evidence/model-followups-641/r1-before-u3-50x30.png)
![u3 r1 after 50](https://raw.githubusercontent.com/damianvtran/local-operator/3f7883626b748af027d16fbb8bd569fe742d1875/docs/evidence/model-followups-641/r1-after-u3-50x30.png)

**U1 — the contradiction on the way to the word.** At `/model defaul`, one keystroke short, `before` shows `no matching models` directly above a footer advertising `/model default`.

![u3 prefix r1 before](https://raw.githubusercontent.com/damianvtran/local-operator/3f7883626b748af027d16fbb8bd569fe742d1875/docs/evidence/model-followups-641/r1-before-u3-prefix-100x30.png)
![u3 prefix r1 after](https://raw.githubusercontent.com/damianvtran/local-operator/3f7883626b748af027d16fbb8bd569fe742d1875/docs/evidence/model-followups-641/r1-after-u3-prefix-100x30.png)

The other two reviewed widths, both clean: [80](https://raw.githubusercontent.com/damianvtran/local-operator/3f7883626b748af027d16fbb8bd569fe742d1875/docs/evidence/model-followups-641/r1-after-notice-80x30.png) · [120](https://raw.githubusercontent.com/damianvtran/local-operator/3f7883626b748af027d16fbb8bd569fe742d1875/docs/evidence/model-followups-641/r1-after-notice-120x30.png). Frames for `/help`, the setup variant and the dead-end variant are **not** re-rendered — the remediation does not touch that copy.

Transcript strings behind the frames, before → after:

```
notice   · model: openrouter/deepseek/deepseek-chat — /model default saves this for new sessions · /model saved switches back to the boot default · or set it in /settings
         · model: openrouter/deepseek/deepseek-chat — /model default saves this for new sessions · switch to the boot default with /model saved · /settings edits the boot default too

u3       · no matching models
         · default is a command — enter runs it        (and `default is a command — keep typing` on every prefix)

setup    · /model default saves this for new sessions · or set it in /settings
         · /model default saves this for new sessions · /settings edits the boot default too

deadend  · /model default saves this for new sessions · or set it in /settings
         · /settings edits the boot default too
```

## Impact / risk / rollback

Copy changes plus three small behavioural gates in `tui/` (one latch predicate, one key branch, one guard walk-back) and one new read-only accessor on `TranscriptView`. No new state, no new dependency, no config or wire change. Rollback is a revert.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended, each confirmed to fail without its fix.
- [x] All new and existing tests pass — **CI green on `446d91eb2`: all 14 checks**, including the five whole-tree `tests/unit` shards and both `tui-e2e` legs.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required (`README.md` row; evidence README on the evidence branch).
- [x] Security considerations are addressed — none apply.
- [x] I have linked all related issues — `Closes #641`.

Closes #641


