### PR TITLE
chore(release): bump version to 0.49.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.49.4"
+version = "0.49.5"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Summary

Release bump for the 0.49.5 window: `0.49.4` → `0.49.5` in `pyproject.toml`, one line, nothing else.

## Window contents

Merged since `v0.49.4` (`git log v0.49.4..c7bee3a6a`):

- `c7bee3a6a` fix(tui): carry launch lineage to followers so the delegated brief renders once (#681)
- `502a75150` fix(evaluation): align optional SDK JWT dependency policy (#686)

## Bump class

**PATCH.** Both window contributors are `fix:` commits — a TUI rendering correction and an optional-dependency policy alignment. Neither adds a new surface or subsystem, so there is no step-function capability to name in an `X.Y.0` title, which AGENTS.md makes the test for a minor. Per "when in doubt, patch", this is a patch.

## Change class

C0 — one-file version bump, no runtime path. Scope-check round only.
