### PR TITLE
fix(evaluation): attribute provider refusals to the provider, not the model

### DIFF
--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -811,6 +811,7 @@ class EpisodeRunner:
         # carry its response and usage before any terminal (verify.py:760) --
         # so recording it eagerly would make the failure path unsealable.
         rejected: DecisionRejected | None = None
+        aborted: BaseException | None = None
         try:
             decision = await self._model.decide(
                 observation, tuple(self._turns), action_surface=self._action_surface
@@ -827,6 +828,7 @@ class EpisodeRunner:
         except BaseException as error:
             from local_operator.evaluation.runner.provider_client import (
                 ContextUnrecoverableError,
+                ProviderStreamAbortedError,
             )
 
             # The client could not fit the context into the window even after
@@ -840,12 +842,28 @@ class EpisodeRunner:
             # one-step-per-batch rule forbids amending it.
             if isinstance(error, ContextUnrecoverableError):
                 raise
-            # Scanned HERE, not only where the message is published: this
-            # rendering is truncated on the way into ``_ProviderFailure``, and
-            # ``_finalize_failure`` later seals it. A cut applied before any
-            # scan severs the canary, so forwarding the redaction set only at
-            # the publish site arrives too late to matter.
-            raise _ProviderFailure(_diagnostic(error, self._redactions)) from error
+            if isinstance(error, ProviderStreamAbortedError):
+                # A refusal (or an abnormal end) is a BILLED call that produced
+                # no reply: the provider read the whole prompt -- 48,000 input
+                # tokens in the observed case -- and then declined to answer.
+                # So it takes the same path a rejection does and falls THROUGH
+                # to the triple below, carrying its own usage. Skipping that
+                # wrote no ``usage_cost`` event at all, and ``_reconcile`` then
+                # published the resulting zero as an AVAILABLE (measured)
+                # figure: a bundle whose only job is honest accounting claiming
+                # a spend of nothing for a turn that was paid for. The episode
+                # still seals as a provider failure -- that is re-raised after
+                # the evidence is written, below.
+                aborted = error
+                decision = error
+            else:
+                # Scanned HERE, not only where the message is published: this
+                # rendering is truncated on the way into ``_ProviderFailure``,
+                # and ``_finalize_failure`` later seals it. A cut applied
+                # before any scan severs the canary, so forwarding the
+                # redaction set only at the publish site arrives too late to
+                # matter.
+                raise _ProviderFailure(_diagnostic(error, self._redactions)) from error
         if decision.compaction is not None:
             # Declared BEFORE the request triple: the client rebuilt its
             # context on the way to this request, so the compaction belongs
@@ -952,6 +970,20 @@ class EpisodeRunner:
             self._usage_totals[name] = self._usage_totals.get(name, 0) + getattr(
                 decision.usage, name
             )
+        if aborted is not None:
+            # Evidence first, failure second. Everything above ran exactly as it
+            # does for a billed decision, so the attempt's request/response/usage
+            # triple is now in the journal and the counters include its spend;
+            # only now is the episode allowed to die. No ``error`` event is
+            # written here because this raise reaches ``_finalize_failure``,
+            # which writes the terminal ``category="provider"`` one -- a second
+            # would double-count the same failure.
+            #
+            # The redaction set is forwarded for the reason ``_diagnostic``
+            # documents: this message quotes the provider's own prose verbatim,
+            # unbounded and unscanned by the client that raised it, so the scan
+            # has to happen before the 500-char bound is applied here.
+            raise _ProviderFailure(_diagnostic(aborted, self._redactions)) from aborted
         if rejected is not None:
             # The diagnostic is what the model will be shown; it is published
             # as an artifact rather than squeezed into the identifier-shaped

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -584,6 +584,54 @@ def parse_decision(
     )
 
 
+#: Stop reasons that end a stream having DELIVERED content (or having been cut
+#: off mid-content). Everything else -- ``refusal``, ``error``, ``aborted``, and
+#: any marker a future wire client normalizes to -- ended the turn without the
+#: provider ever committing to an answer. Named as an allow-list rather than a
+#: deny-list of the abnormal ones so a newly introduced abnormal marker is
+#: classified as abnormal by default: mis-reading an outage as a normal stop is
+#: the failure this constant exists to prevent, and mis-reading a normal stop as
+#: an outage would be caught immediately by the parse tests.
+_NORMAL_CONTENT_STOPS = frozenset({"stop", "length", "toolUse"})
+
+
+class ProviderStreamAbortedError(RuntimeError):
+    """The stream ended abnormally without producing any usable content.
+
+    Deliberately NOT a :class:`DecisionRejected`. That type means the provider
+    answered, was billed, and the MODEL's reply failed strict parsing -- which
+    the runner corrects by re-prompting, because a model that emitted bad JSON
+    can emit good JSON when told what was wrong. None of that holds here: a
+    refusal (or a mid-stream provider error) produced no reply at all, so there
+    is nothing for the model to correct and a correction prompt asks it to fix
+    text it never wrote.
+
+    Raising a plain exception puts this on the protocol's provider path
+    (``EpisodeModelClient``: "raising anything else is the contract for an
+    unrecoverable provider failure"), so the runner seals the episode unscored
+    as ``category="provider"`` / ``reason="infrastructure_failure"`` instead of
+    ``model_failure``. That attribution is the point: the agent under test never
+    got the chance to act, so charging it a model failure would fold a provider
+    outage into the agent's number.
+
+    Observed, and the reason this exists: three consecutive ``refusal`` ends
+    (one billing zero tokens both ways) had their ``error`` dropped by
+    ``_stream``, so empty text reached ``parse_decision`` and the episode's
+    evidence recorded "decision is not valid JSON: Unterminated string" against
+    a model that had emitted no bytes. The diagnostic named the wrong cause, so
+    the failure was not diagnosable from the bundle at all.
+
+    The message quotes the provider's own words UNBOUNDED and UNSCANNED on
+    purpose. This client holds no ``RedactionSet``; the episode renders the
+    exception through ``_diagnostic(error, self._redactions)``, which scans the
+    whole string BEFORE applying its 500-character bound. Cutting the prose here
+    first would sever a canary and let the surviving prefix pass that scan --
+    the truncate-then-scan inversion documented on ``_diagnostic``. Retention is
+    therefore unchanged: the same bounded, scanned artifact every other fatal
+    error already produces, and nothing new held anywhere else.
+    """
+
+
 class ContextUnrecoverableError(ValueError):
     """The context cannot be made to fit the window, so the request must not
     be sent.
@@ -862,9 +910,15 @@ class ProviderModelClient:
             tool_choice="none",
             prompt_cache_key=self._prompt_cache_key,
         )
-        text, usage, cost_micros, stop_reason, provider_request_id, context_tokens = (
-            await self._stream(request)
-        )
+        (
+            text,
+            usage,
+            cost_micros,
+            stop_reason,
+            provider_request_id,
+            context_tokens,
+            stream_error,
+        ) = await self._stream(request)
         self._last_request_ms = _now_ms()
         if context_tokens is not None:
             # A figure reported FOR the request just sent is measured against
@@ -878,6 +932,22 @@ class ProviderModelClient:
         if extra_usage is not None:
             usage = _add_usage(usage, extra_usage)
             cost_micros += extra_cost
+        # Checked BEFORE parsing, because parsing an empty string produces a
+        # confident and completely wrong diagnosis. ``parse_decision`` reports
+        # "decision is not valid JSON", the runner turns that into a correction
+        # prompt asking the model to fix its JSON, and the model -- which said
+        # nothing -- is re-prompted until the retry bound is spent. The episode
+        # then seals as a MODEL failure for a provider's refusal.
+        #
+        # Both halves of the condition are required. ``error`` alone misses a
+        # wire client that ends abnormally without composing prose; an abnormal
+        # ``stop_reason`` alone would swallow the recoverable case where the
+        # provider refused only AFTER streaming a parseable batch -- that text
+        # is real model output and stays on the correctable rejection path.
+        if (stream_error or stop_reason not in _NORMAL_CONTENT_STOPS) and not text.strip():
+            raise ProviderStreamAbortedError(
+                stream_error or f"provider ended the stream as '{stop_reason}' with no content"
+            )
         try:
             return parse_decision(
                 text.strip(),
@@ -985,7 +1055,9 @@ class ProviderModelClient:
 
         async def summarize(prompt: str) -> str:
             nonlocal summary_usage, summary_cost
-            text, usage, cost, _stop, _rid, _ctx = await self._stream(self._summary_request(prompt))
+            text, usage, cost, _stop, _rid, _ctx, _err = await self._stream(
+                self._summary_request(prompt)
+            )
             summary_usage = usage
             summary_cost = cost
             return text
@@ -1180,13 +1252,16 @@ class ProviderModelClient:
             replayable=True,
         )
 
-    async def _stream(self, request: Any) -> tuple[str, ModelUsage, int, str, str, int | None]:
+    async def _stream(
+        self, request: Any
+    ) -> tuple[str, ModelUsage, int, str, str, int | None, str | None]:
         text = ""
         usage = ModelUsage()
         cost_micros = 0
         stop_reason = "stop"
         provider_request_id = "unknown"
         context_tokens: int | None = None
+        stream_error: str | None = None
         async for event in self._stream_fn(request, None):
             if event.type == "text_delta":
                 text += event.delta
@@ -1202,7 +1277,21 @@ class ProviderModelClient:
                 # bundle's model_response back to the provider's records, so it
                 # is worth carrying when the wire client reports one.
                 provider_request_id = _provider_request_id(event.provider_payload)
-        return text, usage, cost_micros, stop_reason, provider_request_id, context_tokens
+                # The wire clients are the ONLY layer where the provider's
+                # actual terminal marker (``content_filter``, ``refusal``,
+                # ``SAFETY``…) is still visible; downstream sees only the
+                # normalized stop. Dropping this field is what left a refused
+                # episode's evidence blaming the model's JSON.
+                stream_error = event.error
+        return (
+            text,
+            usage,
+            cost_micros,
+            stop_reason,
+            provider_request_id,
+            context_tokens,
+            stream_error,
+        )
 
 
 def _frames_line(observation: Observation) -> str:

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -594,6 +594,18 @@ def parse_decision(
 #: an outage would be caught immediately by the parse tests.
 _NORMAL_CONTENT_STOPS = frozenset({"stop", "length", "toolUse"})
 
+#: Stands in for a terminal marker the stream never supplied -- either no ``end``
+#: event arrived at all, or one arrived carrying an empty ``stop_reason``. It is
+#: deliberately a value OUTSIDE ``_NORMAL_CONTENT_STOPS``: coercing an absent
+#: marker to ``"stop"`` would punch a fail-OPEN hole through an allow-list whose
+#: entire purpose is to fail closed, and a probe confirmed the hole was live
+#: (``stop_reason=""`` with empty text was classified as a normal stop and fell
+#: into the JSON-parse misdiagnosis this module exists to remove). It is also a
+#: valid ``StrictIdentifier``, so it can be recorded verbatim in the bundle's
+#: ``model_response`` rather than being laundered into a stop the provider never
+#: sent.
+_UNSPECIFIED_STOP = "unspecified"
+
 
 class ProviderStreamAbortedError(RuntimeError):
     """The stream ended abnormally without producing any usable content.
@@ -622,14 +634,57 @@ class ProviderStreamAbortedError(RuntimeError):
     the failure was not diagnosable from the bundle at all.
 
     The message quotes the provider's own words UNBOUNDED and UNSCANNED on
-    purpose. This client holds no ``RedactionSet``; the episode renders the
-    exception through ``_diagnostic(error, self._redactions)``, which scans the
-    whole string BEFORE applying its 500-character bound. Cutting the prose here
-    first would sever a canary and let the surviving prefix pass that scan --
-    the truncate-then-scan inversion documented on ``_diagnostic``. Retention is
-    therefore unchanged: the same bounded, scanned artifact every other fatal
-    error already produces, and nothing new held anywhere else.
+    purpose, and this class cannot promise what happens to them: it holds no
+    ``RedactionSet``, so the scan-then-bound ordering that keeps the prose safe
+    is enforced one layer away, by the raise site's handler in
+    ``episode._decide_once``, which renders it through
+    ``_diagnostic(error, self._redactions)`` -- the scan-before-truncate
+    contract documented on ``_diagnostic`` itself. Cutting the prose HERE would
+    invert that order, severing a canary and letting the surviving prefix pass
+    the later scan. Anyone changing where this exception is caught owns keeping
+    that call redaction-carrying: most ``_diagnostic`` sites in ``episode.py``
+    pass an explicit ``None`` (in-process renderings that never reach
+    evidence), so "a handler exists" is not by itself the guarantee.
+
+    The billing fields mirror :class:`DecisionRejected`'s. A refused turn is
+    still a BILLED turn -- the provider read the whole prompt before deciding
+    to refuse, and the motivating case carried a 48k input -- so the runner
+    writes this attempt's request/response/usage triple from these fields
+    before sealing. Without them a refused episode reported zero spend as a
+    MEASURED figure, which is a false claim inside evidence whose only purpose
+    is honest accounting.
     """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        route: RouteIdentity | None = None,
+        usage: ModelUsage | None = None,
+        cost_micros: int = 0,
+        stop_reason: str = _UNSPECIFIED_STOP,
+        provider_request_id: str = "unknown",
+        tool_call_count: int = 0,
+        prompt_cache_key: str | None = None,
+        context_tokens: int | None = None,
+        compaction: CompactionRecord | None = None,
+    ) -> None:
+        super().__init__(message)
+        # ``route`` may be None for the same reason it may be on a rejection: a
+        # stream that aborted need not have reported what it served, and the
+        # runner falls back to the requested route rather than inventing one.
+        self.route = route
+        self.usage = usage or ModelUsage()
+        self.cost_micros = cost_micros
+        self.stop_reason = stop_reason
+        self.provider_request_id = provider_request_id
+        self.tool_call_count = tool_call_count
+        self.prompt_cache_key = prompt_cache_key
+        self.context_tokens = context_tokens
+        # A compaction on the way to this request already happened and was
+        # billed; it must still be declared before the triple or the verifier
+        # sees a compaction with no request to attach it to.
+        self.compaction = compaction
 
 
 class ContextUnrecoverableError(ValueError):
@@ -946,7 +1001,18 @@ class ProviderModelClient:
         # is real model output and stays on the correctable rejection path.
         if (stream_error or stop_reason not in _NORMAL_CONTENT_STOPS) and not text.strip():
             raise ProviderStreamAbortedError(
-                stream_error or f"provider ended the stream as '{stop_reason}' with no content"
+                stream_error or f"provider ended the stream as '{stop_reason}' with no content",
+                # The same billing provenance a rejection carries, and for the
+                # same reason: the request was sent and read, so its usage is
+                # part of the episode's bill whether or not a reply came back.
+                route=self._route,
+                usage=usage,
+                cost_micros=cost_micros,
+                stop_reason=stop_reason,
+                provider_request_id=provider_request_id,
+                prompt_cache_key=self._prompt_cache_key,
+                context_tokens=_estimate_context(messages),
+                compaction=compaction,
             )
         try:
             return parse_decision(
@@ -1055,6 +1121,15 @@ class ProviderModelClient:
 
         async def summarize(prompt: str) -> str:
             nonlocal summary_usage, summary_cost
+            # TODO(F3, review round 2): this path discards ``_err`` and
+            # ``_stop``, so a compaction summary call that the provider REFUSED
+            # returns empty text and is folded into the context as a legitimate
+            # (if useless) summary, rather than being attributed to the
+            # provider the way the decision call now is. Pre-existing and
+            # deliberately out of scope here; fixing it needs a decision about
+            # whether an unsummarizable context is a provider failure or a
+            # harness one (``ContextUnrecoverableError``), which is a different
+            # question from this change's.
             text, usage, cost, _stop, _rid, _ctx, _err = await self._stream(
                 self._summary_request(prompt)
             )
@@ -1258,7 +1333,9 @@ class ProviderModelClient:
         text = ""
         usage = ModelUsage()
         cost_micros = 0
-        stop_reason = "stop"
+        # A stream that never emits an ``end`` event never told us how it
+        # ended, so it starts abnormal and only a real marker makes it normal.
+        stop_reason = _UNSPECIFIED_STOP
         provider_request_id = "unknown"
         context_tokens: int | None = None
         stream_error: str | None = None
@@ -1269,7 +1346,11 @@ class ProviderModelClient:
                 usage, cost_micros = _usage_from(event.usage)
                 context_tokens = _context_tokens_from(event.usage)
             elif event.type == "end":
-                stop_reason = event.stop_reason or "stop"
+                # NOT ``or "stop"``. An empty marker is an ABSENT marker, and
+                # normalizing it to a normal content stop would let a stream
+                # that said nothing about how it ended take the parse path --
+                # the exact misdiagnosis the allow-list below exists to stop.
+                stop_reason = event.stop_reason or _UNSPECIFIED_STOP
                 if event.usage is not None:
                     usage, cost_micros = _usage_from(event.usage)
                     context_tokens = _context_tokens_from(event.usage)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.50.0"
+version = "0.50.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/evaluation/runner/test_episode.py
+++ b/tests/unit/evaluation/runner/test_episode.py
@@ -21,7 +21,9 @@ from local_operator.evaluation.evidence.models import (
     CleanupPayload,
     EnvironmentStepPayload,
     ErrorPayload,
+    ModelResponsePayload,
     ObservationPayload,
+    ReconciliationPayload,
     ScoreArtifact,
 )
 from local_operator.evaluation.evidence.store import EvidenceWriter
@@ -32,7 +34,9 @@ from local_operator.evaluation.runner.episode import (
     EpisodeRunner,
 )
 from tests.unit.evaluation.runner.conftest import (
+    ROUTE,
     FakeAdapter,
+    ModelUsage,
     RecordingResponder,
     ScriptedModel,
     build_config,
@@ -764,6 +768,84 @@ async def test_context_unrecoverable_seals_as_a_harness_error_not_a_provider_one
     assert len(errors) == 1
     assert errors[0].category == "adapter"
     assert errors[0].diagnostic_code == "contextunrecoverableerror"
+
+
+@pytest.mark.asyncio
+async def test_an_aborted_stream_seals_as_provider_but_still_bills_its_input(
+    tmp_path: Path, episode_id: str
+) -> None:
+    """A refusal is unanswered, not unbilled, and the bundle must say so.
+
+    The provider read the whole prompt before declining -- the observed case
+    carried 48,000 input tokens -- so the attempt is a real cost. Without its
+    triple the episode sealed with NO ``usage_cost`` event, and ``_reconcile``
+    then published the resulting zero as an AVAILABLE (measured) figure: a
+    bundle whose only purpose is honest accounting claiming a paid turn cost
+    nothing. The episode still ends as a provider failure; what changes is that
+    the spend it caused is in the evidence.
+    """
+
+    from local_operator.evaluation.runner.provider_client import (
+        ProviderStreamAbortedError,
+    )
+
+    class RefusingModel:
+        async def decide(self, observation: Any, history: Any, **kwargs: Any) -> Any:
+            raise ProviderStreamAbortedError(
+                "model refused: I can't help with that (stop_reason=refusal)",
+                route=ROUTE,
+                usage=ModelUsage(input_tokens=48_000, output_tokens=0),
+                cost_micros=144_000,
+                stop_reason="refusal",
+                provider_request_id="req-refused-1",
+            )
+
+    adapter = FakeAdapter(tmp_path, episode_id)
+    runner = EpisodeRunner(
+        build_spec(episode_id),
+        build_config(tmp_path),
+        selector=selector(tmp_path),
+        model=RefusingModel(),
+        launch=lambda _: adapter,
+        rescue=_rescue_ok,
+    )
+
+    outcome = await runner.run()
+
+    assert outcome.status == "failed"
+    assert outcome.score is not None and outcome.score.reason == "infrastructure_failure"
+    root = outcome.bundle_root
+    assert root is not None
+    report = verify_bundle(root)
+    assert report.valid, [issue.code for issue in report.issues]
+    # The billed attempt is a full triple, not a hole: the counters are the
+    # verifier's own sum over the journal's usage events.
+    assert report.counters is not None
+    assert report.counters.model_request_count == 1
+    assert report.counters.model_response_count == 1
+    assert report.counters.input_tokens == 48_000
+    assert report.counters.cost_microusd == 144_000
+    # The provider's real marker is recorded rather than laundered into "stop".
+    responses = payloads(root, ModelResponsePayload)
+    assert [response.stop_reason for response in responses] == ["refusal"]
+    assert responses[0].provider_request_id == "req-refused-1"
+    # ``_reconcile`` reports that same spend, so the bundle's budget record and
+    # its journal agree instead of the record claiming a measured zero.
+    reconciliations = payloads(root, ReconciliationPayload)
+    assert reconciliations[0].provider_cost_microusd == 144_000
+    # Exactly one error event, the terminal provider one: writing the triple
+    # must not also mint a retryable model error the way a rejection does.
+    errors = payloads(root, ErrorPayload)
+    assert [(e.category, e.retryable) for e in errors] == [("provider", False)]
+    # The provider's own words survive into the bundle. They matter more here
+    # than anywhere else: ``diagnostic_code`` is derived from the wrapping
+    # ``_ProviderFailure``, so it buckets this identically to a transport
+    # outage, and the detail is the only thing naming which mechanism fired.
+    detail = errors[0].detail_artifact
+    assert detail is not None
+    recorded = (root / "artifacts" / detail.sha256).read_text()
+    assert "stop_reason=refusal" in recorded
+    assert "I can't help with that" in recorded
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/evaluation/runner/test_provider_client.py
+++ b/tests/unit/evaluation/runner/test_provider_client.py
@@ -675,6 +675,113 @@ async def test_client_still_rejects_a_reply_the_provider_cut_short() -> None:
 
 
 @pytest.mark.asyncio
+async def test_client_attributes_a_normal_stop_carrying_an_error_to_the_provider() -> None:
+    """A NORMAL stop and a set ``error`` together, which only the first half of
+    the guard's condition catches.
+
+    Real and reachable: a provider whose content filter fires after it has
+    committed to a normal terminal marker reports ``stop`` and puts the reason
+    in ``error``, so the stop alone says the turn was fine while the stream in
+    fact delivered nothing. Dropping the ``stream_error or`` half of the
+    condition leaves every other case in this file passing, so without this
+    test that half is unpinned and the empty reply goes back to being reported
+    as bad JSON.
+    """
+
+    current = observation()
+    stream = ScriptedStream(
+        "",
+        stop_reason="stop",
+        usage=Usage(input_tokens=48_000, output_tokens=0),
+        error="content filter blocked the response (stop_reason=content_filter)",
+    )
+
+    with pytest.raises(ProviderStreamAbortedError) as info:
+        await _client(stream).decide(current, _turns(current))
+
+    assert "content filter blocked the response" in str(info.value)
+    # The normal marker is reported as-is; the abort is justified by the error,
+    # not by rewriting what the provider said it did.
+    assert info.value.stop_reason == "stop"
+
+
+@pytest.mark.asyncio
+async def test_client_treats_a_length_end_with_no_text_as_a_correctable_rejection() -> None:
+    """``length`` is in the allow-list, and its membership is load-bearing.
+
+    A token cap that truncates before any parseable JSON is a MODEL problem the
+    runner can correct by re-prompting -- not an outage. Dropping ``length``
+    from ``_NORMAL_CONTENT_STOPS`` would convert every legitimate cap-truncated
+    turn into a sealed unscored infrastructure failure, and no other test in
+    this file notices, because the allow-list is otherwise only exercised
+    through ``stop``.
+    """
+
+    current = observation()
+    stream = ScriptedStream(
+        "",
+        stop_reason="length",
+        usage=Usage(input_tokens=48_000, output_tokens=4_096),
+    )
+
+    with pytest.raises(DecisionRejected) as info:
+        await _client(stream).decide(current, _turns(current))
+
+    assert info.value.stop_reason == "length"
+    assert info.value.diagnostic.startswith("Your previous reply was rejected:")
+
+
+@pytest.mark.asyncio
+async def test_client_does_not_normalize_an_absent_stop_marker_into_a_normal_stop() -> None:
+    """An empty ``stop_reason`` is an ABSENT marker, not a normal content stop.
+
+    ``event.stop_reason or "stop"`` coerced it into one, punching a fail-OPEN
+    hole through an allow-list built to fail closed: a stream that said nothing
+    about how it ended took the parse path and produced exactly the "not valid
+    JSON" misdiagnosis this guard removes.
+    """
+
+    current = observation()
+    stream = ScriptedStream("", stop_reason="", usage=Usage(input_tokens=48_000, output_tokens=0))
+
+    with pytest.raises(ProviderStreamAbortedError) as info:
+        await _client(stream).decide(current, _turns(current))
+
+    assert "JSON" not in str(info.value)
+    # Recorded verbatim rather than laundered into a stop the provider never
+    # sent, and a valid ``StrictIdentifier`` so the bundle can carry it.
+    assert info.value.stop_reason == "unspecified"
+
+
+@pytest.mark.asyncio
+async def test_an_aborted_stream_carries_the_usage_the_refused_turn_was_billed() -> None:
+    """A refusal is unanswered, not unbilled.
+
+    The provider read the whole prompt before declining, so the episode owes
+    for those input tokens. Carrying nothing meant a refused episode sealed
+    with no usage event at all and reported that zero as a MEASURED spend.
+    """
+
+    current = observation()
+    stream = ScriptedStream(
+        "",
+        stop_reason="refusal",
+        usage=Usage(input_tokens=48_000, output_tokens=0),
+        provider_payload={"id": "req-refused-1"},
+        error="model refused: I can't help with that (stop_reason=refusal)",
+    )
+
+    with pytest.raises(ProviderStreamAbortedError) as info:
+        await _client(stream).decide(current, _turns(current))
+
+    assert info.value.usage.input_tokens == 48_000
+    assert info.value.usage.output_tokens == 0
+    assert info.value.route == ROUTE
+    assert info.value.stop_reason == "refusal"
+    assert info.value.provider_request_id == "req-refused-1"
+
+
+@pytest.mark.asyncio
 async def test_client_still_treats_ordinary_malformed_json_as_correctable() -> None:
     """Regression guard on the fix's blast radius.
 

--- a/tests/unit/evaluation/runner/test_provider_client.py
+++ b/tests/unit/evaluation/runner/test_provider_client.py
@@ -36,6 +36,7 @@ from local_operator.evaluation.runner.provider_client import (
     MAX_TOLERATED_TRAILING_CHARS,
     DecisionParseError,
     ProviderModelClient,
+    ProviderStreamAbortedError,
     build_system_prompt,
     parse_decision,
 )
@@ -110,12 +111,18 @@ class ScriptedStream:
         stop_reason: str = "stop",
         chunk: int = 7,
         provider_payload: dict[str, Any] | None = None,
+        error: str | None = None,
     ) -> None:
         self.text = text
         self.usage = usage
         self.stop_reason = stop_reason
         self.chunk = chunk
         self.provider_payload = provider_payload
