### PR TITLE
feat(tui): draw /session as charts using the /analytics vocabulary

### DIFF
--- a/local_operator/analytics/model.py
+++ b/local_operator/analytics/model.py
@@ -530,6 +530,13 @@ class SessionReport:
     available: bool = True
     aggregate: UsageAggregate = field(default_factory=UsageAggregate)
     by_model: dict[tuple[str, str], UsageAggregate] = field(default_factory=dict)
+    # Consumption grouped by the ``purpose`` column (``turn``, ``compaction``,
+    # ``aside``, ``naming``, ``compaction_advisor``). Distinct from
+    # ``by_purpose_outcome``, which is COUNT(*) only: a count cannot answer
+    # "what did compaction cost me", which is the question the /session screen's
+    # by-purpose chart exists to answer. Both are kept because they carry
+    # different facts — this one the consumption, that one the failure tally.
+    by_purpose: dict[str, UsageAggregate] = field(default_factory=dict)
     by_purpose_outcome: dict[tuple[str, str], int] = field(default_factory=dict)
     missing_usage_calls: int = 0
     unknown_usage_calls: int = 0

--- a/local_operator/analytics/store.py
+++ b/local_operator/analytics/store.py
@@ -1061,6 +1061,18 @@ class AnalyticsStore:
             }
             purpose = col("purpose", "'unknown'")
             outcome = col("outcome", "'unknown'")
