### PR TITLE
feat(desktop): acknowledge viewed completions from the desktop app

### DIFF
--- a/local_operator/mobile/attach_client.py
+++ b/local_operator/mobile/attach_client.py
@@ -196,6 +196,10 @@ class AttachClient:
     def connected(self) -> bool:
         return self._connected
 
+    @property
+    def supports_completion_ack(self) -> bool:
+        return self.connected and self._attention_supported
+
     async def connect(self, record: SessionRecord, session_id: str) -> None:
         """Dial, authenticate as an attach client, and verify identity.
 

--- a/local_operator/server/models/desktop_sessions.py
+++ b/local_operator/server/models/desktop_sessions.py
@@ -107,3 +107,23 @@ class AnswerReceipt(BaseModel):
 
 class WatchReceipt(BaseModel):
     lease_seconds: Literal[45]
+
+
+class AttentionState(BaseModel):
+    """The shared read watermark, mirrored by the UI's `CompletionAttention`.
+
+    Typed rather than `dict[str, Any]` so the renderer's hand-written copy of
+    this shape cannot drift from the authority silently: the field set is the
+    contract both sides agree on.
+    """
+
+    conversation_id: str
+    completion_token: str | None
+    anchor_id: str | None
+    kind: Literal["complete", "error", "interrupted"] | None
+    unseen: bool
+    #: ``[published, acknowledged]`` -- monotonic, and independent of the owner
+    #: epoch, which is why a client merges on it rather than on arrival order.
+    revision: list[int]
+    #: Absent on the cold list path; only a live owner can answer it.
+    supported: bool | None = None

--- a/local_operator/server/routes/capabilities.py
+++ b/local_operator/server/routes/capabilities.py
@@ -26,6 +26,8 @@ async def capabilities():
                 "commands": 1,
                 "catalogues": 1,
                 "lifecycle": 1,
+                # Watch leases route notification delivery; they never mark read.
+                "completion-ack-v1": 1,
                 "mcp": 1,
                 "radient": 1,
             },

--- a/local_operator/server/routes/capabilities.py
+++ b/local_operator/server/routes/capabilities.py
@@ -27,7 +27,10 @@ async def capabilities():
                 "catalogues": 1,
                 "lifecycle": 1,
                 # Watch leases route notification delivery; they never mark read.
-                "completion-ack-v1": 1,
+                # Named for this map's convention (`<subsystem>: <version>`); the
+                # runtime record's capability LIST is a different namespace and
+                # keeps its versioned `completion-ack-v1` string.
+                "completion_ack": 1,
                 "mcp": 1,
                 "radient": 1,
             },

--- a/local_operator/server/routes/desktop_sessions.py
+++ b/local_operator/server/routes/desktop_sessions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import sqlite3
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Annotated, Any, Literal
@@ -24,6 +25,7 @@ from starlette.background import BackgroundTask
 from local_operator.server.desktop import require_desktop
 from local_operator.server.models.desktop_sessions import (
     AnswerReceipt,
+    AttentionState,
     CommandReceipt,
     CreatedSession,
     HistoryPage,
@@ -162,6 +164,14 @@ async def errors() -> AsyncIterator[None]:
         raise HTTPException(404, "Session or subscription not found") from None
     except (ReceiptConflict, ValueError) as error:
         raise HTTPException(409, str(error)) from None
+    except sqlite3.Error:
+        # Contention on the shared receipt store is transient and retryable, so
+        # it gets a vetted sentence rather than a bare 500 carrying SQLite's own
+        # wording. The text is NOT echoed for the same reason the ConnectionError
+        # ladder below refuses to echo: a store error can name file paths.
+        raise HTTPException(
+            503, "Read state is busy right now. It will catch up on its own."
+        ) from None
     except ConnectionError as error:
         # A cold session that cannot start an owner reports WHY -- but only when
         # the reason arrives as an `ActionableConnectionError`, whose TYPE is
@@ -187,7 +197,12 @@ async def errors() -> AsyncIterator[None]:
 
 @router.get("/v1/desktop/sessions", response_model=CRUDResponse[SessionList])
 async def list_sessions(request: Request, limit: int = Query(default=100, ge=1, le=500)):
-    return reply({"sessions": await host(request).list(limit)})
+    # Wrapped like its neighbours: the list gained a receipt-store read, and an
+    # unmapped failure there answered the app's primary navigation surface with
+    # a bare 500. The decoration is already omitted per row inside `list()`;
+    # this ladder covers anything else the pool can raise.
+    async with errors():
+        return reply({"sessions": await host(request).list(limit)})
 
 
 @router.post("/v1/desktop/sessions", response_model=CRUDResponse[CreatedSession])
@@ -368,7 +383,7 @@ async def answer(session_id: str, body: Answer, request: Request):
         return reply({"detail": detail})
 
 
-@router.post("/v1/desktop/sessions/{session_id}/seen", response_model=CRUDResponse[dict[str, Any]])
+@router.post("/v1/desktop/sessions/{session_id}/seen", response_model=CRUDResponse[AttentionState])
 async def seen(session_id: str, body: Seen, request: Request):
     async with errors():
         return reply(await host(request).acknowledge_attention(session_id, body.completion_token))

--- a/local_operator/server/routes/desktop_sessions.py
+++ b/local_operator/server/routes/desktop_sessions.py
@@ -55,6 +55,12 @@ class Input(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class Seen(Input):
+    # A durable completion UUID is the only admission: timestamps or a caller's
+    # owner epoch could accidentally acknowledge a later, unseen outcome.
+    completion_token: RequestID
+
+
 class CreateSession(Input):
     request_id: RequestID
     cwd: str = Field(min_length=1, max_length=4096)
@@ -360,6 +366,12 @@ async def answer(session_id: str, body: Answer, request: Request):
         except RuntimeError:
             raise HTTPException(409, "This question or approval is no longer pending") from None
         return reply({"detail": detail})
+
+
+@router.post("/v1/desktop/sessions/{session_id}/seen", response_model=CRUDResponse[dict[str, Any]])
+async def seen(session_id: str, body: Seen, request: Request):
+    async with errors():
+        return reply(await host(request).acknowledge_attention(session_id, body.completion_token))
 
 
 @router.post("/v1/desktop/sessions/{session_id}/watch", response_model=CRUDResponse[WatchReceipt])

--- a/local_operator/server/utils/desktop_sessions.py
+++ b/local_operator/server/utils/desktop_sessions.py
@@ -71,6 +71,8 @@ class DesktopSessionBridge:
         self.watch_lock = asyncio.Lock()
         self.unsubscribers: list[Any] = []
         self.watch_task: asyncio.Task[None] | None = None
+        self.attention_task: asyncio.Task[None] | None = None
+        self.attention: dict[str, Any] = {}
 
     async def acquire(self) -> RemoteSession:
         async with self.lock:
@@ -97,6 +99,8 @@ class DesktopSessionBridge:
                         remote.subscribe_frontend(self._frontend).unsubscribe,
                     ]
                 await self.remote.attach_existing()
+                if self.attention_task is None:
+                    self.attention_task = asyncio.create_task(self._poll_attention())
                 return self.remote
             except BaseException:
                 self.users -= 1
@@ -112,6 +116,11 @@ class DesktopSessionBridge:
                 await self._detach()
 
     async def _detach(self) -> None:
+        if self.attention_task is not None:
+            self.attention_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self.attention_task
+            self.attention_task = None
         if self.watch_task is not None:
             self.watch_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -172,6 +181,10 @@ class DesktopSessionBridge:
         # Trajectories are intentionally opt-in on the runtime and absent here;
         # large roster/usage fields still pass through the shared wire budget.
         payload = update.model_dump(mode="json")
+        # Receipt revisions outlive an owner epoch. Only the independent durable
+        # projection below may update them; a delayed owner delta must not undo
+        # a read made through another process while this stream stays mounted.
+        payload["changes"].pop("attention", None)
         payload["job_trajectory_appends"] = {}
         payload["job_trajectory_replacements"] = []
         if {"jobs", "usage_components"} & update.changes.keys():
@@ -181,9 +194,36 @@ class DesktopSessionBridge:
                     payload["changes"][key] = bounded[key]
         self.publish("frontend.update", payload)
 
+    async def refresh_attention(self) -> dict[str, Any]:
+        from local_operator.session.attention import AttentionStore
+
+        state = await asyncio.to_thread(
+            AttentionStore(self.root / "attention.db").state, f"session/{self.session_id}"
+        )
+        remote = self.remote
+        state["supported"] = bool(
+            remote is not None
+            and (remote.is_cold or getattr(remote, "supports_completion_ack", False))
+        )
+        if state != self.attention:
+            previous = self.attention
+            self.attention = state
+            # The initial snapshot owns the baseline; later changes have their
+            # own receipt clock rather than borrowing a runtime owner sequence.
+            if previous:
+                self.publish("attention", state)
+        return state
+
+    async def _poll_attention(self) -> None:
+        # Read-only polling is shared by every subscriber of this bridge and
+        # independent of watch leases. It also works while no owner is running.
+        while True:
+            await self.refresh_attention()
+            await asyncio.sleep(1)
+
     def state(self) -> dict[str, Any]:
         assert self.remote is not None
-        state = self.remote.frontend_state
+        state = self.remote.frontend_state.model_copy(update={"attention": self.attention})
         return sync_wire_payload(
             FrontendSync(
                 epoch=state.epoch,
@@ -194,6 +234,7 @@ class DesktopSessionBridge:
         )
 
     async def snapshot(self) -> dict[str, Any]:
+        await self.refresh_attention()
         state = self.state()
         seq, epoch = self.sequence, self.epoch
         cursor = state["snapshot"].get("history_cursor")
@@ -345,6 +386,27 @@ class DesktopSessions:
         self.bridges: dict[str, DesktopSessionBridge] = {}
         self.lock = asyncio.Lock()
 
+    async def acknowledge_attention(self, session_id: str, token: str) -> dict[str, Any]:
+        """A read receipt never admits work, binds a viewer, or starts an owner.
+
+        Validate the same durable user-session namespace as the bridge, but do
+        not enter its acquire path: a completed cold conversation is readable
+        even when its owner and the mobile daemon are both stopped.
+        """
+        from local_operator.session.attention import AttentionStore
+
+        def acknowledge() -> dict[str, Any]:
+            if not SESSION_ID.fullmatch(session_id):
+                raise KeyError("Unknown session")
+            path = self.root / "sessions" / session_id
+            if not path.is_dir() or not is_user_session(path):
+                raise KeyError("Unknown session")
+            return AttentionStore(self.root / "attention.db").acknowledge(
+                f"session/{session_id}", token
+            )
+
+        return await asyncio.to_thread(acknowledge)
+
     async def create(self, cwd: str) -> str:
         directory = Path(cwd).expanduser().resolve()
         if not directory.is_dir():
@@ -377,8 +439,15 @@ class DesktopSessions:
             # runs once per row the caller will actually see rather than once
             # per session on disk. Measured 0.10 ms per row on a 38-session
             # store; the whole call already runs on a worker thread.
+            from local_operator.session.attention import AttentionStore
+
+            # One read connection per list, never one per row or an owner bind.
+            attention = AttentionStore(self.root / "attention.db").state_many(
+                f"session/{row['id']}" for row in visible
+            )
             for row in visible:
                 row["preview"] = session_preview(self.root / "sessions" / row["id"])
+                row["attention"] = attention[f"session/{row['id']}"]
             return visible
 
         return await asyncio.to_thread(rows)

--- a/local_operator/server/utils/desktop_sessions.py
+++ b/local_operator/server/utils/desktop_sessions.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import logging
 import re
+import sqlite3
 import time
 import uuid
 from collections import deque
@@ -23,6 +25,7 @@ from typing import Any
 from anyio import CancelScope
 
 from local_operator.resume import is_user_session, recent_session_rows, session_preview
+from local_operator.session.attention import AttentionStore
 from local_operator.session.frontend_state import (
     FrontendSync,
     FrontendUpdate,
@@ -30,6 +33,8 @@ from local_operator.session.frontend_state import (
 )
 from local_operator.session.remote import RemoteSession
 from local_operator.session.transcript import read_transcript_page
+
+logger = logging.getLogger(__name__)
 
 SESSION_ID = re.compile(r"^[a-f0-9]{12}$")
 REPLAY_COUNT = 256
@@ -73,6 +78,7 @@ class DesktopSessionBridge:
         self.watch_task: asyncio.Task[None] | None = None
         self.attention_task: asyncio.Task[None] | None = None
         self.attention: dict[str, Any] = {}
+        self.attention_poll_key: tuple[tuple[int, int], bool] | None = None
 
     async def acquire(self) -> RemoteSession:
         async with self.lock:
@@ -116,11 +122,6 @@ class DesktopSessionBridge:
                 await self._detach()
 
     async def _detach(self) -> None:
-        if self.attention_task is not None:
-            self.attention_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self.attention_task
-            self.attention_task = None
         if self.watch_task is not None:
             self.watch_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -132,6 +133,18 @@ class DesktopSessionBridge:
         remote, self.remote = self.remote, None
         if remote is not None:
             await remote.dispose()
+        # LAST, and suppressing the task's OWN failure rather than only
+        # CancelledError: awaiting a task that already died re-raises its
+        # exception, and with this block ahead of `dispose()` a store error
+        # aborted teardown midway -- leaking the owner session and its
+        # subscriptions while `users` had already reached 0, so a later
+        # `acquire()` reused a half-torn bridge. A read receipt must never
+        # strand a session owner.
+        if self.attention_task is not None:
+            self.attention_task.cancel()
+            with contextlib.suppress(BaseException):
+                await self.attention_task
+            self.attention_task = None
 
     async def close(self) -> None:
         for sub in self.subscribers.values():
@@ -195,8 +208,6 @@ class DesktopSessionBridge:
         self.publish("frontend.update", payload)
 
     async def refresh_attention(self) -> dict[str, Any]:
-        from local_operator.session.attention import AttentionStore
-
         state = await asyncio.to_thread(
             AttentionStore(self.root / "attention.db").state, f"session/{self.session_id}"
         )
@@ -217,8 +228,37 @@ class DesktopSessionBridge:
     async def _poll_attention(self) -> None:
         # Read-only polling is shared by every subscriber of this bridge and
         # independent of watch leases. It also works while no owner is running.
+        #
+        # The body is guarded because this store has other writers: a `database
+        # is locked` that outlives its 2 s timeout is routine contention, and
+        # letting it end the loop stopped cross-process read sync for the life
+        # of the bridge -- the phone and the TUI would clear an unread
+        # completion while the desktop kept showing it, silently and forever.
+        # A transient store error must cost one poll, not the feature. Matches
+        # the suppression `_expire_watches` already uses for the same reason.
+        store = AttentionStore(self.root / "attention.db")
         while True:
-            await self.refresh_attention()
+            try:
+                # `revision()` exists for exactly this loop and is far cheaper
+                # than the full per-conversation read; the steady state is a
+                # store nothing has written since the last tick.
+                #
+                # The owner's own state is part of the key because `supported`
+                # is derived from it, not from the store: an owner starting or
+                # going cold changes that answer while the store is untouched,
+                # so gating on the revision alone would pin `supported` to
+                # whatever happened to be true when the bridge attached.
+                remote = self.remote
+                key = (
+                    await asyncio.to_thread(store.revision),
+                    remote is not None
+                    and (remote.is_cold or getattr(remote, "supports_completion_ack", False)),
+                )
+                if key != self.attention_poll_key:
+                    await self.refresh_attention()
+                    self.attention_poll_key = key
+            except Exception as error:
+                logger.warning("attention poll failed for %s: %s", self.session_id, error)
             await asyncio.sleep(1)
 
     def state(self) -> dict[str, Any]:
@@ -234,7 +274,14 @@ class DesktopSessionBridge:
         )
 
     async def snapshot(self) -> dict[str, Any]:
-        await self.refresh_attention()
+        # Decorative, so a busy or damaged receipt sidecar cannot stop a
+        # conversation from OPENING. Before this field existed the snapshot
+        # never touched `attention.db`; letting it raise here turned routine
+        # write contention into a failure of the primary read path. The last
+        # known state is kept rather than blanked -- it is what the previous
+        # successful poll actually saw.
+        with contextlib.suppress(sqlite3.Error, OSError):
+            await self.refresh_attention()
         state = self.state()
         seq, epoch = self.sequence, self.epoch
         cursor = state["snapshot"].get("history_cursor")
@@ -393,7 +440,6 @@ class DesktopSessions:
         not enter its acquire path: a completed cold conversation is readable
         even when its owner and the mobile daemon are both stopped.
         """
