### PR TITLE
chore(release): bump version to 0.49.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.49.7"
+version = "0.49.8"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Version bump for the v0.49.8 release.

## Window

Exactly one commit since `v0.49.7` (5b3b6ad44):

- `fe4ae219d` — feat(config): apply approvals, web-tool and model settings live on the watcher poll (#671)

## Bump class

**PATCH → 0.49.8.** Per AGENTS.md "Versioning", the bump follows user-facing materiality, not commit type: a single self-contained `feat:` is a patch. #671 makes an existing surface (`config.yml`) behave as it already claimed to; there is no new surface or subsystem to name in an X.Y.0 title.

## Diff

One line — the `version` field in `pyproject.toml`. No dependency, script, or entry-point line moved.

## Verification

- `git log 5b3b6ad44..origin/main --oneline` confirms the window is exactly `fe4ae219d`.
- Worktree `/tmp/lop-rel-0498` on its own real `.venv`; `import local_operator` resolves to `/private/tmp/lop-rel-0498/local_operator/__init__.py`.
- `git diff --numstat` → `1	1	pyproject.toml`.