### PR TITLE
feat(tui): add current-session usage diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ current session's cost live).
 | `/btw` | Ask a side question off the record — it never joins the conversation |
 | `/compact` | Compact the context now (it also happens automatically) |
 | `/usage`, `/context` | Provider quota and account spend · what's occupying the context window |
+| `/session` | Current-session recorded usage, combined cost, cache and request diagnostics |
 | `/provider`, `/login`, `/logout`, `/accounts`, `/credential` | Manage providers and stored credentials |
 | `/search` | Configure web-search providers and load balancing |
 | `/team` | Launch a saved team: `/team <name> <request>` puts a manager and roster on it |

--- a/docs/SESSION_DIAGNOSTICS.md
+++ b/docs/SESSION_DIAGNOSTICS.md
@@ -3,7 +3,9 @@
 `/session` opens a read-only, scrollable snapshot of the current session. It
 accepts no arguments, does not call a model, and does not append a prompt or a
 receipt to conversation history. Escape or `q` closes the view and returns focus
-to the composer. Close and reopen to refresh; arrow, page, Home and End keys
+to the composer. A loading screen appears immediately while the ledger is read;
+Escape or `q` cancels that presentation too, so a late disk result cannot open
+over a new draft. Close and reopen to refresh; arrow, page, Home and End keys
 navigate the report.
 
 ## Scope
@@ -59,8 +61,11 @@ shown as unavailable.
 `AnalyticsStore.session_report` uses one short-lived, read-only connection and
 an explicit SQLite read transaction. Totals, grouping, timings and bounded recent
 rows all observe the same snapshot even while a WAL writer commits new calls.
-The UI runs that read off the event loop. Before displaying the result it checks
-the captured session object, ID and (when exposed) mirrored owner epoch, so
+The UI runs that read off the event loop and updates only the loading screen
+that owns it; it never pushes a second screen on completion. Closing/unmounting
+invalidates that presentation even if the bounded read finishes in the background.
+Before displaying the result it checks the captured session object, ID and
+(when exposed) mirrored owner epoch, so
 `/new` or `/resume` cannot surface a stale report over another session, including
 an owner replacement behind the same remote facade.
 

--- a/docs/SESSION_DIAGNOSTICS.md
+++ b/docs/SESSION_DIAGNOSTICS.md
@@ -1,0 +1,75 @@
+# Current-session diagnostics
+
+`/session` opens a read-only, scrollable snapshot of the current session. It
+accepts no arguments, does not call a model, and does not append a prompt or a
+receipt to conversation history. Escape or `q` closes the view and returns focus
+to the composer. Close and reopen to refresh; arrow, page, Home and End keys
+navigate the report.
+
+## Scope
+
+The usage source is the shared local analytics SQLite ledger, filtered by the
+**exact current session ID**, not a transcript traversal or an ID prefix. A
+resumed session includes that ID's retained records. Child sessions have their
+own IDs and are excluded. A fork's copied conversation history does not become
+new ledger spend. Older rows can be pruned by analytics retention, and in-flight
+requests or asynchronous recorder writes may not have reached the ledger yet.
+The report is therefore recorded, retained usage, not a lifetime invoice.
+
+An absent database or an exact ID with no rows is an empty report. An unreadable,
+corrupt or incompatible ledger is explicitly unavailable. Opening diagnostics
+does not create or migrate a database. Legacy optional fields are projected as
+unknown (timings, request IDs, purpose/outcome, usage reporting) or unattributed
+(estimated components), rather than fabricated observations.
+
+## Accounting
+
+- Input context is the normalized full input count, including cached context.
+  Total tokens are input context plus output. Reasoning is a **subset** of
+  output, never an additional charge or extra token total.
+- Cache hit rate is cache-read tokens divided by full input context. Cache
+  writes are shown separately and are not added on top of normalized context.
+- Input components are the existing character-weighted estimates recorded by
+  analytics. Tool inventory, schemas, results and conversation are distinct
+  components. Their token split is estimated, not provider itemization.
+- Combined costs are summed exactly in integer micro-USD, grouped by both
+  provider and model ID. Costs are provider-reported where available, otherwise
+  list-price estimates. The stored ledger does not retain provenance per row,
+  so the view does not claim to distinguish those sources. Unknown costs are
+  not free; a `+` marks a partial known sum, and a known zero remains `$0.0000`.
+- Separate input/output/tool dollar amounts cannot be recovered from this
+  ledger. In particular, assigning dollar shares by token ratio would confuse
+  discounted cached input with full-price output and is deliberately not done.
+- Timings are logical-request observations, with a separate sample count for
+  each mean/range. Unknown historical timings are excluded, not zero-filled.
+  Duration includes retries and consumer backpressure; first output is the
+  first text or tool-call delta, not a provider-internal compute measurement. Recent rows (12 by default, hard cap
+  50 in the API) identify logical requests, not retry attempts.
+
+## Runtime snapshot and implementation boundary
+
+The view captures name, full session ID, selected/effective model identity and
+streaming state before yielding to the ledger worker. When the canonical
+frontend snapshot is available it also reads its context occupancy, measurement
+limit and turn generation. Reduced session facades can omit those fields; the
+view reports unavailable rather than reading private prompts/context or adding
+new protocol requirements. Compaction count is not currently exposed and is
+shown as unavailable.
+
+`AnalyticsStore.session_report` uses one short-lived, read-only connection and
+an explicit SQLite read transaction. Totals, grouping, timings and bounded recent
+rows all observe the same snapshot even while a WAL writer commits new calls.
+The UI runs that read off the event loop. Before displaying the result it checks
+the captured session object, ID and (when exposed) mirrored owner epoch, so
+`/new` or `/resume` cannot surface a stale report over another session, including
+an owner replacement behind the same remote facade.
+
+Remote terminal frontends use the same shared local analytics database and
+mirrored session identity/runtime scalars. The command is frontend-local, like
+`/analytics`; no analytics RPC or transport schema is added. Slash autocomplete,
+help and the daemon's mirrored command registry discover it from the standard
+command table.
+
+The report does not render prompts, tool schemas/payloads/results, credentials,
+provider URLs or raw exception text. Its only tool-related data is the existing
+aggregate estimated token count.

--- a/local_operator/analytics/model.py
+++ b/local_operator/analytics/model.py
@@ -490,6 +490,56 @@ class UsageAggregate:
 
 
 @dataclass(frozen=True)
+class TimingSummary:
+    """Observed logical-request timing; absent samples are never zero latency."""
+
+    samples: int = 0
+    mean_ms: float | None = None
+    min_ms: float | None = None
+    max_ms: float | None = None
+
+
+@dataclass(frozen=True)
+class SessionRequest:
+    """A bounded recent-ledger row, deliberately excluding payloads and errors."""
+
+    request_id: str
+    ts_ms: int
+    provider: str
+    model_id: str
+    purpose: str
+    outcome: str
+    usage_reported: bool | None
+    context_tokens: int
+    output_tokens: int
+    duration_ms: float | None
+    ttft_ms: float | None
+    preparation_ms: float | None
+
+
+@dataclass(frozen=True)
+class SessionReport:
+    """One consistent exact-ID ledger snapshot, not a transcript-derived bill.
+
+    No child IDs or copied fork history are joined. A resumed ID sees its
+    retained rows; queued recorder writes and pruned history cannot be recovered.
+    ``available=False`` is distinct from an available report with zero calls.
+    """
+
+    session_id: str
+    available: bool = True
+    aggregate: UsageAggregate = field(default_factory=UsageAggregate)
+    by_model: dict[tuple[str, str], UsageAggregate] = field(default_factory=dict)
+    by_purpose_outcome: dict[tuple[str, str], int] = field(default_factory=dict)
+    missing_usage_calls: int = 0
+    unknown_usage_calls: int = 0
+    timings: dict[str, TimingSummary] = field(default_factory=dict)
+    recent: tuple[SessionRequest, ...] = ()
+    first_ts_ms: int | None = None
+    last_ts_ms: int | None = None
+
+
+@dataclass(frozen=True)
 class UsagePeriod:
     """One row of the daily/monthly rollup: a calendar bucket's summed spend.
 

--- a/local_operator/analytics/store.py
+++ b/local_operator/analytics/store.py
@@ -20,8 +20,9 @@ Instead each call is an append (no contention beyond the WAL) and the
 ``/analytics`` screen runs a ``GROUP BY`` when it opens. On a bounded ledger
 that scan is milliseconds, and it is paid only when someone actually looks.
 
-Everything degrades silently: a store that cannot open is a no-op recorder and
-an empty report, never an exception on a session's path.
+Failures never interrupt a session: a store that cannot open is a no-op
+recorder. Aggregate reads retain their empty fallback; the current-session
+diagnostic additionally distinguishes an unavailable ledger from zero usage.
 """
 
 from __future__ import annotations
@@ -38,6 +39,9 @@ from typing import Any, Iterable, Sequence
 from local_operator.analytics.model import (
     COMPONENT_KEYS,
     CallSnapshot,
+    SessionReport,
+    SessionRequest,
+    TimingSummary,
     UsageAggregate,
     UsagePeriod,
     apportion_components,
@@ -998,6 +1002,135 @@ class AnalyticsStore:
         }
         setattr(result, "session_names", result_session_names)
         return result