-        from local_operator.session.attention import AttentionStore
 
         def acknowledge() -> dict[str, Any]:
             if not SESSION_ID.fullmatch(session_id):
@@ -439,15 +485,23 @@ class DesktopSessions:
             # runs once per row the caller will actually see rather than once
             # per session on disk. Measured 0.10 ms per row on a 38-session
             # store; the whole call already runs on a worker thread.
-            from local_operator.session.attention import AttentionStore
-
             # One read connection per list, never one per row or an owner bind.
-            attention = AttentionStore(self.root / "attention.db").state_many(
-                f"session/{row['id']}" for row in visible
-            )
+            #
+            # Guarded for the same reason as `snapshot()`: unread badges are a
+            # decoration on the session list, and losing every session row
+            # because the receipt sidecar is busy is strictly worse than
+            # showing the sessions without badges. Omitting the key degrades to
+            # "not ackable" on the client, which is correct rather than a false
+            # read state.
+            attention: dict[str, dict[str, Any]] = {}
+            with contextlib.suppress(sqlite3.Error, OSError):
+                attention = AttentionStore(self.root / "attention.db").state_many(
+                    f"session/{row['id']}" for row in visible
+                )
             for row in visible:
                 row["preview"] = session_preview(self.root / "sessions" / row["id"])
