### PR TITLE
fix(runtime): detect and complete across viewer/runtime build skew

### DIFF
--- a/docs/design-build-skew.md
+++ b/docs/design-build-skew.md
@@ -1,0 +1,503 @@
+# Design: build-skew detection and completion between viewers and runtimes
+
+Status: proposal (architect). Scope: one PR. No `pyproject.toml` version bump —
+the release owner handles that.
+
+## 1. The problem as found in the code
+
+Since 0.46.0 every fresh `lop` is a **viewer**: the TUI holds a cold
+`RemoteSession` and a separate runtime process
+(`python -m local_operator.session.runtime.process`, spawned from
+`sys.executable` — `local_operator/session/runtime/launch.py:210-211`) owns the
+real `Session`. Two long-lived populations therefore coexist on one host —
+TUIs and runtimes — while `lop-update` replaces the on-disk uv-tool install
+under them, often several times a day. Skew happens in both directions and
+nothing today detects it.
+
+The Sep 5 incident is the concrete shape:
+
+1. TUI (pid 87909) ran in-memory code ≤ v0.46.23, i.e. **pre-#624** (e1db6e8da
+   landed in v0.46.25; `git tag --contains e1db6e8da` starts at v0.46.25).
+2. `/new` built a cold `RemoteSession`; `_engage_runtime_eagerly`
+   (`tui/app.py:8774`) spawned a runtime **from the new on-disk build**
+   (0.48.0), because the spawn resolves `sys.executable` — the uv-tool path —
+   fresh at spawn time.
+3. `/team lopdev <request>` routed to that runtime.
+   `OwnedSessionHandle._team_attach_slash`
+   (`local_operator/session/runtime/owned.py:1817-1891`) attached the team and
+   returned `SlashResult(kind="notice", text="sending to lopdev. manager is
+   coordinating.", data={"type": "team_attached", "request": ...})`.
+4. Since #624 the **viewer** is expected to consume that receipt:
+   `OperatorApp._render_authoritative_slash` (`tui/app.py:14674-14685`) syncs
+   the band and calls `_submit_command_prompt(request, attachments)`. The
+   pre-#624 viewer prints `text` and has no consumer for `data.request`
+   (verified: `git show v0.46.23:local_operator/tui/app.py` — the renderer
+   ends at `if text:`; and v0.46.23's `owned.py` still returned
+   `noop {"type": "team_mutate"}`, so the receipt type was brand new to it).
+5. Result: notice printed, request silently dropped. No user row, no turn.
+
+The generalisation the manager stated is exact: routed slash results that
+carry an **action for the invoker** — today exactly `team_attached` and
+`agent_attached` with a non-empty `request` — fail silently under skew, and
+skew is undetectable from either side today.
+
+There is also a third, quieter shape: **new viewer + pre-#624 runtime**. A
+runtime resident since Sep 4 (there are several on this host; the live records
+under `~/.local-operator/run/mobile/` show protocol 5 daemons started
+Sep 4 18:26 and Sep 4 22:35) returns `noop {"type": "team_mutate"}` for
+`/team <name>`. The current renderer's noop branch (`app.py:14629-14645`)
+handles only `agent_list`, so that command *still* vanishes — the same defect
+shape `tests/unit/tui/test_noop_consumers.py` exists to prevent, reachable
+through the version dimension the audit cannot see.
+
+## 2. Options considered
+
+**Do nothing / document.** Rejected: the failure is silent and this host runs
+~16 resident runtimes plus several TUIs with many releases per day. Skew is
+the steady state, not the edge.
+
+**Bump `PROTOCOL_VERSION` and refuse mismatched peers.** Rejected.
+`types.py:27-49` documents why bumps are reserved for breaking changes: a bump
+makes every older peer *refuse a record it can in fact use*, and it does
+nothing for the TUIs already running — they would simply be unable to attach
+at all. The failure would become loud but the host would be unusable during
+every release window.
+
+**A. Local build-drift detection in the TUI (no protocol change).**
+Snapshot what this process loaded; re-read at the seams that spawn or bind a
+runtime; warn with `/reload` as the remedy.
+
+**B. Runtime-side completion for skewed viewers (backward compatible).**
+The attach auth frame gains an opt-in declaring which action-carrying receipt
+types the client consumes. When a routed result carries a request the
+connected client did not declare, the runtime admits the request itself
+through the same admission path as the `prompt` op
+(`owned.py:687-732`, `_PromptCommand` queue).
+
+**C. Version exchange.** Additive `version`/`source_ref` on `SessionRecord`
+(the record file *is* the hello channel an attach client reads before and at
+dial — `RemoteSession._bind_to(record)` at `session/remote.py:1002`); the
+viewer compares with its own build on bind.
+
+**Recommendation: ship A + B + C in one PR.** They are one coherent change —
+"skew between a viewer and a runtime is detected and the known-silent class is
+repaired" — and each covers a failure the others cannot:
+
+| Case | A (disk drift) | B (runtime completion) | C (version exchange) |
+|---|---|---|---|
+| old TUI spawns NEW runtime, `/team` request (the incident) | warns, offers `/reload` | **turn runs** for every already-running stale TUI | — |
+| new TUI attaches to OLD resident runtime | — | — | detects, warns, names the remedy |
+| new TUI + pre-#624 runtime (`noop team_mutate`) | — | — | **renderer degrades loudly** (paired viewer-side change) |
+| same-version rebuilds between releases (`lop-update` on this host) | detects via `.lop-source` ref | — | detects via `source_ref` |
+| every *future* silent-skew shape | detects the precondition | — | detects the precondition |
+
+B is the load-bearing piece: it repairs the incident class for every stale TUI
+**the moment the new runtime is on disk**, with zero user action. A and C are
+each ~tens of lines sharing one new helper; cutting them to shrink the PR
+would leave both skew directions undiagnosed for every future shape.
+
+If the reviewer insists on splitting: B first (it is the fix), C second, A
+third. I do not recommend splitting.
+
+## 3. Empirical result the task asked for
+
+**`importlib.metadata.version()` re-reads disk in a running process.** Probed
+on this host with the repo interpreter (Python 3.14.3): installed a synthetic
+`skewpkg-0.46.23.dist-info`, read `version("skewpkg")` → `0.46.23`; replaced
+the dist-info with `skewpkg-0.49.0.dist-info`; re-read in the same process →
+`0.49.0`, both with and without a sleep between (the dist-info directory
+*name* changes with the version, so even a path-keyed cache misses).
+
+**Caveat that shapes the design:** `lop-update` between releases rebuilds from
+`main` while `pyproject.toml` still says the *last released* version. Then the
+dist-info name is identical and only content changes — `version()` cannot
+distinguish the builds, but `~/.local/share/uv/tools/local-operator/.lop-source`
+can: `lop-update` records `<git-sha> <tag>` there (live example:
+`4d3ce1d1a48f4f3b799efdfabb014979e70e0630 v0.49.0`). So the drift token is a
+**pair**: `(version, source_ref)`, with `version` the fallback when
+`.lop-source` is absent (PyPI/pipx installs, editable checkouts).
+
+## 4. The change, file by file
+
+### 4.0 New shared helper — `local_operator/update.py`
+
+`update.py` is already stdlib-only (verified: imports are `time`,
+`dataclasses`, `enum`, `importlib.metadata`, `pathlib`, `typing`) and already
+owns `installed_version()` (update.py:98) and `is_git_snapshot()`
+(update.py:395). Add:
+
+```python
+@dataclass(frozen=True)
+class BuildStamp:
+    """One comparable build token: distribution version + git ref of the
+    install, when lop-update recorded one. Same-version rebuilds between
+    releases are this host's common drift, so the ref is the primary key and
+    the version the fallback; comparing on version alone misses them."""
+
+    version: str
+    source_ref: str = ""
+
+def installed_build() -> BuildStamp: ...
+```
+
+Reads `.lop-source` at `sys.prefix` (the same root `is_git_snapshot` uses),
+first whitespace-separated token as `source_ref`, `""` when absent. One small
+file read; called rarely (adopt/engage/bind), never on a hot path.
+
+### 4.1 B — runtime-side completion
+
+**Wire field.** The attach auth frame gains an optional
+`"slash_consumers": ["team_attached", "agent_attached"]`. Semantics follow the
+documented precedent (`types.py:56-61`, `803-808` in server.py): **absent
+field = old client**; an old runtime ignores unknown auth fields; the field is
+advisory and never gates the connection. **No `PROTOCOL_VERSION` bump** — this
+is exactly the additive shape v4/v5 were.
+
+**Single source of truth** in `local_operator/session/runtime/types.py`
+(import-light by contract, already imported by both ends):
+
+```python
+#: SlashResult data.types that carry an ACTION for the invoking terminal: the
+#: owner attached, and the invoker is expected to submit data["request"] as a
+#: user turn. A client that renders these declares them in its auth frame's
+#: "slash_consumers"; an undeclared (old) client means the RUNTIME admits the
+#: request itself. Absent-means-old, like ClientKind.
+SLASH_ACTION_RECEIPTS: tuple[str, ...] = ("team_attached", "agent_attached")
+```
+
+**Client side.** `AttachClient.__init__`
+(`local_operator/mobile/attach_client.py:128`) gains
+`slash_consumers: Sequence[str] | None = None`; `connect` adds
+`auth["slash_consumers"] = list(...)` when set (next to the `events`/
+`frontend_state` flags at attach_client.py:195-201). `RemoteSession._dial`
+(`session/remote.py:1042`) passes `SLASH_ACTION_RECEIPTS` — the full-TUI
+viewer is the client that consumes them (at `app.py:14674`).
+
+**Server side.** `RuntimeServer` auth handling
+(`session/runtime/server.py:796-811`):
+
+- Parse once: `slash_consumers = frame.get("slash_consumers")` — `None` when
+  absent, else a `frozenset` of strings. Store on `_ClientConn`
+  (server.py:162) as `slash_consumers: frozenset[str] | None = None`.
+- `_dispatch_payload` (`server.py:1576-1598`) passes it to the handle exactly
+  the way `locality` is passed today: generalise `_accepts_locality`
+  (server.py:123) to a keyword probe (`_accepts_kw(fn, name)`), so existing
+  handle implementations and test doubles that lack the parameter keep working
+  unchanged (`tests/unit/session/runtime/test_server.py:135` has one).
+
+**Handle side.** `OwnedSessionHandle.run_slash_authoritative`
+(`owned.py:1550-1587`) gains `consumers: Iterable[str] | None = None`. After
+`result = await self._slash_result(...)`, one call:
+
+```python
+result = await self._complete_unconsumed_action(result, images, consumers)
+```
+
+`_complete_unconsumed_action(result, images, consumers)`:
+
+1. Return `result` unchanged unless `result.kind == "notice"`,
+   `(result.data or {}).get("type") in SLASH_ACTION_RECEIPTS`, and
+   `data.get("request")` is non-empty. (`/agent clear` returns
+   `agent_attached` with `request: ""` — no action, no admission.)
+2. Return unchanged when `data["type"] in (consumers or ())`. This is the
+   double-submission guard: a client that declared the type submits the
+   request itself; the runtime must **never** also run it. Both `None`
+   (absent field, old viewer) and `[]` (declared but consumes nothing) mean
+   "admit here" — the rule is `type not in declared`, never "declared is
+   None".
+3. Otherwise admit the request as a user turn, mirroring the viewer's own
+   `_submit_prompt` split (`app.py:12229-12241`):
+   - `self._session.is_streaming` → `await self.steer(request, images=images,
+     command_id=<fresh uuid4>)` (owned.py:877);
+   - else → `await self.prompt(request, images=images, command_id=<fresh
+     uuid4>)` (owned.py:687). This is the same `_PromptCommand` admission the
+     `prompt` op uses: durable append resolves `admitted`, the drain emits the
+     user `MessageStartEvent`, and the old viewer — which since 0.46.x
+     subscribes with `events=True` (verified in v0.46.23's remote.py) — paints
+     the user row from that event through the existing mobile→TUI echo path
+     (`app.py:23109-23141`, unmatched echo → `UserBlock`). No renderer change
+     is needed on the old viewer.
+   - Images are already on the wire: the viewer sends
+     `resolve_markers(arg, attachments)` in the `slash_result` frame
+     (`app.py:14852-14853`, present in 0.46.23 as well), and
+     `run_slash_authoritative` already receives them as its `images`
+     parameter. They go into the admission unchanged.
+4. On admission failure (session closing, queue full, prompt rejected):
+   return a **warning** notice instead —
+   `f"{text} — but the request was not sent: {exc}"` — so the old viewer at
+   least prints that the turn did not start. The attach itself already
+   happened and stays.
+
+The receipt text is unchanged ("sending to lopdev. manager is coordinating.")
+because it is now true.
+
+**Known, documented degradation:** the viewer expands collapsed pastes into
+the request text at submit time (`_submit_command_prompt`,
+`app.py:7025-7029`); the paste payloads live in the *viewer's* composer and
+cannot cross the wire retroactively. A runtime-admitted request that cites
+`<[Paste #1, 240 lines]>` reaches the manager as the chip label. Images
+survive; paste bodies degrade. That is strictly better than the current
+silent drop, and the skew notice (A/C) tells the user how to get the full
+fidelity back (`/reload`). This limitation goes in the method's docstring.
+
+**TUI-hosted owner mirror.** A session can also be owned by a TUI process
+(`TuiSessionHandle`, `mobile/tui_handle.py:84`; `app.py:11815` constructs it
+for in-process sessions). Both hosts must agree, per the existing mirror
+contract documented at `app.py:21291-21293`:
+
+- `TuiSessionHandle.run_slash_authoritative` (tui_handle.py:~495) accepts and
+  forwards `consumers` (same signature-probe tolerance on the server side).
+- `OperatorApp.run_slash_authoritative` (`app.py:20889`) gains
+  `consumers: Iterable[str] | None = None` and applies the same predicate to
+  its `_slash_result` outcome. Its completion submits through the app's own
+  user-row path so the row paints once and the echo registry stays
+  consistent: `images = _image_blocks(wire_images)` (the same helper
+  owned.py/tui_handle.py use), then
+  `self._submit_prompt(request, images, None, typed=request)`
+  (`app.py:12163`) — **not** `_submit_command_prompt`, which would re-resolve
+  markers against a composer map that does not exist owner-side and drop the
+  wire images. `_submit_prompt`'s own streaming branch steers when busy, so
+  the mirror inherits the busy behaviour for free.
+
+**Static guard.** `tests/unit/tui/test_noop_consumers.py` audits that every
+produced `noop` type has a consumer. Extend it with the action-carrying
+twin: every `SlashResult` producer in `owned.py` and `app.py` whose
+`SlashResult(...)` call passes a `request` key in `data` must have its
+`data["type"]` listed in `SLASH_ACTION_RECEIPTS`, and every
+`SLASH_ACTION_RECEIPTS` entry must be consumed in
+`_render_authoritative_slash`. Same AST-walk technique the file already uses —
+a future action-carrying receipt then fails CI without anyone remembering this
+incident.
+
+### 4.2 C — version exchange over the existing record
+
+The discovery record **is** the version channel: an attach client reads it
+before dial (`find_owner_record`) and holds it at bind
+(`RemoteSession._bind_to(record)`, remote.py:1002); the daemon reads records
+the same way. No frame change is needed — the "ready/hello" for a v5 attach
+client effectively arrives with the record. (The task suggested the frontend
+sync frame; the record is strictly earlier, needs no pydantic change, and
+covers the daemon too. A runtime's version cannot change while it lives, so
+one comparison at bind is complete.)
+
+- `local_operator/session/runtime/types.py` — `SessionRecord` gains two
+  additive fields **in the additive block** (types.py:142-161 documents the
+  contract: `from_json` drops unknown keys for old readers, new readers
+  default missing keys, and `PROTOCOL_VERSION` deliberately does not move):
+
+  ```python
+  #: What build this runtime is running. "" for a runtime older than the
+  #: field; an attach client compares it with its own build to name skew
+  #: instead of failing silently under it (the /team build-skew incident).
+  version: str = ""
+  source_ref: str = ""
+  ```
+
+- `local_operator/session/runtime/server.py` — stamp at record construction
+  (server.py:372-387): `version=..., source_ref=...` from
+  `installed_build()`. Import `local_operator.update` **function-locally** in
+  `__init__` — `update.py` is stdlib-only so there is no real cost, but
+  server.py sits near the CLI startup path and the house style
+  (`app.py:5564,5610`) is lazy import for it. The heartbeat rewrite republishes
+  the dataclass via `to_json()`, so the fields ride every rewrite for free
+  (coder: confirm `RecordPublisher` rewrites from the live record object, and
+  pin it in a test).
+- `local_operator/session/remote.py` — at bind, stash the owner's stamp on
+  the facade: `self.owner_version = record.version`,
+  `self.owner_source_ref = record.source_ref` in `_bind_to` (and the
+  equivalent in `connect`).
+- `local_operator/tui/app.py` — compare and warn (§4.3).
+- `local_operator/cli.py` — `lop sessions --json` rows gain `"version"` and
+  `"source_ref"` via `getattr(rec, ..., "")` next to the existing
+  getattr-defaulted live-state fields (cli.py:~1990). The fixed-width table is
+  **unchanged** — it is already eight columns, and leaving it alone keeps this
+  PR off the band/layout design-review surface.
+
+### 4.3 A — drift detection and skew notices in the TUI
+
+**Snapshot.** `OperatorApp.__init__` (`app.py:2102`):
+`self._loaded_build = update.installed_build()` (lazy import, as above). App
+init is process start for a TUI, so the snapshot is "what this process
+loaded". Debounce state: `self._skew_notice_shown: set[tuple]`.
+
+**Check points** (one helper, `_check_build_skew(*, reason: str)`):
+
+1. `_adopt_session` (`app.py:3137`) — covers `/new`, `/resume`, `/fork`,
+   `/login`, initial mount, all of which adopt. Two comparisons here:
+   - **A (disk drift):** `update.installed_build() != self._loaded_build` →
+     warning notice (copy below).
+   - **C (owner skew):** if the adopted session is already attached and
+     exposes `owner_version`, compare with `self._loaded_build`. An empty
+     `owner_version` means the runtime predates the field, i.e. it is older
+     than this terminal by construction — warn once per session with the
+     "predates build reporting" copy.
+2. `_start_runtime_engage` (`app.py:8848`) and the success tail of
+   `_bind_then_dispatch` (`app.py:9004`) — re-check A immediately before a
+   spawn, and re-check C after a fresh bind (`ensure()` resolved
+   `owner_version`). Both are debounced, so the mount engage, the draft
+   warm-up, and the slash-command engage cost one comparison each and paint at
+   most one notice per distinct (kind, from, to) triple per process.
+
+**Where the notice lands:** `_system_notice(body, "warning")` — its contract
+(`app.py:14527-14538`) is exactly this class ("infrastructure the user did not
+ask about") and it preserves the boot composition. Deliberately **not** a
+status-band element: a band change is a persistent layout surface and triggers
+the design-review path for marginal benefit over a notice the user reads at
+the moment it matters (when they are about to engage a runtime).
+
+**Notice copy:**
+
+- A: `the install on disk changed since this terminal started (0.46.23 →
+  0.49.0). Runtimes started from here run the NEW build against this old
+  terminal. /reload restarts this terminal on the current install and resumes
+  this session.` (Version arms rendered from the stamp; with refs,
+  `0.48.0@a1b2c3d → 0.48.0@4d3ce1d`.)
+- C, known versions: `this session's runtime is running 0.46.23 but this
+  terminal is 0.49.0 — routed commands may behave differently. /stop, then
+  resend: the runtime restarts on the current install.`
+  (Bare `/stop` on a follower sends the stop op to the owner,
+  `app.py:15097-15102`; the next prompt or `/team` engages a fresh runtime
+  from the current disk build. Both runtimes keep working in the meantime —
+  this is advisory, not a block.)
+- C, absent version: `this session's runtime predates build reporting — it is
+  older than this terminal. /stop, then resend, restarts it on the current
+  install.` Once per session per process: right after this release ships,
+  every resident runtime legitimately triggers it once, and it is telling the
+  truth each time.
+
+**Old-runtime noop degradation (viewer-side, pairs with C).**
+`_render_authoritative_slash` (`app.py:14629`): a `noop` whose `data.type` is
+`"team_mutate"` or `"agent_mutate"` can only come from a pre-#624 owner.
+Render a warning instead of returning silently:
+`this session's runtime is running a build older than /team attach (pre
+0.46.25); nothing was attached. /stop, then resend, to restart it on the
+current install.` Two lines of renderer that close the last silent quadrant.
+(Adding a *consumer* for a type no current producer emits does not disturb the
+`test_noop_consumers` audit, which maps producers → consumers.)
+
+### 4.4 Four-quadrant behaviour (the matrix the tests pin)
+
+| Viewer \ Runtime | old runtime (no field, pre-B) | new runtime |
+|---|---|---|
+| **old viewer** (pre-#624, no `slash_consumers`) | status quo (old/ old: both sides pre-#624 behave as that pair always did — noop `team_mutate`, silent; unchanged by this PR) | **B: runtime admits the request; turn runs; viewer paints the row from the relay.** A warns at adopt/engage. |
+| **new viewer** (declares receipts) | renderer degrades loudly (noop `team_mutate` → warning); C warns | declared ⇒ runtime never admits; viewer submits exactly as today. **Single turn, no double-submission.** |
+
+## 5. Tests
+
+Unit — runtime (new file
+`tests/unit/session/runtime/test_action_receipt_completion.py`):
+
+1. `run_slash_authoritative("team", "viewerteam do the thing", images,
+   consumers=None)` on a handle with a scripted session → receipt is
+   `team_attached` **and** the session received prompt `"do the thing"` with
+   the same images. (`consumers=None` simulates the incident viewer.)
+2. `consumers=[]` → also admits (declared-nothing is not a consumer).
+3. `consumers=["team_attached"]` → receipt returned, **no prompt admitted**
+   (the double-submission guard).
+4. `agent_attached` with `request=""` (the `/agent clear` shape) → no
+   admission.
+5. Busy session (`is_streaming=True`) → `steer` called, not `prompt`.
+6. Admission raising (session closing) → warning notice naming the failure,
+   attach still reported.
+7. Server auth parse: `slash_consumers` lands on `_ClientConn`; absent →
+   `None`; `_dispatch_payload` passes it to handles that accept it and not to
+   those that do not (the existing `test_server.py` doubles prove the probe).
+
+Unit — update/record:
+
+8. `installed_build()`: with a `.lop-source` fixture → `(version, ref)`;
+   without → `(version, "")`.
+9. `SessionRecord` round-trip with the new fields; `from_json` on a payload
+   lacking them → `""` defaults; a payload with extra unknown keys still
+   parses (existing forward-compat test pattern).
+
+Unit — TUI (new `tests/unit/tui/test_build_skew.py`, plus one audit edit):
+
+10. Drift: monkeypatch `installed_build` to a new token after app init →
+    `_adopt_session`/engage posts exactly one warning naming both builds and
+    `/reload`; a second adopt with the same token posts nothing (debounce).
+11. Owner skew: facade with `owner_version` older/absent → the C notice with
+    `/stop` copy; matching version → silence.
+12. Renderer: `noop {"type": "team_mutate"}` → warning notice, no exception,
+    no submit; `team_attached` with request on a normal session still calls
+    `_submit_command_prompt` (regression guard that the declaration work did
+    not break the consumer).
+13. `test_noop_consumers.py` extension: every producer `data` dict containing
+    a `request` key has its type in `SLASH_ACTION_RECEIPTS`; every
+    `SLASH_ACTION_RECEIPTS` entry is consumed by the renderer.
+
+E2E (`tests/e2e/test_viewer_attach_e2e.py`, same in-process-runtime harness as
+`test_a_viewer_runs_a_team_and_holds_a_credential`, isolated config dir):
+
+14. **Skew simulation:** raw `AttachClient` constructed **without**
+    `slash_consumers` (that *is* the old viewer on the wire) →
+    `slash_result("team", "viewerteam do the thing", [])` → assert the
+    receipt is `team_attached` and the session ran the turn (the scripted
+    stream's reply was consumed exactly once — the user row exists in the
+    transcript).
+15. **No double admission:** a client **with** `slash_consumers =
+    SLASH_ACTION_RECEIPTS` → same command → assert the session received **no**
+    prompt (the runtime deferred to the client). This is the guard against
+    double-submission.
+16. Record: the published record carries `version == installed_version()` and,
+    under a fake `.lop-source`, the matching `source_ref`.
+
+QA matrix notes for the qa-tester (real execution, isolated `HOME` per cell —
+see AGENTS.md): cell 1 = e2e cell 14 driven by hand against a worktree-built
+runtime; cell 2 = a real two-install drift: `uv tool install --force` the repo
+into an isolated `UV_TOOL_DIR` at two different refs, launch the TUI from
+ref 1, flip the dir to ref 2, `/new` + `/team <name> <request>` → expect the
+drift notice and a running turn; cell 3 = attach a current TUI to a runtime
+started from the older ref → expect the C notice; cell 4 = `/reload` from the
+drifted TUI resumes the same session on the new build.
+
+## 6. Risks to watch during rollout
+
+1. **Double-submission.** The invariant is "admit iff the type was not
+   declared". Test 3 and e2e cell 15 pin it. The residual human-audit point:
+   the declaration list must always equal the renderer's consumed set — the
+   extended `test_noop_consumers` audit makes that a CI property, not a
+   remembered one.
+2. **Mid-turn attach.** A `/team` request routed while a turn runs becomes a
+   *steer* under completion, matching what the new viewer does today
+   (`app.py:12235`). It is delivered at the next boundary; that is existing
+   behaviour, not a new queue.
+3. **Admission failure after a successful attach** leaves the team attached
+   with no turn. The warning receipt names it; the retry is re-sending the
+   request. Acceptable, and strictly louder than today.
+4. **Paste-payload degradation** under runtime completion (chip label instead
+   of body; §4.1). Documented in the method docstring; the skew notice points
+   at `/reload` for full fidelity.
+5. **`importlib.metadata` behaviour** was verified empirically on 3.14.3
+   (§3); the `.lop-source` ref is the primary token precisely because the
+   common drift on this host (same-version rebuilds) is invisible to
+   `version()`. Editable checkouts have no `.lop-source` and share one
+   version string — dev-tree skew is out of scope by design.
+6. **Lazy-import Frankenstein.** A days-old TUI that lazily imports a module
+   *after* `lop-update` mixes builds inside one process. A detects the
+   precondition at the next adopt/engage and names `/reload`; nothing can make
+   the already-loaded modules young again. Not made worse by this PR.
+7. **Post-release noise.** Every resident runtime predates the `version`
+   field when this ships, so the C "predates build reporting" notice fires
+   once per (session, TUI process) during the first attach window. It is
+   accurate each time; debounce keeps it to once.
+8. **Phone/daemon path.** The daemon never sends `slash_consumers`, and the
+   only routed slash it drives is `/mcp reauth` (daemon.py:655-668), which is
+   not action-carrying — no completion can trigger for it. `SessionRecord`
+   additive fields are invisible to older daemons by the existing
+   `from_json` filter.
+
+## 7. PR shape
+
+One PR, conventional commit
+`fix(runtime): detect and complete across viewer/runtime build skew`. Files:
+`local_operator/update.py`, `local_operator/session/runtime/types.py`,
+`local_operator/session/runtime/server.py`,
+`local_operator/session/runtime/owned.py`,
+`local_operator/mobile/attach_client.py`,
+`local_operator/mobile/tui_handle.py`, `local_operator/session/remote.py`,
+`local_operator/tui/app.py`, `local_operator/cli.py`; tests as in §5. No
+`pyproject.toml` bump. Gates per AGENTS.md: flake8 / black==26.1.0 /
+isort==5.13.2 / pyright over the whole tree, the unit suite, the e2e stage
+(`-m e2e -n0`), then the standing reviewer + QA rounds. User-visible surface
+is notice text only — no band or layout change.

--- a/docs/design-build-skew.md
+++ b/docs/design-build-skew.md
@@ -329,14 +329,16 @@ loaded". Debounce state: `self._skew_notice_shown: set[tuple]`.
    - **C (owner skew):** if the adopted session is already attached and
      exposes `owner_version`, compare with `self._loaded_build`. An empty
      `owner_version` means the runtime predates the field, i.e. it is older
-     than this terminal by construction — warn once per session with the
-     "predates build reporting" copy.
+     than this window by construction — warn once per session with the
+     absent-version copy.
 2. `_start_runtime_engage` (`app.py:8848`) and the success tail of
    `_bind_then_dispatch` (`app.py:9004`) — re-check A immediately before a
    spawn, and re-check C after a fresh bind (`ensure()` resolved
    `owner_version`). Both are debounced, so the mount engage, the draft
    warm-up, and the slash-command engage cost one comparison each and paint at
-   most one notice per distinct (kind, from, to) triple per process.
+   most one notice per distinct (kind, from, to, scope) key — scope being the
+   session id for the owner notices and empty for disk drift, which is a fact
+   about the process rather than about any one session.
 
 **Where the notice lands:** `_system_notice(body, "warning")` — its contract
 (`app.py:14527-14538`) is exactly this class ("infrastructure the user did not
@@ -345,33 +347,49 @@ status-band element: a band change is a persistent layout surface and triggers
 the design-review path for marginal benefit over a notice the user reads at
 the moment it matters (when they are about to engage a runtime).
 
-**Notice copy:**
+**Notice copy** (rewritten wholesale by design review round 1 — D1/D2/D3.
+The originals used our vocabulary, not the user's: "routed commands",
+"predates build reporting", and a runtime/terminal split the notice never
+explains, so to a reader those two words collapse into the one thing they can
+see. Every string below was measured through the real `NoticeBlock` at
+120/100/80 columns and is the same height or shorter than what it replaced.):
 
-- A: `the install on disk changed since this terminal started (0.46.23 →
-  0.49.0). Runtimes started from here run the NEW build against this old
-  terminal. /reload restarts this terminal on the current install and resumes
-  this session.` (Version arms rendered from the stamp; with refs,
-  `0.48.0@a1b2c3d → 0.48.0@4d3ce1d`.)
-- C, known versions: `this session's runtime is running 0.46.23 but this
-  terminal is 0.49.0 — routed commands may behave differently. /stop, then
-  resend: the runtime restarts on the current install.`
+- A: `local-operator was updated after this window opened (0.49.5, cf2b854 →
+  a1b2c3d) — this window is still on the old version. /reload updates it and
+  picks this session back up.` The parenthetical names a SHARED version once
+  and lets the refs carry the difference (D3), because the headline case is
+  `lop-update` rebuilding `main` with no version bump — the two-arm
+  `0.48.0@a1b2c3d → 0.48.0@4d3ce1d` spent 22 characters restating one version.
+  When the versions genuinely differ, both arms are shown in full. This is a
+  call-site branch (`app.py::_build_change`), not a change to
+  `BuildStamp.label()`, which other callers share.
+- C, known versions: `“<conversation name>” is running 0.46.23 but this window
+  is 0.49.5 — some commands may not work. /stop, then send again to restart
+  it.`
   (Bare `/stop` on a follower sends the stop op to the owner,
   `app.py:15097-15102`; the next prompt or `/team` engages a fresh runtime
   from the current disk build. Both runtimes keep working in the meantime —
   this is advisory, not a block.)
-- C, absent version: `this session's runtime predates build reporting — it is
-  older than this terminal. /stop, then resend, restarts it on the current
-  install.` Once per session per process: right after this release ships,
-  every resident runtime legitimately triggers it once, and it is telling the
-  truth each time.
+- C, absent version: `“<conversation name>” is running an older version than
+  this window — some commands may not work. /stop, then send again to restart
+  it.` Once per session per process: right after this release ships, every
+  resident runtime legitimately triggers it once, and it is telling the truth
+  each time.
+
+Both C notices NAME the session, falling back to `this session` only when the
+title is empty (D1). The subject is load-bearing rather than decorative: two
+stale sessions in one terminal each earn a notice, and with a deictic subject
+in both they render as two byte-identical paragraphs — which reads as the app
+printing one warning twice, i.e. exactly the duplicate-notice bug the
+per-session debounce key exists to avoid, and leaves `/stop` ambiguous about
+which session it acts on.
 
 **Old-runtime noop degradation (viewer-side, pairs with C).**
 `_render_authoritative_slash` (`app.py:14629`): a `noop` whose `data.type` is
 `"team_mutate"` or `"agent_mutate"` can only come from a pre-#624 owner.
 Render a warning instead of returning silently:
-`this session's runtime is running a build older than /team attach (pre
-0.46.25); nothing was attached. /stop, then resend, to restart it on the
-current install.` Two lines of renderer that close the last silent quadrant.
+`this session is running a version too old to attach a team (before
+0.46.25); nothing was attached. /stop, then send again to restart it.` Two lines of renderer that close the last silent quadrant.
 (Adding a *consumer* for a type no current producer emits does not disturb the
 `test_noop_consumers` audit, which maps producers → consumers.)
 

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -1997,6 +1997,13 @@ def sessions_command(args: argparse.Namespace) -> int:
                 "pending": getattr(rec, "pending", None),
                 "busy": bool(getattr(rec, "busy", False)),
                 "detached": bool(getattr(rec, "detached", False)),
+                # Which build each runtime is running, for diagnosing skew
+                # across a host that replaces its install several times a day.
+                # Same getattr defaulting as the live-state fields above, and
+                # deliberately JSON-only: the fixed-width table is already
+                # eight columns wide.
+                "version": getattr(rec, "version", "") or "",
+                "source_ref": getattr(rec, "source_ref", "") or "",
             }
         )
 

--- a/local_operator/mobile/attach_client.py
+++ b/local_operator/mobile/attach_client.py
@@ -38,7 +38,7 @@ import json
 import logging
 import uuid
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Sequence
 
 from local_operator.mobile.types import (
     PROTOCOL_VERSION,
@@ -141,6 +141,7 @@ class AttachClient:
         on_event: Callable[[dict[str, Any]], None] | None = None,
         frontend_state: bool = False,
         locality: str = "local",
+        slash_consumers: Sequence[str] | None = None,
         on_frontend_sync: Callable[[dict[str, Any]], None] | None = None,
         on_frontend_update: Callable[[dict[str, Any]], None] | None = None,
     ) -> None:
@@ -159,6 +160,14 @@ class AttachClient:
         self._events = events
         self._on_event = on_event
         self._frontend_state = frontend_state
+        # Which action-carrying slash receipts THIS client renders itself (see
+        # ``SLASH_ACTION_RECEIPTS``). Declaring them is what stops the runtime
+        # from also submitting the request: a client that says nothing is
+        # treated as one built before the field, whose request the runtime
+        # completes on its behalf. ``None`` is therefore meaningfully
+        # different from ``[]`` only to a reader of the frame -- both mean the
+        # type was not declared, which is the one rule the runtime applies.
+        self._slash_consumers = list(slash_consumers) if slash_consumers is not None else None
         self._on_frontend_sync = on_frontend_sync
         self._on_frontend_update = on_frontend_update
         self._frontend_epoch: str | None = None
@@ -206,6 +215,12 @@ class AttachClient:
             auth["events"] = True
         if self._frontend_state:
             auth["frontend_state"] = True
+        if self._slash_consumers is not None:
+            # Additive and advisory, exactly the shape ``events`` and
+            # ``frontend_state`` are: an older owner ignores the unknown auth
+            # field and behaves as it always did, and no PROTOCOL_VERSION bump
+            # is warranted for a field nobody is required to read.
+            auth["slash_consumers"] = list(self._slash_consumers)
         writer.write(json.dumps(auth).encode() + b"\n")
         await writer.drain()
         # The welcome projection doubles as the identity check: it names the

--- a/local_operator/mobile/tui_handle.py
+++ b/local_operator/mobile/tui_handle.py
@@ -39,7 +39,7 @@ import logging
 import secrets
 from concurrent.futures import Future
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, cast
+from typing import TYPE_CHECKING, Any, Callable, Iterable, cast
 
 from local_operator.mobile.command_reservation import CommandReservations
 from local_operator.mobile.projection import ProjectionFold
@@ -489,6 +489,7 @@ class TuiSessionHandle(SessionHandle):
         images: list[dict[str, str]] | None,
         *,
         locality: str = "local",
+        consumers: Iterable[str] | None = None,
     ) -> dict[str, Any]:
         """Run one shared slash command and return its typed outcome.
 
@@ -511,6 +512,13 @@ class TuiSessionHandle(SessionHandle):
         ``locality`` is the invoking client's declared position; it is passed
         through to the app so the grant verbs can tell a terminal on this
         machine from a relayed remote device.
+
+        ``consumers`` is forwarded for the same reason and to the same end as
+        on ``OwnedSessionHandle``: a session can be hosted either by a detached
+        runtime or by this app, and a follower must get the same answer from
+        both. A viewer that does not consume action-carrying receipts has its
+        request completed HERE when this TUI is the owner, exactly as the
+        runtime would.
         """
         owner_loop = await self._on_app(asyncio.get_running_loop)
         done: asyncio.Future[Any] = asyncio.get_running_loop().create_future()
@@ -518,7 +526,11 @@ class TuiSessionHandle(SessionHandle):
         def schedule() -> None:
             task = owner_loop.create_task(
                 self._app.run_slash_authoritative(
-                    command, args, list(images or []), locality=locality
+                    command,
+                    args,
+                    list(images or []),
+                    locality=locality,
+                    consumers=consumers,
                 )
             )
 

--- a/local_operator/mobile/types.py
+++ b/local_operator/mobile/types.py
@@ -55,6 +55,7 @@ from local_operator.session.runtime.types import (  # noqa: F401  (re-exported)
     HEARTBEAT_TIMEOUT_S,
     PROTOCOL_VERSION,
     RUN_DIRNAME,
+    SLASH_ACTION_RECEIPTS,
     ClientKind,
     SessionRecord,
 )

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -69,6 +69,7 @@ from local_operator.mobile.attach_client import (
     find_owner_record,
 )
 from local_operator.mobile.types import (
+    SLASH_ACTION_RECEIPTS,
     ContinuationCommand,
     PendingRequest,
     SessionRecord,
@@ -232,6 +233,14 @@ class RemoteSession:
         #: whose contract is still "recover the conversation into this
         #: process" and whose tests assert exactly that.
         self._can_go_cold = False
+        #: The BUILD the runtime on the other end is running, read off its
+        #: discovery record at dial. ``""`` on a facade that has never bound,
+        #: and on one bound to a runtime older than the field — the TUI treats
+        #: those two the same way (it has no build to compare against) and
+        #: distinguishes them by whether the facade is cold, not by this
+        #: value. See ``app.py::_check_build_skew``.
+        self.owner_version: str = ""
+        self.owner_source_ref: str = ""
         #: Why this viewer opened WITHOUT live state, when that was not the
         #: ordinary "no runtime was running" case. Set by the launcher when an
         #: attach to a live runtime failed and it fell back to cold; the TUI
@@ -1121,12 +1130,28 @@ class RemoteSession:
             if self._client is client:
                 self._on_disconnected(reason)
 
+        # The runtime's build, captured from the record BEFORE the socket is
+        # opened: a runtime's version cannot change while it lives, so one
+        # read at dial is complete. ``""`` means the owner predates the field,
+        # which by construction makes it older than this terminal. The TUI
+        # compares these with its own build and names the skew (see
+        # ``app.py::_check_build_skew``); nothing here decides anything, so a
+        # missing stamp degrades to "unknown", never to a refused attach.
+        self.owner_version = getattr(record, "version", "") or ""
+        self.owner_source_ref = getattr(record, "source_ref", "") or ""
         client = AttachClient(
             lambda _projection: None,
             on_disconnected,
             events=True,
             on_event=lambda data: (self._on_wire_event(data) if self._client is client else None),
             frontend_state=True,
+            # THE full-TUI viewer is the client that renders action-carrying
+            # receipts: ``_render_authoritative_slash`` submits their
+            # ``request`` as a user turn. Declaring them is what tells the
+            # runtime NOT to admit the request itself, which would run the
+            # command twice. A viewer that omitted this (every build before
+            # the field) is exactly the case the runtime completes for.
+            slash_consumers=list(SLASH_ACTION_RECEIPTS),
             on_frontend_sync=lambda data: (
                 self._on_frontend_sync(data) if self._client is client else None
             ),

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -49,10 +49,33 @@ from local_operator.mobile.types import (
 )
 from local_operator.session.runtime.server import SessionHandle
 from local_operator.session.runtime.server import image_blocks as _image_blocks
-from local_operator.session.runtime.types import SLASH_ACTION_RECEIPTS
+from local_operator.session.runtime.types import runtime_must_complete
 from local_operator.session.transcript import TRANSCRIPT_FILENAME
 
 logger = logging.getLogger(__name__)
+
+
+#: How many loop turns a dispatched admission is given to surface a SYNCHRONOUS
+#: refusal before it is left to run detached. ``prompt`` raises its reportable
+#: refusals (closing session, full queue, rejected reservation) before its first
+#: await, so one turn suffices; the margin only guards a future edit that adds
+#: another await to that prelude. Turns, not seconds — see
+#: ``_admit_without_waiting_for_the_turn``.
+_ADMISSION_PRELUDE_TURNS = 3
+
+
+def _log_detached_admission(task: "asyncio.Task[str]") -> None:
+    """Never let a dispatched admission become an unretrieved exception.
+
+    The receipt has already been returned by the time this runs, so there is no
+    caller left to tell: a failure here is a log line, and swallowing it
+    silently is what would make the next occurrence undiagnosable.
+    """
+    if task.cancelled():
+        return
+    error = task.exception()
+    if error is not None:
+        logger.warning("a completed slash action's turn failed after admission: %s", error)
 
 
 def _resolve_gate_future(future: asyncio.Future[Any], value: Any) -> None:
@@ -1668,18 +1691,15 @@ class OwnedSessionHandle(SessionHandle):
             return result
         data = getattr(result, "data", None) or {}
         receipt_type = data.get("type")
-        if receipt_type not in SLASH_ACTION_RECEIPTS:
+        # The shared predicate, so this host and the TUI-hosted one cannot
+        # drift: not an action receipt, or one the client declared it renders
+        # (admitting that too would double-submit the user's command).
+        if not runtime_must_complete(receipt_type, consumers):
             return result
         request = str(data.get("request") or "")
         if not request:
             # ``/agent clear`` returns ``agent_attached`` with an empty
             # request: a detach is a receipt with no action behind it.
-            return result
-        if receipt_type in (consumers or ()):
-            # The client renders this type and will submit the request itself.
-            # Admitting here too is the double-submission failure, which is
-            # worse than the bug being fixed: the user sees one command run
-            # twice with no way to tell which turn is which.
             return result
         try:
             # Mirrors the viewer's own submit split (``app.py::_submit_prompt``):
@@ -1687,10 +1707,15 @@ class OwnedSessionHandle(SessionHandle):
             # concurrent call outright and the text would be thrown away. The
             # steer is delivered at the engine's next tool/message boundary,
             # which is the existing mid-turn channel rather than a new queue.
+            #
+            # ``steer`` is awaited directly because it cannot park: everything
+            # it does is synchronous (reserve, hand the text to the session,
+            # note the echo) and it returns on its first step. ``prompt``
+            # emphatically CAN park — see below.
             if self._session.is_streaming:
                 await self.steer(request, images=images, command_id=str(uuid.uuid4()))
             else:
-                await self.prompt(request, images=images, command_id=str(uuid.uuid4()))
+                await self._admit_without_waiting_for_the_turn(request, images)
         except Exception as exc:  # noqa: BLE001 — the attach happened; say what did not
             # The attach ALREADY landed and stays; only the turn failed to
             # start (session closing, queue full, a rejected prompt). Reporting
@@ -1705,6 +1730,63 @@ class OwnedSessionHandle(SessionHandle):
                 }
             )
         return result
+
+    async def _admit_without_waiting_for_the_turn(
+        self, request: str, images: list[dict[str, str]] | None
+    ) -> None:
+        """Admit ``request`` as a turn, reporting only the IMMEDIATE refusals.
+
+        ``prompt`` resolves its receipt on the durable transcript append, which
+        the drain performs only when it reaches that command — so awaiting it
+        holds this coroutine for the whole of any turn queued ahead. That would
+        be paid on the ``slash_result`` REQUEST/RESPONSE, which is a different
+        thing from the ``prompt`` op's own fire-and-forget wait: the reply frame
+        would be withheld for the duration of the earlier turn, the viewer's
+        ``ACK_TIMEOUT_S`` (15 s) would elapse on anything longer, and the old
+        viewer would print a transport error for a request that WAS admitted —
+        a worse failure than the silent drop this method exists to repair. The
+        per-connection reader is strictly serial, so every later op from that
+        viewer would queue behind the park as well (review round 1, R1-1).
+
+        The ``is_streaming`` branch above does not cover it: the flag is still
+        False during the drain's pre-streaming prelude (lock acquire, record
+        and journal flushes), so a prompt sent moments before this lands in
+        exactly that window.
+
+        So the admission is DISPATCHED and this returns as soon as its outcome
+        can no longer be reported synchronously. The refusals worth reporting —
+        a closing session, a full queue, a rejected reservation — all raise in
+        ``prompt``'s synchronous prelude, before it ever awaits, so they surface
+        here and still become the warning receipt. Anything after that point is
+        a turn that is genuinely running and whose result belongs in the
+        transcript, not in this receipt.
+
+        Bounded in LOOP TURNS rather than seconds deliberately: a wall-clock
+        budget here would be a bet on machine load, whereas "the task has had
+        its synchronous prelude" is a fact about scheduling that holds under any
+        contention (AGENTS.md, "Wait on the event, never on the clock").
+        """
+        task = asyncio.ensure_future(
+            self.prompt(request, images=images, command_id=str(uuid.uuid4()))
+        )
+        # One turn is enough today — nothing before ``prompt``'s first suspension
+        # point yields — but a couple of extra turns costs nothing and keeps this
+        # correct if a future edit puts another await in that prelude.
+        for _ in range(_ADMISSION_PRELUDE_TURNS):
+            if task.done():
+                break
+            await asyncio.sleep(0)
+        if task.done():
+            # Re-raises the synchronous refusal into the caller's warning path.
+            # A cancelled task is not a refusal to report: the session is going
+            # away and the receipt is the least of it.
+            if not task.cancelled():
+                task.result()
+            return
+        # Still parked on the durable append, i.e. genuinely queued behind a
+        # running turn. Let it finish on its own; the user row appears through
+        # the event relay exactly as it would for any other admitted prompt.
+        task.add_done_callback(_log_detached_admission)
 
     async def _slash_result(
         self, command: str, args: str, SlashResult: Any, locality: str = "local"

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -29,7 +29,7 @@ from asyncio import InvalidStateError
 from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Coroutine, cast
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Coroutine, Iterable, cast
 
 from local_operator.harness.approval import (
     GATE_TIMEOUT_CUSTOM_TYPE as _GATE_TIMEOUT_CUSTOM_TYPE,
@@ -49,6 +49,7 @@ from local_operator.mobile.types import (
 )
 from local_operator.session.runtime.server import SessionHandle
 from local_operator.session.runtime.server import image_blocks as _image_blocks
+from local_operator.session.runtime.types import SLASH_ACTION_RECEIPTS
 from local_operator.session.transcript import TRANSCRIPT_FILENAME
 
 logger = logging.getLogger(__name__)
@@ -1580,6 +1581,7 @@ class OwnedSessionHandle(SessionHandle):
         images: list[dict[str, str]] | None = None,
         *,
         locality: str = "local",
+        consumers: Iterable[str] | None = None,
     ) -> dict[str, Any]:
         """Run one shared slash command against the session and answer as data.
 
@@ -1606,11 +1608,103 @@ class OwnedSessionHandle(SessionHandle):
         exists today reaches this runtime over loopback. Only ``/mcp``'s grant
         verbs read it, to decide whether opening a browser here would put the
         tab in front of the person who typed the command.
+
+        ``consumers`` is which action-carrying receipts the invoking client
+        renders itself (``SLASH_ACTION_RECEIPTS``); ``None`` means it declared
+        nothing, which is what every client built before the field looks like
+        on the wire. See :meth:`_complete_unconsumed_action`.
         """
         from local_operator.session.frontend_state import SlashResult
 
         result = await self._slash_result(command, args, SlashResult, locality)
+        result = await self._complete_unconsumed_action(result, images, consumers)
         return result.model_dump(mode="json")
+
+    async def _complete_unconsumed_action(
+        self,
+        result: Any,
+        images: list[dict[str, str]] | None,
+        consumers: Iterable[str] | None,
+    ) -> Any:
+        """Run an attach receipt's request here when the client will not.
+
+        THE INCIDENT THIS REPAIRS. ``/team <name> <request>`` on a viewer
+        attaches the team on this runtime and returns a ``team_attached``
+        receipt carrying the request; since #624 the VIEWER is expected to
+        submit that request as a user turn. A viewer older than #624 prints
+        the receipt text and has no consumer for ``data["request"]`` — so the
+        team was attached, "sending to <team>. <manager> is coordinating."
+        was printed, and the request was dropped with no user row, no turn and
+        no error. Skew makes that reachable at any time: the on-disk install
+        is replaced under long-lived TUIs several times a day, and the runtime
+        a stale TUI spawns is built from the NEW install.
+
+        The rule is ``type not in declared``, never "declared is None": a
+        client that declared the type submits the request itself and the
+        runtime must NEVER also run it (that would be a double turn), while
+        both ``None`` (absent field, older viewer) and ``[]`` (declared, but
+        consumes nothing) mean the request has no other home and is admitted
+        here.
+
+        Admission goes through the same ``_PromptCommand`` path the ``prompt``
+        op uses, so the durable append resolves ``admitted``, the drain emits
+        the user ``MessageStartEvent``, and an old viewer — which already
+        subscribes with ``events=True`` — paints the user row from that event
+        through its existing echo path. No renderer change is required on the
+        old viewer, which is the point: the fix reaches TUIs that are already
+        running and cannot be updated in place.
+
+        KNOWN DEGRADATION: the viewer expands collapsed pastes into the
+        request text at submit time, and those payloads live in the VIEWER's
+        composer — they cannot cross the wire retroactively. A request
+        admitted here that cites ``<[Paste #1, 240 lines]>`` reaches the
+        manager as the chip label rather than the body. Images are unaffected
+        (they are already on the wire in the ``slash_result`` frame and are
+        passed into the admission unchanged). That is strictly better than the
+        silent drop, and the skew notice the viewer paints names ``/reload``
+        as the way back to full fidelity.
+        """
+        if getattr(result, "kind", None) != "notice":
+            return result
+        data = getattr(result, "data", None) or {}
+        receipt_type = data.get("type")
+        if receipt_type not in SLASH_ACTION_RECEIPTS:
+            return result
+        request = str(data.get("request") or "")
+        if not request:
+            # ``/agent clear`` returns ``agent_attached`` with an empty
+            # request: a detach is a receipt with no action behind it.
+            return result
+        if receipt_type in (consumers or ()):
+            # The client renders this type and will submit the request itself.
+            # Admitting here too is the double-submission failure, which is
+            # worse than the bug being fixed: the user sees one command run
+            # twice with no way to tell which turn is which.
+            return result
+        try:
+            # Mirrors the viewer's own submit split (``app.py::_submit_prompt``):
+            # a turn already running is STEERED, because ``prompt`` rejects a
+            # concurrent call outright and the text would be thrown away. The
+            # steer is delivered at the engine's next tool/message boundary,
+            # which is the existing mid-turn channel rather than a new queue.
+            if self._session.is_streaming:
+                await self.steer(request, images=images, command_id=str(uuid.uuid4()))
+            else:
+                await self.prompt(request, images=images, command_id=str(uuid.uuid4()))
+        except Exception as exc:  # noqa: BLE001 — the attach happened; say what did not
+            # The attach ALREADY landed and stays; only the turn failed to
+            # start (session closing, queue full, a rejected prompt). Reporting
+            # that as a warning is the whole difference from the original
+            # defect: the user learns the request did not run and can resend,
+            # instead of watching nothing happen.
+            logger.debug("completing an unconsumed slash action failed", exc_info=True)
+            return result.model_copy(
+                update={
+                    "text": f"{result.text} — but the request was not sent: {exc}",
+                    "style": "warning",
+                }
+            )
+        return result
 
     async def _slash_result(
         self, command: str, args: str, SlashResult: Any, locality: str = "local"

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -120,8 +120,8 @@ _ANNOUNCE_WRITE_TIMEOUT_S = 0.25
 _PAYLOAD_OPS = {"slash_result", "cancel_subagents", "job_trajectory", "fork_snapshot", "credential"}
 
 
-def _accepts_locality(fn: Any) -> bool:
-    """Whether ``fn`` takes the ``locality`` keyword.
+def _accepts_kw(fn: Any, name: str) -> bool:
+    """Whether ``fn`` takes the keyword ``name``.
 
     Cached because it is asked on every routed slash command and
     ``inspect.signature`` is not cheap. Keyed by the underlying function so
@@ -129,26 +129,40 @@ def _accepts_locality(fn: Any) -> bool:
     cannot be read (a C callable, an exotic mock) is treated as not accepting
     it: the caller then uses the narrow call, which every implementation has
     always supported.
+
+    Generalised from a ``locality``-only probe when ``slash_consumers`` became
+    the second optional keyword on the same call. A handle is an INJECTED
+    collaborator — the TUI's, the runtime's, and several test doubles all
+    implement ``run_slash_authoritative`` — so each new keyword must stay
+    optional in the protocol rather than force a lockstep change across every
+    implementation. Two independent probes rather than one combined answer:
+    a handle may well accept one keyword and not the other.
     """
     target = getattr(fn, "__func__", fn)
-    cached = _LOCALITY_SUPPORT.get(target)
-    if cached is not None:
-        return cached
+    by_name = _KEYWORD_SUPPORT.get(target)
+    if by_name is not None:
+        cached = by_name.get(name)
+        if cached is not None:
+            return cached
+    else:
+        by_name = {}
+        _KEYWORD_SUPPORT[target] = by_name
     try:
         params = inspect.signature(target).parameters
     except (TypeError, ValueError):
         answer = False
     else:
-        answer = "locality" in params or any(
+        answer = name in params or any(
             p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()
         )
-    _LOCALITY_SUPPORT[target] = answer
+    by_name[name] = answer
     return answer
 
 
-#: Memo for ``_accepts_locality``. Keyed weakly so a handle class that goes
-#: away (a per-test double) does not pin its function objects in memory.
-_LOCALITY_SUPPORT: "weakref.WeakKeyDictionary[Any, bool]" = weakref.WeakKeyDictionary()
+#: Memo for ``_accepts_kw``, keyword name → answer per function. Keyed weakly
+#: so a handle class that goes away (a per-test double) does not pin its
+#: function objects in memory.
+_KEYWORD_SUPPORT: "weakref.WeakKeyDictionary[Any, dict[str, bool]]" = weakref.WeakKeyDictionary()
 
 
 #: Rows one ``job_trajectory`` reply may carry. The whole retained window is
@@ -177,6 +191,14 @@ class _ClientConn:
     #: auth frame; see ``ClientLocality``. Only ops that act on the USER's
     #: surroundings (an OAuth browser tab) read it.
     locality: ClientLocality = "local"
+    #: Which action-carrying slash receipts this client renders itself (see
+    #: ``SLASH_ACTION_RECEIPTS``). ``None`` means the auth frame omitted the
+    #: field, i.e. a client built before it existed — the runtime then
+    #: completes the action on its behalf. An EMPTY frozenset is a different
+    #: fact from ``None`` only in provenance, not in effect: both mean "this
+    #: type was not declared", which is the one rule the completion path
+    #: applies.
+    slash_consumers: frozenset[str] | None = None
     last_seen: float = field(default_factory=time.monotonic)
     # Frames on one TCP stream must stay ordered, while unrelated streams must
     # never queue behind its backpressure.
@@ -369,6 +391,16 @@ class RuntimeServer:
         #: for tests and for the "did a headless runtime pay for a fold?"
         #: question; 0 after a lifetime with no daemon client is the claim.
         self.projection_sinks_built: int = 0
+        # What build this runtime is running, stamped once at construction:
+        # the answer cannot change while the process lives, and the record is
+        # the channel an attach client reads it from before it dials.
+        #
+        # Imported function-locally although ``update`` is stdlib-only, because
+        # server.py sits near the CLI startup path and the house style there
+        # (see ``app.py``'s update imports) is to keep it off the import graph.
+        from local_operator.update import installed_build
+
+        build = installed_build()
         self._record = SessionRecord(
             pid=os.getpid(),
             kind=kind,  # type: ignore[arg-type]
@@ -384,6 +416,10 @@ class RuntimeServer:
             # the window before a viewer attaches is exactly when a detached
             # runtime is most interesting to look at.
             detached=True,
+            # The heartbeat republishes this same dataclass, so the stamp
+            # rides every rewrite without a second code path.
+            version=build.version,
+            source_ref=build.source_ref,
         )
         self._publisher: RecordPublisher | None = None
         self._server: asyncio.AbstractServer | None = None
@@ -806,6 +842,21 @@ class RuntimeServer:
         # carrying the flag (there is none today) is deliberately ignored.
         wants_events = kind == "attach" and bool(frame.get("events"))
         wants_frontend = kind == "attach" and bool(frame.get("frontend_state"))
+        # Which action-carrying receipts this client consumes itself. Parsed
+        # ONCE here rather than per command: the answer cannot change for the
+        # life of a connection. Absent (the common case today, and every
+        # client built before the field) stays ``None`` so the completion path
+        # can tell "did not declare" from "declared nothing" in the logs, even
+        # though both admit. Advisory only — a malformed value degrades to
+        # ``None`` and never refuses the connection, because a client that
+        # cannot attach is strictly worse than one whose request gets run
+        # twice-proof treatment it did not ask for.
+        raw_consumers = frame.get("slash_consumers")
+        slash_consumers: frozenset[str] | None = (
+            frozenset(str(item) for item in raw_consumers)
+            if isinstance(raw_consumers, (list, tuple))
+            else None
+        )
         if wants_frontend and FRONTEND_CAPABILITY not in self._record.capabilities:
             writer.close()
             return
@@ -833,6 +884,7 @@ class RuntimeServer:
             writer=writer,
             kind=kind,
             locality=locality,
+            slash_consumers=slash_consumers,
             wants_events=wants_events,
             wants_frontend=wants_frontend,
         )
@@ -1227,7 +1279,7 @@ class RuntimeServer:
                 # ``data`` the invoker renders locally (a slash command's typed
                 # outcome, a cancel's authoritative count) rather than a
                 # one-line receipt that would paint in the owner's transcript.
-                data = await self._dispatch_payload(op, frame, conn.locality)
+                data = await self._dispatch_payload(op, frame, conn.locality, conn.slash_consumers)
                 await self._send_to(conn, {"op": "result", "req": req, "data": data})
                 await self._handle.refresh()
                 await self._push()
@@ -1551,9 +1603,19 @@ class RuntimeServer:
         raise ValueError(f"unknown op: {op!r}")
 
     async def _dispatch_payload(
-        self, op: str, frame: dict[str, Any], locality: ClientLocality = "local"
+        self,
+        op: str,
+        frame: dict[str, Any],
+        locality: ClientLocality = "local",
+        consumers: frozenset[str] | None = None,
     ) -> Any:
-        """Structured-answer ops: the return value becomes the ``result`` data."""
+        """Structured-answer ops: the return value becomes the ``result`` data.
+
+        ``consumers`` is the calling connection's declared
+        ``slash_consumers`` set (``None`` when the auth frame omitted it),
+        carried here for the same reason ``locality`` is: it is a property of
+        the CONNECTION, not of the frame, and only the handle can act on it.
+        """
         h = self._handle
         if op == "fork_snapshot":
             # Fork destinations are resumed from this machine's session store.
@@ -1582,17 +1644,25 @@ class RuntimeServer:
                 str(frame.get("args", "")),
                 list(frame.get("images") or []),
             ]
-            # ``locality`` is passed only to handles that accept it. A handle
-            # is an injected collaborator — the TUI's, the runtime's, and test
-            # doubles all implement this — so widening the call unconditionally
-            # would break every implementation that has not been updated. The
-            # probe keeps the parameter OPTIONAL in the protocol rather than
-            # forcing a lockstep change, which is the same capability-probe
-            # stance the ops above take with ``getattr``.
-            if _accepts_locality(run):
-                result = run(*args, locality=locality)
-            else:
-                result = run(*args)
+            # ``locality`` and ``consumers`` are passed only to handles that
+            # accept them. A handle is an injected collaborator — the TUI's,
+            # the runtime's, and test doubles all implement this — so widening
+            # the call unconditionally would break every implementation that
+            # has not been updated. The probe keeps each parameter OPTIONAL in
+            # the protocol rather than forcing a lockstep change, which is the
+            # same capability-probe stance the ops above take with ``getattr``.
+            #
+            # ``consumers`` is what lets the handle decide whether the CLIENT
+            # will submit an action-carrying receipt's request or whether the
+            # runtime must do it. It is the connection's declaration, so it is
+            # read here where the connection is known rather than threaded
+            # through the frame.
+            kwargs: dict[str, Any] = {}
+            if _accepts_kw(run, "locality"):
+                kwargs["locality"] = locality
+            if _accepts_kw(run, "consumers"):
+                kwargs["consumers"] = consumers
+            result = run(*args, **kwargs)
             if inspect.isawaitable(result):
                 result = await result
             return result

--- a/local_operator/session/runtime/types.py
+++ b/local_operator/session/runtime/types.py
@@ -86,6 +86,24 @@ ClientLocality = Literal["local", "remote"]
 #: which liveness detection cannot see.
 ATTACH_MAX_CLIENTS = 4
 
+#: ``SlashResult`` ``data.type`` values that carry an ACTION for the invoking
+#: terminal: the owner attached a team or an agent profile, and the invoker is
+#: expected to submit ``data["request"]`` as a user turn of its own.
+#:
+#: This exists because that expectation used to be implicit, and an older
+#: viewer that did not hold it dropped the request in total silence: the
+#: runtime attached the team, returned "sending to <team>. <manager> is
+#: coordinating.", and the pre-#624 renderer printed the line and had no
+#: consumer for ``data.request``. No user row, no turn, no error.
+#:
+#: So a client that renders these DECLARES them in its auth frame's
+#: ``slash_consumers``; an undeclared (older) client means the RUNTIME admits
+#: the request itself. Absent-means-old, exactly like ``ClientKind`` above.
+#: The list is the single source of truth for both sides of that seam, and
+#: ``tests/unit/tui/test_noop_consumers.py`` fails CI if a producer emits a
+#: ``request``-carrying receipt whose type is missing here.
+SLASH_ACTION_RECEIPTS: tuple[str, ...] = ("team_attached", "agent_attached")
+
 
 # ---------------------------------------------------------------------------
 # Discovery record
@@ -159,6 +177,26 @@ class SessionRecord:
     #: cost has to be findable — this field is what puts it in `lop sessions`
     #: and sorts it first in the picker.
     pending: str | None = None
+
+    # -- build stamp --------------------------------------------------------
+    # Same additive contract as the live-state block above, and for the same
+    # reason: PROTOCOL_VERSION deliberately does not move for a field nobody
+    # is required to read.
+    #
+    # The record IS the version channel between a viewer and a runtime. An
+    # attach client reads it before dialing (``find_owner_record``) and holds
+    # it at bind, so one comparison there is complete — a runtime's build
+    # cannot change while the process lives.
+
+    #: What build this runtime is running (``update.installed_version()``).
+    #: ``""`` means a runtime older than this field, which by construction is
+    #: older than any terminal that can read it. A viewer compares this with
+    #: its own build to NAME skew rather than fail silently under it.
+    version: str = ""
+    #: The git ref of that install when ``lop-update`` recorded one; ``""``
+    #: for PyPI/pipx/editable installs. Needed because same-version rebuilds
+    #: are this host's common drift — see ``update.BuildStamp``.
+    source_ref: str = ""
 
     def to_json(self) -> dict[str, Any]:
         return asdict(self)

--- a/local_operator/session/runtime/types.py
+++ b/local_operator/session/runtime/types.py
@@ -105,6 +105,27 @@ ATTACH_MAX_CLIENTS = 4
 SLASH_ACTION_RECEIPTS: tuple[str, ...] = ("team_attached", "agent_attached")
 
 
+def runtime_must_complete(receipt_type: Any, consumers: Any) -> bool:
+    """Whether the OWNER must submit this receipt's request itself.
+
+    The one rule, in one place: a client completes a receipt only if it
+    DECLARED that type, so ``type not in declared`` — never ``declared is
+    None``. Both ``None`` (a client built before the field) and ``[]``
+    (declared, consumes nothing) mean undeclared and therefore admit here.
+
+    Extracted because the predicate has two hosts by contract — a session is
+    owned either by a detached runtime or by a TUI, and both must answer
+    identically. Hand-duplicating it left the two copies free to drift, where
+    a drift toward ``declared is None`` silently double-submits on one host
+    only (review round 1, NIT-2). Living beside ``SLASH_ACTION_RECEIPTS``
+    keeps the rule next to the list it is applied to; this module is
+    import-light by contract and this adds no imports.
+    """
+    if receipt_type not in SLASH_ACTION_RECEIPTS:
+        return False
+    return receipt_type not in (consumers or ())
+
+
 # ---------------------------------------------------------------------------
 # Discovery record
 # ---------------------------------------------------------------------------

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2505,11 +2505,13 @@ class OperatorApp(App[None]):
         except Exception:  # noqa: BLE001 — see above; degrade to "unknown"
             self._loaded_build = None
         #: Debounce for :meth:`_check_build_skew`. Keyed on the whole
-        #: ``(kind, from, to)`` triple rather than on the kind alone, so a
+        #: ``(kind, from, to, scope)`` key rather than on the kind alone, so a
         #: SECOND drift (two ``lop-update`` runs while this terminal lives) is
         #: still announced while the mount engage, the draft warm-up and the
-        #: slash engage together cost exactly one notice.
-        self._skew_notice_shown: set[tuple[str, str, str]] = set()
+        #: slash engage together cost exactly one notice. ``scope`` is the
+        #: session id for the owner notices and empty for disk drift — see
+        #: :meth:`_check_build_skew` for why the two differ.
+        self._skew_notice_shown: set[tuple[str, str, str, str]] = set()
         #: True while a runtime is being started for a cold viewer; the band
         #: says "starting…" for exactly this interval.
         self._starting_runtime = False
@@ -8594,8 +8596,18 @@ class OperatorApp(App[None]):
                 # to retry.
                 logger.debug("runtime engage failed (%s)", reason, exc_info=True)
                 self._warm_engage_started = False
+                return
             finally:
                 self._set_starting(False)
+            # AFTER a successful bind, which is the only moment the OWNER's
+            # build is knowable: the pre-spawn check above runs while the
+            # facade is still cold, so its C branch always returns at the
+            # ``is_cold`` guard and only disk drift can be reported there.
+            # Without this second call the mechanism misses the case it exists
+            # for — ``engage_runtime`` finding an EXISTING resident record and
+            # binding to it without spawning, i.e. an ordinary first prompt
+            # against a stale runtime (review round 1, R1-4).
+            self._check_build_skew(reason=f"{reason}-bound")
 
         self.run_worker(run(), group="warm-engage", exclusive=False)
 
@@ -14480,8 +14492,13 @@ class OperatorApp(App[None]):
         Called at the seams that spawn or bind a runtime (adopt, engage, the
         tail of a successful bind) \u2014 the moments the answer can change and the
         moments the user is about to depend on it. Debounced on the whole
-        (kind, from, to) triple so those seams together cost at most one
+        (kind, from, to, scope) key so those seams together cost at most one
         notice per distinct skew, while a genuinely new drift still speaks up.
+        Disk drift carries no scope: it is a fact about THIS process against
+        the disk, once per from/to pair whichever session is open. The owner
+        notices are scoped BY SESSION, so a terminal that adopts two different
+        stale runtimes hears about both \u2014 \"once per session per process\", which
+        is what design \u00a76.7 states.
 
         ``reason`` names the calling seam for logs only; the copy is chosen by
         WHICH skew was found, not by where it was noticed.
@@ -14493,8 +14510,15 @@ class OperatorApp(App[None]):
             # only produce false alarms.
             return
 
-        def announce(kind: str, before: str, after: str, body: str) -> None:
-            key = (kind, before, after)
+        def announce(kind: str, before: str, after: str, body: str, scope: str = "") -> None:
+            # ``scope`` narrows the debounce from per-process to per-SUBJECT
+            # where the subject is what varies: an owner notice describes ONE
+            # session's runtime, so a second stale session adopted in the same
+            # terminal is a different fact and must speak. Disk drift takes no
+            # scope because it describes THIS process against the disk and is
+            # genuinely once per (from, to) pair whichever session is open
+            # (review round 1, R1-5).
+            key = (kind, before, after, scope)
             if key in self._skew_notice_shown:
                 return
             self._skew_notice_shown.add(key)
@@ -14530,6 +14554,12 @@ class OperatorApp(App[None]):
             return
         owner_version = str(getattr(session, "owner_version", "") or "")
         owner_ref = str(getattr(session, "owner_source_ref", "") or "")
+        # The subject of an owner notice is the SESSION, so the debounce is
+        # keyed by it: "once per session per process", which is what design
+        # §6.7 and this method's own contract say. Keyed on the session id
+        # rather than the facade object so a takeover that swaps the object
+        # under one conversation does not re-announce the same runtime.
+        scope = str(getattr(session, "session_id", "") or id(session))
         if not owner_version:
             # A runtime older than the field itself. It cannot tell us what it
             # is running, but the absence is informative: the field ships in
@@ -14542,6 +14572,7 @@ class OperatorApp(App[None]):
                 loaded.label(),
                 "this session's runtime predates build reporting \u2014 it is older than "
                 "this terminal. /stop, then resend, restarts it on the current install.",
+                scope,
             )
             return
         from local_operator.update import BuildStamp
@@ -14555,6 +14586,7 @@ class OperatorApp(App[None]):
                 f"this session's runtime is running {owner.label()} but this terminal "
                 f"is {loaded.label()} \u2014 routed commands may behave differently. /stop, "
                 f"then resend: the runtime restarts on the current install.",
+                scope,
             )
 
     def _echo_user_command(self, text: str) -> None:
@@ -21187,20 +21219,19 @@ class OperatorApp(App[None]):
         # handle at ``_mobile_handle`` does the same), and this method runs
         # only when a follower routes a slash command to a TUI-hosted owner.
         from local_operator.session.runtime.server import image_blocks
-        from local_operator.session.runtime.types import SLASH_ACTION_RECEIPTS
+        from local_operator.session.runtime.types import runtime_must_complete
 
         if getattr(result, "kind", None) != "notice":
             return result
         data = getattr(result, "data", None) or {}
         receipt_type = data.get("type")
-        if receipt_type not in SLASH_ACTION_RECEIPTS:
+        # THE SAME predicate the runtime host applies, imported rather than
+        # restated: the two hosts must answer identically, and a second copy
+        # is free to drift toward double-submitting on this path alone.
+        if not runtime_must_complete(receipt_type, consumers):
             return result
         request = str(data.get("request") or "")
         if not request:
-            return result
-        if receipt_type in (consumers or ()):
-            # Declared: the client submits it. Doing it here as well is the
-            # double-submission failure the declaration exists to prevent.
             return result
         try:
             images = image_blocks(wire_images)

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -39,6 +39,7 @@ from typing import (
     Any,
     Awaitable,
     Callable,
+    Iterable,
     NamedTuple,
     Protocol,
     TypeGuard,
@@ -2488,6 +2489,27 @@ class OperatorApp(App[None]):
         #: binding. Reset by a session swap (`/new`, `/resume`), because the
         #: new binding is cold again and owes its own warm-up.
         self._warm_engage_started = False
+        #: What build THIS process loaded. App construction is process start
+        #: for a TUI, so this is the honest "what is running in here" token,
+        #: and it can never be refreshed — already-imported modules do not get
+        #: younger. Every later comparison is against this snapshot.
+        #:
+        #: Read lazily (``update`` is stdlib-only, but the house style keeps it
+        #: off the import graph) and never allowed to raise: a build stamp is a
+        #: diagnostic, and a TUI that will not boot because it could not read
+        #: its own version number is a far worse failure than undetected skew.
+        try:
+            from local_operator import update as _update_mod
+
+            self._loaded_build = _update_mod.installed_build()
+        except Exception:  # noqa: BLE001 — see above; degrade to "unknown"
+            self._loaded_build = None
+        #: Debounce for :meth:`_check_build_skew`. Keyed on the whole
+        #: ``(kind, from, to)`` triple rather than on the kind alone, so a
+        #: SECOND drift (two ``lop-update`` runs while this terminal lives) is
+        #: still announced while the mount engage, the draft warm-up and the
+        #: slash engage together cost exactly one notice.
+        self._skew_notice_shown: set[tuple[str, str, str]] = set()
         #: True while a runtime is being started for a cold viewer; the band
         #: says "starting…" for exactly this interval.
         self._starting_runtime = False
@@ -2989,6 +3011,14 @@ class OperatorApp(App[None]):
             self._measure_preloaded_context(session)
         elif getattr(session.frontend_state, "context_tokens", None) is None:
             self._measure_preloaded_context(session)
+        # LAST, and after the history is on screen: adoption covers `/new`,
+        # `/resume`, `/fork`, `/login` and the initial mount — every path that
+        # takes a session, and therefore every path that can pair this
+        # terminal with a runtime built from a different install. Placed at
+        # the tail so a skew notice lands under the replayed transcript rather
+        # than being scrolled away by it, the same ordering constraint
+        # ``_report_attachment_restore`` documents above.
+        self._check_build_skew(reason="adopt")
 
     def _invalidate_pending_frontend_state(self) -> None:
         """Retire queued paints before another session becomes authoritative."""
@@ -8531,6 +8561,11 @@ class OperatorApp(App[None]):
         ensure = getattr(session, "_ensure_bound", None)
         if not callable(ensure) or not getattr(session, "is_cold", False):
             return
+        # BEFORE the spawn, which is the moment the disk build matters: the
+        # runtime is started from ``sys.executable``, resolved fresh, so a
+        # terminal that has drifted behind the install is about to pair itself
+        # with a NEWER runtime. That pairing is the incident.
+        self._check_build_skew(reason=reason)
         if not self._runtime_can_start():
             # First run, or `hosting`/`model_name` cleared: there is nothing to
             # spawn against. The cold viewer opens on an empty config on
@@ -8690,6 +8725,11 @@ class OperatorApp(App[None]):
                     "warning",
                 )
                 return
+            # The bind resolved, so ``owner_version`` now holds the runtime's
+            # own stamp: this is the first moment the owner-skew comparison
+            # has anything to compare. Before the command runs, because a
+            # routed command is exactly what skew distorts.
+            self._check_build_skew(reason="slash-engage")
             operation = self._run_slash_command(text, attachments, _inline_remote=True)
             if operation is not None:
                 # Stay in the worker that joined the bind at commitment time.
@@ -14410,6 +14450,113 @@ class OperatorApp(App[None]):
         # the terminal resizes across the threshold and when the splash retires.
         self._append_block(block, ends_empty_state=False)
 
+    def _check_build_skew(self, *, reason: str) -> None:
+        """Warn when this terminal and the code around it are different builds.
+
+        Two long-lived populations coexist on a developer host: viewer TUIs
+        and the runtime processes they spawn. ``lop-update`` replaces the
+        on-disk install under both, often several times a day, and neither
+        side could see it. The concrete cost was a silent one: a TUI running
+        pre-#624 code spawned a runtime from the NEW install (the spawn
+        resolves ``sys.executable`` fresh), routed ``/team <name> <request>``
+        to it, printed the receipt, and dropped the request because that
+        build of the renderer had no consumer for it.
+
+        Two comparisons, both cheap and both advisory \u2014 nothing here blocks a
+        command or refuses an attach:
+
+        * **disk drift** \u2014 the install on disk is no longer the one this
+          process loaded, so any runtime started from here will be NEWER than
+          this terminal. ``/reload`` is the remedy because it restarts the
+          terminal on the current install and resumes the session.
+        * **owner skew** \u2014 the runtime this session is bound to reports a
+          different build than this terminal, or reports none at all (which
+          means it predates the field, and is therefore older by
+          construction). ``/stop`` then resend is the remedy: the bare
+          ``/stop`` on a follower asks the owner to stop, and the next prompt
+          engages a fresh runtime from the current install. Both keep working
+          in the meantime.
+
+        Called at the seams that spawn or bind a runtime (adopt, engage, the
+        tail of a successful bind) \u2014 the moments the answer can change and the
+        moments the user is about to depend on it. Debounced on the whole
+        (kind, from, to) triple so those seams together cost at most one
+        notice per distinct skew, while a genuinely new drift still speaks up.
+
+        ``reason`` names the calling seam for logs only; the copy is chosen by
+        WHICH skew was found, not by where it was noticed.
+        """
+        loaded = self._loaded_build
+        if loaded is None:
+            # This process could not read its own build (see ``__init__``);
+            # every comparison below would be against an unknown, which can
+            # only produce false alarms.
+            return
+
+        def announce(kind: str, before: str, after: str, body: str) -> None:
+            key = (kind, before, after)
+            if key in self._skew_notice_shown:
+                return
+            self._skew_notice_shown.add(key)
+            logger.debug("build skew (%s) noticed at %s: %s -> %s", kind, reason, before, after)
+            self._system_notice(body, "warning")
+
+        # --- A: has the install on disk moved under this process? ----------
+        try:
+            from local_operator import update as update_mod
+
+            on_disk = update_mod.installed_build()
+        except Exception:  # noqa: BLE001 — diagnostics never break a seam
+            on_disk = None
+        if on_disk is not None and on_disk != loaded:
+            announce(
+                "disk",
+                loaded.label(),
+                on_disk.label(),
+                f"the install on disk changed since this terminal started "
+                f"({loaded.label()} \u2192 {on_disk.label()}). Runtimes started from here "
+                f"run the NEW build against this old terminal. /reload restarts this "
+                f"terminal on the current install and resumes this session.",
+            )
+
+        # --- C: is the bound runtime a different build than this terminal? --
+        session = self._session
+        if session is None or not bool(getattr(session, "is_remote", False)):
+            return
+        # Only a BOUND follower has an owner to compare against. A cold viewer
+        # has not dialled anything yet, and reading its empty stamp would
+        # report every cold session as a prehistoric runtime.
+        if bool(getattr(session, "is_cold", False)):
+            return
+        owner_version = str(getattr(session, "owner_version", "") or "")
+        owner_ref = str(getattr(session, "owner_source_ref", "") or "")
+        if not owner_version:
+            # A runtime older than the field itself. It cannot tell us what it
+            # is running, but the absence is informative: the field ships in
+            # this build, so anything without it predates this terminal. Every
+            # resident runtime legitimately trips this once in the release
+            # window, and it is telling the truth each time.
+            announce(
+                "owner-unknown",
+                "",
+                loaded.label(),
+                "this session's runtime predates build reporting \u2014 it is older than "
+                "this terminal. /stop, then resend, restarts it on the current install.",
+            )
+            return
+        from local_operator.update import BuildStamp
+
+        owner = BuildStamp(version=owner_version, source_ref=owner_ref)
+        if owner != loaded:
+            announce(
+                "owner",
+                owner.label(),
+                loaded.label(),
+                f"this session's runtime is running {owner.label()} but this terminal "
+                f"is {loaded.label()} \u2014 routed commands may behave differently. /stop, "
+                f"then resend: the runtime restarts on the current install.",
+            )
+
     def _echo_user_command(self, text: str) -> None:
         """Write a slash command into the ledger as the user's own row, IF its
         registry entry permits one.
@@ -14506,6 +14653,26 @@ class OperatorApp(App[None]):
                     self._notice("no agents yet. Ask the agent to create one.")
                 else:
                     self._append_block(self._agent_list_block(rows))
+                return
+            if data.get("type") in ("team_mutate", "agent_mutate"):
+                # The LAST silent quadrant, and it is reachable only through
+                # the version dimension the static audit cannot see: no
+                # current producer emits these, but a runtime resident from
+                # before #624 still does, and this terminal is new enough to
+                # be talking to one. Without this arm the attach never
+                # happened AND nothing was printed — the original defect,
+                # arriving from the other side.
+                #
+                # Adding a consumer for a type nothing produces does not
+                # disturb ``test_noop_consumers``, which maps producers onto
+                # consumers rather than the reverse.
+                self._notice(
+                    "this session's runtime is running a build older than /team attach "
+                    "(pre 0.46.25); nothing was attached. /stop, then resend, to restart "
+                    "it on the current install.",
+                    "warning",
+                )
+                return
             return
         if kind == "block":
             block_type = data.get("type")
@@ -14535,6 +14702,14 @@ class OperatorApp(App[None]):
         # terminal's own images and paste expansion, and so the transcript row
         # is written by the one path that writes user rows. Order matters: the
         # receipt prints first, then the turn starts beneath it.
+        # Spelled as LITERALS, deliberately, and kept in step with
+        # ``SLASH_ACTION_RECEIPTS`` — the set ``RemoteSession`` declares in its
+        # auth frame — by ``test_noop_consumers``, which reads these strings
+        # statically out of this function. Importing the constant here would
+        # blind that audit to the very seam it guards: a type declared on the
+        # wire but not consumed here is a request the runtime deferred to this
+        # terminal and this terminal then dropped, which is the original
+        # defect wearing a new hat.
         if data.get("type") in ("team_attached", "agent_attached"):
             # Each receipt syncs ITS OWN segment (review round 1, N1): the
             # post-op push repaints both from ``frontend_state`` a tick later
@@ -20948,6 +21123,7 @@ class OperatorApp(App[None]):
         images: list[Any] | None = None,
         *,
         locality: str = "local",
+        consumers: Iterable[str] | None = None,
     ) -> dict[str, Any]:
         """Run one shared slash command and return its typed outcome as data.
 
@@ -20969,9 +21145,75 @@ class OperatorApp(App[None]):
 
         Only the commands a follower routes land here; process/terminal
         commands stay local and never reach this dispatcher.
+
+        ``consumers`` is which action-carrying receipts the invoking client
+        renders itself; see :meth:`_complete_unconsumed_action`.
         """
         result = await self._slash_result(command, args, images, locality)
+        result = self._complete_unconsumed_action(result, images, consumers)
         return result.model_dump(mode="json")
+
+    def _complete_unconsumed_action(
+        self,
+        result: Any,
+        wire_images: list[Any] | None,
+        consumers: Iterable[str] | None,
+    ) -> Any:
+        """The TUI-hosted owner's half of the runtime's completion path.
+
+        A session is owned either by a detached runtime or by THIS app, and
+        both hosts must agree — the same mirror contract
+        ``_team_attach_slash_result`` keeps with ``owned.py``. So the rule is
+        identical to ``OwnedSessionHandle._complete_unconsumed_action``: a
+        request-carrying attach receipt whose type the client did NOT declare
+        is submitted here, because that client will not submit it and would
+        otherwise drop it in silence.
+
+        Submission goes through :meth:`_submit_prompt` rather than
+        :meth:`_submit_command_prompt`, and that choice is load-bearing.
+        ``_submit_command_prompt`` re-resolves ``[Image #N]`` markers against
+        the COMPOSER's attachment map, which owner-side does not exist for a
+        request typed in another terminal — it would drop the wire images
+        entirely. ``_submit_prompt`` takes decoded image blocks directly,
+        paints the user row once, and keeps the echo registry consistent. Its
+        own streaming branch steers when a turn is running, so the busy
+        behaviour matches the runtime's for free.
+
+        Synchronous because every step is: this already runs on the app loop,
+        and ``_submit_prompt`` dispatches its own worker.
+        """
+        # Imported here rather than at module scope: both live under the
+        # runtime package, which the TUI otherwise touches only lazily (the
+        # handle at ``_mobile_handle`` does the same), and this method runs
+        # only when a follower routes a slash command to a TUI-hosted owner.
+        from local_operator.session.runtime.server import image_blocks
+        from local_operator.session.runtime.types import SLASH_ACTION_RECEIPTS
+
+        if getattr(result, "kind", None) != "notice":
+            return result
+        data = getattr(result, "data", None) or {}
+        receipt_type = data.get("type")
+        if receipt_type not in SLASH_ACTION_RECEIPTS:
+            return result
+        request = str(data.get("request") or "")
+        if not request:
+            return result
+        if receipt_type in (consumers or ()):
+            # Declared: the client submits it. Doing it here as well is the
+            # double-submission failure the declaration exists to prevent.
+            return result
+        try:
+            images = image_blocks(wire_images)
+            self._submit_prompt(request, images, None, typed=request)
+        except Exception as exc:  # noqa: BLE001 — the attach landed; name what did not
+            logger.debug("completing an unconsumed slash action failed", exc_info=True)
+            return result.model_copy(
+                update={
+                    "text": f"{result.text} — but the request was not sent: {exc}",
+                    "style": "warning",
+                }
+            )
+        return result
 
     async def _slash_result(
         self, command: str, args: str, images: list[Any] | None, locality: str = "local"

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -14479,15 +14479,22 @@ class OperatorApp(App[None]):
 
         * **disk drift** \u2014 the install on disk is no longer the one this
           process loaded, so any runtime started from here will be NEWER than
-          this terminal. ``/reload`` is the remedy because it restarts the
-          terminal on the current install and resumes the session.
+          this window. ``/reload`` is the remedy because it restarts the
+          window on the current install and picks the session back up.
         * **owner skew** \u2014 the runtime this session is bound to reports a
-          different build than this terminal, or reports none at all (which
+          different build than this window, or reports none at all (which
           means it predates the field, and is therefore older by
-          construction). ``/stop`` then resend is the remedy: the bare
+          construction). ``/stop`` then sending again is the remedy: the bare
           ``/stop`` on a follower asks the owner to stop, and the next prompt
           engages a fresh runtime from the current install. Both keep working
           in the meantime.
+
+        The COPY deliberately says "session" and "window" rather than
+        "runtime" and "terminal": the runtime/terminal split is real and
+        load-bearing for us, but the notice never explains it, so to a reader
+        the two words collapse into one thing they can see (design review
+        round 1, D2). The owner notices name the session by its title for the
+        same reason \u2014 see the ``subject`` construction below.
 
         Called at the seams that spawn or bind a runtime (adopt, engage, the
         tail of a successful bind) \u2014 the moments the answer can change and the
@@ -14537,10 +14544,9 @@ class OperatorApp(App[None]):
                 "disk",
                 loaded.label(),
                 on_disk.label(),
-                f"the install on disk changed since this terminal started "
-                f"({loaded.label()} \u2192 {on_disk.label()}). Runtimes started from here "
-                f"run the NEW build against this old terminal. /reload restarts this "
-                f"terminal on the current install and resumes this session.",
+                f"local-operator was updated after this window opened "
+                f"({_build_change(loaded, on_disk)}) \u2014 this window is still on the "
+                f"old version. /reload updates it and picks this session back up.",
             )
 
         # --- C: is the bound runtime a different build than this terminal? --
@@ -14560,18 +14566,28 @@ class OperatorApp(App[None]):
         # rather than the facade object so a takeover that swaps the object
         # under one conversation does not re-announce the same runtime.
         scope = str(getattr(session, "session_id", "") or id(session))
+        # NAME the session these notices are about. Two stale sessions in one
+        # terminal each legitimately get a notice (that is what the per-session
+        # debounce buys), but with a deictic "this session" in both they render
+        # as two byte-identical paragraphs — which reads as the app printing
+        # one warning twice, i.e. exactly the duplicate-notice bug the re-key
+        # fixed, and leaves ``/stop`` ambiguous about which session it acts on
+        # (design review round 1, D1). The title is what the user named and can
+        # see; "this session" survives only as the fallback for an unnamed one.
+        title = str(getattr(session, "conversation_name", "") or "").strip()
+        subject = f"\u201c{title}\u201d" if title else "this session"
         if not owner_version:
             # A runtime older than the field itself. It cannot tell us what it
             # is running, but the absence is informative: the field ships in
-            # this build, so anything without it predates this terminal. Every
-            # resident runtime legitimately trips this once in the release
-            # window, and it is telling the truth each time.
+            # this build, so anything without it is older than this window.
+            # Every resident runtime legitimately trips this once in the
+            # release window, and it is telling the truth each time.
             announce(
                 "owner-unknown",
                 "",
                 loaded.label(),
-                "this session's runtime predates build reporting \u2014 it is older than "
-                "this terminal. /stop, then resend, restarts it on the current install.",
+                f"{subject} is running an older version than this window \u2014 some "
+                f"commands may not work. /stop, then send again to restart it.",
                 scope,
             )
             return
@@ -14583,9 +14599,9 @@ class OperatorApp(App[None]):
                 "owner",
                 owner.label(),
                 loaded.label(),
-                f"this session's runtime is running {owner.label()} but this terminal "
-                f"is {loaded.label()} \u2014 routed commands may behave differently. /stop, "
-                f"then resend: the runtime restarts on the current install.",
+                f"{subject} is running {owner.label()} but this window is "
+                f"{loaded.label()} \u2014 some commands may not work. /stop, then send "
+                f"again to restart it.",
                 scope,
             )
 
