### PR TITLE
fix(evaluation): disclose proxy policy and scope infrastructure values

### DIFF
--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
@@ -393,8 +393,16 @@ class OSWorldV2Adapter:
                 instruction="",
                 source_sha256="0" * 64,
             )
-            return RequirementsResult(requirements=requirements_mod.derive_requirements(baseline))
-        return RequirementsResult(requirements=requirements_mod.derive_requirements(self._task))
+            return RequirementsResult(
+                requirements=requirements_mod.derive_requirements(
+                    baseline, infra_values=self._infra_values
+                )
+            )
+        return RequirementsResult(
+            requirements=requirements_mod.derive_requirements(
+                self._task, infra_values=self._infra_values
+            )
+        )
 
     # ------------------------------------------------------------------
     # prepare: declarative, allocates nothing
@@ -407,6 +415,7 @@ class OSWorldV2Adapter:
         # a pure plan (when the task is already known), mints the deterministic
         # cleanup refs, and returns the plan the parent persists BEFORE any
         # side effect exists.
+        provisioning.resolve_proxy_policy(params.infra_values)
         self._refs = cleanup_mod.CleanupRefs.mint(params.episode_id)
         self._infra_values = params.infra_values
         vendor_bridge.inject_infra_environment(params.infra_values)

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/provisioning.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/provisioning.py
@@ -153,12 +153,36 @@ def resolve(
         subnet_id=subnet_id,
         security_group_id=security_group_id,
         scheduler_role_arn=scheduler_role_arn,
-        enable_proxy=bool(task.proxy),
+        enable_proxy=resolve_proxy_policy(infra_values, task_proxy=bool(task.proxy)),
         client_password=client_password,
         file_base_url=file_base_url,
         tags=tags,
         client_token=client_token,
     )
