### PR TITLE
fix(evaluation): deliver adapter-owned public user answers

### DIFF
--- a/benchmarks/osworld_v2_adapter/README.md
+++ b/benchmarks/osworld_v2_adapter/README.md
@@ -19,13 +19,36 @@ wheel + digest + isolated worker, not from the source's location.
 
 ## Computer input capability
 
-Adapter 0.1.2 uses RPC 1.5 and explicitly advertises clipboard `paste_text`
+The current source uses RPC 1.6 and explicitly advertises clipboard `paste_text`
 with caller-chosen keys and overwrite policy. Native `type` remains ASCII-only
 on this backend; Unicode requires the explicit paste action, never an automatic
 fallback. See [the negotiated computer-input contract](../../docs/benchmarks/computer-input.md)
 for limits, clipboard ownership, application semantics and frozen-environment
 compatibility. Historical 0.1.1 environment examples below are not migration
 instructions: new proofs need a newly built wheel and exact selector pins.
+
+## Simulator answer ownership
+
+RPC 1.6 advertises
+`ask_user_answer_owner="adapter"` separately from `ask_user` support. The runner
+locally registers the question, sends one existing `ask_user_exchange` request
+with `answer=null`, and the adapter calls `provider.respond(prompt)` once. Only
+the bounded, nonempty public reply returns, bound by `ask_id` and a canonical
+request digest (episode, ask identity, exact prompt). Simulator profiles and
+evaluator state never enter host model context. A missing simulator or provider
+refusal cancels unscored, without publishing an answer. Explicit host responder
+overrides are rejected before prepare; there is no host finish RPC or second
+generation. Ambiguous generation timeouts poison the worker and require rescue,
+never automatic regeneration.
+Generic migrated adapters default to `ask_user_answer_owner="host"`; their
+existing responder path is preserved, but refusal cannot publish a supplied
+answer. Accepted exchanges still produce the ordinary public response artifact,
+asking-turn `ask_answer`, and next model input before executing the ask batch.
+RPC 1.5/1.6 mixtures fail negotiation before allocation. Build and pin a new
+wheel/selector together; do not modify frozen environments or rescue pins.
+This source change does not itself bump the distribution or publish an artifact.
+See [offline answer-path verification](../../docs/benchmarks/adapter-user-answers.md)
+for the baseline reproduction, installed-worker proofs, and release limitations.
 
 ## Prerequisite: the gated inputs, in a DURABLE root
 
@@ -490,9 +513,6 @@ it must print `[]`.**
 - **Screenshot-only observations.** The a11y tree is not shipped as a frame
   (a geometry for an XML document is a fiction). Its presence is recorded in
   observation metadata; shipping it is a protocol addition, not a fake frame.
