### PR TITLE
feat(tui): add an owner-bound session sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,10 @@ with its title and age:
   same TUI. `cmd+b` is also accepted when the terminal forwards the Super
   modifier. `/settings` → **Session sidebar** and **Sidebar position** control
   visibility and left/right placement; the defaults are hidden and left.
+  `f9` or `/sidebar focus` opens and focuses the list without changing your
+  draft. Arrow keys choose a row, Enter opens it, and Escape returns to the
+  previous input surface. F9 also returns focus without hiding a pinned list.
+  On narrow terminals, selecting a conversation dismisses the overlay drawer.
 - `f8` — open an aside (side question) without losing what you were typing;
   `ctrl+f` promotes the aside into the conversation.
 - `shift+tab`: cycle reasoning effort.

--- a/README.md
+++ b/README.md
@@ -447,8 +447,12 @@ with its title and age:
   (`$research the payments rewrite`); `$` alone opens the picker.
 - **Type while the agent works**: your message is delivered at the next
   step as steering, no need to wait.
-- `esc`: stop the agent without ending the session.
-- `ctrl+b`: open an aside (side question) without losing what you were typing;
+- `esc` — stop the agent without ending the session.
+- `ctrl+b` or `/sidebar` — show or hide active and recent conversations in the
+  same TUI. `cmd+b` is also accepted when the terminal forwards the Super
+  modifier. `/settings` → **Session sidebar** and **Sidebar position** control
+  visibility and left/right placement; the defaults are hidden and left.
+- `f8` — open an aside (side question) without losing what you were typing;
   `ctrl+f` promotes the aside into the conversation.
 - `shift+tab`: cycle reasoning effort.
 - `ctrl+l`: clear the transcript (history is untouched).

--- a/README.md
+++ b/README.md
@@ -455,6 +455,9 @@ with its title and age:
   `f9` or `/sidebar focus` opens and focuses the list without changing your
   draft. Arrow keys choose a row, Enter opens it, and Escape returns to the
   previous input surface. F9 also returns focus without hiding a pinned list.
+  `ctrl+shift+↑` / `ctrl+shift+↓` switch straight to the previous/next
+  conversation in the list's order without opening it, wrapping at the ends;
+  the caret and your unsent draft stay where they were.
   On narrow terminals, selecting a conversation dismisses the overlay drawer.
 - `f8` — open an aside (side question) without losing what you were typing;
   `ctrl+f` promotes the aside into the conversation.

--- a/docs/SESSION_SIDEBAR.md
+++ b/docs/SESSION_SIDEBAR.md
@@ -1,0 +1,85 @@
+# In-app session sidebar
+
+The sidebar is an opt-in terminal view over existing session owners, not another
+owner or a new scheduler. `Ctrl+B` and `/sidebar` toggle visibility without moving
+the editor caret. `F9` and `/sidebar focus` enter the list; F9 returns focus while
+leaving it open, and Escape dismisses it and returns to the last usable surface.
+Settings control visibility and left/right placement. Narrow layouts use a drawer
+that ends above the input dock and closes after any valid selection.
+
+## Ownership and readiness
+
+`SessionInteraction` owns each source's turns, loop, shell, compaction, draft,
+approval policy, gate input and accounting. A prepared/retained view owns widgets,
+not work. Switching does not answer a gate, cancel a turn, or redirect its eventual
+result. Preparation never acknowledges completion attention. The current binding
+changes only after canonical attachment and prepared replay; navigation stays
+pending until a real displayed frame also has the correct scroll/gate surface.
+
+`SessionNavigation` is latest-wins and bounds preparation. Retained presentations
+are separately budgeted from data-only source contexts and drafts. Private draft
+spill files are temporary, not session journals; secret gate text never enters
+those files. Focus restoration uses weak references so a dismissed login widget
+and its pasted secret cannot be retained by sidebar bookkeeping.
+
+## Opt-in durable display history
+
+An upgraded owner advertises `display-history-window-v1`. Sidebar connections ask
+for `RemoteSession.connect(..., display_window=True)`; ordinary connections retain
+full-history initialization. The window rides the existing atomic frontend sync:
+owner snapshot, durable cursor, window selection and subscription share one
+no-yield authoritative-loop boundary.
+
+`Transcript.build_llm_history(through_id=...)` selects the journal cut before
+interpreting compaction and prunes. The window reuses that canonical replay,
+including custom roles, attachments and preserved user turns. Compaction markers
+reuse their durable entry ID. Tool call/result groups stay together, including
+results separated by custom messages. There is no second transcript index or
+projection of live model context.
+
+Pages are capped at 120 messages and 512 KiB, including actual JSON escaping, with
+space reserved for metadata. The entire sync still respects the transport's
+1 MiB frame ceiling. Required prose or a tool group that cannot fit is **not
+truncated**: an explicit `full_required` result selects the existing off-thread
+local full replay at the captured cut. That fallback does not promise low latency.
+
+Signed tokens bind conversation, owner epoch, replay generation, durable cut and
+message position; clients cannot provide filesystem paths or byte offsets.
+Appends preserve a captured cut. Compaction, pruning and file folding invalidate
+its generation. Paging returns a typed reset rather than mixing generations;
+the viewer obtains a fresh canonical sync without restarting or prompting the
+owner. A missing saved anchor resets to the new canonical tail, never a different
+row presented as the old anchor.
+
+`display_history_window()` is explicitly partial. `history_message_count`,
+`history_theme_turn_count` and `history_opener_text` carry whole-cut metadata.
+`history_page()` and `load_older_display_page()` read older pages as needed.
+`ensure_display_anchor()` validates a saved message/tool anchor and hydrates a
+contiguous interval through it for the existing two-direction renderer.
+`materialize_history()` is the explicit full-trajectory API used by background
+naming. Calling `history()` on an unhydrated window raises, rather than silently
+returning a partial conversation. Owner/model/idempotency full-history callers
+are unchanged.
+
+Loaded IDs, painted IDs and pre-cut live-seed IDs are distinct. Canonical live
+messages and tool outcomes are retained separately from the durable window so a
+source that leaves the screen during a gate does not lose its initiating prompt
+or the later result. Reconnect pages back through the previous durable frontier;
+a replay-changing generation produces an explicit presentation reset.
+
+## Local workflows and compatibility
+
+The invoking TUI schedules `/loop`, while each iteration prompts its captured
+owner. Another conversation's stop cannot cancel it. Bang commands execute in the
+invoking terminal and forward their receipt to the captured owner. Stable IDs
+from the submitted tool-call ID make duplicate receipt delivery idempotent. A
+busy owner queues the receipt behind its turn; acceptance is not a claim that
+queued persistence is already durable. Offscreen completion retains its result.
+
+Already-running older owners remain visible and selectable through authenticated
+full-history attachment. They are never restarted, stopped, prompted, or marked
+read to accelerate selection. An immediate first click before legacy preparation
+finishes can still require a full journal parse. Older owners without the shell
+receipt operation report a save failure explicitly; the terminal cannot retrofit
+that capability into another running process. No universal sub-100 ms guarantee
+is implied, particularly for large required content or unprepared legacy owners.

--- a/docs/SESSION_SIDEBAR.md
+++ b/docs/SESSION_SIDEBAR.md
@@ -4,6 +4,10 @@ The sidebar is an opt-in terminal view over existing session owners, not another
 owner or a new scheduler. `Ctrl+B` and `/sidebar` toggle visibility without moving
 the editor caret. `F9` and `/sidebar focus` enter the list; F9 returns focus while
 leaving it open, and Escape dismisses it and returns to the last usable surface.
+`Ctrl+Shift+↑`/`Ctrl+Shift+↓` attach the previous/next conversation directly — the
+one-press form of F9-then-arrow-then-Enter — in the list's own ranking, wrapping
+at the ends and without moving the caret; with the list closed the catalog is read
+fresh first so "next" is what the list would show, never a stale snapshot.
 Settings control visibility and left/right placement. Narrow layouts use a drawer
 that ends above the input dock and closes after any valid selection.
 

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -1160,6 +1160,8 @@ class HistoryDeltaEvent(AgentEvent[Literal["history_delta"]]):
 
     type: Literal["history_delta"] = "history_delta"
     messages: list[AgentMessage] = Field(default_factory=list)
+    # A replay-changing generation cannot be appended to the old viewport.
+    reset: bool = False
 
 
 class ToolCallComposeEvent(AgentEvent[Literal["tool_call_compose"]]):

--- a/local_operator/mcp/__init__.py
+++ b/local_operator/mcp/__init__.py
@@ -45,8 +45,15 @@ async def discover_and_load_mcp_tools(
 
     A hard discovery failure never raises: it yields the manager, an empty
     tool list, and one synthetic error entry (established behavior).
+
+    ``tool_cache`` defaults to :class:`McpToolCache` under :func:`config_dir`
+    so a deferred server can advertise last-good schemas at the 250 ms gate
+    without every runtime waiting on spawn+handshake. The owner still spawns;
+    live ``tools/list`` after connect overwrites the row. Passing ``None``
+    used to mean "no cache", which made every runtime pay the handshake even
+    when a sibling had just listed the same server.
     """
-    manager = McpManager(cwd, tool_cache, auth_store=auth_store)
+    manager = McpManager(cwd, tool_cache or McpToolCache(), auth_store=auth_store)
     try:
         result = await manager.discover_and_connect()
     except Exception as exc:

--- a/local_operator/mcp/manager.py
+++ b/local_operator/mcp/manager.py
@@ -69,7 +69,7 @@ from local_operator.mcp.tool_bridge import (
     is_retriable_connection_error,
     prepare_outbound_args,
 )
-from local_operator.mcp.tool_cache import McpToolCache
+from local_operator.mcp.tool_cache import McpToolCache, config_digest
 from local_operator.optional import missing_extra_error
 
 if TYPE_CHECKING:
@@ -1402,7 +1402,11 @@ class McpManager:
             # re-report the combined outcome instead of the gate snapshot.
             self._startup_deferred.add(name)
             # Still pending at the gate: defer from cache, or contribute nothing.
-            cached = self.tool_cache.get(name) if self.tool_cache is not None else None
+            cached = (
+                self.tool_cache.get(name, config_digest(self._configs.get(name)))
+                if self.tool_cache is not None
+                else None
+            )
             if cached:
                 self._unregister_origins(name)
                 self._tools_by_server[name] = [
@@ -1455,7 +1459,11 @@ class McpManager:
         conn.tools = tools
         self._register_tools(name, tools)
         if self.tool_cache is not None:
-            self.tool_cache.put(name, [_tool_to_cache_entry(tool) for tool in tools])
+            self.tool_cache.put(
+                name,
+                [_tool_to_cache_entry(tool) for tool in tools],
+                config_digest(self._configs.get(name)),
+            )
         self._fire_tools_changed()
 
     async def reconnect_server(self, name: str) -> ServerConnection | None:
@@ -1688,7 +1696,11 @@ class McpManager:
 
         conn.tools = tools
         if self.tool_cache is not None:
-            self.tool_cache.put(name, [_tool_to_cache_entry(tool) for tool in tools])
+            self.tool_cache.put(
+                name,
+                [_tool_to_cache_entry(tool) for tool in tools],
+                config_digest(self._configs.get(name)),
+            )
         return conn
 
     async def _open_transport_and_session(

--- a/local_operator/mcp/tool_cache.py
+++ b/local_operator/mcp/tool_cache.py
@@ -5,65 +5,144 @@ stores the JSON of each server's last successful ``tools/list`` so a deferred
 tool knows its name, description, and input schema before the connection is
 up. Every operation is best-effort — a locked/corrupt/unwritable database
 degrades to ``None`` reads and no-op writes, never an exception.
+
+The file lives under :func:`config_dir`, not ``Path.home()``. Tests isolate
+via ``LOCAL_OPERATOR_CONFIG_DIR`` / ``HOME`` the same way catalogue and usage
+do; writing under the real home from a cell that only overrode CONFIG_DIR is
+how a previous cache leaked into ``~/.local-operator/mcp_cache.db``.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
+import os
 import sqlite3
 import time
 from pathlib import Path
 from typing import Any
 
+from local_operator.paths import config_dir
+
 logger = logging.getLogger(__name__)
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS mcp_tool_cache (
-    server TEXT PRIMARY KEY,
+    server TEXT NOT NULL,
+    digest TEXT NOT NULL,
     tools_json TEXT NOT NULL,
-    saved_at REAL NOT NULL
+    saved_at REAL NOT NULL,
+    PRIMARY KEY (server, digest)
 )
 """
 
+_CACHE_FILENAME = "mcp_cache.db"
+
+
+def default_cache_path() -> Path:
+    """``<config_dir>/mcp_cache.db`` — honouring CONFIG_DIR and HOME every call."""
+    return config_dir() / _CACHE_FILENAME
+
+
+def config_digest(config: Any) -> str:
+    """Stable digest of a server's config so a rewrite cannot serve old schemas.
+
+    Command, args, url, env, headers, and tool allow/deny lists all change
+    what ``tools/list`` would return. A cache keyed on the name alone would
+    advertise the previous server's tools after the user pointed the same
+    name at a different command. ``model_dump`` keeps this independent of
+    which transport the config is.
+    """
+    if hasattr(config, "model_dump"):
+        payload = config.model_dump(mode="json", exclude_none=True)
+    elif isinstance(config, dict):
+        payload = config
+    else:
+        payload = {"repr": repr(config)}
+    encoded = json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:32]
+
 
 class McpToolCache:
-    """Persist per-server ``tools/list`` payloads at ``~/.local-operator/mcp_cache.db``.
+    """Persist per-server ``tools/list`` payloads under the config dir.
 
-    The ``path`` argument exists for tests; production callers rely on the
-    default location.
+    Rows are keyed by ``(server, digest)``. :meth:`get` with a digest that
+    does not match drops the stale row so a rewritten mcp.json cannot keep
+    advertising the previous schema. The ``path`` argument exists for tests;
+    production callers rely on :func:`default_cache_path`.
     """
 
     def __init__(self, path: str | Path | None = None) -> None:
-        self._path = (
-            Path(path) if path is not None else Path.home() / ".local-operator" / "mcp_cache.db"
-        )
+        self._path = Path(path) if path is not None else default_cache_path()
 
     def _connect(self) -> sqlite3.Connection | None:
         """Open the database, creating the parent dir and schema as needed."""
         try:
             self._path.parent.mkdir(parents=True, exist_ok=True)
+            # 0600 before sqlite opens it: tool schemas are not tokens, but
+            # they name the user's servers and this is the same-account
+            # boundary as auth.db / usage_cache.db. connect-then-chmod leaves
+            # a readable window.
+            if not self._path.exists():
+                fd = os.open(self._path, os.O_CREAT | os.O_WRONLY, 0o600)
+                os.close(fd)
             conn = sqlite3.connect(str(self._path), timeout=1.0)
+            conn.execute("PRAGMA busy_timeout=1000")
             conn.execute(_SCHEMA)
+            self._migrate_legacy(conn)
+            try:
+                os.chmod(self._path, 0o600)
+            except OSError:
+                pass
             return conn
         except (OSError, sqlite3.Error):
             logger.debug("MCP tool cache unavailable at %s", self._path, exc_info=True)
             return None
 
-    def get(self, server: str) -> list[dict[str, Any]] | None:
-        """Return the cached tool definitions for ``server``, or ``None``.
+    @staticmethod
+    def _migrate_legacy(conn: sqlite3.Connection) -> None:
+        """Drop a pre-digest table so a leftover name-only row cannot be served.
+
+        The old primary key was ``server`` alone. Keeping those rows would
+        make :meth:`get` with a digest look like a miss AND leave a name-only
+        row a future reader without a digest (there is none) could still hit.
+        Dropping is the honest migration: the next live ``tools/list`` rewrites.
+        """
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(mcp_tool_cache)").fetchall()}
+        if "digest" not in columns:
+            conn.execute("DROP TABLE IF EXISTS mcp_tool_cache")
+            conn.execute(_SCHEMA)
+            conn.commit()
+
+    def get(self, server: str, digest: str | None = None) -> list[dict[str, Any]] | None:
+        """Return cached tool definitions for ``server`` at ``digest``, or ``None``.
 
         Each entry is the raw ``tools/list`` item shape: ``{"name",
         "description", "inputSchema"}`` (extra keys pass through).
+
+        ``digest`` is required for a hit. A name-only read cannot tell a
+        rewritten config from the one that wrote the row, so it is a miss
+        (and any leftover rows for that name are dropped). A digest mismatch
+        deletes the stale row: the next connect will ``put`` the live list.
         """
         conn = self._connect()
         if conn is None:
             return None
         try:
+            if not digest:
+                conn.execute("DELETE FROM mcp_tool_cache WHERE server = ?", (server,))
+                conn.commit()
+                return None
             row = conn.execute(
-                "SELECT tools_json FROM mcp_tool_cache WHERE server = ?", (server,)
+                "SELECT tools_json FROM mcp_tool_cache WHERE server = ? AND digest = ?",
+                (server, digest),
             ).fetchone()
             if row is None:
+                # Stale digest(s) for this name: drop them so a removed or
+                # rewritten server does not accumulate.
+                conn.execute("DELETE FROM mcp_tool_cache WHERE server = ?", (server,))
+                conn.commit()
                 return None
             parsed = json.loads(row[0])
             return parsed if isinstance(parsed, list) else None
@@ -73,16 +152,23 @@ class McpToolCache:
         finally:
             conn.close()
 
-    def put(self, server: str, tools: list[dict[str, Any]]) -> None:
-        """Store ``tools`` for ``server``; failures are swallowed."""
+    def put(self, server: str, tools: list[dict[str, Any]], digest: str | None = None) -> None:
+        """Store ``tools`` for ``server`` at ``digest``; failures are swallowed.
+
+        Without a digest the write is skipped: a name-only row is exactly the
+        stale-schema bug this cache exists to close.
+        """
+        if not digest:
+            return
         conn = self._connect()
         if conn is None:
             return
         try:
+            conn.execute("DELETE FROM mcp_tool_cache WHERE server = ?", (server,))
             conn.execute(
                 "INSERT OR REPLACE INTO mcp_tool_cache "
-                "(server, tools_json, saved_at) VALUES (?, ?, ?)",
-                (server, json.dumps(tools), time.time()),
+                "(server, digest, tools_json, saved_at) VALUES (?, ?, ?, ?)",
+                (server, digest, json.dumps(tools), time.time()),
             )
             conn.commit()
         except (sqlite3.Error, ValueError, TypeError):
@@ -91,7 +177,7 @@ class McpToolCache:
             conn.close()
 
     def delete(self, server: str) -> None:
-        """Drop the cache entry for ``server`` (e.g. after a config removal)."""
+        """Drop every cache entry for ``server`` (e.g. after a config removal)."""
         conn = self._connect()
         if conn is None:
             return

--- a/local_operator/mobile/attach_client.py
+++ b/local_operator/mobile/attach_client.py
@@ -149,6 +149,7 @@ class AttachClient:
         events: bool = False,
         on_event: Callable[[dict[str, Any]], None] | None = None,
         frontend_state: bool = False,
+        display_window: bool = False,
         locality: str = "local",
         slash_consumers: Sequence[str] | None = None,
         on_frontend_sync: Callable[[dict[str, Any]], None] | None = None,
@@ -179,6 +180,7 @@ class AttachClient:
         # different from ``[]`` only to a reader of the frame -- both mean the
         # type was not declared, which is the one rule the runtime applies.
         self._slash_consumers = list(slash_consumers) if slash_consumers is not None else None
+        self._display_window = display_window
         self._on_frontend_sync = on_frontend_sync
         self._on_frontend_update = on_frontend_update
         self._frontend_epoch: str | None = None
@@ -246,6 +248,8 @@ class AttachClient:
             # field and behaves as it always did, and no PROTOCOL_VERSION bump
             # is warranted for a field nobody is required to read.
             auth["slash_consumers"] = list(self._slash_consumers)
+        if self._display_window and "display-history-window-v1" in record.capabilities:
+            auth["display_window"] = True
         writer.write(json.dumps(auth).encode() + b"\n")
         await writer.drain()
         # The welcome projection doubles as the identity check: it names the
@@ -626,6 +630,13 @@ class AttachClient:
         answers the unknown-op error, which the caller reads as kept.
         """
         return await self._request("refresh_if_idle")
+
+    async def record_shell(self, command: str, result: dict[str, Any]) -> str:
+        return str(await self._request_payload("record_shell", command=command, result=result))
+
+    async def history_page(self, before: str, anchor: str = "") -> Any:
+        """Read a signed canonical display page on the authenticated socket."""
+        return await self._request_payload("history_page", before=before, anchor=anchor)
 
     async def job_trajectory(self, job_id: str, offset: int = 0, limit: int = 120) -> Any:
         """Fetch one page of a child job's retained events from the owner.

--- a/local_operator/mobile/attach_client.py
+++ b/local_operator/mobile/attach_client.py
@@ -172,6 +172,7 @@ class AttachClient:
         self._events = events
         self._on_event = on_event
         self._frontend_state = frontend_state
+        self._display_window = display_window
         # Which action-carrying slash receipts THIS client renders itself (see
         # ``SLASH_ACTION_RECEIPTS``). Declaring them is what stops the runtime
         # from also submitting the request: a client that says nothing is
@@ -180,7 +181,6 @@ class AttachClient:
         # different from ``[]`` only to a reader of the frame -- both mean the
         # type was not declared, which is the one rule the runtime applies.
         self._slash_consumers = list(slash_consumers) if slash_consumers is not None else None
-        self._display_window = display_window
         self._on_frontend_sync = on_frontend_sync
         self._on_frontend_update = on_frontend_update
         self._frontend_epoch: str | None = None
@@ -242,14 +242,14 @@ class AttachClient:
             auth["events"] = True
         if self._frontend_state:
             auth["frontend_state"] = True
+        if self._display_window and "display-history-window-v1" in record.capabilities:
+            auth["display_window"] = True
         if self._slash_consumers is not None:
             # Additive and advisory, exactly the shape ``events`` and
             # ``frontend_state`` are: an older owner ignores the unknown auth
             # field and behaves as it always did, and no PROTOCOL_VERSION bump
             # is warranted for a field nobody is required to read.
             auth["slash_consumers"] = list(self._slash_consumers)
-        if self._display_window and "display-history-window-v1" in record.capabilities:
-            auth["display_window"] = True
         writer.write(json.dumps(auth).encode() + b"\n")
         await writer.drain()
         # The welcome projection doubles as the identity check: it names the
@@ -618,6 +618,16 @@ class AttachClient:
         """
         return await self._request("retire_if_pristine")
 
+    async def record_shell(self, command: str, result: dict[str, Any]) -> str:
+        return str(await self._request_payload("record_shell", command=command, result=result))
+
+    async def frontend_sync(self) -> Any:
+        """Refresh the canonical cut without abandoning admitted RPCs."""
+        return await self._request_payload("frontend_sync")
+
+    async def history_page(self, before: str, anchor: str = "") -> Any:
+        """Read a signed canonical display page on the authenticated socket."""
+        return await self._request_payload("history_page", before=before, anchor=anchor)
     async def request_refresh(self) -> str:
         """Ask a STALE owner to retire now if it is idle, so the next engage
         runs the build on disk.
@@ -630,13 +640,6 @@ class AttachClient:
         answers the unknown-op error, which the caller reads as kept.
         """
         return await self._request("refresh_if_idle")
-
-    async def record_shell(self, command: str, result: dict[str, Any]) -> str:
-        return str(await self._request_payload("record_shell", command=command, result=result))
-
-    async def history_page(self, before: str, anchor: str = "") -> Any:
-        """Read a signed canonical display page on the authenticated socket."""
-        return await self._request_payload("history_page", before=before, anchor=anchor)
 
     async def job_trajectory(self, job_id: str, offset: int = 0, limit: int = 120) -> Any:
         """Fetch one page of a child job's retained events from the owner.

--- a/local_operator/mobile/attach_client.py
+++ b/local_operator/mobile/attach_client.py
@@ -628,6 +628,7 @@ class AttachClient:
     async def history_page(self, before: str, anchor: str = "") -> Any:
         """Read a signed canonical display page on the authenticated socket."""
         return await self._request_payload("history_page", before=before, anchor=anchor)
+
     async def request_refresh(self) -> str:
         """Ask a STALE owner to retire now if it is idle, so the next engage
         runs the build on disk.

--- a/local_operator/mobile/tui_handle.py
+++ b/local_operator/mobile/tui_handle.py
@@ -243,9 +243,19 @@ class TuiSessionHandle(SessionHandle):
         """Canonical state seed for full-TUI attach clients only."""
         return self._session().frontend_state
 
-    async def subscribe_frontend(self, on_update):  # type: ignore[no-untyped-def]
+    async def subscribe_frontend(
+        self, on_update, *, display_window=False
+    ):  # type: ignore[no-untyped-def]
         """Capture snapshot+subscription atomically on Textual's owner loop."""
-        return await self._on_app(lambda: self._session().subscribe_frontend(on_update))
+        return await self._on_app(
+            lambda: self._session().subscribe_frontend(on_update, display_window=display_window)
+        )
+
+    async def record_shell(self, command: str, result: Any) -> None:
+        await self._on_app(lambda: self._session().record_shell(command, result))
+
+    async def history_page(self, before: str, anchor: str = "") -> dict[str, Any]:
+        return await self._on_app(lambda: self._session().history_page(before, anchor))
 
     def subscribe_events(self, on_event: Callable[[dict[str, Any]], None]) -> Callable[[], None]:
         """Feed serialized AgentEvents to the registrant's v4 relay.

--- a/local_operator/providers/auth_store.py
+++ b/local_operator/providers/auth_store.py
@@ -19,11 +19,12 @@ Side effect preserved: session stickiness for a provider is cleared as soon
 as resolution LEAVES the OAuth tier (before the env tier), so identity
 lookups stop attributing OAuth accounts.
 
-Single-process limitation (PR-24): refresh single-flight is a per-process
-``asyncio.Lock``. Two local-operator processes racing a rotating OAuth
-refresh token can invalidate each other's new token; a guard with a
-cross-process ``auth_credential_refresh_leases`` table, which is deliberately
-deferred here.
+Refresh single-flight is a per-process ``asyncio.Lock`` PLUS a cross-process
+lease in ``auth_credential_refresh_leases`` (same atomic upsert as
+:meth:`UsageCacheStore.try_lease`). Two TUI+runtime processes racing a
+rotating OAuth refresh token used to invalidate each other's new token
+(PR-24); the loser now waits out the winner's write instead of POSTing a
+consumed token. Clients are still per-process — only the refresh is leased.
 """
 
 from __future__ import annotations
@@ -36,6 +37,7 @@ import os
 import sqlite3
 import threading
 import time
+import uuid
 import zlib
 from collections.abc import Iterable
 from pathlib import Path
@@ -58,6 +60,11 @@ logger = logging.getLogger("local_operator.providers.auth_store")
 
 OAUTH_REFRESH_SKEW_MS = 60_000  # pre-emptive refresh trigger
 DEFAULT_BLOCK_MS = 60_000  # rate-limit / 401 backoff
+
+#: How long a process may hold the cross-process refresh lease. Copied from
+#: usage (30 s): long enough for a slow IdP, short enough that a crashed
+#: holder cannot strand every sibling until they reboot.
+AUTH_REFRESH_LEASE_MS = 30_000
 
 #: Hard ceiling on ANY credential block, whatever computed it (a usage
 #: reset estimate, a provider Retry-After header, a caller's block_ms). A
@@ -131,6 +138,12 @@ CREATE TABLE IF NOT EXISTS auth_credential_blocks (
 );
 CREATE INDEX IF NOT EXISTS idx_auth_credential_blocks_expires
   ON auth_credential_blocks(blocked_until_ms);
+
+CREATE TABLE IF NOT EXISTS auth_credential_refresh_leases (
+  credential_id INTEGER PRIMARY KEY,
+  holder TEXT NOT NULL,
+  expires_at_ms INTEGER NOT NULL
+);
 """
 
 
@@ -291,8 +304,9 @@ class AuthStore:
     where refresh/network happens.
 
     .. note::
-        Single-process (PR-24): the refresh lock is a per-process
-        ``asyncio.Lock``; cross-process refresh leases are not implemented.
+        Refresh is single-flight per process (``asyncio.Lock``) and across
+        processes (``auth_credential_refresh_leases``, same upsert as usage).
+        HTTP clients stay per-process.
     """
 
     def __init__(
@@ -329,6 +343,9 @@ class AuthStore:
         # pool whose members are all equally valid.
         self._deprioritized: dict[str, dict[int, int]] = {}
         self._refresh_locks: dict[int, asyncio.Lock] = {}
+        #: Identity of this process in lease rows, so a release only frees a
+        #: lease THIS process took. Same shape as :class:`UsageCacheStore`.
+        self._refresh_holder = f"{os.getpid()}:{uuid.uuid4().hex[:8]}"
         # The first-resolve account pick (``_usage_ranked_order``). ON by
         # default: a store built without a settings mapping (the CLI's login
         # surface, the server's per-job stores) should still spread load, and
@@ -814,6 +831,50 @@ class AuthStore:
             self._refresh_locks[credential_id] = lock
         return lock
 
+    def _try_refresh_lease(self, credential_id: int) -> bool:
+        """Take the cross-process refresh lease if it is free (or expired).
+
+        Copied from :meth:`UsageCacheStore.try_lease`: one atomic upsert,
+        judged by rowcount, because SELECT-then-INSERT is not atomic even
+        inside ``with conn`` (sqlite3 defers BEGIN until the first write).
+        True means THIS process POSTs. False means a peer already owns the
+        refresh; the caller re-reads the row instead of joining the fan-out.
+        A coordination failure returns True — efficiency depends on the lease,
+        correctness of a single refresher does not.
+        """
+        now = self._now_ms()
+        expires = now + AUTH_REFRESH_LEASE_MS
+        try:
+            cursor = self._conn.execute(
+                """
+                INSERT INTO auth_credential_refresh_leases
+                    (credential_id, holder, expires_at_ms)
+                VALUES (?, ?, ?)
+                ON CONFLICT(credential_id) DO UPDATE SET
+                  holder = excluded.holder,
+                  expires_at_ms = excluded.expires_at_ms
+                WHERE auth_credential_refresh_leases.expires_at_ms <= ?
+                """,
+                (credential_id, self._refresh_holder, expires, now),
+            )
+            self._conn.commit()
+            return cursor.rowcount > 0
+        except sqlite3.Error:
+            logger.debug("auth refresh lease failed", exc_info=True)
+            return True
+
+    def _release_refresh_lease(self, credential_id: int) -> None:
+        """Free the lease if this process holds it (a refresh finished)."""
+        try:
+            self._conn.execute(
+                "DELETE FROM auth_credential_refresh_leases "
+                "WHERE credential_id = ? AND holder = ?",
+                (credential_id, self._refresh_holder),
+            )
+            self._conn.commit()
+        except sqlite3.Error:
+            logger.debug("auth refresh lease release failed", exc_info=True)
+
     @staticmethod
     def _needs_refresh(creds: dict[str, Any], *, force: bool = False) -> bool:
         if force:
@@ -856,6 +917,25 @@ class AuthStore:
             fresh = dict(current.data)
             if not self._needs_refresh(fresh, force=force):
                 return fresh
+            if not self._try_refresh_lease(row.id):
+                # A peer holds the lease. Wait out a slice of it and re-read:
+                # POSTing the same rotating refresh token is how the loser
+                # used to earn a real invalid_grant against a live grant.
+                await asyncio.sleep(0.05)
+                now_row = self.get_credential(row.id)
+                if now_row is None or now_row.disabled_cause is not None:
+                    raise AuthStoreError(f"Credential {row.id} disappeared during refresh")
+                now_data = dict(now_row.data)
+                if not self._needs_refresh(now_data, force=force):
+                    return now_data
+                # Peer still in flight or failed without writing. Fall through
+                # and try the lease again below only if force requires it;
+                # otherwise serve whatever they left. force=True still needs
+                # a live token, so we retry the lease once.
+                if not force:
+                    return now_data
+                if not self._try_refresh_lease(row.id):
+                    return now_data
             # Imported here, not at module scope: `callback_server` drags in
             # http.server/ssl/email (~138 ms, 150-odd modules), and three
             # separate comments in this codebase exist to stop anyone
@@ -866,6 +946,7 @@ class AuthStore:
             try:
                 refreshed = await refresh(fresh)
             except AuthStoreError:
+                self._release_refresh_lease(row.id)
                 raise
             except InvalidGrantError as exc:
                 # RFC 6749 SS5.2 terminal grant error. Re-raised as the store's
@@ -895,11 +976,14 @@ class AuthStore:
                         "process; keeping its token rather than declaring the grant dead",
                         row.id,
                     )
+                    self._release_refresh_lease(row.id)
                     return dict(now_row.data)
+                self._release_refresh_lease(row.id)
                 raise CredentialInvalidError(
                     f"OAuth grant for '{row.provider}' is no longer valid: {exc}"
                 ) from exc
             except Exception as exc:
+                self._release_refresh_lease(row.id)
                 raise AuthStoreError(f"OAuth refresh failed for '{row.provider}': {exc}") from exc
             merged = dict(fresh)
             merged.update(refreshed)
@@ -923,12 +1007,14 @@ class AuthStore:
                     "refresh race on %s: another process refreshed first; " "keeping its token",
                     row.id,
                 )
+                self._release_refresh_lease(row.id)
                 return dict(now_row.data)
             self._conn.execute(
                 "UPDATE auth_credentials SET data = ?, updated_at = ? WHERE id = ?",
                 (json.dumps(merged), self._now_ms(), row.id),
             )
             self._conn.commit()
+            self._release_refresh_lease(row.id)
             return merged
 
     async def ensure_oauth_fresh(self, credential_id: int) -> dict[str, Any] | None:

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -131,7 +131,16 @@ JOB_ERROR_WIRE_CHARS = 2_000
 #: is bounded by roster COUNT alone at roughly 1,400 children. That is stated
 #: rather than engineered away: the deepest roster observed across every session
 #: on the reference machine is 19.
-JOB_TEXT_FRAME_BUDGET_CHARS = 120_000
+#:
+#: Reduced from 120,000 by the 128 bytes that `history_generation` and its
+#: sibling window fields add to every frame. The socket line limit is fixed at
+#: 1 MiB, so a new session-level field has to be PAID FOR out of an elastic
+#: budget rather than shrinking the guard's margin: at the worst case the size
+#: guard asserts, the frame had 13 bytes of headroom and the new field costs
+#: 25. Per-row text is the right place to take it from — it is already shared,
+#: already floored at a legible preview, and 128 chars spread across a roster
+#: is invisible, whereas an over-limit frame cannot be sent at all.
+JOB_TEXT_FRAME_BUDGET_CHARS = 119_872
 JOB_TEXT_FLOOR_CHARS = 200
 
 #: Smallest catalogue the wire will clip to, however little the frame has left.

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -191,32 +191,51 @@ _MODEL_CATALOGUE_LINE_LIMIT = 1 << 20
 #: whole-state deep copy — see that method for the measurement that motivates
 #: it.
 #:
-#: The membership test is the SAFETY ARGUMENT, not a convenience list. Two
-#: properties are required of every name here, and both were checked against
-#: the reducer rather than assumed:
+#: The membership test is the SAFETY ARGUMENT, not a convenience list, and the
+#: bar is DEEP IMMUTABILITY OF THE HANDED-OUT VALUE — not "the reducer replaces
+#: it".
 #:
-#: 1. IMMUTABLE OR REPLACED WHOLESALE. A `str`/`bool`/`None` cannot be mutated
-#:    by a caller at all; `FrontendModelSpec` and `FrontendUsage` are Pydantic
-#:    shells the reducer swaps out via `mutate()` rather than editing in place,
-#:    so handing out the instance cannot corrupt the store.
-#: 2. NOT A MUTABLE COLLECTION. `jobs`, `usage_components`, `child_costs`,
-#:    `attention` and `context_breakdown` are deliberately EXCLUDED even though
-#:    single-field readers exist for some of them: a `dict`/`list` handed out
-#:    unguarded can be mutated by its caller, which is exactly the corruption
-#:    `state`'s deep copy exists to prevent. Those reads keep paying for it.
+#: An earlier version of this set admitted `selected_model`, `effective_model`
+#: and `last_usage` on the reducer-replacement argument. That argument is
+#: wrong, and review round 2 (Q6/F4) demonstrated it: `ModelSpec` and `Usage`
+#: are ordinary NON-FROZEN pydantic models, so `read_field` handed out the
+#: store's own instance and a caller writing `spec.model_id = ...` or
+#: `usage.input_tokens += n` rewrote canonical session state in place. Nothing
+#: shipped did that — but this codebase accumulates `Usage` with `+=` in
+#: `harness/jobs.py` and `harness/subagent.py`, so it was one ordinary edit
+#: from silent corruption, and `state` DOES protect those fields by returning a
+#: fresh object per read. Admitting them removed an existing invariant.
+#:
+#: They are therefore back on the copying path. Freezing the two models was the
+#: alternative and was rejected here: 13 in-place mutation sites across the
+#: harness rely on them being writable, which is a refactor well outside the
+#: change that introduced this accessor. The measured saving is nearly all in
+#: the scalars regardless (a per-read `model_copy` costs ~0.0075 ms against
+#: ~0.0001 ms shared, versus ~0.15 ms for the whole-state clone at a 19-job
+#: roster), so the fast path keeps the reads that are genuinely free.
+#:
+#: What remains admitted satisfies both requirements:
+#:
+#: 1. DEEPLY IMMUTABLE. Every entry is a `str`, `bool`, `int`, `float` or
+#:    `None`. A caller cannot mutate any of them, so sharing the value cannot
+#:    reach the store at all.
+#: 2. NOT A MUTABLE CONTAINER. `jobs`, `usage_components`, `child_costs`,
+#:    `attention`, `context_breakdown` and `todos` are excluded even though
+#:    single-field readers exist for some: a `dict`/`list` handed out unguarded
+#:    can be mutated by its caller, which is exactly what `state`'s deep copy
+#:    exists to prevent. Those reads keep paying for it.
+#:
+#: `test_shareable_state_fields_are_real_and_immutable` asserts both properties
+#: against `model_fields`, so neither a renamed field nor a newly mutable type
+#: can silently re-enter this set.
 _SHAREABLE_STATE_FIELDS = frozenset(
     {
-        "model_label",
-        "effective_model_label",
-        "selected_model",
-        "effective_model",
-        "last_usage",
         "streaming",
         "session_id",
         "epoch",
         "sequence",
         "history_generation",
-        "conversation_name",
+        "conversation_title",
         "goal",
         "active_agent",
         "active_team",
@@ -2269,12 +2288,14 @@ class FrontendStateStore:
         all of it from single-field reads like `model_label` and
         `effective_model`.
 
-        RESTRICTED TO FIELDS THAT ARE SAFE TO SHARE, and the restriction is
-        enforced rather than documented: the reducer REPLACES these values
-        instead of mutating them in place, so a caller cannot reach the store's
-        instance through them. `jobs`, `usage_components` and the other mutable
-        collections are deliberately absent — reading those still goes through
-        `state` and still pays for its protection.
+        RESTRICTED TO DEEPLY IMMUTABLE FIELDS, and the restriction is enforced
+        rather than documented. The value is the store's OWN object, so the bar
+        is that a caller cannot mutate it at all — every admitted field is a
+        `str`/`bool`/`int`/`float`/`None`. Model-valued fields and mutable
+        collections are deliberately absent: reading those still goes through
+        `state` and still pays for the deep copy that protects them. See
+        :data:`_SHAREABLE_STATE_FIELDS` for why "the reducer replaces it" was
+        NOT a sufficient bar.
         """
         if name not in _SHAREABLE_STATE_FIELDS:
             raise KeyError(

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -187,6 +187,45 @@ MODEL_CATALOGUE_FLOOR_ROWS = 50
 #: ``tools.builtin.BASH_SHELL_PATH``, and for the same reason: the consumer
 #: must stay cheap to import.
 _MODEL_CATALOGUE_LINE_LIMIT = 1 << 20
+#: Fields :meth:`FrontendStateStore.read_field` may serve without the
+#: whole-state deep copy — see that method for the measurement that motivates
+#: it.
+#:
+#: The membership test is the SAFETY ARGUMENT, not a convenience list. Two
+#: properties are required of every name here, and both were checked against
+#: the reducer rather than assumed:
+#:
+#: 1. IMMUTABLE OR REPLACED WHOLESALE. A `str`/`bool`/`None` cannot be mutated
+#:    by a caller at all; `FrontendModelSpec` and `FrontendUsage` are Pydantic
+#:    shells the reducer swaps out via `mutate()` rather than editing in place,
+#:    so handing out the instance cannot corrupt the store.
+#: 2. NOT A MUTABLE COLLECTION. `jobs`, `usage_components`, `child_costs`,
+#:    `attention` and `context_breakdown` are deliberately EXCLUDED even though
+#:    single-field readers exist for some of them: a `dict`/`list` handed out
+#:    unguarded can be mutated by its caller, which is exactly the corruption
+#:    `state`'s deep copy exists to prevent. Those reads keep paying for it.
+_SHAREABLE_STATE_FIELDS = frozenset(
+    {
+        "model_label",
+        "effective_model_label",
+        "selected_model",
+        "effective_model",
+        "last_usage",
+        "streaming",
+        "session_id",
+        "epoch",
+        "sequence",
+        "history_generation",
+        "conversation_name",
+        "goal",
+        "active_agent",
+        "active_team",
+        "context_tokens",
+        "context_window",
+        "context_is_estimate",
+        "cumulative_parent_cost",
+    }
+)
 
 #: Wire bounds for the launch-row reconciliation identities (see
 #: :func:`_wire_launch_prompts`).
@@ -2217,6 +2256,32 @@ class FrontendStateStore:
         return snapshot.model_copy(
             update={"jobs": _FrozenSequence(_public_job(job) for job in self._state.jobs)}
         )
+
+    def read_field(self, name: str) -> Any:
+        """One field of the state, WITHOUT cloning the whole state.
+
+        The general sibling of :attr:`pending_gate`, and it exists for the same
+        measured reason: `state` deep-copies every job, usage component and
+        trajectory row so no caller can mutate the store's instance, and the
+        per-frame accessors that read a SINGLE field were paying that clone
+        each time. Profiling one cold sidebar navigation measured 37 `state`
+        reads and ~25,000 `deepcopy` calls, ~30 ms of a 135 ms frame, almost
+        all of it from single-field reads like `model_label` and
+        `effective_model`.
+
+        RESTRICTED TO FIELDS THAT ARE SAFE TO SHARE, and the restriction is
+        enforced rather than documented: the reducer REPLACES these values
+        instead of mutating them in place, so a caller cannot reach the store's
+        instance through them. `jobs`, `usage_components` and the other mutable
+        collections are deliberately absent — reading those still goes through
+        `state` and still pays for its protection.
+        """
+        if name not in _SHAREABLE_STATE_FIELDS:
+            raise KeyError(
+                f"{name!r} is not a copy-free state field; read it through `state` "
+                "so the caller cannot mutate the store's own instance"
+            )
+        return getattr(self._state, name)
 
     @property
     def has_subscribers(self) -> bool:

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -143,50 +143,6 @@ JOB_ERROR_WIRE_CHARS = 2_000
 JOB_TEXT_FRAME_BUDGET_CHARS = 119_872
 JOB_TEXT_FLOOR_CHARS = 200
 
-#: Smallest catalogue the wire will clip to, however little the frame has left.
-#:
-#: ``model_catalogue`` is the same shape as the job text above — one row per
-#: offerable model, bounded by "whatever the provider lists" rather than by
-#: anything in this process — but it CANNOT take the same fixed budget, and the
-#: arithmetic is worth recording because the obvious fix is the wrong one.
-#:
-#: A production row is 11 keys and ~267 B (see :meth:`refresh_model_catalogue`).
-#: Real providers already list ~600 models and one QA backend published 1,410,
-#: so honouring the real catalogue needs ~392 KB. But the frame guard's
-#: pathological session (a 200-child roster, every collection field maxed) is
-#: already ~981 KB with an EMPTY catalogue, leaving only ~67 KB of the 1 MiB
-#: socket line — about 241 rows. No constant satisfies both: a budget big
-#: enough for a real provider overflows that frame, and one small enough to fit
-#: it hides two thirds of OpenRouter from the picker to satisfy a fixture.
-#:
-#: So the budget is RESIDUAL rather than constant: the catalogue is measured
-#: against what the socket line actually has left once every other field has
-#: been bounded, which is the only quantity that answers both cases. An
-#: ordinary session — the deepest roster ever observed on the reference machine
-#: is 19, and 1,410 models there serialize to ~442 KB against a 1 MiB cap —
-#: has hundreds of kilobytes spare and is never touched. Only the pathological
-#: combination clips, which is the case the socket cannot carry anyway.
-#:
-#: Clipping keeps the FIRST rows in the owner's existing sort order (best/most
-#: relevant first, the order the picker already renders) rather than dropping
-#: from the middle, and sets ``model_catalogue_truncated`` so the reader can
-#: say the list is partial instead of presenting it as the whole set.
-#:
-#: The floor is what stops a frame that is over budget for OTHER reasons from
-#: emptying the picker: an empty catalogue reads as "this session can switch to
-#: nothing", which is a lie the reader cannot detect, exactly the reasoning
-#: :data:`JOB_TEXT_FRAME_BUDGET_CHARS` gives for never dropping a job row.
-MODEL_CATALOGUE_FLOOR_ROWS = 50
-
-#: The control socket's line limit, mirrored rather than imported.
-#:
-#: ``runtime.server`` imports THIS module (``FRONTEND_CAPABILITY``), so
-#: importing ``_MAX_LINE_BYTES`` back would close a cycle. The value is pinned
-#: to the reader's by ``test_the_catalogue_budget_tracks_the_socket_line_limit``
-#: — the same "mirror it and pin it" discipline ``settings_io`` uses for
-#: ``tools.builtin.BASH_SHELL_PATH``, and for the same reason: the consumer
-#: must stay cheap to import.
-_MODEL_CATALOGUE_LINE_LIMIT = 1 << 20
 #: Fields :meth:`FrontendStateStore.read_field` may serve without the
 #: whole-state deep copy — see that method for the measurement that motivates
 #: it.
@@ -245,6 +201,51 @@ _SHAREABLE_STATE_FIELDS = frozenset(
         "cumulative_parent_cost",
     }
 )
+
+#: Smallest catalogue the wire will clip to, however little the frame has left.
+#:
+#: ``model_catalogue`` is the same shape as the job text above — one row per
+#: offerable model, bounded by "whatever the provider lists" rather than by
+#: anything in this process — but it CANNOT take the same fixed budget, and the
+#: arithmetic is worth recording because the obvious fix is the wrong one.
+#:
+#: A production row is 11 keys and ~267 B (see :meth:`refresh_model_catalogue`).
+#: Real providers already list ~600 models and one QA backend published 1,410,
+#: so honouring the real catalogue needs ~392 KB. But the frame guard's
+#: pathological session (a 200-child roster, every collection field maxed) is
+#: already ~981 KB with an EMPTY catalogue, leaving only ~67 KB of the 1 MiB
+#: socket line — about 241 rows. No constant satisfies both: a budget big
+#: enough for a real provider overflows that frame, and one small enough to fit
+#: it hides two thirds of OpenRouter from the picker to satisfy a fixture.
+#:
+#: So the budget is RESIDUAL rather than constant: the catalogue is measured
+#: against what the socket line actually has left once every other field has
+#: been bounded, which is the only quantity that answers both cases. An
+#: ordinary session — the deepest roster ever observed on the reference machine
+#: is 19, and 1,410 models there serialize to ~442 KB against a 1 MiB cap —
+#: has hundreds of kilobytes spare and is never touched. Only the pathological
+#: combination clips, which is the case the socket cannot carry anyway.
+#:
+#: Clipping keeps the FIRST rows in the owner's existing sort order (best/most
+#: relevant first, the order the picker already renders) rather than dropping
+#: from the middle, and sets ``model_catalogue_truncated`` so the reader can
+#: say the list is partial instead of presenting it as the whole set.
+#:
+#: The floor is what stops a frame that is over budget for OTHER reasons from
+#: emptying the picker: an empty catalogue reads as "this session can switch to
+#: nothing", which is a lie the reader cannot detect, exactly the reasoning
+#: :data:`JOB_TEXT_FRAME_BUDGET_CHARS` gives for never dropping a job row.
+MODEL_CATALOGUE_FLOOR_ROWS = 50
+
+#: The control socket's line limit, mirrored rather than imported.
+#:
+#: ``runtime.server`` imports THIS module (``FRONTEND_CAPABILITY``), so
+#: importing ``_MAX_LINE_BYTES`` back would close a cycle. The value is pinned
+#: to the reader's by ``test_the_catalogue_budget_tracks_the_socket_line_limit``
+#: — the same "mirror it and pin it" discipline ``settings_io`` uses for
+#: ``tools.builtin.BASH_SHELL_PATH``, and for the same reason: the consumer
+#: must stay cheap to import.
+_MODEL_CATALOGUE_LINE_LIMIT = 1 << 20
 
 #: Wire bounds for the launch-row reconciliation identities (see
 #: :func:`_wire_launch_prompts`).
@@ -1470,6 +1471,7 @@ class FrontendSessionState(BaseModel):
     #: omitting hundreds of them.
     model_catalogue_truncated: bool = False
     history_cursor: str | None = None
+    history_generation: int = 0
     attachment_root: str | None = None
     # Durable receipts are independent of owner epoch and pending action gates.
     attention: dict[str, Any] = Field(default_factory=dict)
@@ -2305,6 +2307,19 @@ class FrontendStateStore:
         return getattr(self._state, name)
 
     @property
+    def pending_gate(self) -> "PendingGateState | None":
+        """The pending gate alone, WITHOUT cloning the whole state.
+
+        ``state`` deep-copies every job, usage and trajectory row so no caller
+        can mutate the store's instance. A per-frame readiness check only needs
+        this one immutable field, and paying that clone on every display cost
+        ~23 ms of the cold sidebar frame — the single largest item in its
+        profile. ``PendingGateState`` is never mutated in place by the reducer
+        (it is replaced), so sharing the instance is safe here.
+        """
+        return self._state.pending_gate
+
+    @property
     def has_subscribers(self) -> bool:
         return bool(self._subscribers)
 
@@ -2730,6 +2745,7 @@ class FrontendStateStore:
             mcp_servers=mcp_servers,
             mcp_startup=mcp_startup,
             history_cursor=history_cursor,
+            history_generation=int(getattr(transcript, "_history_generation", 0)),
             attachment_root=str(getattr(transcript, "directory", "") or "") or None,
             slash_capabilities=_slash_capabilities(),
         )

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -53,6 +53,7 @@ from local_operator.harness.types import (
     Usage,
 )
 from local_operator.mcp.grants import GRANT_SUBCOMMANDS as _GRANT_SUBCOMMANDS
+from local_operator.session.history_window import DisplayHistoryWindow
 from local_operator.tui.costs import cost_summary, job_cost, turn_cost
 
 FRONTEND_STATE_VERSION = 1
@@ -478,6 +479,10 @@ _FRONTEND_LOCAL_SLASHES = {
     "help",
     "exit",
     "clear",
+    # The terminal schedules source-bound iterations and owns sidebar focus;
+    # each iteration still submits through that conversation's real owner.
+    "loop",
+    "sidebar",
     # The clipboard is the machine the USER IS SITTING AT, and every part of
     # this command is already here: the transcript it reads is painted by this
     # frontend, the picker it opens is painted by this frontend, and the OSC 52
@@ -1492,6 +1497,7 @@ class FrontendSync(BaseModel):
     sequence: int
     snapshot: FrontendSessionState
     live_cursor: str | None = None
+    display_history: DisplayHistoryWindow | None = None
 
 
 class FrontendUpdate(BaseModel):

--- a/local_operator/session/history_window.py
+++ b/local_operator/session/history_window.py
@@ -1,0 +1,189 @@
+"""Opt-in display pages of the owner's canonical durable replay.
+
+The journal may contain hundreds of MB of ignored host checkpoints while its
+conversation is only a few KB. Reuse the resident canonical replay, not a second
+index or the live model context. Signed cursors name a replay cut, never a path;
+appends preserve that cut, while prune/compaction/folding require reconciliation.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+from typing import TYPE_CHECKING, Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from local_operator.harness.types import AgentMessage, Message
+
+if TYPE_CHECKING:
+    from local_operator.session.transcript import Transcript
+
+DISPLAY_HISTORY_CAPABILITY = "display-history-window-v1"
+DISPLAY_HISTORY_MESSAGES = 120
+DISPLAY_HISTORY_BYTES = 512 * 1024
+
+
+class DisplayHistoryWindow(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok", "reset", "full_required"] = "ok"
+    conversation_id: str
+    owner_epoch: str
+    history_generation: int
+    through_id: str | None
+    messages: list[AgentMessage] = Field(default_factory=list)
+    before_token: str | None = None
+    snapshot_token: str | None = None
+    has_more: bool = False
+    total_message_count: int = 0
+    theme_turn_count: int = 0
+    opener_text: str = ""
+    start: int = 0
+    # Only seed identities already durable at this cut. These are NOT painted
+    # IDs: older unseen messages must remain pageable without being suppressed.
+    durable_seed_ids: list[str] = Field(default_factory=list)
+    durable_seed_tool_ids: list[str] = Field(default_factory=list)
+
+
+def _sign(payload: dict[str, Any], key: bytes) -> str:
+    raw = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+    data = base64.urlsafe_b64encode(raw).decode()
+    return data + "." + hmac.new(key, data.encode(), hashlib.sha256).hexdigest()
+
+
+def _verify(token: str, key: bytes) -> dict[str, Any]:
+    if len(token) > 4096:
+        raise ValueError("invalid history token")
+    try:
+        data, signature = token.split(".")
+        expected = hmac.new(key, data.encode(), hashlib.sha256).hexdigest()
+        if not hmac.compare_digest(signature, expected):
+            raise ValueError("invalid history token")
+        value = json.loads(base64.urlsafe_b64decode(data))
+        if not isinstance(value, dict):
+            raise ValueError("invalid history token")
+        return value
+    except (ValueError, TypeError) as exc:
+        raise ValueError("invalid history token") from exc
+
+
+def display_window(
+    transcript: Transcript,
+    *,
+    conversation_id: str,
+    owner_epoch: str,
+    through_id: str | None,
+    before: str | None = None,
+    anchor: str = "",
+    max_messages: int = DISPLAY_HISTORY_MESSAGES,
+    max_wire_bytes: int = DISPLAY_HISTORY_BYTES,
+) -> DisplayHistoryWindow:
+    """Return complete replay rows, with tool call/result groups kept together.
+
+    A single group larger than the byte budget explicitly requests the existing
+    full local replay path. It is never replaced by a prefix or marked complete.
+    The authenticated attach has already established access to that transcript.
+    """
+    generation = transcript._history_generation
+    envelope: dict[str, Any] = dict(
+        conversation_id=conversation_id,
+        owner_epoch=owner_epoch,
+        history_generation=generation,
+        through_id=through_id,
+    )
+    claims = None
+    if before is not None:
+        claims = _verify(before, transcript._history_page_key)
+        if claims.get("conversation_id") != conversation_id:
+            raise ValueError("history token belongs to another conversation")
+        if (
+            claims.get("owner_epoch") != owner_epoch
+            or claims.get("history_generation") != generation
+        ):
+            return DisplayHistoryWindow(status="reset", **envelope)
+        through_id = claims.get("through_id")
+        envelope["through_id"] = through_id
+    try:
+        history = transcript.build_llm_history(through_id=through_id) if through_id else []
+    except ValueError:
+        return DisplayHistoryWindow(status="reset", **envelope)
+    total = len(history)
+    end = int(claims["position"]) if claims is not None else total
+    if end < 0 or end > total:
+        raise ValueError("invalid history page position")
+    # Message.tool_results are rendered on their preceding call's card. Do not
+    # split that group across pages, or a settled call looks interrupted until
+    # an unrelated scroll fetch happens to supply the result.
+    result_positions = {
+        message.tool_call_id: index
+        for index, message in enumerate(history)
+        if isinstance(message, Message) and message.role == "tool"
+    }
+    boundaries = [0]
+    paired_through = -1
+    for index, message in enumerate(history):
+        if index > paired_through and index and getattr(message, "role", "") != "tool":
+            boundaries.append(index)
+        for call in getattr(message, "tool_calls", ()):
+            paired_through = max(paired_through, result_positions.get(call.id, index))
+    boundaries.append(total)
+    if anchor:
+        wanted = next(
+            (
+                index
+                for index, message in enumerate(history)
+                if message.id == anchor
+                or any("tool:" + call.id == anchor for call in getattr(message, "tool_calls", ()))
+            ),
+            None,
+        )
+        if wanted is None:
+            return DisplayHistoryWindow(status="reset", **envelope)
+        # Include the anchor and a real viewport's worth after it. The TUI can
+        # page in either direction using the snapshot token without guessing IDs.
+        end = next((b for b in boundaries if b >= min(total, wanted + max_messages // 2)), total)
+    start = end
+    selected: list[AgentMessage] = []
+    used = 0
+    for left in reversed([b for b in boundaries if b < end]):
+        group = history[left:start]
+        # Match the socket's JSON encoding, including escaped non-ASCII text;
+        # a character budget or UTF-8-only estimate understates that frame.
+        cost = sum(len(json.dumps(m.model_dump(mode="json")).encode()) + 1 for m in group)
+        if used + cost > max_wire_bytes - 8192 or len(selected) + len(group) > max_messages:
+            if not selected or (
+                anchor
+                and not any(
+                    m.id == anchor
+                    or any("tool:" + c.id == anchor for c in getattr(m, "tool_calls", ()))
+                    for m in selected
+                )
+            ):
+                return DisplayHistoryWindow(status="full_required", **envelope)
+            break
+        selected[0:0] = group
+        used += cost
+        start = left
+        if len(selected) >= max_messages:
+            break
+    token_fields = dict(envelope)
+    snapshot_token = _sign(dict(token_fields, position=total), transcript._history_page_key)
+    before_token = (
+        _sign(dict(token_fields, position=start), transcript._history_page_key) if start else None
+    )
+    return DisplayHistoryWindow(
+        **envelope,
+        messages=selected,
+        before_token=before_token,
+        snapshot_token=snapshot_token,
+        has_more=start > 0,
+        total_message_count=total,
+        start=start,
+        theme_turn_count=sum(getattr(m, "role", "") in ("user", "assistant") for m in history),
+        opener_text=next(
+            (m.text[:256] for m in history if isinstance(m, Message) and m.role == "user"), ""
+        ),
+    )

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -1439,6 +1439,60 @@ class RemoteSession:
             raise RuntimeError("this session uses full-history replay")
         return await self._fetch_history_page(before, window.owner_epoch, window.through_id, anchor)
 
+    def pending_display_tool_ids(self) -> set[str]:
+        """Unanswered calls in the pending gate's current serialized user turn.
+
+        A gate can precede tool_execution_start, so no invented start event is
+        needed. The latest call group after the latest user boundary is the
+        only eligible group; old interrupted turns must remain interrupted.
+        """
+        if self.pending_gate is None:
+            return set()
+        answered: set[str] = set()
+        for message in reversed(self.display_history_window()):
+            role = getattr(message, "role", "")
+            if role == "user":
+                break
+            if role == "tool":
+                answered.add(str(getattr(message, "tool_call_id", "")))
+            calls = getattr(message, "tool_calls", None)
+            if role == "assistant" and calls:
+                return {call.id for call in calls} - answered
+        return set()
+
+    @property
+    def display_history_revision(self) -> int:
+        return self._display_revision
+
+    @property
+    def display_history_current(self) -> bool:
+        return not self._display_invalidated
+
+    def _invalidate_display_history(self) -> None:
+        if not self._display_window_supported:
+            return
+        self._display_invalidated = True
+        self._display_revision += 1
+        task = self._display_refresh_task
+        if task is None or task.done():
+            task = asyncio.create_task(self._refresh_display_history())
+            self._display_refresh_task = task
+
+            def finished(done: asyncio.Task[None]) -> None:
+                if not done.cancelled() and done.exception() is not None:
+                    # Keep the invalidation fence closed. Selection awaits this
+                    # task and reports the failure instead of painting stale rows.
+                    logger.warning("canonical display refresh failed: %s", done.exception())
+
+            task.add_done_callback(finished)
+
+    async def ensure_display_current(self) -> None:
+        task = self._display_refresh_task
+        if task is not None:
+            await asyncio.shield(task)
+        if self._display_invalidated:
+            await self._refresh_display_history()
+
     async def _refresh_display_history(self) -> None:
         """Reattach only this viewer; never restart, stop, or prompt the owner."""
         async with self._display_refresh_lock:
@@ -2015,7 +2069,7 @@ class RemoteSession:
         if self._disposed or not self._ready_for_events:
             return
         if pending is None:
-            pending = _pending_request(self.frontend_state.pending_gate)
+            pending = _pending_request(self.pending_gate)
         if pending is None or self._gate_task is not None:
             return
         if self._gate_identity(pending) == self._gate_answered_key:
@@ -2729,32 +2783,66 @@ class RemoteSession:
             raise RuntimeError("frontend state has not synchronized")
         return self._frontend_store.state
 
+    @property
+    def pending_gate(self) -> Any:
+        """The pending gate without the full-state clone ``frontend_state`` pays.
+
+        For per-frame readiness checks only; see the store's own property.
+        """
+        if self._frontend_store is None:
+            raise RuntimeError("frontend state has not synchronized")
+        return self._frontend_store.pending_gate
+
+    @property
+    def epoch(self) -> str:
+        """The owner epoch without the full-state clone.
+
+        Paired with :attr:`pending_gate` because gate IDENTITY is epoch plus
+        gate, and reading the epoch through ``frontend_state`` would put the
+        clone back on the same per-frame path.
+        """
+        return self._read_state_field("epoch")
+
     def subscribe_frontend(self, handler):  # type: ignore[no-untyped-def]
         if self._frontend_store is None:
             raise RuntimeError("frontend state has not synchronized")
         return self._frontend_store.subscribe(handler)
 
+    def _read_state_field(self, name: str) -> Any:
+        """One canonical field without the whole-state clone.
+
+        These accessors are called per FRAME by the band and panels, and each
+        `frontend_state` read deep-copies every job and usage row (measured:
+        ~30 ms of a 135 ms cold sidebar frame). The store enforces which fields
+        are safe to share; anything else still goes through `frontend_state`.
+        """
+        if self._frontend_store is None:
+            raise RuntimeError("frontend state has not synchronized")
+        return self._frontend_store.read_field(name)
+
     @property
     def model_label(self) -> str:
-        return self.frontend_state.model_label
+        return self._read_state_field("model_label")
 
     @property
     def model(self) -> ModelSpec:
-        model = self.frontend_state.selected_model
+        model = self._read_state_field("selected_model")
         if model is None:
             raise RuntimeError("owner has no selected model spec")
         return model
 
     @property
     def effective_model(self) -> ModelSpec:
-        model = self.frontend_state.effective_model or self.frontend_state.selected_model
+        model = self._read_state_field("effective_model") or self._read_state_field(
+            "selected_model"
+        )
         if model is None:
             raise RuntimeError("owner has no effective model spec")
         return model
 
     @property
     def effective_model_label(self) -> str:
-        return self.frontend_state.effective_model_label
+        return self._read_state_field("effective_model_label")
 
     def set_model(self, model: ModelSpec, *, explicit: bool = False) -> None:
         old = self.model
@@ -3256,7 +3344,7 @@ class RemoteSession:
         return self.frontend_state.active_team
 
     def restored_usage(self) -> Usage | None:
-        return self.frontend_state.last_usage
+        return self._read_state_field("last_usage")
 
     def running_subagents(self) -> int:
         return sum(

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -2822,27 +2822,31 @@ class RemoteSession:
 
     @property
     def model_label(self) -> str:
-        return self._read_state_field("model_label")
+        return self.frontend_state.model_label
 
     @property
     def model(self) -> ModelSpec:
-        model = self._read_state_field("selected_model")
+        # Through the COPYING path deliberately: a spec is a non-frozen model,
+        # and handing out the store's own instance let a caller rewrite
+        # canonical state in place (review round 2, Q6/F4).
+        model = self.frontend_state.selected_model
         if model is None:
             raise RuntimeError("owner has no selected model spec")
         return model
 
     @property
     def effective_model(self) -> ModelSpec:
-        model = self._read_state_field("effective_model") or self._read_state_field(
-            "selected_model"
-        )
+        # One snapshot, not two reads: the fallback must not be able to pair a
+        # spec with a newer state's selection. Copying path, per `model`.
+        state = self.frontend_state
+        model = state.effective_model or state.selected_model
         if model is None:
             raise RuntimeError("owner has no effective model spec")
         return model
 
     @property
     def effective_model_label(self) -> str:
-        return self._read_state_field("effective_model_label")
+        return self.frontend_state.effective_model_label
 
     def set_model(self, model: ModelSpec, *, explicit: bool = False) -> None:
         old = self.model
@@ -3344,7 +3348,9 @@ class RemoteSession:
         return self.frontend_state.active_team
 
     def restored_usage(self) -> Usage | None:
-        return self._read_state_field("last_usage")
+        # Copying path: `Usage` is accumulated in place elsewhere in the
+        # harness, so a shared instance is one `+=` from corrupting state.
+        return self.frontend_state.last_usage
 
     def running_subagents(self) -> int:
         return sum(

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -76,6 +76,7 @@ from local_operator.mobile.types import (
     PendingRequest,
     SessionRecord,
 )
+from local_operator.session.attachments import AttachmentStore
 from local_operator.session.frontend_state import (
     FRONTEND_CAPABILITY,
     FRONTEND_CHECKPOINT_CUSTOM_TYPE,
@@ -92,7 +93,11 @@ from local_operator.session.frontend_state import (
 from local_operator.session.history_window import DisplayHistoryWindow
 from local_operator.session.naming import ConversationName
 from local_operator.session.protocol import CompactionOutcome
-from local_operator.session.transcript import Transcript
+from local_operator.session.transcript import (
+    Transcript,
+    read_replay_suffix,
+    replay_entries,
+)
 from local_operator.session_lease import SessionLeaseHeldError
 
 logger = logging.getLogger(__name__)
@@ -1619,12 +1624,10 @@ class RemoteSession:
         file, so a long session's replay is file I/O plus JSON parsing from
         end to end, with nothing the loop needs until the result is bound.
         """
-        entries, history = await self._read_transcript(
+        history = await self._read_transcript(
             want_checkpoint=want_checkpoint, through_id=live_cursor, strict_cut=strict_cut
         )
-        self._bind_history(
-            entries, history, live_cursor, drop_history_duplicates=drop_history_duplicates
-        )
+        self._bind_history(history, live_cursor, drop_history_duplicates=drop_history_duplicates)
 
     async def _read_transcript(
         self,
@@ -1632,8 +1635,8 @@ class RemoteSession:
         want_checkpoint: bool = False,
         through_id: str | None = None,
         strict_cut: bool = False,
-    ) -> tuple[list[Any], list[Any]]:
-        """Parse the durable transcript off-loop, once per sync.
+    ) -> list[Any]:
+        """Replay the durable transcript off-loop, once per sync.
 
         The single threaded read shared by initial connect AND reconnect:
         review round 3 (MAJOR-2) found the reconnect path re-running this
@@ -1655,26 +1658,39 @@ class RemoteSession:
         long-lived holds a reference on any path.
         """
 
-        def _replay() -> tuple[list[Any], list[Any]]:
-            transcript = Transcript(self._config_dir / "sessions" / self._session_id)
+        def _replay() -> list[Any]:
+            directory = self._config_dir / "sessions" / self._session_id
+            # Backward suffix read instead of ``Transcript(directory)``: the
+            # constructor JSON-decodes every row (220 ms at 47 MB, 1.5 s at
+            # 204 MB on the reference owners) when the replay only ever uses
+            # rows from the latest compaction's kept window. The suffix reader
+            # stops at that boundary and replays through the SAME module
+            # function the constructor path uses, so the result is identical
+            # by construction; a journal with no compaction reads to the
+            # start, which is today's cost, not a shortcut. The checkpoint is
+            # extracted from the same pass for the cold path so nothing
+            # re-reads the file on the loop.
+            suffix = read_replay_suffix(
+                directory,
+                through_id=through_id,
+                checkpoint_type=FRONTEND_CHECKPOINT_CUSTOM_TYPE if want_checkpoint else None,
+            )
             if want_checkpoint:
-                # Read here, on the worker, while the object is alive and
-                # already parsed: a second ``Transcript(...)`` on the loop
-                # would re-read and re-parse the whole file (0.68 s on the
-                # largest observed session).
-                self._cold_checkpoint = transcript.latest_custom(FRONTEND_CHECKPOINT_CUSTOM_TYPE)
+                self._cold_checkpoint = suffix.checkpoint
             cut = through_id
-            if cut is not None and not transcript.has_entry(cut) and not strict_cut:
+            if cut is not None and not suffix.through_present and not strict_cut:
                 # Older owners used best-effort cursors; preserve that fallback
                 # only for legacy full replay, never the negotiated window cut.
+                # ``through_present`` is false only after the reader reached
+                # the file START without meeting the cursor, so this is the
+                # same "id is not in the journal" the whole-file parse saw.
                 cut = None
-            return transcript.entries(), transcript.build_llm_history(through_id=cut)
+            return replay_entries(suffix.entries, AttachmentStore(directory), through_id=cut)
 
         return await asyncio.to_thread(_replay)
 
     def _bind_history(
         self,
-        entries: list[Any],
         history: list[Any],
         live_cursor: str | None,
         *,
@@ -2578,14 +2594,13 @@ class RemoteSession:
                         if self._display_window_requested and frontend.display_history is not None:
                             await self._load_frontend_history(frontend)
                         else:
-                            entries, history = (
+                            history = (
                                 await self._read_transcript(through_id=frontend.live_cursor)
                                 if frontend.live_cursor is not None
                                 else await self._read_transcript()
                             )
                             self._replay_durable_suffix(history)
                             self._bind_history(
-                                entries,
                                 history,
                                 frontend.live_cursor,
                                 drop_history_duplicates=False,

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -303,6 +303,14 @@ class RemoteSession:
         self._display_window_requested = False
         self._owner_record: SessionRecord | None = None
         self._display_refresh_lock = asyncio.Lock()
+        self._display_refresh_task: asyncio.Task[None] | None = None
+        self._prompt_completion_waiters: set[asyncio.Future[AgentEndEvent]] = set()
+        self._prompt_completion_observers: set[EventHandler] = set()
+        self._display_invalidated = False
+        self._display_revision = 0
+        self._loaded_history_generation = 0
+        self._display_window_supported = False
+        self._frontend_refresh_cut: tuple[str, int] | None = None
         self._hydrated_once = False
         self._display_history: DisplayHistoryWindow | None = None
         self._history_hydrated = True
@@ -511,8 +519,8 @@ class RemoteSession:
         *,
         config_dir: Path,
         takeover_factory: Callable[[], Any],
-        surface: str = "terminal",
         display_window: bool = False,
+        surface: str = "terminal",
     ) -> "RemoteSession":
         if record.protocol < 5 or FRONTEND_CAPABILITY not in record.capabilities:
             raise ConnectionError(
@@ -1295,6 +1303,7 @@ class RemoteSession:
             events=True,
             on_event=lambda data: (self._on_wire_event(data) if self._client is client else None),
             frontend_state=True,
+            display_window=self._display_window_requested,
             surface=self._surface,
             # THE full-TUI viewer is the client that renders action-carrying
             # receipts: ``_render_authoritative_slash`` submits their
@@ -1303,7 +1312,6 @@ class RemoteSession:
             # command twice. A viewer that omitted this (every build before
             # the field) is exactly the case the runtime completes for.
             slash_consumers=list(SLASH_ACTION_RECEIPTS),
-            display_window=self._display_window_requested,
             on_frontend_sync=lambda data: (
                 self._on_frontend_sync(data) if self._client is client else None
             ),
@@ -1357,6 +1365,13 @@ class RemoteSession:
     async def _load_frontend_history(self, frontend: FrontendSync) -> None:
         """Install the durable cut before live replay or command readiness."""
         window = frontend.display_history if self._display_window_requested else None
+        self._display_window_supported = window is not None
+        self._loaded_history_generation = (
+            window.history_generation
+            if window is not None
+            else frontend.snapshot.history_generation
+        )
+        self._display_revision += 1
         previous = self._display_history
         if window is None or window.status != "ok":
             # Legacy owners and oversized prose keep the honest full replay.
@@ -1499,16 +1514,50 @@ class RemoteSession:
             await self._refresh_display_history()
 
     async def _refresh_display_history(self) -> None:
-        """Reattach only this viewer; never restart, stop, or prompt the owner."""
+        """Capture a fresh canonical cut on the existing authenticated stream.
+
+        Redialling here abandons pending RPCs (including the compact operation
+        whose success triggered this refresh) or leaks their old connection.
+        A read-only sync uses the same atomic owner capture and buffers live
+        deltas until its exact cursor/gates/history are installed instead.
+        """
         async with self._display_refresh_lock:
-            record = self._owner_record
-            if record is None or self._client is None or not self._client.connected:
-                record, _ = await asyncio.to_thread(
-                    find_owner_record, self._config_dir, self._session_id
-                )
-            if record is None:
-                raise ConnectionError("history owner is unavailable")
-            await self._bind_to(record)
+            self._display_invalidated = True
+            while self._display_invalidated:
+                client = self._client
+                if client is None or not client.connected:
+                    raise ConnectionError("history owner is unavailable")
+                self._ready_for_events = False
+                self._owner_ready.clear()
+                self._pending_frontend_updates = []
+                try:
+                    frontend = FrontendSync.model_validate(await client.frontend_sync())
+                    if (
+                        self._client is not client
+                        or self._disposed
+                        or frontend.snapshot.session_id != self._session_id
+                        or frontend.epoch != self.frontend_state.epoch
+                    ):
+                        raise ConnectionError("history binding changed during refresh")
+                    self._frontend_refresh_cut = (frontend.epoch, frontend.sequence)
+                    self._install_frontend(frontend.snapshot, publish=True)
+                    await self._load_frontend_history(frontend)
+                    self._display_invalidated = (
+                        self.frontend_state.history_generation != self._loaded_history_generation
+                    )
+                    self._finish_sync()
+                except BaseException:
+                    # The transport remains usable even when this read fails.
+                    # Preserve its ordered updates and surface the history error
+                    # to navigation, without cancelling source work or its gates.
+                    pending, self._pending_frontend_updates = self._pending_frontend_updates, None
+                    for update in pending or ():
+                        self._on_frontend_update(update.model_dump(mode="json"))
+                    self._ready_for_events = True
+                    self._drain_buffered_events()
+                    raise
+                finally:
+                    self._owner_ready.set()
 
     @property
     def history_before_token(self) -> str | None:
@@ -1940,6 +1989,12 @@ class RemoteSession:
 
     def _on_frontend_update(self, data: dict[str, Any]) -> None:
         update = FrontendUpdate.model_validate(data)
+        cut = self._frontend_refresh_cut
+        if cut is not None and update.epoch == cut[0] and update.sequence <= cut[1]:
+            # The old subscription can deliver this captured prefix after the
+            # read response. Its fields are already in the installed snapshot;
+            # the AttachClient still validates the original stream's sequence.
+            return
         if self._pending_frontend_updates is not None:
             self._pending_frontend_updates.append(update)
             return
@@ -1947,6 +2002,8 @@ class RemoteSession:
             raise ConnectionError("frontend update arrived before synchronization")
         state = self._frontend_store.apply_update(update)
         self._apply_frontend_facades(state)
+        if state.history_generation != self._loaded_history_generation:
+            self._invalidate_display_history()
 
     def _install_frontend(self, state: FrontendSessionState, *, publish: bool = False) -> None:
         if state.session_id != self._session_id:
@@ -1967,6 +2024,11 @@ class RemoteSession:
         self._apply_frontend_facades(state)
         pending, self._pending_frontend_updates = self._pending_frontend_updates, None
         for update in pending or ():
+            # A same-connection refresh can overtake queued deltas already
+            # represented by its snapshot. Only this captured prefix is skipped;
+            # future gaps still fail the ordinary exact-sequence check.
+            if update.epoch == state.epoch and update.sequence <= state.sequence:
+                continue
             self._on_frontend_update(update.model_dump(mode="json"))
 
     def _apply_frontend_facades(self, state: FrontendSessionState) -> None:
@@ -1995,6 +2057,15 @@ class RemoteSession:
 
     def _on_wire_event(self, data: dict[str, Any]) -> None:
         event = deserialize_event(data)
+        # Command completion is an owner lifecycle fact, not a painting event.
+        # A canonical display refresh may buffer/dedupe UI replay, but it must
+        # never hide the requested turn's terminal outcome from its scheduler.
+        for observer in tuple(self._prompt_completion_observers):
+            observer(event)
+        if isinstance(event, CompactionEndEvent) and event.success:
+            # The success event itself closes eligibility even if its preceding
+            # canonical generation delta has not reached this reader yet.
+            self._invalidate_display_history()
         # A message-grade event whose row is already durable (history was read
         # after the socket began buffering) or already painted live is dropped
         # by stable message id — the single dedup rule for both seams. The
@@ -2127,7 +2198,6 @@ class RemoteSession:
                 approved = await call_approval_gate(handler, pending.title, pending.detail)
             else:
                 return
-            approved = await call_approval_gate(handler, pending.title, pending.detail)
             if not self._gate_reply_is_current(pending, client):
                 return
             await client.approval_answer(pending.request_id, approved)
@@ -2178,6 +2248,8 @@ class RemoteSession:
                 secret=pending.secret,
             )
             answer = await handler([question])
+            if not self._gate_reply_is_current(pending, client):
+                return
             if not answer:
                 return
             values = answer.get(pending.request_id) or []
@@ -2202,6 +2274,7 @@ class RemoteSession:
     # -- owner loss ---------------------------------------------------------
 
     def _on_disconnected(self, _reason: str) -> None:
+        self._fail_prompt_completion_waiters("owner connection lost while awaiting turn completion")
         self._runtime_pid = None
         if self._disposed or self._recovering:
             return
@@ -3074,9 +3147,7 @@ class RemoteSession:
 
     def resume_viewer_gates(self) -> None:
         """Recreate bridges only after the source is the visible input target."""
-        if self._gates_detached:
-            self._gates_detached = False
-            self._gate_handled_key = None
+        self._gates_detached = False
         self._maybe_start_gate()
 
     async def adopt_aside(self, messages: list[Message]) -> None:
@@ -3163,6 +3234,85 @@ class RemoteSession:
         return CompactionOutcome(True, detail=detail)
 
     # -- driving turns ------------------------------------------------------
+
+    def _fail_prompt_completion_waiters(self, reason: str) -> None:
+        for waiter in tuple(self._prompt_completion_waiters):
+            if not waiter.done():
+                waiter.set_exception(ConnectionError(reason))
+
+    async def prompt_and_wait(
+        self,
+        text: str,
+        images: Sequence[ImageContent] | None = None,
+        *,
+        message_id: str | None = None,
+    ) -> None:
+        """Submit one FIFO prompt and await its owner's actual terminal outcome.
+
+        ``prompt`` intentionally returns on durable admission for interactive
+        callers. A loop cannot treat that ACK as completion. Correlate the
+        producer's user-row ID, then the owner's generation(s), on the same
+        serialized event stream. Auto-continuations remain inside the owner's
+        pipeline; its held final agent_end is the completion, not a busy flag.
+        This also works with older owners that implement the existing ID/epoch/
+        generation contract, without a new scheduler or longer RPC timeout.
+        """
+        await self._ensure_bound()
+        await self._owner_ready.wait()
+        if self._takeover_target is not None:
+            await self.prompt(text, images=images, message_id=message_id)
+            return
+        client = self._client
+        if client is None or not client.connected:
+            raise ConnectionError("owner connection lost")
+        images_wire = [_image_to_wire(image) for image in (images or [])]
+        command = (
+            ContinuationCommand(message_id, self._session_id, text, images_wire)
+            if message_id
+            else ContinuationCommand.create(self._session_id, text, images_wire)
+        )
+        epoch = self.frontend_state.epoch
+        admitted = False
+        generation: int | None = None
+        completed: asyncio.Future[AgentEndEvent] = asyncio.get_running_loop().create_future()
+        self._prompt_completion_waiters.add(completed)
+
+        def observe(event: AgentEvent[Any]) -> None:
+            nonlocal admitted, generation
+            if completed.done():
+                return
+            if self.frontend_state.epoch != epoch:
+                completed.set_exception(ConnectionError("owner changed during loop iteration"))
+                return
+            message = getattr(event, "message", None)
+            if (
+                isinstance(event, MessageStartEvent)
+                and getattr(message, "id", None) == command.command_id
+            ):
+                admitted = True
+            elif isinstance(event, AgentStartEvent) and admitted:
+                generation = event.generation
+            elif isinstance(event, AgentEndEvent) and admitted:
+                if generation is None or event.generation == generation:
+                    completed.set_result(event)
+
+        self._prompt_completion_observers.add(observe)
+        try:
+            # Loop iterations are queued prompt turns, never steering inferred
+            # from a transient current-busy observation.
+            await client.send_command(command, streaming=False)
+            outcome = await completed
+            if outcome.error:
+                raise RuntimeError(outcome.error)
+            if outcome.aborted:
+                raise RuntimeError("owner interrupted the loop iteration")
+        finally:
+            self._prompt_completion_observers.discard(observe)
+            self._prompt_completion_waiters.discard(completed)
+            if not completed.done():
+                completed.cancel()
+            elif not completed.cancelled():
+                completed.exception()
 
     async def prompt(
         self,
@@ -3441,6 +3591,11 @@ class RemoteSession:
 
     async def dispose(self) -> None:
         self._disposed = True
+        self._fail_prompt_completion_waiters("viewer disposed while awaiting turn completion")
+        refresh = self._display_refresh_task
+        if refresh is not None and refresh is not asyncio.current_task() and not refresh.done():
+            refresh.cancel()
+            await asyncio.gather(refresh, return_exceptions=True)
         if self._gate_task is not None:
             self._gate_task.cancel()
         if self._recovery_task is not None and self._recovery_task is not asyncio.current_task():

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -58,6 +58,7 @@ from local_operator.harness.types import (
     ToolExecutionEndEvent,
     ToolExecutionStartEvent,
     ToolExecutionUpdateEvent,
+    ToolResult,
     TurnEndEvent,
     TurnStartEvent,
     Usage,
@@ -88,6 +89,7 @@ from local_operator.session.frontend_state import (
     SnapshotSubagentComms,
     SnapshotWakeScheduler,
 )
+from local_operator.session.history_window import DisplayHistoryWindow
 from local_operator.session.naming import ConversationName
 from local_operator.session.protocol import CompactionOutcome
 from local_operator.session.transcript import Transcript
@@ -292,6 +294,15 @@ class RemoteSession:
         self._subagent_comms = SnapshotSubagentComms()
         self.mcp_startup: Any | None = None
         self._history: list[Any] = []
+        self._live_history: dict[str, Any] = {}
+        self._display_window_requested = False
+        self._owner_record: SessionRecord | None = None
+        self._display_refresh_lock = asyncio.Lock()
+        self._hydrated_once = False
+        self._display_history: DisplayHistoryWindow | None = None
+        self._history_hydrated = True
+        self._durable_seed_ids: set[str] = set()
+        self._durable_seed_tool_ids: set[str] = set()
         self._history_ids: set[str] = set()
         #: The durable frontend checkpoint, handed from the threaded history
         #: read to the cold path's restore so the roster/todo/title recovery
@@ -496,6 +507,7 @@ class RemoteSession:
         config_dir: Path,
         takeover_factory: Callable[[], Any],
         surface: str = "terminal",
+        display_window: bool = False,
     ) -> "RemoteSession":
         if record.protocol < 5 or FRONTEND_CAPABILITY not in record.capabilities:
             raise ConnectionError(
@@ -507,11 +519,12 @@ class RemoteSession:
             takeover_factory=takeover_factory,
             surface=surface,
         )
+        self._display_window_requested = display_window
         await self._dial(record)
         try:
             frontend = await self._await_frontend()
             self._install_frontend(frontend.snapshot)
-            await self._load_history(frontend.live_cursor)
+            await self._load_frontend_history(frontend)
         except BaseException:
             # The caller gets the error and no facade — so nothing would ever
             # close the connection ``_dial`` just opened. See
@@ -1166,7 +1179,7 @@ class RemoteSession:
             if self._disposed:
                 raise ConnectionError("viewer disposed while synchronizing")
             self._install_frontend(frontend.snapshot, publish=True)
-            await self._load_history(frontend.live_cursor)
+            await self._load_frontend_history(frontend)
             if self._disposed:
                 raise ConnectionError("viewer disposed while synchronizing")
             self._finish_sync()
@@ -1226,6 +1239,7 @@ class RemoteSession:
             logger.debug("closing a rejected owner connection failed", exc_info=True)
 
     async def _dial(self, record: SessionRecord) -> None:
+        self._owner_record = record
         # Freeze relay delivery until the canonical sync is installed ahead of
         # raw event frames that follow it on the same socket.
         self._ready_for_events = False
@@ -1284,6 +1298,7 @@ class RemoteSession:
             # command twice. A viewer that omitted this (every build before
             # the field) is exactly the case the runtime completes for.
             slash_consumers=list(SLASH_ACTION_RECEIPTS),
+            display_window=self._display_window_requested,
             on_frontend_sync=lambda data: (
                 self._on_frontend_sync(data) if self._client is client else None
             ),
@@ -1334,12 +1349,205 @@ class RemoteSession:
         except TimeoutError as exc:
             raise ConnectionError("owner did not send frontend synchronization") from exc
 
+    async def _load_frontend_history(self, frontend: FrontendSync) -> None:
+        """Install the durable cut before live replay or command readiness."""
+        window = frontend.display_history if self._display_window_requested else None
+        previous = self._display_history
+        if window is None or window.status != "ok":
+            # Legacy owners and oversized prose keep the honest full replay.
+            self._display_history = None
+            self._history_hydrated = True
+            self._durable_seed_ids.clear()
+            self._durable_seed_tool_ids.clear()
+            await self._load_history(frontend.live_cursor, strict_cut=window is not None)
+            if previous is not None:
+                self._buffered_events.insert(
+                    0, HistoryDeltaEvent(messages=list(self._history), reset=True)
+                )
+            return
+        self._validate_display_window(window, frontend.epoch, frontend.live_cursor)
+        rows = list(window.messages)
+        page = window
+        reset = self._hydrated_once and (
+            previous is None
+            or previous.owner_epoch != window.owner_epoch
+            or previous.history_generation != window.history_generation
+        )
+        if previous is not None and self._hydrated_once and not reset:
+            # Reconnect must include ALL rows since the last durable frontier,
+            # not just a recent tail. Appends preserve signed snapshot positions.
+            while page.start > previous.total_message_count and page.before_token:
+                page = await self._fetch_history_page(
+                    page.before_token, frontend.epoch, frontend.live_cursor
+                )
+                if page.status != "ok":
+                    raise ConnectionError("history changed during reconnect; retry attachment")
+                rows[:0] = page.messages
+        self._display_history = window.model_copy(
+            update={
+                "messages": rows,
+                "start": page.start,
+                "before_token": page.before_token,
+                "has_more": page.has_more,
+            }
+        )
+        self._history = rows
+        self._live_history.clear()
+        self._history_hydrated = page.start == 0 and len(rows) == window.total_message_count
+        self._history_ids = {m.id for m in rows}
+        self._durable_seed_ids = set(window.durable_seed_ids)
+        self._durable_seed_tool_ids = set(window.durable_seed_tool_ids)
+        if reset:
+            self._message_events.clear()
+            self._buffered_events.insert(0, HistoryDeltaEvent(messages=rows, reset=True))
+        elif self._hydrated_once and previous is not None:
+            self._replay_durable_suffix(rows[max(0, previous.total_message_count - page.start) :])
+        # Loaded rows suppress duplicate relay, but are not all painted: the
+        # TUI mounts only its viewport and pages older rows later.
+        self._live_message_phase.clear()
+        if not self._hydrated_once:
+            self._filter_known_messages()
+        self._hydrated_once = True
+
+    def _validate_display_window(
+        self, window: DisplayHistoryWindow, epoch: str, cursor: str | None
+    ) -> None:
+        if (
+            window.conversation_id != self.session_id
+            or window.owner_epoch != epoch
+            or window.through_id != cursor
+        ):
+            raise ConnectionError("display history does not match canonical sync")
+        if window.start < 0 or window.start + len(window.messages) > window.total_message_count:
+            raise ConnectionError("invalid display history range")
+
+    async def _fetch_history_page(
+        self, before: str, epoch: str, cursor: str | None, anchor: str = ""
+    ) -> DisplayHistoryWindow:
+        client = self._client
+        if client is None:
+            raise ConnectionError("history owner is disconnected")
+        page = DisplayHistoryWindow.model_validate(await client.history_page(before, anchor))
+        if page.status != "reset":
+            self._validate_display_window(page, epoch, cursor)
+        return page
+
+    async def history_page(self, before: str, *, anchor: str = "") -> DisplayHistoryWindow:
+        """Read a signed page; reset is explicit and never silently mixed in."""
+        window = self._display_history
+        if window is None:
+            raise RuntimeError("this session uses full-history replay")
+        return await self._fetch_history_page(before, window.owner_epoch, window.through_id, anchor)
+
+    async def _refresh_display_history(self) -> None:
+        """Reattach only this viewer; never restart, stop, or prompt the owner."""
+        async with self._display_refresh_lock:
+            record = self._owner_record
+            if record is None or self._client is None or not self._client.connected:
+                record, _ = await asyncio.to_thread(
+                    find_owner_record, self._config_dir, self._session_id
+                )
+            if record is None:
+                raise ConnectionError("history owner is unavailable")
+            await self._bind_to(record)
+
+    @property
+    def history_before_token(self) -> str | None:
+        window = self._display_history
+        return window.before_token if window is not None and not self._history_hydrated else None
+
+    async def load_older_display_page(self) -> list[Any]:
+        window = self._display_history
+        if window is None or not self.history_before_token:
+            return []
+        page = await self.history_page(self.history_before_token)
+        if self._display_history is not window:
+            raise RuntimeError("history changed while paging; retry")
+        if page.status == "reset":
+            await self._refresh_display_history()
+            return []
+        if page.status == "full_required":
+            old_ids = set(self._history_ids)
+            return [m for m in await self.materialize_history() if m.id not in old_ids]
+        if page.start + len(page.messages) != window.start:
+            raise ConnectionError("history page is not contiguous with the loaded window")
+        self._history[:0] = page.messages
+        self._history_ids.update(m.id for m in page.messages)
+        self._display_history = window.model_copy(
+            update={
+                "start": page.start,
+                "before_token": page.before_token,
+                "has_more": page.has_more,
+                "messages": list(self._history),
+            }
+        )
+        self._history_hydrated = page.start == 0
+        return list(page.messages)
+
+    async def ensure_display_anchor(self, anchor: str) -> bool:
+        window = self._display_history
+        if window is None or not window.snapshot_token or not anchor:
+            return True
+        page = await self.history_page(window.snapshot_token, anchor=anchor)
+        if page.status == "reset":
+            await self._refresh_display_history()
+            fresh = self._display_history
+            if fresh is None or not fresh.snapshot_token:
+                return False
+            page = await self.history_page(fresh.snapshot_token, anchor=anchor)
+            if page.status == "reset":
+                return False
+        if page.status == "full_required":
+            await self.materialize_history()
+            return True
+        # Keep a contiguous loaded interval: the existing renderer pages both
+        # ways inside it and must never mistake a disjoint anchor/tail for a
+        # complete trajectory. The signed seek determines the exact frontier.
+        while self._display_history is not None and self._display_history.start > page.start:
+            await self.load_older_display_page()
+        return True
+
+    async def materialize_history(self) -> list[Any]:
+        """Explicit full replay, off the click path, at the captured sync cut."""
+        if self._history_hydrated:
+            return self.history()
+        window = self._display_history
+        if window is None:
+            raise RuntimeError("no canonical display history is installed")
+        rows: list[Any] = []
+        token = window.snapshot_token
+        while token:
+            page = await self.history_page(token)
+            if page.status == "reset":
+                raise RuntimeError("history changed while materializing; reconnect")
+            if page.status == "full_required":
+
+                def replay() -> list[Any]:
+                    transcript = Transcript(self._config_dir / "sessions" / self._session_id)
+                    return (
+                        transcript.build_llm_history(through_id=window.through_id)
+                        if window.through_id
+                        else []
+                    )
+
+                rows = await asyncio.to_thread(replay)
+                break
+            rows[:0] = page.messages
+            token = page.before_token
+        if self._display_history is not window:
+            raise RuntimeError("history changed while materializing; retry")
+        self._history = rows
+        self._history_ids = {m.id for m in rows}
+        self._history_hydrated = True
+        return self.display_history_window()
+
     async def _load_history(
         self,
         live_cursor: str | None = None,
         *,
         drop_history_duplicates: bool = True,
         want_checkpoint: bool = False,
+        strict_cut: bool = False,
     ) -> None:
         """Read durable history exactly up to the sync's advertised boundary.
 
@@ -1357,13 +1565,19 @@ class RemoteSession:
         file, so a long session's replay is file I/O plus JSON parsing from
         end to end, with nothing the loop needs until the result is bound.
         """
-        entries, history = await self._read_transcript(want_checkpoint=want_checkpoint)
+        entries, history = await self._read_transcript(
+            want_checkpoint=want_checkpoint, through_id=live_cursor, strict_cut=strict_cut
+        )
         self._bind_history(
             entries, history, live_cursor, drop_history_duplicates=drop_history_duplicates
         )
 
     async def _read_transcript(
-        self, *, want_checkpoint: bool = False
+        self,
+        *,
+        want_checkpoint: bool = False,
+        through_id: str | None = None,
+        strict_cut: bool = False,
     ) -> tuple[list[Any], list[Any]]:
         """Parse the durable transcript off-loop, once per sync.
 
@@ -1395,7 +1609,12 @@ class RemoteSession:
                 # would re-read and re-parse the whole file (0.68 s on the
                 # largest observed session).
                 self._cold_checkpoint = transcript.latest_custom(FRONTEND_CHECKPOINT_CUSTOM_TYPE)
-            return transcript.entries(), transcript.build_llm_history()
+            cut = through_id
+            if cut is not None and not transcript.has_entry(cut) and not strict_cut:
+                # Older owners used best-effort cursors; preserve that fallback
+                # only for legacy full replay, never the negotiated window cut.
+                cut = None
+            return transcript.entries(), transcript.build_llm_history(through_id=cut)
 
         return await asyncio.to_thread(_replay)
 
@@ -1407,24 +1626,14 @@ class RemoteSession:
         *,
         drop_history_duplicates: bool,
     ) -> None:
-        """Adopt one parsed transcript as ``_history``, bounded by the cursor."""
-        if live_cursor is not None:
-            # Keep only the message entries at or before the advertised cursor.
-            # The cursor names a transcript ENTRY id (any type); walk to it and
-            # drop the durable suffix past the boundary the sync already sealed.
-            boundary_index = None
-            for index, entry in enumerate(entries):
-                if entry.id == live_cursor:
-                    boundary_index = index
-                    break
-            if boundary_index is not None:
-                kept_ids = {entry.id for entry in entries[: boundary_index + 1]}
-                history = [
-                    message
-                    for message in history
-                    if not getattr(message, "id", None) or str(message.id) in kept_ids
-                ]
+        """Adopt canonical replay already selected at the journal cut.
+
+        Filtering materialized IDs here used to lose synthetic compaction
+        markers and could apply prunes newer than the cut. The parser now
+        selects journal entries before running the shared replay semantics.
+        """
         self._history = history
+        self._live_history.clear()
         self._history_ids = {
             str(message.id) for message in self._history if getattr(message, "id", None)
         }
@@ -1463,6 +1672,10 @@ class RemoteSession:
         for data in self.frontend_state.live_events:
             event = deserialize_event(data)
             if self._is_duplicate(event):
+                # Already painted is not the same as durable. Rebuild source
+                # display storage from the canonical seed even when no event
+                # should be re-emitted into an already-painted live surface.
+                self._remember_live(event)
                 continue
             self._track(event)
             seeded.append(event)
@@ -1567,7 +1780,11 @@ class RemoteSession:
         if isinstance(event, (MessageStartEvent, MessageEndEvent)):
             # Durable or already-painted-complete: a replayed row, never the
             # same live message's first/last beat.
-            if message_id in self._message_events:
+            if (
+                message_id in self._message_events
+                or message_id in self._history_ids
+                or message_id in self._durable_seed_ids
+            ):
                 return True
         phase = _MESSAGE_PHASE.get(type(event))
         if phase is None:
@@ -1584,7 +1801,29 @@ class RemoteSession:
         return False
 
     def _track(self, event: AgentEvent[Any]) -> None:
-        """Record a painted live message id so a later sync/durable row skips it."""
+        """Record painted identity separately from complete source display data."""
+        self._remember_live(event)
+        message = getattr(event, "message", None)
+        message_id = str(getattr(message, "id", "") or "")
+        if message_id and (
+            isinstance(event, MessageEndEvent)
+            or (
+                isinstance(event, MessageStartEvent)
+                and bool(getattr(message, "text", "") or getattr(message, "tool_calls", None))
+            )
+        ):
+            self._message_events.add(message_id)
+
+    def _remember_live(self, event: AgentEvent[Any]) -> None:
+        if isinstance(event, ToolExecutionEndEvent):
+            if event.tool_call_id in self._durable_seed_tool_ids:
+                return
+            # Tool results arrive as execution events rather than message_end.
+            # Keep a LIVE pairing dependency until its real durable message ID
+            # arrives at the next sync; never claim this synthetic ID as durable.
+            result = Message.tool_result(event.result)
+            result.id = f"live-tool:{event.tool_call_id}"
+            self._live_history[result.id] = result
         message = getattr(event, "message", None)
         message_id = str(getattr(message, "id", "") or "")
         if not message_id:
@@ -1607,7 +1846,14 @@ class RemoteSession:
             isinstance(event, MessageStartEvent)
             and bool(getattr(message, "text", "") or getattr(message, "tool_calls", None))
         ):
-            self._message_events.add(message_id)
+            if message_id in self._history_ids or message_id in self._durable_seed_ids:
+                return
+            # Paint dedupe is not presentation storage. A source can leave the
+            # screen while this row is in the live seed but not in its durable
+            # attach window. Retain the complete row for the next prepared view.
+            if isinstance(message, Message) and message.role == "tool":
+                self._live_history.pop(f"live-tool:{message.tool_call_id}", None)
+            self._live_history[message_id] = message
 
     def _drain_buffered_events(self) -> None:
         """Deliver buffered sync frames once both ordering and a subscriber exist."""
@@ -2275,14 +2521,21 @@ class RemoteSession:
                         # follower has not painted; the bind afterwards brings
                         # ``_history`` to the same point and the live seed
                         # dedupes against the ids the replay just claimed (M4).
-                        entries, history = await self._read_transcript()
-                        self._replay_durable_suffix(history)
-                        self._bind_history(
-                            entries,
-                            history,
-                            frontend.live_cursor,
-                            drop_history_duplicates=False,
-                        )
+                        if self._display_window_requested and frontend.display_history is not None:
+                            await self._load_frontend_history(frontend)
+                        else:
+                            entries, history = (
+                                await self._read_transcript(through_id=frontend.live_cursor)
+                                if frontend.live_cursor is not None
+                                else await self._read_transcript()
+                            )
+                            self._replay_durable_suffix(history)
+                            self._bind_history(
+                                entries,
+                                history,
+                                frontend.live_cursor,
+                                drop_history_duplicates=False,
+                            )
                         self._finish_sync()
                         return
                     except (ConnectionError, OSError, TimeoutError):
@@ -2541,8 +2794,69 @@ class RemoteSession:
 
     # -- history / host errands --------------------------------------------
 
+    async def record_shell(self, command: str, result: ToolResult) -> None:
+        from local_operator.session.shell_record import shell_record_messages
+
+        await self._ensure_bound()
+        client = self._client
+        if client is None:
+            raise ConnectionError("shell receipt owner is disconnected")
+        await client.record_shell(command, result.model_dump(mode="json"))
+        # The owner may queue persistence behind a running turn. These are
+        # accepted LIVE display rows, not a fabricated durable cursor or ACK.
+        for message in shell_record_messages(command, result):
+            self._live_history[message.id] = message
+
     def history(self) -> list[Any]:
-        return list(self._history)
+        if not self._history_hydrated:
+            raise RuntimeError(
+                "display-window history is not hydrated; await materialize_history()"
+            )
+        return self.display_history_window()
+
+    def display_history_window(self) -> list[Any]:
+        """Loaded durable rows plus canonical live rows, in display order."""
+        durable_results = {
+            m.tool_call_id for m in self._history if isinstance(m, Message) and m.role == "tool"
+        }
+        return [self._live_history.get(m.id, m) for m in self._history] + [
+            m
+            for key, m in self._live_history.items()
+            if key not in self._history_ids
+            and not (
+                isinstance(m, Message) and m.role == "tool" and m.tool_call_id in durable_results
+            )
+        ]
+
+    @property
+    def history_message_count(self) -> int:
+        durable = (
+            self._display_history.total_message_count
+            if self._display_history
+            else len(self._history)
+        )
+        return durable + len(self.display_history_window()) - len(self._history)
+
+    @property
+    def history_theme_turn_count(self) -> int:
+        if self._display_history is not None:
+            return self._display_history.theme_turn_count + sum(
+                key not in self._history_ids and getattr(m, "role", "") in ("user", "assistant")
+                for key, m in self._live_history.items()
+            )
+        return sum(
+            getattr(m, "role", "") in ("user", "assistant") for m in self.display_history_window()
+        )
+
+    @property
+    def history_opener_text(self) -> str:
+        if self._display_history is not None:
+            return self._display_history.opener_text
+        return next((m.text for m in self._history if getattr(m, "role", "") == "user"), "")
+
+    def history_last_message(self) -> Any:
+        rows = self.display_history_window()
+        return rows[-1] if rows else None
 
     def context_breakdown(self) -> dict[str, int]:
         return dict(self.frontend_state.context_breakdown or {})
@@ -2799,7 +3113,7 @@ class RemoteSession:
         await client.send_command(command, streaming=self._streaming)
 
     async def seed_history(self, messages: list[Message]) -> None:
-        if self._history:
+        if self.history_message_count:
             return
         self._history = list(messages)
 

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -326,6 +326,9 @@ class RemoteSession:
         self._ask_handler: AskUserFn | None = None
         self._gate_task: asyncio.Task[None] | None = None
         self._gates_detached = False
+        self._background_approval = False
+        self._keep_gate_reply = False
+        self._gate_answered_key: tuple[str, str, int] | None = None
         # Snapshot creation is not retryable: navigation must retire the UI,
         # not close the response channel after the owner has begun a copy.
         self._snapshot_clients: dict[AttachClient, int] = {}
@@ -1480,6 +1483,7 @@ class RemoteSession:
         self._ready_for_events = True
         self._owner_ready.set()
         self._drain_buffered_events()
+        self._maybe_start_gate()
 
     def _replay_durable_suffix(self, history: list[Any]) -> None:
         """Emit ONE typed history delta for durable rows nothing ever painted.
@@ -1631,6 +1635,13 @@ class RemoteSession:
     def _install_frontend(self, state: FrontendSessionState, *, publish: bool = False) -> None:
         if state.session_id != self._session_id:
             raise ConnectionError("frontend state belongs to another session")
+        if self._frontend_store is None or self._frontend_store.state.epoch != state.epoch:
+            if self._gate_task is not None:
+                self._gate_task.cancel()
+                self._gate_task = None
+            self._gate_key = None
+            self._gate_answered_key = None
+            self._keep_gate_reply = False
         if self._frontend_store is None:
             self._frontend_store = FrontendStateStore(state)
         elif publish:
@@ -1750,29 +1761,61 @@ class RemoteSession:
             self._gate_task.cancel()
             self._gate_task = None
         self._gate_key = key
+        self._keep_gate_reply = False
         if pending is not None:
             self._maybe_start_gate(pending)
 
     def _maybe_start_gate(self, pending: PendingRequest | None = None) -> None:
-        if self._gates_detached:
+        if self._disposed or not self._ready_for_events:
             return
         if pending is None:
             pending = _pending_request(self.frontend_state.pending_gate)
         if pending is None or self._gate_task is not None:
             return
-        if pending.kind == "approval" and self._approval_handler is not None:
+        if self._gate_identity(pending) == self._gate_answered_key:
+            return
+        background = (
+            self._gates_detached and self._background_approval and pending.kind == "approval"
+        )
+        if self._gates_detached and not background:
+            return
+        if pending.kind == "approval" and (self._approval_handler is not None or background):
             self._gate_task = asyncio.create_task(self._run_approval(pending))
         elif pending.kind == "ask" and self._ask_handler is not None:
             self._gate_task = asyncio.create_task(self._run_ask(pending))
+
+    def _gate_reply_is_current(self, pending: PendingRequest, client: Any) -> bool:
+        # Cancelling a bridge requests cooperation; even a handler that swallows
+        # cancellation must not answer after another view/gate replaced it.
+        return (
+            (
+                not self._gates_detached
+                or self._keep_gate_reply
+                or (self._background_approval and pending.kind == "approval")
+            )
+            and not self._disposed
+            and self._gate_task is asyncio.current_task()
+            and self._client is client
+            and self._gate_key == self._gate_identity(pending)
+        )
 
     async def _run_approval(self, pending: PendingRequest) -> None:
         try:
             handler = self._approval_handler
             client = self._client
-            if handler is None or client is None:
+            if client is None:
+                return
+            if self._gates_detached and self._background_approval:
+                approved = True
+            elif handler is not None:
+                approved = await call_approval_gate(handler, pending.title, pending.detail)
+            else:
                 return
             approved = await call_approval_gate(handler, pending.title, pending.detail)
+            if not self._gate_reply_is_current(pending, client):
+                return
             await client.approval_answer(pending.request_id, approved)
+            self._gate_answered_key = self._gate_identity(pending)
         except (asyncio.CancelledError, RuntimeError, ConnectionError):
             # Cancellation means another front end settled it. RuntimeError is
             # the owner's stale-request answer to the losing race. Both are an
@@ -1828,6 +1871,7 @@ class RemoteSession:
                     values[0],
                     question_index=pending.question_index,
                 )
+                self._gate_answered_key = self._gate_identity(pending)
         except (asyncio.CancelledError, RuntimeError, ConnectionError):
             # Same three outcomes as the approval gate above, including the
             # stop path's dead-owner post (round-6 NIT-3).
@@ -2573,21 +2617,38 @@ class RemoteSession:
         """
         # A sibling frontend may settle Q1 while detach awaits cancellation.
         # Suppress the ensuing Q2 bridge as well, until this viewer is disposed.
+        self._background_approval = False
+        self._keep_gate_reply = False
         task = self.suspend_viewer_gates()
         if task is not None:
             await asyncio.gather(task, return_exceptions=True)
 
-    def suspend_viewer_gates(self) -> asyncio.Task[Any] | None:
-        """Stop the answer bridge before an atomic presentation swap.
+    @property
+    def has_pending_gate_reply(self) -> bool:
+        return bool(
+            self._keep_gate_reply and self._gate_task is not None and not self._gate_task.done()
+        )
 
-        Cancellation is requested synchronously, before clearing a widget can
-        resolve its waiter as a rejection. The runtime's pending gate is never
-        answered by navigation; only this viewer's bridge is suspended.
+    def suspend_viewer_gates(
+        self, *, auto_approve: bool = False, keep_answer: bool = False
+    ) -> asyncio.Task[Any] | None:
+        """Suspend presentation, never invent an answer during navigation.
+
+        An answer the user already committed must finish reaching its owner.
+        A visited source's explicit allow-all grant can keep approving that
+        source in the background; speculative viewers always pass False.
         """
         self._gates_detached = True
-        task, self._gate_task = self._gate_task, None
+        self._background_approval = auto_approve
+        task = self._gate_task
+        if task is not None and (keep_answer or self._keep_gate_reply):
+            self._keep_gate_reply = True
+            return task
+        self._keep_gate_reply = False
+        self._gate_task = None
         if task is not None:
             task.cancel()
+        self._maybe_start_gate()
         return task
 
     def resume_viewer_gates(self) -> None:

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -1787,7 +1787,10 @@ class RemoteSession:
             # (round-6 NIT-3).
             pass
         finally:
-            if self._gate_key == self._gate_identity(pending):
+            if (
+                self._gate_key == self._gate_identity(pending)
+                and self._gate_task is asyncio.current_task()
+            ):
                 self._gate_task = None
 
     async def _run_ask(self, pending: PendingRequest) -> None:
@@ -1830,7 +1833,10 @@ class RemoteSession:
             # stop path's dead-owner post (round-6 NIT-3).
             pass
         finally:
-            if self._gate_key == self._gate_identity(pending):
+            if (
+                self._gate_key == self._gate_identity(pending)
+                and self._gate_task is asyncio.current_task()
+            ):
                 self._gate_task = None
 
     # -- owner loss ---------------------------------------------------------
@@ -2567,11 +2573,29 @@ class RemoteSession:
         """
         # A sibling frontend may settle Q1 while detach awaits cancellation.
         # Suppress the ensuing Q2 bridge as well, until this viewer is disposed.
+        task = self.suspend_viewer_gates()
+        if task is not None:
+            await asyncio.gather(task, return_exceptions=True)
+
+    def suspend_viewer_gates(self) -> asyncio.Task[Any] | None:
+        """Stop the answer bridge before an atomic presentation swap.
+
+        Cancellation is requested synchronously, before clearing a widget can
+        resolve its waiter as a rejection. The runtime's pending gate is never
+        answered by navigation; only this viewer's bridge is suspended.
+        """
         self._gates_detached = True
         task, self._gate_task = self._gate_task, None
         if task is not None:
             task.cancel()
-            await asyncio.gather(task, return_exceptions=True)
+        return task
+
+    def resume_viewer_gates(self) -> None:
+        """Recreate bridges only after the source is the visible input target."""
+        if self._gates_detached:
+            self._gates_detached = False
+            self._gate_handled_key = None
+        self._maybe_start_gate()
 
     async def adopt_aside(self, messages: list[Message]) -> None:
         """Promote the aside exchange into the conversation through the owner.

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -960,7 +960,9 @@ class OwnedSessionHandle(SessionHandle):
         """Canonical state seed for full-TUI attach clients."""
         return self._session.frontend_state
 
-    async def subscribe_frontend(self, on_update: Callable[[Any], None]) -> Any:
+    async def subscribe_frontend(
+        self, on_update: Callable[[Any], None], *, display_window: bool = False
+    ) -> Any:
         """Snapshot and subscribe atomically, on the loop that publishes.
 
         ``Session.subscribe_frontend`` refreshes through the publishing path
@@ -968,7 +970,13 @@ class OwnedSessionHandle(SessionHandle):
         every client's exact-``+1`` gap check detect transport loss. Awaited
         rather than wrapped because the caller is already on this loop.
         """
-        return self._session.subscribe_frontend(on_update)
+        return self._session.subscribe_frontend(on_update, display_window=display_window)
+
+    async def record_shell(self, command: str, result: Any) -> None:
+        await self._session.record_shell(command, result)
+
+    async def history_page(self, before: str, anchor: str = "") -> dict[str, Any]:
+        return self._session.history_page(before, anchor)
 
     def subscribe_events(self, on_event: Callable[[dict[str, Any]], None]) -> Callable[[], None]:
         """Feed serialized AgentEvents to the runtime's v4 relay.

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -1820,7 +1820,16 @@ class OwnedSessionHandle(SessionHandle):
         from local_operator.harness.types import Message
 
         messages = [Message.model_validate(turn) for turn in turns]
-        return await self._session.complete_aside(messages)
+        complete = self._session.complete_aside
+        store = getattr(self._session, "_frontend_state_store", None)
+        if store is not None and "on_usage" in inspect.signature(complete).parameters:
+            # A remote caller receives text, not a billable usage callback. The
+            # authoritative owner must charge the request here; otherwise a
+            # hidden goal judge (and other remote asides) silently costs zero.
+            return await complete(
+                messages, on_usage=lambda usage: store.accrue_usage(self._session, usage)
+            )
+        return await complete(messages)
 
     async def adopt_aside(self, messages: list[dict[str, Any]]) -> str:
         """Fork a viewer's aside exchange into the durable conversation."""

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -224,7 +224,15 @@ _EVENT_QUEUE_MAX = 64
 #: frame degrades to the pre-announcement behaviour; the stop is unaffected.
 _ANNOUNCE_WRITE_TIMEOUT_S = 0.25
 
-_PAYLOAD_OPS = {"slash_result", "cancel_subagents", "job_trajectory", "fork_snapshot", "credential"}
+_PAYLOAD_OPS = {
+    "slash_result",
+    "cancel_subagents",
+    "job_trajectory",
+    "fork_snapshot",
+    "credential",
+    "history_page",
+    "record_shell",
+}
 
 
 def _accepts_kw(fn: Any, name: str) -> bool:
@@ -547,6 +555,7 @@ class RuntimeServer:
                 [DESKTOP_WATCH_CAPABILITY]
                 + ([FRONTEND_CAPABILITY] if hasattr(handle, "subscribe_frontend") else [])
                 + (["completion-ack-v1"] if hasattr(handle, "acknowledge_attention") else [])
+                + (["display-history-window-v1"] if hasattr(handle, "history_page") else [])
             ),
             # A runtime is born with no terminal watching it. Stamped at
             # construction rather than left to the first transition, because
@@ -1130,7 +1139,14 @@ class RuntimeServer:
                 sync_wire_payload,
             )
 
-            outcome = subscribe_frontend(on_update)
+            window_requested = bool(frame.get("display_window")) and (
+                "display-history-window-v1" in self._record.capabilities
+            )
+            outcome = (
+                subscribe_frontend(on_update, display_window=True)
+                if window_requested
+                else subscribe_frontend(on_update)
+            )
             if inspect.isawaitable(outcome):
                 outcome = await outcome
             subscription = cast(FrontendSubscription, outcome)
@@ -1152,6 +1168,21 @@ class RuntimeServer:
             # the next unbounded list is one log line to find rather than a
             # profiling session.
             oversize = oversized_frame_report(sync_frame, _MAX_LINE_BYTES)
+            if oversize is not None and sync.display_history is not None:
+                # The budget covers the WHOLE frame, not just history. A busy
+                # canonical state may leave too little room even for our page.
+                # Request the existing exact local replay, never truncate prose.
+                fallback = sync.display_history.model_copy(
+                    update={
+                        "status": "full_required",
+                        "messages": [],
+                        "durable_seed_ids": [],
+                        "before_token": None,
+                        "snapshot_token": None,
+                    }
+                )
+                sync_payload["display_history"] = fallback.model_dump(mode="json")
+                oversize = oversized_frame_report(sync_frame, _MAX_LINE_BYTES)
             if oversize is not None:
                 logger.error("session runtime: frontend_sync will not fit — %s", oversize)
             await self._send_to(conn, sync_frame)
@@ -2064,6 +2095,34 @@ class RuntimeServer:
             if inspect.isawaitable(result):
                 result = await result
             return result if isinstance(result, int) else 0
+        if op == "record_shell":
+            from local_operator.harness.types import ToolResult
+
+            record = getattr(h, "record_shell", None)
+            command = frame.get("command")
+            if not callable(record) or not isinstance(command, str) or not command.strip():
+                raise ValueError("invalid shell receipt")
+            result = ToolResult.model_validate(frame.get("result"))
+            if (
+                result.tool_name != "bash"
+                or not result.tool_call_id
+                or len(result.tool_call_id) > 128
+            ):
+                raise ValueError("invalid shell receipt identity")
+            outcome = record(command, result)
+            if inspect.isawaitable(outcome):
+                await outcome
+            return "accepted"
+        if op == "history_page":
+            fetch = getattr(h, "history_page", None)
+            before = frame.get("before")
+            anchor = frame.get("anchor", "")
+            if not callable(fetch) or not isinstance(before, str) or not isinstance(anchor, str):
+                raise ValueError("invalid history page request")
+            if len(before) > 4096 or len(anchor) > 512:
+                raise ValueError("invalid history page request")
+            result = fetch(before, anchor)
+            return await result if inspect.isawaitable(result) else result
         if op == "job_trajectory":
             # The other half of the frame-size fix: the attach snapshot omits
             # trajectories, so a viewer opening a child page pulls that one

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -231,6 +231,7 @@ _PAYLOAD_OPS = {
     "fork_snapshot",
     "credential",
     "history_page",
+    "frontend_sync",
     "record_shell",
 }
 
@@ -544,13 +545,12 @@ class RuntimeServer:
             model_label=seed.model_label,
             control_port=0,  # stamped when the listener binds
             control_key=secrets.token_hex(32),
-            # Three independent capabilities, each gated by its own condition.
-            # The desktop watch surface is unconditional (this server always
-            # serves it), while the frontend and completion-ack capabilities
-            # are advertised only when the handle actually implements them --
-            # advertising one the handle cannot honour is worse than omitting
-            # it, because the client then negotiates a surface that is not
-            # there.
+            # Independent capabilities, each gated by its own condition. The
+            # desktop watch surface is unconditional (this server always serves
+            # it), while the rest are advertised only when the handle actually
+            # implements them -- advertising one the handle cannot honour is
+            # worse than omitting it, because the client then negotiates a
+            # surface that is not there.
             capabilities=(
                 [DESKTOP_WATCH_CAPABILITY]
                 + ([FRONTEND_CAPABILITY] if hasattr(handle, "subscribe_frontend") else [])
@@ -2113,6 +2113,43 @@ class RuntimeServer:
             if inspect.isawaitable(outcome):
                 await outcome
             return "accepted"
+        if op == "frontend_sync":
+            from local_operator.session.frontend_state import (
+                FrontendSubscription,
+                oversized_frame_report,
+                sync_wire_payload,
+            )
+
+            capture = getattr(h, "subscribe_frontend", None)
+            if not callable(capture):
+                raise ValueError("canonical history refresh is unavailable")
+            outcome = capture(lambda _update: None, display_window=True)
+            subscription = cast(
+                FrontendSubscription, await outcome if inspect.isawaitable(outcome) else outcome
+            )
+            try:
+                payload = sync_wire_payload(subscription.sync)
+                # Keep the existing live subscription. This temporary capture
+                # only supplies an atomic cut; it must not multiply observers.
+                response = {"op": "result", "req": frame.get("req"), "data": payload}
+                if oversized_frame_report(response, _MAX_LINE_BYTES) is not None:
+                    window = subscription.sync.display_history
+                    if window is not None:
+                        payload["display_history"] = window.model_copy(
+                            update={
+                                "status": "full_required",
+                                "messages": [],
+                                "durable_seed_ids": [],
+                                "durable_seed_tool_ids": [],
+                                "before_token": None,
+                                "snapshot_token": None,
+                            }
+                        ).model_dump(mode="json")
+                    if oversized_frame_report(response, _MAX_LINE_BYTES) is not None:
+                        raise ValueError("canonical refresh exceeds the transport frame limit")
+                return payload
+            finally:
+                subscription.unsubscribe()
         if op == "history_page":
             fetch = getattr(h, "history_page", None)
             before = frame.get("before")

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -5500,6 +5500,24 @@ class Session:
         """Current canonical state for any full terminal frontend."""
         return self._frontend_state_store.state
 
+    @property
+    def pending_gate(self):  # type: ignore[no-untyped-def]
+        """The pending gate without the full-state clone ``frontend_state`` pays.
+
+        For per-frame readiness checks only; see the store's own property.
+        """
+        return self._frontend_state_store.pending_gate
+
+    @property
+    def epoch(self):  # type: ignore[no-untyped-def]
+        """The owner epoch without the full-state clone.
+
+        Paired with :attr:`pending_gate`: gate identity is epoch plus gate, so
+        reading the epoch through ``frontend_state`` would restore the clone on
+        the same per-frame path.
+        """
+        return self._frontend_state_store.read_field("epoch")
+
     def subscribe_frontend(self, handler, *, display_window=False):  # type: ignore[no-untyped-def]
         """Atomically refresh, snapshot and subscribe on the session loop.
 

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -5786,6 +5786,12 @@ class Session:
         # snapshot that already contains this event, never an off-by-one view.
         store = getattr(self, "_frontend_state_store", None)
         if store is not None and (self._has_ui or store.has_subscribers):
+            # Replay-changing commits precede their public events. Publish the
+            # scalar first so retained viewers cannot select a stale tail after
+            # compaction, pruning, or a fold; unchanged events do no extra work.
+            replay_generation = self._transcript._history_generation
+            if store.state.history_generation != replay_generation:
+                store.mutate(history_generation=replay_generation)
             store.observe_event(self, event)
         for handler in list(self._handlers):
             try:

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -107,7 +107,6 @@ from local_operator.harness.types import (
     StreamToolCallDelta,
     StreamUsageEvent,
     TextContent,
-    ToolCall,
     ToolContext,
     ToolExecutionEndEvent,
     ToolResult,
@@ -5501,7 +5500,7 @@ class Session:
         """Current canonical state for any full terminal frontend."""
         return self._frontend_state_store.state
 
-    def subscribe_frontend(self, handler):  # type: ignore[no-untyped-def]
+    def subscribe_frontend(self, handler, *, display_window=False):  # type: ignore[no-untyped-def]
         """Atomically refresh, snapshot and subscribe on the session loop.
 
         The refresh must go through the PUBLISHING path: silently replacing
@@ -5511,7 +5510,60 @@ class Session:
         is reserved for store construction, before any subscriber exists.
         """
         self._frontend_state_store.refresh_from_session(self)
-        return self._frontend_state_store.subscribe(handler)
+        subscription = self._frontend_state_store.subscribe(handler)
+        if display_window:
+            from local_operator.session.history_window import (
+                display_window as capture_window,
+            )
+
+            sync = subscription.sync
+            try:
+                window = capture_window(
+                    self._transcript,
+                    conversation_id=sync.snapshot.session_id,
+                    owner_epoch=sync.epoch,
+                    through_id=sync.live_cursor,
+                )
+                window.durable_seed_ids = [
+                    str(event["message"]["id"])
+                    for event in sync.snapshot.live_events
+                    if isinstance(event.get("message"), dict)
+                    and self._transcript.has_entry(str(event["message"].get("id", "")))
+                ]
+                seed_tools = {
+                    str(event.get("tool_call_id", ""))
+                    for event in sync.snapshot.live_events
+                    if event.get("type") == "tool_execution_end"
+                }
+                if seed_tools:
+                    window.durable_seed_tool_ids = [
+                        str(message.tool_call_id)
+                        for message in self._transcript.build_llm_history(
+                            through_id=sync.live_cursor
+                        )
+                        if isinstance(message, Message)
+                        and message.role == "tool"
+                        and message.tool_call_id in seed_tools
+                    ]
+                sync.display_history = window
+            except BaseException:
+                subscription.unsubscribe()
+                raise
+        return subscription
+
+    def history_page(self, before: str, anchor: str = ""):  # type: ignore[no-untyped-def]
+        """Authenticated reads reuse the resident replay at the signed sync cut."""
+        from local_operator.session.history_window import display_window
+
+        state = self.frontend_state
+        return display_window(
+            self._transcript,
+            conversation_id=state.session_id,
+            owner_epoch=state.epoch,
+            through_id=state.history_cursor,
+            before=before,
+            anchor=anchor,
+        ).model_dump(mode="json")
 
     def refresh_frontend_state(self) -> None:
         """Publish non-event source changes through the canonical contract.
@@ -9586,6 +9638,10 @@ class Session:
         the user can see disappear on resume. The lock owner flushes the FIFO at
         its safe boundary before another prompt can start.
         """
+        if self._transcript.has_entry(f"shell:{result.tool_call_id}:result") or any(
+            queued.tool_call_id == result.tool_call_id for _, queued in self._pending_shell_records
+        ):
+            return
         if self._is_streaming or self._turn_lock.locked():
             self._pending_shell_records.append((command, result))
             return
@@ -9606,13 +9662,11 @@ class Session:
         # TUI's resume replay already knows how to mount a ToolCard from a
         # call and its result, and a wall of stdout attributed to the user
         # would read as something they typed.
-        user = Message.user(f"! {command}")
-        assistant = Message.assistant("")
-        assistant.tool_calls = [
-            ToolCall(id=result.tool_call_id, name="bash", arguments={"command": command})
-        ]
-        tool = Message.tool_result(result)
-        messages = [user, assistant, tool]
+        from local_operator.session.shell_record import shell_record_messages
+
+        messages = shell_record_messages(command, result)
+        if self._transcript.has_entry(messages[-1].id):
+            return
         # The synthetic assistant/tool exchange is one fork-visible unit.
         await self._transcript.append_messages(messages)
         self._context.messages.extend(messages)

--- a/local_operator/session/shell_record.py
+++ b/local_operator/session/shell_record.py
@@ -1,0 +1,20 @@
+"""Stable identities for an explicitly user-run shell command's receipt.
+
+The terminal executes; only the owner journals. Retrying an acknowledged receipt
+must not create a second synthetic exchange, including after an owner restart.
+The tool call ID is minted once at submission and is the idempotency identity.
+"""
+
+from local_operator.harness.types import Message, ToolCall, ToolResult
+
+
+def shell_record_messages(command: str, result: ToolResult) -> list[Message]:
+    user = Message.user(f"! {command}")
+    assistant = Message.assistant("")
+    assistant.tool_calls = [
+        ToolCall(id=result.tool_call_id, name="bash", arguments={"command": command})
+    ]
+    tool = Message.tool_result(result)
+    for message, suffix in zip((user, assistant, tool), ("user", "call", "result")):
+        message.id = f"shell:{result.tool_call_id}:{suffix}"
+    return [user, assistant, tool]

--- a/local_operator/session/transcript.py
+++ b/local_operator/session/transcript.py
@@ -324,6 +324,169 @@ def read_transcript_page(
     return TranscriptPage(entries=rows[-limit:], has_more=len(rows) > limit)
 
 
+@dataclass(frozen=True)
+class ReplaySuffix:
+    """What :func:`read_replay_suffix` found, with the facts a caller needs.
+
+    ``entries`` is the journal suffix in append order — enough to reproduce
+    :meth:`Transcript.build_llm_history` exactly (see the reader for why a
+    suffix is sufficient). ``through_present`` tells a caller whose cursor was
+    NOT found whether it should trust the whole-file fallback semantics or
+    treat the cursor as unknown; ``checkpoint`` is the durable frontend
+    checkpoint when it was requested and is inside the suffix.
+    """
+
+    entries: tuple[TranscriptEntry, ...]
+    through_present: bool
+    checkpoint: dict[str, Any] | None
+    #: Bytes actually read, for the caller's own evidence; not a contract.
+    bytes_read: int
+
+
+#: Backward read granularity. One MiB is large enough that a compaction's kept
+#: window (355–456 messages on the reference owners) is usually inside the
+#: first or second chunk, and small enough that a whole-file fallback on a
+#: journal with no compaction costs no more than the forward parse it replaces.
+_SUFFIX_CHUNK_BYTES = 1 << 20
+
+
+def read_replay_suffix(
+    directory: str | Path,
+    *,
+    through_id: str | None = None,
+    checkpoint_type: str | None = None,
+) -> ReplaySuffix:
+    """Read only the journal suffix :func:`replay_entries` needs, from EOF.
+
+    WHY: an attach used to build a whole ``Transcript``, which JSON-decodes
+    every line — 220 ms for a 47 MB journal and 1.5 s for 204 MB on the
+    reference machine — when the replay only ever looks at rows from the
+    latest compaction's ``first_kept_entry_id`` onward (a few hundred
+    messages). Reading 1 MiB chunks backward and stopping once that boundary is
+    inside the buffer makes the cost proportional to the live window rather
+    than to the journal's history: 6.6–17 ms on the same files.
+
+    WHY a suffix is exactly sufficient: every prune that affects a replayed
+    row is appended AFTER that row (a prune targets an existing message), so
+    once the buffer holds the compaction marker and its ``first_kept`` row it
+    holds every prune those rows can carry. A ``compaction`` row itself embeds
+    its summary; nothing before ``first_kept`` is read by the replay at all.
+
+    Stop conditions, all of which must be met before returning:
+
+    - the newest ``compaction`` row AND its ``first_kept_entry_id`` row are
+      both in the buffer (or the file start is reached — no compaction means
+      today's whole-file cost, which is the correct fallback, not a shortcut);
+    - ``through_id``, when given, is in the buffer — a cursor not yet seen
+      means "read further", never "cut at the tail" (the strict-cut contract);
+    - the newest custom row of ``checkpoint_type`` is in the buffer, when one
+      is requested, so the caller does not pay a second read for it. It is a
+      parameter rather than an import: the frontend checkpoint's type constant
+      lives in ``frontend_state``, whose import graph reaches the TUI, and this
+      module must stay a leaf.
+
+    Malformed rows are skipped individually, matching forward replay. The
+    first partial line of the earliest chunk is discarded: it is the tail of a
+    row whose head is in the chunk before it, and is completed once that chunk
+    is read.
+    """
+    path = Path(directory) / TRANSCRIPT_FILENAME
+    if not path.exists():
+        # ``Transcript(directory)`` treats an absent journal as empty history
+        # — a session that has not written yet, or whose directory a sweep
+        # removed. The attach path relies on that, so the suffix reader
+        # answers the same way rather than turning "nothing yet" into an
+        # error the whole-file parse never raised.
+        return ReplaySuffix(
+            entries=(), through_present=through_id is None, checkpoint=None, bytes_read=0
+        )
+    checkpoint: dict[str, Any] | None = None
+    compaction: TranscriptEntry | None = None
+    first_kept_id: str | None = None
+    seen_ids: set[str] = set()
+    cursor_reached = through_id is None
+    parsed: list[TranscriptEntry] = []  # newest first while reading backward
+    with path.open("rb") as handle:
+        handle.seek(0, os.SEEK_END)
+        position = handle.tell()
+        # Invariant: ``pending`` is the bytes after ``position`` that have NOT
+        # yet been split into rows. It only ever grows by one chunk and is
+        # split exactly once, when a row boundary lands inside it — so a row
+        # larger than a chunk (the 256 KiB bookkeeping rows in the fixtures)
+        # costs one join, not one re-split per chunk. The first version
+        # re-split the carried tail every step and the no-compaction fallback
+        # over a 100 MB file went quadratic, slower than the forward parse it
+        # is meant to match.
+        pending = b""
+        while True:
+            chunk_size = min(_SUFFIX_CHUNK_BYTES, position)
+            position -= chunk_size
+            handle.seek(position)
+            pending = handle.read(chunk_size) + pending
+            if position > 0:
+                boundary = pending.find(b"\n")
+                if boundary < 0:
+                    # No complete row yet; the whole buffer is a row's tail.
+                    continue
+                # Everything before the first newline is the tail of a row
+                # whose head is still unread; keep it for the next chunk.
+                complete = pending[boundary + 1 :].split(b"\n")
+                pending = pending[:boundary]
+            else:
+                complete = pending.split(b"\n")
+                pending = b""
+            for raw in reversed(complete):
+                if not raw.strip():
+                    continue
+                entry = TranscriptEntry.from_json(raw.decode("utf-8", errors="replace"))
+                if entry is None:
+                    continue
+                parsed.append(entry)
+                seen_ids.add(entry.id)
+                if through_id is not None and entry.id == through_id:
+                    # Rows after the cursor are discarded by the replay, so a
+                    # compaction among them is NOT the boundary: the replay
+                    # of the cut list sees only compactions at or before the
+                    # cursor. Forget any marker met above the cut and keep
+                    # looking below it, exactly as the forward parse would
+                    # after ``entries[: index + 1]``.
+                    compaction = None
+                    first_kept_id = None
+                    cursor_reached = True
+                if (
+                    compaction is None
+                    and entry.type == ENTRY_COMPACTION
+                    and (through_id is None or cursor_reached)
+                ):
+                    compaction = entry
+                    first_kept_id = entry.payload.get("first_kept_entry_id") or None
+                if (
+                    checkpoint_type is not None
+                    and checkpoint is None
+                    and entry.type == ENTRY_CUSTOM
+                    and entry.payload.get("custom_type") == checkpoint_type
+                ):
+                    checkpoint = dict(entry.payload.get("details", {}))
+            at_start = position == 0
+            boundary_seen = compaction is not None and (
+                first_kept_id is None or first_kept_id in seen_ids
+            )
+            cursor_seen = through_id is None or through_id in seen_ids
+            checkpoint_seen = checkpoint_type is None or checkpoint is not None
+            if at_start or (boundary_seen and cursor_seen and checkpoint_seen):
+                break
+            # A journal with no compaction has no boundary to stop at: keep
+            # reading to the start, which is the forward parse's cost and the
+            # honest one — never pretend a prefix is the whole history.
+    parsed.reverse()
+    return ReplaySuffix(
+        entries=tuple(parsed),
+        through_present=through_id is None or through_id in seen_ids,
+        checkpoint=checkpoint,
+        bytes_read=os.path.getsize(path) - position,
+    )
+
+
 class Transcript:
     """Append-only JSONL store, thread/async-safe via an asyncio lock.
 
@@ -831,107 +994,7 @@ class Transcript:
         pruned live context byte for byte rather than resurrecting the tool
         output compaction already decided was dead weight.
         """
-        entries = self._entries
-        if through_id is not None:
-            # Select the journal cut BEFORE compaction/prune interpretation.
-            # Filtering materialized message IDs afterwards resurrects future
-            # prunes and drops the compaction marker/preserved user turns.
-            for index in range(len(entries) - 1, -1, -1):
-                if entries[index].id == through_id:
-                    entries = entries[: index + 1]
-                    break
-            else:
-                raise ValueError("history cursor is no longer retained")
-        compaction_index: int | None = None
-        for i in range(len(entries) - 1, -1, -1):
-            if entries[i].type == ENTRY_COMPACTION:
-                compaction_index = i
-                break
-
-        start = 0
-        prefix: list[AgentMessage] = []
-        if compaction_index is not None:
-            compaction = entries[compaction_index]
-            details: dict[str, Any] = {"summary": compaction.payload.get("summary", "")}
-            preserve_data = compaction.payload.get("preserve_data")
-            if preserve_data is not None:
-                details["preserve_data"] = preserve_data
-            prefix.append(
-                CustomMessage(
-                    id=compaction.id,
-                    custom_type="compaction_summary",
-                    attribution="system",
-                    details=details,
-                )
-            )
-            # User-authored turns that fell into the summarized partition are
-            # re-injected VERBATIM right after the marker, so the user's own
-            # words survive the pass byte for byte instead of being paraphrased
-            # away (see :meth:`append_compaction`). They sit before the cut in
-            # the transcript, so the contiguous ``first_kept_entry_id`` suffix
-            # below never replays them — the marker payload is the only carrier
-            # that reaches a resumed session. Reusing each turn's original id is
-            # safe: those message entries live before ``start`` and are not
-            # replayed, so there is no duplicate, and the guard that expires
-            # stale asides keys on ``CustomMessage`` (a real ``user`` Message is
-            # never mistaken for one).
-            preserved_turns = compaction.payload.get("preserved_user_turns") or ()
-            if preserved_turns:
-                # Lazy import keeps this low-level store free of a hard compaction
-                # dependency (the session imports compaction lazily for the same
-                # reason). The flag marks these as already-compacted content so a
-                # post-resume pass does not re-count them as fresh history.
-                from local_operator.compaction.cutpoint import PRESERVED_USER_TURN_KEY
-
-                for turn in preserved_turns:
-                    if not isinstance(turn, dict):
-                        continue
-                    message = Message.user(str(turn.get("text", "")))
-                    turn_id = turn.get("id")
-                    if isinstance(turn_id, str) and turn_id:
-                        message.id = turn_id
-                    message.provider_payload = {PRESERVED_USER_TURN_KEY: True}
-                    prefix.append(message)
-            first_kept_id = compaction.payload.get("first_kept_entry_id")
-            # The first kept entry normally sits BEFORE the compaction marker
-            # (messages are persisted as they happen; the marker comes last),
-            # so scan the whole transcript. If the id no longer resolves (a
-            # dropped malformed line, a converter-minted id), replaying from
-            # compaction_index + 1 would point PAST the kept window and lose
-            # every message compaction promised to preserve. Replaying too
-            # much is recoverable at the next compaction; silent amnesia is
-            # not, so fall back to the full history with an error.
-            start = 0
-            if first_kept_id is None:
-                start = compaction_index + 1
-            else:
-                for i in range(len(entries)):
-                    if entries[i].id == first_kept_id:
-                        start = i
-                        break
-                else:
-                    logger.error(
-                        "first_kept_entry_id %s not found in transcript; " "replaying full history",
-                        first_kept_id,
-                    )
-
-        prunes = {
-            str(entry.payload.get("target")): str(entry.payload.get("notice", ""))
-            for entry in entries
-            if entry.type == ENTRY_PRUNE and entry.payload.get("target")
-        }
-        out: list[AgentMessage] = list(prefix)
-        for entry in entries[start:]:
-            if entry.type != ENTRY_MESSAGE:
-                continue
-            message = _entry_to_message(entry, self._attachments)
-            if message is None:
-                continue
-            notice = prunes.get(entry.id)
-            if notice is not None and isinstance(message, Message):
-                _apply_prune(message, notice)
-            out.append(message)
-        return out
+        return replay_entries(self._entries, self._attachments, through_id=through_id)
 
     # -- lifecycle ----------------------------------------------------------
 
@@ -1174,6 +1237,123 @@ def _shrink_marked(entry: TranscriptEntry) -> TranscriptEntry:
     provider_payload[SHRUNK_KEY] = True
     payload["provider_payload"] = provider_payload
     return TranscriptEntry(id=entry.id, ts=entry.ts, type=entry.type, payload=payload)
+
+
+def replay_entries(
+    entries: Sequence[TranscriptEntry],
+    attachments: AttachmentStore | None,
+    *,
+    through_id: str | None = None,
+) -> list[AgentMessage]:
+    """The replay semantics behind :meth:`Transcript.build_llm_history`.
+
+    A module function rather than a method so a caller that has read ONLY a
+    suffix of the journal (:func:`read_replay_suffix`) replays it through the
+    same code path as the whole-file parse, and equivalence between the two is
+    a property of one function applied to two inputs rather than two
+    implementations kept in step by hand.
+    """
+    entries = list(entries)
+    if through_id is not None:
+        # Select the journal cut BEFORE compaction/prune interpretation.
+        # Filtering materialized message IDs afterwards resurrects future
+        # prunes and drops the compaction marker/preserved user turns.
+        for index in range(len(entries) - 1, -1, -1):
+            if entries[index].id == through_id:
+                entries = entries[: index + 1]
+                break
+        else:
+            raise ValueError("history cursor is no longer retained")
+    compaction_index: int | None = None
+    for i in range(len(entries) - 1, -1, -1):
+        if entries[i].type == ENTRY_COMPACTION:
+            compaction_index = i
+            break
+
+    start = 0
+    prefix: list[AgentMessage] = []
+    if compaction_index is not None:
+        compaction = entries[compaction_index]
+        details: dict[str, Any] = {"summary": compaction.payload.get("summary", "")}
+        preserve_data = compaction.payload.get("preserve_data")
+        if preserve_data is not None:
+            details["preserve_data"] = preserve_data
+        prefix.append(
+            CustomMessage(
+                id=compaction.id,
+                custom_type="compaction_summary",
+                attribution="system",
+                details=details,
+            )
+        )
+        # User-authored turns that fell into the summarized partition are
+        # re-injected VERBATIM right after the marker, so the user's own
+        # words survive the pass byte for byte instead of being paraphrased
+        # away (see :meth:`append_compaction`). They sit before the cut in
+        # the transcript, so the contiguous ``first_kept_entry_id`` suffix
+        # below never replays them — the marker payload is the only carrier
+        # that reaches a resumed session. Reusing each turn's original id is
+        # safe: those message entries live before ``start`` and are not
+        # replayed, so there is no duplicate, and the guard that expires
+        # stale asides keys on ``CustomMessage`` (a real ``user`` Message is
+        # never mistaken for one).
+        preserved_turns = compaction.payload.get("preserved_user_turns") or ()
+        if preserved_turns:
+            # Lazy import keeps this low-level store free of a hard compaction
+            # dependency (the session imports compaction lazily for the same
+            # reason). The flag marks these as already-compacted content so a
+            # post-resume pass does not re-count them as fresh history.
+            from local_operator.compaction.cutpoint import PRESERVED_USER_TURN_KEY
+
+            for turn in preserved_turns:
+                if not isinstance(turn, dict):
+                    continue
+                message = Message.user(str(turn.get("text", "")))
+                turn_id = turn.get("id")
+                if isinstance(turn_id, str) and turn_id:
+                    message.id = turn_id
+                message.provider_payload = {PRESERVED_USER_TURN_KEY: True}
+                prefix.append(message)
+        first_kept_id = compaction.payload.get("first_kept_entry_id")
+        # The first kept entry normally sits BEFORE the compaction marker
+        # (messages are persisted as they happen; the marker comes last),
+        # so scan the whole transcript. If the id no longer resolves (a
+        # dropped malformed line, a converter-minted id), replaying from
+        # compaction_index + 1 would point PAST the kept window and lose
+        # every message compaction promised to preserve. Replaying too
+        # much is recoverable at the next compaction; silent amnesia is
+        # not, so fall back to the full history with an error.
+        start = 0
+        if first_kept_id is None:
+            start = compaction_index + 1
+        else:
+            for i in range(len(entries)):
+                if entries[i].id == first_kept_id:
+                    start = i
+                    break
+            else:
+                logger.error(
+                    "first_kept_entry_id %s not found in transcript; " "replaying full history",
+                    first_kept_id,
+                )
+
+    prunes = {
+        str(entry.payload.get("target")): str(entry.payload.get("notice", ""))
+        for entry in entries
+        if entry.type == ENTRY_PRUNE and entry.payload.get("target")
+    }
+    out: list[AgentMessage] = list(prefix)
+    for entry in entries[start:]:
+        if entry.type != ENTRY_MESSAGE:
+            continue
+        message = _entry_to_message(entry, attachments)
+        if message is None:
+            continue
+        notice = prunes.get(entry.id)
+        if notice is not None and isinstance(message, Message):
+            _apply_prune(message, notice)
+        out.append(message)
+    return out
 
 
 def _admitted_command_id(entry: TranscriptEntry) -> str | None:

--- a/local_operator/session/transcript.py
+++ b/local_operator/session/transcript.py
@@ -351,6 +351,10 @@ class Transcript:
         self.path = self.directory / TRANSCRIPT_FILENAME
         self._lock = asyncio.Lock()
         self._entries: list[TranscriptEntry] = []
+        # Paging tokens survive appends, but not a replay-changing mutation or
+        # a new owner. The signing key never leaves this resident transcript.
+        self._history_generation = 0
+        self._history_page_key = os.urandom(32)
         # Derived indexes only describe durable rows. They are updated after
         # fsync, rebuilt after a file fold, and never published from a worker.
         self._entry_ids: set[str] = set()
@@ -645,6 +649,8 @@ class Transcript:
                 raise
 
     def _index_entry(self, entry: TranscriptEntry) -> None:
+        if entry.type in (ENTRY_COMPACTION, ENTRY_PRUNE):
+            self._history_generation += 1
         self._entry_ids.add(entry.id)
         self._latest_by_type[entry.type] = entry
         if entry.type == ENTRY_CUSTOM:
@@ -814,7 +820,7 @@ class Transcript:
             if entry.type == ENTRY_PRUNE and entry.payload.get("target")
         }
 
-    def build_llm_history(self) -> list[AgentMessage]:
+    def build_llm_history(self, *, through_id: str | None = None) -> list[AgentMessage]:
         """Replay the transcript into LLM-visible messages.
 
         Latest compaction entry wins: a marker for its summary followed by the
@@ -826,6 +832,16 @@ class Transcript:
         output compaction already decided was dead weight.
         """
         entries = self._entries
+        if through_id is not None:
+            # Select the journal cut BEFORE compaction/prune interpretation.
+            # Filtering materialized message IDs afterwards resurrects future
+            # prunes and drops the compaction marker/preserved user turns.
+            for index in range(len(entries) - 1, -1, -1):
+                if entries[index].id == through_id:
+                    entries = entries[: index + 1]
+                    break
+            else:
+                raise ValueError("history cursor is no longer retained")
         compaction_index: int | None = None
         for i in range(len(entries) - 1, -1, -1):
             if entries[i].type == ENTRY_COMPACTION:
@@ -842,6 +858,7 @@ class Transcript:
                 details["preserve_data"] = preserve_data
             prefix.append(
                 CustomMessage(
+                    id=compaction.id,
                     custom_type="compaction_summary",
                     attribution="system",
                     details=details,
@@ -898,7 +915,11 @@ class Transcript:
                         first_kept_id,
                     )
 
-        prunes = self.pending_prunes()
+        prunes = {
+            str(entry.payload.get("target")): str(entry.payload.get("notice", ""))
+            for entry in entries
+            if entry.type == ENTRY_PRUNE and entry.payload.get("target")
+        }
         out: list[AgentMessage] = list(prefix)
         for entry in entries[start:]:
             if entry.type != ENTRY_MESSAGE:
@@ -1075,6 +1096,7 @@ class Transcript:
                         worker.result()
                         break
             self._entries = folded
+            self._history_generation += 1
             self._entry_ids.clear()
             self._latest_by_type.clear()
             self._latest_custom_entries.clear()

--- a/local_operator/session/transcript.py
+++ b/local_operator/session/transcript.py
@@ -409,6 +409,10 @@ def read_replay_suffix(
     with path.open("rb") as handle:
         handle.seek(0, os.SEEK_END)
         position = handle.tell()
+        # EOF as the handle saw it. Re-stat'ing after the close would measure a
+        # file an appending owner may have grown in between, reporting bytes
+        # this call never read (round 5, NIT).
+        end_of_file = position
         # Invariant: ``pending`` is the bytes after ``position`` that have NOT
         # yet been split into rows. It only ever grows by one chunk and is
         # split exactly once, when a row boundary lands inside it — so a row
@@ -483,7 +487,7 @@ def read_replay_suffix(
         entries=tuple(parsed),
         through_present=through_id is None or through_id in seen_ids,
         checkpoint=checkpoint,
-        bytes_read=os.path.getsize(path) - position,
+        bytes_read=end_of_file - position,
     )
 
 

--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -821,6 +821,29 @@ SETTINGS: tuple[Setting, ...] = (
             Choice("hidden", "hidden", "not shown"),
         ),
     ),
+    Setting(
+        key="tui.sidebar_visible",
+        path=("tui", "sidebar_visible"),
+        section="appearance",
+        label="Session sidebar",
+        kind=Kind.BOOL,
+        default=False,
+        help="Active and recent conversations. Ctrl+B toggles the sidebar.",
+        choices=_bool_choices("show the sidebar", "keep the full conversation width"),
+    ),
+    Setting(
+        key="tui.sidebar_position",
+        path=("tui", "sidebar_position"),
+        section="appearance",
+        label="Sidebar position",
+        kind=Kind.ENUM,
+        default="left",
+        help="Which side of the conversation holds the session sidebar.",
+        choices=(
+            Choice("left", "left", "sessions to the left of the conversation"),
+            Choice("right", "right", "sessions to the right of the conversation"),
+        ),
+    ),
     # -- approvals ----------------------------------------------------------
     Setting(
         key="tool_approval_mode",

--- a/local_operator/slash_commands.py
+++ b/local_operator/slash_commands.py
@@ -249,6 +249,11 @@ SLASH_COMMANDS: list[SlashCommand] = [
         desktop_destination="settings",
     ),
     SlashCommand(
+        "sidebar",
+        "Show or hide active and recent conversations",
+        desktop_destination="sessions.sidebar",
+    ),
+    SlashCommand(
         "search",
         "Configure web search providers and load balancing",
         desktop_destination="settings.search",

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -171,7 +171,13 @@ from local_operator.tui.session_catalog import CatalogEntry, SidebarSettings
 from local_operator.tui.session_drafts import SessionDraftStore
 from local_operator.tui.session_interaction import SessionDraft, SessionInteraction
 from local_operator.tui.session_navigation import SessionNavigation
-from local_operator.tui.session_presentation import HistoryPageNotice, PreparedReplay, SessionPresentation
+from local_operator.tui.session_presentation import (
+    DraftRecoveryNotice,
+    HistoryPageNotice,
+    PreparedReplay,
+    SessionPresentation,
+)
+from local_operator.tui.session_workspace import SessionWorkspace
 from local_operator.tui.settings import settings_get
 from local_operator.tui.terminal_title import (
     TerminalTitle,
@@ -179,7 +185,12 @@ from local_operator.tui.terminal_title import (
     terminal_title_enabled,
 )
 from local_operator.tui.widgets.approval import ApprovalBlock, ApprovalPrompt
-from local_operator.tui.widgets.aside_panel import ASIDE_PROMPT, AsidePanel
+from local_operator.tui.widgets.aside_panel import (
+    ASIDE_PROMPT,
+    AsidePanel,
+    AsideSnapshot,
+    AsideTurn,
+)
 from local_operator.tui.widgets.ask_picker import AskPickerScreen
 from local_operator.tui.widgets.assistant import AssistantBlock
 from local_operator.tui.widgets.command_picker import CommandPicker
@@ -2189,7 +2200,7 @@ class OperatorApp(App[None]):
         # costs a delayed name instead of a permanently nameless session: the
         # next substantive message retries, which is bounded by the user's own
         # sends and only ever fires while no name exists to displace.
-        self._name_requested: bool = False
+        self._name_requested = False
         #: A receipt that must survive a session transition, as
         #: ``(fork_id, text)``. `fork.mode=switch` reboots onto the fork, which
         #: wipes the ledger about half a second after the notice is written, so
@@ -2216,17 +2227,17 @@ class OperatorApp(App[None]):
         # through the session's history instead of naming the session. Held
         # here and not on the session because it is a DISPLAY stand-in, not a
         # stored title — see :meth:`_show_provisional_name`.
-        self._provisional_name: str = ""
+        self._provisional_name = ""
         # Ownership token for the latch above. Reload can supersede an
         # in-flight naming worker synchronously, then let the replacement
         # session schedule its own attempt before cancellation has unwound;
         # only the current generation may clear the new latch or store a title.
-        self._name_generation: int = 0
+        self._name_generation = 0
         # Monotonic stamp of the last moment a title was DECIDED — either
         # stored, or checked against a new message and left alone. The re-title
         # throttle's SECONDARY time floor measures its gap from here; see
         # :meth:`_maybe_retitle_conversation` for why the gap exists.
-        self._retitle_checked_at: float = 0.0
+        self._retitle_checked_at = 0.0
         # The growth-gated re-title schedule's two counters, mirroring omp's
         # `lastTitledTurnCount`/`refreshCount`. `_last_titled_turn_count` is the
         # transcript turn-count at the moment the title in force was set (0 until
@@ -2240,14 +2251,14 @@ class OperatorApp(App[None]):
         # holder (`ConversationName`) is shared with the session and persisted,
         # while these are display-schedule bookkeeping for the live host — the
         # same split `_provisional_name` already makes.
-        self._last_titled_turn_count: int = 0
-        self._theme_refresh_count: int = 0
+        self._last_titled_turn_count = 0
+        self._theme_refresh_count = 0
         # Opener text of a naming attempt that returned nothing. A quota
         # fallback pins AFTER the isolated naming call has already 429'd on
         # the dead primary, so the next substantive message is too late —
         # the phone stays "untitled" for the whole first turn. The route
         # edge re-fires this opener once a serving model exists.
-        self._pending_name_text: str = ""
+        self._pending_name_text = ""
         # A turn holds this for its whole provider round trip, and `_dispose`
         # waits on it so a session is never torn down under a live request.
         # Naming does NOT take it: the title call is `isolated` (see
@@ -2341,7 +2352,7 @@ class OperatorApp(App[None]):
         #: ``_request_login_key``). Distinct from ``_key_prompt``, which is
         #: cleared the moment the prompt is answered.
         self._last_login_prompt: Any = None
-        self._approve_all: bool = False
+        self._approve_all = False
         #: The phone-facing bridge: registrant (discovery record + control
         #: socket) and the handle adapting this app to it. None until the
         #: first session is adopted; torn down in ``on_unmount``.
@@ -2486,21 +2497,21 @@ class OperatorApp(App[None]):
         # stash whatever the user had half typed for the main chat, and Esc has
         # to hand it back. `None` means the aside is closed; `""` is a real
         # value (the draft was empty) and must not collapse into it.
-        self._aside_draft: str | None = None
+        self._aside_draft = None
         #: and its attachments. The aside CLEARS the composer to borrow it, and
         #: `clear_content` drops attachments by design — so without stashing
         #: these the draft came back with its `[Image #N]` markers resolving to
         #: nothing, and Enter sent the words alone. Worse, an image pasted
         #: INSIDE the aside took number 1, so the restored marker resolved to
         #: the aside's image instead (review round 17).
-        self._aside_draft_images: dict[int, Marked] = {}
+        self._aside_draft_images = {}
         #: Whether bang-mode was ON when the aside borrowed the composer. The
         #: aside disables the gesture for the life of the card, but the command
         #: the user had half typed is stashed and returned verbatim — returning
         #: it into a composer that silently left bang-mode would arm Enter with
         #: a shell command aimed at the model. Restored in `_close_aside` with
         #: the draft it belongs to.
-        self._aside_draft_shell_mode: bool = False
+        self._aside_draft_shell_mode = False
         # The reasoning-effort level the USER picked, or None while the model's
         # own default stands. Held on the app rather than only on the session
         # spec because the session is replaceable — `/new`, `/reload` and
@@ -2525,6 +2536,13 @@ class OperatorApp(App[None]):
         self._sidebar_refresh_generation = 0
         self._sidebar_refresh_pending = False
         self._sidebar_prefetch: Any = None
+        self._sidebar_prior_workers: set[Any] = set()
+        self._sidebar_last_prefetch = ""
+        self._sidebar_settings_applied = False
+        self._sidebar_ready_frame: tuple[SessionInteraction, int, asyncio.Future[None]] | None = (
+            None
+        )
+        self._sidebar_frame_pending = False
         self._sidebar_focus_restore: Widget | None = None
         self._sidebar_presentations: dict[str, SessionPresentation] = {}
         self._sidebar_sources: dict[str, SessionInteraction] = {}
@@ -2691,10 +2709,136 @@ class OperatorApp(App[None]):
     def _spend_is_floor(self, value: bool) -> None:
         self._interaction.accounting.is_floor = value
 
+    @property
+    def _completion_deferred(self) -> bool:
+        return self._interaction.turn.completion_deferred
+
+    @_completion_deferred.setter
+    def _completion_deferred(self, value: bool) -> None:
+        self._interaction.turn.completion_deferred = value
+
+    @property
+    def _settled_child_ids(self) -> set[str]:
+        return self._interaction.turn.settled_child_ids
+
+    @_settled_child_ids.setter
+    def _settled_child_ids(self, value: set[str]) -> None:
+        self._interaction.turn.settled_child_ids = value
+
+    @property
+    def _waiting_kind(self) -> str | None:
+        return self._interaction.turn.waiting_kind
+
+    @_waiting_kind.setter
+    def _waiting_kind(self, value: str | None) -> None:
+        self._interaction.turn.waiting_kind = value
+
+    @property
+    def _approvals_denied_epoch(self) -> int | None:
+        return self._interaction.turn.approvals_denied_epoch
+
+    @_approvals_denied_epoch.setter
+    def _approvals_denied_epoch(self, value: int | None) -> None:
+        self._interaction.turn.approvals_denied_epoch = value
+
+    @property
+    def _name_requested(self) -> bool:
+        return self._interaction.naming.requested
+
+    @_name_requested.setter
+    def _name_requested(self, value: bool) -> None:
+        self._interaction.naming.requested = value
+
+    @property
+    def _provisional_name(self) -> str:
+        return self._interaction.naming.provisional
+
+    @_provisional_name.setter
+    def _provisional_name(self, value: str) -> None:
+        self._interaction.naming.provisional = value
+
+    @property
+    def _name_generation(self) -> int:
+        return self._interaction.naming.generation
+
+    @_name_generation.setter
+    def _name_generation(self, value: int) -> None:
+        self._interaction.naming.generation = value
+
+    @property
+    def _retitle_checked_at(self) -> float:
+        return self._interaction.naming.checked_at
+
+    @_retitle_checked_at.setter
+    def _retitle_checked_at(self, value: float) -> None:
+        self._interaction.naming.checked_at = value
+
+    @property
+    def _last_titled_turn_count(self) -> int:
+        return self._interaction.naming.last_titled_turn_count
+
+    @_last_titled_turn_count.setter
+    def _last_titled_turn_count(self, value: int) -> None:
+        self._interaction.naming.last_titled_turn_count = value
+
+    @property
+    def _theme_refresh_count(self) -> int:
+        return self._interaction.naming.refresh_count
+
+    @_theme_refresh_count.setter
+    def _theme_refresh_count(self, value: int) -> None:
+        self._interaction.naming.refresh_count = value
+
+    @property
+    def _pending_name_text(self) -> str:
+        return self._interaction.naming.pending_text
+
+    @_pending_name_text.setter
+    def _pending_name_text(self, value: str) -> None:
+        self._interaction.naming.pending_text = value
+
+    @property
+    def _aside_draft(self) -> str | None:
+        return self._interaction.draft.aside_main_text
+
+    @_aside_draft.setter
+    def _aside_draft(self, value: str | None) -> None:
+        self._interaction.draft.aside_main_text = value
+
+    @property
+    def _aside_draft_images(self) -> dict[int, Marked]:
+        return self._interaction.draft.aside_main_images
+
+    @_aside_draft_images.setter
+    def _aside_draft_images(self, value: dict[int, Marked]) -> None:
+        self._interaction.draft.aside_main_images = value
+
+    @property
+    def _aside_draft_shell_mode(self) -> bool:
+        return self._interaction.draft.aside_main_shell_mode
+
+    @_aside_draft_shell_mode.setter
+    def _aside_draft_shell_mode(self, value: bool) -> None:
+        self._interaction.draft.aside_main_shell_mode = value
+
+    @property
+    def _approve_all(self) -> bool:
+        return bool(self._interaction.draft.approve_all)
+
+    @_approve_all.setter
+    def _approve_all(self, value: bool) -> None:
+        self._interaction.draft.approve_all = value
+
     async def _on_message(self, message: TextualMessage) -> None:
         if isinstance(message, SessionEvent) and message.origin is not None:
             source = self._event_sources.get(message.origin)
             if source is not None:
+                if (
+                    isinstance(message, TurnAbandoned)
+                    and message.operation is not None
+                    and message.operation != source.turn.operation
+                ):
+                    return
                 source.presentation_revision += 1
                 if not self._is_current(source):
                     self._reduce_hidden_session_event(source, message)
@@ -2719,9 +2863,13 @@ class OperatorApp(App[None]):
         # Hiding a view is not cancelling its work. In particular, accepted
         # input held during compaction still owes delivery to its source.
         if isinstance(message, TurnStarted):
-            source.turn.epoch += 1
+            if not message.projection:
+                source.turn.epoch += 1
             source.turn.open = True
             source.turn.notified = False
+            source.turn.completion_deferred = False
+            source.turn.settled_child_ids.clear()
+            source.turn.waiting_kind = None
         elif isinstance(message, TurnEnded):
             source.turn.open = False
             source.turn.notified = True
@@ -2741,9 +2889,17 @@ class OperatorApp(App[None]):
         typed, source.compaction.held_typed = source.compaction.held_typed, ""
         images, source.compaction.held_images = source.compaction.held_images, {}
         accepted, source.compaction.accepted_draft = source.compaction.accepted_draft, None
+        message_id, source.compaction.accepted_message_id = (
+            source.compaction.accepted_message_id,
+            "",
+        )
         if held or images:
             self._start_turn_for(
-                source, held, resolve_markers(typed or held, images), accepted=accepted
+                source,
+                held,
+                resolve_markers(typed or held, images),
+                accepted=accepted,
+                message_id=message_id,
             )
 
     def _is_current(self, source: SessionInteraction) -> bool:
@@ -2758,6 +2914,25 @@ class OperatorApp(App[None]):
             source.notices.append((text, kind))
             del source.notices[:-64]
 
+    def _capture_editor_draft(self) -> SessionDraft:
+        editor = self._editor()
+        # Only the editor payload: copying the source's whole view state would
+        # recursively capture its own recovery queue and overwrite newer state.
+        return SessionDraft(
+            text=editor.text,
+            attachments=editor.attachments(),
+            selection=editor.selection,
+            shell_mode=editor.shell_mode,
+        )
+
+    def _load_editor_draft(self, draft: SessionDraft) -> None:
+        editor = self._editor()
+        editor.load_text(draft.text)
+        editor.adopt_attachments(draft.attachments)
+        editor.set_shell_mode(draft.shell_mode)
+        if draft.selection is not None:
+            editor.selection = draft.selection
+
     def _restore_unsent_for(
         self,
         source: SessionInteraction,
@@ -2767,16 +2942,74 @@ class OperatorApp(App[None]):
         accepted: SessionDraft | None = None,
     ) -> None:
         restored = accepted or SessionDraft(text=text)
+        if accepted is None and images:
+            from local_operator.tui.widgets.editor import Attachment, _marker_indices
+
+            index = max(_marker_indices(text), default=0)
+            for image in images:
+                index += 1
+                marker = f"[Image #{index}]"
+                restored.attachments[index] = Attachment(image, marker)
+                restored.text += "\n" + marker
         if self._is_current(source):
             editor = self._editor()
-            if not editor.text.strip():
-                editor.forget_prompt(text)
-                editor.load_text(restored.text)
-                editor.adopt_attachments(restored.attachments)
-        else:
-            source.unsent.append((text, list(images or [])))
-            if not source.draft.text.strip():
-                source.draft = restored
+            editor.forget_prompt(text)
+            if not self._aside_is_open() and not editor.text and not editor.attachments():
+                self._load_editor_draft(restored)
+                return
+        elif not source.aside_open and not source.draft.text and not source.draft.attachments:
+            source.draft.text = restored.text
+            source.draft.attachments = dict(restored.attachments)
+            source.draft.selection = restored.selection
+            source.draft.shell_mode = restored.shell_mode
+            return
+        if not any(draft is restored for draft in source.unsent):
+            source.unsent.append(restored)
+        self._sync_draft_recoveries(source)
+
+    def _sync_draft_recoveries(self, source: SessionInteraction) -> None:
+        if not self._is_current(source):
+            return
+        view = self._transcript_view()
+        notices = [block for block in view.blocks() if isinstance(block, DraftRecoveryNotice)]
+        for notice in notices:
+            if notice.source_token != source.token or not any(
+                draft is notice.draft for draft in source.unsent
+            ):
+                view.remove_block(notice)
+        for draft in source.unsent:
+            if not any(
+                notice.source_token == source.token and notice.draft is draft for notice in notices
+            ):
+                self._append_block(DraftRecoveryNotice(source.token, draft))
+
+    def on_draft_recovery_notice_requested(self, message: DraftRecoveryNotice.Requested) -> None:
+        message.stop()
+        source = self._interaction
+        notice = message.notice
+        if (
+            self._session_transition_pending
+            or notice.source_token != source.token
+            or notice not in self._transcript_view().blocks()
+        ):
+            return
+        index = next(
+            (index for index, draft in enumerate(source.unsent) if draft is notice.draft), None
+        )
+        if index is None:
+            return
+        if self._aside_is_open():
+            panel = self._aside_panel()
+            if panel is not None:
+                panel.set_notice("Close the aside to restore this main prompt")
+            return
+        restored = source.unsent.pop(index)
+        current = self._capture_editor_draft()
+        if current.text or current.attachments:
+            source.unsent.append(current)
+        self._load_editor_draft(restored)
+        self._sync_draft_recoveries(source)
+        self._editor().focus()
 
     def _register_user_echo_for(
         self, source: SessionInteraction, text: str, *, message_id: str = ""
@@ -2791,7 +3024,12 @@ class OperatorApp(App[None]):
         ]
 
     def _post_turn_abandoned_for(
-        self, source: SessionInteraction, *, aborted: bool, error: str | None
+        self,
+        source: SessionInteraction,
+        *,
+        aborted: bool,
+        error: str | None,
+        operation: int | None = None,
     ) -> None:
         message = TurnAbandoned(
             source.turn.epoch,
@@ -2800,7 +3038,18 @@ class OperatorApp(App[None]):
             outcome_known=not bool(getattr(source.session, "is_remote", False)),
         )
         message.origin = source.controller
+        message.operation = operation
         self.post_message(message)
+
+    @staticmethod
+    def _sidebar_source_stamp(source: SessionInteraction) -> tuple[Any, ...]:
+        state = getattr(source.session, "frontend_state", None)
+        return (
+            getattr(state, "epoch", ""),
+            getattr(state, "generation", 0),
+            getattr(state, "history_cursor", None),
+            getattr(state, "streaming", False),
+        )
 
     def _capture_sidebar_presentation(self) -> SessionPresentation:
         replay = PreparedReplay(
@@ -2818,6 +3067,10 @@ class OperatorApp(App[None]):
         return SessionPresentation(
             replay=replay,
             revision=self._interaction.presentation_revision,
+            source_stamp=self._sidebar_source_stamp(self._interaction),
+            source_token=self._interaction.token,
+            history_size=len(self._session.history()) if self._session is not None else 0,
+            needs_live_projection=False,
             streaming_block=self._streaming_block,
             tool_cards=self._tool_cards,
             composing_cards=self._composing_cards,
@@ -2856,7 +3109,7 @@ class OperatorApp(App[None]):
         self._deferred_steer_notices = presentation.deferred_steer_notices
         self._held_steer_blocks = presentation.held_steer_blocks
         self._welcome = presentation.welcome
-        self._welcome_visible = presentation.welcome_visible
+        self._welcome_visible = None
         # Gesture tasks belong to the abandoned viewport, not its history.
         self._resume_paging = False
         self._resume_check_pending = False
@@ -2869,61 +3122,121 @@ class OperatorApp(App[None]):
         self._exit_hint = None
         self._superseded_steer_controllers.clear()
 
-    async def _prepare_sidebar_session(
-        self, session_id: str
-    ) -> tuple[SessionInteraction, SessionPresentation]:
+    async def _lease_sidebar_source(
+        self, session_id: str, *, speculative: bool
+    ) -> SessionInteraction:
         from local_operator.mobile.attach_client import find_owner_record
         from local_operator.paths import config_dir
         from local_operator.session.remote import RemoteSession
 
-        if self._session is not None and self._session.session_id == session_id:
-            return self._interaction, self._capture_sidebar_presentation()
         source = self._sidebar_sources.get(session_id)
-        if source is None:
-            directory = config_dir()
-            record, owner = await asyncio.to_thread(find_owner_record, directory, session_id)
-            if record is not None and record.protocol < 4:
-                raise RuntimeError("Update the older Local Operator session before opening it here")
+        if source is not None and not source.retired:
+            source.preparations += 1
+            return source
+        directory = config_dir()
+        record, owner = await asyncio.to_thread(find_owner_record, directory, session_id)
 
-            async def takeover() -> Any:
-                if self._resume_factory is None:
-                    raise RuntimeError("This launcher cannot reopen an inactive conversation")
-                return await self._resume_factory(session_id)
+        async def no_takeover() -> Any:
+            # Match the CLI viewer policy: discovery/preparation must never
+            # turn this TUI into an owner or recursively create a cold facade.
+            raise RuntimeError("a sidebar viewer never takes over a session")
 
-            if record is not None and owner is not None:
-                remote = await RemoteSession.connect(
-                    record, session_id, config_dir=directory, takeover_factory=takeover
-                )
-            else:
-                remote = await takeover()
-                if not isinstance(remote, RemoteSession):
-                    raise RuntimeError("Sidebar navigation requires an owner-backed session")
-                await remote._ensure_bound()
+        if record is not None and owner is not None:
+            remote = await RemoteSession.connect(
+                record, session_id, config_dir=directory, takeover_factory=no_takeover
+            )
+        else:
+            if speculative:
+                raise RuntimeError("The prepared owner is no longer active")
+            if self._resume_factory is None:
+                raise RuntimeError("This launcher cannot reopen an inactive conversation")
+            remote = await self._resume_factory(session_id)
+        if not isinstance(remote, RemoteSession):
+            raise RuntimeError("Sidebar navigation requires an owner-backed session")
+        try:
+            if remote.session_id != session_id:
+                raise RuntimeError("The launcher returned a different conversation")
             source = SessionInteraction(remote)
             source.draft = await self._sidebar_drafts.get(session_id)
+            if source.draft.approve_all is None:
+                source.draft.approve_all = self._approvals_default_auto
+            source.preparations = 1
+            remote.suspend_viewer_gates()
             self._interactions[id(remote)] = source
             self._sidebar_sources[session_id] = source
             source.controller = EventController(remote, self)
             self._event_sources[source.controller] = source
             source.controller.subscribe()
-        session = source.session
-        if not isinstance(session, RemoteSession):
-            raise RuntimeError("Sidebar navigation requires an owner-backed session")
-        if session.is_cold:
-            await session._ensure_bound()
-        if session.is_cold:
-            raise RuntimeError("The conversation has not finished connecting")
-        cached = self._sidebar_presentations.get(session_id)
-        if cached is not None and cached.revision == source.presentation_revision:
-            if not source.draft.following_tail and source.draft.scroll_anchor_id:
-                cached.replay.view.restore_navigation_anchor(source.draft.scroll_anchor_id, source.draft.scroll_anchor_part, source.draft.scroll_offset)
-            return source, cached
-        replay = PreparedReplay()
-        source.preparations += 1
-        revision = source.presentation_revision
+            self._watch_source_frontend(source)
+            return source
+        except BaseException:
+            if remote is not self._session:
+                await remote.dispose()
+            raise
+
+    async def _drain_sidebar_prior_transitions(self) -> None:
+        from textual.worker import WorkerCancelled, WorkerFailed
+
+        for worker in tuple(self._sidebar_prior_workers):
+            try:
+                # A cancellation-resistant old reload must finish touching its
+                # own view before the replacement can publish another one.
+                await asyncio.shield(worker.wait())
+            except WorkerCancelled:
+                pass
+            except WorkerFailed:
+                logger.debug("prior session transition failed while draining", exc_info=True)
+            self._sidebar_prior_workers.discard(worker)
+
+    async def _prepare_sidebar_session(
+        self, session_id: str, *, speculative: bool = False
+    ) -> tuple[SessionInteraction, SessionPresentation]:
+        from local_operator.session.remote import RemoteSession
+        from local_operator.tui.session_catalog import session_directory_name
+
+        if self._session is not None and self._session.session_id == session_id:
+            return self._interaction, self._capture_sidebar_presentation()
+        if not speculative:
+            await self._drain_sidebar_prior_transitions()
+        source = await self._lease_sidebar_source(session_id, speculative=speculative)
+        replay: PreparedReplay | None = None
+        succeeded = False
         try:
+            session = source.session
+            if not isinstance(session, RemoteSession):
+                raise RuntimeError("Sidebar navigation requires an owner-backed session")
+            if session.is_cold:
+                if speculative:
+                    raise RuntimeError("The prepared owner is no longer ready")
+                await asyncio.wait_for(session._ensure_bound(), 15)
+            if session.is_cold:
+                raise RuntimeError("The conversation has not finished connecting")
+            gate = session.frontend_state.pending_gate
+            if gate is not None and gate.kind not in {"ask", "approval"}:
+                raise RuntimeError("This viewer does not support the conversation's pending input")
+            cached = self._sidebar_presentations.get(session_id)
+            if (
+                cached is not None
+                and cached.source_token == source.token
+                and cached.revision == source.presentation_revision
+                and cached.source_stamp == self._sidebar_source_stamp(source)
+            ):
+                if not source.draft.following_tail and source.draft.scroll_anchor_id:
+                    cached.replay.view.restore_navigation_anchor(
+                        source.draft.scroll_anchor_id,
+                        source.draft.scroll_anchor_part,
+                        source.draft.scroll_offset,
+                    )
+                succeeded = True
+                return source, cached
+            replay = PreparedReplay()
+            welcome: WelcomeView | None = None
+            revision = source.presentation_revision
+            history = list(session.history())
+            source_stamp = self._sidebar_source_stamp(source)
             replay.prepare(
-                list(session.history()), bound=max(12, self.size.height // 2),
+                history,
+                bound=max(12, self.size.height // 2),
                 anchor_id=source.draft.scroll_anchor_id if not source.draft.following_tail else "",
             )
             replay.view.styles.layer = "session-cache"
@@ -2932,6 +3245,18 @@ class OperatorApp(App[None]):
             conversation = self.query_one("#session-conversation")
             conversation.styles.layers = "default session-cache"
             await conversation.mount(replay.view)
+            if not replay.blocks:
+                welcome = WelcomeView(
+                    lambda: session_welcome_info(
+                        session,
+                        self._providers,
+                        notice=self._splash_notice,
+                        setup=self._setup_state,
+                        update_available=self._update_available,
+                    )
+                )
+                welcome.set_navigation_visible(False)
+                await replay.view.mount(welcome)
             with replay.view.batch_append():
                 for block in replay.blocks:
                     replay.view.append_block(block)
@@ -2942,27 +3267,187 @@ class OperatorApp(App[None]):
             self.call_after_refresh(laid_out.set)
             await laid_out.wait()
             if not source.draft.following_tail and source.draft.scroll_anchor_id:
-                replay.view.restore_navigation_anchor(source.draft.scroll_anchor_id, source.draft.scroll_anchor_part, source.draft.scroll_offset)
+                replay.view.restore_navigation_anchor(
+                    source.draft.scroll_anchor_id,
+                    source.draft.scroll_anchor_part,
+                    source.draft.scroll_offset,
+                )
+            succeeded = True
             return source, SessionPresentation(
-                replay, revision=revision, working_fallback=DEFAULT_ACTIVITY
+                replay,
+                revision=revision,
+                source_stamp=source_stamp,
+                source_token=source.token,
+                history_size=len(history),
+                working_fallback=DEFAULT_ACTIVITY,
+                welcome=welcome,
+                welcome_visible=welcome is not None,
             )
         except BaseException:
-            if replay.view.is_mounted:
+            if replay is not None and replay.view.parent is not None:
                 await replay.view.remove()
-            if (
-                source.preparations == 1
-                and not source.must_retain
-                and source is not self._interaction
-                and session_id not in self._sidebar_presentations
-            ):
-                source.controller.dispose()
-                self._event_sources.pop(source.controller, None)
-                self._sidebar_sources.pop(session_id, None)
-                self._interactions.pop(id(session), None)
-                await session.dispose()
             raise
         finally:
             source.preparations -= 1
+            if not succeeded:
+                await self._release_sidebar_source(source)
+
+    @staticmethod
+    def _sidebar_gate_identity(source: SessionInteraction) -> tuple[Any, ...] | None:
+        state = getattr(source.session, "frontend_state", None)
+        gate = getattr(state, "pending_gate", None)
+        if gate is None:
+            return None
+        return (getattr(state, "epoch", ""), gate.kind, gate.request_id, gate.question_index)
+
+    def _watch_source_frontend(self, source: SessionInteraction) -> None:
+        from local_operator.session.frontend_state import FrontendSubscription
+
+        subscribe = getattr(source.session, "subscribe_frontend", None)
+        if source.unsubscribe_frontend is None and callable(subscribe):
+            subscription = subscribe(
+                lambda _update: self.call_later(self._source_frontend_changed, source)
+            )
+            source.unsubscribe_frontend = cast(FrontendSubscription, subscription).unsubscribe
+
+    def _source_frontend_changed(self, source: SessionInteraction) -> None:
+        if source.retired:
+            return
+        if source.gate_draft is not None and source.gate_draft[0] != self._sidebar_gate_identity(
+            source
+        ):
+            source.gate_draft = None
+        if self._sidebar_source_releasable(source) and self.is_running:
+            self.run_worker(self._release_sidebar_source(source))
+
+    def _restore_gate_draft(self, source: SessionInteraction, card: AskPickerScreen) -> None:
+        saved = source.gate_draft
+        if saved is not None and saved[0] == self._sidebar_gate_identity(source):
+            card.restore_state(saved[1])
+
+    def _suspend_sidebar_gates(self, source: SessionInteraction) -> None:
+        from local_operator.session.remote import RemoteSession
+
+        session = source.session
+        if not isinstance(session, RemoteSession):
+            return
+        view_generation = source.gate_view_generation
+        source.gate_view_generation += 1
+        keep_answer = False
+        if self._is_current(source):
+            card = self._ask_screen or self._approval
+            key = self._sidebar_gate_identity(source)
+            owns_card = card is not None and card.source_binding == (
+                source.token,
+                key,
+                view_generation,
+            )
+            if card is not None:
+                if owns_card and key is not None and not card.settled:
+                    snapshot = card.snapshot_state()
+                    snapshot.focused = source.draft.focus_id == "@gate"
+                    source.gate_draft = (key, snapshot)
+                card.disabled = True
+            keep_answer = owns_card and bool(
+                (self._approval is not None and self._approval.answered)
+                or (
+                    self._ask_pending is not None
+                    and self._ask_pending.done()
+                    and not self._ask_pending.cancelled()
+                )
+            )
+        denied = source.turn.approvals_denied_epoch
+        auto = bool(source.draft.approve_all) and not (
+            denied is not None and source.turn.epoch <= denied
+        )
+        task = session.suspend_viewer_gates(auto_approve=auto, keep_answer=keep_answer)
+        if task is not None:
+            task.add_done_callback(
+                lambda _task: self.call_later(self._source_frontend_changed, source)
+            )
+
+    def _sidebar_gate_surface_ready(self, source: SessionInteraction) -> bool:
+        if not self._is_current(source) or getattr(source.session, "is_cold", False):
+            return False
+        view = self._transcript_view()
+        editor = self._editor()
+        if not view.is_on_screen or not editor.is_mounted or editor.disabled:
+            return False
+        blocks = view.blocks()
+        if source.draft.following_tail:
+            last = next((block for block in reversed(blocks) if block.display), None)
+            if not view.is_near_bottom() or (
+                last is not None and last.region.bottom > view.content_region.bottom
+            ):
+                return False
+        elif source.draft.scroll_anchor_id:
+            anchor = next(
+                (
+                    block
+                    for block in blocks
+                    if block.navigation_anchor_id == source.draft.scroll_anchor_id
+                    and block.navigation_anchor_part == source.draft.scroll_anchor_part
+                ),
+                None,
+            )
+            if anchor is not None:
+                offset = min(source.draft.scroll_offset, max(0, anchor.region.height - 1))
+                if (
+                    anchor.region.y + offset != view.content_region.y
+                    and 0 < view.scroll_y < view.max_scroll_y
+                ):
+                    return False
+        state = getattr(source.session, "frontend_state", None)
+        gate = getattr(state, "pending_gate", None)
+        if gate is None:
+            return self._ask_screen is None and self._approval is None
+        if gate.kind == "approval" and bool(source.draft.approve_all):
+            return True
+        card = self._ask_screen if gate.kind == "ask" else self._approval
+        return bool(
+            card is not None
+            and card.source_binding
+            == (source.token, self._sidebar_gate_identity(source), source.gate_view_generation)
+            and card.is_mounted
+            and card.is_on_screen
+            and not card.disabled
+            and not card.settled
+        )
+
+    def _await_sidebar_frame(
+        self, source: SessionInteraction, generation: int
+    ) -> asyncio.Future[None]:
+        future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+        self._sidebar_ready_frame = (source, generation, future)
+
+        def expired() -> None:
+            if not future.done():
+                future.set_exception(
+                    RuntimeError(
+                        "The conversation connected but its input surface did not become ready"
+                    )
+                )
+
+        timer = self.set_timer(15, expired)
+        future.add_done_callback(lambda _future: timer.stop())
+        self.refresh()
+        return future
+
+    def post_display_hook(self) -> None:
+        super().post_display_hook()
+        pending = getattr(self, "_sidebar_ready_frame", None)
+        if pending is None:
+            return
+        source, generation, future = pending
+        if future.done():
+            self._sidebar_ready_frame = None
+        elif generation == self._sidebar_navigation.generation and self._sidebar_gate_surface_ready(
+            source
+        ):
+            # This is the real display path, not a timer or a cosmetic selection
+            # update. Only now are the target frame and its input surface ready.
+            self._sidebar_ready_frame = None
+            future.set_result(None)
 
     def _sidebar_navigation_pending(self, session_id: str) -> None:
         from local_operator.session.remote import RemoteSession
@@ -2970,16 +3455,75 @@ class OperatorApp(App[None]):
         current = self._session
         if isinstance(current, RemoteSession):
             if session_id:
-                current.suspend_viewer_gates()
+                self._suspend_sidebar_gates(self._interaction)
             else:
                 current.resume_viewer_gates()
         self._session_transition_pending = bool(session_id)
+        self._sidebar_frame_pending = True
+        if not session_id:
+            source = self._interaction
+            generation = self._sidebar_navigation.generation
+
+            def painted() -> None:
+                if (
+                    self._interaction is source
+                    and self._sidebar_navigation.generation == generation
+                ):
+                    self._sidebar_frame_pending = False
+
+            self.call_after_refresh(painted)
         self._session_sidebar.requested_id = session_id
         self._session_sidebar.refresh()
 
     def _sidebar_navigation_failed(self, session_id: str, error: Exception) -> None:
         self._session_sidebar.show_error(str(error))
         self._system_notice(f"Could not open conversation: {error}", "warning")
+
+    def _sidebar_source_releasable(self, source: SessionInteraction) -> bool:
+        from local_operator.session.remote import RemoteSession
+
+        return (
+            isinstance(source.session, RemoteSession)
+            and source is not self._interaction
+            and not source.retired
+            and not source.must_retain
+            and not source.preparations
+            and not getattr(source.session, "has_pending_gate_reply", False)
+            and source.session is not None
+            and source.session is not self._fork_source_session
+            and source.session.session_id not in self._sidebar_presentations
+        )
+
+    async def _release_sidebar_source(self, source: SessionInteraction) -> None:
+        if not self._sidebar_source_releasable(source) or source.session is None:
+            return
+        session = source.session
+        try:
+            await self._sidebar_drafts.put(
+                session.session_id,
+                replace(source.draft, attachments=dict(source.draft.attachments)),
+            )
+        except OSError:
+            self._system_notice(
+                "Could not save the draft to disk; it is still kept in memory", "warning"
+            )
+            return
+        # Saving overflow yields. A rapid return may have acquired this same
+        # source; neither its event controller nor its socket may close then.
+        if not self._sidebar_source_releasable(source):
+            return
+        source.retired = True
+        if source.unsubscribe_frontend is not None:
+            source.unsubscribe_frontend()
+            source.unsubscribe_frontend = None
+        if source.controller is not None:
+            source.controller.dispose()
+            self._event_sources.pop(source.controller, None)
+        if self._sidebar_sources.get(session.session_id) is source:
+            self._sidebar_sources.pop(session.session_id, None)
+        if self._interactions.get(id(session)) is source:
+            self._interactions.pop(id(session), None)
+        await session.dispose()
 
     async def _release_sidebar_preparation(
         self, prepared: tuple[SessionInteraction, SessionPresentation]
@@ -2992,45 +3536,53 @@ class OperatorApp(App[None]):
             return
         if presentation.replay.view.is_mounted:
             await presentation.replay.view.remove()
-        # Detaching this speculative viewer never stops its runtime. A source
-        # with accepted input or executing work retains its facade separately.
-        if (
-            source is not self._interaction
-            and not source.must_retain
-            and not source.preparations
-            and source.session is not None
-        ):
-            if source.controller is not None:
-                source.controller.dispose()
-                self._event_sources.pop(source.controller, None)
-            try:
-                await self._sidebar_drafts.put(
-                    source.session.session_id,
-                    replace(source.draft, attachments=dict(source.draft.attachments)),
-                )
-            except OSError:
-                self._system_notice(
-                    "Could not save the draft to disk; it is still kept in memory", "warning"
-                )
-                return
-            # Saving overflow yields to disk. A rapid return may have acquired
-            # this same facade meanwhile, so recheck ownership before closing.
-            if (
-                source is self._interaction
-                or source.preparations
-                or source.session.session_id in self._sidebar_presentations
-            ):
-                return
-            self._sidebar_sources.pop(source.session.session_id, None)
-            self._interactions.pop(id(source.session), None)
-            await source.session.dispose()
+        await self._release_sidebar_source(source)
+
+    def _park_sidebar_aside(self, source: SessionInteraction) -> None:
+        panel = self._aside_panel()
+        if panel is None or not panel.is_open:
+            return
+        source.draft.aside = panel.snapshot()
+        source.aside_generation = source.draft.aside.generation
+        source.aside_open = True
+        # Closing the projection must not cancel the source-bound provider
+        # request. Its data reducer keeps the detached exchange up to date.
+        panel.close()
+        panel._on_height = None
+        self._transcript_view().styles.clear_rule("padding")
+        self.screen.remove_class(ASIDE_LAYOUT_CLASS)
+
+    def _restore_sidebar_aside(self, source: SessionInteraction) -> None:
+        editor = self._editor()
+        snapshot = source.draft.aside
+        panel = self._aside_panel()
+        if isinstance(snapshot, AsideSnapshot) and panel is not None:
+            source.aside_open = True
+            source.aside_generation = snapshot.generation
+            editor.set_allows_shell(False)
+            editor.placeholder = ASIDE_PLACEHOLDER
+            editor.set_commands([])
+            editor.set_records_history(False)
+            self.screen.add_class(ASIDE_LAYOUT_CLASS)
+            panel._on_height = self._reserve_ground_for_aside
+            panel.restore(snapshot)
+            self._sync_aside_fork_hint()
+        else:
+            source.aside_open = False
+            editor.set_allows_shell(True)
+            editor.set_shell_mode(source.draft.shell_mode)
+            editor.placeholder = (
+                SHELL_PLACEHOLDER if editor.shell_mode else editor.resting_placeholder
+            )
+            editor.set_commands(SLASH_COMMANDS)
+            editor.set_records_history(True)
 
     def _commit_sidebar_session(
         self,
         session_id: str,
         prepared: tuple[SessionInteraction, SessionPresentation],
         generation: int,
-    ) -> None:
+    ) -> asyncio.Future[None] | None:
         from local_operator.session.remote import RemoteSession
 
         source, incoming = prepared
@@ -3045,6 +3597,9 @@ class OperatorApp(App[None]):
         previous = outgoing.session
         if previous is not None and not isinstance(previous, RemoteSession):
             raise RuntimeError("Sidebar navigation requires an owner-backed current session")
+        self._close_subagent_view()
+        self._close_org_chart_view()
+        self._close_settings_view()
         editor = self._editor()
         outgoing.draft.text = editor.text
         outgoing.draft.attachments = editor.attachments()
@@ -3054,18 +3609,36 @@ class OperatorApp(App[None]):
         outgoing.draft.following_tail = old_view.is_following_tail
         if not outgoing.draft.following_tail:
             top = old_view.content_region.y
-            anchor = next((block for block in old_view.blocks() if block.navigation_anchor_id and block.display and block.region.bottom > top), None)
+            anchor = next(
+                (
+                    block
+                    for block in old_view.blocks()
+                    if block.navigation_anchor_id and block.display and block.region.bottom > top
+                ),
+                None,
+            )
             if anchor is not None:
                 outgoing.draft.scroll_anchor_id = anchor.navigation_anchor_id
                 outgoing.draft.scroll_anchor_part = anchor.navigation_anchor_part
                 outgoing.draft.scroll_offset = top - anchor.region.y
+        outgoing_presentation = None
         if previous is not None:
             self._sidebar_sources[previous.session_id] = outgoing
-            self._sidebar_presentations[previous.session_id] = self._capture_sidebar_presentation()
+            outgoing_presentation = self._capture_sidebar_presentation()
+            if outgoing_presentation.retainable():
+                self._sidebar_presentations[previous.session_id] = outgoing_presentation
+                outgoing_presentation = None
+        self._park_sidebar_aside(outgoing)
         if isinstance(previous, RemoteSession):
-            previous.suspend_viewer_gates()
-        self._deny_queued_approvals()
-        self._settle_ask_picker()
+            self._suspend_sidebar_gates(outgoing)
+        # Detach the old projection without fabricating a deny/empty answer or
+        # poisoning the source's turn-scoped denial latch for its next visit.
+        for card in (self._ask_screen, self._approval):
+            if card is not None:
+                card.display = False
+                self._unmount_prompt(card)
+        self._ask_screen = None
+        self._ask_pending = None
         self._settle_key_prompt()
         self._approval = None
         old_view = self._transcript_view()
@@ -3085,22 +3658,54 @@ class OperatorApp(App[None]):
         incoming.replay.view.set_on_tail_requested(self._jump_newer_resume_tail)
         self._swapping_session = True
         try:
+            factory = self._resume_factory
+            if factory is not None:
+                self._session_factory = lambda: factory(session_id)
             self._adopt_session(session, replay_history=False, reuse_controller=True)
+            history = list(session.history())
+            if len(history) > incoming.history_size:
+                self._project_settled_rows(history[incoming.history_size :])
+            elif len(history) < incoming.history_size:
+                # A compaction/recovery changed the snapshot while its widgets
+                # were preparing. Reconcile the viewport without invoking the
+                # ordinary /clear hook, which would settle this source's gates.
+                incoming.replay.view.set_on_clear(None)
+                incoming.replay.view.clear_blocks()
+                incoming.replay.view.set_on_clear(self._on_transcript_cleared)
+                self._resume_pending_head = []
+                self._resume_pending_tail = []
+                self._resume_results = {}
+                self._resume_mounted_ids.clear()
+                self._resume_head_notice = None
+                self._resume_tail_notice = None
+                self._project_settled_rows(history, bound=max(12, self.size.height // 2))
+            if incoming.needs_live_projection and self._controller is not None:
+                self._controller.restore_live_projection(
+                    session.frontend_state, self._resume_mounted_ids, set(self._resume_results)
+                )
             editor.load_text(source.draft.text)
             editor.adopt_attachments(source.draft.attachments)
             editor.set_shell_mode(source.draft.shell_mode)
             if source.draft.selection is not None:
                 editor.selection = source.draft.selection
+            self._restore_sidebar_aside(source)
+            self._sync_draft_recoveries(source)
+            for text, kind in source.notices:
+                self._system_notice(text, kind)
+            source.notices.clear()
+            self._submit_boot_prompt(session)
             session.resume_viewer_gates()
             self._session_sidebar.current_id = session_id
             self._session_sidebar.refresh()
-            self._set_welcome_visible(False)
             if source.draft.focus_id == "@transcript":
                 incoming.replay.view.focus()
             else:
                 editor.focus()
         finally:
             self._swapping_session = False
+        self._set_welcome_visible(not bool(incoming.replay.view.blocks()))
+        if outgoing_presentation is not None:
+            self.run_worker(self._release_sidebar_preparation((outgoing, outgoing_presentation)))
         if displaced is not None and displaced is not incoming:
             self.run_worker(self._release_sidebar_preparation((source, displaced)))
         # Active + one retained presentation. Executing contexts stay alive
@@ -3111,6 +3716,11 @@ class OperatorApp(App[None]):
             self.run_worker(
                 self._release_sidebar_preparation((self._sidebar_sources[evicted_id], evicted))
             )
+        if self.query_one("#session-workspace").has_class("sidebar-overlay"):
+            # A drawer cannot count as a correct visible conversation while it
+            # covers the response. Pinned wide sidebars stay open.
+            self._set_sidebar_open(False)
+        return self._await_sidebar_frame(source, generation)
 
     def on_session_sidebar_selected(self, message: SessionSidebar.Selected) -> None:
         message.stop()
@@ -3119,21 +3729,33 @@ class OperatorApp(App[None]):
                 self._sidebar_navigation.cancel()
             self._editor().focus()
             return
-        if self._session_transition_pending and not self._sidebar_navigation.requested_id:
-            self.workers.cancel_group(self, "session")
+        self._sidebar_prior_workers.update(self.workers.cancel_group(self, "session"))
         self._sidebar_navigation.select(message.session_id)
 
     def _apply_sidebar_settings(self) -> None:
-        self._sidebar_settings = SidebarSettings.from_values(self._config_values())
-        self._set_sidebar_open(self._sidebar_settings.visible)
+        settings = SidebarSettings.from_values(self._config_values())
+        apply_visibility = (
+            not self._sidebar_settings_applied or settings.visible != self._sidebar_settings.visible
+        )
+        self._sidebar_settings = settings
+        self._sidebar_settings_applied = True
+        if apply_visibility:
+            self._set_sidebar_open(settings.visible)
+        else:
+            self._sync_sidebar_layout(self.size)
 
     def action_toggle_sidebar(self) -> None:
+        if not self._session_sidebar.display:
+            self._close_subagent_view()
+            self._close_org_chart_view()
+            self._close_settings_view()
         self._set_sidebar_open(not self._session_sidebar.display)
 
     def _set_sidebar_open(self, opened: bool) -> None:
         sidebar = self._session_sidebar
         if opened and not sidebar.display:
             self._sidebar_focus_restore = self.focused
+            self._sidebar_last_prefetch = ""
         sidebar.set_open(opened)
         self._sync_sidebar_layout(self.size)
         if self._sidebar_timer is not None:
@@ -3223,18 +3845,20 @@ class OperatorApp(App[None]):
         candidate = next(
             (entry for entry in entries if entry.id != current and entry.row.live_state), None
         )
-        if candidate is None:
+        if candidate is None or candidate.id == self._sidebar_last_prefetch:
             return
+        self._sidebar_last_prefetch = candidate.id
 
         async def prepare() -> None:
             prepared = None
             try:
-                prepared = await self._prepare_sidebar_session(candidate.id)
+                prepared = await self._prepare_sidebar_session(candidate.id, speculative=True)
                 if (
                     self._session_sidebar.display
                     and not self._sidebar_navigation.requested_id
                     and not self._sidebar_presentations
                     and candidate.id != str(getattr(self._session, "session_id", ""))
+                    and prepared[1].retainable()
                 ):
                     self._sidebar_presentations[candidate.id] = prepared[1]
                     prepared = None
@@ -3245,9 +3869,11 @@ class OperatorApp(App[None]):
                 # An explicit selection reports the same failure normally.
                 logger.debug("sidebar prewarm failed", exc_info=True)
             finally:
-                if prepared is not None:
-                    await self._release_sidebar_preparation(prepared)
-                self._sidebar_prefetch = None
+                try:
+                    if prepared is not None:
+                        await self._release_sidebar_preparation(prepared)
+                finally:
+                    self._sidebar_prefetch = None
 
         self._sidebar_prefetch = self.run_worker(prepare(), group="sidebar-prefetch")
 
@@ -3527,10 +4153,20 @@ class OperatorApp(App[None]):
         """
         self._invalidate_pending_frontend_state()
         source = self._interactions.get(id(session))
-        if source is None:
+        if source is None or source.retired:
             source = SessionInteraction(session)
             self._interactions[id(session)] = source
+        if source.draft.approve_all is None:
+            source.draft.approve_all = (
+                self._approve_all
+                if self._interaction.session is None
+                else self._approvals_default_auto
+            )
         self._interaction = source
+        self._watch_source_frontend(source)
+        self._set_approve_all(self._approve_all)
+        if getattr(session, "session_id", ""):
+            self._sidebar_sources[session.session_id] = source
         self._session = session
         # The latch belongs to the BINDING, not to the app: a swapped-in
         # session is cold again and owes its own engage. Its declaration has
@@ -3583,7 +4219,7 @@ class OperatorApp(App[None]):
         if bool(getattr(session, "is_remote", False)):
             set_takeover = getattr(session, "set_takeover_callback", None)
             if callable(set_takeover):
-                set_takeover(self._adopt_takeover_session)
+                set_takeover(partial(self._adopt_takeover_session, source=source))
             # The opposite outcome to takeover, and equally in need of a
             # screen: the owner ENDED this session, so this viewer stays a
             # viewer of something cold and must say so rather than leaving
@@ -3643,9 +4279,11 @@ class OperatorApp(App[None]):
         # Every session enters the same widget path through Textual's pump.
         # Remote socket callbacks require the marshal; using it locally too
         # removes a second gate state machine without changing arbitration.
-        session.set_approval_handler(self._request_tool_approval_on_app_loop)
+        session.set_approval_handler(
+            partial(self._request_tool_approval_on_app_loop, source=source)
+        )
         # Installing this hook is what makes the ask tool exist for a UI host.
-        session.set_ask_handler(self._request_user_choice_on_app_loop)
+        session.set_ask_handler(partial(self._request_user_choice_on_app_loop, source=source))
         if reuse_controller and source.controller is not None:
             self._controller = source.controller
         else:
@@ -3963,7 +4601,30 @@ class OperatorApp(App[None]):
         origin = "" if self._issued_own_stop else " from another terminal"
         self._system_notice(f"this session was stopped{origin}{way_back}", "warning")
 
-    async def _adopt_takeover_session(self, session: Any) -> None:
+    def _rebind_takeover_source(self, source: SessionInteraction, session: Any) -> None:
+        previous = source.session
+        if source.unsubscribe_frontend is not None:
+            source.unsubscribe_frontend()
+            source.unsubscribe_frontend = None
+        if previous is not None:
+            self._interactions.pop(id(previous), None)
+        source.session = session
+        source.gate_draft = None
+        source.gate_view_generation += 1
+        self._interactions[id(session)] = source
+        self._sidebar_sources[session.session_id] = source
+        session.set_approval_handler(
+            partial(self._request_tool_approval_on_app_loop, source=source)
+        )
+        session.set_ask_handler(partial(self._request_user_choice_on_app_loop, source=source))
+        source.controller = EventController(session, self)
+        self._event_sources[source.controller] = source
+        source.controller.subscribe()
+        self._watch_source_frontend(source)
+
+    async def _adopt_takeover_session(
+        self, session: Any, *, source: SessionInteraction | None = None
+    ) -> None:
         """Become the owner after the remote facade wins the transcript lease.
 
         Unlike /new or /resume, this is NOT a conversation change: every block
@@ -3973,47 +4634,38 @@ class OperatorApp(App[None]):
         unpersisted killed-owner tail honestly; repainting durable history here
         would duplicate everything and cause visible reflow.
         """
-        remote = self._session
-        if self._controller is not None:
-            # A takeover KEEPS the conversation, so it also keeps the receipt's
-            # right to settle (review round 1, F3). The steer-delivery guard
-            # drops events from a superseded controller because a `/reload`
-            # cleared the rows they would have settled — but here the rows are
-            # deliberately still on screen and their messages are still the
-            # same session's, so a drain already in flight across the swap is
-            # about a row this app is still holding. Recording the outgoing
-            # controller as still-honoured is what keeps that receipt landing
-            # instead of leaving the row stuck on `queued` after the message
-            # actually went.
-            self._superseded_steer_controllers.add(self._controller)
-            self._controller.dispose()
-            self._controller = None
+        source = source or self._interaction
+        remote = source.session
+        if source.controller is not None:
+            self._superseded_steer_controllers.add(source.controller)
+            source.controller.dispose()
+            self._event_sources.pop(source.controller, None)
+            if self._is_current(source):
+                self._controller = None
         if remote is not None:
             try:
                 await remote.dispose()
             except Exception:
                 pass
+        if not self._is_current(source):
+            self._rebind_takeover_source(source, session)
+            return
         unsubscribe_frontend = getattr(self, "_unsubscribe_frontend", None)
         if callable(unsubscribe_frontend):
             unsubscribe_frontend()
         self._unsubscribe_frontend = None
         self._invalidate_pending_frontend_state()
+        self._rebind_takeover_source(source, session)
         self._session = session
+        self._controller = source.controller
         self._mobile_adopted(session)
         subscribe_frontend = getattr(session, "subscribe_frontend", None)
         if callable(subscribe_frontend):
             from local_operator.session.frontend_state import FrontendSubscription
 
-            subscription = cast(
-                FrontendSubscription,
-                subscribe_frontend(self._on_frontend_update),
-            )
+            subscription = cast(FrontendSubscription, subscribe_frontend(self._on_frontend_update))
             self._unsubscribe_frontend = subscription.unsubscribe
             self._apply_frontend_state(subscription.sync.snapshot)
-        session.set_approval_handler(self.request_tool_approval)
-        session.set_ask_handler(self.request_user_choice)
-        self._controller = EventController(session, self)
-        self._controller.subscribe()
         assert self._status is not None
         self._status.update(
             model_label=_effective_label(session),
@@ -4073,7 +4725,12 @@ class OperatorApp(App[None]):
                 )
 
     async def _request_tool_approval_on_app_loop(
-        self, tool_name: str, description: str, *, job_id: str | None = None
+        self,
+        tool_name: str,
+        description: str,
+        *,
+        job_id: str | None = None,
+        source: SessionInteraction | None = None,
     ) -> bool:
         """Enter the real approval surface from a pre-Textual socket task.
 
@@ -4082,17 +4739,27 @@ class OperatorApp(App[None]):
         future mirrors completion/cancellation back to RemoteSession without
         letting a late card settle a cancelled owner request.
         """
+        source = source or self._interaction
+        if not self._is_current(source):
+            raise asyncio.CancelledError
         return bool(
             await self._run_gate_on_app_loop(
-                lambda: self.request_tool_approval(tool_name, description, job_id=job_id)
+                lambda: self.request_tool_approval(
+                    tool_name, description, job_id=job_id, source=source
+                )
             )
         )
 
     async def _request_user_choice_on_app_loop(
-        self, questions: list[AskQuestion]
+        self, questions: list[AskQuestion], *, source: SessionInteraction | None = None
     ) -> dict[str, list[str]] | None:
         """Enter the real ask picker through Textual's message-pump context."""
-        result = await self._run_gate_on_app_loop(lambda: self.request_user_choice(questions))
+        source = source or self._interaction
+        if not self._is_current(source):
+            raise asyncio.CancelledError
+        result = await self._run_gate_on_app_loop(
+            lambda: self.request_user_choice(questions, source=source)
+        )
         return cast(dict[str, list[str]] | None, result)
 
     async def _run_gate_on_app_loop(self, build: Callable[[], Awaitable[Any]]) -> Any:
@@ -4253,6 +4920,7 @@ class OperatorApp(App[None]):
         # otherwise be lost with it — a coroutine's locals die with the
         # `CancelledError`, but the completed future's result does not. See
         # `_park_unadopted_session`.
+        navigation_generation = self._sidebar_navigation.generation
         built = asyncio.ensure_future(self._construct_session())
         try:
             session = await built
@@ -4261,6 +4929,10 @@ class OperatorApp(App[None]):
             raise
         except Exception as error:  # TUI-012: construction error path
             self._on_boot_failed(error)
+            return
+        if navigation_generation != self._sidebar_navigation.generation:
+            if session is not self._session:
+                await session.dispose()
             return
         self._adopt_session(session)
         self._report_degraded_attach(session)
@@ -4597,7 +5269,10 @@ class OperatorApp(App[None]):
             # The middle gap stays reachable without moving it after that tail.
             return
         start = _resume_tail_start(self._resume_pending_tail, max(12, self.size.height // 2))
-        page, self._resume_pending_tail = self._resume_pending_tail[start:], self._resume_pending_tail[:start]
+        page, self._resume_pending_tail = (
+            self._resume_pending_tail[start:],
+            self._resume_pending_tail[:start],
+        )
         blocks = self._collect_resume_page_blocks(page)
         if not self._resume_pending_tail and notice is not None:
             view.remove_block(notice)
@@ -4613,13 +5288,30 @@ class OperatorApp(App[None]):
         generation = self._sidebar_navigation.generation
         self._resume_tail_paging = True
         top = view.content_region.y
-        anchor = next((block for block in view.blocks() if block.navigation_anchor_id and block.region.bottom > top), None)
+        anchor = next(
+            (
+                block
+                for block in view.blocks()
+                if block.navigation_anchor_id and block.region.bottom > top
+            ),
+            None,
+        )
         if anchor is not None:
-            view.restore_navigation_anchor(anchor.navigation_anchor_id, anchor.navigation_anchor_part, top - anchor.region.y)
+            view.restore_navigation_anchor(
+                anchor.navigation_anchor_id, anchor.navigation_anchor_part, top - anchor.region.y
+            )
         count = min(len(self._resume_pending_tail), max(12, self.size.height // 2))
-        page, self._resume_pending_tail = self._resume_pending_tail[:count], self._resume_pending_tail[count:]
-        page = [message for message in page if str(getattr(message, "id", "")) not in self._resume_mounted_ids]
+        page, self._resume_pending_tail = (
+            self._resume_pending_tail[:count],
+            self._resume_pending_tail[count:],
+        )
+        page = [
+            message
+            for message in page
+            if str(getattr(message, "id", "")) not in self._resume_mounted_ids
+        ]
         blocks = self._collect_resume_page_blocks(page)
+
         def settled() -> None:
             if self._transcript is view and self._sidebar_navigation.generation == generation:
                 self._resume_tail_paging = False
@@ -5146,6 +5838,7 @@ class OperatorApp(App[None]):
         """
         # Explicit reload replaces this workflow source. Sidebar navigation
         # never calls this path and therefore never retires its loops.
+        navigation_generation = self._sidebar_navigation.generation
         self._interaction.retired = True
         previous_id = self._conversation_id()
         previous_len = self._history_length()
@@ -5408,6 +6101,10 @@ class OperatorApp(App[None]):
                         "warning",
                     )
             else:
+                if navigation_generation != self._sidebar_navigation.generation:
+                    if session is not self._session:
+                        await session.dispose()
+                    return
                 carried_spend = self._reset_ledger_for_swap()
                 self._adopt_session(session)
                 # Reload retired the outgoing turn before adopting a fresh
@@ -9565,12 +10262,19 @@ class OperatorApp(App[None]):
         and something lost it, and only the pair covers "the composer went dark
         because the usage panel lit up".
         """
-        if not self._swapping_session and event.widget is not self._session_sidebar:
+        if (
+            not self._swapping_session
+            and bool(self.screen_stack)
+            and self.focused is event.widget
+            and event.widget is not self._session_sidebar
+        ):
             view = self._transcript
             if view is not None and (event.widget is view or view in event.widget.ancestors):
                 self._interaction.draft.focus_id = "@transcript"
             elif isinstance(event.widget, Editor):
                 self._interaction.draft.focus_id = "@editor"
+            elif isinstance(event.widget, AskPickerScreen):
+                self._interaction.draft.focus_id = "@gate"
         self._sync_composer_focus()
 
     def on_descendant_blur(self, event: DescendantBlur) -> None:
@@ -10555,7 +11259,12 @@ class OperatorApp(App[None]):
 
     # -- tool approvals -------------------------------------------------------
     async def request_tool_approval(
-        self, tool_name: str, description: str, *, job_id: str | None = None
+        self,
+        tool_name: str,
+        description: str,
+        *,
+        job_id: str | None = None,
+        source: SessionInteraction | None = None,
     ) -> bool:
         """The session's approval gate while this app owns the terminal.
 
@@ -10594,19 +11303,26 @@ class OperatorApp(App[None]):
         """
         # Captured BEFORE the first await: this asker belongs to the turn that was
         # running when the engine called it, and no later turn's start can move it.
-        epoch = self._turn_epoch
-        if job_id is None and self._approvals_are_denied(epoch):
+        source = source or self._interaction
+        if not self._is_current(source):
+            raise asyncio.CancelledError
+        epoch = source.turn.epoch
+        view_generation = source.gate_view_generation
+        gate_key = self._sidebar_gate_identity(source)
+        if job_id is None and self._source_approvals_are_denied(source, epoch):
             return False
-        if self._approve_all:
+        if bool(source.draft.approve_all):
             return True
         while self._approval is not None and not self._approval.answered:
             await self._approval.wait()
+            if not self._is_current(source):
+                raise asyncio.CancelledError
             # Same exemption as the check above, and it has to be: a job's ask
             # that merely QUEUED behind a foreground prompt would otherwise be
             # denied on waking by a latch that has nothing to do with it.
-            if job_id is None and self._approvals_are_denied(epoch):
+            if job_id is None and self._source_approvals_are_denied(source, epoch):
                 return False
-            if self._approve_all:
+            if bool(source.draft.approve_all):
                 return True
         # The prompt is a transcript block, and the subagent page hides the
         # transcript — mounted behind it the question was invisible while
@@ -10626,7 +11342,15 @@ class OperatorApp(App[None]):
         # while still taking focus off the composer the card is pointed at —
         # a turn parked on an answer the user can neither see nor reach.
         self._close_aside()
-        prompt = ApprovalPrompt(tool_name, description, on_answer=self._latch_approval_answer)
+        prompt = ApprovalPrompt(
+            tool_name,
+            description,
+            on_answer=partial(
+                self._latch_source_approval_answer, source, gate_key, view_generation
+            ),
+        )
+        prompt.source_binding = (source.token, gate_key, view_generation)
+        self._restore_gate_draft(source, prompt)
         self._approval = prompt
         # The QUESTION goes in the dock, where it cannot scroll away from the
         # turn it is blocking and where it reliably owns its own answer keys.
@@ -10652,7 +11376,8 @@ class OperatorApp(App[None]):
             if self._approval is prompt:
                 self._approval = None
             self._unmount_prompt(prompt)
-            self._notify_mobile_approval_settled(prompt)
+            if self._is_current(source):
+                self._notify_mobile_approval_settled(prompt)
             # The decision belongs in the conversation: what was asked, and what
             # was answered. Appended after the fact so the transcript records a
             # settled fact rather than a question it would then have to revise.
@@ -10663,7 +11388,7 @@ class OperatorApp(App[None]):
             # `#transcript`), and a receipt is a nice-to-have on that path while
             # the future underneath it is not: raising here would propagate out
             # of the approval gate and fail the tool call itself.
-            if prompt.answered:
+            if self._is_current(source) and prompt.answered:
                 try:
                     self._append_block(
                         ApprovalBlock.receipt(tool_name, description, prompt.answer or "n")
@@ -10696,7 +11421,7 @@ class OperatorApp(App[None]):
 
     # -- the agent's own questions --------------------------------------------
     async def request_user_choice(
-        self, questions: list[AskQuestion]
+        self, questions: list[AskQuestion], *, source: SessionInteraction | None = None
     ) -> dict[str, list[str]] | None:
         """The ``ask`` tool's surface while this app owns the terminal.
 
@@ -10714,6 +11439,10 @@ class OperatorApp(App[None]):
         coroutine is the tool call, and moving it into a worker would put the
         answer on the far side of a second hop with nothing gained.
         """
+        source = source or self._interaction
+        if not self._is_current(source):
+            raise asyncio.CancelledError
+        view_generation = source.gate_view_generation
         while self._ask_pending is not None:
             # Unreachable through the advertised tool — `ask` is `exclusive`, so
             # the loop never runs two at once — and cheap to be right about:
@@ -10721,6 +11450,8 @@ class OperatorApp(App[None]):
             # while its tool call went on waiting. Shielded because a cancel of
             # THIS call must not cancel the future the other one is parked on.
             await asyncio.shield(self._ask_pending)
+            if not self._is_current(source):
+                raise asyncio.CancelledError
         future: asyncio.Future[dict[str, list[str]] | None] = (
             asyncio.get_running_loop().create_future()
         )
@@ -10729,7 +11460,8 @@ class OperatorApp(App[None]):
             # Guarded: a cancelled tool call (steering, abort, teardown) resolves
             # the future on the way out, and the dismissal that follows would
             # otherwise raise InvalidStateError out of Textual's callback.
-            if not future.done():
+            if not future.done() and view_generation == source.gate_view_generation:
+                source.gate_draft = None
                 future.set_result(result)
 
         # The subagent page hides the transcript and the aside floats over it,
@@ -10742,6 +11474,8 @@ class OperatorApp(App[None]):
         self._close_settings_view()
         self._close_aside()
         card = AskPickerScreen(questions, answered)
+        card.source_binding = (source.token, self._sidebar_gate_identity(source), view_generation)
+        self._restore_gate_draft(source, card)
         self._ask_screen = card
         self._ask_pending = future
         self._mount_prompt(card)
@@ -10780,8 +11514,9 @@ class OperatorApp(App[None]):
             # terminal answer, Escape, a cancelled tool call, or teardown all
             # pass through this finally. Card-scoped so it cannot clear a card
             # a later ask already mounted.
-            self._notify_mobile_ask_settled(card)
-            self._refresh_working_activity()
+            if self._is_current(source):
+                self._notify_mobile_ask_settled(card)
+                self._refresh_working_activity()
 
     def _notify_mobile_ask_pending(self, card: AskPickerScreen) -> None:
         """Tell the mobile bridge an ask picker went up, if one is attached.
@@ -11123,6 +11858,22 @@ class OperatorApp(App[None]):
                 block.resolve(None)
             except Exception:  # pragma: no cover - teardown races only
                 logger.debug("key prompt was already settled", exc_info=True)
+
+    @staticmethod
+    def _source_approvals_are_denied(source: SessionInteraction, epoch: int) -> bool:
+        armed = source.turn.approvals_denied_epoch
+        return armed is not None and epoch <= armed
+
+    def _latch_source_approval_answer(
+        self, source: SessionInteraction, key: tuple[Any, ...] | None, generation: int, answer: str
+    ) -> None:
+        if (
+            self._is_current(source)
+            and source.gate_view_generation == generation
+            and (key is None or key == self._sidebar_gate_identity(source))
+        ):
+            source.gate_draft = None
+            self._latch_approval_answer(answer)
 
     def _latch_approval_answer(self, answer: str) -> None:
         """What an answer means beyond the one call. Runs BEFORE the future.
@@ -12067,7 +12818,12 @@ class OperatorApp(App[None]):
     def _completion_anchor_visible(self, anchor: str) -> bool:
         from local_operator.tui.widgets.transcript import TranscriptBlock
 
-        if len(self.screen_stack) != 1 or not self.app_focus:
+        if (
+            len(self.screen_stack) != 1
+            or not self.app_focus
+            or self._session_transition_pending
+            or self._sidebar_frame_pending
+        ):
             return False
         transcript = self._transcript_view()
         if not transcript.display or not transcript.is_near_bottom():
@@ -12432,6 +13188,16 @@ class OperatorApp(App[None]):
             self.exit()
 
     async def on_unmount(self) -> None:
+        from textual.worker import WorkerCancelled, WorkerFailed
+
+        if self._sidebar_prefetch is not None:
+            self._sidebar_prefetch.cancel()
+            try:
+                await self._sidebar_prefetch.wait()
+            except WorkerCancelled:
+                pass
+            except WorkerFailed:
+                logger.debug("sidebar prewarm failed during shutdown", exc_info=True)
         await self._sidebar_navigation.close()
         await self._sidebar_drafts.close()
         if self._sidebar_timer is not None:
@@ -12439,6 +13205,10 @@ class OperatorApp(App[None]):
         from local_operator.session.remote import RemoteSession
 
         for source in tuple(self._interactions.values()):
+            source.gate_draft = None
+            if source.unsubscribe_frontend is not None:
+                source.unsubscribe_frontend()
+                source.unsubscribe_frontend = None
             if source.session is not self._session and isinstance(source.session, RemoteSession):
                 if source.controller is not None:
                     source.controller.dispose()
@@ -12664,9 +13434,11 @@ class OperatorApp(App[None]):
                 await run_shell()
             finally:
                 source.active_workers -= 1
+                self.call_later(self._source_frontend_changed, source)
                 _clear_shell_state()
                 if source.shell.worker is worker:
                     source.shell.worker = None
+                    self.call_later(self._source_frontend_changed, source)
 
         worker = self.run_worker(run_and_clear(), thread=False, group=source.worker_group("shell"))
         source.shell.worker = worker
@@ -12902,8 +13674,10 @@ class OperatorApp(App[None]):
         # what used to make it arrive minutes late.
         self._maybe_name_conversation(named)
 
-    def _start_turn(self, text: str, images: list[ImageContent] | None = None) -> None:
-        self._start_turn_for(
+    def _start_turn(
+        self, text: str, images: list[ImageContent] | None = None
+    ) -> _PendingUserEcho | None:
+        return self._start_turn_for(
             self._interaction, text, images, accepted=self._interaction.turn.submitted_draft
         )
 
@@ -12940,6 +13714,8 @@ class OperatorApp(App[None]):
         # back to text. Both in-tree sessions accept it -- `RemoteSession`
         # included, which is what an attached follower TUI drives and which
         # swallowed cross-surface prompts until it did (round 1, F1).
+        source.turn.operation += 1
+        turn_operation = source.turn.operation
         echo = self._register_user_echo_for(
             source, text, message_id=self._echo_message_id(session.prompt)
         )
@@ -13032,7 +13808,10 @@ class OperatorApp(App[None]):
                 # the entry.
                 self._discard_user_echo_for(source, echo)
             finally:
+                if source.turn.submitted_draft is accepted:
+                    source.turn.submitted_draft = None
                 source.active_workers -= 1
+                self.call_later(self._source_frontend_changed, source)
                 # THE TWO-MECHANISM HAZARD, and why these two lines belong
                 # together. The status band and the working line used to be
                 # retired by DIFFERENT mechanisms: the band by this `finally`
@@ -13124,7 +13903,9 @@ class OperatorApp(App[None]):
                 # and the fallback is a no-op on every normal turn. Calling
                 # `_finalize_turn` directly instead would run AHEAD of the
                 # queued real end and double-notify every single turn.
-                self._post_turn_abandoned_for(source, aborted=aborted, error=error_text)
+                self._post_turn_abandoned_for(
+                    source, aborted=aborted, error=error_text, operation=turn_operation
+                )
 
         self.run_worker(run_prompt(), thread=False, group=source.worker_group("turns"))
 
@@ -13210,7 +13991,7 @@ class OperatorApp(App[None]):
         """
         self._name_generation += 1
         self._name_requested = False
-        self.workers.cancel_group(self, "naming")
+        self.workers.cancel_group(self, self._interaction.worker_group("naming"))
 
     def _maybe_name_conversation(self, text: str) -> None:
         """Name this conversation, or re-name it when the subject has moved.
@@ -13262,9 +14043,9 @@ class OperatorApp(App[None]):
         # stored 1.8 seconds after the answer was already on screen.
         self._show_provisional_name(text)
         self.run_worker(
-            self._name_conversation_worker(session, text, generation),
+            self._name_conversation_worker(session, text, generation, source=self._interaction),
             thread=False,
-            group="naming",
+            group=self._interaction.worker_group("naming"),
         )
 
     def _show_provisional_name(self, text: str) -> None:
@@ -13391,10 +14172,16 @@ class OperatorApp(App[None]):
         turns = list(session.history()) if hasattr(session, "history") else []
         self.run_worker(
             self._retitle_conversation_worker(
-                session, session.conversation_name, text, generation, turns, turn_count
+                session,
+                session.conversation_name,
+                text,
+                generation,
+                turns,
+                turn_count,
+                source=self._interaction,
             ),
             thread=False,
-            group="naming",
+            group=self._interaction.worker_group("naming"),
         )
 
     async def _retitle_conversation_worker(
@@ -13405,6 +14192,7 @@ class OperatorApp(App[None]):
         generation: int,
         turns: list[AgentMessage],
         turn_count: int,
+        source: SessionInteraction | None = None,
     ) -> None:
         """One isolated re-title call; ``None`` from it means "leave it alone".
 
@@ -13427,33 +14215,45 @@ class OperatorApp(App[None]):
         charge is applied at the store when a title lands, and here when the
         model answered "no change" — both spend one refresh.
         """
+        source = source or self._interactions.get(id(session), self._interaction)
+        source.active_workers += 1
         try:
-            title = await naming.generate_retitle(current, text, session.complete_once, turns=turns)
-        except asyncio.CancelledError:
-            return
-        # A generation/session mismatch means this attempt was superseded (a
-        # reload) or belongs to a session no longer on screen: it must touch
-        # neither the title nor the shared growth budget.
-        if generation != self._name_generation or session is not self._session:
-            return
-        if not title:
-            # Unchanged subject, or the call failed: leave the title alone, but
-            # STILL spend a refresh on a genuine "no change" answer so the
-            # growth schedule advances. A failed call is indistinguishable here
-            # from "no change" (both are None), and charging it is the safe
-            # direction — it slows re-titling, never speeds it — while leaving
-            # the never-titled baseline untouched.
-            self._charge_theme_refresh(session, turn_count)
-            return
-        # Re-read rather than trusting `current`: a rename or a reload may have
-        # landed during the call, and both outrank a check made against a title
-        # that is no longer in force.
-        if session.conversation_name != current:
-            return
-        self._store_title(session, title, turn_count=turn_count)
+            try:
+                title = await naming.generate_retitle(
+                    current, text, session.complete_once, turns=turns
+                )
+            except asyncio.CancelledError:
+                return
+            # A generation/session mismatch means this attempt was superseded (a
+            # reload) or belongs to a session no longer on screen: it must touch
+            # neither the title nor the shared growth budget.
+            if generation != source.naming.generation or source.retired:
+                return
+            if not title:
+                # Unchanged subject, or the call failed: leave the title alone, but
+                # STILL spend a refresh on a genuine "no change" answer so the
+                # growth schedule advances. A failed call is indistinguishable here
+                # from "no change" (both are None), and charging it is the safe
+                # direction — it slows re-titling, never speeds it — while leaving
+                # the never-titled baseline untouched.
+                self._charge_theme_refresh_for(source, session, turn_count)
+                return
+            # Re-read rather than trusting `current`: a rename or a reload may have
+            # landed during the call, and both outrank a check made against a title
+            # that is no longer in force.
+            if session.conversation_name != current:
+                return
+            self._store_title_for(source, session, title, turn_count=turn_count)
+        finally:
+            source.active_workers -= 1
+            self.call_later(self._source_frontend_changed, source)
 
     async def _name_conversation_worker(
-        self, session: SessionProtocol, text: str, generation: int
+        self,
+        session: SessionProtocol,
+        text: str,
+        generation: int,
+        source: SessionInteraction | None = None,
     ) -> None:
         """Ask the model for a title NOW, alongside the turn it decorates.
 
@@ -13485,35 +14285,46 @@ class OperatorApp(App[None]):
         the conversation better than the second message would. Reload and user
         rename are re-checked immediately before the store.
         """
+        source = source or self._interactions.get(id(session), self._interaction)
+        source.active_workers += 1
         try:
-            title = await naming.generate_title(text, session.complete_once)
-        except asyncio.CancelledError:
-            if (
-                generation == self._name_generation
-                and session is self._session
-                and not session.conversation_name
-            ):
-                self._name_requested = False
-            return
+            try:
+                title = await naming.generate_title(text, session.complete_once)
+            except asyncio.CancelledError:
+                if (
+                    generation == source.naming.generation
+                    and not source.retired
+                    and not session.conversation_name
+                ):
+                    source.naming.requested = False
+                return
 
-        if generation != self._name_generation or session is not self._session:
-            return
-        if not title:
-            # Provider failure, cancellation, or "no topic": a later
-            # substantive message may retry while the conversation is unnamed.
-            # The opener's excerpt stays on the band and the tab meanwhile —
-            # that is the point of it being a stand-in and not a placeholder.
-            if not session.conversation_name:
-                self._name_requested = False
-                # Remember the opener so a fallback that pins AFTER this
-                # isolated 429 can re-fire naming on the serving model
-                # without waiting for the next user message.
-                self._pending_name_text = text
-            return
-        self._pending_name_text = ""
-        self._store_title(session, title)
+            if generation != source.naming.generation or source.retired:
+                return
+            if not title:
+                # Provider failure, cancellation, or "no topic": a later
+                # substantive message may retry while the conversation is unnamed.
+                # The opener's excerpt stays on the band and the tab meanwhile —
+                # that is the point of it being a stand-in and not a placeholder.
+                if not session.conversation_name:
+                    source.naming.requested = False
+                    # Remember the opener so a fallback that pins AFTER this
+                    # isolated 429 can re-fire naming on the serving model
+                    # without waiting for the next user message.
+                    source.naming.pending_text = text
+                return
+            source.naming.pending_text = ""
+            self._store_title_for(source, session, title)
+        finally:
+            source.active_workers -= 1
+            self.call_later(self._source_frontend_changed, source)
 
     def _charge_theme_refresh(self, session: SessionProtocol, turn_count: int) -> None:
+        self._charge_theme_refresh_for(self._interaction, session, turn_count)
+
+    def _charge_theme_refresh_for(
+        self, source: SessionInteraction, session: SessionProtocol, turn_count: int
+    ) -> None:
         """Spend one growth-budget refresh without changing the title.
 
         The "no change" (and, indistinguishably, the failed-call) branch of a
@@ -13528,12 +14339,22 @@ class OperatorApp(App[None]):
         stays geometric regardless of how much history the concurrent turn wrote
         while the call was in flight.
         """
-        self._last_titled_turn_count = turn_count
-        self._theme_refresh_count += 1
-        self._retitle_checked_at = self._clock()
+        source.naming.last_titled_turn_count = turn_count
+        source.naming.refresh_count += 1
+        source.naming.checked_at = self._clock()
 
     def _store_title(
         self, session: SessionProtocol, title: str, *, turn_count: int | None = None
+    ) -> str:
+        return self._store_title_for(self._interaction, session, title, turn_count=turn_count)
+
+    def _store_title_for(
+        self,
+        source: SessionInteraction,
+        session: SessionProtocol,
+        title: str,
+        *,
+        turn_count: int | None = None,
     ) -> str:
         """Store a generated title and put it on both surfaces.
 
@@ -13562,25 +14383,25 @@ class OperatorApp(App[None]):
             # at SUBMIT, before the opener is in history, so a raw count of 0
             # would make the next refresh eligible at four turns instead of the
             # documented "titled at 1, refresh at >=6" schedule.
-            self._last_titled_turn_count = max(1, self._theme_turn_count(session))
-            self._theme_refresh_count = 0
+            source.naming.last_titled_turn_count = max(1, self._theme_turn_count(session))
+            source.naming.refresh_count = 0
         else:
             # A re-title landed: advance the baseline to the dispatch count and
             # spend one refresh, exactly as `_charge_theme_refresh` does for the
             # no-change branch — a rename and a "same subject" answer cost the
             # same one call against the budget.
-            self._last_titled_turn_count = turn_count
-            self._theme_refresh_count += 1
+            source.naming.last_titled_turn_count = turn_count
+            source.naming.refresh_count += 1
         # A title just took effect, so the re-title window restarts from here
         # rather than from whenever the last CHECK was dispatched. Without
         # this, a title landing at the tail of an open window would be eligible
         # for replacement by the very next message.
-        self._retitle_checked_at = self._clock()
+        source.naming.checked_at = self._clock()
         # Superseded: an answer beats a quote of the question. Cleared rather
         # than left set so nothing downstream still believes the band is
         # showing a stand-in.
-        self._provisional_name = ""
-        if self._status is not None:
+        source.naming.provisional = ""
+        if self._is_current(source) and self._status is not None:
             # The band's setter also pushes the terminal title (see
             # `StatusLine._sync_terminal_title`), so both surfaces follow from
             # this one call and neither can lag the other by a frame.
@@ -13596,7 +14417,8 @@ class OperatorApp(App[None]):
         # The title lands on a detached worker AFTER the last turn event, so
         # the mobile fold never re-reads it on its own. Push now so the
         # phone's header and list update the same moment the band does.
-        self._notify_mobile_title(stored)
+        if self._is_current(source):
+            self._notify_mobile_title(stored)
         return stored
 
     def _cmd_rename(self, arg: str, notice: NoticeFn) -> None:
@@ -19265,6 +20087,8 @@ class OperatorApp(App[None]):
                 # prompt. Register it so the event is consumed silently instead
                 # of painting the loudest mark in the transcript for words the
                 # user never typed.
+                source.turn.operation += 1
+                turn_operation = source.turn.operation
                 echo = self._register_user_echo_for(
                     source, LOOP_PROMPT, message_id=self._echo_message_id(session.prompt)
                 )
@@ -19300,11 +20124,15 @@ class OperatorApp(App[None]):
                     # verbatim under `/loop`: spinner climbing, band idle,
                     # nothing announced. A healthy iteration's real `TurnEnded`
                     # is already queued ahead of this, so it is a no-op there.
-                    self._post_turn_abandoned_for(source, aborted=False, error=loop_error)
+                    self._post_turn_abandoned_for(
+                        source, aborted=False, error=loop_error, operation=turn_operation
+                    )
                 completed = index + 1
         finally:
             source.active_workers -= 1
+            self.call_later(self._source_frontend_changed, source)
             source.loop.running = False
+            self.call_later(self._source_frontend_changed, source)
         if source.loop.cancelled:
             notice(f"loop cancelled after {completed} iteration(s)")
         elif source.retired:
@@ -19411,6 +20239,8 @@ class OperatorApp(App[None]):
                 # string byte-for-byte, so a second `.format` here could drift
                 # and leave the user MessageStartEvent unconsumed.
                 prompt = LOOP_GOAL_PROMPT.format(goal=goal)
+                source.turn.operation += 1
+                turn_operation = source.turn.operation
                 echo = self._register_user_echo_for(
                     source, prompt, message_id=self._echo_message_id(session.prompt)
                 )
@@ -19434,7 +20264,9 @@ class OperatorApp(App[None]):
                     # takes its ERROR branch — a held loop that dies outright
                     # must not go silent, which is the one notification the
                     # suppression deliberately does not cover.
-                    self._post_turn_abandoned_for(source, aborted=False, error=str(error))
+                    self._post_turn_abandoned_for(
+                        source, aborted=False, error=str(error), operation=turn_operation
+                    )
                     break
                 # NOTE: the status is deliberately NOT reset to idle here — it
                 # stays in a working state across the judge call below so the
@@ -19494,6 +20326,7 @@ class OperatorApp(App[None]):
             # release path is unaffected: it calls `_notify` directly, and its
             # own `await _judge_goal` already drained the final `TurnEnded`.
             source.loop.running = False
+            self.call_later(self._source_frontend_changed, source)
             source.loop.goal = ""
             self.call_later(self._release_loop_completion_suppression, source, operation)
         # Terminal outcome (mirrors the numeric worker's tail). Only the release
@@ -20616,6 +21449,7 @@ class OperatorApp(App[None]):
         self.screen.add_class(ASIDE_LAYOUT_CLASS)
         panel._on_height = self._reserve_ground_for_aside
         panel.open()
+        self._interaction.aside_open = True
         self._sync_aside_fork_hint()
         return panel
 
@@ -20661,7 +21495,10 @@ class OperatorApp(App[None]):
         # Retire the request as well as the surface: workers and messages are
         # separate queues, so cancelling alone cannot stop a delta already
         # posted. ``close`` bumps the card's generation, which drops it.
-        self.workers.cancel_group(self, "aside")
+        self.workers.cancel_group(self, self._interaction.worker_group("aside"))
+        self._interaction.aside_open = False
+        self._interaction.aside_generation += 1
+        self._interaction.draft.aside = None
         panel.close()
         panel._on_height = None
         # Give the transcript its own last rows back, and land the reader at
@@ -20719,15 +21556,36 @@ class OperatorApp(App[None]):
             panel.fail_answer(generation, "the session is still starting…")
             return
         generation = panel.ask(question)
+        source = self._interaction
+        source.aside_open = True
+        source.aside_generation = generation
         self._sync_aside_fork_hint()
         self.run_worker(
-            self._aside_worker(session, question, generation),
+            self._aside_worker(
+                session,
+                question,
+                generation,
+                source=source,
+                turn=panel.turns[-1],
+                prior_turns=panel.turns[:-1],
+                in_flight=self._streaming_block.text() if self._streaming_block is not None else "",
+            ),
             thread=False,
-            group="aside",
+            group=source.worker_group("aside"),
             exclusive=True,
         )
 
-    async def _aside_worker(self, session: SessionProtocol, question: str, generation: int) -> None:
+    async def _aside_worker(
+        self,
+        session: SessionProtocol,
+        question: str,
+        generation: int,
+        *,
+        source: SessionInteraction | None = None,
+        turn: AsideTurn | None = None,
+        prior_turns: list[AsideTurn] | None = None,
+        in_flight: str = "",
+    ) -> None:
         """One off-the-record request, streamed into the card.
 
         The turns handed to ``complete_aside`` are this aside's whole history
@@ -20749,45 +21607,78 @@ class OperatorApp(App[None]):
         free, and a status line that an F8 popup could move without moving
         would be a number the user cannot act on.
         """
+        source = source or self._interactions.get(id(session), self._interaction)
         panel = self._aside_panel()
         if panel is None:
             return
+        if turn is None:
+            if not panel.turns:
+                return
+            turn = panel.turns[-1]
+            prior_turns = panel.turns[:-1]
+            source.aside_open = panel.is_open
+            source.aside_generation = generation
+            streaming = self._streaming_block
+            in_flight = streaming.text() if streaming is not None else ""
+        target = turn
+
+        def accepts() -> bool:
+            return (
+                source.aside_open
+                and not source.retired
+                and source.aside_generation == generation
+                and target.state == "running"
+            )
+
+        def delta(text: str) -> None:
+            if not accepts():
+                return
+            if self._is_current(source) and panel.accepts(generation):
+                panel.append_answer(generation, text)
+            else:
+                target.append_delta(text)
+
         turns: list[AgentMessage] = []
-        streaming = self._streaming_block
-        # ``AssistantBlock.text`` is a METHOD, not a property — reading it
-        # without the call handed the model a bound function and blew up the
-        # one path this branch exists for.
-        in_flight = streaming.text() if streaming is not None else ""
         if in_flight.strip():
             history = session.history()
             tail = history[-1] if history else None
             if getattr(tail, "text", None) != in_flight:
                 turns.append(Message.assistant(in_flight))
-        for turn in panel.turns[:-1]:
-            if not turn.forkable:
-                continue
-            turns.append(Message.user(turn.question))
-            turns.append(Message.assistant(turn.answer))
+        for previous in prior_turns or []:
+            if previous.forkable:
+                turns.extend((Message.user(previous.question), Message.assistant(previous.answer)))
         turns.append(Message.user(ASIDE_PROMPT.format(question=question)))
+        source.active_workers += 1
         try:
-            answer = await session.complete_aside(
-                turns,
-                on_delta=lambda delta: panel.append_answer(generation, delta),
-                on_usage=self._charge_aside,
-            )
-        except Exception as error:  # noqa: BLE001 — any provider failure is the card's news
-            # ``CancelledError`` is a ``BaseException``, so a worker cancelled
-            # by `_close_aside` never lands here — no re-raise clause needed.
-            panel.fail_answer(generation, str(error))
-            # The question goes back in the composer so the footer's `enter ask
-            # again` is a real retry, editable first. It is the only gesture
-            # anyone wants under a failed answer.
-            if panel.accepts(generation):
-                self._editor().load_text(question)
-            self._sync_aside_fork_hint()
-            return
-        panel.settle_answer(generation, answer)
-        self._sync_aside_fork_hint()
+            try:
+                answer = await session.complete_aside(
+                    turns,
+                    on_delta=delta,
+                    on_usage=lambda usage: self._charge_aside_for(source, usage),
+                )
+            except Exception as error:
+                if not accepts():
+                    return
+                if self._is_current(source) and panel.accepts(generation):
+                    panel.fail_answer(generation, str(error))
+                    if not self._editor().text.strip():
+                        self._editor().load_text(question)
+                    self._sync_aside_fork_hint()
+                else:
+                    target.fail(str(error))
+                    if not source.draft.text.strip():
+                        source.draft.text = question
+                return
+            if not accepts():
+                return
+            if self._is_current(source) and panel.accepts(generation):
+                panel.settle_answer(generation, answer)
+                self._sync_aside_fork_hint()
+            else:
+                target.settle(answer)
+        finally:
+            source.active_workers -= 1
+            self.call_later(self._source_frontend_changed, source)
 
     def _charge_aside(self, usage: Any) -> None:
         self._charge_aside_for(self._interaction, usage)

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -214,6 +214,7 @@ from local_operator.tui.widgets.editor import (
     InterruptRequested,
     Marked,
     ModelQueryOpened,
+    RecallState,
     RefreshArgumentChoices,
     ShellModeChanged,
     SkillQueryOpened,
@@ -991,6 +992,15 @@ ASIDE_LAYOUT_CLASS = "aside"
 #: `local_operator/` binds and `TextArea` does not claim.
 ASIDE_SCROLL_BACK_KEY = "ctrl+pageup"
 ASIDE_SCROLL_FORWARD_KEY = "ctrl+pagedown"
+
+#: Parked sidebar presentations kept beside the active one, LRU-evicted. One
+#: made every non-adjacent click cold; four covers the handful of live
+#: conversations a user alternates between, at ~1.2 MiB RSS per parked view
+#: and no measurable per-frame cost (six parked: frame 16–17 ms, unchanged).
+RETAINED_PRESENTATIONS = 4
+#: Ranked entries warmed per catalog poll. Two is the top of the list — the
+#: rows the eye lands on — without turning every poll into a prepare storm.
+PREWARM_PER_REFRESH = 2
 
 #: The chord that lifts the aside's full text to the clipboard.
 #:
@@ -2555,7 +2565,6 @@ class OperatorApp(App[None]):
         self._sidebar_refresh_pending = False
         self._sidebar_prefetch: Any = None
         self._sidebar_prior_workers: set[Any] = set()
-        self._sidebar_last_prefetch = ""
         self._sidebar_settings_applied = False
         self._sidebar_ready_frame: tuple[SessionInteraction, int, asyncio.Future[None]] | None = (
             None
@@ -2563,6 +2572,13 @@ class OperatorApp(App[None]):
         self._sidebar_frame_pending = False
         self._sidebar_focus_restore: ReferenceType[Widget] | None = None
         self._sidebar_presentations: dict[str, SessionPresentation] = {}
+        #: The source whose draft was snapshotted at ``pending(id)`` and whose
+        #: editor buffer was handed to the transition. ``None`` outside a
+        #: switch. Commit consumes it (buffer appended to the target's draft);
+        #: failure or cancel restores it (buffer appended back to the outgoing
+        #: draft). Its presence is what distinguishes the two ``pending("")``
+        #: callers — the navigation makes both — without a second flag.
+        self._sidebar_transition_from: SessionInteraction | None = None
         self._sidebar_sources: dict[str, SessionInteraction] = {}
         self._sidebar_drafts = SessionDraftStore()
         self._sidebar_navigation = SessionNavigation(
@@ -3060,6 +3076,46 @@ class OperatorApp(App[None]):
         self.post_message(message)
 
     @staticmethod
+    def _sidebar_presentation_current(
+        cached: SessionPresentation, source: SessionInteraction, gate: Any
+    ) -> bool:
+        """Whether a parked presentation can be revealed without rebuilding.
+
+        The strict form — every stamp equal — made nearly every click cold:
+        ANY event on a hidden session bumps ``presentation_revision`` (see
+        ``_on_message``), so a session that received a single durable row
+        while parked was rebuilt from scratch on return. The reveal path
+        already projects appended rows at commit (``_commit_sidebar_session``
+        paints ``history[-(total - history_size):]``), so staleness that is
+        ONLY "more durable rows were appended" is safe to accept.
+
+        Everything else still misses, because the widgets would be wrong:
+
+        - a different ``source_token`` is a different attachment entirely;
+        - a streaming turn has a live block the cache did not capture;
+        - a changed ``replay_revision`` means compaction/prune/recovery
+          rewrote rows the cache already painted — the commit's "fewer rows"
+          branch handles a rewrite only from a rebuild;
+        - a pending ask/approval is PRESENTATION state (a gate card in the
+          view), not a durable row, so the delta projection cannot supply it.
+          A session waiting on the user must always rebuild.
+        """
+        session = source.session
+        if cached.source_token != source.token:
+            return False
+        if gate is not None:
+            return False
+        state = getattr(session, "frontend_state", None)
+        if getattr(state, "streaming", False):
+            return False
+        if cached.replay_revision != getattr(session, "display_history_revision", 0):
+            return False
+        total = getattr(session, "history_message_count", None)
+        if total is None or total < cached.history_size:
+            return False
+        return True
+
+    @staticmethod
     def _sidebar_source_stamp(source: SessionInteraction) -> tuple[Any, ...]:
         state = getattr(source.session, "frontend_state", None)
         return (
@@ -3237,12 +3293,12 @@ class OperatorApp(App[None]):
             if gate is not None and gate.kind not in {"ask", "approval"}:
                 raise RuntimeError("This viewer does not support the conversation's pending input")
             cached = self._sidebar_presentations.get(session_id)
-            if (
-                cached is not None
-                and cached.source_token == source.token
-                and cached.revision == source.presentation_revision
-                and cached.source_stamp == self._sidebar_source_stamp(source)
-            ):
+            if cached is not None and self._sidebar_presentation_current(cached, source, gate):
+                # Reinsert so dict order is recency: eviction pops the OLDEST
+                # key, and a hit must count as a use or a hot pair of sessions
+                # would evict each other the moment a third is visited.
+                self._sidebar_presentations.pop(session_id, None)
+                self._sidebar_presentations[session_id] = cached
                 if not source.draft.following_tail and source.draft.scroll_anchor_id:
                     cached.replay.view.restore_navigation_anchor(
                         source.draft.scroll_anchor_id,
@@ -3494,6 +3550,13 @@ class OperatorApp(App[None]):
                 self._suspend_sidebar_gates(self._interaction)
             else:
                 current.resume_viewer_gates()
+        if session_id:
+            self._begin_sidebar_transition()
+        elif self._sidebar_transition_from is not None:
+            # ``pending("")`` without a commit in between: the switch failed
+            # or was cancelled, and the user is still in the session they
+            # were leaving. Give them back their draft PLUS what they typed.
+            self._abandon_sidebar_transition()
         self._session_transition_pending = bool(session_id)
         self._sidebar_frame_pending = True
         if not session_id:
@@ -3514,6 +3577,65 @@ class OperatorApp(App[None]):
     def _sidebar_navigation_failed(self, session_id: str, error: Exception) -> None:
         self._session_sidebar.show_error(str(error))
         self._system_notice(f"Could not open conversation: {error}", "warning")
+
+    def _begin_sidebar_transition(self) -> None:
+        """Freeze the outgoing draft and hand the editor to the transition.
+
+        Everything typed after a click, until the target is ready, used to
+        land in the OUTGOING editor buffer and then be copied into the
+        outgoing draft at commit — shown as belonging to the session the user
+        had just left. That is the lie this fixes: from the click onward the
+        buffer is a transition buffer, and its contents are attributed at the
+        moment the outcome is known (commit → target, failure → outgoing).
+        Synchronous, before any await, so nothing can slip in between the
+        snapshot and the empty buffer. A burst of clicks re-enters here with
+        a transition already open; the snapshot is kept and only the buffer
+        is carried on.
+        """
+        if self._sidebar_transition_from is not None:
+            return
+        editor = self._editor()
+        outgoing = self._interaction
+        outgoing.draft.text = editor.text
+        outgoing.draft.attachments = editor.attachments()
+        outgoing.draft.selection = editor.selection
+        outgoing.draft.shell_mode = editor.shell_mode
+        recall = editor.recall_state()
+        outgoing.draft.history_index = recall.index
+        outgoing.draft.history_stash = recall.stash
+        outgoing.draft.history_stash_attachments = dict(recall.stash_attachments)
+        self._sidebar_transition_from = outgoing
+        # The buffer now belongs to no session. Leave recall as it was: a
+        # transition is not a prompt, and load_text must not reset the index
+        # the outgoing session will get back if this fails.
+        editor.load_text("")
+        editor.adopt_attachments({})
+
+    def _take_sidebar_transition_buffer(self) -> tuple[str, dict[int, Any]]:
+        editor = self._editor()
+        return editor.text, editor.attachments()
+
+    def _abandon_sidebar_transition(self) -> None:
+        """Failure/cancel: the user stays put, so what they typed is theirs."""
+        outgoing = self._sidebar_transition_from
+        self._sidebar_transition_from = None
+        if outgoing is None or outgoing is not self._interaction:
+            return
+        editor = self._editor()
+        typed, typed_attachments = self._take_sidebar_transition_buffer()
+        editor.load_text(outgoing.draft.text + typed)
+        merged = dict(outgoing.draft.attachments)
+        merged.update(typed_attachments)
+        editor.adopt_attachments(merged)
+        editor.set_shell_mode(outgoing.draft.shell_mode)
+        editor.restore_recall_state(
+            RecallState(
+                index=outgoing.draft.history_index,
+                stash=outgoing.draft.history_stash,
+                stash_attachments=dict(outgoing.draft.history_stash_attachments),
+            )
+        )
+        editor.move_cursor(editor._end_of_buffer())
 
     def _sidebar_source_releasable(self, source: SessionInteraction) -> bool:
         from local_operator.session.remote import RemoteSession
@@ -3637,10 +3759,24 @@ class OperatorApp(App[None]):
         self._close_org_chart_view()
         self._close_settings_view()
         editor = self._editor()
-        outgoing.draft.text = editor.text
-        outgoing.draft.attachments = editor.attachments()
-        outgoing.draft.selection = editor.selection
-        outgoing.draft.shell_mode = editor.shell_mode
+        if self._sidebar_transition_from is outgoing:
+            # The outgoing draft was frozen at ``pending``; the editor holds
+            # the transition buffer, which belongs to the TARGET. Take it now,
+            # before the incoming draft is loaded over it.
+            typed, typed_attachments = self._take_sidebar_transition_buffer()
+        else:
+            # No transition was opened (a programmatic swap); the buffer is
+            # still the outgoing draft, exactly as before.
+            typed, typed_attachments = "", {}
+            outgoing.draft.text = editor.text
+            outgoing.draft.attachments = editor.attachments()
+            outgoing.draft.selection = editor.selection
+            outgoing.draft.shell_mode = editor.shell_mode
+            recall = editor.recall_state()
+            outgoing.draft.history_index = recall.index
+            outgoing.draft.history_stash = recall.stash
+            outgoing.draft.history_stash_attachments = dict(recall.stash_attachments)
+        self._sidebar_transition_from = None
         old_view = self._transcript_view()
         outgoing.draft.following_tail = old_view.is_following_tail
         if not outgoing.draft.following_tail:
@@ -3727,11 +3863,24 @@ class OperatorApp(App[None]):
                         if isinstance(block, ToolCard)
                     }
                 )
-            editor.load_text(source.draft.text)
-            editor.adopt_attachments(source.draft.attachments)
+            editor.load_text(source.draft.text + typed)
+            merged_attachments = dict(source.draft.attachments)
+            merged_attachments.update(typed_attachments)
+            editor.adopt_attachments(merged_attachments)
             editor.set_shell_mode(source.draft.shell_mode)
-            if source.draft.selection is not None:
+            if typed:
+                # Text typed during the switch goes at the end; the caret
+                # follows it, which is where the user is.
+                editor.move_cursor(editor._end_of_buffer())
+            elif source.draft.selection is not None:
                 editor.selection = source.draft.selection
+            editor.restore_recall_state(
+                RecallState(
+                    index=source.draft.history_index,
+                    stash=source.draft.history_stash,
+                    stash_attachments=dict(source.draft.history_stash_attachments),
+                )
+            )
             self._restore_sidebar_aside(source)
             self._sync_draft_recoveries(source)
             for text, kind in source.notices:
@@ -3752,9 +3901,14 @@ class OperatorApp(App[None]):
             self.run_worker(self._release_sidebar_preparation((outgoing, outgoing_presentation)))
         if displaced is not None and displaced is not incoming:
             self.run_worker(self._release_sidebar_preparation((source, displaced)))
-        # Active + one retained presentation. Executing contexts stay alive
-        # without retaining their widgets, and drafts remain source-owned.
-        while len(self._sidebar_presentations) > 1:
+        # Retain the most recently used presentations. One was the original
+        # bound, and it made every non-adjacent click cold; four covers the
+        # two-or-three live conversations a user actually alternates between
+        # at ~1.2 MiB RSS and no per-frame cost per parked view (measured with
+        # six parked). Dict order is recency — hits reinsert — so the oldest
+        # key is the LRU victim. Executing contexts stay alive without
+        # retaining their widgets, and drafts remain source-owned.
+        while len(self._sidebar_presentations) > RETAINED_PRESENTATIONS:
             evicted_id = next(iter(self._sidebar_presentations))
             evicted = self._sidebar_presentations.pop(evicted_id)
             self.run_worker(
@@ -3823,22 +3977,39 @@ class OperatorApp(App[None]):
         Focus is untouched: the composer keeps the caret and the draft, so
         switching mid-sentence does not cost the sentence.
         """
-        entries = self._session_sidebar.entries
-        if not entries:
-            # The catalog is only polled while the list is open, so a closed
-            # list has nothing to traverse. Load it once, then switch — the
-            # shortcut is meant to work without opening the drawer first.
+        if self.screen is not self.screen_stack[0]:
+            # A pushed modal (the /resume picker, a settings sheet) owns the
+            # keyboard. A priority binding would otherwise fire through it and
+            # switch the conversation underneath the very list the user is
+            # choosing from (round 4, MINOR-2).
+            return
+        if not self._session_sidebar.display or not self._session_sidebar.entries:
+            # The catalog is polled ONLY while the list is open. A closed list
+            # keeps whatever it last showed — with four sessions created since,
+            # the "next" it computed was from a ranking that no longer exists
+            # (round 4, M2/Q8/U6). Branch on visibility, not emptiness: a
+            # closed list is stale by definition, so read fresh and then step.
             self.run_worker(self._switch_session_cold(delta), group="sidebar-switch")
             return
-        current = self._session.session_id if self._session is not None else ""
-        index = next((i for i, entry in enumerate(entries) if entry.id == current), None)
+        self._switch_session_from(self._session_sidebar.entries, delta)
+
+    def _switch_session_from(self, entries: Sequence[CatalogEntry], delta: int) -> None:
+        # Step from where the user is HEADED, not where they are: a second
+        # press before the first commits used to read ``_session`` (still the
+        # old one) and recompute the same target, so a burst of three presses
+        # collapsed into one hop (round 4, U6 / MINOR-1). The requested id is
+        # the honest origin while a switch is in flight.
+        origin = self._sidebar_navigation.requested_id or (
+            self._session.session_id if self._session is not None else ""
+        )
+        index = next((i for i, entry in enumerate(entries) if entry.id == origin), None)
         if index is None:
             # Attached to something outside the list (or nothing yet): enter at
             # the nearest end rather than refusing to move.
             target = entries[0] if delta > 0 else entries[-1]
         else:
             target = entries[(index + delta) % len(entries)]
-        if target.id == current:
+        if target.id == origin:
             return
         self._session_sidebar.cursor_id = target.id
         self.post_message(SessionSidebar.Selected(target.id))
@@ -3862,18 +4033,18 @@ class OperatorApp(App[None]):
         except Exception:
             logger.debug("sidebar switch catalog load failed", exc_info=True)
             return
-        if self._session_sidebar.entries:
-            # A concurrent refresh won the race and its entries are current;
-            # adopting this older read would step from a stale order.
-            pass
-        elif entries:
-            self._session_sidebar.current_id = str(getattr(self._session, "session_id", ""))
-            self._session_sidebar.set_entries(entries)
-        else:
-            # Nothing to traverse. Returning here is also what stops the
-            # re-entry below from recursing on an empty catalog.
+        if not entries:
             return
-        self.action_switch_session(delta)
+        if self._session_sidebar.display:
+            # The list opened while we were reading: its own poll is now the
+            # source of truth, and it will be at least as fresh as this read.
+            self._switch_session_from(self._session_sidebar.entries or entries, delta)
+            return
+        # Closed list: adopt the fresh read so the drawer, when it next opens,
+        # shows the order the switch just traversed rather than the stale one.
+        self._session_sidebar.current_id = str(getattr(self._session, "session_id", ""))
+        self._session_sidebar.set_entries(entries)
+        self._switch_session_from(self._session_sidebar.entries, delta)
 
     def action_toggle_sidebar(self) -> None:
         if not self._session_sidebar.display:
@@ -3886,7 +4057,6 @@ class OperatorApp(App[None]):
         sidebar = self._session_sidebar
         if opened and not sidebar.display:
             self._sidebar_focus_restore = ref(self.focused) if self.focused is not None else None
-            self._sidebar_last_prefetch = ""
         sidebar.set_open(opened)
         self._sync_sidebar_layout(self.size)
         if self._sidebar_timer is not None:
@@ -3969,48 +4139,78 @@ class OperatorApp(App[None]):
         self.run_worker(refresh(), group="sidebar-catalog")
 
     def _prewarm_sidebar(self, entries: list[CatalogEntry]) -> None:
+        """Warm the top-ranked sessions the user is likeliest to click next.
+
+        Ranked order is the list's own (``rank_entries``), so what is warm is
+        what sits at the top of the list. At most ``PREWARM_PER_REFRESH`` per
+        catalog poll and one prefetch worker at a time, only while no
+        navigation is in flight, so speculation never competes with a click.
+
+        An entry with an EMPTY ``live_state`` is never warmed: preparing it
+        would resume a runtime, and speculation must not start processes the
+        user did not ask for. Already-cached and current sessions are skipped
+        rather than blocking the whole prewarm as they used to.
+        """
         if (
             not self._session_sidebar.display
             or self._sidebar_prefetch is not None
-            or self._sidebar_presentations
             or self._sidebar_navigation.requested_id
         ):
             return
         current = str(getattr(self._session, "session_id", ""))
-        candidate = next(
-            (entry for entry in entries if entry.id != current and entry.row.live_state), None
-        )
-        if candidate is None or candidate.id == self._sidebar_last_prefetch:
+        candidates = [
+            entry
+            for entry in entries
+            if entry.id != current
+            and entry.row.live_state
+            and entry.id not in self._sidebar_presentations
+        ][:PREWARM_PER_REFRESH]
+        if not candidates:
             return
-        self._sidebar_last_prefetch = candidate.id
 
         async def prepare() -> None:
-            prepared = None
-            try:
-                prepared = await self._prepare_sidebar_session(candidate.id, speculative=True)
-                if (
-                    self._session_sidebar.display
-                    and not self._sidebar_navigation.requested_id
-                    and not self._sidebar_presentations
-                    and candidate.id != str(getattr(self._session, "session_id", ""))
-                    and prepared[1].retainable()
-                ):
-                    self._sidebar_presentations[candidate.id] = prepared[1]
-                    prepared = None
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                # Speculation never overwrites a usable catalog with an error.
-                # An explicit selection reports the same failure normally.
-                logger.debug("sidebar prewarm failed", exc_info=True)
-            finally:
+            for candidate in candidates:
+                prepared = None
                 try:
+                    if (
+                        not self._session_sidebar.display
+                        or self._sidebar_navigation.requested_id
+                        or candidate.id in self._sidebar_presentations
+                    ):
+                        return
+                    prepared = await self._prepare_sidebar_session(candidate.id, speculative=True)
+                    if (
+                        self._session_sidebar.display
+                        and not self._sidebar_navigation.requested_id
+                        and candidate.id not in self._sidebar_presentations
+                        and candidate.id != str(getattr(self._session, "session_id", ""))
+                        and prepared[1].retainable()
+                    ):
+                        self._sidebar_presentations[candidate.id] = prepared[1]
+                        prepared = None
+                        while len(self._sidebar_presentations) > RETAINED_PRESENTATIONS:
+                            evicted_id = next(iter(self._sidebar_presentations))
+                            evicted = self._sidebar_presentations.pop(evicted_id)
+                            await self._release_sidebar_preparation(
+                                (self._sidebar_sources[evicted_id], evicted)
+                            )
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    # Speculation never overwrites a usable catalog with an
+                    # error. An explicit selection reports the same failure.
+                    logger.debug("sidebar prewarm failed", exc_info=True)
+                finally:
                     if prepared is not None:
                         await self._release_sidebar_preparation(prepared)
-                finally:
-                    self._sidebar_prefetch = None
 
-        self._sidebar_prefetch = self.run_worker(prepare(), group="sidebar-prefetch")
+        async def run() -> None:
+            try:
+                await prepare()
+            finally:
+                self._sidebar_prefetch = None
+
+        self._sidebar_prefetch = self.run_worker(run(), group="sidebar-prefetch")
 
     def on_session_sidebar_dismissed(self, message: SessionSidebar.Dismissed) -> None:
         message.stop()
@@ -23482,6 +23682,10 @@ class OperatorApp(App[None]):
         # can now shrink to a row or go away (#525).
         lines.append(_key_row("ctrl+g", "cycle the subagent panel: full, summary, hidden"))
         lines.append(_key_row("ctrl+b", "show or hide the session sidebar"))
+        # Beside ctrl+b, because it is the same surface: the list is where the
+        # user learns what "next" means, and the one-press switch is otherwise
+        # undiscoverable (UX round 3, U5).
+        lines.append(_key_row("ctrl+shift+↑/↓", "switch to the previous/next conversation"))
         lines.append(_key_row("F8", "open an aside; ctrl+f forks it in"))
         # Directly under `F8`, because it is only meaningful once an aside
         # is open. ONE row for the pair rather than two: the partner chord fits

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -13457,6 +13457,7 @@ class OperatorApp(App[None]):
             self._subagent_panel,
             self._subagent_view,
             self._status,
+            self._session_sidebar,
         ):
             if surface is None:
                 continue

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3306,11 +3306,19 @@ class OperatorApp(App[None]):
 
     @staticmethod
     def _sidebar_gate_identity(source: SessionInteraction) -> tuple[Any, ...] | None:
-        state = getattr(source.session, "frontend_state", None)
-        gate = getattr(state, "pending_gate", None)
+        # Per-frame, so it reads the two fields it needs without the
+        # whole-state clone `frontend_state` pays; reduced facades that lack
+        # the narrow accessors still fall back to it.
+        session = source.session
+        gate = getattr(session, "pending_gate", None)
+        if gate is None and not hasattr(session, "pending_gate"):
+            gate = getattr(getattr(session, "frontend_state", None), "pending_gate", None)
         if gate is None:
             return None
-        return (getattr(state, "epoch", ""), gate.kind, gate.request_id, gate.question_index)
+        epoch = getattr(session, "epoch", None)
+        if epoch is None:
+            epoch = getattr(getattr(session, "frontend_state", None), "epoch", "")
+        return (epoch, gate.kind, gate.request_id, gate.question_index)
 
     def _watch_source_frontend(self, source: SessionInteraction) -> None:
         from local_operator.session.frontend_state import FrontendSubscription

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -30,7 +30,6 @@ import sys
 import time
 import uuid
 from collections.abc import Mapping, Sequence
-from contextlib import nullcontext
 from dataclasses import dataclass, replace
 from functools import partial
 from typing import (
@@ -75,8 +74,6 @@ from textual.widget import Widget
 from textual.widgets import Static
 
 from local_operator.ansi import strip_control_sequences
-from local_operator.compaction.marker import COMPACTION_REFUSED_TYPE
-from local_operator.harness.approval import GATE_TIMEOUT_CUSTOM_TYPE
 from local_operator.harness.intent import (
     ACTIVITY_RESPONDING,
     batch_activity,
@@ -146,6 +143,7 @@ from local_operator.tui.events import (
     PeerMessageDelivered,
     RetryEnded,
     RetryStarted,
+    SessionEvent,
     StartFlushTimer,
     SteeringDelivered,
     SubagentEnded,
@@ -169,6 +167,11 @@ from local_operator.tui.markdown_theme import (
     install_markdown_theme,
 )
 from local_operator.tui.notify import Notifier, notifications_enabled
+from local_operator.tui.session_catalog import CatalogEntry, SidebarSettings
+from local_operator.tui.session_drafts import SessionDraftStore
+from local_operator.tui.session_interaction import SessionDraft, SessionInteraction
+from local_operator.tui.session_navigation import SessionNavigation
+from local_operator.tui.session_presentation import HistoryPageNotice, PreparedReplay, SessionPresentation
 from local_operator.tui.settings import settings_get
 from local_operator.tui.terminal_title import (
     TerminalTitle,
@@ -215,6 +218,11 @@ from local_operator.tui.widgets.org_chart_view import (
 from local_operator.tui.widgets.session_picker import (
     RESUME_EMPTY_NOTICE,
     SessionPickerScreen,
+)
+from local_operator.tui.widgets.session_sidebar import (
+    SIDEBAR_MAIN_MIN_WIDTH,
+    SIDEBAR_WIDTH,
+    SessionSidebar,
 )
 from local_operator.tui.widgets.settings_view import (
     SettingsChanged,
@@ -1515,9 +1523,17 @@ class OperatorApp(App[None]):
         # when the side question occurs to them would have to delete their
         # draft to ask it. The draft is stashed and Esc puts it back.
         #
-        # `ctrl+b` because TextArea binds neither it nor anything near it, so
-        # the composer keeps every editing key it had.
-        Binding("ctrl+b", "aside", "Aside", show=False),
+        # Ctrl+B is navigation across platforms; F8 keeps Aside independent of
+        # terminal modifier encoding and leaves every TextArea editing key alone.
+        Binding("f8", "aside", "Aside", show=False),
+        Binding("ctrl+b", "toggle_sidebar", "Sessions", show=False),
+        # Textual decodes Kitty's Super modifier. Terminals that intercept Cmd+B
+        # never deliver it, so Ctrl+B and /sidebar remain unconditional routes.
+        *(
+            [Binding("super+b", "toggle_sidebar", "Sessions", show=False)]
+            if sys.platform == "darwin"
+            else []
+        ),
         # Promote the aside exchange into the conversation. Only meaningful
         # while the card is open, and the action says so rather than the
         # binding: a key that silently does nothing elsewhere is worse than one
@@ -1668,6 +1684,9 @@ class OperatorApp(App[None]):
         warm_session_imports: bool = True,
     ) -> None:
         super().__init__()
+        self._interaction = SessionInteraction(None)
+        self._interactions: dict[int, SessionInteraction] = {}
+        self._event_sources: dict[EventController, SessionInteraction] = {}
         # Dark is the product's island night and the fallback: `theme_name`
         # arrives from config.yml, and a saved name a build no longer ships
         # (downgrade, hand-edited config) must not keep the app from booting.
@@ -1844,7 +1863,7 @@ class OperatorApp(App[None]):
         #: turn so the other is a no-op. Kept physically beside
         #: ``_completion_deferred``/``_settled_child_ids`` because all three are
         #: turn-scoped and every site that resets one must reset the others.
-        self._turn_open: bool = False
+        self._turn_open = False
         #: Whether this turn's notification ladder has already RUN. Distinct
         #: from ``_turn_open``, which says whether the turn is still live:
         #: retiring a turn and announcing it are two different claims, and a
@@ -1856,7 +1875,7 @@ class OperatorApp(App[None]):
         #: without which a FAILED turn was toasted "task complete" while the
         #: title on the same turn read ``✗`` (review R4). Turn-scoped, so every
         #: site that resets ``_turn_open`` resets this too.
-        self._turn_notified: bool = False
+        self._turn_notified = False
         self._streaming_block: AssistantBlock | None = None
         self._tool_cards: dict[str, ToolCard] = {}
         # Rows for calls the model is still dictating. Separate from
@@ -1926,13 +1945,13 @@ class OperatorApp(App[None]):
         #: because both triggers announce themselves through those events, so one
         #: flag covers the automatic pass and `/compact` alike. It is what stops
         #: a prompt being sent into a history that is being rewritten.
-        self._compacting: bool = False
+        self._compacting = False
         #: Whether the working line on screen was mounted by a compaction (a
         #: manual pass has no turn to mount one), so only the handler that
         #: started it takes it away.
         self._compaction_owns_working_block: bool = False
         #: A prompt typed DURING a pass, sent when the pass ends.
-        self._prompt_held_for_compaction: str = ""
+        self._prompt_held_for_compaction = ""
         #: What the USER typed for that held prompt, when it differs from the
         #: string above — a ``$skill`` invocation holds the expanded SKILL.md
         #: body to SEND while the composer must get the short line back.
@@ -1944,15 +1963,15 @@ class OperatorApp(App[None]):
         #: ended` SENDS the held prompt (the payload), while the `/reload`
         #: teardown HANDS IT BACK to the composer (the typed line). One field
         #: could not serve both without one of them being wrong.
-        self._typed_held_for_compaction: str = ""
+        self._typed_held_for_compaction = ""
         #: Its attachments, held in parallel. Separate so the line above keeps
         #: `""` as its sentinel — that field's emptiness is load-bearing and
         #: mutation-tested (round 13), and widening it to a tuple would move
         #: the check every one of those tests makes.
-        self._images_held_for_compaction: dict[int, Marked] = {}
+        self._images_held_for_compaction = {}
         #: This session's OWN spend, accumulated per turn. The number the band
         #: shows is this plus every child's — see :meth:`_spend_total`.
-        self._total_cost: float = 0.0
+        self._total_cost = 0.0
         #: Delegated spend, keyed by job id and holding the LAST cost observed
         #: for that child. A dict rather than a running sum because a child's
         #: figure grows while it works, so each tick has to replace its entry
@@ -1960,14 +1979,14 @@ class OperatorApp(App[None]):
         #: ``AsyncJobManager`` sweeps settled jobs out of the ledger after a
         #: retention window and a spend counter that goes DOWN when a finished
         #: child is evicted is worse than no counter at all.
-        self._subagent_costs: dict[str, float] = {}
+        self._subagent_costs = {}
         #: True when `_total_cost` includes money RESTORED from a resumed
         #: conversation, which makes the band's figure a lower bound rather than
         #: a total (see `_restore_reported_usage`). Sticky for the life of the
         #: session: adding a real turn to a floor leaves a floor, so nothing
         #: this session does can make the figure exactly known again. Cleared
         #: only on a swap, where the ledger it qualifies is cleared too.
-        self._spend_is_floor: bool = False
+        self._spend_is_floor = False
         #: Queued-steer rows still promising a delivery that has not happened.
         #: Appended when a mid-turn submit is steered, drained when the engine
         #: reports it took them (`on_steering_delivered`). A list because several
@@ -2058,7 +2077,7 @@ class OperatorApp(App[None]):
         #: as the key the two retire-on-failure sites already use. Those
         #: entries keep the historical by-text behaviour, limit included. Both
         #: in-tree sessions take the keyword, so no shipping path relies on it.
-        self._pending_user_echoes: list[_PendingUserEcho] = []
+        self._pending_user_echoes = []
         #: Discovered skills by name, for the ``$skill`` composer prefix.
         #: ``None`` until the first submit or picker sync asks; see
         #: :meth:`_discovered_skills` for why one discovery per session is the
@@ -2091,6 +2110,9 @@ class OperatorApp(App[None]):
         #: scrolling up reveal real history instead of a re-read from disk that
         #: could race `compact_file` replacing the transcript underneath it.
         self._resume_pending_head: list[Any] = []
+        self._resume_pending_tail: list[Any] = []
+        self._resume_tail_notice: NoticeBlock | None = None
+        self._resume_tail_paging = False
         #: Every tool result in the WHOLE resumed conversation, keyed by call
         #: id. A deferred page's calls are paired with their results from here,
         #: because a call in the head can be answered by a result that already
@@ -2118,6 +2140,8 @@ class OperatorApp(App[None]):
         #: `_collect_resume_page_blocks`, which is synchronous — no await
         #: crosses it, so no live event can be diverted into a history page.
         self._block_sink: list[Any] | None = None
+        self._projection_message_id = ""
+        self._projection_part = 0
         #: One page per USER GESTURE, not per scroll callback. Held from the
         #: first trigger until the mount's settle pass has restored the scroll
         #: anchor: Textual ANIMATES pageup/home, so the scroll watcher fires
@@ -2155,7 +2179,7 @@ class OperatorApp(App[None]):
         #: and this resets to 0.0 at every turn boundary. Without it the two
         #: writers would each bill the same tokens and the band would report
         #: roughly double what a turn actually cost.
-        self._turn_accrued_cost: float = 0.0
+        self._turn_accrued_cost = 0.0
         # Auto-naming fires while the conversation is STILL unnamed, at most
         # one attempt in flight. Latched here rather than on the session
         # holder because the app is what schedules the call, and a second
@@ -2230,7 +2254,7 @@ class OperatorApp(App[None]):
         # `ChatRequest.isolated`) and runs concurrently with the turn on
         # purpose, so serialising it here would restore the very latency this
         # feature exists to remove.
-        self._turn_provider_lock: asyncio.Lock = asyncio.Lock()
+        self._turn_provider_lock = asyncio.Lock()
         # Last subagent count painted, so the 1 Hz poll repaints only on a
         # real change instead of every tick.
         # (task jobs, bash jobs) last painted, so a repaint only happens on change.
@@ -2249,14 +2273,14 @@ class OperatorApp(App[None]):
         self._login_lock: Any | None = None
         # ``/loop`` state: one loop at a time, cooperatively cancellable at
         # the turn boundary (never mid-turn, so a turn is never half-applied).
-        self._loop_running: bool = False
-        self._loop_cancelled: bool = False
+        self._loop_running = False
+        self._loop_cancelled = False
         #: Goal-mode state for `/loop <goal text>`. `_loop_goal` is BOTH the
         #: mode flag and the payload: goal mode is active iff it is truthy while
         #: `_loop_running`. Carrying the goal here (not via `set_goal`) keeps the
         #: standing `/goal` and the system prompt's tail untouched — a `/loop do
         #: X` must not silently overwrite a goal the user set for the session.
-        self._loop_goal: str = ""
+        self._loop_goal = ""
         #: While a held goal loop is running, the per-turn completion toast that
         #: the `TurnEnded` handler fires on every clean turn is SUPPRESSED — the
         #: loop owns a single release toast fired only when the judge says the
@@ -2265,12 +2289,12 @@ class OperatorApp(App[None]):
         #: worker's `finally`; a stuck-True flag would mute completions for the
         #: rest of the process (and across sessions), so that reset is
         #: load-bearing, never best-effort.
-        self._loop_suppress_completion: bool = False
+        self._loop_suppress_completion = False
         #: AbortSignal for the in-flight bang-mode command, if any. Owned by
         #: the app rather than the session because bang-mode is a TUI gesture
         #: — the session's abort stops a TURN, and a user-typed `sleep 30`
         #: is not one. Esc/Ctrl+C abort this the same way they abort a turn.
-        self._shell_signal: Any = None
+        self._shell_signal = None
         #: The ToolCard currently painting a bang-mode run, so a second
         #: submit cannot start another command over a live one (omp refuses
         #: a second bash while one is running) and so Esc can mark it
@@ -2279,7 +2303,7 @@ class OperatorApp(App[None]):
         #: Textual worker owning the command above. Kept separately from the
         #: card/signal so a session swap can abort and AWAIT process reaping
         #: before disposing the session captured by the worker.
-        self._shell_worker: Any = None
+        self._shell_worker = None
         # The one pending tool-approval prompt, if any. The TUI owns approvals
         # (see widgets/approval.py) because the default stdin gate deadlocks
         # under a full-screen app; `_approve_all` is the session-scoped "allow
@@ -2356,7 +2380,7 @@ class OperatorApp(App[None]):
         # the epoch a stop/teardown armed the deny latch in. An asker captures the
         # epoch it entered in and denies if the latch covers that epoch, so a
         # `TurnStarted` racing the wake cannot un-deny a stopped turn's tools.
-        self._turn_epoch: int = 0
+        self._turn_epoch = 0
         self._approvals_denied_epoch: int | None = None
         # Tool cards the last turn boundary marked interrupted. Read once, by
         # `on_turn_ended`, to decide whether an abort still owes the user a
@@ -2495,6 +2519,741 @@ class OperatorApp(App[None]):
         # probing an unfamiliar key four times got four warning rows, which is
         # the transcript noise the key's silence exists to avoid.
         self._effort_refusal_shown: str | None = None
+        self._session_sidebar = SessionSidebar()
+        self._sidebar_settings = SidebarSettings()
+        self._sidebar_timer: Timer | None = None
+        self._sidebar_refresh_generation = 0
+        self._sidebar_refresh_pending = False
+        self._sidebar_prefetch: Any = None
+        self._sidebar_focus_restore: Widget | None = None
+        self._sidebar_presentations: dict[str, SessionPresentation] = {}
+        self._sidebar_sources: dict[str, SessionInteraction] = {}
+        self._sidebar_drafts = SessionDraftStore()
+        self._sidebar_navigation = SessionNavigation(
+            prepare=self._prepare_sidebar_session,
+            commit=self._commit_sidebar_session,
+            release=self._release_sidebar_preparation,
+            pending=self._sidebar_navigation_pending,
+            failed=self._sidebar_navigation_failed,
+        )
+
+    # UI accessors address the current source; workers capture the context
+    # before scheduling and never use these aliases after yielding.
+    @property
+    def _turn_provider_lock(self) -> asyncio.Lock:
+        return self._interaction.turn.provider_lock
+
+    @_turn_provider_lock.setter
+    def _turn_provider_lock(self, value: asyncio.Lock) -> None:
+        self._interaction.turn.provider_lock = value
+
+    @property
+    def _turn_epoch(self) -> int:
+        return self._interaction.turn.epoch
+
+    @_turn_epoch.setter
+    def _turn_epoch(self, value: int) -> None:
+        self._interaction.turn.epoch = value
+
+    @property
+    def _turn_open(self) -> bool:
+        return self._interaction.turn.open
+
+    @_turn_open.setter
+    def _turn_open(self, value: bool) -> None:
+        self._interaction.turn.open = value
+
+    @property
+    def _turn_notified(self) -> bool:
+        return self._interaction.turn.notified
+
+    @_turn_notified.setter
+    def _turn_notified(self, value: bool) -> None:
+        self._interaction.turn.notified = value
+
+    @property
+    def _turn_accrued_cost(self) -> float:
+        return self._interaction.turn.accrued_cost
+
+    @_turn_accrued_cost.setter
+    def _turn_accrued_cost(self, value: float) -> None:
+        self._interaction.turn.accrued_cost = value
+
+    @property
+    def _pending_user_echoes(self) -> list[_PendingUserEcho]:
+        return self._interaction.turn.pending_echoes
+
+    @_pending_user_echoes.setter
+    def _pending_user_echoes(self, value: list[_PendingUserEcho]) -> None:
+        self._interaction.turn.pending_echoes = value
+
+    @property
+    def _loop_running(self) -> bool:
+        return self._interaction.loop.running
+
+    @_loop_running.setter
+    def _loop_running(self, value: bool) -> None:
+        self._interaction.loop.running = value
+
+    @property
+    def _loop_cancelled(self) -> bool:
+        return self._interaction.loop.cancelled
+
+    @_loop_cancelled.setter
+    def _loop_cancelled(self, value: bool) -> None:
+        self._interaction.loop.cancelled = value
+
+    @property
+    def _loop_goal(self) -> str:
+        return self._interaction.loop.goal
+
+    @_loop_goal.setter
+    def _loop_goal(self, value: str) -> None:
+        self._interaction.loop.goal = value
+
+    @property
+    def _loop_suppress_completion(self) -> bool:
+        return self._interaction.loop.suppress_completion
+
+    @_loop_suppress_completion.setter
+    def _loop_suppress_completion(self, value: bool) -> None:
+        self._interaction.loop.suppress_completion = value
+
+    @property
+    def _shell_signal(self) -> Any:
+        return self._interaction.shell.signal
+
+    @_shell_signal.setter
+    def _shell_signal(self, value: Any) -> None:
+        self._interaction.shell.signal = value
+
+    @property
+    def _shell_worker(self) -> Any:
+        return self._interaction.shell.worker
+
+    @_shell_worker.setter
+    def _shell_worker(self, value: Any) -> None:
+        self._interaction.shell.worker = value
+
+    @property
+    def _compacting(self) -> bool:
+        return self._interaction.compaction.active
+
+    @_compacting.setter
+    def _compacting(self, value: bool) -> None:
+        self._interaction.compaction.active = value
+
+    @property
+    def _prompt_held_for_compaction(self) -> str:
+        return self._interaction.compaction.held_prompt
+
+    @_prompt_held_for_compaction.setter
+    def _prompt_held_for_compaction(self, value: str) -> None:
+        self._interaction.compaction.held_prompt = value
+
+    @property
+    def _typed_held_for_compaction(self) -> str:
+        return self._interaction.compaction.held_typed
+
+    @_typed_held_for_compaction.setter
+    def _typed_held_for_compaction(self, value: str) -> None:
+        self._interaction.compaction.held_typed = value
+
+    @property
+    def _images_held_for_compaction(self) -> dict[int, Marked]:
+        return self._interaction.compaction.held_images
+
+    @_images_held_for_compaction.setter
+    def _images_held_for_compaction(self, value: dict[int, Marked]) -> None:
+        self._interaction.compaction.held_images = value
+
+    @property
+    def _total_cost(self) -> float:
+        return self._interaction.accounting.total
+
+    @_total_cost.setter
+    def _total_cost(self, value: float) -> None:
+        self._interaction.accounting.total = value
+
+    @property
+    def _subagent_costs(self) -> dict[str, float]:
+        return self._interaction.accounting.child_costs
+
+    @_subagent_costs.setter
+    def _subagent_costs(self, value: dict[str, float]) -> None:
+        self._interaction.accounting.child_costs = value
+
+    @property
+    def _spend_is_floor(self) -> bool:
+        return self._interaction.accounting.is_floor
+
+    @_spend_is_floor.setter
+    def _spend_is_floor(self, value: bool) -> None:
+        self._interaction.accounting.is_floor = value
+
+    async def _on_message(self, message: TextualMessage) -> None:
+        if isinstance(message, SessionEvent) and message.origin is not None:
+            source = self._event_sources.get(message.origin)
+            if source is not None:
+                source.presentation_revision += 1
+                if not self._is_current(source):
+                    self._reduce_hidden_session_event(source, message)
+                    return
+        if (
+            isinstance(message, SessionEvent)
+            and message.origin is not None
+            and message.origin is not self._controller
+            and not (
+                isinstance(message, SteeringDelivered)
+                and message.origin in self._superseded_steer_controllers
+            )
+        ):
+            # The queue outlives subscriptions. Late source events must never
+            # mutate the newly committed transcript, prompts or status band.
+            return
+        await super()._on_message(message)
+
+    def _reduce_hidden_session_event(
+        self, source: SessionInteraction, message: SessionEvent
+    ) -> None:
+        # Hiding a view is not cancelling its work. In particular, accepted
+        # input held during compaction still owes delivery to its source.
+        if isinstance(message, TurnStarted):
+            source.turn.epoch += 1
+            source.turn.open = True
+            source.turn.notified = False
+        elif isinstance(message, TurnEnded):
+            source.turn.open = False
+            source.turn.notified = True
+        elif isinstance(message, TurnAbandoned):
+            if message.epoch == source.turn.epoch and not bool(
+                getattr(source.session, "is_streaming", False)
+            ):
+                source.turn.open = False
+        elif isinstance(message, CompactionStarted):
+            source.compaction.active = True
+        elif isinstance(message, CompactionEnded):
+            source.compaction.active = False
+            self._consume_compaction_input(source)
+
+    def _consume_compaction_input(self, source: SessionInteraction) -> None:
+        held, source.compaction.held_prompt = source.compaction.held_prompt, ""
+        typed, source.compaction.held_typed = source.compaction.held_typed, ""
+        images, source.compaction.held_images = source.compaction.held_images, {}
+        accepted, source.compaction.accepted_draft = source.compaction.accepted_draft, None
+        if held or images:
+            self._start_turn_for(
+                source, held, resolve_markers(typed or held, images), accepted=accepted
+            )
+
+    def _is_current(self, source: SessionInteraction) -> bool:
+        return self._interaction is source
+
+    def _notice_for(self, source: SessionInteraction, text: str, kind: Any = "info") -> None:
+        if self._is_current(source):
+            self._notice(text, kind)
+        else:
+            # Canonical history owns durable output. This bounded fallback is
+            # only for frontend failures that never reached an owner journal.
+            source.notices.append((text, kind))
+            del source.notices[:-64]
+
+    def _restore_unsent_for(
+        self,
+        source: SessionInteraction,
+        text: str,
+        images: list[ImageContent] | None,
+        *,
+        accepted: SessionDraft | None = None,
+    ) -> None:
+        restored = accepted or SessionDraft(text=text)
+        if self._is_current(source):
+            editor = self._editor()
+            if not editor.text.strip():
+                editor.forget_prompt(text)
+                editor.load_text(restored.text)
+                editor.adopt_attachments(restored.attachments)
+        else:
+            source.unsent.append((text, list(images or [])))
+            if not source.draft.text.strip():
+                source.draft = restored
+
+    def _register_user_echo_for(
+        self, source: SessionInteraction, text: str, *, message_id: str = ""
+    ) -> _PendingUserEcho:
+        entry = _PendingUserEcho(message_id, text)
+        source.turn.pending_echoes.append(entry)
+        return entry
+
+    def _discard_user_echo_for(self, source: SessionInteraction, entry: _PendingUserEcho) -> None:
+        source.turn.pending_echoes[:] = [
+            held for held in source.turn.pending_echoes if held is not entry
+        ]
+
+    def _post_turn_abandoned_for(
+        self, source: SessionInteraction, *, aborted: bool, error: str | None
+    ) -> None:
+        message = TurnAbandoned(
+            source.turn.epoch,
+            aborted=aborted,
+            error=error,
+            outcome_known=not bool(getattr(source.session, "is_remote", False)),
+        )
+        message.origin = source.controller
+        self.post_message(message)
+
+    def _capture_sidebar_presentation(self) -> SessionPresentation:
+        replay = PreparedReplay(
+            view=self._transcript_view(),
+            _resume_results=self._resume_results,
+            _resume_pending_head=self._resume_pending_head,
+            _resume_pending_tail=self._resume_pending_tail,
+            _resume_tail_notice=self._resume_tail_notice,
+            _resume_head_notice=self._resume_head_notice,
+            _resume_mounted_ids=self._resume_mounted_ids,
+            _replay_bang_pending=self._replay_bang_pending,
+            _live_peer_receipts=self._live_peer_receipts,
+            _live_wake_receipts=self._live_wake_receipts,
+        )
+        return SessionPresentation(
+            replay=replay,
+            revision=self._interaction.presentation_revision,
+            streaming_block=self._streaming_block,
+            tool_cards=self._tool_cards,
+            composing_cards=self._composing_cards,
+            working_block=self._working_block,
+            working_fallback=self._working_fallback,
+            compaction_owns_working_block=self._compaction_owns_working_block,
+            shell_card=self._shell_card,
+            queued_steer_notices=self._queued_steer_notices,
+            deferred_steer_notices=self._deferred_steer_notices,
+            held_steer_blocks=self._held_steer_blocks,
+            welcome=self._welcome,
+            welcome_visible=self._welcome_visible,
+        )
+
+    def _apply_sidebar_presentation(self, presentation: SessionPresentation) -> None:
+        replay = presentation.replay
+        self._transcript = replay.view
+        self._resume_results = replay._resume_results
+        self._resume_pending_head = replay._resume_pending_head
+        self._resume_pending_tail = replay._resume_pending_tail
+        self._resume_tail_notice = replay._resume_tail_notice
+        self._resume_tail_paging = False
+        self._resume_head_notice = replay._resume_head_notice
+        self._resume_mounted_ids = replay._resume_mounted_ids
+        self._replay_bang_pending = replay._replay_bang_pending
+        self._live_peer_receipts = replay._live_peer_receipts
+        self._live_wake_receipts = replay._live_wake_receipts
+        self._streaming_block = presentation.streaming_block
+        self._tool_cards = presentation.tool_cards
+        self._composing_cards = presentation.composing_cards
+        self._working_block = presentation.working_block
+        self._working_fallback = presentation.working_fallback
+        self._compaction_owns_working_block = presentation.compaction_owns_working_block
+        self._shell_card = presentation.shell_card
+        self._queued_steer_notices = presentation.queued_steer_notices
+        self._deferred_steer_notices = presentation.deferred_steer_notices
+        self._held_steer_blocks = presentation.held_steer_blocks
+        self._welcome = presentation.welcome
+        self._welcome_visible = presentation.welcome_visible
+        # Gesture tasks belong to the abandoned viewport, not its history.
+        self._resume_paging = False
+        self._resume_check_pending = False
+        self._resume_in_zone = False
+        self._stop_offered_at = None
+        self._stop_offer_count = 0
+        self._stop_notice = None
+        self._stop_all_armed_at = None
+        self._stop_all_listing = None
+        self._exit_hint = None
+        self._superseded_steer_controllers.clear()
+
+    async def _prepare_sidebar_session(
+        self, session_id: str
+    ) -> tuple[SessionInteraction, SessionPresentation]:
+        from local_operator.mobile.attach_client import find_owner_record
+        from local_operator.paths import config_dir
+        from local_operator.session.remote import RemoteSession
+
+        if self._session is not None and self._session.session_id == session_id:
+            return self._interaction, self._capture_sidebar_presentation()
+        source = self._sidebar_sources.get(session_id)
+        if source is None:
+            directory = config_dir()
+            record, owner = await asyncio.to_thread(find_owner_record, directory, session_id)
+            if record is not None and record.protocol < 4:
+                raise RuntimeError("Update the older Local Operator session before opening it here")
+
+            async def takeover() -> Any:
+                if self._resume_factory is None:
+                    raise RuntimeError("This launcher cannot reopen an inactive conversation")
+                return await self._resume_factory(session_id)
+
+            if record is not None and owner is not None:
+                remote = await RemoteSession.connect(
+                    record, session_id, config_dir=directory, takeover_factory=takeover
+                )
+            else:
+                remote = await takeover()
+                if not isinstance(remote, RemoteSession):
+                    raise RuntimeError("Sidebar navigation requires an owner-backed session")
+                await remote._ensure_bound()
+            source = SessionInteraction(remote)
+            source.draft = await self._sidebar_drafts.get(session_id)
+            self._interactions[id(remote)] = source
+            self._sidebar_sources[session_id] = source
+            source.controller = EventController(remote, self)
+            self._event_sources[source.controller] = source
+            source.controller.subscribe()
+        session = source.session
+        if not isinstance(session, RemoteSession):
+            raise RuntimeError("Sidebar navigation requires an owner-backed session")
+        if session.is_cold:
+            await session._ensure_bound()
+        if session.is_cold:
+            raise RuntimeError("The conversation has not finished connecting")
+        cached = self._sidebar_presentations.get(session_id)
+        if cached is not None and cached.revision == source.presentation_revision:
+            if not source.draft.following_tail and source.draft.scroll_anchor_id:
+                cached.replay.view.restore_navigation_anchor(source.draft.scroll_anchor_id, source.draft.scroll_anchor_part, source.draft.scroll_offset)
+            return source, cached
+        replay = PreparedReplay()
+        source.preparations += 1
+        revision = source.presentation_revision
+        try:
+            replay.prepare(
+                list(session.history()), bound=max(12, self.size.height // 2),
+                anchor_id=source.draft.scroll_anchor_id if not source.draft.following_tail else "",
+            )
+            replay.view.styles.layer = "session-cache"
+            replay.view.styles.visibility = "hidden"
+            replay.view.styles.height = self._transcript_view().outer_size.height
+            conversation = self.query_one("#session-conversation")
+            conversation.styles.layers = "default session-cache"
+            await conversation.mount(replay.view)
+            with replay.view.batch_append():
+                for block in replay.blocks:
+                    replay.view.append_block(block)
+            replay.view.follow_tail()
+            # Preparation waits for layout, not for a guessed sleep. The commit
+            # can then reveal already measured rows without replaying history.
+            laid_out = asyncio.Event()
+            self.call_after_refresh(laid_out.set)
+            await laid_out.wait()
+            if not source.draft.following_tail and source.draft.scroll_anchor_id:
+                replay.view.restore_navigation_anchor(source.draft.scroll_anchor_id, source.draft.scroll_anchor_part, source.draft.scroll_offset)
+            return source, SessionPresentation(
+                replay, revision=revision, working_fallback=DEFAULT_ACTIVITY
+            )
+        except BaseException:
+            if replay.view.is_mounted:
+                await replay.view.remove()
+            if (
+                source.preparations == 1
+                and not source.must_retain
+                and source is not self._interaction
+                and session_id not in self._sidebar_presentations
+            ):
+                source.controller.dispose()
+                self._event_sources.pop(source.controller, None)
+                self._sidebar_sources.pop(session_id, None)
+                self._interactions.pop(id(session), None)
+                await session.dispose()
+            raise
+        finally:
+            source.preparations -= 1
+
+    def _sidebar_navigation_pending(self, session_id: str) -> None:
+        from local_operator.session.remote import RemoteSession
+
+        current = self._session
+        if isinstance(current, RemoteSession):
+            if session_id:
+                current.suspend_viewer_gates()
+            else:
+                current.resume_viewer_gates()
+        self._session_transition_pending = bool(session_id)
+        self._session_sidebar.requested_id = session_id
+        self._session_sidebar.refresh()
+
+    def _sidebar_navigation_failed(self, session_id: str, error: Exception) -> None:
+        self._session_sidebar.show_error(str(error))
+        self._system_notice(f"Could not open conversation: {error}", "warning")
+
+    async def _release_sidebar_preparation(
+        self, prepared: tuple[SessionInteraction, SessionPresentation]
+    ) -> None:
+        source, presentation = prepared
+        if (
+            presentation.replay.view is self._transcript
+            or presentation in self._sidebar_presentations.values()
+        ):
+            return
+        if presentation.replay.view.is_mounted:
+            await presentation.replay.view.remove()
+        # Detaching this speculative viewer never stops its runtime. A source
+        # with accepted input or executing work retains its facade separately.
+        if (
+            source is not self._interaction
+            and not source.must_retain
+            and not source.preparations
+            and source.session is not None
+        ):
+            if source.controller is not None:
+                source.controller.dispose()
+                self._event_sources.pop(source.controller, None)
+            try:
+                await self._sidebar_drafts.put(
+                    source.session.session_id,
+                    replace(source.draft, attachments=dict(source.draft.attachments)),
+                )
+            except OSError:
+                self._system_notice(
+                    "Could not save the draft to disk; it is still kept in memory", "warning"
+                )
+                return
+            # Saving overflow yields to disk. A rapid return may have acquired
+            # this same facade meanwhile, so recheck ownership before closing.
+            if (
+                source is self._interaction
+                or source.preparations
+                or source.session.session_id in self._sidebar_presentations
+            ):
+                return
+            self._sidebar_sources.pop(source.session.session_id, None)
+            self._interactions.pop(id(source.session), None)
+            await source.session.dispose()
+
+    def _commit_sidebar_session(
+        self,
+        session_id: str,
+        prepared: tuple[SessionInteraction, SessionPresentation],
+        generation: int,
+    ) -> None:
+        from local_operator.session.remote import RemoteSession
+
+        source, incoming = prepared
+        session = source.session
+        if session is None or session.session_id != session_id:
+            raise RuntimeError("The prepared conversation identity changed")
+        if source is self._interaction:
+            return
+        if not isinstance(session, RemoteSession) or session.is_cold:
+            raise RuntimeError("The conversation is not ready for input")
+        outgoing = self._interaction
+        previous = outgoing.session
+        if previous is not None and not isinstance(previous, RemoteSession):
+            raise RuntimeError("Sidebar navigation requires an owner-backed current session")
+        editor = self._editor()
+        outgoing.draft.text = editor.text
+        outgoing.draft.attachments = editor.attachments()
+        outgoing.draft.selection = editor.selection
+        outgoing.draft.shell_mode = editor.shell_mode
+        old_view = self._transcript_view()
+        outgoing.draft.following_tail = old_view.is_following_tail
+        if not outgoing.draft.following_tail:
+            top = old_view.content_region.y
+            anchor = next((block for block in old_view.blocks() if block.navigation_anchor_id and block.display and block.region.bottom > top), None)
+            if anchor is not None:
+                outgoing.draft.scroll_anchor_id = anchor.navigation_anchor_id
+                outgoing.draft.scroll_anchor_part = anchor.navigation_anchor_part
+                outgoing.draft.scroll_offset = top - anchor.region.y
+        if previous is not None:
+            self._sidebar_sources[previous.session_id] = outgoing
+            self._sidebar_presentations[previous.session_id] = self._capture_sidebar_presentation()
+        if isinstance(previous, RemoteSession):
+            previous.suspend_viewer_gates()
+        self._deny_queued_approvals()
+        self._settle_ask_picker()
+        self._settle_key_prompt()
+        self._approval = None
+        old_view = self._transcript_view()
+        old_view.set_on_user_scroll(None)
+        old_view.set_on_tail_requested(None)
+        old_view.set_on_clear(None)
+        old_view.styles.layer = "session-cache"
+        old_view.styles.visibility = "hidden"
+        old_view.styles.height = old_view.outer_size.height
+        displaced = self._sidebar_presentations.pop(session_id, None)
+        self._apply_sidebar_presentation(incoming)
+        incoming.replay.view.styles.layer = "default"
+        incoming.replay.view.styles.visibility = "visible"
+        incoming.replay.view.styles.height = "1fr"
+        incoming.replay.view.set_on_clear(self._on_transcript_cleared)
+        incoming.replay.view.set_on_user_scroll(self._transcript_scrolled)
+        incoming.replay.view.set_on_tail_requested(self._jump_newer_resume_tail)
+        self._swapping_session = True
+        try:
+            self._adopt_session(session, replay_history=False, reuse_controller=True)
+            editor.load_text(source.draft.text)
+            editor.adopt_attachments(source.draft.attachments)
+            editor.set_shell_mode(source.draft.shell_mode)
+            if source.draft.selection is not None:
+                editor.selection = source.draft.selection
+            session.resume_viewer_gates()
+            self._session_sidebar.current_id = session_id
+            self._session_sidebar.refresh()
+            self._set_welcome_visible(False)
+            if source.draft.focus_id == "@transcript":
+                incoming.replay.view.focus()
+            else:
+                editor.focus()
+        finally:
+            self._swapping_session = False
+        if displaced is not None and displaced is not incoming:
+            self.run_worker(self._release_sidebar_preparation((source, displaced)))
+        # Active + one retained presentation. Executing contexts stay alive
+        # without retaining their widgets, and drafts remain source-owned.
+        while len(self._sidebar_presentations) > 1:
+            evicted_id = next(iter(self._sidebar_presentations))
+            evicted = self._sidebar_presentations.pop(evicted_id)
+            self.run_worker(
+                self._release_sidebar_preparation((self._sidebar_sources[evicted_id], evicted))
+            )
+
+    def on_session_sidebar_selected(self, message: SessionSidebar.Selected) -> None:
+        message.stop()
+        if self._session is not None and self._session.session_id == message.session_id:
+            if self._sidebar_navigation.requested_id:
+                self._sidebar_navigation.cancel()
+            self._editor().focus()
+            return
+        if self._session_transition_pending and not self._sidebar_navigation.requested_id:
+            self.workers.cancel_group(self, "session")
+        self._sidebar_navigation.select(message.session_id)
+
+    def _apply_sidebar_settings(self) -> None:
+        self._sidebar_settings = SidebarSettings.from_values(self._config_values())
+        self._set_sidebar_open(self._sidebar_settings.visible)
+
+    def action_toggle_sidebar(self) -> None:
+        self._set_sidebar_open(not self._session_sidebar.display)
+
+    def _set_sidebar_open(self, opened: bool) -> None:
+        sidebar = self._session_sidebar
+        if opened and not sidebar.display:
+            self._sidebar_focus_restore = self.focused
+        sidebar.set_open(opened)
+        self._sync_sidebar_layout(self.size)
+        if self._sidebar_timer is not None:
+            if opened:
+                self._sidebar_timer.resume()
+                self._refresh_sidebar()
+            else:
+                self._sidebar_timer.pause()
+                # Late off-loop reads are harmless, but must not repaint or
+                # restart work after the user reclaimed the full-width view.
+                self._sidebar_refresh_generation += 1
+                if self._sidebar_prefetch is not None:
+                    self._sidebar_prefetch.cancel()
+                retained, self._sidebar_presentations = self._sidebar_presentations, {}
+                for session_id, presentation in retained.items():
+                    source = self._sidebar_sources.get(session_id)
+                    if source is not None:
+                        self.run_worker(self._release_sidebar_preparation((source, presentation)))
+        if not opened and sidebar.has_focus:
+            target = self._sidebar_focus_restore
+            if target is not None and target.is_mounted:
+                target.focus()
+            else:
+                self._editor().focus()
+
+    def _sync_sidebar_layout(self, size: Size) -> None:
+        sidebar = self._session_sidebar
+        if not sidebar.is_mounted:
+            return
+        narrow = size.width < SIDEBAR_WIDTH + SIDEBAR_MAIN_MIN_WIDTH + 2
+        workspace = self.query_one("#session-workspace")
+        workspace.set_class(narrow, "sidebar-overlay")
+        sidebar.styles.dock = self._sidebar_settings.position
+        sidebar.styles.width = min(SIDEBAR_WIDTH, max(16, size.width - 2))
+        if narrow:
+            # The small-screen list floats over the transcript, never over the
+            # composer or a pending prompt. The conversation retains its width.
+            dock = self.query_one("#input-dock")
+            sidebar.styles.height = max(3, size.height - dock.outer_size.height - 2)
+        else:
+            sidebar.styles.height = "1fr"
+
+    def _refresh_sidebar(self) -> None:
+        if not self._session_sidebar.display or self._sidebar_refresh_pending:
+            return
+        self._sidebar_refresh_generation += 1
+        generation = self._sidebar_refresh_generation
+        self._sidebar_refresh_pending = True
+
+        def collect() -> list[CatalogEntry]:
+            from local_operator.paths import config_dir
+            from local_operator.resume import recent_session_rows
+
+            rows = self._overlay_live_state(recent_session_rows(config_dir(), limit=None))
+            return [CatalogEntry(row) for row in rows]
+
+        async def refresh() -> None:
+            try:
+                entries = await asyncio.to_thread(collect)
+                if (
+                    generation != self._sidebar_refresh_generation
+                    or not self._session_sidebar.display
+                ):
+                    return
+                session = self._session
+                self._session_sidebar.current_id = str(getattr(session, "session_id", ""))
+                self._session_sidebar.set_entries(entries)
+                self._prewarm_sidebar(entries)
+            except Exception:
+                if generation == self._sidebar_refresh_generation and self._session_sidebar.display:
+                    self._session_sidebar.show_error("Could not refresh conversations")
+                logger.debug("sidebar catalog refresh failed", exc_info=True)
+            finally:
+                self._sidebar_refresh_pending = False
+
+        self.run_worker(refresh(), group="sidebar-catalog")
+
+    def _prewarm_sidebar(self, entries: list[CatalogEntry]) -> None:
+        if (
+            not self._session_sidebar.display
+            or self._sidebar_prefetch is not None
+            or self._sidebar_presentations
+            or self._sidebar_navigation.requested_id
+        ):
+            return
+        current = str(getattr(self._session, "session_id", ""))
+        candidate = next(
+            (entry for entry in entries if entry.id != current and entry.row.live_state), None
+        )
+        if candidate is None:
+            return
+
+        async def prepare() -> None:
+            prepared = None
+            try:
+                prepared = await self._prepare_sidebar_session(candidate.id)
+                if (
+                    self._session_sidebar.display
+                    and not self._sidebar_navigation.requested_id
+                    and not self._sidebar_presentations
+                    and candidate.id != str(getattr(self._session, "session_id", ""))
+                ):
+                    self._sidebar_presentations[candidate.id] = prepared[1]
+                    prepared = None
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # Speculation never overwrites a usable catalog with an error.
+                # An explicit selection reports the same failure normally.
+                logger.debug("sidebar prewarm failed", exc_info=True)
+            finally:
+                if prepared is not None:
+                    await self._release_sidebar_preparation(prepared)
+                self._sidebar_prefetch = None
+
+        self._sidebar_prefetch = self.run_worker(prepare(), group="sidebar-prefetch")
+
+    def on_session_sidebar_dismissed(self, message: SessionSidebar.Dismissed) -> None:
+        message.stop()
+        self._set_sidebar_open(False)
 
     # -- composition --------------------------------------------------------
     def get_default_screen(self) -> Screen[None]:
@@ -2511,87 +3270,90 @@ class OperatorApp(App[None]):
         return TranscriptScreen(id="_default")
 
     def compose(self) -> ComposeResult:
-        # The welcome splash is the transcript's EMPTY STATE, so it is mounted
-        # INSIDE the transcript rather than beside it: that hands it exactly the
-        # region above the input panel with no arithmetic here. It supersedes the
-        # old D9 boot-hint line, which was a real transcript block and would have
-        # hidden the splash on mount.
-        self._transcript = TranscriptView(id="transcript")
-        with self._transcript:
-            yield WelcomeView(
-                lambda: session_welcome_info(
-                    self._session,
-                    self._providers,
-                    notice=self._splash_notice,
-                    setup=self._setup_state,
-                    update_available=self._update_available,
-                )
-            )
-        # The dock band: subagent task list + todo list, sitting between the
-        # transcript and the composer. It is a transparent POSITIONER (zero own
-        # height when empty) holding one filled body per panel; the two panels
-        # each manage their own `display` so the band collapses to nothing when
-        # neither has content. Holding a ref lets the 1 Hz poll and the
-        # Subagent*/tool-end handlers repaint it without a relookup per tick.
-        self._subagent_panel = SubagentPanel(on_open=self._open_subagent_view)
-        self._wake_panel = WakePanel()
-        self._todo_panel = TodoPanel()
-        # Two containers for one panel: the dock is the docked POSITIONER, and
-        # the shell is the panel the user sees — the fill, the padding, and the
-        # boot layout's clamp. A docked widget cannot be centred by its parent,
-        # so the clamp has to sit on a child of the dock rather than on the dock
-        # itself; see the tcss.
-        #
-        # The status line IS the input box's last row: the band docks at the
-        # bottom of the shell and carries the structural rule styling, so it can
-        # never be overdrawn or pushed off-screen by the editor, and it travels
-        # with the input when the panel becomes a card. One row does double duty
-        # — zero extra height (D3/D17).
-        with Container(id="input-dock"):
-            # The prompt host: where a question the turn is PARKED ON lives.
-            #
-            # Above the band and inside the dock, and both halves of that are
-            # deliberate. Inside the dock, because a question anchored to the
-            # composer stays put while the user scrolls the transcript back to
-            # find what they need to answer it — the whole point of moving these
-            # surfaces out of `ModalScreen`, which covered the conversation it
-            # was asking about. Above the band, because the band is STATUS
-            # (subagent jobs, todos) and this is a BLOCKER: the thing being
-            # waited on belongs closest to the composer, and a status list that
-            # grew and shrank underneath the question would shift it under the
-            # user's cursor mid-answer.
-            #
-            # Zero rows when empty, like the band: a transparent positioner
-            # holding at most one prompt. Mounted once and kept, so a question
-            # never has to await a mount before it can be shown.
-            yield Container(id="prompt-host")
-            # The dock band (subagent + todo) lives INSIDE the same bottom-docked
-            # container as the input shell, ABOVE it (D-15-01). A sibling
-            # `dock: bottom` overlapped the input (Textual anchors same-edge
-            # docks to the bottom edge independently), and a margin to fix that
-            # violates the sheet's one-margin rule. As a child here, the band is
-            # a normal-flow row the dock's vertical layout reserves before the
-            # shell; it collapses to zero when both panels are hidden.
-            with Container(id="band"):
-                yield self._subagent_panel
-                yield self._wake_panel
-                yield self._todo_panel
-            with Container(id="input-shell"):
-                yield Band(id="status-band")
-                editor = Editor(commands=SLASH_COMMANDS)
-                with Horizontal(id="input-row"):
-                    yield Chrome(PROMPT_CHEVRON, id="prompt-chevron")
-                    yield editor
-                # The picker is the editor's, but it cannot be the editor's
-                # CHILD: it has to draw across the full panel width, outside the
-                # chevron row. Mounted here it lands between the input row and
-                # the bottom-docked status band — under the text it completes,
-                # above the footer — and it claims zero rows while closed.
-                yield editor.picker
-                # Same placement rule, same reason. The two are mutually
-                # exclusive — the buffer parse that opens one closes the other —
-                # so they can share the row band without ever competing for it.
-                yield editor.model_picker
+        with Horizontal(id="session-workspace"):
+            yield self._session_sidebar
+            with Container(id="session-conversation"):
+                # The welcome splash is the transcript's EMPTY STATE, so it is mounted
+                # INSIDE the transcript rather than beside it: that hands it exactly the
+                # region above the input panel with no arithmetic here. It supersedes the
+                # old D9 boot-hint line, which was a real transcript block and would have
+                # hidden the splash on mount.
+                self._transcript = TranscriptView(id="transcript")
+                with self._transcript:
+                    yield WelcomeView(
+                        lambda: session_welcome_info(
+                            self._session,
+                            self._providers,
+                            notice=self._splash_notice,
+                            setup=self._setup_state,
+                            update_available=self._update_available,
+                        )
+                    )
+                # The dock band: subagent task list + todo list, sitting between the
+                # transcript and the composer. It is a transparent POSITIONER (zero own
+                # height when empty) holding one filled body per panel; the two panels
+                # each manage their own `display` so the band collapses to nothing when
+                # neither has content. Holding a ref lets the 1 Hz poll and the
+                # Subagent*/tool-end handlers repaint it without a relookup per tick.
+                self._subagent_panel = SubagentPanel(on_open=self._open_subagent_view)
+                self._wake_panel = WakePanel()
+                self._todo_panel = TodoPanel()
+                # Two containers for one panel: the dock is the docked POSITIONER, and
+                # the shell is the panel the user sees — the fill, the padding, and the
+                # boot layout's clamp. A docked widget cannot be centred by its parent,
+                # so the clamp has to sit on a child of the dock rather than on the dock
+                # itself; see the tcss.
+                #
+                # The status line IS the input box's last row: the band docks at the
+                # bottom of the shell and carries the structural rule styling, so it can
+                # never be overdrawn or pushed off-screen by the editor, and it travels
+                # with the input when the panel becomes a card. One row does double duty
+                # — zero extra height (D3/D17).
+                with Container(id="input-dock"):
+                    # The prompt host: where a question the turn is PARKED ON lives.
+                    #
+                    # Above the band and inside the dock, and both halves of that are
+                    # deliberate. Inside the dock, because a question anchored to the
+                    # composer stays put while the user scrolls the transcript back to
+                    # find what they need to answer it — the whole point of moving these
+                    # surfaces out of `ModalScreen`, which covered the conversation it
+                    # was asking about. Above the band, because the band is STATUS
+                    # (subagent jobs, todos) and this is a BLOCKER: the thing being
+                    # waited on belongs closest to the composer, and a status list that
+                    # grew and shrank underneath the question would shift it under the
+                    # user's cursor mid-answer.
+                    #
+                    # Zero rows when empty, like the band: a transparent positioner
+                    # holding at most one prompt. Mounted once and kept, so a question
+                    # never has to await a mount before it can be shown.
+                    yield Container(id="prompt-host")
+                    # The dock band (subagent + todo) lives INSIDE the same bottom-docked
+                    # container as the input shell, ABOVE it (D-15-01). A sibling
+                    # `dock: bottom` overlapped the input (Textual anchors same-edge
+                    # docks to the bottom edge independently), and a margin to fix that
+                    # violates the sheet's one-margin rule. As a child here, the band is
+                    # a normal-flow row the dock's vertical layout reserves before the
+                    # shell; it collapses to zero when both panels are hidden.
+                    with Container(id="band"):
+                        yield self._subagent_panel
+                        yield self._wake_panel
+                        yield self._todo_panel
+                    with Container(id="input-shell"):
+                        yield Band(id="status-band")
+                        editor = Editor(commands=SLASH_COMMANDS)
+                        with Horizontal(id="input-row"):
+                            yield Chrome(PROMPT_CHEVRON, id="prompt-chevron")
+                            yield editor
+                        # The picker is the editor's, but it cannot be the editor's
+                        # CHILD: it has to draw across the full panel width, outside the
+                        # chevron row. Mounted here it lands between the input row and
+                        # the bottom-docked status band — under the text it completes,
+                        # above the footer — and it claims zero rows while closed.
+                        yield editor.picker
+                        # Same placement rule, same reason. The two are mutually
+                        # exclusive — the buffer parse that opens one closes the other —
+                        # so they can share the row band without ever competing for it.
+                        yield editor.model_picker
         # The toast slot lives on its own CSS layer (see the tcss), so it
         # overlays the transcript's top-right corner without taking a row from
         # it. Mounted once and kept: showing a message never has to await a
@@ -2624,6 +3386,8 @@ class OperatorApp(App[None]):
     # -- lifecycle ----------------------------------------------------------
     async def on_mount(self) -> None:
         install_markdown_theme()
+        self._sidebar_timer = self.set_interval(2.0, self._refresh_sidebar, pause=True)
+        self._apply_sidebar_settings()
         try:
             self.console.push_theme(brand_markdown_theme())  # D1 markdown ramp
             self._markdown_theme_pushed = True
@@ -2747,7 +3511,9 @@ class OperatorApp(App[None]):
             await self._warm_session_imports()
         return await self._session_factory()
 
-    def _adopt_session(self, session: Any) -> None:
+    def _adopt_session(
+        self, session: Any, *, replay_history: bool = True, reuse_controller: bool = False
+    ) -> None:
         """Take ``session`` as the app's, and put its history on screen.
 
         SYNCHRONOUS end to end, and that is load-bearing rather than incidental:
@@ -2760,6 +3526,11 @@ class OperatorApp(App[None]):
         :meth:`_measure_preloaded_context` already puts its measurement in one.
         """
         self._invalidate_pending_frontend_state()
+        source = self._interactions.get(id(session))
+        if source is None:
+            source = SessionInteraction(session)
+            self._interactions[id(session)] = source
+        self._interaction = source
         self._session = session
         # The latch belongs to the BINDING, not to the app: a swapped-in
         # session is cold again and owes its own engage. Its declaration has
@@ -2875,8 +3646,13 @@ class OperatorApp(App[None]):
         session.set_approval_handler(self._request_tool_approval_on_app_loop)
         # Installing this hook is what makes the ask tool exist for a UI host.
         session.set_ask_handler(self._request_user_choice_on_app_loop)
-        self._controller = EventController(session, self)
-        self._controller.subscribe()
+        if reuse_controller and source.controller is not None:
+            self._controller = source.controller
+        else:
+            self._controller = EventController(session, self)
+            self._interaction.controller = self._controller
+            self._event_sources[self._controller] = self._interaction
+            self._controller.subscribe()
         # Beside the event controller because it answers the same question for
         # a different source: the controller renders what the SESSION says, this
         # renders what the CONFIG FILE says (a change from another pane).
@@ -2912,7 +3688,8 @@ class OperatorApp(App[None]):
         )
         self._wire_mcp_status(session)
         self._report_mcp_startup(session)
-        self._render_resumed_history(session)
+        if replay_history:
+            self._render_resumed_history(session)
         # AFTER the replay, and the order is load-bearing (D1). A stale
         # attachment is by definition only reachable on a session that ALREADY
         # RAN, so this notice always lands on a transcript with history. Raised
@@ -3782,6 +4559,8 @@ class OperatorApp(App[None]):
         # into a short session would otherwise page the OLD conversation onto
         # the new transcript the first time the reader scrolled up.
         self._resume_pending_head = []
+        self._resume_pending_tail = []
+        self._resume_tail_notice = None
         self._resume_results = {}
         self._resume_head_notice = None
         self._resume_mounted_ids.clear()
@@ -3795,312 +4574,65 @@ class OperatorApp(App[None]):
         self._project_settled_rows(history, bound=RESUME_RENDER_MESSAGES)
 
     def _project_settled_rows(self, history: list[Any], *, bound: int | None = None) -> bool:
-        """Mount settled transcript rows through the ONE role-aware renderer.
+        from local_operator.tui.session_presentation import project_settled_rows
 
-        The shared history/render seam: cold resume feeds it the whole
-        conversation and a reconnect's durable gap replay
-        (:class:`HistoryRowsSettled`) feeds it exactly the rows no frontend
-        painted. One implementation is the point — the gap replay previously
-        synthesized role-blind assistant events and a recovered user prompt
-        painted as agent speech (review round 3, MAJOR-1/U7/D1). Whatever
-        this method does for ``--resume`` is by construction what a
-        reconnect gap does: user rows as :class:`UserBlock` with images,
-        assistant prose + tool cards paired with results, wake/peer custom
-        rows as their own blocks, refusal/error notices.
+        try:
+            return project_settled_rows(self, history, bound=bound)
+        finally:
+            self._projection_message_id = ""
 
-        Returns whether anything mounted, so callers can skip tail-follow
-        work for an empty projection.
+    def on_history_page_notice_requested(self, message: HistoryPageNotice.Requested) -> None:
+        message.stop()
+        if message.notice is self._resume_tail_notice:
+            self._mount_newer_resume_page()
 
-        ``bound`` renders only the LAST ``bound`` messages and holds the rest
-        for :meth:`_mount_older_resume_page`. It is a display bound and nothing
-        else: the deferred messages stay in ``_resume_pending_head`` in full,
-        and the model's conversation — built from the transcript, not from this
-        projection — never sees the split at all. The gap-replay caller passes
-        no bound, because a reconnect gap is by definition the small set of
-        rows no frontend painted and bounding it could hide one.
-        """
-        # Results are keyed by the call they answer, and a tool message can sit
-        # several messages after its call (one assistant turn issues a batch).
-        # Indexing first is what lets each call render WITH its outcome instead
-        # of as a second, orphaned row.
-        #
-        # Indexed over the WHOLE history, before any bound is applied: a call in
-        # the deferred head is often answered by a result inside the rendered
-        # tail, and a per-page index would show that call as `interrupted`.
-        #
-        # Seeded from the whole-conversation index a bounded resume kept, so a
-        # deferred page's call still finds a result that lives in the already
-        # rendered tail. Empty for every unbounded caller.
-        results: dict[str, Any] = dict(self._resume_results)
-        settled_results: set[str] = set()
-        # Harness chrome the LIVE path never paints as a user row, so replay
-        # must not either (see the `role == "user"` branch). Deferred once to
-        # the top of this method rather than inside the loop, matching the
-        # file's other lazy session.* imports.
-        from local_operator.harness.loop import CONNECTIVITY_CONTINUATION_PROMPT
-        from local_operator.session.session import _CONTINUATION_PROMPT
+    def _jump_newer_resume_tail(self) -> None:
+        if not self._resume_pending_tail:
+            return
+        view = self._transcript_view()
+        notice = self._resume_tail_notice
+        mounted = view.blocks()
+        if notice is not None and mounted and mounted[-1] is not notice:
+            # Live output (or an earlier End) already supplies the true tail.
+            # The middle gap stays reachable without moving it after that tail.
+            return
+        start = _resume_tail_start(self._resume_pending_tail, max(12, self.size.height // 2))
+        page, self._resume_pending_tail = self._resume_pending_tail[start:], self._resume_pending_tail[:start]
+        blocks = self._collect_resume_page_blocks(page)
+        if not self._resume_pending_tail and notice is not None:
+            view.remove_block(notice)
+            self._resume_tail_notice = None
+        with view.batch_append():
+            for block in blocks:
+                view.append_block(block)
 
-        for message in history:
-            if getattr(message, "role", None) != "tool":
-                continue
-            call_id = getattr(message, "tool_call_id", None)
-            if not call_id:
-                continue
-            results[call_id] = message
-            # A result whose call painted LIVE before a disconnect must
-            # settle the card already on screen — the disconnect marked it
-            # ``interrupted``, and replaying it as a new row would double the
-            # card (review round 4, MINOR-1). The disconnect retired the card
-            # out of ``_tool_cards`` but left it mounted, so scan the
-            # transcript for the painted card carrying this call id.
-            painted = self._painted_tool_card(call_id)
-            if painted is not None:
-                self._settle_painted_tool_card(painted, message)
-                settled_results.add(call_id)
-        # Fresh batch, fresh pairing: a flag left by an earlier replay (or a
-        # truncated one) must not open a card in this conversation.
-        self._replay_bang_pending = False
+    def _mount_newer_resume_page(self) -> None:
+        if self._resume_tail_paging or self._resume_paging or not self._resume_pending_tail:
+            return
+        view = self._transcript_view()
+        generation = self._sidebar_navigation.generation
+        self._resume_tail_paging = True
+        top = view.content_region.y
+        anchor = next((block for block in view.blocks() if block.navigation_anchor_id and block.region.bottom > top), None)
+        if anchor is not None:
+            view.restore_navigation_anchor(anchor.navigation_anchor_id, anchor.navigation_anchor_part, top - anchor.region.y)
+        count = min(len(self._resume_pending_tail), max(12, self.size.height // 2))
+        page, self._resume_pending_tail = self._resume_pending_tail[:count], self._resume_pending_tail[count:]
+        page = [message for message in page if str(getattr(message, "id", "")) not in self._resume_mounted_ids]
+        blocks = self._collect_resume_page_blocks(page)
+        def settled() -> None:
+            if self._transcript is view and self._sidebar_navigation.generation == generation:
+                self._resume_tail_paging = False
 
-        # Split the conversation into the head this frame defers and the tail it
-        # paints. Sliced on MESSAGES rather than on rendered blocks because the
-        # split has to be decided before anything is built — deciding it by
-        # block count would mean building the blocks first, which is the cost
-        # being avoided. A message mounts 0-2 blocks, so the block count lands
-        # near the bound rather than on it, which is fine: the bound is a budget,
-        # not a contract about how many rows appear.
-        if bound is not None and len(history) > bound:
-            start = _resume_tail_start(history, bound)
-            if start > 0:
-                deferred, history = history[:start], history[start:]
-                # Whole-conversation results, so a deferred call still pairs with a
-                # result that renders (or already rendered) in the tail.
-                self._resume_results = results
-                self._resume_pending_head = deferred
-        transcript = self._transcript_view()
-
-        appended = bool(settled_results)
-        # The "older messages" notice has to be the FIRST row, so it is
-        # appended before the batch rather than prepended after it.
-        # `prepend_blocks` restores a scroll anchor on a later refresh, which
-        # would fight `follow_tail` for the same frame — the reflow-after-paint
-        # #451/#452 exist to prevent. One extra mount of a one-line notice is
-        # not the cost this bound is avoiding.
-        if (
-            self._block_sink is None
-            and self._resume_pending_head
-            and self._resume_head_notice is None
-        ):
-            notice = NoticeBlock(RESUME_OLDER_NOTICE, "note")
-            self._resume_head_notice = notice
-            self._append_block(notice)
-            appended = True
-        # ONE mount for the whole conversation. Per-block mounting made Textual
-        # re-walk its stylesheet, invalidate the container and schedule a settle
-        # callback 297 times over on a 396-message session, for a layout that is
-        # only looked at once — see `TranscriptView.batch_append`. A collected
-        # backward page must not open a batch on the live transcript: the
-        # blocks are inserted later, and an empty batch still schedules a
-        # settle pass that would race the insert's own settle.
-        batch = nullcontext() if self._block_sink is not None else transcript.batch_append()
-        with batch:
-            for message in history:
-                # A wake delivery is a CustomMessage, so it has no ``role``
-                # and would fall through every branch below — which is exactly
-                # why a resumed session showed the agent answering a wake with
-                # no sign the wake ever fired. Replaying it as its own block
-                # keeps the receipt on screen. The catch-up prompt is
-                # user-attributed, so replaying it too would put a raw
-                # '(alarm) The session resumed…' line in the transcript as if
-                # the user had typed it.
-                if getattr(message, "custom_type", None) == WAKE_PROMPT_MESSAGE_TYPE:
-                    details = getattr(message, "details", None) or {}
-                    if not details.get("wake_catchup"):
-                        key = (str(details.get("wake_id", "")), details.get("occurrence"))
-                        # Skip a receipt this session already painted live —
-                        # replaying it would double the line (round 2, m2).
-                        if key not in self._live_wake_receipts:
-                            self._append_block(
-                                WakeBlock(str(details.get("text", "")), catchup=False)
-                            )
-                            appended = True
-                    continue
-                # A peer message (`lop send` from another session) is also a
-                # CustomMessage with no ``role`` and would otherwise fall
-                # through, leaving a resumed session with the agent's reply but
-                # no sign the peer note arrived. Replay it as its own block,
-                # skipping one already painted live this session (double-paint
-                # guard, mirroring the wake branch above).
-                if getattr(message, "custom_type", None) == PEER_MESSAGE_MESSAGE_TYPE:
-                    details = getattr(message, "details", None) or {}
-                    if str(getattr(message, "id", "")) not in self._live_peer_receipts:
-                        self._append_block(
-                            PeerMessageBlock(
-                                str(details.get("body", "")),
-                                details.get("sender") or {},
-                            )
-                        )
-                        appended = True
-                    continue
-                # A gate that timed out unattended is the most expensive event
-                # in the detached feature — up to a day of held residency ends
-                # here — and it rendered NOWHERE (round 1, D2/U2): the user
-                # returned to a conversation that promised an action and
-                # appeared to simply stop. The payload already carried the
-                # tool, the description and the wait; only a renderer was
-                # missing.
-                #
-                # `warning` ink because it is a state the user must know about,
-                # not a receipt they can skip: a tool was denied, and denied by
-                # expiry rather than by their decision — which is the same
-                # distinction the transcript row itself exists to preserve.
-                if getattr(message, "custom_type", None) == GATE_TIMEOUT_CUSTOM_TYPE:
-                    details = getattr(message, "details", None) or {}
-                    self._append_block(NoticeBlock(_gate_timeout_notice(details), kind="warning"))
-                    appended = True
-                    continue
-                # A compaction that did NOT run. Rendered here for the same
-                # reason as the row above: a custom row with no renderer is a
-                # row nobody sees, and this one exists to CORRECT the
-                # optimistic "compacting context…" receipt the routed command
-                # already showed (round 5, U17). `warning` ink because the
-                # context the user asked to reclaim is still there.
-                if getattr(message, "custom_type", None) == COMPACTION_REFUSED_TYPE:
-                    details = getattr(message, "details", None) or {}
-                    text = str(details.get("detail") or "compaction did not run").strip()
-                    kind = "error" if text.startswith("compaction failed") else "warning"
-                    self._append_block(NoticeBlock(text, kind=kind))
-                    appended = True
-                    continue
-                role = getattr(message, "role", None)
-                if role == "tool":
-                    continue  # already rendered beside the call that asked for it
-                text = getattr(message, "text", "") or ""
-                text = text.strip() if isinstance(text, str) else ""
-                if role == "user":
-                    # The live path never paints harness chrome as a user row
-                    # (LOOP_PROMPT is registered as a pending echo and consumed;
-                    # the auto-continuation prompt is never announced at all).
-                    # Replay must make the same choice, or a resumed session
-                    # shows rows the live one deliberately suppressed — the
-                    # live/replay divergence review round 2 pinned.
-                    #
-                    # The network-continuation prompt joins them for the same
-                    # reason: it is persisted so the TRANSCRIPT explains why one
-                    # answer arrived in two pieces, but the user never typed it
-                    # and the live run showed a NoticeEvent instead.
-                    if text in (
-                        LOOP_PROMPT,
-                        _CONTINUATION_PROMPT,
-                        CONNECTIVITY_CONTINUATION_PROMPT,
-                    ):
-                        continue
-                    # A `$skill` invocation persists as its EXPANDED payload,
-                    # because that is what the model was sent. Replaying it
-                    # verbatim showed a resumed conversation the whole SKILL.md
-                    # body as the user's row — and, since the picker titles a
-                    # session from its first user turn, named every such thread
-                    # "The user invoked the `research` skill…". The typed line
-                    # rides the payload's own opening tag, so replay repaints
-                    # exactly what the live session painted. Same live/replay
-                    # parity rule as the two prompts skipped above.
-                    text = _typed_line_of(text) or text
-                    # The images ride the persisted message as base64 content
-                    # blocks — the same bytes the model saw — so a resumed
-                    # prompt replays WITH its pictures, not just the receipt
-                    # count. This is the resume half of the promise the live
-                    # path makes in `_submit_prompt`.
-                    replay_images = [
-                        block
-                        for block in (getattr(message, "content", None) or [])
-                        if isinstance(block, ImageContent)
-                    ]
-                    if text or replay_images:
-                        self._append_block(UserBlock(text, len(replay_images)))
-                        self._append_image_blocks(replay_images, marker_text=text)
-                        appended = True
-                    # A bang-mode receipt replays as open as it lived: the
-                    # user row is `! <command>` and the assistant message that
-                    # follows carries exactly one bash call. Remembered so the
-                    # call's card can open on settle, the same contract the
-                    # live path makes.
-                    if text.startswith("! "):
-                        self._replay_bang_pending = True
-                    continue
-                if role != "assistant":
-                    continue
-                # Consume the pending bang marker on EVERY assistant message:
-                # record_shell writes the call-bearing assistant immediately
-                # after the `!` row, and a later unrelated turn must never
-                # inherit the open-on-settle flag.
-                bang_pending = self._replay_bang_pending
-                self._replay_bang_pending = False
-                if text:
-                    block = AssistantBlock()
-                    block.completion_anchor_id = str(getattr(message, "id", ""))
-                    block.update_text(text)
-                    block.finalize_text()
-                    self._append_block(block)
-                    appended = True
-                tool_calls = getattr(message, "tool_calls", None) or []
-                for call in tool_calls:
-                    # Only the FIRST call of a bang assistant message is the
-                    # command's own card; the shape record_shell writes has
-                    # exactly one, so consuming here is exact in practice and
-                    # conservative in theory.
-                    user_run = bool(
-                        bang_pending
-                        and tool_calls[0] is call
-                        and getattr(call, "name", "") == "bash"
-                    )
-                    self._replay_tool_call(call, results, user_run=user_run)
-                    appended = True
-                stop = getattr(message, "stop_reason", None)
-                if stop == "refusal":
-                    # A refused turn replays its refusal even when the model DID
-                    # stream some prose first (Gemini safety stops often cut a
-                    # partial answer): the prose alone reads as a complete,
-                    # oddly short reply, and the user re-reading the session
-                    # needs to know the provider cut it off and why. The message
-                    # itself was stashed on the assistant message by the loop
-                    # precisely so this replay could show it.
-                    payload = getattr(message, "provider_payload", None) or {}
-                    # The fallback keeps the marker grammar (D3): every other
-                    # refusal line ends in a parenthetical, and a user who has
-                    # learned that shape would read its absence as meaningful.
-                    refusal = str(payload.get("refusal") or "") or (
-                        "model refused the request (no details recorded)"
-                    )
-                    self._append_block(NoticeBlock(refusal, "error"))
-                    appended = True
-                elif not text and not tool_calls:
-                    # An assistant message with neither prose nor a call is a
-                    # turn that FAILED. Skipping it is what left a resumed
-                    # session showing a prompt and nothing after it, with no
-                    # hint that the answer had errored rather than never been
-                    # asked for.
-                    if stop in ("error", "aborted"):
-                        reason = "turn failed" if stop == "error" else "interrupted"
-                        self._append_block(NoticeBlock(reason, "error"))
-                        appended = True
-        # Every message this pass rendered, by stable id — the dedupe key a
-        # later backward page is filtered through.
-        self._resume_mounted_ids.update(
-            str(getattr(message, "id", "")) for message in history if getattr(message, "id", None)
-        )
-        if self._block_sink is not None:
-            # A collected page mounts nothing and owns no viewport: the head
-            # notice belongs to the first render, and `follow_tail` would drag
-            # the reader from the history they scrolled up to read down to the
-            # newest turn — the exact opposite of the gesture that asked for it.
-            return appended
-        if appended:
-            # Replay is mounted as one synchronous batch, before Textual can
-            # remeasure the growing container between blocks. Land the reader on
-            # the latest turn and ARM the anchor there, so the first thing the
-            # resumed session streams carries them with it rather than growing
-            # off the bottom of a viewport pinned to the replay's last frame.
-            transcript.follow_tail()
-        return appended
+        mounted = view.blocks()
+        notice = self._resume_tail_notice
+        index = mounted.index(notice) if notice is not None and notice in mounted else len(mounted)
+        # New live output may already follow the gap. Insert older missing
+        # rows BEFORE its marker, never after that newer output.
+        view.insert_blocks(index, blocks, on_settled=settled)
+        if not self._resume_pending_tail and notice is not None:
+            view.remove_block(notice)
+            self._resume_tail_notice = None
 
     def _transcript_scrolled(self, *_args: Any, continuous: bool = False) -> None:
         """Mount the next older page when the reader reaches the top.
@@ -4138,6 +4670,10 @@ class OperatorApp(App[None]):
         reported loop the operator actually saw — chunks loading "without
         requiring me to scroll up to the top again on the new height".
         """
+        view = self._transcript_view()
+        if self._resume_pending_tail and view.scroll_y > 0 and view.is_near_bottom():
+            self._mount_newer_resume_page()
+            return
         if not self._resume_pending_head:
             return
         if self._resume_paging:
@@ -4161,7 +4697,11 @@ class OperatorApp(App[None]):
             return
         self._resume_check_pending = True
 
+        generation = self._sidebar_navigation.generation
+
         def run_check() -> None:
+            if self._transcript is not view or self._sidebar_navigation.generation != generation:
+                return
             self._resume_check_pending = False
             self._check_resume_page()
 
@@ -4380,56 +4920,9 @@ class OperatorApp(App[None]):
     def _replay_tool_call(
         self, call: Any, results: dict[str, Any], *, user_run: bool = False
     ) -> None:
-        """Mount one settled tool row for a call from a previous session.
+        from local_operator.tui.session_presentation import replay_tool_call
 
-        The card is built exactly as a live one is — same constructor, same
-        summary derivation from the arguments — so a resumed row is
-        indistinguishable from the row the user watched run, apart from the
-        duration the transcript never recorded.
-        """
-        card = ToolCard(
-            getattr(call, "id", "") or "",
-            getattr(call, "name", "") or "",
-            getattr(call, "arguments", None) or {},
-            user_run=user_run,
-        )
-        self._append_block(card)
-        result = results.get(getattr(call, "id", "") or "")
-        if result is None:
-            # No result recorded: the session ended between the call and its
-            # answer. Showing it as complete would invent an outcome.
-            card.restore(state="interrupted")
-            return
-        result_text = getattr(result, "text", "") or ""
-        payload = getattr(result, "provider_payload", None) or {}
-        details = payload.get("details") if isinstance(payload, dict) else None
-        if getattr(result, "is_error", False) and result_text.startswith("aborted ("):
-            # A user-stopped bang command persists as an error result (the
-            # model-facing shape), but the LIVE frame it came from was the dim
-            # shut `interrupted ⊘` row. Replaying it through the error branch
-            # would reopen the user's own Esc as a red failure (design round
-            # 1, D1). The aborted prefix is execute_bash's stable contract.
-            card.restore(state="interrupted")
-            return
-        if getattr(result, "is_error", False):
-            card.restore(
-                state="error",
-                result_text=result_text,
-                details=details,
-                error=_first_line(result_text),
-            )
-        else:
-            card.restore(state="success", result_text=result_text, details=details)
-        # Same rule as `on_tool_ended`: a result carrying image blocks shows
-        # them under the settled card, so a resumed session's screenshots are
-        # back on screen exactly where the live session showed them.
-        self._append_image_blocks(
-            [
-                block
-                for block in (getattr(result, "content", None) or [])
-                if isinstance(block, ImageContent)
-            ]
-        )
+        return replay_tool_call(self, call, results, user_run=user_run)
 
     def _on_boot_failed(self, error: Exception) -> None:
         """Report a session that never constructed, WITHOUT retiring the splash.
@@ -4651,6 +5144,9 @@ class OperatorApp(App[None]):
         discover it from an answer that has forgotten everything.
         ``/reload`` itself no longer calls this path; it re-execs.
         """
+        # Explicit reload replaces this workflow source. Sidebar navigation
+        # never calls this path and therefore never retires its loops.
+        self._interaction.retired = True
         previous_id = self._conversation_id()
         previous_len = self._history_length()
         preserve_outgoing = preserve_outgoing or (
@@ -4914,6 +5410,11 @@ class OperatorApp(App[None]):
             else:
                 carried_spend = self._reset_ledger_for_swap()
                 self._adopt_session(session)
+                # Reload retired the outgoing turn before adopting a fresh
+                # interaction context. Its late unowned fallback must not give
+                # that new context a failed outcome before its first start.
+                self._turn_open = False
+                self._turn_notified = True
                 self._flush_fork_receipt(getattr(session, "session_id", "") or "")
                 # The IN-PROCESS adoption path needs the boot prompt too, not
                 # just the cold-boot one. `/fork <message>` with
@@ -5663,65 +6164,11 @@ class OperatorApp(App[None]):
                 return resolved
         return False
 
-    def _overlay_live_state(self, rows: "list[Any]") -> "list[Any]":
-        """Fill in each row's runtime state, and float the ones needing a person.
-
-        Two reads for the whole list: the discovery records say which sessions
-        are running, working, attached or wedged, and the wake index says which
-        have reminders armed. Best-effort — a picker that cannot read either
-        one still lists every session exactly as it did before, because the
-        fields are defaulted and the markers simply do not appear.
-        """
+    def _overlay_live_state(self, rows: list[Any]) -> list[Any]:
         from local_operator.paths import config_dir
-        from local_operator.session.runtime import registry
-        from local_operator.tui.widgets.session_picker import sort_needs_you_first
+        from local_operator.tui.session_catalog import decorate_rows
 
-        try:
-            scanned = registry.scan(config_dir())
-        except Exception:  # noqa: BLE001 — markers are an enhancement, never a gate
-            logger.debug("picker could not scan session records", exc_info=True)
-            scanned = []
-        try:
-            from local_operator.wakes.store import read_index
-
-            wake_index = read_index(config_dir())
-        except Exception:  # noqa: BLE001
-            logger.debug("picker could not read the wake index", exc_info=True)
-            wake_index = {}
-
-        live: dict[str, tuple[Any, str]] = {}
-        for record, state in scanned:
-            session_id = getattr(record, "session_id", "")
-            if session_id:
-                live[session_id] = (record, state)
-
-        updated: list[Any] = []
-        for row in rows:
-            record_state = live.get(row.id)
-            live_state = ""
-            pending: str | None = None
-            if record_state is not None:
-                record, state = record_state
-                if state == "wedged":
-                    live_state = "wedged"
-                elif getattr(record, "busy", False):
-                    live_state = "busy"
-                elif not getattr(record, "detached", False):
-                    live_state = "attached"
-                else:
-                    live_state = "idle"
-                pending = getattr(record, "pending", None) or None
-            entry = wake_index.get(row.id) or {}
-            schedules = entry.get("schedules") or () if isinstance(entry, dict) else ()
-            updated.append(
-                row._replace(
-                    live_state=live_state,
-                    pending=pending,
-                    wakes=len(schedules),
-                    wakes_dormant=bool(isinstance(entry, dict) and entry.get("stopped_at")),
-                )
-            )
-        return sort_needs_you_first(updated)
+        return decorate_rows(config_dir(), rows)
 
     def _run_session_transition(self, operation: Awaitable[None]) -> None:
         """Run one session replacement behind the standard composer boundary.
@@ -5754,20 +6201,21 @@ class OperatorApp(App[None]):
         try:
             await operation
         finally:
-            # Both success and refusal/failure reopen the same ordinary composer:
-            # either the new session is now authoritative or the old one remains.
-            self._session_transition_pending = False
-            outcome, self._pending_fork_outcome = self._pending_fork_outcome, None
-            if outcome is not None:
-                self._notice(*outcome)
-            # If the settled session has an authoritative EMPTY roster, retire
-            # the one-row transition reserve now. Waiting for another keystroke
-            # would leave a blank/loading hole indefinitely after a refused
-            # attach or an empty replacement session. A filled roster is cheap
-            # to re-derive and stays in the same reserved geometry.
-            editor = self._editor()
-            if editor.argument_command in ("team", "teams", "agent", "agents"):
-                self._fill_name_argument_list(editor, editor.argument_command)
+            if not self._sidebar_navigation.requested_id:
+                # Both success and refusal/failure reopen the same ordinary composer:
+                # either the new session is now authoritative or the old one remains.
+                self._session_transition_pending = False
+                outcome, self._pending_fork_outcome = self._pending_fork_outcome, None
+                if outcome is not None:
+                    self._notice(*outcome)
+                # If the settled session has an authoritative EMPTY roster, retire
+                # the one-row transition reserve now. Waiting for another keystroke
+                # would leave a blank/loading hole indefinitely after a refused
+                # attach or an empty replacement session. A filled roster is cheap
+                # to re-derive and stays in the same reserved geometry.
+                editor = self._editor()
+                if editor.argument_command in ("team", "teams", "agent", "agents"):
+                    self._fill_name_argument_list(editor, editor.argument_command)
 
     def composer_submission_blocked(self) -> bool:
         """Whether Editor must retain rather than submit its current draft."""
@@ -8045,6 +8493,7 @@ class OperatorApp(App[None]):
         # about to be exactly wide enough for the card. It is also the last handler
         # to run BEFORE the screen arranges, which is what lets the composition below
         # land in the first frame the terminal ever sees.
+        self._sync_sidebar_layout(event.size)
         self._sync_boot_layout(size=event.size)
         self._sync_subagent_compact_layout(event.size.height)
         # The overlay cards are hosted in `width: auto` containers, so a
@@ -9042,13 +9491,20 @@ class OperatorApp(App[None]):
         # Showing the typed line instead makes paste and non-paste `$skill`
         # behave identically and makes the two rows agree by construction.
         row = text if sent is not None else expand_pastes(text, message.attachments)
-        self._submit_prompt(
-            row,
-            images,
-            message.attachments,
-            sent=sent,
-            typed=text,
+        source = self._interaction
+        source.turn.submitted_draft = SessionDraft(
+            text=message.text, attachments=dict(message.attachments)
         )
+        try:
+            self._submit_prompt(
+                row,
+                images,
+                message.attachments,
+                sent=sent,
+                typed=text,
+            )
+        finally:
+            source.turn.submitted_draft = None
 
     def on_inline_command_requested(self, message: InlineCommandRequested) -> None:
         """Run a slash command spliced out of the MIDDLE of a draft.
@@ -9109,6 +9565,12 @@ class OperatorApp(App[None]):
         and something lost it, and only the pair covers "the composer went dark
         because the usage panel lit up".
         """
+        if not self._swapping_session and event.widget is not self._session_sidebar:
+            view = self._transcript
+            if view is not None and (event.widget is view or view in event.widget.ancestors):
+                self._interaction.draft.focus_id = "@transcript"
+            elif isinstance(event.widget, Editor):
+                self._interaction.draft.focus_id = "@editor"
         self._sync_composer_focus()
 
     def on_descendant_blur(self, event: DescendantBlur) -> None:
@@ -9393,6 +9855,9 @@ class OperatorApp(App[None]):
         already exists for "the user is done with this card": it discards the
         aside and hands back the main-chat draft it borrowed.
         """
+        if self._sidebar_navigation.requested_id:
+            self._sidebar_navigation.cancel()
+            return
         editor = self._editor()
         # A COPY GESTURE IN FLIGHT is not a draft the user is scrapping, so
         # Ctrl+C keeps its older meaning there — the interrupt and the first
@@ -11077,6 +11542,8 @@ class OperatorApp(App[None]):
         # longer holds. The model's context is untouched by any of this, which
         # is what /clear already promises.
         self._resume_pending_head = []
+        self._resume_pending_tail = []
+        self._resume_tail_notice = None
         self._resume_results = {}
         self._resume_head_notice = None
         self._resume_mounted_ids.clear()
@@ -11965,6 +12432,17 @@ class OperatorApp(App[None]):
             self.exit()
 
     async def on_unmount(self) -> None:
+        await self._sidebar_navigation.close()
+        await self._sidebar_drafts.close()
+        if self._sidebar_timer is not None:
+            self._sidebar_timer.stop()
+        from local_operator.session.remote import RemoteSession
+
+        for source in tuple(self._interactions.values()):
+            if source.session is not self._session and isinstance(source.session, RemoteSession):
+                if source.controller is not None:
+                    source.controller.dispose()
+                await source.session.dispose()
         # Unpublish the discovery record BEFORE anything can block: the mobile
         # daemon reaps by pid liveness anyway, and this removes the record in
         # the common case so the phone list drops the session immediately
@@ -12042,6 +12520,8 @@ class OperatorApp(App[None]):
             command = command[1:].lstrip()
         if not command:
             return
+        import weakref
+
         from local_operator.harness.types import (
             AbortSignal,
             AgentToolUpdate,
@@ -12049,6 +12529,7 @@ class OperatorApp(App[None]):
         )
         from local_operator.tools.builtin import execute_bash
 
+        source = self._interaction
         call_id = f"shell-{time.monotonic_ns()}"
         # user_run: the row says WHO ran it (`you:` chip) and opens at settle,
         # because the user ran the command to read its output.
@@ -12058,7 +12539,9 @@ class OperatorApp(App[None]):
         signal = AbortSignal()
         self._shell_signal = signal
         self._shell_card = card
-        session = self._session
+        card_ref = weakref.ref(card)
+        source.shell.call_id = call_id
+        session = source.session
         cwd = os.getcwd()
         session_cwd = getattr(session, "_cwd", None) if session is not None else None
         if isinstance(session_cwd, str) and session_cwd:
@@ -12084,7 +12567,10 @@ class OperatorApp(App[None]):
         def on_update(update: AgentToolUpdate) -> None:
             detail = _partial_text(update)
             if detail:
-                card.set_partial_detail(detail)
+                source.shell.progress = detail[-4096:]
+                current_card = card_ref()
+                if self._is_current(source) and current_card is not None:
+                    current_card.set_partial_detail(detail)
 
         async def persist(result: ToolResult) -> None:
             """One persistence hop; a spawn failure is still a completed
@@ -12125,8 +12611,14 @@ class OperatorApp(App[None]):
                     context,
                 )
             except Exception as error:  # surface, never crash the app
-                if self._shell_card is card and not signal.aborted:
-                    card.mark_failed(str(error), str(error))
+                current_card = card_ref()
+                if (
+                    self._is_current(source)
+                    and self._shell_card is current_card
+                    and current_card is not None
+                    and not signal.aborted
+                ):
+                    current_card.mark_failed(str(error), str(error))
                 await persist(
                     ToolResult(
                         tool_call_id=call_id,
@@ -12145,31 +12637,39 @@ class OperatorApp(App[None]):
             # authoritative until the subprocess is reaped. Do not overwrite
             # that interrupted frame with execute_bash's abort result; DO still
             # persist the result so the command cannot disappear on resume.
-            if self._shell_card is card and not signal.aborted:
+            current_card = card_ref()
+            if (
+                self._is_current(source)
+                and self._shell_card is current_card
+                and current_card is not None
+                and not signal.aborted
+            ):
                 if result.is_error:
-                    card.mark_failed(_first_line(result.text), result.text, result.details)
+                    current_card.mark_failed(_first_line(result.text), result.text, result.details)
                 else:
-                    card.mark_done(result.text, result.details)
+                    current_card.mark_done(result.text, result.details)
             await persist(result)
 
         def _clear_shell_state() -> None:
-            if self._shell_card is card:
+            if self._is_current(source) and self._shell_card is card_ref():
                 self._shell_card = None
-            if self._shell_signal is signal:
-                self._shell_signal = None
+            if source.shell.signal is signal:
+                source.shell.signal = None
 
         worker: Any = None
+        source.active_workers += 1
 
         async def run_and_clear() -> None:
             try:
                 await run_shell()
             finally:
+                source.active_workers -= 1
                 _clear_shell_state()
-                if self._shell_worker is worker:
-                    self._shell_worker = None
+                if source.shell.worker is worker:
+                    source.shell.worker = None
 
-        worker = self.run_worker(run_and_clear(), thread=False, group="shell")
-        self._shell_worker = worker
+        worker = self.run_worker(run_and_clear(), thread=False, group=source.worker_group("shell"))
+        source.shell.worker = worker
 
     def _abort_shell_command(self) -> bool:
         """Abort the in-flight bang-mode command. True if there was one.
@@ -12373,6 +12873,7 @@ class OperatorApp(App[None]):
             # minutes and then sent the words without the screenshot would be
             # worse than not queueing at all.
             self._prompt_held_for_compaction = sent
+            self._interaction.compaction.accepted_draft = self._interaction.turn.submitted_draft
             # Only when they differ, so the common path leaves this empty and
             # the hand-back below falls through to the held prompt itself.
             #
@@ -12402,6 +12903,18 @@ class OperatorApp(App[None]):
         self._maybe_name_conversation(named)
 
     def _start_turn(self, text: str, images: list[ImageContent] | None = None) -> None:
+        self._start_turn_for(
+            self._interaction, text, images, accepted=self._interaction.turn.submitted_draft
+        )
+
+    def _start_turn_for(
+        self,
+        source: SessionInteraction,
+        text: str,
+        images: list[ImageContent] | None = None,
+        *,
+        accepted: SessionDraft | None = None,
+    ) -> None:
         """Run one user prompt as a turn, reporting a failure as a notice.
 
         Extracted from :meth:`_submit_prompt` so a prompt HELD through a
@@ -12409,7 +12922,7 @@ class OperatorApp(App[None]):
         the alternative was re-entering `_submit_prompt`, which would write the
         user's row into the ledger a second time.
         """
-        session = self._session
+        session = source.session
         if session is None or self._status is None:
             return
         # The turn's first append announces this prompt back as a user
@@ -12427,14 +12940,17 @@ class OperatorApp(App[None]):
         # back to text. Both in-tree sessions accept it -- `RemoteSession`
         # included, which is what an attached follower TUI drives and which
         # swallowed cross-surface prompts until it did (round 1, F1).
-        echo = self._register_user_echo(text, message_id=self._echo_message_id(session.prompt))
+        echo = self._register_user_echo_for(
+            source, text, message_id=self._echo_message_id(session.prompt)
+        )
         # A turn STARTING ends any barren click gesture: from here Ctrl+C means
         # "stop this turn", and a claim raised before the turn existed cannot
         # speak for a press aimed at it (agent review round 3, R3-3). Belt and
         # braces with the editor's own submit seam, because a prompt held
         # through a compaction reaches this dispatch point long after the
         # submit that queued it.
-        self._editor().retire_barren_click()
+        if self._is_current(source):
+            self._editor().retire_barren_click()
         # Naming is deliberately NOT cancelled here. It used to be, because the
         # title call took the same provider lane the turn takes and a follow-up
         # had to be able to evict it. The call is now `isolated` and concurrent,
@@ -12442,13 +12958,16 @@ class OperatorApp(App[None]):
         # would throw away a title generated from the OPENER and re-derive one
         # from the follow-up, which names the conversation after its second
         # subject. Reload still cancels: see `_cancel_naming_attempt`.
-        self._status.update(streaming=True)
+        if self._is_current(source):
+            self._status.update(streaming=True)
+
+        source.active_workers += 1
 
         async def run_prompt() -> None:
             aborted = False
             error_text: str | None = None
             try:
-                async with self._turn_provider_lock:
+                async with source.turn.provider_lock:
                     await session.prompt(text, images, **echo.prompt_kwargs())
             except asyncio.CancelledError:
                 # NOT OPTIONAL, and not covered by the clause below:
@@ -12468,9 +12987,13 @@ class OperatorApp(App[None]):
                 # the dropped text and the way back are exactly what the user
                 # needs, and this refusal is what remains on screen after the
                 # stop notice scrolls off (round-4 D4-2).
-                if self._stopped_session_id and "stopped" in str(error):
+                if (
+                    self._is_current(source)
+                    and self._stopped_session_id
+                    and "stopped" in str(error)
+                ):
                     text_line, kind = self._no_session_notice(unsent=True)
-                    self._append_block(NoticeBlock(text_line, kind))
+                    self._notice_for(source, text_line, kind)
                 elif _is_runtime_gone(error):
                     # THE RUNTIME DIED UNDER US (crash, OOM, kill -9). What
                     # the user got was `✗ owner socket unreachable: [Errno 61]
@@ -12484,16 +13007,15 @@ class OperatorApp(App[None]):
                     # again with one keystroke, and the viewer drops its
                     # binding so the NEXT send engages a fresh runtime rather
                     # than dialling a socket that is never coming back.
-                    self._restore_unsent(text, images)
+                    self._restore_unsent_for(source, text, images, accepted=accepted)
                     go_cold = getattr(session, "_go_cold", None)
                     if callable(go_cold):
                         go_cold()
-                    self._append_block(
-                        NoticeBlock(
-                            "this session's runtime stopped — your message is back in the "
-                            "composer; send it again to start a new one",
-                            "warning",
-                        )
+                    self._notice_for(
+                        source,
+                        "this session's runtime stopped — your message is back in the "
+                        "composer; send it again to start a new one",
+                        "warning",
                     )
                 else:
                     # THROUGH the same helper the `agent_end` path uses. This
@@ -12502,14 +13024,15 @@ class OperatorApp(App[None]):
                     # and the other did not purely by route — and this is the
                     # route the reported incident took, because an MCP auth
                     # failure is what makes `prompt()` raise.
-                    self._append_block(NoticeBlock(self._with_recovery_hint(str(error)), "error"))
+                    self._notice_for(source, self._with_recovery_hint(str(error)), "error")
                 # A prompt that failed never announced itself, so its echo
                 # entry has no event coming. Left standing it would swallow
                 # the next identical prompt's event; `_discard_user_echo` is
                 # safe because a delivered announcement has already consumed
                 # the entry.
-                self._discard_user_echo(echo)
+                self._discard_user_echo_for(source, echo)
             finally:
+                source.active_workers -= 1
                 # THE TWO-MECHANISM HAZARD, and why these two lines belong
                 # together. The status band and the working line used to be
                 # retired by DIFFERENT mechanisms: the band by this `finally`
@@ -12601,9 +13124,9 @@ class OperatorApp(App[None]):
                 # and the fallback is a no-op on every normal turn. Calling
                 # `_finalize_turn` directly instead would run AHEAD of the
                 # queued real end and double-notify every single turn.
-                self._post_turn_abandoned(aborted=aborted, error=error_text)
+                self._post_turn_abandoned_for(source, aborted=aborted, error=error_text)
 
-        self.run_worker(run_prompt(), thread=False, group="turns")
+        self.run_worker(run_prompt(), thread=False, group=source.worker_group("turns"))
 
     def _retire_turn_band(self, session: Any, *, failed: bool | None = None) -> None:
         """Clear the status band for a turn whose worker is done with it.
@@ -12675,14 +13198,7 @@ class OperatorApp(App[None]):
         why it is retiring, and deriving it here keeps all three from having to
         remember it.
         """
-        self.post_message(
-            TurnAbandoned(
-                self._turn_epoch,
-                aborted=aborted,
-                error=error,
-                outcome_known=not bool(getattr(self._session, "is_remote", False)),
-            )
-        )
+        self._post_turn_abandoned_for(self._interaction, aborted=aborted, error=error)
 
     # -- conversation naming --------------------------------------------------
     def _cancel_naming_attempt(self) -> None:
@@ -14087,6 +14603,8 @@ class OperatorApp(App[None]):
         try:
             if message.key == "tui.theme" and message.value:
                 self._apply_theme(str(message.value))
+            elif message.key in ("tui.sidebar_visible", "tui.sidebar_position"):
+                self._apply_sidebar_settings()
             elif message.key == "display.comfortable_rows":
                 # Layout, not ink: the padding lives in the stylesheet behind
                 # one Screen class, so flipping the class is the whole apply
@@ -14511,6 +15029,10 @@ class OperatorApp(App[None]):
         resume already retired it when it painted the tail, and a page mounted
         into the scrollback is not the edge that starts a conversation.
         """
+        if self._projection_message_id:
+            block.navigation_anchor_id = self._projection_message_id
+            block.navigation_anchor_part = self._projection_part
+            self._projection_part += 1
         if self._block_sink is not None:
             self._block_sink.append(block)
             return
@@ -14527,49 +15049,9 @@ class OperatorApp(App[None]):
     def _append_image_blocks(
         self, images: list[ImageContent], *, marker_text: str | None = None
     ) -> list[ImageBlock]:
-        """Mount one :class:`ImageBlock` per image, in order.
+        from local_operator.tui.session_presentation import append_image_blocks
 
-        The single entry point for putting pictures on the transcript — the
-        prompt path, the tool-result path, and the resume replay all route
-        here so a rendering decision (caps, protocol, the unavailable
-        receipt) is made in exactly one place. Guarded per block: a block
-        whose bytes will not decode still mounts (as its unavailable
-        receipt), but a failure CONSTRUCTING one must not take down the
-        message dispatch that carried a perfectly good tool result.
-
-        Labels name WHICH of several images a receipt is about, and only
-        when the batch has more than one — a receipt for a batch of one
-        names nothing the row above it has not already said (review round
-        1, F4). Where ``marker_text`` is given (the prompt paths), the
-        numbers are read from the text's own ``[Image #N]`` citations, in
-        citation order — the same walk ``resolve_markers`` built ``images``
-        from — because marker numbers are not positional: delete #1 and
-        paste again and the draft reads ``[Image #2] [Image #3]``, so a
-        positional ``#1`` would name a marker the prompt does not contain
-        (review round 2, F9). Tool results have no markers and fall back to
-        positions.
-        """
-        indices: list[int] = []
-        if marker_text:
-            from local_operator.tui.widgets.editor import IMAGE_MARKER
-
-            indices = [int(match.group("index")) for match in IMAGE_MARKER.finditer(marker_text)]
-        mounted: list[ImageBlock] = []
-        for index, image in enumerate(images):
-            if len(images) <= 1:
-                label = ""
-            elif index < len(indices):
-                label = f"#{indices[index]}"
-            else:
-                label = f"#{index + 1}"
-            try:
-                block = ImageBlock(image.data or None, image.mime_type, label=label)
-            except Exception:
-                logger.debug("image block construction failed", exc_info=True)
-                continue
-            self._append_block(block)
-            mounted.append(block)
-        return mounted
+        return append_image_blocks(self, images, marker_text=marker_text)
 
     # -- slash commands -----------------------------------------------------
     def _notice(self, body: str, kind: NoticeKind = "info") -> None:
@@ -14820,6 +15302,8 @@ class OperatorApp(App[None]):
                 logger.debug("display settings cache could not be dropped", exc_info=True)
         if "display.dock" in changed:
             self._apply_dock_density()
+        if any(key in changed for key in ("tui.sidebar_visible", "tui.sidebar_position")):
+            self._apply_sidebar_settings()
         if "tui.theme" in changed:
             values = getattr(change, "values", {})
             tui_block = values.get("tui") if isinstance(values, Mapping) else None
@@ -15510,6 +15994,15 @@ class OperatorApp(App[None]):
         parts = text.split(maxsplit=1)
         entry = slash_command_for(text)
         command = f"/{entry.name}" if entry is not None else parts[0].lower()
+        if self._sidebar_navigation.requested_id and command not in (
+            "/sidebar",
+            "/help",
+            "/settings",
+        ):
+            self._system_notice(
+                "Wait for the conversation to open before sending a command", "warning"
+            )
+            return
         arg = parts[1].strip() if len(parts) > 1 else ""
         # The argument of a ``consumes_prompt`` command with its collapsed
         # pastes spliced back in. That flag's own definition is "this argument
@@ -15672,6 +16165,9 @@ class OperatorApp(App[None]):
             route_session = self._session
             route_generation = getattr(self, "_frontend_session_generation", 0)
 
+            route_session = self._session
+            route_generation = getattr(self, "_frontend_session_generation", 0)
+
             async def run_remote_slash() -> None:
                 # A queued operation belongs to its committed session, and an
                 # already-sent operation's receipt must not paint a replacement
@@ -15769,6 +16265,8 @@ class OperatorApp(App[None]):
             self._cmd_theme(arg, notice)
         elif command == "/provider":
             self._cmd_providers(notice)
+        elif command == "/sidebar":
+            self.action_toggle_sidebar()
         elif command == "/settings":
             self._cmd_settings(notice)
         elif command == "/search":
@@ -15871,9 +16369,15 @@ class OperatorApp(App[None]):
         # announced `compacting context…` with no end event to retire it. The
         # session refuses a second concurrent pass itself (``already_running``),
         # which is one authority for the whole question instead of two.
-        self.run_worker(self._compact_worker(session), thread=False, group="compact")
+        self.run_worker(
+            self._compact_worker(session, self._interaction),
+            thread=False,
+            group=self._interaction.worker_group("compact"),
+        )
 
-    async def _compact_worker(self, session: SessionProtocol) -> None:
+    async def _compact_worker(
+        self, session: SessionProtocol, source: SessionInteraction | None = None
+    ) -> None:
         """Await one manual compaction and report what it did.
 
         A pass that RUNS narrates itself through the ``compaction_start`` /
@@ -15891,15 +16395,16 @@ class OperatorApp(App[None]):
         louder than the one carrying the reason. :meth:`on_compaction_ended`
         now leaves the manual case to this line.
         """
+        source = source or self._interactions.get(id(session), self._interaction)
         try:
             outcome = await session.compact_now()
         except Exception as exc:  # noqa: BLE001 — a failed pass must not kill the app
             logger.debug("manual compaction failed", exc_info=True)
-            self._system_notice(f"compaction failed: {exc}", "error")
+            self._notice_for(source, f"compaction failed: {exc}", "error")
             return
         if not outcome.ran:
             kind: NoticeKind = "error" if outcome.reason == "failed" else "warning"
-            self._system_notice(outcome.detail or "compaction did not run", kind)
+            self._notice_for(source, outcome.detail or "compaction did not run", kind)
         # A pass that RAN needs nothing further here: the band is settled from
         # the END EVENT, in `on_compaction_ended`, so the automatic trigger gets
         # the same treatment instead of leaving its own reading stale.
@@ -18679,7 +19184,11 @@ class OperatorApp(App[None]):
             return
         self._loop_cancelled = False
         notice(f"looping toward the goal ({iterations} iteration(s)) — /loop stop to cancel")
-        self.run_worker(self._loop_worker(iterations), thread=False, group="loop")
+        self.run_worker(
+            self._loop_worker(iterations, self._interaction),
+            thread=False,
+            group=self._interaction.worker_group("loop"),
+        )
 
     def _start_goal_loop(self, goal: str, notice: NoticeFn) -> None:
         """Launch goal mode (`/loop <goal text>`) — loop turns until a judge
@@ -18702,18 +19211,26 @@ class OperatorApp(App[None]):
         # sequence must not rewrite the terminal) and length-capped for the
         # notice only — the full string still drives the loop.
         notice(f"looping toward: {_loop_goal_label(goal)} — /loop stop to cancel")
-        self.run_worker(self._loop_goal_worker(goal), thread=False, group="loop")
+        self.run_worker(
+            self._loop_goal_worker(goal, self._interaction),
+            thread=False,
+            group=self._interaction.worker_group("loop"),
+        )
 
-    async def _loop_worker(self, iterations: int) -> None:
+    async def _loop_worker(self, iterations: int, source: SessionInteraction | None = None) -> None:
         """Run up to ``iterations`` goal-advancing turns, sequentially."""
 
-        def notice(body: str, kind: NoticeKind = "info") -> None:
-            self._append_block(NoticeBlock(body, kind))
+        source = source or self._interaction
 
-        session = self._session
+        def notice(body: str, kind: NoticeKind = "info") -> None:
+            self._notice_for(source, body, kind)
+
+        session = source.session
         if session is None:
             return
-        self._loop_running = True
+        source.loop.running = True
+        source.active_workers += 1
+        source.loop.operation += 1
         completed = 0
         #: Whether the loop ended by CRASHING rather than by running out of
         #: iterations. Without it a loop whose first prompt died signed off
@@ -18723,7 +19240,7 @@ class OperatorApp(App[None]):
         crashed = False
         try:
             for index in range(iterations):
-                if self._loop_cancelled:
+                if source.loop.cancelled:
                     break
                 # Re-checked every iteration, not captured once: `/reload`
                 # replaces `self._session` underneath a running loop, and the
@@ -18731,7 +19248,7 @@ class OperatorApp(App[None]):
                 # old one took the remaining prompts, the new one took none, and
                 # `_loop_running` stayed True so `/loop` answered "already
                 # running". Same guard `_name_conversation_worker` already makes.
-                if session is not self._session:
+                if source.retired:
                     break
                 # A NOTICE, not a `UserBlock`: this line is app-authored chrome
                 # (the comment on `SLASH_COMMANDS["loop"]` says as much of the
@@ -18740,7 +19257,7 @@ class OperatorApp(App[None]):
                 # ten of them, so the loudest new mark in the transcript would
                 # belong to the one turn the user did not type.
                 notice(f"loop {index + 1}/{iterations}", "note")
-                if self._status is not None:
+                if self._is_current(source) and self._status is not None:
                     self._status.update(streaming=True)
                 # LOOP_PROMPT is app-authored chrome and deliberately gets no
                 # user row (the notice above is its receipt) — but the session
@@ -18748,8 +19265,8 @@ class OperatorApp(App[None]):
                 # prompt. Register it so the event is consumed silently instead
                 # of painting the loudest mark in the transcript for words the
                 # user never typed.
-                echo = self._register_user_echo(
-                    LOOP_PROMPT, message_id=self._echo_message_id(session.prompt)
+                echo = self._register_user_echo_for(
+                    source, LOOP_PROMPT, message_id=self._echo_message_id(session.prompt)
                 )
                 loop_error: str | None = None
                 try:
@@ -18766,7 +19283,7 @@ class OperatorApp(App[None]):
                     notice(f"loop stopped: {self._with_recovery_hint(str(error))}", "error")
                     # Same stale-entry hazard as `_start_turn`: a failed
                     # prompt never announces, so take the entry back out.
-                    self._discard_user_echo(echo)
+                    self._discard_user_echo_for(source, echo)
                     crashed = True
                     break
                 finally:
@@ -18783,13 +19300,14 @@ class OperatorApp(App[None]):
                     # verbatim under `/loop`: spinner climbing, band idle,
                     # nothing announced. A healthy iteration's real `TurnEnded`
                     # is already queued ahead of this, so it is a no-op there.
-                    self._post_turn_abandoned(aborted=False, error=loop_error)
+                    self._post_turn_abandoned_for(source, aborted=False, error=loop_error)
                 completed = index + 1
         finally:
-            self._loop_running = False
-        if self._loop_cancelled:
+            source.active_workers -= 1
+            source.loop.running = False
+        if source.loop.cancelled:
             notice(f"loop cancelled after {completed} iteration(s)")
-        elif session is not self._session:
+        elif source.retired:
             # Reported as stopped, not finished: the remaining iterations never
             # ran, and "finished" on a reload reads as the loop having completed.
             notice(f"loop stopped by reload after {completed} iteration(s)", "warning")
@@ -18824,20 +19342,23 @@ class OperatorApp(App[None]):
         # where `complete_aside` is the real implementation (a follower's raises),
         # but guard in case a future path reaches the worker on a session lacking
         # it — treat a missing primitive as a judge failure, not a crash.
+        source = self._interactions.get(id(session), self._interaction)
         if not hasattr(session, "complete_aside"):
             return None, ""
         turns = [Message.user(LOOP_JUDGE_PROMPT.format(goal=goal))]
         try:
-            answer = await session.complete_aside(turns, on_usage=self._charge_aside)
+            answer = await session.complete_aside(
+                turns, on_usage=lambda usage: self._charge_aside_for(source, usage)
+            )
         except Exception as error:  # noqa: BLE001 — any provider failure is a judge failure
             self._append_block(NoticeBlock(f"judge unavailable, continuing: {error}", "warning"))
             return None, ""
         achieved, reason = _parse_loop_verdict(answer)
         if achieved is None:
-            self._append_block(NoticeBlock("judge returned no verdict, continuing", "warning"))
+            self._notice_for(source, "judge returned no verdict, continuing", "warning")
         return achieved, reason
 
-    async def _loop_goal_worker(self, goal: str) -> None:
+    async def _loop_goal_worker(self, goal: str, source: SessionInteraction | None = None) -> None:
         """Run goal mode: loop turns toward ``goal`` until the judge releases.
 
         Separate from `_loop_worker` on purpose — the two share only their
@@ -18848,36 +19369,41 @@ class OperatorApp(App[None]):
         the judge saying ACHIEVED, or the consecutive-judge-failure breaker.
         """
 
-        def notice(body: str, kind: NoticeKind = "info") -> None:
-            self._append_block(NoticeBlock(body, kind))
+        source = source or self._interaction
 
-        session = self._session
+        def notice(body: str, kind: NoticeKind = "info") -> None:
+            self._notice_for(source, body, kind)
+
+        session = source.session
         if session is None:
             return
-        self._loop_running = True
-        self._loop_goal = goal
+        source.loop.running = True
+        source.active_workers += 1
+        source.loop.operation += 1
+        operation = source.loop.operation
+        source.loop.goal = goal
         # Suppress the per-turn completion toast for the whole held loop; the
         # release path below fires the single toast. Set here, cleared in the
         # `finally` — the reset is load-bearing (see the field's init comment).
-        self._loop_suppress_completion = True
+        source.loop.suppress_completion = True
         completed = 0
         judge_failures = 0
         released = False
         reason = ""
         try:
             while True:
-                if self._loop_cancelled:
+                if source.loop.cancelled:
                     break
                 # Re-checked every iteration, not captured once: `/reload`
                 # replaces `self._session` underneath a running loop, and the
                 # captured reference would go on driving the DISPOSED session.
                 # Same guard the numeric worker documents.
-                if session is not self._session:
+                if source.retired:
                     break
                 # A NOTICE, not a UserBlock: the per-turn prompt is app-authored
                 # chrome, exactly as in numeric mode.
                 notice(f"loop {completed + 1} (goal mode)", "note")
-                if self._status is not None:
+                if self._is_current(source) and self._status is not None:
                     self._status.update(streaming=True)
                 # Format ONCE and reuse the exact string for both the echo
                 # registration and the prompt: an id-less entry (a session
@@ -18885,8 +19411,8 @@ class OperatorApp(App[None]):
                 # string byte-for-byte, so a second `.format` here could drift
                 # and leave the user MessageStartEvent unconsumed.
                 prompt = LOOP_GOAL_PROMPT.format(goal=goal)
-                echo = self._register_user_echo(
-                    prompt, message_id=self._echo_message_id(session.prompt)
+                echo = self._register_user_echo_for(
+                    source, prompt, message_id=self._echo_message_id(session.prompt)
                 )
                 try:
                     await session.prompt(prompt, **echo.prompt_kwargs())
@@ -18898,7 +19424,7 @@ class OperatorApp(App[None]):
                     notice(f"loop stopped: {self._with_recovery_hint(str(error))}", "error")
                     # A failed prompt never announces, so take the stale echo
                     # entry back out (same hazard as numeric mode / `_start_turn`).
-                    self._discard_user_echo(echo)
+                    self._discard_user_echo_for(source, echo)
                     # Retire the dead turn, exactly as the other two call sites
                     # do. The goal loop's single-toast contract is preserved by
                     # `_loop_suppress_completion`, which is still set here and is
@@ -18908,14 +19434,14 @@ class OperatorApp(App[None]):
                     # takes its ERROR branch — a held loop that dies outright
                     # must not go silent, which is the one notification the
                     # suppression deliberately does not cover.
-                    self._post_turn_abandoned(aborted=False, error=str(error))
+                    self._post_turn_abandoned_for(source, aborted=False, error=str(error))
                     break
                 # NOTE: the status is deliberately NOT reset to idle here — it
                 # stays in a working state across the judge call below so the
                 # loop never looks frozen while the verdict is being computed.
                 completed += 1
                 # --- yield boundary reached: judge the settled turn ---
-                if self._loop_cancelled or session is not self._session:
+                if source.loop.cancelled or source.retired:
                     self._retire_turn_band(session)
                     break
                 # Keep the status in a working state ACROSS the judge call. The
@@ -18967,15 +19493,15 @@ class OperatorApp(App[None]):
             # AFTER any already-queued `TurnEnded` has been suppressed. The
             # release path is unaffected: it calls `_notify` directly, and its
             # own `await _judge_goal` already drained the final `TurnEnded`.
-            self._loop_running = False
-            self._loop_goal = ""
-            self.call_later(self._release_loop_completion_suppression)
+            source.loop.running = False
+            source.loop.goal = ""
+            self.call_later(self._release_loop_completion_suppression, source, operation)
         # Terminal outcome (mirrors the numeric worker's tail). Only the release
         # path fires the toast — one notification, exactly when the judge said
         # the goal was met, which is the whole notify-once contract.
-        if self._loop_cancelled:
+        if source.loop.cancelled:
             notice(f"loop cancelled after {completed} turn(s)")
-        elif session is not self._session:
+        elif source.retired:
             notice(f"loop stopped by reload after {completed} turn(s)", "warning")
         elif released:
             # The NoticeBlock is the unconditional in-transcript receipt (visible
@@ -18985,10 +19511,13 @@ class OperatorApp(App[None]):
             # while they are still working (the existing deferral machinery then
             # delivers it when the last child lands).
             notice(f"goal achieved after {completed} turn(s): {reason}", "info")
-            self._notify("complete", running_children=self._outstanding_delegated_jobs())
+            if self._is_current(source):
+                self._notify("complete", running_children=self._outstanding_delegated_jobs())
         # (judge-failure and turn-error paths already emitted their own notice.)
 
-    def _release_loop_completion_suppression(self) -> None:
+    def _release_loop_completion_suppression(
+        self, source: SessionInteraction | None = None, operation: int | None = None
+    ) -> None:
         """Clear the goal-loop completion-toast suppression, deferred one pump
         cycle past the worker's exit so a still-queued final ``TurnEnded``
         cannot fire a spurious "task complete" on a cancelled/reloaded loop.
@@ -19000,8 +19529,9 @@ class OperatorApp(App[None]):
         ends. Without the guard, a `/loop` typed within one pump cycle of the
         last one ending could unmute the fresh loop's per-turn toasts.
         """
-        if not self._loop_running:
-            self._loop_suppress_completion = False
+        source = source or self._interaction
+        if not source.loop.running and (operation is None or operation == source.loop.operation):
+            source.loop.suppress_completion = False
 
     # -- providers / accounts / usage --------------------------------------
     def _cmd_search(self, arg: str, notice: NoticeFn) -> None:
@@ -20021,7 +20551,7 @@ class OperatorApp(App[None]):
             self._ask_aside(arg)
 
     def action_aside(self) -> None:
-        """Ctrl+B — open the aside WITHOUT spending the composer's draft."""
+        """F8 — open the aside WITHOUT spending the composer's draft."""
         self._open_aside()
 
     def _open_aside(self) -> AsidePanel | None:
@@ -20216,7 +20746,7 @@ class OperatorApp(App[None]):
         cleared the block it streamed into.
 
         Spend IS counted. An aside carries the whole conversation, so it is not
-        free, and a status line that a ctrl+b popup could move without moving
+        free, and a status line that an F8 popup could move without moving
         would be a number the user cannot act on.
         """
         panel = self._aside_panel()
@@ -20259,7 +20789,12 @@ class OperatorApp(App[None]):
         panel.settle_answer(generation, answer)
         self._sync_aside_fork_hint()
 
-    def _charge_aside(self, usage) -> None:  # noqa: ANN001 - harness Usage
+    def _charge_aside(self, usage: Any) -> None:
+        self._charge_aside_for(self._interaction, usage)
+
+    def _charge_aside_for(
+        self, source: SessionInteraction, usage: Any
+    ) -> None:  # noqa: ANN001 - harness Usage
         """Fold an aside's provider usage into the session's running cost.
 
         Through the SAME ``_cost_for`` the turn path uses, so the status line
@@ -20267,14 +20802,14 @@ class OperatorApp(App[None]):
         its own tick; nothing is forced here, because a delta-rate repaint of
         the whole band is exactly the input lag the working line was fixed for.
         """
-        session = self._session
+        session = source.session
         store = getattr(session, "_frontend_state_store", None) if session is not None else None
         if store is not None:
             store.accrue_usage(session, usage)
             return
-        cost = self._cost_for(usage)
+        cost = turn_cost(_effective_label(session), usage) if session is not None else None
         if cost is not None:
-            self._total_cost += cost
+            source.accounting.total += cost
         # Cache instrumentation (debug-only, off by default): an aside is meant
         # to ride the working turn's cached prefix, so cache_read should be a
         # large fraction of the prompt while input (the uncached remainder)
@@ -20338,7 +20873,7 @@ class OperatorApp(App[None]):
             # in the same verb they just learned, for the operation this is not
             # — left them with no route to the thing they actually wanted.
             self._system_notice(
-                "ctrl+f folds an open aside into the chat (ctrl+b opens one) — "
+                "ctrl+f folds an open aside into the chat (F8 opens one) — "
                 "to branch this conversation, use /fork",
                 "warning",
             )
@@ -21831,8 +22366,9 @@ class OperatorApp(App[None]):
         # stops so a user who only ever saw "expand/collapse" learns the panel
         # can now shrink to a row or go away (#525).
         lines.append(_key_row("ctrl+g", "cycle the subagent panel: full, summary, hidden"))
-        lines.append(_key_row("ctrl+b", "open an aside; ctrl+f forks it in"))
-        # Directly under `ctrl+b`, because it is only meaningful once an aside
+        lines.append(_key_row("ctrl+b", "show or hide the session sidebar"))
+        lines.append(_key_row("F8", "open an aside; ctrl+f forks it in"))
+        # Directly under `F8`, because it is only meaningful once an aside
         # is open. ONE row for the pair rather than two: the partner chord fits
         # inside the description, which keeps the gutter reading as one gesture
         # per row. MEASURED at 62 composed cells against the 74-cell ceiling
@@ -22835,7 +23371,11 @@ class OperatorApp(App[None]):
                 style="warning",
             )
         self._loop_cancelled = False
-        self.run_worker(self._loop_worker(iterations), thread=False, group="loop")
+        self.run_worker(
+            self._loop_worker(iterations, self._interaction),
+            thread=False,
+            group=self._interaction.worker_group("loop"),
+        )
         return SlashResult(
             kind="notice",
             text=f"looping toward the goal ({iterations} iteration(s)) — /loop stop to cancel",
@@ -22860,7 +23400,11 @@ class OperatorApp(App[None]):
                 text="no session yet — there is no context to compact",
                 style="warning",
             )
-        self.run_worker(self._compact_worker(session), thread=False, group="compact")
+        self.run_worker(
+            self._compact_worker(session, self._interaction),
+            thread=False,
+            group=self._interaction.worker_group("compact"),
+        )
         return SlashResult(kind="notice", text="compacting context…", style="info")
 
     def _approvals_slash_result(self, arg: str, SlashResult: Any) -> Any:
@@ -25193,23 +25737,7 @@ class OperatorApp(App[None]):
         self._refresh_working_activity()
         # A prompt typed DURING the pass was held rather than sent into a
         # history being rewritten; now the history is settled, it goes.
-        held, self._prompt_held_for_compaction = self._prompt_held_for_compaction, ""
-        # Kept, not dropped: the markers are resolved against the TYPED text
-        # below. Cleared after that so a later `/reload` cannot hand back a
-        # line whose prompt already went.
-        typed, self._typed_held_for_compaction = self._typed_held_for_compaction, ""
-        held_images, self._images_held_for_compaction = self._images_held_for_compaction, {}
-        if held or held_images:
-            # `resolve_markers` orders images by WHERE the citation sits, so it
-            # must read the text the user actually wrote. Run against the
-            # expanded payload, a `[Image #N]` appearing anywhere in the
-            # SKILL.md body (a skill about screenshots is the obvious case)
-            # shifts the citation positions and the model silently receives the
-            # attachments in the wrong order — verified: a draft citing #2 then
-            # #1 sent `[BBB, AAA]` on the normal path and `[AAA, BBB]` here.
-            # The PAYLOAD is still what gets sent; only the marker walk uses
-            # the typed line.
-            self._start_turn(held, resolve_markers(typed or held, held_images))
+        self._consume_compaction_input(self._interaction)
 
     def on_effective_model_changed(self, message: EffectiveModelChanged) -> None:
         """Repaint the model segment with the model actually serving requests.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -232,7 +232,9 @@ from local_operator.tui.widgets.session_picker import (
     SessionPickerScreen,
 )
 from local_operator.tui.widgets.session_sidebar import (
+    SIDEBAR_GUTTER,
     SIDEBAR_MAIN_MIN_WIDTH,
+    SIDEBAR_MIN_CONTENT_WIDTH,
     SIDEBAR_WIDTH,
     SessionSidebar,
 )
@@ -1540,6 +1542,20 @@ class OperatorApp(App[None]):
         Binding("f8", "aside", "Aside", show=False),
         Binding("ctrl+b", "toggle_sidebar", "Sessions", show=False),
         Binding("f9", "focus_sidebar", "Focus sessions", show=False),
+        # Chosen after auditing the table: `up`/`down`, `pageup`/`pagedown`,
+        # `home`/`end` and `shift+up`/`shift+down` are TextArea cursor or
+        # selection keys, `ctrl+u`/`ctrl+d` are destructive in the composer,
+        # `alt+up`/`alt+down` are rewritten by `Editor.VERTICAL_CHORD_KEYS`,
+        # `ctrl+up`/`ctrl+down` page the todos, `ctrl+home`/`ctrl+end` page the
+        # transcript and `ctrl+pageup`/`ctrl+pagedown` scroll the aside. That
+        # leaves `ctrl+shift+up`/`ctrl+shift+down`, which nothing in
+        # `local_operator/` binds and `TextArea` does not claim. `priority`
+        # because the composer holds focus in the common case and must not
+        # swallow them.
+        Binding(
+            "ctrl+shift+up", "switch_session(-1)", "Previous session", show=False, priority=True
+        ),
+        Binding("ctrl+shift+down", "switch_session(1)", "Next session", show=False, priority=True),
         # Textual decodes Kitty's Super modifier. Terminals that intercept Cmd+B
         # never deliver it, so Ctrl+B and /sidebar remain unconditional routes.
         *(
@@ -3789,6 +3805,76 @@ class OperatorApp(App[None]):
         else:
             self._editor().focus()
 
+    def action_switch_session(self, delta: int) -> None:
+        """``ctrl+shift+up``/``ctrl+shift+down`` — attach the adjacent session.
+
+        Distinct from `F9`, which focuses the list so the arrows move a cursor
+        and `enter` commits: this is the one-press form that ATTACHES, for
+        moving between two or three live conversations without a detour
+        through the list's focus.
+
+        The order is the list's own ranking, so what the user sees is what they
+        traverse — including while the list is closed, which is why the
+        catalog is read rather than the widget's rendered window. Wrapping is
+        deliberate: the convention here is that a discrete, deliberate press
+        wraps while wheel and page movement clamp, and stopping dead at the end
+        of a three-session list would make the shortcut feel broken.
+
+        Focus is untouched: the composer keeps the caret and the draft, so
+        switching mid-sentence does not cost the sentence.
+        """
+        entries = self._session_sidebar.entries
+        if not entries:
+            # The catalog is only polled while the list is open, so a closed
+            # list has nothing to traverse. Load it once, then switch — the
+            # shortcut is meant to work without opening the drawer first.
+            self.run_worker(self._switch_session_cold(delta), group="sidebar-switch")
+            return
+        current = self._session.session_id if self._session is not None else ""
+        index = next((i for i, entry in enumerate(entries) if entry.id == current), None)
+        if index is None:
+            # Attached to something outside the list (or nothing yet): enter at
+            # the nearest end rather than refusing to move.
+            target = entries[0] if delta > 0 else entries[-1]
+        else:
+            target = entries[(index + delta) % len(entries)]
+        if target.id == current:
+            return
+        self._session_sidebar.cursor_id = target.id
+        self.post_message(SessionSidebar.Selected(target.id))
+
+    async def _switch_session_cold(self, delta: int) -> None:
+        """Populate the catalog for a switch pressed while the list is closed.
+
+        Reuses the list's own loader and ranking so a closed-list switch
+        traverses exactly the order an open list would show; anything else
+        would be a second, silently diverging notion of "next".
+        """
+
+        def collect() -> list[CatalogEntry]:
+            from local_operator.paths import config_dir
+            from local_operator.tui.session_catalog import load_catalog
+
+            return load_catalog(config_dir())
+
+        try:
+            entries = await asyncio.to_thread(collect)
+        except Exception:
+            logger.debug("sidebar switch catalog load failed", exc_info=True)
+            return
+        if self._session_sidebar.entries:
+            # A concurrent refresh won the race and its entries are current;
+            # adopting this older read would step from a stale order.
+            pass
+        elif entries:
+            self._session_sidebar.current_id = str(getattr(self._session, "session_id", ""))
+            self._session_sidebar.set_entries(entries)
+        else:
+            # Nothing to traverse. Returning here is also what stops the
+            # re-entry below from recursing on an empty catalog.
+            return
+        self.action_switch_session(delta)
+
     def action_toggle_sidebar(self) -> None:
         if not self._session_sidebar.display:
             self._close_subagent_view()
@@ -3826,18 +3912,26 @@ class OperatorApp(App[None]):
         sidebar = self._session_sidebar
         if not sidebar.is_mounted:
             return
-        narrow = size.width < SIDEBAR_WIDTH + SIDEBAR_MAIN_MIN_WIDTH + 2
+        position = self._sidebar_settings.position
+        # The gutter faces the CONVERSATION, so it swaps sides with the dock:
+        # right edge when docked left, left edge when docked right. Applied as
+        # padding on the widget rather than a margin on the main lane so the
+        # overlay case (where nothing is displaced) gets the same separation.
+        total_width = SIDEBAR_WIDTH + SIDEBAR_GUTTER
+        narrow = size.width < total_width + SIDEBAR_MAIN_MIN_WIDTH + 2
         workspace = self.query_one("#session-workspace")
         workspace.set_class(narrow, "sidebar-overlay")
-        sidebar.styles.dock = self._sidebar_settings.position
-        sidebar.styles.width = min(SIDEBAR_WIDTH, max(16, size.width - 2))
-        if narrow:
-            # The small-screen list floats over the transcript, never over the
-            # composer or a pending prompt. The conversation retains its width.
-            dock = self.query_one("#input-dock")
-            sidebar.styles.height = max(3, size.height - dock.outer_size.height - 2)
-        else:
-            sidebar.styles.height = "1fr"
+        sidebar.styles.dock = position
+        # Squeezed terminals give the gutter back before the list: separation
+        # is worthless once there is no room left to read a title in.
+        available = max(16, size.width - 2)
+        width = min(total_width, available)
+        gutter = max(0, min(SIDEBAR_GUTTER, width - SIDEBAR_MIN_CONTENT_WIDTH))
+        sidebar.styles.width = width
+        sidebar.styles.padding = (0, gutter, 0, 1) if position == "left" else (0, 1, 0, gutter)
+        # The workspace clips overlay height against the dock's same-frame
+        # arrangement, including draft wrapping and gates, without a reflow.
+        sidebar.styles.height = "1fr"
 
     def _refresh_sidebar(self) -> None:
         if not self._session_sidebar.display or self._sidebar_refresh_pending:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1874,7 +1874,7 @@ class OperatorApp(App[None]):
         #: suppressed, so a question raised while the user was watching was
         #: never announced after they tabbed away — indefinitely, since the
         #: latch re-arms only by answering the question they do not know exists.
-        self._waiting_kind: str | None = None
+        self._waiting_kind = None
         #: Whether a turn completion was suppressed because delegated work was
         #: still outstanding, and therefore still owes the user a toast. The
         #: docstring's original claim — that silence costs nothing because a
@@ -1884,7 +1884,7 @@ class OperatorApp(App[None]):
         #: manager's cancel branch never delivers at all. Left to that, a
         #: parent that finished while a child was later CANCELLED was never
         #: announced. This flag is what lets the last child's settle deliver it.
-        self._completion_deferred: bool = False
+        self._completion_deferred = False
         #: Job ids whose ``SubagentEnded`` this app has already handled but
         #: which the job manager may not have marked settled yet. A SET, not a
         #: single id, because a `task` batch settles its children inside one
@@ -1893,7 +1893,7 @@ class OperatorApp(App[None]):
         #: ITSELF saw its siblings as outstanding and returned early. Nobody was
         #: last, so nobody delivered the completion — and the deferred flag then
         #: latched, swallowing every later completion in the session.
-        self._settled_child_ids: set[str] = set()
+        self._settled_child_ids = set()
         #: Whether a turn is OPEN — set by ``TurnStarted``, cleared by
         #: ``_finalize_turn`` and by the two teardown paths that throw a turn
         #: away. It is the latch that makes turn retirement at-most-once: a
@@ -2420,7 +2420,7 @@ class OperatorApp(App[None]):
         # epoch it entered in and denies if the latch covers that epoch, so a
         # `TurnStarted` racing the wake cannot un-deny a stopped turn's tools.
         self._turn_epoch = 0
-        self._approvals_denied_epoch: int | None = None
+        self._approvals_denied_epoch = None
         # Tool cards the last turn boundary marked interrupted. Read once, by
         # `on_turn_ended`, to decide whether an abort still owes the user a
         # standalone notice or has already said it on the rows themselves.
@@ -2618,6 +2618,48 @@ class OperatorApp(App[None]):
     @property
     def _turn_notified(self) -> bool:
         return self._interaction.turn.notified
+        self._status = StatusLine(self.query_one("#status-band", Static))
+        self._status.update(model_label=MODEL_PENDING, cwd=os.getcwd())
+        # Attached AFTER the first `update`, so the first STABLE title already
+        # carries the working directory it falls back to while the conversation
+        # is unnamed. Attaching first would leave a bare `lo ›` on screen for
+        # as long as the boot takes.
+        self._start_terminal_title()
+        # Inline images write kitty graphics APCs through the same driver door
+        # (`tui/images.py` docs the interleaving hazard). Installed with the
+        # same gate as the title: no driver or headless means no terminal to
+        # transmit to, and ImageBlock then falls back to half-cells or text on
+        # its own — the writer's absence is a mode signal, never an error.
+        driver = self._driver
+        if driver is not None and not self.is_headless:
+            images_mod.set_escape_writer(driver.write)
+        # Same driver, same gating, one line later: the notifier is the title's
+        # out-of-app counterpart (state vs edge — see `tui/notify.py`), and both
+        # want the terminal available and the app non-headless.
+        self._start_notifier()
+        # Straight after the band exists and before the session is asked for:
+        # the saved mode has to be in force by the time the first tool can ask,
+        # and the band has to say so on the boot frame rather than on whichever
+        # later event happens to repaint it.
+        self._load_approvals_default()
+        editor = self.query_one(Editor)
+        # Installed here rather than in the Editor's constructor: the editor is
+        # built inside `compose`, before the app has anything for it to call, and a
+        # widget that reached back into its host would invert the dependency this
+        # whole module is arranged around.
+        editor.set_model_handler(self._on_model_row_chosen)
+        editor.focus()
+        # The count has no event to hang off (see JOB_POLL_INTERVAL_S).
+        self.set_interval(JOB_POLL_INTERVAL_S, self._poll_subagents)
+        self.set_interval(1.0, self._poll_completion_attention)
+        self.set_interval(TERMINAL_LIFECYCLE_CHECK_S, self._check_terminal_frontend)
+        # Prime the reader observation while mount still owns a known-live
+        # driver. A tty can EOF before the first interval tick, and requiring a
+        # prior observation is what keeps headless/alternate drivers safe.
+        self._check_terminal_frontend()
+        # Keep the active provider's quota warm in the shared cache so `/usage`
+        # answers from disk (see USAGE_WARM_INTERVAL_S).
+        self.set_interval(USAGE_WARM_INTERVAL_S, self._warm_usage_background)
 
     @_turn_notified.setter
     def _turn_notified(self, value: bool) -> None:
@@ -3123,6 +3165,7 @@ class OperatorApp(App[None]):
             getattr(state, "generation", 0),
             getattr(state, "history_cursor", None),
             getattr(state, "streaming", False),
+            getattr(source.session, "display_history_revision", 0),
         )
 
     def _capture_sidebar_presentation(self) -> SessionPresentation:
@@ -3141,6 +3184,7 @@ class OperatorApp(App[None]):
         return SessionPresentation(
             replay=replay,
             revision=self._interaction.presentation_revision,
+            replay_revision=getattr(self._session, "display_history_revision", 0),
             source_stamp=self._sidebar_source_stamp(self._interaction),
             source_token=self._interaction.token,
             history_size=self._history_length(),
@@ -3272,6 +3316,8 @@ class OperatorApp(App[None]):
         from local_operator.session.remote import RemoteSession
         from local_operator.tui.session_catalog import session_directory_name
 
+        if not session_directory_name(session_id):
+            raise ValueError("The conversation identifier is not valid")
         if self._session is not None and self._session.session_id == session_id:
             return self._interaction, self._capture_sidebar_presentation()
         if not speculative:
@@ -3289,6 +3335,7 @@ class OperatorApp(App[None]):
                 await asyncio.wait_for(session._ensure_bound(), 15)
             if session.is_cold:
                 raise RuntimeError("The conversation has not finished connecting")
+            await session.ensure_display_current()
             gate = session.frontend_state.pending_gate
             if gate is not None and gate.kind not in {"ask", "approval"}:
                 raise RuntimeError("This viewer does not support the conversation's pending input")
@@ -3317,17 +3364,28 @@ class OperatorApp(App[None]):
                     source.draft.following_tail = True
                     source.draft.scroll_anchor_id = ""
             history = session.display_history_window()
+            replay_revision = session.display_history_revision
             source_stamp = self._sidebar_source_stamp(source)
             replay.prepare(
                 history,
                 bound=max(12, self.size.height // 2),
                 anchor_id=source.draft.scroll_anchor_id if not source.draft.following_tail else "",
             )
+            self._mark_pending_tool_rows(replay.blocks, session)
             replay.view.styles.layer = "session-cache"
-            replay.view.styles.visibility = "hidden"
+            # visibility:hidden removes the compositor map and makes size=0.
+            # A screen overlay is excluded from flow/virtual bounds; parking it
+            # one viewport to the right preserves its real dimensions and scroll
+            # layout while clipping ALL ink/hit targets (unlike cached opacity).
+            replay.view.styles.overlay = "screen"
+            replay.view.styles.offset = ("100vw", 0)
+            replay.view.disabled = True
+            replay.view.set_navigation_visible(False)
+            for block in replay.blocks:
+                block.set_navigation_visible(False)
             replay.view.styles.height = self._transcript_view().outer_size.height
             conversation = self.query_one("#session-conversation")
-            conversation.styles.layers = "default session-cache"
+            conversation.styles.layers = "session-cache default"
             await conversation.mount(replay.view)
             if not replay.blocks:
                 welcome = WelcomeView(
@@ -3360,6 +3418,7 @@ class OperatorApp(App[None]):
             return source, SessionPresentation(
                 replay,
                 revision=revision,
+                replay_revision=replay_revision,
                 source_stamp=source_stamp,
                 source_token=source.token,
                 history_size=session.history_message_count,
@@ -3459,17 +3518,55 @@ class OperatorApp(App[None]):
             )
 
     def _sidebar_gate_surface_ready(self, source: SessionInteraction) -> bool:
-        if not self._is_current(source) or getattr(source.session, "is_cold", False):
+        if (
+            not self._is_current(source)
+            or getattr(source.session, "is_cold", False)
+            or not getattr(source.session, "display_history_current", True)
+        ):
             return False
         view = self._transcript_view()
         editor = self._editor()
-        if not view.is_on_screen or not editor.is_mounted or editor.disabled:
+        # Widget.region may lazily reflow a newer layout after the display that
+        # invoked this hook. Only the compositor map used by that display can
+        # prove its target pixels/gates were actually on screen. Never rebuild
+        # a map here and then treat the next frame's geometry as already shown.
+        displayed = getattr(self, "_sidebar_displayed_frame", None)
+        if displayed is None:
             return False
+        frame_token, frame_generation, replay_revision, presentation_revision, painted = displayed
+        if (
+            frame_token != source.token
+            or frame_generation != self._sidebar_navigation.generation
+            or replay_revision != getattr(source.session, "display_history_revision", 0)
+            or presentation_revision != source.presentation_revision
+        ):
+            return False
+
+        def region(widget: Widget) -> Any:
+            entry = painted.get(id(widget._render_widget))
+            return entry[0] if entry is not None else None
+
+        view_region = region(view)
+        if (
+            view_region is None
+            or region(editor) is None
+            or not editor.is_mounted
+            or editor.disabled
+        ):
+            return False
+        content = view_region.shrink(view.styles.gutter)
         blocks = view.blocks()
+        if blocks and not any(
+            (area := region(block)) is not None and area.overlaps(content) for block in blocks
+        ):
+            return False
         if source.draft.following_tail:
             last = next((block for block in reversed(blocks) if block.display), None)
-            if not view.is_near_bottom() or (
-                last is not None and last.region.bottom > view.content_region.bottom
+            last_region = region(last) if last is not None else None
+            if last is not None and (
+                last_region is None
+                or not last_region.overlaps(content)
+                or last_region.bottom > content.bottom
             ):
                 return False
         elif source.draft.scroll_anchor_id:
@@ -3483,14 +3580,20 @@ class OperatorApp(App[None]):
                 None,
             )
             if anchor is not None:
-                offset = min(source.draft.scroll_offset, max(0, anchor.region.height - 1))
-                if (
-                    anchor.region.y + offset != view.content_region.y
-                    and 0 < view.scroll_y < view.max_scroll_y
-                ):
+                anchor_region = region(anchor)
+                if anchor_region is None or not anchor_region.overlaps(content):
                     return False
-        state = getattr(source.session, "frontend_state", None)
-        gate = getattr(state, "pending_gate", None)
+                offset = min(source.draft.scroll_offset, max(0, anchor_region.height - 1))
+                if anchor_region.y + offset != content.y and 0 < view.scroll_y < view.max_scroll_y:
+                    return False
+        # `pending_gate`, not `frontend_state.pending_gate`: the latter clones
+        # the entire state (jobs, usage, trajectories) on every display, which
+        # profiling measured as the largest single cost of the cold frame. A
+        # reduced facade without the narrow accessor still falls back below.
+        session = source.session
+        gate = getattr(session, "pending_gate", None)
+        if gate is None and not hasattr(session, "pending_gate"):
+            gate = getattr(getattr(session, "frontend_state", None), "pending_gate", None)
         if gate is None:
             return self._ask_screen is None and self._approval is None
         if gate.kind == "approval" and bool(source.draft.approve_all):
@@ -3501,7 +3604,7 @@ class OperatorApp(App[None]):
             and card.source_binding
             == (source.token, self._sidebar_gate_identity(source), source.gate_view_generation)
             and card.is_mounted
-            and card.is_on_screen
+            and region(card) is not None
             and not card.disabled
             and not card.settled
         )
@@ -3522,8 +3625,37 @@ class OperatorApp(App[None]):
 
         timer = self.set_timer(15, expired)
         future.add_done_callback(lambda _future: timer.stop())
-        self.refresh()
+        # The first target frame must cover its transcript, draft and gates,
+        # not merely a sidebar/status fragment sharing the new geometry map.
+        self.screen.refresh(layout=True)
         return future
+
+    def _display(self, screen: "Screen[Any]", renderable: Any) -> None:
+        from textual._compositor import LayoutUpdate
+
+        if (
+            getattr(self, "_sidebar_ready_frame", None) is not None
+            and isinstance(renderable, LayoutUpdate)
+            and self._running
+            and not self._closed
+            and not self._batch_count
+            and screen is self.screen
+        ):
+            painted = screen._compositor._visible_widgets
+            if painted is not None:
+                # Textual calls post_display_hook even for renderable=None.
+                # A full update proves all target surfaces were painted, not
+                # just a sidebar fragment. Store only IDs/geometry so this
+                # evidence cannot retain a dismissed secret-input widget.
+                source = self._interaction
+                self._sidebar_displayed_frame = (
+                    source.token,
+                    self._sidebar_navigation.generation,
+                    getattr(source.session, "display_history_revision", 0),
+                    source.presentation_revision,
+                    {id(widget): geometry for widget, geometry in painted.items()},
+                )
+        super()._display(screen, renderable)
 
     def post_display_hook(self) -> None:
         super().post_display_hook()
@@ -3540,11 +3672,23 @@ class OperatorApp(App[None]):
             # update. Only now are the target frame and its input surface ready.
             self._sidebar_ready_frame = None
             future.set_result(None)
+        elif (
+            generation == self._sidebar_navigation.generation
+            and self._is_current(source)
+            and getattr(source.session, "display_history_current", True)
+        ):
+            # A container can land before its parked children's translated
+            # scroll map. Request the actual follow-up layout/paint now rather
+            # than waiting for the unrelated two-second catalog poll. The same
+            # displayed-map gate still decides readiness; no timer waives it.
+            self.screen.refresh(layout=True)
 
     def _sidebar_navigation_pending(self, session_id: str) -> None:
         from local_operator.session.remote import RemoteSession
 
         current = self._session
+        if session_id:
+            self._sidebar_displayed_frame = None
         if isinstance(current, RemoteSession):
             if session_id:
                 self._suspend_sidebar_gates(self._interaction)
@@ -3768,6 +3912,13 @@ class OperatorApp(App[None]):
             return
         if not isinstance(session, RemoteSession) or session.is_cold:
             raise RuntimeError("The conversation is not ready for input")
+        if (
+            not session.display_history_current
+            or incoming.replay_revision != session.display_history_revision
+        ):
+            from local_operator.tui.session_navigation import PreparationInvalidated
+
+            raise PreparationInvalidated("canonical replay changed during preparation")
         outgoing = self._interaction
         previous = outgoing.session
         if previous is not None and not isinstance(previous, RemoteSession):
@@ -3831,16 +3982,26 @@ class OperatorApp(App[None]):
         self._settle_key_prompt()
         self._approval = None
         old_view = self._transcript_view()
+        old_view.set_navigation_visible(False)
+        if self._welcome is not None:
+            self._welcome.set_navigation_visible(False)
         old_view.set_on_user_scroll(None)
         old_view.set_on_tail_requested(None)
         old_view.set_on_clear(None)
         old_view.styles.layer = "session-cache"
-        old_view.styles.visibility = "hidden"
+        old_view.styles.overlay = "screen"
+        old_view.styles.offset = ("100vw", 0)
+        old_view.disabled = True
         old_view.styles.height = old_view.outer_size.height
         displaced = self._sidebar_presentations.pop(session_id, None)
         self._apply_sidebar_presentation(incoming)
         incoming.replay.view.styles.layer = "default"
-        incoming.replay.view.styles.visibility = "visible"
+        incoming.replay.view.styles.overlay = "none"
+        incoming.replay.view.styles.offset = (0, 0)
+        incoming.replay.view.disabled = False
+        incoming.replay.view.set_navigation_visible(True)
+        if incoming.welcome is not None:
+            incoming.welcome.set_navigation_visible(True)
         incoming.replay.view.styles.height = "1fr"
         incoming.replay.view.set_on_clear(self._on_transcript_cleared)
         incoming.replay.view.set_on_user_scroll(self._transcript_scrolled)
@@ -3851,6 +4012,7 @@ class OperatorApp(App[None]):
             if factory is not None:
                 self._session_factory = lambda: factory(session_id)
             self._adopt_session(session, replay_history=False, reuse_controller=True)
+            self._mark_pending_tool_rows(incoming.replay.view.blocks(), session)
             history = session.display_history_window()
             total = session.history_message_count
             if total > incoming.history_size:
@@ -4164,10 +4326,9 @@ class OperatorApp(App[None]):
 
         def collect() -> list[CatalogEntry]:
             from local_operator.paths import config_dir
-            from local_operator.resume import recent_session_rows
+            from local_operator.tui.session_catalog import load_catalog
 
-            rows = self._overlay_live_state(recent_session_rows(config_dir(), limit=None))
-            return [CatalogEntry(row) for row in rows]
+            return load_catalog(config_dir())
 
         async def refresh() -> None:
             try:
@@ -4180,7 +4341,7 @@ class OperatorApp(App[None]):
                 session = self._session
                 self._session_sidebar.current_id = str(getattr(session, "session_id", ""))
                 self._session_sidebar.set_entries(entries)
-                self._prewarm_sidebar(entries)
+                self._prewarm_sidebar(list(self._session_sidebar.visible_entries))
             except Exception:
                 if generation == self._sidebar_refresh_generation and self._session_sidebar.display:
                     self._session_sidebar.show_error("Could not refresh conversations")
@@ -4283,7 +4444,7 @@ class OperatorApp(App[None]):
         return TranscriptScreen(id="_default")
 
     def compose(self) -> ComposeResult:
-        with Horizontal(id="session-workspace"):
+        with SessionWorkspace(id="session-workspace"):
             yield self._session_sidebar
             with Container(id="session-conversation"):
                 # The welcome splash is the transcript's EMPTY STATE, so it is mounted
@@ -4613,7 +4774,7 @@ class OperatorApp(App[None]):
             # the transcript to stop mid-air (round-3 D3-1/Q3-2/U3-1).
             set_stopped = getattr(session, "set_stopped_callback", None)
             if callable(set_stopped):
-                set_stopped(self._on_watched_session_stopped)
+                set_stopped(lambda: self._on_watched_session_stopped(source))
             # The third outcome, and the only one that is housekeeping rather
             # than an ending: the runtime retired ITSELF because `lop-update`
             # put a newer build on disk. Re-engage at once so the band never
@@ -4917,7 +5078,7 @@ class OperatorApp(App[None]):
         )
         self._refresh_band()
 
-    def _on_watched_session_stopped(self) -> None:
+    def _on_watched_session_stopped(self, source: SessionInteraction | None = None) -> None:
         """A viewer's session was ended deliberately by whoever owns it.
 
         Says the same thing the owner's own ``/stop`` says, because it is the
@@ -4925,7 +5086,18 @@ class OperatorApp(App[None]):
         id is recorded FIRST — ``_no_session_notice`` is gated on it, so it
         is what turns every later "owner is reconnecting" into the truth.
         """
-        session = self._session
+        source = source or self._interaction
+        session = source.session
+        source.turn.open = False
+        source.loop.cancelled = True
+        source.gate_draft = None
+        source.gate_view_generation += 1
+        source.presentation_revision += 1
+        if not self._is_current(source):
+            # The facade already owns its stopped state and invokes this same
+            # source-bound callback on a later adoption. A hidden owner's stop
+            # must never settle the selected conversation's approval/ask widgets.
+            return
         session_id = getattr(session, "session_id", "") if session is not None else ""
         if session_id:
             self._stopped_session_id = session_id
@@ -5637,11 +5809,22 @@ class OperatorApp(App[None]):
         self._resume_in_zone = True
         self._project_settled_rows(history, bound=RESUME_RENDER_MESSAGES)
 
+    @staticmethod
+    def _mark_pending_tool_rows(blocks: list[Any], session: Any) -> None:
+        pending = getattr(session, "pending_display_tool_ids", None)
+        if callable(pending):
+            call_ids = cast(set[str], pending())
+            for block in blocks:
+                if isinstance(block, ToolCard) and block.tool_call_id in call_ids:
+                    block.mark_waiting()
+
     def _project_settled_rows(self, history: list[Any], *, bound: int | None = None) -> bool:
         from local_operator.tui.session_presentation import project_settled_rows
 
         try:
-            return project_settled_rows(self, history, bound=bound)
+            projected = project_settled_rows(self, history, bound=bound)
+            self._mark_pending_tool_rows(self._transcript_view().blocks(), self._session)
+            return projected
         finally:
             self._projection_message_id = ""
 
@@ -13470,10 +13653,9 @@ class OperatorApp(App[None]):
         # — but through the SAME public `sync_animation_rate` seam as the four
         # above, not through its privates: a second convention for "re-rate
         # yourself" is exactly what this module's docstring warns against.
-        try:
-            welcome = self.query_one(WelcomeView)
-        except Exception:
-            return  # no splash mounted, or already torn down: the ordinary case
+        welcome = self._welcome
+        if welcome is None:
+            return
         try:
             welcome.sync_animation_rate()
         except Exception:  # pragma: no cover - defensive; chrome must not raise
@@ -14059,6 +14241,7 @@ class OperatorApp(App[None]):
             # No such implementation exists in tree, and unlike the prompt path
             # there is no signature to probe — a re-minting host would have to
             # be caught by its own tests (round 1, F2).
+            user_block.navigation_anchor_id = steer_message.id
             self._register_user_echo(sent, message_id=steer_message.id)
             # Held with the notice so Esc can lift the whole steer — the queued
             # row, the user row and its image blocks — back out of the
@@ -14099,6 +14282,8 @@ class OperatorApp(App[None]):
             # worse than not queueing at all.
             self._prompt_held_for_compaction = sent
             self._interaction.compaction.accepted_draft = self._interaction.turn.submitted_draft
+            self._interaction.compaction.accepted_message_id = self._echo_message_id(session.prompt)
+            user_block.navigation_anchor_id = self._interaction.compaction.accepted_message_id
             # Only when they differ, so the common path leaves this empty and
             # the hand-back below falls through to the held prompt itself.
             #
@@ -14120,7 +14305,9 @@ class OperatorApp(App[None]):
             self._append_block(NoticeBlock("queued — sends when compaction finishes", "note"))
             self._maybe_name_conversation(named)
             return
-        self._start_turn(sent, images)
+        echo = self._start_turn(sent, images)
+        if isinstance(echo, _PendingUserEcho):
+            user_block.navigation_anchor_id = echo.message_id
         # AFTER the turn is dispatched, and then concurrently with it: the
         # title is decoration, so it must never sit in front of the user's
         # first reply — but it must also not wait for the whole turn, which is
@@ -14141,7 +14328,8 @@ class OperatorApp(App[None]):
         images: list[ImageContent] | None = None,
         *,
         accepted: SessionDraft | None = None,
-    ) -> None:
+        message_id: str = "",
+    ) -> _PendingUserEcho | None:
         """Run one user prompt as a turn, reporting a failure as a notice.
 
         Extracted from :meth:`_submit_prompt` so a prompt HELD through a
@@ -14170,7 +14358,7 @@ class OperatorApp(App[None]):
         source.turn.operation += 1
         turn_operation = source.turn.operation
         echo = self._register_user_echo_for(
-            source, text, message_id=self._echo_message_id(session.prompt)
+            source, text, message_id=message_id or self._echo_message_id(session.prompt)
         )
         # A turn STARTING ends any barren click gesture: from here Ctrl+C means
         # "stop this turn", and a claim raised before the turn existed cannot
@@ -14342,10 +14530,11 @@ class OperatorApp(App[None]):
                 # working blip bounded by the owner's prompt preparation, not by
                 # the relay of the OUTCOME. That is not the flash this closes.
                 knows_outcome = not bool(getattr(session, "is_remote", False))
-                self._retire_turn_band(
-                    session,
-                    failed=(bool(error_text) and not aborted) if knows_outcome else None,
-                )
+                if self._is_current(source):
+                    self._retire_turn_band(
+                        session,
+                        failed=(bool(error_text) and not aborted) if knows_outcome else None,
+                    )
                 # POSTED, NEVER CALLED INLINE. For an in-process `Session`,
                 # `prompt()` returns only after the pipeline's `finally` has
                 # flushed the held end, which `_emit`s `agent_end`
@@ -14361,6 +14550,7 @@ class OperatorApp(App[None]):
                 )
 
         self.run_worker(run_prompt(), thread=False, group=source.worker_group("turns"))
+        return echo
 
     def _retire_turn_band(self, session: Any, *, failed: bool | None = None) -> None:
         """Clear the status band for a turn whose worker is done with it.
@@ -16316,8 +16506,9 @@ class OperatorApp(App[None]):
         into the scrollback is not the edge that starts a conversation.
         """
         if self._projection_message_id:
-            block.navigation_anchor_id = self._projection_message_id
-            block.navigation_anchor_part = self._projection_part
+            if not block.navigation_anchor_id:
+                block.navigation_anchor_id = self._projection_message_id
+                block.navigation_anchor_part = self._projection_part
             self._projection_part += 1
         if self._block_sink is not None:
             self._block_sink.append(block)
@@ -16586,10 +16777,10 @@ class OperatorApp(App[None]):
                 settings_reload()
             except Exception:  # noqa: BLE001 — the cache drop is best-effort
                 logger.debug("display settings cache could not be dropped", exc_info=True)
-        if "display.dock" in changed:
-            self._apply_dock_density()
         if any(key in changed for key in ("tui.sidebar_visible", "tui.sidebar_position")):
             self._apply_sidebar_settings()
+        if "display.dock" in changed:
+            self._apply_dock_density()
         if "tui.theme" in changed:
             values = getattr(change, "values", {})
             tui_block = values.get("tui") if isinstance(values, Mapping) else None
@@ -20513,6 +20704,13 @@ class OperatorApp(App[None]):
             group=self._interaction.worker_group("loop"),
         )
 
+    @staticmethod
+    async def _prompt_loop_turn(session: SessionProtocol, prompt: str, **kwargs: Any) -> None:
+        # Local Session.prompt already awaits the pipeline. Remote interactive
+        # prompt only admits it; a loop needs its explicit terminal-outcome API.
+        complete = getattr(session, "prompt_and_wait", session.prompt)
+        await cast(Callable[..., Awaitable[None]], complete)(prompt, **kwargs)
+
     async def _loop_worker(self, iterations: int, source: SessionInteraction | None = None) -> None:
         """Run up to ``iterations`` goal-advancing turns, sequentially."""
 
@@ -20568,7 +20766,7 @@ class OperatorApp(App[None]):
                 )
                 loop_error: str | None = None
                 try:
-                    await session.prompt(LOOP_PROMPT, **echo.prompt_kwargs())
+                    await self._prompt_loop_turn(session, LOOP_PROMPT, **echo.prompt_kwargs())
                 except Exception as error:  # surface and stop; never spin
                     loop_error = str(error)
                     # THROUGH the same helper the composer's turn uses. A loop
@@ -20585,11 +20783,8 @@ class OperatorApp(App[None]):
                     crashed = True
                     break
                 finally:
-                    # Through the shared gate, not a bare write: on a follower
-                    # this `finally` runs on the owner's ACK, mid-turn, and the
-                    # bare write published `lo ›` for a turn still running (see
-                    # `_retire_turn_band`).
-                    self._retire_turn_band(session)
+                    if self._is_current(source):
+                        self._retire_turn_band(session)
                     # The SAME retirement the composer's turn gets. A loop
                     # iteration is an ordinary turn as far as the transcript is
                     # concerned — it mounts a working line and opens the latch —
@@ -20640,10 +20835,9 @@ class OperatorApp(App[None]):
         aside worker). We do not pass `on_delta`: the judge answer must not
         stream to any visible surface.
         """
-        # Belt-and-suspenders: `/loop` already routes to the session OWNER,
-        # where `complete_aside` is the real implementation (a follower's raises),
-        # but guard in case a future path reaches the worker on a session lacking
-        # it — treat a missing primitive as a judge failure, not a crash.
+        # The local scheduler passes the captured source facade. Modern remotes
+        # route complete_aside to that owner; an older source without the
+        # primitive is a judge failure, not a reason to affect the current view.
         source = self._interactions.get(id(session), self._interaction)
         if not hasattr(session, "complete_aside"):
             return None, ""
@@ -20653,7 +20847,7 @@ class OperatorApp(App[None]):
                 turns, on_usage=lambda usage: self._charge_aside_for(source, usage)
             )
         except Exception as error:  # noqa: BLE001 — any provider failure is a judge failure
-            self._append_block(NoticeBlock(f"judge unavailable, continuing: {error}", "warning"))
+            self._notice_for(source, f"judge unavailable, continuing: {error}", "warning")
             return None, ""
         achieved, reason = _parse_loop_verdict(answer)
         if achieved is None:
@@ -20719,9 +20913,10 @@ class OperatorApp(App[None]):
                     source, prompt, message_id=self._echo_message_id(session.prompt)
                 )
                 try:
-                    await session.prompt(prompt, **echo.prompt_kwargs())
+                    await self._prompt_loop_turn(session, prompt, **echo.prompt_kwargs())
                 except Exception as error:  # surface and stop; never spin
-                    self._retire_turn_band(session)
+                    if self._is_current(source):
+                        self._retire_turn_band(session)
                     # Same helper, same reason as the numeric worker: a held
                     # goal loop is the MOST unattended surface in the app, and
                     # it was printing a bare `str(error)` (review U6).
@@ -20748,7 +20943,8 @@ class OperatorApp(App[None]):
                 completed += 1
                 # --- yield boundary reached: judge the settled turn ---
                 if source.loop.cancelled or source.retired:
-                    self._retire_turn_band(session)
+                    if self._is_current(source):
+                        self._retire_turn_band(session)
                     break
                 # Keep the status in a working state ACROSS the judge call. The
                 # judge is a real `complete_aside` network round-trip that can
@@ -20756,7 +20952,8 @@ class OperatorApp(App[None]):
                 # `loop N` and `loop N+1` while it is in fact spending tokens on
                 # the verdict. Cleared once the verdict is in hand (below).
                 achieved, reason = await self._judge_goal(session, goal)
-                self._retire_turn_band(session)
+                if self._is_current(source):
+                    self._retire_turn_band(session)
                 if achieved is True:
                     released = True
                     break
@@ -20800,6 +20997,9 @@ class OperatorApp(App[None]):
             # release path is unaffected: it calls `_notify` directly, and its
             # own `await _judge_goal` already drained the final `TurnEnded`.
             source.loop.running = False
+            # Match the numeric worker: every exit releases its one retained
+            # source lease before retirement eligibility is checked.
+            source.active_workers -= 1
             self.call_later(self._source_frontend_changed, source)
             source.loop.goal = ""
             self.call_later(self._release_loop_completion_suppression, source, operation)
@@ -25474,7 +25674,8 @@ class OperatorApp(App[None]):
         # already in the message queue when the stop landed ran before the parked
         # asker woke, so the stopped turn's write/exec tool got a fresh question.
         # An epoch bump cannot arrive early for an asker that captured the old one.
-        self._turn_epoch += 1
+        if not message.projection:
+            self._turn_epoch += 1
         # The turn is OPEN from here, and exactly one of `_finalize_turn` or a
         # teardown path closes it again. Set after the epoch bump so the flag
         # and the epoch a queued fallback is matched against always agree.
@@ -26369,7 +26570,9 @@ class OperatorApp(App[None]):
         entry", not from any ordering guarantee."""
         if self._consume_user_echo(message.prompt, message_id=message.message_id):
             return  # our own echo — the row is already painted
-        self._append_block(UserBlock(message.prompt, message.image_count))
+        block = UserBlock(message.prompt, message.image_count)
+        block.navigation_anchor_id = message.message_id
+        self._append_block(block)
         self._append_image_blocks(list(message.images))
 
     @staticmethod
@@ -26510,6 +26713,7 @@ class OperatorApp(App[None]):
         # TUI-020: adopt the authoritative text carried by the event.
         block.update_text(message.text)
         block.completion_anchor_id = message.message_id
+        block.navigation_anchor_id = message.message_id
         block.finalize_text()
         self._streaming_block = None
         # The prose is settled, so "responding…" is over: whatever the turn does

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -43,6 +43,7 @@ from typing import (
     TypeGuard,
     cast,
 )
+from weakref import ReferenceType, ref
 
 from rich.console import Group
 from rich.padding import Padding
@@ -1538,6 +1539,7 @@ class OperatorApp(App[None]):
         # terminal modifier encoding and leaves every TextArea editing key alone.
         Binding("f8", "aside", "Aside", show=False),
         Binding("ctrl+b", "toggle_sidebar", "Sessions", show=False),
+        Binding("f9", "focus_sidebar", "Focus sessions", show=False),
         # Textual decodes Kitty's Super modifier. Terminals that intercept Cmd+B
         # never deliver it, so Ctrl+B and /sidebar remain unconditional routes.
         *(
@@ -2543,7 +2545,7 @@ class OperatorApp(App[None]):
             None
         )
         self._sidebar_frame_pending = False
-        self._sidebar_focus_restore: Widget | None = None
+        self._sidebar_focus_restore: ReferenceType[Widget] | None = None
         self._sidebar_presentations: dict[str, SessionPresentation] = {}
         self._sidebar_sources: dict[str, SessionInteraction] = {}
         self._sidebar_drafts = SessionDraftStore()
@@ -3069,7 +3071,7 @@ class OperatorApp(App[None]):
             revision=self._interaction.presentation_revision,
             source_stamp=self._sidebar_source_stamp(self._interaction),
             source_token=self._interaction.token,
-            history_size=len(self._session.history()) if self._session is not None else 0,
+            history_size=self._history_length(),
             needs_live_projection=False,
             streaming_block=self._streaming_block,
             tool_cards=self._tool_cards,
@@ -3143,7 +3145,11 @@ class OperatorApp(App[None]):
 
         if record is not None and owner is not None:
             remote = await RemoteSession.connect(
-                record, session_id, config_dir=directory, takeover_factory=no_takeover
+                record,
+                session_id,
+                config_dir=directory,
+                takeover_factory=no_takeover,
+                display_window=True,
             )
         else:
             if speculative:
@@ -3232,7 +3238,13 @@ class OperatorApp(App[None]):
             replay = PreparedReplay()
             welcome: WelcomeView | None = None
             revision = source.presentation_revision
-            history = list(session.history())
+            if not source.draft.following_tail and source.draft.scroll_anchor_id:
+                if not await session.ensure_display_anchor(source.draft.scroll_anchor_id):
+                    # A canonical compaction can remove an old anchor. The owner
+                    # explicitly reset that seek; never pretend another row is it.
+                    source.draft.following_tail = True
+                    source.draft.scroll_anchor_id = ""
+            history = session.display_history_window()
             source_stamp = self._sidebar_source_stamp(source)
             replay.prepare(
                 history,
@@ -3278,7 +3290,7 @@ class OperatorApp(App[None]):
                 revision=revision,
                 source_stamp=source_stamp,
                 source_token=source.token,
-                history_size=len(history),
+                history_size=session.history_message_count,
                 working_fallback=DEFAULT_ACTIVITY,
                 welcome=welcome,
                 welcome_visible=welcome is not None,
@@ -3662,10 +3674,11 @@ class OperatorApp(App[None]):
             if factory is not None:
                 self._session_factory = lambda: factory(session_id)
             self._adopt_session(session, replay_history=False, reuse_controller=True)
-            history = list(session.history())
-            if len(history) > incoming.history_size:
-                self._project_settled_rows(history[incoming.history_size :])
-            elif len(history) < incoming.history_size:
+            history = session.display_history_window()
+            total = session.history_message_count
+            if total > incoming.history_size:
+                self._project_settled_rows(history[-(total - incoming.history_size) :])
+            elif total < incoming.history_size:
                 # A compaction/recovery changed the snapshot while its widgets
                 # were preparing. Reconcile the viewport without invoking the
                 # ordinary /clear hook, which would settle this source's gates.
@@ -3682,6 +3695,13 @@ class OperatorApp(App[None]):
             if incoming.needs_live_projection and self._controller is not None:
                 self._controller.restore_live_projection(
                     session.frontend_state, self._resume_mounted_ids, set(self._resume_results)
+                )
+                self._controller.register_restored_tools(
+                    {
+                        block.tool_call_id
+                        for block in incoming.replay.view.blocks()
+                        if isinstance(block, ToolCard)
+                    }
                 )
             editor.load_text(source.draft.text)
             editor.adopt_attachments(source.draft.attachments)
@@ -3727,6 +3747,8 @@ class OperatorApp(App[None]):
         if self._session is not None and self._session.session_id == message.session_id:
             if self._sidebar_navigation.requested_id:
                 self._sidebar_navigation.cancel()
+            if self.query_one("#session-workspace").has_class("sidebar-overlay"):
+                self._set_sidebar_open(False)
             self._editor().focus()
             return
         self._sidebar_prior_workers.update(self.workers.cancel_group(self, "session"))
@@ -3744,6 +3766,21 @@ class OperatorApp(App[None]):
         else:
             self._sync_sidebar_layout(self.size)
 
+    def action_focus_sidebar(self) -> None:
+        if self._session_sidebar.has_focus:
+            self._restore_sidebar_focus()
+            return
+        self._sidebar_focus_restore = ref(self.focused) if self.focused is not None else None
+        self._set_sidebar_open(True)
+        self._session_sidebar.focus()
+
+    def _restore_sidebar_focus(self) -> None:
+        target = self._sidebar_focus_restore() if self._sidebar_focus_restore is not None else None
+        if target is not None and target.is_mounted and target.can_focus and target.display:
+            target.focus()
+        else:
+            self._editor().focus()
+
     def action_toggle_sidebar(self) -> None:
         if not self._session_sidebar.display:
             self._close_subagent_view()
@@ -3754,7 +3791,7 @@ class OperatorApp(App[None]):
     def _set_sidebar_open(self, opened: bool) -> None:
         sidebar = self._session_sidebar
         if opened and not sidebar.display:
-            self._sidebar_focus_restore = self.focused
+            self._sidebar_focus_restore = ref(self.focused) if self.focused is not None else None
             self._sidebar_last_prefetch = ""
         sidebar.set_open(opened)
         self._sync_sidebar_layout(self.size)
@@ -3775,11 +3812,7 @@ class OperatorApp(App[None]):
                     if source is not None:
                         self.run_worker(self._release_sidebar_preparation((source, presentation)))
         if not opened and sidebar.has_focus:
-            target = self._sidebar_focus_restore
-            if target is not None and target.is_mounted:
-                target.focus()
-            else:
-                self._editor().focus()
+            self._restore_sidebar_focus()
 
     def _sync_sidebar_layout(self, size: Size) -> None:
         sidebar = self._session_sidebar
@@ -5011,6 +5044,11 @@ class OperatorApp(App[None]):
         """
         if self._status is None or session.conversation_name or self._provisional_name:
             return
+        opener = getattr(session, "history_opener_text", None)
+        if isinstance(opener, str):
+            if opener.strip():
+                self._show_provisional_name(opener)
+            return
         try:
             history = list(session.history())
         except Exception:
@@ -5224,7 +5262,7 @@ class OperatorApp(App[None]):
         where a slow `/resume` actually goes.
         """
         try:
-            history = list(session.history())
+            history = self._display_history(session)
         except Exception:
             return  # defensive: reduced hosts may lack the accessor
         # A previous resume's deferred head must not leak into this one: /resume
@@ -5326,6 +5364,32 @@ class OperatorApp(App[None]):
             view.remove_block(notice)
             self._resume_tail_notice = None
 
+    async def _fetch_older_display_page(self, source: SessionInteraction) -> None:
+        session = source.session
+        try:
+            from local_operator.session.remote import RemoteSession
+
+            if not isinstance(session, RemoteSession):
+                return
+            rows = await session.load_older_display_page()
+            source.presentation_revision += 1
+            if not self._is_current(source):
+                return
+            self._resume_pending_head = rows + self._resume_pending_head
+            for message in rows:
+                if getattr(message, "role", "") == "tool" and getattr(
+                    message, "tool_call_id", None
+                ):
+                    self._resume_results[message.tool_call_id] = message
+            self._resume_paging = False
+            self._mount_older_resume_page()
+        except Exception as exc:
+            if self._is_current(source):
+                self._notice(f"Could not load earlier messages: {exc}", "error")
+        finally:
+            if self._is_current(source):
+                self._resume_paging = False
+
     def _transcript_scrolled(self, *_args: Any, continuous: bool = False) -> None:
         """Mount the next older page when the reader reaches the top.
 
@@ -5367,6 +5431,20 @@ class OperatorApp(App[None]):
             self._mount_newer_resume_page()
             return
         if not self._resume_pending_head:
+            session = self._session
+            if (
+                session is not None
+                and getattr(session, "history_before_token", None)
+                and not self._resume_paging
+                and view.scroll_y <= RESUME_PAGE_TRIGGER_ROWS
+                and (not continuous or self._resume_in_zone)
+            ):
+                self._resume_paging = True
+                self._resume_in_zone = False
+                self.run_worker(
+                    self._fetch_older_display_page(self._interaction),
+                    group=self._interaction.worker_group("history-page"),
+                )
             return
         if self._resume_paging:
             # A page this same gesture requested is still mounting. The
@@ -6278,13 +6356,21 @@ class OperatorApp(App[None]):
         session = self._session
         return getattr(session, "session_id", "") if session is not None else ""
 
+    @staticmethod
+    def _display_history(session: Any) -> list[Any]:
+        accessor = getattr(session, "display_history_window", None)
+        return list(
+            cast(Callable[[], list[Any]], accessor)() if callable(accessor) else session.history()
+        )
+
     def _history_length(self) -> int:
         """How many messages the model currently has, as the session reports it."""
         session = self._session
         if session is None:
             return 0
         try:
-            return len(session.history())
+            count = getattr(session, "history_message_count", None)
+            return count if isinstance(count, int) else len(session.history())
         except Exception:  # reduced hosts (embedders, pilot fakes) may lack it
             return 0
 
@@ -8657,7 +8743,8 @@ class OperatorApp(App[None]):
         if detail:
             self._system_notice(detail, "warning")
         goal = str(getattr(session, "goal", "") or "").strip()
-        if goal:
+        if goal and goal != self._interaction.restored_goal_notice:
+            self._interaction.restored_goal_notice = goal
             from local_operator.tui.widgets.tool_card import truncate_cells
 
             # Capped so a goal written up to MAX_GOAL_CHARS (2000) cannot turn
@@ -9752,8 +9839,9 @@ class OperatorApp(App[None]):
         if entry is None:
             return False
         name = entry.name
-        if name == "credential":
-            # Its masked interaction is local but its in-memory store is not.
+        if name in {"credential", "loop"}:
+            # The credential store and each locally scheduled loop iteration
+            # belong to the owner, even though their invoking UI is local.
             return True
         if name in _FRONTEND_LOCAL_SLASHES:
             return False
@@ -10268,6 +10356,7 @@ class OperatorApp(App[None]):
             and self.focused is event.widget
             and event.widget is not self._session_sidebar
         ):
+            self._sidebar_focus_restore = ref(event.widget)
             view = self._transcript
             if view is not None and (event.widget is view or view in event.widget.ancestors):
                 self._interaction.draft.focus_id = "@transcript"
@@ -13311,6 +13400,7 @@ class OperatorApp(App[None]):
         self._shell_card = card
         card_ref = weakref.ref(card)
         source.shell.call_id = call_id
+        source.shell.result = None
         session = source.session
         cwd = os.getcwd()
         session_cwd = getattr(session, "_cwd", None) if session is not None else None
@@ -13345,13 +13435,21 @@ class OperatorApp(App[None]):
         async def persist(result: ToolResult) -> None:
             """One persistence hop; a spawn failure is still a completed
             command, so the "never dropped" invariant covers it too."""
+            source.shell.result = result
+            source.presentation_revision += 1
             record = getattr(session, "record_shell", None) if session is not None else None
             if not callable(record):
+                self._notice_for(
+                    source, "Shell finished, but this owner cannot save its receipt", "error"
+                )
                 return
             try:
                 await cast(Callable[..., Awaitable[None]], record)(command, result)
             except Exception:
                 logger.debug("could not persist bang-mode result", exc_info=True)
+                self._notice_for(
+                    source, "Shell finished, but its receipt could not be saved", "error"
+                )
 
         def _nonzero_exit(res: ToolResult) -> bool:
             # execute_bash reports a nonzero exit as a SUCCESSFUL tool result
@@ -14097,6 +14195,9 @@ class OperatorApp(App[None]):
         count matches exactly what :func:`naming.build_theme_context` samples
         from. Mirrors omp's ``#titleTurnCount``.
         """
+        count = getattr(session, "history_theme_turn_count", None)
+        if isinstance(count, int):
+            return count
         history = session.history() if hasattr(session, "history") else []
         return sum(1 for turn in history if getattr(turn, "role", "") in ("user", "assistant"))
 
@@ -14169,7 +14270,13 @@ class OperatorApp(App[None]):
         # submitted rather than as it may look after the turn it kicked off has
         # written more history. `history()` returns the live list; a shallow
         # copy is enough because the sampler only reads role/text off each entry.
-        turns = list(session.history()) if hasattr(session, "history") else []
+        # Full-trajectory naming is explicitly hydrated in its background worker,
+        # never sampled from a partial tail or charged to a sidebar click.
+        turns = (
+            None
+            if hasattr(session, "materialize_history")
+            else (list(session.history()) if hasattr(session, "history") else [])
+        )
         self.run_worker(
             self._retitle_conversation_worker(
                 session,
@@ -14190,7 +14297,7 @@ class OperatorApp(App[None]):
         current: str,
         text: str,
         generation: int,
-        turns: list[AgentMessage],
+        turns: list[AgentMessage] | None,
         turn_count: int,
         source: SessionInteraction | None = None,
     ) -> None:
@@ -14219,6 +14326,8 @@ class OperatorApp(App[None]):
         source.active_workers += 1
         try:
             try:
+                if turns is None:
+                    turns = await getattr(session, "materialize_history")()
                 title = await naming.generate_retitle(
                     current, text, session.complete_once, turns=turns
                 )
@@ -16878,6 +16987,11 @@ class OperatorApp(App[None]):
             )
         }
         remote_capability = remote_capabilities.get(command)
+        if command in {"/loop", "/sidebar"}:
+            # The invoking TUI owns scheduling/interaction, even when a legacy
+            # owner advertises the older authoritative classification. Each
+            # loop iteration still uses the source's real owner prompt route.
+            remote_capability = None
         # Bare ``/mcp`` is argument-dependent: its LISTING is canonical and
         # renders locally from the follower's own snapshot facade, while its
         # grant subcommands mutate owner-side OAuth state and must route. The
@@ -17088,7 +17202,12 @@ class OperatorApp(App[None]):
         elif command == "/provider":
             self._cmd_providers(notice)
         elif command == "/sidebar":
-            self.action_toggle_sidebar()
+            if arg.strip().casefold() == "focus":
+                self.action_focus_sidebar()
+            elif arg.strip():
+                notice("Use /sidebar or /sidebar focus", "error")
+            else:
+                self.action_toggle_sidebar()
         elif command == "/settings":
             self._cmd_settings(notice)
         elif command == "/search":
@@ -21640,8 +21759,11 @@ class OperatorApp(App[None]):
 
         turns: list[AgentMessage] = []
         if in_flight.strip():
-            history = session.history()
-            tail = history[-1] if history else None
+            tail_accessor = getattr(session, "history_last_message", None)
+            history = [] if callable(tail_accessor) else session.history()
+            tail = (
+                tail_accessor() if callable(tail_accessor) else (history[-1] if history else None)
+            )
             if getattr(tail, "text", None) != in_flight:
                 turns.append(Message.assistant(in_flight))
         for previous in prior_turns or []:
@@ -26048,7 +26170,28 @@ class OperatorApp(App[None]):
         with their results, custom rows reach their own blocks (review round
         3, MAJOR-1/U7/D1).
         """
-        self._project_settled_rows(message.messages)
+        if message.reset:
+            # Canonical reconciliation is not /clear, which would cancel
+            # source work and settle gates that the owner still owns.
+            view = self._transcript_view()
+            view.set_on_clear(None)
+            view.clear_blocks()
+            view.set_on_clear(self._on_transcript_cleared)
+            self._resume_pending_head = []
+            self._resume_pending_tail = []
+            self._resume_head_notice = None
+            self._resume_tail_notice = None
+            self._resume_results = {}
+            self._resume_mounted_ids.clear()
+            self._tool_cards = {}
+            self._composing_cards = {}
+            self._streaming_block = None
+            self._working_block = None
+            self._shell_card = None
+            self._project_settled_rows(message.messages, bound=RESUME_RENDER_MESSAGES)
+            view.follow_tail()
+        else:
+            self._project_settled_rows(message.messages)
 
     def on_context_usage_reported(self, message: ContextUsageReported) -> None:
         """Move the context reading AND the cost DURING a turn, not only at its end.
@@ -26121,6 +26264,11 @@ class OperatorApp(App[None]):
         # and swapping it out would flicker a row away and an identical row back
         # at the exact moment the call starts running.
         card = self._adopt_composing_card(event.tool_call_id, event.tool_name)
+        if card is None:
+            # A prepared durable/live replay may already own this call's row.
+            # Adopt it when the canonical in-flight seed arrives; a second card
+            # leaves an interrupted ghost behind after the real one completes.
+            card = self._painted_tool_card(event.tool_call_id)
         if card is not None:
             card.begin_running(event.tool_name, event.args, event.intent)
         else:
@@ -26165,6 +26313,8 @@ class OperatorApp(App[None]):
     def on_tool_ended(self, message: ToolEnded) -> None:
         event = message.event
         card = self._tool_cards.pop(event.tool_call_id, None)
+        if card is None:
+            card = self._painted_tool_card(event.tool_call_id)
         # Before the early return below: a batch that just lost one of three
         # calls still has to drop its count, and a call that ended with no card
         # on screen still ended.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3925,6 +3925,10 @@ class OperatorApp(App[None]):
         if self._session is not None and self._session.session_id == message.session_id:
             if self._sidebar_navigation.requested_id:
                 self._sidebar_navigation.cancel()
+            # Selecting the attached session is a no-op navigation, so nothing
+            # downstream will clear the intent published for it. Drop it here
+            # or the next burst would step from an id no switch is pursuing.
+            self._sidebar_navigation.intend("")
             if self.query_one("#session-workspace").has_class("sidebar-overlay"):
                 self._set_sidebar_open(False)
             self._editor().focus()
@@ -3996,10 +4000,20 @@ class OperatorApp(App[None]):
     def _switch_session_from(self, entries: Sequence[CatalogEntry], delta: int) -> None:
         # Step from where the user is HEADED, not where they are: a second
         # press before the first commits used to read ``_session`` (still the
-        # old one) and recompute the same target, so a burst of three presses
-        # collapsed into one hop (round 4, U6 / MINOR-1). The requested id is
-        # the honest origin while a switch is in flight.
-        origin = self._sidebar_navigation.requested_id or (
+        # old one) and recompute the same target, so a burst collapsed into
+        # one hop (round 4, U6 / MINOR-1).
+        #
+        # ``requested_id`` was the wrong publication point (round 5, U7): it is
+        # only set inside ``select``, which runs when the posted ``Selected``
+        # message DISPATCHES. A held key auto-repeats into a single event
+        # batch, so press 2 ran before press 1's message was delivered and read
+        # the pre-press origin again. ``intent_id`` is set synchronously below,
+        # in the same batch, which is the only value a burst can rely on.
+        # Stepping from ``cursor_id`` was the alternative and is rejected: the
+        # cursor is a LIST-focus concept that arrow keys move without
+        # attaching, so a user who moved the cursor and then pressed the
+        # shortcut would hop from a row they never opened.
+        origin = self._sidebar_navigation.intent_id or (
             self._session.session_id if self._session is not None else ""
         )
         index = next((i for i, entry in enumerate(entries) if entry.id == origin), None)
@@ -4012,6 +4026,9 @@ class OperatorApp(App[None]):
         if target.id == origin:
             return
         self._session_sidebar.cursor_id = target.id
+        # Synchronous, BEFORE the post: the next press in the same batch reads
+        # this, not the message queue (round 5, U7).
+        self._sidebar_navigation.intend(target.id)
         self.post_message(SessionSidebar.Selected(target.id))
 
     async def _switch_session_cold(self, delta: int) -> None:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3637,14 +3637,29 @@ class OperatorApp(App[None]):
         )
         editor.move_cursor(editor._end_of_buffer())
 
-    def _sidebar_source_releasable(self, source: SessionInteraction) -> bool:
+    def _sidebar_source_releasable(
+        self, source: SessionInteraction, *, reason: str = "idle"
+    ) -> bool:
+        """May this leased viewer be disposed now?
+
+        ``reason="idle"`` is the opportunistic path: retention of any kind
+        wins, because the source may still be needed. ``reason="closed"`` is
+        the sidebar-close drain, which additionally drops sources retained
+        ONLY by the owner's turn (:attr:`retained_for_auto_work`): that is a
+        remote fact about a read-only projection, it is unbounded, and each
+        one costs a deep state copy per owner delta forever. Local retention
+        — our own workers, an unsent gate answer — still wins in both.
+        """
         from local_operator.session.remote import RemoteSession
 
+        retained = source.retained_for_local_work or (
+            reason != "closed" and source.retained_for_auto_work
+        )
         return (
             isinstance(source.session, RemoteSession)
             and source is not self._interaction
             and not source.retired
-            and not source.must_retain
+            and not retained
             and not source.preparations
             and not getattr(source.session, "has_pending_gate_reply", False)
             and source.session is not None
@@ -3652,8 +3667,10 @@ class OperatorApp(App[None]):
             and source.session.session_id not in self._sidebar_presentations
         )
 
-    async def _release_sidebar_source(self, source: SessionInteraction) -> None:
-        if not self._sidebar_source_releasable(source) or source.session is None:
+    async def _release_sidebar_source(
+        self, source: SessionInteraction, *, reason: str = "idle"
+    ) -> None:
+        if not self._sidebar_source_releasable(source, reason=reason) or source.session is None:
             return
         session = source.session
         try:
@@ -3668,7 +3685,7 @@ class OperatorApp(App[None]):
             return
         # Saving overflow yields. A rapid return may have acquired this same
         # source; neither its event controller nor its socket may close then.
-        if not self._sidebar_source_releasable(source):
+        if not self._sidebar_source_releasable(source, reason=reason):
             return
         source.retired = True
         if source.unsubscribe_frontend is not None:
@@ -4092,6 +4109,24 @@ class OperatorApp(App[None]):
                     source = self._sidebar_sources.get(session_id)
                     if source is not None:
                         self.run_worker(self._release_sidebar_preparation((source, presentation)))
+                # Then the sources with NO retained presentation. The loop
+                # above only reaches sources the presentation LRU happened to
+                # be holding, so a prewarmed viewer that never became visible
+                # was never visited by any path — `_sidebar_sources` grew
+                # without bound (25 open/close cycles leaked 50 sources, 0
+                # dispose calls). Each leaked viewer keeps a socket and a
+                # frontend subscription alive, and every owner delta then
+                # costs a deep state copy per leak: ~1.2 ms each, which is the
+                # background lag that ends in a frozen TUI.
+                #
+                # `reason="closed"` drops owner-turn retention but never local
+                # work, so a source running our worker or holding an unsent
+                # gate answer survives the close. Closing has the same meaning
+                # as `on_unmount`, which already disposes every non-current
+                # session, and the presentations that could have used a parked
+                # source were just discarded above.
+                for source in list(self._sidebar_sources.values()):
+                    self.run_worker(self._release_sidebar_source(source, reason="closed"))
         if not opened and sidebar.has_focus:
             self._restore_sidebar_focus()
 

--- a/local_operator/tui/events.py
+++ b/local_operator/tui/events.py
@@ -251,9 +251,10 @@ class HistoryRowsSettled(SessionEvent):
     (review round 3, MAJOR-1/U7/D1).
     """
 
-    def __init__(self, messages: list[Any]) -> None:
+    def __init__(self, messages: list[Any], *, reset: bool = False) -> None:
         super().__init__()
         self.messages = messages
+        self.reset = reset
 
 
 class ToolComposing(SessionEvent):
@@ -543,6 +544,20 @@ class EventController:
         finally:
             self._restoring_projection = False
 
+    def register_restored_tools(self, call_ids: set[str]) -> None:
+        """A replayed call row is a valid start counterpart for a later result.
+
+        A gate may precede tool_execution_start, and the owner can omit already
+        durable call messages from its live seed. Without this registration the
+        controller buffers the eventual end forever despite a real card already
+        being present in the restored viewport.
+        """
+        self._started_tools.update(call_ids)
+        for call_id in call_ids:
+            buffered = self._pending_tool_ends.pop(call_id, None)
+            if buffered is not None:
+                self._post(ToolEnded(buffered))
+
     def subscribe(self) -> None:
         """Register with the session; the returned callable unsubscribes."""
         self._unsubscribe = self._session.subscribe(self._on_event)
@@ -735,7 +750,7 @@ class EventController:
         # Settled history, not a live stream: nothing here touches the
         # assistant buffer or the flush timer, because these rows were never
         # streaming in THIS frontend. The app owns the role-aware projection.
-        self._post(HistoryRowsSettled(list(event.messages)))
+        self._post(HistoryRowsSettled(list(event.messages), reset=event.reset))
 
     def _handle_tool_compose(self, event: ToolCallComposeEvent) -> None:
         self._post(ToolComposing(event))

--- a/local_operator/tui/events.py
+++ b/local_operator/tui/events.py
@@ -83,6 +83,7 @@ class SessionEvent(Message):
     """Queued events retain the viewer that emitted them across navigation."""
 
     origin: EventController | None = None
+    projection: bool = False
 
 
 class StartFlushTimer(SessionEvent):
@@ -511,6 +512,7 @@ class EventController:
         self._assistant_seen: str = ""
         self._flush_timer = None
         self._unsubscribe: Callable[[], Any] | None = None
+        self._restoring_projection = False
 
     # -- lifecycle ----------------------------------------------------------
     def restore_live_projection(
@@ -920,4 +922,5 @@ class EventController:
         # Unsubscribe cannot retract messages already in Textual's queue.
         # The consumer rejects this origin after committing another session.
         message.origin = self
+        message.projection = self._restoring_projection
         self._app.post_message(message)

--- a/local_operator/tui/events.py
+++ b/local_operator/tui/events.py
@@ -140,6 +140,8 @@ class TurnAbandoned(SessionEvent):
     real outcome from the end arriving behind it (review R4).
     """
 
+    operation: int | None = None
+
     def __init__(
         self,
         epoch: int,
@@ -510,6 +512,37 @@ class EventController:
         self._unsubscribe: Callable[[], Any] | None = None
 
     # -- lifecycle ----------------------------------------------------------
+    def restore_live_projection(
+        self, state: Any, rendered_ids: set[str], settled_tools: set[str]
+    ) -> None:
+        """Rebuild a newly visible viewport from the owner's canonical seed.
+
+        A hidden context reduced events without retaining widgets. Replaying
+        the seed paints its in-flight state, but is not a new source turn or a
+        completion acknowledgement.
+        """
+        from local_operator.harness.types import AgentStartEvent
+        from local_operator.session.remote import deserialize_event
+
+        if not getattr(state, "streaming", False):
+            return
+        self._restoring_projection = True
+        try:
+            self._on_event(AgentStartEvent(generation=state.generation))
+            for data in state.live_events:
+                event = deserialize_event(data)
+                identity = str(getattr(getattr(event, "message", None), "id", "") or "")
+                if identity and identity in rendered_ids:
+                    continue
+                if getattr(event, "tool_call_id", None) in settled_tools:
+                    continue
+                self._on_event(event)
+            # A prepared attachment's first frame must include the current
+            # partial answer, not wait another coalescer interval for a token.
+            self._flush_assistant()
+        finally:
+            self._restoring_projection = False
+
     def subscribe(self) -> None:
         """Register with the session; the returned callable unsubscribes."""
         self._unsubscribe = self._session.subscribe(self._on_event)

--- a/local_operator/tui/events.py
+++ b/local_operator/tui/events.py
@@ -79,15 +79,21 @@ FLUSH_INTERVAL_S = 1.0 / 30.0
 # Each wraps the engine event so the app can mutate widgets on its own thread.
 
 
-class StartFlushTimer(Message):
+class SessionEvent(Message):
+    """Queued events retain the viewer that emitted them across navigation."""
+
+    origin: EventController | None = None
+
+
+class StartFlushTimer(SessionEvent):
     """Internal: start the 30 Hz flush timer on the app thread (TUI-024)."""
 
 
-class TurnStarted(Message):
+class TurnStarted(SessionEvent):
     """An ``agent_start`` for the CURRENT generation."""
 
 
-class TurnEnded(Message):
+class TurnEnded(SessionEvent):
     """An ``agent_end`` that matched the current generation."""
 
     def __init__(
@@ -107,7 +113,7 @@ class TurnEnded(Message):
         self.context_is_estimate = context_is_estimate
 
 
-class TurnAbandoned(Message):
+class TurnAbandoned(SessionEvent):
     """A turn whose worker returned without a terminal ``agent_end`` reaching us.
 
     Posted by the APP's turn worker, not by the controller — the controller
@@ -149,7 +155,7 @@ class TurnAbandoned(Message):
         self.outcome_known = outcome_known
 
 
-class ContextUsageReported(Message):
+class ContextUsageReported(SessionEvent):
     """One model call reported how large the context was when it ran.
 
     Separate from :class:`TurnEnded` because it fires per CALL, not per turn.
@@ -175,15 +181,15 @@ class ContextUsageReported(Message):
         self.usage = usage
 
 
-class TurnBoundaryStart(Message):
+class TurnBoundaryStart(SessionEvent):
     """A ``turn_start`` engine event: one model call is beginning."""
 
 
-class TurnBoundaryEnd(Message):
+class TurnBoundaryEnd(SessionEvent):
     """A ``turn_end`` engine event: one model call finished."""
 
 
-class AssistantDelta(Message):
+class AssistantDelta(SessionEvent):
     """Flushed, coalesced assistant text (full accumulated text)."""
 
     def __init__(self, text: str) -> None:
@@ -191,11 +197,11 @@ class AssistantDelta(Message):
         self.text = text
 
 
-class AssistantMessageStart(Message):
+class AssistantMessageStart(SessionEvent):
     """A new assistant message began streaming."""
 
 
-class UserMessageStart(Message):
+class UserMessageStart(SessionEvent):
     """A user message reached the session from ANY front end. Carries the
     prompt (and image count) so the TUI can paint it — the mobile→TUI half of
     keeping the two surfaces in step. The TUI's own prompt path already paints
@@ -223,7 +229,7 @@ class UserMessageStart(Message):
         self.image_count = images if isinstance(images, int) else len(images)
 
 
-class AssistantMessageEnd(Message):
+class AssistantMessageEnd(SessionEvent):
     """The streaming assistant message is complete."""
 
     def __init__(self, text: str, message_id: str = "") -> None:
@@ -232,7 +238,7 @@ class AssistantMessageEnd(Message):
         self.message_id = message_id
 
 
-class HistoryRowsSettled(Message):
+class HistoryRowsSettled(SessionEvent):
     """Durable rows that settled while no frontend painted them (reconnect gap).
 
     Carries the rows verbatim so the app projects them through the SAME
@@ -248,7 +254,7 @@ class HistoryRowsSettled(Message):
         self.messages = messages
 
 
-class ToolComposing(Message):
+class ToolComposing(SessionEvent):
     """The model is still dictating a tool call's arguments."""
 
     def __init__(self, event: ToolCallComposeEvent) -> None:
@@ -256,7 +262,7 @@ class ToolComposing(Message):
         self.event = event
 
 
-class ToolStarted(Message):
+class ToolStarted(SessionEvent):
     """A tool execution started; a buffered completion may follow."""
 
     def __init__(self, event: ToolExecutionStartEvent) -> None:
@@ -264,7 +270,7 @@ class ToolStarted(Message):
         self.event = event
 
 
-class ToolEnded(Message):
+class ToolEnded(SessionEvent):
     """A tool execution finished."""
 
     def __init__(self, event: ToolExecutionEndEvent) -> None:
@@ -272,7 +278,7 @@ class ToolEnded(Message):
         self.event = event
 
 
-class ToolUpdated(Message):
+class ToolUpdated(SessionEvent):
     """A running tool streamed a partial result."""
 
     def __init__(self, event: ToolExecutionUpdateEvent) -> None:
@@ -280,7 +286,7 @@ class ToolUpdated(Message):
         self.event = event
 
 
-class WakeDelivered(Message):
+class WakeDelivered(SessionEvent):
     """A scheduled wake's prompt was delivered — render the expandable receipt."""
 
     def __init__(self, text: str, catchup: bool, wake_id: str = "", occurrence: int = 0) -> None:
@@ -291,7 +297,7 @@ class WakeDelivered(Message):
         self.occurrence = occurrence
 
 
-class PeerMessageDelivered(Message):
+class PeerMessageDelivered(SessionEvent):
     """A message from another local lop session (`lop send`) was delivered.
 
     Carries the raw body and the advisory sender identity so the app can paint
@@ -307,7 +313,7 @@ class PeerMessageDelivered(Message):
         self.message_id = message_id
 
 
-class NoticePosted(Message):
+class NoticePosted(SessionEvent):
     """A notice to surface in the transcript."""
 
     def __init__(self, text: str, kind: NoticeKind, headline: str = "") -> None:
@@ -325,7 +331,7 @@ class NoticePosted(Message):
         self.headline = headline
 
 
-class CompactionStarted(Message):
+class CompactionStarted(SessionEvent):
     """Context compaction began."""
 
     def __init__(self, reason: str) -> None:
@@ -333,7 +339,7 @@ class CompactionStarted(Message):
         self.reason = reason
 
 
-class CompactionEnded(Message):
+class CompactionEnded(SessionEvent):
     """Context compaction finished.
 
     Carries what the pass achieved (the history size either side of it, and the
@@ -361,7 +367,7 @@ class CompactionEnded(Message):
         self.detail = detail
 
 
-class RetryStarted(Message):
+class RetryStarted(SessionEvent):
     """A provider call is being retried."""
 
     def __init__(self, attempt: int, error: str, fallback_model: str | None) -> None:
@@ -371,7 +377,7 @@ class RetryStarted(Message):
         self.fallback_model = fallback_model
 
 
-class EffectiveModelChanged(Message):
+class EffectiveModelChanged(SessionEvent):
     """The model actually serving requests changed (fallback or recovery).
 
     What the status band repaints its model segment from: ``provider`` and
@@ -398,7 +404,7 @@ class EffectiveModelChanged(Message):
         self.is_fallback = is_fallback
 
 
-class RetryEnded(Message):
+class RetryEnded(SessionEvent):
     """A provider retry resolved."""
 
     def __init__(self, success: bool) -> None:
@@ -406,7 +412,7 @@ class RetryEnded(Message):
         self.success = success
 
 
-class SteeringDelivered(Message):
+class SteeringDelivered(SessionEvent):
     """Queued mid-turn messages reached the model's context.
 
     The receipt the ``queued — sends when this step finishes`` row was missing:
@@ -431,7 +437,7 @@ class SteeringDelivered(Message):
         self.origin = origin
 
 
-class SubagentStarted(Message):
+class SubagentStarted(SessionEvent):
     """A child session was registered as a background ``task`` job."""
 
     def __init__(self, job_id: str, label: str, agent_id: str | None = None) -> None:
@@ -441,7 +447,7 @@ class SubagentStarted(Message):
         self.agent_id = agent_id
 
 
-class SubagentProgress(Message):
+class SubagentProgress(SessionEvent):
     """A throttled relay of a child session's activity (tool starts/ends,
     message ends — never per-token deltas; the relay bounds that)."""
 
@@ -452,7 +458,7 @@ class SubagentProgress(Message):
         self.progress = progress
 
 
-class SubagentEnded(Message):
+class SubagentEnded(SessionEvent):
     """A child session settled; the app repaints the band's subagent row.
 
     The band is the only surface this touches — the row flips from its
@@ -862,5 +868,8 @@ class EventController:
         self._assistant_seen = self._assistant_buffer
         self._post(AssistantDelta(self._assistant_buffer))
 
-    def _post(self, message: Message) -> None:
+    def _post(self, message: SessionEvent) -> None:
+        # Unsubscribe cannot retract messages already in Textual's queue.
+        # The consumer rejects this origin after committing another session.
+        message.origin = self
         self._app.post_message(message)

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -99,13 +99,27 @@
     height: 1fr;
 }
 
+/* Width and horizontal padding are set by `_sync_sidebar_layout`, not here:
+ * the gutter that separates the list from the conversation has to MIRROR with
+ * `tui.sidebar_position` (right edge when docked left, left edge when docked
+ * right), which a static rule cannot express. The values below are the
+ * left-docked resting state so the widget still renders sanely before the
+ * first layout pass. */
 SessionSidebar {
-    width: 30;
+    width: 33;
     height: 1fr;
-    padding: 0 1;
+    padding: 0 3 0 1;
     background: $lo-bg;
     color: $lo-fg;
     overflow: hidden;
+    /* Every row is a click target that attaches that session, so the pointer
+     * says so before the click does — the same affordance `SubagentRow` and
+     * the subagent-view hints carry. Textual emits this as an OSC pointer
+     * shape; a terminal without the Kitty pointer-shape protocol ignores it
+     * and loses nothing, which is why the row's hover tint (painted in
+     * `render`, since rows are Text spans in ONE widget and cannot be reached
+     * by `:hover`) is the affordance that does not depend on it. */
+    pointer: pointer;
 }
 
 /* Small terminals keep the conversation's full line length. Each layer lays

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -88,6 +88,34 @@
  * composer — see `TranscriptView` for why that row is the transcript's.
  */
 
+#session-workspace {
+    width: 1fr;
+    height: 1fr;
+    layers: default sidebar;
+}
+
+#session-conversation {
+    width: 1fr;
+    height: 1fr;
+}
+
+SessionSidebar {
+    width: 30;
+    height: 1fr;
+    padding: 0 1;
+    background: $lo-bg;
+    color: $lo-fg;
+    overflow: hidden;
+}
+
+/* Small terminals keep the conversation's full line length. Each layer lays
+ * out independently, so the list overlays only the transcript; its height is
+ * bounded above the live input dock by the app. No frame or dividing rule. */
+.sidebar-overlay SessionSidebar {
+    layer: sidebar;
+    background: $lo-surface;
+}
+
 Screen {
     background: $lo-bg;
     color: $lo-fg;

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -397,7 +397,7 @@ ToolCard.tool-error {
 /* Mouse affordance: the whole row is the click target for expand/collapse,
  * so the whole row lights on hover. Last rule wins over the state tints —
  * pointing at a row should always look the same. */
-ToolCard:hover, WakeBlock:hover {
+ToolCard:hover, WakeBlock:hover, .interactive-notice:hover {
     background: $lo-overlay;
 }
 
@@ -414,7 +414,7 @@ ToolCard:hover, WakeBlock:hover {
  * Last rule in the block, so it wins over the state tints AND over :hover:
  * where the keyboard is, is the more load-bearing fact. Still no border —
  * elevation is a background step here as everywhere. */
-ToolCard:focus, WakeBlock:focus {
+ToolCard:focus, WakeBlock:focus, .interactive-notice:focus {
     background: $lo-tint-select;
 }
 

--- a/local_operator/tui/session_catalog.py
+++ b/local_operator/tui/session_catalog.py
@@ -169,12 +169,94 @@ def decorate_rows(
     return sort_needs_you_first(updated)
 
 
+#: Rows the poll materialises. The sidebar paints a fixed window (~38 rows at a
+#: usual height) and pages within what it holds, so the untruncated answer
+#: `/resume` wants is waste here: on a 665-directory store the poll built 56
+#: rows every 2 s and spent 92-99% of itself doing it. Headroom well past the
+#: viewport keeps paging and ranking honest without materialising the tail.
+CATALOG_SCAN_LIMIT = 200
+
+#: `session_id -> ((activity_mtime, transcript_size), SessionRow)`. A row's
+#: name and fork mark change only when its transcript does, and the scan
+#: already stats that file to rank the session, so the key is free. Only the
+#: DURABLE fields are cached: `live_state`, `pending`, `wakes` and `unseen` are
+#: layered on afterwards by `decorate_rows`/attention on every poll, because
+#: caching a live fact would freeze the list.
+_ROW_CACHE: dict[str, tuple[tuple[float, int], SessionRow]] = {}
+
+
+def _row_stat_key(session_dir: Path) -> tuple[float, int] | None:
+    """``(activity_mtime, size)`` for the transcript, or ``None`` if unreadable.
+
+    Deliberately the same file :func:`session.retention.session_activity`
+    ranks by, so a row whose key is unchanged is a row whose transcript has not
+    been appended to — which is exactly the condition under which its name and
+    fork mark cannot have changed. Size is carried alongside mtime because a
+    coarse filesystem timestamp can hide an append inside the same second.
+    """
+    from local_operator.session.retention import TRANSCRIPT_FILENAME
+
+    try:
+        stat = (session_dir / TRANSCRIPT_FILENAME).stat()
+    except OSError:
+        return None
+    return (stat.st_mtime, stat.st_size)
+
+
+def cached_session_rows(directory: Path, limit: int = CATALOG_SCAN_LIMIT) -> list[SessionRow]:
+    """:func:`recent_session_rows` for the poll, memoized on transcript stat.
+
+    The ``O(directories)`` scan underneath is NOT what this avoids — it still
+    runs, and bounding it is what ``limit`` does. What this avoids is the
+    per-row work above the scan: the bounded head read that builds the name,
+    and the fork-title probe, on rows whose transcript has not been appended to
+    since the last poll two seconds ago.
+
+    Deliberately reimplements ``recent_session_rows``'s loop instead of calling
+    it, because the saving is inside that loop; the scan it calls is the shared
+    one, so ranking and visibility stay identical to ``/resume``. Rows absent
+    from the current answer are dropped, keeping the cache bounded by the live
+    store rather than by every session ever listed.
+    """
+    from local_operator.resume import (
+        ORIGIN_FORK,
+        _recent_sessions_with_origin,
+        session_name,
+        wears_inherited_title,
+    )
+
+    rows: list[SessionRow] = []
+    fresh: dict[str, tuple[tuple[float, int], SessionRow]] = {}
+    for session_id, mtime, origin in _recent_sessions_with_origin(directory, limit):
+        session_dir = directory / "sessions" / session_id
+        key = _row_stat_key(session_dir)
+        cached = _ROW_CACHE.get(session_id)
+        if key is not None and cached is not None and cached[0] == key:
+            # Same transcript bytes as last poll: the name and the fork mark
+            # cannot have changed, so neither read is repeated. `mtime` is
+            # taken fresh from the scan regardless — it also tracks the inbox
+            # spool, which ranks a row without touching the transcript.
+            row = cached[1]._replace(mtime=mtime)
+        else:
+            row = SessionRow(
+                session_id,
+                mtime,
+                session_name(session_dir),
+                forked=origin == ORIGIN_FORK and wears_inherited_title(session_dir),
+            )
+        rows.append(row)
+        if key is not None:
+            fresh[session_id] = (key, row)
+    _ROW_CACHE.clear()
+    _ROW_CACHE.update(fresh)
+    return rows
+
+
 def load_catalog(directory: Path) -> list[CatalogEntry]:
     """One off-loop summary snapshot; never acknowledge or read full histories."""
-    from local_operator.resume import recent_session_rows
     from local_operator.session.attention import AttentionStore, conversation_identity
 
-    rows = decorate_rows(directory, recent_session_rows(directory, limit=None), include_live=True)
+    rows = decorate_rows(directory, cached_session_rows(directory), include_live=True)
     identities = {row.id: conversation_identity(directory / "sessions" / row.id) for row in rows}
     attention = AttentionStore(directory / "attention.db").state_many(identities.values())
     return list(

--- a/local_operator/tui/session_catalog.py
+++ b/local_operator/tui/session_catalog.py
@@ -77,7 +77,22 @@ def rank_entries(entries: Sequence[CatalogEntry]) -> tuple[CatalogEntry, ...]:
     return tuple(sorted(entries, key=lambda entry: entry.rank))
 
 
-def decorate_rows(directory: Path, rows: list[SessionRow]) -> list[SessionRow]:
+def session_directory_name(session_id: str) -> bool:
+    """Discovery metadata cannot redirect a catalog read outside sessions/."""
+    return (
+        isinstance(session_id, str)
+        and bool(session_id)
+        and session_id not in {".", ".."}
+        and not any(
+            character in "/\\\\" or ord(character) < 32 or ord(character) == 127
+            for character in session_id
+        )
+    )
+
+
+def decorate_rows(
+    directory: Path, rows: list[SessionRow], *, include_live: bool = False
+) -> list[SessionRow]:
     """Fill in each row's runtime state, and float the ones needing a person.
 
     Two reads for the whole list: the discovery records say which sessions
@@ -108,6 +123,23 @@ def decorate_rows(directory: Path, rows: list[SessionRow]) -> list[SessionRow]:
         if session_id:
             live[session_id] = (record, state)
 
+    if include_live:
+        from local_operator.resume import is_user_session
+
+        known = {row.id for row in rows}
+        rows = list(rows)
+        for session_id, (record, _state) in live.items():
+            if not session_directory_name(session_id):
+                continue
+            session_dir = directory / "sessions" / session_id
+            if session_id not in known and session_dir.is_dir() and is_user_session(session_dir):
+                rows.append(
+                    SessionRow(
+                        session_id,
+                        float(getattr(record, "started_at", 0.0) or 0.0),
+                        str(getattr(record, "conversation_name", "") or "Untitled conversation"),
+                    )
+                )
     updated: list[SessionRow] = []
     for row in rows:
         record_state = live.get(row.id)
@@ -135,3 +167,25 @@ def decorate_rows(directory: Path, rows: list[SessionRow]) -> list[SessionRow]:
             )
         )
     return sort_needs_you_first(updated)
+
+
+def load_catalog(directory: Path) -> list[CatalogEntry]:
+    """One off-loop summary snapshot; never acknowledge or read full histories."""
+    from local_operator.resume import recent_session_rows
+    from local_operator.session.attention import AttentionStore, conversation_identity
+
+    rows = decorate_rows(directory, recent_session_rows(directory, limit=None), include_live=True)
+    identities = {row.id: conversation_identity(directory / "sessions" / row.id) for row in rows}
+    attention = AttentionStore(directory / "attention.db").state_many(identities.values())
+    return list(
+        rank_entries(
+            [
+                CatalogEntry(
+                    row,
+                    bool(attention[identities[row.id]]["unseen"]),
+                    str(attention[identities[row.id]]["kind"] or ""),
+                )
+                for row in rows
+            ]
+        )
+    )

--- a/local_operator/tui/session_catalog.py
+++ b/local_operator/tui/session_catalog.py
@@ -1,0 +1,137 @@
+"""Immutable sidebar summaries; never prepare a transcript from a paint or click.
+
+Names and runtime marks use the same sources as /resume. Attention is supplied
+by the shared completion authority, not inferred from transcript timestamps.
+The catalog has no acknowledgement path: listing a conversation is not reading it.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from local_operator.resume import SessionRow
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SIDEBAR_VISIBLE = False
+DEFAULT_SIDEBAR_POSITION = "left"
+SidebarPosition = Literal["left", "right"]
+
+
+@dataclass(frozen=True)
+class SidebarSettings:
+    visible: bool = DEFAULT_SIDEBAR_VISIBLE
+    position: SidebarPosition = "left"
+
+    @classmethod
+    def from_values(cls, values: Mapping[str, Any]) -> SidebarSettings:
+        section = values.get("tui")
+        section = section if isinstance(section, Mapping) else {}
+        visible = section.get("sidebar_visible", DEFAULT_SIDEBAR_VISIBLE)
+        position = section.get("sidebar_position", DEFAULT_SIDEBAR_POSITION)
+        return cls(
+            visible=visible if isinstance(visible, bool) else DEFAULT_SIDEBAR_VISIBLE,
+            position="right" if position == "right" else "left",
+        )
+
+
+@dataclass(frozen=True)
+class CatalogEntry:
+    row: SessionRow
+    unseen: bool = False
+    completion_kind: str = ""
+
+    @property
+    def id(self) -> str:
+        return self.row.id
+
+    @property
+    def rank(self) -> tuple[int, float, str]:
+        # Gates are independent of completed turns; acknowledging a completion
+        # must never demote a question still waiting for a person.
+        tier = 0 if self.row.pending else 1 if self.unseen else 2 if self.row.live_state else 3
+        return tier, -self.row.mtime, self.id
+
+    @property
+    def status(self) -> str:
+        if self.row.pending:
+            return "Approval needed" if self.row.pending == "approval" else "Answer needed"
+        if self.unseen:
+            return {"error": "Unseen error", "interrupted": "Unseen interruption"}.get(
+                self.completion_kind, "Unseen completion"
+            )
+        return {
+            "busy": "Working",
+            "idle": "Ready",
+            "attached": "Open",
+            "wedged": "Not responding",
+        }.get(self.row.live_state, "Recent")
+
+
+def rank_entries(entries: Sequence[CatalogEntry]) -> tuple[CatalogEntry, ...]:
+    """Stable identities survive refreshes, including deterministic recency ties."""
+    return tuple(sorted(entries, key=lambda entry: entry.rank))
+
+
+def decorate_rows(directory: Path, rows: list[SessionRow]) -> list[SessionRow]:
+    """Fill in each row's runtime state, and float the ones needing a person.
+
+    Two reads for the whole list: the discovery records say which sessions
+    are running, working, attached or wedged, and the wake index says which
+    have reminders armed. Best-effort — a picker that cannot read either
+    one still lists every session exactly as it did before, because the
+    fields are defaulted and the markers simply do not appear.
+    """
+    from local_operator.session.runtime import registry
+    from local_operator.tui.widgets.session_picker import sort_needs_you_first
+
+    try:
+        scanned = registry.scan(directory)
+    except Exception:  # noqa: BLE001 — markers are an enhancement, never a gate
+        logger.debug("picker could not scan session records", exc_info=True)
+        scanned = []
+    try:
+        from local_operator.wakes.store import read_index
+
+        wake_index = read_index(directory)
+    except Exception:  # noqa: BLE001
+        logger.debug("picker could not read the wake index", exc_info=True)
+        wake_index = {}
+
+    live: dict[str, tuple[Any, str]] = {}
+    for record, state in scanned:
+        session_id = getattr(record, "session_id", "")
+        if session_id:
+            live[session_id] = (record, state)
+
+    updated: list[SessionRow] = []
+    for row in rows:
+        record_state = live.get(row.id)
+        live_state = ""
+        pending: str | None = None
+        if record_state is not None:
+            record, state = record_state
+            if state == "wedged":
+                live_state = "wedged"
+            elif getattr(record, "busy", False):
+                live_state = "busy"
+            elif not getattr(record, "detached", False):
+                live_state = "attached"
+            else:
+                live_state = "idle"
+            pending = getattr(record, "pending", None) or None
+        entry = wake_index.get(row.id) or {}
+        schedules = entry.get("schedules") or () if isinstance(entry, dict) else ()
+        updated.append(
+            row._replace(
+                live_state=live_state,
+                pending=pending,
+                wakes=len(schedules),
+                wakes_dormant=bool(isinstance(entry, dict) and entry.get("stopped_at")),
+            )
+        )
+    return sort_needs_you_first(updated)

--- a/local_operator/tui/session_drafts.py
+++ b/local_operator/tui/session_drafts.py
@@ -14,10 +14,13 @@ import os
 import tempfile
 from collections import OrderedDict
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 from local_operator.harness.types import ImageContent
 from local_operator.tui.session_interaction import SessionDraft
+
+if TYPE_CHECKING:
+    from local_operator.tui.widgets.transcript import NoticeKind
 
 DRAFT_RESIDENT_COUNT = 16
 DRAFT_RESIDENT_BYTES = 1024 * 1024
@@ -43,12 +46,17 @@ class SessionDraftStore:
     def _size(draft: SessionDraft) -> int:
         from local_operator.tui.widgets.editor import Attachment, PastedText
 
-        size = len(draft.text.encode("utf-8"))
-        for attachment in draft.attachments.values():
+        size = len(draft.text.encode("utf-8")) + len((draft.aside_main_text or "").encode("utf-8"))
+        for attachment in (*draft.attachments.values(), *draft.aside_main_images.values()):
             if isinstance(attachment, Attachment):
                 size += len(attachment.image.data)
             elif isinstance(attachment, PastedText):
                 size += len(attachment.text.encode("utf-8"))
+        if draft.aside is not None:
+            for turn in draft.aside.turns:
+                size += len((turn.question + turn.answer + turn.error).encode("utf-8"))
+        size += sum(SessionDraftStore._size(item) for item in draft.recoveries)
+        size += sum(len(text.encode("utf-8")) for text, _kind in draft.notices)
         return size
 
     async def put(self, session_id: str, draft: SessionDraft) -> None:
@@ -58,6 +66,10 @@ class SessionDraftStore:
             self._memory[session_id] = draft
             self._memory.move_to_end(session_id)
             self._sizes[session_id] = self._size(draft)
+            if self._directory is not None:
+                # A dismissed aside or edited draft must not leave its older
+                # plaintext snapshot behind merely because the new one fits RAM.
+                await asyncio.to_thread(self._path(session_id).unlink, missing_ok=True)
             while (
                 self.resident_count > DRAFT_RESIDENT_COUNT
                 or self.resident_bytes > DRAFT_RESIDENT_BYTES
@@ -94,11 +106,12 @@ class SessionDraftStore:
         name = hashlib.sha256(session_id.encode()).hexdigest()
         return Path(self._directory.name) / f"{name}.json"
 
-    def _write(self, session_id: str, draft: SessionDraft) -> None:
+    @staticmethod
+    def _encode_attachments(values: dict[int, Any]) -> dict[str, Any]:
         from local_operator.tui.widgets.editor import Attachment, PastedText
 
         attachments: dict[str, Any] = {}
-        for index, attachment in draft.attachments.items():
+        for index, attachment in values.items():
             if isinstance(attachment, Attachment):
                 attachments[str(index)] = {
                     "kind": "image",
@@ -113,10 +126,15 @@ class SessionDraftStore:
                 }
             else:
                 raise ValueError("unsupported draft attachment type")
+        return attachments
+
+    def _encode_draft(self, draft: SessionDraft) -> dict[str, Any]:
+        from dataclasses import asdict
+
         selection = draft.selection
         payload = {
             "text": draft.text,
-            "attachments": attachments,
+            "attachments": self._encode_attachments(draft.attachments),
             "selection": (
                 {"start": selection.start, "end": selection.end} if selection is not None else None
             ),
@@ -126,7 +144,18 @@ class SessionDraftStore:
             "scroll_anchor_part": draft.scroll_anchor_part,
             "scroll_offset": draft.scroll_offset,
             "following_tail": draft.following_tail,
+            "aside": asdict(draft.aside) if draft.aside is not None else None,
+            "aside_main_text": draft.aside_main_text,
+            "aside_main_images": self._encode_attachments(draft.aside_main_images),
+            "aside_main_shell_mode": draft.aside_main_shell_mode,
+            "approve_all": draft.approve_all,
+            "recoveries": [self._encode_draft(item) for item in draft.recoveries],
+            "notices": draft.notices,
         }
+        return payload
+
+    def _write(self, session_id: str, draft: SessionDraft) -> None:
+        payload = self._encode_draft(draft)
         target = self._path(session_id)
         fd, temporary = tempfile.mkstemp(prefix=".draft-", dir=target.parent)
         try:
@@ -137,26 +166,45 @@ class SessionDraftStore:
             if os.path.exists(temporary):
                 os.unlink(temporary)
 
-    def _read(self, session_id: str) -> SessionDraft:
-        from textual.widgets.text_area import Selection
-
+    @staticmethod
+    def _decode_attachments(values: dict[str, Any]) -> dict[int, Any]:
         from local_operator.tui.widgets.editor import Attachment, PastedText
 
-        path = self._path(session_id)
-        if not path.exists():
-            return SessionDraft()
-        data = json.loads(path.read_text(encoding="utf-8"))
         attachments = {}
-        for index, item in data["attachments"].items():
+        for index, item in values.items():
             attachments[int(index)] = (
                 Attachment(ImageContent.model_validate(item["image"]), item["marker"])
                 if item["kind"] == "image"
                 else PastedText(item["text"], item["marker"])
             )
+        return attachments
+
+    def _decode_draft(self, data: dict[str, Any]) -> SessionDraft:
+        from textual.widgets.text_area import Selection
+
+        from local_operator.tui.widgets.aside_panel import AsideSnapshot, AsideTurn
+
+        if not isinstance(data.get("text"), str):
+            raise ValueError("Saved draft text is invalid")
+        for field in ("shell_mode", "following_tail", "aside_main_shell_mode"):
+            if not isinstance(data.get(field), bool):
+                raise ValueError("Saved draft mode is invalid")
+        if data.get("approve_all") is not None and not isinstance(data["approve_all"], bool):
+            raise ValueError("Saved approval mode is invalid")
         selection = data["selection"]
+        notices = []
+        for item in data.get("notices", []):
+            if (
+                not isinstance(item, list)
+                or len(item) != 2
+                or not all(isinstance(part, str) for part in item)
+                or item[1] not in {"info", "note", "success", "warning", "error"}
+            ):
+                raise ValueError("Saved draft notice is invalid")
+            notices.append((item[0], cast("NoticeKind", item[1])))
         return SessionDraft(
             text=data["text"],
-            attachments=attachments,
+            attachments=self._decode_attachments(data["attachments"]),
             selection=(
                 Selection(tuple(selection["start"]), tuple(selection["end"]))
                 if selection is not None
@@ -168,7 +216,29 @@ class SessionDraftStore:
             scroll_anchor_part=data["scroll_anchor_part"],
             scroll_offset=data["scroll_offset"],
             following_tail=data["following_tail"],
+            aside=(
+                AsideSnapshot(
+                    **{
+                        **data["aside"],
+                        "turns": [AsideTurn(**turn) for turn in data["aside"]["turns"]],
+                    }
+                )
+                if data["aside"] is not None
+                else None
+            ),
+            aside_main_text=data["aside_main_text"],
+            aside_main_images=self._decode_attachments(data["aside_main_images"]),
+            aside_main_shell_mode=data["aside_main_shell_mode"],
+            approve_all=data.get("approve_all"),
+            recoveries=[self._decode_draft(item) for item in data.get("recoveries", [])],
+            notices=notices,
         )
+
+    def _read(self, session_id: str) -> SessionDraft:
+        path = self._path(session_id)
+        if not path.exists():
+            return SessionDraft()
+        return self._decode_draft(json.loads(path.read_text(encoding="utf-8")))
 
     async def close(self) -> None:
         async with self._lock:

--- a/local_operator/tui/session_drafts.py
+++ b/local_operator/tui/session_drafts.py
@@ -1,0 +1,180 @@
+"""Bound draft RAM without ever evicting the user's unsubmitted input.
+
+Only this viewer's overflow goes to a private temporary directory. No pickle,
+shared session file, transcript write or acknowledgement is involved. The store
+is lazy: a hidden, unused sidebar performs no filesystem work.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import tempfile
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any
+
+from local_operator.harness.types import ImageContent
+from local_operator.tui.session_interaction import SessionDraft
+
+DRAFT_RESIDENT_COUNT = 16
+DRAFT_RESIDENT_BYTES = 1024 * 1024
+
+
+class SessionDraftStore:
+    def __init__(self) -> None:
+        self._memory: OrderedDict[str, SessionDraft] = OrderedDict()
+        self._sizes: dict[str, int] = {}
+        self._directory: tempfile.TemporaryDirectory[str] | None = None
+        self._lock = asyncio.Lock()
+        self._closed = False
+
+    @property
+    def resident_bytes(self) -> int:
+        return sum(self._sizes.values())
+
+    @property
+    def resident_count(self) -> int:
+        return len(self._memory)
+
+    @staticmethod
+    def _size(draft: SessionDraft) -> int:
+        from local_operator.tui.widgets.editor import Attachment, PastedText
+
+        size = len(draft.text.encode("utf-8"))
+        for attachment in draft.attachments.values():
+            if isinstance(attachment, Attachment):
+                size += len(attachment.image.data)
+            elif isinstance(attachment, PastedText):
+                size += len(attachment.text.encode("utf-8"))
+        return size
+
+    async def put(self, session_id: str, draft: SessionDraft) -> None:
+        async with self._lock:
+            if self._closed:
+                return
+            self._memory[session_id] = draft
+            self._memory.move_to_end(session_id)
+            self._sizes[session_id] = self._size(draft)
+            while (
+                self.resident_count > DRAFT_RESIDENT_COUNT
+                or self.resident_bytes > DRAFT_RESIDENT_BYTES
+            ):
+                key = next(iter(self._memory))
+                # Remove only AFTER the write succeeds. A full disk can exceed
+                # the desired RAM budget but may never discard accepted input.
+                write = asyncio.create_task(asyncio.to_thread(self._write, key, self._memory[key]))
+                try:
+                    await asyncio.shield(write)
+                except asyncio.CancelledError:
+                    # A worker cancellation cannot interrupt a filesystem write.
+                    # Join it before releasing the lock so close cannot remove
+                    # its private directory while the writer still owns it.
+                    await write
+                    raise
+                del self._memory[key]
+                self._sizes.pop(key)
+
+    async def get(self, session_id: str) -> SessionDraft:
+        async with self._lock:
+            draft = self._memory.get(session_id)
+            if draft is not None:
+                self._memory.move_to_end(session_id)
+                return draft
+            if self._directory is None:
+                return SessionDraft()
+            return await asyncio.to_thread(self._read, session_id)
+
+    def _path(self, session_id: str) -> Path:
+        if self._directory is None:
+            self._directory = tempfile.TemporaryDirectory(prefix="lop-viewer-drafts-")
+            os.chmod(self._directory.name, 0o700)
+        name = hashlib.sha256(session_id.encode()).hexdigest()
+        return Path(self._directory.name) / f"{name}.json"
+
+    def _write(self, session_id: str, draft: SessionDraft) -> None:
+        from local_operator.tui.widgets.editor import Attachment, PastedText
+
+        attachments: dict[str, Any] = {}
+        for index, attachment in draft.attachments.items():
+            if isinstance(attachment, Attachment):
+                attachments[str(index)] = {
+                    "kind": "image",
+                    "image": attachment.image.model_dump(),
+                    "marker": attachment.marker,
+                }
+            elif isinstance(attachment, PastedText):
+                attachments[str(index)] = {
+                    "kind": "text",
+                    "text": attachment.text,
+                    "marker": attachment.marker,
+                }
+            else:
+                raise ValueError("unsupported draft attachment type")
+        selection = draft.selection
+        payload = {
+            "text": draft.text,
+            "attachments": attachments,
+            "selection": (
+                {"start": selection.start, "end": selection.end} if selection is not None else None
+            ),
+            "shell_mode": draft.shell_mode,
+            "focus_id": draft.focus_id,
+            "scroll_anchor_id": draft.scroll_anchor_id,
+            "scroll_anchor_part": draft.scroll_anchor_part,
+            "scroll_offset": draft.scroll_offset,
+            "following_tail": draft.following_tail,
+        }
+        target = self._path(session_id)
+        fd, temporary = tempfile.mkstemp(prefix=".draft-", dir=target.parent)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as stream:
+                json.dump(payload, stream, ensure_ascii=False)
+            os.replace(temporary, target)
+        finally:
+            if os.path.exists(temporary):
+                os.unlink(temporary)
+
+    def _read(self, session_id: str) -> SessionDraft:
+        from textual.widgets.text_area import Selection
+
+        from local_operator.tui.widgets.editor import Attachment, PastedText
+
+        path = self._path(session_id)
+        if not path.exists():
+            return SessionDraft()
+        data = json.loads(path.read_text(encoding="utf-8"))
+        attachments = {}
+        for index, item in data["attachments"].items():
+            attachments[int(index)] = (
+                Attachment(ImageContent.model_validate(item["image"]), item["marker"])
+                if item["kind"] == "image"
+                else PastedText(item["text"], item["marker"])
+            )
+        selection = data["selection"]
+        return SessionDraft(
+            text=data["text"],
+            attachments=attachments,
+            selection=(
+                Selection(tuple(selection["start"]), tuple(selection["end"]))
+                if selection is not None
+                else None
+            ),
+            shell_mode=data["shell_mode"],
+            focus_id=data["focus_id"],
+            scroll_anchor_id=data["scroll_anchor_id"],
+            scroll_anchor_part=data["scroll_anchor_part"],
+            scroll_offset=data["scroll_offset"],
+            following_tail=data["following_tail"],
+        )
+
+    async def close(self) -> None:
+        async with self._lock:
+            self._closed = True
+            if self._directory is not None:
+                await asyncio.to_thread(self._directory.cleanup)
+                self._directory = None
+            self._memory.clear()
+            self._sizes.clear()

--- a/local_operator/tui/session_interaction.py
+++ b/local_operator/tui/session_interaction.py
@@ -113,6 +113,7 @@ class SessionInteraction:
     controller: Any = None
     retired: bool = False
     presentation_revision: int = 0
+    restored_goal_notice: str = ""
     aside_open: bool = False
     aside_generation: int = 0
     preparations: int = 0

--- a/local_operator/tui/session_interaction.py
+++ b/local_operator/tui/session_interaction.py
@@ -1,0 +1,111 @@
+"""Source-owned work that must outlive a terminal's current presentation.
+
+A session ID alone is insufficient: reconnect/takeover can replace its facade.
+The binding token identifies this exact owner-facing incarnation. Widgets do
+not belong here; hidden work updates this state and only the current binding
+may turn those updates into terminal UI mutations.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+from local_operator.harness.types import ImageContent
+from local_operator.session.protocol import SessionProtocol
+
+
+@dataclass
+class TurnInteraction:
+    provider_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    epoch: int = 0
+    open: bool = False
+    notified: bool = False
+    accrued_cost: float = 0.0
+    pending_echoes: list[Any] = field(default_factory=list)
+    submitted_draft: SessionDraft | None = None
+
+
+@dataclass
+class LoopInteraction:
+    running: bool = False
+    cancelled: bool = False
+    goal: str = ""
+    suppress_completion: bool = False
+    worker: Any = None
+    operation: int = 0
+
+
+@dataclass
+class ShellInteraction:
+    signal: Any = None
+    worker: Any = None
+    call_id: str = ""
+    result: Any = None
+    progress: str = ""
+
+
+@dataclass
+class CompactionInteraction:
+    active: bool = False
+    held_prompt: str = ""
+    held_typed: str = ""
+    held_images: dict[int, Any] = field(default_factory=dict)
+    accepted_message_id: str = ""
+    accepted_draft: SessionDraft | None = None
+
+
+@dataclass
+class SessionAccounting:
+    total: float = 0.0
+    child_costs: dict[str, float] = field(default_factory=dict)
+    is_floor: bool = False
+
+
+@dataclass
+class SessionDraft:
+    text: str = ""
+    attachments: dict[int, Any] = field(default_factory=dict)
+    selection: Any = None
+    shell_mode: bool = False
+    focus_id: str = ""
+    scroll_anchor_id: str = ""
+    scroll_anchor_part: int = 0
+    scroll_offset: int = 0
+    following_tail: bool = True
+
+
+@dataclass
+class SessionInteraction:
+    session: SessionProtocol | None
+    token: str = field(default_factory=lambda: uuid.uuid4().hex)
+    turn: TurnInteraction = field(default_factory=TurnInteraction)
+    loop: LoopInteraction = field(default_factory=LoopInteraction)
+    shell: ShellInteraction = field(default_factory=ShellInteraction)
+    compaction: CompactionInteraction = field(default_factory=CompactionInteraction)
+    accounting: SessionAccounting = field(default_factory=SessionAccounting)
+    draft: SessionDraft = field(default_factory=SessionDraft)
+    # Accepted-but-unsent input is data, not a widget reference. It remains
+    # recoverable even if this conversation's presentation has been evicted.
+    unsent: list[tuple[str, list[ImageContent]]] = field(default_factory=list)
+    notices: list[tuple[str, str]] = field(default_factory=list)
+    active_workers: int = 0
+    controller: Any = None
+    retired: bool = False
+    presentation_revision: int = 0
+    preparations: int = 0
+
+    @property
+    def must_retain(self) -> bool:
+        return bool(
+            self.active_workers
+            or self.loop.running
+            or self.shell.worker is not None
+            or self.compaction.held_prompt
+            or self.unsent
+        )
+
+    def worker_group(self, name: str) -> str:
+        return f"{name}:{self.token}"

--- a/local_operator/tui/session_interaction.py
+++ b/local_operator/tui/session_interaction.py
@@ -96,6 +96,13 @@ class SessionDraft:
     approve_all: bool | None = None
     recoveries: list[SessionDraft] = field(default_factory=list)
     notices: list[tuple[str, NoticeKind]] = field(default_factory=list)
+    #: Prompt-history recall position and the draft it displaced, so Up in
+    #: one session and Down after switching back lands on THAT session's
+    #: draft rather than whatever the shared editor stashed last. In-memory
+    #: only: a switch is what needs it, not a restart.
+    history_index: int | None = None
+    history_stash: str = ""
+    history_stash_attachments: dict[int, Any] = field(default_factory=dict)
 
 
 @dataclass

--- a/local_operator/tui/session_interaction.py
+++ b/local_operator/tui/session_interaction.py
@@ -11,16 +11,19 @@ from __future__ import annotations
 import asyncio
 import uuid
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from local_operator.harness.types import ImageContent
 from local_operator.session.protocol import SessionProtocol
+
+if TYPE_CHECKING:
+    from local_operator.tui.widgets.transcript import NoticeKind
 
 
 @dataclass
 class TurnInteraction:
     provider_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     epoch: int = 0
+    operation: int = 0
     open: bool = False
     notified: bool = False
     accrued_cost: float = 0.0
@@ -65,6 +68,17 @@ class SessionAccounting:
 
 
 @dataclass
+class SessionNaming:
+    requested: bool = False
+    provisional: str = ""
+    generation: int = 0
+    checked_at: float = 0.0
+    last_titled_turn_count: int = 0
+    refresh_count: int = 0
+    pending_text: str = ""
+
+
+@dataclass
 class SessionDraft:
     text: str = ""
     attachments: dict[int, Any] = field(default_factory=dict)
@@ -75,36 +89,61 @@ class SessionDraft:
     scroll_anchor_part: int = 0
     scroll_offset: int = 0
     following_tail: bool = True
+    aside: Any = None
+    aside_main_text: str | None = None
+    aside_main_images: dict[int, Any] = field(default_factory=dict)
+    aside_main_shell_mode: bool = False
+    approve_all: bool | None = None
+    recoveries: list[SessionDraft] = field(default_factory=list)
+    notices: list[tuple[str, NoticeKind]] = field(default_factory=list)
 
 
 @dataclass
 class SessionInteraction:
     session: SessionProtocol | None
     token: str = field(default_factory=lambda: uuid.uuid4().hex)
-    turn: TurnInteraction = field(default_factory=TurnInteraction)
-    loop: LoopInteraction = field(default_factory=LoopInteraction)
-    shell: ShellInteraction = field(default_factory=ShellInteraction)
-    compaction: CompactionInteraction = field(default_factory=CompactionInteraction)
-    accounting: SessionAccounting = field(default_factory=SessionAccounting)
-    draft: SessionDraft = field(default_factory=SessionDraft)
-    # Accepted-but-unsent input is data, not a widget reference. It remains
-    # recoverable even if this conversation's presentation has been evicted.
-    unsent: list[tuple[str, list[ImageContent]]] = field(default_factory=list)
-    notices: list[tuple[str, str]] = field(default_factory=list)
+    turn: TurnInteraction = field(default_factory=TurnInteraction, repr=False)
+    loop: LoopInteraction = field(default_factory=LoopInteraction, repr=False)
+    shell: ShellInteraction = field(default_factory=ShellInteraction, repr=False)
+    compaction: CompactionInteraction = field(default_factory=CompactionInteraction, repr=False)
+    accounting: SessionAccounting = field(default_factory=SessionAccounting, repr=False)
+    draft: SessionDraft = field(default_factory=SessionDraft, repr=False)
+    naming: SessionNaming = field(default_factory=SessionNaming, repr=False)
     active_workers: int = 0
     controller: Any = None
     retired: bool = False
     presentation_revision: int = 0
+    aside_open: bool = False
+    aside_generation: int = 0
     preparations: int = 0
+    # A gate draft can contain a secret. It stays only in this live context,
+    # never in the general draft spill or diagnostic repr.
+    gate_draft: tuple[tuple[Any, ...], Any] | None = field(default=None, repr=False)
+    gate_view_generation: int = 0
+    unsubscribe_frontend: Any = field(default=None, repr=False)
+
+    @property
+    def unsent(self) -> list[SessionDraft]:
+        return self.draft.recoveries
+
+    @property
+    def notices(self) -> list[tuple[str, NoticeKind]]:
+        return self.draft.notices
 
     @property
     def must_retain(self) -> bool:
+        state = getattr(self.session, "frontend_state", None)
+        auto_work = self.draft.approve_all and (
+            getattr(self.session, "is_streaming", False)
+            or any(getattr(job, "status", "") == "running" for job in getattr(state, "jobs", ()))
+        )
         return bool(
             self.active_workers
             or self.loop.running
             or self.shell.worker is not None
             or self.compaction.held_prompt
-            or self.unsent
+            or auto_work
+            or self.gate_draft is not None
         )
 
     def worker_group(self, name: str) -> str:

--- a/local_operator/tui/session_interaction.py
+++ b/local_operator/tui/session_interaction.py
@@ -29,6 +29,10 @@ class TurnInteraction:
     accrued_cost: float = 0.0
     pending_echoes: list[Any] = field(default_factory=list)
     submitted_draft: SessionDraft | None = None
+    completion_deferred: bool = False
+    settled_child_ids: set[str] = field(default_factory=set)
+    waiting_kind: str | None = None
+    approvals_denied_epoch: int | None = None
 
 
 @dataclass

--- a/local_operator/tui/session_interaction.py
+++ b/local_operator/tui/session_interaction.py
@@ -139,20 +139,49 @@ class SessionInteraction:
         return self.draft.notices
 
     @property
-    def must_retain(self) -> bool:
-        state = getattr(self.session, "frontend_state", None)
-        auto_work = self.draft.approve_all and (
-            getattr(self.session, "is_streaming", False)
-            or any(getattr(job, "status", "") == "running" for job in getattr(state, "jobs", ()))
-        )
+    def retained_for_local_work(self) -> bool:
+        """Retention this process OWNS: our coroutines, the user's unsent state.
+
+        Every clause is something only WE hold — an in-flight worker awaiting
+        this socket, a shell or loop we started, a held prompt, a gate answer
+        the user typed and has not sent. Disposing the source breaks a live
+        worker or loses that answer, so nothing may drain these. They are also
+        bounded by user action: a turn has to be started before it can be
+        abandoned by switching away.
+        """
         return bool(
             self.active_workers
             or self.loop.running
             or self.shell.worker is not None
             or self.compaction.held_prompt
-            or auto_work
             or self.gate_draft is not None
         )
+
+    @property
+    def retained_for_auto_work(self) -> bool:
+        """Retention driven by the OWNER's turn — a remote fact, and unbounded.
+
+        Kept so an auto-approving viewer keeps noticing a background turn finishing;
+        but the viewer is a read-only projection (``no_takeover``), so dropping
+        it cannot stop or corrupt the owner's turn. Unbounded is the problem:
+        prewarming any busy background agent mints one, and each retained
+        viewer costs a deep state copy on EVERY owner delta, so closing the
+        sidebar must be allowed to drop these (see ``_release_sidebar_source``).
+        """
+        state = getattr(self.session, "frontend_state", None)
+        return bool(
+            self.draft.approve_all
+            and (
+                getattr(self.session, "is_streaming", False)
+                or any(
+                    getattr(job, "status", "") == "running" for job in getattr(state, "jobs", ())
+                )
+            )
+        )
+
+    @property
+    def must_retain(self) -> bool:
+        return self.retained_for_local_work or self.retained_for_auto_work
 
     def worker_group(self, name: str) -> str:
         return f"{name}:{self.token}"

--- a/local_operator/tui/session_navigation.py
+++ b/local_operator/tui/session_navigation.py
@@ -21,7 +21,7 @@ class SessionNavigation(Generic[Prepared]):
         self,
         *,
         prepare: Callable[[str], Awaitable[Prepared]],
-        commit: Callable[[str, Prepared, int], None],
+        commit: Callable[[str, Prepared, int], Awaitable[None] | None],
         release: Callable[[Prepared], Awaitable[None]],
         pending: Callable[[str], None],
         failed: Callable[[str, Exception], None],
@@ -78,9 +78,14 @@ class SessionNavigation(Generic[Prepared]):
             # There is deliberately no await between the final identity check
             # and commit. The app swaps every source-bound presentation field
             # together, then enables input on that exact authoritative facade.
-            self._commit(session_id, prepared, generation)
-            self.committed_id = session_id
+            ready = self._commit(session_id, prepared, generation)
             transferred = True
+            if ready is not None:
+                # Ownership already moved atomically. The requested boundary
+                # stays raised until its actual frame and input gates exist.
+                await ready
+            if not self._closed and generation == self.generation:
+                self.committed_id = session_id
         except asyncio.CancelledError:
             raise
         except Exception as error:

--- a/local_operator/tui/session_navigation.py
+++ b/local_operator/tui/session_navigation.py
@@ -33,11 +33,30 @@ class SessionNavigation(Generic[Prepared]):
         self._failed = failed
         self.generation = 0
         self.requested_id = ""
+        #: Where the user is HEADED, published SYNCHRONOUSLY — before the
+        #: ``Selected`` message that starts the navigation has been dispatched.
+        #: ``requested_id`` only becomes true inside :meth:`select`, which runs
+        #: on message dispatch; a held key auto-repeats into ONE event batch,
+        #: so a second press read the pre-press origin and both presses
+        #: computed the same target (round 5, U7). Anything choosing a target
+        #: relative to "where I am going" must read this, not ``requested_id``.
+        self.intent_id = ""
         self.committed_id = ""
         self._task: asyncio.Task[None] | None = None
         self._tasks: set[asyncio.Task[None]] = set()
         self._preparation_lock = asyncio.Lock()
         self._closed = False
+
+    def intend(self, session_id: str) -> None:
+        """Publish the target synchronously, before ``select`` can dispatch.
+
+        Separate from :meth:`select` because a caller that posts a message to
+        reach ``select`` has already decided; the decision must be readable in
+        the same event batch, or the next press in an auto-repeat burst steps
+        from a stale origin. Deliberately does NOT raise the input boundary or
+        touch ``generation``: intent is not a commitment to prepare anything.
+        """
+        self.intent_id = session_id
 
     def select(self, session_id: str) -> asyncio.Task[None]:
         if self._closed:
@@ -45,6 +64,7 @@ class SessionNavigation(Generic[Prepared]):
         self.generation += 1
         generation = self.generation
         self.requested_id = session_id
+        self.intent_id = session_id
         if self._task is not None:
             self._task.cancel()
         # The boundary is raised before yielding: a following Enter cannot
@@ -98,6 +118,7 @@ class SessionNavigation(Generic[Prepared]):
             finally:
                 if not self._closed and generation == self.generation:
                     self.requested_id = ""
+                    self.intent_id = ""
                     self._pending("")
 
     def cancel(self) -> None:
@@ -105,6 +126,7 @@ class SessionNavigation(Generic[Prepared]):
         if self._task is not None:
             self._task.cancel()
         self.requested_id = ""
+        self.intent_id = ""
         self._pending("")
 
     async def close(self) -> None:
@@ -118,3 +140,4 @@ class SessionNavigation(Generic[Prepared]):
             # preparations prevents callbacks touching an already closed app.
             await asyncio.gather(*tasks, return_exceptions=True)
         self.requested_id = ""
+        self.intent_id = ""

--- a/local_operator/tui/session_navigation.py
+++ b/local_operator/tui/session_navigation.py
@@ -16,6 +16,10 @@ Prepared = TypeVar("Prepared")
 logger = logging.getLogger(__name__)
 
 
+class PreparationInvalidated(RuntimeError):
+    """The authoritative replay changed before presentation ownership moved."""
+
+
 class SessionNavigation(Generic[Prepared]):
     def __init__(
         self,
@@ -86,15 +90,18 @@ class SessionNavigation(Generic[Prepared]):
         async with self._preparation_lock:
             if self._closed or generation != self.generation:
                 return
-            await self._prepare_and_commit(session_id, generation)
+            while not self._closed and generation == self.generation:
+                if not await self._prepare_and_commit(session_id, generation):
+                    break
 
-    async def _prepare_and_commit(self, session_id: str, generation: int) -> None:
+    async def _prepare_and_commit(self, session_id: str, generation: int) -> bool:
         prepared: Prepared | None = None
         transferred = False
+        retry = False
         try:
             prepared = await self._prepare(session_id)
             if self._closed or generation != self.generation or session_id != self.requested_id:
-                return
+                return False
             # There is deliberately no await between the final identity check
             # and commit. The app swaps every source-bound presentation field
             # together, then enables input on that exact authoritative facade.
@@ -108,6 +115,10 @@ class SessionNavigation(Generic[Prepared]):
                 self.committed_id = session_id
         except asyncio.CancelledError:
             raise
+        except PreparationInvalidated:
+            # Keep the requested/input boundary raised while the stale widgets
+            # are released and the same latest intent prepares a canonical cut.
+            retry = True
         except Exception as error:
             if not self._closed and generation == self.generation:
                 self._failed(session_id, error)
@@ -116,10 +127,11 @@ class SessionNavigation(Generic[Prepared]):
                 if prepared is not None and not transferred:
                     await self._release(prepared)
             finally:
-                if not self._closed and generation == self.generation:
+                if not retry and not self._closed and generation == self.generation:
                     self.requested_id = ""
                     self.intent_id = ""
                     self._pending("")
+        return retry
 
     def cancel(self) -> None:
         self.generation += 1

--- a/local_operator/tui/session_navigation.py
+++ b/local_operator/tui/session_navigation.py
@@ -1,0 +1,115 @@
+"""Generation-fenced preparation followed by one synchronous presentation commit.
+
+The coordinator never knows how to stop a runtime. Its release callback owns
+only speculative viewer resources, so cancellation, failure and rapid clicks
+cannot inherit /resume's preference to stop the outgoing owner.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Generic, TypeVar
+
+Prepared = TypeVar("Prepared")
+logger = logging.getLogger(__name__)
+
+
+class SessionNavigation(Generic[Prepared]):
+    def __init__(
+        self,
+        *,
+        prepare: Callable[[str], Awaitable[Prepared]],
+        commit: Callable[[str, Prepared, int], None],
+        release: Callable[[Prepared], Awaitable[None]],
+        pending: Callable[[str], None],
+        failed: Callable[[str, Exception], None],
+    ) -> None:
+        self._prepare = prepare
+        self._commit = commit
+        self._release = release
+        self._pending = pending
+        self._failed = failed
+        self.generation = 0
+        self.requested_id = ""
+        self.committed_id = ""
+        self._task: asyncio.Task[None] | None = None
+        self._tasks: set[asyncio.Task[None]] = set()
+        self._preparation_lock = asyncio.Lock()
+        self._closed = False
+
+    def select(self, session_id: str) -> asyncio.Task[None]:
+        if self._closed:
+            raise RuntimeError("session navigation is closed")
+        self.generation += 1
+        generation = self.generation
+        self.requested_id = session_id
+        if self._task is not None:
+            self._task.cancel()
+        # The boundary is raised before yielding: a following Enter cannot
+        # accidentally submit to the conversation the user just left.
+        self._pending(session_id)
+        self._task = asyncio.create_task(self._navigate(session_id, generation))
+        self._tasks.add(self._task)
+        self._task.add_done_callback(self._settled)
+        return self._task
+
+    def _settled(self, task: asyncio.Task[None]) -> None:
+        self._tasks.discard(task)
+        if not task.cancelled() and task.exception() is not None:
+            logger.error("session navigation cleanup failed", exc_info=task.exception())
+
+    async def _navigate(self, session_id: str, generation: int) -> None:
+        # One preparation owns sockets/history/widgets at a time. A rapid
+        # burst replaces the desired ID, not a queue of expensive cold reads.
+        async with self._preparation_lock:
+            if self._closed or generation != self.generation:
+                return
+            await self._prepare_and_commit(session_id, generation)
+
+    async def _prepare_and_commit(self, session_id: str, generation: int) -> None:
+        prepared: Prepared | None = None
+        transferred = False
+        try:
+            prepared = await self._prepare(session_id)
+            if self._closed or generation != self.generation or session_id != self.requested_id:
+                return
+            # There is deliberately no await between the final identity check
+            # and commit. The app swaps every source-bound presentation field
+            # together, then enables input on that exact authoritative facade.
+            self._commit(session_id, prepared, generation)
+            self.committed_id = session_id
+            transferred = True
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            if not self._closed and generation == self.generation:
+                self._failed(session_id, error)
+        finally:
+            try:
+                if prepared is not None and not transferred:
+                    await self._release(prepared)
+            finally:
+                if not self._closed and generation == self.generation:
+                    self.requested_id = ""
+                    self._pending("")
+
+    def cancel(self) -> None:
+        self.generation += 1
+        if self._task is not None:
+            self._task.cancel()
+        self.requested_id = ""
+        self._pending("")
+
+    async def close(self) -> None:
+        self._closed = True
+        self.generation += 1
+        tasks, self._task = tuple(self._tasks), None
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            # _settled records non-cancellation failures. Joining all retired
+            # preparations prevents callbacks touching an already closed app.
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self.requested_id = ""

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -1,0 +1,600 @@
+"""Bounded prepared transcript presentations, independent of owner attachment.
+
+The owner and its canonical state stay authoritative. This module only owns
+widgets and replay bookkeeping; preparing one has no subscription, prompt,
+acknowledgement, or reference to the currently selected app session.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from textual import events
+from textual.binding import Binding
+from textual.message import Message
+
+from local_operator.harness.types import ImageContent
+from local_operator.tui.widgets.image_block import ImageBlock
+from local_operator.tui.widgets.transcript import (
+    NoticeBlock,
+    TranscriptBlock,
+    TranscriptView,
+)
+
+
+class HistoryPageNotice(NoticeBlock, can_focus=True):
+    BINDINGS = [Binding("enter", "more", "More recent messages", show=False)]
+
+    class Requested(Message):
+        def __init__(self, notice: HistoryPageNotice) -> None:
+            super().__init__()
+            self.notice = notice
+
+    def __init__(self) -> None:
+        super().__init__("More recent messages below", "note")
+
+    def action_more(self) -> None:
+        self.post_message(self.Requested(self))
+
+    def on_click(self, event: events.Click) -> None:
+        event.stop()
+        self.action_more()
+
+
+@dataclass
+class ReplayState:
+    _resume_results: dict[str, Any] = field(default_factory=dict)
+    _resume_pending_head: list[Any] = field(default_factory=list)
+    _resume_pending_tail: list[Any] = field(default_factory=list)
+    _resume_tail_notice: NoticeBlock | None = None
+    _resume_head_notice: NoticeBlock | None = None
+    _resume_mounted_ids: set[str] = field(default_factory=set)
+    _replay_bang_pending: bool = False
+    _live_peer_receipts: set[str] = field(default_factory=set)
+    _live_wake_receipts: set[tuple[str, object]] = field(default_factory=set)
+    _block_sink: list[Any] | None = None
+    _projection_message_id: str = ""
+    _projection_part: int = 0
+
+
+class ReplayTarget(Protocol):
+    _resume_results: dict[str, Any]
+    _resume_pending_head: list[Any]
+    _resume_pending_tail: list[Any]
+    _resume_tail_notice: NoticeBlock | None
+    _resume_head_notice: NoticeBlock | None
+    _resume_mounted_ids: set[str]
+    _replay_bang_pending: bool
+    _live_peer_receipts: set[str]
+    _live_wake_receipts: set[tuple[str, object]]
+    _block_sink: list[Any] | None
+    _projection_message_id: str
+    _projection_part: int
+
+    def _transcript_view(self) -> TranscriptView: ...
+
+    def _append_block(
+        self, block: Any, *, ends_empty_state: bool = True, pin_tail: bool = False
+    ) -> None: ...
+
+    def _append_image_blocks(
+        self, images: list[ImageContent], *, marker_text: str | None = None
+    ) -> list[ImageBlock]: ...
+
+    def _painted_tool_card(self, call_id: str) -> Any: ...
+
+    def _settle_painted_tool_card(self, card: Any, result: Any) -> None: ...
+
+    def _replay_tool_call(
+        self, call: Any, results: dict[str, Any], *, user_run: bool = False
+    ) -> None: ...
+
+
+@dataclass
+class PreparedReplay(ReplayState):
+    _resume_head_notice: NoticeBlock | None = None
+    _resume_tail_notice: NoticeBlock | None = None
+    view: TranscriptView = field(default_factory=TranscriptView)
+    blocks: list[TranscriptBlock] = field(default_factory=list)
+
+    def _transcript_view(self) -> TranscriptView:
+        return self.view
+
+    def _append_block(
+        self, block: Any, *, ends_empty_state: bool = True, pin_tail: bool = False
+    ) -> None:
+        block.navigation_anchor_id = self._projection_message_id
+        block.navigation_anchor_part = self._projection_part
+        self._projection_part += 1
+        self.blocks.append(block)
+
+    def _append_image_blocks(
+        self, images: list[ImageContent], *, marker_text: str | None = None
+    ) -> list[ImageBlock]:
+        return append_image_blocks(self, images, marker_text=marker_text)
+
+    def _painted_tool_card(self, call_id: str) -> None:
+        return None
+
+    def _settle_painted_tool_card(self, card: Any, result: Any) -> None:
+        raise AssertionError("a prepared replay cannot contain a live tool card")
+
+    def _replay_tool_call(
+        self, call: Any, results: dict[str, Any], *, user_run: bool = False
+    ) -> None:
+        replay_tool_call(self, call, results, user_run=user_run)
+
+    def prepare(self, history: list[Any], *, bound: int = 12, anchor_id: str = "") -> None:
+        self._block_sink = self.blocks
+        anchor = next((index for index, message in enumerate(history) if str(getattr(message, "id", "")) == anchor_id), None) if anchor_id else None
+        end = min(len(history), anchor + bound) if anchor is not None else None
+        project_settled_rows(self, history, bound=bound, end=end)
+        if self._resume_pending_head:
+            from local_operator.tui.app import RESUME_OLDER_NOTICE
+
+            self._resume_head_notice = NoticeBlock(RESUME_OLDER_NOTICE, "note")
+            self.blocks.insert(0, self._resume_head_notice)
+        if self._resume_pending_tail:
+            self._resume_tail_notice = HistoryPageNotice()
+            self.blocks.append(self._resume_tail_notice)
+        self._block_sink = None
+
+
+@dataclass
+class SessionPresentation:
+    replay: PreparedReplay
+    revision: int = 0
+    streaming_block: Any = None
+    tool_cards: dict[str, Any] = field(default_factory=dict)
+    composing_cards: dict[str, Any] = field(default_factory=dict)
+    working_block: Any = None
+    working_fallback: str = ""
+    compaction_owns_working_block: bool = False
+    shell_card: Any = None
+    queued_steer_notices: list[Any] = field(default_factory=list)
+    deferred_steer_notices: list[Any] = field(default_factory=list)
+    held_steer_blocks: list[Any] = field(default_factory=list)
+    welcome: Any = None
+    welcome_visible: bool | None = False
+
+
+def project_settled_rows(
+    self: ReplayTarget, history: list[Any], *, bound: int | None = None, end: int | None = None
+) -> bool:
+    """Mount settled transcript rows through the ONE role-aware renderer.
+
+    The shared history/render seam: cold resume feeds it the whole
+    conversation and a reconnect's durable gap replay
+    (:class:`HistoryRowsSettled`) feeds it exactly the rows no frontend
+    painted. One implementation is the point — the gap replay previously
+    synthesized role-blind assistant events and a recovered user prompt
+    painted as agent speech (review round 3, MAJOR-1/U7/D1). Whatever
+    this method does for ``--resume`` is by construction what a
+    reconnect gap does: user rows as :class:`UserBlock` with images,
+    assistant prose + tool cards paired with results, wake/peer custom
+    rows as their own blocks, refusal/error notices.
+
+    Returns whether anything mounted, so callers can skip tail-follow
+    work for an empty projection.
+
+    ``bound`` renders only the LAST ``bound`` messages and holds the rest
+    for :meth:`_mount_older_resume_page`. It is a display bound and nothing
+    else: the deferred messages stay in ``_resume_pending_head`` in full,
+    and the model's conversation — built from the transcript, not from this
+    projection — never sees the split at all. The gap-replay caller passes
+    no bound, because a reconnect gap is by definition the small set of
+    rows no frontend painted and bounding it could hide one.
+    """
+    from contextlib import nullcontext
+
+    from local_operator.compaction.marker import COMPACTION_REFUSED_TYPE
+    from local_operator.harness.approval import GATE_TIMEOUT_CUSTOM_TYPE
+    from local_operator.tui.app import (
+        LOOP_PROMPT,
+        PEER_MESSAGE_MESSAGE_TYPE,
+        RESUME_OLDER_NOTICE,
+        WAKE_PROMPT_MESSAGE_TYPE,
+        AssistantBlock,
+        PeerMessageBlock,
+        UserBlock,
+        WakeBlock,
+        _gate_timeout_notice,
+        _resume_tail_start,
+        _typed_line_of,
+    )
+
+    # Results are keyed by the call they answer, and a tool message can sit
+    # several messages after its call (one assistant turn issues a batch).
+    # Indexing first is what lets each call render WITH its outcome instead
+    # of as a second, orphaned row.
+    #
+    # Indexed over the WHOLE history, before any bound is applied: a call in
+    # the deferred head is often answered by a result inside the rendered
+    # tail, and a per-page index would show that call as `interrupted`.
+    #
+    # Seeded from the whole-conversation index a bounded resume kept, so a
+    # deferred page's call still finds a result that lives in the already
+    # rendered tail. Empty for every unbounded caller.
+    results: dict[str, Any] = dict(self._resume_results)
+    settled_results: set[str] = set()
+    # Harness chrome the LIVE path never paints as a user row, so replay
+    # must not either (see the `role == "user"` branch). Deferred once to
+    # the top of this method rather than inside the loop, matching the
+    # file's other lazy session.* imports.
+    from local_operator.harness.loop import CONNECTIVITY_CONTINUATION_PROMPT
+    from local_operator.session.session import _CONTINUATION_PROMPT
+
+    for message in history:
+        if getattr(message, "role", None) != "tool":
+            continue
+        call_id = getattr(message, "tool_call_id", None)
+        if not call_id:
+            continue
+        results[call_id] = message
+        # A result whose call painted LIVE before a disconnect must
+        # settle the card already on screen — the disconnect marked it
+        # ``interrupted``, and replaying it as a new row would double the
+        # card (review round 4, MINOR-1). The disconnect retired the card
+        # out of ``_tool_cards`` but left it mounted, so scan the
+        # transcript for the painted card carrying this call id.
+        painted = self._painted_tool_card(call_id)
+        if painted is not None:
+            self._settle_painted_tool_card(painted, message)
+            settled_results.add(call_id)
+    # Fresh batch, fresh pairing: a flag left by an earlier replay (or a
+    # truncated one) must not open a card in this conversation.
+    self._replay_bang_pending = False
+
+    # Split the conversation into the head this frame defers and the tail it
+    # paints. Sliced on MESSAGES rather than on rendered blocks because the
+    # split has to be decided before anything is built — deciding it by
+    # block count would mean building the blocks first, which is the cost
+    # being avoided. A message mounts 0-2 blocks, so the block count lands
+    # near the bound rather than on it, which is fine: the bound is a budget,
+    # not a contract about how many rows appear.
+    if end is not None and end < len(history):
+        # Pair results against the whole history, then retain only the chosen
+        # viewport window. Newer rows remain reachable through forward paging.
+        self._resume_results = results
+        self._resume_pending_tail = history[end:]
+        history = history[:end]
+    if bound is not None and len(history) > bound:
+        start = _resume_tail_start(history, bound)
+        if start > 0:
+            deferred, history = history[:start], history[start:]
+            # Whole-conversation results, so a deferred call still pairs with a
+            # result that renders (or already rendered) in the tail.
+            self._resume_results = results
+            self._resume_pending_head = deferred
+    transcript = self._transcript_view()
+
+    appended = bool(settled_results)
+    # The "older messages" notice has to be the FIRST row, so it is
+    # appended before the batch rather than prepended after it.
+    # `prepend_blocks` restores a scroll anchor on a later refresh, which
+    # would fight `follow_tail` for the same frame — the reflow-after-paint
+    # #451/#452 exist to prevent. One extra mount of a one-line notice is
+    # not the cost this bound is avoiding.
+    if self._block_sink is None and self._resume_pending_head and self._resume_head_notice is None:
+        notice = NoticeBlock(RESUME_OLDER_NOTICE, "note")
+        self._resume_head_notice = notice
+        self._append_block(notice)
+        appended = True
+    # ONE mount for the whole conversation. Per-block mounting made Textual
+    # re-walk its stylesheet, invalidate the container and schedule a settle
+    # callback 297 times over on a 396-message session, for a layout that is
+    # only looked at once — see `TranscriptView.batch_append`. A collected
+    # backward page must not open a batch on the live transcript: the
+    # blocks are inserted later, and an empty batch still schedules a
+    # settle pass that would race the insert's own settle.
+    batch = nullcontext() if self._block_sink is not None else transcript.batch_append()
+    with batch:
+        for message in history:
+            self._projection_message_id = str(getattr(message, "id", ""))
+            self._projection_part = 0
+            # A wake delivery is a CustomMessage, so it has no ``role``
+            # and would fall through every branch below — which is exactly
+            # why a resumed session showed the agent answering a wake with
+            # no sign the wake ever fired. Replaying it as its own block
+            # keeps the receipt on screen. The catch-up prompt is
+            # user-attributed, so replaying it too would put a raw
+            # '(alarm) The session resumed…' line in the transcript as if
+            # the user had typed it.
+            if getattr(message, "custom_type", None) == WAKE_PROMPT_MESSAGE_TYPE:
+                details = getattr(message, "details", None) or {}
+                if not details.get("wake_catchup"):
+                    key = (str(details.get("wake_id", "")), details.get("occurrence"))
+                    # Skip a receipt this session already painted live —
+                    # replaying it would double the line (round 2, m2).
+                    if key not in self._live_wake_receipts:
+                        self._append_block(WakeBlock(str(details.get("text", "")), catchup=False))
+                        appended = True
+                continue
+            # A peer message (`lop send` from another session) is also a
+            # CustomMessage with no ``role`` and would otherwise fall
+            # through, leaving a resumed session with the agent's reply but
+            # no sign the peer note arrived. Replay it as its own block,
+            # skipping one already painted live this session (double-paint
+            # guard, mirroring the wake branch above).
+            if getattr(message, "custom_type", None) == PEER_MESSAGE_MESSAGE_TYPE:
+                details = getattr(message, "details", None) or {}
+                if str(getattr(message, "id", "")) not in self._live_peer_receipts:
+                    self._append_block(
+                        PeerMessageBlock(
+                            str(details.get("body", "")),
+                            details.get("sender") or {},
+                        )
+                    )
+                    appended = True
+                continue
+            # A gate that timed out unattended is the most expensive event
+            # in the detached feature — up to a day of held residency ends
+            # here — and it rendered NOWHERE (round 1, D2/U2): the user
+            # returned to a conversation that promised an action and
+            # appeared to simply stop. The payload already carried the
+            # tool, the description and the wait; only a renderer was
+            # missing.
+            #
+            # `warning` ink because it is a state the user must know about,
+            # not a receipt they can skip: a tool was denied, and denied by
+            # expiry rather than by their decision — which is the same
+            # distinction the transcript row itself exists to preserve.
+            if getattr(message, "custom_type", None) == GATE_TIMEOUT_CUSTOM_TYPE:
+                details = getattr(message, "details", None) or {}
+                self._append_block(NoticeBlock(_gate_timeout_notice(details), kind="warning"))
+                appended = True
+                continue
+            # A compaction that did NOT run. Rendered here for the same
+            # reason as the row above: a custom row with no renderer is a
+            # row nobody sees, and this one exists to CORRECT the
+            # optimistic "compacting context…" receipt the routed command
+            # already showed (round 5, U17). `warning` ink because the
+            # context the user asked to reclaim is still there.
+            if getattr(message, "custom_type", None) == COMPACTION_REFUSED_TYPE:
+                details = getattr(message, "details", None) or {}
+                text = str(details.get("detail") or "compaction did not run").strip()
+                kind = "error" if text.startswith("compaction failed") else "warning"
+                self._append_block(NoticeBlock(text, kind=kind))
+                appended = True
+                continue
+            role = getattr(message, "role", None)
+            if role == "tool":
+                continue  # already rendered beside the call that asked for it
+            text = getattr(message, "text", "") or ""
+            text = text.strip() if isinstance(text, str) else ""
+            if role == "user":
+                # The live path never paints harness chrome as a user row
+                # (LOOP_PROMPT is registered as a pending echo and consumed;
+                # the auto-continuation prompt is never announced at all).
+                # Replay must make the same choice, or a resumed session
+                # shows rows the live one deliberately suppressed — the
+                # live/replay divergence review round 2 pinned.
+                #
+                # The network-continuation prompt joins them for the same
+                # reason: it is persisted so the TRANSCRIPT explains why one
+                # answer arrived in two pieces, but the user never typed it
+                # and the live run showed a NoticeEvent instead.
+                if text in (
+                    LOOP_PROMPT,
+                    _CONTINUATION_PROMPT,
+                    CONNECTIVITY_CONTINUATION_PROMPT,
+                ):
+                    continue
+                # A `$skill` invocation persists as its EXPANDED payload,
+                # because that is what the model was sent. Replaying it
+                # verbatim showed a resumed conversation the whole SKILL.md
+                # body as the user's row — and, since the picker titles a
+                # session from its first user turn, named every such thread
+                # "The user invoked the `research` skill…". The typed line
+                # rides the payload's own opening tag, so replay repaints
+                # exactly what the live session painted. Same live/replay
+                # parity rule as the two prompts skipped above.
+                text = _typed_line_of(text) or text
+                # The images ride the persisted message as base64 content
+                # blocks — the same bytes the model saw — so a resumed
+                # prompt replays WITH its pictures, not just the receipt
+                # count. This is the resume half of the promise the live
+                # path makes in `_submit_prompt`.
+                replay_images = [
+                    block
+                    for block in (getattr(message, "content", None) or [])
+                    if isinstance(block, ImageContent)
+                ]
+                if text or replay_images:
+                    self._append_block(UserBlock(text, len(replay_images)))
+                    self._append_image_blocks(replay_images, marker_text=text)
+                    appended = True
+                # A bang-mode receipt replays as open as it lived: the
+                # user row is `! <command>` and the assistant message that
+                # follows carries exactly one bash call. Remembered so the
+                # call's card can open on settle, the same contract the
+                # live path makes.
+                if text.startswith("! "):
+                    self._replay_bang_pending = True
+                continue
+            if role != "assistant":
+                continue
+            # Consume the pending bang marker on EVERY assistant message:
+            # record_shell writes the call-bearing assistant immediately
+            # after the `!` row, and a later unrelated turn must never
+            # inherit the open-on-settle flag.
+            bang_pending = self._replay_bang_pending
+            self._replay_bang_pending = False
+            if text:
+                block = AssistantBlock()
+                # Replayed completions must stay acknowledgeable: the viewed
+                # receipt is keyed by the anchoring message id, so a block
+                # rebuilt from history carries the same id the live render
+                # would have (upstream #697).
+                block.completion_anchor_id = str(getattr(message, "id", ""))
+                block.update_text(text)
+                block.finalize_text()
+                self._append_block(block)
+                appended = True
+            tool_calls = getattr(message, "tool_calls", None) or []
+            for call in tool_calls:
+                # Only the FIRST call of a bang assistant message is the
+                # command's own card; the shape record_shell writes has
+                # exactly one, so consuming here is exact in practice and
+                # conservative in theory.
+                user_run = bool(
+                    bang_pending and tool_calls[0] is call and getattr(call, "name", "") == "bash"
+                )
+                self._replay_tool_call(call, results, user_run=user_run)
+                appended = True
+            stop = getattr(message, "stop_reason", None)
+            if stop == "refusal":
+                # A refused turn replays its refusal even when the model DID
+                # stream some prose first (Gemini safety stops often cut a
+                # partial answer): the prose alone reads as a complete,
+                # oddly short reply, and the user re-reading the session
+                # needs to know the provider cut it off and why. The message
+                # itself was stashed on the assistant message by the loop
+                # precisely so this replay could show it.
+                payload = getattr(message, "provider_payload", None) or {}
+                # The fallback keeps the marker grammar (D3): every other
+                # refusal line ends in a parenthetical, and a user who has
+                # learned that shape would read its absence as meaningful.
+                refusal = str(payload.get("refusal") or "") or (
+                    "model refused the request (no details recorded)"
+                )
+                self._append_block(NoticeBlock(refusal, "error"))
+                appended = True
+            elif not text and not tool_calls:
+                # An assistant message with neither prose nor a call is a
+                # turn that FAILED. Skipping it is what left a resumed
+                # session showing a prompt and nothing after it, with no
+                # hint that the answer had errored rather than never been
+                # asked for.
+                if stop in ("error", "aborted"):
+                    reason = "turn failed" if stop == "error" else "interrupted"
+                    self._append_block(NoticeBlock(reason, "error"))
+                    appended = True
+    # Every message this pass rendered, by stable id — the dedupe key a
+    # later backward page is filtered through.
+    self._projection_message_id = ""
+    self._resume_mounted_ids.update(
+        str(getattr(message, "id", "")) for message in history if getattr(message, "id", None)
+    )
+    if self._block_sink is not None:
+        # A collected page mounts nothing and owns no viewport: the head
+        # notice belongs to the first render, and `follow_tail` would drag
+        # the reader from the history they scrolled up to read down to the
+        # newest turn — the exact opposite of the gesture that asked for it.
+        return appended
+    if appended:
+        # Replay is mounted as one synchronous batch, before Textual can
+        # remeasure the growing container between blocks. Land the reader on
+        # the latest turn and ARM the anchor there, so the first thing the
+        # resumed session streams carries them with it rather than growing
+        # off the bottom of a viewport pinned to the replay's last frame.
+        transcript.follow_tail()
+    return appended
+
+
+def replay_tool_call(
+    self: ReplayTarget, call: Any, results: dict[str, Any], *, user_run: bool = False
+) -> None:
+    """Mount one settled tool row for a call from a previous session.
+
+    The card is built exactly as a live one is — same constructor, same
+    summary derivation from the arguments — so a resumed row is
+    indistinguishable from the row the user watched run, apart from the
+    duration the transcript never recorded.
+    """
+    from local_operator.tui.app import ImageContent, ToolCard, _first_line
+
+    card = ToolCard(
+        getattr(call, "id", "") or "",
+        getattr(call, "name", "") or "",
+        getattr(call, "arguments", None) or {},
+        user_run=user_run,
+    )
+    self._append_block(card)
+    result = results.get(getattr(call, "id", "") or "")
+    if result is None:
+        # No result recorded: the session ended between the call and its
+        # answer. Showing it as complete would invent an outcome.
+        card.restore(state="interrupted")
+        return
+    result_text = getattr(result, "text", "") or ""
+    payload = getattr(result, "provider_payload", None) or {}
+    details = payload.get("details") if isinstance(payload, dict) else None
+    if getattr(result, "is_error", False) and result_text.startswith("aborted ("):
+        # A user-stopped bang command persists as an error result (the
+        # model-facing shape), but the LIVE frame it came from was the dim
+        # shut `interrupted ⊘` row. Replaying it through the error branch
+        # would reopen the user's own Esc as a red failure (design round
+        # 1, D1). The aborted prefix is execute_bash's stable contract.
+        card.restore(state="interrupted")
+        return
+    if getattr(result, "is_error", False):
+        card.restore(
+            state="error",
+            result_text=result_text,
+            details=details,
+            error=_first_line(result_text),
+        )
+    else:
+        card.restore(state="success", result_text=result_text, details=details)
+    # Same rule as `on_tool_ended`: a result carrying image blocks shows
+    # them under the settled card, so a resumed session's screenshots are
+    # back on screen exactly where the live session showed them.
+    self._append_image_blocks(
+        [
+            block
+            for block in (getattr(result, "content", None) or [])
+            if isinstance(block, ImageContent)
+        ]
+    )
+
+
+def append_image_blocks(
+    self: ReplayTarget, images: list[ImageContent], *, marker_text: str | None = None
+) -> list[ImageBlock]:
+    """Mount one :class:`ImageBlock` per image, in order.
+
+    The single entry point for putting pictures on the transcript — the
+    prompt path, the tool-result path, and the resume replay all route
+    here so a rendering decision (caps, protocol, the unavailable
+    receipt) is made in exactly one place. Guarded per block: a block
+    whose bytes will not decode still mounts (as its unavailable
+    receipt), but a failure CONSTRUCTING one must not take down the
+    message dispatch that carried a perfectly good tool result.
+
+    Labels name WHICH of several images a receipt is about, and only
+    when the batch has more than one — a receipt for a batch of one
+    names nothing the row above it has not already said (review round
+    1, F4). Where ``marker_text`` is given (the prompt paths), the
+    numbers are read from the text's own ``[Image #N]`` citations, in
+    citation order — the same walk ``resolve_markers`` built ``images``
+    from — because marker numbers are not positional: delete #1 and
+    paste again and the draft reads ``[Image #2] [Image #3]``, so a
+    positional ``#1`` would name a marker the prompt does not contain
+    (review round 2, F9). Tool results have no markers and fall back to
+    positions.
+    """
+    from local_operator.tui.app import logger
+
+    indices: list[int] = []
+    if marker_text:
+        from local_operator.tui.widgets.editor import IMAGE_MARKER
+
+        indices = [int(match.group("index")) for match in IMAGE_MARKER.finditer(marker_text)]
+    mounted: list[ImageBlock] = []
+    for index, image in enumerate(images):
+        if len(images) <= 1:
+            label = ""
+        elif index < len(indices):
+            label = f"#{indices[index]}"
+        else:
+            label = f"#{index + 1}"
+        try:
+            block = ImageBlock(image.data or None, image.mime_type, label=label)
+        except Exception:
+            logger.debug("image block construction failed", exc_info=True)
+            continue
+        self._append_block(block)
+        mounted.append(block)
+    return mounted

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -130,15 +130,16 @@ class PreparedReplay(ReplayState):
     def _append_block(
         self, block: Any, *, ends_empty_state: bool = True, pin_tail: bool = False
     ) -> None:
-        block.navigation_anchor_id = self._projection_message_id
-        block.navigation_anchor_part = self._projection_part
+        if not block.navigation_anchor_id:
+            block.navigation_anchor_id = self._projection_message_id
+            block.navigation_anchor_part = self._projection_part
         self._projection_part += 1
         self.blocks.append(block)
 
     def _append_image_blocks(
         self, images: list[ImageContent], *, marker_text: str | None = None
     ) -> list[ImageBlock]:
-        return append_image_blocks(self, images, marker_text=marker_text)
+        return append_image_blocks(self, images, marker_text=marker_text, navigation_visible=False)
 
     def _painted_tool_card(self, call_id: str) -> None:
         return None
@@ -186,6 +187,7 @@ class PreparedReplay(ReplayState):
 class SessionPresentation:
     replay: PreparedReplay
     revision: int = 0
+    replay_revision: int = 0
     source_stamp: tuple[Any, ...] = ()
     source_token: str = ""
     history_size: int = 0
@@ -538,10 +540,6 @@ def project_settled_rows(
             self._replay_bang_pending = False
             if text:
                 block = AssistantBlock()
-                # Replayed completions must stay acknowledgeable: the viewed
-                # receipt is keyed by the anchoring message id, so a block
-                # rebuilt from history carries the same id the live render
-                # would have (upstream #697).
                 block.completion_anchor_id = str(getattr(message, "id", ""))
                 block.update_text(text)
                 block.finalize_text()
@@ -666,7 +664,11 @@ def replay_tool_call(
 
 
 def append_image_blocks(
-    self: ReplayTarget, images: list[ImageContent], *, marker_text: str | None = None
+    self: ReplayTarget,
+    images: list[ImageContent],
+    *,
+    marker_text: str | None = None,
+    navigation_visible: bool = True,
 ) -> list[ImageBlock]:
     """Mount one :class:`ImageBlock` per image, in order.
 
@@ -706,7 +708,12 @@ def append_image_blocks(
         else:
             label = f"#{index + 1}"
         try:
-            block = ImageBlock(image.data or None, image.mime_type, label=label)
+            block = ImageBlock(
+                image.data or None,
+                image.mime_type,
+                label=label,
+                navigation_visible=navigation_visible,
+            )
         except Exception:
             logger.debug("image block construction failed", exc_info=True)
             continue

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -7,14 +7,17 @@ acknowledgement, or reference to the currently selected app session.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
+from pydantic import BaseModel
 from textual import events
 from textual.binding import Binding
 from textual.message import Message
 
 from local_operator.harness.types import ImageContent
+from local_operator.tui.session_interaction import SessionDraft
 from local_operator.tui.widgets.image_block import ImageBlock
 from local_operator.tui.widgets.transcript import (
     NoticeBlock,
@@ -33,6 +36,7 @@ class HistoryPageNotice(NoticeBlock, can_focus=True):
 
     def __init__(self) -> None:
         super().__init__("More recent messages below", "note")
+        self.add_class("interactive-notice")
 
     def action_more(self) -> None:
         self.post_message(self.Requested(self))
@@ -40,6 +44,28 @@ class HistoryPageNotice(NoticeBlock, can_focus=True):
     def on_click(self, event: events.Click) -> None:
         event.stop()
         self.action_more()
+
+
+class DraftRecoveryNotice(NoticeBlock, can_focus=True):
+    BINDINGS = [Binding("enter", "restore", "Restore unsent prompt", show=False)]
+
+    class Requested(Message):
+        def __init__(self, notice: DraftRecoveryNotice) -> None:
+            super().__init__()
+            self.notice = notice
+
+    def __init__(self, source_token: str, draft: SessionDraft) -> None:
+        super().__init__("Restore unsent prompt", "warning")
+        self.source_token = source_token
+        self.draft = draft
+        self.add_class("interactive-notice")
+
+    def action_restore(self) -> None:
+        self.post_message(self.Requested(self))
+
+    def on_click(self, event: events.Click) -> None:
+        event.stop()
+        self.action_restore()
 
 
 @dataclass
@@ -127,7 +153,22 @@ class PreparedReplay(ReplayState):
 
     def prepare(self, history: list[Any], *, bound: int = 12, anchor_id: str = "") -> None:
         self._block_sink = self.blocks
-        anchor = next((index for index, message in enumerate(history) if str(getattr(message, "id", "")) == anchor_id), None) if anchor_id else None
+        anchor = (
+            next(
+                (
+                    index
+                    for index, message in enumerate(history)
+                    if str(getattr(message, "id", "")) == anchor_id
+                    or any(
+                        f"tool:{getattr(call, 'id', '')}" == anchor_id
+                        for call in getattr(message, "tool_calls", ())
+                    )
+                ),
+                None,
+            )
+            if anchor_id
+            else None
+        )
         end = min(len(history), anchor + bound) if anchor is not None else None
         project_settled_rows(self, history, bound=bound, end=end)
         if self._resume_pending_head:
@@ -145,6 +186,10 @@ class PreparedReplay(ReplayState):
 class SessionPresentation:
     replay: PreparedReplay
     revision: int = 0
+    source_stamp: tuple[Any, ...] = ()
+    source_token: str = ""
+    history_size: int = 0
+    needs_live_projection: bool = True
     streaming_block: Any = None
     tool_cards: dict[str, Any] = field(default_factory=dict)
     composing_cards: dict[str, Any] = field(default_factory=dict)
@@ -157,6 +202,68 @@ class SessionPresentation:
     held_steer_blocks: list[Any] = field(default_factory=list)
     welcome: Any = None
     welcome_visible: bool | None = False
+
+    def retainable(self) -> bool:
+        """Bound explicit payloads, not a widget's private object graph.
+
+        One cached view can otherwise retain arbitrarily much history. Unknown
+        renderers (including decoded images) are rebuilt instead of guessing.
+        """
+        if len(self.replay.view.blocks()) > 128:
+            return False
+        state = self.replay
+        stack: list[Any] = [
+            self.replay.view.blocks(),
+            state._resume_pending_head,
+            state._resume_pending_tail,
+            state._resume_results,
+            self.tool_cards,
+            self.composing_cards,
+            self.streaming_block,
+            self.working_block,
+            self.shell_card,
+            self.queued_steer_notices,
+            self.deferred_steer_notices,
+            self.held_steer_blocks,
+        ]
+        seen: set[int] = set()
+        remaining = 1024 * 1024
+        nodes = 0
+        while stack:
+            value = stack.pop()
+            nodes += 1
+            if nodes > 4096:
+                return False
+            if isinstance(value, str):
+                remaining -= len(value) * 4
+            elif isinstance(value, bytes):
+                remaining -= len(value)
+            elif value is None or isinstance(value, (bool, int, float)):
+                pass
+            elif id(value) in seen:
+                continue
+            else:
+                seen.add(id(value))
+                if isinstance(value, TranscriptBlock):
+                    payload = value.retained_payloads()
+                    if payload is None:
+                        return False
+                    stack.append(payload)
+                elif isinstance(value, BaseModel):
+                    stack.extend(getattr(value, key) for key in type(value).model_fields)
+                elif isinstance(value, Mapping):
+                    if len(value) + len(stack) > 4096:
+                        return False
+                    stack.extend(value.values())
+                elif isinstance(value, (list, tuple, set)):
+                    if len(value) + len(stack) > 4096:
+                        return False
+                    stack.extend(value)
+                else:
+                    return False
+            if remaining < 0:
+                return False
+        return True
 
 
 def project_settled_rows(

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -232,7 +232,15 @@ class SessionPresentation:
         while stack:
             value = stack.pop()
             nodes += 1
-            if nodes > 4096:
+            # The node cap guards against a pathological object graph, not
+            # memory — the 1 MiB string budget below is the memory bound. At
+            # 4096 it silently refused every real owner: a pydantic Message
+            # costs ~14 nodes, so a kept window past ~290 messages (the live
+            # owners hold 355–456) was never retained and every return click
+            # was cold (retained_views stayed at 1 with N=4 configured).
+            # 65536 admits ~4,600 plain messages, which the string budget
+            # trips long before on any real content.
+            if nodes > 65536:
                 return False
             if isinstance(value, str):
                 remaining -= len(value) * 4

--- a/local_operator/tui/session_workspace.py
+++ b/local_operator/tui/session_workspace.py
@@ -1,0 +1,43 @@
+"""Keep the narrow session drawer above the dock on the first painted frame."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from textual.containers import Horizontal
+from textual.geometry import Size
+from textual.layout import DockArrangeResult
+
+
+class SessionWorkspace(Horizontal):
+    def arrange(self, size: Size, optimal: bool = False) -> DockArrangeResult:
+        arrangement = super().arrange(size, optimal)
+        sidebar = next(
+            (item for item in arrangement.placements if item.widget.id == "session-sidebar"), None
+        )
+        conversation = next(
+            (item for item in arrangement.placements if item.widget.id == "session-conversation"),
+            None,
+        )
+        if sidebar is None or conversation is None or not self.has_class("sidebar-overlay"):
+            return arrangement
+        # A region read from the preceding frame is too late: a restored draft
+        # or gate can change dock height without a terminal resize. Ask the
+        # conversation's ordinary cached arrangement for THIS frame instead.
+        # The compositor will reuse that same result when it descends; there is
+        # no second stylesheet, measurement loop, or post-paint correction.
+        gutter = conversation.widget.styles.gutter
+        inner = conversation.region.shrink(gutter)
+        children = conversation.widget.arrange(inner.size, optimal)
+        dock = next((item for item in children.placements if item.widget.id == "input-dock"), None)
+        if dock is None:
+            return arrangement
+        ceiling = conversation.region.y + gutter.top + dock.region.y
+        region = sidebar.region
+        clipped = sidebar._replace(region=region._replace(height=max(0, ceiling - region.y)))
+        # Do not mutate Textual's cached arrangement or its lazy spatial map.
+        return replace(
+            arrangement,
+            placements=[clipped if item is sidebar else item for item in arrangement.placements],
+            _spatial_map=None,
+        )

--- a/local_operator/tui/widgets/aside_panel.py
+++ b/local_operator/tui/widgets/aside_panel.py
@@ -204,10 +204,34 @@ class AsideTurn:
     #: never be forked into the chat as if the model had said it.
     error: str = ""
 
+    def append_delta(self, delta: str) -> None:
+        self.answer += delta
+
+    def settle(self, answer: str) -> None:
+        if answer.strip():
+            self.answer = answer
+        self.state = "done" if self.answer.strip() else "error"
+        if self.state == "error":
+            self.error = "the model returned nothing"
+
+    def fail(self, message: str) -> None:
+        self.state = "error"
+        self.error = message
+
     @property
     def forkable(self) -> bool:
         """Whether this turn is a real exchange, worth promoting to the chat."""
         return self.state == "done" and bool(self.answer.strip())
+
+
+@dataclass
+class AsideSnapshot:
+    turns: list[AsideTurn]
+    generation: int
+    notice: str = ""
+    following_tail: bool = True
+    anchor_turn: int = 0
+    anchor_offset: int = 0
 
 
 @dataclass
@@ -348,6 +372,35 @@ class AsidePanel(Static):
         self._notice = text
         self._repaint()
 
+    def snapshot(self) -> AsideSnapshot:
+        snapshot = AsideSnapshot(list(self._turns), self._generation, self._notice)
+        if self._scroll_back_rows:
+            flat = self._flat_body()
+            end = max(1, len(flat.lines) - self._scroll_back_rows)
+            if flat.owners:
+                turn = flat.owners[min(end - 1, len(flat.owners) - 1)]
+                snapshot.following_tail = False
+                snapshot.anchor_turn = turn
+                snapshot.anchor_offset = end - flat.heads[turn][0]
+        return snapshot
+
+    def restore(self, snapshot: AsideSnapshot) -> None:
+        """Restore another source's data without retaining its rendered cache."""
+        self._turns = list(snapshot.turns)
+        self._generation = snapshot.generation
+        self._notice = snapshot.notice
+        self._scroll_back_rows = 0
+        self._answer_cache.clear()
+        self._used_answers.clear()
+        self._invalidate_flat()
+        self.display = True
+        if not snapshot.following_tail:
+            flat = self._flat_body()
+            if snapshot.anchor_turn < len(flat.heads):
+                end = flat.heads[snapshot.anchor_turn][0] + snapshot.anchor_offset
+                self._scroll_back_rows = max(0, len(flat.lines) - end)
+        self._repaint()
+
     def open(self) -> None:
         """Show an EMPTY aside. Reopening never restores a dismissed exchange."""
         self._turns = []
@@ -413,7 +466,7 @@ class AsidePanel(Static):
         # while the offset itself never changed. Holding the NUMBER still is
         # not the rule — holding the ROWS still is.
         anchored = len(self._flat_body().lines) if self._scroll_back_rows else 0
-        self._turns[-1].answer += delta
+        self._turns[-1].append_delta(delta)
         # BETWEEN the two measurements, and that placement is the whole point:
         # `anchored` is the pre-delta height and the count below is the
         # post-delta one, so the memo has to be dropped here or the second
@@ -448,11 +501,7 @@ class AsidePanel(Static):
         if not self.accepts(generation):
             return
         turn = self._turns[-1]
-        if answer.strip():
-            turn.answer = answer
-        turn.state = "done" if turn.answer.strip() else "error"
-        if turn.state == "error":
-            turn.error = "the model returned nothing"
+        turn.settle(answer)
         # The settled text routinely differs from what streamed (and is often
         # shorter), and the state row under it changes with `turn.state`, so
         # both the row COUNT and the rows themselves can move here.
@@ -464,8 +513,7 @@ class AsidePanel(Static):
         if not self.accepts(generation):
             return
         turn = self._turns[-1]
-        turn.state = "error"
-        turn.error = message
+        turn.fail(message)
         # The error rows are part of the answer block, so this changes height.
         self._invalidate_flat()
         self._repaint()

--- a/local_operator/tui/widgets/ask_picker.py
+++ b/local_operator/tui/widgets/ask_picker.py
@@ -43,7 +43,8 @@ Two things it does that no other picker in this app does:
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
+from typing import Any
 
 from rich.cells import cell_len
 from rich.style import Style
@@ -389,6 +390,18 @@ class _QuestionState:
     revealed: bool = False
 
 
+@dataclass
+class AskPickerSnapshot:
+    """Transient view data; never serialize a possibly secret unfinished answer."""
+
+    question_ids: tuple[str, ...]
+    states: list[_QuestionState] = field(repr=False)
+    answers: dict[str, list[str]] = field(repr=False)
+    index: int = 0
+    offset: int = 0
+    focused: bool = False
+
+
 @dataclass(frozen=True)
 class _CardLayout:
     """How one paint divides the card's rows, decided before anything is drawn.
@@ -656,6 +669,31 @@ class AskPickerScreen(Container):
     # names are already Textual's (``Widget.visible``, ``Widget._render``) and
     # shadowing them breaks focus, layout or paint from inside the screen, with
     # a traceback that points somewhere else entirely.
+    _restored_focus: bool | None = None
+    source_binding: tuple[Any, ...] | None = None
+
+    def snapshot_state(self) -> AskPickerSnapshot:
+        return AskPickerSnapshot(
+            tuple(question.id for question in self._questions),
+            [replace(state, checked=set(state.checked)) for state in self._states],
+            {key: list(values) for key, values in self._answers.items()},
+            self._index,
+            self._offset,
+            self.has_focus,
+        )
+
+    def restore_state(self, snapshot: AskPickerSnapshot) -> None:
+        if snapshot.question_ids != tuple(question.id for question in self._questions):
+            return
+        self._states = [replace(state, checked=set(state.checked)) for state in snapshot.states]
+        self._answers = {key: list(values) for key, values in snapshot.answers.items()}
+        self._index = snapshot.index
+        self._offset = snapshot.offset
+        self._restored_focus = snapshot.focused
+        self._invalidate_description_wraps()
+        if self.is_mounted:
+            self._repaint()
+
     @property
     def question(self) -> AskQuestion:
         return self._questions[self._index]
@@ -2159,7 +2197,9 @@ class AskPickerScreen(Container):
         """
         screen = self.screen
         self._restore_target = screen.focused if screen is not None else None
-        if not self._composer_has_draft():
+        if self._restored_focus is True or (
+            self._restored_focus is None and not self._composer_has_draft()
+        ):
             self.focus()
         self._repaint()
 

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -1229,6 +1229,21 @@ ASIDE_PLACEHOLDER = "Ask the aside…"
 SHELL_PLACEHOLDER = "Run a command… — esc to leave"
 
 
+@dataclass(frozen=True)
+class RecallState:
+    """Prompt-history recall position and the draft it displaced.
+
+    ``index`` is ``None`` when the user is not navigating. The stash is the
+    unsent buffer saved when Up first left it, so Down past the newest entry
+    can bring it back; it belongs to the session that was being edited, which
+    is why it rides on the session's draft across a sidebar switch.
+    """
+
+    index: int | None
+    stash: str
+    stash_attachments: dict[int, Marked]
+
+
 class Editor(TextArea):
     """Multiline prompt editor with submit-on-Enter, history, slash-completion."""
 
@@ -5228,6 +5243,48 @@ class Editor(TextArea):
             if span is not None and start < span[1] and span[0] < end:
                 touched.append(index)
         return touched
+
+    def recall_state(self) -> RecallState:
+        """Where the user is in prompt-history recall, plus the stash it hides.
+
+        Captured beside the draft when a sidebar switch parks a session.
+        Without it, Up×2 in A, switch to B, switch back and Down would
+        "restore" whatever stash B had left in the one shared editor — the
+        other session's draft — because ``_history_index``, ``_draft`` and
+        ``_draft_attachments`` all lived only on the widget. The list itself
+        (``_history``) stays editor-global: shell-history semantics, and the
+        clamp in :meth:`restore_recall_state` covers the case where more
+        prompts were submitted meanwhile and the indices shifted.
+        """
+        return RecallState(
+            index=self._history_index,
+            stash=self._draft,
+            stash_attachments=dict(self._draft_attachments),
+        )
+
+    def restore_recall_state(self, state: RecallState) -> None:
+        """Re-enter recall exactly where the parked session left it.
+
+        Called AFTER ``load_text`` has put the session's own text back, so a
+        session that was not navigating is untouched. An index past the end
+        of the (possibly shorter — the cap pops from the front) list exits
+        navigation rather than pointing at a prompt that has moved: the user
+        sees their draft, which is the honest state, instead of a recalled
+        entry that is not the one they were looking at.
+        """
+        if state.index is None:
+            self._history_index = None
+            self._draft = ""
+            self._draft_attachments = {}
+            return
+        if not self._history or state.index >= len(self._history):
+            self._history_index = None
+            self._draft = ""
+            self._draft_attachments = {}
+            return
+        self._history_index = max(0, state.index)
+        self._draft = state.stash
+        self._draft_attachments = dict(state.stash_attachments)
 
     def load_text(self, text: str) -> None:
         """Whole-buffer replacement — the OTHER mutation funnel.

--- a/local_operator/tui/widgets/image_block.py
+++ b/local_operator/tui/widgets/image_block.py
@@ -134,10 +134,16 @@ class ImageBlock(TranscriptBlock):
     SPACING_KIND: ClassVar[str] = "image"
 
     def __init__(
-        self, data_b64: str | None, mime_type: str = "image/png", *, label: str = ""
+        self,
+        data_b64: str | None,
+        mime_type: str = "image/png",
+        *,
+        label: str = "",
+        navigation_visible: bool = True,
     ) -> None:
         super().__init__()
         self.add_class("image-block")
+        self._navigation_visible = navigation_visible
         #: Short human name for the unavailable receipt (marker text or file
         #: name). Never rendered while the image itself is on screen — the
         #: caption already lives on the tool card or in the prompt text.
@@ -228,6 +234,10 @@ class ImageBlock(TranscriptBlock):
         so they cannot interleave with a frame Textual is writing.
         """
         assert self._pil is not None
+        if not self._navigation_visible:
+            # Prepared views still need the real grid for layout, but must not
+            # transmit/place a terminal image before the source is selected.
+            return Text("\n".join(" " * (SPINE_INDENT + cols) for _ in range(rows)))
         cell = images_mod.cell_size()
         box_aspect = (cols * cell.width) / max(1, rows * cell.height)
         if self._kitty_id is not None and self._placed != (cols, rows):
@@ -439,6 +449,12 @@ class ImageBlock(TranscriptBlock):
             self.set_content(self._build())
         finally:
             self._finalized = was_finalized
+
+    def set_navigation_visible(self, visible: bool) -> None:
+        changed = visible != self._navigation_visible
+        super().set_navigation_visible(visible)
+        if changed and self.is_mounted and self._mode == "kitty":
+            self._repaint()
 
     def on_mount(self) -> None:
         """First paint at the real width (construction guessed 80 cols)."""

--- a/local_operator/tui/widgets/overlay.py
+++ b/local_operator/tui/widgets/overlay.py
@@ -78,7 +78,11 @@ def rows_above_dock(widget: Widget) -> int:
         return screen_size(widget)[1]
     content = screen.content_region
     ceiling = content.bottom
-    for sibling in screen.children:
+    # The session workspace nests the conversation and its dock together.
+    # Only that layout owns this ceiling; walking every descendant would also
+    # mistake a picker footer for a screen-level bottom dock.
+    conversation = next(iter(screen.query("#session-conversation")), screen)
+    for sibling in conversation.children:
         if sibling.display and sibling.styles.dock == "bottom":
             ceiling = min(ceiling, sibling.region.y)
     return max(1, ceiling - content.y)

--- a/local_operator/tui/widgets/session_sidebar.py
+++ b/local_operator/tui/widgets/session_sidebar.py
@@ -70,7 +70,7 @@ SIDEBAR_MAIN_MIN_WIDTH = 60
 #: The band animates ONE glyph; this list repaints every visible row per tick,
 #: so the same nominal rate costs ~38x more terminal output for the same
 #: information. At 0.15s the eight-frame cycle still reads as clearly alive
-#: (4.8s) while writing ~1.9x less, and it does not visibly disagree with the
+#: (1.2s) while writing ~1.9x less, and it does not visibly disagree with the
 #: band because the rate a throttled surface ACHIEVES is well under its
 #: nominal one either way. Local rather than a change to the shared constant:
 #: the other surfaces read that one and are not paying this cost.
@@ -161,10 +161,11 @@ class SessionSidebar(Widget, can_focus=True):
 
     @property
     def page_size(self) -> int:
-        # Minus the "Sessions" title, the footer, and whatever section headers
-        # the current window draws — a header occupies a line that cannot hold
-        # a session, so the count of ENTRIES that fit shrinks by exactly that.
-        return max(1, self.size.height - 2 - self._header_lines())
+        # Minus the footer, the title if one is drawn, and whatever section
+        # chrome the window carries: each occupies a line that cannot hold a
+        # session, so the count of ENTRIES that fit shrinks by exactly that.
+        chrome = self._header_lines()
+        return max(1, self.size.height - 1 - (0 if chrome else 1) - chrome)
 
     def _header_lines(self) -> int:
         """Lines the section headers will consume in the current window.
@@ -177,13 +178,24 @@ class SessionSidebar(Widget, can_focus=True):
         if not self.entries:
             return 0
         tiers = {0 if entry.rank[0] <= 2 else 1 for entry in self.entries}
-        # One line per header present, plus a blank line before the SECOND
-        # header only — whitespace is this chrome's only separator.
-        return len(tiers) + (1 if len(tiers) > 1 else 0)
+        # Per section: its heading and the blank beneath it, plus a blank
+        # above every heading after the first. The outer "Sessions" title is
+        # not counted — it is not drawn at all once any header is (`render`).
+        return len(tiers) * 2 + (len(tiers) - 1)
 
     @property
     def visible_entries(self) -> tuple[CatalogEntry, ...]:
         return self.entries[self._offset : self._offset + self.page_size]
+
+    @staticmethod
+    def _draws_section_headers(rows: tuple[tuple[str, CatalogEntry | None], ...]) -> bool:
+        """Whether these display rows carry section headings.
+
+        The single rule both `render` and `_entry_at` consult, so the painted
+        title line and the hit-test can never disagree about whether it is
+        there.
+        """
+        return any(kind.startswith("header:") for kind, _entry in rows)
 
     def _display_rows(self) -> tuple[tuple[str, CatalogEntry | None], ...]:
         """The lines to paint: ``("header", None)`` or ``("entry", entry)``.
@@ -206,9 +218,20 @@ class SessionSidebar(Widget, can_focus=True):
         for entry in self.visible_entries:
             current = "active" if entry.rank[0] <= 2 else "previous"
             if current != section:
+                # A blank ABOVE every heading but the first, and one BELOW
+                # every heading. The ask was "an active sessions header and
+                # then padding, previous sessions": the heading owns the space
+                # beneath it, so the gap reads as "this group starts here"
+                # rather than "the last one ended". The leading blank is still
+                # needed or the second heading collides with the row above it
+                # — with padding only underneath, `Previous Sessions` sat
+                # flush against the last active row and the two groups ran
+                # together. The first heading takes no leading blank: nothing
+                # sits above it to separate from.
                 if section is not None:
                     rows.append(("blank", None))
                 rows.append((f"header:{current}", None))
+                rows.append(("blank", None))
                 section = current
             rows.append(("entry", entry))
         return tuple(rows)
@@ -327,13 +350,15 @@ class SessionSidebar(Widget, can_focus=True):
         self.post_message(self.Dismissed())
 
     def _entry_at(self, y: int) -> CatalogEntry | None:
-        index = y - 1
         # Against the DISPLAY rows, not the entries: a header and its blank
         # line occupy lines that hold no session, so indexing entries directly
         # would attribute a click to whatever sits that many rows further
         # down. `None` on a header is already what hover and click want — both
         # no-op on it.
         rows = self._display_rows()
+        # Same rule `render` uses to decide whether a title line is drawn, so
+        # the hit-test cannot drift a row away from the paint.
+        index = y - (0 if self._draws_section_headers(rows) else 1)
         if not 0 <= index < len(rows):
             return None
         kind, entry = rows[index]
@@ -517,11 +542,29 @@ class SessionSidebar(Widget, can_focus=True):
     def render(self) -> Text:
         width = max(1, self.size.width)
         result = Text(no_wrap=True, overflow="crop")
-        result.append(
-            truncate_cells("Sessions", width).ljust(width), style=theme_mod.semantic_color("muted")
-        )
-        for kind, entry in self._display_rows():
-            result.append("\n")
+        rows = self._display_rows()
+        # The outer title only when nothing else heads the list. Once the
+        # section headings are present it paints identically to them — same
+        # `muted`, same weight, same indent, on the adjacent line — so the
+        # frame opened with the word "Sessions" twice and no rendered cue
+        # which was the panel and which the group. The relay this mirrors has
+        # its two headings under the PRODUCT BRAND, not under a third
+        # "Sessions" label. The quiet states still need it: with no sections
+        # there is nothing to head, and loading/empty/error would open on bare
+        # body copy — which an empty list gets for free, since it emits no
+        # headers.
+        first = True
+        if not self._draws_section_headers(rows):
+            result.append(
+                truncate_cells("Sessions", width).ljust(width),
+                style=theme_mod.semantic_color("muted"),
+            )
+            first = False
+        for kind, entry in rows:
+            if first:
+                first = False
+            else:
+                result.append("\n")
             if kind == "blank":
                 # Whitespace is the separator; the chrome stays borderless.
                 result.append(" " * width)

--- a/local_operator/tui/widgets/session_sidebar.py
+++ b/local_operator/tui/widgets/session_sidebar.py
@@ -265,6 +265,12 @@ class SessionSidebar(Widget, can_focus=True):
         self.refresh()
 
     def set_open(self, opened: bool) -> None:
+        if not opened and self._pressed_id is not None:
+            self.release_mouse()
+            self._pressed_id = None
+            if self._deferred is not None:
+                deferred, self._deferred = self._deferred, None
+                self.set_entries(deferred)
         self.display = opened
         self._sync_animation()
         self.refresh()
@@ -366,8 +372,18 @@ class SessionSidebar(Widget, can_focus=True):
 
     def on_mouse_down(self, event: events.MouseDown) -> None:
         entry = self._entry_at(event.y)
-        if entry is not None:
+        if entry is not None and event.button == 1:
             self._pressed_id = entry.id
+            self.capture_mouse()
+        event.stop()
+
+    def on_mouse_up(self, event: events.MouseUp) -> None:
+        self.release_mouse()
+        if not self.region.contains(event.screen_x, event.screen_y):
+            self._pressed_id = None
+            if self._deferred is not None:
+                deferred, self._deferred = self._deferred, None
+                self.set_entries(deferred)
         event.stop()
 
     def on_click(self, event: events.Click) -> None:

--- a/local_operator/tui/widgets/session_sidebar.py
+++ b/local_operator/tui/widgets/session_sidebar.py
@@ -26,6 +26,32 @@ from local_operator.tui.widgets.session_picker import row_state_mark
 from local_operator.tui.widgets.tool_card import truncate_cells
 
 SIDEBAR_WIDTH = 30
+
+#: Blank cells between the list and the conversation it sits beside.
+#:
+#: The list's right-hand age column ("6m", "23h", "1d") ended one cell from the
+#: transcript's first character, which read as two columns jammed together
+#: rather than two regions — the user's report was that it "looks overcrowded".
+#: Three cells is what actually separates them at a glance; two still reads as
+#: tight against a full-bleed transcript.
+#:
+#: ADDED TO THE WIDTH rather than taken out of the content, because the content
+#: has none to give: at 28 cells the title column is already 20 after the
+#: cursor, state mark and age, and real titles ellipsize there today. Spending
+#: the gutter from that budget would have paid for whitespace with the one
+#: thing the list exists to show. The main lane can afford it — at 100 columns
+#: it keeps 65, above the 60-column floor `SIDEBAR_MAIN_MIN_WIDTH` sets, and
+#: below that threshold the drawer is an overlay that does not displace the
+#: conversation at all.
+#:
+#: Whitespace, not a rule: the chrome is borderless, so the gap IS the
+#: separator (see the stylesheet's own note on the app's outer inset).
+SIDEBAR_GUTTER = 3
+
+#: Below this the gutter is surrendered before the list narrows further. A
+#: squeezed terminal needs the cells for a legible title far more than it needs
+#: the separation the gutter buys.
+SIDEBAR_MIN_CONTENT_WIDTH = 24
 SIDEBAR_MAIN_MIN_WIDTH = 60
 
 
@@ -62,6 +88,13 @@ class SessionSidebar(Widget, can_focus=True):
         self._timer: Timer | None = None
         self._pressed_id: str | None = None
         self._deferred: tuple[CatalogEntry, ...] | None = None
+        #: Row under the pointer, by identity rather than by row index: a
+        #: catalog refresh reorders rows beneath a stationary pointer, and a
+        #: remembered index would light (and describe) whichever session slid
+        #: into that slot. `_hover_y` is what re-resolves the identity when the
+        #: order changes without the mouse moving.
+        self._hover_id: str = ""
+        self._hover_y: int | None = None
         self.display = False
 
     @property
@@ -80,14 +113,17 @@ class SessionSidebar(Widget, can_focus=True):
             self._deferred = ordered
             return
         self.entries = ordered
-        # A stationary pointer may now cover a different row. Do not advertise
-        # its old identity until a new pointer event resolves the current row.
-        self.tooltip = None
         self._catalog_loading = False
         self.error = ""
         if not any(entry.id == self.cursor_id for entry in ordered):
             self.cursor_id = self.current_id or (ordered[0].id if ordered else "")
         self._offset = min(self._offset, max(0, len(ordered) - self.page_size))
+        # Re-resolve against the NEW order at the pointer's unchanged position:
+        # a reorder under a resting pointer must relabel the row it is actually
+        # over, not keep describing the session that moved away. Blanking it
+        # instead left the affordance and description dark until the user
+        # jiggled the mouse.
+        self._set_hover(self._hover_y)
         self._sync_animation()
         self.refresh()
 
@@ -179,9 +215,47 @@ class SessionSidebar(Widget, can_focus=True):
             self.set_entries(deferred)
         event.stop()
 
+    def _describe(self, entry: CatalogEntry | None) -> str | None:
+        return f"{entry.row.name}\n{entry.status}\n{entry.id}" if entry else None
+
+    def _set_hover(self, y: int | None) -> bool:
+        """Point the hover affordance and the tooltip at the row under `y`.
+
+        Called both from pointer movement and from a catalog refresh, because a
+        stationary pointer covers a DIFFERENT session once the ranking
+        reorders — the row must re-resolve without waiting for a mouse event.
+
+        Returns whether the hovered identity changed, so the caller can repaint
+        exactly once instead of on every pointer move within a row.
+        """
+        self._hover_y = y
+        entry = self._entry_at(y) if y is not None else None
+        hover_id = entry.id if entry is not None else ""
+        description = self._describe(entry)
+        # Textual hides a showing tooltip on the next move over the SAME widget
+        # (`Screen._handle_mouse_move`), which is why it vanished after about a
+        # second of resting on a row. Rows live inside ONE widget, so every
+        # in-row move looked like that repeat. Re-arming only when the row
+        # identity actually changes keeps the description up while the pointer
+        # rests, and still swaps it the moment a different row is under it.
+        changed = hover_id != self._hover_id
+        if changed or self.tooltip != description:
+            self._hover_id = hover_id
+            self.tooltip = description
+        return changed
+
     def on_mouse_move(self, event: events.MouseMove) -> None:
-        entry = self._entry_at(event.y)
-        self.tooltip = f"{entry.row.name}\n{entry.status}\n{entry.id}" if entry else None
+        if self._set_hover(event.y):
+            self.refresh()
+
+    def on_leave(self, event: events.Leave) -> None:
+        # The pointer left the list: drop both the affordance and the
+        # description rather than leaving a row lit under an absent cursor.
+        if self._hover_id or self._hover_y is not None:
+            self._hover_id = ""
+            self._hover_y = None
+            self.tooltip = None
+            self.refresh()
 
     def on_mouse_scroll_down(self, event: events.MouseScrollDown) -> None:
         self._scroll(1)
@@ -215,7 +289,20 @@ class SessionSidebar(Widget, can_focus=True):
             result.append("\n")
             current = entry.id == self.current_id
             cursor = self.has_focus and entry.id == self.cursor_id
-            background = "tint-select" if cursor else "surface" if current else None
+            hovered = entry.id == self._hover_id and entry.id != ""
+            # Three states have to stay separable, so they occupy three
+            # different grounds: the keyboard cursor keeps `tint-select` (the
+            # only tinted one), the attached session keeps `surface` plus bold,
+            # and hover is `overlay` — the SAME ground `ToolCard:hover` and
+            # `SubagentRow:hover` use, because pointing at a row should look
+            # the same everywhere in this app. Hover yields to both of the
+            # other two: it is transient pointer feedback, and must not
+            # overpaint the identity of where you ARE or where the keyboard is.
+            background = (
+                "tint-select"
+                if cursor
+                else "surface" if current else "overlay" if hovered else None
+            )
             style = Style(
                 color=theme_mod.semantic_color("fg"),
                 bgcolor=theme_mod.semantic_color(background) if background else None,

--- a/local_operator/tui/widgets/session_sidebar.py
+++ b/local_operator/tui/widgets/session_sidebar.py
@@ -21,7 +21,7 @@ from textual.widget import Widget
 from local_operator.resume import format_age
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.session_catalog import CatalogEntry, rank_entries
-from local_operator.tui.terminal_title import SPINNER_INTERVAL_S
+from local_operator.tui.terminal_title import SPINNER_FRAMES, SPINNER_INTERVAL_S
 from local_operator.tui.widgets.session_picker import row_state_mark
 from local_operator.tui.widgets.tool_card import truncate_cells
 
@@ -56,7 +56,7 @@ class SessionSidebar(Widget, can_focus=True):
         self.requested_id = ""
         self.cursor_id = ""
         self.error = ""
-        self.loading = True
+        self._catalog_loading = True
         self._offset = 0
         self._frame = 0
         self._timer: Timer | None = None
@@ -80,7 +80,10 @@ class SessionSidebar(Widget, can_focus=True):
             self._deferred = ordered
             return
         self.entries = ordered
-        self.loading = False
+        # A stationary pointer may now cover a different row. Do not advertise
+        # its old identity until a new pointer event resolves the current row.
+        self.tooltip = None
+        self._catalog_loading = False
         self.error = ""
         if not any(entry.id == self.cursor_id for entry in ordered):
             self.cursor_id = self.current_id or (ordered[0].id if ordered else "")
@@ -91,7 +94,7 @@ class SessionSidebar(Widget, can_focus=True):
     def show_error(self, message: str) -> None:
         # A refresh error does not erase the last usable catalog.
         self.error = message
-        self.loading = False
+        self._catalog_loading = False
         self.refresh()
 
     def set_open(self, opened: bool) -> None:
@@ -106,7 +109,10 @@ class SessionSidebar(Widget, can_focus=True):
     def _sync_animation(self) -> None:
         if self._timer is None:
             return
-        if self.display and any(entry.row.live_state == "busy" for entry in self.visible_entries):
+        if self.display and (
+            self._catalog_loading
+            or any(entry.row.live_state == "busy" for entry in self.visible_entries)
+        ):
             self._timer.resume()
         else:
             self._timer.pause()
@@ -209,10 +215,10 @@ class SessionSidebar(Widget, can_focus=True):
             result.append("\n")
             current = entry.id == self.current_id
             cursor = self.has_focus and entry.id == self.cursor_id
-            background = "tint-select" if cursor else "surface" if current else "bg"
+            background = "tint-select" if cursor else "surface" if current else None
             style = Style(
                 color=theme_mod.semantic_color("fg"),
-                bgcolor=theme_mod.semantic_color(background),
+                bgcolor=theme_mod.semantic_color(background) if background else None,
                 bold=current,
             )
             line = Text(style=style, no_wrap=True)
@@ -242,14 +248,20 @@ class SessionSidebar(Widget, can_focus=True):
             text = (
                 "Could not load conversations"
                 if self.error
-                else "Loading conversations…" if self.loading else "No conversations yet"
+                else (
+                    f"{SPINNER_FRAMES[self._frame % len(SPINNER_FRAMES)]} Loading conversations…"
+                    if self._catalog_loading
+                    else "No conversations yet"
+                )
             )
             result.append("\n" + truncate_cells(text, width), style=theme_mod.semantic_color("dim"))
         while result.plain.count("\n") < self.size.height - 2:
             result.append("\n")
-        footer = (
-            "Refresh failed" if self.error else "Opening…" if self.requested_id else "ctrl+b hide"
-        )
+        hint = "esc return" if self.has_focus else "f9 focus · ctrl+b hide"
+        if len(self.entries) > self.page_size:
+            last = min(len(self.entries), self._offset + self.page_size)
+            hint = f"{self._offset + 1}–{last}/{len(self.entries)} · ctrl+b hide"
+        footer = "Refresh failed" if self.error else "Opening…" if self.requested_id else hint
         result.append(
             "\n" + truncate_cells(footer, width),
             style=theme_mod.semantic_color("warning" if self.error else "dim"),

--- a/local_operator/tui/widgets/session_sidebar.py
+++ b/local_operator/tui/widgets/session_sidebar.py
@@ -394,10 +394,10 @@ class SessionSidebar(Widget, can_focus=True):
             cursor = self.has_focus and entry.id == self.cursor_id
             hovered = entry.id == self._hover_id and entry.id != ""
             # The row a click asked for, until it becomes current. It shares
-            # the cursor's ground and `›` so the eye reads "this one is being
-            # opened" where it just clicked, and stays distinct from current
-            # (bold on `surface`) because it is NOT current yet — readiness
-            # is a separate, later fact that only commit may assert.
+            # the cursor's ground so the eye reads "this one is being opened"
+            # where it just clicked, and stays distinct from current (bold on
+            # `surface`) because it is NOT current yet — readiness is a
+            # separate, later fact that only commit may assert.
             requested = entry.id == self._requested_id and entry.id != "" and not current
             # Three states have to stay separable, so they occupy three
             # different grounds: the keyboard cursor keeps `tint-select` (the
@@ -418,7 +418,16 @@ class SessionSidebar(Widget, can_focus=True):
                 bold=current,
             )
             line = Text(style=style, no_wrap=True)
-            line.append("› " if cursor or requested else "  ")
+            # The requested row gets a caret the cursor does not have. Sharing
+            # BOTH `tint-select` and `›` made the two indistinguishable, and
+            # they are reachable on opposite rows from real bindings (focus the
+            # list, ctrl+shift+down, or press down before commit) — the frame
+            # then could not say which row was opening (round 5, D6). `»` is
+            # the doubled form of the same caret: one cell, same ink, same
+            # column, so nothing reflows and the ramp is untouched. Requested
+            # wins when a row is both, because "this is opening" is the fact
+            # the user is waiting on.
+            line.append("» " if requested else "› " if cursor else "  ")
             mark, ink = row_state_mark(entry.row, self._frame)
             if requested and self._requested_spinning():
                 # Same ink a busy row's spinner uses (``row_state_mark``), so one

--- a/local_operator/tui/widgets/session_sidebar.py
+++ b/local_operator/tui/widgets/session_sidebar.py
@@ -27,6 +27,14 @@ from local_operator.tui.widgets.tool_card import truncate_cells
 
 SIDEBAR_WIDTH = 30
 
+#: How long a requested row waits before its state mark becomes a spinner.
+#: The tint itself is immediate — it is the acknowledgement that the click
+#: landed. The spinner is only for a switch that is genuinely taking a while,
+#: and in practice a warm switch completes well inside this window, so the
+#: glyph should almost never be seen: a warm sample that shows it is a
+#: regression, not a feature working.
+REQUESTED_SPINNER_DELAY_S = 0.15
+
 #: Blank cells between the list and the conversation it sits beside.
 #:
 #: The list's right-hand age column ("6m", "23h", "1d") ended one cell from the
@@ -79,7 +87,8 @@ class SessionSidebar(Widget, can_focus=True):
         super().__init__(id="session-sidebar")
         self.entries: tuple[CatalogEntry, ...] = ()
         self.current_id = ""
-        self.requested_id = ""
+        self._requested_id = ""
+        self._requested_at = 0.0
         self.cursor_id = ""
         self.error = ""
         self._catalog_loading = True
@@ -95,7 +104,35 @@ class SessionSidebar(Widget, can_focus=True):
         #: order changes without the mouse moving.
         self._hover_id: str = ""
         self._hover_y: int | None = None
+        #: When the pointer entered the current row. An in-row move restores
+        #: the description only once Textual's own show delay has elapsed
+        #: since then, so it never appears earlier than Textual would show it.
+        self._hover_since: float | None = None
         self.display = False
+
+    @property
+    def requested_id(self) -> str:
+        """The row a click asked for that has not yet become ``current_id``.
+
+        Set synchronously at ``_sidebar_navigation_pending`` — before any
+        await — so the tint is on the very next frame after the click. It is
+        an acknowledgement and nothing more: it does not move ``current_id``,
+        does not touch the transcript, enables no input and acks nothing.
+        Cleared by ``pending("")`` on commit, failure or cancel.
+        """
+        return self._requested_id
+
+    @requested_id.setter
+    def requested_id(self, session_id: str) -> None:
+        if session_id != self._requested_id:
+            self._requested_at = time.monotonic() if session_id else 0.0
+        self._requested_id = session_id
+        self._sync_animation()
+
+    def _requested_spinning(self) -> bool:
+        return bool(self._requested_id) and (
+            time.monotonic() - self._requested_at >= REQUESTED_SPINNER_DELAY_S
+        )
 
     @property
     def page_size(self) -> int:
@@ -147,6 +184,7 @@ class SessionSidebar(Widget, can_focus=True):
             return
         if self.display and (
             self._catalog_loading
+            or bool(self._requested_id)
             or any(entry.row.live_state == "busy" for entry in self.visible_entries)
         ):
             self._timer.resume()
@@ -232,13 +270,18 @@ class SessionSidebar(Widget, can_focus=True):
         entry = self._entry_at(y) if y is not None else None
         hover_id = entry.id if entry is not None else ""
         description = self._describe(entry)
-        # Textual hides a showing tooltip on the next move over the SAME widget
-        # (`Screen._handle_mouse_move`), which is why it vanished after about a
-        # second of resting on a row. Rows live inside ONE widget, so every
-        # in-row move looked like that repeat. Re-arming only when the row
-        # identity actually changes keeps the description up while the pointer
-        # rests, and still swaps it the moment a different row is under it.
+        # Re-arm the widget's ``tooltip`` only when the row identity changes.
+        # This is NOT what keeps it up under pointer movement (round 4, M1:
+        # ``Screen._handle_mouse_move`` hides a showing tooltip BEFORE the
+        # event reaches this widget, so nothing set here can prevent that —
+        # see ``on_mouse_move`` for the restore). What this does fix is the
+        # OTHER way the description vanished: the 2 s catalog poll called
+        # ``set_entries``, which blanked ``tooltip`` under a perfectly still
+        # pointer. Keeping the value stable across a refresh is what lets a
+        # resting description survive the poll.
         changed = hover_id != self._hover_id
+        if changed:
+            self._hover_since = time.monotonic() if hover_id else None
         if changed or self.tooltip != description:
             self._hover_id = hover_id
             self.tooltip = description
@@ -247,6 +290,65 @@ class SessionSidebar(Widget, can_focus=True):
     def on_mouse_move(self, event: events.MouseMove) -> None:
         if self._set_hover(event.y):
             self.refresh()
+            # A NEW row: Textual's delay timer was (re)armed by this very
+            # move only if its tooltip was not showing; when it WAS showing
+            # it hid it and armed nothing, so a resting pointer on the new
+            # row would never get that row's description. Arm our own
+            # one-shot at the same delay, so a row change behaves like a
+            # first arrival rather than a dead end.
+            if self._hover_id:
+                self.set_timer(
+                    float(self.app.TOOLTIP_DELAY),
+                    self._show_tooltip_if_still_here,
+                    name="sidebar-tooltip",
+                )
+            return
+        # Same row, pointer merely moved within it. Textual has ALREADY hidden
+        # the tooltip by the time this runs (``Screen._handle_mouse_move``
+        # sets ``display = False`` on any move over the widget that owns a
+        # showing tooltip, before forwarding the event) and will not re-show
+        # it until a further move restarts its delay timer — so one cell of
+        # jitter dropped the description and resting did not bring it back.
+        # The user's ask is "stays while the mouse is hovered over the
+        # session": restore it. Only when it was showing for THIS widget, so
+        # a tooltip that was never up (first arrival, or a different widget's)
+        # still goes through Textual's normal delay rather than popping.
+        if self._hover_id and self._tooltip_due():
+            self._show_tooltip_now()
+
+    def _tooltip_due(self) -> bool:
+        """Has the description been up (or is it owed) for the hovered row?
+
+        Textual keeps no "was shown" bit a widget can read, and by the time
+        this runs it has already hidden the tooltip — so the honest signal is
+        time: the pointer entered this row at ``_hover_since`` and Textual's
+        own ``TOOLTIP_DELAY`` has elapsed, which is exactly the condition
+        under which its timer would have shown it. Using its constant means
+        the restore never pops earlier than Textual itself would.
+        """
+        if self._hover_since is None:
+            return False
+        return time.monotonic() - self._hover_since >= float(self.app.TOOLTIP_DELAY)
+
+    def _show_tooltip_if_still_here(self) -> None:
+        # The one-shot may fire after the pointer moved on or left; only the
+        # row it was armed for gets shown, and only if nothing hid it since.
+        if self._hover_id and self._tooltip_due() and self.screen.app.mouse_over is self:
+            self._show_tooltip_now()
+
+    def _show_tooltip_now(self) -> None:
+        """Re-show the description Textual just hid for an in-row move."""
+        try:
+            from textual.widgets import Tooltip
+
+            tooltip = self.screen.get_child_by_type(Tooltip)
+        except Exception:
+            return
+        if self.tooltip is None:
+            return
+        tooltip.display = True
+        tooltip.absolute_offset = self.app.mouse_position
+        tooltip.update(self.tooltip)
 
     def on_leave(self, event: events.Leave) -> None:
         # The pointer left the list: drop both the affordance and the
@@ -254,6 +356,7 @@ class SessionSidebar(Widget, can_focus=True):
         if self._hover_id or self._hover_y is not None:
             self._hover_id = ""
             self._hover_y = None
+            self._hover_since = None
             self.tooltip = None
             self.refresh()
 
@@ -290,6 +393,12 @@ class SessionSidebar(Widget, can_focus=True):
             current = entry.id == self.current_id
             cursor = self.has_focus and entry.id == self.cursor_id
             hovered = entry.id == self._hover_id and entry.id != ""
+            # The row a click asked for, until it becomes current. It shares
+            # the cursor's ground and `›` so the eye reads "this one is being
+            # opened" where it just clicked, and stays distinct from current
+            # (bold on `surface`) because it is NOT current yet — readiness
+            # is a separate, later fact that only commit may assert.
+            requested = entry.id == self._requested_id and entry.id != "" and not current
             # Three states have to stay separable, so they occupy three
             # different grounds: the keyboard cursor keeps `tint-select` (the
             # only tinted one), the attached session keeps `surface` plus bold,
@@ -300,7 +409,7 @@ class SessionSidebar(Widget, can_focus=True):
             # overpaint the identity of where you ARE or where the keyboard is.
             background = (
                 "tint-select"
-                if cursor
+                if cursor or requested
                 else "surface" if current else "overlay" if hovered else None
             )
             style = Style(
@@ -309,9 +418,16 @@ class SessionSidebar(Widget, can_focus=True):
                 bold=current,
             )
             line = Text(style=style, no_wrap=True)
-            line.append("› " if cursor else "  ")
+            line.append("› " if cursor or requested else "  ")
             mark, ink = row_state_mark(entry.row, self._frame)
-            if entry.unseen and not entry.row.pending:
+            if requested and self._requested_spinning():
+                # Same ink a busy row's spinner uses (``row_state_mark``), so one
+                # spinner means one thing everywhere in the list.
+                # Only after the delay: a switch that is taking long enough to
+                # notice gets a spinner ON THE ROW, where the eye is. The
+                # footer "Opening…" stays as the textual counterpart.
+                mark, ink = SPINNER_FRAMES[self._frame % len(SPINNER_FRAMES)], "accent"
+            elif entry.unseen and not entry.row.pending:
                 mark, ink = (
                     ("✗", "danger")
                     if entry.completion_kind in ("error", "interrupted")

--- a/local_operator/tui/widgets/session_sidebar.py
+++ b/local_operator/tui/widgets/session_sidebar.py
@@ -14,14 +14,17 @@ from rich.style import Style
 from rich.text import Text
 from textual import events
 from textual.binding import Binding
+from textual.geometry import Region
 from textual.message import Message
+from textual.reactive import Reactive
 from textual.timer import Timer
 from textual.widget import Widget
 
 from local_operator.resume import format_age
 from local_operator.tui import theme as theme_mod
+from local_operator.tui.animation import BLURRED_SPINNER_INTERVAL_S, animation_focused
 from local_operator.tui.session_catalog import CatalogEntry, rank_entries
-from local_operator.tui.terminal_title import SPINNER_FRAMES, SPINNER_INTERVAL_S
+from local_operator.tui.terminal_title import SPINNER_FRAMES
 from local_operator.tui.widgets.session_picker import row_state_mark
 from local_operator.tui.widgets.tool_card import truncate_cells
 
@@ -62,8 +65,29 @@ SIDEBAR_GUTTER = 3
 SIDEBAR_MIN_CONTENT_WIDTH = 24
 SIDEBAR_MAIN_MIN_WIDTH = 60
 
+#: The list's own spinner cadence, deliberately slower than
+#: :data:`terminal_title.SPINNER_INTERVAL_S` that the band and the panels use.
+#: The band animates ONE glyph; this list repaints every visible row per tick,
+#: so the same nominal rate costs ~38x more terminal output for the same
+#: information. At 0.15s the eight-frame cycle still reads as clearly alive
+#: (4.8s) while writing ~1.9x less, and it does not visibly disagree with the
+#: band because the rate a throttled surface ACHIEVES is well under its
+#: nominal one either way. Local rather than a change to the shared constant:
+#: the other surfaces read that one and are not paying this cost.
+SIDEBAR_SPINNER_INTERVAL_S = 0.15
+
 
 class SessionSidebar(Widget, can_focus=True):
+    #: Textual re-renders a widget on every pointer move to look for link
+    #: spans (``Widget.watch_hover_style``, whose own comment notes it fires
+    #: "even when there are no links"). That repaint is paid INLINE on the
+    #: input thread, before the handler runs, and it fires for every widget
+    #: under the pointer anywhere in the app — measured at 4.03ms and 9KB of
+    #: terminal output per hover event here, against 0.90ms with it off. This
+    #: list renders no links (its rows are `Text` spans with colour and bold
+    #: only), so nothing is given up; if a link is ever added here, this must
+    #: go back to True or its hover highlight will silently stop working.
+    auto_links: Reactive[bool] = Reactive(False)
     BINDINGS = [
         Binding("up", "move(-1)", show=False),
         Binding("down", "move(1)", show=False),
@@ -95,6 +119,7 @@ class SessionSidebar(Widget, can_focus=True):
         self._offset = 0
         self._frame = 0
         self._timer: Timer | None = None
+        self._spinner_rate = SIDEBAR_SPINNER_INTERVAL_S
         self._pressed_id: str | None = None
         self._deferred: tuple[CatalogEntry, ...] | None = None
         #: Row under the pointer, by identity rather than by row index: a
@@ -136,11 +161,57 @@ class SessionSidebar(Widget, can_focus=True):
 
     @property
     def page_size(self) -> int:
-        return max(1, self.size.height - 2)
+        # Minus the "Sessions" title, the footer, and whatever section headers
+        # the current window draws — a header occupies a line that cannot hold
+        # a session, so the count of ENTRIES that fit shrinks by exactly that.
+        return max(1, self.size.height - 2 - self._header_lines())
+
+    def _header_lines(self) -> int:
+        """Lines the section headers will consume in the current window.
+
+        Computed from the whole ranked list rather than the visible slice
+        because it feeds ``page_size``, which decides that slice: asking the
+        slice would be circular. Over-counting by one on a boundary scroll
+        costs a row of headroom, never a wrong or hidden entry.
+        """
+        if not self.entries:
+            return 0
+        tiers = {0 if entry.rank[0] <= 2 else 1 for entry in self.entries}
+        # One line per header present, plus a blank line before the SECOND
+        # header only — whitespace is this chrome's only separator.
+        return len(tiers) + (1 if len(tiers) > 1 else 0)
 
     @property
     def visible_entries(self) -> tuple[CatalogEntry, ...]:
         return self.entries[self._offset : self._offset + self.page_size]
+
+    def _display_rows(self) -> tuple[tuple[str, CatalogEntry | None], ...]:
+        """The lines to paint: ``("header", None)`` or ``("entry", entry)``.
+
+        Headers are RENDERED ROWS and never members of ``self.entries``. That
+        is load-bearing: ``action_move`` indexes ``entries``, and
+        ``_switch_session_from`` traverses it while the list is CLOSED, so a
+        header in that tuple would let ``ctrl+shift+down`` "switch" to one and
+        desync open-from-closed navigation. Keeping the split purely
+        presentational is also what makes keyboard traversal cross a boundary
+        as an ordinary step, with no stall and no skip.
+
+        The boundary is ``CatalogEntry.rank``'s existing tier — 0-2 (pending,
+        unseen, live) is active, 3 is previous — which is the same partition
+        the mobile relay draws, so the two surfaces agree without a new field.
+        An empty section contributes no header.
+        """
+        rows: list[tuple[str, CatalogEntry | None]] = []
+        section: str | None = None
+        for entry in self.visible_entries:
+            current = "active" if entry.rank[0] <= 2 else "previous"
+            if current != section:
+                if section is not None:
+                    rows.append(("blank", None))
+                rows.append((f"header:{current}", None))
+                section = current
+            rows.append(("entry", entry))
+        return tuple(rows)
 
     def set_entries(self, entries: Sequence[CatalogEntry]) -> None:
         ordered = rank_entries(entries)
@@ -176,7 +247,36 @@ class SessionSidebar(Widget, can_focus=True):
         self.refresh()
 
     def on_mount(self) -> None:
-        self._timer = self.set_interval(SPINNER_INTERVAL_S, self._advance_spinner, pause=True)
+        self._spinner_rate = self._spinner_interval()
+        self._timer = self.set_interval(self._spinner_rate, self._advance_spinner, pause=True)
+        self._sync_animation()
+
+    def _spinner_interval(self) -> float:
+        """Full cadence when the terminal is focused, reduced when it is not.
+
+        Every other animated surface (the band, both subagent surfaces) already
+        rates through :func:`animation_focused`; this list was the only one
+        that did not, so a blurred window kept repainting 38 rows for nobody.
+        """
+        return SIDEBAR_SPINNER_INTERVAL_S if animation_focused() else BLURRED_SPINNER_INTERVAL_S
+
+    def sync_animation_rate(self) -> None:
+        """Re-rate the tick after a focus change, through the shared seam.
+
+        A Textual timer's interval is fixed at creation, so the timer is
+        replaced rather than adjusted — the same thing the subagent panel does
+        for the same reason. Whether it should be RUNNING is left to
+        ``_sync_animation``, which owns that question already.
+        """
+        if not self.is_mounted:
+            return
+        rate = self._spinner_interval()
+        if rate == self._spinner_rate:
+            return
+        self._spinner_rate = rate
+        if self._timer is not None:
+            self._timer.stop()
+        self._timer = self.set_interval(rate, self._advance_spinner, pause=True)
         self._sync_animation()
 
     def _sync_animation(self) -> None:
@@ -228,8 +328,16 @@ class SessionSidebar(Widget, can_focus=True):
 
     def _entry_at(self, y: int) -> CatalogEntry | None:
         index = y - 1
-        visible = self.visible_entries
-        return visible[index] if 0 <= index < len(visible) else None
+        # Against the DISPLAY rows, not the entries: a header and its blank
+        # line occupy lines that hold no session, so indexing entries directly
+        # would attribute a click to whatever sits that many rows further
+        # down. `None` on a header is already what hover and click want — both
+        # no-op on it.
+        rows = self._display_rows()
+        if not 0 <= index < len(rows):
+            return None
+        kind, entry = rows[index]
+        return entry if kind == "entry" else None
 
     def on_mouse_down(self, event: events.MouseDown) -> None:
         entry = self._entry_at(event.y)
@@ -287,9 +395,33 @@ class SessionSidebar(Widget, can_focus=True):
             self.tooltip = description
         return changed
 
+    def _refresh_rows(self, *rows: int | None) -> None:
+        """Repaint just these row lines, skipping any outside the widget.
+
+        A row's ``y`` is a widget-local line, which is exactly what a
+        one-line ``Region`` wants; anything off the edge (or ``None``, the
+        pointer having left the list) is simply not painted.
+        """
+        width = max(1, self.size.width)
+        for y in rows:
+            if y is not None and 0 <= y < self.size.height:
+                self.refresh(Region(0, y, width, 1))
+
     def on_mouse_move(self, event: events.MouseMove) -> None:
+        # The row being LEFT, captured before `_set_hover` overwrites it.
+        left = self._hover_y
         if self._set_hover(event.y):
-            self.refresh()
+            # Only the two rows whose ground changes, not all 38: a hover move
+            # wrote 9,092 bytes of escape sequences to the terminal and now
+            # writes 924. That output is CPU burned in the terminal emulator
+            # competing with the pointer, which is why bytes are worth
+            # scoping even though the widget's own repaint cost is unchanged.
+            #
+            # Rows are independent (see `render`: each line reads only its own
+            # entry), so repainting two of them cannot leave a third stale.
+            # This only pays stacked on `auto_links = False` — Textual's own
+            # hover watcher would otherwise dirty the whole widget anyway.
+            self._refresh_rows(left, self._hover_y)
             # A NEW row: Textual's delay timer was (re)armed by this very
             # move only if its tooltip was not showing; when it WAS showing
             # it hid it and armed nothing, so a resting pointer on the new
@@ -388,8 +520,23 @@ class SessionSidebar(Widget, can_focus=True):
         result.append(
             truncate_cells("Sessions", width).ljust(width), style=theme_mod.semantic_color("muted")
         )
-        for entry in self.visible_entries:
+        for kind, entry in self._display_rows():
             result.append("\n")
+            if kind == "blank":
+                # Whitespace is the separator; the chrome stays borderless.
+                result.append(" " * width)
+                continue
+            if kind.startswith("header:"):
+                label = "Active Sessions" if kind == "header:active" else "Previous Sessions"
+                # Same treatment as the "Sessions" title above: `muted`, no
+                # rule, no new palette entry. Mirrors the mobile relay's two
+                # headings so the surfaces read the same.
+                result.append(
+                    truncate_cells(label, width).ljust(width),
+                    style=theme_mod.semantic_color("muted"),
+                )
+                continue
+            assert entry is not None
             current = entry.id == self.current_id
             cursor = self.has_focus and entry.id == self.cursor_id
             hovered = entry.id == self._hover_id and entry.id != ""

--- a/local_operator/tui/widgets/session_sidebar.py
+++ b/local_operator/tui/widgets/session_sidebar.py
@@ -1,0 +1,249 @@
+"""A viewport-sized session list, distinct from the conversation it navigates.
+
+One widget renders only the visible row window: a growing session directory
+must not grow the Textual DOM. Cursor, current session and requested session
+are separate identities, so a pending attach cannot pretend to have succeeded.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Sequence
+
+from rich.style import Style
+from rich.text import Text
+from textual import events
+from textual.binding import Binding
+from textual.message import Message
+from textual.timer import Timer
+from textual.widget import Widget
+
+from local_operator.resume import format_age
+from local_operator.tui import theme as theme_mod
+from local_operator.tui.session_catalog import CatalogEntry, rank_entries
+from local_operator.tui.terminal_title import SPINNER_INTERVAL_S
+from local_operator.tui.widgets.session_picker import row_state_mark
+from local_operator.tui.widgets.tool_card import truncate_cells
+
+SIDEBAR_WIDTH = 30
+SIDEBAR_MAIN_MIN_WIDTH = 60
+
+
+class SessionSidebar(Widget, can_focus=True):
+    BINDINGS = [
+        Binding("up", "move(-1)", show=False),
+        Binding("down", "move(1)", show=False),
+        Binding("pageup", "page(-1)", show=False),
+        Binding("pagedown", "page(1)", show=False),
+        Binding("home", "edge(False)", show=False),
+        Binding("end", "edge(True)", show=False),
+        Binding("enter", "select", show=False),
+        Binding("escape", "leave", show=False),
+    ]
+
+    class Selected(Message):
+        def __init__(self, session_id: str) -> None:
+            super().__init__()
+            self.session_id = session_id
+
+    class Dismissed(Message):
+        pass
+
+    def __init__(self) -> None:
+        super().__init__(id="session-sidebar")
+        self.entries: tuple[CatalogEntry, ...] = ()
+        self.current_id = ""
+        self.requested_id = ""
+        self.cursor_id = ""
+        self.error = ""
+        self.loading = True
+        self._offset = 0
+        self._frame = 0
+        self._timer: Timer | None = None
+        self._pressed_id: str | None = None
+        self._deferred: tuple[CatalogEntry, ...] | None = None
+        self.display = False
+
+    @property
+    def page_size(self) -> int:
+        return max(1, self.size.height - 2)
+
+    @property
+    def visible_entries(self) -> tuple[CatalogEntry, ...]:
+        return self.entries[self._offset : self._offset + self.page_size]
+
+    def set_entries(self, entries: Sequence[CatalogEntry]) -> None:
+        ordered = rank_entries(entries)
+        # A refresh between mouse-down and click must not change what was
+        # pressed. Freeze the entire order until that gesture has completed.
+        if self._pressed_id is not None:
+            self._deferred = ordered
+            return
+        self.entries = ordered
+        self.loading = False
+        self.error = ""
+        if not any(entry.id == self.cursor_id for entry in ordered):
+            self.cursor_id = self.current_id or (ordered[0].id if ordered else "")
+        self._offset = min(self._offset, max(0, len(ordered) - self.page_size))
+        self._sync_animation()
+        self.refresh()
+
+    def show_error(self, message: str) -> None:
+        # A refresh error does not erase the last usable catalog.
+        self.error = message
+        self.loading = False
+        self.refresh()
+
+    def set_open(self, opened: bool) -> None:
+        self.display = opened
+        self._sync_animation()
+        self.refresh()
+
+    def on_mount(self) -> None:
+        self._timer = self.set_interval(SPINNER_INTERVAL_S, self._advance_spinner, pause=True)
+        self._sync_animation()
+
+    def _sync_animation(self) -> None:
+        if self._timer is None:
+            return
+        if self.display and any(entry.row.live_state == "busy" for entry in self.visible_entries):
+            self._timer.resume()
+        else:
+            self._timer.pause()
+
+    def _advance_spinner(self) -> None:
+        self._frame += 1
+        self.refresh()
+
+    def _cursor_index(self) -> int:
+        return next((i for i, row in enumerate(self.entries) if row.id == self.cursor_id), 0)
+
+    def _reveal(self) -> None:
+        index = self._cursor_index()
+        self._offset = max(min(self._offset, index), index - self.page_size + 1)
+        self._sync_animation()
+        self.refresh()
+
+    def action_move(self, delta: int) -> None:
+        if self.entries:
+            index = max(0, min(len(self.entries) - 1, self._cursor_index() + delta))
+            self.cursor_id = self.entries[index].id
+            self._reveal()
+
+    def action_page(self, delta: int) -> None:
+        self.action_move(delta * self.page_size)
+
+    def action_edge(self, end: bool) -> None:
+        if self.entries:
+            self.cursor_id = self.entries[-1 if end else 0].id
+            self._reveal()
+
+    def action_select(self) -> None:
+        if self.cursor_id and any(entry.id == self.cursor_id for entry in self.entries):
+            self._reveal()
+            self.post_message(self.Selected(self.cursor_id))
+
+    def action_leave(self) -> None:
+        self.post_message(self.Dismissed())
+
+    def _entry_at(self, y: int) -> CatalogEntry | None:
+        index = y - 1
+        visible = self.visible_entries
+        return visible[index] if 0 <= index < len(visible) else None
+
+    def on_mouse_down(self, event: events.MouseDown) -> None:
+        entry = self._entry_at(event.y)
+        if entry is not None:
+            self._pressed_id = entry.id
+        event.stop()
+
+    def on_click(self, event: events.Click) -> None:
+        entry = self._entry_at(event.y)
+        target = self._pressed_id or (entry.id if entry else "")
+        self._pressed_id = None
+        if target:
+            self.cursor_id = target
+            self.post_message(self.Selected(target))
+        if self._deferred is not None:
+            deferred, self._deferred = self._deferred, None
+            self.set_entries(deferred)
+        event.stop()
+
+    def on_mouse_move(self, event: events.MouseMove) -> None:
+        entry = self._entry_at(event.y)
+        self.tooltip = f"{entry.row.name}\n{entry.status}\n{entry.id}" if entry else None
+
+    def on_mouse_scroll_down(self, event: events.MouseScrollDown) -> None:
+        self._scroll(1)
+        event.stop()
+
+    def on_mouse_scroll_up(self, event: events.MouseScrollUp) -> None:
+        self._scroll(-1)
+        event.stop()
+
+    def _scroll(self, direction: int) -> None:
+        # Wheel moves the viewport, never the keyboard target. Match the live
+        # app sensitivity rather than invent a second scrolling speed.
+        step = max(1, int(self.app.scroll_sensitivity_y))
+        self._offset = max(
+            0, min(max(0, len(self.entries) - self.page_size), self._offset + direction * step)
+        )
+        self._sync_animation()
+        self.refresh()
+
+    def on_resize(self, event: events.Resize) -> None:
+        self._offset = min(self._offset, max(0, len(self.entries) - self.page_size))
+        self._sync_animation()
+
+    def render(self) -> Text:
+        width = max(1, self.size.width)
+        result = Text(no_wrap=True, overflow="crop")
+        result.append(
+            truncate_cells("Sessions", width).ljust(width), style=theme_mod.semantic_color("muted")
+        )
+        for entry in self.visible_entries:
+            result.append("\n")
+            current = entry.id == self.current_id
+            cursor = self.has_focus and entry.id == self.cursor_id
+            background = "tint-select" if cursor else "surface" if current else "bg"
+            style = Style(
+                color=theme_mod.semantic_color("fg"),
+                bgcolor=theme_mod.semantic_color(background),
+                bold=current,
+            )
+            line = Text(style=style, no_wrap=True)
+            line.append("› " if cursor else "  ")
+            mark, ink = row_state_mark(entry.row, self._frame)
+            if entry.unseen and not entry.row.pending:
+                mark, ink = (
+                    ("✗", "danger")
+                    if entry.completion_kind in ("error", "interrupted")
+                    else ("✓", "success")
+                )
+            line.append(f"{mark or ' '} ", style=theme_mod.semantic_color(ink))
+            age = (
+                format_age(max(0, time.time() - entry.row.mtime)).replace(" ago", "")
+                if width >= 28
+                else ""
+            )
+            if len(age) > 4:
+                age = ""
+            title_width = max(1, width - 4 - (len(age) + 1 if age else 0))
+            title = truncate_cells(entry.row.name or "Untitled conversation", title_width)
+            line.append(title)
+            line.pad_right(max(0, width - line.cell_len - len(age)))
+            line.append(age, style=theme_mod.semantic_color("dim"))
+            result.append_text(line)
+        if not self.entries:
+            text = "Loading conversations…" if self.loading else "No conversations yet"
+            result.append("\n" + truncate_cells(text, width), style=theme_mod.semantic_color("dim"))
+        while result.plain.count("\n") < self.size.height - 2:
+            result.append("\n")
+        footer = (
+            "Refresh failed" if self.error else "Opening…" if self.requested_id else "ctrl+b hide"
+        )
+        result.append(
+            "\n" + truncate_cells(footer, width),
+            style=theme_mod.semantic_color("warning" if self.error else "dim"),
+        )
+        return result

--- a/local_operator/tui/widgets/session_sidebar.py
+++ b/local_operator/tui/widgets/session_sidebar.py
@@ -158,8 +158,12 @@ class SessionSidebar(Widget, can_focus=True):
         event.stop()
 
     def on_click(self, event: events.Click) -> None:
-        entry = self._entry_at(event.y)
-        target = self._pressed_id or (entry.id if entry else "")
+        entry = (
+            self._entry_at(event.y)
+            if self.region.contains(event.screen_x, event.screen_y)
+            else None
+        )
+        target = (self._pressed_id or (entry.id if entry else "")) if entry is not None else ""
         self._pressed_id = None
         if target:
             self.cursor_id = target
@@ -235,7 +239,11 @@ class SessionSidebar(Widget, can_focus=True):
             line.append(age, style=theme_mod.semantic_color("dim"))
             result.append_text(line)
         if not self.entries:
-            text = "Loading conversations…" if self.loading else "No conversations yet"
+            text = (
+                "Could not load conversations"
+                if self.error
+                else "Loading conversations…" if self.loading else "No conversations yet"
+            )
             result.append("\n" + truncate_cells(text, width), style=theme_mod.semantic_color("dim"))
         while result.plain.count("\n") < self.size.height - 2:
             result.append("\n")

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -861,6 +861,7 @@ class ToolCard(ExpandableActionBlock):
     ) -> None:
         super().__init__()
         self.tool_call_id = tool_call_id
+        self.navigation_anchor_id = f"tool:{tool_call_id}"
         # tool_name is MODEL-CONTROLLED: the loop takes it from the tool call
         # itself, so a hallucinated or injected name reaches the frame. It was
         # the one raw-text entry point the sanitisation pass missed, and it is
@@ -1028,6 +1029,16 @@ class ToolCard(ExpandableActionBlock):
         self.add_class("tool-error")
         self._refresh_row()
         self._apply_open_on_settle()
+        self.finalize()
+
+    def mark_waiting(self) -> None:
+        """Project a canonical pending gate without inventing execution events."""
+        self._settle_live()
+        self._state = "waiting"
+        self._duration = None
+        self._error = ""
+        self.remove_class("tool-running", "tool-interrupted", "tool-error")
+        self._refresh_row()
         self.finalize()
 
     def mark_interrupted(self) -> None:
@@ -1219,6 +1230,17 @@ class ToolCard(ExpandableActionBlock):
         self._summary = f"composing… {facts}"
         self._refresh_row()
 
+    def set_navigation_visible(self, visible: bool) -> None:
+        super().set_navigation_visible(visible)
+        if not visible:
+            if self._clock_timer is not None:
+                self._clock_timer.pause()
+        elif self._state in ("running", "composing"):
+            self._start_clock()
+            if self._clock_timer is not None:
+                self._clock_timer.resume()
+            self._tick_clock()
+
     def _start_clock(self) -> None:
         """Run the 1 Hz repaint for as long as this row is live (idempotent).
 
@@ -1233,7 +1255,7 @@ class ToolCard(ExpandableActionBlock):
         no start time to count from and nothing streams into it, so every
         tick would repaint an unchanged row. See :attr:`_started`.
         """
-        if self._started is None:
+        if self._started is None or not self._navigation_visible:
             return
         if self._clock_timer is None and self.is_running:
             self._clock_timer = self.set_interval(CLOCK_INTERVAL_S, self._tick_clock)
@@ -2269,6 +2291,12 @@ class ToolCard(ExpandableActionBlock):
         it wrote is meta. ``terse`` goes one step further and drops the
         failure reason too; see :meth:`_outcome_runs`.
         """
+        if self._state == "waiting":
+            # A pending approval is not an interruption or an execution clock.
+            # At very narrow widths omit the label, never replace it with an
+            # outcome glyph that falsely says the tool completed.
+            text = "waiting" if not cap or cap >= len("waiting") else ""
+            return [(text, bindings.style("tool.status.running_duration"))]
         if self._state == "composing":
             # Nothing has RUN, so there is no execution time to report. The
             # dictation clock rides in the summary instead (`_render_composing`)

--- a/local_operator/tui/widgets/tool_card.py
+++ b/local_operator/tui/widgets/tool_card.py
@@ -848,6 +848,9 @@ class ToolCard(ExpandableActionBlock):
     #: toggle expansion without knowing this subclass's CSS selector.
     EXPANDED_CLASS = "tool-expanded"
 
+    def retained_payloads(self) -> tuple[Any, ...]:
+        return self._args, self._output, self._live, self._diff
+
     def __init__(
         self,
         tool_call_id: str,

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -267,6 +267,10 @@ class TranscriptBlock(Static):
     # anchor a viewport, but only a rendered terminal completion may be read.
     navigation_anchor_id: str = ""
     navigation_anchor_part: int = 0
+    _navigation_visible: bool = True
+
+    def set_navigation_visible(self, visible: bool) -> None:
+        self._navigation_visible = visible
     #: True for a block that always opens a gap above itself regardless of
     #: what preceded it — the turn boundary, not a content difference.
     SPACING_LEAD: ClassVar[bool] = False
@@ -520,6 +524,11 @@ class TranscriptBlock(Static):
         return self._multirow_cache
 
     # -- text selection (TUI-021) -------------------------------------------
+    def retained_payloads(self) -> tuple[Any, ...] | None:
+        """Data a hidden view retains; unknown block kinds are not cacheable."""
+        text = getattr(self, "text", None)
+        return (text(),) if callable(text) else None
+
     def copy_gutter(self, index: int) -> int:
         """Leading CHARACTERS of rendered row ``index`` that are the block's
         own gutter — structure the block paints, never text the model or the
@@ -2976,15 +2985,26 @@ class TranscriptView(ScrollableContainer):
     def restore_navigation_anchor(self, anchor_id: str, part: int, offset: int) -> bool:
         """Restore the same message, not a stale screen-row offset after resize."""
         anchor = next(
-            (block for block in self._blocks if block.navigation_anchor_id == anchor_id and block.navigation_anchor_part == part),
+            (
+                block
+                for block in self._blocks
+                if block.navigation_anchor_id == anchor_id and block.navigation_anchor_part == part
+            ),
             None,
         )
         if anchor is None:
-            anchor = next((block for block in self._blocks if block.navigation_anchor_id == anchor_id), None)
+            anchor = next(
+                (block for block in self._blocks if block.navigation_anchor_id == anchor_id), None
+            )
         if anchor is None:
             return False
         self._tail_anchor.release()
-        y = self.scroll_y + anchor.region.y - self.content_region.y + min(offset, max(0, anchor.region.height - 1))
+        y = (
+            self.scroll_y
+            + anchor.region.y
+            - self.content_region.y
+            + min(offset, max(0, anchor.region.height - 1))
+        )
         with self._tail_anchor.programmatic_scroll():
             self.scroll_to(y=max(0, y), animate=False, immediate=True)
         return True

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -262,7 +262,6 @@ class TranscriptBlock(Static):
     #: Grouping key for adaptive spacing. Blocks that share a kind stack
     #: tight while each stays one row; a change of kind always opens a gap.
     SPACING_KIND: ClassVar[str] = "block"
-    completion_anchor_id: str = ""
     # Scroll identity is separate from completion receipts: every message may
     # anchor a viewport, but only a rendered terminal completion may be read.
     navigation_anchor_id: str = ""
@@ -271,6 +270,8 @@ class TranscriptBlock(Static):
 
     def set_navigation_visible(self, visible: bool) -> None:
         self._navigation_visible = visible
+
+    completion_anchor_id: str = ""
     #: True for a block that always opens a gap above itself regardless of
     #: what preceded it — the turn boundary, not a content difference.
     SPACING_LEAD: ClassVar[bool] = False
@@ -2133,6 +2134,17 @@ class WorkingBlock(TranscriptBlock):
             self._timer.stop()
         self._timer = self.set_interval(self._tick_ms / 1000, self._tick)
 
+    def set_navigation_visible(self, visible: bool) -> None:
+        super().set_navigation_visible(visible)
+        if self._timer is not None:
+            if visible:
+                self._sync_rate()
+                if self._timer is not None:
+                    self._timer.resume()
+                self._paint()
+            else:
+                self._timer.pause()
+
     def sync_animation_rate(self) -> None:
         """Re-rate after a focus change, and repaint so nothing reads stale.
 
@@ -2982,6 +2994,10 @@ class TranscriptView(ScrollableContainer):
         """Whether growth currently carries the viewport with it."""
         return self._tail_anchor.following
 
+    def set_navigation_visible(self, visible: bool) -> None:
+        for block in self._blocks:
+            block.set_navigation_visible(visible)
+
     def restore_navigation_anchor(self, anchor_id: str, part: int, offset: int) -> bool:
         """Restore the same message, not a stale screen-row offset after resize."""
         anchor = next(
@@ -3006,7 +3022,9 @@ class TranscriptView(ScrollableContainer):
             + min(offset, max(0, anchor.region.height - 1))
         )
         with self._tail_anchor.programmatic_scroll():
-            self.scroll_to(y=max(0, y), animate=False, immediate=True)
+            # Disabled means no user input, not no restoration: staged views
+            # are non-interactive while their canonical anchor is laid out.
+            self.scroll_to(y=max(0, y), animate=False, immediate=True, force=True)
         return True
 
     def follow_tail(self) -> None:
@@ -3101,7 +3119,7 @@ class TranscriptView(ScrollableContainer):
         short of the tail.
         """
         with self._tail_anchor.programmatic_scroll():
-            self.scroll_to(y=self.max_scroll_y, animate=False, immediate=True)
+            self.scroll_to(y=self.max_scroll_y, animate=False, immediate=True, force=True)
 
     def _size_updated(
         self, size: Size, virtual_size: Size, container_size: Size, layout: bool = True

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -263,6 +263,10 @@ class TranscriptBlock(Static):
     #: tight while each stays one row; a change of kind always opens a gap.
     SPACING_KIND: ClassVar[str] = "block"
     completion_anchor_id: str = ""
+    # Scroll identity is separate from completion receipts: every message may
+    # anchor a viewport, but only a rendered terminal completion may be read.
+    navigation_anchor_id: str = ""
+    navigation_anchor_part: int = 0
     #: True for a block that always opens a gap above itself regardless of
     #: what preceded it — the turn boundary, not a content difference.
     SPACING_LEAD: ClassVar[bool] = False
@@ -2324,6 +2328,7 @@ class TranscriptView(ScrollableContainer):
         #: re-arms on a deliberate act at the top but not on a wheel notch
         #: clamped against it.
         self._on_user_scroll: UserScrollHook | None = None
+        self._on_tail_requested: Callable[[], None] | None = None
         # The ledger's shared name column, recomputed lazily. Cached because it
         # is read once per card per repaint and only changes when the set of tool
         # names on screen does.
@@ -2387,6 +2392,10 @@ class TranscriptView(ScrollableContainer):
         mount cannot re-acquire following for a reader who just left the tail.
         """
         self._on_user_scroll = hook
+
+    def set_on_tail_requested(self, callback: Callable[[], None] | None) -> None:
+        """Let a bounded history window materialize its latest rows on End."""
+        self._on_tail_requested = callback
 
     def pin_tail(self, block: TranscriptBlock) -> None:
         """Append ``block`` and hold it last as the transcript grows.
@@ -2964,6 +2973,22 @@ class TranscriptView(ScrollableContainer):
         """Whether growth currently carries the viewport with it."""
         return self._tail_anchor.following
 
+    def restore_navigation_anchor(self, anchor_id: str, part: int, offset: int) -> bool:
+        """Restore the same message, not a stale screen-row offset after resize."""
+        anchor = next(
+            (block for block in self._blocks if block.navigation_anchor_id == anchor_id and block.navigation_anchor_part == part),
+            None,
+        )
+        if anchor is None:
+            anchor = next((block for block in self._blocks if block.navigation_anchor_id == anchor_id), None)
+        if anchor is None:
+            return False
+        self._tail_anchor.release()
+        y = self.scroll_y + anchor.region.y - self.content_region.y + min(offset, max(0, anchor.region.height - 1))
+        with self._tail_anchor.programmatic_scroll():
+            self.scroll_to(y=max(0, y), animate=False, immediate=True)
+        return True
+
     def follow_tail(self) -> None:
         """Go to the end and stay there — the caller is asking for the tail.
 
@@ -3135,6 +3160,8 @@ class TranscriptView(ScrollableContainer):
         short of the new end — where ``watch_scroll_y`` correctly concludes they
         are not at the bottom and releases the anchor they had just asked for.
         """
+        if self._on_tail_requested is not None:
+            self._on_tail_requested()
         self.follow_tail()
 
 

--- a/local_operator/tui/widgets/welcome.py
+++ b/local_operator/tui/widgets/welcome.py
@@ -1281,6 +1281,12 @@ class WelcomeView(Static):
         self._sync_pulse_timer()
         self._sync_tip_timer()
 
+    _navigation_visible = True
+
+    def set_navigation_visible(self, visible: bool) -> None:
+        self._navigation_visible = visible
+        self.sync_animation_rate()
+
     def _sync_pulse_timer(self) -> None:
         """Glow only while the splash is on screen and animation is allowed.
 
@@ -1307,7 +1313,7 @@ class WelcomeView(Static):
         therefore also restarts it at rest, which is the right frame to come
         back to and the one `_stop_pulse_timer` already guarantees.
         """
-        wanted = bool(self.display) and motion_enabled()
+        wanted = self._navigation_visible and bool(self.display) and motion_enabled()
         if wanted and self._pulse_timer is None:
             self._pulse_origin = time.monotonic()
             self._pulse_timer = self.set_interval(MARK_PULSE_INTERVAL_S, self._pulse_tick)
@@ -1378,7 +1384,7 @@ class WelcomeView(Static):
         an arbitrary sample of the ring. The env kill switch still
         suppresses the *pulse*. It does not freeze the tip.
         """
-        wanted = bool(self.display) and animation_focused()
+        wanted = self._navigation_visible and bool(self.display) and animation_focused()
         if wanted and self._tip_timer is None:
             # The row OPENS on `TIPS[0]` (or TIP_SETUP / TIP_PASTE) and never
             # on a lottery. The pool is ordered, and the first thing a

--- a/tests/unit/mcp/test_manager.py
+++ b/tests/unit/mcp/test_manager.py
@@ -17,6 +17,7 @@ import pytest
 from mcp.types import CallToolResult, ListToolsResult, TextContent, Tool
 
 from local_operator.harness.types import AbortSignal, ToolContext, ToolResult
+from local_operator.mcp.config import MCPStdioServerConfig
 from local_operator.mcp.manager import (
     McpManager,
     ServerConnection,
@@ -24,7 +25,11 @@ from local_operator.mcp.manager import (
     build_stdio_argv,
     stdio_start_new_session,
 )
-from local_operator.mcp.tool_cache import McpToolCache
+from local_operator.mcp.tool_cache import McpToolCache, config_digest
+
+
+def _stdio_digest(command: str) -> str:
+    return config_digest(MCPStdioServerConfig(command=command))
 
 
 def _tool(name: str, schema: dict[str, Any] | None = None) -> Tool:
@@ -138,6 +143,7 @@ class TestFastStartupGate:
                     "inputSchema": {"type": "object"},
                 }
             ],
+            _stdio_digest("slow-cmd"),
         )
         manager = McpManager(str(project), tool_cache=cache)
 
@@ -436,7 +442,11 @@ class TestDeferredExecuteFailure:
         self, project: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         cache = McpToolCache(tmp_path / "cache.db")
-        cache.put("slow", [{"name": "search", "description": "", "inputSchema": {}}])
+        cache.put(
+            "slow",
+            [{"name": "search", "description": "", "inputSchema": {}}],
+            _stdio_digest("slow-cmd"),
+        )
         manager = McpManager(str(project), tool_cache=cache)
         release = asyncio.Event()
 
@@ -787,6 +797,7 @@ class TestBreakerTrippedCallsFailPromptly:
         cache.put(
             "fast",
             [{"name": "search", "description": "", "inputSchema": {"type": "object"}}],
+            _stdio_digest("fast-cmd"),
         )
         manager = McpManager(str(project), tool_cache=cache)
         state = {"fail": False}
@@ -832,7 +843,11 @@ class TestBreakerTrippedCallsFailPromptly:
         self, project: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         cache = McpToolCache(tmp_path / "cache.db")
-        cache.put("slow", [{"name": "search", "description": "", "inputSchema": {}}])
+        cache.put(
+            "slow",
+            [{"name": "search", "description": "", "inputSchema": {}}],
+            _stdio_digest("slow-cmd"),
+        )
         manager = McpManager(str(project), tool_cache=cache)
         release = asyncio.Event()
 

--- a/tests/unit/mcp/test_tool_cache.py
+++ b/tests/unit/mcp/test_tool_cache.py
@@ -1,0 +1,101 @@
+"""McpToolCache: config_dir isolation, digest keys, 0600, silent degradation."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from local_operator.mcp.config import MCPStdioServerConfig
+from local_operator.mcp.tool_cache import (
+    McpToolCache,
+    config_digest,
+    default_cache_path,
+)
+from local_operator.paths import config_dir
+
+_TOOLS = [{"name": "echo", "description": "say", "inputSchema": {"type": "object"}}]
+
+
+def test_default_path_honours_config_dir_env(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "cfg"))
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    (tmp_path / "home").mkdir()
+    path = default_cache_path()
+    assert path == config_dir() / "mcp_cache.db"
+    assert path.parent == tmp_path / "cfg"
+    cache = McpToolCache()
+    digest = config_digest(MCPStdioServerConfig(command="echo"))
+    cache.put("echo", _TOOLS, digest)
+    assert cache.get("echo", digest) == _TOOLS
+    leaked = tmp_path / "home" / ".local-operator" / "mcp_cache.db"
+    assert not leaked.exists()
+
+
+def test_digest_mismatch_deletes_stale_row(tmp_path: Path) -> None:
+    cache = McpToolCache(tmp_path / "mcp_cache.db")
+    old = config_digest(MCPStdioServerConfig(command="old-cmd"))
+    new = config_digest(MCPStdioServerConfig(command="new-cmd"))
+    assert old != new
+    cache.put("echo", _TOOLS, old)
+    assert cache.get("echo", old) == _TOOLS
+    assert cache.get("echo", new) is None
+    assert cache.get("echo", old) is None  # stale row dropped on mismatch
+
+
+def test_name_only_get_is_a_miss_and_drops_rows(tmp_path: Path) -> None:
+    cache = McpToolCache(tmp_path / "mcp_cache.db")
+    digest = config_digest(MCPStdioServerConfig(command="echo"))
+    cache.put("echo", _TOOLS, digest)
+    assert cache.get("echo") is None
+    assert cache.get("echo", digest) is None
+
+
+def test_put_without_digest_is_a_noop(tmp_path: Path) -> None:
+    cache = McpToolCache(tmp_path / "mcp_cache.db")
+    cache.put("echo", _TOOLS)
+    assert cache.get("echo", config_digest(MCPStdioServerConfig(command="echo"))) is None
+
+
+def test_cache_file_is_0600(tmp_path: Path) -> None:
+    path = tmp_path / "mcp_cache.db"
+    cache = McpToolCache(path)
+    cache.put("echo", _TOOLS, config_digest(MCPStdioServerConfig(command="echo")))
+    assert path.exists()
+    mode = os.stat(path).st_mode & 0o777
+    assert mode == 0o600
+
+
+def test_discover_and_load_defaults_a_config_dir_cache(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "cfg"))
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    (tmp_path / "cfg").mkdir()
+    (tmp_path / "home").mkdir()
+    captured: list[object] = []
+
+    class FakeManager:
+        def __init__(self, cwd, tool_cache, auth_store=None):
+            captured.append(tool_cache)
+
+        async def discover_and_connect(self):
+            from local_operator.mcp.manager import McpLoadResult
+
+            return McpLoadResult()
+
+    monkeypatch.setattr("local_operator.mcp.McpManager", FakeManager)
+    import asyncio
+
+    from local_operator.mcp import discover_and_load_mcp_tools
+    from local_operator.mcp.tool_cache import McpToolCache
+
+    asyncio.run(discover_and_load_mcp_tools(str(tmp_path)))
+    assert len(captured) == 1
+    assert isinstance(captured[0], McpToolCache)
+    assert captured[0]._path.parent == tmp_path / "cfg"
+
+
+def test_removed_server_delete_drops_every_digest(tmp_path: Path) -> None:
+    cache = McpToolCache(tmp_path / "mcp_cache.db")
+    a = config_digest(MCPStdioServerConfig(command="a"))
+    cache.put("echo", _TOOLS, a)
+    cache.delete("echo")
+    assert cache.get("echo", a) is None

--- a/tests/unit/providers/test_auth_store.py
+++ b/tests/unit/providers/test_auth_store.py
@@ -170,6 +170,53 @@ async def test_oauth_auto_refresh_with_skew(
     assert rows[-1].data["access"] == "access-2"
 
 
+async def test_cross_process_refresh_lease_lets_only_one_store_post(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two AuthStores on one db: the loser does not POST a rotating token.
+
+    This is the PR-24 race: N TUI+runtime processes, one refresh token.
+    The lease is the same atomic upsert as usage; clients stay per-store.
+    """
+    import time
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    db = tmp_path / "auth.db"
+    a = AuthStore(db)
+    b = AuthStore(db)
+    expired = _oauth(expires=int(time.time() * 1000) + 1000)
+    expired["org_id"] = "org-1"
+    a.upsert_credential("openai", expired)
+    row = a.list_credentials("openai")[-1]
+    posts: list[str] = []
+    release = asyncio.Event()
+    held = asyncio.Event()
+
+    async def slow_refresh(creds: dict[str, Any]) -> dict[str, Any]:
+        posts.append(creds["refresh"])
+        held.set()
+        await release.wait()
+        return {
+            "access": "access-2",
+            "refresh": "rotated",
+            "expires": int(time.time() * 1000) + 3600_000,
+        }
+
+    monkeypatch.setattr(a, "_refresh_fn", lambda provider: slow_refresh)
+    monkeypatch.setattr(b, "_refresh_fn", lambda provider: slow_refresh)
+
+    task = asyncio.create_task(a.get_api_key("openai"))
+    await asyncio.wait_for(held.wait(), 2)
+    assert b._try_refresh_lease(row.id) is False
+    key_b = await b.get_api_key("openai")
+    assert posts == [expired["refresh"]]
+    release.set()
+    key_a = await task
+    assert key_a == "access-2"
+    assert len(posts) == 1
+    assert key_b in {expired["access"], "access-2"}
+
+
 async def test_force_refresh_failure_blocks_and_raises(
     store: AuthStore, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/session/test_attach_frame_size.py
+++ b/tests/unit/session/test_attach_frame_size.py
@@ -29,6 +29,7 @@ from local_operator.mobile.attach_client import _READ_LIMIT_BYTES
 from local_operator.session.attention import AttentionStore
 from local_operator.session.frontend_state import (
     _MODEL_CATALOGUE_LINE_LIMIT,
+    _SHAREABLE_STATE_FIELDS,
     MODEL_CATALOGUE_FLOOR_ROWS,
     USAGE_COMPONENT_CAP,
     FrontendSessionState,
@@ -472,6 +473,47 @@ def test_every_collection_field_is_classified() -> None:
     # stale entry here implying coverage that no longer exists.
     stale = classified - _collection_fields()
     assert not stale, f"stale entries for fields that no longer exist: {sorted(stale)}"
+
+
+def test_shareable_state_fields_are_real_and_immutable() -> None:
+    """The copy-free allow-list must name real fields that cannot be mutated.
+
+    ``read_field`` hands out the store's OWN object, so the allow-list is the
+    entire safety argument. Round 2 found it asserting neither half: it listed
+    ``conversation_name`` (the field is ``conversation_title``), which passed
+    the ``KeyError`` gate and then raised ``AttributeError`` from ``getattr``
+    on a per-frame path, and it admitted ``selected_model``/``effective_model``
+    /``last_usage`` — non-frozen models whose instance a caller could rewrite,
+    removing an invariant ``state`` provides by copying.
+
+    Driven off ``model_fields`` and the annotation, in the same shape as the
+    collection-field guard above: a renamed field fails here rather than at a
+    user's terminal, and a field whose type becomes mutable cannot re-enter the
+    set without someone stating why sharing it is safe.
+    """
+    immutable = (str, bool, int, float)
+
+    unknown = _SHAREABLE_STATE_FIELDS - set(FrontendSessionState.model_fields)
+    assert not unknown, (
+        f"copy-free field(s) that do not exist on FrontendSessionState: {sorted(unknown)}. "
+        "`read_field` checks membership BEFORE `getattr`, so a name that is not a real "
+        "field passes the guard and then raises AttributeError on a per-frame path."
+    )
+
+    mutable: list[str] = []
+    for name in sorted(_SHAREABLE_STATE_FIELDS):
+        annotation = FrontendSessionState.model_fields[name].annotation
+        types = {
+            arg for arg in getattr(annotation, "__args__", (annotation,)) if arg is not type(None)
+        }
+        if not types or not all(isinstance(t, type) and issubclass(t, immutable) for t in types):
+            mutable.append(name)
+    assert not mutable, (
+        f"copy-free field(s) whose value is not deeply immutable: {mutable}. "
+        "`read_field` shares the store's own object, so anything a caller can mutate "
+        "in place — a model, a dict, a list — must read through `state` instead and "
+        "pay for its deep copy."
+    )
 
 
 def test_every_job_row_field_is_classified() -> None:

--- a/tests/unit/session/test_history_window.py
+++ b/tests/unit/session/test_history_window.py
@@ -1,0 +1,202 @@
+"""Canonical display pages never substitute a truncated context for history."""
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from local_operator.harness.types import (
+    CustomMessage,
+    Message,
+    TextContent,
+    ToolCall,
+    ToolResult,
+)
+from local_operator.session.history_window import display_window
+from local_operator.session.remote import RemoteSession
+from local_operator.session.runtime.owned import OwnedSessionHandle
+from local_operator.session.runtime.server import RuntimeServer
+from local_operator.session.transcript import Transcript
+from tests.e2e.harness import ScriptedStream, build_session, seed_transcript, text_turn
+from tests.unit.session.test_remote import _never_take_over
+
+
+def window(transcript: Transcript, **kwargs):  # noqa: ANN003, ANN201
+    return display_window(
+        transcript,
+        conversation_id="window-test",
+        owner_epoch="synthetic-epoch",
+        through_id=transcript.entries()[-1].id if transcript.entries() else None,
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_pages_match_canonical_cut_across_appends_and_reset_on_prune(tmp_path: Path) -> None:
+    transcript = Transcript(tmp_path)
+    messages = [Message.user(f"row {index}") for index in range(270)]
+    await transcript.append_messages(messages)
+    first = window(transcript)
+    assert first.total_message_count == 270
+    assert len(first.messages) == 120
+    assert first.start == 150
+    assert first.before_token and first.snapshot_token
+    await transcript.append_message(Message.assistant("after captured cut"))
+    rows = list(first.messages)
+    token = first.before_token
+    while token:
+        page = window(transcript, before=token)
+        assert page.through_id == first.through_id
+        rows[:0] = page.messages
+        token = page.before_token
+    assert [m.model_dump() for m in rows] == [m.model_dump() for m in messages]
+    await transcript.append_prune(messages[-1].id, "pruned")
+    assert window(transcript, before=first.before_token).status == "reset"
+    last = transcript.build_llm_history(through_id=first.through_id)[-1]
+    assert isinstance(last, Message) and last.text == "row 269"
+
+
+@pytest.mark.asyncio
+async def test_compaction_roles_and_delayed_tool_results_share_canonical_replay(
+    tmp_path: Path,
+) -> None:
+    transcript = Transcript(tmp_path)
+    opener = Message.user("preserved verbatim")
+    call = Message.assistant("running a tool")
+    call.tool_calls = [ToolCall(id="tool-one", name="bash", arguments={"command": "echo hello"})]
+    custom = CustomMessage(custom_type="aside", attribution="user", details={"text": "context"})
+    result = Message.tool_result(
+        ToolResult(tool_call_id="tool-one", tool_name="bash", content=[TextContent(text="hello")])
+    )
+    await transcript.append_messages([opener, call, custom, result])
+    compact = await transcript.append_compaction(
+        "summary", call.id, 500, preserved_user_turns=[{"id": opener.id, "text": opener.text}]
+    )
+    canonical = transcript.build_llm_history()
+    assert canonical[0].id == compact.id
+    assert canonical[1].id == opener.id
+    first = window(transcript, max_messages=3)
+    assert [m.id for m in first.messages] == [call.id, custom.id, result.id]
+    assert first.before_token
+    previous = window(transcript, before=first.before_token, max_messages=3)
+    assert [m.model_dump() for m in previous.messages + first.messages] == [
+        m.model_dump() for m in canonical
+    ]
+    anchored = window(transcript, before=first.snapshot_token, anchor="tool:tool-one")
+    assert any(m.id == call.id for m in anchored.messages)
+
+
+@pytest.mark.asyncio
+async def test_wire_budget_never_returns_oversized_or_truncated_required_prose(
+    tmp_path: Path,
+) -> None:
+    transcript = Transcript(tmp_path)
+    message = Message.assistant("required prose " * 100_000)
+    await transcript.append_message(message)
+    page = window(transcript)
+    assert page.status == "full_required"
+    assert page.messages == []
+    assert len(page.model_dump_json().encode()) < 1024 * 1024
+    replayed = transcript.build_llm_history()[0]
+    assert isinstance(replayed, Message) and replayed.text == message.text
+
+
+@pytest.mark.asyncio
+async def test_signed_page_scope_and_anchor_validation(tmp_path: Path) -> None:
+    transcript = Transcript(tmp_path)
+    await transcript.append_messages([Message.user(str(i)) for i in range(130)])
+    first = window(transcript)
+    assert first.before_token
+    with pytest.raises(ValueError, match="invalid history token"):
+        window(transcript, before=first.before_token + "bad")
+    with pytest.raises(ValueError, match="another conversation"):
+        display_window(
+            transcript,
+            conversation_id="wrong",
+            owner_epoch="synthetic-epoch",
+            through_id=first.through_id,
+            before=first.before_token,
+        )
+    assert (
+        display_window(
+            transcript,
+            conversation_id="window-test",
+            owner_epoch="new-epoch",
+            through_id=first.through_id,
+            before=first.before_token,
+        ).status
+        == "reset"
+    )
+    assert window(transcript, before=first.snapshot_token, anchor="missing-id").status == "reset"
+
+
+@pytest.mark.asyncio
+async def test_real_attach_pages_without_viewer_journal_parse_and_records_shell_once(
+    tmp_path: Path, monkeypatch
+) -> None:  # noqa: ANN001
+    config = tmp_path / "config"
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config))
+    directory = config / "sessions" / "window-test"
+    messages = [Message.user(f"canonical {index}") for index in range(250)]
+    await seed_transcript(directory, messages)
+    session = build_session(directory, ScriptedStream([text_turn("owner reply")]), cwd=tmp_path)
+    handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd=str(tmp_path))
+    server = RuntimeServer(handle, kind="daemon")
+    remote = None
+    await server.start_in_process()
+    try:
+
+        async def forbidden(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+            raise AssertionError("window attach must not parse the viewer journal")
+
+        monkeypatch.setattr(RemoteSession, "_read_transcript", forbidden)
+        remote = await RemoteSession.connect(
+            server._record,
+            "window-test",
+            config_dir=config,
+            takeover_factory=_never_take_over,
+            display_window=True,
+        )
+        assert not remote.is_cold
+        assert remote.history_message_count == 250
+        assert len(remote.display_history_window()) == 120
+        with pytest.raises(RuntimeError, match="not hydrated"):
+            remote.history()
+        await remote.seed_history([Message.user("must not seed a nonempty window")])
+        assert remote.history_message_count == 250
+        old_token = remote.history_before_token
+        assert old_token is not None
+        await remote.ensure_display_anchor(messages[10].id)
+        assert any(m.id == messages[10].id for m in remote.display_history_window())
+        assert [m.id for m in await remote.materialize_history()] == [m.id for m in messages]
+        result = ToolResult(
+            tool_call_id="synthetic-shell",
+            tool_name="bash",
+            content=[TextContent(text="exit code: 0\nhello")],
+        )
+        await remote.record_shell("echo hello", result)
+        await remote.record_shell("echo hello", result)
+        durable = session._transcript.build_llm_history()
+        assert sum(m.id == "shell:synthetic-shell:user" for m in durable) == 1
+        assert sum(m.id == "shell:synthetic-shell:result" for m in durable) == 1
+        assert (
+            sum(m.id == "shell:synthetic-shell:user" for m in remote.display_history_window()) == 1
+        )
+        assert json.loads(remote.frontend_state.model_dump_json())["session_id"] == "window-test"
+        received = []
+        remote.subscribe(received.append)
+        await session._transcript.append_compaction("new canonical cut", messages[-1].id, 500)
+        stale = await remote.history_page(old_token)
+        assert stale.status == "reset"
+        await remote._refresh_display_history()
+        assert not remote.is_cold
+        assert any(getattr(event, "reset", False) for event in received)
+        marker = remote.display_history_window()[0]
+        assert isinstance(marker, CustomMessage) and marker.custom_type == "compaction_summary"
+        assert not await remote.ensure_display_anchor(messages[0].id)
+    finally:
+        if remote is not None:
+            await remote.dispose()
+        server.close()
+        await handle.dispose()

--- a/tests/unit/session/test_history_window.py
+++ b/tests/unit/session/test_history_window.py
@@ -200,3 +200,145 @@ async def test_real_attach_pages_without_viewer_journal_parse_and_records_shell_
             await remote.dispose()
         server.close()
         await handle.dispose()
+
+
+@pytest.mark.asyncio
+async def test_live_replay_mutations_refresh_without_replacing_the_connection(
+    tmp_path, monkeypatch
+):
+    from local_operator.harness.types import CompactionEndEvent, NoticeEvent
+
+    config = tmp_path / "config"
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config))
+    directory = config / "sessions" / "window-live"
+    messages = [Message.user(f"canonical {index}") for index in range(250)]
+    await seed_transcript(directory, messages)
+    session = build_session(directory, ScriptedStream([text_turn("unused")]), cwd=tmp_path)
+    handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd=str(tmp_path))
+    server = RuntimeServer(handle, kind="daemon")
+    await server.start_in_process()
+    assert server._record is not None
+    remote = None
+    try:
+        remote = await RemoteSession.connect(
+            server._record,
+            "window-live",
+            config_dir=config,
+            takeover_factory=_never_take_over,
+            display_window=True,
+        )
+        connection = remote._client
+        received = asyncio.Event()
+        remote.subscribe(
+            lambda event: received.set() if isinstance(event, CompactionEndEvent) else None
+        )
+        old_token = remote.history_before_token
+        await session._transcript.append_compaction("canonical summary", messages[-1].id, 1000)
+        await session._emit(CompactionEndEvent(reason="manual", success=True))
+        await asyncio.wait_for(received.wait(), 3)
+        await remote.ensure_display_current()
+        assert remote._client is connection
+        assert remote.display_history_current
+        assert remote.history_message_count == 2
+        assert remote._display_history is not None
+        assert remote._display_history.history_generation == session._transcript._history_generation
+        assert any(
+            isinstance(row, CustomMessage) and row.custom_type == "compaction_summary"
+            for row in remote.display_history_window()
+        )
+        assert old_token is not None and (await remote.history_page(old_token)).status == "reset"
+        # Non-compaction mutations publish the same generation fence before
+        # ordinary events; callers need not page an obsolete token to find out.
+        await session._transcript.append_prune(messages[-1].id, "pruned")
+        await session._emit(NoticeEvent(text="pruned", kind="info"))
+        for _ in range(100):
+            if remote.frontend_state.history_generation == session._transcript._history_generation:
+                break
+            await asyncio.sleep(0.01)
+        await remote.ensure_display_current()
+        assert remote._client is connection
+        assert [row.model_dump() for row in remote.display_history_window()] == [
+            row.model_dump() for row in session._transcript.build_llm_history()
+        ]
+        assert remote._display_history.history_generation == session._transcript._history_generation
+        assert len(server._clients) == 1
+    finally:
+        if remote is not None:
+            await remote.dispose()
+        server.close()
+        await handle.dispose()
+
+
+@pytest.mark.asyncio
+async def test_prompt_and_wait_does_not_complete_on_admission(tmp_path, monkeypatch):
+    config = tmp_path / "config"
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config))
+    directory = config / "sessions" / "window-loop"
+    await seed_transcript(directory, [Message.user("initial")])
+    started, release = asyncio.Event(), asyncio.Event()
+    calls = []
+
+    async def stream(request, signal=None):
+        # The session also issues a tool-less naming errand off the first
+        # prompt. Only a real agent turn carries the tool schema, and counting
+        # the errand would make "how many turns ran" unreadable here.
+        if not getattr(request, "tools", None):
+            for event in text_turn("named"):
+                yield event
+            return
+        calls.append(len(calls) + 1)
+        started.set()
+        await release.wait()
+        for event in text_turn("completed"):
+            yield event
+
+    session = build_session(directory, stream, cwd=tmp_path)
+    handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd=str(tmp_path))
+    server = RuntimeServer(handle, kind="daemon")
+    await server.start_in_process()
+    assert server._record is not None
+    remote = None
+    task = None
+    try:
+        remote = await RemoteSession.connect(
+            server._record,
+            "window-loop",
+            config_dir=config,
+            takeover_factory=_never_take_over,
+            display_window=True,
+        )
+        task = asyncio.create_task(
+            remote.prompt_and_wait("one", message_id="11111111-1111-4111-8111-111111111111")
+        )
+
+        async def provider_started():
+            while not started.is_set():
+                if task.done():
+                    await task
+                    raise AssertionError("turn completed before the provider started")
+                await asyncio.sleep(0.01)
+
+        await asyncio.wait_for(provider_started(), 3)
+        await asyncio.sleep(0.05)
+        assert not task.done(), "durable admission is not terminal completion"
+        assert calls == [1]
+        # A refresh can pause UI event delivery. The scheduler still observes
+        # the authenticated terminal outcome, not whether a card was painted.
+        remote._ready_for_events = False
+        release.set()
+        await asyncio.wait_for(task, 3)
+        remote._ready_for_events = True
+        await asyncio.wait_for(
+            remote.prompt_and_wait("two", message_id="22222222-2222-4222-8222-222222222222"), 3
+        )
+        assert calls == [1, 2]
+        assert not remote._prompt_completion_waiters
+    finally:
+        release.set()
+        if task is not None and not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+        if remote is not None:
+            await remote.dispose()
+        server.close()
+        await handle.dispose()

--- a/tests/unit/session/test_no_session_deletion.py
+++ b/tests/unit/session/test_no_session_deletion.py
@@ -72,6 +72,26 @@ _FS_MODULES = frozenset({"os", "shutil", "pathlib"})
 #: declared one: a new same-shape call fails until a reviewer bumps the
 #: count with a reason, and a removed one fails as stale.
 _ALLOWED_ROWS: tuple[tuple[str | int, ...], ...] = (
+    (
+        "local_operator/tui/app.py::OperatorApp._release_sidebar_preparation",
+        "<path>.remove",
+        "Textual TranscriptView.remove unmounts a widget; no filesystem path",
+    ),
+    (
+        "local_operator/tui/app.py::OperatorApp._prepare_sidebar_session",
+        "<path>.remove",
+        "Textual TranscriptView.remove unmounts failed preparation; no filesystem path",
+    ),
+    (
+        "local_operator/tui/session_drafts.py::SessionDraftStore._write",
+        "os.replace",
+        "Atomic file replacement inside this store's private tempfile directory, never sessions/",
+    ),
+    (
+        "local_operator/tui/session_drafts.py::SessionDraftStore._write",
+        "os.unlink",
+        "Removes only its named temporary draft file after a failed atomic replacement",
+    ),
     # -- the one legitimate remover -----------------------------------------
     (
         "local_operator/session/cleanup.py::remove_session_dir",

--- a/tests/unit/session/test_remote_registries.py
+++ b/tests/unit/session/test_remote_registries.py
@@ -177,10 +177,9 @@ async def test_every_session_attribute_the_tui_reads_exists_on_the_viewer(
         "journal_credential_change",
         # Guarded fallbacks in app.py that degrade to a documented default
         # (fork clones from disk, routing reads config.yml, usage/context
-        # measurement is skipped, bang-mode results are not journalled).
+        # measurement is skipped).
         "has_pending_fork",
         "routing_settings",
-        "record_shell",
         "measure_preloaded_context",
         "preflight_usage",
         "refresh_frontend_usage",

--- a/tests/unit/session/test_transcript.py
+++ b/tests/unit/session/test_transcript.py
@@ -16,11 +16,14 @@ from local_operator.harness.types import (
     Usage,
 )
 from local_operator.mcp.tool_bridge import format_mcp_result
+from local_operator.session.attachments import AttachmentStore
 from local_operator.session.transcript import (
     ENTRY_MESSAGE,
     Transcript,
     TranscriptEntry,
+    read_replay_suffix,
     read_transcript_page,
+    replay_entries,
 )
 
 
@@ -611,3 +614,105 @@ async def test_cancelled_fold_cannot_replace_a_successors_new_message(tmp_path, 
     assert transcript.has_entry("new")
     history = reopened.build_llm_history()
     assert any(isinstance(message, Message) and message.text == "new" for message in history)
+
+
+# -- backward suffix replay ---------------------------------------------------
+#
+# ``read_replay_suffix`` exists so a legacy attach stops paying for a whole-file
+# JSON parse when the replay only uses rows from the latest compaction's kept
+# window. The property that makes that safe is EQUIVALENCE with the whole-file
+# parse, so every shape the replay handles specially is asserted here against
+# ``Transcript(...).build_llm_history()`` rather than against expected values:
+# if the semantics move, both sides move together and the suffix must follow.
+
+
+def _dump(history):
+    return [message.model_dump(mode="json") for message in history]
+
+
+async def _journal(directory: Path, *, shape: str) -> list[str]:
+    """A journal whose kept window sits behind enough bulk to span chunks."""
+    transcript = Transcript(directory)
+    ids: list[str] = []
+    for n in range(8):
+        ids.append((await transcript.append_message(Message.user(f"early q{n}"))).id)
+        ids.append((await transcript.append_message(Message.assistant(f"early a{n}"))).id)
+    # Bookkeeping rows larger than the reader's chunk, so a single row spans
+    # a chunk boundary and the incomplete-head handling is exercised.
+    for index in range(3):
+        await transcript.append_custom("bulk", {"index": index, "pad": "x" * (1 << 20)})
+    if shape != "no-compaction":
+        for n in range(6):
+            ids.append((await transcript.append_message(Message.user(f"kept q{n}"))).id)
+            ids.append((await transcript.append_message(Message.assistant(f"kept a{n}"))).id)
+        preserved = (
+            [{"id": ids[2], "text": "early q1"}] if shape == "compaction+preserved" else None
+        )
+        await transcript.append_compaction("summary", ids[-12], 100, preserved_user_turns=preserved)
+        for n in range(2):
+            ids.append((await transcript.append_message(Message.user(f"post q{n}"))).id)
+            ids.append((await transcript.append_message(Message.assistant(f"post a{n}"))).id)
+        if shape in ("compaction+prunes", "folded"):
+            await transcript.append_prune(ids[-6], "[pruned]")
+            await transcript.append_prune(ids[-1], "[pruned]")
+        if shape == "folded":
+            await transcript.compact_file(min_reclaim_bytes=0)
+    await transcript.append_custom("checkpoint", {"epoch": "e1"})
+    return ids
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "shape",
+    ["no-compaction", "compaction", "compaction+prunes", "compaction+preserved", "folded"],
+)
+async def test_replay_suffix_matches_whole_file_parse(tmp_path, shape):
+    directory = tmp_path / "sess"
+    ids = await _journal(directory, shape=shape)
+    full = Transcript(directory)
+    store = AttachmentStore(directory)
+
+    suffix = read_replay_suffix(directory, checkpoint_type="checkpoint")
+    assert _dump(replay_entries(suffix.entries, store)) == _dump(full.build_llm_history())
+    assert suffix.checkpoint == full.latest_custom("checkpoint")
+    if shape != "no-compaction":
+        # The point of the reader: it must NOT have read the early history.
+        assert suffix.bytes_read < (directory / "transcript.jsonl").stat().st_size
+    else:
+        # No compaction means no boundary to stop at: whole file, honestly.
+        assert suffix.bytes_read == (directory / "transcript.jsonl").stat().st_size
+
+    # Cuts at the tail, inside the kept window, and (for compacted journals)
+    # BEFORE the marker — where a compaction above the cut must be ignored
+    # exactly as the whole-file replay ignores it after slicing at the cursor.
+    cuts = [ids[-1], ids[-3]] + ([ids[-6]] if shape != "no-compaction" else [])
+    for cut in cuts:
+        cut_suffix = read_replay_suffix(directory, through_id=cut)
+        assert cut_suffix.through_present
+        assert _dump(replay_entries(cut_suffix.entries, store, through_id=cut)) == _dump(
+            full.build_llm_history(through_id=cut)
+        ), (shape, cut)
+
+
+@pytest.mark.asyncio
+async def test_replay_suffix_reports_an_unknown_cursor_instead_of_cutting(tmp_path):
+    """A cursor not in the journal is an answer, never a silent tail cut.
+
+    The strict-cut contract: the caller decides whether an absent cursor means
+    "legacy best-effort, replay everything" or "the negotiated window is gone".
+    The reader's job is to have read far enough to KNOW it is absent.
+    """
+    directory = tmp_path / "sess"
+    await _journal(directory, shape="compaction")
+    suffix = read_replay_suffix(directory, through_id="not-a-row")
+    assert not suffix.through_present
+    assert suffix.bytes_read == (directory / "transcript.jsonl").stat().st_size
+
+
+def test_replay_suffix_absent_journal_is_empty_history(tmp_path):
+    """Same answer as ``Transcript(directory)``: no file means nothing yet."""
+    suffix = read_replay_suffix(tmp_path / "absent")
+    assert suffix.entries == () and suffix.bytes_read == 0
+    assert (
+        replay_entries(suffix.entries, None) == Transcript(tmp_path / "absent").build_llm_history()
+    )

--- a/tests/unit/test_fork.py
+++ b/tests/unit/test_fork.py
@@ -1362,7 +1362,10 @@ class TestTheWindowTitleNamesTheFork:
         fork = _build_session(tmp_path / "sessions" / fork_id)
         assert fork.wears_inherited_title is True
 
+        from local_operator.tui.session_interaction import SessionInteraction
+
         app = OperatorApp.__new__(OperatorApp)
+        app._interaction = SessionInteraction(fork)
         app._session = fork
         app._provisional_name = ""
         app._status = _titled_band(forked=True)

--- a/tests/unit/test_settings_io.py
+++ b/tests/unit/test_settings_io.py
@@ -63,6 +63,10 @@ def _consumer_defaults() -> dict[str, object]:
         DEFAULT_FORK_MODE,
     )
     from local_operator.tools.builtin import BASH_SHELL_DEFAULT
+    from local_operator.tui.session_catalog import (
+        DEFAULT_SIDEBAR_POSITION,
+        DEFAULT_SIDEBAR_VISIBLE,
+    )
     from local_operator.tui.theme import DEFAULT_THEME
     from local_operator.web_fetch.models import DEFAULT_WEB_FETCH_CONFIG
     from local_operator.web_search.models import DEFAULT_WEB_SEARCH_CONFIG
@@ -76,6 +80,8 @@ def _consumer_defaults() -> dict[str, object]:
         # registry said `""` while the app used `dark`, so the page reported a
         # user explicitly on `dark` as having changed the setting (round 1, M1).
         "tui.theme": DEFAULT_THEME,
+        "tui.sidebar_visible": DEFAULT_SIDEBAR_VISIBLE,
+        "tui.sidebar_position": DEFAULT_SIDEBAR_POSITION,
         "retry.enabled": retry.enabled,
         "retry.maxRetries": retry.max_retries,
         "retry.baseDelayMs": retry.base_delay_ms,

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -1335,8 +1335,12 @@ async def test_every_authoritative_slash_routes_to_owner_with_supported_images()
             arg = "coder inspect [Image #1]" if attachments else "value"
             app._run_slash_command(f"/{capability.command} {arg}", attachments)
             await pilot.pause()
+    # A legacy owner's loop classification cannot move the terminal's local
+    # source-bound scheduler to the owner (which explicitly refuses /loop).
     assert [name for name, _, _ in routed] == [
-        capability.command for capability in session.frontend_state.slash_capabilities
+        capability.command
+        for capability in session.frontend_state.slash_capabilities
+        if capability.command != "loop"
     ]
     assert [(name, count) for name, _, count in routed if name in {"agent", "team"}] == [
         ("agent", 1),
@@ -5876,9 +5880,9 @@ async def test_loop_goal_stop_cancels() -> None:
 
 @pytest.mark.asyncio
 async def test_loop_goal_reload_safety() -> None:
-    # Swapping app._session mid-loop must stop the worker cleanly and reset all
-    # three fields (esp. the suppress flag, which would otherwise mute the NEXT
-    # session's completion toasts).
+    # Reload explicitly retires the source; an ordinary sidebar selection must
+    # NOT cancel its loop. All source fields still reset and a late TurnEnded
+    # must not notify the newly selected conversation.
     session = GoalSession()
     session.prompt_gate = asyncio.Event()
     app = OperatorApp(lambda: _factory(session))
@@ -5891,12 +5895,16 @@ async def test_loop_goal_reload_safety() -> None:
         session.judge_verdicts = ["VERDICT: CONTINUE\nnot yet"] * 50
         await _type_command(pilot, app, "loop do the thing")
         assert app._loop_running is True
-        # Simulate a reload: the session the worker captured is no longer live.
+        # Mirror _reload_session's explicit retirement, not a sidebar switch.
+        source = app._interaction
+        source.retired = True
         app._session = GoalSession()
         session.prompt_gate.set()
         await _settle_loop(pilot, app)
         for _ in range(6):
             await pilot.pause()
+        # This reduced host still displays the retired source until adoption;
+        # its receipt must say stopped, never that the goal was achieved.
         text = _transcript_text(app)
     assert "stopped by reload" in text
     assert app._loop_running is False

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -2039,6 +2039,54 @@ async def test_follower_model_picker_lists_the_owners_models() -> None:
 
 
 @pytest.mark.asyncio
+async def test_model_picker_first_frame_is_initial_catalogue_not_live() -> None:
+    """P1-c: opening /model paints initial_catalogue; live_catalogue is a worker.
+
+    Boot must not call live_catalogue. The first painted rows are the disk
+    catalogue; the network refresh is the worker `_refresh_catalogue`.
+    """
+    from local_operator.providers.controller import CatalogueEntry
+
+    calls: list[str] = []
+
+    class RecordingController(FakeProviderController):
+        def initial_catalogue(self, *, cache_dir: Any = None) -> list[Any]:
+            calls.append("initial")
+            return [
+                CatalogueEntry(
+                    provider="anthropic",
+                    model_id="claude-sonnet-4-6",
+                    label="Claude Sonnet 4.6",
+                    context_window=1_000_000,
+                    input_price=3.0,
+                    output_price=15.0,
+                    connected=True,
+                    aggregated=False,
+                )
+            ]
+
+        async def live_catalogue(
+            self, *, ttl_s: float | None = None
+        ) -> tuple[list[Any], dict[str, str]]:
+            calls.append("live")
+            return [], {}
+
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session), provider_controller=RecordingController())
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(40):
+            await pilot.pause()
+            if app._session is session:
+                break
+        assert "live" not in calls, "boot/mount must not call live_catalogue"
+        app._populate_model_picker()
+        assert calls[0] == "initial", calls
+        assert calls.count("initial") == 1
+        # live_catalogue is the worker, not the first frame.
+        assert "live" not in calls[:1]
+
+
+@pytest.mark.asyncio
 async def test_resume_owned_session_adopts_remote_in_standard_app(monkeypatch, tmp_path) -> None:
     """A live owner becomes a RemoteSession in the existing OperatorApp.
 

--- a/tests/unit/tui/test_aside.py
+++ b/tests/unit/tui/test_aside.py
@@ -195,7 +195,7 @@ async def test_closing_the_aside_returns_the_composer_to_bang_mode() -> None:
         for key in "echo hi":
             await pilot.press("space" if key == " " else key)
         assert editor.shell_mode is True
-        await pilot.press("ctrl+b")
+        await pilot.press("f8")
         await pilot.pause()
         assert editor.shell_mode is False
         await pilot.press("escape")  # the user's door out of the card
@@ -354,7 +354,7 @@ async def test_the_card_shares_the_composer_s_column(size) -> None:  # noqa: ANN
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=size) as pilot:
         await pilot.pause()
-        await pilot.press("ctrl+b")
+        await pilot.press("f8")
         await pilot.pause()
         await pilot.pause()
 
@@ -381,7 +381,7 @@ async def test_width_parity_survives_a_live_resize() -> None:
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
-        await pilot.press("ctrl+b")
+        await pilot.press("f8")
         await pilot.pause()
         await pilot.resize_terminal(60, 24)
 
@@ -530,7 +530,7 @@ async def test_the_aside_yields_to_anything_that_acts_on_the_conversation(
 # -- leaving ---------------------------------------------------------------
 @pytest.mark.asyncio
 async def test_escape_restores_the_main_chat_and_its_half_typed_prompt() -> None:
-    """Ctrl+B mid-draft, ask, Esc: the draft is back and the chat is intact.
+    """F8 mid-draft, ask, Esc: the draft is back and the chat is intact.
 
     The draft is what makes the aside a place you STEP INTO. Losing it would
     make the feature cost a retype every time, which is exactly the tax that
@@ -544,7 +544,7 @@ async def test_escape_restores_the_main_chat_and_its_half_typed_prompt() -> None
         editor.focus()
         await pilot.pause()
         editor.load_text("port the compaction gate to")
-        await pilot.press("ctrl+b")
+        await pilot.press("f8")
         await pilot.pause()
 
         assert app.query_one(AsidePanel).is_open
@@ -601,7 +601,7 @@ async def test_reopening_the_aside_opens_an_empty_one() -> None:
         await pilot.press("escape")
         await pilot.pause()
 
-        await pilot.press("ctrl+b")
+        await pilot.press("f8")
         await pilot.pause()
 
         assert app.query_one(AsidePanel).is_open

--- a/tests/unit/tui/test_command_picker.py
+++ b/tests/unit/tui/test_command_picker.py
@@ -840,7 +840,7 @@ async def test_click_on_the_overflow_row_does_nothing() -> None:
         # `settings` and its `config` alias join these two prefixes; both are
         # ranked ahead of their neighbours because a prefix match on a longer
         # word still beats one that starts later in the name.
-        ("s", ["settings", "search", "session", "stop", "skills"]),
+        ("s", ["settings", "sidebar", "search", "session", "stop", "skills"]),
         # Every one of these is a flat 900 prefix match (verified, not assumed:
         # `score_command_text_match("/c", …)` returns 900 for all six), so
         # `match_commands` sorts them on `(-score, registry_index)` and the

--- a/tests/unit/tui/test_image_block.py
+++ b/tests/unit/tui/test_image_block.py
@@ -177,6 +177,26 @@ def test_text_mode_is_a_receipt_with_dimensions(monkeypatch) -> None:
     assert "image attached (160x100)" in _plain(block)
 
 
+def test_parked_kitty_image_keeps_grid_without_protocol_writes(monkeypatch) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_IMAGES", "kitty")
+    written: list[str] = []
+    set_escape_writer(written.append)
+    block = ImageBlock(_png(1600, 1000), navigation_visible=False)
+    grid = block._grid()
+    assert not written and PLACEHOLDER not in _plain(block)
+    assert grid[0] > 0 and grid[1] > 0
+    block.set_navigation_visible(True)
+    block._repaint()
+    assert sum("a=t,i=" in seq for seq in written) == 1
+    assert sum("a=p,i=" in seq for seq in written) == 1
+    assert PLACEHOLDER in _plain(block)
+    writes = len(written)
+    block.set_navigation_visible(False)
+    block._repaint()
+    assert len(written) == writes and block._grid() == grid
+    assert PLACEHOLDER not in _plain(block)
+
+
 def test_kitty_mode_transmits_once_and_replaces_on_resize(monkeypatch) -> None:
     monkeypatch.setenv("LOCAL_OPERATOR_IMAGES", "kitty")
     written: list[str] = []

--- a/tests/unit/tui/test_session_drafts.py
+++ b/tests/unit/tui/test_session_drafts.py
@@ -1,0 +1,75 @@
+"""Draft cache limits are never permissions to discard unsubmitted input."""
+
+from __future__ import annotations
+
+import stat
+
+import pytest
+from textual.widgets.text_area import Selection
+
+from local_operator.harness.types import ImageContent
+from local_operator.tui import session_drafts
+from local_operator.tui.session_drafts import SessionDraftStore
+from local_operator.tui.session_interaction import SessionDraft
+from local_operator.tui.widgets.editor import Attachment, PastedText
+
+
+@pytest.mark.asyncio
+async def test_unused_store_does_no_io_and_spill_preserves_exact_draft(monkeypatch):
+    monkeypatch.setattr(session_drafts, "DRAFT_RESIDENT_BYTES", 32)
+    store = SessionDraftStore()
+    assert store._directory is None
+    assert await store.get("missing") == SessionDraft()
+    assert store._directory is None
+    draft = SessionDraft(
+        text="編輯草稿 [Paste #3] [Image #4]",
+        attachments={
+            3: PastedText("long pasted text " * 20, "[Paste #3]"),
+            4: Attachment(ImageContent(data="YWJj", mime_type="image/png"), "[Image #4]"),
+        },
+        selection=Selection((0, 1), (0, 3)),
+        shell_mode=True,
+        focus_id="@editor",
+    )
+    await store.put("../../outside", draft)
+    assert store.resident_count == 0
+    assert store.resident_bytes == 0
+    assert await store.get("../../outside") == draft
+    path = store._path("../../outside")
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(path.parent.stat().st_mode) == 0o700
+    assert len(path.stem) == 64
+    directory = path.parent
+    await store.close()
+    assert not directory.exists()
+
+
+@pytest.mark.asyncio
+async def test_count_limit_spills_oldest_without_losing_any_draft(monkeypatch):
+    monkeypatch.setattr(session_drafts, "DRAFT_RESIDENT_COUNT", 2)
+    store = SessionDraftStore()
+    try:
+        for index in range(10):
+            await store.put(str(index), SessionDraft(text=f"draft {index}"))
+        assert store.resident_count == 2
+        for index in range(10):
+            assert (await store.get(str(index))).text == f"draft {index}"
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_failed_spill_keeps_input_in_memory(monkeypatch):
+    monkeypatch.setattr(session_drafts, "DRAFT_RESIDENT_BYTES", 1)
+    store = SessionDraftStore()
+
+    def full_disk(*args):
+        raise OSError("no space")
+
+    monkeypatch.setattr(store, "_write", full_disk)
+    try:
+        with pytest.raises(OSError, match="no space"):
+            await store.put("source", SessionDraft(text="never discard this input"))
+        assert (await store.get("source")).text == "never discard this input"
+    finally:
+        await store.close()

--- a/tests/unit/tui/test_session_interaction.py
+++ b/tests/unit/tui/test_session_interaction.py
@@ -1,0 +1,166 @@
+"""The terminal may leave a source without stealing or cancelling its work."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from unittest.mock import patch
+
+import pytest
+
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.events import CompactionEnded, TurnAbandoned
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+@pytest.fixture(autouse=True)
+def isolate_sources(tmp_path, monkeypatch):
+    for key in tuple(os.environ):
+        if key.startswith("CMUX_"):
+            monkeypatch.delenv(key)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_NOTIFICATIONS", "1")
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_TERMINAL_TITLE", "1")
+    monkeypatch.setattr(OperatorApp, "_check_for_update", lambda self: None)
+
+
+class HeldSession(FakeSession):
+    @property
+    def goal(self) -> str:
+        return "finish the source work"
+
+    def __init__(self, *, fail=False):
+        super().__init__()
+        self.entered = asyncio.Event()
+        self.release = asyncio.Event()
+        self.fail = fail
+        self.recorded_shell = []
+
+    async def prompt(self, text, images=None):
+        self.prompts.append(text)
+        self.entered.set()
+        await self.release.wait()
+        if self.fail:
+            raise ConnectionError("owner socket unreachable")
+
+    async def record_shell(self, command, result):
+        self.recorded_shell.append((command, result))
+
+
+@pytest.mark.asyncio
+async def test_loop_continues_source_and_other_context_stop_does_not_cancel_it():
+    first = HeldSession()
+    second = FakeSession()
+    app = OperatorApp(lambda: _factory(first))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        source = app._interaction
+        task = asyncio.create_task(app._loop_worker(3, source))
+        await asyncio.wait_for(first.entered.wait(), 10)
+        app._adopt_session(second, replay_history=False)
+        app._cmd_loop("stop", lambda body, kind="info": None)
+        assert not source.loop.cancelled
+        first.release.set()
+        await asyncio.wait_for(task, 10)
+        assert len(first.prompts) == 3
+        assert not second.prompts
+        assert not source.loop.running
+        assert source.active_workers == 0
+
+
+@pytest.mark.asyncio
+async def test_failed_source_prompt_restores_only_its_own_input():
+    first = HeldSession(fail=True)
+    second = FakeSession()
+    app = OperatorApp(lambda: _factory(first))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        source = app._interaction
+        app._start_turn("source A message")
+        await asyncio.wait_for(first.entered.wait(), 10)
+        app._adopt_session(second, replay_history=False)
+        app._editor().load_text("source B draft")
+        first.release.set()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert source.unsent == [("source A message", [])]
+        assert app._editor().text == "source B draft"
+        assert not second.prompts
+        assert source.active_workers == 0
+
+
+@pytest.mark.asyncio
+async def test_hidden_compaction_delivers_held_input_exactly_once_to_source():
+    first = HeldSession()
+    first.release.set()
+    second = FakeSession()
+    app = OperatorApp(lambda: _factory(first))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        source = app._interaction
+        source.compaction.active = True
+        source.compaction.held_prompt = "accepted by A"
+        source.compaction.held_typed = "accepted by A"
+        app._adopt_session(second, replay_history=False)
+        for _ in range(2):
+            event = CompactionEnded("manual", True)
+            event.origin = source.controller
+            app.post_message(event)
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        assert first.prompts == ["accepted by A"]
+        assert second.prompts == []
+        assert not source.compaction.held_prompt
+        assert not source.compaction.active
+
+
+@pytest.mark.asyncio
+async def test_late_source_fallback_cannot_retire_current_turn():
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        source = app._interaction
+        source.turn.open = True
+        app._adopt_session(FakeSession(), replay_history=False)
+        app._turn_open = True
+        event = TurnAbandoned(source.turn.epoch, aborted=False, error="source failed")
+        event.origin = source.controller
+        app.post_message(event)
+        await pilot.pause()
+        assert app._turn_open
+        assert not source.turn.open
+
+
+@pytest.mark.asyncio
+async def test_source_usage_never_charges_visible_conversation():
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        source = app._interaction
+        app._adopt_session(FakeSession(), replay_history=False)
+        with patch("local_operator.tui.app.turn_cost", return_value=1.25):
+            app._charge_aside_for(source, object())
+        assert source.accounting.total == 1.25
+        assert app._total_cost == 0.0
+
+
+@pytest.mark.asyncio
+async def test_bang_settles_and_records_on_hidden_source():
+    first = HeldSession()
+    second = FakeSession()
+    app = OperatorApp(lambda: _factory(first))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        source = app._interaction
+        app._run_shell_command("sleep 0.1; printf source-A")
+        worker = source.shell.worker
+        app._adopt_session(second, replay_history=False)
+        app._shell_card = None
+        await asyncio.wait_for(worker.wait(), 20)
+        assert len(first.recorded_shell) == 1
+        assert "source-A" in first.recorded_shell[0][1].text
+        assert not second.prompts
+        assert source.shell.worker is None
+        assert source.active_workers == 0
+        assert app._shell_card is None

--- a/tests/unit/tui/test_session_interaction.py
+++ b/tests/unit/tui/test_session_interaction.py
@@ -84,7 +84,8 @@ async def test_failed_source_prompt_restores_only_its_own_input():
         first.release.set()
         await app.workers.wait_for_complete()
         await pilot.pause()
-        assert source.unsent == [("source A message", [])]
+        assert source.draft.text == "source A message"
+        assert source.unsent == []
         assert app._editor().text == "source B draft"
         assert not second.prompts
         assert source.active_workers == 0

--- a/tests/unit/tui/test_session_interaction.py
+++ b/tests/unit/tui/test_session_interaction.py
@@ -10,6 +10,7 @@ import pytest
 
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.events import CompactionEnded, TurnAbandoned
+from tests.e2e.harness import wait_for_adoption
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
 
 
@@ -54,6 +55,7 @@ async def test_loop_continues_source_and_other_context_stop_does_not_cancel_it()
     second = FakeSession()
     app = OperatorApp(lambda: _factory(first))
     async with app.run_test(size=(100, 30)) as pilot:
+        await wait_for_adoption(app, pilot)
         await pilot.pause()
         source = app._interaction
         task = asyncio.create_task(app._loop_worker(3, source))
@@ -75,6 +77,7 @@ async def test_failed_source_prompt_restores_only_its_own_input():
     second = FakeSession()
     app = OperatorApp(lambda: _factory(first))
     async with app.run_test(size=(100, 30)) as pilot:
+        await wait_for_adoption(app, pilot)
         await pilot.pause()
         source = app._interaction
         app._start_turn("source A message")
@@ -98,6 +101,7 @@ async def test_hidden_compaction_delivers_held_input_exactly_once_to_source():
     second = FakeSession()
     app = OperatorApp(lambda: _factory(first))
     async with app.run_test(size=(100, 30)) as pilot:
+        await wait_for_adoption(app, pilot)
         await pilot.pause()
         source = app._interaction
         source.compaction.active = True
@@ -120,6 +124,7 @@ async def test_hidden_compaction_delivers_held_input_exactly_once_to_source():
 async def test_late_source_fallback_cannot_retire_current_turn():
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 30)) as pilot:
+        await wait_for_adoption(app, pilot)
         await pilot.pause()
         source = app._interaction
         source.turn.open = True
@@ -137,6 +142,7 @@ async def test_late_source_fallback_cannot_retire_current_turn():
 async def test_source_usage_never_charges_visible_conversation():
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 30)) as pilot:
+        await wait_for_adoption(app, pilot)
         await pilot.pause()
         source = app._interaction
         app._adopt_session(FakeSession(), replay_history=False)
@@ -152,6 +158,7 @@ async def test_bang_settles_and_records_on_hidden_source():
     second = FakeSession()
     app = OperatorApp(lambda: _factory(first))
     async with app.run_test(size=(100, 30)) as pilot:
+        await wait_for_adoption(app, pilot)
         await pilot.pause()
         source = app._interaction
         app._run_shell_command("sleep 0.1; printf source-A")

--- a/tests/unit/tui/test_session_navigation.py
+++ b/tests/unit/tui/test_session_navigation.py
@@ -1,0 +1,92 @@
+"""Navigation generations protect identity and bound speculative resources."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from local_operator.tui.session_navigation import SessionNavigation
+
+
+@pytest.mark.asyncio
+async def test_rapid_selection_prepares_only_latest_after_retired_work_settles():
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    prepared = []
+    committed = []
+    released = []
+    pending = []
+    active = 0
+    peak = 0
+
+    async def prepare(session_id):
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        prepared.append(session_id)
+        try:
+            if session_id == "first":
+                first_started.set()
+                try:
+                    await release_first.wait()
+                except asyncio.CancelledError:
+                    # A filesystem read may finish despite cancellation. The
+                    # generation still forbids it from becoming the input target.
+                    await release_first.wait()
+            return session_id
+        finally:
+            active -= 1
+
+    async def release(value):
+        released.append(value)
+
+    navigation = SessionNavigation(
+        prepare=prepare,
+        commit=lambda session_id, value, generation: committed.append(value),
+        release=release,
+        pending=pending.append,
+        failed=lambda session_id, error: pytest.fail(str(error)),
+    )
+    first = navigation.select("first")
+    await asyncio.wait_for(first_started.wait(), 5)
+    skipped = navigation.select("skipped")
+    final = navigation.select("final")
+    release_first.set()
+    await asyncio.wait_for(final, 5)
+    await asyncio.gather(first, skipped, return_exceptions=True)
+    assert prepared == ["first", "final"]
+    assert committed == ["final"]
+    assert released == ["first"]
+    assert peak == 1
+    assert pending == ["first", "skipped", "final", ""]
+    assert navigation.committed_id == "final"
+    await navigation.close()
+    assert not navigation._tasks
+
+
+@pytest.mark.asyncio
+async def test_failure_preserves_committed_identity_and_releases_input_boundary():
+    errors = []
+    pending = []
+
+    async def prepare(session_id):
+        raise ConnectionError("owner unavailable")
+
+    async def release(value):
+        pytest.fail("no resource was prepared")
+
+    navigation = SessionNavigation(
+        prepare=prepare,
+        commit=lambda *_: pytest.fail("failed preparation committed"),
+        release=release,
+        pending=pending.append,
+        failed=lambda session_id, error: errors.append((session_id, str(error))),
+    )
+    navigation.committed_id = "original"
+    await navigation.select("unavailable")
+    assert navigation.committed_id == "original"
+    assert not navigation.requested_id
+    assert pending == ["unavailable", ""]
+    assert errors == [("unavailable", "owner unavailable")]
+    await navigation.close()

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -254,7 +254,16 @@ async def test_switch_session_attaches_from_the_composer_and_wraps(position):
         editor.focus()
         await pilot.pause()
         order = [entry.id for entry in sidebar.entries]
-        with patch.object(app._sidebar_navigation, "select", side_effect=attached.append):
+
+        def settle(session_id: str) -> None:
+            # Stands in for a whole navigation: the real ``select`` prepares,
+            # commits, and then clears the in-flight intent. Each case below
+            # then starts from a settled app, which is what moving
+            # ``session_id`` by hand is pretending happened.
+            attached.append(session_id)
+            app._sidebar_navigation.intent_id = ""
+
+        with patch.object(app._sidebar_navigation, "select", side_effect=settle):
             for start, key, expected in (
                 (order[1], "ctrl+shift+down", order[2]),
                 (order[1], "ctrl+shift+up", order[0]),
@@ -311,13 +320,51 @@ async def test_closed_list_switch_reads_a_fresh_ranking():
 
 
 @pytest.mark.asyncio
-async def test_switch_burst_steps_from_the_requested_target():
-    """Three presses before the first commit are three hops, not one.
+async def test_switch_burst_in_one_event_batch_steps_once_per_press():
+    """A HELD key is many Key events in one batch, and each must hop.
 
-    The origin used to be ``_session`` — still the old session until commit
-    — so every press in a burst recomputed the same target (round 4, U6 /
-    MINOR-1). While a switch is in flight the requested id is the origin.
+    The shape matters and the earlier regression test had the wrong one.
+    ``pilot.press(k, k)`` drains the event loop between keys, so the posted
+    ``Selected`` message dispatches and ``select`` sets ``requested_id``
+    before the next press reads it — that shape passed while the user's did
+    not (round 5, U7). Auto-repeat delivers the events back-to-back with NO
+    drain, so the origin has to be published synchronously by the action
+    itself. These events are posted straight at the driver, without the
+    ``wait_for_idle`` ``press`` inserts, to reproduce that exactly.
     """
+    from textual import events
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.press("ctrl+b")
+        await pilot.pause()
+        assert app._sidebar_timer is not None
+        app._sidebar_timer.pause()
+        app._session_sidebar.set_entries(_hover_entries(("a", "sess", "c", "d")))
+        hops: list[str] = []
+
+        def select(session_id: str) -> None:
+            hops.append(session_id)
+            app._sidebar_navigation.requested_id = session_id
+
+        driver = app._driver
+        assert driver is not None
+        with patch.object(app._sidebar_navigation, "select", side_effect=select):
+            for _ in range(3):
+                event = events.Key("ctrl+shift+down", None)
+                event.set_sender(app)
+                driver.send_message(event)
+            await pilot.pause()
+            await pilot.pause()
+        app._sidebar_navigation.requested_id = ""
+        app._sidebar_navigation.intent_id = ""
+        assert hops == ["c", "d", "a"], hops
+
+
+@pytest.mark.asyncio
+async def test_switch_burst_with_a_drain_between_presses_still_steps_once_each():
+    """The separated shape keeps working — intent is set on both paths."""
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
@@ -337,6 +384,7 @@ async def test_switch_burst_steps_from_the_requested_target():
                 await pilot.press("ctrl+shift+down")
             await pilot.pause()
         app._sidebar_navigation.requested_id = ""
+        app._sidebar_navigation.intent_id = ""
         assert hops == ["c", "d", "a"], hops
 
 
@@ -484,3 +532,44 @@ async def test_speculative_prepare_does_not_ensure_bound_on_a_cold_owner():
         with pytest.raises(RuntimeError, match="no longer ready"):
             await app._prepare_sidebar_session("other", speculative=True)
         bound.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_requested_row_is_distinguishable_from_the_keyboard_cursor():
+    """The frame must say WHICH row is opening when the two are not the same.
+
+    Requested and cursor shared both signals — `tint-select` and `›` — so
+    rendering the mirror case (cursor on one row, requested on another) and
+    its swap produced identical frames: the display could not answer "which
+    one is opening" (round 5, D6). Reachable from real bindings: focus the
+    list, then ctrl+shift+down, or press down before the switch commits.
+    """
+    from textual.geometry import Region
+
+    async def grid(cursor: str, requested: str) -> list[str]:
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            await pilot.press("ctrl+b")
+            await pilot.pause()
+            assert app._sidebar_timer is not None
+            app._sidebar_timer.pause()
+            sidebar = app._session_sidebar
+            sidebar.set_entries(_hover_entries(("alpha", "sess", "gamma")))
+            sidebar.focus()
+            await pilot.pause()
+            sidebar.cursor_id = cursor
+            sidebar.requested_id = requested
+            sidebar.refresh()
+            await pilot.pause()
+            lines = sidebar.render_lines(Region(0, 0, sidebar.size.width, sidebar.size.height))
+            return ["".join(segment.text for segment in line) for line in lines]
+
+    straight = await grid("alpha", "gamma")
+    mirrored = await grid("gamma", "alpha")
+    assert straight != mirrored, "requested and cursor render identically"
+    # And the distinction is the caret, in the same two columns as before, so
+    # nothing reflows: the title still starts where it always did.
+    assert straight[1].startswith(" ›   Session alpha"), repr(straight[1])
+    assert straight[3].startswith(" »   Session gamma"), repr(straight[3])
+    assert mirrored[1].startswith(" »   Session alpha"), repr(mirrored[1])

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -573,3 +573,82 @@ async def test_requested_row_is_distinguishable_from_the_keyboard_cursor():
     assert straight[1].startswith(" ›   Session alpha"), repr(straight[1])
     assert straight[3].startswith(" »   Session gamma"), repr(straight[3])
     assert mirrored[1].startswith(" »   Session alpha"), repr(mirrored[1])
+
+
+@pytest.mark.asyncio
+async def test_closing_the_sidebar_drains_leased_sources_but_keeps_local_work():
+    """Open/close cycles must not accumulate live viewers (the freeze).
+
+    `_sidebar_presentations` is LRU-bounded and drained on close, but
+    `_sidebar_sources` was neither: the close path walked the presentations it
+    had just emptied, so a prewarmed viewer that never became visible was
+    never visited by any path. Measured at 25 cycles: 50 leaked sources, 0
+    dispose calls. Each one keeps a socket and a frontend subscription alive,
+    and every owner delta then costs a deep state copy per leak (~1.2ms), so
+    the cost grows with time-open until the UI stops responding.
+
+    Both directions are asserted. Draining owner-turn retention is safe — the
+    viewer is a read-only projection and cannot stop the owner's turn — but
+    draining LOCAL retention would kill a live worker or lose an unsent gate
+    answer, so a source with local work must survive the close. That second
+    assertion is the guard against over-fixing.
+    """
+    from unittest.mock import MagicMock
+
+    from local_operator.session.remote import RemoteSession
+    from local_operator.tui.session_interaction import SessionInteraction
+
+    disposed: list[str] = []
+    unsubscribed: list[str] = []
+
+    def lease(app, session_id: str, *, kind: str) -> SessionInteraction:
+        remote = MagicMock(spec=RemoteSession)
+        remote.session_id = session_id
+        remote.is_cold = False
+        remote.has_pending_gate_reply = False
+        remote.is_streaming = kind == "owner-busy"
+
+        async def _dispose() -> None:
+            disposed.append(session_id)
+
+        remote.dispose = MagicMock(side_effect=_dispose)
+        source = SessionInteraction(remote)
+        # approve_all + owner streaming is the `auto_work` clause: what a
+        # prewarmed viewer of a busy background agent looks like.
+        source.draft.approve_all = True
+        if kind == "local-work":
+            # A turn WE submitted over that socket and are still awaiting.
+            source.active_workers = 1
+        source.unsubscribe_frontend = lambda: unsubscribed.append(session_id)
+        source.controller = MagicMock()
+        app._sidebar_sources[session_id] = source
+        app._interactions[id(remote)] = source
+        app._event_sources[source.controller] = source
+        return source
+
+    cycles = 8
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        current = str(getattr(app._session, "session_id", ""))
+        keep = lease(app, "local-work", kind="local-work")
+
+        for cycle in range(cycles):
+            app.action_toggle_sidebar()
+            await pilot.pause()
+            lease(app, f"ownerbusy{cycle}", kind="owner-busy")
+            lease(app, f"idle{cycle}", kind="idle")
+            await pilot.pause()
+            app.action_toggle_sidebar()
+            await pilot.pause()
+            await pilot.pause()
+
+        leftover = set(app._sidebar_sources) - {current}
+        assert leftover == {"local-work"}, f"leaked {sorted(leftover - {'local-work'})}"
+        # Every leased viewer released its socket AND its subscription; the
+        # count does not climb with cycles.
+        assert len(disposed) == cycles * 2, disposed
+        assert len(unsubscribed) == cycles * 2, unsubscribed
+        # The over-fix guard: local in-flight work was never touched.
+        assert "local-work" not in disposed
+        assert not keep.retired

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -450,3 +450,37 @@ async def test_sidebar_escape_restores_settings_and_current_narrow_selection_clo
         await pilot.pause()
         await pilot.click("#session-sidebar", offset=(4, 1))
         assert not app._session_sidebar.display
+
+
+@pytest.mark.asyncio
+async def test_speculative_prepare_does_not_ensure_bound_on_a_cold_owner():
+    """P1-d: prewarm must not engage a runtime. A cold speculative prepare
+    raises instead of calling ``_ensure_bound`` — that is how speculation
+    stays look-only.
+    """
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    from local_operator.session.remote import RemoteSession
+    from local_operator.tui.session_interaction import SessionInteraction
+
+    bound = AsyncMock()
+    remote = MagicMock(spec=RemoteSession)
+    remote.session_id = "other"
+    remote.is_cold = True
+    remote._ensure_bound = bound
+    remote.frontend_state = SimpleNamespace(pending_gate=None)
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        source = SessionInteraction(remote)
+        app._sidebar_sources["other"] = source
+
+        async def lease(session_id, *, speculative=False):
+            source.preparations += 1
+            return source
+
+        app._lease_sidebar_source = lease  # type: ignore[method-assign]
+        with pytest.raises(RuntimeError, match="no longer ready"):
+            await app._prepare_sidebar_session("other", speculative=True)
+        bound.assert_not_awaited()

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -115,8 +115,65 @@ async def test_list_window_current_cursor_and_footer_are_independent():
         assert len(sidebar.visible_entries) <= sidebar.page_size
         lines = sidebar.render().plain.splitlines()
         assert len(lines) <= sidebar.size.height
-        assert lines[-1] == "ctrl+b hide"
+        assert lines[-1] == f"1–{sidebar.page_size}/101 · ctrl+b hide"
         assert all(cell_len(line) <= sidebar.size.width for line in lines)
         sidebar.show_error("read failed")
         assert sidebar.entries
         assert sidebar.render().plain.splitlines()[-1] == "Refresh failed"
+
+
+@pytest.mark.asyncio
+async def test_focus_shortcut_preserves_draft_and_returns_to_editor():
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        editor = app._editor()
+        editor.load_text("draft")
+        await pilot.press("f9")
+        assert app._session_sidebar.display
+        assert app._session_sidebar.has_focus
+        assert editor.text == "draft"
+        await pilot.press("f9", "x")
+        assert app.focused is editor
+        assert "x" in editor.text
+        assert app._session_sidebar.display
+
+
+@pytest.mark.asyncio
+async def test_loading_keeps_sidebar_chrome_without_textual_loading_overlay():
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        sidebar = app._session_sidebar
+        sidebar.set_open(True)
+        sidebar.entries = ()
+        sidebar._catalog_loading = True
+        await pilot.pause()
+        assert sidebar.loading is False
+        text = sidebar.render().plain
+        assert "Sessions" in text
+        assert "Loading conversations" in text
+        assert "f9 focus" in text
+
+
+@pytest.mark.asyncio
+async def test_sidebar_escape_restores_settings_and_current_narrow_selection_closes(monkeypatch):
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    monkeypatch.setattr(app, "_refresh_sidebar", lambda: None)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.action_toggle_sidebar()
+        app._cmd_settings(app._notice)
+        await pilot.pause()
+        settings_focus = app.focused
+        assert settings_focus is not None and settings_focus is not app._editor()
+        await pilot.click("#session-sidebar", offset=(2, 0))
+        await pilot.press("escape")
+        assert app.focused is settings_focus
+        app._close_settings_view()
+        await pilot.resize_terminal(80, 24)
+        app.action_toggle_sidebar()
+        app._session_sidebar.set_entries([CatalogEntry(SessionRow("sess", 1, "Current"))])
+        await pilot.pause()
+        await pilot.click("#session-sidebar", offset=(4, 1))
+        assert not app._session_sidebar.display

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -134,6 +134,25 @@ async def test_gutter_faces_the_conversation_at_either_position(size, position):
             assert app.query_one("#session-conversation").size.width >= SIDEBAR_MAIN_MIN_WIDTH
 
 
+async def _focus_settled(pilot, sidebar) -> None:
+    """Focus the list and WAIT until it has actually landed.
+
+    ``Widget.focus()`` defers the real work through ``App.call_later``, so a
+    single ``pilot.pause()`` after it is a coin toss. That matters here
+    because ``render`` gates the cursor mark and its ``tint-select`` ground on
+    ``has_focus``: a frame captured before focus arrives is missing a ``›``
+    and a background colour that the next frame has. Any test comparing two
+    painted frames from two app instances will then fail intermittently, and
+    it CLUSTERS, so a handful of consecutive passes proves nothing.
+    """
+    sidebar.focus()
+    for _ in range(20):
+        await pilot.pause()
+        if sidebar.has_focus:
+            return
+    raise AssertionError("sidebar never took focus")
+
+
 def _hover_entries(ids: tuple[str, ...] = ("alpha", "sess", "gamma")) -> list[CatalogEntry]:
     now = time.time()
     return [
@@ -567,8 +586,7 @@ async def test_requested_row_is_distinguishable_from_the_keyboard_cursor():
             app._sidebar_timer.pause()
             sidebar = app._session_sidebar
             sidebar.set_entries(_hover_entries(("alpha", "sess", "gamma")))
-            sidebar.focus()
-            await pilot.pause()
+            await _focus_settled(pilot, sidebar)
             sidebar.cursor_id = cursor
             sidebar.requested_id = requested
             sidebar.refresh()
@@ -766,7 +784,21 @@ async def test_disabling_auto_links_leaves_the_painted_frame_identical():
             sidebar = app._session_sidebar
             sidebar.auto_links = auto_links
             sidebar.set_entries(_mixed_entries())
-            sidebar.focus()
+            # Deliberately NOT focused. `render` gates the cursor mark and its
+            # tinted ground on `has_focus`, and `focus()` lands through
+            # `call_later`, so a focused frame here is a race that fails ~half
+            # the time on the identical diff (`'  '` vs `'› '`, `#14110c` vs
+            # `#16221a`). Focus has nothing to do with whether the list
+            # renders a LINK, which is the only question this guard asks, so
+            # the stable frame is the honest instrument rather than a weaker
+            # one. The frame IS captured under hover, which is the state a
+            # link would be highlighted in at all — that is what keeps this
+            # able to fail if a link is ever rendered here.
+            await pilot.pause()
+            first_row = next(
+                y for y in range(1, sidebar.size.height) if sidebar._entry_at(y) is not None
+            )
+            sidebar._set_hover(first_row)
             await pilot.pause()
             painted: list[tuple[str, str]] = []
             for line in sidebar.render_lines(Region(0, 0, sidebar.size.width, sidebar.size.height)):
@@ -843,8 +875,7 @@ async def test_navigation_crosses_a_section_header_without_stalling():
         app._sidebar_timer.pause()
         sidebar = app._session_sidebar
         sidebar.set_entries(_mixed_entries())
-        sidebar.focus()
-        await pilot.pause()
+        await _focus_settled(pilot, sidebar)
         # The frame really does carry both headers.
         # Two headings, each owning the blank beneath it, plus the blank that
         # separates the second heading from the group above.

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -1,0 +1,122 @@
+"""Sidebar identity, urgency, geometry and existing composer interactions."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import replace
+from unittest.mock import patch
+
+import pytest
+from rich.cells import cell_len
+
+from local_operator.resume import SessionRow
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.session_catalog import (
+    CatalogEntry,
+    SidebarSettings,
+    rank_entries,
+)
+from local_operator.tui.widgets.editor import Editor
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+@pytest.fixture(autouse=True)
+def isolated_sidebar(tmp_path, monkeypatch):
+    # Headless apps must never rename the caller's real multiplexer workspace.
+    for key in tuple(os.environ):
+        if key.startswith("CMUX_"):
+            monkeypatch.delenv(key)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_NOTIFICATIONS", "1")
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_TERMINAL_TITLE", "1")
+    monkeypatch.setattr(OperatorApp, "_check_for_update", lambda self: None)
+
+
+def test_urgency_ranking_keeps_gates_independent_of_acknowledgement():
+    rows = [
+        CatalogEntry(SessionRow("recent", 100, "Recent")),
+        CatalogEntry(SessionRow("active", 50, "Working", live_state="busy")),
+        CatalogEntry(SessionRow("done", 10, "Completed"), unseen=True),
+        CatalogEntry(SessionRow("ask", 1, "Question", pending="ask"), unseen=True),
+    ]
+    assert [row.id for row in rank_entries(rows)] == ["ask", "done", "active", "recent"]
+    acknowledged = [replace(row, unseen=False) for row in rows]
+    assert [row.id for row in rank_entries(acknowledged)] == ["ask", "active", "recent", "done"]
+    assert [
+        row.id for row in rank_entries([CatalogEntry(SessionRow(id, 0, id)) for id in ("b", "a")])
+    ] == ["a", "b"]
+
+
+@pytest.mark.parametrize(
+    "values",
+    [{}, {"tui": None}, {"tui": {"sidebar_visible": "false", "sidebar_position": "bottom"}}],
+)
+def test_sidebar_settings_fail_to_safe_defaults(values):
+    assert SidebarSettings.from_values(values) == SidebarSettings()
+
+
+def test_sidebar_settings_use_nested_registry_paths():
+    assert SidebarSettings.from_values(
+        {"tui": {"sidebar_visible": True, "sidebar_position": "right"}}
+    ) == SidebarSettings(True, "right")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(80, 24), (100, 30), (150, 40)])
+@pytest.mark.parametrize("position", ["left", "right"])
+async def test_toggle_preserves_draft_and_full_width_when_hidden(size, position):
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=size) as pilot:
+        await pilot.pause()
+        editor = app.query_one(Editor)
+        editor.text = "Keep my unsubmitted draft"
+        before = editor.region.width
+        with patch.object(app, "_overlay_live_state", return_value=[]) as read:
+            # A hidden sidebar has no catalog I/O, including manual poll calls.
+            app._refresh_sidebar()
+            read.assert_not_called()
+            app._sidebar_settings = SidebarSettings(False, position)
+            await pilot.press("ctrl+b")
+            await pilot.pause()
+            assert app._session_sidebar.display
+            assert editor.text == "Keep my unsubmitted draft"
+            if size[0] == 80:
+                assert editor.region.width == before
+                assert app._session_sidebar.region.bottom <= app.query_one("#input-dock").region.y
+            else:
+                assert app.query_one("#session-conversation").size.width >= 60
+            await pilot.press("ctrl+b")
+            await pilot.pause()
+            assert not app._session_sidebar.display
+            assert editor.region.width == before
+            assert app.screen.virtual_size == app.screen.size
+            assert not app.screen.show_vertical_scrollbar
+
+
+@pytest.mark.asyncio
+async def test_list_window_current_cursor_and_footer_are_independent():
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        sidebar = app._session_sidebar
+        sidebar.current_id = "current"
+        entries = [CatalogEntry(SessionRow("current", 1, "Current conversation"))]
+        entries.extend(
+            CatalogEntry(SessionRow(str(i), i + 2, "語言 long name " * 8)) for i in range(100)
+        )
+        sidebar.set_open(True)
+        sidebar.set_entries(entries)
+        await pilot.pause()
+        sidebar.focus()
+        sidebar.action_edge(False)
+        assert sidebar.cursor_id != "current"
+        assert sidebar.current_id == "current"
+        assert len(sidebar.visible_entries) <= sidebar.page_size
+        lines = sidebar.render().plain.splitlines()
+        assert len(lines) <= sidebar.size.height
+        assert lines[-1] == "ctrl+b hide"
+        assert all(cell_len(line) <= sidebar.size.width for line in lines)
+        sidebar.show_error("read failed")
+        assert sidebar.entries
+        assert sidebar.render().plain.splitlines()[-1] == "Refresh failed"

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -670,11 +670,20 @@ async def test_closing_the_sidebar_drains_leased_sources_but_keeps_local_work():
 
 
 def _mixed_entries() -> list[CatalogEntry]:
-    """Two ACTIVE rows (rank tier <=2) and two PREVIOUS (tier 3)."""
+    """Two ACTIVE rows (rank tier <=2) and two PREVIOUS (tier 3).
+
+    Deliberately reaches Active WITHOUT ``live_state="busy"``: a busy row
+    animates, and a test that compares frames from two app instances then
+    compares two spinner PHASES. That made the `auto_links` frame-equality
+    guard flaky under ``-n0`` (fail/fail/pass, the diff a single glyph) while
+    passing under xdist — a broken instrument in front of the one test that
+    closes the `auto_links=False` risk. `pending` and `unseen` are tiers 0 and
+    1, so the section split is still exercised with a still frame.
+    """
     now = 1_700_000_000.0
     return [
-        CatalogEntry(SessionRow("act1", now - 60, "Live one", live_state="busy")),
-        CatalogEntry(SessionRow("act2", now - 120, "Live two", live_state="busy")),
+        CatalogEntry(SessionRow("act1", now - 60, "Needs you", pending="approval")),
+        CatalogEntry(SessionRow("act2", now - 120, "Has news"), True, "completed"),
         CatalogEntry(SessionRow("old1", now - 9000, "Old one")),
         CatalogEntry(SessionRow("old2", now - 99000, "Old two")),
     ]
@@ -787,15 +796,21 @@ async def test_the_spinner_does_not_tick_while_blurred_or_closed():
         async with app.run_test(size=(100, 30)) as pilot:
             await pilot.pause()
             sidebar = app._session_sidebar
-            # Closed: no ticks regardless of busy rows.
-            sidebar.set_entries(_mixed_entries())
+            # Closed: no ticks regardless of busy rows. A BUSY fixture is
+            # required here — `_mixed_entries` is deliberately still, because
+            # the frame-equality guard cannot compare two spinner phases.
+            busy = [
+                CatalogEntry(SessionRow("b1", 1_700_000_000.0, "Working", live_state="busy")),
+                CatalogEntry(SessionRow("o1", 1_699_000_000.0, "Old one")),
+            ]
+            sidebar.set_entries(busy)
             await pilot.pause()
             assert sidebar._timer is not None
             assert sidebar._timer._active.is_set() is False
 
             await pilot.press("ctrl+b")
             await pilot.pause()
-            sidebar.set_entries(_mixed_entries())
+            sidebar.set_entries(busy)
             await pilot.pause()
             # Open with a busy row: running, at the list's own slower cadence.
             assert sidebar._timer is not None
@@ -831,7 +846,9 @@ async def test_navigation_crosses_a_section_header_without_stalling():
         sidebar.focus()
         await pilot.pause()
         # The frame really does carry both headers.
-        assert sidebar._header_lines() == 3  # two headers plus one blank
+        # Two headings, each owning the blank beneath it, plus the blank that
+        # separates the second heading from the group above.
+        assert sidebar._header_lines() == 5
         sidebar.cursor_id = "act1"
 
         walked: list[str] = []
@@ -920,3 +937,60 @@ async def test_rows_are_independent_so_a_row_scoped_repaint_is_sound():
         differing = [i for i, (a, b) in enumerate(zip(before, after)) if a != b]
         # Hovering one row changes that row's line and nothing else.
         assert len(differing) <= 1, differing
+
+
+@pytest.mark.asyncio
+async def test_the_outer_title_yields_to_section_headers_but_survives_quiet_states():
+    """One title, not two — and never a frame that opens on bare body copy.
+
+    The panel title and the group headings painted identically (same `muted`,
+    same weight, same indent, adjacent lines), so the list opened by saying
+    "Sessions" twice with no rendered cue which was which — 2 of 13 usable
+    lines at 80x24. The headings now do the title's job when they are there.
+
+    But the quiet states have nothing to head: without the title, loading,
+    empty and error would open straight into body copy. Conditioning on "any
+    header row exists" gets that for free, since an empty list emits none.
+    """
+    from textual.geometry import Region
+
+    async def first_lines(setup) -> list[str]:
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            await pilot.press("ctrl+b")
+            await pilot.pause()
+            assert app._sidebar_timer is not None
+            app._sidebar_timer.pause()
+            sidebar = app._session_sidebar
+            setup(sidebar)
+            if sidebar._timer is not None:
+                sidebar._timer.pause()
+            await pilot.pause()
+            return [
+                "".join(segment.text for segment in line).strip()
+                for line in sidebar.render_lines(
+                    Region(0, 0, sidebar.size.width, sidebar.size.height)
+                )
+            ]
+
+    populated = await first_lines(lambda sidebar: sidebar.set_entries(_mixed_entries()))
+    assert populated[0] == "Active Sessions"
+    assert "Sessions" not in populated[:1] or populated[0] != "Sessions"
+    # The word appears only inside the two headings, never on its own line.
+    assert not any(line == "Sessions" for line in populated)
+
+    # Each heading owns the padding BENEATH it, and the second is separated
+    # from the group above: "header, gap, rows" reads as a group starting.
+    assert populated[1] == ""
+    previous = populated.index("Previous Sessions")
+    assert populated[previous - 1] == "", "the second heading collides with the group above"
+    assert populated[previous + 1] == "", "the heading does not own its padding"
+
+    for setup in (
+        lambda sidebar: sidebar.set_entries([]),
+        lambda sidebar: sidebar.show_error("Could not load conversations"),
+        lambda sidebar: None,  # loading: never received a catalog
+    ):
+        quiet = await first_lines(setup)
+        assert quiet[0] == "Sessions", quiet[:2]

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import time
 from dataclasses import replace
 from unittest.mock import patch
 
@@ -17,6 +18,10 @@ from local_operator.tui.session_catalog import (
     rank_entries,
 )
 from local_operator.tui.widgets.editor import Editor
+from local_operator.tui.widgets.session_sidebar import (
+    SIDEBAR_GUTTER,
+    SIDEBAR_MAIN_MIN_WIDTH,
+)
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
 
 
@@ -92,6 +97,147 @@ async def test_toggle_preserves_draft_and_full_width_when_hidden(size, position)
             assert editor.region.width == before
             assert app.screen.virtual_size == app.screen.size
             assert not app.screen.show_vertical_scrollbar
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(80, 24), (100, 30), (150, 40)])
+@pytest.mark.parametrize("position", ["left", "right"])
+async def test_gutter_faces_the_conversation_at_either_position(size, position):
+    """The gap belongs on the edge facing the transcript, and must swap sides.
+
+    The list's age column previously sat one cell from the transcript's first
+    character, which read as one crowded block rather than two regions. The
+    separation is only worth anything on the side the conversation is on, so a
+    hardcoded edge would fix the left dock and leave the right one tight.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=size) as pilot:
+        await pilot.pause()
+        app._sidebar_settings = SidebarSettings(False, position)
+        await pilot.press("ctrl+b")
+        await pilot.pause()
+        sidebar = app._session_sidebar
+        outer, content = sidebar.region, sidebar.content_region
+        leading = content.x - outer.x
+        trailing = outer.right - content.right
+        gutter, edge = (trailing, leading) if position == "left" else (leading, trailing)
+        assert gutter == SIDEBAR_GUTTER, f"{position}: conversation-facing gap is {gutter}"
+        assert edge == 1, f"{position}: outer edge should keep the 1-cell inset, got {edge}"
+        # Whitespace has to come from the width, not from the title column: at
+        # 28 cells titles already ellipsize, so paying for the gap out of the
+        # content would spend the one thing the list exists to show.
+        assert content.width >= 28
+        if size[0] > 80:
+            assert app.query_one("#session-conversation").size.width >= SIDEBAR_MAIN_MIN_WIDTH
+
+
+def _hover_entries(ids: tuple[str, ...] = ("alpha", "sess", "gamma")) -> list[CatalogEntry]:
+    now = time.time()
+    return [
+        CatalogEntry(SessionRow(sid, now - 60 * (index + 1), f"Session {sid}"))
+        for index, sid in enumerate(ids)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_tooltip_persists_while_the_pointer_rests_on_a_row():
+    """A description must stay up while the pointer rests, not blink out.
+
+    Textual hides a showing tooltip on the next mouse move over the SAME
+    widget. Every row here lives inside ONE widget, so ordinary within-row
+    movement looked like that repeat and the description vanished after about
+    a second of hovering.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30), tooltips=True) as pilot:
+        await pilot.pause()
+        await pilot.press("ctrl+b")
+        await pilot.pause()
+        assert app._sidebar_timer is not None
+        app._sidebar_timer.pause()
+        sidebar = app._session_sidebar
+        sidebar.set_entries(_hover_entries())
+        await pilot.hover("#session-sidebar", offset=(8, 2))
+        resting = sidebar.tooltip
+        assert resting is not None
+        for x in (9, 10, 11):
+            await pilot.hover("#session-sidebar", offset=(x, 2))
+        assert sidebar.tooltip == resting, "description dropped while the pointer rested"
+        await pilot.hover("#session-sidebar", offset=(8, 3))
+        assert sidebar.tooltip != resting, "description did not follow the pointer to a new row"
+
+
+@pytest.mark.asyncio
+async def test_hover_reresolves_when_a_refresh_reorders_under_the_pointer():
+    """A reorder must relabel the row the pointer is actually over.
+
+    The ranking moves rows beneath a stationary pointer, so an identity
+    remembered from the last mouse event would light and describe whichever
+    session slid into that slot.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30), tooltips=True) as pilot:
+        await pilot.pause()
+        await pilot.press("ctrl+b")
+        await pilot.pause()
+        assert app._sidebar_timer is not None
+        app._sidebar_timer.pause()
+        sidebar = app._session_sidebar
+        sidebar.set_entries(_hover_entries(("a", "b", "c")))
+        await pilot.hover("#session-sidebar", offset=(8, 2))
+        sidebar.set_entries(_hover_entries(("c", "b", "a")))
+        await pilot.pause()
+        under_pointer = sidebar._entry_at(2)
+        assert under_pointer is not None
+        assert sidebar._hover_id == under_pointer.id
+        assert under_pointer.row.name in str(sidebar.tooltip or "")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("position", ["left", "right"])
+async def test_switch_session_attaches_from_the_composer_and_wraps(position):
+    """The shortcut ATTACHES, keeps the caret, and wraps at both ends.
+
+    Distinct from F9's focus-then-arrow flow: this is the one-press form for
+    moving between live conversations. Wrapping follows the convention that a
+    discrete deliberate press wraps while wheel and page movement clamp.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        attached: list[str] = []
+        app._sidebar_settings = SidebarSettings(False, position)
+        await pilot.press("ctrl+b")
+        await pilot.pause()
+        assert app._sidebar_timer is not None
+        app._sidebar_timer.pause()
+        sidebar = app._session_sidebar
+        sidebar.set_entries(_hover_entries())
+        editor = app.query_one(Editor)
+        editor.text = "keep my draft"
+        editor.focus()
+        await pilot.pause()
+        order = [entry.id for entry in sidebar.entries]
+        with patch.object(app._sidebar_navigation, "select", side_effect=attached.append):
+            for start, key, expected in (
+                (order[1], "ctrl+shift+down", order[2]),
+                (order[1], "ctrl+shift+up", order[0]),
+                (order[0], "ctrl+shift+up", order[-1]),
+                (order[-1], "ctrl+shift+down", order[0]),
+            ):
+                # The action reads the ATTACHED session, which a real attach
+                # would have moved; the list's own cursor is not the source of
+                # truth for "where am I".
+                with patch.object(
+                    type(app._session), "session_id", property(lambda _s, v=start: v)
+                ):
+                    attached.clear()
+                    await pilot.press(key)
+                    await pilot.pause()
+                    assert attached == [expected], f"{start} + {key} attached {attached}"
+        # The composer must keep both the focus and the unsent draft.
+        assert app.focused is editor
+        assert editor.text == "keep my draft"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -23,6 +23,7 @@ from local_operator.tui.widgets.editor import Editor
 from local_operator.tui.widgets.session_sidebar import (
     SIDEBAR_GUTTER,
     SIDEBAR_MAIN_MIN_WIDTH,
+    SIDEBAR_SPINNER_INTERVAL_S,
 )
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
 
@@ -173,15 +174,20 @@ async def test_tooltip_survives_in_row_movement_and_the_catalog_poll():
         sidebar.set_entries(_hover_entries(tuple(f"s{i}" for i in range(1, 7))))
         await pilot.pause()
         tooltip = app.screen.get_child_by_type(Tooltip)
+        # By identity, not a literal y: the Active/Previous headers occupy
+        # lines that hold no session, so a hardcoded row number would land on
+        # a header and never change the hovered identity at all.
+        entry_rows = [y for y in range(1, sidebar.size.height) if sidebar._entry_at(y) is not None]
+        last_row, first_row = entry_rows[-1], entry_rows[0]
 
-        await pilot.hover("#session-sidebar", offset=(8, 6))
+        await pilot.hover("#session-sidebar", offset=(8, last_row))
         await asyncio.sleep(float(app.TOOLTIP_DELAY) + 0.2)
         await pilot.pause()
         assert tooltip.display, "description never appeared after the delay"
         shown_for = str(tooltip.render())
 
         for x in (9, 10, 11):
-            await pilot.hover("#session-sidebar", offset=(x, 6))
+            await pilot.hover("#session-sidebar", offset=(x, last_row))
             await pilot.pause()
             assert tooltip.display, f"in-row move to x={x} dropped the description"
         await asyncio.sleep(0.3)
@@ -195,7 +201,7 @@ async def test_tooltip_survives_in_row_movement_and_the_catalog_poll():
 
         # A different row is a fresh arrival: hidden until the delay passes,
         # then THAT row's description — never the previous row's.
-        await pilot.hover("#session-sidebar", offset=(8, 1))
+        await pilot.hover("#session-sidebar", offset=(8, first_row))
         await pilot.pause()
         assert not tooltip.display, "a row change must not pop the old description"
         await asyncio.sleep(float(app.TOOLTIP_DELAY) + 0.2)
@@ -220,10 +226,13 @@ async def test_hover_reresolves_when_a_refresh_reorders_under_the_pointer():
         app._sidebar_timer.pause()
         sidebar = app._session_sidebar
         sidebar.set_entries(_hover_entries(("a", "b", "c")))
-        await pilot.hover("#session-sidebar", offset=(8, 2))
+        first_row = next(
+            y for y in range(1, sidebar.size.height) if sidebar._entry_at(y) is not None
+        )
+        await pilot.hover("#session-sidebar", offset=(8, first_row))
         sidebar.set_entries(_hover_entries(("c", "b", "a")))
         await pilot.pause()
-        under_pointer = sidebar._entry_at(2)
+        under_pointer = sidebar._entry_at(first_row)
         assert under_pointer is not None
         assert sidebar._hover_id == under_pointer.id
         assert under_pointer.row.name in str(sidebar.tooltip or "")
@@ -496,7 +505,9 @@ async def test_sidebar_escape_restores_settings_and_current_narrow_selection_clo
         app.action_toggle_sidebar()
         app._session_sidebar.set_entries([CatalogEntry(SessionRow("sess", 1, "Current"))])
         await pilot.pause()
-        await pilot.click("#session-sidebar", offset=(4, 1))
+        sidebar = app._session_sidebar
+        row_y = next(y for y in range(1, sidebar.size.height) if sidebar._entry_at(y) is not None)
+        await pilot.click("#session-sidebar", offset=(4, row_y))
         assert not app._session_sidebar.display
 
 
@@ -568,11 +579,15 @@ async def test_requested_row_is_distinguishable_from_the_keyboard_cursor():
     straight = await grid("alpha", "gamma")
     mirrored = await grid("gamma", "alpha")
     assert straight != mirrored, "requested and cursor render identically"
+
     # And the distinction is the caret, in the same two columns as before, so
     # nothing reflows: the title still starts where it always did.
-    assert straight[1].startswith(" ›   Session alpha"), repr(straight[1])
-    assert straight[3].startswith(" »   Session gamma"), repr(straight[3])
-    assert mirrored[1].startswith(" »   Session alpha"), repr(mirrored[1])
+    def row_line(lines: list[str], title: str) -> str:
+        return next(line for line in lines if title in line)
+
+    assert row_line(straight, "Session alpha").startswith(" ›   ")
+    assert row_line(straight, "Session gamma").startswith(" »   ")
+    assert row_line(mirrored, "Session alpha").startswith(" »   ")
 
 
 @pytest.mark.asyncio
@@ -652,3 +667,256 @@ async def test_closing_the_sidebar_drains_leased_sources_but_keeps_local_work():
         # The over-fix guard: local in-flight work was never touched.
         assert "local-work" not in disposed
         assert not keep.retired
+
+
+def _mixed_entries() -> list[CatalogEntry]:
+    """Two ACTIVE rows (rank tier <=2) and two PREVIOUS (tier 3)."""
+    now = 1_700_000_000.0
+    return [
+        CatalogEntry(SessionRow("act1", now - 60, "Live one", live_state="busy")),
+        CatalogEntry(SessionRow("act2", now - 120, "Live two", live_state="busy")),
+        CatalogEntry(SessionRow("old1", now - 9000, "Old one")),
+        CatalogEntry(SessionRow("old2", now - 99000, "Old two")),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_hover_repaints_the_widget_at_most_once_per_move():
+    """Textual re-renders a widget inline on every pointer move to hunt links.
+
+    `Screen._forward_event` calls `get_style_at` BEFORE dispatch, which forces
+    `_render_content` whenever the widget is dirty — 0.039ms clean against
+    1.975ms dirty. Two callers dirtied it per event: our own hover refresh and
+    Textual's `watch_hover_style`, which fires for every widget under the
+    pointer anywhere in the app and admits in its own comment that it repaints
+    "even when there are no links". With `auto_links = False` only ours
+    remains.
+    """
+    from textual import events
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.press("ctrl+b")
+        await pilot.pause()
+        assert app._sidebar_timer is not None
+        app._sidebar_timer.pause()
+        sidebar = app._session_sidebar
+        sidebar.set_entries(_hover_entries(("a", "b", "c")))
+        await pilot.pause()
+
+        renders = 0
+        original = sidebar._render_content
+
+        def counted() -> None:
+            nonlocal renders
+            renders += 1
+            original()
+
+        sidebar._render_content = counted  # type: ignore[method-assign]
+        moves = 6
+        for step in range(moves):
+            event = events.MouseMove(
+                sidebar,
+                x=5,
+                y=1 + (step % 3),
+                delta_x=0,
+                delta_y=0,
+                button=0,
+                shift=False,
+                meta=False,
+                ctrl=False,
+                screen_x=sidebar.region.x + 5,
+                screen_y=sidebar.region.y + 1 + (step % 3),
+                style=None,
+            )
+            app.screen._forward_event(event)
+            await pilot.pause()
+        assert renders <= moves, f"{renders} repaints for {moves} moves"
+
+
+@pytest.mark.asyncio
+async def test_disabling_auto_links_leaves_the_painted_frame_identical():
+    """The one real risk of `auto_links = False`, closed by measurement.
+
+    It would silently kill hover highlighting IF this list ever rendered a
+    link. It renders none — rows are `Text` spans carrying colour and bold
+    only — so the painted output must be identical either way, in text AND in
+    style. If a link is ever added here this test is what fails.
+    """
+    from textual.geometry import Region
+
+    async def frame(auto_links: bool) -> list[tuple[str, str]]:
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            await pilot.press("ctrl+b")
+            await pilot.pause()
+            assert app._sidebar_timer is not None
+            app._sidebar_timer.pause()
+            sidebar = app._session_sidebar
+            sidebar.auto_links = auto_links
+            sidebar.set_entries(_mixed_entries())
+            sidebar.focus()
+            await pilot.pause()
+            painted: list[tuple[str, str]] = []
+            for line in sidebar.render_lines(Region(0, 0, sidebar.size.width, sidebar.size.height)):
+                for segment in line:
+                    painted.append((segment.text, str(segment.style)))
+            return painted
+
+    with_links = await frame(True)
+    without = await frame(False)
+    assert without == with_links
+    # And the premise holds: nothing in the frame carries a link.
+    assert not any("link" in style for _text, style in without)
+
+
+@pytest.mark.asyncio
+async def test_the_spinner_does_not_tick_while_blurred_or_closed():
+    """Every other animated surface rates through `animation_focused`; this
+    list was the only one that did not, so a blurred window kept repainting
+    every visible row for a terminal nobody was looking at."""
+    from local_operator.tui.animation import (
+        BLURRED_SPINNER_INTERVAL_S,
+        reset_animation_focus,
+    )
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    try:
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            sidebar = app._session_sidebar
+            # Closed: no ticks regardless of busy rows.
+            sidebar.set_entries(_mixed_entries())
+            await pilot.pause()
+            assert sidebar._timer is not None
+            assert sidebar._timer._active.is_set() is False
+
+            await pilot.press("ctrl+b")
+            await pilot.pause()
+            sidebar.set_entries(_mixed_entries())
+            await pilot.pause()
+            # Open with a busy row: running, at the list's own slower cadence.
+            assert sidebar._timer is not None
+            assert sidebar._timer._active.is_set() is True
+            assert sidebar._spinner_rate == SIDEBAR_SPINNER_INTERVAL_S
+
+            app._set_animation_focused(False)
+            await pilot.pause()
+            assert sidebar._spinner_rate == BLURRED_SPINNER_INTERVAL_S
+    finally:
+        reset_animation_focus()
+
+
+@pytest.mark.asyncio
+async def test_navigation_crosses_a_section_header_without_stalling():
+    """Headers are rendered rows, never entries — the keyboard never sees one.
+
+    `action_move` indexes `entries` and `_switch_session_from` traverses it
+    while the list is CLOSED, so a header in that tuple would let
+    ctrl+shift+down "switch" to a header and desync open-from-closed
+    navigation. Keeping the split presentational is what makes crossing a
+    boundary an ordinary step.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.press("ctrl+b")
+        await pilot.pause()
+        assert app._sidebar_timer is not None
+        app._sidebar_timer.pause()
+        sidebar = app._session_sidebar
+        sidebar.set_entries(_mixed_entries())
+        sidebar.focus()
+        await pilot.pause()
+        # The frame really does carry both headers.
+        assert sidebar._header_lines() == 3  # two headers plus one blank
+        sidebar.cursor_id = "act1"
+
+        walked: list[str] = []
+        for _ in range(3):
+            await pilot.press("down")
+            await pilot.pause()
+            walked.append(sidebar.cursor_id)
+        # act2 is the last ACTIVE row and old1 the first PREVIOUS one: the
+        # boundary costs no extra press and never parks on a header.
+        assert walked == ["act2", "old1", "old2"], walked
+        assert all(step in {entry.id for entry in sidebar.entries} for step in walked)
+
+
+@pytest.mark.asyncio
+async def test_an_empty_section_draws_no_header():
+    """All-idle shows only "Previous"; a store of live rows only "Active"."""
+    from textual.geometry import Region
+
+    async def headers(entries: list[CatalogEntry]) -> list[str]:
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            await pilot.press("ctrl+b")
+            await pilot.pause()
+            assert app._sidebar_timer is not None
+            app._sidebar_timer.pause()
+            sidebar = app._session_sidebar
+            sidebar.set_entries(entries)
+            await pilot.pause()
+            lines = [
+                "".join(segment.text for segment in line)
+                for line in sidebar.render_lines(
+                    Region(0, 0, sidebar.size.width, sidebar.size.height)
+                )
+            ]
+            return [
+                line.strip()
+                for line in lines
+                if line.strip() in {"Active Sessions", "Previous Sessions"}
+            ]
+
+    now = 1_700_000_000.0
+    only_previous = [
+        CatalogEntry(SessionRow(f"o{i}", now - 9000 * (i + 1), f"Old {i}")) for i in range(3)
+    ]
+    only_active = [
+        CatalogEntry(SessionRow(f"a{i}", now - 60 * (i + 1), f"Live {i}", live_state="busy"))
+        for i in range(3)
+    ]
+    assert await headers(only_previous) == ["Previous Sessions"]
+    assert await headers(only_active) == ["Active Sessions"]
+    assert await headers(_mixed_entries()) == ["Active Sessions", "Previous Sessions"]
+
+
+@pytest.mark.asyncio
+async def test_rows_are_independent_so_a_row_scoped_repaint_is_sound():
+    """Row-scoped hover refresh assumes one row's paint never affects another.
+
+    If that ever stops holding, repainting the two rows whose ground changed
+    would leave a third stale — so the assumption is asserted, not trusted.
+    """
+    from textual.geometry import Region
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.press("ctrl+b")
+        await pilot.pause()
+        assert app._sidebar_timer is not None
+        app._sidebar_timer.pause()
+        sidebar = app._session_sidebar
+        sidebar.set_entries(_mixed_entries())
+        await pilot.pause()
+
+        def painted() -> list[str]:
+            return [
+                "".join(segment.text for segment in line)
+                for line in sidebar.render_lines(
+                    Region(0, 0, sidebar.size.width, sidebar.size.height)
+                )
+            ]
+
+        before = painted()
+        sidebar._set_hover(2)
+        after = painted()
+        differing = [i for i, (a, b) in enumerate(zip(before, after)) if a != b]
+        # Hovering one row changes that row's line and nothing else.
+        assert len(differing) <= 1, differing

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import time
 from dataclasses import replace
@@ -9,6 +10,7 @@ from unittest.mock import patch
 
 import pytest
 from rich.cells import cell_len
+from textual.widgets import Tooltip
 
 from local_operator.resume import SessionRow
 from local_operator.tui.app import OperatorApp
@@ -140,13 +142,25 @@ def _hover_entries(ids: tuple[str, ...] = ("alpha", "sess", "gamma")) -> list[Ca
 
 
 @pytest.mark.asyncio
-async def test_tooltip_persists_while_the_pointer_rests_on_a_row():
-    """A description must stay up while the pointer rests, not blink out.
+async def test_tooltip_survives_in_row_movement_and_the_catalog_poll():
+    """The description stays up while the pointer is on the row, observed on
+    the screen's real ``Tooltip.display`` — not on the widget attribute.
 
-    Textual hides a showing tooltip on the next mouse move over the SAME
-    widget. Every row here lives inside ONE widget, so ordinary within-row
-    movement looked like that repeat and the description vanished after about
-    a second of hovering.
+    Round 4 (M1) found the previous guard vacuous: it asserted
+    ``sidebar.tooltip``, which the parent also kept stable, so it passed on
+    the very commit it claimed to test. Two distinct mechanisms hid the
+    description and both are covered here:
+
+    - ``Screen._handle_mouse_move`` hides a showing tooltip on ANY move over
+      the owning widget, before the widget sees the event, and re-arms
+      nothing. One cell of jitter dropped it and resting did not bring it
+      back. The widget now restores it on an in-row move.
+    - The 2 s catalog poll's ``set_entries`` blanked the widget attribute
+      under a perfectly still pointer. It now re-resolves instead.
+
+    The hovered row is the LAST one so the tooltip's own footprint never
+    covers a row the pointer moves to (it did, and made the previous probe
+    read the tooltip widget instead of the list).
     """
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(100, 30), tooltips=True) as pilot:
@@ -156,15 +170,37 @@ async def test_tooltip_persists_while_the_pointer_rests_on_a_row():
         assert app._sidebar_timer is not None
         app._sidebar_timer.pause()
         sidebar = app._session_sidebar
-        sidebar.set_entries(_hover_entries())
-        await pilot.hover("#session-sidebar", offset=(8, 2))
-        resting = sidebar.tooltip
-        assert resting is not None
+        sidebar.set_entries(_hover_entries(tuple(f"s{i}" for i in range(1, 7))))
+        await pilot.pause()
+        tooltip = app.screen.get_child_by_type(Tooltip)
+
+        await pilot.hover("#session-sidebar", offset=(8, 6))
+        await asyncio.sleep(float(app.TOOLTIP_DELAY) + 0.2)
+        await pilot.pause()
+        assert tooltip.display, "description never appeared after the delay"
+        shown_for = str(tooltip.render())
+
         for x in (9, 10, 11):
-            await pilot.hover("#session-sidebar", offset=(x, 2))
-        assert sidebar.tooltip == resting, "description dropped while the pointer rested"
-        await pilot.hover("#session-sidebar", offset=(8, 3))
-        assert sidebar.tooltip != resting, "description did not follow the pointer to a new row"
+            await pilot.hover("#session-sidebar", offset=(x, 6))
+            await pilot.pause()
+            assert tooltip.display, f"in-row move to x={x} dropped the description"
+        await asyncio.sleep(0.3)
+        await pilot.pause()
+        assert tooltip.display, "description did not stay up while resting after a move"
+
+        sidebar.set_entries(list(sidebar.entries))
+        await pilot.pause()
+        assert tooltip.display, "the catalog poll blanked a resting description"
+        assert str(tooltip.render()) == shown_for
+
+        # A different row is a fresh arrival: hidden until the delay passes,
+        # then THAT row's description — never the previous row's.
+        await pilot.hover("#session-sidebar", offset=(8, 1))
+        await pilot.pause()
+        assert not tooltip.display, "a row change must not pop the old description"
+        await asyncio.sleep(float(app.TOOLTIP_DELAY) + 0.2)
+        await pilot.pause()
+        assert tooltip.display and str(tooltip.render()) != shown_for
 
 
 @pytest.mark.asyncio
@@ -238,6 +274,97 @@ async def test_switch_session_attaches_from_the_composer_and_wraps(position):
         # The composer must keep both the focus and the unsent draft.
         assert app.focused is editor
         assert editor.text == "keep my draft"
+
+
+@pytest.mark.asyncio
+async def test_closed_list_switch_reads_a_fresh_ranking():
+    """A switch with the drawer closed must not step over a stale snapshot.
+
+    The catalog is polled only while the list is open, and closing it keeps
+    the last entries. Round 4 (M2/Q8/U6) created four sessions with the list
+    closed and the shortcut never called the loader — it branched on
+    "entries empty", and they were not. The branch is now on visibility.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.press("ctrl+b")
+        await pilot.pause()
+        assert app._sidebar_timer is not None
+        app._sidebar_timer.pause()
+        app._session_sidebar.set_entries(_hover_entries(("sess", "old")))
+        await pilot.press("ctrl+b")
+        await pilot.pause()
+        assert not app._session_sidebar.display
+        attached: list[str] = []
+        fresh = _hover_entries(("sess", "new1", "new2", "old"))
+        with (
+            patch.object(app._sidebar_navigation, "select", side_effect=attached.append),
+            patch("local_operator.tui.session_catalog.load_catalog", return_value=fresh) as load,
+        ):
+            await pilot.press("ctrl+shift+down")
+            await asyncio.sleep(0.15)
+            await pilot.pause()
+        assert load.called, "a closed list must read the catalog before stepping"
+        assert attached == ["new1"], f"stepped over the stale ranking: {attached}"
+        assert [entry.id for entry in app._session_sidebar.entries][:2] == ["sess", "new1"]
+
+
+@pytest.mark.asyncio
+async def test_switch_burst_steps_from_the_requested_target():
+    """Three presses before the first commit are three hops, not one.
+
+    The origin used to be ``_session`` — still the old session until commit
+    — so every press in a burst recomputed the same target (round 4, U6 /
+    MINOR-1). While a switch is in flight the requested id is the origin.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.press("ctrl+b")
+        await pilot.pause()
+        assert app._sidebar_timer is not None
+        app._sidebar_timer.pause()
+        app._session_sidebar.set_entries(_hover_entries(("a", "sess", "c", "d")))
+        hops: list[str] = []
+
+        def select(session_id: str) -> None:
+            hops.append(session_id)
+            app._sidebar_navigation.requested_id = session_id
+
+        with patch.object(app._sidebar_navigation, "select", side_effect=select):
+            for _ in range(3):
+                await pilot.press("ctrl+shift+down")
+            await pilot.pause()
+        app._sidebar_navigation.requested_id = ""
+        assert hops == ["c", "d", "a"], hops
+
+
+@pytest.mark.asyncio
+async def test_switch_does_not_fire_under_a_pushed_modal():
+    """A priority binding must not switch the conversation beneath a picker.
+
+    ``priority=True`` is what lets the shortcut work while the composer holds
+    focus; the cost is that it also fires through a pushed screen unless the
+    action itself checks (round 4, MINOR-2).
+    """
+    from local_operator.tui.widgets.session_picker import SessionPickerScreen
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.press("ctrl+b")
+        await pilot.pause()
+        assert app._sidebar_timer is not None
+        app._sidebar_timer.pause()
+        app._session_sidebar.set_entries(_hover_entries())
+        attached: list[str] = []
+        with patch.object(app._sidebar_navigation, "select", side_effect=attached.append):
+            app.push_screen(SessionPickerScreen([], time.time()))
+            await pilot.pause()
+            await pilot.press("ctrl+shift+down")
+            await pilot.pause()
+        assert attached == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_sidebar_source_state.py
+++ b/tests/unit/tui/test_sidebar_source_state.py
@@ -200,3 +200,121 @@ async def test_pending_choice_snapshot_restores_typed_and_checked_state():
         assert restored.selected_index == restored.other_row
         assert restored.has_focus == snapshot.focused
         app._unmount_prompt(restored)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("gate_kind", ["approval", "ask"])
+async def test_hidden_stopped_callback_cannot_answer_selected_sources_gate(gate_kind):
+    class Watched(FakeSession):
+        is_remote = True
+
+        def set_stopped_callback(self, callback):
+            self.stopped_callback = callback
+
+    first, second = Watched(), FakeSession()
+    app = OperatorApp(lambda: _factory(first))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        source_a = app._interaction
+        source_a.turn.open = True
+        stopped = first.stopped_callback
+        app._adopt_session(second)
+        source_b = app._interaction
+        stopped_id = app._stopped_session_id
+        if gate_kind == "approval":
+            pending = asyncio.create_task(app.request_tool_approval("write", "only B"))
+        else:
+            pending = asyncio.create_task(
+                app._request_user_choice_on_app_loop(
+                    [
+                        AskQuestion(
+                            id="only-b",
+                            question="Only B",
+                            options=[AskOption(label="yes"), AskOption(label="no")],
+                        )
+                    ],
+                    source=source_b,
+                )
+            )
+        await pilot.pause()
+        stopped()
+        await pilot.pause()
+        assert app._session is second
+        assert app._stopped_session_id == stopped_id
+        assert not pending.done()
+        assert not source_a.turn.open and source_a.loop.cancelled
+        assert not source_b.loop.cancelled
+        if gate_kind == "approval":
+            assert app._approval is not None
+            app._approval.resolve(False)
+        else:
+            assert app._ask_screen is not None
+            await pilot.press("escape")
+        await pending
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("outcome", ["achieved", "cancelled", "error"])
+async def test_goal_loop_releases_one_worker_lease_on_every_exit(outcome, monkeypatch):
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        source = app._interaction
+        source.loop.running = True
+
+        async def prompt(*_args, **_kwargs):
+            assert source.active_workers == 1
+            if outcome == "cancelled":
+                source.loop.cancelled = True
+                raise asyncio.CancelledError
+            if outcome == "error":
+                raise RuntimeError("synthetic source failure")
+
+        async def judge(_session, _goal):
+            return True, "achieved"
+
+        monkeypatch.setattr(session, "prompt", prompt)
+        monkeypatch.setattr(app, "_judge_goal", judge)
+        if outcome == "cancelled":
+            with pytest.raises(asyncio.CancelledError):
+                await app._loop_goal_worker("goal", source)
+        else:
+            await app._loop_goal_worker("goal", source)
+        await pilot.pause()
+        assert source.active_workers == 0
+        assert not source.loop.running
+        assert not source.must_retain
+
+
+@pytest.mark.asyncio
+async def test_replay_invalidation_retries_without_clearing_pending_intent():
+    from local_operator.tui.session_navigation import PreparationInvalidated
+
+    prepared, released, pending, committed = [], [], [], []
+
+    async def prepare(_session_id):
+        prepared.append(len(prepared) + 1)
+        return prepared[-1]
+
+    async def release(value):
+        released.append(value)
+
+    def commit(_session_id, value, _generation):
+        if value == 1:
+            raise PreparationInvalidated("replay changed")
+        committed.append(value)
+
+    navigation = SessionNavigation(
+        prepare=prepare,
+        commit=commit,
+        release=release,
+        pending=pending.append,
+        failed=lambda *_args: pytest.fail("must retry canonical replay"),
+    )
+    navigation.select("source-b")
+    assert navigation._task is not None
+    await navigation._task
+    assert prepared == [1, 2] and released == [1] and committed == [2]
+    assert pending == ["source-b", ""]
+    await navigation.close()

--- a/tests/unit/tui/test_sidebar_source_state.py
+++ b/tests/unit/tui/test_sidebar_source_state.py
@@ -1,0 +1,202 @@
+"""Source state survives navigation; a view change is never a user answer."""
+
+import asyncio
+import base64
+import io
+import os
+from unittest.mock import patch
+
+import pytest
+from PIL import Image
+from textual.widgets.text_area import Selection
+
+from local_operator.harness.types import AskOption, AskQuestion, ImageContent
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.session_drafts import SessionDraftStore
+from local_operator.tui.session_interaction import SessionDraft
+from local_operator.tui.session_navigation import SessionNavigation
+from local_operator.tui.session_presentation import DraftRecoveryNotice
+from local_operator.tui.widgets.ask_picker import AskPickerScreen
+from local_operator.tui.widgets.editor import Attachment, PastedText
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+@pytest.fixture(autouse=True)
+def isolate_source_state(tmp_path, monkeypatch):
+    for key in tuple(os.environ):
+        if key.startswith("CMUX_"):
+            monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setattr(OperatorApp, "_start_update_check", lambda _self: None)
+    monkeypatch.setattr(OperatorApp, "_start_terminal_title", lambda _self: None)
+    monkeypatch.setattr(OperatorApp, "_start_multiplexer_broadcast", lambda _self: None)
+    monkeypatch.setattr(OperatorApp, "_start_herdr_reporter", lambda _self: None)
+
+
+@pytest.mark.asyncio
+async def test_navigation_stays_pending_until_committed_frame_is_usable():
+    ready = asyncio.get_running_loop().create_future()
+    pending = []
+
+    async def prepare(session_id):
+        return session_id
+
+    async def release(_prepared):
+        pass
+
+    navigator = SessionNavigation(
+        prepare=prepare,
+        commit=lambda *_args: ready,
+        release=release,
+        pending=pending.append,
+        failed=lambda *_args: pytest.fail("unexpected navigation failure"),
+    )
+    navigator.select("synthetic-b")
+    await asyncio.sleep(0)
+    assert navigator.requested_id == "synthetic-b"
+    assert not navigator.committed_id
+    ready.set_result(None)
+    await asyncio.sleep(0)
+    assert navigator.committed_id == "synthetic-b"
+    assert pending[-1] == ""
+    await navigator.close()
+
+
+@pytest.mark.asyncio
+async def test_temporary_allow_all_does_not_follow_another_session():
+    first, second = FakeSession(), FakeSession()
+    app = OperatorApp(lambda: _factory(first))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app._set_approve_all(True)
+        first_source = app._interaction
+        app._adopt_session(second)
+        assert not app._approve_all
+        pending = asyncio.create_task(app.request_tool_approval("write", "synthetic target"))
+        await pilot.pause()
+        assert app._approval is not None
+        assert not pending.done()
+        app._approval.resolve(False)
+        assert await pending is False
+        app._adopt_session(first)
+        assert app._interaction is first_source
+        assert app._approve_all
+
+
+@pytest.mark.asyncio
+async def test_late_source_gate_cannot_mount_in_another_conversation():
+    first, second = FakeSession(), FakeSession()
+    app = OperatorApp(lambda: _factory(first))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        source = app._interaction
+        app._adopt_session(second)
+        with pytest.raises(asyncio.CancelledError):
+            await app._request_user_choice_on_app_loop(
+                [
+                    AskQuestion(
+                        id="source-a",
+                        question="Only source A",
+                        options=[AskOption(label="yes"), AskOption(label="no")],
+                    )
+                ],
+                source=source,
+            )
+        assert app._ask_screen is None
+        assert app._approval is None
+
+
+@pytest.mark.asyncio
+async def test_recovery_restores_exact_markers_without_overwriting_newer_input():
+    first, second = FakeSession(), FakeSession()
+    app = OperatorApp(lambda: _factory(first))
+    image_bytes = io.BytesIO()
+    Image.new("RGB", (2, 2)).save(image_bytes, format="PNG")
+    image = ImageContent(
+        data=base64.b64encode(image_bytes.getvalue()).decode(), mime_type="image/png"
+    )
+    raw = "[Image #1, 2x2]\n[Paste #2, 120 lines]\noriginal question"
+    accepted = SessionDraft(
+        text=raw,
+        attachments={
+            1: Attachment(image, "[Image #1, 2x2]"),
+            2: PastedText("\n".join(["pasted source"] * 120), "[Paste #2, 120 lines]"),
+        },
+        selection=Selection((2, 0), (2, 8)),
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        source = app._interaction
+        source.draft.text = "newer source A draft"
+        app._adopt_session(second)
+        app._restore_unsent_for(source, "expanded question", [image], accepted=accepted)
+        assert source.unsent == [accepted]
+        app._adopt_session(first)
+        app._load_editor_draft(source.draft)
+        app._sync_draft_recoveries(source)
+        await pilot.pause()
+        await pilot.click(DraftRecoveryNotice)
+        await pilot.pause()
+        editor = app._editor()
+        assert editor.text == raw
+        assert editor.attachments() == accepted.attachments
+        assert editor.selection == accepted.selection
+        assert source.unsent[0].text == "newer source A draft"
+        assert first.prompts == []
+
+
+@pytest.mark.asyncio
+async def test_draft_spill_retains_recoveries_notices_and_policy():
+    store = SessionDraftStore()
+    draft = SessionDraft(
+        text="current",
+        approve_all=False,
+        recoveries=[SessionDraft(text="recover this exact draft", shell_mode=True)],
+        notices=[("Source-specific failure", "warning")],
+    )
+    try:
+        with patch("local_operator.tui.session_drafts.DRAFT_RESIDENT_BYTES", 0):
+            await store.put("synthetic-a", draft)
+        restored = await store.get("synthetic-a")
+        assert restored.recoveries[0].text == "recover this exact draft"
+        assert restored.recoveries[0].shell_mode
+        assert restored.notices == draft.notices
+        assert restored.approve_all is False
+        path = store._path("synthetic-a")
+        assert path.exists()
+        await store.put("synthetic-a", SessionDraft())
+        assert not path.exists()
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_pending_choice_snapshot_restores_typed_and_checked_state():
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    question = AskQuestion(
+        id="synthetic-choice",
+        question="Choose a synthetic result",
+        options=[AskOption(label="first"), AskOption(label="second")],
+        multi=True,
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        card = AskPickerScreen([question], lambda _value: None)
+        app._mount_prompt(card)
+        await pilot.pause()
+        card.action_move(1)
+        card.action_toggle_row()
+        card.action_jump_other()
+        await pilot.press(*"unfinished")
+        snapshot = card.snapshot_state()
+        app._unmount_prompt(card)
+        restored = AskPickerScreen([question], lambda _value: None)
+        restored.restore_state(snapshot)
+        app._mount_prompt(restored)
+        await pilot.pause()
+        assert restored.typed_text == "unfinished"
+        assert restored.checked_indexes == [1]
+        assert restored.selected_index == restored.other_row
+        assert restored.has_focus == snapshot.focused
+        app._unmount_prompt(restored)

--- a/tests/unit/tui/test_slash_echo.py
+++ b/tests/unit/tui/test_slash_echo.py
@@ -79,6 +79,7 @@ ECHO_POLICY = {
     # replaces the transcript region, so a user row printed behind it would
     # only be readable after leaving. It takes no argument at all.
     "settings": False,
+    "sidebar": False,
     "search": False,
     "accounts": False,
     # The cascade tree IS the receipt, and there is no argument to restate.
@@ -149,6 +150,7 @@ PROMPT_POLICY = {
     # replaces the transcript region, so a user row printed behind it would
     # only be readable after leaving. It takes no argument at all.
     "settings": False,
+    "sidebar": False,
     "search": False,
     "accounts": False,
     "failovers": False,


### PR DESCRIPTION
## Summary

**DRAFT / HOLD: do not merge or release.** C2 standard/pre-authorized implementation of an opt-in session sidebar inside the same terminal. This PR is the review record, not a claim that every acceptance criterion is complete.

- Ctrl+B or `/sidebar` toggles without stealing the typing caret. F9 or `/sidebar focus` enters the list; arrows/Enter navigate, Escape restores the latest usable prior surface. Settings choose left/right placement; narrow layouts use a drawer above the input dock. Aside moves to F8.
- Source-owned turns, loops, shell work, compaction, drafts/attachments/selections/scroll, gate input and accounting survive navigation. Prepared widgets and bounded retained views are separate from source data/work.
- Sidebar attachment opts into a canonical owner-authored durable display window. The owner’s resident replay replaces a viewer’s full parse of historical host bookkeeping, without substituting model-context or mobile-projection tails.

## Delivery contract and non-goals

Selecting a row must bind the correct live owner, show its actual requested history/gate/scroll frame, and route immediate subsequent input to it. Other owners continue. Selection/preparation must never restart, stop, take over, prompt, or acknowledge completion attention on an owner.

The target is **under 100 ms to a correct, usable target frame**, not merely a selected-row highlight. This target is **not met across the current recorded samples**; see the measurements and open findings below. Legacy cold attachment and arbitrarily large required text remain explicit compatibility limits, not hidden rows or truncated content.

Real source workflows are part of the contract: `/loop 3` entered in A continues while B is viewed and B’s stop cannot cancel A; a real bang command’s receipt belongs durably to A exactly once, survives a cold reattach and settles its returned card; A→B→A gate completion preserves its initiating user row and one correctly settled tool row.

Non-goals: a generalized transcript index, a second model-context policy, a new owner-side loop scheduler, a mobile/web sidebar, retrofitting new RPCs into old running owners, native OS/Cmd-key forwarding certification, or a version/runtime/release change. Non-goals do not waive correctness or the measured performance gap.

## Protocol and caller boundaries

Details and maintenance constraints are in [`docs/SESSION_SIDEBAR.md`](docs/SESSION_SIDEBAR.md).

- Additive `display-history-window-v1` capability, requested through the existing authenticated attach handshake. Snapshot, exact durable cursor, window and subscription are captured together on the authoritative loop without an unrelated await.
- `Transcript.build_llm_history(through_id=...)` selects the journal cut before compaction/prune interpretation. The same replay supplies custom roles, preserved user turns, attachments, and complete tool-call/result groups. Compaction markers keep a stable durable ID.
- Window limit: 120 messages and 512 KiB using actual JSON escaping; entire sync remains within the 1 MiB transport limit. Oversized required content returns explicit `full_required` and uses exact off-thread full replay, never a prefix represented as complete.
- Signed page tokens bind conversation, owner epoch, replay generation, cut and message position; no client-supplied paths or byte offsets. Appends preserve a cut; replay-changing mutations invalidate it and return typed reset/reconciliation.
- Separate display, paging, full materialization, count/opener and tail APIs. Unhydrated window-mode `history()` raises rather than returning a partial list under a full-history name. Default attachment and owner/model/idempotency full-history callers retain their existing contract.
- TUI caller census: preparation/commit/replay, total counts, canonical title/fallback opener, whole-history background title sampling, aside tail duplicate check, old/new paging and saved anchors. Loaded, painted and pre-cut live-seed identities are separate. Live source rows/results are retained for re-adoption; reconnect includes the durable gap or explicitly resets the replay generation.
- The TUI schedules `/loop`; each iteration still prompts its captured real owner. Bang execution stays local but receipt persistence is an authenticated owner operation, idempotent by stable tool-call-derived IDs. Busy owners can queue persistence: acceptance is not a false fsync acknowledgement.

## Dependencies and disposition

- Integrated main base: `f001c417606255007544e10bb698add48edd8033`.
- Startup #682 is integrated.
- Attention #687 is an **open/draft dependency**, not assumed shipped. Product `9110085` is integrated; its exact `9110085..d0de7f3` two-file test delta was reviewed and applied. Native-foreground attention proof remains pending with that dependency’s owner.
- Older owners remain visible/selectable using full-history attachment. An old owner without the shell-receipt operation produces an explicit save failure, not a fake local journal entry. No forced restart/takeover is used to conceal that compatibility limit.
- User requested HOLD. No version bump, tag, release, global `lop` installation change, human review request, or merge is authorized here.

## Executed validation on frozen head

Candidate: **`59fedb3e35b1f9c5660bf3c4c0c45263815bb79e`**.

All TUI/fork/owner invocations scrubbed every inherited `CMUX_*`, used isolated HOME and config, synthetic IDs and the worktree’s own Python3.12. No live operator sessions were touched. The isolation wrapper leaves terminal-title assertions observable; it does not suppress the behavior those tests validate.

| Command / surface | Actual result |
|---|---|
| `.venv/bin/python -m flake8 .` | PASS |
| `uvx --from black==26.1.0 black --check .` | PASS; 964 files unchanged |
| `uvx isort==5.13.2 --check .` | PASS |
| `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | 0 errors, 0 warnings |
| Isolated `.venv/bin/python -m pytest tests/unit -q` | **14689 passed, 17 skipped**, 589.54 s |
| Isolated `.venv/bin/python -m pytest tests/e2e -m e2e -n0 -q` | **31 passed**, 32.24 s |
| Real authenticated window/paging/materialization/reset and shell idempotency tests | PASS; parse-forbidden spy proves negotiated reads do not parse the viewer journal; full API errors before hydration |
| Actual editor `/loop 3`, A hidden and B stop | A emitted 3 provider iterations; B emitted 0; A was not cancelled |
| Actual bang, then A→B→A and a cold A reattach | File/stdout observed; A user/result receipt exactly once; B unchanged; one successful returned card |
| Real ask and approval A→B→A | Correct owner answered/wrote file; initiating ASK-QA/APPROVE-QA retained; exactly one successful call card; ask survives an additional round trip |
| Keyboard/drawer/focus | F9 preserves draft and returns focus; Settings regains focus after sidebar Escape; current-row selection dismisses narrow drawer |
| Rendered state matrix | 45 exact-head captures at 80×24, 100×30, 150×40; left/right/off/loading/empty/error/populated/overflow/long names/consecutive frames |

The behavioral probes use production `Session → OwnedSessionHandle → RuntimeServer → RemoteSession → OperatorApp` with real sockets, journal IO, tool execution and subprocesses; only model output is scripted. These are author execution results, **not independent QA sign-off**. Formal QA is separately reviewing this frozen candidate.

Initial moving-tree full-suite failures were retained, classified and remediated rather than hidden: 14660 passed / 24 failed / 17 skipped. The exact-head full run above supersedes that initial gate. Some combined exploratory matrix cells retained a previous cell’s scroll anchor and failed a tail-only assertion; fresh isolated cells were rerun, and the combined failure log remains available.

## Actual click latency, including misses

Three independent real owners stay alive throughout each run. The probe times actual `Sidebar.Selected` through canonical readiness, atomic commit, a correct rendered frame, usable binding and an immediate typed key. Cold-path runs explicitly disable speculative prewarming **in the probe only**, not in the product. They never hide a row or acknowledge attention to obtain a faster sample.

The large fixture is **about 103 MiB / 108 million bytes of real ignored journal bookkeeping**, with 21 canonical messages and a 22-character final reply. Owner canonical replay plus JSON is about 0.13–0.55 ms / 9252 B; full viewer parsing was the measured bottleneck.

| Real first cold 103 MiB selection | Canonical/prepared ready | Correct frame | Usable binding | Immediate-key frame |
|---|---:|---:|---:|---:|
| Frozen43c before window | 281.94 ms | 327.36 ms | 330.65 ms | 395.77 ms |
| Current59 owner + viewer | 58.16 ms | 141.17 ms | 145.18 ms | 181.13 ms |
| Current59 viewer + legacy43c owner | 347.86 ms | 392.03 ms | 393.99 ms | 428.98 ms |

Current59 new-owner seven-frame samples: **141.17, 46.41, 45.77, 98.48, 98.88, 44.91, 163.67 ms**. Usable samples: **145.18, 51.40, 51.51, 100.30, 102.30, 52.30, 165.38 ms**. Recorded load was 41.60/36.66/42.10; legacy comparison load 44.99/37.44/42.35. These are not controlled idle-host comparisons. Earlier prewarmed samples were faster, and are not substituted for the cold results.

A separate real attach-only probe reduced viewer peak RSS from about 539 MiB to 90 MiB and avoided `_load_history`, but its process-cold 248 ms connect is **not** presented as sidebar performance proof. Frame-path CPU/wall profiling after our heavy validation jobs settle is still pending; host contention is recorded, not used to excuse avoidable work.

## Rendered before/after evidence

The captures were rendered to PNG and actually inspected locally, not judged as SVG source. Shared synthetic screenshot artifact: https://gist.github.com/damianvtran/da85a401341b5edca06a2615edddac3b (unlisted; contains no credentials or real customer/session content).

| Before sidebar (100×30) | Exact59 populated (100×30) |
|---|---|
| ![Before sidebar](https://gist.githubusercontent.com/damianvtran/da85a401341b5edca06a2615edddac3b/raw/04b97de54c03d4350b3c6d23b0236909210c5dcb/populated-100x30-0.svg) | ![Populated sidebar](https://gist.githubusercontent.com/damianvtran/da85a401341b5edca06a2615edddac3b/raw/bbd68f6e7aecb1287e4379543056a63600fbd37b/100x30-left-focused-0.svg) |

| Narrow left | Narrow right | Compact loading |
|---|---|---|
| ![Left](https://gist.githubusercontent.com/damianvtran/da85a401341b5edca06a2615edddac3b/raw/478840ac806f3294bdd25ed759f33587db5524d9/80x24-left-focused-0.svg) | ![Right](https://gist.githubusercontent.com/damianvtran/da85a401341b5edca06a2615edddac3b/raw/74525987c027b82abebf65756d4732d924aec9aa/80x24-right-focused-0.svg) | ![Loading](https://gist.githubusercontent.com/damianvtran/da85a401341b5edca06a2615edddac3b/raw/bce0b09dfb370dadd3d865079e74d1caeee303df/100x30-loading.svg) |

Empty/error SVGs and all downloadable sources are in the artifact. Full exact-head PNG/SVG/geometry matrix: `~/workspace/lo-sidebar-evidence/design-59fedb3/`. At 80×24 with a tall draft the sidebar region `[1,1,30,11]` ends exactly above dock `[1,12,78,11]`; consecutive tall-draft PNGs were identical. All 45 matrix frames have screen virtual size equal to actual size and no screen scrollbar.

Complete local commands, responses, immutable timing filenames, failed attempts and proof provenance: `~/workspace/lo-sidebar-evidence/CANDIDATE-59fedb3.md`. Exact-head unit/e2e logs: `gate-unit-59fedb3.log`, `gate-e2e-59fedb3.log` under that evidence root.

## Known limitations recorded at round 5

- **Suffix replay is not universal.** `read_replay_suffix` stops at the newest
  compaction's `first_kept_entry_id`. A journal that has NEVER compacted has no
  such marker, so the backward read walks to byte 0 and costs what the forward
  parse cost. The win applies to sessions long enough to have compacted — which
  is where the latency was measured — and NOT to the common under-threshold
  session. Read "suffix replay" as "bounded by the last compaction", not as a
  universal bound.
- **The 150ms requested-row spinner effectively never appears.** UX could not
  make it render on real owners: the pending window measured only ~32-36ms even
  for a 2200-message owner, because the expensive work happens outside that
  window. It renders correctly when the state is held open, and it is the right
  safety net for a genuinely slow switch, but it should be read as dead code in
  practice rather than as something users routinely see.
- **On the mouse-click path a keystroke during the pending window reaches
  neither session.** At pending, focus is on `SessionSidebar`, so keys go to the
  list; focus returns to the composer at commit. Nothing is stuck and nothing is
  misfiled into the wrong draft. UX judged losing those keystrokes better than
  misattributing them and did not raise it as a finding; it is recorded here so
  it is not later discovered as a surprise. The keyboard path (`ctrl+shift+*`)
  is unaffected — it keeps composer focus and buffers into the transition.

## Open findings / next gate

1. **Performance acceptance remains unmet** across recorded correct/usable-frame samples. Profile the remaining frame path after our heavy tests settle and batch remediation with the independent review findings.
2. **Author self-audit pending review:** successful live compaction changes the owner replay generation, but a retained tail-following source may not discover that invalidation until paging/seek/reconnect. Verify and remediate that cache-refresh path before treating the canonical-history contract as complete.
3. Independent code, QA, design and UX candidate rounds are in progress. Findings will be batched into **one unified remediation round**, answered per finding on this PR. No stream is represented as approved yet.
4. Attention dependency/native-foreground proof remains pending. No native Cmd-key or OS focus proof is claimed by these headless tests.

Even after clean review and CI, this PR remains held for the user: **no merge or release**.

