### PR TITLE
fix(evaluation): align optional SDK JWT dependency policy

### DIFF
--- a/benchmarks/osworld_v2_adapter/probes/jwt_signing.py
+++ b/benchmarks/osworld_v2_adapter/probes/jwt_signing.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from importlib import import_module
 from importlib.metadata import version
 from unittest.mock import patch
 
@@ -17,7 +18,10 @@ EXPECTED_DIGEST = "b8a059da3a7ff0ab0a4267332a61e69a5e98cce8e16d96adbbfa9e37503f1
 
 def probe() -> dict[str, str | bool]:
     import jwt
-    from zhipuai.core._jwt_token import generate_token
+
+    # This SDK belongs to the paid OSWorld extra, not the normal development
+    # or CI dependency set. Resolve it only when this explicit probe runs.
+    generate_token = import_module("zhipuai.core._jwt_token").generate_token
 
     secret = "synthetic-" + "x" * 48
     generate_token.cache_clear()

--- a/benchmarks/osworld_v2_adapter/probes/jwt_signing.py
+++ b/benchmarks/osworld_v2_adapter/probes/jwt_signing.py
@@ -1,0 +1,55 @@
+"""Probe the installed legacy SDK's JWT path, without pytest or real secrets.
+
+Run with the isolated benchmark interpreter, e.g. ``python -I -B <this file>``.
+The fixed synthetic input makes old/new installations directly comparable. No
+network request, credential-store lookup, or token output is performed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from importlib.metadata import version
+from unittest.mock import patch
+
+EXPECTED_DIGEST = "b8a059da3a7ff0ab0a4267332a61e69a5e98cce8e16d96adbbfa9e37503f1f43"
+
+
+def probe() -> dict[str, str | bool]:
+    import jwt
+    from zhipuai.core._jwt_token import generate_token
+
+    secret = "synthetic-" + "x" * 48
+    generate_token.cache_clear()
+    try:
+        with patch("zhipuai.core._jwt_token.time.time", return_value=1800000000.0):
+            token = generate_token("synthetic-id." + secret)
+        digest = hashlib.sha256(token.encode()).hexdigest()
+        if digest != EXPECTED_DIGEST:
+            raise RuntimeError("SDK signing bytes differ from the retained control")
+        claims = jwt.decode(token, secret, algorithms=["HS256"], options={"verify_exp": False})
+        if claims != {
+            "api_key": "synthetic-id",
+            "exp": 1800000210000,
+            "timestamp": 1800000000000,
+        }:
+            raise RuntimeError("SDK signing claims differ from the synthetic input")
+        if jwt.get_unverified_header(token) != {
+            "alg": "HS256",
+            "sign_type": "SIGN",
+            "typ": "JWT",
+        }:
+            raise RuntimeError("SDK signing header differs from the control")
+        return {
+            "pyjwt": version("PyJWT"),
+            "zhipuai": version("zhipuai"),
+            "token_sha256": digest,
+            "claims_verified": True,
+            "header_verified": True,
+        }
+    finally:
+        generate_token.cache_clear()
+
+
+if __name__ == "__main__":
+    print(json.dumps(probe(), sort_keys=True))

--- a/benchmarks/osworld_v2_adapter/pyproject.toml
+++ b/benchmarks/osworld_v2_adapter/pyproject.toml
@@ -66,4 +66,12 @@ evaluation_examples = ["UPSTREAM.json"]
 # overridden onto OSWorld. This is a resolver-level override: the resulting
 # locked set is the one the paid proof runs against, and the previous pilot
 # ran thirteen paid episodes on exactly this override without incident.
-override-dependencies = ["requests>=2.32.0"]
+# OSWorld also installs ZhipuAI 2.1.5.20250825, whose PyJWT<2.9 bound
+# conflicts with the current harness's PyJWT[crypto]>=2.10,<3 requirement.
+# Keep the harness requirement rather than downgrading it. The SDK's only JWT
+# use is HS256 token signing; its actual signing helper produces byte-identical
+# tokens under the old and current pinned versions in the offline compatibility
+# proof documented in docs/benchmarks/osworld_2/dependency-policy.md. This is an
+# explicit resolver override, not a rewrite of the upstream wheel's metadata:
+# plain pip check will still report these two intentionally superseded bounds.
+override-dependencies = ["requests>=2.32.0", "pyjwt[crypto]>=2.10,<3"]

--- a/docs/benchmarks/osworld_2/dependency-policy.md
+++ b/docs/benchmarks/osworld_2/dependency-policy.md
@@ -1,0 +1,67 @@
+# Isolated runtime dependency policy
+
+The adapter's `[tool.uv].override-dependencies` is authoritative when resolving
+its optional OSWorld dependency set. Keep the current harness requirements;
+do not downgrade shared libraries to satisfy stale upstream SDK metadata.
+
+| Upstream declaration | Explicit override | Pilot installation |
+| --- | --- | --- |
+| OSWorld `requests~=2.31.0` | `requests>=2.32.0`, matching the harness | 2.34.2, unchanged from prior pilot |
+| ZhipuAI `pyjwt>=2.8.0,<2.9.0` | `pyjwt[crypto]>=2.10,<3`, matching the harness | 2.13.0, matching the development environment |
+
+The requests override was already declared and exercised by the preceding
+pilot. Rebuilding against the current harness exposed the second conflict:
+the old copied lock had PyJWT2.8.0, which no longer satisfies the harness.
+Updating PyJWT satisfies the harness but exposes the optional ZhipuAI SDK's old
+upper bound. The installed SDK is `zhipuai==2.1.5.20250825`; its current published
+metadata still has that bound ([PyPI metadata](https://pypi.org/pypi/zhipuai/json)).
+No upstream task, evaluator, framework source, or wheel metadata is rewritten.
+
+## Actual compatibility evidence
+
+The SDK's real `zhipuai.core._jwt_token.generate_token` helper was executed in
+separate isolated interpreters with PyJWT2.8.0 and2.13.0, using identical fixed
+time and a synthetic key. Both returned the same token SHA256:
+
+```text
+b8a059da3a7ff0ab0a4267332a61e69a5e98cce8e16d96adbbfa9e37503f1f43
+```
+
+Claims and the HS256/sign_type header were independently verified under each
+version. No token was printed and no network/model request was made. This proves
+the SDK's signing path, not an unperformed live ZhipuAI inference request. The
+pilot actor and simulator use OpenRouter, not ZhipuAI.
+
+The reusable regression is
+`tests/unit/evaluation/adapters/osworld/test_dependency_policy.py`:
+
+- The override specifiers and extras must exactly match the current harness.
+- Superseded versions are rejected and the tested modern versions are admitted.
+- The real optional SDK signing path must match the retained control digest.
+
+The SDK test may skip in a lean development/CI environment lacking the optional
+OSWorld tree; do not describe that skip as runtime compatibility validation.
+The paid runtime deliberately has no pytest dependency. Run the exact shared
+signing probe directly with that interpreter instead:
+
+```sh
+"$BENCHMARK_PYTHON" -I -B benchmarks/osworld_v2_adapter/probes/jwt_signing.py
+```
+
+The probe was run successfully with both isolated PyJWT versions above. A direct
+attempt to run pytest in the paid environment correctly reported that pytest was
+absent; no test dependencies were installed there.
+
+## Honest dependency checks and pins
+
+Plain `uv pip check` reads installed wheel metadata, not uv's project overrides.
+It therefore still reports the two intentionally superseded upstream bounds.
+Retain that raw output; do **not** describe it as a green pip check. Validate that
+these are the only conflicts, that the installed versions satisfy the declared
+overrides and current harness, and preserve the actual installed version list.
+Any other conflict blocks admission until understood and resolved.
+
+The new pilot environment changes PyJWT2.8.0 to2.13.0; requests remains2.34.2.
+Record this alongside the source revision, wheel hashes, interpreter, complete
+locked dependency list, and adapter/workspace digests. This policy does not
+change normal TUI/mobile startup or install into an already-running environment.

--- a/tests/unit/evaluation/adapters/osworld/test_dependency_policy.py
+++ b/tests/unit/evaluation/adapters/osworld/test_dependency_policy.py
@@ -2,7 +2,7 @@
 
 The optional SDK test exercises its real signing helper without making a model
 call. CI need not install OSWorld's large optional dependency tree merely to
-check policy; the paid runtime runs this same test with that tree installed.
+check policy; the paid runtime runs the shared standalone probe without pytest.
 """
 
 from __future__ import annotations