-                row["attention"] = attention[f"session/{row['id']}"]
+                if f"session/{row['id']}" in attention:
+                    row["attention"] = attention[f"session/{row['id']}"]
             return visible
 
         return await asyncio.to_thread(rows)

--- a/local_operator/server/utils/desktop_sessions.py
+++ b/local_operator/server/utils/desktop_sessions.py
@@ -237,6 +237,7 @@ class DesktopSessionBridge:
         # A transient store error must cost one poll, not the feature. Matches
         # the suppression `_expire_watches` already uses for the same reason.
         store = AttentionStore(self.root / "attention.db")
+        failing = 0
         while True:
             try:
                 # `revision()` exists for exactly this loop and is far cheaper
@@ -257,8 +258,29 @@ class DesktopSessionBridge:
                 if key != self.attention_poll_key:
                     await self.refresh_attention()
                     self.attention_poll_key = key
+                if failing:
+                    logger.info(
+                        "attention poll recovered for %s after %d failure(s)",
+                        self.session_id,
+                        failing,
+                    )
+                    failing = 0
             except Exception as error:
-                logger.warning("attention poll failed for %s: %s", self.session_id, error)
+                # Log the TRANSITION, not the tick. A transient error costs one
+                # line, but a persistent one (corrupt schema, permissions, full
+                # disk) would otherwise write ~3,600 identical warnings an hour
+                # per bridge, across up to BRIDGE_COUNT bridges, burying
+                # whatever else the operator needs to read. Recovery is logged
+                # too, so the pair brackets the outage rather than leaving a
+                # single warning of unknown duration.
+                failing += 1
+                if failing == 1:
+                    logger.warning(
+                        "attention poll failed for %s (further failures quiet "
+                        "until it recovers): %s",
+                        self.session_id,
+                        error,
+                    )
             await asyncio.sleep(1)
 
     def state(self) -> dict[str, Any]:

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -2520,6 +2520,10 @@ class RemoteSession:
             on_delta(answer)
         return answer
 