-- **`user_simulator` is one-sided.** The harness's own responder supplies the
-  answer the model sees; the benchmark's simulator is notified for the record.
-  Faithful two-sided wiring is a later PR. Pilot tasks declare no simulator.
 - **Temporary security groups and IP-drift repair are not automated.** The
   operator supplies a pre-existing group (`AWS_SECURITY_GROUP_ID`); a
   per-episode group with a `CleanupActionKind` of its own is a later PR.

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
@@ -288,6 +288,7 @@ class OSWorldV2Adapter:
             capabilities=AdapterCapabilities(
                 routes=("computer",),
                 ask_user=actions.ACTION_SURFACE.ask_user,  # V2 has user_simulator
+                ask_user_answer_owner="adapter",
                 scoring=True,
                 paste_text=actions.ACTION_SURFACE.paste_text,
                 type_text_mode=actions.ACTION_SURFACE.type_text_mode,
@@ -711,18 +712,22 @@ class OSWorldV2Adapter:
     # ------------------------------------------------------------------
 
     async def ask_user_exchange(self, params: AskUserExchangeParams) -> AskUserExchangeResult:
-        # Two-phase: answer is None = begin, set = finish. When the task
-        # declares no user_simulator, refusing is the honest, recordable
-        # answer — inventing one would be a benchmark violation. Detection is
-        # from the parsed task descriptor, never from probing the provider.
+        # The task's simulator owns generation. A host-supplied finish would
+        # substitute an answer and/or invoke the simulator twice, so reject it.
+        if params.answer is not None:
+            raise ValueError("OSWorld requires adapter-owned answers")
         has_simulator = isinstance(self._task.user_simulator, dict) if self._task else False
-        if params.answer is None:
-            return AskUserExchangeResult(ask_id=params.ask_id, accepted=has_simulator)
-        # Finish phase: the harness's responder already produced the answer
-        # the model sees; we notify the benchmark's simulator for the record.
+        answer = None
         if has_simulator and self._provider is not None:
-            await self._provider.respond(params.prompt)
-        return AskUserExchangeResult(ask_id=params.ask_id, accepted=has_simulator)
+            answer = await self._provider.respond(params.prompt)
+        # None is the provider's clean refusal. Invalid non-None replies fail
+        # protocol validation rather than being silently replaced or regenerated.
+        return AskUserExchangeResult(
+            ask_id=params.ask_id,
+            request_digest=params.request_digest,
+            accepted=answer is not None,
+            answer=answer,
+        )
 
     # ------------------------------------------------------------------
     # score: scored or raise

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/aws.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/aws.py
@@ -825,7 +825,12 @@ class AwsProvider:
         if simulator is None:
             return None
         answer = await asyncio.to_thread(simulator.respond, prompt)
-        return str(answer)
+        # None is a refusal, not the public string "None". Other objects may
+        # contain private simulator state; never stringify them into replies or
+        # diagnostics. Public string content is validated by the adapter wire.
+        if answer is not None and not isinstance(answer, str):
+            raise TypeError("simulator response must be a string or None")
+        return answer
 
     # ------------------------------------------------------------------
     # teardown (usable with only credentials + refs; see for_teardown)

--- a/docs/benchmarks/adapter-user-answers.md
+++ b/docs/benchmarks/adapter-user-answers.md
@@ -108,6 +108,54 @@ Final static gates: `git diff --check`, flake8 on every changed Python file,
 and pyright on the modified runtime and behavioral-test files all passed
 (`0 errors, 0 warnings, 0 informations`).
 
+## Integration with proxy/scoped infrastructure
+
+Rebased onto PR #683's merged `origin/main`,
+`da293e177009e5135afc9b853ad136fd61ea19c1`. Both implementation/documentation
+commits replayed without conflicts; `git range-diff` confirmed unchanged patches.
+The compatibility census included the new proxy/scoped-infrastructure tests:
+remaining `1.5` literals in executable tests are exclusively intentional
+old-protocol rejection fixtures. Shared fixture builders use RPC 1.6.
+
+Pinned isort 5.13.2 required only mechanical nested-import formatting in
+`test_episode_subprocess.py`, `test_spawn.py`, and `test_fake_end_to_end.py`.
+No proxy/scoped-infrastructure implementation or protocol behavior needed
+remediation. Black 26.1.0, isort 5.13.2, and flake8 7.3.0 were installed into an
+isolated temporary target and run with the shared interpreter; the shared
+virtual environment remained unchanged. Pyright used pinned 1.1.411.
+
+The bounded matrix above, plus the following proxy/scoped-infrastructure files,
+passed together with explicit `PYTHONPATH="$PWD"` imports and `-n 2`:
+**415 passed in 186.15s**.
+
+```text
+tests/unit/evaluation/adapters/osworld/test_proxy_policy.py
+tests/unit/evaluation/adapters/osworld/test_aws_provider.py
+tests/unit/evaluation/adapters/osworld/test_requirements.py
+tests/unit/evaluation/adapters/osworld/test_run_episode_script.py
+tests/unit/evaluation/adapters/osworld/test_provisioning.py
+tests/unit/evaluation/runner/test_run_episode_infra.py
+```
+
+This includes botocore Stubber/loopback-only provider tests and the actual
+`run_episode.py` subprocess against the installed fake-provider wheel, not
+cloud or paid-model calls. After import remediation, all whole-tree gates
+passed: `black --check --workers 2 .` (940 unchanged files), `isort --check .`,
+`flake8 --jobs 2 .`, and `pyright --pythonpath ~/local-operator/.venv/bin/python`
+(`0 errors, 0 warnings, 0 informations`).
+
+After formatting, the three affected test modules were rerun together with
+`PYTHONPATH="$PWD"` and `-n 2`: **47 passed in 119.95s**. This re-exercised the
+real supervisor/worker exchange, installed OSWorld wheel, response artifacts,
+next model requests, refusal paths, and no-regeneration checks on the final
+Python tree.
+
+A separate actual `scripts/run_episode.py` subprocess with
+`--infra unknown:NAME=synthetic-marker` returned exit 2 before reading its
+nonexistent selector: stdout was empty, stderr was
+`--infra expects [purpose:]NAME=VALUE with a valid name, purpose and value`,
+and the requested run root was not created. The value was not echoed.
+
 ## Limits and release boundary
 
 This is offline synthetic evidence, not task 098 benchmark performance. No

--- a/docs/benchmarks/adapter-user-answers.md
+++ b/docs/benchmarks/adapter-user-answers.md
@@ -1,0 +1,119 @@
+# Adapter-owned public answers — offline verification
+
+## Contract
+
+Adapter RPC 1.6 adds `AdapterCapabilities.ask_user_answer_owner` (`host` by
+default, or explicitly `adapter`) and a request-bound public answer in
+`AskUserExchangeResult`. Ownership is selected from the validated handshake,
+never the benchmark name, task identity, credential presence, or `ask_user`
+boolean. Adapter ownership without ask support is invalid.
+
+The adapter-owned path registers the outstanding question locally, sends one
+existing `ask_user_exchange` RPC with `answer=null`, validates the returned
+`ask_id`, canonical request digest, acceptance and bounded nonempty answer,
+and completes locally. There is no host-finish RPC or second generation.
+OSWorld calls its provider once and returns only the provider's public answer.
+Missing simulators and provider refusals cancel unscored. Explicit responder
+overrides fail before prepare. Host-owned exchanges preserve `UserResponder`
+but cannot publish an answer the adapter refused.
+
+Successful answers use the existing response artifact → `ask_answer` → next
+model request path. The exchange event still precedes execution of the ask
+batch. Empty/oversized replies and identity mismatches fail closed. An unanswered
+mutating call poisons the session and requires rescue; neither automatic nor
+explicit retry may regenerate an answer on that session.
+
+## Reproduction
+
+Baseline: `481d4fbbef94baf27fc0601784ba71e6d615c356`.
+
+A temporary pytest plugin extracted `EpisodeRunner._run_ask` verbatim from that
+commit using Python AST and rebound only that method in the current runner.
+This isolates the proven choreography defect without changing the worktree,
+reverting wire models, or touching an existing benchmark environment. The real
+installed-worker regression was then run with that plugin:
+
+```text
+test_public_answer_crosses_worker_into_next_model_request[adapter]
+FAILED: assert 'cancelled' == 'completed'
+diagnostic: ask-user was not answered
+1 failed in 8.02s
+```
+
+The installed adapter's `tiny_ask_calls` marker was absent: **zero adapter
+exchange/simulator invocations**. This is a replay of the old method, not a claim
+that the complete historical wheel was rebuilt or exercised.
+
+## Post-fix verification
+
+All commands used explicit worktree imports with the shared interpreter
+read-only; no cloud or external model calls were made.
+
+```sh
+PYTHONPATH="$PWD" ~/local-operator/.venv/bin/python -m pytest -n 2 -q \
+  tests/unit/evaluation/adapters/test_api.py \
+  tests/unit/evaluation/adapters/test_supervisor.py \
+  tests/unit/evaluation/adapters/test_worker.py \
+  tests/unit/evaluation/adapters/test_discovery.py \
+  tests/unit/evaluation/adapters/test_launch.py \
+  tests/unit/evaluation/adapters/test_rpc.py \
+  tests/unit/evaluation/runner/test_episode.py \
+  tests/unit/evaluation/runner/test_episode_subprocess.py \
+  tests/unit/evaluation/adapters/osworld/test_fake_end_to_end.py \
+  tests/unit/evaluation/adapters/osworld/test_spawn.py \
+  tests/unit/evaluation/adapters/osworld/test_build_and_scripts.py \
+  tests/unit/evaluation/adapters/osworld/test_secrets_and_rescue.py \
+  tests/unit/evaluation/test_action_surface.py \
+  tests/unit/evaluation/runner/test_provider_client.py::test_ask_answer_reaches_the_model_with_the_next_observation
+```
+
+Result: **245 passed in 150.90s**. The final direct-retry and provider-refusal
+assertions were then included in this focused delta/real-path run:
+
+```sh
+PYTHONPATH="$PWD" ~/local-operator/.venv/bin/python -m pytest -n 2 -q \
+  tests/unit/evaluation/adapters/test_supervisor.py::test_a_timeout_never_claims_the_observation_phase \
+  tests/unit/evaluation/adapters/osworld/test_fake_end_to_end.py::test_simulator_is_called_once_and_host_finish_is_refused \
+  tests/unit/evaluation/runner/test_episode_subprocess.py::test_public_answer_crosses_worker_into_next_model_request \
+  tests/unit/evaluation/adapters/osworld/test_spawn.py::test_real_wheel_simulator_answer_enters_public_artifact_and_next_request
+```
+
+Result: **7 passed in 18.44s**. These exercise real `ProviderModelClient` request
+construction through a local `RecordingStream`, not a paid model. A copied,
+installed interpreter runs the real supervisor/worker boundary. The OSWorld
+case builds and installs the actual adapter wheel with the existing fixture
+helper and selects its no-cloud fake provider using a pinned synthetic
+workspace. No gated task/profile/evaluator or private fixture data was read.
+
+The reopened sealed bundles independently verified; their public response bytes
+and SHA-256 values were:
+
+| Case | Public answer | SHA-256 |
+| --- | --- | --- |
+| Adapter-owned subprocess | `public simulator answer 1` | `d6f51f4a8e995dd62eb2fd257caa19951339c77159bb8e5306413147bc44b61f` |
+| Host-owned subprocess | `host public answer` | `e770afcf8a3cc200763802a360d29ff6a05fedb64604872aa9d0fabe0c4ddfb4` |
+| Installed OSWorld wheel | `simulated user answer` | `c7ace92bfbe173154b7186db8059238b3bc768e9cad01e321601a4dfb9b5fdfd` |
+
+The adapter-owned invocation log was exactly `["None"]`; the host-owned log
+was exactly `["host public answer"]`. Each next `ChatRequest` contained the
+matching `Answer from the user: ...` string, and the exchange event immediately
+preceded the ask batch and environment step. The simulator's counted answer
+changes on another invocation, so a hidden regeneration cannot pass as the
+same reply. Adversarial subprocess cases cover refusal, missing/empty/oversized
+answers, wrong IDs/prompts/episodes, and a timeout **after** generation; none
+publishes a substitute or requests another model decision. Protocol 1.5 and
+incompatible capability declarations fail before allocation.
+
+Final static gates: `git diff --check`, flake8 on every changed Python file,
+and pyright on the modified runtime and behavioral-test files all passed
+(`0 errors, 0 warnings, 0 informations`).
+
+## Limits and release boundary
+
+This is offline synthetic evidence, not task 098 benchmark performance. No
+private profile, benchmark model call, cloud allocation, existing environment,
+or existing benchmark evidence was touched. Root and adapter distribution
+versions were deliberately not bumped; a release must build a new artifact
+and pin its selector together with RPC 1.6. Frozen environments/rescue pins
+must remain intact. No full repository suite, push, PR, or merge was performed
+as part of this bounded slice.

--- a/docs/benchmarks/computer-input.md
+++ b/docs/benchmarks/computer-input.md
@@ -67,8 +67,8 @@ phase can be re-read, without reapplying input.
 
 ## Negotiation, evidence, and compatibility
 
-Adapter RPC **1.5** explicitly negotiates clipboard support and native text
-restrictions. Exact version checks refuse mixed workers before allocation.
+Adapter RPC **1.6** retains 1.5's explicit clipboard support and native text
+restrictions and adds explicit host/adapter ownership of ask-user answers. Exact version checks refuse mixed workers before allocation.
 Supervisor admission and adapter compilation independently enforce the surface;
 known model admission failures use existing bounded corrective decisions and do
 not enter ambiguous-mutation poisoning.
@@ -82,7 +82,7 @@ of the episode ID; capability changes alter it. Unsupported kinds are not
 advertised in the generated prompt.
 
 Adapter 0.1.2 is a new artifact identity, not a replacement of frozen 0.1.1
-wheels. Build/pin a new worker environment and selector for RPC 1.5. Keep frozen
+wheels. Build/pin a new worker environment and selector for RPC 1.6. Keep frozen
 older environments and their rescue launch paths intact until their episodes
 and descriptors are settled; do not rewrite historical bundles, selectors,
 attestations or rescue descriptors to make them look compatible. Root harness

--- a/local_operator/evaluation/adapters/api.py
+++ b/local_operator/evaluation/adapters/api.py
@@ -82,10 +82,13 @@ from local_operator.evaluation.receipts import (
 # 1.5 advertises clipboard paste and the native text execution restriction.
 # Exact negotiation rejects old workers before prepare/reset can allocate, rather
 # than discovering an unknown action after a preceding click has already applied.
-ADAPTER_SCHEMA_VERSION = "1.5"
+# 1.6 makes answer ownership explicit and binds the public answer to its request.
+# Canonical replies gain fields, so mixed peers must fail during hello in
+# either direction, before any environment allocation or simulator invocation.
+ADAPTER_SCHEMA_VERSION = "1.6"
 # One alias for the three models that pin the version, so a future bump cannot
 # move the constant while leaving a model silently accepting the older literal.
-SchemaVersion: TypeAlias = Literal["1.5"]
+SchemaVersion: TypeAlias = Literal["1.6"]
 ADAPTER_ENTRY_POINT_GROUP = "local_operator.evaluation_adapters.v1"
 MAX_RESCUE_REFS = 256
 MAX_REQUIREMENTS = 256
@@ -192,6 +195,9 @@ class AdapterSelector(ProtocolModel):
 class AdapterCapabilities(ProtocolModel):
     routes: tuple[RouteCapability, ...] = Field(min_length=1, max_length=3)
     ask_user: bool
+    # Generic adapters retain their host responder; simulator ownership must be
+    # advertised separately rather than inferred from support for the action.
+    ask_user_answer_owner: Literal["host", "adapter"] = "host"
     scoring: bool
     paste_text: bool = False
     type_text_mode: Literal["unicode", "ascii"] = "unicode"
@@ -210,6 +216,8 @@ class AdapterCapabilities(ProtocolModel):
 
     @model_validator(mode="after")
     def _unique_routes(self) -> "AdapterCapabilities":
+        if self.ask_user_answer_owner == "adapter" and not self.ask_user:
+            raise ValueError("adapter answer ownership requires ask_user support")
         if len(self.routes) != len(set(self.routes)):
             raise ValueError("adapter routes must be unique")
         return self
@@ -639,10 +647,35 @@ class AskUserExchangeParams(OperationParams):
     prompt: str = Field(min_length=1, max_length=100_000)
     answer: str | None = Field(default=None, min_length=1, max_length=100_000)
 
+    @field_validator("answer")
+    @classmethod
+    def _nonblank_answer(cls, value: str | None) -> str | None:
+        if value is not None and not value.strip():
+            raise ValueError("a public answer must be nonempty")
+        return value
+
+    @property
+    def request_digest(self) -> Digest:
+        # Completion data may vary, but the episode, ask identity and exact
+        # public prompt must remain bound across the process boundary.
+        return canonical_digest(
+            "adapter-ask-user-request-v1",
+            self.model_dump(mode="json", exclude={"operation_id", "answer"}),
+        )
+
 
 class AskUserExchangeResult(ProtocolModel):
     ask_id: StrictIdentifier
+    request_digest: Digest
     accepted: bool
+    # Only the public reply crosses the boundary, never simulator state/profile.
+    answer: str | None = Field(default=None, min_length=1, max_length=100_000)
+
+    @model_validator(mode="after")
+    def _public_answer(self) -> "AskUserExchangeResult":
+        if self.answer is not None and (not self.accepted or not self.answer.strip()):
+            raise ValueError("a public answer must be nonempty and accepted")
+        return self
 
 
 class ScoreParams(OperationParams):

--- a/local_operator/evaluation/adapters/supervisor.py
+++ b/local_operator/evaluation/adapters/supervisor.py
@@ -486,6 +486,7 @@ class HostVerifier:
         self.current_observation: Any | None = None
         self._sequences: set[int] = set()
         self._outstanding_ask: tuple[AskUserExchangeParams, Digest] | None = None
+        self._completed_asks: set[str] = set()
         self._score_ids: set[str] = set()
 
     def accept_initial(self, observation: Any) -> None:
@@ -541,7 +542,11 @@ class HostVerifier:
     def begin_ask(self, params: AskUserExchangeParams) -> None:
         if params.episode_id != self.episode_id:
             raise SupervisionError("ask-user exchange belongs to another episode")
-        if self._outstanding_ask is not None or params.answer is not None:
+        if (
+            self._outstanding_ask is not None
+            or params.answer is not None
+            or params.ask_id in self._completed_asks
+        ):
             raise SupervisionError("ask-user exchange must begin once without an answer")
         request_digest = self._ask_request_digest(params)
         self._outstanding_ask = (params, request_digest)
@@ -550,6 +555,8 @@ class HostVerifier:
         self,
         params: AskUserExchangeParams,
         result: AskUserExchangeResult | None = None,
+        *,
+        answer_owner: str = "host",
     ) -> None:
         outstanding = self._outstanding_ask
         request_digest = self._ask_request_digest(params)
@@ -558,23 +565,37 @@ class HostVerifier:
             or outstanding is None
             or outstanding[1] != request_digest
             or outstanding[0].ask_id != params.ask_id
-            or (result is not None and result.ask_id != params.ask_id)
-            or params.answer is None
+            or (
+                result is not None
+                and (result.ask_id != params.ask_id or result.request_digest != request_digest)
+            )
+            or (answer_owner == "host" and params.answer is None)
+            or (answer_owner == "adapter" and params.answer is not None)
         ):
             raise SupervisionError("ask-user response is stale, unsolicited, or mismatched")
 