+
+    def session_report(self, session_id: str, *, recent_limit: int = 12) -> SessionReport:
+        """Read one exact session ID without creating, migrating or pricing data.
+
+        A single explicit read transaction pins all queries to the same WAL
+        snapshot, even if the recorder commits between totals and recent rows.
+        Inspect columns on THIS connection rather than writer migration flags:
+        diagnostics must also work against a read-only, older ledger. Missing
+        optional fields remain unknown, not invented successes or zero timings.
+        """
+        conn: sqlite3.Connection | None = None
+        try:
+            if not self._db_path.exists():
+                return SessionReport(session_id=session_id)
+            conn = sqlite3.connect(
+                self._db_path.resolve().as_uri() + "?mode=ro", uri=True, timeout=5
+            )
+            conn.execute("BEGIN")
+            columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(calls)")}
+            if not {"session_id", "provider", "model_id", "ts_ms", "id"} <= columns:
+                return SessionReport(session_id=session_id, available=False)
+
+            def col(name: str, default: str = "0") -> str:
+                # Names are code-owned constants, never user input. Only the ID
+                # is caller supplied, and every query binds it as a parameter.
+                return name if name in columns else default
+
+            sums = ["COUNT(*)", f"SUM({col('ok')})"]
+            sums += [
+                f"SUM({col(name)})"
+                for name in (
+                    "input_tokens",
+                    "output_tokens",
+                    "cache_read_tokens",
+                    "cache_write_tokens",
+                    "reasoning_tokens",
+                    "context_tokens",
+                    "cost_micro",
+                    "cost_known",
+                    *(f"c_{key}" for key in COMPONENT_KEYS),
+                )
+            ]
+            measures = ", ".join(sums)
+            scope = " FROM calls WHERE session_id = ?"
+            params = (session_id,)
+            aggregate = _aggregate_from_row(
+                conn.execute(f"SELECT {measures}" + scope, params).fetchone()
+            )
+            by_model = {
+                (str(row[0]), str(row[1])): _aggregate_from_row(row[2:])
+                for row in conn.execute(
+                    f"SELECT provider, model_id, {measures}"
+                    + scope
+                    + " GROUP BY provider, model_id",
+                    params,
+                )
+            }
+            purpose = col("purpose", "'unknown'")
+            outcome = col("outcome", "'unknown'")
+            groups = {
+                (str(row[0]), str(row[1])): int(row[2])
+                for row in conn.execute(
+                    f"SELECT {purpose}, {outcome}, COUNT(*)" + scope + " GROUP BY 1, 2", params
+                )
+            }
+            usage = col("usage_reported", "NULL")
+            missing, unknown, first, last = conn.execute(
+                f"SELECT SUM({usage} = 0), SUM({usage} IS NULL), MIN(ts_ms), MAX(ts_ms)" + scope,
+                params,
+            ).fetchone()
+            timings: dict[str, TimingSummary] = {}
+            for name in ("duration_ms", "ttft_ms", "preparation_ms"):
+                expression = col(name, "NULL")
+                row = conn.execute(
+                    f"SELECT COUNT({expression}), AVG({expression}), "
+                    f"MIN({expression}), MAX({expression})" + scope + f" AND {expression} >= 0",
+                    params,
+                ).fetchone()
+                timings[name] = TimingSummary(int(row[0]), row[1], row[2], row[3])
+            fields = [
+                col("request_id", "''"),
+                "ts_ms",
+                "provider",
+                "model_id",
+                purpose,
+                outcome,
+                usage,
+                col("context_tokens"),
+                col("output_tokens"),
+                *(f"NULLIF({col(name, '-1')}, -1)" for name in timings),
+            ]
+            recent = tuple(
+                SessionRequest(
+                    request_id=row[0],
+                    ts_ms=row[1],
+                    provider=row[2],
+                    model_id=row[3],
+                    purpose=row[4],
+                    outcome=row[5],
+                    usage_reported=None if row[6] is None else bool(row[6]),
+                    context_tokens=row[7],
+                    output_tokens=row[8],
+                    duration_ms=row[9],
+                    ttft_ms=row[10],
+                    preparation_ms=row[11],
+                )
+                for row in conn.execute(
+                    "SELECT " + ", ".join(fields) + scope + " ORDER BY ts_ms DESC, id DESC LIMIT ?",
+                    (*params, max(0, min(int(recent_limit), 50))),
+                )
+            )
+            return SessionReport(
+                session_id=session_id,
+                aggregate=aggregate,
+                by_model=by_model,
+                by_purpose_outcome=groups,
+                missing_usage_calls=int(missing or 0),
+                unknown_usage_calls=int(unknown or 0),
+                timings=timings,
+                recent=recent,
+                first_ts_ms=first,
+                last_ts_ms=last,
+            )
+        except Exception:  # noqa: BLE001 — diagnostics must not interrupt a turn
+            logger.debug("analytics: session report unavailable", exc_info=True)
+            return SessionReport(session_id=session_id, available=False)
+        finally:
+            if conn is not None:
+                conn.close()
 
     # -- rollup reads (calendar time series) ---------------------------------
     def _series(self, table: str, key: str, buckets: int, *, by_model: bool) -> list[UsagePeriod]:

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -330,6 +330,9 @@ _FRONTEND_LOCAL_SLASHES = {
     "failovers",
     "usage",
     "analytics",
+    # Like analytics, reads the shared local ledger for the mirrored current
+    # session ID. No owner RPC or new transport payload is needed.
+    "session",
     "skills",
     "login",
     "logout",

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -261,6 +261,7 @@ if TYPE_CHECKING:  # keeps the provider graph off the TUI's runtime import path
     from local_operator.providers.controller import CatalogueEntry
     from local_operator.providers.oauth.callback_server import LoginCallbacks
     from local_operator.skills.discovery import Skill
+    from local_operator.tui.widgets.session_panel import SessionDiagnostics
 
 
 #: ONE sentence for ONE instruction, carried verbatim by every surface that
@@ -682,6 +683,7 @@ SLASH_COMMANDS: list[SlashCommand] = [
     # The panel is the receipt — the row the owner reported as noise.
     SlashCommand("usage", "Show provider usage quota"),
     SlashCommand("context", "Show prompt, tool-schema and message token usage"),
+    SlashCommand("session", "Current-session usage, cost and request diagnostics"),
     # The screen it opens IS the receipt (same rule as `/usage`). The argument
     # names WHICH analytics view; today only `usage` exists, so the list is an
     # OFFER — a bare `/analytics` opens the usage view rather than doing
@@ -15011,6 +15013,8 @@ class OperatorApp(App[None]):
             self._cmd_usage(arg, notice)
         elif command == "/analytics":
             self._cmd_analytics(arg, notice)
+        elif command == "/session":
+            self._cmd_session(arg, notice)
         elif command == "/context":
             block = self._context_block()
             if block is not None:
@@ -18504,6 +18508,47 @@ class OperatorApp(App[None]):
         self.push_screen(
             AnalyticsScreen(aggregate, daily=daily, monthly=monthly, window_totals=window_totals)
         )
+
+    def _cmd_session(self, arg: str, notice: NoticeFn) -> None:
+        """Read only this session's ledger; never interpret arguments as a prompt."""
+        from local_operator.tui.widgets.session_panel import SessionDiagnostics
+
+        if arg.strip():
+            self._system_notice(
+                "/session takes no arguments; it reports the current session", "warning"
+            )
+            return
+        session = self._session
+        if session is None:
+            self._system_notice("session is not ready yet", "warning")
+            return
+        # Capture mutable identity and model selection BEFORE yielding. A /new
+        # or /resume during the disk read must not put an old bill over a new
+        # conversation. Object identity also catches resuming the same ID.
+        runtime = SessionDiagnostics.capture(session)
+        self.run_worker(
+            self._open_session_report_worker(session, runtime),
+            thread=False,
+            group="session-report",
+            exclusive=True,
+        )
+
+    async def _open_session_report_worker(
+        self, session: SessionProtocol, runtime: SessionDiagnostics
+    ) -> None:
+        from local_operator.analytics import AnalyticsStore
+        from local_operator.tui.widgets.session_panel import SessionScreen
+
+        report = await asyncio.to_thread(AnalyticsStore().session_report, runtime.session_id)
+        if self._session is not session or session.session_id != runtime.session_id:
+            return
+        # A mirrored facade may survive an owner replacement for the SAME ID.
+        # Its public epoch, unlike the per-event sequence, changes only across
+        # that lifecycle boundary and must not invalidate ordinary live usage.
+        state = getattr(session, "frontend_state", None)
+        if runtime.epoch is not None and getattr(state, "epoch", None) != runtime.epoch:
+            return
+        self.push_screen(SessionScreen(report, runtime))
 
     def _cmd_usage(self, arg: str, notice: NoticeFn) -> None:
         """``/usage [provider]`` — fetch live quota for a provider (or all)."""

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -261,7 +261,10 @@ if TYPE_CHECKING:  # keeps the provider graph off the TUI's runtime import path
     from local_operator.providers.controller import CatalogueEntry
     from local_operator.providers.oauth.callback_server import LoginCallbacks
     from local_operator.skills.discovery import Skill
-    from local_operator.tui.widgets.session_panel import SessionDiagnostics
+    from local_operator.tui.widgets.session_panel import (
+        SessionDiagnostics,
+        SessionScreen,
+    )
 
 
 #: ONE sentence for ONE instruction, carried verbatim by every surface that
@@ -18511,7 +18514,10 @@ class OperatorApp(App[None]):
 
     def _cmd_session(self, arg: str, notice: NoticeFn) -> None:
         """Read only this session's ledger; never interpret arguments as a prompt."""
-        from local_operator.tui.widgets.session_panel import SessionDiagnostics
+        from local_operator.tui.widgets.session_panel import (
+            SessionDiagnostics,
+            SessionScreen,
+        )
 
         if arg.strip():
             self._system_notice(
@@ -18526,29 +18532,36 @@ class OperatorApp(App[None]):
         # or /resume during the disk read must not put an old bill over a new
         # conversation. Object identity also catches resuming the same ID.
         runtime = SessionDiagnostics.capture(session)
+        # Own a visible, cancellable surface before starting IO. A late disk
+        # result must update this surface, never push over a user's new draft.
+        screen = SessionScreen(None, runtime)
+        self.push_screen(screen)
         self.run_worker(
-            self._open_session_report_worker(session, runtime),
+            self._open_session_report_worker(session, runtime, screen),
             thread=False,
             group="session-report",
             exclusive=True,
         )
 
     async def _open_session_report_worker(
-        self, session: SessionProtocol, runtime: SessionDiagnostics
+        self, session: SessionProtocol, runtime: SessionDiagnostics, screen: SessionScreen
     ) -> None:
         from local_operator.analytics import AnalyticsStore
-        from local_operator.tui.widgets.session_panel import SessionScreen
 
         report = await asyncio.to_thread(AnalyticsStore().session_report, runtime.session_id)
+        if screen.presentation_cancelled or screen not in self.screen_stack:
+            return
         if self._session is not session or session.session_id != runtime.session_id:
+            screen.invalidate()
             return
         # A mirrored facade may survive an owner replacement for the SAME ID.
         # Its public epoch, unlike the per-event sequence, changes only across
         # that lifecycle boundary and must not invalidate ordinary live usage.
         state = getattr(session, "frontend_state", None)
         if runtime.epoch is not None and getattr(state, "epoch", None) != runtime.epoch:
+            screen.invalidate()
             return
-        self.push_screen(SessionScreen(report, runtime))
+        screen.set_report(report)
 
     def _cmd_usage(self, arg: str, notice: NoticeFn) -> None:
         """``/usage [provider]`` — fetch live quota for a provider (or all)."""

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -1809,12 +1809,12 @@ SessionPickerScreen .session-picker {
  * the body can be long (a per-session table grows without bound), so the card
  * pins a title and a hint and puts the report itself in a VerticalScroll
  * between them, rather than sizing to content the way the picker does. */
-AnalyticsScreen {
+AnalyticsScreen, SessionScreen {
     align: center middle;
     background: $lo-sunken;
 }
 
-AnalyticsScreen .analytics-panel {
+AnalyticsScreen .analytics-panel, SessionScreen .analytics-panel {
     /* Responsive: 90% of the terminal, capped generously so a large screen
      * actually gets a larger frame (the token+cost tables have more columns to
      * show) while a small one still fits. The old max-width of 100 left a wide
@@ -1830,7 +1830,7 @@ AnalyticsScreen .analytics-panel {
     padding: 1 2;
 }
 
-#analytics-title {
+#analytics-title, #session-report-title {
     /* Title line + a `─` rule under it (two lines), then a blank padding row
      * before the scrolling body. */
     width: 100%;
@@ -1838,7 +1838,7 @@ AnalyticsScreen .analytics-panel {
     padding-bottom: 1;
 }
 
-#analytics-scroll {
+#analytics-scroll, #session-report-scroll {
     width: 100%;
     height: 1fr;
     /* A grabbable scrollbar consistent with the transcript's: `edge` keeps it
@@ -1860,19 +1860,34 @@ AnalyticsScreen .analytics-panel {
     scrollbar-color-active: $lo-accent;
 }
 
-#analytics-body {
+#analytics-body, #session-report-body {
     width: auto;
     height: auto;
     color: $lo-fg;
 }
 
-#analytics-hint {
+#analytics-hint, #session-report-hint {
     width: 100%;
     height: 2;
     padding-top: 1;
     color: $lo-faint;
 }
 
+
+/* Unlike the all-session aligned tables, session diagnostics wrap long IDs
+ * and model names. Width must be constrained to the scroll viewport so a
+ * 50-column terminal never acquires a horizontal scrollbar. */
+#session-report-body {
+    width: 100%;
+}
+
+#session-report-title {
+    text-style: bold;
+}
+
+#session-report-hint {
+    color: $lo-muted;
+}
 
 /* ── prompts: the ask picker and the approval gate ────────────────────── *
  *

--- a/local_operator/tui/widgets/session_panel.py
+++ b/local_operator/tui/widgets/session_panel.py
@@ -1,0 +1,298 @@
+"""Read-only current-session diagnostics, using the analytics ledger's units.
+
+The report is a close/reopen snapshot, not a live bill. Runtime scalars are
+captured before the worker reads SQLite; neither prompts nor tool payloads ever
+enter this view. Keep this screen independent of AnalyticsScreen's calendar
+charts and metric-toggle bindings while sharing its visual chrome and formatters.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from rich.style import Style
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Container, VerticalScroll
+from textual.screen import ModalScreen
+from textual.widgets import Static
+
+from local_operator.analytics.model import COMPONENT_LABELS, SessionReport
+from local_operator.session.protocol import SessionProtocol
+from local_operator.tui import theme as theme_mod
+from local_operator.tui.widgets.analytics_panel import (
+    format_cost,
+    format_percent,
+    format_tokens,
+)
+
+
+@dataclass(frozen=True)
+class SessionDiagnostics:
+    """Only scalar public state; never hold a mutable session across a disk read."""
+
+    session_id: str
+    name: str
+    selected_model: str
+    effective_model: str
+    streaming: bool
+    context_tokens: int | None = None
+    context_window: int | None = None
+    context_is_estimate: bool | None = None
+    generation: int | None = None
+    epoch: str | None = None
+
+    @classmethod
+    def capture(cls, session: SessionProtocol) -> SessionDiagnostics:
+        # The canonical frontend snapshot is already mirrored on RemoteSession.
+        # Reduced SDK facades need not have it; don't traverse private context or
+        # tokenize history just to fill a missing diagnostic.
+        state = getattr(session, "frontend_state", None)
+        model = session.effective_model
+        return cls(
+            session_id=session.session_id,
+            name=session.conversation_name,
+            selected_model=session.model_label,
+            effective_model=session.effective_model_label,
+            streaming=session.is_streaming,
+            context_tokens=getattr(state, "context_tokens", None),
+            context_window=getattr(state, "context_window", None)
+            or getattr(model, "context_window", None),
+            context_is_estimate=getattr(state, "context_is_estimate", None),
+            generation=getattr(state, "generation", None),
+            epoch=getattr(state, "epoch", None),
+        )
+
+
+def _stamp(ts_ms: int | None) -> str:
+    if ts_ms is None:
+        return "unknown"
+    return datetime.fromtimestamp(ts_ms / 1000).astimezone().strftime("%Y-%m-%d %H:%M:%S %Z")
+
+
+def _milliseconds(value: float | None) -> str:
+    return "unknown" if value is None else f"{value:,.0f} ms"
+
+
+def build_session_report(report: SessionReport, runtime: SessionDiagnostics) -> Text:
+    """Stacked, wrapping rows keep full IDs readable even in a 50-column pane."""
+    fg = Style(color=theme_mod.semantic_color("fg"))
+    muted = Style(color=theme_mod.semantic_color("muted"))
+    result = Text(style=fg, overflow="fold")
+
+    def line(label: str, value: str = "") -> None:
+        result.append(label, style=muted)
+        if value:
+            result.append("  " + value, style=fg)
+        result.append("\n")
+
+    def section(title: str) -> None:
+        result.append(
+            "\n" + title + "\n", style=Style(color=theme_mod.semantic_color("fg"), bold=True)
+        )
+
+    line(runtime.name or "Untitled session")
+    line("ID", runtime.session_id)
+    line("Current session only. Close and reopen to refresh.")
+    aggregate = report.aggregate
+    if not report.available:
+        section("Ledger unavailable")
+        line("Could not read local usage records. Close and reopen to try again.")
+    elif not aggregate.calls:
+        section("No recorded requests")
+        line("No retained usage records for this session yet.")
+    else:
+        section("Recorded usage")
+        line("Requests", f"{aggregate.calls:,}")
+        line("Cost (reported / est.)", format_cost(aggregate))
+        line("Tokens", f"{aggregate.total_tokens:,} total")
+        line("Input context", f"{aggregate.context_tokens:,}")
+        line(
+            "Output",
+            f"{aggregate.output_tokens:,} (includes {aggregate.reasoning_tokens:,} reasoning)",
+        )
+        line(
+            "Cache read",
+            f"{aggregate.cache_read_tokens:,} / {aggregate.context_tokens:,} "
+            f"context ({format_percent(aggregate.cache_hit_rate)})",
+        )
+        line("Cache write", f"{aggregate.cache_write_tokens:,}")
+        line(
+            "Usage missing",
+            f"{report.missing_usage_calls:,} requests; {report.unknown_usage_calls:,} unknown",
+        )
+        line("Period", _stamp(report.first_ts_ms) + " to " + _stamp(report.last_ts_ms))
+        line("Cost is provider-reported or a list-price estimate. Source is not retained per row.")
+        line(
+            "+ means a partial cost; unknown cost is not free. "
+            "Input/output/tool dollars are unavailable separately."
+        )
+
+        section("Provider / model")
+        for (provider, model), group in sorted(
+            report.by_model.items(), key=lambda item: -item[1].total_tokens
+        ):
+            line(f"{provider}/{model}")
+            line(
+                "  Usage",
+                f"{group.calls:,} requests · {format_tokens(group.total_tokens)} "
+                f"tokens · {format_cost(group)}",
+            )
+            line(
+                "  Input / output",
+                f"{format_tokens(group.context_tokens)} / {format_tokens(group.output_tokens)}",
+            )
+
+        section("Estimated input breakdown")
+        line(
+            "Character-weighted attribution of recorded input "
+            "context, not separately billed tokens or dollars."
+        )
+        for key, value in sorted(aggregate.components.items(), key=lambda item: -item[1]):
+            line(COMPONENT_LABELS.get(key, key), f"~{format_tokens(value)}")
+        unattributed = max(0, aggregate.context_tokens - sum(aggregate.components.values()))
+        if unattributed:
+            line("Unattributed (older records)", format_tokens(unattributed))
+
+        section("Request purpose / outcome")
+        for (purpose, outcome), count in sorted(report.by_purpose_outcome.items()):
+            line(f"{purpose} / {outcome}", f"{count:,}")
+
+        section("Logical request timings")
+        line(
+            "Observed wall time includes retries and consumer "
+            "backpressure; not provider compute or per-attempt timing. "
+            "First output is the first text or tool-call delta."
+        )
+        for key, label in (
+            ("duration_ms", "Duration"),
+            ("ttft_ms", "First output"),
+            ("preparation_ms", "Preparation"),
+        ):
+            timing = report.timings.get(key)
+            if timing is None or not timing.samples:
+                line(label, "unknown (0 samples)")
+            else:
+                line(label, f"{_milliseconds(timing.mean_ms)} mean ({timing.samples:,} samples)")
+                line("  Range", f"{_milliseconds(timing.min_ms)} to {_milliseconds(timing.max_ms)}")
+
+    section("Runtime snapshot")
+    line("Selected", runtime.selected_model)
+    line("Effective", runtime.effective_model)
+    line("State", "streaming" if runtime.streaming else "idle")
+    line(
+        "Turn generation",
+        str(runtime.generation) if runtime.generation is not None else "unavailable",
+    )
+    context = "unavailable"
+    if runtime.context_tokens is not None:
+        context = ("~" if runtime.context_is_estimate else "") + f"{runtime.context_tokens:,}"
+    limit = f"{runtime.context_window:,}" if runtime.context_window else "unavailable"
+    line("Context / limit", context + " / " + limit)
+    line("Compaction count", "unavailable")
+
+    if report.recent:
+        section(f"Recent requests ({len(report.recent)} of {aggregate.calls:,})")
+        line("Newest first; request IDs identify logical requests, not retry attempts.")
+        for row in report.recent:
+            line(_stamp(row.ts_ms))
+            line("ID", row.request_id or "not recorded")
+            line(f"{row.provider}/{row.model_id}")
+            line(f"{row.purpose} / {row.outcome}")
+            usage = (
+                "unknown"
+                if row.usage_reported is None
+                else "reported" if row.usage_reported else "missing"
+            )
+            line(
+                "Usage",
+                f"{usage} · input {format_tokens(row.context_tokens)} "
+                f"· output {format_tokens(row.output_tokens)}",
+            )
+            line(
+                "Duration / first output",
+                f"{_milliseconds(row.duration_ms)} / {_milliseconds(row.ttft_ms)}",
+            )
+            line("Preparation", _milliseconds(row.preparation_ms))
+            result.append("\n")
+    section("Scope and limits")
+    line(
+        "Retained local ledger rows for this exact ID only. Child sessions and copied "
+        "fork history are excluded; resuming the same ID includes its retained records."
+    )
+    line(
+        "Older records may have been pruned. In-flight requests and pending "
+        "recorder writes may not appear yet. This command makes no model request."
+    )
+    return result
+
+
+class SessionScreen(ModalScreen[None]):
+    """A snapshot with analytics chrome, but no all-session charts or toggles."""
+
+    BINDINGS = [
+        Binding("escape", "dismiss_screen", "Back", show=False),
+        Binding("q", "dismiss_screen", "Back", show=False),
+        Binding("up", "scroll_up", "Up", show=False),
+        Binding("down", "scroll_down", "Down", show=False),
+        Binding("pageup", "page_up", "Page up", show=False),
+        Binding("pagedown", "page_down", "Page down", show=False),
+        Binding("home", "scroll_home", "Top", show=False),
+        Binding("end", "scroll_end", "Bottom", show=False),
+    ]
+
+    def __init__(self, report: SessionReport, runtime: SessionDiagnostics) -> None:
+        super().__init__()
+        self.report = report
+        self.runtime = runtime
+
+    def compose(self) -> ComposeResult:
+        with Container(classes="analytics-panel"):
+            yield Static(
+                Text("Session diagnostics\n" + "─" * 140, no_wrap=True, overflow="crop"),
+                id="session-report-title",
+            )
+            with VerticalScroll(id="session-report-scroll") as scroll:
+                self._scroll = scroll
+                yield Static(
+                    build_session_report(self.report, self.runtime), id="session-report-body"
+                )
+            self._hint = Static("esc / q back", id="session-report-hint")
+            yield self._hint
+
+    def on_mount(self) -> None:
+        self.call_after_refresh(self._sync_hint)
+
+    def on_resize(self) -> None:
+        self.call_after_refresh(self._sync_hint)
+
+    def _sync_hint(self) -> None:
+        # Like analytics, don't advertise a dead scroll control when an empty
+        # report fits a tall terminal. Layout must settle before measuring it.
+        scroll = getattr(self, "_scroll", None)
+        hint = getattr(self, "_hint", None)
+        if scroll is not None and hint is not None and hint.is_mounted:
+            hint.update("esc / q back" + (" · ↑↓ scroll" if scroll.max_scroll_y > 0 else ""))
+
+    def action_dismiss_screen(self) -> None:
+        self.dismiss(None)
+
+    def action_scroll_up(self) -> None:
+        self._scroll.scroll_up()
+
+    def action_scroll_down(self) -> None:
+        self._scroll.scroll_down()
+
+    def action_page_up(self) -> None:
+        self._scroll.scroll_page_up()
+
+    def action_page_down(self) -> None:
+        self._scroll.scroll_page_down()
+
+    def action_scroll_home(self) -> None:
+        self._scroll.scroll_home()
+
+    def action_scroll_end(self) -> None:
+        self._scroll.scroll_end()

--- a/local_operator/tui/widgets/session_panel.py
+++ b/local_operator/tui/widgets/session_panel.py
@@ -76,7 +76,7 @@ def _milliseconds(value: float | None) -> str:
     return "unknown" if value is None else f"{value:,.0f} ms"
 
 
-def build_session_report(report: SessionReport, runtime: SessionDiagnostics) -> Text:
+def build_session_report(report: SessionReport | None, runtime: SessionDiagnostics) -> Text:
     """Stacked, wrapping rows keep full IDs readable even in a 50-column pane."""
     fg = Style(color=theme_mod.semantic_color("fg"))
     muted = Style(color=theme_mod.semantic_color("muted"))
@@ -95,6 +95,11 @@ def build_session_report(report: SessionReport, runtime: SessionDiagnostics) -> 
 
     line(runtime.name or "Untitled session")
     line("ID", runtime.session_id)
+    if report is None:
+        section("Loading usage records")
+        line("Reading the local ledger. Esc or q cancels.")
+        line("No model request is made.")
+        return result
     line("Current session only. Close and reopen to refresh.")
     aggregate = report.aggregate
     if not report.available:
@@ -243,10 +248,11 @@ class SessionScreen(ModalScreen[None]):
         Binding("end", "scroll_end", "Bottom", show=False),
     ]
 
-    def __init__(self, report: SessionReport, runtime: SessionDiagnostics) -> None:
+    def __init__(self, report: SessionReport | None, runtime: SessionDiagnostics) -> None:
         super().__init__()
         self.report = report
         self.runtime = runtime
+        self.presentation_cancelled = False
 
     def compose(self) -> ComposeResult:
         with Container(classes="analytics-panel"):
@@ -256,14 +262,55 @@ class SessionScreen(ModalScreen[None]):
             )
             with VerticalScroll(id="session-report-scroll") as scroll:
                 self._scroll = scroll
-                yield Static(
+                self._body = Static(
                     build_session_report(self.report, self.runtime), id="session-report-body"
                 )
-            self._hint = Static("esc / q back", id="session-report-hint")
+                yield self._body
+            self._hint = Static(self._back_hint(), id="session-report-hint")
             yield self._hint
 
     def on_mount(self) -> None:
-        self.call_after_refresh(self._sync_hint)
+        # A fast disk read can finish while this screen is still mounting. The
+        # stored result, not the first compose-time text, must win that race.
+        self._repaint()
+        self.call_after_refresh(self._dismiss_if_cancelled)
+
+    def on_unmount(self) -> None:
+        self.presentation_cancelled = True
+
+    def on_screen_resume(self) -> None:
+        self._dismiss_if_cancelled()
+
+    def invalidate(self) -> None:
+        """Retire this request without ever popping a newer modal above it."""
+        self.presentation_cancelled = True
+        self._dismiss_if_cancelled()
+
+    def _dismiss_if_cancelled(self) -> None:
+        # An owner switch may happen while another modal covers this one.
+        # Dismiss only when resumed: Screen.dismiss() pops the CURRENT screen,
+        # not necessarily the instance on which it was called.
+        # A queued screen is registered before its mount finishes. Popping it
+        # during that mount races Textual's parent teardown; on_mount schedules
+        # another check after layout, without ever publishing the stale data.
+        if self.presentation_cancelled and self.is_mounted and self.app.screen is self:
+            self.dismiss(None)
+
+    def set_report(self, report: SessionReport) -> None:
+        """Publish the disk result only while this presentation is still owned."""
+        if self.presentation_cancelled:
+            return
+        self.report = report
+        self._repaint()
+
+    def _repaint(self) -> None:
+        body = getattr(self, "_body", None)
+        if body is not None and body.is_mounted and not self.presentation_cancelled:
+            body.update(build_session_report(self.report, self.runtime))
+            self.call_after_refresh(self._sync_hint)
+
+    def _back_hint(self) -> str:
+        return "esc / q cancel" if self.report is None else "esc / q back"
 
     def on_resize(self) -> None:
         self.call_after_refresh(self._sync_hint)
@@ -274,10 +321,10 @@ class SessionScreen(ModalScreen[None]):
         scroll = getattr(self, "_scroll", None)
         hint = getattr(self, "_hint", None)
         if scroll is not None and hint is not None and hint.is_mounted:
-            hint.update("esc / q back" + (" · ↑↓ scroll" if scroll.max_scroll_y > 0 else ""))
+            hint.update(self._back_hint() + (" · ↑↓ scroll" if scroll.max_scroll_y > 0 else ""))
 
     def action_dismiss_screen(self) -> None:
-        self.dismiss(None)
+        self.invalidate()
 
     def action_scroll_up(self) -> None:
         self._scroll.scroll_up()

--- a/scripts/session_report_shot.py
+++ b/scripts/session_report_shot.py
@@ -1,0 +1,172 @@
+"""Capture the real /session slash path with synthetic ledger data.
+
+Usage: python scripts/session_report_shot.py OUTDIR 80x24 populated|empty|unavailable
+Copy this script into a preserved base worktree to capture the pre-command path
+with the same fixture. No provider request, live session or operator config is used.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Clear every multiplexer identifier BEFORE any application import: a headless
+# pilot must not rename the operator's real workspace through inherited CMUX IDs.
+for _key in tuple(os.environ):
+    if _key.startswith("CMUX_"):
+        os.environ.pop(_key)
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import asyncio  # noqa: E402
+import hashlib  # noqa: E402
+import json  # noqa: E402
+from dataclasses import replace  # noqa: E402
+
+import scripts.probe_isolation  # noqa: E402, F401
+from local_operator.analytics.store import AnalyticsStore, default_db_path  # noqa: E402
+from local_operator.harness.types import ModelSpec  # noqa: E402
+from local_operator.session.frontend_state import FrontendSessionState  # noqa: E402
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.widgets.editor import Editor  # noqa: E402
+from scripts.visual_capture import save_capture  # noqa: E402
+from tests.unit.analytics.test_store import _snap  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+from tests.unit.tui.test_slash_echo import _submit  # noqa: E402
+
+
+class DiagnosticSession(FakeSession):
+    frontend_state: FrontendSessionState
+
+    @property
+    def session_id(self) -> str:
+        return "session-diagnostic-demo-0123456789abcdef"
+
+    @property
+    def model(self) -> ModelSpec:
+        return ModelSpec(provider="anthropic", model_id="claude-sonnet-4-6", context_window=200000)
+
+    @property
+    def effective_model(self) -> ModelSpec:
+        return ModelSpec(provider="openai", model_id="gpt-5.2", context_window=200000)
+
+    @property
+    def model_label(self) -> str:
+        return "anthropic/claude-sonnet-4-6"
+
+    @property
+    def effective_model_label(self) -> str:
+        return "openai/gpt-5.2"
+
+
+async def main() -> None:
+    out = Path(sys.argv[1]).resolve()
+    out.mkdir(parents=True, exist_ok=True)
+    cols, rows = sys.argv[2].split("x")
+    size = (int(cols), int(rows))
+    scenario = sys.argv[3] if len(sys.argv) > 3 else "populated"
+    session = DiagnosticSession()
+    session.set_conversation_name("Investigate request latency")
+    session.frontend_state = FrontendSessionState(
+        session_id=session.session_id,
+        epoch="capture",
+        generation=6,
+        context_tokens=28400,
+        context_is_estimate=False,
+        context_window=200000,
+    )
+    if scenario == "populated":
+        store = AnalyticsStore()
+        snapshots = []
+        for i in range(18):
+            snapshots.append(
+                replace(
+                    _snap(
+                        session_id=session.session_id,
+                        provider="anthropic" if i < 12 else "openai",
+                        model_id="claude-sonnet-4-6" if i < 12 else "gpt-5.2",
+                        context=28400,
+                        input_tokens=4400,
+                        cache_read=23000,
+                        cache_write=1000,
+                        output_tokens=1700,
+                        reasoning=400,
+                        cost_micro=18500,
+                        chars={
+                            "system_prompt": 400,
+                            "tool_inventory": 150,
+                            "tool_schemas": 250,
+                            "conversation": 1400,
+                            "tool_results": 600,
+                        },
+                        ts_ms=1788602400000 + i * 10000,
+                    ),
+                    request_id=f"logical-request-{i:03d}-0123456789abcdef",
+                    purpose="turn" if i < 16 else "compaction",
+                    outcome="ok",
+                    duration_ms=2800 + i * 15,
+                    ttft_ms=350 + i * 10,
+                    preparation_ms=24,
+                )
+            )
+        store.record_batch(snapshots)
+        store.close()
+    elif scenario == "unavailable":
+        path = default_db_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("synthetic corrupt ledger")
+    ledger = default_db_path()
+    before_digest = hashlib.sha256(ledger.read_bytes()).hexdigest() if ledger.exists() else None
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=size) as pilot:
+        await pilot.pause()
+        await _submit(pilot, app, "/session")
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        save_capture(app, str(out / "opened.svg"))
+        await pilot.pause()
+        save_capture(app, str(out / "settled.svg"))
+        if type(app.screen).__name__ == "SessionScreen":
+            for page in range(1, 7):
+                await pilot.press("pagedown")
+                await pilot.pause()
+                save_capture(app, str(out / f"page-{page}.svg"))
+        await pilot.press("end")
+        await pilot.pause()
+        save_capture(app, str(out / "bottom.svg"))
+        screen = app.screen
+        scroll = getattr(screen, "_scroll", None)
+        metrics = {
+            "source": str(Path(__file__).resolve().parents[1]),
+            "scenario": scenario,
+            "size": size,
+            "screen": type(screen).__name__,
+            "screen_geometry": {
+                "size": list(screen.size),
+                "virtual_size": list(screen.virtual_size),
+                "region": list(screen.region),
+            },
+            "prompts": session.prompts,
+            "ledger_unchanged": before_digest
+            == (hashlib.sha256(ledger.read_bytes()).hexdigest() if ledger.exists() else None),
+            "scroll": (
+                {
+                    "size": list(scroll.size),
+                    "virtual_size": list(scroll.virtual_size),
+                    "max_x": scroll.max_scroll_x,
+                    "max_y": scroll.max_scroll_y,
+                }
+                if scroll
+                else None
+            ),
+        }
+        await pilot.press("escape")
+        await pilot.pause()
+        save_capture(app, str(out / "closed.svg"))
+        metrics["composer_focused_after_close"] = app.focused is app.query_one(Editor)
+        (out / "result.json").write_text(json.dumps(metrics, indent=2) + "\n")
+        print(json.dumps(metrics))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/unit/analytics/test_session_report.py
+++ b/tests/unit/analytics/test_session_report.py
@@ -1,0 +1,162 @@
+"""Exact-ID reports use one read-only snapshot, never transcript inheritance."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import replace
+
+from local_operator.analytics.store import AnalyticsStore
+from tests.unit.analytics.test_store import _snap
+
+
+def test_exact_session_scope_models_purposes_and_costs(tmp_path):
+    store = AnalyticsStore(tmp_path / "ledger.db")
+    first = replace(
+        _snap(session_id="parent", model_id="one"),
+        request_id="r1",
+        purpose="turn",
+        outcome="ok",
+        duration_ms=200,
+        ttft_ms=50,
+        preparation_ms=10,
+    )
+    assert (
+        store.record_batch(
+            [
+                first,
+                replace(first, request_id="r2", model_id="two", cost_micro=0, cost_known=True),
+                replace(
+                    first,
+                    request_id="r3",
+                    provider="other",
+                    model_id="one",
+                    cost_micro=0,
+                    cost_known=False,
+                    usage_reported=False,
+                    outcome="error",
+                    ok=False,
+                ),
+                replace(first, session_id="child", parent_session_id="parent"),
+                replace(first, session_id="fork"),
+            ]
+        )
+        == 5
+    )
+    report = store.session_report("parent")
+    assert report.available and report.aggregate.calls == 3
+    assert report.aggregate.total_tokens == 3 * (920 + 40)
+    assert report.aggregate.generation_tokens == 90
+    assert report.aggregate.cost_micro == 1000
+    assert report.aggregate.cost_is_partial
+    assert set(report.by_model) == {("anthropic", "one"), ("anthropic", "two"), ("other", "one")}
+    assert report.by_model["anthropic", "two"].cost_is_known
+    assert report.by_model["anthropic", "two"].cost_micro == 0
+    assert not report.by_model["other", "one"].cost_is_known
+    assert report.by_purpose_outcome == {("turn", "ok"): 2, ("turn", "error"): 1}
+    assert report.missing_usage_calls == 1
+    assert report.unknown_usage_calls == 0
+    assert report.timings["duration_ms"].samples == 3
+    assert report.timings["duration_ms"].mean_ms == 200
+    assert len(report.recent) == 3
+    assert store.session_report("parent").aggregate.calls == 3  # resume retains the ID
+    assert store.session_report("fork-new").aggregate.calls == 0  # copied history isn't ledger data
+    store.close()
+
+
+def test_recent_bounded_order_and_unknown_timing(tmp_path):
+    store = AnalyticsStore(tmp_path / "ledger.db")
+    assert (
+        store.record_batch(
+            [
+                replace(_snap(ts_ms=100 + n), request_id=f"r{n}", duration_ms=n if n else -1)
+                for n in range(60)
+            ]
+        )
+        == 60
+    )
+    report = store.session_report("s1", recent_limit=500)
+    assert len(report.recent) == 50
+    assert [r.request_id for r in report.recent[:2]] == ["r59", "r58"]
+    assert report.timings["duration_ms"].samples == 59
+    assert report.timings["duration_ms"].min_ms == 1
+    assert report.timings["ttft_ms"].samples == 0
+    assert report.timings["ttft_ms"].mean_ms is None
+    assert report.first_ts_ms == 100 and report.last_ts_ms == 159
+    assert not store.session_report("s1", recent_limit=-1).recent
+    store.close()
+
+
+def test_missing_database_is_empty_without_creating_it(tmp_path):
+    path = tmp_path / "missing" / "ledger.db"
+    report = AnalyticsStore(path).session_report("s1")
+    assert report.available and report.aggregate.calls == 0
+    assert not path.parent.exists()
+
+
+def test_corrupt_database_is_unavailable_not_empty(tmp_path):
+    path = tmp_path / "ledger.db"
+    path.write_text("not sqlite")
+    report = AnalyticsStore(path).session_report("s1")
+    assert not report.available
+    assert path.read_text() == "not sqlite"
+
+
+def test_legacy_columns_remain_unknown_and_schema_unchanged(tmp_path):
+    path = tmp_path / "legacy.db"
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            "CREATE TABLE calls(id INTEGER PRIMARY KEY, ts_ms INTEGER, session_id TEXT, "
+            "provider TEXT, model_id TEXT, context_tokens INTEGER, output_tokens INTEGER)"
+        )
+        conn.execute("INSERT INTO calls VALUES(1, 100, 's1', 'p', 'm', 100, 20)")
+    before = path.read_bytes()
+    report = AnalyticsStore(path).session_report("s1")
+    assert report.available and report.aggregate.calls == 1
+    assert report.aggregate.total_tokens == 120
+    assert not report.aggregate.cost_is_known
+    assert report.unknown_usage_calls == 1 and report.missing_usage_calls == 0
+    assert report.by_purpose_outcome == {("unknown", "unknown"): 1}
+    assert report.recent[0].duration_ms is None
+    assert report.recent[0].usage_reported is None
+    assert path.read_bytes() == before
+
+
+def test_id_is_bound_not_interpolated(tmp_path):
+    store = AnalyticsStore(tmp_path / "ledger.db")
+    store.record_batch([_snap()])
+    assert store.session_report("' OR 1=1 --").aggregate.calls == 0
+    assert store.session_report("s1").aggregate.calls == 1
+    store.close()
+
+
+def test_all_sections_share_snapshot_during_concurrent_commit(tmp_path, monkeypatch):
+    store = AnalyticsStore(tmp_path / "ledger.db")
+    store.record_batch([replace(_snap(), request_id="before")])
+    original = sqlite3.connect
+    added = False
+
+    class Connection(sqlite3.Connection):
+        def execute(self, sql, parameters=()):
+            nonlocal added
+            result = super().execute(sql, parameters)
+            if sql.startswith("SELECT COUNT(*)") and not added:
+                added = True
+                # A separate WAL writer commits AFTER the read transaction's
+                # snapshot is established, before the group/recent queries.
+                other = AnalyticsStore(tmp_path / "ledger.db")
+                assert other.record_batch([replace(_snap(), request_id="after")]) == 1
+                other.close()
+            return result
+
+    def connect(*args, **kwargs):
+        if kwargs.get("uri"):
+            kwargs["factory"] = Connection
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(sqlite3, "connect", connect)
+    report = store.session_report("s1")
+    assert added and report.aggregate.calls == 1
+    assert sum(g.calls for g in report.by_model.values()) == 1
+    assert [r.request_id for r in report.recent] == ["before"]
+    assert store.session_report("s1").aggregate.calls == 2
+    store.close()

--- a/tests/unit/tui/test_command_picker.py
+++ b/tests/unit/tui/test_command_picker.py
@@ -840,7 +840,7 @@ async def test_click_on_the_overflow_row_does_nothing() -> None:
         # `settings` and its `config` alias join these two prefixes; both are
         # ranked ahead of their neighbours because a prefix match on a longer
         # word still beats one that starts later in the name.
-        ("s", ["settings", "search", "stop", "skills"]),
+        ("s", ["settings", "search", "session", "stop", "skills"]),
         # Every one of these is a flat 900 prefix match (verified, not assumed:
         # `score_command_text_match("/c", …)` returns 900 for all six), so
         # `match_commands` sorts them on `(-score, registry_index)` and the

--- a/tests/unit/tui/test_session_panel.py
+++ b/tests/unit/tui/test_session_panel.py
@@ -1,0 +1,210 @@
+"""Current-session diagnostics: real slash dispatch, read-only and stale-safe."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from dataclasses import replace
+
+import pytest
+
+from local_operator.analytics.model import SessionReport, UsageAggregate
+from local_operator.analytics.store import AnalyticsStore
+from local_operator.session.frontend_state import FrontendSessionState
+from local_operator.tui.app import OperatorApp, slash_command_for
+from local_operator.tui.widgets.editor import Editor
+from local_operator.tui.widgets.session_panel import (
+    SessionDiagnostics,
+    SessionScreen,
+    build_session_report,
+)
+from tests.unit.analytics.test_store import _snap
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+from tests.unit.tui.test_slash_echo import _submit
+
+
+def runtime():
+    return SessionDiagnostics(
+        "sess",
+        "Investigate request latency",
+        "selected/model",
+        "effective/model",
+        False,
+        context_tokens=1200,
+        context_window=200000,
+        context_is_estimate=True,
+        generation=3,
+    )
+
+
+def test_report_empty_unavailable_and_cost_knowledge():
+    empty = build_session_report(SessionReport("sess"), runtime()).plain
+    unavailable = build_session_report(SessionReport("sess", available=False), runtime()).plain
+    assert "No recorded requests" in empty and "Ledger unavailable" not in empty
+    assert "Ledger unavailable" in unavailable and "No recorded requests" not in unavailable
+    assert "selected/model" in empty and "effective/model" in empty
+    assert "~1,200 / 200,000" in empty
+    for cost, known, expected in [
+        (0, 0, "$—"),
+        (0, 1, "$0.0000+"),
+        (0, 2, "$0.0000"),
+        (1000, 1, "$0.0010+"),
+    ]:
+        report = SessionReport(
+            "sess", aggregate=UsageAggregate(calls=2, cost_micro=cost, cost_known_calls=known)
+        )
+        text = build_session_report(report, runtime()).plain
+        assert expected in text
+        assert "Input/output/tool dollars are unavailable separately" in text
+        assert "list-price estimate" in text
+        assert "pending recorder writes" in text
+        assert "not provider compute" in text
+        assert "Tool inventory" in text and "Tool schemas" in text and "Tool results" in text
+        assert "Conversation" in text
+
+
+def test_runtime_captures_only_supported_scalars():
+    class SessionWithState(FakeSession):
+        frontend_state: FrontendSessionState
+
+    session = SessionWithState()
+    session.frontend_state = FrontendSessionState(
+        session_id="sess", epoch="test", generation=8, context_tokens=90, context_window=100
+    )
+    captured = SessionDiagnostics.capture(session)
+    session.frontend_state = session.frontend_state.model_copy(update={"generation": 9})
+    assert captured.generation == 8 and captured.context_tokens == 90
+    assert SessionDiagnostics.capture(FakeSession()).context_tokens is None
+
+
+def test_slash_discovery_and_locality():
+    from local_operator.session.frontend_state import CommandScope, _slash_capabilities
+
+    command = slash_command_for("/session")
+    assert command is not None and not command.echo and not command.consumes_prompt
+    capabilities = _slash_capabilities()
+    assert (
+        next(c for c in capabilities if c.command == "session").scope == CommandScope.FRONTEND_LOCAL
+    )
+
+
+@pytest.mark.parametrize("size", [(80, 24), (50, 24)])
+@pytest.mark.parametrize("close_key", ["escape", "q"])
+@pytest.mark.asyncio
+async def test_assembled_slash_snapshot_scroll_and_focus(tmp_path, monkeypatch, size, close_key):
+    path = tmp_path / "ledger.db"
+    monkeypatch.setattr("local_operator.analytics.store.default_db_path", lambda: path)
+    store = AnalyticsStore(path)
+    store.record_batch([replace(_snap(session_id="sess"), request_id="request-" + "a" * 80)])
+    store.close()
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=size) as pilot:
+        await pilot.pause()
+        history = list(session.history())
+        await _submit(pilot, app, "/session")
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert isinstance(app.screen, SessionScreen)
+        screen = app.screen
+        assert screen.report.aggregate.calls == 1
+        assert screen._scroll.max_scroll_y > 0
+        assert screen._scroll.max_scroll_x == 0
+        await pilot.press("end")
+        await pilot.pause()
+        assert screen._scroll.scroll_y > 0
+        await pilot.press("home")
+        await pilot.pause()
+        assert screen._scroll.scroll_y == 0
+        store.record_batch([_snap(session_id="sess")])
+        store.close()
+        assert screen.report.aggregate.calls == 1  # pinned until close/reopen
+        await pilot.press(close_key)
+        await pilot.pause()
+        assert not isinstance(app.screen, SessionScreen)
+        assert app.focused is app.query_one(Editor)
+        assert session.history() == history
+        assert not session.prompts
+        await _submit(pilot, app, "/session")
+        await app.workers.wait_for_complete()
+        assert isinstance(app.screen, SessionScreen)
+        assert app.screen.report.aggregate.calls == 2
+
+
+@pytest.mark.parametrize("replacement_kind", ["new", "resume", "epoch"])
+@pytest.mark.asyncio
+async def test_disk_worker_is_off_loop_and_drops_stale_session(monkeypatch, replacement_kind):
+    started = threading.Event()
+    finish = threading.Event()
+    ui_thread = threading.get_ident()
+    observed = []
+
+    def delayed(self, session_id):
+        observed.append(threading.get_ident())
+        started.set()
+        assert finish.wait(5)
+        return SessionReport(session_id)
+
+    monkeypatch.setattr(AnalyticsStore, "session_report", delayed)
+
+    class EpochSession(FakeSession):
+        frontend_state: FrontendSessionState
+
+    session = EpochSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        session.frontend_state = FrontendSessionState(session_id="sess", epoch="before")
+        app._cmd_session("", lambda body, kind="info": None)
+        try:
+            assert await asyncio.to_thread(started.wait, 5)
+
+            # This loop-side mutation is possible while SQLite is blocked. A
+            # replacement for the same ID models /resume as well as /new.
+            class NewSession(FakeSession):
+                @property
+                def session_id(self) -> str:
+                    return "new"
+
+            if replacement_kind == "epoch":
+                session.frontend_state = session.frontend_state.model_copy(
+                    update={"epoch": "after"}
+                )
+            else:
+                app._session = FakeSession() if replacement_kind == "resume" else NewSession()
+            finish.set()
+            await app.workers.wait_for_complete()
+            assert len(observed) == 1 and observed[0] != ui_thread
+            assert not isinstance(app.screen, SessionScreen)
+        finally:
+            finish.set()
+            app._session = session
+
+
+@pytest.mark.asyncio
+async def test_invalid_arguments_never_request_model():
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await _submit(pilot, app, "/session another-id")
+        await app.workers.wait_for_complete()
+        assert not isinstance(app.screen, SessionScreen)
+        assert not session.prompts
+
+
+@pytest.mark.asyncio
+async def test_scroll_hint_tracks_actual_overflow_after_resize():
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 60)) as pilot:
+        await pilot.pause()
+        screen = SessionScreen(SessionReport("sess"), runtime())
+        app.push_screen(screen)
+        await pilot.pause()
+        assert screen._scroll.max_scroll_y == 0
+        assert "scroll" not in str(screen._hint.render())
+        await pilot.resize_terminal(50, 24)
+        await pilot.pause()
+        assert screen._scroll.max_scroll_y > 0
+        assert "↑↓ scroll" in str(screen._hint.render())
+        assert screen._scroll.max_scroll_x == 0

--- a/tests/unit/tui/test_session_panel.py
+++ b/tests/unit/tui/test_session_panel.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import sqlite3
 import threading
 from dataclasses import replace
 
@@ -107,6 +108,7 @@ async def test_assembled_slash_snapshot_scroll_and_focus(tmp_path, monkeypatch, 
         await pilot.pause()
         assert isinstance(app.screen, SessionScreen)
         screen = app.screen
+        assert screen.report is not None
         assert screen.report.aggregate.calls == 1
         assert screen._scroll.max_scroll_y > 0
         assert screen._scroll.max_scroll_x == 0
@@ -128,6 +130,7 @@ async def test_assembled_slash_snapshot_scroll_and_focus(tmp_path, monkeypatch, 
         await _submit(pilot, app, "/session")
         await app.workers.wait_for_complete()
         assert isinstance(app.screen, SessionScreen)
+        assert app.screen.report is not None
         assert app.screen.report.aggregate.calls == 2
 
 
@@ -175,6 +178,11 @@ async def test_disk_worker_is_off_loop_and_drops_stale_session(monkeypatch, repl
             finish.set()
             await app.workers.wait_for_complete()
             assert len(observed) == 1 and observed[0] != ui_thread
+            # The result cannot be published, even if the pending modal is
+            # still finishing its queued mount before it can safely be popped.
+            if isinstance(app.screen, SessionScreen):
+                assert app.screen.presentation_cancelled and app.screen.report is None
+            await pilot.pause()
             assert not isinstance(app.screen, SessionScreen)
         finally:
             finish.set()
@@ -208,3 +216,87 @@ async def test_scroll_hint_tracks_actual_overflow_after_resize():
         assert screen._scroll.max_scroll_y > 0
         assert "↑↓ scroll" in str(screen._hint.render())
         assert screen._scroll.max_scroll_x == 0
+
+
+@pytest.mark.parametrize("cancel_key", ["escape", "q"])
+@pytest.mark.asyncio
+async def test_real_locked_read_can_be_cancelled_without_interrupting_draft(
+    tmp_path, monkeypatch, cancel_key
+):
+    path = tmp_path / "ledger.db"
+    monkeypatch.setattr("local_operator.analytics.store.default_db_path", lambda: path)
+    store = AnalyticsStore(path)
+    store.record_batch([_snap(session_id="sess")])
+    store.close()
+    # WAL readers intentionally bypass a writer lock. A real legacy DELETE
+    # journal reproduces the reported slow-read path without sleeping a mock.
+    locker = sqlite3.connect(path)
+    locker.execute("PRAGMA journal_mode=DELETE")
+    locker.execute("BEGIN EXCLUSIVE")
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    try:
+        async with app.run_test(size=(50, 24)) as pilot:
+            await pilot.pause()
+            await _submit(pilot, app, "/session")
+            try:
+                assert isinstance(app.screen, SessionScreen)
+                pending = app.screen
+                assert pending.report is None
+                assert "Loading usage records" in str(pending._body.render())
+                assert "esc / q cancel" in str(pending._hint.render())
+                await pilot.press(cancel_key)
+                await pilot.press(*list("next task"))
+                await pilot.pause()
+                assert app.focused is app.query_one(Editor)
+                assert app.query_one(Editor).text == "next task"
+            finally:
+                locker.rollback()
+                await app.workers.wait_for_complete()
+            await pilot.pause()
+            assert not isinstance(app.screen, SessionScreen)
+            assert pending.presentation_cancelled and pending.report is None
+            assert app.focused is app.query_one(Editor)
+            assert app.query_one(Editor).text == "next task"
+            assert session.prompts == [] and session.aborts == []
+    finally:
+        locker.close()
+
+
+@pytest.mark.asyncio
+async def test_fast_result_during_mount_replaces_loading_text():
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        screen = SessionScreen(None, runtime())
+        app.push_screen(screen)
+        # No pause/await: the SQLite worker can settle before the mounted body
+        # exists. Losing this update would strand a fast read in loading state.
+        screen.set_report(SessionReport("sess"))
+        await pilot.pause()
+        assert "No recorded requests" in str(screen._body.render())
+        assert "Loading usage records" not in str(screen._body.render())
+        assert "cancel" not in str(screen._hint.render())
+
+
+@pytest.mark.asyncio
+async def test_invalidating_buried_pending_view_never_pops_newer_modal():
+    from local_operator.tui.widgets.analytics_panel import AnalyticsScreen
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        pending = SessionScreen(None, runtime())
+        app.push_screen(pending)
+        await pilot.pause()
+        other = AnalyticsScreen(UsageAggregate())
+        app.push_screen(other)
+        await pilot.pause()
+        pending.invalidate()
+        pending.set_report(SessionReport("sess"))
+        assert app.screen is other
+        assert pending.report is None
+        await pilot.press("escape")
+        await pilot.pause()
+        assert not isinstance(app.screen, (SessionScreen, AnalyticsScreen))
+        assert app.focused is app.query_one(Editor)

--- a/tests/unit/tui/test_slash_echo.py
+++ b/tests/unit/tui/test_slash_echo.py
@@ -87,6 +87,7 @@ ECHO_POLICY = {
     # The screen it opens IS the receipt (same rule as `/usage`); the argument
     # names a view, never words the model is told.
     "analytics": False,
+    "session": False,
     "goal": True,
     "loop": False,
     # The aside's whole promise is that the exchange leaves no trace in the
@@ -155,6 +156,7 @@ PROMPT_POLICY = {
     # A view selector, not a prompt: `/analytics [view]` names which screen to
     # open, so it splices-and-runs inline like `/usage` rather than reassembling.
     "analytics": False,
+    "session": False,
     # Free text the model is given (the objective / a loop instruction / a side
     # question), so an inline engage reassembles to the front.
     "goal": True,


### PR DESCRIPTION
## Summary of Changes

**C2, standard/pre-authorized feature.** Add `/session`: a read-only, analytics-style diagnostic view of the exact current session, with no model request. This is distinct from account quota (`/usage`), estimated next-request context (`/context`), and all-session analytics (`/analytics`).

- Add typed `AnalyticsStore.session_report`: one short-lived read-only SQLite transaction for totals, provider/model grouping, purpose/outcome counts, usage completeness, timing sample counts and at most 12 recent logical requests by default (API hard cap 50).
- Add a scrollable modal with full identity, normalized input/output/cache accounting, honest combined cost, estimated input components, runtime scalars and bounded request IDs. Reuse analytics formatting and visual chrome without inheriting its chart/toggle behavior.
- Read the ledger off the event loop; capture selected/effective model, name, ID and supported runtime scalars before yielding. Show an immediate cancellable loading screen, update only that owned view, and reject stale results after cancellation or session object/ID/owner-epoch replacement.
- Register the command in normal slash discovery/help and the mirrored daemon contract; keep remote terminal execution frontend-local against the shared local ledger. Add command/accounting documentation and a reproducible, isolated capture script.

## Delivery contract

- Scope is **exact current session ID**, never all sessions, ID prefixes, child IDs or copied fork history. Resuming an ID includes that ID's retained records.
- Full normalized input context plus output is the total. Reasoning is a subset of output; cache reads divide by full context. Estimated tool inventory/schema/result and conversation token components remain explicitly estimated.
- Costs are combined recorded micro-USD by both provider and model. Preserve unknown, partial and known-zero distinctions. A recorded cost may be provider-reported or list-price estimated; row-level provenance and separate input/output/tool dollars are unavailable and are not invented via token ratios.
- Show empty versus unavailable states explicitly; tolerate legacy optional columns without migrating the database. No prompt, payload, secret or raw exception text enters the view.
- Timing means/ranges disclose sample counts and measure logical requests including retry/backpressure, not provider compute or individual retry attempts. Recent request IDs are bounded and never truncated out of the rendered content.
- Snapshot close/reopen refresh; Escape and `q` return focus to the composer, including during a blocked disk read. Late results cannot steal a new draft's focus. Wrapping remains usable at 80×24 and 50×24 with no horizontal overflow.

## Testing evidence

All app/test execution uses isolated `HOME` and `LOCAL_OPERATOR_CONFIG_DIR`, removes **every `CMUX_*` variable before app import**, and uses synthetic session IDs. The worktree owns its real editable `.venv`; the operator's dirty main checkout and installed `lop` runtime are untouched.

### Real assembled slash path

```sh
.venv/bin/python scripts/session_report_shot.py OUTDIR 80x24 populated
.venv/bin/python scripts/session_report_shot.py OUTDIR 50x24 populated
.venv/bin/python scripts/session_report_shot.py OUTDIR 80x24 empty
.venv/bin/python scripts/session_report_shot.py OUTDIR 50x24 unavailable
```

The capture script drives **OperatorApp with its real stylesheet**, a synthetic session facade and real SQLite data, entering `/session` through the actual editor/Enter path. Preserved base `547136ee8` reports `unknown command: /session`; the new command opens `SessionScreen`. This is local command/UI verification, not a claim of making a paid provider request.

Populated report: **18 requests, 541,800 total tokens = 511,200 full input + 30,600 output**, including 7,200 reasoning tokens; 414,000 cache-read tokens (81% of context); combined cost $0.333. Two provider/model groups; 12 bounded recent rows. Captures report `prompts: []`, unchanged ledger file hash, and composer focus restored after close.

| Grid | Modal content / virtual size | Scroll viewport / content | Horizontal overflow | Consecutive opened/settled frames |
| --- | --- | --- | --- | --- |
| 80×24 | 78×22 / 78×22 | 66×11 / 65×171 | 0 | Pixel-identical |
| 50×24 | 48×22 / 48×22 | 39×11 / 38×223 | 0 | Pixel-identical |

Frames use the repository's faithful capture helper: native 8×17-pixel cells, locally resolved Menlo, SVG rasterized with `rsvg-convert`, PNGs actually viewed. Empty and unavailable states also have no horizontal overflow. The report wraps long full IDs instead of widening the modal.

### Rendered screenshots

[Full before/after, accounting, empty/error and real-lock matrix](https://github.com/damianvtran/local-operator/pull/680#issuecomment-5554597241). [Corrected readiness-aware narrow evidence](https://github.com/damianvtran/local-operator/pull/680#issuecomment-5554621355).

One current narrow capture raced startup and showed `session is not ready`, not a report. That attachment was withdrawn. An RGBA bounding-box comparison had incorrectly ignored RGB differences under a zero alpha difference; the correction uses actual state/geometry JSON, RGB pixels and direct PNG-byte equality. The designer independently recaptured after readiness; the corrected current narrow frame below is byte-identical to the valid initial narrow report and its own settled frame. The 80-column, empty and unavailable comparisons were rechecked and genuinely unchanged.

<details>
<summary>Before/after overview and current loading/cancellation frames</summary>

![Before the command existed, 80x24](https://github.com/user-attachments/assets/44585729-0179-4f31-aee8-229d10c6994a)

![Current session overview, 80x24](https://github.com/user-attachments/assets/8d3c2cf4-d390-4934-9cd8-677c68cef809)

![Corrected current session overview, 50x24](https://github.com/user-attachments/assets/33b014d0-e0f7-43f4-a6d0-11590294f74b)

![Current loading and cancellation, 50x24](https://github.com/user-attachments/assets/c55e69c7-7d9b-409e-99d3-5ad0a9df9e66)

![After Escape and lock release, the draft retains focus](https://github.com/user-attachments/assets/f85c21bc-6763-402a-8a85-6749b0e8622a)

</details>

### Store execution and regression coverage

A direct `AnalyticsStore(path).session_report("current")` smoke against three synthetic stored rows (two current, one child) returned:

```json
{"available":true,"calls":2,"input_context":2000,"output_including_reasoning":400,"reasoning_subset":120,"total_tokens":2400,"cache_rate":0.8,"cost_micro":500,"known_cost_calls":1,"partial_cost":true,"provider_models":["p1/shared","p2/shared"],"recent_request_ids":["r2","r1"],"zero_preparation_samples":2,"zero_preparation_mean_ms":0.0,"ledger_unchanged":true}
```

Regression tests cover exact-ID/child/fork scoping, resumed retained rows, provider/model key separation, unknown/partial/known-zero cost, purpose/outcome and missing usage, timing sample counts, recent-row bounds/order, corrupt/absent/legacy ledgers, parameter binding, a writer committing between report queries, worker thread ownership, `/new`/`/resume`/same-facade epoch races, real slash dispatch, invalid arguments, close/reopen refresh, scrolling/resizing and Escape/`q` focus restoration.

- Focused diagnostics + analytics + slash-echo neighbours: **112 passed** before the final epoch/scroll-hint additions.
- Frozen-head focused results: **19 passed** (16.92s), including same-facade owner-epoch replacement and no-overflow/resize scroll hints.
- Whole-tree `.venv/bin/python -m flake8 .`, pinned `uvx --from black==26.1.0 black --check .`, `uvx isort==5.13.2 --check .`, and `.venv/bin/python -m pyright --pythonpath .venv/bin/python .`: **all exit 0; Pyright 0 errors/warnings**.
- Initial complete unit suite (`.venv/bin/python -m pytest tests/unit -n2 -q`; two workers per shared-host coordinator): **4 failed, 14,327 passed, 17 skipped** in 47m21s. This initial run was NOT green. Three terminal-title tests were disabled by an unnecessary author-injected `LOCAL_OPERATOR_NO_TERMINAL_TITLE=1` wrapper flag; rerunning those exact three with isolated HOME/config and all CMUX variables removed, but without that flag, passed **3/3**. The fourth failure was the command picker's `/s` expectation missing the newly registered `session`; corrected in the unified remediation.
- Final scoped remediation matrix (session store/UI, command picker, analytics and slash-echo neighbours): **384 passed** in 74.42s at `43756fe1d65f45cf7542b6a66f792a96fd7f0146`. Per coordinator direction, no second 14k-test full run; validate the delta and direct regression surfaces instead.
- Assembled author e2e: **29 passed**. Independent QA additionally reported **18/18 matrix PASS and 29 e2e passed** at the initial review head; current-head convergence is recorded in PR comments.

### Review-driven loading/cancellation reproduction

Initial UX finding **U1 (major)** was reproduced with a real SQLite `BEGIN EXCLUSIVE` lock in DELETE journal mode:

```text
Before: /session pending -> TranscriptScreen, no loading feedback
        Esc -> type 'next task' -> release lock
        SessionScreen opens late; focus moves to VerticalScroll
After:  /session pending -> SessionScreen, visible Loading usage records / esc-q cancel
        Esc -> type 'next task' -> release lock
        TranscriptScreen remains active; focus remains Editor; draft intact
```

The fix owns the modal before the read and updates that instance rather than pushing on completion. Cancellation/unmount invalidates presentation. Owner object/ID/epoch guards remain; a stale screen hidden under another modal never pops the newer modal. New regressions also cover results and invalidation during mounting. Loading/cancellation before/after PNGs were rendered and viewed; existing populated 80×24/50×24 frames remained pixel-identical.

## Non-goals and limits

No account quota view, cross-session/child rollup, transcript-derived billing, live auto-refresh, per-tool billing, invented dollar attribution, per-attempt retry tracing, new model/tool request or transport endpoint. Runtime fields not exposed by a facade remain unavailable; compaction count is currently unavailable. In-flight requests, asynchronous recorder writes and pruned records may be absent. The displayed retained ledger is not a lifetime invoice.

## Risks, rollout and rollback

The main risks are accounting ambiguity, stale session identity, optional-column compatibility and blocking the UI. Those have explicit unit/assembled-path coverage and visible availability/provenance caveats. The read-only transaction pins a consistent snapshot without pricing or migration, and bounded recent rows limit modal payload. No dependencies, schema migration, version bump or installed-runtime mutation. Rollback is a normal revert of the command/report/UI change, leaving recorded data intact.

Independent agent, QA, design and UX round2 reviews are all clean on `43756fe1d`, with all eight round1/round2 author remediation headings recorded. All CI checks now pass, including five unit shards, Linux/macOS e2e, Windows filesystem boundaries, coverage and CLI/server sanity. One CI teardown failure was reproduced in the same post-remove compositor window on both the preserved base and current head; the exact test passed 12/12 on each locally, and the one authorized failed-shard retry passed. [Baseline proof and retry](https://github.com/damianvtran/local-operator/pull/680#issuecomment-5554676846); [final green verification](https://github.com/damianvtran/local-operator/pull/680#issuecomment-5554713041). No human reviewers were added; the implementing agent has not merged or updated the installed runtime.

Release: patch — Adds /session for current-session usage, cache, routing and request diagnostics
