### PR TITLE
chore(release): bump version to 0.49.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.49.1"
+version = "0.49.2"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Summary

Release bump for the current window: `0.49.1` → `0.49.2`. One file, one line, no behaviour change.

**Change class:** C0 (release metadata) — standard/pre-authorized.

## Window contents

`git log v0.49.1..origin/main --oneline` at the time of the cut:

```
cb3c31a53 feat(herdr): report lifecycle state to Herdr's Agents panel (#673)
e587f2590 fix(tui): refuse /model honestly on a cold, stopped, or recovering viewer (#654)
5a08e1c34 fix(tui): lazy-load subagent transcript history on attached viewers (#669)
b03e256d7 fix(tools): run the bash tool through real bash, configurable via bash.shell (#629) (#665)
```

Four PRs in the window. #669, #654 and #673 merged while this bump's CI was running and all landed inside the window, so they ride 0.49.2 rather than waiting; their authors confirmed patch class and that no branch touched `pyproject.toml` (verified: `git log b03e256d7..origin/main -- pyproject.toml` is empty and `origin/main:pyproject.toml` still reads `0.49.1`).

Bump class **patch** by materiality, per AGENTS.md "Versioning: choose the bump by materiality, not commit type". Three bug fixes plus one small config key, plus one `feat:` (#673) that is an env-gated integration active only inside a Herdr pane and a measured no-op everywhere else. A single small `feat:` is explicitly a patch, and there is no step-function capability to name in an `X.Y.0:` title.

Window ownership was polled across the live `lop` sessions on this host before claiming; no peer held it. Verified that PR #656 ("chore(release): claim release window") is MERGED — it carried the 0.49.0 bump — and that `release-next` no longer exists on origin, so it was not a live claim. The six Dependabot/CI PRs (#658–#663) are all ancestors of `v0.49.1` and are correctly absent from this window.

## Evidence

No runtime path: this diff changes a packaging version string only. Validation is the scope check below plus CI.

```
$ git diff origin/main..HEAD
-version = "0.49.1"
+version = "0.49.2"
```

That is the complete diff: one line in `pyproject.toml`. No dependency pin, script, or entry point moved beside the bump, and no deploy pipeline consumes this field as an input.

Rebased onto the moved base as #669, #654 and #673 landed. The rebase changed no content and neither upstream commit touches `pyproject.toml`, so there is no semantic conflict surface on the one file this PR changes:

```
$ git log --oneline b03e256d7..origin/main -- pyproject.toml
(no output — untouched upstream)

$ git range-diff 6b9d52f9b^..6b9d52f9b origin/main..44b310530
1:  6b9d52f9b = 1:  44b310530 chore(release): bump version to 0.49.2

$ git rev-parse 6b9d52f9b:pyproject.toml 44b310530:pyproject.toml
9a425202d14a4202eb7c9cc1e1286ce74e52fdf8
9a425202d14a4202eb7c9cc1e1286ce74e52fdf8
```

Rebased twice as latecomers landed; the second rebase is shown above. The resulting blob is the same git object both times, so the content is provably identical across each move.

## Rollout / rollback

Merged as admin, then tagged `v0.49.2` with a GitHub Release targeting the bump SHA; `publish.yml` builds and pushes to PyPI. Rollback is a further bump, never a tag move or a yank of a consumed version.