-    def finish_ask(self, params: AskUserExchangeParams, result: AskUserExchangeResult) -> None:
-        self.validate_ask_completion(params, result)
+        if result is not None:
+            if answer_owner == "host" and result.answer is not None:
+                raise SupervisionError("host-owned ask cannot return an adapter answer")
+            if answer_owner == "adapter" and result.accepted and result.answer is None:
+                raise SupervisionError("accepted adapter-owned ask requires a public answer")
+
+    def finish_ask(
+        self,
+        params: AskUserExchangeParams,
+        result: AskUserExchangeResult,
+        *,
+        answer_owner: str = "host",
+    ) -> None:
+        self.validate_ask_completion(params, result, answer_owner=answer_owner)
+        self._completed_asks.add(params.ask_id)
         self._outstanding_ask = None
 
     @staticmethod
     def _ask_request_digest(params: AskUserExchangeParams) -> Digest:
         # The answer and retry operation key are completion data. Everything
         # model-visible in the initiating request remains immutable.
-        return canonical_digest(
-            "adapter-ask-user-request-v1",
-            params.model_dump(mode="json", exclude={"operation_id", "answer"}),
-        )
+        return params.request_digest
 
     def accept_score(self, params: ScoreParams, result: ScoreResult) -> None:
         if params.episode_id != self.episode_id:
@@ -600,7 +621,11 @@ class VerifiedAdapterSession:
         verifier: HostVerifier,
         *,
         rescue_required: Callable[[], None] | None = None,
+        answer_owner: str = "host",
     ) -> None:
+        if answer_owner not in ("host", "adapter"):
+            raise SupervisionError("invalid ask-user answer ownership")
+        self._answer_owner = answer_owner
         self._supervisor = supervisor
         self.verifier = verifier
         self._rescue_required = rescue_required or (lambda: None)
@@ -834,20 +859,24 @@ class VerifiedAdapterSession:
     ) -> AskUserExchangeResult:
         self._ensure_usable()
         # This prospective check rejects changed prompts before an adapter call.
-        self.verifier.validate_ask_completion(params)
+        self.verifier.validate_ask_completion(params, answer_owner=self._answer_owner)
+        # Both owners use one existing exchange RPC. In adapter mode the null
+        # answer requests generation; completion is local, never a second call.
         result = await self._mutating_call(
             "ask_user_exchange",
             params,
             AskUserExchangeResult,
             timeout=timeout,
             validate=lambda value: (
-                self.verifier.validate_ask_completion(params, value)
+                self.verifier.validate_ask_completion(
+                    params, value, answer_owner=self._answer_owner
+                )
                 if isinstance(value, AskUserExchangeResult)
                 else (_ for _ in ()).throw(SupervisionError("ask returned the wrong result"))
             ),
         )
         assert isinstance(result, AskUserExchangeResult)
-        self.verifier.finish_ask(params, result)
+        self.verifier.finish_ask(params, result, answer_owner=self._answer_owner)
         return result
 
     async def score(self, params: ScoreParams, *, timeout: float) -> ScoreResult:

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -371,7 +371,9 @@ class EpisodeRunner:
         self._config = config
         self._selector = selector
         self._model = model
-        self._responder = responder or NullUserResponder()
+        self._responder = responder if responder is not None else NullUserResponder()
+        self._responder_override = responder is not None
+        self._answer_owner = "host"
         self._redactions = redactions or RedactionSet.from_resolved_values(())
         # ``None`` means "this episode has no secrets to resolve", which is only
         # true when the spec declares no refs. An empty static resolver makes a
@@ -462,6 +464,9 @@ class EpisodeRunner:
         self._supervisor = supervisor
         handshake = await supervisor.handshake(timeout=self._config.handshake_timeout)
         self._action_surface = handshake.metadata.capabilities.action_surface()
+        self._answer_owner = handshake.metadata.capabilities.ask_user_answer_owner
+        if self._answer_owner == "adapter" and self._responder_override:
+            raise ValueError("adapter-owned answers cannot override the user responder")
         verifier = HostVerifier(
             self._spec.task_id,
             self._spec.episode_id,
@@ -471,6 +476,7 @@ class EpisodeRunner:
             supervisor,
             verifier,
             rescue_required=self._mark_rescue_required,
+            answer_owner=self._answer_owner,
         )
         self._session = session
 
@@ -1200,13 +1206,27 @@ class EpisodeRunner:
             prompt=prompt,
         )
         session.begin_ask(begin)
-        answer = await self._responder.ask(prompt, self._config.ask_deadline_ms)
-        if answer is None:
-            # An outstanding ask may not be left open, and there is no way to
-            # withdraw one. Cancelling is the only coherent resolution.
+        if self._answer_owner == "adapter":
+            # The simulator lives behind the adapter boundary. A null-answer
+            # exchange generates once; sending a host finish would generate twice.
+            result = await session.finish_ask(begin, timeout=self._config.step_timeout)
+            answer = result.answer
+        else:
+            answer = await self._responder.ask(prompt, self._config.ask_deadline_ms)
+            if answer is None:
+                raise _Cancelled("ask-user was not answered")
+            finish = AskUserExchangeParams(
+                operation_id=f"ask-finish-{ask_id}",
+                episode_id=begin.episode_id,
+                ask_id=ask_id,
+                prompt=prompt,
+                answer=answer,
+            )
+            result = await session.finish_ask(finish, timeout=self._config.step_timeout)
+        # Refusal is a clean, unscored cancellation, never permission to publish
+        # a host substitute or a synthetic empty answer into the model history.
+        if not result.accepted or answer is None:
             raise _Cancelled("ask-user was not answered")
-        finish = begin.model_copy(update={"operation_id": f"ask-finish-{ask_id}", "answer": answer})
-        result = await session.finish_ask(finish, timeout=self._config.step_timeout)
         request_artifact = self._publish(prompt.encode("utf-8"), media_type="text/plain")
         response_artifact = self._publish(answer.encode("utf-8"), media_type="text/plain")
         exchange_id = ask_id

--- a/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
+++ b/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
@@ -1353,6 +1353,179 @@ async def test_execute_settles_after_the_batch_and_respond_without_simulator_is_
         assert (await provider.observe())["screenshot"] == b"png"
 
 