+            # Consumption per purpose, on the SAME ``measures`` contract as
+            # ``by_model`` — one extra GROUP BY on a column that already exists
+            # beside the token and cost sums, so no schema change and no second
+            # aggregation vocabulary. ``col`` folds an older ledger without the
+            # column into a single ``unknown`` row, which is honest: we know the
+            # tokens, we do not know what they were spent on.
+            by_purpose = {
+                str(row[0]): _aggregate_from_row(row[1:])
+                for row in conn.execute(
+                    f"SELECT {purpose}, {measures}" + scope + " GROUP BY 1", params
+                )
+            }
             groups = {
                 (str(row[0]), str(row[1])): int(row[2])
                 for row in conn.execute(
@@ -1117,6 +1129,7 @@ class AnalyticsStore:
                 session_id=session_id,
                 aggregate=aggregate,
                 by_model=by_model,
+                by_purpose=by_purpose,
                 by_purpose_outcome=groups,
                 missing_usage_calls=int(missing or 0),
                 unknown_usage_calls=int(unknown or 0),

--- a/local_operator/tui/widgets/analytics_panel.py
+++ b/local_operator/tui/widgets/analytics_panel.py
@@ -52,7 +52,7 @@ from local_operator.tui import theme as theme_mod
 class _CostLike(Protocol):
     """The cost interface both a scope and a calendar bucket expose.
 
-    ``format_cost``/``_append_cost`` render the same ``$—``/``$X.XX``/``$X+``
+    ``format_cost``/``append_cost`` render the same ``$—``/``$X.XX``/``$X+``
     honesty for a :class:`UsageAggregate` (a provider/session scope) AND a
     :class:`UsagePeriod` (a day/month bucket). Rather than duplicate the money
     formatter or widen the annotation to a lie, this Protocol names the three
@@ -142,8 +142,14 @@ def format_cost(aggregate: "_CostLike") -> str:
     return body + ("+" if aggregate.cost_is_partial else "")
 
 
-def _append_cost(block: Text, aggregate: "_CostLike", cell: int, fg: Style, dim: Style) -> None:
+def append_cost(block: Text, aggregate: "_CostLike", cell: int, fg: Style, dim: Style) -> None:
     """Append a right-aligned cost cell, with the lower-bound ``+`` in ``dim``.
+
+    Public (it was ``_append_cost``) because ``session_panel`` renders the same
+    money cells: one screen showing ``$1.20+`` and its sibling showing a plain
+    ``$1.20`` for the same partial sum would be two honesty vocabularies. An
+    underscore name imported across modules is a private contract in all but
+    spelling, so the name says what the visibility already is.
 
     The ``+`` is a STATUS FLAG, not a digit (review D1): rendering it in the same
     full-strength weight as the number let it read as part of the figure, so a
@@ -161,6 +167,17 @@ def _append_cost(block: Text, aggregate: "_CostLike", cell: int, fg: Style, dim:
         block.append(text, style=fg)
 
 
+def scope_needs_cost_legend(scope: "_CostLike") -> bool:
+    """Whether ONE scope renders a ``+`` (partial) or a ``$—`` (unknown).
+
+    The predicate, not the loop: ``/session`` decides the same question over a
+    different set of scopes (its per-model and per-purpose groups), and two
+    copies of "what counts as a marked figure" would eventually disagree about
+    when the footnote is owed.
+    """
+    return (scope.cost_is_partial and scope.cost_is_known) or not scope.cost_is_known
+
+
 def _needs_cost_legend(aggregate: "UsageAggregate") -> bool:
     """Whether any scope on screen shows a ``+`` (partial) or ``$—`` (unknown).
 
@@ -169,7 +186,7 @@ def _needs_cost_legend(aggregate: "UsageAggregate") -> bool:
     noise.
     """
     scopes = [aggregate, *aggregate.by_provider.values(), *aggregate.by_session.values()]
-    return any((s.cost_is_partial and s.cost_is_known) or not s.cost_is_known for s in scopes)
+    return any(scope_needs_cost_legend(s) for s in scopes)
 
 
 def proportion_bar(fraction: float, width: int) -> str:
@@ -224,7 +241,13 @@ def _component_rows(aggregate: UsageAggregate) -> list[_Row]:
     return rows
 
 
-def _semantic(name: str) -> Style:
+def semantic_style(name: str) -> Style:
+    """A ``rich`` style for one semantic theme token.
+
+    Public (it was ``_semantic``) so ``session_panel`` resolves its row colours
+    through the same one-line helper rather than re-spelling
+    ``Style(color=theme_mod.semantic_color(...))`` at every call site.
+    """
     return Style(color=theme_mod.semantic_color(name))
 
 
@@ -237,8 +260,13 @@ def _semantic(name: str) -> Style:
 _SECTION_MARK = "▌"
 
 
-def _section_header(title: str, meta: str = "") -> Text:
+def section_header(title: str, meta: str = "") -> Text:
     """A section header in the app's own voice: title-case, bold ``fg``, marked.
+
+    Public (it was ``_section_header``) for the same reason as
+    :func:`append_cost`: ``/session`` draws the identical ``▌``-marked headers,
+    and forking the glyph or the meta styling would give the two diagnostics
+    screens two visual languages.
 
     NOT all-caps (review: the app uses that pattern nowhere else). The ``▌``
     accent bar in the left margin is the delineation — it gives a scrolling
@@ -266,6 +294,10 @@ def _section_header(title: str, meta: str = "") -> Text:
 #: legal values.
 METRIC_COST = "cost"
 METRIC_TOKENS = "tokens"
+
+#: The footnote explaining the two money marks. One string so ``/analytics`` and
+#: ``/session`` cannot drift into two different explanations of the same glyph.
+COST_LEGEND = "+ lower bound (some calls unpriced)   $— no published price"
 
 
 def _month_name(mm: int) -> str:
@@ -366,11 +398,11 @@ def _series_chart(
     Pure: returns ``Text`` lines so ``render_lines_for_test`` reads the chart
     back as plain strings, exactly like the rest of ``build_report``.
     """
-    fg = _semantic("fg")
-    dim = _semantic("dim")
-    accent = _semantic("accent")
+    fg = semantic_style("fg")
+    dim = semantic_style("dim")
+    accent = semantic_style("accent")
 
-    lines: list[Text] = [_section_header(title, meta)]
+    lines: list[Text] = [section_header(title, meta)]
     if not periods:
         empty = Text()
         empty.append(f"  {empty_note}", style=dim)
@@ -439,9 +471,9 @@ def build_report(
     report.
     """
     width = max(40, width)
-    fg = _semantic("fg")
-    dim = _semantic("dim")
-    accent = _semantic("accent")
+    fg = semantic_style("fg")
+    dim = semantic_style("dim")
+    accent = semantic_style("accent")
 
     lines: list[Text] = []
 
@@ -465,7 +497,7 @@ def build_report(
         # Failed-call count is real information, not chrome — keep it in the meta.
         calls_meta += f" ({aggregate.calls - aggregate.ok_calls} failed)"
     calls_meta += " · measured"
-    lines.append(_section_header("Totals", calls_meta))
+    lines.append(section_header("Totals", calls_meta))
 
     # Value cells share a gutter so notes line up even when compact figures
     # differ in width (``3M`` vs ``387k``). 11 cells matches the existing
@@ -571,13 +603,13 @@ def build_report(
         cost_note = "no published price"
     # Built directly (not via ``kv``) so the lower-bound ``+`` is dimmed like the
     # table cells (review D1) — the figure reads as a number, the ``+`` as a flag.
-    # ``_append_cost`` right-aligns (table cells); here we pass the figure's own
+    # ``append_cost`` right-aligns (table cells); here we pass the figure's own
     # width so it left-aligns with the token values, then pad out to
     # ``_VALUE_CELL`` so the cost note shares the gutter (D2).
     cost_text = format_cost(aggregate)
     cost_row = Text()
     cost_row.append(f"  {'Est. cost':<22}", style=dim)
-    _append_cost(cost_row, aggregate, len(cost_text), fg, dim)
+    append_cost(cost_row, aggregate, len(cost_text), fg, dim)
     cost_row.append(" " * max(0, _VALUE_CELL - len(cost_text)))
     cost_row.append(f"  {cost_note}", style=dim)
     lines.append(cost_row)
@@ -646,7 +678,7 @@ def build_report(
     # word "estimated" is why this section reads differently from Totals, and it
     # is ALSO carried at the data level — the ``≈`` mark and the ``~`` on every
     # percentage below — so the distinction survives the heading scrolling away.
-    lines.append(_section_header("Where input went", "≈ estimated split of context tokens"))
+    lines.append(section_header("Where input went", "≈ estimated split of context tokens"))
 
     rows = _component_rows(aggregate)
     if not rows:
@@ -704,7 +736,7 @@ def build_report(
     if _needs_cost_legend(aggregate):
         lines.append(Text())
         legend = Text()
-        legend.append("  + lower bound (some calls unpriced)   $— no published price", style=dim)
+        legend.append("  " + COST_LEGEND, style=dim)
         lines.append(legend)
 
     return lines
@@ -737,11 +769,11 @@ def _group_section(
     cache; a narrow one drops the cache column (see ``_WIDE_TABLE_MIN``) so the
     cost column this feature adds always survives.
     """
-    fg = _semantic("fg")
-    dim = _semantic("dim")
+    fg = semantic_style("fg")
+    dim = semantic_style("dim")
 
     # Same marked, title-case header as every other section (no all-caps).
-    block = _section_header(title)
+    block = section_header(title)
 
     # Sort by cost when any of these groups is priced, else by tokens. Keyed on
     # the tuple so an unpriced group sorts by tokens as a tiebreak rather than
@@ -763,9 +795,9 @@ def _group_section(
         block.append(f"{format_tokens(agg.total_tokens):>8} tokens", style=fg)
         # Cost sits next to tokens as the other headline number, in full-strength
         # ``fg`` — it is the answer this feature exists to give, not a footnote.
-        # The lower-bound ``+`` is dimmed by ``_append_cost`` (review D1).
+        # The lower-bound ``+`` is dimmed by ``append_cost`` (review D1).
         block.append("   ")
-        _append_cost(block, agg, cost_col, fg, dim)
+        append_cost(block, agg, cost_col, fg, dim)
         block.append(f"   {agg.calls:>4} calls", style=dim)
         if show_cache:
             block.append(f"   {format_percent(agg.cache_hit_rate):>4} cache", style=dim)

--- a/local_operator/tui/widgets/session_panel.py
+++ b/local_operator/tui/widgets/session_panel.py
@@ -1,17 +1,41 @@
-"""Read-only current-session diagnostics, using the analytics ledger's units.
+"""Read-only current-session diagnostics, drawn with the analytics chart vocabulary.
 
 The report is a close/reopen snapshot, not a live bill. Runtime scalars are
 captured before the worker reads SQLite; neither prompts nor tool payloads ever
-enter this view. Keep this screen independent of AnalyticsScreen's calendar
-charts and metric-toggle bindings while sharing its visual chrome and formatters.
+enter this view.
+
+Every proportional row on this screen is drawn by :func:`_render_rows` on top of
+``analytics_panel``'s primitives (``proportion_bar``, ``section_header``,
+``format_tokens``/``format_cost``/``format_percent``, ``append_cost``,
+``METRIC_COST``/``METRIC_TOKENS``), imported rather than copied: two diagnostics
+screens with two bar styles, two money formatters or two honesty vocabularies
+would be a defect, not a variation.
+
+**The denominators differ deliberately, and each is commented where it is
+computed.** A bar means nothing without knowing what it is a fraction OF, and
+this screen answers four different questions:
+
+- *by model* / *by purpose* — share of the session total, because those rows
+  PARTITION one quantity and the reader's question is "what fraction of this
+  session was X".
+- *context window* — share of a hard limit, an absolute gauge.
+- *where input went* / *tool surface* — share of the component total, so the
+  three tool components read with identical percentages in both sections.
+- *last N requests* — share of the window max, because a tail does NOT partition
+  the session and share-of-total would render twelve indistinguishable 4% bars.
+
+What is deliberately NOT here: per-tool-name tokens or dollars (the ledger has no
+such column and the provider bills one input total per call — see
+:data:`_TOOL_KEYS`), and any calendar chart (the daily/monthly rollups are
+machine-wide, not session-scoped, so drawing them under a "this session" heading
+would attribute other sessions' spend to this one).
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 
-from rich.style import Style
 from rich.text import Text
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -19,14 +43,66 @@ from textual.containers import Container, VerticalScroll
 from textual.screen import ModalScreen
 from textual.widgets import Static
 
-from local_operator.analytics.model import COMPONENT_LABELS, SessionReport
+from local_operator.analytics.model import (
+    COMPONENT_KEYS,
+    COMPONENT_LABELS,
+    SessionReport,
+    TimingSummary,
+    UsageAggregate,
+)
 from local_operator.session.protocol import SessionProtocol
-from local_operator.tui import theme as theme_mod
 from local_operator.tui.widgets.analytics_panel import (
+    COST_LEGEND,
+    METRIC_COST,
+    METRIC_TOKENS,
+    append_cost,
     format_cost,
     format_percent,
     format_tokens,
+    proportion_bar,
+    scope_needs_cost_legend,
+    section_header,
+    semantic_style,
 )
+
+#: The ledger's tool-shaped component columns, biggest-first for the child rows
+#: of the Tool surface section. These are the ONLY tool-shaped numbers recorded:
+#: there is no per-tool-name token or cost column anywhere in ``calls``, and
+#: there cannot be one without both a schema migration and a recording-side
+#: change, because the provider bills one input total per call and never
+#: attributes it to a tool. Anything labelled "cost per tool" here would be an
+#: invented number, which is why the section carries a caveat instead.
+_TOOL_KEYS = ("tool_results", "tool_schemas", "tool_inventory")
+
+#: Responsive ladder, in the order things shed as the card narrows. Modelled on
+#: ``analytics_panel._WIDE_TABLE_MIN`` — the value column never sheds, because a
+#: bar without its number is a picture and a number without its bar is the
+#: prose screen this replaces.
+#:
+#: - below :data:`_NOTE_MIN` the trailing note column goes (``N req``, the
+#:   purpose tag, the timing range, the Totals qualifiers). Measured need: at 50
+#:   columns a note pushes the row past the viewport and folds onto its own
+#:   line, where it reads as a separate record.
+#: - below :data:`_PCT_MIN` the percentage goes too, leaving label + bar + value.
+_NOTE_MIN = 60
+_PCT_MIN = 52
+
+#: Card width the column arithmetic degrades to before mount, when the app size
+#: is not yet knowable. Matches ``AnalyticsScreen._card_width``'s fallback.
+_DEFAULT_CARD_WIDTH = 88
+
+#: The narrowest frame the ladder in :data:`_NOTE_MIN` / :data:`_PCT_MIN` is
+#: defined down to: a 50-column terminal's measured content box.
+_MIN_CARD_WIDTH = 38
+
+#: Bar floor. Below eight cells a bar cannot express a proportion, so the label
+#: column yields (and its labels ellipsise) before the bar is allowed to shrink.
+_BAR_MIN = 8
+_BAR_MAX = 24
+
+#: Value cell for the Totals ``kv`` rows, matching ``build_report``'s so the two
+#: screens' headline blocks have the same rhythm.
+_VALUE_CELL = 11
 
 
 @dataclass(frozen=True)
@@ -72,174 +148,846 @@ def _stamp(ts_ms: int | None) -> str:
     return datetime.fromtimestamp(ts_ms / 1000).astimezone().strftime("%Y-%m-%d %H:%M:%S %Z")
 
 
+def _clock(ts_ms: int | None) -> str:
+    """Wall-clock label for one request row: ``HH:MM:SS``.
+
+    Only the time of day, not the date: the sequence chart's rows are a tail of
+    one session, so the date is the same on every row and repeating it would
+    spend the whole label column saying nothing.
+    """
+    if ts_ms is None:
+        return "unknown"
+    return datetime.fromtimestamp(ts_ms / 1000).astimezone().strftime("%H:%M:%S")
+
+
 def _milliseconds(value: float | None) -> str:
     return "unknown" if value is None else f"{value:,.0f} ms"
 
 
-def build_session_report(report: SessionReport | None, runtime: SessionDiagnostics) -> Text:
-    """Stacked, wrapping rows keep full IDs readable even in a 50-column pane."""
-    fg = Style(color=theme_mod.semantic_color("fg"))
-    muted = Style(color=theme_mod.semantic_color("muted"))
-    result = Text(style=fg, overflow="fold")
+# -- the shared row engine ---------------------------------------------------
 
-    def line(label: str, value: str = "") -> None:
-        result.append(label, style=muted)
-        if value:
-            result.append("  " + value, style=fg)
-        result.append("\n")
 
-    def section(title: str) -> None:
-        result.append(
-            "\n" + title + "\n", style=Style(color=theme_mod.semantic_color("fg"), bold=True)
-        )
+@dataclass(frozen=True)
+class _BarRow:
+    """One proportional row, pre-measured so a whole table shares its columns.
 
-    line(runtime.name or "Untitled session")
-    line("ID", runtime.session_id)
-    if report is None:
-        section("Loading usage records")
-        line("Reading the local ledger. Esc or q cancels.")
-        line("No model request is made.")
-        return result
-    line("Current session only. Close and reopen to refresh.")
-    aggregate = report.aggregate
-    if not report.available:
-        section("Ledger unavailable")
-        line("Could not read local usage records. Close and reopen to try again.")
-    elif not aggregate.calls:
-        section("No recorded requests")
-        line("No retained usage records for this session yet.")
-    else:
-        section("Recorded usage")
-        line("Requests", f"{aggregate.calls:,}")
-        line("Cost (reported / est.)", format_cost(aggregate))
-        line("Tokens", f"{aggregate.total_tokens:,} total")
-        line("Input context", f"{aggregate.context_tokens:,}")
-        line(
-            "Output",
-            f"{aggregate.output_tokens:,} (includes {aggregate.reasoning_tokens:,} reasoning)",
-        )
-        line(
-            "Cache read",
-            f"{aggregate.cache_read_tokens:,} / {aggregate.context_tokens:,} "
-            f"context ({format_percent(aggregate.cache_hit_rate)})",
-        )
-        line("Cache write", f"{aggregate.cache_write_tokens:,}")
-        line(
-            "Usage missing",
-            f"{report.missing_usage_calls:,} requests; {report.unknown_usage_calls:,} unknown",
-        )
-        line("Period", _stamp(report.first_ts_ms) + " to " + _stamp(report.last_ts_ms))
-        line("Cost is provider-reported or a list-price estimate. Source is not retained per row.")
-        line(
-            "+ means a partial cost; unknown cost is not free. "
-            "Input/output/tool dollars are unavailable separately."
-        )
+    ``note`` is a sequence of ``(text, semantic token)`` pairs rather than a
+    plain string because the parts are not all the same kind of thing: a request
+    count is ``dim`` status chrome, while ``N failed`` is a fact a reader must
+    not scroll past and is drawn in ``warning``.
 
-        section("Provider / model")
-        for (provider, model), group in sorted(
-            report.by_model.items(), key=lambda item: -item[1].total_tokens
-        ):
-            line(f"{provider}/{model}")
-            line(
-                "  Usage",
-                f"{group.calls:,} requests · {format_tokens(group.total_tokens)} "
-                f"tokens · {format_cost(group)}",
-            )
-            line(
-                "  Input / output",
-                f"{format_tokens(group.context_tokens)} / {format_tokens(group.output_tokens)}",
-            )
+    ``bar=False`` suppresses the bar for a row that is not a peer of the others
+    — the ``Unattributed`` residual, or an unpriced row in cost mode — so the
+    reader is never shown a fill implying a share the row does not have.
+    """
 
-        section("Estimated input breakdown")
-        line(
-            "Character-weighted attribution of recorded input "
-            "context, not separately billed tokens or dollars."
-        )
-        for key, value in sorted(aggregate.components.items(), key=lambda item: -item[1]):
-            line(COMPONENT_LABELS.get(key, key), f"~{format_tokens(value)}")
-        unattributed = max(0, aggregate.context_tokens - sum(aggregate.components.values()))
-        if unattributed:
-            line("Unattributed (older records)", format_tokens(unattributed))
+    label: str
+    fraction: float
+    value: str
+    note: tuple[tuple[str, str], ...] = ()
+    bar: bool = True
+    #: The scope whose money this row's value renders, when the active metric is
+    #: cost. Carried (rather than pre-formatted into ``value``) so the row is
+    #: drawn by ``append_cost`` and inherits its dimmed lower-bound ``+``;
+    #: ``None`` on a token row, which has no such flag.
+    cost: UsageAggregate | None = None
 
-        section("Request purpose / outcome")
-        for (purpose, outcome), count in sorted(report.by_purpose_outcome.items()):
-            line(f"{purpose} / {outcome}", f"{count:,}")
 
-        section("Logical request timings")
-        line(
-            "Observed wall time includes retries and consumer "
-            "backpressure; not provider compute or per-attempt timing. "
-            "First output is the first text or tool-call delta."
-        )
-        for key, label in (
-            ("duration_ms", "Duration"),
-            ("ttft_ms", "First output"),
-            ("preparation_ms", "Preparation"),
-        ):
-            timing = report.timings.get(key)
-            if timing is None or not timing.samples:
-                line(label, "unknown (0 samples)")
-            else:
-                line(label, f"{_milliseconds(timing.mean_ms)} mean ({timing.samples:,} samples)")
-                line("  Range", f"{_milliseconds(timing.min_ms)} to {_milliseconds(timing.max_ms)}")
+@dataclass(frozen=True)
+class _Columns:
+    """The measured column widths one or more bar tables are drawn into."""
 
-    section("Runtime snapshot")
-    line("Selected", runtime.selected_model)
-    line("Effective", runtime.effective_model)
-    line("State", "streaming" if runtime.streaming else "idle")
-    line(
-        "Turn generation",
-        str(runtime.generation) if runtime.generation is not None else "unavailable",
+    label: int
+    bar: int
+    value: int
+    show_pct: bool
+    show_note: bool
+
+
+def _measure_columns(rows: list[_BarRow], width: int, *, show_pct: bool = True) -> _Columns:
+    """Measure label/bar/value columns across EVERY row before any is emitted.
+
+    Callers pass the UNION of rows from every section that must line up, so one
+    left edge, one bar column and one number column run down the whole screen.
+    ``/analytics`` measures per table, which is why its component bars and its
+    per-provider numbers start at two different x positions on one panel; that
+    is the flaw this signature exists to make impossible here.
+
+    The label cap is bounded by the FRAME, not only by a constant: at 40 cells
+    of card width a 34-character label such as ``Custom instructions
+    (agents/teams)`` cannot coexist with a bar, so the label column collapses
+    (and :func:`_render_rows` ellipsises) rather than starving the bar, which
+    below :data:`_BAR_MIN` cells stops expressing a proportion at all.
+
+    The note column is measured too, and shed WHOLE rather than cropped: a note
+    that runs off the right edge renders as ``14 req · 2 f``, which reads as a
+    truncated number and is worse than no note at all. So the bar gives back
+    width down to its floor to keep the notes, and if even that is not enough
+    the whole note column drops — the ladder's rule that a qualifier sheds and
+    the fact stays.
+    """
+    show_pct = show_pct and width >= _PCT_MIN
+    pct_col = 5 if show_pct else 0
+    value_col = max((len(r.value) for r in rows), default=0)
+    natural = max((len(r.label) for r in rows), default=0) + 2
+    note_col = max((sum(len(text) for text, _ in r.note) for r in rows), default=0)
+    show_note = width >= _NOTE_MIN and note_col > 0
+    # 5 = the 2-cell left indent, the value gutter, and the note gutter.
+    fixed = value_col + pct_col + 5 + (note_col if show_note else 0)
+    label_col = min(36, natural, max(_BAR_MIN, width - _BAR_MIN - fixed))
+    if show_note and width - label_col - fixed < _BAR_MIN:
+        # The bar is at its floor and the row still does not fit, so the note —
+        # the least load-bearing column — goes and the label reclaims the space.
+        show_note = False
+        fixed -= note_col
+        label_col = min(36, natural, max(_BAR_MIN, width - _BAR_MIN - fixed))
+    bar_width = max(_BAR_MIN, min(_BAR_MAX, width - label_col - fixed))
+    return _Columns(
+        label=max(1, label_col),
+        bar=bar_width,
+        value=value_col,
+        show_pct=show_pct,
+        show_note=show_note,
     )
-    context = "unavailable"
-    if runtime.context_tokens is not None:
-        context = ("~" if runtime.context_is_estimate else "") + f"{runtime.context_tokens:,}"
-    limit = f"{runtime.context_window:,}" if runtime.context_window else "unavailable"
-    line("Context / limit", context + " / " + limit)
-    line("Compaction count", "unavailable")
 
-    if report.recent:
-        section(f"Recent requests ({len(report.recent)} of {aggregate.calls:,})")
-        line("Newest first; request IDs identify logical requests, not retry attempts.")
-        for row in report.recent:
-            line(_stamp(row.ts_ms))
-            line("ID", row.request_id or "not recorded")
-            line(f"{row.provider}/{row.model_id}")
-            line(f"{row.purpose} / {row.outcome}")
-            usage = (
-                "unknown"
-                if row.usage_reported is None
-                else "reported" if row.usage_reported else "missing"
+
+def _render_rows(
+    rows: list[_BarRow], cols: _Columns, width: int, *, estimated: bool = False
+) -> list[Text]:
+    """Draw pre-measured rows: label, bar, value, percentage, note.
+
+    ``estimated`` prefixes every percentage with ``~``, the mark ``/analytics``
+    already uses for a modelled (character-apportioned) split rather than a
+    measured one. Full-strength ``fg`` carries the digits; ``dim`` carries the
+    status flags, because a flag is not a number.
+
+    Rows are cropped to ``width`` at build time rather than declared
+    ``no_wrap``: the screen flattens these lines into one container ``Text``
+    with ``Text.append_text``, which copies characters and spans but NOT the
+    per-line wrap policy, so a row long enough to fold would fold anyway and
+    read as two records. The container keeps ``fold`` so the prose footnotes
+    below still wrap, which is right for prose and wrong for a table.
+    """
+    fg = semantic_style("fg")
+    dim = semantic_style("dim")
+    accent = semantic_style("accent")
+    out: list[Text] = []
+    for row in rows:
+        label = row.label
+        if len(label) > cols.label - 1:
+            label = label[: max(0, cols.label - 2)] + "…"
+        line = Text()
+        line.append(f"  {label:<{cols.label}}", style=fg)
+        # A row with ``bar=False`` still consumes the bar column so its value
+        # stays in the shared number column; it simply draws no fill.
+        line.append(proportion_bar(row.fraction, cols.bar) if row.bar else " " * cols.bar, accent)
+        line.append(" ")
+        if row.cost is not None:
+            # A money cell goes through ``append_cost`` so the lower-bound ``+``
+            # is dimmed as the status flag it is. Rendering it at the same
+            # strength as the digits makes a lower bound read as a precise
+            # total — the exact defect that helper was written to fix, which a
+            # second hand-rolled cost cell here would silently reintroduce.
+            append_cost(line, row.cost, cols.value, fg, dim)
+        else:
+            line.append(f"{row.value:>{cols.value}}", style=fg)
+        if cols.show_pct:
+            # A bar-less row has no share to state, so it prints neither a
+            # percentage nor the ``~`` estimate mark — marking a blank as
+            # "modelled" would attach an honesty flag to nothing.
+            mark = ("~" if estimated else " ") if row.bar else " "
+            pct = format_percent(row.fraction) if row.bar else ""
+            line.append(f" {mark}{pct:>3}", style=dim)
+        if cols.show_note and row.note:
+            line.append("  ")
+            for text, token in row.note:
+                line.append(text, style=semantic_style(token))
+        line.truncate(width, overflow="crop")
+        out.append(line)
+    return out
+
+
+def _metric_value(aggregate: UsageAggregate, metric: str) -> float:
+    """The number a bar is drawn proportional to, for the active metric.
+
+    Cost in micro-USD (an exact integer accumulator, floated only for the
+    fraction), tokens as the full billed total — the same pair
+    ``analytics_panel._metric_value`` reads off a calendar bucket.
+    """
+    if metric == METRIC_TOKENS:
+        return float(aggregate.total_tokens)
+    return float(aggregate.cost_micro)
+
+
+def _metric_cell(aggregate: UsageAggregate, metric: str) -> str:
+    """The right-hand numeric label for the active metric."""
+    if metric == METRIC_TOKENS:
+        return format_tokens(aggregate.total_tokens)
+    return format_cost(aggregate)
+
+
+def _metric_meta(metric: str, prefix: str) -> str:
+    """``share of session tokens · t → cost`` — the section's own key.
+
+    The toggle is disclosed in TWO places (here and in the hint line), the same
+    redundancy ``/analytics`` uses, so a reader parked halfway down a scrolling
+    report can still discover what ``t`` does and what the bars currently plot.
+    """
+    active = "tokens" if metric == METRIC_TOKENS else "cost"
+    other = "cost" if metric == METRIC_TOKENS else "tokens"
+    # Without a prefix this is the narrow form: the toggle disclosure alone.
+    return f"{prefix} {active} · t → {other}" if prefix else f"t → {other}"
+
+
+def _group_rows(
+    groups: list[tuple[str, UsageAggregate]],
+    metric: str,
+    *,
+    failures: dict[str, int] | None = None,
+) -> tuple[list[_BarRow], bool]:
+    """Rows for a partitioning table (by model, by purpose), biggest first.
+
+    Returns the rows and whether the active metric has anything to be a fraction
+    of. **Denominator: share of the session total for the active metric.** These
+    groups partition one quantity, so the percentages sum to 100% and the row
+    answers "what fraction of this session was the expensive model / was not a
+    turn". A window-max denominator (the rule ``_series_chart`` uses, correct
+    there because calendar buckets do NOT partition a total) would make the
+    largest group always full-width and destroy exactly that reading.
+
+    Sorted by the active metric with ``total_tokens`` as the tiebreak — the same
+    ``(cost_micro, total_tokens)`` key ``_group_section`` sorts by, so an
+    unpriced group falls back to token order rather than collapsing into one
+    indistinguishable $0 bucket.
+    """
+    total = sum(_metric_value(agg, metric) for _, agg in groups)
+    ordered = sorted(
+        groups,
+        key=lambda item: (_metric_value(item[1], metric), item[1].total_tokens),
+        reverse=True,
+    )
+    rows: list[_BarRow] = []
+    for name, agg in ordered:
+        note: list[tuple[str, str]] = [(f"{agg.calls} req", "dim")]
+        failed = (failures or {}).get(name, 0)
+        if failed:
+            # ``warning``, not ``dim``: a failed request is the one thing on this
+            # screen a reader must not scroll past, and at the far right of the
+            # widest column a dim tally reads as decoration.
+            note.append((" · ", "dim"))
+            note.append((f"{failed} failed", "warning"))
+        rows.append(
+            _BarRow(
+                label=name,
+                fraction=(_metric_value(agg, metric) / total) if total > 0 else 0.0,
+                value=_metric_cell(agg, metric),
+                note=tuple(note),
+                bar=total > 0,
+                cost=agg if metric == METRIC_COST else None,
             )
-            line(
-                "Usage",
-                f"{usage} · input {format_tokens(row.context_tokens)} "
-                f"· output {format_tokens(row.output_tokens)}",
+        )
+    return rows, total > 0
+
+
+def _failures(report: SessionReport) -> dict[str, int]:
+    """Non-``ok`` request count per purpose, from the existing outcome cross-tab.
+
+    ``by_purpose`` carries the consumption and ``by_purpose_outcome`` carries
+    the outcomes; the failure tally is the second folded onto the first, not a
+    third query.
+    """
+    # ``unknown`` is excluded, not folded into the failures: an older ledger has
+    # no ``outcome`` column, so every row reads ``unknown`` and counting those
+    # would paint a healthy legacy session as entirely failed — in ``warning``,
+    # the one colour on this screen that must never cry wolf.
+    return {
+        purpose: sum(
+            count
+            for (name, outcome), count in report.by_purpose_outcome.items()
+            if name == purpose and outcome not in ("ok", "unknown")
+        )
+        for purpose in report.by_purpose
+    }
+
+
+def _component_rows(aggregate: UsageAggregate) -> tuple[list[_BarRow], int]:
+    """Nonzero input components, biggest first, plus the component total.
+
+    **Denominator: share of the component total, not of ``context_tokens``.**
+    The split is apportioned by largest-remainder to sum exactly to the recorded
+    context, so share-of-components is the only denominator under which these
+    percentages sum to 100%.
+
+    Zero-value components are dropped: a fresh session has no tool results, and
+    ``Environment ~0`` / ``Images (est.) ~0`` are rows that say nothing.
+    """
+    total = sum(aggregate.components.get(key, 0) for key in COMPONENT_KEYS)
+    rows = [
+        _BarRow(
+            label=COMPONENT_LABELS.get(key, key),
+            fraction=aggregate.components.get(key, 0) / total,
+            value=format_tokens(aggregate.components.get(key, 0)),
+        )
+        for key in COMPONENT_KEYS
+        if total > 0 and aggregate.components.get(key, 0) > 0
+    ]
+    rows.sort(key=lambda row: -row.fraction)
+    return rows, total
+
+
+def _tool_rows(aggregate: UsageAggregate, component_total: int) -> list[_BarRow]:
+    """The tool machinery's share of input: a subtotal row plus its children.
+
+    **Denominator: the component total — the SAME denominator as "Where input
+    went".** A reader must be able to check the three child rows against the
+    other section and find identical percentages; scaling these to the tool
+    subtotal instead would print ``Tool results`` as 60% here and 23% there, on
+    one screen, for the same tokens.
+
+    The parent is a subtotal, not a peer, so it holds a fixed first position and
+    is drawn in the same denominator, making "parent ≈ sum of children" visually
+    checkable.
+    """
+    values = {key: aggregate.components.get(key, 0) for key in _TOOL_KEYS}
+    subtotal = sum(values.values())
+    if component_total <= 0 or subtotal <= 0:
+        return []
+    rows = [
+        _BarRow(
+            label="All tool context",
+            fraction=subtotal / component_total,
+            value=format_tokens(subtotal),
+        )
+    ]
+    for key, value in sorted(values.items(), key=lambda item: -item[1]):
+        if value > 0:
+            rows.append(
+                _BarRow(
+                    label=" └ " + COMPONENT_LABELS.get(key, key),
+                    fraction=value / component_total,
+                    value=format_tokens(value),
+                )
             )
-            line(
-                "Duration / first output",
-                f"{_milliseconds(row.duration_ms)} / {_milliseconds(row.ttft_ms)}",
+    return rows
+
+
+def _timing_rows(timings: dict[str, TimingSummary], width: int) -> list[Text]:
+    """Three range bars on ONE shared millisecond scale.
+
+    **Denominator: the maximum across all three rows.** Three independently
+    scaled bars would draw preparation and total duration the same length, which
+    is the opposite of the truth; a shared scale makes ``First output`` visibly
+    a fraction of ``Duration``. The legend states that the scale is shared,
+    because a shared axis the reader cannot see is a trap.
+
+    Glyphs: ``·`` outside the observed range, ``─`` inside min–max, ``█`` at the
+    mean, which wins the cell on a collision. This is a purpose-built track
+    rather than ``proportion_bar`` because a range is not a proportion —
+    reaching for the proportion primitive here would draw a fill from zero and
+    claim a share that does not exist.
+
+    Fixed order (Duration, First output, Prep): these are nested concepts, not
+    competitors, and sorting them by size would scramble a stable mental model.
+    """
+    fg = semantic_style("fg")
+    dim = semantic_style("dim")
+    accent = semantic_style("accent")
+    keys = (("duration_ms", "Duration"), ("ttft_ms", "First output"), ("preparation_ms", "Prep"))
+    present = [timings.get(key) for key, _ in keys]
+    scale = max(
+        (t.max_ms for t in present if t is not None and t.samples and t.max_ms is not None),
+        default=0.0,
+    )
+    label_col = max(len(label) for _, label in keys) + 2
+    value_col = max(
+        (len(_milliseconds(t.mean_ms)) for t in present if t is not None and t.samples), default=8
+    )
+    bar_width = max(10, min(_BAR_MAX, width - label_col - value_col - 6))
+    lines: list[Text] = []
+    for (key, label), timing in zip(keys, present):
+        row = Text()
+        row.append(f"  {label:<{label_col}}", style=fg)
+        if timing is None or not timing.samples or scale <= 0:
+            # No bar at all: a zero-width bar beside a real one implies a
+            # measured zero, and an absent sample is not a fast one.
+            row.append("unknown (0 samples)", style=dim)
+            row.truncate(width, overflow="crop")
+            lines.append(row)
+            continue
+        low = int(round((timing.min_ms or 0) / scale * bar_width))
+        high = int(round((timing.max_ms or 0) / scale * bar_width))
+        mean = min(int(round((timing.mean_ms or 0) / scale * bar_width)), bar_width - 1)
+        track = "".join(
+            "█" if i == mean else "─" if low <= i < max(high, low + 1) else "·"
+            for i in range(bar_width)
+        )
+        row.append(track, style=accent)
+        row.append(f" {_milliseconds(timing.mean_ms):>{value_col}}", style=fg)
+        if width >= _NOTE_MIN:
+            row.append(
+                f"  {_milliseconds(timing.min_ms)}–{_milliseconds(timing.max_ms)}", style=dim
             )
-            line("Preparation", _milliseconds(row.preparation_ms))
-            result.append("\n")
-    section("Scope and limits")
-    line(
+        row.truncate(width, overflow="crop")
+        lines.append(row)
+    return lines
+
+
+@dataclass
+class _Body:
+    """Accumulates the report's lines, keeping the append shapes in one place."""
+
+    width: int
+    lines: list[Text] = field(default_factory=list)
+
+    def blank(self) -> None:
+        self.lines.append(Text())
+
+    def kv(self, name: str, value: str, note: str = "") -> None:
+        """A Totals-style scalar row, matching ``build_report``'s ``kv`` exactly."""
+        row = Text()
+        row.append(f"  {name:<22}", style=semantic_style("dim"))
+        row.append(f"{value:<{_VALUE_CELL}}", style=semantic_style("fg"))
+        # Below _NOTE_MIN the qualifier is shed and the fact kept: at 50 columns
+        # the note wraps onto its own unindented line and reads as a new record.
+        if note and self.width >= _NOTE_MIN:
+            row.append(f"  {note}", style=semantic_style("dim"))
+        row.truncate(self.width, overflow="crop")
+        self.lines.append(row)
+
+    def note(self, text: str) -> None:
+        """A dim footnote. Wrapped, not cropped — it is prose, not a table row."""
+        row = Text(overflow="fold")
+        row.append(f"  {text}", style=semantic_style("dim"))
+        self.lines.append(row)
+
+    def header(self, title: str, meta: str = "", short: str = "") -> None:
+        """A section header, shedding its meta to ``short`` on a narrow frame.
+
+        A header is one ``Text`` and its meta is not a column, so cropping it
+        would silently lose the toggle disclosure — and left alone it wraps to
+        an unindented second line that reads as a new record, the very fault
+        the table rows shed their notes to avoid. So the qualifier goes and the
+        operative part stays: ``share of session tokens · t → cost`` becomes
+        ``t → cost``, which is what a reader needs in order to act.
+        """
+        if meta and self.width < _NOTE_MIN:
+            meta = short
+        self.lines.append(section_header(title, meta))
+
+    def extend(self, lines: list[Text]) -> None:
+        self.lines.extend(lines)
+
+    def to_text(self) -> Text:
+        # ``fold`` on the container so the prose footnotes wrap; every table row
+        # was already cropped to width at build time, because ``append_text``
+        # discards a line's own wrap policy (see ``_render_rows``).
+        out = Text(style=semantic_style("fg"), overflow="fold")
+        for index, line in enumerate(self.lines):
+            if index:
+                out.append("\n")
+            out.append_text(line)
+        return out
+
+
+def build_session_report(
+    report: SessionReport | None,
+    runtime: SessionDiagnostics,
+    width: int = _DEFAULT_CARD_WIDTH,
+    *,
+    metric: str = METRIC_TOKENS,
+) -> Text:
+    """Render one session's diagnostics as charts, at ``width`` content cells.
+
+    ``metric`` (the screen's ``t`` toggle) selects what the by-model, by-purpose
+    and request-sequence bars plot. Tokens is the default here — unlike
+    ``/analytics``, whose stated purpose is historical spend, this screen is
+    read mid-session to answer "where did my context go", which is a token
+    question.
+    """
+    width = max(_MIN_CARD_WIDTH, width)
+    body = _Body(width)
+    fg = semantic_style("fg")
+    dim = semantic_style("dim")
+
+    # -- header: name, then the ID as a dim lookup key, not a headline --------
+    head = Text()
+    head.append(runtime.name or "Untitled session", style=fg)
+    head.truncate(width, overflow="crop")
+    body.lines.append(head)
+    ident = Text()
+    ident.append(f"  {runtime.session_id}", style=dim)
+    ident.truncate(width, overflow="crop")
+    body.lines.append(ident)
+
+    if report is None:
+        body.blank()
+        body.header("Loading usage records")
+        body.note("Reading the local ledger. Esc or q cancels.")
+        body.note("No model request is made.")
+        return body.to_text()
+
+    aggregate = report.aggregate
+    gauge = _gauge_row(runtime)
+    body.blank()
+    if not report.available:
+        # No chart sections at all here, including the live gauge: when the read
+        # failed we cannot say which of these numbers are trustworthy, and one
+        # lone bar under a failure heading invites the reader to trust the rest.
+        body.header("Ledger unavailable")
+        body.note("Could not read local usage records. Close and reopen to try again.")
+        body.blank()
+    elif not aggregate.calls:
+        body.header("No recorded requests")
+        body.note("No retained usage records for this session yet.")
+        body.blank()
+        # The gauge is LIVE runtime data, so it is available even with an empty
+        # ledger — a fresh session's one true visual.
+        _draw_context_gauge(body, gauge, _measure_columns([gauge] if gauge else [], width), width)
+    else:
+        _draw_recorded_usage(body, report, gauge, width, metric)
+
+    _draw_runtime_and_scope(body, report, runtime)
+    return body.to_text()
+
+
+def _gauge_row(runtime: SessionDiagnostics) -> _BarRow | None:
+    """The live context gauge's single row, or ``None`` when unmeasured.
+
+    **Denominator: the model's context window — a hard limit, not a share of
+    anything else on screen.** That is why the gauge is its own section rather
+    than a Totals row: "how full am I" is a different question from "where did
+    my tokens go", and an absolute gauge inside a partitioning table would draw
+    a bar incomparable with its neighbours'.
+
+    ``None`` when the window is unmeasured, which drops the section entirely: a
+    0% bar would claim an empty context, and an unmeasured window is not an
+    empty one.
+    """
+    if runtime.context_tokens is None or not runtime.context_window:
+        return None
+    estimate_mark = "~" if runtime.context_is_estimate else ""
+    return _BarRow(
+        label="In context now",
+        fraction=min(1.0, runtime.context_tokens / runtime.context_window),
+        value=f"{estimate_mark}{format_tokens(runtime.context_tokens)}",
+        note=((f"of {format_tokens(runtime.context_window)}", "dim"),),
+    )
+
+
+def _draw_context_gauge(body: _Body, row: _BarRow | None, cols: _Columns, width: int) -> None:
+    """Draw the gauge, sourced from the RUNTIME snapshot rather than the ledger.
+
+    The meta says so out loud: every other number on this screen is retained
+    ledger data, and silently mixing a live scalar into it would be the
+    dishonest move.
+    """
+    if row is None:
+        return
+    body.header("Context window", "live · not from the ledger", "live")
+    body.extend(_render_rows([row], cols, width))
+    body.blank()
+
+
+def _shared_columns(
+    report: SessionReport,
+    aggregate: UsageAggregate,
+    gauge: _BarRow | None,
+    width: int,
+    metric: str,
+) -> _Columns:
+    """ONE column set measured across every proportional section on the screen.
+
+    The gauge, by model, by purpose, where input went and tool surface are
+    measured TOGETHER. Sizing each table on its own rows is what gives
+    ``/analytics`` two different bar columns down one panel — its component bars
+    start at x≈46 while its per-provider numbers start at x≈35 — and measuring
+    the union is what gives this screen one left edge, one bar column and one
+    number column top to bottom.
+
+    The request-sequence chart is deliberately excluded: its labels are a fixed
+    8-cell clock, and forcing them into a column sized for model names would
+    push twelve bars far right for no alignment gain.
+    """
+    rows: list[_BarRow] = [gauge] if gauge else []
+    if report.by_model:
+        rows.extend(
+            _group_rows([(f"{p}/{m}", a) for (p, m), a in report.by_model.items()], metric)[0]
+        )
+    # Measured WITH the failure annotations, because they are what the draw
+    # pass emits: measuring `14 req` and then drawing `14 req · 2 failed` sizes
+    # the note column too small and crops it to `14 req · 2 f`.
+    rows.extend(_group_rows(list(report.by_purpose.items()), metric, failures=_failures(report))[0])
+    component_rows, component_total = _component_rows(aggregate)
+    rows.extend(component_rows)
+    rows.extend(_tool_rows(aggregate, component_total))
+    return _measure_columns(rows, width)
+
+
+def _draw_recorded_usage(
+    body: _Body,
+    report: SessionReport,
+    gauge: _BarRow | None,
+    width: int,
+    metric: str,
+) -> None:
+    """Totals, then every proportional section, on one shared column set."""
+    aggregate = report.aggregate
+    cols = _shared_columns(report, aggregate, gauge, width, metric)
+
+    # -- Totals: five unrelated scalars, so no bars ---------------------------
+    # A bar implies a shared denominator, and these five do not have one.
+    meta = f"{aggregate.calls} requests"
+    if aggregate.ok_calls != aggregate.calls:
+        meta += f" ({aggregate.calls - aggregate.ok_calls} failed)"
+    body.header("Totals", meta + " · measured", meta)
+    body.kv(
+        "Total billed",
+        format_tokens(aggregate.total_tokens) + " tokens",
+        f"{format_tokens(aggregate.context_tokens)} in · "
+        f"{format_tokens(aggregate.output_tokens)} out",
+    )
+    body.kv(
+        "Context read",
+        format_tokens(aggregate.context_tokens),
+        f"{format_tokens(aggregate.fresh_tokens)} fresh · "
+        f"{format_tokens(aggregate.cache_read_tokens)} cached",
+    )
+    body.kv(
+        "Output",
+        format_tokens(aggregate.output_tokens),
+        f"{format_tokens(aggregate.generation_tokens)} generation · "
+        f"{format_tokens(aggregate.reasoning_tokens)} thinking",
+    )
+    body.kv("Cache hit rate", format_percent(aggregate.cache_hit_rate), "of context from cache")
+    body.kv(
+        "Est. cost",
+        format_cost(aggregate),
+        "≈ list price × tokens" if aggregate.cost_is_known else "no published price",
+    )
+    # Suppressed when both are zero: on the healthy path "0 requests; 0 unknown"
+    # is a row whose only content is the absence of a problem.
+    if report.missing_usage_calls or report.unknown_usage_calls:
+        body.note(
+            f"{report.missing_usage_calls:,} requests missing usage · "
+            f"{report.unknown_usage_calls:,} unknown"
+        )
+    body.blank()
+
+    _draw_context_gauge(body, gauge, cols, width)
+    _draw_by_model(body, report, width, metric, cols)
+    _draw_by_purpose(body, report, width, metric, cols)
+    _draw_input_split(body, aggregate, width, cols)
+    _draw_tool_surface(body, aggregate, width, cols)
+    _draw_request_sequence(body, report, width, metric)
+    body.header("Timings", "observed wall time · includes retries", "wall time")
+    body.extend(_timing_rows(report.timings, width))
+    body.note("█ mean · ─ min–max range · shared ms scale")
+    body.note(
+        "Wall time includes retries and consumer backpressure, not provider "
+        "compute or per-attempt timing. First output is the first text or "
+        "tool-call delta."
+    )
+    body.blank()
+
+    # The money footnote is drawn only when a mark is actually on screen, over
+    # exactly the scopes this report renders — a footnote for a symbol nobody
+    # can see is noise.
+    scopes = [aggregate, *report.by_model.values(), *report.by_purpose.values()]
+    if any(scope_needs_cost_legend(scope) for scope in scopes):
+        body.note(COST_LEGEND)
+        body.blank()
+
+
+def _unpriced_note(body: _Body, metric: str, priced: bool) -> bool:
+    """Say why the bars are missing in cost mode, instead of drawing floor marks.
+
+    A fully unpriced scope in cost mode would render every row as a one-cell
+    floor bar — a wall of identical marks that looks like data. The rows still
+    show their ``$—``; the bar is what is withheld, plus a line naming the
+    escape hatch.
+    """
+    if priced or metric != METRIC_COST:
+        return False
+    body.note("no published price for these models · t → tokens")
+    return True
+
+
+def _draw_by_model(
+    body: _Body, report: SessionReport, width: int, metric: str, cols: _Columns
+) -> None:
+    if not report.by_model:
+        return
+    groups = [(f"{provider}/{model}", agg) for (provider, model), agg in report.by_model.items()]
+    rows, priced = _group_rows(groups, metric)
+    body.header("By model", _metric_meta(metric, "share of session"), _metric_meta(metric, ""))
+    _unpriced_note(body, metric, priced)
+    body.extend(_render_rows(rows, cols, width))
+    body.blank()
+
+
+def _draw_by_purpose(
+    body: _Body, report: SessionReport, width: int, metric: str, cols: _Columns
+) -> None:
+    """Consumption per purpose — the "by use case" read, not a bare count.
+
+    Labels are the RAW stored values (``turn``, ``compaction``, ``aside``,
+    ``naming``, ``compaction_advisor``): they are what a reader greps the code
+    for, and a friendly relabelling would create a second vocabulary for the
+    same thing. A legend explains them instead, and only when there is something
+    to explain.
+    """
+    if not report.by_purpose:
+        return
+    rows, priced = _group_rows(list(report.by_purpose.items()), metric, failures=_failures(report))
+    body.header("By purpose", _metric_meta(metric, "share of session"), _metric_meta(metric, ""))
+    # Only when there is a contrast to explain: the legend defines ``turn``
+    # against the harness's own purposes, so it is noise when the rows are all
+    # ``turn``, and meaningless on a legacy ledger whose single row is
+    # ``unknown`` and where no ``turn`` row exists to be contrasted with.
+    if "turn" in report.by_purpose and len(report.by_purpose) > 1:
+        body.note("turn = your requests · others are the harness working on your behalf")
+    _unpriced_note(body, metric, priced)
+    body.extend(_render_rows(rows, cols, width))
+    body.blank()
+
+
+def _draw_input_split(body: _Body, aggregate: UsageAggregate, width: int, cols: _Columns) -> None:
+    rows, total = _component_rows(aggregate)
+    body.header("Where input went", "≈ estimated split of context tokens", "≈ estimated")
+    if not rows:
+        body.note("no component data yet")
+        body.blank()
+        return
+    # The residual is what the recorded context exceeds the attributed
+    # components by — a leftover, not a component. It gets no bar: giving it one
+    # in the same denominator would double-count against the rows above it.
+    unattributed = max(0, aggregate.context_tokens - total)
+    if unattributed:
+        rows = rows + [
+            _BarRow(
+                label="Unattributed (older records)",
+                fraction=0.0,
+                value=format_tokens(unattributed),
+                bar=False,
+            )
+        ]
+    body.extend(_render_rows(rows, cols, width, estimated=True))
+    body.blank()
+
+
+def _draw_tool_surface(body: _Body, aggregate: UsageAggregate, width: int, cols: _Columns) -> None:
+    rows = _tool_rows(aggregate, _component_rows(aggregate)[1])
+    body.header("Tool surface", "≈ estimated share of context tokens", "≈ estimated")
+    if rows:
+        body.extend(_render_rows(rows, cols, width, estimated=True))
+    else:
+        body.note("no tool context recorded yet")
+    # NOT optional and NOT shortened. It is the only thing preventing this
+    # section from being read as per-tool billing, which the ledger cannot
+    # support: there is no per-tool-name token or cost column, and cost is
+    # priced per call at record time, so splitting it across these three
+    # components would invent a number the provider never billed.
+    body.note(
+        "Per-tool-name tokens and dollars are not recorded; this is the tool "
+        "machinery's share of input, not the cost of any one tool call."
+    )
+    body.blank()
+
+
+def _draw_request_sequence(body: _Body, report: SessionReport, width: int, metric: str) -> None:
+    """The recent tail as one bar per request, oldest → newest.
+
+    **Denominator: the window max (the largest request in view).** These rows do
+    NOT partition the session — they are a tail of it — so a share-of-total
+    denominator would draw twelve bars at 4% each and communicate nothing. The
+    question here is "which requests were big", and window-max is the shape that
+    answers it. This is the ``_series_chart`` rule, applied for the same reason.
+
+    The x axis is the request ORDINAL, not time: rows are evenly spaced whatever
+    the gap between them, so the meta says ``oldest → newest`` rather than "over
+    time" and no gap is drawn or interpolated. A session with a four-hour idle
+    stretch must not render a misleading flat run.
+
+    In cost mode the bars plot ``duration_ms`` instead, and the meta says so:
+    ``SessionRequest`` carries no cost field, and dividing the session total by
+    the request count would fabricate a per-request price the ledger never held.
+    """
+    if not report.recent:
+        return
+    series = list(reversed(report.recent))  # the store returns newest-first
+    tokens = metric == METRIC_TOKENS
+    values = [
+        float(r.context_tokens + r.output_tokens) if tokens else float(r.duration_ms or 0.0)
+        for r in series
+    ]
+    top = max(values) if values else 0.0
+    rows: list[_BarRow] = []
+    for request, value in zip(series, values):
+        note: tuple[tuple[str, str], ...] = ((request.purpose, "dim"),)
+        if request.outcome != "ok":
+            note = ((request.purpose, "dim"), (" · ", "dim"), (request.outcome, "warning"))
+        rows.append(
+            _BarRow(
+                label=_clock(request.ts_ms),
+                fraction=(value / top) if top > 0 else 0.0,
+                value=format_tokens(int(value)) if tokens else _milliseconds(value),
+                note=note,
+            )
+        )
+    plural = "request" if len(series) == 1 else "requests"
+    bars = "tokens" if tokens else "duration"
+    body.header(
+        f"Last {len(series)} {plural}",
+        f"of {report.aggregate.calls} · oldest → newest · bars: {bars}",
+        f"bars: {bars}",
+    )
+    # Its own column set: these labels are a fixed 8-cell clock, and forcing
+    # them into the model-name column above would push every bar far right for
+    # no alignment gain.
+    body.extend(_render_rows(rows, _measure_columns(rows, width, show_pct=False), width))
+    body.blank()
+
+
+def _draw_runtime_and_scope(
+    body: _Body, report: SessionReport | None, runtime: SessionDiagnostics
+) -> None:
+    body.header("Runtime", "live")
+    body.kv("Selected", runtime.selected_model)
+    body.kv("Effective", runtime.effective_model)
+    body.kv("State", "streaming" if runtime.streaming else "idle")
+    # Dropped when absent rather than printed as "unavailable": a row whose only
+    # content is the word "unavailable" is exactly the noise this screen sheds.
+    if runtime.generation is not None:
+        body.kv("Turn generation", str(runtime.generation))
+    if report is not None and report.first_ts_ms is not None:
+        body.note("Period  " + _stamp(report.first_ts_ms) + " to " + _stamp(report.last_ts_ms))
+    body.blank()
+
+    body.header("Scope", "this session ID only")
+    body.note(
         "Retained local ledger rows for this exact ID only. Child sessions and copied "
         "fork history are excluded; resuming the same ID includes its retained records."
     )
-    line(
-        "Older records may have been pruned. In-flight requests and pending "
-        "recorder writes may not appear yet. This command makes no model request."
+    body.note(
+        "Older records may have been pruned. In-flight requests and pending recorder "
+        "writes may not appear yet. Cost is provider-reported or a list-price estimate; "
+        "input, output and tool dollars are not recorded separately. This command makes "
+        "no model request."
     )
-    return result
 
 
 class SessionScreen(ModalScreen[None]):
-    """A snapshot with analytics chrome, but no all-session charts or toggles."""
+    """A snapshot with analytics chrome and its bar vocabulary, session-scoped.
+
+    Deliberately without the calendar charts: the daily/monthly rollups are
+    machine-wide, so a "this session" heading over them would attribute other
+    sessions' spend here.
+    """
 
     BINDINGS = [
         Binding("escape", "dismiss_screen", "Back", show=False),
         Binding("q", "dismiss_screen", "Back", show=False),
+        Binding("t", "toggle_metric", "Cost/tokens", show=False),
         Binding("up", "scroll_up", "Up", show=False),
         Binding("down", "scroll_down", "Down", show=False),
         Binding("pageup", "page_up", "Page up", show=False),
@@ -253,18 +1001,18 @@ class SessionScreen(ModalScreen[None]):
         self.report = report
         self.runtime = runtime
         self.presentation_cancelled = False
+        #: Which metric the bars plot; ``t`` flips it. Tokens by default: this
+        #: screen is read mid-session to answer "where did my context go", which
+        #: is a token question, where ``/analytics`` answers a spend question.
+        self._metric = METRIC_TOKENS
 
     def compose(self) -> ComposeResult:
         with Container(classes="analytics-panel"):
-            yield Static(
-                Text("Session diagnostics\n" + "─" * 140, no_wrap=True, overflow="crop"),
-                id="session-report-title",
-            )
+            self._title = Static(self._title_text(), id="session-report-title")
+            yield self._title
             with VerticalScroll(id="session-report-scroll") as scroll:
                 self._scroll = scroll
-                self._body = Static(
-                    build_session_report(self.report, self.runtime), id="session-report-body"
-                )
+                self._body = Static(self._report_text(), id="session-report-body")
                 yield self._body
             self._hint = Static(self._back_hint(), id="session-report-hint")
             yield self._hint
@@ -303,16 +1051,76 @@ class SessionScreen(ModalScreen[None]):
         self.report = report
         self._repaint()
 
+    def _card_width(self) -> int:
+        """The content cells a report row may actually occupy.
+
+        MEASURED off the mounted scroll container rather than recomputed from
+        the CSS, because a formula and a stylesheet drift: ``AnalyticsScreen``
+        derives ``card - 6`` from the ``.analytics-panel`` rule (90% of the
+        terminal, capped at 140, ``padding: 1 2``) and lands one cell wide,
+        because ``#*-scroll`` also reserves a stable scrollbar gutter. That one
+        cell is why ``/analytics`` overflows horizontally at 50 columns, and
+        building rows one cell too wide here folded the session ID onto a
+        second line — the exact "one record reads as two" fault these charts
+        exist to remove.
+
+        Before mount there is nothing to measure, so the same geometry is
+        derived arithmetically, gutter included.
+        """
+        scroll = getattr(self, "_scroll", None)
+        try:
+            if scroll is not None and scroll.is_mounted and scroll.size.width:
+                # The gutter is reserved whether or not the thumb is showing,
+                # so subtracting it unconditionally matches the painted box.
+                return max(_MIN_CARD_WIDTH, scroll.size.width - 1)
+            card = min(140, int(self.app.size.width * 0.9))
+            return max(_MIN_CARD_WIDTH, card - 7)  # 4 padding + 2 border + 1 gutter
+        except Exception:  # noqa: BLE001 — before mount, a sane default
+            return _DEFAULT_CARD_WIDTH
+
+    def _title_text(self) -> Text:
+        # The rule is sized to the measured card rather than a hardcoded 140
+        # cropped by the widget, matching AnalyticsScreen.
+        return Text(
+            "Session diagnostics\n" + "─" * max(1, self._card_width()),
+            no_wrap=True,
+            overflow="crop",
+        )
+
+    def _report_text(self) -> Text:
+        return build_session_report(
+            self.report, self.runtime, self._card_width(), metric=self._metric
+        )
+
     def _repaint(self) -> None:
         body = getattr(self, "_body", None)
         if body is not None and body.is_mounted and not self.presentation_cancelled:
-            body.update(build_session_report(self.report, self.runtime))
+            body.update(self._report_text())
+            title = getattr(self, "_title", None)
+            if title is not None and title.is_mounted:
+                title.update(self._title_text())
             self.call_after_refresh(self._sync_hint)
 
+    def _has_charts(self) -> bool:
+        """Whether any bar is on screen for ``t`` to act on.
+
+        A loading, unavailable or empty report has no bars, so advertising the
+        toggle would promise a dead control — the same rule the scroll hint
+        follows.
+        """
+        report = self.report
+        return bool(report and (report.by_model or report.by_purpose or report.recent))
+
     def _back_hint(self) -> str:
-        return "esc / q cancel" if self.report is None else "esc / q back"
+        hint = "esc / q cancel" if self.report is None else "esc / q back"
+        if self._has_charts():
+            hint += " · t cost/tokens"
+        return hint
 
     def on_resize(self) -> None:
+        # Column arithmetic is a function of the card width, so a resize is a
+        # re-render, not just a hint refresh.
+        self._repaint()
         self.call_after_refresh(self._sync_hint)
 
     def _sync_hint(self) -> None:
@@ -325,6 +1133,18 @@ class SessionScreen(ModalScreen[None]):
 
     def action_dismiss_screen(self) -> None:
         self.invalidate()
+
+    def action_toggle_metric(self) -> None:
+        """Flip the bars between tokens and cost, repainting from the held report.
+
+        No second store read: the numbers do not change, only which of them the
+        bars are proportional to. A no-op when nothing is charted, so the key
+        never silently toggles invisible state.
+        """
+        if not self._has_charts():
+            return
+        self._metric = METRIC_COST if self._metric == METRIC_TOKENS else METRIC_TOKENS
+        self._repaint()
 
     def action_scroll_up(self) -> None:
         self._scroll.scroll_up()

--- a/local_operator/tui/widgets/session_panel.py
+++ b/local_operator/tui/widgets/session_panel.py
@@ -100,6 +100,16 @@ _MIN_CARD_WIDTH = 38
 _BAR_MIN = 8
 _BAR_MAX = 24
 
+#: Width of the percentage cell: a leading space, the estimate mark, and the
+#: widest figure ``format_percent`` can return. That figure is ``100%`` — FOUR
+#: characters, not three (design D1). Budgeting three overflowed every
+#: full-share row by one cell, and the crop landed on the rightmost column: the
+#: ``warning``-coloured failure tally, which rendered as ``2 faile``. A single-
+#: model or single-purpose session is 100% by construction, so this was not an
+#: edge case. Derived from the formatter rather than restated as a literal, so
+#: a future change to ``format_percent`` cannot silently reintroduce the crop.
+_PCT_CELL = 2 + max(len(format_percent(f)) for f in (0.0, 0.5, 1.0, None))
+
 #: Value cell for the Totals ``kv`` rows, matching ``build_report``'s so the two
 #: screens' headline blocks have the same rhythm.
 _VALUE_CELL = 11
@@ -227,7 +237,11 @@ def _measure_columns(rows: list[_BarRow], width: int, *, show_pct: bool = True) 
     the fact stays.
     """
     show_pct = show_pct and width >= _PCT_MIN
-    pct_col = 5 if show_pct else 0
+    pct_col = _PCT_CELL if show_pct else 0
+    # The ``default=0`` arms describe an EMPTY row list, whose measurements no
+    # caller draws with (review n1): the empty-report path measures ``[]`` when
+    # there is no gauge and then renders no rows at all. They keep this total
+    # rather than making the caller special-case a section it is about to skip.
     value_col = max((len(r.value) for r in rows), default=0)
     natural = max((len(r.label) for r in rows), default=0) + 2
     note_col = max((sum(len(text) for text, _ in r.note) for r in rows), default=0)
@@ -295,9 +309,13 @@ def _render_rows(
             # A bar-less row has no share to state, so it prints neither a
             # percentage nor the ``~`` estimate mark — marking a blank as
             # "modelled" would attach an honesty flag to nothing.
-            mark = ("~" if estimated else " ") if row.bar else " "
+            mark = "~" if (estimated and row.bar) else ""
             pct = format_percent(row.fraction) if row.bar else ""
-            line.append(f" {mark}{pct:>3}", style=dim)
+            # The mark and its figure are right-aligned as ONE unit inside the
+            # cell ``_measure_columns`` reserved, so a ``100%`` row cannot push
+            # the note past the frame (design D1) and the ``~`` still hugs the
+            # number it qualifies instead of floating a space away from it.
+            line.append(f" {mark + pct:>{_PCT_CELL - 1}}", style=dim)
         if cols.show_note and row.note:
             line.append("  ")
             for text, token in row.note:
@@ -359,6 +377,18 @@ def _group_rows(
     ``(cost_micro, total_tokens)`` key ``_group_section`` sorts by, so an
     unpriced group falls back to token order rather than collapsing into one
     indistinguishable $0 bucket.
+
+    **In cost mode a group with no published price gets no bar and no
+    percentage** (QA Q1 / design D2). Its ``cost_micro`` is 0 because the price
+    is UNKNOWN, not because it spent nothing, so dividing it by the session
+    total yields a 0% that reads as a measured zero share — beside another
+    row's real ``100%``, in the same column. QA's case: a local model taking 9
+    of 10 requests and 99% of the tokens rendered an empty track at 0% while a
+    single priced call read as the entire spend. ``bar=False`` is the primitive
+    the residual row already uses; it suppresses the track and the percentage
+    and leaves the honest ``$—``, which is the only figure here we can stand
+    behind. This is the same rule as ``_timing_rows`` and ``_gauge_row``: an
+    absent measurement is never drawn as a measured zero.
     """
     total = sum(_metric_value(agg, metric) for _, agg in groups)
     ordered = sorted(
@@ -376,13 +406,14 @@ def _group_rows(
             # widest column a dim tally reads as decoration.
             note.append((" · ", "dim"))
             note.append((f"{failed} failed", "warning"))
+        measurable = total > 0 and (metric != METRIC_COST or agg.cost_is_known)
         rows.append(
             _BarRow(
                 label=name,
-                fraction=(_metric_value(agg, metric) / total) if total > 0 else 0.0,
+                fraction=(_metric_value(agg, metric) / total) if measurable else 0.0,
                 value=_metric_cell(agg, metric),
                 note=tuple(note),
-                bar=total > 0,
+                bar=measurable,
                 cost=agg if metric == METRIC_COST else None,
             )
         )
@@ -420,6 +451,14 @@ def _component_rows(aggregate: UsageAggregate) -> tuple[list[_BarRow], int]:
 
     Zero-value components are dropped: a fresh session has no tool results, and
     ``Environment ~0`` / ``Images (est.) ~0`` are rows that say nothing.
+
+    The unattributed residual is built HERE, not appended by the drawing code
+    (review M2). ``_shared_columns`` measures whatever this function returns, so
+    a row added after measurement is the one row outside the shared column set
+    this screen exists to establish — it ellipsised its label with 30 cells of
+    frame unused and landed its value one cell off the shared number column,
+    both on an ordinary 88-cell card. Returning it with its peers is what makes
+    "one function owns the section's rows" true rather than nearly true.
     """
     total = sum(aggregate.components.get(key, 0) for key in COMPONENT_KEYS)
     rows = [
@@ -432,6 +471,21 @@ def _component_rows(aggregate: UsageAggregate) -> tuple[list[_BarRow], int]:
         if total > 0 and aggregate.components.get(key, 0) > 0
     ]
     rows.sort(key=lambda row: -row.fraction)
+    # The residual is what the recorded context exceeds the attributed
+    # components by — a leftover, not a component. It gets no bar: giving it one
+    # in the same denominator would double-count against the rows above it. It
+    # is appended last (not sorted in) because it is not a peer of the rows it
+    # follows, the same fixed position the tool subtotal holds.
+    unattributed = max(0, aggregate.context_tokens - total) if rows else 0
+    if unattributed:
+        rows.append(
+            _BarRow(
+                label="Unattributed (older records)",
+                fraction=0.0,
+                value=format_tokens(unattributed),
+                bar=False,
+            )
+        )
     return rows, total
 
 
@@ -792,6 +846,13 @@ def _draw_recorded_usage(
     # The money footnote is drawn only when a mark is actually on screen, over
     # exactly the scopes this report renders — a footnote for a symbol nobody
     # can see is noise.
+    #
+    # INVARIANT (review m2): this list must name every scope from which a ``$``
+    # figure is drawn. Today those are the Totals ``Est. cost`` row (the
+    # aggregate) and, in cost mode, the by-model and by-purpose cost cells —
+    # so the three sources below are exhaustive. A future section rendering a
+    # cost cell from a scope outside them would silently suppress the legend
+    # for a ``+`` or ``$—`` that is on screen; add its scopes here.
     scopes = [aggregate, *report.by_model.values(), *report.by_purpose.values()]
     if any(scope_needs_cost_legend(scope) for scope in scopes):
         body.note(COST_LEGEND)
@@ -852,25 +913,14 @@ def _draw_by_purpose(
 
 
 def _draw_input_split(body: _Body, aggregate: UsageAggregate, width: int, cols: _Columns) -> None:
-    rows, total = _component_rows(aggregate)
+    # ``_component_rows`` returns the residual row too, so what is drawn here is
+    # exactly what ``_shared_columns`` measured (review M2).
+    rows, _ = _component_rows(aggregate)
     body.header("Where input went", "≈ estimated split of context tokens", "≈ estimated")
     if not rows:
         body.note("no component data yet")
         body.blank()
         return
-    # The residual is what the recorded context exceeds the attributed
-    # components by — a leftover, not a component. It gets no bar: giving it one
-    # in the same denominator would double-count against the rows above it.
-    unattributed = max(0, aggregate.context_tokens - total)
-    if unattributed:
-        rows = rows + [
-            _BarRow(
-                label="Unattributed (older records)",
-                fraction=0.0,
-                value=format_tokens(unattributed),
-                bar=False,
-            )
-        ]
     body.extend(_render_rows(rows, cols, width, estimated=True))
     body.blank()
 
@@ -911,16 +961,32 @@ def _draw_request_sequence(body: _Body, report: SessionReport, width: int, metri
     In cost mode the bars plot ``duration_ms`` instead, and the meta says so:
     ``SessionRequest`` carries no cost field, and dividing the session total by
     the request count would fabricate a per-request price the ledger never held.
+
+    An UNRECORDED duration stays ``None`` all the way to the row (review M1).
+    The store deliberately produces ``None`` via ``NULLIF(col(name, '-1'), -1)``
+    to keep "not recorded" distinct from a value, so coercing it to ``0.0``
+    here printed a full-strength ``0 ms`` beside an empty track for a legacy
+    ledger — a measured-looking zero for a sample that does not exist, which is
+    ``$0.00`` for time. Such a row draws no bar and reads ``unknown``, matching
+    ``_timing_rows`` ("an absent sample is not a fast one") and ``_gauge_row``.
     """
     if not report.recent:
         return
     series = list(reversed(report.recent))  # the store returns newest-first
     tokens = metric == METRIC_TOKENS
-    values = [
-        float(r.context_tokens + r.output_tokens) if tokens else float(r.duration_ms or 0.0)
+    values: list[float | None] = [
+        (
+            float(r.context_tokens + r.output_tokens)
+            if tokens
+            else (None if r.duration_ms is None else float(r.duration_ms))
+        )
         for r in series
     ]
-    top = max(values) if values else 0.0
+    # An unmeasured request is excluded from the window max as well as from the
+    # bars: it must not be able to define the scale the measured rows are drawn
+    # against.
+    measured = [value for value in values if value is not None]
+    top = max(measured) if measured else 0.0
     rows: list[_BarRow] = []
     for request, value in zip(series, values):
         note: tuple[tuple[str, str], ...] = ((request.purpose, "dim"),)
@@ -929,9 +995,14 @@ def _draw_request_sequence(body: _Body, report: SessionReport, width: int, metri
         rows.append(
             _BarRow(
                 label=_clock(request.ts_ms),
-                fraction=(value / top) if top > 0 else 0.0,
-                value=format_tokens(int(value)) if tokens else _milliseconds(value),
+                fraction=(value / top) if value is not None and top > 0 else 0.0,
+                value=(
+                    format_tokens(int(value))
+                    if tokens and value is not None
+                    else _milliseconds(value)
+                ),
                 note=note,
+                bar=value is not None,
             )
         )
     plural = "request" if len(series) == 1 else "requests"
@@ -1068,14 +1139,18 @@ class SessionScreen(ModalScreen[None]):
         derived arithmetically, gutter included.
         """
         scroll = getattr(self, "_scroll", None)
+        if scroll is not None and scroll.is_mounted and scroll.size.width:
+            # The gutter is reserved whether or not the thumb is showing, so
+            # subtracting it unconditionally matches the painted box. NOT inside
+            # the guard below (review n2): once mounted this is a plain
+            # measurement, and swallowing a failure here would silently pin the
+            # report at the fallback width forever instead of surfacing a real
+            # geometry bug.
+            return max(_MIN_CARD_WIDTH, scroll.size.width - 1)
         try:
-            if scroll is not None and scroll.is_mounted and scroll.size.width:
-                # The gutter is reserved whether or not the thumb is showing,
-                # so subtracting it unconditionally matches the painted box.
-                return max(_MIN_CARD_WIDTH, scroll.size.width - 1)
             card = min(140, int(self.app.size.width * 0.9))
             return max(_MIN_CARD_WIDTH, card - 7)  # 4 padding + 2 border + 1 gutter
-        except Exception:  # noqa: BLE001 — before mount, a sane default
+        except Exception:  # noqa: BLE001 — before mount there is no app size
             return _DEFAULT_CARD_WIDTH
 
     def _title_text(self) -> Text:

--- a/scripts/session_report_shot.py
+++ b/scripts/session_report_shot.py
@@ -40,7 +40,13 @@ class DiagnosticSession(FakeSession):
 
     @property
     def session_id(self) -> str:
-        return "session-diagnostic-demo-0123456789abcdef"
+        # A REAL-SHAPED ID: the harness generates ``uuid4().hex[:12]``
+        # (``harness/types.py``, ``fork.py``), and every session directory on a
+        # live machine is exactly 12 characters. The previous 40-character
+        # demo string was ~3.3x anything reachable, so it manufactured a header
+        # crop at 50 columns that no operator can hit — a defect in the
+        # evidence, not in the screen.
+        return "a3f9c21b7e40"
 
     @property
     def model(self) -> ModelSpec:
@@ -57,6 +63,96 @@ class DiagnosticSession(FakeSession):
     @property
     def effective_model_label(self) -> str:
         return "openai/gpt-5.2"
+
+
+#: The populated demo session, as (context, output, reasoning, duration_ms,
+#: purpose, ok) per request. Module scope so a sibling capture script can
+#: seed the SAME session — one fixture, one place to change it.
+POPULATED_SHAPE = [
+    # (context, output, reasoning, duration_ms, purpose, ok)
+    (8_400, 900, 120, 1_850, "turn", True),
+    (14_200, 1_400, 260, 2_310, "turn", True),
+    (21_800, 620, 0, 1_240, "aside", True),
+    (33_500, 2_900, 800, 4_120, "turn", True),
+    (46_100, 1_100, 180, 2_050, "turn", True),
+    (52_700, 480, 0, 980, "naming", True),
+    (61_400, 3_600, 1_240, 5_870, "turn", True),
+    (74_900, 1_750, 320, 2_640, "turn", True),
+    (88_300, 210, 0, 1_420, "turn", False),
+    (96_800, 2_150, 540, 3_180, "turn", True),
+    (112_400, 1_320, 210, 2_260, "turn", True),
+    (128_900, 4_800, 1_900, 7_240, "turn", True),
+    (141_200, 760, 0, 1_510, "aside", True),
+    (158_600, 2_400, 620, 3_450, "turn", True),
+    (172_300, 1_180, 240, 2_180, "turn", True),
+    (186_700, 5_200, 2_100, 8_960, "turn", True),
+    # The compaction pair: expensive reads, and the context it buys back.
+    (194_100, 3_100, 0, 6_320, "compaction", True),
+    (42_600, 1_450, 280, 2_390, "turn", True),
+]
+
+
+def seed_populated(session_id: str) -> None:
+    """Write the demo session into the ambient (isolated) ledger.
+
+    A session that VARIES, because a constant fixture makes the two best new
+    charts render as a wall of identical bars and a degenerate
+    ``2,800 ms-2,800 ms`` timing range (QA Q3, echoed by the design and code
+    rounds). Those frames are correct renderings of uniform input, but they are
+    what a reader judges the feature by, and they make a working chart look
+    broken. ``POPULATED_SHAPE`` is what a real session does: context grows as
+    history accumulates, a compaction resets it, a couple of turns are large,
+    one fails, and a cheap model handles the short asides. No number is
+    load-bearing here - only the spread is.
+
+    Shared with the cost-mode capture so the two never seed different sessions.
+    """
+    store = AnalyticsStore()
+    snapshots = []
+    for i, (context, output, reasoning, duration, purpose, ok) in enumerate(POPULATED_SHAPE):
+        # The cheap model takes the short non-turn work, so `By model` has a
+        # real split to draw rather than one dominant row.
+        aside = purpose in ("aside", "naming")
+        cache_read = int(context * 0.72)
+        snapshots.append(
+            replace(
+                _snap(
+                    session_id=session_id,
+                    provider="openai" if aside else "anthropic",
+                    model_id="gpt-5.2-mini" if aside else "claude-sonnet-4-6",
+                    context=context,
+                    input_tokens=context - cache_read - 800,
+                    cache_read=cache_read,
+                    cache_write=800,
+                    output_tokens=output,
+                    reasoning=reasoning,
+                    # Roughly list price for the tokens, so `t` (cost) gives a
+                    # different ordering rather than a rescale of the same one.
+                    cost_micro=int(context * 0.55 + output * 8.5),
+                    chars={
+                        "system_prompt": 400,
+                        "custom_instructions": 110,
+                        "tool_inventory": 150,
+                        "tool_schemas": 250,
+                        # Conversation and tool results grow with context; a
+                        # flat split makes `Where input went` identical on
+                        # every frame.
+                        "conversation": 300 + i * 95,
+                        "tool_results": 120 + i * 60,
+                    },
+                    ts_ms=1788602400000 + i * 47000,
+                    ok=ok,
+                ),
+                request_id=f"logical-request-{i:03d}",
+                purpose=purpose,
+                outcome="ok" if ok else "error",
+                duration_ms=duration,
+                ttft_ms=int(duration * 0.19) + 180,
+                preparation_ms=18 + (i % 5) * 7,
+            )
+        )
+    store.record_batch(snapshots)
+    store.close()
 
 
 async def main() -> None:
@@ -76,41 +172,7 @@ async def main() -> None:
         context_window=200000,
     )
     if scenario == "populated":
-        store = AnalyticsStore()
-        snapshots = []
-        for i in range(18):
-            snapshots.append(
-                replace(
-                    _snap(
-                        session_id=session.session_id,
-                        provider="anthropic" if i < 12 else "openai",
-                        model_id="claude-sonnet-4-6" if i < 12 else "gpt-5.2",
-                        context=28400,
-                        input_tokens=4400,
-                        cache_read=23000,
-                        cache_write=1000,
-                        output_tokens=1700,
-                        reasoning=400,
-                        cost_micro=18500,
-                        chars={
-                            "system_prompt": 400,
-                            "tool_inventory": 150,
-                            "tool_schemas": 250,
-                            "conversation": 1400,
-                            "tool_results": 600,
-                        },
-                        ts_ms=1788602400000 + i * 10000,
-                    ),
-                    request_id=f"logical-request-{i:03d}-0123456789abcdef",
-                    purpose="turn" if i < 16 else "compaction",
-                    outcome="ok",
-                    duration_ms=2800 + i * 15,
-                    ttft_ms=350 + i * 10,
-                    preparation_ms=24,
-                )
-            )
-        store.record_batch(snapshots)
-        store.close()
+        seed_populated(session.session_id)
     elif scenario == "unavailable":
         path = default_db_path()
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/analytics/test_session_report.py
+++ b/tests/unit/analytics/test_session_report.py
@@ -53,6 +53,14 @@ def test_exact_session_scope_models_purposes_and_costs(tmp_path):
     assert report.by_model["anthropic", "two"].cost_micro == 0
     assert not report.by_model["other", "one"].cost_is_known
     assert report.by_purpose_outcome == {("turn", "ok"): 2, ("turn", "error"): 1}
+    # by_purpose carries CONSUMPTION, which the count-only cross-tab above
+    # cannot: "what did compaction cost me" is not answerable from a count.
+    # Same `measures` contract as by_model, so the two must agree on the total.
+    assert set(report.by_purpose) == {"turn"}
+    assert report.by_purpose["turn"].calls == 3
+    assert report.by_purpose["turn"].total_tokens == report.aggregate.total_tokens
+    assert report.by_purpose["turn"].cost_micro == report.aggregate.cost_micro
+    assert report.by_purpose["turn"].cost_is_partial
     assert report.missing_usage_calls == 1
     assert report.unknown_usage_calls == 0
     assert report.timings["duration_ms"].samples == 3
@@ -116,6 +124,10 @@ def test_legacy_columns_remain_unknown_and_schema_unchanged(tmp_path):
     assert not report.aggregate.cost_is_known
     assert report.unknown_usage_calls == 1 and report.missing_usage_calls == 0
     assert report.by_purpose_outcome == {("unknown", "unknown"): 1}
+    # No `purpose` column on this ledger: `col()` folds every row into one
+    # honest `unknown` bucket rather than failing the query or inventing labels.
+    assert set(report.by_purpose) == {"unknown"}
+    assert report.by_purpose["unknown"].total_tokens == 120
     assert report.recent[0].duration_ms is None
     assert report.recent[0].usage_reported is None
     assert path.read_bytes() == before
@@ -159,4 +171,32 @@ def test_all_sections_share_snapshot_during_concurrent_commit(tmp_path, monkeypa
     assert sum(g.calls for g in report.by_model.values()) == 1
     assert [r.request_id for r in report.recent] == ["before"]
     assert store.session_report("s1").aggregate.calls == 2
+    store.close()
+
+
+def test_by_purpose_splits_consumption_across_real_purposes(tmp_path):
+    """One GROUP BY on an existing column; the parts must sum to the whole."""
+    store = AnalyticsStore(tmp_path / "ledger.db")
+    base = replace(_snap(), request_id="r0", outcome="ok")
+    store.record_batch(
+        [
+            replace(base, request_id="r1", purpose="turn"),
+            replace(base, request_id="r2", purpose="turn"),
+            replace(base, request_id="r3", purpose="compaction", cost_micro=250),
+            replace(
+                base, request_id="r4", purpose="naming", cost_micro=90, ok=False, outcome="error"
+            ),
+        ]
+    )
+    report = store.session_report("s1")
+    assert set(report.by_purpose) == {"turn", "compaction", "naming"}
+    assert report.by_purpose["turn"].calls == 2
+    # The partition is exact: every purpose's tokens and cost sum to the total,
+    # which is what lets the by-purpose bars carry share-of-session percentages.
+    assert sum(a.calls for a in report.by_purpose.values()) == report.aggregate.calls
+    assert sum(a.total_tokens for a in report.by_purpose.values()) == report.aggregate.total_tokens
+    assert sum(a.cost_micro for a in report.by_purpose.values()) == report.aggregate.cost_micro
+    # The failure annotation still comes from the outcome cross-tab, not here.
+    assert report.by_purpose_outcome[("naming", "error")] == 1
+    assert report.by_purpose["naming"].calls == 1
     store.close()

--- a/tests/unit/tui/test_session_panel.py
+++ b/tests/unit/tui/test_session_panel.py
@@ -8,11 +8,20 @@ import threading
 from dataclasses import replace
 
 import pytest
+from rich.style import Style
 
-from local_operator.analytics.model import SessionReport, UsageAggregate
+from local_operator.analytics.model import (
+    COMPONENT_KEYS,
+    SessionReport,
+    SessionRequest,
+    TimingSummary,
+    UsageAggregate,
+)
 from local_operator.analytics.store import AnalyticsStore
 from local_operator.session.frontend_state import FrontendSessionState
+from local_operator.tui import theme as theme_mod
 from local_operator.tui.app import OperatorApp, slash_command_for
+from local_operator.tui.widgets.analytics_panel import METRIC_COST, METRIC_TOKENS
 from local_operator.tui.widgets.editor import Editor
 from local_operator.tui.widgets.session_panel import (
     SessionDiagnostics,
@@ -44,7 +53,13 @@ def test_report_empty_unavailable_and_cost_knowledge():
     assert "No recorded requests" in empty and "Ledger unavailable" not in empty
     assert "Ledger unavailable" in unavailable and "No recorded requests" not in unavailable
     assert "selected/model" in empty and "effective/model" in empty
-    assert "~1,200 / 200,000" in empty
+    # An empty ledger still gets the live gauge — it is runtime data, not a
+    # ledger read — with the `~` estimate mark and the window as the note.
+    assert "Context window" in empty and "In context now" in empty
+    assert "~1.2k" in empty and "of 200k" in empty
+    # A failed read draws NO chart section, gauge included: nothing on that
+    # frame should invite the reader to trust a number.
+    assert "Context window" not in unavailable and "In context now" not in unavailable
     for cost, known, expected in [
         (0, 0, "$—"),
         (0, 1, "$0.0000+"),
@@ -56,12 +71,15 @@ def test_report_empty_unavailable_and_cost_knowledge():
         )
         text = build_session_report(report, runtime()).plain
         assert expected in text
-        assert "Input/output/tool dollars are unavailable separately" in text
+        assert "input, output and tool dollars are not recorded separately" in text
         assert "list-price estimate" in text
         assert "pending recorder writes" in text
         assert "not provider compute" in text
-        assert "Tool inventory" in text and "Tool schemas" in text and "Tool results" in text
-        assert "Conversation" in text
+        # The tool caveat is unconditional, so its wording is pinned here: it is
+        # the only thing keeping the Tool surface section from being read as
+        # per-tool billing, and shortening it away is a §3.7 blocker.
+        assert "Per-tool-name tokens and dollars are not recorded" in text
+        assert "not the cost of any one tool call" in text
 
 
 def test_runtime_captures_only_supported_scalars():
@@ -300,3 +318,426 @@ async def test_invalidating_buried_pending_view_never_pops_newer_modal():
         await pilot.pause()
         assert not isinstance(app.screen, (SessionScreen, AnalyticsScreen))
         assert app.focused is app.query_one(Editor)
+
+
+# -- chart rendering ---------------------------------------------------------
+#
+# The screen is a set of bar tables whose whole value is that a bar means a
+# known fraction of a known denominator. These tests pin the arithmetic, the
+# column discipline that lets a reader compare rows across sections, and the
+# degraded frames where the honest answer is "we cannot draw that".
+
+
+def _agg(calls=1, ok=None, ctx=0, out=0, cost=0, known=0, components=None, reasoning=0, cached=0):
+    aggregate = UsageAggregate(
+        calls=calls,
+        ok_calls=calls if ok is None else ok,
+        context_tokens=ctx,
+        output_tokens=out,
+        cost_micro=cost,
+        cost_known_calls=known,
+        reasoning_tokens=reasoning,
+        cache_read_tokens=cached,
+    )
+    if components:
+        aggregate.components = {key: components.get(key, 0) for key in COMPONENT_KEYS}
+    return aggregate
+
+
+def _request(index, purpose="turn", outcome="ok", ctx=40000, out=1000, duration=2000.0):
+    return SessionRequest(
+        request_id=f"r{index}",
+        ts_ms=1788602400000 + index * 47000,
+        provider="anthropic",
+        model_id="claude-sonnet-4-6",
+        purpose=purpose,
+        outcome=outcome,
+        usage_reported=True,
+        context_tokens=ctx,
+        output_tokens=out,
+        duration_ms=duration,
+        ttft_ms=400.0,
+        preparation_ms=25.0,
+    )
+
+
+def _populated():
+    """A session with every section populated, priced, and partly failed."""
+    components = {
+        "conversation": 312200,
+        "tool_results": 202600,
+        "system_prompt": 172700,
+        "tool_schemas": 103000,
+        "custom_instructions": 46500,
+        "tool_inventory": 29900,
+    }
+    return SessionReport(
+        "sess",
+        aggregate=_agg(25, 23, 900000, 37800, 49000, 25, components, 9500, 630000),
+        by_model={
+            ("anthropic", "claude-sonnet-4-6"): _agg(14, 14, 560000, 33600, 24990, 14),
+            ("anthropic", "claude-haiku-4-5"): _agg(5, 5, 270000, 2700, 3870, 5),
+            ("openai", "gpt-5.2-mini"): _agg(6, 4, 52000, 1500, 20140, 6),
+        },
+        by_purpose={
+            "turn": _agg(14, 12, 560000, 33600, 24990, 14),
+            "compaction": _agg(3, 2, 270000, 2700, 3870, 3),
+            "aside": _agg(4, 4, 48000, 1200, 5340, 4),
+        },
+        by_purpose_outcome={
+            ("turn", "ok"): 12,
+            ("turn", "error"): 2,
+            ("compaction", "ok"): 2,
+            ("compaction", "error"): 1,
+            ("aside", "ok"): 4,
+        },
+        timings={
+            "duration_ms": TimingSummary(25, 2223, 400, 3770),
+            "ttft_ms": TimingSummary(25, 410, 320, 606),
+            "preparation_ms": TimingSummary(25, 26, 18, 44),
+        },
+        recent=tuple(
+            _request(i, ctx=40000 + i * 4000, duration=2000.0 + i * 70)
+            for i in range(11, -1, -1)  # the store returns newest-first
+        ),
+        first_ts_ms=1788602400000,
+        last_ts_ms=1788602400000 + 700000,
+    )
+
+
+def _section(text, section):
+    """Every line of one section: from its header to the next blank line."""
+    lines = text.split("\n")
+    start = next(i for i, line in enumerate(lines) if line.startswith(f"▌ {section}"))
+    out = []
+    for line in lines[start + 1 :]:
+        if not line.strip():
+            break
+        out.append(line)
+    return out
+
+
+def _rows(text, section):
+    """Just the table rows of one section, without its prose footnotes.
+
+    A bar row is identified by its TRACK (`···`), not by any single glyph: the
+    purpose legend and the tool caveat are prose containing `·` as a separator,
+    and matching on that swept them in as rows.
+    """
+    return [line for line in _section(text, section) if "███" in line or "···" in line]
+
+
+def _bar_column(line):
+    """The x position where a row's bar starts."""
+    return min(line.index(ch) for ch in "█·" if ch in line)
+
+
+def test_sections_share_one_measured_column_set():
+    """One left edge, one bar column, one number column, down the whole screen.
+
+    This is the finding against /analytics that this screen exists not to
+    repeat: measuring each table on its own rows starts the component bars and
+    the per-provider numbers at two different x positions on one panel.
+    """
+    text = build_session_report(_populated(), runtime(), 88).plain
+    sections = ["Context window", "By model", "By purpose", "Where input went", "Tool surface"]
+    bar_starts = {_bar_column(row) for section in sections for row in _rows(text, section)}
+    assert len(bar_starts) == 1, f"bars start at {sorted(bar_starts)}, expected one column"
+
+
+def test_by_model_and_purpose_partition_the_session_total():
+    """Share-of-total, so the rows of one section sum to ~100%."""
+    text = build_session_report(_populated(), runtime(), 88).plain
+    for section in ("By model", "By purpose"):
+        percents = [
+            int(p.rstrip("%"))
+            for row in _rows(text, section)
+            for p in row.split()
+            if p.endswith("%")
+        ]
+        assert len(percents) == 3
+        assert 99 <= sum(percents) <= 101, f"{section} percentages sum to {sum(percents)}"
+        assert percents == sorted(percents, reverse=True), f"{section} is not sorted descending"
+
+
+def test_tool_surface_percentages_match_where_input_went():
+    """The same three components, the same denominator, so the same numbers.
+
+    A different denominator here would print Tool results as 60% in one section
+    and 23% in the other, on one screen, for the same tokens.
+    """
+    text = build_session_report(_populated(), runtime(), 88).plain
+    split = {
+        row.split("█")[0].strip(): row.split()[-1]
+        for row in _rows(text, "Where input went")
+        if "Tool" in row
+    }
+    tools = {
+        row.split("█")[0].strip().removeprefix("└ "): row.split()[-1]
+        for row in _rows(text, "Tool surface")
+        if row.strip().startswith("└")
+    }
+    assert tools and tools == split
+    # The parent is drawn in that same denominator, so parent ≈ Σ children.
+    parent = next(r for r in _rows(text, "Tool surface") if "All tool context" in r)
+    # Within one point: each row rounds its own percentage independently, so
+    # the subtotal need not equal the sum of the rounded children exactly.
+    assert (
+        abs(
+            int(parent.split()[-1].lstrip("~").rstrip("%"))
+            - sum(int(v.lstrip("~").rstrip("%")) for v in tools.values())
+        )
+        <= 1
+    )
+
+
+def test_request_sequence_uses_window_max_not_share_of_total():
+    """A tail does not partition the session; share-of-total would say nothing."""
+    text = build_session_report(_populated(), runtime(), 88).plain
+    rows = _rows(text, "Last 12 requests")
+    assert len(rows) == 12
+    # Oldest first, so the chart reads left-to-right in time like the transcript.
+    assert rows[0].strip().startswith("06:00:00")
+    # The largest request fills the bar completely — the window-max rule.
+    assert "·" not in rows[-1].split()[1]
+    assert "·" in rows[0].split()[1]
+    assert "%" not in text.split("▌ Last 12 requests")[1].split("▌")[0]
+
+
+def _span_colours(text):
+    """Every styled run of a report as ``(text, colour name)`` pairs.
+
+    A span's style may be a Style OR a style-name string, so it is normalised
+    before the colour is read.
+    """
+    out = []
+    for span in text.spans:
+        style = span.style if isinstance(span.style, Style) else Style.parse(str(span.style))
+        out.append((text.plain[span.start : span.end], style.color.name if style.color else ""))
+    return out
+
+
+def test_partial_cost_plus_is_dimmed_as_a_flag_not_a_digit():
+    """A lower-bound `+` at digit strength reads as part of the figure.
+
+    The row engine routes money cells through `append_cost` precisely so this
+    cannot regress into a second, hand-rolled cost cell.
+    """
+    aggregate = _agg(4, 4, 900, 100, cost=1000, known=2)
+    report = SessionReport("sess", aggregate=aggregate, by_model={("p", "m"): aggregate})
+    text = build_session_report(report, runtime(), 88, metric=METRIC_COST)
+    colours = dict(_span_colours(text))
+    assert colours["$0.0010"] == theme_mod.semantic_color("fg")
+    assert colours["+"] == theme_mod.semantic_color("dim")
+
+
+def test_failed_requests_are_warning_not_dim():
+    """A failed request is the one thing on this screen a reader must not miss."""
+    report = _populated()
+    text = build_session_report(report, runtime(), 88)
+    warning = theme_mod.semantic_color("warning")
+    dim = theme_mod.semantic_color("dim")
+    assert warning != dim
+    styled = _span_colours(text)
+    assert ("2 failed", warning) in styled
+    assert ("14 req", dim) in styled
+    # A healthy purpose carries no failure annotation at all.
+    assert "aside" in text.plain and "0 failed" not in text.plain
+
+
+def test_metric_toggle_switches_bars_and_says_so():
+    report = _populated()
+    tokens = build_session_report(report, runtime(), 88, metric=METRIC_TOKENS).plain
+    cost = build_session_report(report, runtime(), 88, metric=METRIC_COST).plain
+    assert "share of session tokens · t → cost" in tokens
+    assert "share of session cost · t → tokens" in cost
+    # Cost mode re-sorts by spend: the priciest model leads even though it is
+    # not the biggest by tokens.
+    assert _rows(tokens, "By model")[0].strip().startswith("anthropic/claude-sonnet-4-6")
+    assert "$" in _rows(cost, "By model")[0]
+    # SessionRequest holds no cost, so the sequence chart plots duration instead
+    # of dividing the session total by the request count.
+    assert "bars: tokens" in tokens and "bars: duration" in cost
+    assert "ms" in _rows(cost, "Last 12 requests")[0]
+
+
+def test_old_ledger_without_purpose_column_reads_as_one_unknown_row():
+    """`col()` folds a missing column into `unknown`; `unknown` is not a failure."""
+    aggregate = _agg(3, 3, 900, 100)
+    report = SessionReport(
+        "sess",
+        aggregate=aggregate,
+        by_model={("p", "m"): aggregate},
+        by_purpose={"unknown": aggregate},
+        by_purpose_outcome={("unknown", "unknown"): 3},
+    )
+    text = build_session_report(report, runtime(), 88).plain
+    rows = _rows(text, "By purpose")
+    assert len(rows) == 1 and rows[0].strip().startswith("unknown")
+    # An outcome column that does not exist must not paint the session red.
+    assert "failed" not in text
+    # The legend contrasts `turn` with the harness's purposes; there is no
+    # `turn` row here for it to contrast with.
+    assert "turn = your requests" not in text
+
+
+def test_fully_unpriced_cost_mode_explains_itself_instead_of_drawing_floor_bars():
+    aggregate = _agg(3, 3, 900, 100, cost=0, known=0)
+    report = SessionReport(
+        "sess",
+        aggregate=aggregate,
+        by_model={("ollama", "llama3"): aggregate},
+        by_purpose={"turn": aggregate},
+    )
+    text = build_session_report(report, runtime(), 88, metric=METRIC_COST).plain
+    assert "no published price for these models · t → tokens" in text
+    assert "$—" in text and "$0.00" not in text
+    # No bar at all rather than a wall of identical one-cell floor marks.
+    assert not any("█" in row for row in _rows(text, "By model"))
+    assert "+ lower bound (some calls unpriced)" in text
+
+
+def test_partial_pricing_marks_a_lower_bound_and_earns_the_legend():
+    aggregate = _agg(4, 4, 900, 100, cost=1000, known=2)
+    report = SessionReport("sess", aggregate=aggregate, by_model={("p", "m"): aggregate})
+    text = build_session_report(report, runtime(), 88).plain
+    assert "$0.0010+" in text
+    assert "+ lower bound (some calls unpriced)" in text
+    # A fully priced report needs no footnote for a mark nobody can see.
+    priced = _agg(4, 4, 900, 100, cost=1000, known=4)
+    clean = build_session_report(
+        SessionReport("sess", aggregate=priced, by_model={("p", "m"): priced}), runtime(), 88
+    ).plain
+    assert "+ lower bound" not in clean
+
+
+def _timing_rows(text):
+    """The three fixed timing rows, whether or not they drew a track."""
+    return _section(text, "Timings")[:3]
+
+
+def test_zero_sample_timings_draw_no_bar():
+    """A zero-width bar beside a real one implies a measured zero."""
+    aggregate = _agg(3, 3, 900, 100)
+    empty = {name: TimingSummary(0, None, None, None) for name in ("duration_ms", "ttft_ms")}
+    report = SessionReport("sess", aggregate=aggregate, timings=empty)
+    rows = _timing_rows(build_session_report(report, runtime(), 88).plain)
+    assert all("unknown (0 samples)" in row for row in rows)
+    assert not any("█" in row or "─" in row for row in rows)
+
+
+def test_timings_share_one_millisecond_scale():
+    """Independently scaled bars would draw prep and duration the same length."""
+    text = build_session_report(_populated(), runtime(), 88).plain
+    rows = _timing_rows(text)
+    # Labels contain spaces, so locate the mean marker in the row itself.
+    filled = [row.index("█") for row in rows]
+    # Duration's mean sits far right of first-output's, which sits right of prep.
+    assert filled[0] > filled[1] >= filled[2]
+    # And the reader is told the axis is shared; an invisible shared scale is a trap.
+    assert "shared ms scale" in text
+
+
+def test_empty_components_say_so_but_keep_the_tool_caveat():
+    aggregate = _agg(3, 3, 900, 100)
+    text = build_session_report(SessionReport("sess", aggregate=aggregate), runtime(), 88).plain
+    assert "no component data yet" in text
+    assert "no tool context recorded yet" in text
+    assert "Per-tool-name tokens and dollars are not recorded" in text
+
+
+def test_zero_value_rows_and_healthy_path_noise_are_suppressed():
+    text = build_session_report(_populated(), runtime(), 88).plain
+    # A component with no tokens is a row that says nothing.
+    assert "Environment" not in text and "Images (est.)" not in text
+    # "0 requests missing usage · 0 unknown" is the absence of a problem.
+    assert "missing usage" not in text
+    assert "unavailable" not in text
+
+
+def test_unattributed_residual_gets_no_bar():
+    """It is a leftover, not a component; a bar would double-count it."""
+    components = {"conversation": 400, "system_prompt": 100}
+    aggregate = _agg(3, 3, 900, 100, components=components)
+    text = build_session_report(SessionReport("sess", aggregate=aggregate), runtime(), 88).plain
+    row = next(r for r in _section(text, "Where input went") if "Unattributed" in r)
+    assert "█" not in row and "·" not in row
+    assert "400" in text  # its peers still carry theirs
+    assert row.split()[-1] == "400"  # 900 context − 500 attributed
+
+
+@pytest.mark.parametrize("width,note,pct", [(88, True, True), (60, True, True), (50, False, False)])
+def test_responsive_ladder_sheds_qualifiers_but_never_the_value(width, note, pct):
+    """Below the ladder's steps the note and percentage shed; the number stays."""
+    text = build_session_report(_populated(), runtime(), width).plain
+    rows = _rows(text, "By model")
+    assert len(rows) == 3
+    for row in rows:
+        assert len(row) <= width, f"row overflows {width}: {row!r}"
+        # The bar never falls below the floor at which it stops meaning anything.
+        assert sum(row.count(c) for c in "█·") >= 8
+        assert row.split()[-1] if not note else True
+    assert ("req" in "".join(rows)) is note
+    assert ("%" in "".join(rows)) is pct
+    # The value column never sheds: a bar without its number is a picture.
+    assert all(any(ch.isdigit() for ch in row) for row in rows)
+
+
+def test_narrow_labels_ellipsise_rather_than_starving_the_bar():
+    text = build_session_report(_populated(), runtime(), 40).plain
+    assert "…" in text
+    for section in ("By model", "Where input went"):
+        for row in _rows(text, section):
+            assert len(row) <= 40
+            assert sum(row.count(c) for c in "█·") >= 8
+
+
+@pytest.mark.asyncio
+async def test_metric_toggle_and_resize_repaint_through_the_real_screen():
+    """`t` flips the bars in place and a resize re-does the column arithmetic."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        screen = SessionScreen(_populated(), runtime())
+        app.push_screen(screen)
+        await pilot.pause()
+        wide = str(screen._body.render())
+        assert "share of session tokens · t → cost" in wide
+        assert "t cost/tokens" in str(screen._hint.render())
+
+        await pilot.press("t")
+        await pilot.pause()
+        flipped = str(screen._body.render())
+        assert "share of session cost · t → tokens" in flipped
+        assert "bars: duration" in flipped and "bars: tokens" not in flipped
+        await pilot.press("t")
+        await pilot.pause()
+        assert str(screen._body.render()) == wide
+
+        # The body is a function of the card width, so a resize must re-render
+        # it, not merely refresh the scroll hint.
+        await pilot.resize_terminal(50, 24)
+        await pilot.pause()
+        narrow = str(screen._body.render())
+        assert narrow != wide
+        # Every TABLE row fits the frame, so one row stays one record. The prose
+        # footnotes are longer and are meant to wrap — they are prose.
+        assert all(len(row) <= 50 for row in _rows(narrow, "By model"))
+        assert all(len(row) <= 50 for row in _rows(narrow, "Where input went"))
+        assert screen._scroll.max_scroll_x == 0
+
+
+@pytest.mark.asyncio
+async def test_toggle_is_not_advertised_when_there_is_nothing_to_plot():
+    """Promising a key that does nothing is a dead control."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        screen = SessionScreen(SessionReport("sess"), runtime())
+        app.push_screen(screen)
+        await pilot.pause()
+        assert "t cost/tokens" not in str(screen._hint.render())
+        before = str(screen._body.render())
+        await pilot.press("t")
+        await pilot.pause()
+        assert str(screen._body.render()) == before

--- a/tests/unit/tui/test_session_panel.py
+++ b/tests/unit/tui/test_session_panel.py
@@ -673,6 +673,57 @@ def test_unattributed_residual_gets_no_bar():
     assert row.split()[-1] == "400"  # 900 context − 500 attributed
 
 
+def test_unattributed_residual_is_measured_with_its_peers():
+    """It was appended AFTER measurement, so it was the one row off the grid.
+
+    Review M2: with short component labels its own 28-char label ellipsised
+    while the frame had ~30 cells free, and a residual wider than any measured
+    value pushed its number off the shared column the screen exists to create.
+    """
+    # Short peer labels, so nothing else widens the label column for it.
+    aggregate = _agg(6, 6, 280000, 5000, components={"conversation": 140000, "tool_results": 60000})
+    text = build_session_report(SessionReport("sess", aggregate=aggregate), runtime(), 88).plain
+    rows = _section(text, "Where input went")
+    residual = next(r for r in rows if "Unattributed" in r)
+    assert "…" not in residual, "label ellipsised while the frame had room"
+    assert residual.rstrip().endswith("80k")
+
+    # A residual WIDER than every measured value must still land in the shared
+    # number column rather than pushing its own.
+    wide = _agg(6, 6, 500900, 5000, components={"conversation": 400, "tool_results": 100})
+    text = build_session_report(SessionReport("sess", aggregate=wide), runtime(), 88).plain
+    rows = _section(text, "Where input went")
+    residual = next(r for r in rows if "Unattributed" in r)
+    peer = next(r for r in rows if "Conversation" in r)
+    # Both values end in the same column: one number column, whole section.
+    assert residual.index("500.4k") + len("500.4k") == peer.index("400") + len("400")
+
+
+def test_full_share_row_does_not_crop_its_failure_count():
+    """`format_percent(1.0)` is 4 chars; a 3-char cell cropped `2 failed`.
+
+    Design D1: the overflowing cell pushed every 100% row one cell past the
+    frame and `truncate(crop)` ate the rightmost column — the warning-coloured
+    failure tally, rendering `2 faile`. Any single-model or single-purpose
+    session is 100% by construction, so this was not an edge case.
+    """
+    one = _agg(18, 16, 460000, 14100, 49000, 18)
+    report = SessionReport(
+        "sess",
+        aggregate=one,
+        by_model={("anthropic", "claude-sonnet-4-6"): one},
+        by_purpose={"turn": one},
+        by_purpose_outcome={("turn", "ok"): 16, ("turn", "error"): 2},
+    )
+    # 84 is the real card width of a 100-column terminal, where this reproduced.
+    for width in (84, 88, 100):
+        text = build_session_report(report, runtime(), width).plain
+        row = next(r for r in _rows(text, "By purpose") if "turn" in r)
+        assert "100%" in row
+        assert row.rstrip().endswith("2 failed"), f"cropped at {width}: {row!r}"
+        assert len(row) <= width
+
+
 @pytest.mark.parametrize("width,note,pct", [(88, True, True), (60, True, True), (50, False, False)])
 def test_responsive_ladder_sheds_qualifiers_but_never_the_value(width, note, pct):
     """Below the ladder's steps the note and percentage shed; the number stays."""
@@ -748,3 +799,85 @@ async def test_toggle_is_not_advertised_when_there_is_nothing_to_plot():
         await pilot.press("t")
         await pilot.pause()
         assert str(screen._body.render()) == before
+
+
+def test_unpriced_group_in_cost_mode_shows_no_share_not_a_zero_share():
+    """QA Q1 / design D2: `cost_micro == 0` because the price is UNKNOWN.
+
+    Dividing it by the session total yields a 0% that reads as a measured zero
+    share, beside another row's real 100%, in the same column. QA's case: a
+    local model taking 9 of 10 requests and 99% of the tokens rendered an empty
+    track at 0% while a single priced call read as the entire spend.
+    """
+    priced = _agg(1, 1, 8000, 200, 3000, 1)
+    unpriced = _agg(9, 9, 810000, 9000, 0, 0)
+    total = _agg(10, 10, 818000, 9200, 3000, 1)
+    report = SessionReport(
+        "sess",
+        aggregate=total,
+        by_model={
+            ("anthropic", "claude-sonnet-4-6"): priced,
+            ("meta", "llama-4-scout"): unpriced,
+        },
+    )
+    cost = build_session_report(report, runtime(), 88, metric=METRIC_COST).plain
+    row = next(r for r in _section(cost, "By model") if "llama-4-scout" in r)
+    assert "$—" in row, "the honest figure stays"
+    assert "0%" not in row, "an unknown price is not a measured zero share"
+    assert "█" not in row and "·" not in row, "no track for an uncomputed share"
+    # The priced row is unaffected and still carries its real measurement.
+    priced_row = next(r for r in _section(cost, "By model") if "claude" in r)
+    assert "100%" in priced_row and "█" in priced_row
+    # In TOKEN mode both rows are measured, so both keep their bars: the
+    # suppression is about unknown COST, not about the model.
+    tokens = build_session_report(report, runtime(), 88).plain
+    assert all("█" in r for r in _rows(tokens, "By model"))
+    assert "99%" in "".join(_rows(tokens, "By model"))
+
+
+def test_sequence_chart_never_renders_an_absent_duration_as_zero():
+    """Review M1: the store keeps `None` distinct from a value; so must the row.
+
+    A legacy ledger has no `duration_ms`, and `or 0.0` printed a full-strength
+    `0 ms` beside an empty track — `$0.00` for time. Same rule as `_timing_rows`
+    ("an absent sample is not a fast one") and `_gauge_row`.
+    """
+    recent = tuple(
+        SessionRequest(
+            f"r{i}",
+            1788602400000 + i * 10000,
+            "p",
+            "m",
+            "unknown",
+            "unknown",
+            None,
+            1000,
+            100,
+            None,
+            None,
+            None,
+        )
+        for i in range(3, -1, -1)
+    )
+    report = SessionReport("sess", aggregate=_agg(4, 4, 4000, 400), recent=recent)
+    cost = build_session_report(report, runtime(), 88, metric=METRIC_COST).plain
+    rows = _section(cost, "Last 4 requests")
+    assert rows and all("unknown" in r for r in rows)
+    assert not any("0 ms" in r for r in rows), "an absent sample rendered as measured zero"
+    assert not any("█" in r for r in rows), "no bar for an unmeasured request"
+    # A MIXED tail keeps the measured rows drawn and scales them among
+    # themselves: an unmeasured request must not define the window max either.
+    mixed = (
+        SessionRequest(
+            "b", 1788602400000 + 10000, "p", "m", "turn", "ok", True, 1000, 100, 4000.0, None, None
+        ),
+        SessionRequest(
+            "a", 1788602400000, "p", "m", "turn", "ok", True, 1000, 100, None, None, None
+        ),
+    )
+    report = SessionReport("sess", aggregate=_agg(2, 2, 2000, 200), recent=mixed)
+    rows = _section(
+        build_session_report(report, runtime(), 88, metric=METRIC_COST).plain, "Last 2 requests"
+    )
+    assert sum("█" in r for r in rows) == 1
+    assert any("4,000 ms" in r for r in rows) and any("unknown" in r for r in rows)

--- a/tests/unit/tui/test_session_panel.py
+++ b/tests/unit/tui/test_session_panel.py
@@ -6,6 +6,7 @@ import asyncio
 import sqlite3
 import threading
 from dataclasses import replace
+from datetime import datetime
 
 import pytest
 from rich.style import Style
@@ -493,11 +494,17 @@ def test_tool_surface_percentages_match_where_input_went():
 
 def test_request_sequence_uses_window_max_not_share_of_total():
     """A tail does not partition the session; share-of-total would say nothing."""
-    text = build_session_report(_populated(), runtime(), 88).plain
+    report = _populated()
+    text = build_session_report(report, runtime(), 88).plain
     rows = _rows(text, "Last 12 requests")
     assert len(rows) == 12
-    # Oldest first, so the chart reads left-to-right in time like the transcript.
-    assert rows[0].strip().startswith("06:00:00")
+    # Oldest first, so the chart reads left-to-right in time like the
+    # transcript. The expected label is DERIVED in the ambient zone rather than
+    # written out: the renderer formats local time, so a hardcoded stamp pins
+    # the developer's timezone and fails on a UTC CI runner.
+    oldest = min(request.ts_ms for request in report.recent)
+    expected = datetime.fromtimestamp(oldest / 1000).astimezone().strftime("%H:%M:%S")
+    assert rows[0].strip().startswith(expected)
     # The largest request fills the bar completely — the window-max rule.
     assert "·" not in rows[-1].split()[1]
     assert "·" in rows[0].split()[1]


### PR DESCRIPTION
## Summary of Changes

`/session` was **all words and numbers with no visuals**. Every fact was one `label  value` line, so at 100x30 the body ran **166 rows** to say less than `/analytics` says in 52, and nothing was proportional to anything. The questions the screen exists to answer — *where did my context go*, *what did compaction cost me*, *which requests were big* — each required arithmetic in the reader's head.

This rebuilds the body as bar tables using the chart vocabulary `/analytics` already owns, **imported rather than copied**, and adds the sections that make consumption comparable: a context gauge, by model, by purpose, where input went, tool surface, a request-sequence chart, and range-bar timings.

**Change class: C2, standard / pre-authorized.** No version bump; `pyproject.toml` stays at `0.49.8` and this rides the next combined release.

Release: patch — /session reads as charts: consumption by model, purpose, input component and request, with a `t` cost/tokens toggle.

Implements the design spec written against rendered frames of both real screens (`/private/tmp/lop-session-charts-design/SPEC.md`), closing its findings D1–D8.

## Delivery contract

**One chart vocabulary, by import.** `_append_cost`, `_section_header` and `_semantic` become public `append_cost`, `section_header` and `semantic_style`; the cost-legend predicate (`scope_needs_cost_legend`) and its footnote string (`COST_LEGEND`) are shared. An underscore name imported across modules is a private contract in all but spelling, so the rename states the visibility the usage already implies. `proportion_bar`, `format_tokens`/`format_cost`/`format_percent` and `METRIC_COST`/`METRIC_TOKENS` are reused unchanged. **No second bar style, money formatter or honesty vocabulary is introduced.**

**One measured column set.** Label, bar and value columns are measured **once across the union of rows** from the gauge, by model, by purpose, where input went and tool surface, then shared by all five — so one left edge and one bar column run down the whole screen. Measuring per table is exactly why `/analytics` starts its component bars at x≈46 while its provider numbers start at x≈35 on one panel.

**The denominators differ on purpose, and each is commented with why:**

| section | denominator | why |
|---|---|---|
| By model / By purpose | share of session total | these rows **partition** one quantity, so they sum to 100% and answer "what fraction of this session was X" |
| Context window | share of the model's window | an absolute gauge against a hard limit — "how close am I to compaction", a different question |
| Where input went / Tool surface | share of the component total | the split is apportioned to sum to the recorded context; **the same denominator in both**, so the three tool components read with identical percentages in the two places they appear |
| Last N requests | window max (largest in view) | a tail does **not** partition the session; share-of-total would draw twelve bars at 4% each and communicate nothing |

**One additive store read.** `by_purpose` is a single `GROUP BY` on the existing `purpose` column, on the same `measures` contract as `by_model`. A `COUNT(*)` cross-tab cannot answer "what did compaction cost me". **No schema migration**; `col()` folds an older ledger without the column into one honest `unknown` row. `by_purpose_outcome` is retained as the failure tally.

**`t` cost/tokens toggle**, mirroring `AnalyticsScreen` — repaints from the held report with no second store read, advertised both in the hint line and in each affected section's meta. **`SessionScreen._card_width()`** now exists and threads width into `build_session_report`, repainting on resize. Rows are cropped, not folded, so one row is one record at 50 columns.

## Non-goals (deliberate, not omissions)

- **No per-tool cost or "$ by tool" column.** The ledger has `c_tool_inventory`, `c_tool_schemas` and `c_tool_results` and **no per-tool-name column anywhere**; the provider bills one input total per call and never attributes it to a tool. A cost-per-tool chart would be an invented number. The Tool surface section shows the tool machinery's share of the estimated input split and carries a two-line caveat saying exactly that — **the caveat is not optional and is pinned by a test.**
- **`cost_micro` is not apportioned across the three `c_tool_*` components.** Cost is priced per call at record time; splitting it by character length would fabricate a figure the provider never billed.
- **No transcript-counted tool invocations** presented beside ledger tokens as if they shared a source.
- **No daily/monthly calendar chart on `/session`.** `daily_series`/`monthly_series`/`series_totals` read the machine-wide `usage_daily`/`usage_monthly` rollups and take **no session parameter**, so drawing them here would show other sessions' spend under a heading that says "this session". The only session-scoped time field is `SessionRequest.ts_ms` on a `LIMIT`ed tail — enough for a *sequence* chart, not a *calendar* one, and the meta says `oldest → newest` rather than "over time" because the rows are evenly spaced regardless of the gap between them.
- **No per-request cost bars.** `SessionRequest` has no cost field, so cost mode switches that chart to `duration_ms` and its meta says `bars: duration`.
- **No sparklines and no categorical bar colours** — a second chart vocabulary, or new semantic tokens fighting the app's single-accent voice, for no added information.

## Notable fixes found while building

- **`_card_width()` is MEASURED off the mounted scroll container, not recomputed from the CSS.** `AnalyticsScreen`'s `card - 6` formula omits the stable scrollbar gutter `#*-scroll` reserves and lands **one cell wide** — verified: at 100 cols the formula says 84 while the painted content box is 83. Building rows one cell too wide folded the session ID onto a second line at 50 columns, which is the same "one record reads as two" fault these charts exist to remove. (This one cell is also why `/analytics` overflows horizontally at 50 cols today; not fixed here, out of scope.)
- **`N failed` renders in `warning`, not `dim`** — a failed request is the one thing on this screen a reader must not scroll past.
- **A legacy ledger's `unknown` outcome is not counted as a failure.** Older rows have no `outcome` column, so every row reads `unknown`; counting those would paint a healthy legacy session as entirely failed, in the one colour that must never cry wolf.
- **The money cells go through `append_cost`**, so a partial cost renders `$0.0010` at digit strength with the lower-bound `+` dimmed as the flag it is — verified as `#e9e5db` vs `#837c6d` and pinned by a test, because a hand-rolled second cost cell would silently reintroduce the exact defect that helper was written to fix.
- **Zero-value noise suppressed**: `Environment ~0`, `Images (est.) ~0`, `Usage missing 0 requests; 0 unknown`, `Compaction count unavailable`.

## Testing evidence

Static gates on this head, **whole tree, exactly as CI**:

```
flake8 .                                    exit 0
black==26.1.0 --check .                     949 files unchanged
isort==5.13.2 --check .                     clean
pyright (--pythonpath .venv/bin/python)     0 errors, 0 warnings
```

> `pyright` must be given the venv interpreter. A bare `pyright` resolved a different interpreter and reported 1260 spurious `reportMissingImports` — the trap documented in `AGENTS.md`.

Unit suite, whole tree via the worktree venv:

```
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q -n4
14840 passed, 18 skipped, 684 warnings in 1052.24s (0:17:32)
```

**Correction (round 1).** An earlier revision of this description claimed `test_disk_worker_is_off_loop_and_drops_stale_session` fails on the base commit under load. **That claim is withdrawn — QA could not reproduce it and neither premise holds.** QA ran it 16 times across head and base, `-n0`, isolated, including under 6 synthetic CPU hogs at load average 76: **16/16 passed**. The test is green at both commits. My original observation was made while several other agents were saturating this host, and I did not isolate it well enough to attribute the failure; treating it as "pre-existing on base" was unsupported.

### Round 1 remediation (head `dc209806f`)

Three review streams landed on `6f30639e2`; all findings are dispositioned in the three remediation comments on this PR. Four defects were fixed in one commit, all on the row-rendering path:

| id | stream | defect | fix |
|---|---|---|---|
| **D1** | design, MAJOR | `format_percent(1.0)` returns `100%` (4 chars) into a 3-char cell, so every full-share row overflowed and the crop ate the `warning`-coloured failure tally: `2 faile` | the cell is **derived** from the formatter's widest output, so a future change to `format_percent` cannot reintroduce it |
| **Q1 / D2** | QA MAJOR + design MINOR (one defect) | in cost mode an unpriced group rendered an empty track and `0%` — a local model at 9/10 requests and 99% of tokens read as 0% of spend | `bar=False`, the primitive the residual already used: no track, no percentage, honest `$—` left standing |
| **M1** | code, MAJOR | `duration_ms or 0.0` printed a full-strength `0 ms` for a sample the store deliberately keeps as `None` | `None` survives to the row, which reads `unknown` with no bar and cannot define the window max |
| **M2** | code, MAJOR | the unattributed residual was appended *after* `_shared_columns` measured, so it ellipsised with ~30 cells free and sat off the shared number column | built in `_component_rows` with its peers, so what is drawn is what was measured |

`m2`/`n1`/`n2` (MINOR/NIT) are also fixed here. `Q2`/`m3` (the header ID crop) is **deferred**: QA and design independently established that every ID this harness generates is `uuid4().hex[:12]` (580/580 sessions on this machine) and renders uncropped at the 38-cell floor, so it is unreachable in production — see the remediation comments.

Because `pct_col` feeds `label_col` and `bar_width`, the **whole responsive ladder was re-verified** after D1: 103 widths (38–140) × 2 metrics, **zero table rows overflowing**, bar never below its 8-cell floor, and the shed thresholds unmoved (pct below 52, note below 60).

**The demo fixture was the common thread across all three rounds** (`Q3`). It seeded 18 identical requests and a 40-character session ID, so the two best new charts rendered as a wall of identical bars, the timings showed a degenerate `2,800 ms–2,800 ms` range, and the header crop was manufactured. Those were correct renderings of uniform input — and they are the frames the feature gets judged by. The fixture is now a session that varies the way a real one does (context growing with history, a compaction resetting it, large turns, one failure, a cheap model on the asides) with a real-shaped 12-char ID. **Every frame below is re-captured on `dc209806f`.**

New/updated tests:

- `tests/unit/analytics/test_session_report.py` — the additive read: `by_purpose` partitions the session exactly (calls, tokens and cost each sum to the aggregate), agrees with `by_model` on the totals, carries `cost_is_partial`, keeps the failure tally in `by_purpose_outcome`, and folds a legacy ledger with no `purpose` column into one `unknown` row.
- `tests/unit/tui/test_session_panel.py` — the column discipline (**all five sections' bars start at exactly one x position**), share-of-total summing to 100% and sorted descending, tool percentages **identical** to the input split for the same components with parent ≈ Σ children, window-max on the request tail with the largest bar full and oldest first, `warning` vs `dim` on `N failed`, the dimmed `+`, the `t` toggle flipping metas and switching the sequence chart to duration, and the honesty cases: **unpriced** (explains itself instead of drawing a wall of floor bars), **partial** (earns the legend; a fully-priced report does not), **old ledger with no purpose column**, **zero-sample timings** (no bar at all — a zero-width bar beside a real one implies a measured zero), **empty components**, and the **narrow-width ladder** at 88/60/50 plus label ellipsisation at 40.
- **Round 1**: one test per fixed defect, each confirmed to **fail against `6f30639e2` and pass here** — the 100% row keeping its `2 failed` at widths 84/88/100; an unpriced cost row carrying `$—` with no track and no `0%` while token mode keeps both bars; an absent `duration_ms` rendering `unknown` with no bar, plus a mixed tail proving an unmeasured request does not define the window max; and the residual neither ellipsising with room to spare nor leaving the shared number column.
- Two pilot tests drive the real `SessionScreen`: `t` flips the bars in place and back, and a resize re-renders the body (not just the hint) with every table row inside the frame and `max_scroll_x == 0`.

### Rendered evidence

All frames captured from the **real `OperatorApp` with the production stylesheet** via `scripts/session_report_shot.py`, isolated config dir, every `CMUX_*` cleared, `ledger_unchanged: true` on every run. Before-frames are from this same base commit; after-frames are re-captured on `dc209806f` with the varied fixture. `prompts: []` on every run — no provider request is made.

Measured geometry, after:

| capture | body virtual rows | `max_scroll_x` |
|---|---|---|
| 100x30 | **76** (was **166**, −54%) | 0 |
| 80x24 | 81 (was 171) | 0 |
| 50x24 | 91 (was 223) | 0 |
| empty | 22 | 0 |
| unavailable | 19 | 0 |

(Row counts are marginally higher than the pre-remediation figures because the varied fixture produces more distinct purposes and models to chart — more rows, carrying more information.)

**No reflow**: the `opened` and `settled` SVGs are **byte-identical** at all three sizes (`cmp` exit 0), so nothing settles visibly after the first frame.

#### 100x30 — before / after

![BEFORE 100x30 — prose, no visuals](https://github.com/user-attachments/assets/7744f80a-e3bf-42bb-b36e-df72fac78bec)

![AFTER 100x30 — Totals, live gauge, By model](https://github.com/user-attachments/assets/b337e459-90c3-48e4-98a0-e777d19f3ccb)

The `Request purpose / outcome` cross-tab was counts only — it could not answer what compaction cost:

![BEFORE 100x30 page 2 — counts only](https://github.com/user-attachments/assets/05627bf1-82c8-43d4-a670-fd9d04b8870c)

![AFTER 100x30 page 1 — By purpose with an intact `1 failed`, and the input split](https://github.com/user-attachments/assets/4537ab0b-3097-4d6f-a08a-7d5674a65f75)

One shared bar column across all five sections, and `Tool results ~21%` reads identically in **both** `Where input went` and `Tool surface`.

The request tail was 7 lines × 12 = 84 rows of prose; it is now 12 bars:

![AFTER 100x30 page 2 — tool surface, and a sequence chart that discriminates](https://github.com/user-attachments/assets/1fbc45f3-27ae-4419-a78c-a0abbff1dcae)

#### 50x24 — the fold is gone

Before, a row folded mid-record so one record read as two:

![BEFORE 50x24 — rows fold mid-record](https://github.com/user-attachments/assets/6ce93d32-6096-480c-a57c-a4e1562e0b1d)

![AFTER 50x24 — real 12-char ID uncropped, one row per record](https://github.com/user-attachments/assets/a4f1bdf1-692b-464d-af54-3f17eb06dadb)

![AFTER 50x24 page 1 — ladder sheds notes and percentages](https://github.com/user-attachments/assets/4ed937f0-3c0b-4f9f-95a6-4e1592643caf)

The ladder sheds the note column below 60 and the percentage below 52; labels ellipsise and the bar is pinned at its 8-cell floor. **The value column never sheds** — a bar without its number is a picture, a number without its bar is the screen being replaced.

![AFTER 80x24 page 1](https://github.com/user-attachments/assets/aa27aa9f-2677-4b89-8f49-c4325caa3752)

#### Timings — a real range, not a degenerate point

![AFTER 100x30 page 3 — timings with a real 980ms-8,960ms range](https://github.com/user-attachments/assets/3611be5c-bc4e-4246-aa40-901aaf8a9e61)

The shared-ms-scale range bars now show what they are for: `Duration` 980 ms–8,960 ms against `First output` 366 ms–1,882 ms and `Prep` 18 ms–46 ms, on one axis. The old constant fixture rendered all three as points.

#### Cost mode (`t`)

![AFTER cost mode — dollars, and a different ordering from tokens](https://github.com/user-attachments/assets/e7f30a16-5f36-4aaa-90dc-26e8189d9c28)

![AFTER cost mode — sequence chart on bars: duration](https://github.com/user-attachments/assets/ff9b5a59-37b9-40fb-ade4-f17c9263460f)

The sequence chart switches to `bars: duration` because `SessionRequest` holds no cost — and the tool caveat is still there.

#### Degraded states

![AFTER empty ledger — the live gauge survives](https://github.com/user-attachments/assets/8b78e770-114c-4778-a409-36cd8c60b07c)

An empty ledger keeps the gauge: it is **live runtime data, not a ledger read**, which is why its meta says `live · not from the ledger`. This gives a fresh session one true visual where the old empty state was 21 rows of mostly nothing.

![AFTER unavailable ledger — no chart sections at all](https://github.com/user-attachments/assets/1db4f0af-208e-4432-9e06-86376f484efe)

A failed read draws **no chart section at all**, gauge included: when the read failed we cannot say which numbers are trustworthy, and one lone bar under a failure heading invites the reader to trust the rest.

## Risks and rollback

- **Read-only and additive.** One extra `GROUP BY` inside the existing read transaction — same connection, same WAL snapshot, same `measures` contract, no schema change, no write path touched. `ledger_unchanged: true` on every capture.
- **The three renames touch `analytics_panel` call sites only** (mechanical; `/analytics` behaviour is unchanged and its own tests pass untouched). `_needs_cost_legend` keeps its name and now delegates to the shared predicate.
- **Blast radius is two screens**, both read-only diagnostics overlays. No provider request is made by either.
- **Rollback**: revert this commit. Nothing persists, migrates, or is written, so a revert is complete.

---

Assignee: @damianvtran. No human reviewers added yet, pending the agent review, QA and design rounds.