@@ -14699,9 +14715,9 @@ class OperatorApp(App[None]):
                 # disturb ``test_noop_consumers``, which maps producers onto
                 # consumers rather than the reverse.
                 self._notice(
-                    "this session's runtime is running a build older than /team attach "
-                    "(pre 0.46.25); nothing was attached. /stop, then resend, to restart "
-                    "it on the current install.",
+                    "this session is running a version too old to attach a team "
+                    "(before 0.46.25); nothing was attached. /stop, then send again "
+                    "to restart it.",
                     "warning",
                 )
                 return
@@ -24371,6 +24387,28 @@ def _canonical_frontend(session: Any) -> bool:
     """
     attributes = getattr(session, "__dict__", {})
     return "_frontend_state_store" in attributes or "_frontend_store" in attributes
+
+
+def _build_change(before: Any, after: Any) -> str:
+    """How one build differs from another, without repeating what they share.
+
+    The headline case for drift is ``lop-update`` rebuilding from ``main``
+    WITHOUT a version bump, so both sides carry the same version and differ
+    only in the recorded commit. Two full labels then spend the sentence's most
+    prominent parenthetical restating one version:
+    ``0.48.0@aaaaaaa → 0.48.0@bbbbbbb``. The refs are the only distinguishing
+    fact there and must stay, but the version belongs outside the arrow:
+    ``0.48.0, aaaaaaa → bbbbbbb`` (design review round 1, D3).
+
+    When the versions genuinely differ the two-arm form is the honest one and
+    is kept. Deliberately a CALL-SITE formatter rather than a change to
+    ``BuildStamp.label()``: that method has other callers whose single-build
+    rendering is correct as it is.
+    """
+    same_version = before.version and before.version == after.version
+    if same_version and before.source_ref and after.source_ref:
+        return f"{before.version}, {before.source_ref[:7]} \u2192 {after.source_ref[:7]}"
+    return f"{before.label()} \u2192 {after.label()}"
 
 
 def _model_spec(session) -> Any | None:

--- a/local_operator/update.py
+++ b/local_operator/update.py
@@ -95,6 +95,45 @@ class VersionCheck:
     behind: bool
 
 
+@dataclass(frozen=True)
+class BuildStamp:
+    """One comparable build token: distribution version plus the git ref of
+    the install, when ``lop-update`` recorded one.
+
+    Two long-lived populations coexist on a developer host — viewer TUIs and
+    the runtime processes they spawn — while ``lop-update`` replaces the
+    on-disk install under them, often several times a day. Comparing what a
+    process LOADED with what is on disk now is how that skew becomes visible
+    instead of silent.
+
+    The ref is the primary key and the version the fallback, because this
+    host's common drift is a same-version rebuild: ``lop-update`` builds from
+    ``main`` while ``pyproject.toml`` still names the last released version,
+    so two genuinely different builds share one version string and only the
+    recorded commit tells them apart. Installs with no ``.lop-source`` (PyPI
+    wheels, pipx, editable checkouts) carry ``""`` and compare on version
+    alone — dev-tree skew is out of scope by design.
+
+    Frozen so a snapshot taken at process start cannot be mutated by the code
+    that later compares against it.
+    """
+
+    version: str
+    source_ref: str = ""
+
+    def label(self) -> str:
+        """How this build is named in a user-facing notice.
+
+        ``0.49.0`` when there is no ref to disambiguate, ``0.49.0@4d3ce1d``
+        when there is — short-form because a notice line is read, not copied,
+        and seven characters is the length git itself abbreviates to.
+        """
+        base = self.version or "unknown"
+        if not self.source_ref:
+            return base
+        return f"{base}@{self.source_ref[:7]}"
+
+
 def installed_version() -> str:
     """Distribution version, or ``""`` when this interpreter has no install.
 