+class _OpaqueSimulatorValue:
+    def __str__(self) -> str:
+        raise AssertionError("private simulator objects must not be stringified")
+
+
+_SIMULATOR_VALUES = [
+    None,
+    123,
+    {"internal": "PRIVATE_SIMULATOR_CANARY"},
+    _OpaqueSimulatorValue(),
+    "public answer",
+    "",
+    "   ",
+]
+_SIMULATOR_IDS = [
+    "refusal",
+    "number",
+    "mapping",
+    "opaque-object",
+    "public-string",
+    "empty",
+    "whitespace",
+]
+
+
+def _answer_adapter(tmp_path: Path, stubs: _Stubs, value: Any) -> Any:
+    from types import SimpleNamespace
+    from unittest.mock import Mock
+
+    from lop_osworld_v2_adapter.adapter import OSWorldV2Adapter
+
+    provider = AwsProvider(CREDS, region=REGION, lease_ref="lop-ttl-answer", clients=stubs.clients)
+    respond = Mock(return_value=value)
+    provider._env = SimpleNamespace(user_simulator=SimpleNamespace(respond=respond))
+    adapter = OSWorldV2Adapter(workspace_root=tmp_path)
+    # Only the upstream simulator is scripted. No task module, profile, cloud
+    # allocation or FakeProvider participates in this answer-bearing boundary.
+    adapter._task = taskfile.TaskDescriptor(
+        task_id="synthetic",
+        instruction="",
+        source_sha256="0" * 64,
+        user_simulator={"type": "scripted"},
+    )
+    adapter._provider = provider
+    return adapter, respond
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", _SIMULATOR_VALUES, ids=_SIMULATOR_IDS)
+@pytest.mark.parametrize("boundary", ["provider", "adapter"])
+async def test_real_aws_simulator_answer_contract(
+    tmp_path: Path, value: Any, boundary: str
+) -> None:
+    from pydantic import ValidationError
+
+    from local_operator.evaluation.adapters.api import AskUserExchangeParams
+
+    with _Stubs() as stubs:
+        adapter, respond = _answer_adapter(tmp_path, stubs, value)
+        params = AskUserExchangeParams(
+            operation_id="begin", episode_id="episode", ask_id="ask", prompt="Public question?"
+        )
+
+        async def call() -> Any:
+            if boundary == "provider":
+                return await adapter._provider.respond(params.prompt)
+            return await adapter.ask_user_exchange(params)
+
+        if value is not None and not isinstance(value, str):
+            with pytest.raises(TypeError) as error:
+                await call()
+            assert str(error.value) == "simulator response must be a string or None"
+        elif boundary == "adapter" and isinstance(value, str) and not value.strip():
+            with pytest.raises(ValidationError):
+                await call()
+        else:
+            result = await call()
+            if boundary == "provider":
+                assert result is value
+            else:
+                assert result.accepted == (value is not None)
+                assert result.answer == value and result.request_digest == params.request_digest
+        respond.assert_called_once_with("Public question?")
+        assert not stubs.http_calls and not stubs.guest_posts
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", _SIMULATOR_VALUES, ids=_SIMULATOR_IDS)
+async def test_real_aws_answer_never_publishes_coerced_values(
+    tmp_path: Path, episode_id: str, value: Any
+) -> None:
+    from types import SimpleNamespace
+
+    from local_operator.evaluation.evidence.models import UserSimulatorExchangePayload
+    from local_operator.evaluation.evidence.verify import verify_bundle
+    from local_operator.evaluation.runner.episode import EpisodeRunner
+    from tests.unit.evaluation.runner.conftest import (
+        FakeAdapter,
+        ScriptedModel,
+        build_config,
+        build_spec,
+        payloads,
+        selector,
+    )
+
+    with _Stubs() as stubs:
+        adapter, respond = _answer_adapter(tmp_path, stubs, value)
+
+        class AnswerTransport(FakeAdapter):
+            # Reuse the existing no-cloud lifecycle fixture for everything
+            # except the real OSWorld -> AwsProvider -> upstream answer path.
+            async def handshake(self, *, timeout: float = 10.0) -> Any:
+                result = await super().handshake(timeout=timeout)
+                metadata = result.metadata.model_copy(
+                    update={"capabilities": adapter.metadata.capabilities}
+                )
+                return result.model_copy(update={"metadata": metadata})
+
+            async def _call_raw(
+                self, method: Any, params: Any, result_type: Any, *, timeout: float
+            ) -> Any:
+                if method == "ask_user_exchange":
+                    self.calls.append(method)
+                    return await adapter.ask_user_exchange(params)
+                return await super()._call_raw(method, params, result_type, timeout=timeout)
+
+        async def rescue(descriptor: Any, **kwargs: Any) -> Any:
+            return SimpleNamespace(complete=True)
+
+        transport = AnswerTransport(tmp_path, episode_id)
+        model = ScriptedModel(["ask", "finish"])
+        outcome = await EpisodeRunner(
+            build_spec(episode_id),
+            build_config(tmp_path),
+            selector=selector(tmp_path),
+            model=model,
+            launch=lambda _: transport,
+            rescue=rescue,
+            synthetic_model=True,
+        ).run()
+        respond.assert_called_once_with("What next?")
+        assert transport.calls.count("ask_user_exchange") == 1
+        assert outcome.bundle_root is not None
+        report = verify_bundle(outcome.bundle_root)
+        assert report.valid, report.issues
+        exchanges = payloads(outcome.bundle_root, UserSimulatorExchangePayload)
+        if isinstance(value, str) and value.strip():
+            assert outcome.status == "completed", outcome.diagnostic
+            assert len(exchanges) == 1 and model.calls == 2
+            answer_file = next(
+                path
+                for path in outcome.bundle_root.rglob(exchanges[0].response_artifact.sha256)
+                if path.is_file()
+            )
+            assert answer_file.read_text() == value
+            assert model.histories[1][0].ask_answer == value
+        else:
+            assert outcome.status == (
+                "cancelled" if value is None else "failed"
+            ), outcome.diagnostic
+            assert outcome.score is not None and outcome.score.status == "unscored"
+            assert not exchanges and model.calls == 1
+            assert all(turn.ask_answer is None for history in model.histories for turn in history)
+            assert "execute" not in transport.calls and "score" not in transport.calls
+            assert "PRIVATE_SIMULATOR_CANARY" not in (outcome.diagnostic or "")
+            assert not any(
+                b"PRIVATE_SIMULATOR_CANARY" in path.read_bytes()
+                for path in outcome.bundle_root.rglob("*")
+                if path.is_file()
+            )
+        assert not stubs.http_calls and not stubs.guest_posts
+
+
 # ---------------------------------------------------------------------------
 # audit
 # ---------------------------------------------------------------------------

