### PR TITLE
fix(runtime): idle runtimes refresh themselves onto the build on disk

### DIFF
--- a/docs/design-runtime-autorefresh.md
+++ b/docs/design-runtime-autorefresh.md
@@ -1,0 +1,786 @@
+# Design: idle runtimes refresh themselves, and viewers never fake an abort
+
+Status: proposal (architect). Base: `origin/main` b0db51d9c. Two PRs (§8).
+No `pyproject.toml` bump in either — the window's release owner handles that.
+
+Operator's requirement, verbatim:
+
+> make sure that runtimes that are inactive automatically refresh and update
+> and/or bring down the runtime on inactive sessions so that resuming would do
+> the update. In practice, on resume we should never see this message, and we
+> shouldn't show it if resuming an active session regardless. The user should
+> never need to run /stop to refresh or update a runtime.
+
+> make sure the TUI can properly stay connected during waits and there's
+> nothing that's killing or interrupting waiting sessions.
+
+Every line reference below is against b0db51d9c.
+
+## 1. The problems as found in the code
+
+### 1.1 A stale runtime is immortal while somebody is looking at it
+
+`process.py::_should_exit` (`session/runtime/process.py:121-152`) is the only
+exit policy a runtime has, and it is three terms: not busy, no wake within
+`WARM_WINDOW_S`, **no attach client**. Term 3 is why runtime pid 57079
+(0.49.8@46a4e9b, last turn ended 05:01) was still resident at 10:00 on a host
+whose disk had been 0.49.9@f4a70b99 since ~05:00: `lop --resume a6a8186ea42d`
+(pid 55933) held an `attach` socket to it. Nothing in the runtime compares
+`installed_build()` against what it loaded — the stamp is read exactly once,
+at record construction (`server.py:411-443`), and never again.
+
+The only thing that notices is the *viewer*: `OperatorApp._check_build_skew`
+(`tui/app.py:14870-15011`) compares `owner_version/owner_source_ref` off the
+record with its own `_loaded_build` and paints notice C —
+`“<name>” is running 0.49.8@46a4e9b but this window is 0.49.9@f4a70b99 — some
+commands may not work. /stop, then send again to restart it.` — at
+`adopt`, `engage`, `engage-bound`, and `slash-engage` (`app.py:2953, 8513,
+8553, 8687`). It is advisory and hands the user a chore. That chore is what
+the operator is refusing.
+
+### 1.2 The record's `busy` bit sticks at True after any wake/peer turn — PROVEN
+
+Hypothesis in the task: only `_observe_prompt_drain` (`owned.py:1058-1074`)
+publishes `busy` *after* the final `AgentEndEvent`, because that event is
+emitted while `Session._is_streaming` is still True (cleared in the `finally`
+at `session.py:6047`, after `_flush_held_end` at `:5766`). Every turn that
+does not run through the prompt queue therefore ends with the record saying
+`busy: true`.
+
+Verified on this worktree with a throwaway e2e probe (real `Session` from
+`tests/e2e/harness.build_session`, production `OwnedSessionHandle` +
+`RuntimeServer`, `handle.subscribe(server._schedule_push)` as `_serve` does):
+
+| path | `handle.is_busy()` after turn | `server._busy` (record) |
+|---|---|---|
+| `handle.prompt(...)` | False | **False** |
+| `receive_peer_message(mode="mailbox", wake=True)` | False | **True — stuck** |
+| `receive_peer_message(mode="steer")` on an idle session | False | **True — stuck** |
+
+The four `_spawn_background(self._prompt_messages(...))` callers in
+`session.py` all share the shape: peer wake `:4889/:4897`, background-job
+result delivery `:6607`, resume catch-up `:9472`, scheduled wake `:10201`.
+Also the goal loop: `_loop_driver` (`owned.py:1010-1037`) *does* go through
+`self.prompt(..., wait_complete=True)`, so it is covered by the drain
+observer — but only for its last iteration, which is fine.
+
+Consequence today: `lop sessions` shows a running marker on an idle session
+(the 57079 record said `busy: true` for five hours), the desktop/phone
+pickers do the same, and any future "retire when idle" policy that trusted
+the record would never fire for a session whose last turn was a wake. The
+runtime's own `is_busy()` is correct; only the *published* bit is wrong.
+
+### 1.3 A transient viewer disconnect paints "interrupted" on a turn that never stopped
+
+`RemoteSession._on_disconnected` (`session/remote.py:1824-1857`):
+
+```
+self._recovering = True
+self._owner_ready.clear()
+self._end_turn_locally()          # ← synthesises AgentEndEvent(aborted=True, generation=0)
+self._recovery_task = asyncio.create_task(self._recover_owner())
+```
+
+`_end_turn_locally` (`remote.py:1859-1918`) exists for three genuinely
+terminal outcomes (killed owner, stopped owner, going cold) but it is called
+*before* recovery has learned which of those — if any — applies. The
+synthesised end reaches `EventController._handle_agent_end` and the app's
+turn-end path, which calls `_retire_live_tool_cards` (`app.py:24152`, each
+live card → `⊘ interrupted`) and, when no card was live, appends
+`NoticeBlock("interrupted", "warning")` (`app.py:23732-23742`). Then
+`_recover_owner` (`remote.py:2037-2170`) finds the *same* record (same pid),
+re-dials within ~100 ms, and `_finish_sync` (`remote.py:1436-1468`) seeds a
+fresh `AgentStartEvent` because `frontend_state.streaming` is still True.
+The band recovers; the ledger keeps the `⊘ interrupted` cards and the notice.
+That is exactly "interrupted painted mid-wait": the `wait` tool was still
+running on the runtime the whole time.
+
+Why the socket drops in the first place — every one of these is silent
+(`_drop_client`, `server.py:1022-1088`, logs nothing; only cap eviction at
+`:928` does):
+
+1. `_send_to` (`server.py:2110-2119`): any frame whose `writer.drain()`
+   exceeds `_SEND_TIMEOUT_S = 1.0` drops the client. `_push` (`:2053-2067`)
+   sends the **full capped projection to every client including TUI attach
+   viewers**, ~20×/s while streaming (`_push_later` coalesces to 50 ms). The
+   TUI's `AttachClient` was constructed with `lambda _projection: None`
+   (`remote.py:1257`) — it throws every one away. The projection is
+   100–900 KB on this host's resident runtimes. A TUI event-loop stall of
+   >1 s (a large transcript reflow, a 60 MB parse on a sibling path, the
+   compositor under load) leaves the kernel socket buffer full of projection
+   bytes the viewer never wanted, `drain()` times out, and the viewer is
+   dropped from a runtime that is perfectly healthy.
+2. `_enqueue_client_frame` (`server.py:1892-1913`): the 64-deep event FIFO
+   overflows after `_compact_event_queue` fails to free a slot → drop.
+3. `_relay_frontend_to_on_loop` (`server.py:1881-1887`): >64 canonical
+   updates pending before `frontend_ready` → drop.
+4. Reader EOF / reset (`:1010, :1017`) and shutdown (`:779-781`).
+
+Also `RemoteSession.abort` (`remote.py:2662-2664`) is
+`asyncio.create_task(self._client.abort())` with no done-callback; when the
+client is mid-recovery `_request_frame` raises `ConnectionError("not
+attached")` (`attach_client.py:461`) and the loop logs "Task exception was
+never retrieved" — 12 such rows in the operator's log today (10:28).
+
+### 1.4 What is NOT broken
+
+- The `wait` tool's own cancel paths (`tools/builtin.py`) — the task's
+  evidence stands: steer-driven cancels say "the wait was cancelled", they
+  never paint "interrupted". Not touched here.
+- `retire_if_pristine` (`server.py:1450-1517`) and the `stopping` frame
+  (`:545-615`) — the design below reuses both rather than adding a second
+  stop path.
+- `_should_exit` terms 1 and 2 — correct and kept.
+
+## 2. Options
+
+### 2.1 Where the refresh decision lives
+
+**A. Viewer-side only.** `_check_build_skew` sends `stop` when the owner is
+stale and idle, then re-engages. Rejected as the *primary* mechanism: a
+runtime with no viewer attached (the phone's SSE daemon attach is `daemon`
+kind; a `send`-woken session) is never looked at by a TUI, so it would stay
+stale until someone opened it — precisely the "on resume we should never see
+this" case, because the first thing the resume does is bind to the stale
+process. Viewer-side stays as a *belt* (§4.2), not the policy.
+
+**B. Runtime-side self-retirement (recommended).** The runtime compares its
+boot stamp with disk on the reaper's tick; when they differ and the runtime is
+idle, it announces and exits cleanly. The viewer treats that announcement as
+"a fresh runtime is owed, re-engage" rather than "the session was stopped".
+Covers every runtime including unwatched ones; the only new wire item is one
+additive field on an existing frame.
+
+**C. Runtime self-re-exec** (`os.execv` a new `process.py` in place, same
+pid). Rejected: the lease, the record, the socket, and the attach clients all
+key on the pid and port, and a re-exec would have to hand every one of them
+over across the exec boundary. `engage_runtime` already knows how to spawn a
+successor on demand (`launch.py:376-540`); reusing it costs a ~1.2 s cold
+start on the *next* message, which the residency design already accepts as
+the price of an idle exit (`process.py:57-66`).
+
+### 2.2 Should an attached viewer block the refresh?
+
+The operator says no, and the code agrees it need not: a viewer already
+survives owner exit (`_recover_owner` → `_go_cold` after `COLD_FALLBACK_S`,
+`remote.py:2056-2066`) and a cold viewer already re-engages on the next
+prompt (`_ensure_bound`, `remote.py:1074-1144`). What is missing is only
+(a) an announcement so the viewer does not spend 8 s chasing a record and
+then paint "runtime exited" for what was a planned refresh, and (b) that the
+announcement not be confused with `stopping` (which parks the viewer in the
+"this session was stopped; /resume reopens it" state, `app.py:3111-3180`).
+
+So: **an attached viewer does not block retirement**; it receives a
+`retiring` frame with `reason: "stale-build"` and re-engages eagerly.
+
+### 2.3 Eager vs lazy re-engage after a refresh retirement
+
+- *Lazy*: viewer goes cold quietly; next prompt spawns. Cheapest, and the
+  band would show the cold state ("no runtime") until the user types.
+- *Eager* (recommended): viewer calls `_start_runtime_engage(reason=
+  "refresh")` as soon as the retiring runtime's socket closes. The mount path
+  already engages eagerly for exactly the band-completeness reason
+  (`app.py:8427-8455`), and the engage is idempotent behind `_bind_lock`.
+  Cost: one process spawn per stale runtime per `lop-update`, which is the
+  same count the lazy path would pay one message later — but with a band that
+  never goes half-empty. Debounce (§3.4) keeps N viewers from spawning at the
+  same instant.
+
+### 2.4 Disconnect handling: synthesise the abort now, or defer?
+
+- *Now* (status quo): honest for owner death, false for transient drops.
+- *Defer until recovery's verdict* (recommended): `_on_disconnected` marks
+  the turn *suspect* and starts recovery; the synthesised end fires only when
+  recovery goes cold, learns the stop, or re-binds to a snapshot whose
+  `streaming` is False / whose generation moved past the one that was live.
+  On a successful re-bind to the same live turn, nothing is synthesised and
+  `_finish_sync`'s seeded `AgentStartEvent` is the *only* thing the app sees
+  — which its generation guard (`tui/events.py:536-565`) already treats as
+  "same turn, still open" when the generation is unchanged.
+
+The deferral cannot hang the UI: every path out of `_recover_owner` already
+ends in `_go_cold` (which calls `_end_turn_locally(direct=True)`,
+`remote.py:1999`), `_notify_stopped` (§4 keeps the end there), or a
+successful bind. The 8 s cold deadline bounds the wait.
+
+## 3. PR A — self-refresh, busy-bit, notices
+
+### 3.1 Busy bit: publish from the session's turn boundary, not the drain task
+
+Fix at the source: the handle needs a signal that fires **after**
+`_is_streaming` is cleared, for every turn regardless of who opened it.
+
+`session/session.py` — `_prompt_messages` (`:5694-5710`) and
+`Session.prompt`'s lock hold both release `_turn_lock` after
+`_run_turn_pipeline`'s `finally` has already run, but `_is_streaming = False`
+lives one level deeper in `_run_turn`'s `finally` (`:6047`). Add ONE hook,
+called from `_run_turn_pipeline`'s `finally` **after** `_flush_held_end`
+(`:5766`) and **after** the loop's own `_is_streaming = False` has run
+(i.e. as the last statement of that `finally`, guarded so it cannot raise):
+
+```python
+# session.py, Session.__init__
+#: Fired once per turn, after the turn's terminal event has been emitted
+#: AND ``is_streaming`` has been cleared. The OwnedSessionHandle uses it to
+#: republish the record's ``busy`` bit; the per-event path cannot, because
+#: the final AgentEndEvent is emitted while the flag is still True.
+self.on_turn_settled: Callable[[], None] | None = None
+```
+
+and in `_run_turn_pipeline`'s `finally` (after `self._flush_context_journal()`):
+
+```python
+settled = self.on_turn_settled
+if settled is not None:
+    try:
+        settled()
+    except Exception:  # noqa: BLE001 — a publish failure is not a turn failure
+        logger.debug("on_turn_settled hook failed", exc_info=True)
+```
+
+Ordering matters and must be pinned by the test: `_run_turn`'s `finally`
+(`:6030-6047`) runs on the way out of `await self._run_turn(...)` at `:5757`,
+so by the time `_run_turn_pipeline`'s `finally` executes, `_is_streaming` is
+already False and `_held_end` has been flushed. `running_subagents()` may
+still be >0 (a `task` left children running); that is correct — the handle's
+`is_busy()` then still says True and the bit stays True until the next
+`_notify` (a subagent event) republishes it. The hook only guarantees the
+*turn's* contribution is observed.
+
+`session/runtime/owned.py` — `OwnedSessionHandle.__init__`: 
+`session.on_turn_settled = self._publish_busy` (probe `hasattr` so reduced
+sessions in tests keep working). `_observe_prompt_drain` keeps its
+`_publish_busy()` — it is harmless and covers legacy sessions without the
+hook. Also call `self._publish_busy()` at the tail of `receive_peer_message`
+(`owned.py:1273` already calls `_notify()` which does it — no change needed
+there; the missing publish is the *end* of the turn, which the hook covers).
+
+Belt: `RuntimeServer._heartbeat_loop` (`server.py:826-845`) adds
+`self.set_busy(bool(is_busy()))` from a probed `self._handle.is_busy` before
+`_republish_detached()`. A 15 s-stale bit is still wrong for the picker, so
+the hook is the fix and this is only the floor.
+
+### 3.2 Runtime self-refresh: a fourth reaper term, one new frame field
+
+**Boot stamp.** `server.py:411-443` already computes `build = installed_build()`
+for the record; keep it on the server as `self._boot_build: BuildStamp`.
+
+**Detection.** `process.py` gains:
+
+```python
+#: How often an idle runtime re-reads the install on disk. Cheap (one
+#: dist-info lookup + one 60-byte file), but there is no reason to do it on
+#: every 250 ms reaper tick: a runtime that is already idle can afford to
+#: notice an update within a few seconds, and a busy one never checks.
+BUILD_CHECK_S = 5.0
+
+#: A freshly written install is not a stable one: ``lop-update`` runs
+#: ``uv tool install --force`` (which rewrites site-packages over several
+#: seconds) and THEN writes ``.lop-source``. Retiring against a half-written
+#: tree would spawn a successor that imports a mix of two builds. Require
+#: the marker's mtime to be at least this old before acting on it. Also the
+#: natural jitter base for the stagger below.
+BUILD_SETTLE_S = 10.0
+```
+
+`_build_changed(boot: BuildStamp) -> bool`: `installed_build() != boot` AND
+`.lop-source` (when present) has `mtime <= now - BUILD_SETTLE_S`. When
+`.lop-source` is absent (PyPI/pipx install) compare on version alone — that
+is what `BuildStamp` already does — and use the `dist-info` directory mtime
+for the settle check. Editable checkouts have no `.lop-source` and a
+constant version: they never trip this, by design (matches
+`design-build-skew.md` §6.5).
+
+**Policy.** Not a fourth term inside `_should_exit` — that predicate answers
+"may I exit *quietly*", and a refresh must *announce*. Add beside it:
+
+```python
+def _should_refresh(handle, runtime, boot: BuildStamp) -> bool:
+    """Retire so the next engage spawns from the build now on disk.
+
+    Only when the runtime is doing NOTHING it would lose: ``is_busy()``
+    False (the same authority as term 1 — never the record's bit, which
+    §3.1 fixes but which is a derived copy) and no wake inside the warm
+    window (a wake about to fire would just be paid twice). An attached
+    viewer does NOT hold: the viewer re-engages a fresh runtime on its own
+    (``retiring`` frame below); holding for it is exactly what kept a
+    5-hour-stale runtime resident. ``is_pristine()`` runtimes are retired
+    too — a pristine stale runtime is the cheapest possible refresh.
+    """
+```
+
+The reaper loop (`process.py:172-201`) gets a second branch checked every
+`BUILD_CHECK_S`: if `_should_refresh(...)`, re-check once after a jittered
+stagger (see §3.4), then `await runtime.announce_retiring("stale-build")`,
+re-check `is_busy()` **again** (the announce is an await; a `peer_message`
+can open a turn in that gap — same shape as `_retire_if_pristine`'s re-check
+at `server.py:1502-1510`), and if still idle run `_clean_exit` and set
+`stop`. Log at INFO:
+`session runtime: build on disk is 0.49.9@f4a70b9 but this process loaded
+0.49.8@46a4e9b; idle, retiring so the next engage runs the new build`.
+
+Mid-turn is impossible by construction: `is_busy()` is checked immediately
+before `_clean_exit` on the same loop step, and `_clean_exit` →
+`handle.dispose()` is the path a `stop` op already takes.
+
+**Wire.** The `stopping` frame (`server.py:575`) is *the* "deliberate
+disconnect follows" signal and every viewer already reads it. Do **not**
+overload it: a viewer that reads `stopping` parks in the stopped state and
+tells the user `/resume` reopens it (`app.py:3162-3180`), and
+`_session_was_stopped` (`remote.py:1920-1947`) would then look for a
+`stopped_at` marker that a refresh never writes. Add a new frame:
+
+```python
+{"op": "retiring", "session_id": ..., "reason": "stale-build",
+ "from": "0.49.8@46a4e9b", "to": "0.49.9@f4a70b9"}
+```
+
+Emitted by `RuntimeServer.announce_retiring(reason)`, a sibling of
+`announce_stop` that reuses `_write_now`/`_broadcast` exactly as `:576-615`
+do. Additive: an old viewer ignores the unknown op, sees EOF, runs the
+existing `_recover_owner`, and goes cold after 8 s — the pre-PR behaviour, so
+no `PROTOCOL_VERSION` bump. Not sent to `daemon` clients (the phone's
+projection path stays byte-identical; the daemon already handles owner exit
+by re-adopting on the next record).
+
+`attach_client.py::_pump` (`:373-381`): add `elif op == "retiring": reason =
+RETIRING_REASON` with `RETIRING_REASON = "owner retired for a newer build"`
+next to `STOPPED_REASON` (`:61`). `_ClientConn` needs nothing new.
+
+**Viewer.** `RemoteSession._on_disconnected` (`remote.py:1824`):
+
+```python
+if _reason == RETIRING_REASON:
+    # A planned refresh, not owner death and not a stop: the runtime
+    # left so the next engage runs the build now on disk. Nothing to
+    # recover — the successor does not exist yet — and nothing was
+    # interrupted (the runtime retires only when idle). Go cold NOW
+    # rather than chasing a record for 8 s, and tell the app so it can
+    # re-engage eagerly.
+    self._go_cold(refresh=True)
+    return
+```
+
+`_go_cold(refresh: bool = False)` skips `_end_turn_locally` when `refresh`
+(the runtime was idle by contract; `_streaming` is already False — assert
+that in the test) and calls a new `_refresh_callback` instead of
+`_went_cold_callback`. `set_refresh_callback` follows the
+`set_went_cold_callback` shape (`remote.py:2011-2017`).
+
+`tui/app.py`: in `_adopt_session`'s `is_remote` block (`:2812-2830`) install
+`set_refresh(self._on_runtime_refreshed)`:
+
+```python
+def _on_runtime_refreshed(self) -> None:
+    """The bound runtime retired itself for a newer build. Re-engage now so
+    the band never shows the cold state for a refresh the user did not ask
+    for; the next prompt would have done this anyway (``_ensure_bound``)."""
+    self._warm_engage_started = False
+    self._start_runtime_engage(reason="refresh")
+```
+
+`_start_runtime_engage` (`app.py:8501-8555`) already re-runs
+`_check_build_skew` after the bind; with a fresh runtime the owner stamp
+equals the disk stamp and notice C is silent. If the *window* itself is stale
+(notice A), the fresh runtime is newer than the window — that is the
+incident class `design-build-skew.md` §4.1 (B) already repairs, and A's
+`/reload` copy stays.
+
+**No notice is painted for a refresh.** Reasoning: the operator's bar is
+"never see this message"; the band's `starting…` state (`_set_starting`,
+`app.py:8528`) already covers the ~1 s the re-engage takes, and a second
+line of prose for a background housekeeping event is the pattern
+`_system_notice`'s own contract calls noise. A DEBUG log line suffices
+(`runtime for %s retired for %s → %s; re-engaging`). Design review can
+overrule; if it does, the copy is one dim line:
+`updated to 0.49.9@f4a70b9` — never a warning.
+
+### 3.3 Viewer-side belt: resume/bind against a stale idle owner
+
+`_check_build_skew`'s C branch (`app.py:14957-15011`) becomes:
+
+```
+owner stale?
+  ├─ owner idle (frontend_state.streaming False AND no running jobs AND
+  │  no pending gate)  → request refresh; NO notice
+  └─ owner busy       → notice C′ (copy below), once per session
+```
+
+"Request refresh" = `session.request_refresh()` → new `AttachClient.
+request_refresh()` → op `refresh_if_idle`, dispatched next to
+`retire_if_pristine` (`server.py:1332`, and add it to the no-push list at
+`:1425-1432`). Handler: same `_should_refresh` predicate as the reaper (share
+it: move the predicate into `owned.py` as `OwnedSessionHandle.may_refresh()`
+and have `process.py` call that, so both sides use one function). Answers
+`"retiring"` or `"kept: <reason>"`; a `kept` answer because the runtime is
+busy is when C′ paints. An old runtime answers unknown-op → treat as `kept`
+and paint C′ (the honest state for a runtime that predates the op).
+
+Is the belt worth having if the reaper already does this within
+`BUILD_CHECK_S + BUILD_SETTLE_S + stagger` (~15–40 s)? Yes, for one case:
+`lop --resume` in the seconds after `lop-update`, before the reaper has
+noticed. Without the op the viewer binds, sees skew, and either waits or
+warns; with it the refresh happens in the bind path itself. Small (one op,
+~40 lines) and it turns a race into a determinism.
+
+### 3.4 Debounce across many runtimes
+
+This host runs ~16 resident runtimes. `lop-update` rewrites the install over
+several seconds, and all 16 reapers would otherwise see the change on the
+same tick and spawn 16 successors within ~1 s (the eager re-engage). Three
+layers:
+
+1. **Settle**: `BUILD_SETTLE_S` (§3.2) — no runtime acts on a marker
+   younger than 10 s, so nothing retires mid-rewrite.
+2. **Stagger**: after `_should_refresh` first holds, sleep
+   `random.uniform(0, BUILD_STAGGER_S)` with `BUILD_STAGGER_S = 20.0`, then
+   re-check (work may have arrived). Sixteen runtimes spread over ~20 s; the
+   spawn cost of a successor is ~1.2 s CPU-light, so ≤1 spawn/s average.
+3. **Successor only on demand or viewer**: an unwatched idle runtime that
+   retires spawns *nothing* — the next `send`/wake/resume engages from the
+   new build. Only viewer-attached runtimes trigger an eager successor.
+
+`retiring` is announced *after* the stagger, immediately before exit, so a
+viewer never waits on a runtime that is "about to" leave.
+
+### 3.5 Notice copy
+
+- **C′ (stale AND busy)**, replaces both C variants at `app.py:14990-15011`:
+  `“<name>” is running 0.49.8@46a4e9b (this window is 0.49.9@f4a70b9) — it
+  will move to the new version when its current work finishes.` Absent
+  version: `“<name>” is running an older version than this window — it will
+  move to the new version when its current work finishes.` Kind: `"info"`
+  not `"warning"` — nothing is wrong and nothing is asked of the user. The
+  `/stop` sentence is gone from every notice. (`design-build-skew.md` §4.3's
+  old-runtime `noop team_mutate` degradation notice at `app.py:14629` keeps
+  its `/stop` wording for now: it fires only against pre-#624 runtimes, none
+  of which can exist after this ships — drop the sentence there too, cheap.)
+- **A** (window stale) unchanged. Self-reexec of the window when idle
+  (`reexec.py`, `_cmd_reload` at `app.py:5145`) was considered: the machinery
+  exists and `_turn_is_live` (`:5158`) is the guard. **Recommend not** in this
+  PR: a TUI relaunch drops composer draft, scrollback position and any
+  in-progress `ask` picker, and the operator did not ask for it. Leave A as
+  the one notice with a manual remedy; revisit if it becomes the next
+  complaint.
+
+### 3.6 File-by-file (PR A)
+
+| file | change |
+|---|---|
+| `session/session.py` | `on_turn_settled` hook; call in `_run_turn_pipeline` `finally` (`:5764-5776`) |
+| `session/runtime/owned.py` | wire hook in `__init__`; `may_refresh()` predicate + `refresh_if_idle` handle method |
+| `session/runtime/process.py` | `BUILD_CHECK_S/SETTLE_S/STAGGER_S`; `_build_changed`; reaper refresh branch |
+| `session/runtime/server.py` | `_boot_build`; `announce_retiring`; `refresh_if_idle` op; heartbeat republishes busy |
+| `mobile/attach_client.py` | `RETIRING_REASON`; `retiring` op in `_pump`; `request_refresh()` |
+| `session/remote.py` | `_on_disconnected` refresh branch; `_go_cold(refresh=)`; `set_refresh_callback`; `request_refresh()`; `owner_idle` helper |
+| `tui/app.py` | `_on_runtime_refreshed`; `_check_build_skew` C→C′ + belt; copy |
+| `update.py` | `build_marker_age_s()` (mtime of `.lop-source` or dist-info) |
+| `cli.py` | nothing (record fields unchanged) |
+
+## 4. PR B — disconnect and relay hardening
+
+### 4.1 Defer the synthesised abort
+
+`RemoteSession._on_disconnected` (`remote.py:1854-1857`) becomes:
+
+```python
+self._recovering = True
+self._owner_ready.clear()
+# Do NOT end the turn here. A dropped socket says nothing about the
+# turn: the runtime is usually still running it (a send timeout under a
+# stalled TUI loop is the common cause). Recovery decides — see
+# _settle_suspect_turn.
+self._suspect_generation = self._generation if self._streaming else None
+self._recovery_task = asyncio.create_task(self._recover_owner())
+```
+
+`_recover_owner` outcomes and what each does with the suspect turn:
+
+| outcome | today | proposed |
+|---|---|---|
+| re-bind, snapshot `streaming` True and `generation == suspect` | seeds `AgentStartEvent` on top of an already-ended turn | seed as today; **no end synthesised**; ledger untouched |
+| re-bind, snapshot `streaming` False or `generation > suspect` | (already ended, as aborted) | the turn ended while we were away. The durable replay (`_replay_durable_suffix`, `:1470`) paints its real rows; the real `AgentEndEvent` is NOT in `live_events` (the store clears them at turn end, `frontend_state.py:2870-2871`, `agent_end` empties the seed), so the viewer must synthesise one — but it cannot tell aborted from completed today. Add `last_turn_outcome: Literal["completed","aborted","error",""]` to `FrontendSessionState` (additive; set from `_run_turn_pipeline`'s `finally` off the flushed end's `aborted`/`error`), and synthesise `AgentEndEvent(aborted=(outcome=="aborted"), generation=0, error=...)`. An old runtime without the field → `""` → synthesise `aborted=True` (today's behaviour) |
+| `_go_cold` | ends turn (aborted) | unchanged — a runtime that is gone did abort |
+| `_notify_stopped` | ends turn (aborted) | unchanged |
+| `retiring` (PR A) | n/a | never streaming by contract |
+
+`_streaming` stays True during recovery (it is what routes the next message
+to the steer branch, `remote.py:2608`); the app's band keeps `working` —
+correct, since it is.
+
+`_apply_frontend_facades` (`:1631-1633`) already overwrites `_streaming` and
+`_generation` from the snapshot, so the second row's comparison is a
+two-line check right after `_install_frontend` in `_recover_owner`
+(`:2111`).
+
+### 4.2 Stop pushing projections to full-TUI attach clients
+
+`_push` (`server.py:2053-2067`) and `_push_to` send the projection to
+every client. A client that declared `events=True` **and**
+`frontend_state=True` is a full-TUI viewer (`remote.py:1259-1261`); it
+consumes `frontend_sync`/`frontend_update`/`event` and discards
+projections. The welcome projection (`_on_connection:954`) is still needed —
+`AttachClient.connect` (`attach_client.py:259-263`) reads it as the identity
+check. So:
+
+```python
+def _projection_recipients(self):
+    return [c for c in self._clients.values()
+            if not (c.wants_events and c.wants_frontend)]
+```
+
+used by `_push` only; `_push_to` (welcome) unchanged. The daemon (phone) and
+legacy v3/v4-only attach clients keep receiving repaints byte-for-byte.
+Measured motivation: 100–900 KB × ~20 Hz on a socket the viewer needs for
+events; nothing on the TUI side reads it (`_dial:1257`). Justification for
+*not* deferring this: it is the single largest contributor to the
+`_SEND_TIMEOUT_S` drop and it is a pure subtraction.
+
+Desktop surface (`surface == "desktop"`) declares the same two flags
+(`remote.py` constructs the client identically with `surface=self._surface`)
+and also reads nothing from projections — confirm with the desktop tests
+(`tests/e2e/test_desktop_*.py`) that nothing keys on `op == "projection"`
+after the welcome; the coder must grep `desktop` for `_on_projection` before
+relying on this.
+
+### 4.3 Log every drop with its reason and client kind
+
+`_drop_client(conn, *, reason: str)` — every caller names one:
+
+| caller | reason |
+|---|---|
+| `_send_to` timeout (`:2118`) | `send timeout (%.1fs)` |
+| `_send_to` reset/pipe/OSError | `send failed: <exc type>` |
+| `_enqueue_client_frame` overflow (`:1912`) | `event queue overflow (%d frames)` |
+| `_relay_frontend_to_on_loop` pending overflow (`:1886`) | `frontend pending overflow before ready` |
+| reader EOF (`:1010`) | `reader eof` |
+| reader reset (`:1017`) | `reader reset` |
+| daemon replacement (`:918`) | `daemon replaced` |
+| cap eviction (`:929`) | `attach cap` (existing INFO line folds into this) |
+| no `subscribe_frontend` (`:958`) | `frontend requested but unsupported` |
+| shutdown (`:781`) | `runtime shutdown` |
+
+One INFO line: `session runtime: dropped %s client %s (events=%s
+frontend=%s surface=%s): %s`. The second, no-op call from a reader loop's
+`finally` after a send-path drop logs at DEBUG only (guard on
+`was_registered`, which the method already computes at `:1035`).
+
+### 4.4 Raise the send bound for full-TUI clients, once projections are gone
+
+With projections off the viewer socket, the remaining traffic is events
+(~1–10 KB) and canonical updates. Keep `_SEND_TIMEOUT_S = 1.0` for the daemon
+and legacy paths; for `wants_events and wants_frontend` clients use
+`_TUI_SEND_TIMEOUT_S = 5.0`. Rationale: the bound exists to protect
+"authority-bearing ACKs for every healthy front end" (`server.py:101-103`),
+and sends are per-connection under `send_lock` — one slow TUI cannot block
+another client's writes. A 5 s stall on a TUI loop is rare but real (a
+60 MB transcript parse was measured at ~90 ms *per* threaded read; a
+`--resume` reflow is seconds); the cost of a false drop is the whole §1.3
+sequence. Watch it in rollout (§7).
+
+### 4.5 `RemoteSession.abort` unretrieved exception
+
+`remote.py:2662-2664`:
+
+```python
+def abort(self, reason: str = "interrupted") -> None:
+    client = self._client
+    if client is None or not client.connected:
+        return  # nothing to abort on; the local end is what the app shows
+    task = asyncio.create_task(client.abort())
+    task.add_done_callback(_log_abort_failure)   # ConnectionError → DEBUG
+```
+
+### 4.6 File-by-file (PR B)
+
+| file | change |
+|---|---|
+| `session/remote.py` | deferred end (`_suspect_generation`, `_settle_suspect_turn`); `abort` done-callback |
+| `session/frontend_state.py` | `last_turn_outcome` field (additive) |
+| `session/session.py` | set `last_turn_outcome` in `_run_turn_pipeline` finally |
+| `session/runtime/server.py` | `_drop_client(reason=)` + logs; `_projection_recipients`; per-kind send timeout |
+| `session/runtime/types.py` | nothing (no protocol bump) |
+
+## 5. Test plan
+
+### 5.1 PR A
+
+Unit — `tests/unit/session/runtime/test_busy_settles.py`:
+1. Real `Session` + `OwnedSessionHandle` + `RuntimeServer` (the probe in
+   §1.2, promoted): after `prompt`, `receive_peer_message(wake=True)`,
+   `receive_peer_message(mode="steer")` on idle, and a `_spawn_background(
+   _prompt_messages(...))` driven directly — `server._busy is False` within
+   500 ms of `handle.is_busy()` going False. **This test fails on
+   b0db51d9c** (verified: 2 of 3 params fail).
+2. `on_turn_settled` fires after `is_streaming` is False (assert inside the
+   hook) and after the `AgentEndEvent` has been delivered to subscribers.
+3. Hook raising does not fail the turn.
+
+Unit — `tests/unit/session/runtime/test_process_refresh.py` (same fakes as
+`test_process_reaper.py`):
+4. `_should_refresh`: busy → False; wake in window → False; attached viewer
+   → **True** (the operator's rule, pinned); pristine → True.
+5. `_build_changed`: same stamp → False; different ref, marker mtime < settle
+   → False; > settle → True; no marker, version differs → True.
+6. Reaper: stamp flips mid-loop → `announce_retiring("stale-build")` called,
+   then `_clean_exit`, `stop` set; a turn starting between announce and exit
+   → kept (inject busy on the second probe).
+7. Stagger bounded by `BUILD_STAGGER_S` (monkeypatch `random.uniform`).
+
+Unit — `tests/unit/session/test_remote_refresh.py`:
+8. `_on_disconnected(RETIRING_REASON)` → `_go_cold(refresh=True)`;
+   `_end_turn_locally` NOT called; refresh callback fired; `is_cold` True;
+   no recovery task.
+9. `_on_disconnected(STOPPED_REASON)` unchanged (regression guard).
+
+Unit — `tests/unit/tui/test_build_skew.py` (extend):
+10. Stale + idle owner → `request_refresh` called, no notice.
+11. Stale + busy owner → C′ info notice, no `/stop` substring anywhere in
+    the ledger (`assert "/stop" not in transcript_text(app)`).
+12. Refresh callback → `_start_runtime_engage(reason="refresh")` and
+    `_warm_engage_started` reset.
+
+E2E — `tests/e2e/test_runtime_refresh_e2e.py` (production
+`process.py` in a subprocess like `test_cold_wake_e2e.py`, isolated
+`HOME`+config dir, all `CMUX_*` unset, `LOP_SESSION_GRACE_S` small,
+`BUILD_SETTLE_S`/`BUILD_STAGGER_S` overridable via env for the test only —
+add `LOP_BUILD_SETTLE_S` / `LOP_BUILD_STAGGER_S` read the way
+`LOP_SESSION_GRACE_S` is at `process.py:69-75`):
+13. Boot a runtime with `installed_build` monkeypatched via a fake
+    `.lop-source` in a temp prefix (`update.installed_build(prefix=)`
+    already takes one — pass it through an env var `LOP_BUILD_PREFIX` the
+    runtime honours only under test); attach a headless `OperatorApp` via
+    `--resume`; flip the marker; assert within 10 s: old pid gone, record
+    names a new pid, viewer `is_cold` False, `transcript_text(app)` contains
+    no `"/stop"`, no `"interrupted"`, no `"stopped"`; the band shows the
+    model.
+14. Same, runtime busy (scripted stream parked on a `wait`-shaped tool) →
+    still the old pid after 10 s; C′ present; then the turn ends → old pid
+    exits, new pid appears, no further notice.
+15. Unwatched: no viewer; flip; old pid exits; **no** new record appears
+    (no eager spawn without a viewer); `lop send` to it engages a new pid
+    from the new stamp.
+
+### 5.2 PR B
+
+Unit — `tests/unit/session/test_remote_disconnect.py`:
+16. Mid-turn socket close → no `AgentEndEvent` emitted; `_streaming` True;
+    re-bind with `streaming=True, generation==suspect` → seeded start only,
+    still no end.
+17. Re-bind with `generation > suspect` / `streaming False` → exactly one
+    end, `aborted` per `last_turn_outcome`.
+18. Recovery goes cold → one aborted end (unchanged).
+19. `abort()` while detached → no task, no "never retrieved".
+
+Unit — `tests/unit/session/runtime/test_server.py` (extend):
+20. `_push` skips clients with `wants_events and wants_frontend`; welcome
+    still delivered; daemon and events-only clients still receive.
+21. Every drop path logs `dropped ... : <reason>` (caplog), exactly once at
+    INFO per connection.
+22. Send timeout for TUI-class client is `_TUI_SEND_TIMEOUT_S`.
+
+E2E — extend `tests/e2e/test_viewer_attach_e2e.py`:
+23. Viewer attached mid-turn (scripted `wait`); close the viewer's socket
+    from the server side (`_drop_client(conn, reason="test")`); assert the
+    viewer re-binds to the same pid and `transcript_text(app)` never
+    contains `"interrupted"`; the turn then completes normally and the app
+    paints the assistant row once.
+
+QA matrix (qa-tester, real execution, isolated `HOME` per cell; never the
+operator's live `~/.local-operator`): cell A = e2e 13 by hand with two `uv
+tool install --force` refs in an isolated `UV_TOOL_DIR` and a real
+`.lop-source` rewrite; cell B = e2e 14; cell C = e2e 15 with `lop send`;
+cell D = e2e 23 with `kill -STOP` on the TUI pid for 3 s (the real stall)
+and confirm no `interrupted` and one `dropped attach client ... send
+timeout` line in `mobile.log`; cell E = phone daemon still receives
+projections after PR B (`lop mobile status` + a phone attach).
+
+## 6. Interactions and edge cases
+
+- **Refresh while a gate is parked**: `is_busy()` returns True for
+  `_pending_futures` (`owned.py:657-660`) — never retires under a question.
+- **Refresh while subagents run but the parent turn ended**:
+  `running_subagents() > 0` → busy → no refresh. Correct: the children die
+  with `dispose`.
+- **Goal loop between iterations**: `_goal_loop.running` → busy.
+- **Wake due in 60 s**: term 2 holds; the refresh happens after the wake's
+  turn settles. A schedule with a 60 s recurrence never refreshes while it
+  fires — acceptable; the alternative (retire and let the supervisor re-spawn
+  for the wake) is what `WARM_WINDOW_S` exists to avoid, and the stale
+  runtime is only stale until the recurrence pauses.
+- **Two viewers on one runtime**: both get `retiring`; both re-engage;
+  `engage_runtime`'s lease arbitration (`launch.py:447-462`) makes one the
+  winner and the other binds to it — the existing N-contender path.
+- **`lop-update` to a build that fails to construct**: old runtime is gone;
+  `engage_runtime` reports the child's own reason (`launch.py:504-516`) as
+  today for any spawn. No worse than a cold start after the update.
+- **Refresh racing `/stop`**: `stop` op → `request_stop` → `stop.set()`;
+  reaper's `stop.is_set()` check short-circuits. `retiring` never sent after
+  `stopping`.
+- **Old viewer + new runtime**: viewer ignores `retiring`, chases the record
+  for 8 s, goes cold, paints "runtime exited" — today's behaviour for any
+  idle exit while attached. Self-limiting: the viewer is stale, and notice A
+  told it to `/reload`.
+
+## 7. Risks to watch during rollout
+
+1. **Spawn storms.** 16 runtimes × eager re-engage. Settle + stagger bound
+   it to ~1/s; watch `mobile.log` for `engage: spawning` bursts after the
+   first `lop-update` post-merge. If it is still lumpy, `BUILD_STAGGER_S`
+   is the knob (not env-tunable on purpose, like `WARM_WINDOW_S`).
+2. **A half-written install passing the settle check.** `uv tool install
+   --force` on this host takes 3–8 s; `BUILD_SETTLE_S = 10` plus the marker
+   being written *after* the install (`lop-update:291-292`) gives margin. A
+   successor that imports a torn tree fails at construction and the viewer
+   shows the engage error — loud, not silent. If observed, raise the
+   settle.
+3. **Deferred abort hides a real death for up to 8 s.** During recovery the
+   band says `working` for a runtime that may be gone. Today it says
+   `interrupted` for one that is not. The 8 s bound is `COLD_FALLBACK_S`;
+   the go-cold path still paints the abort. Accept.
+4. **Desktop surface reading projections.** §4.2 assumes it does not; the
+   coder verifies with grep + `test_desktop_*` before landing. If it does,
+   scope the recipient filter to `surface == "terminal"`.
+5. **`last_turn_outcome` semantics** for a turn that ended in compaction
+   continuation: set in `_run_turn_pipeline`'s finally, which is after the
+   whole logical turn (start/end pair) — one value per user prompt. Pin it.
+6. **Busy hook and `_disposing`**: `is_busy()` returns False under
+   `_disposing` (`owned.py:633-636`), so a publish from the hook during
+   dispose writes `busy: false` right before the record is unpublished —
+   harmless, and `set_busy` de-dupes.
+
+## 8. PR split
+
+**PR A — `fix(runtime): idle runtimes refresh themselves onto the build on
+disk`**: §3 entirely. Files in §3.6. Tests 1–15. Notice copy is the only
+user-visible surface (design round required: D-findings on C′ and on the
+no-notice refresh decision). No band/layout change. Risk: medium (a new exit
+path for runtimes) — QA cells A–C.
+
+**PR B — `fix(runtime): keep viewers bound across transient socket drops`**:
+§4 entirely. Files in §4.6. Tests 16–23. No user-visible copy change
+(removes a false notice; adds none) — UX round on the flow (mid-wait
+disconnect no longer paints `interrupted`), no design round. Risk: low-medium
+(recipient filtering touches the phone path; test 20 and QA cell E cover
+it).
+
+Order: **B first** if only one can ship in the window — it removes the
+"interrupted" false paint the operator saw in several sessions and is
+independent of A. A depends on nothing in B, but its e2e 13 asserts no
+`interrupted` text, which B makes robust against a viewer stall during the
+re-engage. Both PRs: gates per AGENTS.md (flake8 / black==26.1.0 /
+isort==5.13.2 / pyright over the whole tree, unit suite via
+`.venv/bin/python`, `tests/e2e -m e2e -n0` with `env -u NO_COLOR
+TERM=xterm-256color`), then the standing reviewer + QA rounds; every fork or
+TUI boot in tests unsets inherited `CMUX_*`.
+
+## 9. What I would NOT do
+
+- Bump `PROTOCOL_VERSION` — every frame and op here is additive and
+  ignorable by an older peer.
+- Add a fourth term to `_should_exit` — a quiet exit and an announced
+  retirement are different contracts; mixing them makes an old viewer read
+  a refresh as death.
+- Overload `stopping` for the refresh — it parks the viewer in "stopped".
+- Make the TUI self-reexec for notice A in this PR.
+- Touch the `wait` tool.

--- a/local_operator/mobile/attach_client.py
+++ b/local_operator/mobile/attach_client.py
@@ -60,6 +60,14 @@ ACK_TIMEOUT_S = 15.0
 #: Consumers compare against this exact string to decide whether to recover.
 STOPPED_REASON = "owner stopped the session"
 
+#: Disconnect reason for a PLANNED refresh: the owner retired itself because
+#: ``lop-update`` put a newer build on disk, and the next engage should spawn
+#: from it. Distinct from :data:`STOPPED_REASON` on purpose — a stop parks the
+#: viewer in the stopped state (``/resume`` reopens it); a refresh means "a
+#: fresh runtime is owed, engage one now". Nothing was interrupted: the owner
+#: retires only when idle (``OwnedSessionHandle.may_refresh``).
+RETIRING_REASON = "owner retired for a newer build"
+
 #: Maximum bytes in one frame. Must equal the server's ``_MAX_LINE_BYTES``:
 #: the writer refuses to exceed it and the reader refuses to read past it, so
 #: two different numbers would mean a frame the owner considers sendable is one
@@ -379,6 +387,13 @@ class AttachClient:
                     # viewer that mistakes it for owner death takes over a
                     # session the user just ended (U2-4).
                     reason = STOPPED_REASON
+                elif op == "retiring":
+                    # A planned refresh (design-runtime-autorefresh §3.2). Same
+                    # carrier as ``stopping`` — the disconnect reason — and for
+                    # the same reason: the EOF is moments away and every host
+                    # already reads that string. The host goes cold at once
+                    # and re-engages rather than chasing a record for 8 s.
+                    reason = RETIRING_REASON
                 elif op in ("ack", "error", "result"):
                     future = self._pending.pop(frame.get("req"), None)
                     if future is not None and not future.done():
@@ -594,6 +609,19 @@ class AttachClient:
         the ordinary residency drain.
         """
         return await self._request("retire_if_pristine")
+
+    async def request_refresh(self) -> str:
+        """Ask a STALE owner to retire now if it is idle, so the next engage
+        runs the build on disk.
+
+        The viewer-side belt for the runtime's own reaper-driven refresh: a
+        resume in the seconds after ``lop-update`` binds before the runtime
+        has noticed the change, and without this the viewer would either wait
+        for it or warn. As with ``retire_if_pristine`` the answer is the
+        runtime's ("retiring", or "kept: …"); an owner too old to know the op
+        answers the unknown-op error, which the caller reads as kept.
+        """
+        return await self._request("refresh_if_idle")
 
     async def job_trajectory(self, job_id: str, offset: int = 0, limit: int = 120) -> Any:
         """Fetch one page of a child job's retained events from the owner.

--- a/local_operator/providers/clients.py
+++ b/local_operator/providers/clients.py
@@ -3784,12 +3784,29 @@ class GoogleClient:
 # ---------------------------------------------------------------------------
 
 
+def _mock_bash_sleep(text: str) -> int | None:
+    """The ``N`` of a ``[bash:N]`` marker, bounded to a minute, else ``None``.
+
+    Only the LAST user message is consulted by the caller, for the same
+    reason ``[tool]`` is: the marker stays in history forever, and a mock
+    that re-read it would re-issue the call on every later turn.
+    """
+    match = re.search(r"\[bash:(\d{1,2})\]", text)
+    if match is None:
+        return None
+    return min(int(match.group(1)), 60)
+
+
 class MockClient:
     """Deterministic canned stream for ``--hosting test``.
 
     Emits two text deltas + usage + end; when the last user message contains
     ``[tool]`` it emits one tool call (``echo`` with ``{"text": "hi"}``) and
-    stops with ``toolUse`` instead. ``[refuse]`` ends the stream as a refusal
+    stops with ``toolUse`` instead. ``[bash:N]`` calls the REAL ``bash`` tool
+    with ``sleep N`` — the one way to make an assembled runtime genuinely busy
+    for a known duration from outside (``echo`` is not a production tool, so
+    ``[tool]`` errors and completes at once); the e2e stage uses it to prove
+    a refresh never fires mid-turn. ``[refuse]`` ends the stream as a refusal
     with a canned provider message — the only way to exercise the whole
     refusal path (loop → event → TUI notice → transcript replay) against a
     real running app without needing a provider to actually decline.
@@ -3821,6 +3838,25 @@ class MockClient:
         # analogue is the newest instruction.
         last_user = next((m for m in reversed(request.messages) if m.role == "user"), None)
         wants_tool = last_user is not None and "[tool]" in last_user.text
+        # ``[bash:N]`` fires ONCE per prompt: only when the newest message is
+        # the user's. After the tool result comes back the newest message is
+        # the tool row, and the mock answers with text so the turn completes
+        # instead of sleeping again forever.
+        sleep_for = (
+            _mock_bash_sleep(last_user.text)
+            if last_user is not None and request.messages and request.messages[-1] is last_user
+            else None
+        )
+        if sleep_for is not None:
+            yield StreamToolCallDelta(index=0, id="call_mock_bash", name="bash")
+            yield StreamToolCallDelta(
+                index=0, argument_delta=json.dumps({"command": f"sleep {sleep_for}"})
+            )
+            yield StreamUsageEvent(usage=Usage(input_tokens=10, output_tokens=5))
+            yield StreamEndEvent(
+                stop_reason="toolUse", usage=Usage(input_tokens=10, output_tokens=5)
+            )
+            return
         if wants_tool:
             yield StreamToolCallDelta(index=0, id="call_mock_1", name="echo")
             yield StreamToolCallDelta(index=0, argument_delta=json.dumps({"text": "hi"}))

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -64,6 +64,7 @@ from local_operator.harness.types import (
     WakeDeliveredEvent,
 )
 from local_operator.mobile.attach_client import (
+    RETIRING_REASON,
     STOPPED_REASON,
     AttachClient,
     find_owner_record,
@@ -259,6 +260,11 @@ class RemoteSession:
         self.degraded_reason: str = ""
         #: Told when the runtime vanished for good; see ``_go_cold``.
         self._went_cold_callback: Callable[[], Any] | None = None
+        #: Told when the runtime retired ITSELF for a newer build (the
+        #: ``retiring`` frame): the app re-engages eagerly so the band never
+        #: shows the cold state for a refresh the user did not ask for. See
+        #: ``_go_cold(refresh=True)``.
+        self._refresh_callback: Callable[[], Any] | None = None
         #: True once THIS follower asked the owner to stop the session
         #: (``request_stop`` acked) or the wire evidence says the session was
         #: deliberately ended (the owner served the stop and unpublished).
@@ -1253,6 +1259,14 @@ class RemoteSession:
         # missing stamp degrades to "unknown", never to a refused attach.
         self.owner_version = getattr(record, "version", "") or ""
         self.owner_source_ref = getattr(record, "source_ref", "") or ""
+        # The runtime's working directory, kept so a viewer that was ATTACHED
+        # (``connect``, the `lop --resume` path) can engage a successor after
+        # its owner retires for a refresh. Only ``cold()`` used to set ``_cwd``;
+        # an attached viewer had none, so ``_ensure_bound`` would have spawned
+        # the successor in the wrong directory. Never overwrites a cwd the
+        # viewer was constructed with — that one is the user's choice.
+        if not self._cwd:
+            self._cwd = str(getattr(record, "cwd", "") or "")
         client = AttachClient(
             lambda _projection: None,
             on_disconnected,
@@ -1836,6 +1850,16 @@ class RemoteSession:
         # the cases the local flag cannot: another TUI's /stop all, or a shell
         # `lop stop`, hitting a session THIS viewer merely watches — including
         # a session with no wakes, which leaves no on-disk marker to consult.
+        if _reason == RETIRING_REASON:
+            # A planned refresh, not owner death and not a stop: the runtime
+            # left so the next engage runs the build now on disk. Nothing to
+            # recover — the successor does not exist yet, and chasing the
+            # record for 8 s would end in "runtime exited" for a housekeeping
+            # event — and nothing was interrupted (the runtime retires only
+            # when idle, so there is no turn to end). Go cold NOW and tell
+            # the app so it can re-engage eagerly.
+            self._go_cold(refresh=True)
+            return
         if _reason == STOPPED_REASON:
             self._deliberate_stop = True
         if self._deliberate_stop:
@@ -1959,13 +1983,22 @@ class RemoteSession:
             return "this session was stopped"
         return "session owner is reconnecting"
 
-    def _go_cold(self) -> None:
+    def _go_cold(self, *, refresh: bool = False) -> None:
         """Unbind from a runtime that is gone, keeping the conversation.
 
         The viewer stays exactly as it is on screen; only its binding drops.
         ``_owner_ready`` is SET rather than left clear because a cold viewer is
         ready — the next prompt engages a runtime through ``_ensure_bound``
         instead of waiting for one that is never coming back.
+
+        ``refresh`` is the planned-retirement variant (``RETIRING_REASON``):
+        the runtime was idle by contract when it left, so there is no turn to
+        end — ``_end_turn_locally`` is skipped, which is what keeps a refresh
+        from ever painting ``interrupted`` — and the REFRESH callback fires
+        instead of the went-cold one, so the app re-engages rather than
+        reporting "runtime exited". If the runtime lied and a turn WAS live,
+        ``_end_turn_locally`` would have produced a false abort anyway; the
+        successor's snapshot re-seeds whatever is actually running.
 
         A turn still in flight is ENDED through the event path, not merely
         flagged off (#642, UX U11). Clearing ``_streaming`` alone told the
@@ -1995,18 +2028,87 @@ class RemoteSession:
         # cost — must not propagate out of teardown and skip `_owner_ready`,
         # which would leave the prompt path waiting on an event nothing else
         # will set (review round 1, MINOR-1).
-        try:
-            self._end_turn_locally(direct=True)
-        except Exception:  # noqa: BLE001 — a viewer notice must not break teardown
-            logger.debug("ending the in-flight turn on go-cold failed", exc_info=True)
+        if refresh:
+            if self._streaming:
+                # Should be unreachable (the runtime retires only when idle);
+                # logged rather than asserted because the honest repair is
+                # the successor's snapshot, not a false abort here.
+                logger.warning("runtime retired for a refresh while a turn looked live")
+            # A viewer that ATTACHED (``connect``) rather than started cold
+            # keeps the legacy "recover by taking over" contract for owner
+            # DEATH — but a refresh is not a death, and taking the lease into
+            # this process would make the terminal the runtime for a session
+            # that retired precisely so a fresh runtime could run it. From
+            # here on this facade is a viewer: it engages a successor
+            # (``_ensure_bound`` is gated on this flag) and, should THAT one
+            # die, goes cold rather than taking over. The `lop --resume` TUI
+            # is exactly this case (design-runtime-autorefresh §1.1).
+            self._can_go_cold = True
+        else:
+            try:
+                self._end_turn_locally(direct=True)
+            except Exception:  # noqa: BLE001 — a viewer notice must not break teardown
+                logger.debug("ending the in-flight turn on go-cold failed", exc_info=True)
         self._owner_ready.set()
-        callback = self._went_cold_callback
+        callback = self._refresh_callback if refresh else self._went_cold_callback
         if callback is None:
             return
         try:
             callback()
         except Exception:  # noqa: BLE001 — a viewer notice must not break teardown
-            logger.debug("went-cold callback failed", exc_info=True)
+            logger.debug("%s callback failed", "refresh" if refresh else "went-cold", exc_info=True)
+
+    def set_refresh_callback(self, callback: Callable[[], Any] | None) -> None:
+        """Told when the runtime retired itself for a newer build.
+
+        The viewer re-engages at once (``OperatorApp._on_runtime_refreshed``);
+        the conversation is untouched and no notice is painted — the band's
+        ``starting…`` state covers the ~1 s the re-engage takes.
+        """
+        self._refresh_callback = callback
+
+    def owner_idle(self) -> bool:
+        """Whether the bound runtime is doing nothing a refresh would lose.
+
+        Read off the canonical snapshot rather than asked over the wire, so
+        the build-skew seam can decide synchronously whether to REQUEST a
+        refresh (idle) or paint the busy notice (not idle). The runtime is
+        the authority — ``refresh_if_idle`` re-asks ``may_refresh`` — and
+        this is only the viewer's best reading: streaming, a running job, or
+        a parked gate each mean "busy". A cold viewer is not idle; it has no
+        owner to refresh.
+        """
+        if self.is_cold or self._streaming:
+            return False
+        store = self._frontend_store
+        if store is None:
+            return False
+        state = store.state
+        if getattr(state, "streaming", False) or getattr(state, "pending_gate", None) is not None:
+            return False
+        for job in getattr(state, "jobs", ()) or ():
+            if str(getattr(job, "status", "")) == "running":
+                return False
+        return True
+
+    async def request_refresh(self) -> str:
+        """Ask the bound runtime to retire now if idle and stale; see
+        ``AttachClient.request_refresh``. Never raises: every failure means
+        "the runtime stays", which the reaper's own check repairs within
+        ``BUILD_CHECK_S + BUILD_SETTLE_S + stagger``."""
+        client = self._client
+        if client is None or not client.connected:
+            return "kept: no runtime attached"
+        ask = getattr(client, "request_refresh", None)
+        if not callable(ask):
+            return "kept: client cannot ask for a refresh"
+        try:
+            return str(await cast(Callable[[], Awaitable[str]], ask)())
+        except Exception as exc:  # noqa: BLE001 — the reaper is the fallback
+            # An owner too old to know the op answers the unknown-op error;
+            # that is the honest "kept" for a runtime predating the refresh.
+            logger.debug("refresh request failed", exc_info=True)
+            return f"kept: {exc}"
 
     def set_went_cold_callback(self, callback: Callable[[], Any] | None) -> None:
         """Told when the runtime went away and no successor arrived.

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -308,6 +308,26 @@ class OwnedSessionHandle(SessionHandle):
         #: process's stop event so a socket ``stop`` op exits the way SIGTERM
         #: does. ``None`` under a host that has no process to exit.
         self.on_stop_requested: Callable[[], None] | None = None
+        # The record's ``busy`` bit must settle when the LAST turn settles, and
+        # the per-event path cannot say that: the final AgentEndEvent is
+        # delivered while the turn still counts as busy (the held end is
+        # flushed under ``_turn_lock``; an abort's end is emitted while
+        # ``_is_streaming`` is True). ``_observe_prompt_drain`` covered turns
+        # that ran through the prompt queue; every other opener (peer wake,
+        # scheduled wake, background result delivery, resume catch-up) left
+        # the record saying ``busy: true`` for hours (design §1.2). The
+        # session's turn-boundary hook fires for all of them.
+        #
+        # DEFERRED by one loop iteration rather than published inline: the
+        # hook runs inside ``_run_turn_pipeline``'s ``finally``, which is still
+        # UNDER ``_turn_lock`` (the caller releases it on the way out), and
+        # ``is_busy()`` reads that lock. ``call_soon`` runs after the pipeline
+        # coroutine has returned and the ``async with`` released the lock
+        # synchronously, so the publish reads the settled state
+        # (``test_busy_settles`` pins the ordering). Probed so reduced
+        # sessions in tests that never grew the attribute keep working.
+        if hasattr(session, "on_turn_settled"):
+            session.on_turn_settled = self._publish_busy_soon
         self._install_gates()
 
     # -- gates -----------------------------------------------------------------
@@ -758,6 +778,47 @@ class OwnedSessionHandle(SessionHandle):
             logger.debug("pristine probe: history unreadable", exc_info=True)
             return False
         return True
+
+    def may_refresh(self) -> str:
+        """Why this runtime must NOT retire for a newer build right now, or
+        ``""`` when it may.
+
+        ONE predicate shared by the reaper's self-refresh branch
+        (``process._should_refresh``) and the viewer-driven ``refresh_if_idle``
+        op, so the two paths can never disagree about what "idle" means. Two
+        terms, deliberately the first two of ``process._should_exit`` and NOT
+        the third:
+
+        * ``is_busy()`` False — the same authority the reaper uses, never the
+          record's derived ``busy`` bit. Covers a live turn, a parked gate, a
+          running goal loop, live subagents and background jobs.
+        * no wake due inside the warm window — a wake about to fire would be
+          paid twice (this runtime retires, the supervisor spawns a successor
+          for the wake), and ``WARM_WINDOW_S`` exists to avoid exactly that.
+
+        An attached viewer does NOT hold. That is the operator's rule and the
+        point of the whole mechanism: the viewer re-engages a fresh runtime on
+        its own when it reads ``retiring``, and holding for it is precisely
+        what kept a five-hour-stale runtime resident (design §1.1). Pristine
+        runtimes are not exempt either — a pristine stale runtime is the
+        cheapest possible refresh.
+
+        Returns the REASON rather than a bool because the viewer paints a
+        notice off the ``kept: <reason>`` answer and the log line names it.
+        """
+        try:
+            if self.is_busy():
+                return "busy"
+        except Exception:  # noqa: BLE001 — uncertainty keeps the runtime
+            return "busy probe failed"
+        # Term 2 is the reaper's own helper, not a re-derivation: one place
+        # decides what "inside the warm window" means. Lazy import — the
+        # process module imports this one inside ``amain``, never at load.
+        from local_operator.session.runtime.process import _wake_within_window
+
+        if _wake_within_window(self):
+            return "wake due within the warm window"
+        return ""
 
     def next_wake_due_at(self) -> int | None:
         """Epoch-ms of the earliest armed wake, or ``None`` when none is set.
@@ -3164,6 +3225,14 @@ class OwnedSessionHandle(SessionHandle):
         self._publish_pending_gate()
         if self._on_projection is not None:
             self._on_projection()
+
+    def _publish_busy_soon(self) -> None:
+        """``_publish_busy`` on the next loop iteration; see ``__init__``."""
+        try:
+            self._loop.call_soon(self._publish_busy)
+        except RuntimeError:
+            # Loop closed under a disposing session: nothing left to publish.
+            return
 
     def _publish_busy(self) -> None:
         """Keep the record's ``busy`` bit in step with the session.

--- a/local_operator/session/runtime/process.py
+++ b/local_operator/session/runtime/process.py
@@ -22,6 +22,14 @@ costs nothing and a wake fires in a fresh process later. It stays resident
 while any of three things holds — see :func:`_should_exit` for each term and
 the reasoning behind it.
 
+**Self-refresh (design-runtime-autorefresh §3.2).** Independently of the
+quiet exit, an idle runtime whose install on disk has moved under it
+(``lop-update`` ran) ANNOUNCES ``retiring`` to its viewers and exits, so the
+next engage runs the new build. An attached viewer does not hold this — it
+re-engages a successor itself — which is what keeps a five-hour-stale
+runtime from staying resident because someone was looking at it. See
+:func:`_should_refresh` and :func:`_refresh_for`.
+
 This was ``mobile/child.py``. Only the phone spawns one today, but nothing in
 it is phone-specific: it is the generic "a session running with no interface
 owner" process, which is what later work needs for wakes and background
@@ -37,10 +45,14 @@ import asyncio
 import inspect
 import logging
 import os
+import random
 import signal
 import sys
 import time
-from typing import Any, Awaitable, Callable, cast
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, cast
+
+if TYPE_CHECKING:
+    from local_operator.update import BuildStamp
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +77,29 @@ DEFAULT_GRACE_S = 3.0
 #: layer, and a knob would let the two drift apart.
 WARM_WINDOW_S = 90.0
 
+#: How often an idle runtime re-reads the install on disk. Cheap (one
+#: dist-info lookup + one 60-byte file), but there is no reason to do it on
+#: every 250 ms reaper tick: a runtime that is already idle can afford to
+#: notice an update within a few seconds, and a busy one never checks.
+BUILD_CHECK_S = 5.0
+
+#: A freshly written install is not a stable one: ``lop-update`` runs
+#: ``uv tool install --force`` (which rewrites site-packages over several
+#: seconds) and THEN writes ``.lop-source``. Retiring against a half-written
+#: tree would spawn a successor that imports a mix of two builds. Require
+#: the marker's mtime to be at least this old before acting on it.
+#: Env-overridable ONLY so the e2e stage can flip a fake marker and observe
+#: the retirement within its budget; production never sets the variable.
+BUILD_SETTLE_S = 10.0
+
+#: After the refresh predicate first holds, sleep a uniform random slice of
+#: this before re-checking and retiring. This host runs ~16 resident
+#: runtimes; ``lop-update`` would otherwise have all of them notice on the
+#: same tick and their viewers spawn sixteen successors within a second.
+#: Spread over 20 s the eager re-engages average ≤1 spawn/s. Same env
+#: override rule as the settle: test-only.
+BUILD_STAGGER_S = 20.0
+
 
 def _grace_seconds() -> float:
     raw = os.environ.get("LOP_SESSION_GRACE_S", "")
@@ -73,6 +108,103 @@ def _grace_seconds() -> float:
     except ValueError:
         return DEFAULT_GRACE_S
     return value if value > 0 else DEFAULT_GRACE_S
+
+
+def _positive_seconds(raw: str, default: float) -> float:
+    """``raw`` as a positive float, else ``default``.
+
+    Same shape as ``_grace_seconds``: the refresh timings are constants in
+    production and only the e2e stage shortens them (``LOP_BUILD_SETTLE_S``,
+    ``LOP_BUILD_STAGGER_S``), so a malformed or non-positive value falls back
+    to the constant rather than disabling the protection it names. ``0`` is
+    deliberately NOT accepted for the settle: a zero settle is the torn-tree
+    race this constant exists to prevent, and a test that wants "fast" can
+    say ``0.1``. The two readers below spell their variable names out as
+    literals so the ambient-environment audit (``test_ambient_env_isolation``)
+    can see them.
+    """
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _build_settle_seconds() -> float:
+    return _positive_seconds(os.environ.get("LOP_BUILD_SETTLE_S", ""), BUILD_SETTLE_S)
+
+
+def _build_stagger_seconds() -> float:
+    return _positive_seconds(os.environ.get("LOP_BUILD_STAGGER_S", ""), BUILD_STAGGER_S)
+
+
+def _build_prefix() -> str | None:
+    """Where to read the install stamp from: ``sys.prefix`` in production.
+
+    ``LOP_BUILD_PREFIX`` exists ONLY so the e2e stage can point a real
+    ``process.py`` at a temp directory carrying a fake ``.lop-source`` and
+    flip it under the runtime. Nothing outside ``tests/e2e`` sets it, and a
+    production runtime that inherited it by accident would merely compare
+    against a marker that never changes — it can never retire early.
+    """
+    return os.environ.get("LOP_BUILD_PREFIX") or None
+
+
+def _build_changed(boot: "BuildStamp | None") -> "BuildStamp | None":
+    """The build now on disk, if it differs from ``boot`` AND has settled.
+
+    ``None`` means "nothing to do": same stamp, an unreadable stamp, a boot
+    stamp that was never captured (a reduced test server), or a marker still
+    inside the settle window (see ``BUILD_SETTLE_S``). Editable checkouts have
+    no ``.lop-source`` and a constant version, so they never trip this — by
+    design, matching ``design-build-skew.md`` §6.5: a developer's worktree
+    runtime must not retire because they touched a file.
+    """
+    if boot is None:
+        return None
+    from local_operator import update as update_mod
+
+    prefix = _build_prefix()
+    try:
+        on_disk = update_mod.installed_build(prefix)
+    except Exception:  # noqa: BLE001 — an unreadable stamp is "no change"
+        logger.debug("build stamp unreadable; no refresh", exc_info=True)
+        return None
+    if on_disk == boot:
+        return None
+    age = update_mod.build_marker_age_s(prefix)
+    if age is None or age < _build_settle_seconds():
+        # Younger than the settle, or unknowable: the install may still be
+        # mid-write. Try again next check; the marker only gets older.
+        return None
+    return on_disk
+
+
+def _should_refresh(handle: object, boot: "BuildStamp | None") -> "BuildStamp | None":
+    """Retire so the next engage spawns from the build now on disk?
+
+    Returns the NEW stamp when yes, ``None`` when no. Not a fourth term of
+    :func:`_should_exit`: that predicate answers "may I exit *quietly*", and a
+    refresh must ANNOUNCE (the ``retiring`` frame) so a viewer re-engages
+    rather than reading the exit as owner death. Only when the runtime is
+    doing NOTHING it would lose — ``OwnedSessionHandle.may_refresh`` is the
+    one predicate for that, shared with the viewer-driven ``refresh_if_idle``
+    op so both sides agree what idle means. An attached viewer does NOT hold
+    (the operator's rule; the viewer re-engages on its own), and neither does
+    pristineness — a pristine stale runtime is the cheapest refresh there is.
+    A handle without the probe (an older host, a reduced test handle) never
+    refreshes: unknown state is not an invitation to exit.
+    """
+    may_refresh = getattr(handle, "may_refresh", None)
+    if not callable(may_refresh):
+        return None
+    try:
+        if may_refresh():
+            return None
+    except Exception:  # noqa: BLE001 — uncertainty keeps the runtime
+        logger.debug("refresh predicate failed; keeping runtime", exc_info=True)
+        return None
+    return _build_changed(boot)
 
 
 def _wake_within_window(handle: object, *, now_ms: int | None = None) -> bool:
@@ -180,13 +312,39 @@ async def _reaper(handle: object, runtime: object, stop: asyncio.Event) -> None:
     in-process, with no supervisor involvement.
     """
     grace_s = _grace_seconds()
+    boot: BuildStamp | None = getattr(runtime, "_boot_build", None)
+    next_build_check = time.monotonic() + BUILD_CHECK_S
+
+    async def refresh_check() -> bool:
+        """The refresh branch on its own slower cadence. True once the
+        runtime has retired (the caller returns). Runs on BOTH loop levels
+        below: outside the drain — where an attached viewer, which holds the
+        quiet exit, must not hold this — and inside it, because a grace of
+        minutes (``LOP_SESSION_GRACE_S``) would otherwise starve the check
+        for an unwatched runtime that is exactly the one nobody else will
+        ever refresh."""
+        nonlocal next_build_check
+        if time.monotonic() < next_build_check:
+            return False
+        next_build_check = time.monotonic() + BUILD_CHECK_S
+        newer = _should_refresh(handle, boot)
+        if newer is None:
+            return False
+        return await _refresh_for(newer, handle, runtime, stop)
+
     while not stop.is_set():
         await asyncio.sleep(REAP_CHECK_S)
+        if stop.is_set():
+            continue
+        if await refresh_check():
+            return
         if stop.is_set() or not _should_exit(handle, runtime):
             continue
         deadline = time.monotonic() + grace_s
         while time.monotonic() < deadline:
             await asyncio.sleep(REAP_CHECK_S)
+            if await refresh_check():
+                return
             if stop.is_set() or not _should_exit(handle, runtime):
                 break  # a predicate term flipped back (or shutdown began)
         else:
@@ -199,6 +357,65 @@ async def _reaper(handle: object, runtime: object, stop: asyncio.Event) -> None:
             await _clean_exit(handle, runtime)
             stop.set()  # amain's wait() returns; exit code stays 0
             return
+
+
+async def _refresh_for(
+    newer: "BuildStamp", handle: object, runtime: object, stop: asyncio.Event
+) -> bool:
+    """Announce and retire so the next engage runs ``newer``. True if exited.
+
+    Three checks of the predicate, and each is load-bearing:
+
+    1. Before the stagger (the caller's) — the cheap gate.
+    2. After the stagger — work may have arrived while sixteen siblings
+       spread their exits over ``BUILD_STAGGER_S``; a runtime that picked up
+       a turn meanwhile keeps it and tries again next check.
+    3. After the announce — ``announce_retiring`` is an await (it drains each
+       viewer's writer), and a ``peer_message`` or ``prompt`` can open a turn
+       in that gap. Same shape as ``RuntimeServer._retire_if_pristine``'s
+       re-check after its ``stopping`` broadcast. A turn that starts between
+       THIS re-check and ``_clean_exit`` is aborted by the dispose exactly as
+       a ``stop`` op racing a turn is; the message is persisted and the
+       sender's next engage runs the new build.
+
+    ``retiring`` is announced AFTER the stagger, immediately before exit, so
+    a viewer never waits on a runtime that is merely "about to" leave.
+    """
+    boot: BuildStamp | None = getattr(runtime, "_boot_build", None)
+    delay = random.uniform(0, _build_stagger_seconds())  # noqa: S311 — jitter, not security
+    logger.info(
+        "session runtime: build on disk is %s but this process loaded %s; idle, retiring in "
+        "%.1fs so the next engage runs the new build",
+        newer.label(),
+        boot.label() if boot is not None else "<unknown>",
+        delay,
+    )
+    try:
+        await asyncio.wait_for(stop.wait(), timeout=delay)
+        return False  # a stop landed during the stagger; its path owns the exit
+    except asyncio.TimeoutError:
+        pass
+    if _should_refresh(handle, boot) is None:
+        logger.info("session runtime: work arrived during the refresh stagger; keeping")
+        return False
+    announce = getattr(runtime, "announce_retiring", None)
+    if callable(announce):
+        try:
+            await cast(Callable[..., Awaitable[None]], announce)("stale-build", to=newer.label())
+        except Exception:  # noqa: BLE001 — a viewer that misses this goes cold the slow way
+            logger.debug("retiring announcement failed", exc_info=True)
+    if stop.is_set():
+        return False
+    if _should_refresh(handle, boot) is None:
+        # Refusing AFTER announcing is safe for the same reason it is for
+        # ``stopping``: ``retiring`` only latches the disconnect REASON in an
+        # attach client, and does nothing unless the socket then closes.
+        logger.info("session runtime: work arrived while retiring was announced; keeping")
+        return False
+    logger.info("session runtime: retiring for %s", newer.label())
+    await _clean_exit(handle, runtime)
+    stop.set()
+    return True
 
 
 async def _drain_inbox_into(handle: object) -> int:

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -410,7 +410,18 @@ class RuntimeServer:
         # (see ``app.py``'s update imports) is to keep it off the import graph.
         from local_operator.update import installed_build
 
-        build = installed_build()
+        # ``LOP_BUILD_PREFIX`` is the e2e stage's seam only (see
+        # ``process._build_prefix``): the boot stamp and the reaper's re-read
+        # must come from the SAME root, or a runtime under test would compare
+        # a real install against a fake marker and retire at once.
+        build = installed_build(os.environ.get("LOP_BUILD_PREFIX") or None)
+        #: What this process LOADED, kept for the runtime's self-refresh check:
+        #: ``process._should_refresh`` compares it against the install on disk
+        #: on the reaper's tick and retires an idle runtime whose build has
+        #: moved under it (design-runtime-autorefresh §3.2). Frozen dataclass,
+        #: so the boot snapshot cannot drift toward the disk value it is
+        #: compared against.
+        self._boot_build = build
         self._record = SessionRecord(
             pid=os.getpid(),
             kind=kind,  # type: ignore[arg-type]
@@ -612,6 +623,41 @@ class RuntimeServer:
             return
         if not written.wait(timeout=_ANNOUNCE_WRITE_TIMEOUT_S):
             logger.debug("stop announcement did not reach viewers before the teardown")
+
+    async def announce_retiring(self, reason: str, *, to: str = "") -> None:
+        """Tell attached viewers this runtime is leaving so a NEWER build can
+        take its place — a planned refresh, not a stop and not a death.
+
+        A sibling of :meth:`announce_stop` rather than a reuse of it, and that
+        distinction is the whole point: a viewer that reads ``stopping`` parks
+        in the stopped state and tells the user ``/resume`` reopens it, which
+        is the wrong story for a runtime that retired only because
+        ``lop-update`` ran. ``retiring`` says "a fresh runtime is owed; engage
+        one" and the viewer does so eagerly (``RemoteSession._go_cold(refresh=
+        True)``). Additive on the wire: an old viewer ignores the unknown op,
+        sees the EOF, and runs its ordinary recovery (cold after 8 s) — the
+        pre-refresh behaviour, so no ``PROTOCOL_VERSION`` bump.
+
+        Sent to ATTACH clients only. The phone daemon's projection path stays
+        byte-identical, and the daemon already handles owner exit by adopting
+        the next record it sees.
+
+        Awaited (unlike ``announce_stop``) because its one caller is the
+        reaper on the runtime's own loop, which has time to drain: the exit
+        follows this frame, and a viewer that receives it late merely goes
+        cold the slow way.
+        """
+        if self._closed.is_set():
+            return
+        frame: dict[str, Any] = {
+            "op": "retiring",
+            "session_id": self._record.session_id,
+            "reason": reason,
+            "from": self._boot_build.label(),
+            "to": to,
+        }
+        viewers = [conn for conn in list(self._clients.values()) if conn.kind == "attach"]
+        await asyncio.gather(*(self._send_to(conn, frame) for conn in viewers))
 
     def _write_now(self, frame: dict[str, Any]) -> None:
         """Buffer one frame to every viewer without awaiting a drain.
@@ -829,6 +875,15 @@ class RuntimeServer:
             if self._closed.is_set():
                 return
             try:
+                # The FLOOR for the record's ``busy`` bit, not its fix: the
+                # handle republishes at every turn boundary (the session's
+                # ``on_turn_settled`` hook), and this only bounds how stale a
+                # missed publish can get to one heartbeat. A 15 s-stale bit is
+                # still wrong for the picker; it is right for a `lop sessions`
+                # run hours later, which is the case the hook's absence cost.
+                is_busy = getattr(self._handle, "is_busy", None)
+                if callable(is_busy):
+                    self.set_busy(bool(is_busy()))
                 # A dead renderer can leave its main-process socket alive.
                 # Expiring the lease must reroute a parked gate even when no
                 # TCP disconnect arrives to trigger the ordinary detach path.
@@ -1379,6 +1434,24 @@ class RuntimeServer:
                     detail = f"kept: {observers} viewer(s) still attached"
                 else:
                     detail = await self._retire_if_pristine(leaving=conn)
+            elif op == "refresh_if_idle":
+                # The viewer-side belt for the runtime's own self-refresh
+                # (design-runtime-autorefresh §3.3): a `lop --resume` in the
+                # seconds after `lop-update`, before the reaper has noticed,
+                # binds to a stale idle owner. Rather than paint a notice and
+                # wait ~15-40 s for the reaper, the viewer asks the runtime to
+                # retire NOW if it is idle, and re-engages a fresh one on the
+                # ``retiring`` frame. Same predicate as the reaper
+                # (``OwnedSessionHandle.may_refresh``), same announce, same
+                # re-check after it; no stagger, because one viewer asking for
+                # one runtime is not the sixteen-at-once storm the stagger
+                # bounds. Answers ``retiring`` or ``kept: <reason>``; the
+                # viewer paints its busy notice only on a ``kept: busy``.
+                #
+                # Handled here rather than in ``_dispatch`` for symmetry with
+                # ``retire_if_pristine``: both are lifecycle ops that must not
+                # trigger the post-ack refresh (the exemption list below).
+                detail = await self._refresh_if_idle()
             elif op in _PAYLOAD_OPS:
                 # Structured-answer ops reply with a ``result`` frame whose
                 # ``data`` the invoker renders locally (a slash command's typed
@@ -1429,6 +1502,7 @@ class RuntimeServer:
                 "unwatch_job",
                 "stop",
                 "retire_if_pristine",
+                "refresh_if_idle",
             ):
                 await self._handle.refresh()
                 await self._push()
@@ -1515,6 +1589,54 @@ class RuntimeServer:
         if inspect.isawaitable(result):
             await result
         return "retired"
+
+    async def _refresh_if_idle(self) -> str:
+        """Retire this runtime for the build on disk iff it is idle and stale.
+
+        The viewer-driven twin of the reaper's ``process._refresh_for``, with
+        the stagger removed (see the dispatch comment). Every failure path
+        RETURNS ``kept: …`` rather than raising, and every one keeps the
+        runtime alive — the same asymmetry ``_retire_if_pristine`` records: a
+        wrong "retire" aborts nothing (the predicate is idle by construction)
+        but costs the user a cold start they did not need, a wrong "keep"
+        costs the reaper's next check.
+        """
+        h = self._handle
+        may_refresh = getattr(h, "may_refresh", None)
+        if not callable(may_refresh):
+            return "kept: this runtime cannot judge itself idle"
+        from local_operator.session.runtime import process as process_mod
+
+        newer = process_mod._build_changed(self._boot_build)
+        if newer is None:
+            return "kept: build on disk matches (or has not settled)"
+        try:
+            reason = str(may_refresh() or "")
+        except Exception as exc:  # noqa: BLE001 — uncertainty keeps the runtime
+            return f"kept: idle probe failed ({exc})"
+        if reason:
+            return f"kept: {reason}"
+        request_stop = getattr(h, "request_stop", None)
+        if not callable(request_stop):
+            return "kept: this runtime cannot stop itself gracefully"
+        await self.announce_retiring("stale-build", to=newer.label())
+        # The one await between decision and stop; re-ask, as
+        # ``_retire_if_pristine`` does after its broadcast.
+        try:
+            reason = str(may_refresh() or "")
+        except Exception as exc:  # noqa: BLE001
+            return f"kept: idle probe failed ({exc})"
+        if reason:
+            return f"kept: {reason} (arrived while retiring was announced)"
+        logger.info(
+            "session runtime: viewer asked for a refresh; build on disk is %s, loaded %s; retiring",
+            newer.label(),
+            self._boot_build.label(),
+        )
+        result = request_stop()
+        if inspect.isawaitable(result):
+            await result
+        return "retiring"
 
     def _already_admitted(self, op: str, frame: dict[str, Any]) -> bool:
         """Is this a retry of a turn the transcript already carries?

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1988,6 +1988,20 @@ class Session:
         # occupancy. Carry that newer level to the boundary without rewriting the
         # usage objects that lifetime cost and analytics still need.
         self._held_context_tokens: int | None = None
+        #: Fired once per logical turn, AFTER the turn's terminal event has
+        #: been emitted AND ``is_streaming`` has been cleared, as the last
+        #: statement under ``_turn_lock``. The owned-session handle uses it to
+        #: republish the discovery record's ``busy`` bit; the per-event path
+        #: cannot, because the final ``AgentEndEvent`` is delivered while the
+        #: turn still counts as busy — on the normal path it is the HELD end,
+        #: flushed from the pipeline's ``finally`` with ``_turn_lock`` still
+        #: held; on the abort/error path it is emitted inline while
+        #: ``_is_streaming`` is still True. Either way the last event-driven
+        #: publish carried ``busy=True`` for every turn that did not run through
+        #: the handle's prompt queue — peer wakes, scheduled wakes, background
+        #: result deliveries, resume catch-ups (design-runtime-autorefresh §1.2).
+        #: Sync, non-raising by contract (the pipeline guards it anyway).
+        self.on_turn_settled: Callable[[], None] | None = None
         self._abort_requested = False  # sticky across the continuation gap
         # Boundary-respecting cancel (see request_graceful_cancel). Sticky like
         # ``_abort_requested`` and cleared on the same edges, but honoured at
@@ -5774,6 +5788,20 @@ class Session:
             # aborted turn still hands the notice to the next one instead of
             # stranding it until the session is disposed.
             self._flush_context_journal()
+            # LAST, by design: ``_run_turn``'s own ``finally`` has already
+            # cleared ``_is_streaming`` on the way out of the await above, and
+            # ``_flush_held_end`` has delivered the end event, so a reader
+            # inside the hook sees the turn as genuinely over. The lock is
+            # still held here, which is fine — ``is_busy()`` also reads the
+            # lock, and the next ``_notify`` (or the hook's own republish on
+            # the following turn) settles that; what this guarantees is that
+            # the STREAMING contribution is observed after it changed.
+            settled = self.on_turn_settled
+            if settled is not None:
+                try:
+                    settled()
+                except Exception:  # noqa: BLE001 — a publish failure is not a turn failure
+                    logger.debug("on_turn_settled hook failed", exc_info=True)
 
     async def _flush_held_end(self) -> None:
         """Emit the boundary event the pipeline was holding, if any."""

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -14920,10 +14920,12 @@ class OperatorApp(App[None]):
           construction). The remedy is the RUNTIME's, never the user's: an
           idle stale runtime is asked to retire now (``request_refresh``, the
           belt for the reaper's own self-refresh) and this viewer re-engages
-          a fresh one on its ``retiring`` frame with no notice at all; a busy
-          one is left to finish, and the notice says only that it will move
-          over when its current work does. No notice ever asks the user to
-          ``/stop`` (design-runtime-autorefresh \u00a73.3/\u00a73.5).
+          a fresh one on its ``retiring`` frame with no notice at all. Every
+          other outcome \u2014 a busy runtime, a ``kept`` answer, an old runtime
+          that does not know the op \u2014 is a runtime that is STAYING on the old
+          build, and earns one ``note`` line saying it will move over when its
+          current work finishes. No notice ever asks the user to ``/stop``
+          (design-runtime-autorefresh \u00a73.3/\u00a73.5).
 
         The COPY deliberately says "session" and "window" rather than
         "runtime" and "terminal": the runtime/terminal split is real and
@@ -15025,23 +15027,72 @@ class OperatorApp(App[None]):
         owner = BuildStamp(version=owner_version, source_ref=owner_ref) if owner_version else None
         if owner is not None and owner == loaded:
             return
-        # Stale owner. IDLE: ask it to retire now and say nothing \u2014 the
-        # ``retiring`` frame it answers with re-engages this viewer onto a
-        # fresh runtime (``_on_runtime_refreshed``), and the bind that follows
-        # re-runs this check against a matching stamp. BUSY: one ``note``
-        # line (never a warning: nothing is wrong and nothing is asked of the
-        # user; not ``info`` either, whose dim ink the widget reserves for a
-        # receipt nobody has to read \u2014 this answers "why is my session on
-        # an older version?") saying it will move over when its work finishes,
-        # which the
-        # runtime's own reaper does. The request is fired-and-logged, not
-        # awaited: a runtime that answers ``kept`` (it became busy between
-        # our reading and its own, or it predates the op) is repaired by its
-        # reaper within a settle + stagger, and the notice for THAT state is
-        # painted on the next seam that finds it still stale and busy.
+        # Stale owner, and what the user is told depends on what the RUNTIME
+        # does about it, not on what this viewer guessed.
+        #
+        # IDLE: ask it to retire now (the belt for its own reaper) and say
+        # nothing YET. Only an answer of ``retiring`` earns silence: the
+        # ``retiring`` frame re-engages this viewer onto a fresh runtime
+        # (``_on_runtime_refreshed``) and the bind that follows re-runs this
+        # check against a matching stamp, so the notice would describe a state
+        # that no longer exists by the time it was read.
+        #
+        # Any other answer paints C\u2032. ``kept: \u2026`` means the runtime is
+        # STAYING on the old build \u2014 it became busy between our reading and
+        # its own, or (the upgrade-window population) it predates the op
+        # entirely and answered unknown-op, which is a runtime that can never
+        # self-refresh. Staying silent there left a resume onto a pre-refresh
+        # runtime with no explanation at all, and no later seam would repair
+        # it: an idle seam would take this same branch again (review round 1,
+        # R1-1). Design \u00a73.3 spells out the same rule \u2014 an old runtime's
+        # unknown-op answer is ``kept`` and MUST paint C\u2032.
+        #
+        # BUSY: paint C\u2032 directly, without asking. One ``note`` line (never a
+        # warning: nothing is wrong and nothing is asked of the user; not
+        # ``info`` either, whose dim ink the widget reserves for a receipt
+        # nobody has to read \u2014 this answers "why is my session on an older
+        # version?") saying it will move over when its work finishes, which
+        # the runtime's own reaper does.
         idle_probe = getattr(session, "owner_idle", None)
         ask = getattr(session, "request_refresh", None)
         owner_idle = bool(idle_probe()) if callable(idle_probe) else False
+
+        def announce_stale() -> None:
+            """C\u2032: this session is on an older build and will move on its own.
+
+            One function, two callers (the busy branch and the ``kept`` answer
+            of the idle branch) so the two states cannot drift into two
+            wordings. The version pair is rendered with the same ``old \u2192 new``
+            arrow the drift notice uses (``_build_change``): the parenthetical
+            form wrapped BETWEEN the two stamps on an 80- and 100-column splash,
+            which is where a resume paints it, splitting the one fact the line
+            exists to carry across two rows (design review round 1, D1).
+            """
+            if owner is None:
+                # A runtime older than the field itself. It cannot tell us what
+                # it is running, but the absence is informative: the field ships
+                # in this build, so anything without it is older than this
+                # window.
+                announce(
+                    "owner-unknown",
+                    "",
+                    loaded.label(),
+                    f"{subject} is running an older version than this window \u2014 it "
+                    f"will move to the new version when its current work finishes.",
+                    scope,
+                    notice_kind="note",
+                )
+                return
+            announce(
+                "owner",
+                owner.label(),
+                loaded.label(),
+                f"{subject} is running {owner.label()} \u2192 {loaded.label()} \u2014 it will "
+                f"move to the new version when its current work finishes.",
+                scope,
+                notice_kind="note",
+            )
+
         if owner_idle and callable(ask):
             logger.debug(
                 "build skew (owner) at %s: %s -> %s; owner idle, requesting refresh",
@@ -15051,38 +15102,27 @@ class OperatorApp(App[None]):
             )
 
             async def request() -> None:
+                # Painted from the worker rather than awaited inline: this seam
+                # runs on the bind path and must not block it on a socket
+                # round-trip. The debounce key is unchanged by the deferral, so
+                # a later seam that finds the same state still speaks at most
+                # once \u2014 and a runtime that answered ``retiring`` and then
+                # failed to leave is re-examined by the next bind, which sees a
+                # stale owner again and asks again.
                 try:
                     detail = await cast(Callable[[], Awaitable[str]], ask)()
-                except Exception:  # noqa: BLE001 \u2014 the reaper is the fallback
+                except Exception:  # noqa: BLE001 \u2014 a failed ask is a runtime that stays
                     logger.debug("refresh request failed", exc_info=True)
+                    announce_stale()
                     return
                 logger.debug("refresh request answered: %s", detail)
+                if detail.strip().startswith("retiring"):
+                    return
+                announce_stale()
 
             self.run_worker(request(), group="refresh-request", exclusive=False)
             return
-        if owner is None:
-            # A runtime older than the field itself. It cannot tell us what it
-            # is running, but the absence is informative: the field ships in
-            # this build, so anything without it is older than this window.
-            announce(
-                "owner-unknown",
-                "",
-                loaded.label(),
-                f"{subject} is running an older version than this window \u2014 it "
-                f"will move to the new version when its current work finishes.",
-                scope,
-                notice_kind="note",
-            )
-            return
-        announce(
-            "owner",
-            owner.label(),
-            loaded.label(),
-            f"{subject} is running {owner.label()} (this window is {loaded.label()}) "
-            f"\u2014 it will move to the new version when its current work finishes.",
-            scope,
-            notice_kind="note",
-        )
+        announce_stale()
 
     def _echo_user_command(self, text: str) -> None:
         """Write a slash command into the ledger as the user's own row, IF its
@@ -15193,11 +15233,20 @@ class OperatorApp(App[None]):
                 # Adding a consumer for a type nothing produces does not
                 # disturb ``test_noop_consumers``, which maps producers onto
                 # consumers rather than the reverse.
+                # Two facts, and only the first is a warning: the attach did
+                # NOT happen (the user's request evaporated), which they must
+                # know. The second half used to end in a chore \u2014 "send the
+                # request again then" \u2014 in the same yellow as notice A, whose
+                # ``/reload`` genuinely is an action. Since this build the
+                # runtime refreshes itself, so the resend is not something the
+                # user has to remember: the next message is the natural retry
+                # against whatever runtime is live by then (design review
+                # round 1, D2). Kept ``warning`` because the lost attach is
+                # still the headline; the tail states the automatic repair.
                 self._notice(
                     "this session is running a version too old to attach a team "
                     "(before 0.46.25); nothing was attached. It will move to the new "
-                    "version when its current work finishes \u2014 send the request "
-                    "again then.",
+                    "version on its own when its current work finishes.",
                     "warning",
                 )
                 return

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -15062,11 +15062,19 @@ class OperatorApp(App[None]):
 
             One function, two callers (the busy branch and the ``kept`` answer
             of the idle branch) so the two states cannot drift into two
-            wordings. The version pair is rendered with the same ``old \u2192 new``
-            arrow the drift notice uses (``_build_change``): the parenthetical
-            form wrapped BETWEEN the two stamps on an 80- and 100-column splash,
-            which is where a resume paints it, splitting the one fact the line
-            exists to carry across two rows (design review round 1, D1).
+            wordings. The version pair goes through ``_build_change``, the same
+            formatter notice A uses one block higher: hand-rolling
+            ``old.label() \u2192 new.label()`` rendered this host's HEADLINE drift
+            \u2014 a ``lop-update`` rebuild from ``main`` with no version bump \u2014 as
+            ``0.49.0@aaaaaaa \u2192 0.49.0@bbbbbbb``, restating the version while
+            the seven characters that actually differ were the least prominent
+            thing on the line, and left the two notices naming one fact two
+            ways on one screen (review round 2, R2-2 / design round 2, D3).
+            The arrow form (rather than a parenthetical) is what keeps the pair
+            on ONE row: the parenthetical wrapped BETWEEN the two stamps on an
+            80- and 100-column splash, which is where a resume paints it
+            (design review round 1, D1). ``_build_change``'s collapsed form is
+            shorter still, so D1's fix holds a fortiori.
             """
             if owner is None:
                 # A runtime older than the field itself. It cannot tell us what
@@ -15087,7 +15095,7 @@ class OperatorApp(App[None]):
                 "owner",
                 owner.label(),
                 loaded.label(),
-                f"{subject} is running {owner.label()} \u2192 {loaded.label()} \u2014 it will "
+                f"{subject} is running {_build_change(owner, loaded)} \u2014 it will "
                 f"move to the new version when its current work finishes.",
                 scope,
                 notice_kind="note",
@@ -15116,7 +15124,19 @@ class OperatorApp(App[None]):
                     announce_stale()
                     return
                 logger.debug("refresh request answered: %s", detail)
-                if detail.strip().startswith("retiring"):
+                # COERCED, not trusted. ``ask`` is a duck-typed ``getattr``
+                # probe against arbitrary hosts \u2014 an older runtime facade, an
+                # embedder, a reduced test double \u2014 which is the very
+                # population this notice exists for, and the two in-tree
+                # implementations being annotated ``-> str`` says nothing about
+                # them. Calling ``.strip()`` on the raw answer put an
+                # ``AttributeError`` inside a Textual worker, which runs with
+                # ``exit_on_error=True``: a ``None`` answer ENDED THE SESSION
+                # (``WorkerFailed``) where the previous head merely logged it
+                # (review round 2, R2-1). Everything else this seam probes
+                # degrades rather than raises; a build diagnostic must never be
+                # able to close the window it is diagnosing.
+                if str(detail or "").strip().startswith("retiring"):
                     return
                 announce_stale()
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2820,6 +2820,13 @@ class OperatorApp(App[None]):
             set_stopped = getattr(session, "set_stopped_callback", None)
             if callable(set_stopped):
                 set_stopped(self._on_watched_session_stopped)
+            # The third outcome, and the only one that is housekeeping rather
+            # than an ending: the runtime retired ITSELF because `lop-update`
+            # put a newer build on disk. Re-engage at once so the band never
+            # shows the cold state for a refresh nobody asked for.
+            set_refresh = getattr(session, "set_refresh_callback", None)
+            if callable(set_refresh):
+                set_refresh(self._on_runtime_refreshed)
             # The double-Esc cancel reads the synchronous count the protocol
             # returns, but a follower's REAL count resolves on the owner. The
             # resolver is installed per-press by the Esc handler; arming the
@@ -8497,6 +8504,27 @@ class OperatorApp(App[None]):
         before the user commits to a message.
         """
         self._start_runtime_engage(reason="draft")
+
+    def _on_runtime_refreshed(self) -> None:
+        """The bound runtime retired itself for a newer build; re-engage now.
+
+        Eager rather than lazy (design-runtime-autorefresh §2.3): the next
+        prompt would have engaged anyway (``_ensure_bound``), but the band
+        would show the cold state until the user typed, and the mount path
+        already engages eagerly for exactly that band-completeness reason.
+        The latch is reset because it was set by the engage that bound the
+        runtime that just left — without the reset the first keystroke after
+        ``lop-update`` would pay, in the foreground, a cold start this could
+        have paid in the background. No notice is painted: the operator's bar
+        is "never see this message", the band's ``starting…`` state covers
+        the ~1 s the re-engage takes, and a line of prose for a background
+        housekeeping event is noise. After the bind ``_check_build_skew``
+        runs again and, with a fresh runtime, the owner stamp equals the disk
+        stamp and stays silent.
+        """
+        logger.debug("runtime retired for a newer build; re-engaging")
+        self._warm_engage_started = False
+        self._start_runtime_engage(reason="refresh")
 
     def _start_runtime_engage(self, *, reason: str) -> None:
         """Engage a runtime for a cold viewer, at most once per binding."""
@@ -14889,10 +14917,13 @@ class OperatorApp(App[None]):
         * **owner skew** \u2014 the runtime this session is bound to reports a
           different build than this window, or reports none at all (which
           means it predates the field, and is therefore older by
-          construction). ``/stop`` then sending again is the remedy: the bare
-          ``/stop`` on a follower asks the owner to stop, and the next prompt
-          engages a fresh runtime from the current install. Both keep working
-          in the meantime.
+          construction). The remedy is the RUNTIME's, never the user's: an
+          idle stale runtime is asked to retire now (``request_refresh``, the
+          belt for the reaper's own self-refresh) and this viewer re-engages
+          a fresh one on its ``retiring`` frame with no notice at all; a busy
+          one is left to finish, and the notice says only that it will move
+          over when its current work does. No notice ever asks the user to
+          ``/stop`` (design-runtime-autorefresh \u00a73.3/\u00a73.5).
 
         The COPY deliberately says "session" and "window" rather than
         "runtime" and "terminal": the runtime/terminal split is real and
@@ -14922,7 +14953,15 @@ class OperatorApp(App[None]):
             # only produce false alarms.
             return
 
-        def announce(kind: str, before: str, after: str, body: str, scope: str = "") -> None:
+        def announce(
+            kind: str,
+            before: str,
+            after: str,
+            body: str,
+            scope: str = "",
+            *,
+            notice_kind: NoticeKind = "warning",
+        ) -> None:
             # ``scope`` narrows the debounce from per-process to per-SUBJECT
             # where the subject is what varies: an owner notice describes ONE
             # session's runtime, so a second stale session adopted in the same
@@ -14935,7 +14974,7 @@ class OperatorApp(App[None]):
                 return
             self._skew_notice_shown.add(key)
             logger.debug("build skew (%s) noticed at %s: %s -> %s", kind, reason, before, after)
-            self._system_notice(body, "warning")
+            self._system_notice(body, notice_kind)
 
         # --- A: has the install on disk moved under this process? ----------
         try:
@@ -14981,34 +15020,69 @@ class OperatorApp(App[None]):
         # see; "this session" survives only as the fallback for an unnamed one.
         title = str(getattr(session, "conversation_name", "") or "").strip()
         subject = f"\u201c{title}\u201d" if title else "this session"
-        if not owner_version:
+        from local_operator.update import BuildStamp
+
+        owner = BuildStamp(version=owner_version, source_ref=owner_ref) if owner_version else None
+        if owner is not None and owner == loaded:
+            return
+        # Stale owner. IDLE: ask it to retire now and say nothing \u2014 the
+        # ``retiring`` frame it answers with re-engages this viewer onto a
+        # fresh runtime (``_on_runtime_refreshed``), and the bind that follows
+        # re-runs this check against a matching stamp. BUSY: one ``note``
+        # line (never a warning: nothing is wrong and nothing is asked of the
+        # user; not ``info`` either, whose dim ink the widget reserves for a
+        # receipt nobody has to read \u2014 this answers "why is my session on
+        # an older version?") saying it will move over when its work finishes,
+        # which the
+        # runtime's own reaper does. The request is fired-and-logged, not
+        # awaited: a runtime that answers ``kept`` (it became busy between
+        # our reading and its own, or it predates the op) is repaired by its
+        # reaper within a settle + stagger, and the notice for THAT state is
+        # painted on the next seam that finds it still stale and busy.
+        idle_probe = getattr(session, "owner_idle", None)
+        ask = getattr(session, "request_refresh", None)
+        owner_idle = bool(idle_probe()) if callable(idle_probe) else False
+        if owner_idle and callable(ask):
+            logger.debug(
+                "build skew (owner) at %s: %s -> %s; owner idle, requesting refresh",
+                reason,
+                owner.label() if owner is not None else "<unstamped>",
+                loaded.label(),
+            )
+
+            async def request() -> None:
+                try:
+                    detail = await cast(Callable[[], Awaitable[str]], ask)()
+                except Exception:  # noqa: BLE001 \u2014 the reaper is the fallback
+                    logger.debug("refresh request failed", exc_info=True)
+                    return
+                logger.debug("refresh request answered: %s", detail)
+
+            self.run_worker(request(), group="refresh-request", exclusive=False)
+            return
+        if owner is None:
             # A runtime older than the field itself. It cannot tell us what it
             # is running, but the absence is informative: the field ships in
             # this build, so anything without it is older than this window.
-            # Every resident runtime legitimately trips this once in the
-            # release window, and it is telling the truth each time.
             announce(
                 "owner-unknown",
                 "",
                 loaded.label(),
-                f"{subject} is running an older version than this window \u2014 some "
-                f"commands may not work. /stop, then send again to restart it.",
+                f"{subject} is running an older version than this window \u2014 it "
+                f"will move to the new version when its current work finishes.",
                 scope,
+                notice_kind="note",
             )
             return
-        from local_operator.update import BuildStamp
-
-        owner = BuildStamp(version=owner_version, source_ref=owner_ref)
-        if owner != loaded:
-            announce(
-                "owner",
-                owner.label(),
-                loaded.label(),
-                f"{subject} is running {owner.label()} but this window is "
-                f"{loaded.label()} \u2014 some commands may not work. /stop, then send "
-                f"again to restart it.",
-                scope,
-            )
+        announce(
+            "owner",
+            owner.label(),
+            loaded.label(),
+            f"{subject} is running {owner.label()} (this window is {loaded.label()}) "
+            f"\u2014 it will move to the new version when its current work finishes.",
+            scope,
+            notice_kind="note",
+        )
 
     def _echo_user_command(self, text: str) -> None:
         """Write a slash command into the ledger as the user's own row, IF its
@@ -15121,8 +15195,9 @@ class OperatorApp(App[None]):
                 # consumers rather than the reverse.
                 self._notice(
                     "this session is running a version too old to attach a team "
-                    "(before 0.46.25); nothing was attached. /stop, then send again "
-                    "to restart it.",
+                    "(before 0.46.25); nothing was attached. It will move to the new "
+                    "version when its current work finishes \u2014 send the request "
+                    "again then.",
                     "warning",
                 )
                 return

--- a/local_operator/update.py
+++ b/local_operator/update.py
@@ -572,6 +572,39 @@ def installed_build(prefix: str | Path | None = None) -> BuildStamp:
     return BuildStamp(version=installed_version(), source_ref=source_ref(prefix))
 
 
+def build_marker_age_s(prefix: str | Path | None = None) -> float | None:
+    """Seconds since the install on disk was last written, or ``None``.
+
+    The settle input for a runtime's self-refresh (``process._build_changed``):
+    ``lop-update`` runs ``uv tool install --force`` — which rewrites
+    site-packages over several seconds — and only THEN writes ``.lop-source``,
+    so the marker's mtime is the moment the install became whole. A runtime
+    that acted on a marker younger than ``BUILD_SETTLE_S`` could spawn a
+    successor that imports a torn tree. When there is no marker (a PyPI or
+    pipx install) the ``dist-info`` directory's mtime plays the same role; it
+    is written last by every installer. ``None`` when neither can be read —
+    an editable checkout has no dist-info of its own and no marker, and the
+    caller treats "unknown" as "not settled", which is the safe side.
+    """
+    root = Path(prefix) if prefix is not None else Path(sys.prefix)
+    marker = root / ".lop-source"
+    try:
+        mtime = marker.stat().st_mtime
+    except OSError:
+        try:
+            dist = distribution("local-operator")
+        except PackageNotFoundError:
+            return None
+        located = getattr(dist, "_path", None)
+        if located is None:
+            return None
+        try:
+            mtime = Path(located).stat().st_mtime
+        except OSError:
+            return None
+    return max(0.0, time.time() - mtime)
+
+
 def installer_argv(
     kind: InstallKind,
     *,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,11 @@ _AMBIENT_VARS = (
     # They turn strict --resume validation into adoption of a brand-new id.
     "LOP_RUNTIME_ADOPT_SESSION",
     "LOP_RUNTIME_DEFER_MATERIALISE",
+    # The e2e stage's fake install prefix for the runtime self-refresh: a
+    # runtime that inherited it would compare its boot stamp against a
+    # directory the test owns rather than its real install, and could
+    # retire (or refuse to) on a stranger's marker.
+    "LOP_BUILD_PREFIX",
     # A runtime child spawned by the mobile daemon carries its session id,
     # provider, model and cwd here. A test suite run from inside such a
     # session (agents do this) inherited LOP_MOBILE_CHILD_RESUME and created

--- a/tests/e2e/test_runtime_refresh_e2e.py
+++ b/tests/e2e/test_runtime_refresh_e2e.py
@@ -1,0 +1,459 @@
+"""A stale idle runtime refreshes itself; the viewer never sees a chore.
+
+The operator's requirement, verbatim: "runtimes that are inactive
+automatically refresh and update / bring down the runtime on inactive
+sessions so that resuming would do the update. On resume we should never see
+the [/stop, then send again] message. The user should never need to run
+/stop to refresh or update a runtime."
+
+These tests boot the PRODUCTION ``process.py`` in a subprocess against a
+fake install prefix (``LOP_BUILD_PREFIX`` → a temp dir carrying a
+``.lop-source`` marker), attach the production ``RemoteSession`` under the
+real ``OperatorApp``, and then FLIP the marker the way ``lop-update`` does.
+Asserted on the things a user would notice: the old pid is gone, the viewer
+is bound to a NEW pid, and nothing on screen says ``/stop``, ``interrupted``
+or ``stopped``.
+
+Isolation: the ``headless_tui_env`` fixture redirects the config dir; the
+root conftest redirects ``HOME`` and scrubs the cmux/herdr pane variables.
+The child's environment is rebuilt here with EVERY ``CMUX_*`` removed
+regardless, because a runtime that inherited a workspace id could address
+the operator's live window (#648). Timings that are constants in production
+(settle, stagger) are shortened through the test-only env overrides
+``process.py`` reads.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.session.runtime import registry
+from local_operator.tui.app import OperatorApp
+from local_operator.update import BuildStamp
+from tests.e2e.harness import transcript_text, wait_for_adoption
+from tests.e2e.watchdog import bounded
+
+pytestmark = pytest.mark.e2e
+
+#: The words the operator must never read after a refresh. ``stopped`` covers
+#: the parked "this session was stopped" screen a mis-read ``stopping`` frame
+#: would park the viewer in; ``interrupted`` the synthesised abort a viewer
+#: paints for owner death; ``/stop`` the chore itself.
+FORBIDDEN = ("/stop", "interrupted", "stopped")
+
+OLD_MARKER = "46a4e9b1234567890abcdef v0.49.8\n"
+NEW_MARKER = "f4a70b991234567890abcdef v0.49.9\n"
+
+
+def _seed(config_dir: Path, session_id: str) -> None:
+    """A session with one durable row, on the mock provider."""
+    directory = config_dir / "sessions" / session_id
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "transcript.jsonl").write_text(
+        '{"id": "seed", "ts": 1, "type": "message", "payload": {"kind": "message", '
+        '"role": "user", "content": [{"type": "text", "text": "seed"}]}}\n',
+        encoding="utf-8",
+    )
+    (config_dir / "config.yml").write_text(
+        "values:\n  hosting: test\n  model_name: mock\n", encoding="utf-8"
+    )
+
+
+def _child_env(config_dir: Path, prefix: Path, session_id: str, **extra: str) -> dict[str, str]:
+    env = {k: v for k, v in os.environ.items() if not k.startswith("CMUX_")}
+    env.update(
+        {
+            "LOCAL_OPERATOR_CONFIG_DIR": str(config_dir),
+            "LOP_MOBILE_CHILD_CWD": str(config_dir),
+            "LOP_MOBILE_CHILD_RESUME": session_id,
+            "LOP_BUILD_PREFIX": str(prefix),
+            # Fast enough to observe inside the watchdog, slow enough that a
+            # marker written mid-test is not acted on before it is whole.
+            "LOP_BUILD_SETTLE_S": "0.5",
+            "LOP_BUILD_STAGGER_S": "0.5",
+            # A long grace so the QUIET exit can never be the thing that
+            # retires the runtime in these tests; only the refresh may.
+            "LOP_SESSION_GRACE_S": "120",
+        }
+    )
+    env.update(extra)
+    return env
+
+
+def _spawn(
+    config_dir: Path, prefix: Path, session_id: str, **extra: str
+) -> subprocess.Popen[bytes]:
+    return subprocess.Popen(
+        [sys.executable, "-m", "local_operator.session.runtime.process"],
+        env=_child_env(config_dir, prefix, session_id, **extra),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
+def _record_for(config_dir: Path, session_id: str) -> Any:
+    for record, _state in registry.scan(config_dir):
+        if getattr(record, "session_id", "") == session_id:
+            return record
+    return None
+
+
+async def _wait_for_record(config_dir: Path, session_id: str, timeout: float = 30.0) -> Any:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        record = _record_for(config_dir, session_id)
+        if record is not None:
+            return record
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"no record for {session_id} within {timeout}s")
+
+
+def _alive(child: subprocess.Popen[bytes]) -> bool:
+    """Whether OUR child is still running.
+
+    ``os.kill(pid, 0)`` is the wrong probe for a process this test spawned:
+    an exited child stays a ZOMBIE — kill(0) succeeds — until it is reaped,
+    so the runtime looked resident for the whole 30 s budget after it had
+    already retired. ``poll()`` reaps and answers.
+    """
+    return child.poll() is None
+
+
+async def _never_take_over() -> Any:
+    raise AssertionError("a viewer never takes over a session")
+
+
+def _flip(prefix: Path) -> None:
+    """What ``lop-update`` does last: rewrite the marker to the new build."""
+    (prefix / ".lop-source").write_text(NEW_MARKER, encoding="utf-8")
+
+
+def _stale_child_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every runtime the VIEWER spawns (``engage_runtime`` → ``sys.executable
+    -m process``) inherits this process's environment, so the successor must
+    see the same fake prefix and stay on it — otherwise it would boot on the
+    real install's stamp, and the viewer would paint owner skew against a
+    build this test does not control."""
+    for name in list(os.environ):
+        if name.startswith("CMUX_"):
+            monkeypatch.delenv(name, raising=False)
+
+
+@pytest.mark.asyncio
+async def test_a_watched_idle_runtime_refreshes_and_the_viewer_rebinds_silently(
+    headless_tui_env: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Design test 13: the resume-then-update case, end to end.
+
+    Boot a runtime on OLD, attach a real viewer under the real app, flip the
+    marker to NEW. Within the settle + stagger the old pid must be gone, the
+    record must name a NEW pid, the viewer must be bound (not cold), and the
+    ledger must contain none of :data:`FORBIDDEN`.
+    """
+    from local_operator.session.remote import RemoteSession
+
+    _stale_child_env(monkeypatch)
+    config = headless_tui_env
+    session_id = "refreshsess1"
+    _seed(config, session_id)
+    prefix = tmp_path / "prefix"
+    prefix.mkdir()
+    (prefix / ".lop-source").write_text(OLD_MARKER, encoding="utf-8")
+    # The viewer's spawn path and its own skew check read the same prefix.
+    monkeypatch.setenv("LOP_BUILD_PREFIX", str(prefix))
+    monkeypatch.setenv("LOP_BUILD_SETTLE_S", "0.5")
+    monkeypatch.setenv("LOP_BUILD_STAGGER_S", "0.5")
+    monkeypatch.setenv("LOP_SESSION_GRACE_S", "120")
+
+    child = _spawn(config, prefix, session_id)
+    viewer = None
+    app = None
+    try:
+        record = await _wait_for_record(config, session_id)
+        old_pid = int(record.pid)
+        assert old_pid == child.pid
+        assert record.source_ref == OLD_MARKER.split()[0]
+
+        viewer = await RemoteSession.connect(
+            record, session_id, config_dir=config, takeover_factory=_never_take_over
+        )
+        assert not viewer.is_cold
+
+        async def factory() -> Any:
+            return viewer
+
+        app = OperatorApp(factory)
+        with bounded(90, "runtime refresh: watched idle runtime"):
+            async with app.run_test(size=(100, 30)) as pilot:
+                await wait_for_adoption(app, pilot)
+                # A matching stamp on both sides: no owner-skew notice at
+                # adopt. (The window's own stamp is the real install's, which
+                # this test does not control, so the check is on the copy.)
+                app._loaded_build = BuildStamp(version=record.version, source_ref=record.source_ref)
+                await pilot.pause()
+
+                _flip(prefix)
+
+                # Wait on the EVENT — the old pid exiting — never on a clock.
+                deadline = time.monotonic() + 30
+                while time.monotonic() < deadline and _alive(child):
+                    await pilot.pause()
+                    await asyncio.sleep(0.05)
+                assert not _alive(child), "the stale idle runtime never retired"
+                assert child.returncode == 0, f"the runtime exited {child.returncode}"
+
+                # The viewer re-engages eagerly: a new record, a new pid, bound.
+                deadline = time.monotonic() + 30
+                new_record = None
+                while time.monotonic() < deadline:
+                    new_record = _record_for(config, session_id)
+                    if (
+                        new_record is not None
+                        and int(new_record.pid) != old_pid
+                        and not viewer.is_cold
+                    ):
+                        break
+                    await pilot.pause()
+                    await asyncio.sleep(0.05)
+                assert (
+                    new_record is not None and int(new_record.pid) != old_pid
+                ), "no successor runtime was engaged after the refresh"
+                assert not viewer.is_cold, "the viewer must be bound to the successor"
+                assert (
+                    new_record.source_ref == NEW_MARKER.split()[0]
+                ), "the successor must run the NEW build"
+                await pilot.pause()
+                text = transcript_text(app)
+                for word in FORBIDDEN:
+                    assert word not in text, f"{word!r} reached the ledger:\n{text}"
+                successor_pid = int(new_record.pid)
+        # Leaving the app disposes the viewer; the successor is retired by
+        # the offer-back or the drain. Kill it outright below either way.
+    finally:
+        if viewer is not None:
+            try:
+                await viewer.dispose()
+            except Exception:  # noqa: BLE001
+                pass
+        for pid in {child.pid, *(int(r.pid) for r, _ in registry.scan(config))}:
+            try:
+                os.kill(pid, 9)
+            except ProcessLookupError:
+                pass
+        child.wait(timeout=10)
+    assert successor_pid != old_pid
+
+
+@pytest.mark.asyncio
+async def test_a_busy_runtime_waits_and_refreshes_when_its_turn_ends(
+    headless_tui_env: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Design test 14: never mid-turn.
+
+    The mock provider's ``[bash:N]`` marker calls the REAL ``bash`` tool
+    with ``sleep N`` — a runtime that is genuinely busy (a tool slot held, the
+    turn lock taken) for a known duration, on a config that auto-approves so
+    the gate never parks it. The refresh must not fire while that sleeps;
+    once the turn ends the old pid retires and a successor is engaged — with
+    none of :data:`FORBIDDEN` on screen at any point, and the turn's reply
+    persisted (the update did not cost the work).
+    """
+    from local_operator.session.remote import RemoteSession
+
+    _stale_child_env(monkeypatch)
+    config = headless_tui_env
+    session_id = "refreshbusy1"
+    _seed(config, session_id)
+    (config / "config.yml").write_text(
+        "values:\n  hosting: test\n  model_name: mock\n  tool_approval_mode: auto\n",
+        encoding="utf-8",
+    )
+    prefix = tmp_path / "prefix"
+    prefix.mkdir()
+    (prefix / ".lop-source").write_text(OLD_MARKER, encoding="utf-8")
+    monkeypatch.setenv("LOP_BUILD_PREFIX", str(prefix))
+    monkeypatch.setenv("LOP_BUILD_SETTLE_S", "0.5")
+    monkeypatch.setenv("LOP_BUILD_STAGGER_S", "0.5")
+    monkeypatch.setenv("LOP_SESSION_GRACE_S", "120")
+
+    child = _spawn(config, prefix, session_id)
+    viewer = None
+    try:
+        record = await _wait_for_record(config, session_id)
+        old_pid = int(record.pid)
+        viewer = await RemoteSession.connect(
+            record, session_id, config_dir=config, takeover_factory=_never_take_over
+        )
+
+        async def factory() -> Any:
+            return viewer
+
+        app = OperatorApp(factory)
+        with bounded(120, "runtime refresh: busy runtime"):
+            async with app.run_test(size=(100, 30)) as pilot:
+                await wait_for_adoption(app, pilot)
+                app._loaded_build = BuildStamp(version=record.version, source_ref=record.source_ref)
+                await pilot.pause()
+                # A turn that holds the bash tool for ~6 s: BUSY by every
+                # measure (turn lock, streaming, a running tool).
+                await viewer.prompt("please [bash:6]")
+                deadline = time.monotonic() + 30
+                while time.monotonic() < deadline:
+                    state = getattr(viewer, "frontend_state", None)
+                    if state is not None and getattr(state, "streaming", False):
+                        break
+                    await pilot.pause()
+                    await asyncio.sleep(0.05)
+                else:
+                    raise AssertionError("the runtime never started the turn")
+
+                _flip(prefix)
+                # Long enough for settle + stagger + several checks to have
+                # passed had the runtime wrongly considered itself idle, and
+                # short enough that the sleep is still running.
+                held_until = time.monotonic() + 3.0
+                while time.monotonic() < held_until:
+                    assert _alive(child), "a BUSY runtime retired mid-turn"
+                    await pilot.pause()
+                    await asyncio.sleep(0.1)
+
+                # The sleep ends, the turn completes; the runtime is now idle
+                # AND stale, and must retire on its own.
+                deadline = time.monotonic() + 30
+                while time.monotonic() < deadline and _alive(child):
+                    await pilot.pause()
+                    await asyncio.sleep(0.05)
+                assert not _alive(child), "the runtime never retired after its turn ended"
+
+                deadline = time.monotonic() + 30
+                new_record = None
+                while time.monotonic() < deadline:
+                    new_record = _record_for(config, session_id)
+                    if (
+                        new_record is not None
+                        and int(new_record.pid) != old_pid
+                        and not viewer.is_cold
+                    ):
+                        break
+                    await pilot.pause()
+                    await asyncio.sleep(0.05)
+                assert new_record is not None and int(new_record.pid) != old_pid
+                assert not viewer.is_cold
+                await pilot.pause()
+                text = transcript_text(app)
+                for word in FORBIDDEN:
+                    assert word not in text, f"{word!r} reached the ledger:\n{text}"
+                assert (
+                    "Hello from the mock provider!" in text
+                ), "the turn that was live during the update must have completed"
+    finally:
+        if viewer is not None:
+            try:
+                await viewer.dispose()
+            except Exception:  # noqa: BLE001
+                pass
+        for pid in {child.pid, *(int(r.pid) for r, _ in registry.scan(config))}:
+            try:
+                os.kill(pid, 9)
+            except ProcessLookupError:
+                pass
+        child.wait(timeout=10)
+
+
+def test_an_unwatched_idle_runtime_retires_and_spawns_nothing(
+    headless_tui_env: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Design test 15: no viewer, no successor.
+
+    An unwatched stale runtime retires; NOTHING re-spawns it (only a viewer
+    triggers an eager successor). The next engage — here the CLI's
+    ``lop send`` path, which is what a peer or a wake would use — then boots
+    a runtime from the new stamp.
+    """
+    _stale_child_env(monkeypatch)
+    config = headless_tui_env
+    session_id = "refreshcold1"
+    _seed(config, session_id)
+    prefix = tmp_path / "prefix"
+    prefix.mkdir()
+    (prefix / ".lop-source").write_text(OLD_MARKER, encoding="utf-8")
+    monkeypatch.setenv("LOP_BUILD_PREFIX", str(prefix))
+    monkeypatch.setenv("LOP_BUILD_SETTLE_S", "0.5")
+    monkeypatch.setenv("LOP_BUILD_STAGGER_S", "0.5")
+    monkeypatch.setenv("LOP_SESSION_GRACE_S", "120")
+
+    child = _spawn(config, prefix, session_id)
+    try:
+        deadline = time.monotonic() + 30
+        record = None
+        while time.monotonic() < deadline:
+            record = _record_for(config, session_id)
+            if record is not None:
+                break
+            time.sleep(0.05)
+        assert record is not None
+        old_pid = int(record.pid)
+        assert record.source_ref == OLD_MARKER.split()[0]
+
+        _flip(prefix)
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline and _alive(child):
+            time.sleep(0.05)
+        assert not _alive(child), "the unwatched stale runtime never retired"
+        assert child.returncode == 0
+
+        # NO successor: nothing was watching, nothing is owed.
+        time.sleep(1.0)
+        assert _record_for(config, session_id) is None, "an unwatched refresh must spawn nothing"
+
+        # The next engage runs the new build. ``lop send`` is the peer/wake
+        # path: it engages a runtime for the target when none is live.
+        env = _child_env(config, prefix, session_id)
+        env.pop("LOP_MOBILE_CHILD_RESUME")
+        env.pop("LOP_MOBILE_CHILD_CWD")
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import sys; from local_operator.cli import main; sys.exit(main())",
+                "send",
+                "--session",
+                session_id,
+                "--wake",
+                "hello",
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        deadline = time.monotonic() + 30
+        new_record = None
+        while time.monotonic() < deadline:
+            new_record = _record_for(config, session_id)
+            if new_record is not None and int(new_record.pid) != old_pid:
+                break
+            time.sleep(0.05)
+        assert (
+            new_record is not None and int(new_record.pid) != old_pid
+        ), "`lop send` must engage a fresh runtime for the retired session"
+        assert new_record.source_ref == NEW_MARKER.split()[0], "…from the NEW build"
+    finally:
+        for pid in {child.pid, *(int(r.pid) for r, _ in registry.scan(config))}:
+            try:
+                os.kill(pid, 9)
+            except ProcessLookupError:
+                pass
+        child.wait(timeout=10)

--- a/tests/unit/session/runtime/test_busy_settles.py
+++ b/tests/unit/session/runtime/test_busy_settles.py
@@ -1,0 +1,176 @@
+"""The record's ``busy`` bit must settle when the TURN settles — every turn.
+
+**This file exists because the published bit stuck at ``True`` after any turn
+that did not run through the prompt queue.** ``_observe_prompt_drain`` was the
+only publisher that fires AFTER the final ``AgentEndEvent``, because that event
+is emitted while ``Session._is_streaming`` is still True (cleared in
+``_run_turn``'s ``finally``); the per-event publish therefore carries ``True``
+and nothing after it fires. A peer wake (``lop send``), a scheduled wake, a
+background-job result delivery and a resume catch-up all open their turn with
+``_spawn_background(self._prompt_messages(...))`` — none of them touch the
+drain — so ``lop sessions`` showed a running marker on a session that had been
+idle for five hours (design-runtime-autorefresh.md §1.2).
+
+The fix is a turn-boundary hook, ``Session.on_turn_settled``, fired from
+``_run_turn_pipeline``'s ``finally`` after ``_is_streaming`` is already False.
+These tests drive the REAL ``Session`` behind the production handle and
+server, so the seam under test is the one production runs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.harness.types import AgentEndEvent
+from local_operator.session.runtime.owned import OwnedSessionHandle
+from local_operator.session.runtime.server import RuntimeServer
+from tests.e2e.harness import ScriptedStream, build_session, text_turn
+
+
+async def _rig(directory: Path, replies: int = 2) -> tuple[Any, OwnedSessionHandle, RuntimeServer]:
+    """A real Session under the production handle and a server that is NOT
+    listening: the record's busy bit lives on ``server._busy`` regardless, and
+    the projection subscription is what ``_serve`` installs first."""
+    directory.mkdir(parents=True, exist_ok=True)
+    stream = ScriptedStream([text_turn(f"reply {i}") for i in range(replies)])
+    session = build_session(directory, stream)
+    handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd=str(directory))
+    server = RuntimeServer(handle, kind="daemon")
+    handle.subscribe(server._schedule_push)
+    return session, handle, server
+
+
+def _watch_turn_end(session: Any) -> asyncio.Event:
+    """An event set when the session's final ``AgentEndEvent`` is delivered.
+
+    Every opener except ``prompt(wait_complete=True)`` returns BEFORE its turn
+    runs (the turn is a background task), so a test that checked the record
+    straight away would read the idle it started with and prove nothing.
+    Waiting on the end event is what makes the assertion about the turn.
+    """
+    ended = asyncio.Event()
+
+    def on_event(event: Any) -> None:
+        if isinstance(event, AgentEndEvent):
+            ended.set()
+
+    session.subscribe(on_event)
+    return ended
+
+
+async def _settle(
+    ended: asyncio.Event, handle: OwnedSessionHandle, server: RuntimeServer, timeout: float = 5.0
+) -> None:
+    """Wait for the turn to END, then bounded-poll until the record agrees.
+
+    Never a fixed sleep: the bit is expected to settle within a couple of loop
+    iterations of the turn ending, so the poll is on the record itself and the
+    deadline only bounds a genuine regression. On the unfixed tree the poll
+    runs to the deadline and the caller's assertion names the bit.
+    """
+    await asyncio.wait_for(ended.wait(), timeout)
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + 0.5
+    while loop.time() < deadline:
+        if not handle.is_busy() and not server._busy:
+            return
+        await asyncio.sleep(0.01)
+    assert not handle.is_busy(), "the handle itself never went idle"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["prompt", "mailbox-wake", "idle-steer", "background-prompt"])
+async def test_the_record_busy_bit_settles_for_every_turn_shape(tmp_path: Path, path: str) -> None:
+    """The four ways a turn opens; the record must read idle after each.
+
+    Before the hook only the ``prompt`` cell passed (verified on b0db51d9c:
+    ``mailbox-wake`` and ``idle-steer`` left ``server._busy`` True with
+    ``handle.is_busy()`` False).
+    """
+    session, handle, server = await _rig(tmp_path / "sess")
+    ended = _watch_turn_end(session)
+    try:
+        if path == "prompt":
+            await handle.prompt("hello", wait_complete=True)
+        elif path == "mailbox-wake":
+            await handle.receive_peer_message("wake up", mode="mailbox", wake=True)
+        elif path == "idle-steer":
+            await handle.receive_peer_message("steer me", mode="steer")
+        else:
+            from local_operator.harness.types import Message
+
+            session._spawn_background(session._prompt_messages([Message.user("bg")]))
+        await _settle(ended, handle, server)
+        assert handle.is_busy() is False
+        assert server._busy is False, f"{path}: the record still says busy after the turn"
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_on_turn_settled_fires_after_streaming_cleared_and_after_the_end_event(
+    tmp_path: Path,
+) -> None:
+    """Ordering is the contract: the hook is useless one line earlier.
+
+    Asserted INSIDE the hook — ``is_streaming`` must already be False and the
+    final ``AgentEndEvent`` must already have reached subscribers — because
+    that is the state the handle's ``is_busy()`` reads when the hook
+    republishes. The end event is the HELD one on this path, flushed from the
+    pipeline's ``finally`` after ``_run_turn`` cleared the flag but while
+    ``_turn_lock`` is still held: so at delivery ``is_busy()`` is True (the
+    lock), and the hook — last under the lock — is the earliest point after
+    which a deferred publish reads idle. That is why the handle defers it
+    one loop iteration, and why the third row below must read ``busy=False``.
+    """
+    session, handle, server = await _rig(tmp_path / "sess", replies=1)
+    seen: list[str] = []
+    ended = _watch_turn_end(session)
+
+    def on_event(event: Any) -> None:
+        if isinstance(event, AgentEndEvent):
+            seen.append(f"end:streaming={session.is_streaming}:busy={handle.is_busy()}")
+
+    session.subscribe(on_event)
+    inner = session.on_turn_settled
+
+    def settled() -> None:
+        seen.append(f"settled:streaming={session.is_streaming}")
+        if inner is not None:
+            inner()
+        asyncio.get_running_loop().call_soon(
+            lambda: seen.append(f"deferred:busy={handle.is_busy()}")
+        )
+
+    session.on_turn_settled = settled
+    try:
+        await handle.receive_peer_message("wake up", mode="mailbox", wake=True)
+        await _settle(ended, handle, server)
+    finally:
+        await session.dispose()
+    assert seen == [
+        "end:streaming=False:busy=True",
+        "settled:streaming=False",
+        "deferred:busy=False",
+    ], seen
+
+
+@pytest.mark.asyncio
+async def test_a_raising_hook_does_not_fail_the_turn(tmp_path: Path) -> None:
+    """A publish failure is not a turn failure: the hook is guarded."""
+    session, handle, server = await _rig(tmp_path / "sess", replies=1)
+
+    def boom() -> None:
+        raise RuntimeError("publisher exploded")
+
+    session.on_turn_settled = boom
+    try:
+        detail = await handle.prompt("hello", wait_complete=True)
+        assert "admitted" in detail
+        assert session.history(), "the turn must have run to completion"
+    finally:
+        await session.dispose()

--- a/tests/unit/session/runtime/test_process_refresh.py
+++ b/tests/unit/session/runtime/test_process_refresh.py
@@ -1,0 +1,338 @@
+"""The runtime's self-refresh: an idle runtime whose build has moved under it
+retires, announced, so the next engage runs the build on disk
+(design-runtime-autorefresh §3.2/§3.4).
+
+Same fakes as ``test_process_reaper.py``. The predicate under test is
+``OwnedSessionHandle.may_refresh`` reached through ``process._should_refresh``;
+the fakes carry a ``may_refresh`` of their own so the reaper's branch can be
+driven without a Session.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+import pytest
+
+from local_operator import update as update_mod
+from local_operator.session.runtime import process as child_mod
+from local_operator.session.runtime.process import (
+    _build_changed,
+    _reaper,
+    _should_exit,
+    _should_refresh,
+)
+from local_operator.update import BuildStamp
+
+OLD = BuildStamp(version="0.49.8", source_ref="46a4e9b1234567")
+NEW = BuildStamp(version="0.49.9", source_ref="f4a70b991234567")
+
+
+class FakeRegistrant:
+    def __init__(self, *, attaches: int = 0, boot: BuildStamp | None = OLD) -> None:
+        self.watch_supported = False
+        self.phone_watchers = 0
+        self._attaches = attaches
+        self.closed = False
+        self._boot_build = boot
+        self.retiring: list[tuple[str, str]] = []
+
+    def attach_clients(self) -> int:
+        return self._attaches
+
+    async def announce_retiring(self, reason: str, *, to: str = "") -> None:
+        self.retiring.append((reason, to))
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class FakeHandle:
+    """Carries the SAME two-term predicate the real handle does."""
+
+    def __init__(self, *, busy: bool = False, next_wake_ms: int | None = None) -> None:
+        self._busy = busy
+        self._next_wake_ms = next_wake_ms
+        self.disposed = False
+        self.probes = 0
+        self.on_probe: Any = None
+
+    def is_busy(self) -> bool:
+        return self._busy
+
+    def next_wake_due_at(self) -> int | None:
+        return self._next_wake_ms
+
+    def may_refresh(self) -> str:
+        self.probes += 1
+        if self.on_probe is not None:
+            self.on_probe(self.probes)
+        if self.is_busy():
+            return "busy"
+        if child_mod._wake_within_window(self):
+            return "wake due within the warm window"
+        return ""
+
+    def _deny_pending_gates(self) -> None:
+        pass
+
+    async def dispose(self) -> None:
+        self.disposed = True
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+@pytest.fixture
+def disk(monkeypatch):
+    """Control what ``installed_build``/``build_marker_age_s`` report."""
+    state = {"build": NEW, "age": 999.0}
+    monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: state["build"])
+    monkeypatch.setattr(update_mod, "build_marker_age_s", lambda *_a, **_k: state["age"])
+    monkeypatch.delenv("LOP_BUILD_SETTLE_S", raising=False)
+    monkeypatch.delenv("LOP_BUILD_STAGGER_S", raising=False)
+    monkeypatch.delenv("LOP_BUILD_PREFIX", raising=False)
+    return state
+
+
+# -- 4. the predicate -----------------------------------------------------------
+
+
+def test_busy_never_refreshes(disk) -> None:
+    assert _should_refresh(FakeHandle(busy=True), OLD) is None
+
+
+def test_wake_inside_warm_window_never_refreshes(disk) -> None:
+    handle = FakeHandle(next_wake_ms=_now_ms() + 30_000)
+    assert _should_refresh(handle, OLD) is None
+
+
+def test_wake_beyond_warm_window_refreshes(disk) -> None:
+    handle = FakeHandle(next_wake_ms=_now_ms() + 3_600_000)
+    assert _should_refresh(handle, OLD) == NEW
+
+
+def test_attached_viewer_does_not_hold_a_refresh(disk) -> None:
+    """THE operator's rule, pinned: term 3 of ``_should_exit`` holds a quiet
+    exit, and must NOT hold a refresh — that is exactly what kept a
+    five-hour-stale runtime resident while a `--resume` looked at it."""
+    handle = FakeHandle()
+    reg = FakeRegistrant(attaches=2)
+    assert _should_exit(handle, reg) is False
+    assert _should_refresh(handle, OLD) == NEW
+
+
+def test_pristine_runtime_refreshes(disk) -> None:
+    # Pristineness is not a term at all; an idle pristine runtime refreshes.
+    assert _should_refresh(FakeHandle(), OLD) == NEW
+
+
+def test_a_handle_without_the_probe_never_refreshes(disk) -> None:
+    class Bare:
+        pass
+
+    class Broken:
+        def may_refresh(self) -> str:
+            raise RuntimeError("scheduler gone")
+
+    assert _should_refresh(Bare(), OLD) is None
+    assert _should_refresh(Broken(), OLD) is None
+
+
+# -- 5. build change + settle ---------------------------------------------------
+
+
+def test_same_stamp_is_no_change(disk) -> None:
+    disk["build"] = OLD
+    assert _build_changed(OLD) is None
+
+
+def test_no_boot_stamp_is_no_change(disk) -> None:
+    assert _build_changed(None) is None
+
+
+def test_different_ref_inside_settle_waits(disk) -> None:
+    disk["age"] = child_mod.BUILD_SETTLE_S / 2
+    assert _build_changed(OLD) is None
+
+
+def test_different_ref_past_settle_changes(disk) -> None:
+    disk["age"] = child_mod.BUILD_SETTLE_S + 1
+    assert _build_changed(OLD) == NEW
+
+
+def test_unknown_marker_age_waits(disk) -> None:
+    disk["age"] = None
+    assert _build_changed(OLD) is None
+
+
+def test_version_only_change_without_marker(disk) -> None:
+    # A PyPI install: no ``.lop-source``; BuildStamp compares on version.
+    disk["build"] = BuildStamp(version="0.50.0")
+    assert _build_changed(BuildStamp(version="0.49.9")) == BuildStamp(version="0.50.0")
+
+
+def test_unreadable_stamp_is_no_change(disk, monkeypatch) -> None:
+    def boom(*_a, **_k):
+        raise OSError("dist-info gone")
+
+    monkeypatch.setattr(update_mod, "installed_build", boom)
+    assert _build_changed(OLD) is None
+
+
+def test_settle_and_stagger_env_overrides(monkeypatch) -> None:
+    monkeypatch.delenv("LOP_BUILD_SETTLE_S", raising=False)
+    assert child_mod._build_settle_seconds() == child_mod.BUILD_SETTLE_S == 10.0
+    monkeypatch.setenv("LOP_BUILD_SETTLE_S", "0.2")
+    assert child_mod._build_settle_seconds() == 0.2
+    monkeypatch.setenv("LOP_BUILD_SETTLE_S", "0")
+    assert child_mod._build_settle_seconds() == 10.0, "zero is the torn-tree race; refused"
+    monkeypatch.setenv("LOP_BUILD_SETTLE_S", "nope")
+    assert child_mod._build_settle_seconds() == 10.0
+    monkeypatch.setenv("LOP_BUILD_STAGGER_S", "0.5")
+    assert child_mod._build_stagger_seconds() == 0.5
+
+
+# -- 6. the reaper branch -------------------------------------------------------
+
+
+async def _run_until(stop: asyncio.Event, timeout: float = 3.0) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline and not stop.is_set():
+        await asyncio.sleep(0.01)
+
+
+@pytest.mark.asyncio
+async def test_stamp_flip_announces_then_exits(disk, monkeypatch) -> None:
+    """Flip mid-loop → ``retiring`` announced with both stamps, clean exit,
+    ``stop`` set. A viewer being attached does not matter."""
+    monkeypatch.setattr(child_mod, "REAP_CHECK_S", 0.01)
+    monkeypatch.setattr(child_mod, "BUILD_CHECK_S", 0.03)
+    monkeypatch.setenv("LOP_BUILD_STAGGER_S", "0.05")
+    monkeypatch.setenv("LOP_SESSION_GRACE_S", "60")  # the quiet exit must not win
+    disk["build"] = OLD
+    reg = FakeRegistrant(attaches=1)
+    handle = FakeHandle()
+    stop = asyncio.Event()
+    task = asyncio.ensure_future(_reaper(handle, reg, stop))
+    await asyncio.sleep(0.1)
+    assert not stop.is_set() and reg.retiring == []
+    disk["build"] = NEW  # lop-update ran
+    await _run_until(stop)
+    assert stop.is_set()
+    assert reg.retiring == [("stale-build", NEW.label())]
+    assert handle.disposed and reg.closed
+    await task
+
+
+@pytest.mark.asyncio
+async def test_work_arriving_after_the_announce_keeps_the_runtime(disk, monkeypatch) -> None:
+    """The re-check after ``announce_retiring`` is load-bearing: a
+    ``peer_message`` can open a turn in that await."""
+    monkeypatch.setattr(child_mod, "REAP_CHECK_S", 0.01)
+    monkeypatch.setattr(child_mod, "BUILD_CHECK_S", 0.02)
+    monkeypatch.setenv("LOP_BUILD_STAGGER_S", "0.02")
+    monkeypatch.setenv("LOP_SESSION_GRACE_S", "60")
+    reg = FakeRegistrant()
+    handle = FakeHandle()
+
+    async def announce(reason: str, *, to: str = "") -> None:
+        reg.retiring.append((reason, to))
+        if len(reg.retiring) == 1:
+            handle._busy = True  # a turn starts between announce and exit, ONCE
+
+    reg.announce_retiring = announce  # type: ignore[method-assign]
+    stop = asyncio.Event()
+    task = asyncio.ensure_future(_reaper(handle, reg, stop))
+    await asyncio.sleep(0.25)
+    assert reg.retiring, "the announce must have gone out"
+    assert not stop.is_set() and not handle.disposed, "busy after the announce keeps it"
+    handle._busy = False  # the turn ends; the next check retires
+    await _run_until(stop)
+    assert stop.is_set() and handle.disposed
+    await task
+
+
+@pytest.mark.asyncio
+async def test_work_arriving_during_the_stagger_keeps_the_runtime(disk, monkeypatch) -> None:
+    monkeypatch.setattr(child_mod, "REAP_CHECK_S", 0.01)
+    monkeypatch.setattr(child_mod, "BUILD_CHECK_S", 0.02)
+    monkeypatch.setenv("LOP_BUILD_STAGGER_S", "0.3")
+    monkeypatch.setenv("LOP_SESSION_GRACE_S", "60")
+    monkeypatch.setattr(child_mod.random, "uniform", lambda a, b: b)
+    reg = FakeRegistrant()
+    handle = FakeHandle()
+    stop = asyncio.Event()
+    task = asyncio.ensure_future(_reaper(handle, reg, stop))
+    await asyncio.sleep(0.1)  # inside the stagger
+    handle._busy = True
+    await asyncio.sleep(0.4)
+    assert reg.retiring == [], "no announce while busy"
+    assert not stop.is_set()
+    handle._busy = False
+    await _run_until(stop, timeout=3.0)
+    assert stop.is_set()
+    await task
+
+
+@pytest.mark.asyncio
+async def test_a_stop_during_the_stagger_yields_to_it(disk, monkeypatch) -> None:
+    monkeypatch.setattr(child_mod, "REAP_CHECK_S", 0.01)
+    monkeypatch.setattr(child_mod, "BUILD_CHECK_S", 0.02)
+    monkeypatch.setenv("LOP_BUILD_STAGGER_S", "1.0")
+    monkeypatch.setenv("LOP_SESSION_GRACE_S", "60")
+    monkeypatch.setattr(child_mod.random, "uniform", lambda a, b: b)
+    reg = FakeRegistrant()
+    handle = FakeHandle()
+    stop = asyncio.Event()
+    task = asyncio.ensure_future(_reaper(handle, reg, stop))
+    await asyncio.sleep(0.1)
+    stop.set()  # a /stop landed
+    await asyncio.wait_for(task, timeout=2)
+    assert reg.retiring == [] and not handle.disposed, "the stop path owns the exit"
+
+
+@pytest.mark.asyncio
+async def test_a_runtime_without_a_boot_stamp_never_refreshes(disk, monkeypatch) -> None:
+    monkeypatch.setattr(child_mod, "REAP_CHECK_S", 0.01)
+    monkeypatch.setattr(child_mod, "BUILD_CHECK_S", 0.02)
+    monkeypatch.setenv("LOP_SESSION_GRACE_S", "60")
+    reg = FakeRegistrant(attaches=1, boot=None)
+    handle = FakeHandle()
+    stop = asyncio.Event()
+    task = asyncio.ensure_future(_reaper(handle, reg, stop))
+    await asyncio.sleep(0.2)
+    assert not stop.is_set() and reg.retiring == []
+    stop.set()
+    await task
+
+
+# -- 7. the stagger -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stagger_is_bounded_by_build_stagger_s(disk, monkeypatch) -> None:
+    monkeypatch.setattr(child_mod, "REAP_CHECK_S", 0.01)
+    monkeypatch.setattr(child_mod, "BUILD_CHECK_S", 0.02)
+    monkeypatch.setenv("LOP_SESSION_GRACE_S", "60")
+    monkeypatch.setenv("LOP_BUILD_STAGGER_S", "0.25")
+    draws: list[tuple[float, float]] = []
+
+    def uniform(a: float, b: float) -> float:
+        draws.append((a, b))
+        return b
+
+    monkeypatch.setattr(child_mod.random, "uniform", uniform)
+    reg = FakeRegistrant()
+    handle = FakeHandle()
+    stop = asyncio.Event()
+    started = asyncio.get_running_loop().time()
+    await asyncio.wait_for(_reaper(handle, reg, stop), timeout=3)
+    elapsed = asyncio.get_running_loop().time() - started
+    assert draws == [(0, 0.25)], "one draw, over [0, BUILD_STAGGER_S]"
+    assert elapsed >= 0.25, "the retirement waited out the full stagger"
+    assert stop.is_set()

--- a/tests/unit/session/runtime/test_server_refresh.py
+++ b/tests/unit/session/runtime/test_server_refresh.py
@@ -1,0 +1,154 @@
+"""``refresh_if_idle`` and ``announce_retiring`` on the RuntimeServer.
+
+The viewer-side belt for the runtime's self-refresh (design-runtime-autorefresh
+§3.3): a resume in the seconds after ``lop-update`` binds to a stale idle
+owner before its reaper has noticed, and asks it to retire now. Every
+uncertain answer is ``kept``: a wrong "retire" costs a cold start nobody
+asked for, a wrong "keep" costs the reaper's next check.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from local_operator import update as update_mod
+from local_operator.session.runtime.server import RuntimeServer, _ClientConn
+from local_operator.update import BuildStamp
+from tests.unit.session.runtime.test_server import FakeHandle
+
+OLD = BuildStamp(version="0.49.8", source_ref="46a4e9b1234567")
+NEW = BuildStamp(version="0.49.9", source_ref="f4a70b991234567")
+
+
+class RefreshableHandle(FakeHandle):
+    def __init__(self, *, reason: str = "") -> None:
+        super().__init__()
+        self.reason = reason
+        self.stopped = False
+        self.probes = 0
+
+    def may_refresh(self) -> str:
+        self.probes += 1
+        return self.reason
+
+    def request_stop(self) -> None:
+        self.stopped = True
+
+
+def _conn(kind: str) -> _ClientConn:
+    return _ClientConn(writer=cast(Any, object()), kind=cast(Any, kind))
+
+
+@pytest.fixture
+def stale(monkeypatch):
+    """The server booted on OLD; the disk now carries NEW, settled."""
+    monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: NEW)
+    monkeypatch.setattr(update_mod, "build_marker_age_s", lambda *_a, **_k: 999.0)
+    monkeypatch.delenv("LOP_BUILD_PREFIX", raising=False)
+
+
+def _rig(handle: Any, *, boot: BuildStamp = OLD) -> tuple[RuntimeServer, list[dict[str, Any]]]:
+    """A server booted on ``boot`` whose socket writes are captured, tagged
+    with the recipient's kind so the daemon/attach split is assertable."""
+    server = RuntimeServer(handle, kind="tui")
+    server._boot_build = boot
+    sent: list[dict[str, Any]] = []
+
+    async def capture(target, frame):  # noqa: ANN001
+        sent.append({"_recipient": target.kind, **frame})
+
+    server._send_to = capture  # type: ignore[assignment]
+    return server, sent
+
+
+async def _ask(server: RuntimeServer, sent: list[dict[str, Any]], conn: _ClientConn) -> str:
+    await server._on_request({"op": "refresh_if_idle", "req": 1}, conn)
+    acks = [f for f in sent if f.get("op") in ("ack", "error")]
+    assert acks, "the op never replied"
+    reply = acks[-1]
+    assert reply.get("op") == "ack", f"unexpected reply: {reply}"
+    return str(reply.get("detail", ""))
+
+
+@pytest.mark.asyncio
+async def test_an_idle_stale_runtime_announces_and_retires(stale) -> None:
+    handle = RefreshableHandle(reason="")
+    server, sent = _rig(handle)
+    viewer = _conn("attach")
+    daemon = _conn("daemon")
+    server._clients[id(viewer.writer)] = viewer
+    server._clients[id(daemon.writer)] = daemon
+
+    detail = await _ask(server, sent, viewer)
+
+    assert detail == "retiring"
+    assert handle.stopped is True
+    retiring = [f for f in sent if f.get("op") == "retiring"]
+    assert [f["_recipient"] for f in retiring] == ["attach"], "the phone daemon never sees it"
+    assert retiring[0]["reason"] == "stale-build"
+    assert retiring[0]["from"] == OLD.label() and retiring[0]["to"] == NEW.label()
+    assert handle.probes == 2, "re-asked after the announce (the one await before the stop)"
+
+
+@pytest.mark.asyncio
+async def test_a_busy_stale_runtime_is_kept(stale) -> None:
+    handle = RefreshableHandle(reason="busy")
+    server, sent = _rig(handle)
+    viewer = _conn("attach")
+    server._clients[id(viewer.writer)] = viewer
+
+    assert await _ask(server, sent, viewer) == "kept: busy"
+    assert handle.stopped is False
+    assert not [f for f in sent if f.get("op") == "retiring"]
+
+
+@pytest.mark.asyncio
+async def test_a_matching_build_is_kept(stale, monkeypatch) -> None:
+    monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: OLD)
+    handle = RefreshableHandle(reason="")
+    server, sent = _rig(handle)
+    viewer = _conn("attach")
+    server._clients[id(viewer.writer)] = viewer
+
+    assert (await _ask(server, sent, viewer)).startswith("kept: build on disk matches")
+    assert handle.stopped is False
+
+
+@pytest.mark.asyncio
+async def test_an_unsettled_install_is_kept(stale, monkeypatch) -> None:
+    monkeypatch.setattr(update_mod, "build_marker_age_s", lambda *_a, **_k: 1.0)
+    handle = RefreshableHandle(reason="")
+    server, sent = _rig(handle)
+    viewer = _conn("attach")
+    server._clients[id(viewer.writer)] = viewer
+
+    assert (await _ask(server, sent, viewer)).startswith("kept:")
+    assert handle.stopped is False
+
+
+@pytest.mark.asyncio
+async def test_work_arriving_after_the_announce_is_kept(stale) -> None:
+    class Flips(RefreshableHandle):
+        def may_refresh(self) -> str:
+            self.probes += 1
+            return "" if self.probes == 1 else "busy"
+
+    handle = Flips()
+    server, sent = _rig(handle)
+    viewer = _conn("attach")
+    server._clients[id(viewer.writer)] = viewer
+
+    detail = await _ask(server, sent, viewer)
+    assert detail.startswith("kept: busy")
+    assert handle.stopped is False
+    assert [f for f in sent if f.get("op") == "retiring"], "announced, then refused: safe"
+
+
+@pytest.mark.asyncio
+async def test_a_runtime_that_cannot_judge_itself_is_kept(stale) -> None:
+    server, sent = _rig(FakeHandle())  # no may_refresh
+    viewer = _conn("attach")
+    server._clients[id(viewer.writer)] = viewer
+    assert (await _ask(server, sent, viewer)).startswith("kept: this runtime cannot judge")

--- a/tests/unit/session/test_remote_refresh.py
+++ b/tests/unit/session/test_remote_refresh.py
@@ -1,0 +1,157 @@
+"""A ``retiring`` owner is a refresh, not a death and not a stop.
+
+The runtime retires itself when ``lop-update`` puts a newer build on disk
+and it is idle (design-runtime-autorefresh §3.2). The viewer must read the
+announced disconnect as "a fresh runtime is owed" — go cold at once, fire
+the refresh callback so the app re-engages, and synthesise NO turn end
+(nothing was interrupted; the runtime was idle by contract). Both older
+outcomes keep their behaviour: ``STOPPED_REASON`` still parks the viewer in
+the stopped state, and a bare owner exit still runs recovery.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+import local_operator.session.remote as remote_module
+from local_operator.mobile.attach_client import RETIRING_REASON, STOPPED_REASON
+from local_operator.session.remote import RemoteSession
+
+
+async def _never_take_over() -> Any:
+    raise AssertionError("a refresh must never take over the session")
+
+
+@pytest.mark.asyncio
+async def test_retiring_goes_cold_now_and_fires_the_refresh_callback(tmp_path, monkeypatch):
+    """The whole contract of the frame, on the viewer side.
+
+    No recovery task: chasing the record for 8 s would end in "runtime
+    exited" for a planned housekeeping event, and the successor does not
+    exist yet — the app spawns it. No ``_end_turn_locally``: that is what
+    would paint ``interrupted`` for a turn that never existed.
+    """
+    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    remote = RemoteSession(config_dir=tmp_path, session_id="s1", takeover_factory=_never_take_over)
+    ended: list[str] = []
+    monkeypatch.setattr(
+        remote, "_end_turn_locally", lambda *a, **k: ended.append("end"), raising=True
+    )
+    refreshed: list[str] = []
+    cold: list[str] = []
+    remote.set_refresh_callback(lambda: refreshed.append("refresh"))
+    remote.set_went_cold_callback(lambda: cold.append("cold"))
+
+    remote._on_disconnected(RETIRING_REASON)
+    await asyncio.sleep(0)
+
+    assert remote.is_cold
+    assert remote._recovery_task is None, "a refresh has nothing to recover"
+    assert refreshed == ["refresh"]
+    assert cold == [], "the went-cold callback is the death path; a refresh is not one"
+    assert ended == [], "no turn end may be synthesised for an idle runtime that retired"
+    assert remote._deliberate_stop is False, "a refresh is not a stop; the next prompt engages"
+    assert remote._owner_ready.is_set(), "a cold viewer is READY: the next prompt engages"
+
+
+@pytest.mark.asyncio
+async def test_stopped_reason_still_parks_the_viewer(tmp_path, monkeypatch):
+    """Regression guard: the new branch must not shadow the stop path."""
+    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    remote = RemoteSession(config_dir=tmp_path, session_id="s1", takeover_factory=_never_take_over)
+    refreshed: list[str] = []
+    remote.set_refresh_callback(lambda: refreshed.append("refresh"))
+
+    remote._on_disconnected(STOPPED_REASON)
+    if remote._recovery_task is not None:
+        await asyncio.wait_for(remote._recovery_task, timeout=5)
+
+    assert remote._deliberate_stop is True
+    assert refreshed == []
+
+
+@pytest.mark.asyncio
+async def test_owner_death_still_recovers(tmp_path, monkeypatch):
+    """Regression guard: an unannounced exit still runs ``_recover_owner``."""
+    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    remote = RemoteSession(config_dir=tmp_path, session_id="s1", takeover_factory=_never_take_over)
+    refreshed: list[str] = []
+    remote.set_refresh_callback(lambda: refreshed.append("refresh"))
+
+    remote._on_disconnected("owner exited")
+    task = remote._recovery_task
+    assert task is not None, "an unannounced exit must still start recovery"
+    assert remote._recovering is True
+    assert refreshed == []
+    # The recovery loop's own outcomes (takeover, cold after 8 s) are covered
+    # by test_remote_takeover; here only its START is the property.
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_request_refresh_never_raises(tmp_path, monkeypatch):
+    """Every failure is "kept": the reaper's own check is the fallback."""
+    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    remote = RemoteSession(config_dir=tmp_path, session_id="s1", takeover_factory=_never_take_over)
+    assert (await remote.request_refresh()).startswith("kept:")
+
+    class OldOwner:
+        connected = True
+
+        async def request_refresh(self) -> str:
+            raise RuntimeError("unknown op: refresh_if_idle")
+
+    remote._client = OldOwner()  # type: ignore[assignment]
+    assert (await remote.request_refresh()).startswith("kept:")
+
+    class Owner:
+        connected = True
+
+        async def request_refresh(self) -> str:
+            return "retiring"
+
+    remote._client = Owner()  # type: ignore[assignment]
+    assert await remote.request_refresh() == "retiring"
+
+
+def test_owner_idle_reads_the_snapshot(tmp_path, monkeypatch):
+    """Cold → not idle (nothing to refresh); streaming, a running job or a
+    parked gate → busy; otherwise idle."""
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    remote = RemoteSession(config_dir=tmp_path, session_id="s1", takeover_factory=_never_take_over)
+    assert remote.owner_idle() is False, "a cold viewer has no owner to refresh"
+
+    class Client:
+        connected = True
+
+    remote._client = Client()  # type: ignore[assignment]
+    remote._ready_for_events = True
+    assert not remote.is_cold
+
+    def store(**fields: Any) -> Any:
+        base = {"streaming": False, "pending_gate": None, "jobs": []}
+        base.update(fields)
+        return SimpleNamespace(state=SimpleNamespace(**base))
+
+    def with_state(**fields: Any) -> None:
+        remote._frontend_store = store(**fields)  # type: ignore[assignment]
+
+    with_state()
+    assert remote.owner_idle() is True
+    with_state(streaming=True)
+    assert remote.owner_idle() is False
+    with_state(pending_gate=object())
+    assert remote.owner_idle() is False
+    with_state(jobs=[SimpleNamespace(status="running")])
+    assert remote.owner_idle() is False
+    with_state(jobs=[SimpleNamespace(status="completed")])
+    assert remote.owner_idle() is True
+    remote._streaming = True
+    assert remote.owner_idle() is False

--- a/tests/unit/test_ambient_env_isolation.py
+++ b/tests/unit/test_ambient_env_isolation.py
@@ -82,6 +82,8 @@ _HARMLESS: dict[str, str] = {
     "LOCAL_OPERATOR_CONTEXT_FILES": "extra context file names, read relative to cwd",
     "LOCAL_OPERATOR_SKILL_EXTRA_ROOTS": "extra skill roots; read-only directories",
     "LOP_SESSION_GRACE_S": "runtime residency grace; a duration",
+    "LOP_BUILD_SETTLE_S": "runtime self-refresh settle; a duration",
+    "LOP_BUILD_STAGGER_S": "runtime self-refresh stagger; a duration",
     "LOP_RUNTIME_DEBUG_STACKS": "debug dump switch",
     "LO_MOBILE_NO_DIAL": "disables the mobile dial-out; safer ON",
     # -- evaluation adapter fds: only meaningful inside a spawned adapter ----

--- a/tests/unit/tui/test_build_skew.py
+++ b/tests/unit/tui/test_build_skew.py
@@ -15,8 +15,11 @@ Three notices close that, and each is a different fact:
 
 * **disk drift** — the install moved under this process, so anything spawned
   from here will be newer than this terminal. ``/reload`` is the remedy.
-* **owner skew** — the bound runtime reports a different build. ``/stop`` then
-  resend is the remedy.
+* **owner skew** — the bound runtime reports a different build. The remedy
+  is the RUNTIME's: an idle stale runtime is asked to retire now and the
+  viewer re-engages a fresh one silently; a busy one earns one info line
+  saying it will move over when its work finishes. No notice ever tells the
+  user to ``/stop`` (design-runtime-autorefresh §3.3/§3.5).
 * **owner predates reporting** — the runtime cannot say what it runs, which by
   construction makes it older than a terminal that can read the field.
 
@@ -47,8 +50,9 @@ def _notices(app: OperatorApp) -> list[str]:
 # batch of unrelated test failures. These name the one phrase that identifies
 # each notice.
 DRIFT = "was updated after this window opened"
-OWNER_SKEW = "but this window is"
+OWNER_SKEW = "(this window is"
 OWNER_UNKNOWN = "running an older version than this window"
+MOVES_OVER = "will move to the new version when its current work finishes"
 
 
 class _BoundViewer(FakeSession):
@@ -70,10 +74,16 @@ class _BoundViewer(FakeSession):
         owner_source_ref: str = "",
         session_id: str = "",
         conversation_name: str = "",
+        idle: bool = False,
     ) -> None:
         super().__init__()
         self.owner_version = owner_version
         self.owner_source_ref = owner_source_ref
+        # ``idle`` is what a real ``RemoteSession.owner_idle`` reads off the
+        # canonical snapshot. The default is BUSY so every pre-existing cell
+        # keeps exercising the notice path; the refresh cells opt in.
+        self._skew_idle = idle
+        self.refresh_requests = 0
         # ``session_id`` and ``conversation_name`` are read-only properties on
         # the base double. The debounce is keyed by the first and the notice
         # names the session with the second, so a test that needs two DISTINCT
@@ -88,6 +98,13 @@ class _BoundViewer(FakeSession):
     @property
     def conversation_name(self) -> str:  # type: ignore[override]
         return self._skew_conversation_name
+
+    def owner_idle(self) -> bool:
+        return self._skew_idle
+
+    async def request_refresh(self) -> str:
+        self.refresh_requests += 1
+        return "retiring" if self._skew_idle else "kept: busy"
 
 
 @pytest.mark.asyncio
@@ -226,13 +243,15 @@ async def test_a_matching_build_says_nothing(monkeypatch, tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_an_older_runtime_is_named_with_the_stop_remedy(monkeypatch, tmp_path) -> None:
-    """Owner skew: the bound runtime reports a build this terminal is not on.
+async def test_a_busy_older_runtime_is_told_it_will_move_over(monkeypatch, tmp_path) -> None:
+    """Owner skew on a BUSY runtime: one info line, and no chore for the user.
 
-    ``/stop`` then resend is the remedy rather than ``/reload``: the terminal
-    is fine, it is the runtime that is stale, and a bare ``/stop`` on a
-    follower asks the owner to stop so the next prompt engages a fresh one
-    from the current install.
+    The runtime's own reaper retires it when its work finishes, so the notice
+    only says that. ``note`` rather than ``warning`` because nothing is wrong
+    and nothing is asked. The ``/stop`` sentence that used to end this notice
+    is the chore the operator refused ("the user should never need to run
+    /stop to refresh or update a runtime"), so its absence is asserted on the
+    whole ledger, not just this row.
     """
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
     app = OperatorApp(lambda: _factory(FakeSession()))
@@ -244,15 +263,76 @@ async def test_an_older_runtime_is_named_with_the_stop_remedy(monkeypatch, tmp_p
         import local_operator.update as update_mod
 
         monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
-        app._session = _BoundViewer(owner_version="0.46.23")
+        viewer = _BoundViewer(owner_version="0.46.23", idle=False)
+        app._session = viewer
         app._check_build_skew(reason="bind")
         await pilot.pause()
         notices = _notices(app)
+        tokens = [block._token for block in app.query(NoticeBlock) if MOVES_OVER in block._text]
 
     skew = [n for n in notices if "running 0.46.23" in n and OWNER_SKEW in n]
     assert len(skew) == 1, notices
     assert "0.49.0" in skew[0]
-    assert "/stop" in skew[0]
+    assert MOVES_OVER in skew[0]
+    assert tokens == ["muted"], "a note, never a warning: nothing is wrong and nothing is asked"
+    assert viewer.refresh_requests == 0, "a busy runtime is never asked to retire"
+    assert not any("/stop" in n for n in notices), notices
+
+
+@pytest.mark.asyncio
+async def test_an_idle_older_runtime_is_refreshed_silently(monkeypatch, tmp_path) -> None:
+    """Owner skew on an IDLE runtime: request the refresh, paint nothing.
+
+    The belt for the reaper (design-runtime-autorefresh §3.3): a resume in
+    the seconds after ``lop-update`` binds to a stale idle owner before its
+    reaper has noticed. The viewer asks it to retire now and re-engages on
+    its ``retiring`` frame; the user sees the band's ``starting…`` for a
+    second and no prose at all.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        stamp = BuildStamp(version="0.49.0")
+        app._loaded_build = stamp
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
+        viewer = _BoundViewer(owner_version="0.46.23", idle=True)
+        app._session = viewer
+        app._check_build_skew(reason="bind")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        notices = _notices(app)
+
+    assert viewer.refresh_requests == 1, "an idle stale owner is asked to retire"
+    assert not [n for n in notices if OWNER_SKEW in n or MOVES_OVER in n], notices
+    assert not any("/stop" in n for n in notices), notices
+
+
+@pytest.mark.asyncio
+async def test_the_refresh_callback_re_engages_eagerly(monkeypatch, tmp_path) -> None:
+    """The ``retiring`` frame lands as a re-engage, not as a cold band.
+
+    ``_warm_engage_started`` was latched by the engage that bound the runtime
+    which just left; without the reset the next engage would be a no-op and
+    the first keystroke after ``lop-update`` would pay a cold start in the
+    foreground.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        reasons: list[str] = []
+        monkeypatch.setattr(app, "_start_runtime_engage", lambda *, reason: reasons.append(reason))
+        app._warm_engage_started = True
+        app._on_runtime_refreshed()
+        await pilot.pause()
+
+    assert reasons == ["refresh"]
+    assert app._warm_engage_started is False
 
 
 @pytest.mark.asyncio
@@ -282,7 +362,8 @@ async def test_a_runtime_without_a_stamp_is_reported_as_predating_it(monkeypatch
 
     predates = [n for n in notices if OWNER_UNKNOWN in n]
     assert len(predates) == 1, "one session, repeatedly checked, speaks once"
-    assert "/stop" in predates[0]
+    assert MOVES_OVER in predates[0]
+    assert "/stop" not in predates[0]
 
 
 @pytest.mark.asyncio
@@ -483,7 +564,7 @@ async def test_a_pre_attach_runtime_noop_degrades_loudly(monkeypatch, tmp_path) 
     stale = [n for n in notices if "too old to attach a team" in n]
     assert len(stale) == 1, notices
     assert "nothing was attached" in stale[0], "the user must learn the attach did NOT happen"
-    assert "/stop" in stale[0]
+    assert "/stop" not in stale[0], "the runtime refreshes itself; the user is never told to /stop"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_build_skew.py
+++ b/tests/unit/tui/test_build_skew.py
@@ -44,13 +44,27 @@ def _notices(app: OperatorApp) -> list[str]:
     return [block._text for block in app.query(NoticeBlock)]
 
 
+def _wrapped_rows(block: NoticeBlock) -> list[str]:
+    """The notice's lines AS WRAPPED by the block at its current width.
+
+    ``_text`` is the unwrapped sentence, so a wrap defect is invisible to it;
+    this renders what the compositor laid out, which is what the reader sees.
+    """
+    from rich.console import Console
+
+    console = Console(width=block.content_size.width or 80, no_color=True)
+    with console.capture() as capture:
+        console.print(block.renderable)
+    return [line.rstrip() for line in capture.get().splitlines() if line.strip()]
+
+
 # Match on a STABLE fragment of each notice rather than a whole sentence: the
 # copy is a design surface and was rewritten once already (design review round
 # 1, D1/D2), so cells that quote whole strings turn every wording change into a
 # batch of unrelated test failures. These name the one phrase that identifies
 # each notice.
 DRIFT = "was updated after this window opened"
-OWNER_SKEW = "(this window is"
+OWNER_SKEW = "\u2192"  # the old \u2192 new build pair, kept on one row (design round 1, D1)
 OWNER_UNKNOWN = "running an older version than this window"
 MOVES_OVER = "will move to the new version when its current work finishes"
 
@@ -75,6 +89,7 @@ class _BoundViewer(FakeSession):
         session_id: str = "",
         conversation_name: str = "",
         idle: bool = False,
+        refresh_answer: str = "retiring",
     ) -> None:
         super().__init__()
         self.owner_version = owner_version
@@ -83,6 +98,11 @@ class _BoundViewer(FakeSession):
         # canonical snapshot. The default is BUSY so every pre-existing cell
         # keeps exercising the notice path; the refresh cells opt in.
         self._skew_idle = idle
+        # What the RUNTIME answers ``refresh_if_idle`` with. ``retiring`` is
+        # the happy path; a ``kept: \u2026`` answer (busy again, or an old runtime
+        # that does not know the op) is the case R1-1 painted nothing for.
+        # ``raise`` makes the ask itself fail.
+        self._refresh_answer = refresh_answer
         self.refresh_requests = 0
         # ``session_id`` and ``conversation_name`` are read-only properties on
         # the base double. The debounce is keyed by the first and the notice
@@ -104,7 +124,9 @@ class _BoundViewer(FakeSession):
 
     async def request_refresh(self) -> str:
         self.refresh_requests += 1
-        return "retiring" if self._skew_idle else "kept: busy"
+        if self._refresh_answer == "raise":
+            raise ConnectionError("owner went away mid-ask")
+        return self._refresh_answer
 
 
 @pytest.mark.asyncio
@@ -310,6 +332,124 @@ async def test_an_idle_older_runtime_is_refreshed_silently(monkeypatch, tmp_path
     assert viewer.refresh_requests == 1, "an idle stale owner is asked to retire"
     assert not [n for n in notices if OWNER_SKEW in n or MOVES_OVER in n], notices
     assert not any("/stop" in n for n in notices), notices
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "answer",
+    [
+        "kept: busy",
+        "kept: unknown op: 'refresh_if_idle'",
+        "raise",
+    ],
+)
+async def test_an_idle_owner_that_stays_still_gets_the_notice(
+    monkeypatch, tmp_path, answer
+) -> None:
+    """R1-1: silence is earned by ``retiring``, never by asking.
+
+    The upgrade-window population is a resume onto a runtime built BEFORE this
+    PR: it answers the unknown op with an error, cannot self-refresh, and used
+    to leave the user with nothing at all \u2014 the old ``/stop`` notice gone and
+    no replacement, on every later idle seam too (the debounce is not the
+    reason; that branch simply never announced). A ``kept: busy`` answer and a
+    failed ask are the same shape: the runtime is staying, so say so.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        stamp = BuildStamp(version="0.49.0")
+        app._loaded_build = stamp
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
+        viewer = _BoundViewer(owner_version="0.46.23", idle=True, refresh_answer=answer)
+        app._session = viewer
+        app._check_build_skew(reason="bind")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        notices = _notices(app)
+        tokens = [block._token for block in app.query(NoticeBlock) if MOVES_OVER in block._text]
+
+    assert viewer.refresh_requests == 1, "the refresh is still attempted first"
+    skew = [n for n in notices if MOVES_OVER in n]
+    assert len(skew) == 1, f"a runtime that stays must say so: {notices}"
+    assert "0.46.23" in skew[0] and "0.49.0" in skew[0], "both builds are named"
+    assert tokens == ["muted"], "still a note: the runtime repairs itself when it can"
+    assert not any("/stop" in n for n in notices), notices
+
+
+@pytest.mark.asyncio
+async def test_an_unstamped_idle_owner_that_stays_gets_the_unknown_copy(
+    monkeypatch, tmp_path
+) -> None:
+    """The same rule for a runtime too old to report its build at all.
+
+    It cannot know the op either, so this is the commonest shape of R1-1 in
+    the wild: no stamp AND no ``refresh_if_idle``.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        stamp = BuildStamp(version="0.49.0")
+        app._loaded_build = stamp
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
+        viewer = _BoundViewer(owner_version="", idle=True, refresh_answer="raise")
+        app._session = viewer
+        app._check_build_skew(reason="bind")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        notices = _notices(app)
+
+    predates = [n for n in notices if OWNER_UNKNOWN in n]
+    assert len(predates) == 1, notices
+    assert MOVES_OVER in predates[0]
+    assert "/stop" not in predates[0]
+
+
+@pytest.mark.asyncio
+async def test_the_version_pair_survives_a_narrow_splash(monkeypatch, tmp_path) -> None:
+    """D1: the two stamps are ONE fact and must not wrap apart.
+
+    The parenthetical form split between ``(this window is`` and the second
+    stamp on an 80- and 100-column splash \u2014 which is exactly where a resume
+    paints C\u2032. Asserted on the block the real app wrapped, at the width the
+    finding was reported at, rather than on the unwrapped string.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    for width in (80, 100, 120):
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(width, 24)) as pilot:
+            await pilot.pause()
+            stamp = BuildStamp(version="0.49.9", source_ref="f4a70b991234567")
+            app._loaded_build = stamp
+            app._skew_notice_shown.clear()
+            import local_operator.update as update_mod
+
+            monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
+            app._session = _BoundViewer(
+                owner_version="0.49.8",
+                owner_source_ref="46a4e9b1234567",
+                conversation_name="Runtime refresh notes",
+            )
+            app._check_build_skew(reason="bind")
+            await pilot.pause()
+            await pilot.pause()
+            block = next(b for b in app.query(NoticeBlock) if MOVES_OVER in b._text)
+            rows = _wrapped_rows(block)
+
+        joined = "\n".join(rows)
+        assert "0.49.8@46a4e9b" in joined and "0.49.9@f4a70b9" in joined, (width, rows)
+        pair_rows = [r for r in rows if "0.49.8@46a4e9b" in r or "0.49.9@f4a70b9" in r]
+        assert len(pair_rows) == 1, f"the version pair wrapped apart at {width}: {rows}"
 
 
 @pytest.mark.asyncio
@@ -565,6 +705,11 @@ async def test_a_pre_attach_runtime_noop_degrades_loudly(monkeypatch, tmp_path) 
     assert len(stale) == 1, notices
     assert "nothing was attached" in stale[0], "the user must learn the attach did NOT happen"
     assert "/stop" not in stale[0], "the runtime refreshes itself; the user is never told to /stop"
+    # D2: the tail states the automatic repair rather than handing back a
+    # chore. "send the request again then" was the last remaining instruction
+    # on this surface, in the same ink as notice A's genuine /reload action.
+    assert "on its own" in stale[0]
+    assert "send the request again" not in stale[0]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_build_skew.py
+++ b/tests/unit/tui/test_build_skew.py
@@ -64,7 +64,10 @@ def _wrapped_rows(block: NoticeBlock) -> list[str]:
 # batch of unrelated test failures. These name the one phrase that identifies
 # each notice.
 DRIFT = "was updated after this window opened"
-OWNER_SKEW = "\u2192"  # the old \u2192 new build pair, kept on one row (design round 1, D1)
+# Unique to C\u2032. NOT the bare arrow: ``_build_change`` puts one in the DRIFT
+# notice too, so the four NEGATIVE assertions below would have fired on a drift
+# row and quietly stopped meaning "no owner notice" (review round 2, R2-3).
+OWNER_SKEW = "is running "
 OWNER_UNKNOWN = "running an older version than this window"
 MOVES_OVER = "will move to the new version when its current work finishes"
 
@@ -101,7 +104,9 @@ class _BoundViewer(FakeSession):
         # What the RUNTIME answers ``refresh_if_idle`` with. ``retiring`` is
         # the happy path; a ``kept: \u2026`` answer (busy again, or an old runtime
         # that does not know the op) is the case R1-1 painted nothing for.
-        # ``raise`` makes the ask itself fail.
+        # ``raise`` makes the ask itself fail. Anything else is returned AS
+        # GIVEN \u2014 including a non-string, which is the shape that crashed the
+        # worker in R2-1 and which a duck-typed host may legitimately send.
         self._refresh_answer = refresh_answer
         self.refresh_requests = 0
         # ``session_id`` and ``conversation_name`` are read-only properties on
@@ -122,7 +127,7 @@ class _BoundViewer(FakeSession):
     def owner_idle(self) -> bool:
         return self._skew_idle
 
-    async def request_refresh(self) -> str:
+    async def request_refresh(self):  # deliberately unannotated: see below
         self.refresh_requests += 1
         if self._refresh_answer == "raise":
             raise ConnectionError("owner went away mid-ask")
@@ -413,6 +418,83 @@ async def test_an_unstamped_idle_owner_that_stays_gets_the_unknown_copy(
     assert len(predates) == 1, notices
     assert MOVES_OVER in predates[0]
     assert "/stop" not in predates[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("answer", [None, object(), b"retiring", 0])
+async def test_a_non_string_answer_cannot_take_the_window_down(
+    monkeypatch, tmp_path, answer
+) -> None:
+    """R2-1: a build diagnostic must never close the window it is diagnosing.
+
+    ``request_refresh`` is reached through a duck-typed ``getattr`` probe, so
+    the answer's SHAPE is whatever an older runtime facade, an embedder or a
+    reduced double sends \u2014 exactly the population this notice exists for.
+    Calling ``.strip()`` on it raised inside a Textual worker, which runs with
+    ``exit_on_error=True``: the session ended with ``WorkerFailed`` instead of
+    painting anything. Every other probe on this seam degrades; so does this.
+
+    ``b"retiring"`` is the trap case: it *looks* like the silence answer but is
+    not a ``str``, and it must be treated as "the runtime stays" rather than
+    matched.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        stamp = BuildStamp(version="0.49.0")
+        app._loaded_build = stamp
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
+        app._session = _BoundViewer(owner_version="0.46.23", idle=True, refresh_answer=answer)
+        app._check_build_skew(reason="bind")
+        await pilot.pause()
+        # Raises WorkerFailed on the unfixed tree, before any assertion below.
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        notices = _notices(app)
+        # Sampled INSIDE the pilot: outside it the app has been shut down by
+        # the context manager and this is False for every run.
+        alive = app.is_running
+
+    assert alive, "the app must survive an answer it did not expect"
+    skew = [n for n in notices if MOVES_OVER in n]
+    assert len(skew) == 1, f"an unreadable answer is a runtime that stays: {notices}"
+    assert not any("/stop" in n for n in notices), notices
+
+
+@pytest.mark.asyncio
+async def test_a_same_version_rebuild_names_only_the_refs(monkeypatch, tmp_path) -> None:
+    """R2-2 / D3: C\u2032 and notice A must name one fact the same way.
+
+    A ``lop-update`` rebuild from ``main`` with no version bump is this host's
+    headline drift, and both sides then carry the same version. Hand-rolling
+    the arrow rendered it ``0.49.0@aaaaaaa \u2192 0.49.0@bbbbbbb`` \u2014 the version
+    twice, with the seven characters that actually differ buried \u2014 while the
+    drift notice one block higher already collapsed it. ``_build_change`` is
+    that formatter; this pins C\u2032 to it.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        stamp = BuildStamp(version="0.49.0", source_ref="bbbbbbb2222")
+        app._loaded_build = stamp
+        app._skew_notice_shown.clear()
+        import local_operator.update as update_mod
+
+        monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: stamp)
+        app._session = _BoundViewer(owner_version="0.49.0", owner_source_ref="aaaaaaa1111")
+        app._check_build_skew(reason="bind")
+        await pilot.pause()
+        notices = _notices(app)
+
+    skew = [n for n in notices if MOVES_OVER in n]
+    assert len(skew) == 1, notices
+    assert "0.49.0, aaaaaaa \u2192 bbbbbbb" in skew[0], skew[0]
+    assert "0.49.0@aaaaaaa" not in skew[0], "the shared version must not be stated twice"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# PR Description

## Summary of Changes

Idle runtimes now refresh themselves onto the build on disk. An attached viewer no longer pins a stale runtime forever, and the user is never told to `/stop, then send again`.

This is **PR A** of `docs/design-runtime-autorefresh.md` (§3 in full). **No version bump** — `pyproject.toml` stays at `0.50.1` and this rides the next combined release.

**Change class: C2.** User-visible surface is notice C′ (copy only; no band/layout change). Design round required.

Release: patch — idle runtimes refresh themselves onto the build on disk; resume never shows `/stop, then send again`.

### What was broken

1. **A stale runtime was immortal while somebody was looking at it.** `_should_exit` term 3 (an attached viewer) held pid 57079 at 0.49.8 for five hours after disk had moved to 0.49.9. The only thing that noticed was the *viewer*, which painted notice C and handed the user a chore.
2. **The record's `busy` bit stuck at True after any wake/peer turn.** Only `_observe_prompt_drain` published `busy` after the final `AgentEndEvent`, and that event is emitted while `_is_streaming` / `_turn_lock` still count as busy. Every turn that did not run through the prompt queue therefore ended with the record saying `busy: true`. Proven on b0db51d9c (see Testing).
3. **Notice C told the user to `/stop, then send again`.** That is the chore the operator refused.

### What this does

- **Busy bit.** `Session.on_turn_settled` fires from `_run_turn_pipeline`'s `finally` after `_is_streaming` is cleared. The handle defers the republish one loop iteration so `_turn_lock` is released first. Heartbeat is only the floor.
- **Runtime self-refresh.** A fourth *announced* exit path beside `_should_exit` (which stays the quiet-exit predicate). Idle + disk stamp differs + marker older than `BUILD_SETTLE_S` (10 s) → jittered stagger (`BUILD_STAGGER_S` = 20 s) → `retiring` frame → re-check `is_busy()` → `_clean_exit`. An attached viewer does **not** hold.
- **Wire.** Additive `{"op": "retiring", "reason": "stale-build", "from", "to"}`. Old viewers ignore it and go cold after 8 s. Not sent to daemon clients. No `PROTOCOL_VERSION` bump.
- **Viewer.** `RETIRING_REASON` → `_go_cold(refresh=True)` (no synthesised abort) → `_on_runtime_refreshed` → `_start_runtime_engage(reason="refresh")`. An attached `connect()` viewer also learns `_cwd` from the record and flips `_can_go_cold` so `_ensure_bound` can spawn the successor (the `lop --resume` path; discovered in e2e 13).
- **Belt.** `_check_build_skew` C branch: idle stale owner → `refresh_if_idle` op, no notice. Busy stale owner → C′ info/`note` copy, once per session.
- **Copy.** Every `/stop, then send again` instruction is gone, including the pre-#624 `team_mutate` degradation notice.

### Deliberate deviations from the design

1. **`on_turn_settled` is deferred one loop iteration** (`call_soon`). The design placed the hook last in the pipeline `finally`, still under `_turn_lock`. `is_busy()` reads that lock, so an inline publish would still write `busy: true`. The test pins the real ordering: end event (`streaming=False`, `busy=True`) → hook (`streaming=False`) → deferred publish (`busy=False`).
2. **Notice C′ is `note`, not `info`.** `NoticeBlock`'s `info` is dim ink reserved for a receipt nobody has to read. C′ answers "why is my session on an older version?" so it uses `note` (muted). Design can overrule.
3. **Refresh check also runs inside the quiet-exit drain.** A grace of minutes (`LOP_SESSION_GRACE_S`) would otherwise starve the build check for an unwatched runtime — exactly the one nobody else will refresh.
4. **Attached `connect()` viewers learn `_cwd` and flip `_can_go_cold` on refresh.** Without this, e2e 13's successor never spawned: `_ensure_bound` is gated on `_can_go_cold`, which `connect()` left False (legacy takeover contract). A refresh is not a death; taking the lease into the TUI would make the terminal the runtime.

## Related Issue(s)

Operator request (verbatim): runtimes that are inactive automatically refresh so that resuming would do the update; on resume we should never see `[/stop, then send again]`; the user should never need to run `/stop` to refresh or update a runtime.

Companion: PR B (disconnect/relay hardening) is a separate slice.

## Impact

**Breaking changes:** none. Additive frame and op; old viewers ignore `retiring` and recover as today.

**User-visible:** notice C rewrite (warning + `/stop` chore → `note` "it will move to the new version when its current work finishes"). Idle stale owners paint nothing. Design round required on C′ and on the no-notice refresh decision.

**Not in this PR:** deferred abort on transient disconnects, projection filtering, drop-reason logging (PR B). Window self-reexec for notice A. No `pyproject.toml` bump.

## Testing Details

Static gates on this head, **whole tree, exactly as CI**:

```
flake8 .                                    exit 0
black==26.1.0 --check .                     990 files unchanged
isort==5.13.2 --check .                     clean
pyright (--pythonpath .venv/bin/python)     0 errors, 0 warnings
```

Unit suite, whole tree via the worktree venv (pre-rebase; the four `origin/main` commits since do not touch these files):

```
$ .venv/bin/python -m pytest tests/unit -q
14999 passed, 18 skipped, 698 warnings in 801.22s (0:13:21)
```

E2E, whole `tests/e2e -m e2e -n0` (pre-rebase; same):

```
$ env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q
45 passed, 6 warnings in 64.39s (0:01:04)
```

Post-rebase onto `origin/main` (`7efedc533`, now 0.50.1): the new tests still pass:

```
$ .venv/bin/python -m pytest tests/unit/session/runtime/test_busy_settles.py \
    tests/unit/session/runtime/test_process_refresh.py \
    tests/unit/session/test_remote_refresh.py \
    tests/unit/tui/test_build_skew.py \
    tests/e2e/test_runtime_refresh_e2e.py -n0 -q
57 passed, 2 warnings in 36.08s
```

### Busy-bit repro (design §1.2 / test 1) — fails before, passes after

Throwaway worktree at `b0db51d9c` (venv symlink; `PYTHONPATH` pointed at that tree), same test file:

```
FAILED ...[mailbox-wake]     AssertionError: mailbox-wake: the record still says busy after the turn
FAILED ...[idle-steer]       AssertionError: idle-steer: the record still says busy after the turn
FAILED ...[background-prompt] AssertionError: background-prompt: the record still says busy after the turn
FAILED ...test_on_turn_settled_fires_after_streaming_cleared...
    AttributeError: 'Session' object has no attribute 'on_turn_settled'
4 failed, 2 passed in 2.33s
```

On this head:

```
6 passed in 0.62s
```

`prompt` was the only cell that already passed (the drain observer covers it). The three `_spawn_background(_prompt_messages(...))` openers are the ones that stuck.

### E2E 13–15 (real `process.py`, fake `.lop-source` prefix)

Isolated `HOME`+config dir; every `CMUX_*` unset in the child env; `LOP_BUILD_SETTLE_S=0.5` / `LOP_BUILD_STAGGER_S=0.5`; `LOP_SESSION_GRACE_S=120` so only the refresh may retire.

| cell | what | result |
|---|---|---|
| 13 watched idle | attach real `OperatorApp` via `RemoteSession.connect`; flip marker; old pid exits rc=0; viewer re-binds to a new pid on the new stamp; ledger contains none of `/stop`, `interrupted`, `stopped` | PASS, 6.38s |
| 14 busy | `[bash:6]` holds a real `bash sleep 6` mid-turn; flip; still the old pid after 3 s; turn completes; old pid exits; successor engaged; reply persisted; no forbidden text | PASS, 11.37s |
| 15 unwatched | no viewer; flip; old pid exits rc=0; **no** new record; `lop send --wake` engages a new pid from the new stamp | PASS, 7.71s |

### Visual (notice C → C′)

Captured through the real `OperatorApp` (`run_test` + `scripts.visual_capture.save_capture`), 100×24.

**Before (busy and idle were identical):** warning ink, `/stop, then send again to restart it.`

**After, busy:** `note` (muted): `“Runtime refresh notes” is running 0.49.8@46a4e9b (this window is 0.49.9@f4a70b9) — it will move to the new version when its current work finishes.` No `/stop`.

**After, idle:** no notice at all (the belt requests `refresh_if_idle`).

Frames attached below. Evidence is not committed (`AGENTS.md`: evidence goes on the PR).

Isolation: `LOP_BUILD_PREFIX` added to `_AMBIENT_VARS` (it names a directory); `LOP_BUILD_SETTLE_S` / `LOP_BUILD_STAGGER_S` listed as harmless durations next to `LOP_SESSION_GRACE_S`.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required (`docs/design-runtime-autorefresh.md`).
- [x] Security considerations are addressed (especially for code execution features).
- [x] I have linked all related issues.

## Screenshots (Optional)

Before/after of notice C through the real app are attached as PR images. Do not merge until reviewer + QA + design rounds are clean and fresh on head.
