### PR TITLE
chore(release): bump version to 0.49.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.49.6"
+version = "0.49.7"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Summary

Version bump only — `pyproject.toml`, one line, `0.49.6` → `0.49.7`. No code, no tests, no docs.

## Window contents (`git log v0.49.6..origin/main`)

- **#678** `e93c0f331` — fix(runtime): detect and complete across viewer/runtime build skew
- **#677** `db018cadb` — fix(tui): /model follow-ups — latch edge, /help carrier, setup-state routes (closes #641)

**Updated after opening.** #678 merged while this PR's CI was running. The branch has been rebased onto current `origin/main` so the bump commit sorts **above** both — otherwise #678 would have shipped in the artifact while being absent from the notes.

## Bump rationale

**PATCH.** Two bug-fix PRs. #678 is a runtime fix plus two additive `SessionRecord` fields with no `PROTOCOL_VERSION` bump; #677 is UX corrections and copy fixes to existing TUI surfaces. Neither clears the step-function bar, and two patches do not sum to a minor.

Window contents confirmed against `origin/main` by four peer sessions (pid 3600 — the v0.49.6 owner, 3700, 4197, 4633) as empty of their work, and pid 4324 self-reported #678 and stood down in favour of this window.

## Scope check

This PR is intentionally a one-file change so it can be reviewed by inspection:

```
 pyproject.toml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

Release mechanics per `AGENTS.md`: feature PRs never carry a version bump, so the bump lands here on its own and the tag targets this commit.

## Note on CI

TUI timing tests (`test_aside.py`, `test_render_throttling.py`) are flaking broadly on `main` right now — roughly 50% per run, a different test each time, reported independently by two sessions. A red shard on a timing test that a one-line version diff cannot have caused is that flake; re-run the job and confirm the same test is red on `main`.