--- a/tests/unit/evaluation/adapters/osworld/test_build_and_scripts.py
+++ b/tests/unit/evaluation/adapters/osworld/test_build_and_scripts.py
@@ -91,7 +91,7 @@ def runner_descriptor(tmp_path: Path, episode_id: str, *, secret_refs: Any = ())
 
     tmp_path.mkdir(parents=True, exist_ok=True)
     return RescueDescriptor(
-        schema_version="1.5",
+        schema_version="1.6",
         selector=selector(tmp_path),
         handshake=handshake(tmp_path),
         episode_id=episode_id,

--- a/tests/unit/evaluation/adapters/osworld/test_fake_end_to_end.py
+++ b/tests/unit/evaluation/adapters/osworld/test_fake_end_to_end.py
@@ -266,7 +266,6 @@ async def test_an_unanswered_ask_cancels_the_episode(tmp_path: Path, episode_id:
         build_config(tmp_path),
         selector=selector,
         model=ScriptedModel(["ask"]),
-        responder=RecordingResponder(None),  # the user never answers
         launch=lambda _selector: shim,
     )
     outcome = await runner.run()
@@ -278,25 +277,24 @@ async def test_an_unanswered_ask_cancels_the_episode(tmp_path: Path, episode_id:
 
 @pytest.mark.asyncio
 async def test_an_answered_ask_runs_the_exchange(tmp_path: Path, episode_id: str) -> None:
-    # The task declares no user_simulator, so the adapter refuses the exchange
-    # honestly (accepted=False) while the harness responder still supplies the
-    # answer the model sees — the documented one-sided PR 1 wiring.
-    provider = FakeProvider(has_user_simulator=False)
+    provider = FakeProvider(has_user_simulator=True, simulator_answer="simulator public reply")
     adapter = _adapter(tmp_path, provider)
+    (adapter._workspace_root / "tasks" / "task_plain.py").write_text(fixtures.SCRIPTED_SIMULATOR)
+    model = ScriptedModel(["ask", "finish"])
     selector = _selector(tmp_path, adapter._workspace_root, adapter)
     shim = _AdapterSupervisorShim(adapter, selector)
     runner = EpisodeRunner(
         _spec_with_task(episode_id),
         build_config(tmp_path),
         selector=selector,
-        model=ScriptedModel(["ask", "finish"]),
-        responder=RecordingResponder("the answer"),
+        model=model,
         launch=lambda _selector: shim,
     )
     outcome = await runner.run()
     assert outcome.status == "completed", outcome.diagnostic
     assert outcome.bundle_root is not None
     assert verify_bundle(outcome.bundle_root).valid
+    assert model.histories[1][0].ask_answer == "simulator public reply"
 
 
 @pytest.mark.asyncio
@@ -392,3 +390,57 @@ async def test_a_blind_guest_costs_a_re_read_not_the_episode(
 
     # The re-reads really happened: 1 reset + 2 failed + 2 successful.
     assert provider.observe_calls == 5
+
+
+@pytest.mark.asyncio
+async def test_adapter_owned_responder_override_fails_before_prepare(
+    tmp_path: Path, episode_id: str
+) -> None:
+    provider = FakeProvider(has_user_simulator=True)
+    adapter = _adapter(tmp_path, provider)
+    selector = _selector(tmp_path, adapter._workspace_root, adapter)
+    shim = _AdapterSupervisorShim(adapter, selector)
+    outcome = await EpisodeRunner(
+        _spec_with_task(episode_id),
+        build_config(tmp_path),
+        selector=selector,
+        model=ScriptedModel(["ask"]),
+        responder=RecordingResponder("host substitute"),
+        launch=lambda _: shim,
+    ).run()
+    assert outcome.status == "failed_pre_bundle", outcome.diagnostic
+    assert outcome.diagnostic is not None and "cannot override" in outcome.diagnostic
+    assert not provider.allocated and adapter._plan is None
+    assert shim.terminated
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("answer", [None, "public answer"])
+async def test_simulator_is_called_once_and_host_finish_is_refused(
+    tmp_path: Path, answer: str | None
+) -> None:
+    from local_operator.evaluation.adapters.api import AskUserExchangeParams
+    from unittest.mock import AsyncMock
+    from lop_osworld_v2_adapter import taskfile
+
+    provider = FakeProvider(has_user_simulator=True)
+    provider.respond = AsyncMock(return_value=answer)
+    adapter = _adapter(tmp_path, provider)
+    adapter._provider = provider
+    adapter._task = taskfile.load_static(
+        fixtures.SCRIPTED_SIMULATOR.encode(), module_name="synthetic.py"
+    )
+    begin = AskUserExchangeParams(
+        operation_id="begin", episode_id="episode", ask_id="ask", prompt="Public question?"
+    )
+    result = await adapter.ask_user_exchange(begin)
+    assert result.accepted == (answer is not None) and result.answer == answer
+    assert result.request_digest == begin.request_digest
+    provider.respond.assert_awaited_once_with("Public question?")
+    with pytest.raises(ValueError, match="adapter-owned"):
+        await adapter.ask_user_exchange(begin.model_copy(update={"answer": "host substitute"}))
+    provider.respond.assert_awaited_once()
+    adapter._task = taskfile.load_static(fixtures.PLAIN.encode(), module_name="synthetic.py")
+    refused = await adapter.ask_user_exchange(begin.model_copy(update={"ask_id": "no-simulator"}))
+    assert not refused.accepted and refused.answer is None
+    provider.respond.assert_awaited_once()

--- a/tests/unit/evaluation/adapters/osworld/test_fake_end_to_end.py
+++ b/tests/unit/evaluation/adapters/osworld/test_fake_end_to_end.py
@@ -419,9 +419,11 @@ async def test_adapter_owned_responder_override_fails_before_prepare(
 async def test_simulator_is_called_once_and_host_finish_is_refused(
     tmp_path: Path, answer: str | None
 ) -> None:
-    from local_operator.evaluation.adapters.api import AskUserExchangeParams
     from unittest.mock import AsyncMock
+
     from lop_osworld_v2_adapter import taskfile
+
+    from local_operator.evaluation.adapters.api import AskUserExchangeParams
 
     provider = FakeProvider(has_user_simulator=True)
     provider.respond = AsyncMock(return_value=answer)

--- a/tests/unit/evaluation/adapters/osworld/test_secrets_and_rescue.py
+++ b/tests/unit/evaluation/adapters/osworld/test_secrets_and_rescue.py
@@ -419,7 +419,7 @@ async def test_rescue_without_aws_secrets_fails_closed(
 
 
 def test_schema_is_1_2_and_secrets_live_only_on_reset_and_rescue() -> None:
-    assert ADAPTER_SCHEMA_VERSION == "1.5"
+    assert ADAPTER_SCHEMA_VERSION == "1.6"
     assert "secrets" in ResetStartParams.model_fields
     assert "secrets" in BeginRescueParams.model_fields
     assert "secrets" not in PrepareParams.model_fields

--- a/tests/unit/evaluation/adapters/osworld/test_spawn.py
+++ b/tests/unit/evaluation/adapters/osworld/test_spawn.py
@@ -355,9 +355,10 @@ def test_a_1_1_selector_cannot_even_be_built_against_a_1_2_parent(tmp_path: Path
 async def test_real_wheel_simulator_answer_enters_public_artifact_and_next_request(
     tmp_path: Path, episode_id: str, adapter_wheel: Path
 ) -> None:
+    import hashlib
+
     from local_operator.evaluation.evidence.models import UserSimulatorExchangePayload
     from tests.unit.evaluation.runner.test_episode_subprocess import _offline_ask_client
-    import hashlib
 
     selector = spawn_helpers.build_spawnable_adapter(
         tmp_path,

--- a/tests/unit/evaluation/adapters/osworld/test_spawn.py
+++ b/tests/unit/evaluation/adapters/osworld/test_spawn.py
@@ -349,3 +349,37 @@ def test_a_1_1_selector_cannot_even_be_built_against_a_1_2_parent(tmp_path: Path
             workspace_digest="c" * 64,
             route_capability="computer",
         )
+
+
+@pytest.mark.asyncio
+async def test_real_wheel_simulator_answer_enters_public_artifact_and_next_request(
+    tmp_path: Path, episode_id: str, adapter_wheel: Path
+) -> None:
+    from local_operator.evaluation.evidence.models import UserSimulatorExchangePayload
+    from tests.unit.evaluation.runner.test_episode_subprocess import _offline_ask_client
+    import hashlib
+
+    selector = spawn_helpers.build_spawnable_adapter(
+        tmp_path,
+        adapter_wheel,
+        {"task_plain": fixtures.SCRIPTED_SIMULATOR},
+        provider={"provider": "fake", "has_user_simulator": True},
+    )
+    config = spawn_helpers.spawn_config(tmp_path)
+    model, stream = _offline_ask_client(config.artifact_root)
+    outcome = await EpisodeRunner(
+        _spec_for_spawn(episode_id), config, selector=selector, model=model, synthetic_model=True
+    ).run()
+    assert outcome.status == "completed", outcome.diagnostic
+    assert outcome.bundle_root is not None
+    report = verify_bundle(outcome.bundle_root)
+    assert report.valid, report.issues
+    exchanges = payloads(outcome.bundle_root, UserSimulatorExchangePayload)
+    assert len(exchanges) == 1
+    answer = b"simulated user answer"
+    assert exchanges[0].response_artifact.sha256 == hashlib.sha256(answer).hexdigest()
+    assert len(stream.requests) == 2
+    assert (
+        "Answer from the user: simulated user answer"
+        in stream.requests[1].messages[-1].content[0].text
+    )

--- a/tests/unit/evaluation/adapters/test_api.py
+++ b/tests/unit/evaluation/adapters/test_api.py
@@ -27,7 +27,7 @@ def selector(tmp_path: Path) -> AdapterSelector:
     workspace = tmp_path / "workspace"
     workspace.mkdir(exist_ok=True)
     return AdapterSelector(
-        schema_version="1.5",
+        schema_version="1.6",
         adapter_id="tiny",
         distribution="tiny-adapter",
         version="1.2.3",
@@ -49,7 +49,7 @@ def metadata() -> AdapterMetadata:
         entry_point="tiny_adapter:create",
         package_digest=DIGEST,
         release_digest="b" * 64,
-        schema_version="1.5",
+        schema_version="1.6",
         capabilities=AdapterCapabilities(routes=("computer",), ask_user=True, scoring=True),
     )
 
@@ -133,7 +133,7 @@ def test_scoped_infra_has_no_provider_or_model_purpose() -> None:
 def test_rescue_descriptor_is_content_bound_and_has_refs_not_secrets(tmp_path: Path) -> None:
     selected = selector(tmp_path)
     descriptor = RescueDescriptor(
-        schema_version="1.5",
+        schema_version="1.6",
         selector=selected,
         handshake=handshake(tmp_path),
         episode_id="episode",
@@ -151,3 +151,45 @@ def test_rescue_descriptor_is_content_bound_and_has_refs_not_secrets(tmp_path: P
     changed["episode_id"] = "different"
     with pytest.raises(ValidationError):
         RescueDescriptor.model_validate(changed, strict=True)
+
+
+@pytest.mark.parametrize("answer", ["", "   ", "x" * 100_001])
+def test_public_answer_is_nonempty_and_bounded(answer: str) -> None:
+    from local_operator.evaluation.adapters.api import AskUserExchangeResult
+
+    with pytest.raises(ValidationError):
+        AskUserExchangeResult(ask_id="ask", request_digest=DIGEST, accepted=True, answer=answer)
+
+
+def test_answer_ownership_is_explicit_and_refusal_has_no_answer() -> None:
+    from local_operator.evaluation.adapters.api import AskUserExchangeResult
+
+    assert (
+        AdapterCapabilities(routes=("computer",), ask_user=True, scoring=True).ask_user_answer_owner
+        == "host"
+    )
+    with pytest.raises(ValidationError, match="requires ask_user"):
+        AdapterCapabilities(
+            routes=("computer",), ask_user=False, scoring=True, ask_user_answer_owner="adapter"
+        )
+    with pytest.raises(ValidationError):
+        AdapterCapabilities.model_validate(
+            {
+                "routes": ["computer"],
+                "ask_user": True,
+                "scoring": True,
+                "ask_user_answer_owner": "auto",
+            }
+        )
+    with pytest.raises(ValidationError, match="accepted"):
+        AskUserExchangeResult(
+            ask_id="ask", request_digest=DIGEST, accepted=False, answer="substitute"
+        )
+
+
+@pytest.mark.parametrize("version", ["1.4", "1.5"])
+def test_pre_ownership_wire_is_rejected(version: str, tmp_path: Path) -> None:
+    data = selector(tmp_path).model_dump(mode="json")
+    data["schema_version"] = version
+    with pytest.raises(ValidationError, match="1.6"):
+        AdapterSelector.model_validate(data)

--- a/tests/unit/evaluation/adapters/test_discovery.py
+++ b/tests/unit/evaluation/adapters/test_discovery.py
@@ -101,7 +101,7 @@ def selected(tmp_path: Path, digest: str) -> AdapterSelector:
         shutil.copy2(Path(sys.executable).resolve(), executable)
         executable.chmod(0o755)
     return AdapterSelector(
-        schema_version="1.5",
+        schema_version="1.6",
         adapter_id="tiny",
         distribution="tiny-adapter",
         version="1.0",

--- a/tests/unit/evaluation/adapters/test_launch.py
+++ b/tests/unit/evaluation/adapters/test_launch.py
@@ -75,7 +75,7 @@ def create():
             entry_point="tiny_e2e_adapter:create",
             package_digest=distribution_digest(installed),
             release_digest="%s",
-            schema_version="1.5",
+            schema_version="1.6",
             capabilities=AdapterCapabilities(
                 routes=("computer",), ask_user=False, scoring=False
             ),
@@ -170,7 +170,7 @@ def create():
             entry_point="rescue_e2e_adapter:create",
             package_digest=distribution_digest(installed),
             release_digest="{release}",
-            schema_version="1.5",
+            schema_version="1.6",
             capabilities=AdapterCapabilities(
                 routes=("computer",), ask_user=False, scoring=False
             ),
@@ -272,7 +272,7 @@ async def test_supervisor_launch_completes_real_handshake_and_reaps(tmp_path: Pa
         json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
     )
     selector = AdapterSelector(
-        schema_version="1.5",
+        schema_version="1.6",
         adapter_id="tiny-e2e",
         distribution="tiny-e2e-adapter",
         version="1.0",
@@ -317,7 +317,7 @@ def _rescue_selector(tmp_path: Path) -> AdapterSelector:
         json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
     )
     return AdapterSelector(
-        schema_version="1.5",
+        schema_version="1.6",
         adapter_id="rescue-e2e",
         distribution="rescue-e2e-adapter",
         version="1.0",
@@ -348,7 +348,7 @@ def _rescue_descriptor(selector: AdapterSelector, handshake: Handshake, root: Pa
         ),
     )
     return RescueDescriptor(
-        schema_version="1.5",
+        schema_version="1.6",
         selector=selector,
         handshake=handshake,
         episode_id="episode",
@@ -422,7 +422,7 @@ async def test_spawned_rescue_worker_refuses_an_adapter_without_begin_rescue(
         json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
     )
     selector = AdapterSelector(
-        schema_version="1.5",
+        schema_version="1.6",
         adapter_id="tiny-e2e",
         distribution="tiny-e2e-adapter",
         version="1.0",
@@ -513,7 +513,7 @@ def create():
             entry_point="failing_e2e_adapter:create",
             package_digest=distribution_digest(installed),
             release_digest="{release}",
-            schema_version="1.5",
+            schema_version="1.6",
             capabilities=AdapterCapabilities(
                 routes=("computer",), ask_user=False, scoring=False
             ),
@@ -540,7 +540,7 @@ def _failing_selector(tmp_path: Path) -> AdapterSelector:
         json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
     )
     return AdapterSelector(
-        schema_version="1.5",
+        schema_version="1.6",
         adapter_id="failing-e2e",
         distribution="failing-e2e-adapter",
         version="1.0",
@@ -697,7 +697,7 @@ def create():
             entry_point="leaky_e2e_adapter:create",
             package_digest=distribution_digest(installed),
             release_digest="{release}",
-            schema_version="1.5",
+            schema_version="1.6",
             capabilities=AdapterCapabilities(
                 routes=("computer",), ask_user=False, scoring=False
             ),
@@ -724,7 +724,7 @@ def _leaky_selector(tmp_path: Path) -> AdapterSelector:
         json.dumps({"release_digest": RELEASE_DIGEST}, separators=(",", ":"), sort_keys=True)
     )
     return AdapterSelector(
-        schema_version="1.5",
+        schema_version="1.6",
         adapter_id="leaky-e2e",
         distribution="leaky-e2e-adapter",
         version="1.0",

--- a/tests/unit/evaluation/adapters/test_supervisor.py
+++ b/tests/unit/evaluation/adapters/test_supervisor.py
@@ -68,7 +68,7 @@ def selector(tmp_path: Path) -> AdapterSelector:
     workspace = tmp_path / "workspace"
     workspace.mkdir(exist_ok=True)
     return AdapterSelector(
-        schema_version="1.5",
+        schema_version="1.6",
         adapter_id="tiny",
         distribution="tiny-adapter",
         version="1.0",
@@ -90,7 +90,7 @@ def metadata() -> AdapterMetadata:
         entry_point="tiny_adapter:create",
         package_digest="a" * 64,
         release_digest="b" * 64,
-        schema_version="1.5",
+        schema_version="1.6",
         capabilities=AdapterCapabilities(routes=("computer",), ask_user=False, scoring=True),
     )
 
@@ -122,7 +122,7 @@ def plan() -> CleanupPlan:
 
 def descriptor(tmp_path: Path) -> RescueDescriptor:
     return RescueDescriptor(
-        schema_version="1.5",
+        schema_version="1.6",
         selector=selector(tmp_path),
         handshake=handshake(tmp_path),
         episode_id="episode",
@@ -198,7 +198,7 @@ def test_ask_exchange_requires_expected_episode_and_preserves_pending_on_error(
         prompt="Question?",
         answer="Answer",
     )
-    result = AskUserExchangeResult(ask_id="ask", accepted=True)
+    result = AskUserExchangeResult(ask_id="ask", request_digest=begin.request_digest, accepted=True)
     with pytest.raises(SupervisionError, match="stale, unsolicited, or mismatched"):
         verifier.finish_ask(wrong_finish, result)
     changed_prompt = wrong_finish.model_copy(
@@ -276,7 +276,7 @@ def test_score_missing_artifact_can_retry_after_file_appears(tmp_path: Path) -> 
 
 def test_changed_ask_prompt_is_rejected_without_dispatch(tmp_path: Path) -> None:
     verifier = HostVerifier("task", "episode", tmp_path)
-    raw = RawSupervisor([AskUserExchangeResult(ask_id="ask", accepted=True)])
+    raw = RawSupervisor([])
     session = VerifiedAdapterSession(raw, verifier)  # type: ignore[arg-type]
     begin = AskUserExchangeParams(
         operation_id="begin", episode_id="episode", ask_id="ask", prompt="Original?"
@@ -694,7 +694,8 @@ def test_only_a_declared_observation_phase_escapes_the_poison(tmp_path: Path, ph
     assert rescue_required == ([True] if poisoned else [])
 
 
-def test_a_timeout_never_claims_the_observation_phase(tmp_path: Path) -> None:
+@pytest.mark.parametrize("method", ["execute", "ask_user_exchange"])
+def test_a_timeout_never_claims_the_observation_phase(tmp_path: Path, method: str) -> None:
     """A call that was never ANSWERED is ambiguous whatever its phase would be.
 
     A timeout is the case where the worker may still be mid-mutation, so it
@@ -710,13 +711,76 @@ def test_a_timeout_never_claims_the_observation_phase(tmp_path: Path) -> None:
         raw,  # pyright: ignore[reportArgumentType]
         verifier,
         rescue_required=lambda: rescue_required.append(True),
+        answer_owner="adapter",
     )
+    begin = AskUserExchangeParams(
+        operation_id="begin", episode_id="episode", ask_id="ask", prompt="Question?"
+    )
+    if method == "ask_user_exchange":
+        session.begin_ask(begin)
+
+    async def call() -> None:
+        if method == "ask_user_exchange":
+            await session.finish_ask(begin, timeout=1)
+        else:
+            await session.execute(_execute_params(verifier.current_observation), timeout=1)
 
     async def run() -> None:
         with pytest.raises(TimeoutError):
-            await session.execute(_execute_params(verifier.current_observation), timeout=1)
+            await call()
+        # An explicit second attempt must also fail locally: a simulator may
+        # have generated before the connection died, even without a reply.
+        with pytest.raises(SupervisionError, match="poisoned"):
+            await call()
+        assert raw.calls == [method]
 
     import asyncio
 
     asyncio.run(run())
     assert raw.terminated and rescue_required == [True]
+
+
+@pytest.mark.parametrize("owner", ["host", "adapter"])
+def test_ask_completion_binds_public_request_and_completes_once(tmp_path: Path, owner: str) -> None:
+    verifier = HostVerifier("task", "episode", tmp_path)
+    begin = AskUserExchangeParams(
+        operation_id="begin", episode_id="episode", ask_id="ask", prompt="Original?"
+    )
+    verifier.begin_ask(begin)
+    finish = begin if owner == "adapter" else begin.model_copy(update={"answer": "host answer"})
+    result = AskUserExchangeResult(
+        ask_id="ask",
+        request_digest=begin.request_digest,
+        accepted=True,
+        answer="public answer" if owner == "adapter" else None,
+    )
+    for update in ({"ask_id": "wrong"}, {"request_digest": "f" * 64}):
+        with pytest.raises(SupervisionError, match="mismatched"):
+            verifier.finish_ask(finish, result.model_copy(update=update), answer_owner=owner)
+    for update in ({"prompt": "Changed?"}, {"episode_id": "wrong"}, {"ask_id": "wrong"}):
+        with pytest.raises(SupervisionError, match="mismatched"):
+            verifier.finish_ask(finish.model_copy(update=update), result, answer_owner=owner)
+    verifier.finish_ask(finish, result, answer_owner=owner)
+    with pytest.raises(SupervisionError, match="mismatched"):
+        verifier.finish_ask(finish, result, answer_owner=owner)
+    with pytest.raises(SupervisionError, match="begin once"):
+        verifier.begin_ask(begin)
+
+
+@pytest.mark.parametrize(
+    "owner,accepted,answer", [("adapter", True, None), ("host", True, "unexpected")]
+)
+def test_completion_rejects_incompatible_ownership(
+    tmp_path: Path, owner: str, accepted: bool, answer: str | None
+) -> None:
+    verifier = HostVerifier("task", "episode", tmp_path)
+    begin = AskUserExchangeParams(
+        operation_id="begin", episode_id="episode", ask_id="ask", prompt="Question?"
+    )
+    verifier.begin_ask(begin)
+    params = begin if owner == "adapter" else begin.model_copy(update={"answer": "host"})
+    result = AskUserExchangeResult(
+        ask_id="ask", request_digest=begin.request_digest, accepted=accepted, answer=answer
+    )
+    with pytest.raises(SupervisionError, match="answer"):
+        verifier.finish_ask(params, result, answer_owner=owner)

--- a/tests/unit/evaluation/adapters/test_worker.py
+++ b/tests/unit/evaluation/adapters/test_worker.py
@@ -279,7 +279,7 @@ def rescue_selector(tmp_path: Path) -> AdapterSelector:
     release_digest = "b" * 64
     (workspace / "adapter-release.json").write_text(f'{{"release_digest":"{release_digest}"}}')
     return AdapterSelector(
-        schema_version="1.5",
+        schema_version="1.6",
         adapter_id="rescue",
         distribution="rescue-adapter",
         version="1.0",
@@ -301,7 +301,7 @@ def rescue_metadata() -> AdapterMetadata:
         entry_point="rescue_adapter:create",
         package_digest="a" * 64,
         release_digest="b" * 64,
-        schema_version="1.5",
+        schema_version="1.6",
         capabilities=AdapterCapabilities(routes=("computer",), ask_user=False, scoring=False),
     )
 
@@ -348,7 +348,7 @@ async def test_real_worker_rescue_invokes_each_cleanup_once_and_blocks_normal_fl
             ),
         )
         descriptor = RescueDescriptor(
-            schema_version="1.5",
+            schema_version="1.6",
             selector=selected,
             handshake=handshake,
             episode_id="episode",
@@ -470,7 +470,7 @@ def test_rescue_cleanup_rejects_forged_episode_and_action_without_losing_pin(
         selected_route="computer",
     )
     descriptor = RescueDescriptor(
-        schema_version="1.5",
+        schema_version="1.6",
         selector=selected,
         handshake=pinned_handshake,
         episode_id="episode",

--- a/tests/unit/evaluation/runner/conftest.py
+++ b/tests/unit/evaluation/runner/conftest.py
@@ -73,7 +73,7 @@ def selector(tmp_path: Path) -> AdapterSelector:
     workspace = tmp_path / "workspace"
     workspace.mkdir(exist_ok=True)
     return AdapterSelector(
-        schema_version="1.5",
+        schema_version="1.6",
         adapter_id="tiny",
         distribution="tiny-adapter",
         version="1.0",
@@ -97,7 +97,7 @@ def handshake(tmp_path: Path) -> Handshake:
             entry_point="tiny_adapter:create",
             package_digest="a" * 64,
             release_digest="b" * 64,
-            schema_version="1.5",
+            schema_version="1.6",
             capabilities=AdapterCapabilities(routes=("computer",), ask_user=True, scoring=True),
         ),
         python=PythonRuntime.current(),
@@ -288,7 +288,9 @@ class FakeAdapter:
             self.current = output
             return ExecuteResult(observation=output, receipt=receipt)
         if method == "ask_user_exchange":
-            return AskUserExchangeResult(ask_id=params.ask_id, accepted=True)
+            return AskUserExchangeResult(
+                ask_id=params.ask_id, request_digest=params.request_digest, accepted=True
+            )
         if method == "score":
             return ScoreResult(score=self.score)
         if method == "cleanup":

--- a/tests/unit/evaluation/runner/test_episode.py
+++ b/tests/unit/evaluation/runner/test_episode.py
@@ -1514,3 +1514,37 @@ def test_an_undisclosed_infra_value_is_never_stamped() -> None:
     assert run_episode._infra_disclosure_metadata(
         ["AWS_INSTANCE_TYPE=m5.xlarge", "AWS_ROOT_VOLUME_SIZE=120", "OSWORLD_TTL_SECONDS=900"]
     ) == {"aws_instance_type_override": "m5.xlarge", "aws_root_volume_size_override": "120"}
+
+
+@pytest.mark.asyncio
+async def test_host_refusal_does_not_publish_supplied_answer(
+    tmp_path: Path, episode_id: str
+) -> None:
+    from local_operator.evaluation.adapters.api import AskUserExchangeResult
+
+    adapter = FakeAdapter(tmp_path, episode_id)
+    original = adapter._call_raw
+
+    async def refusing(method: Any, params: Any, result_type: Any, *, timeout: float) -> Any:
+        if method == "ask_user_exchange":
+            adapter.calls.append(method)
+            return AskUserExchangeResult(
+                ask_id=params.ask_id, request_digest=params.request_digest, accepted=False
+            )
+        return await original(method, params, result_type, timeout=timeout)
+
+    adapter._call_raw = refusing
+    model = ScriptedModel(["ask", "finish"])
+    outcome = await _runner(
+        tmp_path,
+        episode_id,
+        adapter=adapter,
+        model=model,
+        responder=RecordingResponder("must not publish"),
+    ).run()
+    assert outcome.status == "cancelled", outcome.diagnostic
+    assert outcome.score is not None and outcome.score.status == "unscored"
+    assert model.calls == 1
+    assert outcome.bundle_root is not None
+    assert "user_simulator_exchange" not in _kinds(outcome.bundle_root)
+    assert "execute" not in adapter.calls and "score" not in adapter.calls

--- a/tests/unit/evaluation/runner/test_episode_subprocess.py
+++ b/tests/unit/evaluation/runner/test_episode_subprocess.py
@@ -1086,7 +1086,10 @@ async def test_worker_importing_from_the_workspace_leaves_no_bytecode_behind(
 
 
 def _offline_ask_client(artifact_root: Path) -> tuple[Any, Any]:
-    from tests.unit.evaluation.runner.test_provider_client import RecordingStream, _client
+    from tests.unit.evaluation.runner.test_provider_client import (
+        RecordingStream,
+        _client,
+    )
 
     def reply(message: Any) -> str:
         text = message.content[0].text

--- a/tests/unit/evaluation/runner/test_episode_subprocess.py
+++ b/tests/unit/evaluation/runner/test_episode_subprocess.py
@@ -53,6 +53,7 @@ from local_operator.evaluation.adapters.api import (
     AckResult,
     AdapterCapabilities,
     AdapterMetadata,
+    AskUserExchangeResult,
     CleanupOutcome,
     CleanupResult,
     ExecuteResult,
@@ -374,7 +375,38 @@ class TinyAdapter:
         return ExecuteResult(observation=output, receipt=receipt)
 
     async def ask_user_exchange(self, params):
-        raise NotImplementedError
+        from pathlib import Path
+        import asyncio
+        site = Path(__file__).parent
+        mode = (site / "tiny_ask_mode").read_text() if (site / "tiny_ask_mode").exists() else "host"
+        with (site / "tiny_ask_calls").open("a") as handle:
+            handle.write(str(params.answer) + "\\n")
+        answer = None
+        if mode != "host":
+            assert params.answer is None
+            # A second generation is observably different, so a retry cannot
+            # accidentally pass as the same public reply.
+            count = len((site / "tiny_ask_calls").read_text().splitlines())
+            answer = "public simulator answer " + str(count)
+            if mode == "timeout":
+                await asyncio.sleep(60)
+            if mode in ("refuse", "missing-answer"):
+                answer = None
+            if mode == "empty":
+                answer = ""
+            if mode == "oversize":
+                answer = "x" * 100_001
+        bound = params
+        if mode == "wrong-prompt":
+            bound = params.model_copy(update={"prompt": "different question"})
+        if mode == "wrong-episode":
+            bound = params.model_copy(update={"episode_id": "wrong-episode"})
+        return AskUserExchangeResult(
+            ask_id="wrong" if mode == "wrong-id" else params.ask_id,
+            request_digest=bound.request_digest,
+            accepted=mode not in ("refuse", "refusal-answer"),
+            answer=answer,
+        )
 
     async def score(self, params):
         self._maybe_die("score")
@@ -399,6 +431,9 @@ class TinyAdapter:
 
 
 def create():
+    from pathlib import Path
+    mode_path = Path(__file__).parent / "tiny_ask_mode"
+    mode = mode_path.read_text() if mode_path.exists() else "host"
     installed = distribution("tiny-runner-adapter")
     return TinyAdapter(
         AdapterMetadata(
@@ -408,9 +443,10 @@ def create():
             entry_point="tiny_runner_adapter:create",
             package_digest=distribution_digest(installed),
             release_digest="%s",
-            schema_version="1.5",
+            schema_version="1.5" if mode == "old-schema" else "1.6",
             capabilities=AdapterCapabilities(
-                routes=("computer",), ask_user=False, scoring=True
+                routes=("computer",), ask_user=mode != "invalid-capability", scoring=True,
+                ask_user_answer_owner="host" if mode == "host" else "adapter",
             ),
         )
     )
@@ -479,7 +515,7 @@ def real_selector(tmp_path: Path, adapter_site: Path) -> AdapterSelector:
     (workspace / "tasks" / "pkg").mkdir(exist_ok=True)
     (workspace / "tasks" / "pkg" / "mod.py").write_text("MARK = 'nested'\n")
     return AdapterSelector(
-        schema_version="1.5",
+        schema_version="1.6",
         adapter_id="tiny-runner",
         distribution="tiny-runner-adapter",
         version="1.0",
@@ -504,16 +540,16 @@ def _subprocess_config(tmp_path: Path, **overrides: Any) -> Any:
     assertion into a flake about machine speed rather than about the runner.
     """
 
-    return build_config(
-        tmp_path,
+    defaults = dict(
         handshake_timeout=60.0,
         prepare_timeout=60.0,
         reset_timeout=60.0,
         step_timeout=60.0,
         score_timeout=60.0,
         cleanup_timeout=60.0,
-        **overrides,
     )
+    defaults.update(overrides)
+    return build_config(tmp_path, **defaults)
 
 
 def _arm_cutpoint(site: Path, cutpoint: str | None) -> None:
@@ -1047,3 +1083,140 @@ async def test_worker_importing_from_the_workspace_leaves_no_bytecode_behind(
     assert caches == [], caches
     assert not list(workspace.rglob("*.pyc"))
     assert workspace_digest(str(workspace)) == real_selector.workspace_digest
+
+
+def _offline_ask_client(artifact_root: Path) -> tuple[Any, Any]:
+    from tests.unit.evaluation.runner.test_provider_client import RecordingStream, _client
+
+    def reply(message: Any) -> str:
+        text = message.content[0].text
+        observation_id = next(
+            line.split(": ", 1)[1]
+            for line in text.splitlines()
+            if line.startswith("Observation ID: ")
+        )
+        action = (
+            {"kind": "ask_user", "request_id": "public-ask", "question": "What next?"}
+            if len(stream.requests) == 1
+            else {"kind": "finish", "status": "done", "reason": "answered"}
+        )
+        return json.dumps({"actions": [{"observation_id": observation_id, **action}]})
+
+    stream = RecordingStream(reply)
+    return _client(stream, artifact_root), stream
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("owner", ["adapter", "host"])
+async def test_public_answer_crosses_worker_into_next_model_request(
+    tmp_path: Path, episode_id: str, real_selector: AdapterSelector, adapter_site: Path, owner: str
+) -> None:
+    from local_operator.evaluation.evidence.models import UserSimulatorExchangePayload
+    from tests.unit.evaluation.runner.conftest import RecordingResponder, payloads
+
+    (adapter_site / "tiny_ask_mode").write_text(owner)
+    config = _subprocess_config(tmp_path)
+    model, stream = _offline_ask_client(config.artifact_root)
+    responder = RecordingResponder("host public answer") if owner == "host" else None
+    outcome = await EpisodeRunner(
+        build_spec(episode_id),
+        config,
+        selector=real_selector,
+        model=model,
+        responder=responder,
+        synthetic_model=True,
+    ).run()
+    assert outcome.status == "completed", outcome.diagnostic
+    assert not outcome.rescue_required
+    assert outcome.bundle_root is not None
+    report = verify_bundle(outcome.bundle_root)
+    assert report.valid, report.issues
+    answer = "public simulator answer 1" if owner == "adapter" else "host public answer"
+    calls = (adapter_site / "tiny_ask_calls").read_text().splitlines()
+    assert calls == (["None"] if owner == "adapter" else [answer])
+    assert len(stream.requests) == 2
+    assert f"Answer from the user: {answer}" in stream.requests[1].messages[-1].content[0].text
+    exchanges = payloads(outcome.bundle_root, UserSimulatorExchangePayload)
+    assert len(exchanges) == 1
+    artifact = exchanges[0].response_artifact
+    assert artifact.sha256 == hashlib.sha256(answer.encode()).hexdigest()
+    assert any(
+        path.read_bytes() == answer.encode()
+        for path in outcome.bundle_root.rglob(artifact.sha256)
+        if path.is_file()
+    )
+    kinds = [event.kind for event in report.events]
+    index = kinds.index("user_simulator_exchange")
+    assert kinds[index + 1 : index + 3] == ["action_batch", "environment_step"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mode",
+    [
+        "refuse",
+        "timeout",
+        "host",
+        "wrong-id",
+        "wrong-prompt",
+        "wrong-episode",
+        "missing-answer",
+        "empty",
+        "oversize",
+        "refusal-answer",
+    ],
+)
+async def test_unanswered_or_ambiguous_exchange_never_regenerates(
+    tmp_path: Path, episode_id: str, real_selector: AdapterSelector, adapter_site: Path, mode: str
+) -> None:
+    from local_operator.evaluation.evidence.models import UserSimulatorExchangePayload
+    from tests.unit.evaluation.runner.conftest import payloads
+
+    (adapter_site / "tiny_ask_mode").write_text(mode)
+    config = _subprocess_config(tmp_path, step_timeout=0.5)
+    model, stream = _offline_ask_client(config.artifact_root)
+
+    rescued: list[Any] = []
+
+    async def rescue(descriptor: Any, **kwargs: Any) -> Any:
+        rescued.append(descriptor)
+        raise RuntimeError("synthetic rescue unavailable")
+
+    outcome = await EpisodeRunner(
+        build_spec(episode_id),
+        config,
+        selector=real_selector,
+        model=model,
+        synthetic_model=True,
+        rescue=rescue,
+    ).run()
+    ambiguous = mode not in ("refuse", "host")
+    assert outcome.status == ("failed" if ambiguous else "cancelled"), outcome.diagnostic
+    assert outcome.rescue_required == ambiguous
+    assert bool(rescued) == ambiguous
+    assert outcome.score is None or outcome.score.status == "unscored"
+    assert len(stream.requests) == 1
+    assert outcome.bundle_root is not None
+    assert not payloads(outcome.bundle_root, UserSimulatorExchangePayload)
+    calls = adapter_site / "tiny_ask_calls"
+    if mode == "host":
+        assert not calls.exists()
+    else:
+        assert calls.read_text().splitlines() == ["None"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["old-schema", "invalid-capability"])
+async def test_incompatible_ownership_protocol_fails_before_allocation(
+    tmp_path: Path, episode_id: str, real_selector: AdapterSelector, adapter_site: Path, mode: str
+) -> None:
+    (adapter_site / "tiny_ask_mode").write_text(mode)
+    config = _subprocess_config(tmp_path)
+    model = ScriptedModel(["ask"])
+    outcome = await EpisodeRunner(
+        build_spec(episode_id), config, selector=real_selector, model=model
+    ).run()
+    assert outcome.status == "failed_pre_bundle", outcome.diagnostic
+    assert model.calls == 0 and outcome.bundle_root is None
+    assert not list(config.artifact_root.iterdir())
+    assert not (adapter_site / "tiny_ask_calls").exists()

--- a/tests/unit/evaluation/test_action_surface.py
+++ b/tests/unit/evaluation/test_action_surface.py
@@ -124,7 +124,7 @@ def test_negotiation_controls_admission_prompt_and_schema_identity() -> None:
 
 
 def test_old_rpc_refused_before_allocation() -> None:
-    with pytest.raises(ValidationError, match="1.5"):
+    with pytest.raises(ValidationError, match="1.6"):
         AdapterSelector.model_validate({"schema_version": "1.4"})
 
 


### PR DESCRIPTION
## Summary

C2 standard/pre-authorized correction to the benchmark-neutral user-answer path. A representative pilot exposed that CLI episodes use NullUserResponder and cancel an ask before any simulator RPC; even a supplied host answer caused OSWorld to generate and discard a different answer. This PR transports the benchmark simulator's actual public answer through the existing exchange and model-input path.

## Delivery contract

- Adapter RPC1.6 negotiates explicit ask_user_answer_owner=host|adapter, host default. Ownership is taken only from the validated handshake, never from task name, credentials or ask_user boolean.
- Adapter-owned asks register locally, send ONE existing ask RPC with answer=null, receive a bounded public answer bound to episode/ask/prompt via request digest, validate acceptance, and finish locally. No second generation or host-finish RPC.
- Host-owned UserResponder behavior stays supported. Refused answers are not published; unanswered/refused asks cancel unscored. Explicit host responder overrides conflict with adapter ownership before prepare.
- Missing/empty/oversized/identity-mismatched replies fail closed; ambiguous timeout poisons/requires rescue without regeneration.
- OSWorld returns only provider.respond(prompt)'s intended public answer. No host-side task/profile loading, alternate simulator, private knowledge/context dump, or task-specific conditions.
- Reuse response artifacts, ask_answer, and next model input; exchange-before-batch ordering remains.

## Compatibility

This is an intentional strict wire-format change from1.5 to1.6. Old/new combinations fail before allocation; do not reinterpret old ask_user=True as answer ownership. Rebuild and repin host, adapter, selector and release artifacts together. Old evidence/runtime/rescue environments remain intact. Root and adapter distribution versions are unchanged in source; exact package and protocol pins identify the new artifact. No dependency, default TUI/mobile/CLI prompt, tool registry, or normal session behavior changes.

## Actual evidence

- Baseline _run_ask method replayed verbatim from481d4fb in a temporary plugin: real installed-worker test fails cancelled!=completed with 'ask-user was not answered'; adapter invocation count0. This isolates the old method, not a claim of rebuilding the entire old wheel.
- Fixed real ProviderModelClient → EpisodeRunner → supervisor → installed worker → adapter produces exactly one null-answer invocation; public artifact is exactly 'public simulator answer 1', and the next ChatRequest contains that same answer. Host-owned control receives its own host answer, separately.
- Installed OSWorld wheel with synthetic fixture also passes. No cloud, paid actor calls or gated task/evaluator/private profile reads were used.
- Bounded protocol/runner/OSWorld matrix plus merged proxy/scoped-infra tests:415 passed in186.15s (-n2).
- Final three touched test-module rerun:47 passed in119.95s, including real worker/wheel, refusal and timeout/no-regeneration proofs.
- Whole-tree pinned Black26.1.0 (940 unchanged), isort5.13.2, Flake87.3.0 and Pyright1.1.411 all pass; zero Pyright errors/warnings.
- Exact commands, artifact hashes and limits: docs/benchmarks/adapter-user-answers.md.

## F1 remediation evidence (round 1)

- Fixed F1 in `ffb64c7ded40fd57501781279cb18d398424512b`: real `AwsProvider.respond` preserves `None` and rejects non-string results with a value-free diagnostic instead of converting simulator state into public text. The protocol/ownership design is unchanged.
- Exact reviewer reproduction independently confirmed `None -> accepted "None"` and `123 -> accepted "123"` before the fix. After: `None -> accepted=False, answer=None`; `123 -> TypeError`; empty/whitespace still raise adapter `ValidationError`; every simulator call count is exactly 1.
- **21 new real-provider/real-adapter/publication cases passed in 1.88s**, covering None, number, dict/private canary, unstringifiable object, valid text, empty text and whitespace. Rejected/refused answers are not published and never trigger a next model decision; correct public text reaches its artifact/history.
- F1 plus direct existing answer matrix: **63 passed in 53.65s**, `-n 2`, including installed-worker/wheel and next-model-input proofs. An initial interleaved-path run had 59 passes + 4 missing-fixture setup errors; that selection issue was independently reproduced on the exact unchanged `0858b1597` baseline (1 setup error, no F1 code present). Grouping the same package/test set passed; no fixture code changes or suppressed tests. Details and exact commands are in the round-1 remediation comment.
- Whole-tree pinned Black 26.1.0, isort 5.13.2, flake8 7.3.0 and pyright 1.1.411 all passed locally; zero pyright errors/warnings. Shared interpreter remains read-only.
- No full suite, cloud/model calls, gated task/profile/evaluator reads, TUI changes, rebase, or version bump. Round-2 remediation-diff review and fresh-head remote CI remain required; no remote-green claim.

## Integration and non-goals

Rebased onto merged PR683 atda293e177; original two patches preserved by range-diff, followed only by import formatting/integration evidence. Does not change proxy policy or scoped-infra behavior.

This proves answer transport, not successful task098 completion or a higher benchmark score. The active frozen pilot remains on its old pinned runtime until this gate is clean and a new artifact is built. No hidden task answers are used to develop the feature. No rendered application UI surface changes.

Independent agent review and current-head CI are mandatory before merge. Rollback means selecting a compatible prior host/adapter/selector set, not downgrading one side of RPC alone.