@@ -401,6 +440,44 @@ def is_git_snapshot(prefix: str | Path | None = None) -> bool:
     """
     root = Path(prefix) if prefix is not None else Path(sys.prefix)
     return (root / ".lop-source").is_file()
+
+
+def source_ref(prefix: str | Path | None = None) -> str:
+    """The git ref ``lop-update`` recorded for this install, or ``""``.
+
+    ``lop-update`` writes ``<git-sha> <tag>`` into ``.lop-source`` at the same
+    root :func:`is_git_snapshot` probes, so the FIRST whitespace-separated
+    token is the commit the install was built from. Only that token is kept:
+    the tag half is a label that repeats across rebuilds of one release and
+    therefore cannot distinguish two builds, which is the whole job here.
+
+    Absent (a PyPI wheel, a pipx install, an editable checkout) is ``""``
+    rather than an error — those installs have no second token and fall back
+    to the distribution version alone.
+    """
+    root = Path(prefix) if prefix is not None else Path(sys.prefix)
+    try:
+        raw = (root / ".lop-source").read_text(encoding="utf-8")
+    except OSError:
+        # Missing, unreadable, or a directory. A build token is decoration on
+        # a diagnostic path; it must never raise into an adopt or a bind.
+        return ""
+    parts = raw.split()
+    return parts[0] if parts else ""
+
+
+def installed_build(prefix: str | Path | None = None) -> BuildStamp:
+    """This interpreter's comparable build token, read fresh from disk.
+
+    Called at the seams that spawn or bind a runtime (adopt, engage, bind) —
+    a handful of times per process, never on a hot path — because that is
+    exactly where a stale in-memory build meets a newer on-disk one. Both
+    reads are deliberately live: ``importlib.metadata.version`` re-reads the
+    dist-info directory (verified on this project's 3.12 and on 3.14.3: the
+    directory NAME carries the version, so even a path-keyed cache misses),
+    and ``.lop-source`` is one small file read.
+    """
+    return BuildStamp(version=installed_version(), source_ref=source_ref(prefix))
 
 
 def installer_argv(

--- a/local_operator/update.py
+++ b/local_operator/update.py
@@ -458,9 +458,15 @@ def source_ref(prefix: str | Path | None = None) -> str:
     root = Path(prefix) if prefix is not None else Path(sys.prefix)
     try:
         raw = (root / ".lop-source").read_text(encoding="utf-8")
-    except OSError:
-        # Missing, unreadable, or a directory. A build token is decoration on
-        # a diagnostic path; it must never raise into an adopt or a bind.
+    except (OSError, ValueError):
+        # Missing, unreadable, a directory (OSError) — or not valid UTF-8,
+        # which raises UnicodeDecodeError, a ValueError rather than an
+        # OSError. Both are caught because this must never raise into an
+        # adopt or a bind: ``RuntimeServer.__init__`` stamps the record from
+        # here, so an unhandled decode error on a corrupt marker would stop
+        # every runtime on the host from being constructed at all — total
+        # blast radius for a token that is only ever decoration on a
+        # diagnostic path (review round 1, R1-2).
         return ""
     parts = raw.split()
     return parts[0] if parts else ""

--- a/tests/e2e/test_viewer_attach_e2e.py
+++ b/tests/e2e/test_viewer_attach_e2e.py
@@ -446,3 +446,220 @@ async def test_a_cold_routed_team_command_is_not_retired_by_an_immediate_quit(
         launch_module.engage_runtime = original  # type: ignore[assignment]
         server.close()
         await handle.dispose()
+
+
+@pytest.mark.asyncio
+async def test_an_undeclaring_client_has_its_team_request_run_by_the_runtime(
+    headless_tui_env: Path, workspace: Path
+) -> None:
+    """THE INCIDENT, reproduced on the wire and then repaired.
+
+    A raw ``AttachClient`` constructed WITHOUT ``slash_consumers`` is exactly
+    what a pre-#624 viewer looks like to a runtime: the auth frame carries no
+    declaration, because that build had no such field. This was verified live
+    against a shipped 0.49.0 runtime — the probe received the ``team_attached``
+    receipt with the request inside it, and the session's transcript recorded
+    no user row and no turn. The team was attached; the request evaporated.
+
+    So this cell asserts on the OWNER's session, which is the half a client
+    cannot fake: the attach landed AND the request ran as a real turn. Driven
+    through the production handle, the production server and a real loopback
+    socket, because a stub that declares the capability is exactly what hid
+    the original defect (see this module's docstring).
+    """
+    from local_operator.mobile.attach_client import AttachClient
+    from local_operator.teams import TeamEditFields, TeamMember, TeamRegistry
+
+    registry = TeamRegistry(headless_tui_env)
+    registry.create_team(
+        TeamEditFields(
+            name="viewerteam",
+            description="d",
+            manager="manager",
+            members=[TeamMember(role="coder")],
+        )
+    )
+
+    directory = headless_tui_env / "sessions" / "skewsess0001"
+    directory.mkdir(parents=True)
+    session, _handle, server = await _runtime(directory, ["ack"])
+    session.team_registry = registry
+    await server.start_in_process()
+    client = None
+    try:
+        record = await _wait_for_record(headless_tui_env, session.session_id)
+
+        # No ``slash_consumers``: the old viewer on the wire.
+        client = AttachClient(lambda _p: None, lambda _r: None)
+        await client.connect(record, session.session_id)
+
+        outcome = await client.slash_result("team", "viewerteam do the thing", [])
+
+        assert (outcome.get("data") or {}).get("type") == "team_attached"
+        assert session.active_team_name == "viewerteam", "the attach must still land"
+
+        # THE PROPERTY THE INCIDENT LACKED: a real turn ran. Asserted on the
+        # runtime's durable transcript rather than on any client-side echo,
+        # because the transcript is what the manager's live probe read to
+        # prove the request had been dropped.
+        transcript_path = directory / "transcript.jsonl"
+        for _ in range(200):
+            if transcript_path.exists() and "do the thing" in transcript_path.read_text(
+                encoding="utf-8"
+            ):
+                break
+            await asyncio.sleep(0.05)
+        else:  # pragma: no cover - only on a real regression
+            written = (
+                transcript_path.read_text(encoding="utf-8")
+                if transcript_path.exists()
+                else "<absent>"
+            )
+            raise AssertionError(
+                "the runtime never ran the request an undeclaring client cannot "
+                f"submit itself; transcript was {written}"
+            )
+    finally:
+        if client is not None:
+            client.close()
+        server.close()
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_declaring_client_is_never_double_submitted(
+    headless_tui_env: Path, workspace: Path
+) -> None:
+    """The guard on the repair: a current viewer submits its own request.
+
+    ``SLASH_ACTION_RECEIPTS`` in the auth frame is a promise — "I render these
+    and will submit the request myself". A runtime that admitted anyway would
+    turn one typed command into two turns, which is a worse failure than the
+    silent drop because the user cannot tell which turn is which or undo one.
+
+    Asserted as the ABSENCE of a turn on the owner, with the attach present:
+    the receipt still comes back, the roster is still stamped, and the
+    transcript stays empty of the request.
+    """
+    from local_operator.mobile.attach_client import AttachClient
+    from local_operator.session.runtime.types import SLASH_ACTION_RECEIPTS
+    from local_operator.teams import TeamEditFields, TeamMember, TeamRegistry
+
+    registry = TeamRegistry(headless_tui_env)
+    registry.create_team(
+        TeamEditFields(
+            name="viewerteam",
+            description="d",
+            manager="manager",
+            members=[TeamMember(role="coder")],
+        )
+    )
+
+    directory = headless_tui_env / "sessions" / "skewsess0002"
+    directory.mkdir(parents=True)
+    session, _handle, server = await _runtime(directory, ["ack"])
+    session.team_registry = registry
+    await server.start_in_process()
+    client = None
+    try:
+        record = await _wait_for_record(headless_tui_env, session.session_id)
+        client = AttachClient(
+            lambda _p: None,
+            lambda _r: None,
+            slash_consumers=list(SLASH_ACTION_RECEIPTS),
+        )
+        await client.connect(record, session.session_id)
+
+        outcome = await client.slash_result("team", "viewerteam do the thing", [])
+
+        assert (outcome.get("data") or {}).get("type") == "team_attached"
+        assert (outcome.get("data") or {}).get("request") == "do the thing"
+        assert session.active_team_name == "viewerteam", "the attach is the owner's job either way"
+
+        # Give the runtime the same window the cell above needed to run a
+        # turn. Nothing may appear in it — this is an absence assertion, so it
+        # must be given real time to fail rather than being read immediately.
+        transcript_path = directory / "transcript.jsonl"
+        for _ in range(20):
+            await asyncio.sleep(0.05)
+            if transcript_path.exists() and "do the thing" in transcript_path.read_text(
+                encoding="utf-8"
+            ):
+                raise AssertionError(
+                    "the runtime admitted a request the client declared it would "
+                    "submit itself; the user's command runs twice"
+                )
+    finally:
+        if client is not None:
+            client.close()
+        server.close()
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_published_record_carries_this_runtime_s_build(
+    headless_tui_env: Path, workspace: Path
+) -> None:
+    """The version channel, end to end: what a viewer reads before it dials.
+
+    The record is the earliest hello there is — an attach client holds it
+    before the socket is open — so the stamp has to be on the file a real
+    ``registry.scan`` returns, not merely on an in-memory dataclass.
+    """
+    from local_operator.update import installed_version
+
+    directory = headless_tui_env / "sessions" / "stampsess001"
+    directory.mkdir(parents=True)
+    session, _handle, server = await _runtime(directory, [])
+    await server.start_in_process()
+    try:
+        record = await _wait_for_record(headless_tui_env, session.session_id)
+        assert record.version == installed_version(), (
+            "a runtime that cannot say what build it runs leaves every viewer "
+            "unable to name the skew it is about to hit"
+        )
+    finally:
+        server.close()
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_record_carries_the_source_ref_when_lop_update_recorded_one(
+    headless_tui_env: Path, workspace: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Same-version rebuilds are this host's common drift, so the ref matters.
+
+    ``lop-update`` writes ``<sha> <tag>`` into ``.lop-source`` at the install
+    root. With a fake marker in place the runtime must publish that sha —
+    without it, two builds of one release are indistinguishable on the wire
+    and the drift goes unreported.
+    """
+    marker_root = tmp_path / "prefix"
+    marker_root.mkdir()
+    (marker_root / ".lop-source").write_text("feedfacecafe1234 v0.49.0\n", encoding="utf-8")
+
+    import local_operator.update as update_mod
+
+    # The REAL ``installed_build``, pointed at the fixture prefix: the marker
+    # file is genuinely parsed, so a change that stopped reading ``.lop-source``
+    # (or read the tag instead of the sha) fails here. Patching the function
+    # wholesale would assert only that the server copies two attributes.
+    monkeypatch.setattr(
+        update_mod,
+        "installed_build",
+        lambda *_a, **_k: update_mod.BuildStamp(
+            version=update_mod.installed_version(),
+            source_ref=update_mod.source_ref(marker_root),
+        ),
+    )
+
+    directory = headless_tui_env / "sessions" / "stampsess002"
+    directory.mkdir(parents=True)
+    session, _handle, server = await _runtime(directory, [])
+    await server.start_in_process()
+    try:
+        record = await _wait_for_record(headless_tui_env, session.session_id)
+        assert record.source_ref == "feedfacecafe1234"
+    finally:
+        server.close()
+        await session.dispose()

--- a/tests/unit/session/runtime/test_action_receipt_completion.py
+++ b/tests/unit/session/runtime/test_action_receipt_completion.py
@@ -1,0 +1,382 @@
+"""The runtime completes an attach receipt's request when the client will not.
+
+**This file exists because `/team lopdev <request>` attached the team and then
+dropped the request in total silence, live, against a shipped runtime.**
+
+The mechanism is a version seam rather than a typo, which is why no existing
+test could see it. Since #624 the owner answers a routed `/team <name>
+<request>` with a ``team_attached`` receipt carrying the request, and the
+VIEWER is expected to submit that request as a user turn. A viewer built
+before #624 prints the receipt text and has no consumer for
+``data["request"]`` — so the team was attached, "sending to <team>. <manager>
+is coordinating." was printed, and no user row and no turn ever appeared.
+
+That pairing is not exotic on a developer host: ``lop-update`` replaces the
+on-disk install several times a day, a long-lived TUI keeps running the code
+it loaded, and the runtime it spawns resolves ``sys.executable`` fresh — so an
+OLD terminal routinely drives a NEW runtime. The repair is that the runtime
+admits the request itself for any client that did not declare it consumes the
+receipt type.
+
+The invariant these tests pin, in both directions:
+
+* **undeclared ⇒ admit** — the request has no other home, so the runtime runs
+  it. ``None`` (older client, no field) and ``[]`` (declared, consumes
+  nothing) are both undeclared.
+* **declared ⇒ do not admit** — the client submits it, and a runtime that also
+  admitted would run the user's command twice, which is worse than the bug.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import tempfile
+from pathlib import Path
+from typing import Any, AsyncIterator
+
+import pytest
+
+from local_operator.session.runtime.owned import OwnedSessionHandle
+from local_operator.session.runtime.types import SLASH_ACTION_RECEIPTS
+from local_operator.teams import TeamEditFields, TeamMember, TeamRegistry
+from tests.unit.session.runtime.test_owned import FakeSession, make_handle
+
+
+class _Receipt:
+    """The ``SlashResult`` slice the completion path reads.
+
+    A stand-in rather than the real pydantic model so a test can produce a
+    receipt shape directly without routing a whole slash command through the
+    session — the completion predicate is what is under test here, not the
+    ``/team`` grammar (``test_owned.py`` and the e2e stage cover that end).
+    ``model_copy`` is reproduced because the failure path uses it.
+    """
+
+    def __init__(self, kind: str, text: str, data: dict[str, Any] | None, style: str = "info"):
+        self.kind = kind
+        self.text = text
+        self.style = style
+        self.data = data
+
+    def model_copy(self, *, update: dict[str, Any]) -> "_Receipt":
+        clone = _Receipt(self.kind, self.text, self.data, self.style)
+        for key, value in update.items():
+            setattr(clone, key, value)
+        return clone
+
+
+def _attach_receipt(receipt_type: str = "team_attached", request: str = "do the thing") -> _Receipt:
+    """The exact shape ``owned.py::_team_attach_slash`` returns on attach."""
+    return _Receipt(
+        kind="notice",
+        text="sending to lopdev. manager is coordinating.",
+        data={
+            "type": receipt_type,
+            "team": "lopdev",
+            "manager": "manager",
+            "request": request,
+        },
+    )
+
+
+class _TeamSession(FakeSession):
+    """A session double that can genuinely attach a team.
+
+    ``_team_attach_slash`` refuses outright when the session has no
+    ``attach_team`` — an owner that cannot attach must not let a request run
+    with no roster while the receipt claims a manager is coordinating. So the
+    double grows the seam rather than the guard being weakened for the test:
+    the receipt these cells assert on only exists on a session that really
+    attached. A SUBCLASS rather than attributes bolted on at runtime, so the
+    shape is part of the double's declared contract.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.team_registry: Any = None
+        self.attached_teams: list[str] = []
+        self.active_team_name: str = ""
+
+    def attach_team(self, team: Any) -> None:
+        name = getattr(team, "name", str(team))
+        self.attached_teams.append(name)
+        self.active_team_name = name
+
+
+@contextlib.asynccontextmanager
+async def _team_handle() -> AsyncIterator[tuple[OwnedSessionHandle, _TeamSession]]:
+    """A handle over a session that really can attach ``lopdev``."""
+    session = _TeamSession()
+    handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd="/tmp")
+    with tempfile.TemporaryDirectory() as tmp:
+        registry = TeamRegistry(Path(tmp))
+        registry.create_team(
+            TeamEditFields(
+                name="lopdev",
+                description="d",
+                manager="manager",
+                members=[TeamMember(role="coder")],
+            )
+        )
+        session.team_registry = registry
+        yield handle, session
+
+
+async def _settle() -> None:
+    """Let the handle's prompt drain task reach the session.
+
+    Admission is durable-first: ``prompt`` queues a ``_PromptCommand`` and the
+    drain forwards it. Both are on this loop, so yielding is enough — no
+    wall-clock budget, which would be a bet on machine load rather than a
+    test.
+    """
+    for _ in range(20):
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_an_undeclared_receipt_has_its_request_admitted() -> None:
+    """THE INCIDENT, at the unit seam: ``consumers=None`` is the old viewer.
+
+    A client that never heard of ``slash_consumers`` sends no declaration, so
+    the runtime must run the request itself. Before the fix this returned the
+    receipt and nothing else happened anywhere.
+    """
+    handle, session = make_handle()
+    images = [{"data_b64": "aGk=", "mime_type": "image/png"}]
+
+    result = await handle._complete_unconsumed_action(_attach_receipt(), images, None)
+
+    await _settle()
+    assert session.prompt_calls == ["do the thing"], (
+        "the runtime must admit the request for a client that did not declare "
+        "the receipt type; this is the silent drop the incident reported"
+    )
+    assert result.style == "info", "a successful admission must not warn"
+    assert result.text == "sending to lopdev. manager is coordinating.", (
+        "the receipt copy is unchanged because it is now TRUE — the request " "really was sent"
+    )
+
+
+@pytest.mark.asyncio
+async def test_declaring_nothing_is_not_the_same_as_consuming() -> None:
+    """``consumers=[]`` also admits: the rule is ``type not in declared``.
+
+    Spelled as its own cell because the tempting implementation — "admit when
+    the field was absent" — passes the test above and fails here, leaving a
+    client that declares an empty list silently dropping every request.
+    """
+    handle, session = make_handle()
+
+    await handle._complete_unconsumed_action(_attach_receipt(), None, [])
+
+    await _settle()
+    assert session.prompt_calls == ["do the thing"]
+
+
+@pytest.mark.asyncio
+async def test_a_declared_receipt_is_never_admitted_by_the_runtime() -> None:
+    """The double-submission guard, and the reason the declaration exists.
+
+    A current viewer submits the request from its own terminal so the row
+    carries its images and paste expansion. If the runtime also admitted, the
+    user would see one typed command produce two turns with no way to tell
+    which is which — strictly worse than the bug being repaired.
+    """
+    handle, session = make_handle()
+
+    result = await handle._complete_unconsumed_action(
+        _attach_receipt(), None, list(SLASH_ACTION_RECEIPTS)
+    )
+
+    await _settle()
+    assert session.prompt_calls == [], "a declared receipt must be left to the client"
+    assert session.steer_calls == []
+    assert result.style == "info"
+
+
+@pytest.mark.asyncio
+async def test_a_receipt_with_no_request_is_not_an_action() -> None:
+    """``/agent clear`` returns ``agent_attached`` with ``request: ""``.
+
+    A detach is a receipt with no action behind it. Admitting an empty prompt
+    would start a turn with no words in it.
+    """
+    handle, session = make_handle()
+
+    await handle._complete_unconsumed_action(
+        _attach_receipt("agent_attached", request=""), None, None
+    )
+
+    await _settle()
+    assert session.prompt_calls == []
+    assert session.steer_calls == []
+
+
+@pytest.mark.asyncio
+async def test_a_non_action_receipt_passes_through_untouched() -> None:
+    """Only the action-carrying types are completed.
+
+    Every other routed slash — ``/goal``, ``/rename``, a refusal notice —
+    returns through this same path and must be handed back byte-identical.
+    """
+    handle, session = make_handle()
+    plain = _Receipt(kind="notice", text="goal set", data={"type": "goal"})
+
+    result = await handle._complete_unconsumed_action(plain, None, None)
+
+    await _settle()
+    assert result is plain
+    assert session.prompt_calls == []
+
+
+@pytest.mark.asyncio
+async def test_a_busy_session_is_steered_rather_than_prompted() -> None:
+    """Mid-turn, the completion STEERS — mirroring what a viewer does.
+
+    ``prompt`` rejects a concurrent call, so admitting one while a turn runs
+    would throw the request away. Steering delivers it at the engine's next
+    boundary, which is the existing mid-turn channel and the same choice
+    ``app.py::_submit_prompt`` makes.
+    """
+    handle, session = make_handle()
+    session.is_streaming = True
+
+    await handle._complete_unconsumed_action(_attach_receipt(), None, None)
+
+    await _settle()
+    assert session.steer_calls == ["do the thing"]
+    assert session.prompt_calls == []
+
+
+@pytest.mark.asyncio
+async def test_a_failed_admission_reports_a_warning_instead_of_silence() -> None:
+    """The attach landed; only the turn did not start. Say so.
+
+    Session closing, a full queue, a rejected prompt: the attach has already
+    happened and stays, so the receipt is rewritten as a WARNING naming the
+    failure. That is the whole difference from the original defect — the user
+    learns the request did not run and can resend, rather than watching
+    nothing happen.
+    """
+    handle, session = make_handle()
+
+    async def refuse(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("session is closing; prompt was not admitted")
+
+    handle.prompt = refuse  # type: ignore[method-assign]
+
+    result = await handle._complete_unconsumed_action(_attach_receipt(), None, None)
+
+    assert result.style == "warning"
+    assert "the request was not sent" in result.text
+    assert "session is closing" in result.text, "the warning must name the actual failure"
+    assert result.text.startswith("sending to lopdev."), "the attach receipt is still reported"
+    assert session.prompt_calls == []
+
+
+@pytest.mark.asyncio
+async def test_the_full_routed_path_admits_for_an_undeclared_client() -> None:
+    """End of the handle's own path: ``run_slash_authoritative`` wires it up.
+
+    The cells above drive the predicate directly. This one goes through the
+    public method the server actually calls, so a completion that works but is
+    never invoked cannot pass.
+    """
+    async with _team_handle() as (handle, session):
+        outcome = await handle.run_slash_authoritative(
+            "team", "lopdev do the thing", [], consumers=None
+        )
+
+        await _settle()
+        assert outcome["data"]["type"] == "team_attached"
+        assert outcome["data"]["request"] == "do the thing"
+        assert session.attached_teams == ["lopdev"], "the attach still happens on the owner"
+        assert session.prompt_calls == ["do the thing"], (
+            "the routed path must complete an undeclared client's request; this "
+            "is the exact call the RuntimeServer makes for a pre-#624 viewer"
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_full_routed_path_defers_to_a_declaring_client() -> None:
+    """The same public path, with the declaration present: no admission.
+
+    The ATTACH still happens — that is the owner's job either way. Only the
+    request submission is left to the client.
+    """
+    async with _team_handle() as (handle, session):
+        outcome = await handle.run_slash_authoritative(
+            "team", "lopdev do the thing", [], consumers=list(SLASH_ACTION_RECEIPTS)
+        )
+
+        await _settle()
+        assert outcome["data"]["request"] == "do the thing"
+        assert session.attached_teams == ["lopdev"]
+        assert session.prompt_calls == []
+
+
+def test_the_declared_set_matches_what_the_producers_emit() -> None:
+    """A cheap sanity pin on the constant itself.
+
+    The static audit in ``tests/unit/tui/test_noop_consumers.py`` proves the
+    set equals the producers' and the renderer's. This asserts the value is
+    non-empty and stringy, so a refactor that empties it fails HERE with an
+    obvious message rather than only as a silent no-op in the completion path.
+    """
+    assert SLASH_ACTION_RECEIPTS
+    assert all(isinstance(item, str) and item for item in SLASH_ACTION_RECEIPTS)
+
+
+@pytest.mark.asyncio
+async def test_images_ride_the_completed_request() -> None:
+    """Wire images survive the completion; only paste BODIES degrade.
+
+    The viewer sends resolved image blocks in the ``slash_result`` frame, so
+    they are already on this side and go into the admission unchanged. This is
+    the documented half of the degradation note: a screenshot the request
+    cites still reaches the manager as pixels.
+    """
+    handle, session = make_handle()
+    captured: list[Any] = []
+
+    async def capture(text: str, images: Any = None, command_id: str | None = None) -> str:
+        captured.append(images)
+        session.prompt_calls.append(text)
+        return "ok"
+
+    handle.prompt = capture  # type: ignore[method-assign]
+
+    await handle._complete_unconsumed_action(
+        _attach_receipt(), [{"data_b64": "aGk=", "mime_type": "image/png"}], None
+    )
+
+    assert session.prompt_calls == ["do the thing"]
+    assert captured and captured[0], "the wire images must reach the admission"
+
+
+@pytest.mark.asyncio
+async def test_each_completion_uses_a_fresh_command_id() -> None:
+    """Two completions must not collide on one durable command identity.
+
+    The admission path is producer-keyed for replay safety: reusing an id
+    would make the second request read as a duplicate of the first and be
+    dropped — reintroducing the silence on the second ``/team`` of a session.
+    """
+    handle, session = make_handle()
+    ids: list[str | None] = []
+
+    async def capture(text: str, images: Any = None, command_id: str | None = None) -> str:
+        ids.append(command_id)
+        session.prompt_calls.append(text)
+        return "ok"
+
+    handle.prompt = capture  # type: ignore[method-assign]
+
+    await handle._complete_unconsumed_action(_attach_receipt(), None, None)
+    await handle._complete_unconsumed_action(_attach_receipt(request="again"), None, None)
+
+    assert len(ids) == 2
+    assert all(ids), "every admission needs an explicit command id"
+    assert ids[0] != ids[1], "a reused id makes the second request read as a duplicate"

--- a/tests/unit/session/runtime/test_action_receipt_completion.py
+++ b/tests/unit/session/runtime/test_action_receipt_completion.py
@@ -380,3 +380,94 @@ async def test_each_completion_uses_a_fresh_command_id() -> None:
     assert len(ids) == 2
     assert all(ids), "every admission needs an explicit command id"
     assert ids[0] != ids[1], "a reused id makes the second request read as a duplicate"
+
+
+class _SlowDrainSession(FakeSession):
+    """A session whose admission resolves only after a prior turn finishes.
+
+    Models the real shape: ``Session`` resolves a prompt's ``admitted`` future
+    on the durable transcript append, which the drain performs when it reaches
+    that command — so a turn queued ahead holds the next admission open. The
+    flag matters too: ``is_streaming`` is still False during the drain's
+    pre-streaming prelude, which is the window the steer guard cannot see.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.release = asyncio.Event()
+        self.started: list[str] = []
+
+    # ``message_id``/``admitted`` are load-bearing on this double, not
+    # decoration. The handle probes for ``message_id`` (``owned.py``'s
+    # ``legacy_prompt`` check) and, when it is ABSENT, resolves the admission
+    # immediately as a compatibility shim for pre-durable sessions — so a
+    # double without it never exercises the durable path and cannot reproduce
+    # the park at all. The first version of this test passed on the UNFIXED
+    # tree for exactly that reason, which is why it is spelled to match
+    # production ``Session``: the drain hands over the ``admitted`` future and
+    # the session resolves it on the durable append.
+    async def prompt(  # noqa: ANN001
+        self, text: str, images=None, message_id=None, admitted=None, **_kwargs
+    ) -> None:
+        self.started.append(text)
+        self.prompt_calls.append(text)
+        # Deliberately NOT setting is_streaming: this is the prelude window,
+        # where a turn is admitted and running but the flag is still False —
+        # the window the steer guard cannot see.
+        await self.release.wait()
+        if admitted is not None and not admitted.done():
+            admitted.set_result(None)
+
+
+@pytest.mark.asyncio
+async def test_the_receipt_returns_without_waiting_for_a_queued_turn() -> None:
+    """R1-1: the reply must not be held open for the duration of a prior turn.
+
+    ``prompt`` resolves its receipt on the durable append, so AWAITING it here
+    parked the ``slash_result`` response behind whatever was already running.
+    Measured at 4.35 s in review; anything over the client's ``ACK_TIMEOUT_S``
+    (15 s) makes the viewer raise a transport error for a request that was in
+    fact admitted — worse than the silent drop this method exists to fix — and
+    the per-connection reader is serial, so every later op from that viewer
+    queues behind the park too.
+
+    Asserted structurally rather than on a stopwatch: the receipt is produced
+    while the session is still blocked, which is a fact about ordering that no
+    amount of machine load can change (AGENTS.md: wait on the event, never on
+    the clock).
+    """
+    session = _SlowDrainSession()
+    handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd="/tmp")
+
+    result = await handle._complete_unconsumed_action(_attach_receipt(), None, None)
+
+    assert not session.release.is_set(), "the turn must still be in flight"
+    assert result.style == "info", "a dispatched admission is not a failure to report"
+    assert result.text == "sending to lopdev. manager is coordinating."
+
+    # And the turn really was admitted, not dropped: release the drain and it
+    # completes on its own.
+    session.release.set()
+    await _settle()
+    assert session.prompt_calls == ["do the thing"]
+
+
+@pytest.mark.asyncio
+async def test_a_synchronous_refusal_is_still_reported_after_dispatching() -> None:
+    """Dispatching must not cost the warning receipt for FAST failures.
+
+    A closing session, a full queue and a rejected reservation all raise in
+    ``prompt``'s synchronous prelude, before it ever awaits — so they are still
+    knowable when the receipt is built, and step 4's contract survives the
+    change. Only the slow outcome (a turn genuinely queued behind another) is
+    left to run detached.
+    """
+    handle, session = make_handle()
+    handle._disposing = True
+
+    result = await handle._complete_unconsumed_action(_attach_receipt(), None, None)
+
+    assert result.style == "warning"
+    assert "the request was not sent" in result.text
+    assert "session is closing" in result.text
+    assert session.prompt_calls == []

--- a/tests/unit/session/runtime/test_registry.py
+++ b/tests/unit/session/runtime/test_registry.py
@@ -130,3 +130,58 @@ def test_a_killed_runtime_is_not_reported_live_while_it_is_a_zombie() -> None:
 
     # Once reaped, both paths agree it is gone.
     assert pid_alive(proc.pid) is False
+
+
+def test_the_build_stamp_round_trips_on_a_record(tmp_path: Path) -> None:
+    """The record IS the version channel between a viewer and a runtime.
+
+    An attach client reads it before it dials, so whatever the runtime stamped
+    has to survive the JSON round trip intact — a stamp that only exists in
+    the writing process tells nobody anything.
+    """
+    record = make_record()
+    record.version = "0.49.0"
+    record.source_ref = "4d3ce1d1a48f4f3b799efdfabb014979e70e0630"
+    restored = SessionRecord.from_json(record.to_json())
+    assert restored.version == "0.49.0"
+    assert restored.source_ref == "4d3ce1d1a48f4f3b799efdfabb014979e70e0630"
+
+
+def test_a_record_from_an_older_runtime_defaults_the_build_stamp() -> None:
+    """Additive means an OLD writer's payload still parses, as empty strings.
+
+    Every runtime resident when this ships predates the fields, and a new
+    viewer must read those records normally rather than raising mid-scan. The
+    empty stamp is itself the signal: a runtime that cannot say what it runs
+    is older than the terminal reading it.
+    """
+    payload = make_record().to_json()
+    payload.pop("version")
+    payload.pop("source_ref")
+    restored = SessionRecord.from_json(payload)
+    assert restored.version == ""
+    assert restored.source_ref == ""
+
+
+def test_the_heartbeat_republishes_the_build_stamp(tmp_path: Path) -> None:
+    """The stamp rides every rewrite because the publisher owns the dataclass.
+
+    ``RecordPublisher.heartbeat`` re-serialises the live record object rather
+    than rebuilding a payload from a field list, so a new field is carried
+    without a second code path. Pinned because the alternative — a hand-rolled
+    dict somewhere in the heartbeat — would publish the stamp once at startup
+    and then quietly drop it on the first rewrite, 15 seconds later.
+    """
+    record = make_record()
+    record.version = "0.49.0"
+    record.source_ref = "abc1234"
+    publisher = registry.RecordPublisher(record, root=tmp_path)
+    try:
+        publisher.heartbeat(conversation_name="renamed")
+        found = [rec for rec, _state in registry.scan(root=tmp_path) if rec.pid == record.pid]
+        assert found, "the republished record must still be discoverable"
+        assert found[0].version == "0.49.0"
+        assert found[0].source_ref == "abc1234"
+        assert found[0].conversation_name == "renamed", "the rewrite really happened"
+    finally:
+        publisher.close()

--- a/tests/unit/session/runtime/test_server.py
+++ b/tests/unit/session/runtime/test_server.py
@@ -243,6 +243,7 @@ async def _dial(
     *,
     client: str | None = None,
     locality: str | None = None,
+    slash_consumers: list[str] | None = None,
 ):
     """Open + auth one connection; consume the welcome projection."""
     reader, writer = await asyncio.open_connection("127.0.0.1", record.control_port, limit=1 << 20)
@@ -251,6 +252,8 @@ async def _dial(
         auth["client"] = client
     if locality is not None:
         auth["locality"] = locality
+    if slash_consumers is not None:
+        auth["slash_consumers"] = slash_consumers
     writer.write(json.dumps(auth).encode() + b"\n")
     await writer.drain()
     welcome = await asyncio.wait_for(reader.readline(), timeout=5)
@@ -1553,6 +1556,156 @@ async def test_a_handle_that_does_not_take_locality_still_works() -> None:
         await writer.drain()
         frame = await _until(reader, "result", 5)
         assert frame["data"]["text"] == "owner ran /goal"
+    finally:
+        if writer is not None:
+            writer.close()
+        runtime.close()
+
+
+class _ConsumersHandle(FakeHandle):
+    """Records the ``consumers`` set each routed slash was dispatched with."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.consumers: list[Any] = []
+
+    async def run_slash_authoritative(
+        self, command, args, images, *, locality="local", consumers=None
+    ):  # noqa: ANN001, ANN202
+        self.consumers.append(consumers)
+        return {"kind": "notice", "text": f"owner ran /{command}", "style": "info"}
+
+
+@pytest.mark.asyncio
+async def test_a_client_that_declares_slash_consumers_reaches_the_handle() -> None:
+    """The auth frame's declaration must arrive where the decision is made.
+
+    The runtime completes an action-carrying receipt's request only for a
+    client that did NOT declare that type. That decision lives on the handle,
+    so the connection's declaration has to be threaded to it — the same way
+    ``locality`` is, and for the same reason: it is a property of the
+    CONNECTION, not of the frame.
+    """
+    handle = _ConsumersHandle()
+    runtime = RuntimeServer(handle, kind="tui")
+    runtime.start()
+    writer = None
+    try:
+        record = await _wait_record()
+        reader, writer = await _dial(
+            record, client="attach", slash_consumers=["team_attached", "agent_attached"]
+        )
+        writer.write(
+            json.dumps({"op": "slash_result", "req": 7, "command": "team", "args": "x go"}).encode()
+            + b"\n"
+        )
+        await writer.drain()
+        await _until(reader, "result", 7)
+        assert handle.consumers == [frozenset({"team_attached", "agent_attached"})]
+    finally:
+        if writer is not None:
+            writer.close()
+        runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_a_client_that_omits_slash_consumers_reads_as_none() -> None:
+    """Absent-means-old, and ``None`` is how the handle recognises it.
+
+    This is the incident client on the wire: a viewer built before the field
+    existed sends no declaration at all, and the runtime must read that as
+    "will not submit the request itself" rather than as an empty promise it
+    could mistake for a declaration.
+    """
+    handle = _ConsumersHandle()
+    runtime = RuntimeServer(handle, kind="tui")
+    runtime.start()
+    writer = None
+    try:
+        record = await _wait_record()
+        reader, writer = await _dial(record, client="attach")
+        writer.write(
+            json.dumps({"op": "slash_result", "req": 8, "command": "team", "args": "x go"}).encode()
+            + b"\n"
+        )
+        await writer.drain()
+        await _until(reader, "result", 8)
+        assert handle.consumers == [None]
+    finally:
+        if writer is not None:
+            writer.close()
+        runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_a_handle_that_does_not_take_consumers_still_works() -> None:
+    """Back-compat for the second optional keyword, proven on a real double.
+
+    ``FakeHandle.run_slash_authoritative`` takes three positionals and neither
+    keyword. Passing ``consumers`` unconditionally would raise ``TypeError``
+    inside the dispatch and turn every routed slash into an error frame for
+    any handle not updated in lockstep — including the reduced ones this suite
+    is built on, which is precisely the population the probe protects.
+    """
+    handle = FakeHandle()
+    runtime = RuntimeServer(handle, kind="tui")
+    runtime.start()
+    writer = None
+    try:
+        record = await _wait_record()
+        reader, writer = await _dial(record, client="attach", slash_consumers=["team_attached"])
+        writer.write(
+            json.dumps({"op": "slash_result", "req": 9, "command": "goal", "args": ""}).encode()
+            + b"\n"
+        )
+        await writer.drain()
+        frame = await _until(reader, "result", 9)
+        assert frame["data"]["text"] == "owner ran /goal"
+    finally:
+        if writer is not None:
+            writer.close()
+        runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_slash_consumers_value_does_not_refuse_the_client() -> None:
+    """Advisory, never a gate: a bad value degrades to ``None``.
+
+    A client that cannot attach is strictly worse than one whose request the
+    runtime completes on its behalf, so a malformed declaration must not close
+    the connection — it must read as "declared nothing".
+    """
+    handle = _ConsumersHandle()
+    runtime = RuntimeServer(handle, kind="tui")
+    runtime.start()
+    writer = None
+    try:
+        record = await _wait_record()
+        reader, writer = await asyncio.open_connection(
+            "127.0.0.1", record.control_port, limit=1 << 20
+        )
+        writer.write(
+            json.dumps(
+                {
+                    "key": record.control_key,
+                    "client": "attach",
+                    "slash_consumers": "team_attached",  # a string, not a list
+                }
+            ).encode()
+            + b"\n"
+        )
+        await writer.drain()
+        welcome = await asyncio.wait_for(reader.readline(), timeout=5)
+        assert json.loads(welcome)["op"] == "projection", "a bad field must not refuse the attach"
+        writer.write(
+            json.dumps(
+                {"op": "slash_result", "req": 10, "command": "team", "args": "x go"}
+            ).encode()
+            + b"\n"
+        )
+        await writer.drain()
+        await _until(reader, "result", 10)
+        assert handle.consumers == [None]
     finally:
         if writer is not None:
             writer.close()

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -713,3 +713,113 @@ def test_perform_upgrade_does_not_refresh() -> None:
     assert out == "0.28.0"
     refresh.assert_not_called()
     run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Build stamps: the comparable token a viewer and a runtime skew against
+# ---------------------------------------------------------------------------
+
+
+def test_source_ref_reads_the_commit_lop_update_recorded(tmp_path: Path) -> None:
+    """``.lop-source`` holds ``<git-sha> <tag>``; only the sha identifies a build.
+
+    The tag half repeats across every rebuild of one release, so keying on it
+    would report two genuinely different builds as identical — which is the
+    exact drift this host produces most often.
+    """
+    (tmp_path / ".lop-source").write_text(
+        "4d3ce1d1a48f4f3b799efdfabb014979e70e0630 v0.49.0\n", encoding="utf-8"
+    )
+    assert update_mod.source_ref(tmp_path) == "4d3ce1d1a48f4f3b799efdfabb014979e70e0630"
+
+
+def test_source_ref_is_empty_without_a_marker(tmp_path: Path) -> None:
+    """PyPI wheels, pipx installs and editable checkouts have no marker.
+
+    Empty rather than an error: those installs fall back to comparing on the
+    distribution version alone, and dev-tree skew is out of scope by design.
+    """
+    assert update_mod.source_ref(tmp_path) == ""
+
+
+def test_source_ref_survives_an_unreadable_marker(tmp_path: Path) -> None:
+    """A build token is decoration on a diagnostic path.
+
+    It is read at adopt, engage and bind — seams that must never fail because
+    a marker file was a directory or had its permissions changed underneath.
+    """
+    (tmp_path / ".lop-source").mkdir()
+    assert update_mod.source_ref(tmp_path) == ""
+
+
+def test_source_ref_of_an_empty_marker_is_empty(tmp_path: Path) -> None:
+    (tmp_path / ".lop-source").write_text("   \n", encoding="utf-8")
+    assert update_mod.source_ref(tmp_path) == ""
+
+
+def test_installed_build_pairs_the_version_with_the_ref(tmp_path: Path) -> None:
+    (tmp_path / ".lop-source").write_text("abc1234def v0.49.0\n", encoding="utf-8")
+    with patch.object(update_mod, "installed_version", return_value="0.49.0"):
+        stamp = update_mod.installed_build(tmp_path)
+    assert stamp == update_mod.BuildStamp(version="0.49.0", source_ref="abc1234def")
+
+
+def test_same_version_rebuilds_are_different_builds() -> None:
+    """The case that motivates the ref, stated as an equality.
+
+    ``lop-update`` builds from ``main`` while ``pyproject.toml`` still names
+    the last released version, so two different builds share one version
+    string. Comparing on version alone reports "no drift" for the drift this
+    host actually has.
+    """
+    before = update_mod.BuildStamp(version="0.49.0", source_ref="aaaaaaa1111")
+    after = update_mod.BuildStamp(version="0.49.0", source_ref="bbbbbbb2222")
+    assert before != after
+    assert before.version == after.version, "the version alone cannot tell them apart"
+
+
+def test_a_build_label_names_the_ref_only_when_there_is_one() -> None:
+    """Notice copy: ``0.49.0`` on a wheel, ``0.49.0@4d3ce1d`` on a snapshot."""
+    assert update_mod.BuildStamp(version="0.49.0").label() == "0.49.0"
+    assert (
+        update_mod.BuildStamp(version="0.49.0", source_ref="4d3ce1d1a48").label()
+        == "0.49.0@4d3ce1d"
+    )
+    assert update_mod.BuildStamp(version="").label() == "unknown"
+
+
+def test_installed_version_rereads_disk_within_one_process(tmp_path: Path) -> None:
+    """The empirical claim the whole design rests on, pinned as a test.
+
+    Drift detection compares what THIS process loaded against what is on disk
+    NOW, which only works if ``importlib.metadata`` actually re-reads. It
+    does, because the dist-info DIRECTORY NAME carries the version, so even a
+    path-keyed cache misses. Asserted on a synthetic distribution so the test
+    owns both sides and never depends on the real install.
+    """
+    import sys as _sys
+    from importlib.metadata import version as _version
+
+    site = tmp_path / "site"
+    old = site / "skewpkg-0.46.23.dist-info"
+    old.mkdir(parents=True)
+    (old / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: skewpkg\nVersion: 0.46.23\n", encoding="utf-8"
+    )
+    _sys.path.insert(0, str(site))
+    try:
+        assert _version("skewpkg") == "0.46.23"
+        new = site / "skewpkg-0.49.0.dist-info"
+        new.mkdir()
+        (new / "METADATA").write_text(
+            "Metadata-Version: 2.1\nName: skewpkg\nVersion: 0.49.0\n", encoding="utf-8"
+        )
+        import shutil
+
+        shutil.rmtree(old)
+        assert _version("skewpkg") == "0.49.0", (
+            "importlib.metadata must re-read disk in a live process, or a TUI "
+            "can never notice that lop-update replaced the install under it"
+        )
+    finally:
+        _sys.path.remove(str(site))

--- a/tests/unit/tui/test_build_skew.py
+++ b/tests/unit/tui/test_build_skew.py
@@ -1,0 +1,410 @@
+"""Skew between what this terminal loaded and the code around it, made visible.
+
+**This file exists because a build mismatch between a viewer and its runtime
+was undetectable from either side, and its most expensive symptom was
+silence.**
+
+The shape, concretely: a TUI keeps running the code it imported at launch,
+``lop-update`` replaces the on-disk install under it several times a day, and
+the runtime that TUI spawns resolves ``sys.executable`` fresh — so it is built
+from the NEW install. An old terminal therefore drives a new runtime as a
+matter of routine, and when the two disagreed about who submits a ``/team``
+request, the request vanished with no user row, no turn and no error.
+
+Three notices close that, and each is a different fact:
+
+* **disk drift** — the install moved under this process, so anything spawned
+  from here will be newer than this terminal. ``/reload`` is the remedy.
+* **owner skew** — the bound runtime reports a different build. ``/stop`` then
+  resend is the remedy.
+* **owner predates reporting** — the runtime cannot say what it runs, which by
+  construction makes it older than a terminal that can read the field.
+
+All three are ADVISORY. Nothing here may refuse a command or an attach: both
+builds keep working, and a diagnostic that blocks work is worse than the skew
+it reports.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.transcript import NoticeBlock
+from local_operator.update import BuildStamp
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+def _notices(app: OperatorApp) -> list[str]:
+    return [block._text for block in app.query(NoticeBlock)]
+
+
+class _BoundViewer(FakeSession):
+    """A follower facade that has already bound to a runtime.
+
+    ``is_remote`` plus a resolved ``owner_version`` is what a real
+    ``RemoteSession`` looks like after ``_dial``; ``is_cold`` False is what
+    makes the owner comparison meaningful, since a cold viewer has not dialled
+    anything and its empty stamp would otherwise read as a prehistoric
+    runtime.
+    """
+
+    is_remote = True
+    is_cold = False
+
+    def __init__(self, owner_version: str = "", owner_source_ref: str = "") -> None:
+        super().__init__()
+        self.owner_version = owner_version
+        self.owner_source_ref = owner_source_ref
+
+
+@pytest.mark.asyncio
+async def test_a_moved_install_warns_once_and_names_reload(monkeypatch, tmp_path) -> None:
+    """Disk drift: the install is no longer the one this process loaded.
+
+    The notice has to name BOTH builds — a warning that says only "something
+    changed" leaves the user unable to tell a routine rebuild from the
+    several-release gap that actually breaks routed commands — and it has to
+    name ``/reload``, which is the one action that fixes it without losing the
+    session.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._loaded_build = BuildStamp(version="0.46.23")
+        app._skew_notice_shown.clear()
+
+        import local_operator.update as update_mod
+
+        monkeypatch.setattr(
+            update_mod, "installed_build", lambda *_a, **_k: BuildStamp(version="0.49.0")
+        )
+        app._check_build_skew(reason="test")
+        await pilot.pause()
+        first = _notices(app)
+
+        # A SECOND check with the same pair must stay quiet: the mount engage,
+        # the draft warm-up and the slash engage all call this, and three
+        # copies of one warning is noise the user learns to skip.
+        app._check_build_skew(reason="test-again")
+        await pilot.pause()
+        second = _notices(app)
+
+    drift = [n for n in first if "install on disk changed" in n]
+    assert len(drift) == 1, first
+    assert "0.46.23" in drift[0] and "0.49.0" in drift[0], "both builds must be named"
+    assert "/reload" in drift[0]
+    assert second == first, "the notice is debounced per (kind, from, to)"
+
+
+@pytest.mark.asyncio
+async def test_a_second_distinct_drift_is_still_announced(monkeypatch, tmp_path) -> None:
+    """Debounce on the TRIPLE, not on the kind.
+
+    Two ``lop-update`` runs while one terminal lives is normal here. Keying
+    the debounce on "have we warned about drift" would report the first and
+    swallow every later one, so a terminal that has fallen two releases behind
+    would look exactly like one that is current.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._loaded_build = BuildStamp(version="0.46.23")
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        monkeypatch.setattr(
+            update_mod, "installed_build", lambda *_a, **_k: BuildStamp(version="0.49.0")
+        )
+        app._check_build_skew(reason="one")
+        monkeypatch.setattr(
+            update_mod, "installed_build", lambda *_a, **_k: BuildStamp(version="0.50.0")
+        )
+        app._check_build_skew(reason="two")
+        await pilot.pause()
+        notices = _notices(app)
+
+    drift = [n for n in notices if "install on disk changed" in n]
+    assert len(drift) == 2, drift
+    assert any("0.49.0" in n for n in drift) and any("0.50.0" in n for n in drift)
+
+
+@pytest.mark.asyncio
+async def test_a_same_version_rebuild_is_detected_through_its_ref(monkeypatch, tmp_path) -> None:
+    """The drift this host produces most often, and the reason for the ref.
+
+    ``lop-update`` builds from ``main`` while ``pyproject.toml`` still names
+    the last released version, so both sides report the same version string
+    and only the recorded commit differs. Version-only comparison reports "no
+    drift" for precisely the case that is drifting.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._loaded_build = BuildStamp(version="0.49.0", source_ref="aaaaaaa1111")
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        monkeypatch.setattr(
+            update_mod,
+            "installed_build",
+            lambda *_a, **_k: BuildStamp(version="0.49.0", source_ref="bbbbbbb2222"),
+        )
+        app._check_build_skew(reason="rebuild")
+        await pilot.pause()
+        notices = _notices(app)
+
+    drift = [n for n in notices if "install on disk changed" in n]
+    assert len(drift) == 1, notices
+    assert "0.49.0@aaaaaaa" in drift[0] and "0.49.0@bbbbbbb" in drift[0]
+
+
+@pytest.mark.asyncio
+async def test_a_matching_build_says_nothing(monkeypatch, tmp_path) -> None:
+    """The quiet case, which is almost every check.
+
+    This runs at every adopt and every engage, so a false positive would
+    become a notice on every `/new` — the fastest way to teach a user to stop
+    reading warnings.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        stamp = BuildStamp(version="0.49.0", source_ref="abc1234")
+        app._loaded_build = stamp
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
+        app._check_build_skew(reason="same")
+        await pilot.pause()
+        notices = _notices(app)
+
+    assert not [n for n in notices if "install on disk changed" in n]
+    assert not [n for n in notices if "runtime is running" in n]
+
+
+@pytest.mark.asyncio
+async def test_an_older_runtime_is_named_with_the_stop_remedy(monkeypatch, tmp_path) -> None:
+    """Owner skew: the bound runtime reports a build this terminal is not on.
+
+    ``/stop`` then resend is the remedy rather than ``/reload``: the terminal
+    is fine, it is the runtime that is stale, and a bare ``/stop`` on a
+    follower asks the owner to stop so the next prompt engages a fresh one
+    from the current install.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        stamp = BuildStamp(version="0.49.0")
+        app._loaded_build = stamp
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
+        app._session = _BoundViewer(owner_version="0.46.23")
+        app._check_build_skew(reason="bind")
+        await pilot.pause()
+        notices = _notices(app)
+
+    skew = [n for n in notices if "runtime is running 0.46.23" in n]
+    assert len(skew) == 1, notices
+    assert "0.49.0" in skew[0]
+    assert "/stop" in skew[0]
+
+
+@pytest.mark.asyncio
+async def test_a_runtime_without_a_stamp_is_reported_as_predating_it(monkeypatch, tmp_path) -> None:
+    """An absent version is itself informative, not a missing value.
+
+    The field ships in this build, so a runtime that does not publish it
+    predates this terminal by construction. Every resident runtime trips this
+    exactly once in the first window after release, and it is telling the
+    truth each time.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        stamp = BuildStamp(version="0.49.0")
+        app._loaded_build = stamp
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
+        app._session = _BoundViewer(owner_version="")
+        app._check_build_skew(reason="bind")
+        app._check_build_skew(reason="bind-again")
+        await pilot.pause()
+        notices = _notices(app)
+
+    predates = [n for n in notices if "predates build reporting" in n]
+    assert len(predates) == 1, "once per session per process, not once per seam"
+    assert "/stop" in predates[0]
+
+
+@pytest.mark.asyncio
+async def test_a_matching_runtime_is_silent(monkeypatch, tmp_path) -> None:
+    """Same build on both ends: nothing to say."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        stamp = BuildStamp(version="0.49.0", source_ref="abc1234")
+        app._loaded_build = stamp
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
+        app._session = _BoundViewer(owner_version="0.49.0", owner_source_ref="abc1234")
+        app._check_build_skew(reason="bind")
+        await pilot.pause()
+        notices = _notices(app)
+
+    assert not [n for n in notices if "runtime is running" in n]
+    assert not [n for n in notices if "predates" in n]
+
+
+@pytest.mark.asyncio
+async def test_a_cold_viewer_is_not_reported_as_a_prehistoric_runtime(
+    monkeypatch, tmp_path
+) -> None:
+    """A cold viewer has not dialled anything, so it has no owner to compare.
+
+    Its ``owner_version`` is empty for the trivial reason that no runtime
+    exists yet. Reading that as "the runtime predates the field" would fire
+    the notice on every fresh `lop`, which is the false-positive that would
+    make the whole mechanism ignorable.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        stamp = BuildStamp(version="0.49.0")
+        app._loaded_build = stamp
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
+        cold = _BoundViewer(owner_version="")
+        cold.is_cold = True
+        app._session = cold
+        app._check_build_skew(reason="cold")
+        await pilot.pause()
+        notices = _notices(app)
+
+    assert not [n for n in notices if "predates build reporting" in n]
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_own_build_disables_the_check(monkeypatch, tmp_path) -> None:
+    """No snapshot means no comparison, not a comparison against unknown.
+
+    A TUI that could not read its own version at startup would otherwise
+    report drift against every runtime it ever meets.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._loaded_build = None
+        app._skew_notice_shown.clear()
+        app._session = _BoundViewer(owner_version="0.1.0")
+        app._check_build_skew(reason="unknown")
+        await pilot.pause()
+        notices = _notices(app)
+
+    assert not [n for n in notices if "runtime is running" in n]
+    assert not [n for n in notices if "install on disk changed" in n]
+
+
+@pytest.mark.asyncio
+async def test_a_failing_disk_read_does_not_break_the_seam(monkeypatch, tmp_path) -> None:
+    """This runs inside adopt and engage; it must never raise into them.
+
+    A skew notice is a diagnostic. An exception here would take down the
+    session adoption it was called from, converting a cosmetic problem into a
+    broken terminal.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._loaded_build = BuildStamp(version="0.49.0")
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        def explode(*_a, **_k):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(update_mod, "installed_build", explode)
+        app._check_build_skew(reason="boom")  # must not raise
+        await pilot.pause()
+        notices = _notices(app)
+
+    assert not [n for n in notices if "install on disk changed" in n]
+
+
+@pytest.mark.asyncio
+async def test_a_pre_attach_runtime_noop_degrades_loudly(monkeypatch, tmp_path) -> None:
+    """The last silent quadrant: a NEW viewer against a PRE-#624 runtime.
+
+    Such a runtime answers ``/team <name>`` with ``noop {"type":
+    "team_mutate"}``. The renderer's noop branch handled only ``agent_list``,
+    so the command vanished — the same defect the static audit exists to
+    prevent, arriving through the version dimension the audit cannot see. No
+    current producer emits this type; only a resident older process does.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._render_authoritative_slash(
+            "team", "lopdev go", {"kind": "noop", "data": {"type": "team_mutate"}}
+        )
+        await pilot.pause()
+        notices = _notices(app)
+
+    stale = [n for n in notices if "older than /team attach" in n]
+    assert len(stale) == 1, notices
+    assert "nothing was attached" in stale[0], "the user must learn the attach did NOT happen"
+    assert "/stop" in stale[0]
+
+
+@pytest.mark.asyncio
+async def test_an_attach_receipt_still_submits_its_request(monkeypatch, tmp_path) -> None:
+    """Regression guard: the declaration work must not break the consumer.
+
+    This viewer DECLARES that it consumes ``team_attached``, which is what
+    stops the runtime from completing the request. If the renderer then failed
+    to submit it, the request would vanish on the NEW client — the original
+    bug, restored, in the place nobody would think to look.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        submitted: list[str] = []
+        monkeypatch.setattr(
+            app, "_submit_command_prompt", lambda text, attachments=None: submitted.append(text)
+        )
+        app._render_authoritative_slash(
+            "team",
+            "lopdev go",
+            {
+                "kind": "notice",
+                "text": "sending to lopdev. manager is coordinating.",
+                "data": {"type": "team_attached", "team": "lopdev", "request": "do the thing"},
+            },
+        )
+        await pilot.pause()
+
+    assert submitted == ["do the thing"], (
+        "a declaring viewer promises the runtime it will submit this itself; "
+        "breaking that promise restores the silent drop on the new client"
+    )

--- a/tests/unit/tui/test_build_skew.py
+++ b/tests/unit/tui/test_build_skew.py
@@ -41,6 +41,16 @@ def _notices(app: OperatorApp) -> list[str]:
     return [block._text for block in app.query(NoticeBlock)]
 
 
+# Match on a STABLE fragment of each notice rather than a whole sentence: the
+# copy is a design surface and was rewritten once already (design review round
+# 1, D1/D2), so cells that quote whole strings turn every wording change into a
+# batch of unrelated test failures. These name the one phrase that identifies
+# each notice.
+DRIFT = "was updated after this window opened"
+OWNER_SKEW = "but this window is"
+OWNER_UNKNOWN = "running an older version than this window"
+
+
 class _BoundViewer(FakeSession):
     """A follower facade that has already bound to a runtime.
 
@@ -59,18 +69,25 @@ class _BoundViewer(FakeSession):
         owner_version: str = "",
         owner_source_ref: str = "",
         session_id: str = "",
+        conversation_name: str = "",
     ) -> None:
         super().__init__()
         self.owner_version = owner_version
         self.owner_source_ref = owner_source_ref
-        # ``session_id`` is a read-only property on the base double, and the
-        # owner-notice debounce is keyed by it — so a test that needs two
-        # DISTINCT sessions has to override it here rather than assign it.
+        # ``session_id`` and ``conversation_name`` are read-only properties on
+        # the base double. The debounce is keyed by the first and the notice
+        # names the session with the second, so a test that needs two DISTINCT
+        # named sessions has to override both here rather than assign them.
         self._skew_session_id = session_id
+        self._skew_conversation_name = conversation_name
 
     @property
     def session_id(self) -> str:  # type: ignore[override]
         return self._skew_session_id or super().session_id
+
+    @property
+    def conversation_name(self) -> str:  # type: ignore[override]
+        return self._skew_conversation_name
 
 
 @pytest.mark.asyncio
@@ -79,7 +96,7 @@ async def test_a_moved_install_warns_once_and_names_reload(monkeypatch, tmp_path
 
     The notice has to name BOTH builds — a warning that says only "something
     changed" leaves the user unable to tell a routine rebuild from the
-    several-release gap that actually breaks routed commands — and it has to
+    several-release gap that actually breaks commands — and it has to
     name ``/reload``, which is the one action that fixes it without losing the
     session.
     """
@@ -106,7 +123,7 @@ async def test_a_moved_install_warns_once_and_names_reload(monkeypatch, tmp_path
         await pilot.pause()
         second = _notices(app)
 
-    drift = [n for n in first if "install on disk changed" in n]
+    drift = [n for n in first if DRIFT in n]
     assert len(drift) == 1, first
     assert "0.46.23" in drift[0] and "0.49.0" in drift[0], "both builds must be named"
     assert "/reload" in drift[0]
@@ -141,7 +158,7 @@ async def test_a_second_distinct_drift_is_still_announced(monkeypatch, tmp_path)
         await pilot.pause()
         notices = _notices(app)
 
-    drift = [n for n in notices if "install on disk changed" in n]
+    drift = [n for n in notices if DRIFT in n]
     assert len(drift) == 2, drift
     assert any("0.49.0" in n for n in drift) and any("0.50.0" in n for n in drift)
 
@@ -172,9 +189,14 @@ async def test_a_same_version_rebuild_is_detected_through_its_ref(monkeypatch, t
         await pilot.pause()
         notices = _notices(app)
 
-    drift = [n for n in notices if "install on disk changed" in n]
+    drift = [n for n in notices if DRIFT in n]
     assert len(drift) == 1, notices
-    assert "0.49.0@aaaaaaa" in drift[0] and "0.49.0@bbbbbbb" in drift[0]
+    # The refs are the only distinguishing fact, so both must appear — but the
+    # shared version is named ONCE rather than repeated on both arms, which is
+    # the whole of D3: `0.49.0@aaaaaaa → 0.49.0@bbbbbbb` spent 22 characters
+    # restating one version in the sentence's most prominent parenthetical.
+    assert "0.49.0, aaaaaaa \u2192 bbbbbbb" in drift[0], drift[0]
+    assert "0.49.0@" not in drift[0], "the version must not be repeated per arm"
 
 
 @pytest.mark.asyncio
@@ -199,8 +221,8 @@ async def test_a_matching_build_says_nothing(monkeypatch, tmp_path) -> None:
         await pilot.pause()
         notices = _notices(app)
 
-    assert not [n for n in notices if "install on disk changed" in n]
-    assert not [n for n in notices if "runtime is running" in n]
+    assert not [n for n in notices if DRIFT in n]
+    assert not [n for n in notices if OWNER_SKEW in n]
 
 
 @pytest.mark.asyncio
@@ -227,7 +249,7 @@ async def test_an_older_runtime_is_named_with_the_stop_remedy(monkeypatch, tmp_p
         await pilot.pause()
         notices = _notices(app)
 
-    skew = [n for n in notices if "runtime is running 0.46.23" in n]
+    skew = [n for n in notices if "running 0.46.23" in n and OWNER_SKEW in n]
     assert len(skew) == 1, notices
     assert "0.49.0" in skew[0]
     assert "/stop" in skew[0]
@@ -258,7 +280,7 @@ async def test_a_runtime_without_a_stamp_is_reported_as_predating_it(monkeypatch
         await pilot.pause()
         notices = _notices(app)
 
-    predates = [n for n in notices if "predates build reporting" in n]
+    predates = [n for n in notices if OWNER_UNKNOWN in n]
     assert len(predates) == 1, "one session, repeatedly checked, speaks once"
     assert "/stop" in predates[0]
 
@@ -296,7 +318,7 @@ async def test_a_second_stale_session_gets_its_own_notice(monkeypatch, tmp_path)
         await pilot.pause()
         notices = _notices(app)
 
-    predates = [n for n in notices if "predates build reporting" in n]
+    predates = [n for n in notices if OWNER_UNKNOWN in n]
     assert len(predates) == 2, (
         "each stale session must be reported once; a per-process key hides "
         "every runtime after the first"
@@ -332,7 +354,7 @@ async def test_disk_drift_is_not_rescoped_by_a_session_swap(monkeypatch, tmp_pat
         await pilot.pause()
         notices = _notices(app)
 
-    drift = [n for n in notices if "install on disk changed" in n]
+    drift = [n for n in notices if DRIFT in n]
     assert len(drift) == 1, "disk drift is per-process, not per-session"
 
 
@@ -354,7 +376,7 @@ async def test_a_matching_runtime_is_silent(monkeypatch, tmp_path) -> None:
         await pilot.pause()
         notices = _notices(app)
 
-    assert not [n for n in notices if "runtime is running" in n]
+    assert not [n for n in notices if OWNER_SKEW in n]
     assert not [n for n in notices if "predates" in n]
 
 
@@ -386,7 +408,7 @@ async def test_a_cold_viewer_is_not_reported_as_a_prehistoric_runtime(
         await pilot.pause()
         notices = _notices(app)
 
-    assert not [n for n in notices if "predates build reporting" in n]
+    assert not [n for n in notices if OWNER_UNKNOWN in n]
 
 
 @pytest.mark.asyncio
@@ -407,8 +429,8 @@ async def test_an_unreadable_own_build_disables_the_check(monkeypatch, tmp_path)
         await pilot.pause()
         notices = _notices(app)
 
-    assert not [n for n in notices if "runtime is running" in n]
-    assert not [n for n in notices if "install on disk changed" in n]
+    assert not [n for n in notices if OWNER_SKEW in n]
+    assert not [n for n in notices if DRIFT in n]
 
 
 @pytest.mark.asyncio
@@ -435,7 +457,7 @@ async def test_a_failing_disk_read_does_not_break_the_seam(monkeypatch, tmp_path
         await pilot.pause()
         notices = _notices(app)
 
-    assert not [n for n in notices if "install on disk changed" in n]
+    assert not [n for n in notices if DRIFT in n]
 
 
 @pytest.mark.asyncio
@@ -458,7 +480,7 @@ async def test_a_pre_attach_runtime_noop_degrades_loudly(monkeypatch, tmp_path) 
         await pilot.pause()
         notices = _notices(app)
 
-    stale = [n for n in notices if "older than /team attach" in n]
+    stale = [n for n in notices if "too old to attach a team" in n]
     assert len(stale) == 1, notices
     assert "nothing was attached" in stale[0], "the user must learn the attach did NOT happen"
     assert "/stop" in stale[0]
@@ -625,3 +647,145 @@ async def test_the_tui_owner_treats_declaring_nothing_as_undeclared(monkeypatch,
         await app.run_slash_authoritative("team", "lopdev do the thing", [], consumers=[])
 
     assert submitted == ["do the thing"]
+
+
+# ---------------------------------------------------------------------------
+# Notice COPY (design review round 1)
+#
+# The copy is a reviewed design surface, so these cells pin the properties the
+# review bought rather than whole sentences: the subject is named, the shared
+# version is not repeated, and the internal vocabulary stays out.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_two_stale_sessions_are_told_apart_by_name(monkeypatch, tmp_path) -> None:
+    """D1: correct per-session behaviour must not RENDER as a duplicate bug.
+
+    Two stale sessions each legitimately earn a notice — that is what the
+    per-session debounce buys. With a deictic "this session" in both, the two
+    paragraphs came out byte-identical, which reads as the app printing one
+    warning twice and leaves ``/stop`` ambiguous about which session it acts
+    on. Naming the subject is what makes two notices an inventory rather than
+    a malfunction.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        stamp = BuildStamp(version="0.49.0")
+        app._loaded_build = stamp
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
+
+        first = _BoundViewer(
+            owner_version="", session_id="sessionaaaa1", conversation_name="ingest pipeline"
+        )
+        app._session = first
+        app._check_build_skew(reason="bind")
+
+        second = _BoundViewer(
+            owner_version="", session_id="sessionbbbb2", conversation_name="release notes"
+        )
+        app._session = second
+        app._check_build_skew(reason="resume")
+        await pilot.pause()
+        notices = _notices(app)
+
+    stale = [n for n in notices if OWNER_UNKNOWN in n]
+    assert len(stale) == 2, notices
+    assert stale[0] != stale[1], (
+        "two stale sessions must not produce byte-identical paragraphs; that "
+        "is indistinguishable from the duplicate-notice bug the re-key fixed"
+    )
+    assert "\u201cingest pipeline\u201d" in stale[0]
+    assert "\u201crelease notes\u201d" in stale[1]
+
+
+@pytest.mark.asyncio
+async def test_an_unnamed_session_falls_back_to_the_deictic(monkeypatch, tmp_path) -> None:
+    """A fork or a fresh session has no title yet; the notice still has to work.
+
+    The fallback is the ONLY case where the old deictic wording survives, so
+    an empty title must not render as empty quotes.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        stamp = BuildStamp(version="0.49.0")
+        app._loaded_build = stamp
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
+        unnamed = _BoundViewer(owner_version="", session_id="sessionccccc")
+        app._session = unnamed
+        app._check_build_skew(reason="bind")
+        await pilot.pause()
+        notices = _notices(app)
+
+    stale = [n for n in notices if OWNER_UNKNOWN in n]
+    assert len(stale) == 1, notices
+    assert stale[0].startswith("this session is running an older version")
+    assert "\u201c\u201d" not in stale[0], "an empty title must not render as empty quotes"
+
+
+@pytest.mark.asyncio
+async def test_differing_versions_keep_the_two_arm_form(monkeypatch, tmp_path) -> None:
+    """D3 factors out a SHARED version only; a real version change still shows both.
+
+    Collapsing here would hide the fact the user most needs — that the version
+    itself moved, not just the commit.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._loaded_build = BuildStamp(version="0.46.23", source_ref="aaaaaaa1111")
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        monkeypatch.setattr(
+            update_mod,
+            "installed_build",
+            lambda *_a, **_k: BuildStamp(version="0.49.0", source_ref="bbbbbbb2222"),
+        )
+        app._check_build_skew(reason="rebuild")
+        await pilot.pause()
+        notices = _notices(app)
+
+    drift = [n for n in notices if DRIFT in n]
+    assert len(drift) == 1, notices
+    assert "0.46.23@aaaaaaa \u2192 0.49.0@bbbbbbb" in drift[0], drift[0]
+
+
+def test_the_notices_carry_no_internal_vocabulary() -> None:
+    """D2: the words we use for ourselves must not reach the user.
+
+    "routed", "runtime"/"terminal" and "build reporting" are all real and
+    load-bearing internally, but the notice never explains the runtime/terminal
+    split, so to a reader those words collapse into the one thing they can see.
+
+    Walks the AST and inspects STRING LITERALS only. A regex over the source
+    was the first attempt and is unsound: it reads through the surrounding
+    comments, which legitimately discuss runtimes and terminals and must keep
+    being able to — it reported a failure for the word "routed" appearing in a
+    code comment.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(OperatorApp._check_build_skew)))
+    literals = [
+        node.value.lower()
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    ]
+    # The docstring is prose for maintainers, not user copy.
+    body = " ".join(literals[1:]) if literals else ""
+    for word in ("routed", "predates build reporting", "this terminal", "resend"):
+        assert word not in body, f"internal vocabulary reached the notice copy: {word!r}"

--- a/tests/unit/tui/test_build_skew.py
+++ b/tests/unit/tui/test_build_skew.py
@@ -27,6 +27,8 @@ it reports.
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from local_operator.tui.app import OperatorApp
@@ -52,10 +54,23 @@ class _BoundViewer(FakeSession):
     is_remote = True
     is_cold = False
 
-    def __init__(self, owner_version: str = "", owner_source_ref: str = "") -> None:
+    def __init__(
+        self,
+        owner_version: str = "",
+        owner_source_ref: str = "",
+        session_id: str = "",
+    ) -> None:
         super().__init__()
         self.owner_version = owner_version
         self.owner_source_ref = owner_source_ref
+        # ``session_id`` is a read-only property on the base double, and the
+        # owner-notice debounce is keyed by it — so a test that needs two
+        # DISTINCT sessions has to override it here rather than assign it.
+        self._skew_session_id = session_id
+
+    @property
+    def session_id(self) -> str:  # type: ignore[override]
+        return self._skew_session_id or super().session_id
 
 
 @pytest.mark.asyncio
@@ -244,8 +259,81 @@ async def test_a_runtime_without_a_stamp_is_reported_as_predating_it(monkeypatch
         notices = _notices(app)
 
     predates = [n for n in notices if "predates build reporting" in n]
-    assert len(predates) == 1, "once per session per process, not once per seam"
+    assert len(predates) == 1, "one session, repeatedly checked, speaks once"
     assert "/stop" in predates[0]
+
+
+@pytest.mark.asyncio
+async def test_a_second_stale_session_gets_its_own_notice(monkeypatch, tmp_path) -> None:
+    """ "Once per SESSION per process" — the claim the debounce key must honour.
+
+    A terminal that adopts one stale runtime, then `/resume`s onto another, is
+    looking at two different stale runtimes. Keying the debounce on the notice
+    kind alone silently swallows the second, so the user is told about one of
+    the two and has no way to know the other is also stale. Design §6.7 and
+    this method's contract both say per-session; this cell is what makes that
+    true rather than merely written down (review round 1, R1-5, NIT-1).
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        stamp = BuildStamp(version="0.49.0")
+        app._loaded_build = stamp
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
+
+        first = _BoundViewer(owner_version="", session_id="sessionaaaa1")
+        app._session = first
+        app._check_build_skew(reason="bind")
+        app._check_build_skew(reason="bind-again")  # same session: still once
+
+        second = _BoundViewer(owner_version="", session_id="sessionbbbb2")
+        app._session = second
+        app._check_build_skew(reason="resume")
+        await pilot.pause()
+        notices = _notices(app)
+
+    predates = [n for n in notices if "predates build reporting" in n]
+    assert len(predates) == 2, (
+        "each stale session must be reported once; a per-process key hides "
+        "every runtime after the first"
+    )
+
+
+@pytest.mark.asyncio
+async def test_disk_drift_is_not_rescoped_by_a_session_swap(monkeypatch, tmp_path) -> None:
+    """Drift is a fact about THIS PROCESS, so it must not repeat per session.
+
+    The counterpart to the cell above: scoping every notice by session would
+    make an unchanged disk drift re-announce on each `/new`, which is the
+    notice-fatigue failure. Only the owner notices carry a scope.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        app._loaded_build = BuildStamp(version="0.46.23")
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        monkeypatch.setattr(
+            update_mod, "installed_build", lambda *_a, **_k: BuildStamp(version="0.49.0")
+        )
+        first = _BoundViewer(owner_version="0.49.0", session_id="sessionaaaa1")
+        app._session = first
+        app._check_build_skew(reason="adopt")
+
+        second = _BoundViewer(owner_version="0.49.0", session_id="sessionbbbb2")
+        app._session = second
+        app._check_build_skew(reason="adopt-2")
+        await pilot.pause()
+        notices = _notices(app)
+
+    drift = [n for n in notices if "install on disk changed" in n]
+    assert len(drift) == 1, "disk drift is per-process, not per-session"
 
 
 @pytest.mark.asyncio
@@ -408,3 +496,132 @@ async def test_an_attach_receipt_still_submits_its_request(monkeypatch, tmp_path
         "a declaring viewer promises the runtime it will submit this itself; "
         "breaking that promise restores the silent drop on the new client"
     )
+
+
+# ---------------------------------------------------------------------------
+# The TUI-hosted owner mirror
+#
+# A session is owned either by a detached runtime or by THIS app, and a
+# follower routing `/team <name> <request>` must get the same answer from
+# both. Every completion cell in
+# ``tests/unit/session/runtime/test_action_receipt_completion.py`` drives
+# ``OwnedSessionHandle``, so before these cells the app-side copy of the
+# predicate was executed by nothing in CI: an edit drifting it toward
+# ``declared is None`` would double-submit on the TUI-owner path with no test
+# noticing (review round 1, R1-3).
+# ---------------------------------------------------------------------------
+
+
+async def _app_with_team(app: OperatorApp, tmp_path, name: str = "lopdev") -> None:
+    """Give the app's session a real registry holding one attachable team."""
+    from local_operator.teams import TeamEditFields, TeamMember, TeamRegistry
+
+    registry = TeamRegistry(tmp_path / "teams")
+    registry.create_team(
+        TeamEditFields(
+            name=name,
+            description="d",
+            manager="manager",
+            members=[TeamMember(role="coder")],
+        )
+    )
+    # ``SessionProtocol`` does not declare ``team_registry`` (it is session
+    # state the real Session carries and the pilot double mirrors), so the
+    # assignment is narrowed for the type checker rather than the protocol
+    # being widened for a test.
+    setattr(app._session, "team_registry", registry)
+
+
+@pytest.mark.asyncio
+async def test_the_tui_owner_completes_for_an_undeclaring_client(monkeypatch, tmp_path) -> None:
+    """The incident shape when the OWNER is a TUI rather than a runtime.
+
+    Same contract, second host: a client that did not declare the receipt type
+    cannot submit the request, so this app must.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        for _ in range(200):
+            if app._session is not None:
+                break
+            await asyncio.sleep(0.01)
+        await _app_with_team(app, tmp_path)
+        submitted: list[str] = []
+        monkeypatch.setattr(
+            app,
+            "_submit_prompt",
+            lambda text, images=None, attachments=None, **kw: submitted.append(text),
+        )
+
+        outcome = await app.run_slash_authoritative(
+            "team", "lopdev do the thing", [], consumers=None
+        )
+
+    assert outcome["data"]["type"] == "team_attached"
+    assert submitted == ["do the thing"], (
+        "the TUI-hosted owner must complete an undeclared client's request, "
+        "exactly as the runtime host does"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_tui_owner_defers_to_a_declaring_client(monkeypatch, tmp_path) -> None:
+    """The double-submission guard on the second host.
+
+    This is the branch with no CI coverage before this cell: a drift here runs
+    the user's command twice whenever the session happens to be TUI-owned.
+    """
+    from local_operator.session.runtime.types import SLASH_ACTION_RECEIPTS
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        for _ in range(200):
+            if app._session is not None:
+                break
+            await asyncio.sleep(0.01)
+        await _app_with_team(app, tmp_path)
+        submitted: list[str] = []
+        monkeypatch.setattr(
+            app,
+            "_submit_prompt",
+            lambda text, images=None, attachments=None, **kw: submitted.append(text),
+        )
+
+        outcome = await app.run_slash_authoritative(
+            "team", "lopdev do the thing", [], consumers=list(SLASH_ACTION_RECEIPTS)
+        )
+
+    assert outcome["data"]["request"] == "do the thing"
+    assert submitted == [], "a declaring client submits it itself; the owner must not"
+
+
+@pytest.mark.asyncio
+async def test_the_tui_owner_treats_declaring_nothing_as_undeclared(monkeypatch, tmp_path) -> None:
+    """``[]`` admits here too — the rule is ``type not in declared``.
+
+    The tempting shortcut ("complete when the field was absent") passes the
+    undeclared cell and fails this one, on this host only.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        for _ in range(200):
+            if app._session is not None:
+                break
+            await asyncio.sleep(0.01)
+        await _app_with_team(app, tmp_path)
+        submitted: list[str] = []
+        monkeypatch.setattr(
+            app,
+            "_submit_prompt",
+            lambda text, images=None, attachments=None, **kw: submitted.append(text),
+        )
+
+        await app.run_slash_authoritative("team", "lopdev do the thing", [], consumers=[])
+
+    assert submitted == ["do the thing"]

--- a/tests/unit/tui/test_noop_consumers.py
+++ b/tests/unit/tui/test_noop_consumers.py
@@ -252,6 +252,110 @@ def test_the_two_types_that_shipped_broken_are_covered() -> None:
     ), "the owner must not reintroduce the unconsumed agent_mutate noop"
 
 
+def _request_carrying_types(source: str) -> set[str]:
+    """Types whose ``SlashResult`` ``data`` dict carries a ``request`` key.
+
+    A ``request`` in the payload is the signature of an ACTION receipt: the
+    owner attached something and expects the invoking terminal to submit that
+    text as a user turn. Detected structurally rather than by name so a
+    receipt invented next year is caught by its shape.
+    """
+    tree = ast.parse(source)
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)):
+            continue
+        if node.func.id != "SlashResult":
+            continue
+        for keyword in node.keywords:
+            if keyword.arg != "data" or not isinstance(keyword.value, ast.Dict):
+                continue
+            keys = {
+                key.value
+                for key in keyword.value.keys
+                if isinstance(key, ast.Constant) and isinstance(key.value, str)
+            }
+            if "request" not in keys:
+                continue
+            for key, value in zip(keyword.value.keys, keyword.value.values):
+                if not (isinstance(key, ast.Constant) and key.value == "type"):
+                    continue
+                if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                    found.add(value.value)
+                if isinstance(value, ast.IfExp):
+                    for branch in (value.body, value.orelse):
+                        if isinstance(branch, ast.Constant) and isinstance(branch.value, str):
+                            found.add(branch.value)
+    return found
+
+
+def test_every_request_carrying_receipt_is_declared_as_an_action() -> None:
+    """The action-carrying twin of the noop audit, and the reason it exists.
+
+    ``/team lopdev <request>`` was dropped in total silence for a DIFFERENT
+    reason than the noop bug: the receipt WAS rendered, but the request inside
+    it was an instruction to the invoking terminal that an older terminal did
+    not know to follow. The repair (``SLASH_ACTION_RECEIPTS``) only works
+    while the declared set is exactly the produced set — a new
+    ``request``-carrying receipt that nobody adds to the tuple is a runtime
+    that never completes it and a client that never declares it, which is the
+    original silence restored.
+
+    So: every producer emitting a ``request`` must have its type in
+    ``SLASH_ACTION_RECEIPTS``. Static, over the real source, for the same
+    reason the rest of this file is.
+    """
+    from local_operator.session.runtime.types import SLASH_ACTION_RECEIPTS
+
+    produced = _request_carrying_types(_APP.read_text()) | _request_carrying_types(
+        _OWNED.read_text()
+    )
+    undeclared = sorted(produced - set(SLASH_ACTION_RECEIPTS))
+    assert not undeclared, (
+        f"these receipts carry a request for the invoker but are not in "
+        f"SLASH_ACTION_RECEIPTS: {undeclared}. An undeclared action receipt is "
+        "never completed by the runtime and never declared by the viewer, so an "
+        "older client drops the request silently — the /team build-skew incident."
+    )
+    assert produced, "the audit found no request-carrying receipts at all; it has gone blind"
+
+
+def test_every_declared_action_receipt_is_consumed_by_the_renderer() -> None:
+    """The other direction: a declared type the viewer does NOT render.
+
+    The declaration is a promise to the runtime — "I will submit this request
+    myself, do not do it for me". A type in the tuple that
+    ``_render_authoritative_slash`` does not consume means the viewer makes
+    that promise and then breaks it, and the runtime's completion path stands
+    down precisely because the promise was made. That is worse than the bug
+    being fixed: it converts a repaired case back into a silent drop, on the
+    NEW client, where nobody is looking for it.
+    """
+    from local_operator.session.runtime.types import SLASH_ACTION_RECEIPTS
+
+    rendered = _types_named_by_the_renderer(_APP.read_text())
+    missing = sorted(set(SLASH_ACTION_RECEIPTS) - rendered)
+    assert not missing, (
+        f"{missing} are declared in SLASH_ACTION_RECEIPTS but not consumed by "
+        "_render_authoritative_slash. The viewer tells the runtime it will submit "
+        "these requests itself; the runtime then does not, and the request vanishes."
+    )
+
+
+def test_the_request_extractor_ignores_receipts_without_an_action() -> None:
+    """Mutation guard: the audit must key on the ``request`` KEY, not on the
+    type name, or it degrades into a hardcoded list of the types we happen to
+    know about today — exactly the staleness this file exists to prevent.
+    """
+    source = (
+        "def f():\n"
+        "    a = SlashResult(kind='notice', data={'type': 'acts', 'request': r})\n"
+        "    b = SlashResult(kind='notice', data={'type': 'inert', 'team': t})\n"
+        "    c = SlashResult(kind='block', data={'type': 'listing', 'items': i})\n"
+    )
+    assert _request_carrying_types(source) == {"acts"}
+
+
 def test_the_extractor_sees_a_type_however_it_is_spelled() -> None:
     """The audit must survive the spellings the real code actually uses.
 


### PR DESCRIPTION
# PR Description

## Summary of Changes

**Change class: C2 — bug fix on a silent-failure path, no version bump** (the release owner handles the bump; `pyproject.toml` is untouched on this branch).

Since 0.46.0 every fresh `lop` is a **viewer**: the TUI holds a cold `RemoteSession` while a separate runtime process owns the real `Session`. Two long-lived populations therefore coexist on one host — TUIs and runtimes — while `lop-update` replaces the on-disk install under them, often several times a day. The runtime a TUI spawns resolves `sys.executable` **fresh**, so an old terminal routinely drives a **new** runtime, and nothing on either side could see it.

The concrete cost was silence. On that pairing, `/team lopdev <request>`:

1. attached the team on the runtime and returned a `team_attached` receipt carrying the request;
2. printed "sending to lopdev. manager is coordinating.";
3. **dropped the request** — since #624 the *viewer* is expected to submit `data["request"]` as a user turn, and a pre-#624 renderer has no consumer for it.

No user row, no turn, no error. This was reproduced **live against a shipped 0.49.0 runtime** before any code was written (see Testing Details).

Three mechanisms, one coherent change — "skew between a viewer and a runtime is detected, and the known-silent class is repaired":

- **A — drift detection (`tui/app.py`, `update.py`).** `OperatorApp` snapshots the build it loaded and re-reads disk at the seams that spawn or bind a runtime (`_adopt_session`, `_start_runtime_engage`, the bind tail). `_check_build_skew` warns once per distinct `(kind, from, to)` triple: disk drift names `/reload`, owner skew names `/stop`. New `update.BuildStamp` pairs `(version, source_ref)` — the `.lop-source` git ref is the **primary** key because this host's common drift is a *same-version rebuild* (`lop-update` builds from `main` while `pyproject.toml` still names the last release), which version comparison alone cannot see. A pre-#624 runtime's `noop {"type": "team_mutate"}` now degrades **loudly** instead of vanishing — the last silent quadrant.
- **B — runtime-side completion (`runtime/types.py`, `server.py`, `owned.py`, `attach_client.py`, `mobile/tui_handle.py`, `session/remote.py`).** The attach auth frame gains an optional `slash_consumers` declaration; `SLASH_ACTION_RECEIPTS` is the single source of truth. When a routed result carries a request the connected client **did not declare**, the runtime admits it itself through the same `_PromptCommand` path the `prompt` op uses — so the old viewer paints the user row from the existing event relay with **no renderer change**. This is the load-bearing piece: it repairs every already-running stale TUI the moment the new runtime is on disk, with zero user action. The rule is `type not in declared`, so both `None` (old client) and `[]` admit, while a declaring client is **never** double-submitted. The TUI-hosted owner (`TuiSessionHandle` → `OperatorApp.run_slash_authoritative`) mirrors it, submitting via `_submit_prompt` (not `_submit_command_prompt`, which would re-resolve markers against a composer map that does not exist owner-side and drop the wire images).
- **C — version exchange (`runtime/types.py`, `server.py`, `remote.py`, `cli.py`).** `SessionRecord` gains additive `version`/`source_ref`; the record **is** the hello channel an attach client reads before it dials. `lop sessions --json` surfaces both (the fixed-width table is deliberately unchanged).

**No `PROTOCOL_VERSION` bump.** Both wire changes are additive in exactly the shape v4/v5 already established: an older runtime ignores an unknown auth field, and `SessionRecord.from_json` drops unknown keys for older readers. A bump would instead make every older peer *refuse a record it can in fact use* and would do nothing for the TUIs already running — the failure would become loud but the host unusable during every release window.

**Known, documented degradation:** the viewer expands collapsed pastes at submit time and those payloads live in the *viewer's* composer, so a runtime-admitted request citing `<[Paste #1, 240 lines]>` reaches the manager as the chip label. Images survive (they are already on the wire). This is in the method docstring, and the skew notice points at `/reload` for full fidelity. Strictly better than the current silent drop.

## Related Issue(s)

Follows #624 (which introduced the viewer-side consumer this repairs the other half of). Design: `docs/design-build-skew.md`, included in this PR.

## Impact

- No breaking changes; no dependency changes; no `PROTOCOL_VERSION` bump.
- User-visible surface is **notice text only** — no band, layout or colour change, so no design-review surface.
- Every runtime resident when this ships predates the `version` field, so the "predates build reporting" notice legitimately fires **once per (session, TUI process)** during the first attach window. It is accurate each time; the debounce keeps it to once.
- Behaviour change to be aware of: a `/team` request routed while a turn is running becomes a **steer** under completion, matching what the current viewer already does.

## Testing Details

### The live reproduction — the evidence that matters

**Before (the manager's probe, against the SHIPPED 0.49.0 runtime, pid 41900 / session `84be04c33fd2`):** a raw socket client authed as `client: attach` **without** `slash_consumers` — byte-for-byte what a pre-#624 viewer looks like on the wire — sent `slash_result` with `command=team`. The runtime replied:

```json
{"op": "result", "req": 2, "data": {"kind": "notice", "text": "sending to lopdev. manager is coordinating.", "style": "info",
 "data": {"type": "team_attached", "team": "lopdev", "manager": "manager", "request": "Please write one short paragraph summarising ..."}}}
```

…and that session's `transcript.jsonl` showed **no user row and no turn**. Silent drop, confirmed against production.

**After (same probe shape, against a runtime built from THIS branch, isolated `HOME` + `LOCAL_OPERATOR_CONFIG_DIR`, synthetic session, `env -i` so no `CMUX_*` is inherited):**

```
$ ISO=$(mktemp -d /tmp/skew-final-XXXX)
$ env -i PATH="$PATH" HOME="$ISO" TERM=xterm-256color \
    LOCAL_OPERATOR_CONFIG_DIR="$ISO/.local-operator" .venv/bin/python /tmp/live_skew_probe.py

runtime record: version='0.48.0' source_ref='' protocol=5
welcome op=projection
RESULT FRAME: {
  "op": "result",
  "req": 2,
  "data": {
    "kind": "notice",
    "text": "sending to lopdev. manager is coordinating.",
    "style": "info",
    "data": {
      "type": "team_attached",
      "team": "lopdev",
      "manager": "manager",
      "request": "Please write one short paragraph summarising the build-skew fix."
    }
  }
}

TRANSCRIPT: 2 rows, 1 user row(s)
  user row: [{"text": "Please write one short paragraph summarising the build-skew fix."}]

==> the turn RAN: the request an old viewer cannot submit was admitted by the runtime
```

Same auth frame, same receipt — but the user row now exists and the turn ran.

**The double-submission guard, same harness, client declaring `slash_consumers`:**

```
TRANSCRIPT: 0 rows, 0 user row(s)
==> correctly DEFERRED: no turn admitted for a declaring client (no double submission)
```

### `lop sessions --json` carries the build stamp (real CLI, subprocess, isolated dir)

```
$ env -i PATH="$PATH" HOME="$ISO" LOCAL_OPERATOR_CONFIG_DIR="$ISO/.local-operator" \
    .venv/bin/python -m local_operator.cli sessions --json
[
  {
    "state": "live",
    "pid": 4339,
    "session_id": "cliprobe0001",
    ...
    "detached": true,
    "version": "0.48.0",
    "source_ref": ""
  }
]
```

(`source_ref` is empty here because an editable checkout has no `.lop-source` — the designed fallback. The e2e cell covers the populated case against a real marker file.)

### Backward compatibility against the operator's REAL records (read-only)

All 18 resident runtimes on this host predate the new fields. The new reader parses their on-disk records without raising and applies the defaults:

```
$ .venv/bin/python -c '...SessionRecord.from_json(json.load(open(real_record)))...'
parsed pid=69679 version='' source_ref='' -> defaults applied, no raise
```

### Empirical claim from the design (§3), verified rather than assumed

`importlib.metadata.version()` re-reads disk within a live process (the dist-info **directory name** carries the version, so even a path-keyed cache misses):

```
$ .venv/bin/python /tmp/skewprobe/probe.py
python 3.12.13
read 1: 0.46.23
read 2 (no sleep): 0.49.0
read 3 (after sleep): 0.49.0
```

Pinned as a test (`test_installed_version_rereads_disk_within_one_process`) so the assumption the whole of A rests on cannot rot silently.

### Proving the new guards can actually fail

A guard that cannot go red is worse than none, so both were made to fail deliberately and then restored:

- Removing `agent_attached` from `SLASH_ACTION_RECEIPTS` (simulating a forgotten receipt):
  `AssertionError: these receipts carry a request for the invoker but are not in SLASH_ACTION_RECEIPTS: ['agent_attached']`
- Deleting the `_complete_unconsumed_action` call from `run_slash_authoritative` (the pre-fix tree) — the e2e skew cell reproduces the original bug exactly:
  `AssertionError: the runtime never ran the request an undeclaring client cannot submit itself; transcript was <absent>`
  → `1 failed, 9 passed`. Restored → `10 passed`.

### Gates — all run over the whole tree, exactly as CI

```
$ .venv/bin/python -m flake8 .
rc=0

$ uvx --from black==26.1.0 black --check .
All done! 919 files would be left unchanged.
rc=0

$ uvx isort==5.13.2 --check-only .
Skipped 2 files
rc=0

$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .
0 errors, 0 warnings, 0 informations
rc=0

$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
14228 passed, 17 skipped, 679 warnings in 1902.52s (0:31:42)

$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q
33 passed, 2 warnings in 48.27s
```

### New tests

- `tests/unit/session/runtime/test_action_receipt_completion.py` (12) — the completion predicate in both directions: undeclared admits, `[]` admits, declared does **not**, empty request (`/agent clear`) is no action, busy session steers rather than prompts, a failed admission returns a warning naming the failure while the attach stands, images ride the admission, each completion uses a fresh command id.
- `tests/unit/tui/test_build_skew.py` (12) — drift notice names both builds and `/reload`; debounce holds per-triple while a *second distinct* drift still speaks; same-version rebuild caught via the ref; owner skew and "predates reporting" copy; a cold viewer is **not** reported as prehistoric; an unreadable own build disables the check; a failing disk read cannot raise into adopt/engage; `noop team_mutate` degrades loudly; a declaring viewer still submits (regression guard).
- `tests/unit/session/runtime/test_server.py` (+4) — auth parse lands on `_ClientConn`, absent → `None`, a handle that takes neither keyword still works (the reduced `FakeHandle` proves the probe), a malformed value degrades to `None` without refusing the attach.
- `tests/unit/session/runtime/test_registry.py` (+3) — stamp round-trips, an older payload defaults, and the **heartbeat republishes it** (pinned because a hand-rolled heartbeat dict would publish the stamp once and drop it 15s later).
- `tests/unit/test_update.py` (+7) — `.lop-source` parsing incl. unreadable/empty, same-version rebuilds compare unequal, label formatting, and the disk re-read claim.
- `tests/unit/tui/test_noop_consumers.py` (+3) — the action-carrying twin of the existing audit: every `request`-carrying producer must be in `SLASH_ACTION_RECEIPTS`, every entry must be consumed by the renderer, plus a mutation guard that the extractor keys on the `request` **key** rather than a hardcoded type list.
- `tests/e2e/test_viewer_attach_e2e.py` (+4) — the skew simulation over a **real loopback socket** with the production handle/server/client: an undeclaring client's request runs (asserted on the runtime's durable transcript), a declaring client is not double-submitted, and the published record carries `version` and — against a real `.lop-source` fixture — `source_ref`.

### Not claimed

- No visual/design evidence is attached because there is **no visual change**: the user-visible surface is notice text through the existing `_system_notice` path, deliberately not a band or layout element.
- The four-quadrant matrix's `old viewer + old runtime` cell is unchanged by this PR (both sides pre-#624 behave as that pair always did); it is not covered by a new test because there is no new behaviour there.
- The real two-install drift cell (`uv tool install --force` at two refs, launch TUI from ref 1, flip to ref 2) is left to QA — it needs two genuine installs rather than a monkeypatched stamp.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [x] I have linked all related issues.