+
+
+def resolve_proxy_policy(
+    infra_values: tuple[ScopedInfraValue, ...], *, task_proxy: bool = False
+) -> bool:
+    """Resolve the upstream system switch without changing the pinned task.
+
+    Omission preserves the adapter's legacy task-derived switch, not upstream's
+    default False. Validate even before a task is loaded: malformed policy must
+    never survive prepare and reach the allocation boundary.
+    """
+
+    policies = [item for item in infra_values if item.name == "OSWORLD_ENABLE_PROXY"]
+    if not policies:
+        return task_proxy
+    if any(
+        item.purpose != "benchmark_compute" or item.value not in {"true", "false"}
+        for item in policies
+    ) or len({item.value for item in policies}) != 1:
+        # Infra can be mistyped secret material; never echo rejected values.
+        raise ProvisioningError(
+            "OSWORLD_ENABLE_PROXY requires benchmark_compute scope and exactly true or false"
+        )
+    return policies[0].value == "true"
 
 
 def _has(infra_values: tuple[ScopedInfraValue, ...], name: str) -> bool:

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/provisioning.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/provisioning.py
@@ -174,10 +174,13 @@ def resolve_proxy_policy(
     policies = [item for item in infra_values if item.name == "OSWORLD_ENABLE_PROXY"]
     if not policies:
         return task_proxy
-    if any(
-        item.purpose != "benchmark_compute" or item.value not in {"true", "false"}
-        for item in policies
-    ) or len({item.value for item in policies}) != 1:
+    if (
+        any(
+            item.purpose != "benchmark_compute" or item.value not in {"true", "false"}
+            for item in policies
+        )
+        or len({item.value for item in policies}) != 1
+    ):
         # Infra can be mistyped secret material; never echo rejected values.
         raise ProvisioningError(
             "OSWORLD_ENABLE_PROXY requires benchmark_compute scope and exactly true or false"

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/requirements.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/requirements.py
@@ -20,9 +20,10 @@ from __future__ import annotations
 
 import ast
 
+from lop_osworld_v2_adapter.provisioning import resolve_proxy_policy
 from lop_osworld_v2_adapter.taskfile import TaskDescriptor
 
-from local_operator.evaluation.adapters.api import Requirement
+from local_operator.evaluation.adapters.api import Requirement, ScopedInfraValue
 
 # ---------------------------------------------------------------------------
 # Always-on requirements. These exist because the worker environment is
@@ -81,6 +82,7 @@ _ALWAYS_INFRA = (
 _OPTIONAL_INFRA = (
     "AWS_INSTANCE_TYPE",
     "AWS_ROOT_VOLUME_SIZE",
+    "OSWORLD_ENABLE_PROXY",
     "OSWORLD_INPUTS_ROOT",
     "OSWORLD_TTL_SECONDS",
 )
@@ -185,9 +187,12 @@ def _evaluator_text(descriptor: TaskDescriptor) -> str:
     return repr(descriptor.evaluator) if descriptor.evaluator is not None else ""
 
 
-def derive_requirements(descriptor: TaskDescriptor) -> tuple[Requirement, ...]:
-    """Return the exact requirement set for one task, in deterministic order."""
+def derive_requirements(
+    descriptor: TaskDescriptor, *, infra_values: tuple[ScopedInfraValue, ...] = ()
+) -> tuple[Requirement, ...]:
+    """Derive requirements after policy, retaining legacy behavior on omission."""
 
+    enable_proxy = resolve_proxy_policy(infra_values, task_proxy=bool(descriptor.proxy))
     out: list[Requirement] = []
 
     for name in _AWS_SECRETS:
@@ -206,9 +211,10 @@ def derive_requirements(descriptor: TaskDescriptor) -> tuple[Requirement, ...]:
 
     # --- Conditional on the task -------------------------------------------
 
-    if descriptor.proxy:
-        # The DataImpulse proxy needs credentials and an endpoint; both are
-        # task-declared needs but account-declared values.
+    if descriptor.proxy and enable_proxy:
+        # Legacy declarations retained for compatibility, NOT working setup:
+        # upstream needs a ProxyPool and these inputs do not construct one.
+        # System-disabled mode must not demand credentials it cannot consume.
         out.append(_requirement("OSWORLD_PROXY_CREDENTIALS", kind="secret", required=True))
         out.append(_requirement("OSWORLD_PROXY_ENDPOINT", kind="infra", required=True))
 

--- a/docs/benchmarks/osworld_2/README.md
+++ b/docs/benchmarks/osworld_2/README.md
@@ -368,6 +368,24 @@ upstream's supported system-disabled mode. Only the exact lowercase strings
 `prepare`, before provider construction or allocation, even before a task is
 loaded. This is apparatus policy, not a task edit or a task-ID exception.
 
+For episodes that also need simulator configuration, the generic CLI accepts
+an optional per-value purpose prefix, without changing the global default:
+
+```sh
+--infra-purpose benchmark_compute \
+  --infra AWS_REGION=us-east-1 \
+  --infra benchmark_compute:OSWORLD_ENABLE_PROXY=false \
+  --infra benchmark_user_simulator:OSWORLD_USER_SIM_MODEL=<simulator-model>
+```
+
+Legacy `NAME=VALUE` entries still use `--infra-purpose` (default
+`benchmark_compute`). A prefix applies only to that entry. Unknown purposes,
+empty names/values, and conflicting entries for the same name (including across
+scopes) fail cleanly before selector loading/allocation without printing their
+values; identical duplicates coalesce. Purpose-prefixed policy and hardware
+inputs receive the same manifest disclosures as unprefixed inputs. Values stay
+non-secret; simulator API keys still travel through the existing secret path.
+
 Omitting the value preserves the adapter's existing behavior:
 `enable_proxy=bool(task.proxy)`. Explicit `true` sets the upstream system switch
 on; upstream still combines it with the task's proxy hint. Explicit `false`

--- a/docs/benchmarks/osworld_2/README.md
+++ b/docs/benchmarks/osworld_2/README.md
@@ -358,7 +358,42 @@ build that does not declare it fails the episode before `prepare` with
 disclosure is a false statement sealed in a `verify_bundle`-valid bundle. Both
 the gate and the stamp derive from a single table
 (`DISCLOSED_INFRA_METADATA_KEYS` in `local_operator/evaluation/runner/episode.py`),
-so a future third value cannot be gated without being disclosed or vice versa.
+so a future value cannot be gated without being disclosed or vice versa.
+
+### Explicit system proxy policy
+
+`--infra OSWORLD_ENABLE_PROXY=false` in `benchmark_compute` scope selects
+upstream's supported system-disabled mode. Only the exact lowercase strings
+`true` and `false` are accepted; malformed values or the wrong scope fail at
+`prepare`, before provider construction or allocation, even before a task is
+loaded. This is apparatus policy, not a task edit or a task-ID exception.
+
+Omitting the value preserves the adapter's existing behavior:
+`enable_proxy=bool(task.proxy)`. Explicit `true` sets the upstream system switch
+on; upstream still combines it with the task's proxy hint. Explicit `false`
+sets the switch off regardless of that hint, and post-policy requirements no
+longer demand `OSWORLD_PROXY_CREDENTIALS` or `OSWORLD_PROXY_ENDPOINT`.
+
+**Enabled setup remains incomplete.** The legacy credential/endpoint declarations
+are retained for omission and enabled proxy tasks for compatibility, but are
+insufficient: upstream expects an actual `ProxyPool`; the adapter does not wire
+those `OSWORLD_PROXY_*` inputs into one. Setting `true` or supplying those inputs
+is not proof of a working proxy. A real enabled setup needs a separately reviewed
+follow-up; this change builds no proxy bridge and fabricates no credentials.
+
+The requested switch is sealed as `osworld_enable_proxy_override` via the same
+manifest disclosure table as the compute overrides. An older adapter that does
+not declare the optional `OSWORLD_ENABLE_PROXY` requirement is refused before
+`prepare`, rather than silently applying its old behavior under a false disclosure.
+Omission adds no override metadata and remains compatible with older selectors;
+no adapter wire-schema change is required.
+
+Disabling proxy does **not** establish direct-network adequacy or benchmark
+comparability. Record the changed apparatus before outcomes, verify necessary
+guest network access separately, and classify blocked access as an infrastructure
+failure rather than inventing credentials or silently changing policy. Local
+validation here uses captured provider constructor arguments and fake-provider
+CLI episodes, not cloud/network validation.
 
 ### Guest disk reclamation at episode start
 

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -158,7 +158,7 @@ _PROVISIONAL_CLEANUP_ACTION = "close-session"
 # Deliberately a NARROW allowlist rather than "reject every undeclared infra
 # value". ``inspect_requirements`` runs before the task is named, so it returns
 # only the adapter's UNCONDITIONAL baseline -- a task-conditional requirement
-# (OSWORLD_PROXY_CREDENTIALS, OSWORLD_PROXY_ENDPOINT) is legitimately absent
+# (GOOGLE_ACCOUNT_CREDENTIALS for a login task) is legitimately absent
 # from it, and a blanket rule would refuse correct proxy runs. Only a value
 # whose silent drop corrupts the evidence record belongs here.
 #
@@ -181,6 +181,9 @@ DISCLOSED_INFRA_METADATA_KEYS: Mapping[str, str] = MappingProxyType(
         # ~t+383s exhaustion wall that truncated earlier runs, so it is not
         # comparable to one that hit it, and the bundle has to say so on its own.
         "AWS_ROOT_VOLUME_SIZE": "aws_root_volume_size_override",
+        # Network policy changes comparability too: older adapters must refuse
+        # this request rather than seal a disabled-policy claim while enabling it.
+        "OSWORLD_ENABLE_PROXY": "osworld_enable_proxy_override",
     }
 )
 _DISCLOSED_INFRA_VALUES = frozenset(DISCLOSED_INFRA_METADATA_KEYS)

--- a/scripts/run_episode.py
+++ b/scripts/run_episode.py
@@ -29,8 +29,9 @@ Inputs, all explicit:
   never reachable, however it is spelled. Anything not listed is resolved
   from the credential store (``CredentialStoreResolver``), the same store the
   model client is built from.
-* ``--infra NAME=VALUE`` (repeatable) -- non-secret infra values
-  (``AWS_REGION``, ``AWS_SUBNET_ID``, ...) with ``--infra-purpose``.
+* ``--infra [purpose:]NAME=VALUE`` (repeatable) -- non-secret infra values
+  (``AWS_REGION``, ``AWS_SUBNET_ID``, ...) default to ``--infra-purpose``;
+  a per-value purpose permits compute and simulator inputs in one episode.
 * Budget and step caps (``--max-steps``, ``--max-usd``, ``--max-wall-s``,
   ``--max-cycle-usd``), all explicit; the defaults are conservative because
   a paid episode with no cap is the one thing this script must not run.
@@ -58,10 +59,11 @@ import time
 import uuid
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Sequence, get_args
 
 from local_operator.evaluation.adapters.api import (
     AdapterSelector,
+    InfraPurpose,
     ResolvedSecret,
     ScopedInfraValue,
     SecretRef,
@@ -452,21 +454,38 @@ def _outcome_json(outcome: EpisodeOutcome) -> dict[str, Any]:
 
 
 def _parse_infra(values: Sequence[str], purpose: str) -> tuple[ScopedInfraValue, ...]:
-    out: list[ScopedInfraValue] = []
+    if purpose not in get_args(InfraPurpose):
+        raise ValueError("--infra-purpose must be a supported infrastructure purpose")
+    out: dict[str, ScopedInfraValue] = {}
     for item in values:
-        name, sep, value = item.partition("=")
-        if not sep or not name:
-            raise SystemExit(f"--infra expects NAME=VALUE, got {item!r}")
-        # ``purpose`` is validated by the model against the closed InfraPurpose
-        # vocabulary; argparse hands it over as a plain string.
-        out.append(
-            ScopedInfraValue.model_validate({"name": name, "purpose": purpose, "value": value})
-        )
-    return tuple(out)
+        scoped_name, sep, value = item.partition("=")
+        scope, scope_sep, name = scoped_name.partition(":")
+        if not scope_sep:
+            scope, name = purpose, scoped_name
+        try:
+            if not sep:
+                raise ValueError
+            parsed = ScopedInfraValue.model_validate(
+                {"name": name, "purpose": scope, "value": value}
+            )
+        except ValueError:
+            # ValidationError includes the raw input, which can contain a
+            # misplaced secret. CLI failures must never print that payload.
+            raise ValueError(
+                "--infra expects [purpose:]NAME=VALUE with a valid name, purpose and value"
+            ) from None
+        # Adapter lookups use NAME, not (purpose, NAME). Two differently scoped
+        # values of the same name would otherwise depend on iteration order.
+        if parsed.name in out and parsed != out[parsed.name]:
+            raise ValueError("--infra has conflicting entries for the same name")
+        out.setdefault(parsed.name, parsed)
+    return tuple(out.values())
 
 
-def _infra_disclosure_metadata(infra: Sequence[str]) -> dict[str, Any]:
-    """Manifest metadata disclosing every infra override that changes the hardware.
+def _infra_disclosure_metadata(
+    infra: Sequence[str], purpose: str = "benchmark_compute"
+) -> dict[str, Any]:
+    """Manifest metadata disclosing infra overrides that change the apparatus.
 
     Driven by ``DISCLOSED_INFRA_METADATA_KEYS`` rather than by a list of names
     repeated here. That table is also what
@@ -491,21 +510,16 @@ def _infra_disclosure_metadata(infra: Sequence[str]) -> dict[str, Any]:
     values is supplied to an adapter build that does not declare it. Requested
     and applied can therefore differ only on a run that produced no bundle.
 
-    Reads the raw ``--infra NAME=VALUE`` strings rather than the parsed
-    ``ScopedInfraValue`` tuple so this stays a pure function of the CLI input
-    and can be tested without building a whole spec. Reporting an unparseable
-    value verbatim is correct: the run fails at prepare, and a bundle, if one
-    exists at all, should still show what was asked for. First occurrence wins,
-    matching ``_parse_infra``'s own left-to-right handling of a repeated name.
+    Use the same parser as the episode spec: a per-value purpose prefix must
+    not hide a requested override from disclosure. Identical duplicates are
+    coalesced; conflicting names and malformed entries fail before the run.
     """
 
-    metadata: dict[str, Any] = {}
-    for item in infra:
-        name, sep, value = item.partition("=")
-        key = DISCLOSED_INFRA_METADATA_KEYS.get(name)
-        if sep and key is not None and value and key not in metadata:
-            metadata[key] = value
-    return metadata
+    return {
+        DISCLOSED_INFRA_METADATA_KEYS[item.name]: item.value
+        for item in _parse_infra(infra, purpose)
+        if item.name in DISCLOSED_INFRA_METADATA_KEYS
+    }
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -531,7 +545,13 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="NAME",
         help="read this secret from the process environment instead of the store",
     )
-    parser.add_argument("--infra", action="append", default=[], metavar="NAME=VALUE")
+    parser.add_argument(
+        "--infra",
+        action="append",
+        default=[],
+        metavar="[purpose:]NAME=VALUE",
+        help="Non-secret infrastructure input; optional purpose overrides --infra-purpose",
+    )
     parser.add_argument("--infra-purpose", default="benchmark_compute")
     parser.add_argument("--config-dir", type=Path, default=None, help="lop config dir")
     parser.add_argument("--max-steps", type=int, default=25)
@@ -592,6 +612,11 @@ class _ScriptedFinish:
 
 
 async def run(args: argparse.Namespace) -> int:
+    try:
+        infra_values = _parse_infra(args.infra, args.infra_purpose)
+    except ValueError as error:
+        print(str(error), file=sys.stderr)
+        return EXIT_PREFLIGHT
     selector = AdapterSelector.model_validate(json.loads(args.selector.read_text()))
     provider, model = args.route
     route = _route_identity(provider, model)
@@ -631,7 +656,7 @@ async def run(args: argparse.Namespace) -> int:
         benchmark_id=args.benchmark_id,
         benchmark_release=args.benchmark_release,
         secret_refs=secret_refs,
-        infra_values=_parse_infra(args.infra, args.infra_purpose),
+        infra_values=infra_values,
         max_usd_micros=max_usd_micros,
         max_wall_ms=args.max_wall_s * 1000,
         max_steps=args.max_steps,
@@ -649,9 +674,9 @@ async def run(args: argparse.Namespace) -> int:
             # read as a result.
             "model_client": args.model_client,
             "script": "scripts/run_episode.py",
-            # Hardware disclosure: the infra overrides REQUESTED for this run
-            # (instance type, root volume size). A score produced on
-            # non-default hardware is not comparable to one produced on the
+            # Apparatus disclosure: the infra overrides REQUESTED for this run
+            # (instance type, root volume size, system proxy policy). A score on
+            # non-default apparatus is not comparable to one produced on the
             # release default, so the bundle has to say so on its own --
             # reading it must not depend on operator memory of which --infra
             # flags were passed. Only OVERRIDES are stamped, and only when
@@ -663,7 +688,7 @@ async def run(args: argparse.Namespace) -> int:
             # through the manifest. Requested can only differ from applied on
             # an episode that produced no bundle: the runner refuses an
             # override an adapter build does not declare.
-            **_infra_disclosure_metadata(args.infra),
+            **_infra_disclosure_metadata(args.infra, args.infra_purpose),
         },
     )
 

--- a/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
+++ b/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
@@ -458,6 +458,39 @@ async def test_an_instance_type_override_reaches_the_real_run_instances_call(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("hint", [False, True])
+@pytest.mark.parametrize("policy", [None, "false", "true"])
+async def test_proxy_policy_reaches_desktop_env_construction(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, hint: bool, policy: str | None
+) -> None:
+    task = taskfile.TaskDescriptor(
+        task_id="synthetic", instruction="", source_sha256="0" * 64, proxy=hint
+    )
+    infra = _infra() + (() if policy is None else (
+        ScopedInfraValue(name="OSWORLD_ENABLE_PROXY", purpose="benchmark_compute", value=policy),
+    ))
+    plan = provisioning.resolve(task, episode_id=EPISODE, infra_values=infra)
+    captured: list[_FakeEnv] = []
+
+    def factory(**kwargs: Any) -> _FakeEnv:
+        env = _FakeEnv(**kwargs)
+        captured.append(env)
+        return env
+
+    with _Stubs() as stubs:
+        _expect_describe_images(stubs)
+        _expect_run_instances(stubs, plan=plan)
+        _expect_create_schedule(stubs)
+        _expect_running(stubs)
+        provider = _provider(stubs, monkeypatch, desktop_env_factory=factory,
+                             task_factory=lambda t: {"id": t.task_id, "proxy": t.proxy})
+        await provider.allocate(plan, task, cache_root=_cache_root(tmp_path))
+        stubs.ec2_stub.assert_no_pending_responses()
+    assert len(captured) == 1
+    assert captured[0].kwargs["enable_proxy"] is (hint if policy is None else policy == "true")
+
+
+@pytest.mark.asyncio
 async def test_desktop_env_cache_dir_is_absolute_and_outside_the_workspace(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
+++ b/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
@@ -466,9 +466,15 @@ async def test_proxy_policy_reaches_desktop_env_construction(
     task = taskfile.TaskDescriptor(
         task_id="synthetic", instruction="", source_sha256="0" * 64, proxy=hint
     )
-    infra = _infra() + (() if policy is None else (
-        ScopedInfraValue(name="OSWORLD_ENABLE_PROXY", purpose="benchmark_compute", value=policy),
-    ))
+    infra = _infra() + (
+        ()
+        if policy is None
+        else (
+            ScopedInfraValue(
+                name="OSWORLD_ENABLE_PROXY", purpose="benchmark_compute", value=policy
+            ),
+        )
+    )
     plan = provisioning.resolve(task, episode_id=EPISODE, infra_values=infra)
     captured: list[_FakeEnv] = []
 
@@ -482,8 +488,12 @@ async def test_proxy_policy_reaches_desktop_env_construction(
         _expect_run_instances(stubs, plan=plan)
         _expect_create_schedule(stubs)
         _expect_running(stubs)
-        provider = _provider(stubs, monkeypatch, desktop_env_factory=factory,
-                             task_factory=lambda t: {"id": t.task_id, "proxy": t.proxy})
+        provider = _provider(
+            stubs,
+            monkeypatch,
+            desktop_env_factory=factory,
+            task_factory=lambda t: {"id": t.task_id, "proxy": t.proxy},
+        )
         await provider.allocate(plan, task, cache_root=_cache_root(tmp_path))
         stubs.ec2_stub.assert_no_pending_responses()
     assert len(captured) == 1

--- a/tests/unit/evaluation/adapters/osworld/test_proxy_policy.py
+++ b/tests/unit/evaluation/adapters/osworld/test_proxy_policy.py
@@ -1,0 +1,109 @@
+"""System proxy policy is explicit infra, never an edit to a benchmark task."""
+
+from pathlib import Path
+
+import pytest
+from lop_osworld_v2_adapter import provisioning, requirements, taskfile
+from lop_osworld_v2_adapter.adapter import OSWorldV2Adapter
+
+from local_operator.evaluation.adapters.api import (
+    InspectRequirementsParams,
+    PrepareParams,
+    ScopedInfraValue,
+)
+from tests.unit.evaluation.adapters.osworld.test_provisioning import _INFRA
+
+
+def _policy(value: str, purpose: str = "benchmark_compute") -> ScopedInfraValue:
+    return ScopedInfraValue.model_validate(
+        {"name": "OSWORLD_ENABLE_PROXY", "purpose": purpose, "value": value}
+    )
+
+
+def _task(proxy: bool) -> taskfile.TaskDescriptor:
+    return taskfile.TaskDescriptor(
+        task_id="synthetic", instruction="", source_sha256="0" * 64, proxy=proxy
+    )
+
+
+@pytest.mark.parametrize("hint", [False, True])
+@pytest.mark.parametrize("value", [None, "false", "true"])
+def test_policy_plan_and_requirements_agree(hint: bool, value: str | None) -> None:
+    infra = _INFRA + (() if value is None else (_policy(value),))
+    plan = provisioning.resolve(_task(hint), episode_id="ep-policy", infra_values=infra)
+    expected = hint if value is None else value == "true"
+    assert plan.enable_proxy is expected
+    reqs = {
+        r.name: r
+        for r in requirements.derive_requirements(_task(hint), infra_values=infra)
+    }
+    assert reqs["OSWORLD_ENABLE_PROXY"].required is False
+    assert reqs["OSWORLD_ENABLE_PROXY"].kind == "infra"
+    for name in ("OSWORLD_PROXY_CREDENTIALS", "OSWORLD_PROXY_ENDPOINT"):
+        assert (name in reqs) is (hint and expected)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("task_known", [False, True])
+@pytest.mark.parametrize(
+    "bad", ["False", "TRUE", "0", "1", " false", "false ", "secret-canary"]
+)
+async def test_malformed_policy_fails_before_allocation(
+    tmp_path: Path, task_known: bool, bad: str
+) -> None:
+    def forbidden_provider():
+        pytest.fail("policy validation must precede provider construction")
+
+    adapter = OSWorldV2Adapter(
+        provider_factory=forbidden_provider, workspace_root=tmp_path
+    )
+    if task_known:
+        adapter._task = _task(True)
+    with pytest.raises(provisioning.ProvisioningError) as error:
+        await adapter.prepare(
+            PrepareParams(
+                operation_id="prepare-policy",
+                episode_id="ep-policy",
+                secret_refs=(),
+                infra_values=_INFRA + (_policy(bad),),
+            )
+        )
+    assert str(error.value) == (
+        "OSWORLD_ENABLE_PROXY requires benchmark_compute scope and exactly true or false"
+    )
+    assert adapter._refs is None and adapter._plan is None
+    with pytest.raises(provisioning.ProvisioningError):
+        requirements.derive_requirements(_task(True), infra_values=(_policy(bad),))
+
+
+def test_wrong_scope_and_conflicting_policy_are_rejected() -> None:
+    for infra in (
+        (_policy("false", "benchmark_user_simulator"),),
+        (_policy("true"), _policy("false")),
+    ):
+        with pytest.raises(provisioning.ProvisioningError):
+            provisioning.resolve_proxy_policy(infra)
+
+
+@pytest.mark.asyncio
+async def test_post_prepare_requirements_respect_disabled_policy(
+    tmp_path: Path,
+) -> None:
+    adapter = OSWorldV2Adapter(workspace_root=tmp_path)
+    baseline = await adapter.inspect_requirements(InspectRequirementsParams())
+    assert any(
+        r.name == "OSWORLD_ENABLE_PROXY" and not r.required
+        for r in baseline.requirements
+    )
+    await adapter.prepare(
+        PrepareParams(
+            operation_id="prepare-policy",
+            episode_id="ep-policy",
+            secret_refs=(),
+            infra_values=_INFRA + (_policy("false"),),
+        )
+    )
+    # The runner names the task after prepare; policy must survive that order.
+    adapter._task = _task(True)
+    post = await adapter.inspect_requirements(InspectRequirementsParams())
+    assert not any(r.name.startswith("OSWORLD_PROXY_") for r in post.requirements)

--- a/tests/unit/evaluation/adapters/osworld/test_proxy_policy.py
+++ b/tests/unit/evaluation/adapters/osworld/test_proxy_policy.py
@@ -33,10 +33,7 @@ def test_policy_plan_and_requirements_agree(hint: bool, value: str | None) -> No
     plan = provisioning.resolve(_task(hint), episode_id="ep-policy", infra_values=infra)
     expected = hint if value is None else value == "true"
     assert plan.enable_proxy is expected
-    reqs = {
-        r.name: r
-        for r in requirements.derive_requirements(_task(hint), infra_values=infra)
-    }
+    reqs = {r.name: r for r in requirements.derive_requirements(_task(hint), infra_values=infra)}
     assert reqs["OSWORLD_ENABLE_PROXY"].required is False
     assert reqs["OSWORLD_ENABLE_PROXY"].kind == "infra"
     for name in ("OSWORLD_PROXY_CREDENTIALS", "OSWORLD_PROXY_ENDPOINT"):
@@ -45,18 +42,14 @@ def test_policy_plan_and_requirements_agree(hint: bool, value: str | None) -> No
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("task_known", [False, True])
-@pytest.mark.parametrize(
-    "bad", ["False", "TRUE", "0", "1", " false", "false ", "secret-canary"]
-)
+@pytest.mark.parametrize("bad", ["False", "TRUE", "0", "1", " false", "false ", "secret-canary"])
 async def test_malformed_policy_fails_before_allocation(
     tmp_path: Path, task_known: bool, bad: str
 ) -> None:
     def forbidden_provider():
         pytest.fail("policy validation must precede provider construction")
 
-    adapter = OSWorldV2Adapter(
-        provider_factory=forbidden_provider, workspace_root=tmp_path
-    )
+    adapter = OSWorldV2Adapter(provider_factory=forbidden_provider, workspace_root=tmp_path)
     if task_known:
         adapter._task = _task(True)
     with pytest.raises(provisioning.ProvisioningError) as error:
@@ -91,10 +84,7 @@ async def test_post_prepare_requirements_respect_disabled_policy(
 ) -> None:
     adapter = OSWorldV2Adapter(workspace_root=tmp_path)
     baseline = await adapter.inspect_requirements(InspectRequirementsParams())
-    assert any(
-        r.name == "OSWORLD_ENABLE_PROXY" and not r.required
-        for r in baseline.requirements
-    )
+    assert any(r.name == "OSWORLD_ENABLE_PROXY" and not r.required for r in baseline.requirements)
     await adapter.prepare(
         PrepareParams(
             operation_id="prepare-policy",

--- a/tests/unit/evaluation/adapters/osworld/test_requirements.py
+++ b/tests/unit/evaluation/adapters/osworld/test_requirements.py
@@ -25,6 +25,7 @@ _ALWAYS = {
     "HF_TOKEN",  # optional at episode time: the corpus is pre-materialised
     "AWS_INSTANCE_TYPE",  # optional: escape hatch from the burstable default
     "AWS_ROOT_VOLUME_SIZE",  # optional: escape hatch from recorder disk exhaustion
+    "OSWORLD_ENABLE_PROXY",  # optional: explicit upstream system proxy policy
     "OSWORLD_INPUTS_ROOT",  # optional: the durable root the assets live in
     "OSWORLD_TTL_SECONDS",  # optional: lease-length override
 }

--- a/tests/unit/evaluation/adapters/osworld/test_run_episode_script.py
+++ b/tests/unit/evaluation/adapters/osworld/test_run_episode_script.py
@@ -484,6 +484,8 @@ def test_a_root_volume_override_is_disclosed_in_the_sealed_manifest(
             "AWS_ROOT_VOLUME_SIZE=120",
             "--infra",
             "AWS_INSTANCE_TYPE=m5.xlarge",
+            "--infra",
+            "OSWORLD_ENABLE_PROXY=false",
         ],
         {"AWS_ACCESS_KEY_ID": CANARY_KEY, "AWS_SECRET_ACCESS_KEY": CANARY_SECRET},
     )
@@ -498,3 +500,4 @@ def test_a_root_volume_override_is_disclosed_in_the_sealed_manifest(
     assert report.manifest is not None
     assert report.manifest.metadata["aws_root_volume_size_override"] == "120"
     assert report.manifest.metadata["aws_instance_type_override"] == "m5.xlarge"
+    assert report.manifest.metadata["osworld_enable_proxy_override"] == "false"

--- a/tests/unit/evaluation/adapters/osworld/test_run_episode_script.py
+++ b/tests/unit/evaluation/adapters/osworld/test_run_episode_script.py
@@ -485,7 +485,9 @@ def test_a_root_volume_override_is_disclosed_in_the_sealed_manifest(
             "--infra",
             "AWS_INSTANCE_TYPE=m5.xlarge",
             "--infra",
-            "OSWORLD_ENABLE_PROXY=false",
+            "benchmark_compute:OSWORLD_ENABLE_PROXY=false",
+            "--infra",
+            "benchmark_user_simulator:OSWORLD_USER_SIM_MODEL=synthetic-simulator",
         ],
         {"AWS_ACCESS_KEY_ID": CANARY_KEY, "AWS_SECRET_ACCESS_KEY": CANARY_SECRET},
     )

--- a/tests/unit/evaluation/runner/test_episode.py
+++ b/tests/unit/evaluation/runner/test_episode.py
@@ -1506,7 +1506,8 @@ def test_an_undisclosed_infra_value_is_never_stamped() -> None:
     import scripts.run_episode as run_episode
 
     assert run_episode._infra_disclosure_metadata(["OSWORLD_TTL_SECONDS=900"]) == {}
-    assert run_episode._infra_disclosure_metadata(["AWS_ROOT_VOLUME_SIZE"]) == {}
+    with pytest.raises(ValueError, match="--infra expects"):
+        run_episode._infra_disclosure_metadata(["AWS_ROOT_VOLUME_SIZE"])
     assert run_episode._infra_disclosure_metadata([]) == {}
     # Both at once, each under its own key.
     assert run_episode._infra_disclosure_metadata(

--- a/tests/unit/evaluation/runner/test_episode.py
+++ b/tests/unit/evaluation/runner/test_episode.py
@@ -1309,7 +1309,10 @@ def _spec_with_infra(episode_id: str, *names: str) -> Any:
         spec,
         "infra_values",
         tuple(
-            ScopedInfraValue(name=name, purpose="benchmark_compute", value="m5.xlarge")
+            ScopedInfraValue(
+                name=name, purpose="benchmark_compute",
+                value="false" if name == "OSWORLD_ENABLE_PROXY" else "m5.xlarge",
+            )
             for name in names
         ),
     )
@@ -1330,8 +1333,9 @@ def _infra_runner(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("name", ["AWS_INSTANCE_TYPE", "OSWORLD_ENABLE_PROXY"])
 async def test_a_disclosed_infra_value_an_adapter_does_not_declare_is_refused(
-    tmp_path: Path, episode_id: str
+    tmp_path: Path, episode_id: str, name: str
 ) -> None:
     """The reviewer's reproduction, as a test: old adapter + new host script.
 
@@ -1344,12 +1348,12 @@ async def test_a_disclosed_infra_value_an_adapter_does_not_declare_is_refused(
 
     adapter = FakeAdapter(tmp_path, episode_id)
     outcome = await _infra_runner(
-        tmp_path, episode_id, _spec_with_infra(episode_id, "AWS_INSTANCE_TYPE"), adapter
+        tmp_path, episode_id, _spec_with_infra(episode_id, name), adapter
     ).run()
 
     assert outcome.status == "failed_pre_bundle"
     assert outcome.bundle_root is None
-    assert "AWS_INSTANCE_TYPE" in (outcome.diagnostic or "")
+    assert name in (outcome.diagnostic or "")
     assert "UndeclaredDisclosedInfra" in (outcome.diagnostic or "")
     # The side-effect boundary was never crossed and the worker was reaped.
     assert "prepare" not in adapter.calls and "reset_start" not in adapter.calls
@@ -1357,8 +1361,9 @@ async def test_a_disclosed_infra_value_an_adapter_does_not_declare_is_refused(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("name", ["AWS_INSTANCE_TYPE", "OSWORLD_ENABLE_PROXY"])
 async def test_a_declared_disclosed_infra_value_runs_normally(
-    tmp_path: Path, episode_id: str
+    tmp_path: Path, episode_id: str, name: str
 ) -> None:
     """The inverse direction: a rebuilt adapter DOES declare it, so it runs.
 
@@ -1371,15 +1376,15 @@ async def test_a_declared_disclosed_infra_value_runs_normally(
         episode_id,
         declared_requirements=(
             Requirement(
-                requirement_id="AWS_INSTANCE_TYPE",
+                requirement_id=name,
                 kind="infra",
-                name="AWS_INSTANCE_TYPE",
+                name=name,
                 required=False,
             ),
         ),
     )
     outcome = await _infra_runner(
-        tmp_path, episode_id, _spec_with_infra(episode_id, "AWS_INSTANCE_TYPE"), adapter
+        tmp_path, episode_id, _spec_with_infra(episode_id, name), adapter
     ).run()
 
     assert outcome.status == "completed", outcome.diagnostic

--- a/tests/unit/evaluation/runner/test_episode.py
+++ b/tests/unit/evaluation/runner/test_episode.py
@@ -1310,7 +1310,8 @@ def _spec_with_infra(episode_id: str, *names: str) -> Any:
         "infra_values",
         tuple(
             ScopedInfraValue(
-                name=name, purpose="benchmark_compute",
+                name=name,
+                purpose="benchmark_compute",
                 value="false" if name == "OSWORLD_ENABLE_PROXY" else "m5.xlarge",
             )
             for name in names

--- a/tests/unit/evaluation/runner/test_run_episode_infra.py
+++ b/tests/unit/evaluation/runner/test_run_episode_infra.py
@@ -1,0 +1,103 @@
+"""Mixed infrastructure purposes reuse the closed adapter value contract."""
+
+import pytest
+
+from scripts import run_episode
+
+
+def test_legacy_global_scope_and_value_bytes_are_preserved() -> None:
+    values = run_episode._parse_infra(
+        ["NAME=https://example.test/a=b"], "benchmark_storage"
+    )
+    assert [(v.name, v.purpose, v.value) for v in values] == [
+        ("NAME", "benchmark_storage", "https://example.test/a=b")
+    ]
+
+
+def test_per_value_scope_overrides_only_its_own_entry() -> None:
+    values = run_episode._parse_infra(
+        [
+            "AWS_REGION=us-east-1",
+            "benchmark_user_simulator:OSWORLD_USER_SIM_MODEL=test/model",
+        ],
+        "benchmark_compute",
+    )
+    assert [(v.name, v.purpose, v.value) for v in values] == [
+        ("AWS_REGION", "benchmark_compute", "us-east-1"),
+        ("OSWORLD_USER_SIM_MODEL", "benchmark_user_simulator", "test/model"),
+    ]
+
+
+def test_identical_scoped_and_legacy_duplicates_coalesce() -> None:
+    values = run_episode._parse_infra(
+        ["NAME=value", "benchmark_compute:NAME=value"], "benchmark_compute"
+    )
+    assert len(values) == 1
+
+
+@pytest.mark.parametrize(
+    "items, purpose",
+    [
+        (["unknown:NAME=secret-canary"], "benchmark_compute"),
+        (["=secret-canary"], "benchmark_compute"),
+        (["benchmark_compute:=secret-canary"], "benchmark_compute"),
+        ([":NAME=secret-canary"], "benchmark_compute"),
+        (["secret-canary"], "benchmark_compute"),
+        (["NAME="], "benchmark_compute"),
+        (["NAME=secret-canary"], "unknown"),
+        (["NAME=one", "benchmark_compute:NAME=secret-canary"], "benchmark_compute"),
+        (
+            ["NAME=secret-canary", "benchmark_storage:NAME=secret-canary"],
+            "benchmark_compute",
+        ),
+    ],
+)
+def test_invalid_or_conflicting_entries_never_echo_input(
+    items: list[str], purpose: str
+) -> None:
+    with pytest.raises(ValueError) as error:
+        run_episode._parse_infra(items, purpose)
+    assert "secret-canary" not in str(error.value)
+
+
+@pytest.mark.parametrize("prefix", ["", "benchmark_compute:"])
+def test_scope_normalization_cannot_bypass_policy_disclosure(prefix: str) -> None:
+    assert run_episode._infra_disclosure_metadata(
+        [f"{prefix}OSWORLD_ENABLE_PROXY=false"]
+    ) == {"osworld_enable_proxy_override": "false"}
+    assert run_episode._infra_disclosure_metadata(
+        [
+            "benchmark_compute:OSWORLD_ENABLE_PROXY=false",
+            "benchmark_compute:AWS_ROOT_VOLUME_SIZE=80",
+        ],
+        "benchmark_user_simulator",
+    ) == {
+        "osworld_enable_proxy_override": "false",
+        "aws_root_volume_size_override": "80",
+    }
+
+
+def test_actual_cli_rejects_invalid_infra_before_reading_selector(
+    capsys, tmp_path
+) -> None:
+    status = run_episode.main(
+        [
+            "--selector",
+            str(tmp_path / "nonexistent.json"),
+            "--task-id",
+            "synthetic",
+            "--route",
+            "test/model",
+            "--run-root",
+            str(tmp_path / "must-not-exist"),
+            "--infra",
+            "unknown:NAME=secret-canary",
+            "--no-store",
+        ]
+    )
+    output = capsys.readouterr()
+    assert status == run_episode.EXIT_PREFLIGHT
+    assert output.out == ""
+    assert output.err.startswith("--infra expects")
+    assert "secret-canary" not in output.err and "Traceback" not in output.err
+    assert not (tmp_path / "must-not-exist").exists()

--- a/tests/unit/evaluation/runner/test_run_episode_infra.py
+++ b/tests/unit/evaluation/runner/test_run_episode_infra.py
@@ -6,9 +6,7 @@ from scripts import run_episode
 
 
 def test_legacy_global_scope_and_value_bytes_are_preserved() -> None:
-    values = run_episode._parse_infra(
-        ["NAME=https://example.test/a=b"], "benchmark_storage"
-    )
+    values = run_episode._parse_infra(["NAME=https://example.test/a=b"], "benchmark_storage")
     assert [(v.name, v.purpose, v.value) for v in values] == [
         ("NAME", "benchmark_storage", "https://example.test/a=b")
     ]
@@ -52,9 +50,7 @@ def test_identical_scoped_and_legacy_duplicates_coalesce() -> None:
         ),
     ],
 )
-def test_invalid_or_conflicting_entries_never_echo_input(
-    items: list[str], purpose: str
-) -> None:
+def test_invalid_or_conflicting_entries_never_echo_input(items: list[str], purpose: str) -> None:
     with pytest.raises(ValueError) as error:
         run_episode._parse_infra(items, purpose)
     assert "secret-canary" not in str(error.value)
@@ -62,9 +58,9 @@ def test_invalid_or_conflicting_entries_never_echo_input(
 
 @pytest.mark.parametrize("prefix", ["", "benchmark_compute:"])
 def test_scope_normalization_cannot_bypass_policy_disclosure(prefix: str) -> None:
-    assert run_episode._infra_disclosure_metadata(
-        [f"{prefix}OSWORLD_ENABLE_PROXY=false"]
-    ) == {"osworld_enable_proxy_override": "false"}
+    assert run_episode._infra_disclosure_metadata([f"{prefix}OSWORLD_ENABLE_PROXY=false"]) == {
+        "osworld_enable_proxy_override": "false"
+    }
     assert run_episode._infra_disclosure_metadata(
         [
             "benchmark_compute:OSWORLD_ENABLE_PROXY=false",
@@ -77,9 +73,7 @@ def test_scope_normalization_cannot_bypass_policy_disclosure(prefix: str) -> Non
     }
 
 
-def test_actual_cli_rejects_invalid_infra_before_reading_selector(
-    capsys, tmp_path
-) -> None:
+def test_actual_cli_rejects_invalid_infra_before_reading_selector(capsys, tmp_path) -> None:
     status = run_episode.main(
         [
             "--selector",


### PR DESCRIPTION
## Summary

C2 standard/pre-authorized apparatus correction for a frozen representative OSWorld pilot. No task-specific logic, new proxy service, credential fabrication, or change to normal TUI/mobile/CLI defaults.

Two incremental commits:
- 19f79d4cd: explicit, disclosed system-level proxy policy.
- 0e30409dc: per-value scopes for mixed compute and auxiliary-model infrastructure settings.

## Delivery contract

Upstream OSWorld combines a task proxy hint with a separate system enable switch; our adapter previously forced the system switch from the hint. Add strict optional `OSWORLD_ENABLE_PROXY=true|false` under benchmark_compute. Omission preserves existing behavior. Explicit false reaches the actual DesktopEnv constructor and suppresses effective proxy prerequisites; malformed values fail before allocation. Register the optional capability and use the existing manifest disclosure + old-adapter refusal path. Enabled proxy configuration remains incomplete: the legacy declared endpoint/credential inputs do not populate upstream ProxyPool. This PR does not pretend to repair that path.

The existing operator script now accepts `[purpose:]NAME=VALUE` for each `--infra`, preserving unprefixed values and the global default. Use the same parser for actual values and disclosure so scoped flags cannot change behavior without being recorded. Reject conflicting duplicates and invalid scopes without echoing supplied values. Reuse ScopedInfraValue; no protocol/schema or model-loop redesign.

## Evidence

- Baseline reproduction: explicit false still produced enable_proxy=True; patched path produces False.
- Stubbed cloud setup exercised the actual DesktopEnv constructor argument (no VM), plus strict prepare-time rejection, effective requirements, disclosure and old-adapter refusal.
- Policy/disclosure rerun:28 passed.
- CLI/runner checks:66 passed, including two real spawned fake-provider episodes (legacy omission and mixed scopes) with sealed manifest evidence.
- Final parser checks:15 passed; malformed-input real CLI exit2, stdout empty, sanitized stderr.
- Explicit worktree import assertions; shared interpreter not modified.
- Whole-tree Flake8, pinned Black26.1.0 (940 files unchanged), isort5.13.2 and Pyright all pass. Parent applied required formatting in9cd822483; no behavior change.
- All14 CI checks pass on9cd822483. Code round1 is clean/TERMINAL (209 independently repeated focused tests); design round1 is clean/TERMINAL with non-gating D1 help-vocabulary follow-up explicitly deferred. Both rounds are answered on the PR.

## Limits and rollout

Direct-network adequacy is not established by accepting false. Future pilot commands must explicitly record proxy-disabled mode and verify network behavior; blocked sites are environment limitations, not grounds to invent credentials or replace sampled tasks. No real benchmark outcomes are claimed by these offline tests.

The separate task098 simulator answer-transport defect is not fixed here. This only permits accurately scoped simulator configuration once that independent fix lands.

No root or adapter distribution bump, release, or installed runtime change in this PR. Rebuild and digest-pin a new adapter artifact before using the new optional policy; preserve previous evidence and runtime. Rollback is a normal revert and reselecting the prior pinned apparatus. Only the standalone developer evaluation script and optional adapter path change; no rendered TUI/mobile surface.