+        # The provider's own words about an abnormal end. Scripted here because
+        # the wire clients are the only layer that sees the real terminal
+        # marker, so a fake that cannot carry one cannot exercise the refusal
+        # path at all -- which is how that path shipped unhandled.
+        self.error = error
         self.requests: list[Any] = []
 
     def __call__(self, request: Any, signal: Any) -> AsyncIterator[Any]:
@@ -134,6 +141,7 @@ class ScriptedStream:
             stop_reason=self.stop_reason,
             usage=self.usage,
             provider_payload=self.provider_payload,
+            error=self.error,
         )
 
 
@@ -579,6 +587,114 @@ async def test_client_raises_on_an_unparseable_reply() -> None:
     assert rejected.provider_request_id == "chatcmpl-REJ"
     assert rejected.route == ROUTE
     assert rejected.diagnostic.startswith("Your previous reply was rejected:")
+
+
+# ---------------------------------------------------------------------------
+# Abnormal stream ends. A provider that refused (or died mid-stream) without
+# producing content is NOT a model that replied badly: there is no reply to
+# correct, so re-prompting for better JSON cannot converge and the failure
+# belongs to the provider. Observed on a paid run whose three refusals were
+# recorded as "decision is not valid JSON: Unterminated string".
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_client_attributes_a_refusal_with_prose_to_the_provider() -> None:
+    current = observation()
+    stream = ScriptedStream(
+        "",
+        stop_reason="refusal",
+        usage=Usage(input_tokens=11, output_tokens=0),
+        error="model refused: I can't help with that (stop_reason=refusal)",
+    )
+
+    with pytest.raises(ProviderStreamAbortedError) as info:
+        await _client(stream).decide(current, _turns(current))
+
+    # The provider's own marker reaches the diagnostic verbatim: it is the only
+    # thing that says WHICH mechanism fired, and the bundle is unreadable
+    # without it.
+    assert "stop_reason=refusal" in str(info.value)
+    assert "I can't help with that" in str(info.value)
+
+
+@pytest.mark.asyncio
+async def test_client_attributes_a_wordless_zero_token_refusal_to_the_provider() -> None:
+    """The exact observed case: ``refusal``, no prose, zero tokens both ways.
+
+    Nothing was streamed and nothing was billed, so there is no model output to
+    blame and no reply a correction prompt could repair.
+    """
+
+    current = observation()
+    stream = ScriptedStream(
+        "",
+        stop_reason="refusal",
+        usage=Usage(input_tokens=0, output_tokens=0),
+    )
+
+    with pytest.raises(ProviderStreamAbortedError) as info:
+        await _client(stream).decide(current, _turns(current))
+
+    # Never the JSON diagnosis the old path produced against an empty string.
+    assert "JSON" not in str(info.value)
+    assert "refusal" in str(info.value)
+
+
+@pytest.mark.asyncio
+async def test_client_attributes_a_wordless_mid_stream_error_to_the_provider() -> None:
+    current = observation()
+    stream = ScriptedStream("   \n  ", stop_reason="error")
+
+    with pytest.raises(ProviderStreamAbortedError):
+        await _client(stream).decide(current, _turns(current))
+
+
+@pytest.mark.asyncio
+async def test_client_still_rejects_a_reply_the_provider_cut_short() -> None:
+    """An abnormal end AFTER real text is the model's output, not an outage.
+
+    A safety stop that truncates a partially-streamed batch leaves bytes the
+    model actually wrote, so it stays on the correctable rejection path where
+    the runner can feed the defect back and re-prompt.
+    """
+
+    current = observation()
+    stream = ScriptedStream(
+        '{"actions": [{"kind": "click", "observation',
+        stop_reason="refusal",
+        usage=Usage(input_tokens=12, output_tokens=9),
+        error="model refused and cut the reply short (stop_reason=refusal)",
+    )
+
+    with pytest.raises(DecisionRejected) as info:
+        await _client(stream).decide(current, _turns(current))
+
+    assert isinstance(info.value.__cause__, DecisionParseError)
+    assert info.value.stop_reason == "refusal"
+
+
+@pytest.mark.asyncio
+async def test_client_still_treats_ordinary_malformed_json_as_correctable() -> None:
+    """Regression guard on the fix's blast radius.
+
+    A normal ``stop`` carrying an unparseable reply must keep raising
+    ``DecisionRejected`` -- widening the provider path to swallow it would
+    convert every recoverable formatting mistake into a sealed unscored
+    episode.
+    """
+
+    current = observation()
+    stream = ScriptedStream(
+        '{"actions": [',
+        usage=Usage(input_tokens=11, output_tokens=4),
+    )
+
+    with pytest.raises(DecisionRejected) as info:
+        await _client(stream).decide(current, _turns(current))
+
+    assert info.value.stop_reason == "stop"
+    assert info.value.diagnostic.startswith("Your previous reply was rejected:")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The evaluation runner discarded `StreamEndEvent.error` — the one field carrying the provider's terminal marker (`content_filter`, `refusal`, `SAFETY`). A provider refusal therefore arrived as empty text, fell into `parse_decision`, and was reported to the model as **malformed JSON it never emitted**. The episode then sealed a `model_failure` naming the wrong cause.

