### PR TITLE
chore(release): bump version to 0.49.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.49.8"
+version = "0.49.9"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release bump for the v0.49.9 window.

## Window contents

- #687 `de06da6c` — fix(attention): share foreground completion acknowledgements across TUI and mobile
- #698 `74451200` — Release: patch — `/session` reads as charts: consumption by model, purpose, input component and request, with a `t` cost/tokens toggle

## Bump class

**Patch.** Both entries are corrections or readability reworks of existing surfaces — shared completion receipts stop double-notifying a session already read at the terminal, and `/session` re-renders as charts. Neither adds an adoptable subsystem, so the window does not clear the minor step-function bar.

## Why #698 is listed

It merged after this PR was opened, but it is an ancestor of `main` and the built artifact ships it either way. Listing it keeps the release record honest rather than under-reporting what shipped.

## Scope

`pyproject.toml` version line only.