### PR TITLE
fix(osworld): type at upstream's speed and bound type length by the guest deadline

### DIFF
--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/actions.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/actions.py
@@ -20,6 +20,12 @@ not be silently repaired.
 
 from __future__ import annotations
 
+from lop_osworld_v2_adapter.providers.base import (
+    GUEST_COMMAND_TIMEOUT_S,
+    GUEST_TYPE_DEADLINE_FRACTION,
+    GUEST_TYPE_MS_PER_CHAR,
+)
+
 from local_operator.computer_input import paste_text_source
 from local_operator.evaluation.action_surface import ActionSurface
 from local_operator.evaluation.protocol import (
@@ -37,10 +43,32 @@ from local_operator.evaluation.protocol import (
     WaitAction,
 )
 
+#: Longest ``type`` this adapter admits, DERIVED so it cannot drift from the
+#: deadline that enforces it. Typing is a per-character loop against a constant
+#: socket timeout, and until these two were related the protocol's 100000-char
+#: ``MAX_TEXT_LENGTH`` was admissible while needing roughly seven minutes — the
+#: batch would be dispatched, blow the deadline, and die with its outcome
+#: unknown, which is fatal to the episode rather than correctable.
+#:
+#: Computed rather than written down: changing the timeout, the per-character
+#: budget, or the fraction moves this bound with them, and a second hardcoded
+#: number here would reintroduce exactly the drift that caused the incident.
+#: Floored to stay conservative, and it is a CEILING on admission, not a
+#: prediction — a payload just under it is expected to finish well inside the
+#: deadline because the per-character budget is ~2x the measured cost.
+MAX_TYPE_CHARS = int(
+    GUEST_COMMAND_TIMEOUT_S * GUEST_TYPE_DEADLINE_FRACTION * 1000.0 / GUEST_TYPE_MS_PER_CHAR
+)
+
 # Admission is independent of neutral data parsing and runs for the ENTIRE
 # batch before a provider sees any statement, so a click cannot precede a
 # silently lossy Unicode TypeAction. The adapter metadata uses this same surface.
-ACTION_SURFACE = ActionSurface(paste_text=True, type_text_mode="ascii", ask_user=True)
+ACTION_SURFACE = ActionSurface(
+    paste_text=True,
+    type_text_mode="ascii",
+    ask_user=True,
+    max_type_chars=MAX_TYPE_CHARS,
+)
 
 # Our named keys (protocol._NAMED_KEYS) -> pyautogui key names. pyautogui
 # uses lowercase single words; the two that differ structurally are META

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/actions.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/actions.py
@@ -131,7 +131,18 @@ def compile_action(action: ComputerAction, geometry: FrameGeometry | None = None
         # repr(), NEVER f-string interpolation: the text is model output and
         # may contain quotes, backslashes, or newlines. repr() produces a
         # Python literal that re-parses to exactly the same string.
-        return f"pyautogui.typewrite({action.text!r}, interval=0.01)"
+        #
+        # NO ``interval``: upstream types with pyautogui's default of 0.0
+        # (python.py:895) and this is the one place we may not deviate.
+        # ``typewrite`` is a per-character loop with an UNCONDITIONAL
+        # ``time.sleep(interval)`` per character, so an interval is not a rate
+        # hint — it is a hard floor of ``interval x len(text)`` seconds that the
+        # guest must burn before the statement can return. At the 0.01 we used
+        # to pass, two real episodes died typing 7332 and 6912 characters: 73 s
+        # and 69 s of mandated sleep alone, against the 90 s guest read deadline
+        # in ``providers/aws.py``, while the guest itself was healthy and idle at
+        # a shell prompt. 71% of our typing time was our own sleep.
+        return f"pyautogui.typewrite({action.text!r})"
 
     if isinstance(action, KeyAction):
         names = [_key_name(key) for key in action.keys]

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
@@ -292,6 +292,7 @@ class OSWorldV2Adapter:
                 scoring=True,
                 paste_text=actions.ACTION_SURFACE.paste_text,
                 type_text_mode=actions.ACTION_SURFACE.type_text_mode,
+                max_type_chars=actions.ACTION_SURFACE.max_type_chars,
             ),
         )
         # Per-episode state. None until the corresponding method runs.

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/aws.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/aws.py
@@ -67,6 +67,7 @@ from lop_osworld_v2_adapter.cleanup import (
     EVIDENCE_TERMINATE_DENIED,
     EVIDENCE_TERMINATE_UNCONFIRMED,
 )