This is a **surface-parity defect**, not a benchmark one. The TUI session path already consumes this field (`session.py:5722`, `loop.py:1396`); the evaluation runner was the only surface dropping it. Any provider refusal or content-filter block reaching the benchmark/exec path was misattributed the same way.

Found while running OSWorld 2.0 with Claude Opus 5, but the fix names no benchmark, model, or provider.

## What changed

- `_stream` returns the provider's `error` alongside `stop_reason`.
- New `ProviderStreamAbortedError`, raised in `decide` **before** `parse_decision` when the stream ended abnormally **and** produced no usable text.
- `_NORMAL_CONTENT_STOPS = {stop, length, toolUse}` as an allow-list, so an unknown future marker is abnormal by default.
- `_UNSPECIFIED_STOP` replaces `stop_reason or "stop"`, which silently coerced an empty marker into a normal content stop — a fail-open hole through a deliberately fail-closed allow-list.

**Both halves of the guard condition are load-bearing.** `error` alone misses a client that ends abnormally without composing prose; abnormal `stop_reason` alone would swallow a refusal that cut off *after* streaming real bytes — that text is model output and stays correctable.

**Typed outcome is deliberately not `DecisionRejected`.** That type asserts the model answered and its reply failed parsing, which the runner corrects by re-prompting — sound for bad JSON, meaningless for a refusal that emitted nothing. The episode now seals `category="provider"` / `infrastructure_failure` instead of charging the agent a `model_failure` for a turn it never got.

