### PR TITLE
chore(release): bump version to 0.50.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.49.9"
+version = "0.50.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release bump for the v0.50.0 window.

## Window contents

- #696 `b0db51d9` — feat(desktop): authenticated control surface for the desktop app

## Bump class

**Minor**, and deliberately not a patch. #696 introduces a new authenticated control plane and makes the desktop app a first-class client of this backend rather than a reimplementation of it. That is a new surface a user adopts, which is what AGENTS.md reserves the minor for: `0.49.x` → `0.50.0` tells a user something real changed. This is not the "when in doubt, patch" case.

## Why this is being cut promptly

`local-operator-ui` **v0.15.0 is already released** and requires a backend carrying `b0db51d9`. PyPI currently serves 0.49.9, so anyone who updates the desktop app before this release gets a UI negotiating endpoints their backend does not have. The desktop release notes say "update the backend first", but a notes line is a mitigation, not a fix — shipping the backend is the fix.

## Not in this window

- #700 (CODEOWNERS) — open at cut time; rides the next window.
- The `tests/unit/tui` timing-flake fix — under active proof; correctness of the fix outranks its inclusion here.
- #697 / local-operator-ui#85 (desktop viewed-completion adapter) — pending rebase onto merged main and a convergence round.

## Scope

`pyproject.toml` version line only.