+from lop_osworld_v2_adapter.providers.base import GUEST_COMMAND_TIMEOUT_S
 from lop_osworld_v2_adapter.provisioning import ProvisioningPlan
 from lop_osworld_v2_adapter.taskfile import TaskDescriptor
 
@@ -777,7 +778,9 @@ class AwsProvider:
                 try:
                     from local_operator.computer_input import python_source_argv
 
-                    result = self._run_guest_command(python_source_argv(script), timeout=90)
+                    result = self._run_guest_command(
+                        python_source_argv(script), timeout=GUEST_COMMAND_TIMEOUT_S
+                    )
                 except Exception:
                     # Neither transport exceptions nor guest stderr are safe to
                     # expose: they may echo the command, credentials or UI text.

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/base.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/base.py
@@ -19,6 +19,34 @@ from typing import Any, Protocol, runtime_checkable
 from lop_osworld_v2_adapter.provisioning import ProvisioningPlan
 from lop_osworld_v2_adapter.taskfile import TaskDescriptor
 
+# How long the client waits for ONE guest statement before giving up. Matches
+# upstream's own client deadline (python.py:670) and is a hang detector, not a
+# throughput budget: a statement that legitimately needs longer than this is a
+# statement we should not be sending. It lives here, at the provider seam,
+# rather than inline at its single call site because the action compiler must
+# derive an admission bound from it (``actions.MAX_TYPE_CHARS``) — the two
+# drifting apart is precisely the defect that cost two episodes.
+GUEST_COMMAND_TIMEOUT_S = 90.0
+
+# Budgeted cost of delivering ONE character through the guest's X11 synthetic
+# key path, with pyautogui's default (zero) inter-key interval.
+#
+# Regression over 21 real batches measured 4.18 ms/char (R^2 = 0.998) on a
+# healthy guest. This is budgeted at ~2x that because the measurement is a
+# single sample of one instance type on one AMI, and that AMI is burstable —
+# the same credit starvation that has already blinded this adapter's screenshot
+# server (see ``providers.fake.blind_observations``) also slows key delivery.
+# Budgeting the measured figure exactly would make the bound below a prediction
+# of the median guest rather than a limit safe on a slow one.
+GUEST_TYPE_MS_PER_CHAR = 8.0
+
+# The largest share of the deadline a single type may be budgeted to consume.
+# The remaining 40% is not slack for typing: it absorbs the fixed per-command
+# overhead the same regression measured at 3.6 s (transport, the guest server's
+# own dispatch, screenshot settle) plus the tail of a guest that is slower than
+# the envelope above already assumes.
+GUEST_TYPE_DEADLINE_FRACTION = 0.6
+
 
 @runtime_checkable
 class EnvironmentProvider(Protocol):

--- a/local_operator/evaluation/action_surface.py
+++ b/local_operator/evaluation/action_surface.py
@@ -29,6 +29,20 @@ class ActionSurface:
     paste_text: bool = False
     type_text_mode: Literal["unicode", "ascii"] = "unicode"
     ask_user: bool = True
+    #: Longest ``TypeAction.text`` this backend can deliver inside its own
+    #: execution deadline, or ``None`` for a backend with no such deadline
+    #: (then only the protocol's ``MAX_TEXT_LENGTH`` applies).
+    #:
+    #: A keyboard backend types character by character, so its cost is linear in
+    #: length while the deadline enforcing it is a constant — two numbers that
+    #: know nothing about each other until one is derived from the other. Left
+    #: unrelated, a text length the protocol happily admits runs past the
+    #: deadline and the batch dies with its outcome UNKNOWN, which is fatal to
+    #: the episode. Rejecting it here instead costs one corrective re-prompt.
+    #: Core deliberately states no default bound: only the backend knows its
+    #: own deadline and per-character cost, so it computes this and negotiates
+    #: it, exactly as it negotiates ``type_text_mode``.
+    max_type_chars: int | None = None
 
     @property
     def models(self) -> tuple[Any, ...]:
@@ -49,6 +63,7 @@ class ActionSurface:
         return {
             "actions": [model.model_json_schema() for model in self.models],
             "type_text_mode": self.type_text_mode,
+            "max_type_chars": self.max_type_chars,
             "named_keys": list(self.named_keys),
         }
 