## Testing evidence

**Real end-to-end episode** (real `ProviderModelClient` + real `EpisodeRunner`/`EvidenceWriter`, refusal with zero tokens), same script against both trees:

| | pre-fix | fixed |
|---|---|---|
| error event | `category=model code=decision-rejected` ×2, then `modelfailure` | `category=provider code=providerfailure` |
| detail artifact | `decision is not valid JSON: Expecting value...` | `model refused and sent no message (stop_reason=refusal)` |
| `score.reason` | `model_failure` | `infrastructure_failure` |

`verify_bundle` valid in both. That reproduces the reported defect and shows it gone.

**Live confirmation on the real path.** Re-running the same OSWorld task on the fixed harness produced the true cause instead of the invented one:

```
ProviderStreamAbortedError: model refused: This request triggered restrictions on
violative cyber content and was blocked under Anthropic's Usage Policy.
(finish_reason=content_filter)
```

Pre-fix, that identical situation reported `decision is not valid JSON: Unterminated string starting at: line 1 column 135`.

**Billing honesty.** A refusal is billed for input — the motivating case carried a 48k-token prompt. The first revision discarded that usage, sealing a fabricated zero that `_reconcile` then published as *measured*. Now fixed: the sealed bundle reports `input_tokens=48000`, `cost_microusd=144000`, `ReconciliationPayload.provider_cost_microusd == 144000`, `stop_reason="refusal"`, and exactly one error event `("provider", False)`. Counters are recomputed by `verify_bundle` from the journal, not restated by the test.

