### PR TITLE
chore(release): bump version to 0.49.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.49.5"
+version = "0.49.6"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## What this does

Bumps `pyproject.toml` to `0.49.6` for the current combined-release window. **One line, one file** — no dependency pin, script, or entry point moved beside it, and no release pipeline consumes this field as an input.

**C0, standard/pre-authorized.** Release mechanics only; no runtime behaviour changes.

## Window contents (`git log v0.49.5..origin/main`)

| PR | SHA | Impact |
|---|---|---|
| [#668](https://github.com/damianvtran/local-operator/pull/668) | `ec25593d7` | `fix(tui)`: a failed turn on an `lop attach` follower no longer flashes the tab title as `lo ›` ("finished cleanly") for the width of the owner's relay latency before settling on `lo ✗`; a follower whose owner goes cold now reaches a defined terminal state instead of an endless spinner. Closes #642 |
| [#672](https://github.com/damianvtran/local-operator/pull/672) | `ff9b16b5c` | `feat(extension)`: browser-extension consent UI reworked — one Allow action with a scope dropdown (all pages on this domain / only this site / just this once) replacing five approval buttons, plus a "Dangerously allow all websites" setting behind a warning dialog. Extension 0.1.8 |
| [#690](https://github.com/damianvtran/local-operator/pull/690) | `2c26ce655` | `docs(benchmarks)`: ten-task OSWorld pilot record and readiness limits |

## Bump class: PATCH

Nothing in this window clears the step-function bar in `AGENTS.md` ("Versioning: choose the bump by materiality, not commit type"). #668 is a bug fix. #690 is docs.

#672 is a `feat:` and was explicitly argued down to patch with its author (pid 3573): the extension version line ships through the **Chrome Web Store**, not through this tag. What lands in the PyPI artifact is a protocol `Literal`, a regenerated `protocol.gen.ts`, and prose. A `lop` user upgrading to 0.49.6 gains no new capability from it.

## Release-line note

**The extension 0.1.8 consent UI is NOT live for users at v0.49.6.** It is `PENDING_REVIEW` at Google (run 34000911184). The runtime and the extension are two release lines by design; this tag moves only the runtime.

## Evidence

No runtime path — this is a version-string change with nothing to exercise end to end. Validated by the full CI matrix on this branch, and by the release smoke test after publish (`lop --version` from outside the repository, plus the `.lop-source` marker check), which will be recorded on this PR.

```
$ git diff v0.49.5..HEAD -- pyproject.toml
-version = "0.49.5"
+version = "0.49.6"
```