@@ -64,6 +79,24 @@ class ActionSurface:
                         if self.paste_text
                         else "type supports only ASCII on this adapter"
                     )
+            if (
+                isinstance(action, TypeAction)
+                and self.max_type_chars is not None
+                and len(action.text) > self.max_type_chars
+            ):
+                # Named alternative, not a bare refusal: paste_text is
+                # clipboard-based and therefore O(1) in length, so it is the
+                # only path that CAN carry this payload. A model told merely
+                # that its text is too long shortens it and retries, which
+                # spends the retry budget converging on a limit it cannot see.
+                raise ActionAdmissionError(
+                    f"type is limited to {self.max_type_chars} characters on this "
+                    f"adapter and this text is {len(action.text)}; "
+                    "use paste_text with an explicit chord"
+                    if self.paste_text
+                    else f"type is limited to {self.max_type_chars} characters on this "
+                    f"adapter and this text is {len(action.text)}"
+                )
 
 
 LEGACY_ACTION_SURFACE = ActionSurface()

--- a/local_operator/evaluation/adapters/api.py
+++ b/local_operator/evaluation/adapters/api.py
@@ -206,9 +206,15 @@ class AdapterCapabilities(ProtocolModel):
     # rather than assumed by core: the deadline and the per-character cost are
     # both the backend's, and a bound core invented would be wrong for every
     # backend but one. ``None`` means the backend has no length-dependent
-    # deadline. Optional with a None default so a 1.6 peer that predates the
-    # field still validates — it simply advertises no bound, which is the
-    # behaviour it already had.
+    # deadline. The None default lets a NEW parent accept an OLD worker that
+    # predates the field — it simply advertises no bound, which is the
+    # behaviour it already had. The reverse is NOT compatible: ``ProtocolModel``
+    # forbids extra keys, and this key is always emitted (even as ``None``), so
+    # an old parent refuses a new worker at hello with ``extra_forbidden``.
+    # That mixed pair is already refused earlier by the selector's
+    # ``package_digest`` pin (``discovery.py``), which is why the schema
+    # version was not bumped for this field; rely on the digest, not on this
+    # default, for the old-parent direction.
     max_type_chars: int | None = Field(default=None, ge=1)
 
     def action_surface(self) -> "ActionSurface":

--- a/local_operator/evaluation/adapters/api.py
+++ b/local_operator/evaluation/adapters/api.py
@@ -201,12 +201,22 @@ class AdapterCapabilities(ProtocolModel):
     scoring: bool
     paste_text: bool = False
     type_text_mode: Literal["unicode", "ascii"] = "unicode"
+    # An adapter whose keyboard delivery is linear in text length advertises the
+    # longest type it can finish inside its own execution deadline. Negotiated
+    # rather than assumed by core: the deadline and the per-character cost are
+    # both the backend's, and a bound core invented would be wrong for every
+    # backend but one. ``None`` means the backend has no length-dependent
+    # deadline. Optional with a None default so a 1.6 peer that predates the
+    # field still validates — it simply advertises no bound, which is the
+    # behaviour it already had.
+    max_type_chars: int | None = Field(default=None, ge=1)
 
     def action_surface(self) -> "ActionSurface":
         return ActionSurface(
             paste_text=self.paste_text,
             type_text_mode=self.type_text_mode,
             ask_user=self.ask_user,
+            max_type_chars=self.max_type_chars,
         )
 
     @field_validator("routes", mode="before")

--- a/local_operator/evaluation/adapters/api.py
+++ b/local_operator/evaluation/adapters/api.py
@@ -211,10 +211,14 @@ class AdapterCapabilities(ProtocolModel):
     # behaviour it already had. The reverse is NOT compatible: ``ProtocolModel``
     # forbids extra keys, and this key is always emitted (even as ``None``), so
     # an old parent refuses a new worker at hello with ``extra_forbidden``.
-    # That mixed pair is already refused earlier by the selector's
-    # ``package_digest`` pin (``discovery.py``), which is why the schema
-    # version was not bumped for this field; rely on the digest, not on this
-    # default, for the old-parent direction.
+    # That is the compatibility gate for the old-parent direction, not the
+    # selector's ``package_digest``: that digest hashes only the adapter
+    # wheel's RECORD (``discovery.verify_distribution``), is checked on the
+    # worker during hello, and does not pin ``local-operator``. A matching
+    # selector plus new adapter plus new worker-venv core plus old parent
+    # core still reaches hello and dies there. Hello fails closed before
+    # ``prepare``/``reset`` allocate, which is why the schema version was
+    # not bumped; do not treat the digest as a protocol-compat substitute.
     max_type_chars: int | None = Field(default=None, ge=1)
 
     def action_surface(self) -> "ActionSurface":

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -234,6 +234,27 @@ def build_system_prompt(surface: ActionSurface = LEGACY_ACTION_SURFACE) -> str:
         if surface.type_text_mode == "ascii"
         else "This adapter supports Unicode native text input."
     )