**Attribution cannot be laundered.** Probed 10 boundary cases: prose-not-JSON, truncated JSON, malformed JSON, bad schema, empty+`stop`, empty+`length` all still resolve to `DecisionRejected` → `model_failure`. Both laundering probes (text-present + transport error; prose + `refusal` marker) stay MODEL. The `and not text.strip()` conjunct holds that line — a model that produced output cannot be reclassified as infrastructure.

**Secret safety proven, not assumed.** A canary planted at index 624 of a 713-char refusal message — past the 500-char bound — yields `<withheld: matched a secret canary>`. Scan-then-bound, not bounded-then-scanned; truncating at the raise site would sever the canary.

**Mutation matrix** — every clause and the allow-list membership pinned:

| Mutant | Killed by |
|---|---|
| M1 drop `stop_reason` clause | 3 tests |
| M2 drop `stream_error or` half | `..._normal_stop_carrying_an_error...` |
| M3 drop `and not text.strip()` | `..._still_rejects_a_reply_the_provider_cut_short` |
| M4 remove guard entirely | 6 tests |
| M5 drop `"length"` from allow-list | `..._length_end_with_no_text_as_a_correctable_rejection` |
| M6 restore `or "stop"` coercion | `..._absent_stop_marker_into_a_normal_stop` |
| F1a revert episode-side arm | `..._seals_as_provider_but_still_bills_its_input` |
| F1b strip usage from exception | 4 tests |

## Gates

`flake8` clean · `black --check` 985 files unchanged · `isort --check` (CI's 5.13.2 pin) clean · `pyright` 0 errors, 0 warnings · `tests/unit` **14968 passed, 18 skipped, 0 failed** on the current head.

## Not in scope

`ProviderModelClient`'s compaction `summarize` call still discards the same `error`/`stop` values one function away: a refused *summary* returns empty text and commits a content-free marker. Narrower blast radius (no evidence misattribution), left as a `TODO(F3, review round 2)` naming the discarded values rather than silently carried.

One residual noted in review: when a stream dies *before* any usage event arrives, the exception carries a genuine-zero usage that `_reconcile` still publishes as available rather than unavailable. Smaller lie than the 144,000-microusd one fixed here, and closing it needs a reconciliation-model decision — follow-up.

Release: patch — a provider refusal or content filter in the evaluation runner is now attributed to the provider instead of being reported as malformed JSON the model never emitted.
