### PR TITLE
chore(release): bump version to 0.49.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.49.2"
+version = "0.49.3"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Summary

Release bump for the current window: `0.49.2` → `0.49.3`. One file, one line, no behaviour change.

**Change class:** C0 (release metadata) — standard/pre-authorized.

## Window contents

`git log v0.49.2..origin/main --oneline` at the time of the cut:

```
232d05112 fix(tui): speed up startup without interrupting input (#682)
da293e177 fix(evaluation): disclose proxy policy and scope infrastructure values (#683)
```

Two PRs in the window, both cut from `232d05112` which is the current `origin/main` head.

Bump class **PATCH** by materiality, per AGENTS.md "Versioning: choose the bump by materiality, not commit type". Both entries are bug fixes — a TUI startup-latency fix and an evaluation disclosure/scoping fix — with no step-function capability change. There is no new surface or subsystem to name in an `X.Y.0:` title, which is the stated test for a minor, so this is a patch.

Window ownership is held by the announcing session, which polled the live `lop` peers and announced the freeze before this bump was cut.

## Evidence

No runtime path: this diff changes a packaging version string only. Validation is the scope check below plus CI.

```
$ git diff --stat
 pyproject.toml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

$ git diff
-version = "0.49.2"
+version = "0.49.3"
```

That is the complete diff: one line in `pyproject.toml`. Parsed both revisions with `tomllib` and compared the trees key by key — the only difference is `project.version`; `dependencies`, `optional-dependencies` and `build-system` are identical, and `git diff --name-only HEAD` lists `pyproject.toml` alone with no source file touched.

## Rollout / rollback

Merged as admin. The window owner then tags `v0.49.3` with a GitHub Release targeting the merge SHA; `publish.yml` builds and pushes to PyPI. This PR does not tag, release, or run `lop-update`. Rollback is a further bump, never a tag move or a yank of a consumed version.

## Note on CI

`cli-sanity` is currently failing on `main` itself — including the released `0.49.2` bump commit — from an upstream HTTP 429 for `qwen/qwen3.7-flash`. That failure is pre-existing and independent of this diff, which cannot reach a model provider. Every other check must pass.