+    # STATED, not left to be discovered. The bound is a real keyboard's speed
+    # against the adapter's execution deadline, and a model that meets it only
+    # as a rejection spends corrective re-prompts bisecting for a limit it was
+    # never shown -- the avoidable cost the named-key vocabulary is spelled out
+    # to prevent. The alternative is named in the same breath, because a length
+    # limit with no way to send long text reads as "give up".
+    length_text = (
+        ""
+        if surface.max_type_chars is None
+        else (
+            f"\n  Text is limited to {surface.max_type_chars} characters per "
+            '"type"; longer text is rejected before any batch action, because '
+            "typing it cannot finish inside the adapter's execution deadline. "
+            + (
+                'Use "paste_text" for anything longer -- it goes through the '
+                "clipboard, so its cost does not grow with length."
+                if surface.paste_text
+                else 'Split it across several "type" actions.'
+            )
+        )
+    )
     ask_text = (
         '* "ask_user" -- you need a human answer. '
         "THE EPISODE PAUSES until the answer is delivered. "
@@ -308,7 +329,7 @@ name all require typing.
 * "type" enters literal text wherever the keyboard focus already is. It does
   NOT click first, so focus the field with a click (or Tab) in an earlier
   action, then type. It uses native keyboard input, not the clipboard.
-  {native_text}
+  {native_text}{length_text}
   It does not press Enter for you.
 {_paste_instructions(surface)}
 * "key" presses named keys, and presses the ones in a single action TOGETHER

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.50.1"
+version = "0.50.2"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]

--- a/tests/unit/evaluation/adapters/osworld/test_actions.py
+++ b/tests/unit/evaluation/adapters/osworld/test_actions.py
@@ -57,7 +57,24 @@ def test_type_uses_repr_for_adversarial_text() -> None:
     compiled = actions.compile_action(TypeAction(observation_id="o", text=text), None)
     # The emitted statement must contain the repr, so re-parsing the argument
     # yields exactly the original string.
-    assert compiled == f"pyautogui.typewrite({text!r}, interval=0.01)"
+    assert compiled == f"pyautogui.typewrite({text!r})"
+
+
+@pytest.mark.parametrize("length", [1, 100, 6092, 7332, 20_000])
+def test_type_never_emits_an_interval_at_any_length(length: int) -> None:
+    """Upstream parity: pyautogui's default interval of 0.0, at every size.
+
+    ``typewrite`` sleeps ``interval`` seconds per character unconditionally, so
+    any interval at all is a hard floor of ``interval x len(text)`` on guest
+    time rather than a pacing hint. Passing 0.01 killed two episodes at 7332 and
+    6912 characters. Parametrised over length because the defect was invisible
+    at the short strings the other compiler tests use.
+    """
+
+    compiled = actions.compile_action(TypeAction(observation_id="o", text="a" * length), None)
+    assert compiled is not None
+    assert "interval" not in compiled
+    assert compiled == f"pyautogui.typewrite({'a' * length!r})"
 
 
 def test_single_key_compiles_to_press() -> None:

--- a/tests/unit/evaluation/adapters/osworld/test_paste.py
+++ b/tests/unit/evaluation/adapters/osworld/test_paste.py
@@ -69,5 +69,5 @@ def test_adapter_metadata_matches_compiler_admission() -> None:
 
 def test_native_type_control_and_small_transport_are_unchanged() -> None:
     assert actions.compile_action(TypeAction(observation_id="obs", text="a\t\n\r")) == (
-        "pyautogui.typewrite('a\\t\\n\\r', interval=0.01)"
+        "pyautogui.typewrite('a\\t\\n\\r')"
     )

