### PR TITLE
chore(release): bump version to 0.49.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.49.3"
+version = "0.49.4"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Summary

Release bump for the 0.49.4 window: `0.49.3` → `0.49.4` in `pyproject.toml`, one line, nothing else.

## Window contents

Merged since `v0.49.3` (`git log v0.49.3..origin/main`):

| PR | Commit | Change |
| --- | --- | --- |
| #674 | `d2be3b590` | `feat(tui)`: dock subagent panel density cycle (full → summary → hidden), plus the hidden-roster dock-height fix |
| #685 | `164c3bf8b` | `fix(evaluation)`: deliver adapter-owned public user answers |

## Bump class

**PATCH.** `#674` is a `feat:` and is user-visible, but AGENTS.md is explicit that a single small `feat:` is a patch: this is one panel's disclosure behaviour plus one LIVE config key, with no step-function capability to name in an `X.Y.0` title. `#685` is a C2 correction to a benchmark-internal path. Both window contributors were consulted and agree on PATCH.

## Change class

C0 — one-file version bump, no runtime path. Scope-check round only.

## Ownership

Window owner confirmed with the two prior claimants of the 0.49.3 window before claiming: pid 4520 carried 0.49.3 (cut as #684) and explicitly released ownership; pid 3700 withdrew its claim and confirmed it has nothing in this window. Both independently re-verified the window contents above.