+    @property
+    def supports_completion_ack(self) -> bool:
+        return bool(self._client and self._client.supports_completion_ack)
+
     async def refresh_attention(self) -> dict[str, Any]:
         return dict(self.frontend_state.attention)
 

--- a/tests/unit/server/test_desktop_attention.py
+++ b/tests/unit/server/test_desktop_attention.py
@@ -9,6 +9,8 @@ shared receipt clock depends on.
 """
 
 import asyncio
+import contextlib
+import sqlite3
 import uuid
 
 import pytest
@@ -170,3 +172,139 @@ async def test_concurrent_receipts_and_publications_converge(tmp_path):
     assert final["unseen"] is True and final["anchor_id"] == "result-2"
     for state in receipts:
         assert state["revision"][1] == 1
+
+
+def _break_store(root) -> None:
+    """Drop the table a read needs, leaving a file that still opens.
+
+    Real contention (`database is locked` past the 2 s timeout) cannot be
+    scheduled deterministically in a test; a missing table raises the same
+    `sqlite3.Error` family through the identical call path, which is what the
+    guards are written against.
+    """
+    import sqlite3 as _sqlite3
+
+    with contextlib.closing(_sqlite3.connect(root / "attention.db")) as conn:
+        conn.execute("DROP TABLE completions")
+        conn.commit()
+
+
+@pytest.mark.asyncio
+async def test_a_store_error_costs_one_poll_not_the_whole_loop(tmp_path):
+    """A transient store failure must not end cross-process read sync.
+
+    The loop was a bare `while True`, so ONE `database is locked` stopped the
+    poller for the life of the bridge: the phone and the TUI would clear an
+    unread completion while the desktop kept showing it, forever and silently.
+    That is a new way to hide an unread result -- the failure this feature
+    exists to prevent.
+    """
+    pool = DesktopSessions(tmp_path)
+    sid = await pool.create(str(tmp_path))
+    token = _publish(tmp_path, sid, "result-1")
+    async with pool.session(sid) as bridge:
+        for _ in range(200):
+            if bridge.attention.get("completion_token"):
+                break
+            await asyncio.sleep(0.01)
+        assert bridge.attention["unseen"] is True
+
+        _break_store(tmp_path)
+        # The fixture must actually reach the failing branch, or this test
+        # passes while exercising nothing.
+        with pytest.raises(sqlite3.Error):
+            AttentionStore(tmp_path / "attention.db").state(f"session/{sid}")
+        bridge.attention_poll_key = None
+        await asyncio.sleep(2.5)
+        assert (
+            bridge.attention_task is not None and not bridge.attention_task.done()
+        ), "the poll loop died on a transient store error"
+
+        # Recovery is the point: once the store is healthy again the loop must
+        # pick the change up on its own, with no remount. Deleting the file is
+        # how the schema is rebuilt from scratch by the store itself.
+        (tmp_path / "attention.db").unlink()
+        recovered = _publish(tmp_path, sid, "result-2")
+        for _ in range(300):
+            if bridge.attention.get("completion_token") == recovered:
+                break
+            await asyncio.sleep(0.01)
+        assert bridge.attention["completion_token"] == recovered
+        assert bridge.attention["unseen"] is True
+    assert token != recovered
+
+
+@pytest.mark.asyncio
+async def test_a_dead_poll_task_can_never_strand_the_session_owner(tmp_path):
+    """Teardown must dispose the owner even when the poller already failed.
+
+    `_detach` awaited the attention task FIRST and suppressed only
+    `CancelledError`, so awaiting an already-failed task re-raised: leaving a
+    conversation raised, `dispose()` never ran, and the owner plus its
+    subscriptions leaked while `users` had already reached 0. A read receipt
+    must never strand a session owner.
+    """
+    pool = DesktopSessions(tmp_path)
+    sid = await pool.create(str(tmp_path))
+    _publish(tmp_path, sid, "result-1")
+    disposed: list[bool] = []
+    async with pool.session(sid) as bridge:
+        remote = bridge.remote
+        assert remote is not None
+        original = remote.dispose
+
+        async def record_dispose():
+            disposed.append(True)
+            await original()
+
+        remote.dispose = record_dispose  # type: ignore[method-assign]
+
+        # Kill the task the way a store error would, and PROVE it is dead
+        # before asserting teardown survives it.
+        assert bridge.attention_task is not None
+        bridge.attention_task.cancel()
+        with contextlib.suppress(BaseException):
+            await bridge.attention_task
+
+        async def already_failed() -> None:
+            raise sqlite3.OperationalError("database is locked")
+
+        bridge.attention_task = asyncio.create_task(already_failed())
+        await asyncio.sleep(0)
+        assert bridge.attention_task.done() and bridge.attention_task.exception() is not None
+
+    # Leaving the conversation did not raise, and teardown completed.
+    assert disposed == [True], "the owner session was never disposed"
+    assert bridge.attention_task is None
+    assert bridge.remote is None and bridge.users == 0
+    assert not bridge.unsubscribers, "frontend subscriptions leaked"
+
+
+@pytest.mark.asyncio
+async def test_a_degraded_store_never_breaks_opening_or_listing(tmp_path):
+    """Unread badges are decoration; they must not fail primary navigation.
+
+    Before this field existed neither path touched `attention.db`, so letting a
+    busy sidecar 500 the session list and the transcript is a straight
+    availability regression on paths that have nothing to do with receipts.
+    """
+    pool = DesktopSessions(tmp_path)
+    sid = await pool.create(str(tmp_path))
+    _publish(tmp_path, sid, "result-1")
+    async with pool.session(sid) as bridge:
+        healthy = await bridge.snapshot()
+        assert healthy["payload"]["frontend"]["snapshot"]["attention"]["unseen"] is True
+        assert (await pool.list(50))[0]["attention"]["unseen"] is True
+
+        _break_store(tmp_path)
+        with pytest.raises(sqlite3.Error):
+            AttentionStore(tmp_path / "attention.db").state(f"session/{sid}")
+
+        # The conversation still OPENS, and the list still lists.
+        degraded = await bridge.snapshot()
+        assert degraded["payload"]["frontend"]["snapshot"]["session_id"] == sid
+        rows = await pool.list(50)
+        assert [row["id"] for row in rows] == [sid]
+        # Omitted rather than fabricated: absent state is "not ackable" on the
+        # client, which is correct. A false "read" would not be.
+        assert "attention" not in rows[0]

--- a/tests/unit/server/test_desktop_attention.py
+++ b/tests/unit/server/test_desktop_attention.py
@@ -1,0 +1,172 @@
+"""Desktop read receipts: a cold durable path that never admits or binds.
+
+The desktop control surface reaches sessions through `DesktopSessionBridge`,
+which acquires a `RemoteSession` and can START an owner. A read receipt must
+not do any of that: the user is looking at a conversation that already ended,
+frequently with no owner alive at all, and marking it read is not a reason to
+spawn a process. These tests pin that separation plus the ordering rules the
+shared receipt clock depends on.
+"""
+
+import asyncio
+import uuid
+
+import pytest
+
+from local_operator.server.utils.desktop_sessions import DesktopSessions
+from local_operator.session.attention import AttentionStore
+
+
+def _publish(root, session_id: str, anchor: str, kind: str = "complete") -> str:
+    token = str(uuid.uuid4())
+    AttentionStore(root / "attention.db").publish(f"session/{session_id}", token, anchor, kind)
+    return token
+
+
+@pytest.mark.asyncio
+async def test_a_read_receipt_never_acquires_a_session_or_starts_an_owner(tmp_path, monkeypatch):
+    """The cold path is the point: no bridge, no attach, no spawn.
+
+    `DesktopSessions.session()` is the only other way in, and it constructs a
+    `RemoteSession` that will start an owner for a cold session. Reading is not
+    an admission, so this route must not reach it -- an exploding `session()`
+    is how that stays true if someone later "simplifies" the implementation.
+    """
+    pool = DesktopSessions(tmp_path)
+    sid = await pool.create(str(tmp_path))
+    token = _publish(tmp_path, sid, "result-1")
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("a read receipt must not acquire a session bridge")
+
+    monkeypatch.setattr(DesktopSessions, "session", forbidden)
+    state = await pool.acknowledge_attention(sid, token)
+    assert state["unseen"] is False and state["revision"] == [1, 1]
+    assert not (tmp_path / "sessions" / sid / ".session.pid").exists()
+    assert not pool.bridges
+
+
+@pytest.mark.asyncio
+async def test_only_a_real_user_session_in_this_root_can_be_acknowledged(tmp_path):
+    """Identity is validated the same way the bridge validates it.
+
+    A path from the caller, a traversal, or another root's session id must be
+    a 404 rather than a receipt written against a fabricated conversation.
+    """
+    pool = DesktopSessions(tmp_path)
+    sid = await pool.create(str(tmp_path))
+    token = _publish(tmp_path, sid, "result-1")
+    for bogus in ("../../etc", "not-hex", "a" * 12, sid.upper(), ""):
+        with pytest.raises(KeyError):
+            await pool.acknowledge_attention(bogus, token)
+    # A valid-shaped id that is not a session on disk is equally unknown.
+    with pytest.raises(KeyError):
+        await pool.acknowledge_attention("0123456789ab", token)
+    # Unchanged by every rejection above.
+    assert AttentionStore(tmp_path / "attention.db").state(f"session/{sid}")["unseen"]
+    assert (await pool.acknowledge_attention(sid, token))["unseen"] is False
+
+
+@pytest.mark.asyncio
+async def test_a_delayed_receipt_for_an_older_completion_never_clears_a_newer_one(tmp_path):
+    """A slow client acknowledging A must not mark B read.
+
+    The renderer captures the token with the anchor it actually saw, so a
+    receipt that arrives after the next turn finished is addressed to the OLD
+    outcome. Advancing to "now" (or to the latest sequence) would silently
+    swallow an unread result -- the exact failure the mobile bodyless `/seen`
+    had before this contract existed.
+    """
+    pool = DesktopSessions(tmp_path)
+    sid = await pool.create(str(tmp_path))
+    first = _publish(tmp_path, sid, "result-1")
+    second = _publish(tmp_path, sid, "result-2")
+
+    late = await pool.acknowledge_attention(sid, first)
+    assert late["unseen"] is True
+    assert late["completion_token"] == second and late["revision"] == [2, 1]
+
+    caught_up = await pool.acknowledge_attention(sid, second)
+    assert caught_up["unseen"] is False and caught_up["revision"] == [2, 2]
+
+    # Reordered duplicate delivery of the old receipt converges, never regresses.
+    assert (await pool.acknowledge_attention(sid, first))["unseen"] is False
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_or_foreign_token_is_refused_without_touching_state(tmp_path):
+    """Tokens are membership-checked against THIS conversation.
+
+    Rejecting a well-formed token that belongs to another session matters more
+    than rejecting garbage: the ids are uniform, so a mixed-up client would
+    otherwise clear a conversation the user never opened.
+    """
+    pool = DesktopSessions(tmp_path)
+    mine = await pool.create(str(tmp_path))
+    other = tmp_path / "other"
+    other.mkdir()
+    theirs = await pool.create(str(other))
+    foreign = _publish(tmp_path, theirs, "their-result")
+    _publish(tmp_path, mine, "my-result")
+
+    for bad in (foreign, str(uuid.uuid4()), "not-a-uuid"):
+        with pytest.raises(ValueError):
+            await pool.acknowledge_attention(mine, bad)
+    store = AttentionStore(tmp_path / "attention.db")
+    assert store.state(f"session/{mine}")["unseen"]
+    assert store.state(f"session/{theirs}")["unseen"]
+
+
+@pytest.mark.asyncio
+async def test_the_session_list_reports_durable_receipts_without_an_owner(tmp_path):
+    """Unread state is a cold read, one connection for the whole list.
+
+    The list is painted before any conversation is opened, so it cannot depend
+    on a live owner or a per-row database connection.
+    """
+    pool = DesktopSessions(tmp_path)
+    read = await pool.create(str(tmp_path))
+    unread = await pool.create(str(tmp_path))
+    token = _publish(tmp_path, read, "seen-result")
+    _publish(tmp_path, unread, "unseen-result")
+    await pool.acknowledge_attention(read, token)
+
+    rows = {row["id"]: row["attention"] for row in await pool.list(50)}
+    assert rows[read]["unseen"] is False and rows[read]["revision"] == [1, 1]
+    assert rows[unread]["unseen"] is True
+    assert rows[unread]["conversation_id"] == f"session/{unread}"
+    # A session that never completed a turn is present and simply has nothing.
+    quiet = await pool.create(str(tmp_path))
+    assert (await pool.list(50))[0]["id"] is not None
+    assert {row["id"]: row["attention"] for row in await pool.list(50)}[quiet][
+        "completion_token"
+    ] is None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_receipts_and_publications_converge(tmp_path):
+    """Independent processes write this store; the API must not serialize it.
+
+    Interleaving a burst of acknowledgements with a new publication has exactly
+    two correct outcomes -- read through the latest, or unread BECAUSE the new
+    completion landed after the last receipt. Neither may lose the newer
+    completion or report a receipt ahead of what was acknowledged.
+    """
+    pool = DesktopSessions(tmp_path)
+    sid = await pool.create(str(tmp_path))
+    token = _publish(tmp_path, sid, "result-1")
+
+    async def publish_later():
+        await asyncio.sleep(0.01)
+        return await asyncio.to_thread(_publish, tmp_path, sid, "result-2")
+
+    receipts, _ = await asyncio.gather(
+        asyncio.gather(*[pool.acknowledge_attention(sid, token) for _ in range(8)]),
+        publish_later(),
+    )
+    final = AttentionStore(tmp_path / "attention.db").state(f"session/{sid}")
+    published, acknowledged = final["revision"]
+    assert published == 2 and acknowledged == 1
+    assert final["unseen"] is True and final["anchor_id"] == "result-2"
+    for state in receipts:
+        assert state["revision"][1] == 1


### PR DESCRIPTION
# PR Description

## Summary of Changes

Release: patch — viewing a session in the TUI, the desktop app, or the mobile relay now marks its completions viewed everywhere, so a session already read in one surface stops showing as new in the others.

Lets the desktop app acknowledge a completion it actually rendered, so a result viewed on
the desktop stops being unread on the phone and in the terminal. Shared read state already
existed for the TUI and the mobile relay (#687); this is the desktop adapter over the same
durable authority.

Everything here is **additive**. No existing desktop route, watch lease, admission path or
attach contract changes behaviour.

- **`POST /v1/desktop/sessions/{id}/seen`.** Admitted by a durable completion token and
  nothing else. A timestamp, or a bodyless "mark it read now", is what let a background
  mobile tab acknowledge a result it never rendered — so a delayed receipt for outcome A
  can no longer clear a newer unread outcome B, and duplicate or reordered delivery
  converges rather than regressing.
- **A cold path, deliberately not the bridge.** `DesktopSessionBridge` acquires a
  `RemoteSession` and will start an owner for a cold session. Reading a conversation that
  already ended is not a reason to spawn a process, so the route validates identity against
  the same durable user-session namespace instead and never acquires a bridge. Unread state
  therefore also resolves while the owner and the mobile daemon are both stopped.
- **Attention as an additive projection.** The initial snapshot carries the baseline and
  later changes ride their own `attention` frame, because the receipt clock is independent
  of the owner epoch. Owner deltas are stripped for the same reason: a reconnecting owner
  must not undo a read made by another process while the stream stayed mounted.
- **Honest capability reporting.** `completion-ack-v1` is advertised on `/v1/capabilities`
  and negotiated per owner, so an older runtime that cannot take receipts reports
  unsupported rather than silently dropping them.

Watch leases are untouched: they continue to route notification delivery and never mark
anything read.

## Related Issue(s)

- Depends on: #687 (shared receipt authority, TUI + mobile)
- Depends on: #696 (desktop control surface) — **held for human C5 approval**
- Companion UI PR: damianvtran/local-operator-ui#84

## Impact

**Breaking changes:** none. The route is new; every existing response gains at most an
additive `attention` field.

**Dependency and review scope.** This branch is stacked on
`integration/desktop-attention-base`, a recorded merge of #687's head (`be394cdc`) and
#696's head (`3aebfe87`). Review only the adapter commit above that base — the
prerequisites carry their own review rounds. **#696 is held for Damian's C5 approval and
must not be assumed merged**; this PR cannot land before it does.

**Privacy and data.** Receipts store a conversation id, a completion token and two
integers. No transcript content, no message text.

## Testing

Real execution against the actual routes and the real bridge, not just unit assertions.
Full evidence: `~/workspace/viewed-state-evidence/desktop-adapter/`.

### The endpoint, over live HTTP (uvicorn + real app)

| Case | Result |
| --- | --- |
| No bearer token | **401** |
| `Origin: https://evil.example` | **403** |
| Bodyless `{}` | **422** |
| `{"seen_at": 123}` (timestamp instead of token) | **422** |
| Non-UUID token | **422** |
| Well-formed but unknown token | **409** `unknown completion token` |
| Token for outcome A, after B completed | **200**, `unseen=true`, revision `[2,1]` |
| Token for current outcome B | **200**, `unseen=false`, revision `[2,2]` |
| Replay of the stale A receipt | **200**, still `[2,2]` — no regression |
| `.session.pid` after every one of the above | **absent** — no owner spawned |

### The bridge, over real SSE

- The snapshot carries `attention`; the initial frames are `open`, `snapshot` with no
  attention frame racing ahead of the baseline.
- An acknowledgement written by **another process** produced an `attention` frame on the
  already-mounted stream — cross-process reconciliation, verified rather than assumed.
- Subscribing to the stream and holding it open **never** acknowledged anything, which is
  the mobile-daemon defect this design exists to avoid.

### Reordering and convergence

`test_desktop_attention.py` drives eight concurrent receipts interleaved with a real
publication and asserts the only two correct outcomes; a foreign session's well-formed
token is refused without touching either conversation's state.

### Gates (whole tree, exactly as CI)

```text
.venv/bin/python -m flake8 .                                  clean
uvx --from black==26.1.0 black --check .                      986 files unchanged
uvx isort==5.13.2 --check .                                   clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .   0 errors, 0 warnings
.venv/bin/python -m pytest tests/unit -q                      14937 passed, 18 skipped
```

## Non-goals

- **No desktop session browser or presence service.** This adapter reuses the existing
  desktop session API; it does not add a way to browse or manage sessions.
- **No native OS notification withdrawal.** Marking a completion read does not retract a
  notification already delivered; that was not requested.
- **Pending approvals and questions are never cleared by reading.** A gate is an action, not
  a notification, and reading the conversation must not answer it.
- **No passive acknowledgement anywhere.** Subscriptions, heartbeats, watch leases and
  mounts do not mark anything read, by construction.

## Rollout

Additive and self-enabling: a desktop build that does not send receipts behaves exactly as
today, and a runtime that predates `completion-ack-v1` reports the capability as
unsupported instead of failing. The store is the same `attention.db` #687 introduced, so no
migration and no new operational surface.