--- a/tests/unit/evaluation/adapters/osworld/test_dependency_policy.py
+++ b/tests/unit/evaluation/adapters/osworld/test_dependency_policy.py
@@ -1,0 +1,56 @@
+"""Keep upstream compatibility overrides explicit and aligned with the harness.
+
+The optional SDK test exercises its real signing helper without making a model
+call. CI need not install OSWorld's large optional dependency tree merely to
+check policy; the paid runtime runs this same test with that tree installed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import tomllib
+from pathlib import Path
+
+import pytest
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+from packaging.version import Version
+
+ROOT = Path(__file__).resolve().parents[5]
+
+
+def _requirements(values: list[str]) -> dict[str, Requirement]:
+    parsed = [Requirement(value) for value in values]
+    return {canonicalize_name(value.name): value for value in parsed}
+
+
+def test_overrides_match_current_harness_floors() -> None:
+    harness = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    adapter = tomllib.loads((ROOT / "benchmarks/osworld_v2_adapter/pyproject.toml").read_text())
+    required = _requirements(harness["project"]["dependencies"])
+    overrides = _requirements(adapter["tool"]["uv"]["override-dependencies"])
+    assert set(overrides) == {"requests", "pyjwt"}
+    for name in overrides:
+        assert overrides[name].specifier == required[name].specifier
+        assert overrides[name].extras == required[name].extras
+    assert Version("2.8.0") not in overrides["pyjwt"].specifier
+    assert Version("2.13.0") in overrides["pyjwt"].specifier
+    assert Version("3.0.0") not in overrides["pyjwt"].specifier
+    assert Version("2.31.0") not in overrides["requests"].specifier
+    assert Version("2.34.2") in overrides["requests"].specifier
+
+
+def test_legacy_sdk_signing_remains_compatible() -> None:
+    pytest.importorskip("jwt")
+    pytest.importorskip("zhipuai.core._jwt_token")
+    # Reuse the exact no-pytest entry point run in the paid environment. Do not
+    # install test dependencies into that frozen interpreter merely for a probe.
+    path = ROOT / "benchmarks/osworld_v2_adapter/probes/jwt_signing.py"
+    spec = importlib.util.spec_from_file_location("sdk_signing_probe", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    result = module.probe()
+    assert result["token_sha256"] == module.EXPECTED_DIGEST
+    assert result["claims_verified"] is True
+    assert result["header_verified"] is True


### PR DESCRIPTION
## Summary

C2 isolated benchmark dependency-policy correction; no normal runtime/default dependency changes. The current harness requires PyJWT[crypto]>=2.10,<3, but OSWorld's optional ZhipuAI2.1.5.20250825 SDK pins PyJWT<2.9. The copied old benchmark lock cannot satisfy both. Do not downgrade the harness.

Extend the existing [tool.uv].override-dependencies policy (already used for OSWorld's stale requests bound) to the exact current harness JWT requirement, including crypto extras. No upstream task/evaluator/framework source or installed wheel metadata is rewritten.

## Delivery contract

- Exactly the two intentional overrides: requests and pyjwt, matching current harness constraints/extras.
- Preserve original upstream code pin and runtime behavior; only resolver policy changes.
- Provide a standalone real-SDK signing compatibility probe that needs no pytest, model calls, credential store, real secrets, or network.
- Keep raw pip-check failures visible. Plain pip check ignores project overrides and still reports the two superseded upstream constraints; any additional conflict blocks admission.
- Document actual PyJWT2.8→2.13 alignment and unchanged requests2.34.2. No change to running benchmark environments.

## Actual evidence

The exact new probes/jwt_signing.py ran in BOTH isolated interpreters (PyJWT2.8.0 and2.13.0), using actual zhipuai.core._jwt_token.generate_token, fixed time and a synthetic key. Both yielded SHA256 b8a059da3a7ff0ab0a4267332a61e69a5e98cce8e16d96adbbfa9e37503f1f43; claims and HS256/sign_type header independently verified. No token printed. This is actual SDK signing-path proof, not an unperformed live ZhipuAI request. The pilot uses OpenRouter, not ZhipuAI.

Development tests:1 passed/1 skipped (optional SDK absent). Do not equate that skip with compatibility proof; the two direct paid-runtime probes supply it. Paid runtime has no pytest; an initial pytest invocation failed accordingly, and no test dependencies were added there. The unit test and direct invocation reuse the same probe implementation.

Whole-tree static gates running; independent review and current-head CI required before merge. Details/reproduction: docs/benchmarks/osworld_2/dependency-policy.md.

## Scope and rollback

Only adapter resolver metadata, optional tests, standalone probe, and engineering documentation. No default TUI/mobile/CLI UI, model prompt, protocol, tool, dependency installation, or source version bump. Rollback reverts this policy and selects a compatible prior complete lock; do not silently install an out-of-policy old JWT into the current harness.