--- a/tests/unit/evaluation/adapters/osworld/test_type_deadline.py
+++ b/tests/unit/evaluation/adapters/osworld/test_type_deadline.py
@@ -1,0 +1,249 @@
+"""The type-length bound, the per-character budget and the guest deadline agree.
+
+Two real episodes died here, and the mechanism is worth stating once. The guest
+types character by character, so a ``type`` action's cost is LINEAR in text
+length; the deadline enforcing it is a CONSTANT socket timeout. While those two
+numbers knew nothing about each other, the protocol admitted a 100000-character
+``type`` that needs minutes, the batch was dispatched, the read timed out, and
+the failure was ``GuestExecutionError`` — outcome unknown, never retried, so
+fatal to an episode that had already cost real money.
+
+Two defects had to be fixed and each has its own tests below:
+
+* We passed ``interval=0.01`` to ``pyautogui.typewrite``, which is not a pacing
+  hint but an unconditional ``time.sleep`` per character — a hard floor of 10 ms
+  x len(text). ``test_the_interval_we_removed_really_did_cost_the_deadline``
+  demonstrates that floor rather than asserting it from the fitted numbers.
+* Nothing related ``MAX_TEXT_LENGTH`` to the timeout. ``MAX_TYPE_CHARS`` is now
+  derived from the deadline and a named per-character budget, and the arithmetic
+  tests fail if any one of the three moves without the others being reconsidered.
+"""
+
+from __future__ import annotations
+
+import pytest
+from lop_osworld_v2_adapter import actions
+from lop_osworld_v2_adapter.providers.base import (
+    GUEST_COMMAND_TIMEOUT_S,
+    GUEST_TYPE_DEADLINE_FRACTION,
+    GUEST_TYPE_MS_PER_CHAR,
+)
+
+from local_operator.evaluation.action_surface import ActionAdmissionError
+from local_operator.evaluation.protocol import (
+    MAX_TEXT_LENGTH,
+    ActionBatch,
+    ClickAction,
+    TypeAction,
+)
+from tests.unit.evaluation.adapters.osworld.test_actions import _geo
+
+# The two payloads that actually killed episodes ep-886aa2229672 and
+# ep-762003dcc9c2, and the largest one that survived (2498 chars, 39.4 s).
+# Real observations, not invented sizes: a bound that admits either fatal
+# payload has not fixed the incident.
+FATAL_PAYLOAD_CHARS = (6912, 7332)
+LARGEST_SURVIVING_PAYLOAD_CHARS = 2498
+
+
+def _batch(*actions_: object) -> ActionBatch:
+    return ActionBatch(
+        protocol_version="1.0",
+        task_id="task",
+        episode_id="episode",
+        observation_id="obs",
+        actions=tuple(actions_),  # type: ignore[arg-type]
+    )
+
+
+# ----------------------------------------------------------------------------
+# The arithmetic: the three numbers cannot drift apart again
+# ----------------------------------------------------------------------------
+
+
+def test_the_bound_is_derived_from_the_deadline_and_the_per_character_budget() -> None:
+    """Recompute the bound independently of the module that publishes it.
+
+    This is the test that prevents recurrence. It does not check that typing is
+    fast; it checks that the length we ADMIT and the deadline we ENFORCE are
+    still expressions of one another, which is the property whose absence let a
+    100000-character ``type`` be dispatched at all.
+    """
+
+    budgeted_seconds = actions.MAX_TYPE_CHARS * GUEST_TYPE_MS_PER_CHAR / 1000.0
+    assert budgeted_seconds <= GUEST_COMMAND_TIMEOUT_S * GUEST_TYPE_DEADLINE_FRACTION
+    # And it is the LARGEST length with that property: a bound that merely fits
+    # would still pass if someone replaced the derivation with a smaller magic
+    # number, which is the shape of the defect being guarded against.
+    over_by_one = (actions.MAX_TYPE_CHARS + 1) * GUEST_TYPE_MS_PER_CHAR / 1000.0
+    assert over_by_one > GUEST_COMMAND_TIMEOUT_S * GUEST_TYPE_DEADLINE_FRACTION
+
+
+def test_the_constants_are_pinned_so_any_one_moving_is_a_deliberate_decision() -> None:
+    """Pin all four values, so changing ANY of them lands here first.
+
+    The derivation above is invariant under a coordinated change, so it alone
+    would let someone halve the timeout and never notice the admission bound
+    halving with it. Changing a value here is legitimate — update it, and say in
+    the commit which measurement or deadline changed and why the others still
+    hold.
+    """
+
+    assert GUEST_COMMAND_TIMEOUT_S == 90.0
+    assert GUEST_TYPE_MS_PER_CHAR == 8.0
+    assert GUEST_TYPE_DEADLINE_FRACTION == 0.6
+    assert actions.MAX_TYPE_CHARS == 6750
+
+
+def test_the_admission_bound_binds_before_the_protocol_length_cap() -> None:
+    """The protocol's cap is a data limit; the deadline is an execution limit.
+
+    ``MAX_TEXT_LENGTH`` stays where it is — it is right for ``paste_text``,
+    whose clipboard cost does not grow with length. What must never return is a
+    state where the only limit on a TYPED payload is the data cap, because that
+    cap is ~15x what the guest can type inside its deadline.
+    """
+
+    assert actions.MAX_TYPE_CHARS < MAX_TEXT_LENGTH
+    protocol_cap_seconds = MAX_TEXT_LENGTH * GUEST_TYPE_MS_PER_CHAR / 1000.0
+    assert protocol_cap_seconds > GUEST_COMMAND_TIMEOUT_S
+
+
+@pytest.mark.parametrize("length", FATAL_PAYLOAD_CHARS)
+def test_the_payloads_that_killed_episodes_are_now_refused(length: int) -> None:
+    assert length > actions.MAX_TYPE_CHARS
+    with pytest.raises(ActionAdmissionError, match="paste_text"):
+        actions.ACTION_SURFACE.validate_batch(
+            _batch(TypeAction(observation_id="obs", text="a" * length))
+        )
+
+
+def test_the_largest_payload_that_actually_worked_is_still_admitted() -> None:
+    """The bound must not be so tight that it refuses work the guest can do.
+
+    2498 characters completed in 39.4 s on a real guest. A fix that rejects it
+    would trade an episode-killing timeout for an episode-killing refusal.
+    """
+
+    assert LARGEST_SURVIVING_PAYLOAD_CHARS < actions.MAX_TYPE_CHARS
+    actions.ACTION_SURFACE.validate_batch(
+        _batch(TypeAction(observation_id="obs", text="a" * LARGEST_SURVIVING_PAYLOAD_CHARS))
+    )
+
+
+# ----------------------------------------------------------------------------
+# Admission: rejected pre-dispatch, alternative named, nothing mutated
+# ----------------------------------------------------------------------------
+
+
+def test_an_over_long_type_is_rejected_before_anything_is_compiled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rejection must precede the whole batch, not just the offending action.
+
+    Same guarantee the ASCII rejection carries: a batch whose first action is a
+    click and whose second is an inadmissible type must not land the click. A
+    half-applied batch is precisely the unknown-outcome state that makes this
+    class of failure unrecoverable rather than correctable.
+    """
+
+    batch = _batch(
+        ClickAction(observation_id="obs", frame_id="screen", x=1, y=1),
+        TypeAction(observation_id="obs", text="a" * (actions.MAX_TYPE_CHARS + 1)),
+    )
+    compiled: list[object] = []
+    monkeypatch.setattr(actions, "compile_action", lambda *args: compiled.append(args))
+    with pytest.raises(ActionAdmissionError) as raised:
+        actions.compile_batch(batch, _geo())
+    assert not compiled
+    # The message must name the alternative and the actual numbers. A model told
+    # only "too long" shortens its text and retries, spending the retry budget
+    # bisecting for a limit it was never shown.
+    message = str(raised.value)
+    assert "paste_text" in message
+    assert str(actions.MAX_TYPE_CHARS) in message
+    assert str(actions.MAX_TYPE_CHARS + 1) in message
+
+
+def test_a_payload_at_the_bound_still_compiles_to_one_typewrite() -> None:
+    text = "a" * actions.MAX_TYPE_CHARS
+    statements = actions.compile_batch(_batch(TypeAction(observation_id="obs", text=text)), _geo())
+    assert statements == [f"pyautogui.typewrite({text!r})"]
+
+
+def test_paste_text_is_not_bounded_by_the_typing_deadline() -> None:
+    """The named alternative has to actually accept what type refused.
+
+    ``paste_text`` writes the clipboard and sends one chord, so its guest cost
+    is O(1) in length. Bounding it by the typing budget would leave a model with
+    a rejection and nowhere to go.
+    """
+
+    from local_operator.evaluation.protocol import PasteTextAction
+
+    actions.ACTION_SURFACE.validate_batch(
+        _batch(
+            PasteTextAction(
+                observation_id="obs",
+                text="a" * MAX_TEXT_LENGTH,
+                keys=("CTRL", "v"),
+                clipboard_policy="overwrite",
+            )
+        )
+    )
+
+
+# ----------------------------------------------------------------------------
+# The mechanism: what interval= actually cost
+# ----------------------------------------------------------------------------
+
+
+class _StubPyAutoGui:
+    """pyautogui's documented ``typewrite`` contract, with a virtual clock.
+
+    Only the guest is stubbed, never the thing under test: the statements
+    executed below are the REAL output of ``compile_action``. The loop body here
+    is pyautogui 0.9.54's own (``__init__.py``: ``for c in message: press(c,
+    _pause=False); time.sleep(interval)``), and ``interval`` is the documented
+    "number of seconds in between each press", so the sleep is unconditional and
+    per character. Time is accumulated rather than slept, because the point is
+    to show a 73-second cost in milliseconds.
+    """
+
+    def __init__(self) -> None:
+        self.slept_seconds = 0.0
+        self.presses = 0
+
+    def typewrite(self, message: str, interval: float = 0.0) -> None:
+        for _ in message:
+            self.presses += 1
+            self.slept_seconds += float(interval)
+
+
+def test_the_interval_we_removed_really_did_cost_the_deadline() -> None:
+    """Demonstrate the 10 ms/char floor instead of inferring it from the fit.
+
+    The regression on real batches attributed 10.00 of 14.18 ms/char to our own
+    ``interval``; this executes both statement forms against the documented
+    contract and shows that 71% directly. The old statement is written out as a
+    frozen literal because it is a historical artifact — the compiler no longer
+    produces it, and that is the property being protected.
+    """
+
+    text = "a" * max(FATAL_PAYLOAD_CHARS)  # 7332, the larger fatal payload
+
+    before = _StubPyAutoGui()
+    exec(f"pyautogui.typewrite({text!r}, interval=0.01)", {"pyautogui": before})
+
+    compiled = actions.compile_action(TypeAction(observation_id="obs", text=text), None)
+    assert compiled is not None
+    after = _StubPyAutoGui()
+    exec(compiled, {"pyautogui": after})
+
+    # Same keystrokes delivered either way: the interval bought nothing.
+    assert before.presses == after.presses == len(text)
+    # Pure mandated sleep, before a single keystroke's real cost is counted.
+    assert before.slept_seconds >= 73.0
+    assert before.slept_seconds > GUEST_COMMAND_TIMEOUT_S * GUEST_TYPE_DEADLINE_FRACTION
+    # What we emit now adds none of it.
+    assert after.slept_seconds == 0.0

--- a/tests/unit/test_computer_input.py
+++ b/tests/unit/test_computer_input.py
@@ -153,7 +153,7 @@ def test_source_arguments_are_literals_not_caller_injection(
 
 
 def test_small_python_commands_keep_legacy_bytes() -> None:
-    source = "pyautogui.typewrite('abc', interval=0.01)"
+    source = "pyautogui.typewrite('abc')"
     assert python_source_argv(source) == ["python", "-c", source]
 
 


### PR DESCRIPTION
## Summary

Two real OSWorld episodes died on the 90 s guest read timeout while typing 6912 and 7332 characters into a terminal. The guest was healthy — the last retained frames show an idle shell at a fresh prompt. The cause was ours: `actions.py` compiled every `TypeAction` to `pyautogui.typewrite(text, interval=0.01)`, and pyautogui's `typewrite` is a per-character loop with an **unconditional `time.sleep(interval)`**. That imposed a hard floor of 10 ms × len(text): **73 s of mandated sleep** before any keystroke work, against a 90 s deadline.

Upstream OSWorld passes no `interval` at all (`python.py:895` at the pinned commit `d578d2d`). Our added interval was the sole deviation and the entire defect.

## Evidence

Regressed guest execution time against typed characters over all 21 text-bearing batches in both failed runs:

```
net_seconds = 3.62 + 0.01418 × chars     R² = 0.998, max residual 0.80 s, n = 21
```

10.00 of the 14.18 ms/char is our sleep — **71 % of typing time was self-inflicted.** Break-even at 90 s is 6092 chars; both fatal payloads sit just past it, the largest survivor was 2498 chars / 39.4 s. A deadlocked guest produces an outlier, not a linear dose–response curve.

## What changed

**Part 1 — remove the interval** (`15f79d42f`). One token at `actions.py`. Restores upstream parity and keeps determinism: the adapter's design intent is avoiding upstream's *randomised* mouse `duration`/easing, and a fixed `0.0` is every bit as deterministic as a fixed `0.01`. 7332 chars now types in ~34 s.

**Part 2 — bound admitted type length by the deadline** (`702c8beb8`). The latent defect was that `MAX_TEXT_LENGTH = 100_000` and the 90 s socket timeout were **unrelated numbers** — 100k chars is ~7 min even after Part 1. The bound is now *derived*, not written down:

```
MAX_TYPE_CHARS = GUEST_COMMAND_TIMEOUT_S (90.0) × GUEST_TYPE_DEADLINE_FRACTION (0.6) × 1000 / GUEST_TYPE_MS_PER_CHAR (8.0) = 6750
```

8.0 ms/char is a ~2× envelope over the measured 4.18, because that figure is one sample of one burstable instance type; the 40 % reserve absorbs the regression's 3.6 s fixed overhead. The bound refuses both fatal payloads and admits the largest that actually completed.

Enforcement is on the negotiated `ActionSurface` (`max_type_chars`, `None` = no bound), mirroring the existing ASCII rejection: **pre-dispatch, whole-batch, mutates nothing, names `paste_text`** (clipboard-based, verifiably O(1) in length). The asymmetry is on the right side — a false rejection costs one bounded corrective re-prompt; a false admission costs the whole episode.

Threaded through `AdapterCapabilities` as optional/`None`-default. No schema bump: the selector's `package_digest` pin already refuses a mixed old-parent/new-worker pair at discovery, and the comment now says so precisely (`10f9e9d39`) rather than asserting a bidirectional compatibility that does not hold.

**Explicitly unchanged:** the 90 s timeout (matches upstream, reasonable hang detector) and the no-retry-on-unknown-outcome policy (correct — 90 s of `typewrite` had committed thousands of keystrokes into a live shell; the safe observation-only subset already exists via `ObservationPhaseError`/`resume_observation`).

## Testing evidence

`tests/unit/evaluation/adapters/osworld/test_type_deadline.py` (10) plus `test_type_never_emits_an_interval_at_any_length` (5 params).

**Anti-drift, independently re-verified by the reviewer** — mutating any one of the three constants fails a test:

| Mutation | Fails |
|---|---|
| `GUEST_COMMAND_TIMEOUT_S` 90→60 | `test_the_constants_are_pinned` |
| `GUEST_TYPE_MS_PER_CHAR` 8.0→4.18 | 3 incl. both fatal-payload params |
| `GUEST_TYPE_DEADLINE_FRACTION` 0.6→0.95 | 4 incl. the timing demo |
| bound hardcoded **and** timeout halved | `bound_is_derived` + `constants_are_pinned` |
| admission rule deleted | 3 incl. `rejected_before_anything_is_compiled` |
| message drops `paste_text` | 3 |
| `validate_batch` removed from `compile_batch` | mine + existing ASCII pre-dispatch test |

**Timing demonstration** with a stubbed `press()` proves the 10 ms/char floor is real: `interval=0.01` costs ≥ 73 s of pure sleep for a 7332-char string; the no-interval form does not.

**Real path**: drove `parse_decision` with the surface taken from `OSWorldV2Adapter().metadata` — 2498/6750 accepted and compile to interval-free statements; 6751/6912/7332/100000 rejected with the `paste_text` message; `paste_text` at 100000 accepted, i.e. the named alternative works at the size `type` refused.

**Gates** (whole tree): flake8 clean · black 986 unchanged · isort (5.13.2) clean · pyright 0/0/0 · `tests/unit` **14983 passed, 18 skipped, 0 failed** (`test_type_deadline.py` accounts for the 10 new tests relative to an earlier local count).

## Residual (follow-ups, per review)

- The bound is per-action; `step_timeout = 120 s` (`episode.py`) is per-batch, and `MAX_BATCH_SIZE = 64` admits a pathological batch of 64 max-length types. The single-action cliff observed in the wild is fixed; the batch-level sibling is the same unrelated-numbers shape one level up.
- 6750 is budgeted, not probed. The live probe that would settle whether the guest keeps serving after a client timeout remains unrun; this fix rests on the R² = 0.998 fit.
- The `"outcome is unknown"` diagnostic still omits action kind and payload length.

Release: patch — OSWorld types at upstream's speed, so long typing actions no longer exhaust the 90s guest deadline.
