### PR TITLE
fix(session): stop a stale abort pre-aborting every later turn

### DIFF
--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -137,9 +137,11 @@ def relay_frame_or_degraded(frame: dict[str, Any], cap_bytes: int) -> dict[str, 
       through and only the oversized BODY is shed. The viewer sees a
       well-sequenced delta whose payload says it was degraded.
 
-    Cheap on the hot path: relay frames are ordinary-sized, so the common case
-    pays one ``len(json.dumps(...))`` — the same measurement the send would
-    perform anyway.
+    Cost on the hot path: one ``json.dumps`` per frame, measured at ~48µs on a
+    20 KB frame (about 41% of the send's own serialization). That is an
+    ADDITIONAL serialization, not a reused one — the send does its own — and it
+    is accepted deliberately: the alternative is a frame the viewer cannot read
+    at all, which costs the connection.
     """
     encoded = len(json.dumps(frame).encode()) + 1  # the socket writes a "\n" too
     if encoded <= cap_bytes:

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -98,6 +98,85 @@ def image_blocks(images: list[dict[str, str]] | None) -> list["ImageContent"]:
 #: A prompt payload past 1 MB is a bug, not a prompt — the line limit the
 #: control socket reader enforces.
 _MAX_LINE_BYTES = 1 << 20
+
+
+def relay_frame_or_degraded(frame: dict[str, Any], cap_bytes: int) -> dict[str, Any]:
+    """Return ``frame``, or a small stand-in when it cannot be read.
+
+    WHY A FRAME THIS BIG IS NOT MERELY LARGE. The attach client dials with
+    ``limit=_READ_LIMIT_BYTES`` (the same 1 MiB as ``cap_bytes``), so an
+    oversized line makes its ``readline`` raise ``LimitOverrunError``. That is
+    unrecoverable rather than lossy: the overrun does NOT consume the buffer,
+    so every later read re-raises on the same bytes. The client's pump
+    therefore dies, and the viewer paints "owner sent a frame too large to
+    read" — the message the operator hit — losing the whole connection over one
+    delta. ``frontend_sync`` has been guarded since it caused exactly this
+    (see ``oversized_frame_report``); ``frontend_update`` and ``event`` were
+    not, and a single 1,039,374-byte transcript row produced a 1,129,319-byte
+    ``event`` frame that killed the socket.
+
+    DEGRADING ONE DELTA IS SAFE; KILLING THE SOCKET IS NOT. Both relay frame
+    types are deltas over state the viewer can recover by other means: it holds
+    durable history and re-syncs through ``frontend_sync``, which carries the
+    canonical snapshot. Dropping the payload costs one animation step that the
+    next snapshot supersedes. Killing the connection costs the session.
+
+    THE STAND-IN MUST STILL BE A VALID FRAME OF ITS OWN OP, which is why this
+    is not one generic placeholder:
+
+    * ``event`` — the payload is deserialized by ``deserialize_event``, which
+      REQUIRES ``type``. A bare marker raises there, and although the client
+      swallows callback failures (so the pump survives), the viewer would then
+      silently miss the frame with nothing said. It degrades to a ``notice``
+      instead: a real event type, rendered, and honest about what happened.
+    * ``frontend_update`` — canonical deltas are NOT replacement-safe. The
+      client checks ``epoch``/``sequence`` and closes the connection on a gap
+      by design, precisely so canonical state can never drift. A placeholder
+      that dropped the sequence would trip that check and kill the connection
+      this function exists to save, so the sequencing fields are carried
+      through and only the oversized BODY is shed. The viewer sees a
+      well-sequenced delta whose payload says it was degraded.
+
+    Cheap on the hot path: relay frames are ordinary-sized, so the common case
+    pays one ``len(json.dumps(...))`` — the same measurement the send would
+    perform anyway.
+    """
+    encoded = len(json.dumps(frame).encode()) + 1  # the socket writes a "\n" too
+    if encoded <= cap_bytes:
+        return frame
+    op = frame.get("op", "frame")
+    logger.error(
+        "session runtime: %s frame is %d bytes, over the %d-byte socket line limit; "
+        "relaying a degraded placeholder instead of killing the connection "
+        "(the viewer recovers this state through frontend_sync + durable history)",
+        op,
+        encoded,
+        cap_bytes,
+    )
+    text = (
+        "A live update was too large to send and was dropped; "
+        "the view refreshes from the session's own history."
+    )
+    if op == "frontend_update":
+        data = frame.get("data")
+        data = data if isinstance(data, dict) else {}
+        # Sequencing preserved (see above): shed the body, never the epoch or
+        # the sequence number the client's gap check depends on.
+        return {
+            "op": op,
+            "data": {
+                "epoch": data.get("epoch"),
+                "sequence": data.get("sequence"),
+                "degraded": True,
+                "degraded_reason": text,
+            },
+        }
+    return {
+        "op": op,
+        "data": {"type": "notice", "text": text, "kind": "warning"},
+    }
+
+
 # A projection is replaceable state. If a peer cannot accept one within this
 # bound, dropping that peer is safer than blocking authority-bearing ACKs for
 # every healthy front end.
@@ -1891,6 +1970,12 @@ class RuntimeServer:
 
     def _enqueue_client_frame(self, conn: _ClientConn, frame: dict[str, Any]) -> None:
         """Queue one state/event frame on the connection's sole ordered FIFO."""
+        # THE chokepoint for both relay frame types: ``frontend_update`` and
+        # ``event`` both arrive here, so guarding once covers both and no
+        # future relay caller can bypass it by forgetting to check. (The
+        # ``frontend_sync`` frame does not come through here — it is written
+        # directly at connect time and carries its own report.)
+        frame = relay_frame_or_degraded(frame, _MAX_LINE_BYTES)
         try:
             conn.event_queue.put_nowait(frame)
         except asyncio.QueueFull:

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -2054,6 +2054,24 @@ class RuntimeServer:
         the append contract UIs rely on. Returns whether any room was freed.
         Runs synchronously on the runtime loop, so the drain task cannot
         observe a half-compacted queue.
+
+        A MERGE THAT WOULD NOT FIT IS REFUSED, and that check cannot be
+        skipped on the grounds that everything in this queue already passed
+        ``relay_frame_or_degraded``. It did — individually. Merging is the one
+        operation here that makes a frame BIGGER than anything the guard was
+        shown, so it can assemble individually-legal frames into an
+        unreadable one downstream of the only guard: 20 frames of 908,157 B
+        merged to 1,060,157 B and killed a real pump, and at 1 KiB deltas a
+        full 64-frame queue merged to 1,109,802 B — within 20 KB of the frame
+        that killed the operator's socket. The trigger is precisely the burst
+        this method exists to absorb.
+
+        REFUSED, not degraded, because refusing is lossless: both frames are
+        individually sendable, so keeping them apart costs one queue slot and
+        no content, while degrading would throw away deltas the viewer needs.
+        Refusing can leave nothing compacted, and that is the honest answer —
+        the caller then drops a client it genuinely cannot serve, which is the
+        documented slow-reader path rather than a silently broken socket.
         """
         frames: list[dict[str, Any]] = []
         while True:
@@ -2080,8 +2098,13 @@ class RuntimeServer:
                 ):
                     merged = dict(data)
                     merged["delta"] = str(prior.get("delta", "")) + str(data.get("delta", ""))
-                    compacted[-1] = {"op": "event", "data": merged}
-                    continue
+                    merged_frame = {"op": "event", "data": merged}
+                    # Measured against the same cap the guard uses. Over it,
+                    # leave the two frames unmerged (see the docstring): the
+                    # pair is readable, their concatenation is not.
+                    if len(json.dumps(merged_frame).encode()) + 1 <= _MAX_LINE_BYTES:
+                        compacted[-1] = merged_frame
+                        continue
             compacted.append(frame)
         for frame in compacted:
             conn.event_queue.put_nowait(frame)

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -100,6 +100,30 @@ def image_blocks(images: list[dict[str, str]] | None) -> list["ImageContent"]:
 _MAX_LINE_BYTES = 1 << 20
 
 
+def _frame_size_without_delta(frame: dict[str, Any]) -> int:
+    """Encoded size of ``frame`` counting its ``delta`` as empty (plus the "\\n").
+
+    Compaction needs a candidate frame's encoded length, but the expensive part
+    of a ``message_update`` is the accumulated ``message`` — hundreds of KB that
+    a merge does not change. Measuring the whole frame per merge is what made
+    compaction quadratic (67.4 MB and 152 ms for one 64-frame pass). Splitting
+    the measurement lets the caller add the delta's escaped bytes itself, which
+    is exact because JSON escaping is per-character: the encoded length of
+    ``a + b`` is the encoded length of ``a`` plus that of ``b``.
+
+    The delta is blanked rather than removed so the key, its quotes and its
+    comma are all still counted — only the VALUE's bytes are the caller's to
+    add.
+    """
+    data = frame.get("data")
+    if not isinstance(data, dict) or "delta" not in data:
+        return len(json.dumps(frame).encode()) + 1
+    probe = {**frame, "data": {**data, "delta": ""}}
+    # ``- 2`` removes the two quotes of the blanked delta: the caller adds the
+    # real value back including its own quotes.
+    return len(json.dumps(probe).encode()) + 1 - 2
+
+
 def relay_frame_or_degraded(frame: dict[str, Any], cap_bytes: int) -> dict[str, Any]:
     """Return ``frame``, or a small stand-in when it cannot be read.
 
@@ -2083,6 +2107,10 @@ class RuntimeServer:
                 break
             conn.event_queue.task_done()
         compacted: list[dict[str, Any]] = []
+        # Escaped byte length of the DELTA currently held by ``compacted[-1]``.
+        # Tracked incrementally so a merge never re-measures the deltas already
+        # folded in; see the size check below for why this is exact.
+        merged_delta_bytes: list[int] = []
         for frame in frames:
             previous = compacted[-1] if compacted else None
             if (
@@ -2098,16 +2126,55 @@ class RuntimeServer:
                     and (data.get("message") or {}).get("id")
                     == (prior.get("message") or {}).get("id")
                 ):
-                    merged = dict(data)
-                    merged["delta"] = str(prior.get("delta", "")) + str(data.get("delta", ""))
-                    merged_frame = {"op": "event", "data": merged}
-                    # Measured against the same cap the guard uses. Over it,
-                    # leave the two frames unmerged (see the docstring): the
-                    # pair is readable, their concatenation is not.
-                    if len(json.dumps(merged_frame).encode()) + 1 <= _MAX_LINE_BYTES:
-                        compacted[-1] = merged_frame
+                    # SIZE THE DELTA, NOT THE WHOLE FRAME. Re-dumping the
+                    # merged frame re-serializes the unchanged accumulated
+                    # ``message`` — hundreds of KB — on every merge, which is
+                    # quadratic in queue depth: one 64-frame compaction
+                    # serialized 67.4 MB and took 152 ms on the runtime loop.
+                    # That loop also owns the ``_SEND_TIMEOUT_S`` sends, so the
+                    # stall pushed a healthy peer's 0.90 s drain past 1.0 s and
+                    # dropped it — manufacturing the very false disconnect this
+                    # guard exists to prevent.
+                    #
+                    # Exact, not an estimate: JSON escaping is per-character,
+                    # so the escaped length of ``a + b`` is exactly the escaped
+                    # length of ``a`` plus that of ``b``. The merged frame is
+                    # THIS frame carrying its own delta with everything already
+                    # folded into ``compacted[-1]`` prepended, so its encoded
+                    # size is this frame's size plus those accumulated escaped
+                    # bytes. Measuring ``frame`` rather than the merge result
+                    # is what makes this O(one frame) per merge — and because
+                    # it is THIS frame's own ``message``, a message that grew
+                    # between frames is sized correctly rather than estimated
+                    # from a stale one. Verified equal to a full re-dump on
+                    # adversarial payloads (quotes, backslashes, control
+                    # characters, emoji, U+2028) and thousands of random ones.
+                    prior_delta_bytes = merged_delta_bytes[-1]
+                    frame_bytes = _frame_size_without_delta(frame) + len(
+                        json.dumps(str(data.get("delta", ""))).encode()
+                    )
+                    if frame_bytes + prior_delta_bytes <= _MAX_LINE_BYTES:
+                        merged = dict(data)
+                        merged["delta"] = str(prior.get("delta", "")) + str(data.get("delta", ""))
+                        compacted[-1] = {"op": "event", "data": merged}
+                        # ACCUMULATES: the new head carries the prior head's
+                        # whole delta plus its own, so the next merge must be
+                        # measured against both. Overwriting this with only the
+                        # newly-folded delta under-counts every merge after the
+                        # second and emitted a 1,048,795-byte frame — over the
+                        # cap this method exists to respect.
+                        merged_delta_bytes[-1] = prior_delta_bytes + (
+                            len(json.dumps(str(data.get("delta", ""))).encode()) - 2
+                        )
                         continue
             compacted.append(frame)
+            # Seeded with THIS frame's own delta, not zero: the running total
+            # is "escaped bytes of the delta ``compacted[-1]`` currently
+            # holds", and a later merge prepends all of it. Seeding zero
+            # under-counted the first merge of every run. Only the delta is
+            # serialized here, never the accumulated message.
+            own_delta = (frame.get("data") or {}).get("delta", "")
+            merged_delta_bytes.append(len(json.dumps(str(own_delta)).encode()) - 2)
         for frame in compacted:
             conn.event_queue.put_nowait(frame)
         return len(compacted) < len(frames)

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -245,6 +245,15 @@ _CONTINUATION_PROMPT = (
 #: recovery band must not re-prompt forever.
 _MAX_CONTINUATIONS = 8
 
+#: How many turns may be dropped as born-pre-aborted before the session says so
+#: on the front end. The first drop is ordinary and silent — one arrival racing
+#: an abort the user just pressed is normal and needs no commentary. A RUN of
+#: them means work keeps arriving into a stopped session, which the user can
+#: only act on if they are told; the notice fires once per run (see
+#: ``_pre_aborted_drops``) rather than once per drop, because N identical rows
+#: at sub-second cadence is the noise this replaced.
+_PRE_ABORT_DROP_NOTICE_AT = 3
+
 #: The builtin tools whose createIf gate reads a field only a SESSION can fill
 #: (``subagent_launcher``, ``jobs``, ``wake_scheduler``, ``subagent_comms``, the
 #: ask hook). Named here rather than inline in
@@ -1989,6 +1998,17 @@ class Session:
         # usage objects that lifetime cost and analytics still need.
         self._held_context_tokens: int | None = None
         self._abort_requested = False  # sticky across the continuation gap
+        # Turns dropped back-to-back because they were born pre-aborted. Reset
+        # by any turn that actually runs, so the honest "I am dropping these"
+        # notice is emitted ONCE per run of drops instead of once per drop —
+        # the live session painted N identical ``interrupted`` rows at
+        # sub-second cadence and none of them said why.
+        self._pre_aborted_drops = 0
+        # Monotonic count of aborts. It is what lets an arriving unit of work
+        # tell "an abort happened before I got here" (stale — my own intent is
+        # newer, so I run) from "an abort happened while I was queued" (that
+        # Esc was aimed at me too, so I am held). See ``_prompt_messages``.
+        self._abort_epoch = 0
         # Boundary-respecting cancel (see request_graceful_cancel). Sticky like
         # ``_abort_requested`` and cleared on the same edges, but honoured at
         # the loop's post-tool boundary instead of by firing the abort signal,
@@ -5011,6 +5031,11 @@ class Session:
         the caller asks the session what it cancelled.
         """
         self._abort_requested = True
+        # Bumped on EVERY abort, before the signal fires. Work already queued
+        # on ``_turn_lock`` samples this on arrival and compares here, so one
+        # press stops the running turn AND the backlog behind it instead of
+        # stopping one turn per press (see ``_prompt_messages``).
+        self._abort_epoch += 1
         self.cancel_fork()
         if self._signal is not None:
             self._signal.abort(reason)
@@ -5696,7 +5721,60 @@ class Session:
         handling so it can REJECT reentrants instead of queueing)."""
         if self._disposed:
             raise RuntimeError("session is disposed")
+        # Sampled BEFORE the lock wait, so it dates this work's ARRIVAL rather
+        # than the moment it reached the front of the queue. An abort landing
+        # during the wait therefore bumps the epoch past this sample, which is
+        # exactly how the honoured-vs-stale test below can tell the two apart.
+        arrived_at_epoch = self._abort_epoch
         async with self._turn_lock:
+            # A newly ARRIVING unit of work is a fresh intent, exactly like a
+            # typed prompt, so it clears the sticky abort the same way
+            # ``prompt()`` does — see that method for the flag's contract.
+            #
+            # WHY THIS IS NOT "just clear it unconditionally": the flag is
+            # sticky on purpose, so a Ctrl+C landing in the gap between a turn
+            # and its post-compaction continuation is still honoured (read at
+            # ``_run_turn`` and ``_drain_continuation``). That case is
+            # untouched here because a continuation never comes through this
+            # method — ``_drain_continuation`` calls ``_run_turn`` directly,
+            # inside the same lock hold this clear can only run after. Every
+            # caller of ``_prompt_messages`` is arriving work (peer message,
+            # wake delivery, resume catch-up, background job result), never a
+            # continuation of the aborted turn.
+            #
+            # AFTER acquiring the lock, not before spawning: while this
+            # coroutine waits for the lock the PREVIOUS turn still owns it, and
+            # an abort landing in that window belongs to that turn and its
+            # continuations. Clearing early would eat it. Once the lock is
+            # ours, that turn and its continuation drain are both finished, so
+            # anything still set applied to work that is over. Identical
+            # ordering to ``prompt()``.
+            #
+            # Without this, ONE abort made every later wake/peer/catch-up turn
+            # pre-aborted forever: each arrival opened a turn that died before
+            # doing anything, and a session with subagents reporting in span at
+            # sub-second cadence spending a provider call per iteration.
+            #
+            # "FRESH" IS RELATIVE TO THE ABORT, WHICH IS WHY THIS IS NOT
+            # UNCONDITIONAL. Arrivals queue on ``_turn_lock`` behind a running
+            # turn, so at the moment the user presses Esc there may be N of
+            # them waiting. Those arrived BEFORE the stop and are part of what
+            # the user is stopping; clearing the flag for each of them in turn
+            # would run all N and force one press per queued item — the
+            # observed "Esc does nothing" (Defect 2a), and a worse loop than
+            # the one Defect 1 describes because each item runs a full turn.
+            #
+            # The epoch is the test. Unchanged since this work arrived means
+            # any pending abort predates it and does not apply: run, clearing
+            # the flag. Bumped means an abort landed while this sat in the
+            # queue, aimed at the backlog it was in: leave the flag set and let
+            # ``_run_turn`` hold the message instead of running it.
+            if self._abort_epoch == arrived_at_epoch:
+                self._abort_requested = False
+                # ...and the boundary cancel, for the reason ``prompt()``
+                # gives: the request applied to the turn the caller was
+                # stopping, not to the work that has just arrived.
+                self._graceful_cancel_requested = False
             # Same shell-receipt boundary as prompt(): a wake turn must not
             # build from context that omits a command already visible in TUI.
             await self._flush_shell_records()
@@ -5801,6 +5879,32 @@ class Session:
         producer_command_id: str | None = None,
     ) -> None:
         """One loop run + persistence. Caller holds ``_turn_lock``."""
+        if self._abort_requested:
+            # BORN PRE-ABORTED: do not open a turn at all. Running one spends a
+            # real provider request — the loop builds and issues the call
+            # before ``_drain_stream`` cancels its pump — and returns an
+            # ``aborted`` end with no output, which is a paid no-op. In the
+            # live incident that was the entire cost: a stopped session
+            # answering arrivals with instant empty turns, billed per
+            # iteration.
+            #
+            # DROPPED, not run, and the distinction matters: the arriving
+            # message is still persisted and still reaches the model on the
+            # next turn (the record-only path ``receive_peer_message`` uses for
+            # a busy session), so nothing is lost — only the model call the
+            # user already said to stop is skipped. No ``AgentStartEvent`` is
+            # emitted either, so no front end paints a turn that is not
+            # running.
+            #
+            # The flag deliberately stays set: it is cleared by an arriving
+            # unit of work (``_prompt_messages``) or a typed prompt, and a drop
+            # is neither. Clearing here would let the next arrival run the very
+            # work the abort was meant to stop.
+            await self._drop_pre_aborted_turn(initial, admitted=admitted, admitted_id=admitted_id)
+            return
+        # A turn is really running, so any run of drops has ended; the next one
+        # earns a fresh notice.
+        self._pre_aborted_drops = 0
         if self._wake.needs_rearm:
             # HC-20: the scheduler could not arm without a running loop at
             # construction; the first turn (with a loop) re-arms via pump().
@@ -5812,9 +5916,9 @@ class Session:
         signal = AbortSignal()
         self._signal = signal
         if self._abort_requested:
-            # A Ctrl+C landed in the gap between turns (signal was None);
-            # honour it on the fresh signal instead of running the
-            # continuation the user tried to stop.
+            # An abort that landed between the drop check above and here — a
+            # Ctrl+C in the microseconds this turn took to start. Honour it on
+            # the fresh signal rather than running work the user just stopped.
             signal.abort("interrupted")
         try:
             for message in initial:
@@ -6045,6 +6149,67 @@ class Session:
             await self._persist_progress(self._context.messages)
             self._signal = None
             self._is_streaming = False
+
+    async def _drop_pre_aborted_turn(
+        self,
+        initial: list[AgentMessage],
+        *,
+        admitted: asyncio.Future[None] | None = None,
+        admitted_id: str | None = None,
+    ) -> None:
+        """Retire a turn that would have been born aborted, without running it.
+
+        The arriving messages are still made DURABLE and still reach the model
+        on the session's next real turn — this drops the model call, never the
+        message. That is the same guarantee the record-only delivery path gives
+        a busy session (see ``receive_peer_message``), which is why the message
+        is appended to the transcript here and handed to
+        ``_append_or_park_journal`` for the live context rather than being
+        appended straight onto ``_context.messages``: the caller holds
+        ``_turn_lock``, so a bare append is the tool-batch splice hazard that
+        method documents.
+
+        No ``AgentStartEvent``/``AgentEndEvent`` pair is emitted. A dropped
+        turn never started, and emitting the pair is precisely what painted a
+        row of identical ``interrupted`` entries for turns that did no work.
+        """
+        self._pre_aborted_drops += 1
+        for message in initial:
+            await self._transcript.append_message(message)
+            if isinstance(message, CustomMessage):
+                self._append_or_park_journal(message)
+            else:
+                # A plain Message has no journal park (that path is typed for
+                # CustomMessage). Park it the same way the steering queue does
+                # so the next turn reads it: the queue is drained at the loop's
+                # injection boundary, which is turn-safe by construction.
+                self._steering_queue.put_nowait(message)
+            if admitted is not None and message.id == admitted_id and not admitted.done():
+                # The producer's durability contract is about the APPEND, not
+                # about a turn running: the row is on disk under Transcript's
+                # fsync boundary, so the producer may discard its retained
+                # command exactly as it would on the normal path. Leaving this
+                # future unresolved would hang the producer forever.
+                admitted.set_result(None)
+        if self._pre_aborted_drops == _PRE_ABORT_DROP_NOTICE_AT:
+            # ONE notice per run of drops. It names the remedy, because the
+            # state is otherwise invisible: the session looks idle, work keeps
+            # arriving, and nothing runs until a prompt clears the abort.
+            await self._emit(
+                NoticeEvent(
+                    text=(
+                        "Work is arriving into a stopped session and is being held, "
+                        "not run. Send a message to resume; the held items are read "
+                        "on that turn."
+                    ),
+                    kind="warning",
+                )
+            )
+        logger.info(
+            "dropped a pre-aborted turn (%d in this run); %d message(s) held for the next turn",
+            self._pre_aborted_drops,
+            len(initial),
+        )
 
     async def _drain_continuation(self) -> None:
         """Run queued auto-continuation prompts (post-compaction resume) as

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -2004,6 +2004,10 @@ class Session:
         # the live session painted N identical ``interrupted`` rows at
         # sub-second cadence and none of them said why.
         self._pre_aborted_drops = 0
+        # Latch for the notice above, reset on the same edge as the counter.
+        # Separate from the count because the count answers "how long is this
+        # run" and this answers "have I already said so".
+        self._pre_abort_notified = False
         # Monotonic count of aborts. It is what lets an arriving unit of work
         # tell "an abort happened before I got here" (stale — my own intent is
         # newer, so I run) from "an abort happened while I was queued" (that
@@ -4529,6 +4533,11 @@ class Session:
                 admitted=admitted,
                 admitted_id=user.id,
                 producer_command_id=producer_command_id,
+                # A typed prompt has a caller awaiting it, so it may never be
+                # dropped silently: an abort landing between the clear above
+                # and the turn's own gate must produce a VISIBLE interrupt,
+                # not a success return for work that never ran.
+                may_drop=False,
             )
         finally:
             self._turn_lock.release()
@@ -5794,6 +5803,7 @@ class Session:
         admitted: asyncio.Future[None] | None = None,
         admitted_id: str | None = None,
         producer_command_id: str | None = None,
+        may_drop: bool = True,
     ) -> None:
         """One turn + its auto-continuations. Caller holds ``_turn_lock``.
 
@@ -5837,6 +5847,7 @@ class Session:
                 admitted=admitted,
                 admitted_id=admitted_id,
                 producer_command_id=producer_command_id,
+                may_drop=may_drop,
             )
             await self._drain_continuation()
         finally:
@@ -5877,9 +5888,14 @@ class Session:
         admitted: asyncio.Future[None] | None = None,
         admitted_id: str | None = None,
         producer_command_id: str | None = None,
+        may_drop: bool = True,
     ) -> None:
-        """One loop run + persistence. Caller holds ``_turn_lock``."""
-        if self._abort_requested:
+        """One loop run + persistence. Caller holds ``_turn_lock``.
+
+        ``may_drop`` is False for a SYNCHRONOUS typed prompt; see the drop gate
+        below for why a caller that is waiting must not be dropped silently.
+        """
+        if self._abort_requested and may_drop:
             # BORN PRE-ABORTED: do not open a turn at all. Running one spends a
             # real provider request — the loop builds and issues the call
             # before ``_drain_stream`` cancels its pump — and returns an
@@ -5900,11 +5916,31 @@ class Session:
             # unit of work (``_prompt_messages``) or a typed prompt, and a drop
             # is neither. Clearing here would let the next arrival run the very
             # work the abort was meant to stop.
-            await self._drop_pre_aborted_turn(initial, admitted=admitted, admitted_id=admitted_id)
+            #
+            # ONLY ARRIVING WORK MAY BE DROPPED (``may_drop``). Dropping is
+            # silent by design — no start/end pair — which is right when
+            # nobody is waiting: a wake or peer message has no caller to
+            # inform, and the message is still held for the next turn.
+            # A TYPED PROMPT IS THE OPPOSITE. ``prompt()`` clears the flag
+            # under the lock, but the pipeline awaits twice before this gate
+            # reads it, so an abort landing in that window (submit, then
+            # immediately Esc — exactly the incident's behaviour) would send
+            # the user's OWN prompt down this path: no events, and ``prompt()``
+            # returning success for work that never ran. A user's typed prompt
+            # must never vanish silently — it either runs or is VISIBLY
+            # interrupted — so that caller keeps the pre-armed-signal
+            # behaviour below, which emits the ordinary aborted start/end pair.
+            await self._drop_pre_aborted_turn(
+                initial,
+                admitted=admitted,
+                admitted_id=admitted_id,
+                producer_command_id=producer_command_id,
+            )
             return
         # A turn is really running, so any run of drops has ended; the next one
         # earns a fresh notice.
         self._pre_aborted_drops = 0
+        self._pre_abort_notified = False
         if self._wake.needs_rearm:
             # HC-20: the scheduler could not arm without a running loop at
             # construction; the first turn (with a loop) re-arms via pump().
@@ -6156,6 +6192,7 @@ class Session:
         *,
         admitted: asyncio.Future[None] | None = None,
         admitted_id: str | None = None,
+        producer_command_id: str | None = None,
     ) -> None:
         """Retire a turn that would have been born aborted, without running it.
 
@@ -6175,32 +6212,63 @@ class Session:
         """
         self._pre_aborted_drops += 1
         for message in initial:
-            await self._transcript.append_message(message)
+            # EXACTLY ONE WRITER PER MESSAGE, and which one differs by type
+            # because the two parking paths have opposite persistence
+            # contracts:
+            #
+            # * ``CustomMessage`` -> ``_append_or_park_journal`` only touches
+            #   LIVE context, so the durable write is owed here.
+            # * plain ``Message`` -> the steering queue's consumer
+            #   (``_drain_steering``) persists whatever it drains. Appending
+            #   here too wrote the row twice, and the duplicate survived into
+            #   replayed history, so a resumed session showed the message
+            #   twice and sent it to the model twice. This is the same
+            #   contract ``receive_peer_message``'s mid-turn steer path relies
+            #   on: queue it, and let the drain be the single writer.
             if isinstance(message, CustomMessage):
+                await self._transcript.append_message(
+                    message,
+                    producer_command_id=(
+                        producer_command_id if message.id == admitted_id else None
+                    ),
+                )
                 self._append_or_park_journal(message)
             else:
-                # A plain Message has no journal park (that path is typed for
-                # CustomMessage). Park it the same way the steering queue does
-                # so the next turn reads it: the queue is drained at the loop's
-                # injection boundary, which is turn-safe by construction.
+                # Provenance rides with the message rather than being dropped:
+                # the drain reads this map and stamps the row, which is what
+                # ``_producer_command_id_from_entry`` needs on replay to
+                # recognise an already-admitted command. Without it a producer
+                # that redialled could re-admit the same command.
+                if producer_command_id is not None and message.id == admitted_id:
+                    self._steering_producers[id(message)] = producer_command_id
                 self._steering_queue.put_nowait(message)
             if admitted is not None and message.id == admitted_id and not admitted.done():
                 # The producer's durability contract is about the APPEND, not
                 # about a turn running: the row is on disk under Transcript's
-                # fsync boundary, so the producer may discard its retained
+                # fsync boundary (or, on the steering branch, guaranteed by the
+                # drain that owns it), so the producer may discard its retained
                 # command exactly as it would on the normal path. Leaving this
                 # future unresolved would hang the producer forever.
                 admitted.set_result(None)
-        if self._pre_aborted_drops == _PRE_ABORT_DROP_NOTICE_AT:
-            # ONE notice per run of drops. It names the remedy, because the
-            # state is otherwise invisible: the session looks idle, work keeps
-            # arriving, and nothing runs until a prompt clears the abort.
+        if self._pre_aborted_drops >= _PRE_ABORT_DROP_NOTICE_AT and not self._pre_abort_notified:
+            # ONE notice per run of drops, held by a LATCH rather than by an
+            # equality test on the counter. With ``==`` a run interrupted by a
+            # real turn at count 2 restarts the counter, so a long stuttering
+            # run could clear the threshold repeatedly and still never say
+            # anything. ``>=`` plus the latch says it once, on the first drop
+            # that crosses the line, however the run got there.
+            self._pre_abort_notified = True
+            # The text does NOT tell the user to act: a new arrival (a wake, a
+            # peer message) is itself fresh intent and clears the abort on its
+            # own, so the session recovers without them. Saying "send a message
+            # to resume" described work they do not have to do and misnamed the
+            # state. What they cannot see — and what this exists to say — is
+            # that things are arriving and being held rather than run.
             await self._emit(
                 NoticeEvent(
                     text=(
-                        "Work is arriving into a stopped session and is being held, "
-                        "not run. Send a message to resume; the held items are read "
-                        "on that turn."
+                        "Work arriving into this stopped session is being held, not run. "
+                        "The held items are read on the next turn."
                     ),
                     kind="warning",
                 )
@@ -10909,6 +10977,14 @@ class Session:
         # A courtesy wake still queued here was never delivered, so its count
         # must not survive to misclassify a later enqueue on a reused Session.
         self._courtesy_wake_count = 0
+        # Same reasoning for a run of pre-aborted drops in progress: the run
+        # ends with the session, so neither the count nor its notice latch may
+        # carry into a reused Session and suppress (or fabricate) a notice for
+        # a run that has not happened. ``_abort_epoch`` is deliberately NOT
+        # reset — it must stay monotonic, or work sampled before disposal could
+        # compare equal to a later epoch and run against a stale abort.
+        self._pre_aborted_drops = 0
+        self._pre_abort_notified = False
         try:
             # HC-14: abort the in-flight turn and await its completion (bounded)
             # before flushing — its persistence must land on a live transcript.

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -6196,19 +6196,38 @@ class Session:
     ) -> None:
         """Retire a turn that would have been born aborted, without running it.
 
-        The arriving messages are still made DURABLE and still reach the model
-        on the session's next real turn — this drops the model call, never the
+        The arriving messages are still made DURABLE — here, before this
+        method returns, not on some later turn — and still reach the model on
+        the session's next real turn. This drops the model call, never the
         message. That is the same guarantee the record-only delivery path gives
-        a busy session (see ``receive_peer_message``), which is why the message
-        is appended to the transcript here and handed to
-        ``_append_or_park_journal`` for the live context rather than being
-        appended straight onto ``_context.messages``: the caller holds
-        ``_turn_lock``, so a bare append is the tool-batch splice hazard that
-        method documents.
+        a busy session (see ``receive_peer_message``).
+
+        Durability cannot wait for the next turn, because there may not be one:
+        ``dispose()`` consumes the steering queue and rejects what it finds
+        without persisting, so a message left queue-resident is destroyed when
+        the session ends. Deferring the write is what turned exactly-once into
+        exactly-zero for held peer/wake traffic.
+
+        The LIVE-context half is separate and does not write: a
+        ``CustomMessage`` goes through ``_append_or_park_journal`` and a plain
+        ``Message`` through the steering queue, rather than straight onto
+        ``_context.messages``, because the caller holds ``_turn_lock`` and a
+        bare append is the tool-batch splice hazard that method documents.
+        ``_drain_steering`` skips anything the transcript already holds, so the
+        row is written once.
 
         No ``AgentStartEvent``/``AgentEndEvent`` pair is emitted. A dropped
         turn never started, and emitting the pair is precisely what painted a
         row of identical ``interrupted`` entries for turns that did no work.
+
+        ``admitted``/``admitted_id``/``producer_command_id`` are currently
+        UNREACHABLE: the only caller that supplies admission is ``prompt()``,
+        which passes ``may_drop=False`` and so never lands here. They are kept
+        because they are the correct handling if any admitting caller ever
+        becomes droppable — resolving the future, and stamping the provenance
+        marker replay needs — and getting that wrong is a hung producer or a
+        re-admitted command rather than a visible bug. Treat them as a
+        contract, not as live behaviour.
         """
         self._pre_aborted_drops += 1
         for message in initial:
@@ -6225,28 +6244,31 @@ class Session:
             #   twice and sent it to the model twice. This is the same
             #   contract ``receive_peer_message``'s mid-turn steer path relies
             #   on: queue it, and let the drain be the single writer.
+            # DURABLE HERE, ON BOTH BRANCHES. Deferring the write to the
+            # steering drain made the held message durable NOWHERE until a turn
+            # that may never come: ``dispose()`` consumes the same queue and
+            # rejects without persisting, so ending the session destroyed a
+            # held peer/wake message outright. Exactly-once must not become
+            # exactly-zero, and this method's contract is that the message
+            # survives even though its turn did not.
+            await self._transcript.append_message(
+                message,
+                producer_command_id=(producer_command_id if message.id == admitted_id else None),
+            )
             if isinstance(message, CustomMessage):
-                await self._transcript.append_message(
-                    message,
-                    producer_command_id=(
-                        producer_command_id if message.id == admitted_id else None
-                    ),
-                )
                 self._append_or_park_journal(message)
             else:
-                # Provenance rides with the message rather than being dropped:
-                # the drain reads this map and stamps the row, which is what
-                # ``_producer_command_id_from_entry`` needs on replay to
-                # recognise an already-admitted command. Without it a producer
-                # that redialled could re-admit the same command.
-                if producer_command_id is not None and message.id == admitted_id:
-                    self._steering_producers[id(message)] = producer_command_id
+                # Queued for the live context only — the write above already
+                # made it durable, and ``_drain_steering`` skips a message the
+                # transcript already holds, so this is not the double-persist
+                # round 1 fixed. Provenance is stamped on the row above rather
+                # than through ``_steering_producers``, which exists for steers
+                # whose write the drain still owns.
                 self._steering_queue.put_nowait(message)
             if admitted is not None and message.id == admitted_id and not admitted.done():
                 # The producer's durability contract is about the APPEND, not
                 # about a turn running: the row is on disk under Transcript's
-                # fsync boundary (or, on the steering branch, guaranteed by the
-                # drain that owns it), so the producer may discard its retained
+                # fsync boundary, so the producer may discard its retained
                 # command exactly as it would on the normal path. Leaving this
                 # future unresolved would hang the producer forever.
                 admitted.set_result(None)
@@ -6893,6 +6915,17 @@ class Session:
         while not self._steering_queue.empty():
             message = self._steering_queue.get_nowait()
             producer_command_id = self._steering_producers.get(id(message))
+            if self._transcript.has_entry(message.id):
+                # ALREADY DURABLE, so this drain is not its writer. A turn
+                # dropped as pre-aborted persists its held message at the drop
+                # (it must survive a ``dispose()`` that never runs another
+                # turn) and queues it here only to reach live context. Writing
+                # it again produced two identical rows that survived into
+                # replayed history. Constant-time check on the transcript's id
+                # set, so the ordinary steer pays effectively nothing.
+                self._steering_producers.pop(id(message), None)
+                messages.append(message)
+                continue
             try:
                 await self._transcript.append_message(
                     message,

--- a/tests/unit/session/test_attach_frame_size.py
+++ b/tests/unit/session/test_attach_frame_size.py
@@ -1303,3 +1303,94 @@ async def test_attach_succeeds_against_an_owner_offering_thousands_of_models(
         if remote is not None:
             await remote.dispose()
         registrant.close()
+
+
+def _oversized_event_frame() -> dict[str, Any]:
+    """An ``event`` frame the size the operator's real transcript produced.
+
+    A single 1,039,374-byte transcript row serialized to a 1,129,319-byte
+    ``event`` frame — past the 1 MiB line limit both sides enforce.
+    """
+    from local_operator.session.runtime.server import _MAX_LINE_BYTES
+
+    return {
+        "op": "event",
+        "data": {
+            "type": "message_update",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "x" * (_MAX_LINE_BYTES + 80_000)}],
+            },
+            "delta": "x",
+        },
+    }
+
+
+def test_oversized_event_frame_degrades_instead_of_killing_the_socket():
+    """``event`` is guarded the way ``frontend_sync`` already was.
+
+    An oversized line makes the client's ``readline`` raise
+    ``LimitOverrunError``, and the overrun does NOT consume the buffer, so every
+    later read re-raises: the pump dies and the viewer paints "owner sent a
+    frame too large to read". Degrading one delta is safe — the viewer recovers
+    through ``frontend_sync`` plus durable history — while killing the socket
+    is not.
+    """
+    from local_operator.session.remote import deserialize_event
+    from local_operator.session.runtime.server import (
+        _MAX_LINE_BYTES,
+        relay_frame_or_degraded,
+    )
+
+    frame = _oversized_event_frame()
+    assert len(json.dumps(frame).encode()) + 1 > _MAX_LINE_BYTES
+
+    sendable = relay_frame_or_degraded(frame, _MAX_LINE_BYTES)
+
+    # It now fits, so the client can read it...
+    assert len(json.dumps(sendable).encode()) + 1 <= _MAX_LINE_BYTES
+    assert sendable["op"] == "event"
+    # ...and it is still a VALID event: the client deserializes every relayed
+    # payload, and a bare marker would raise there and be silently swallowed.
+    event = deserialize_event(sendable["data"])
+    assert event.type == "notice"
+
+
+def test_oversized_frontend_update_keeps_its_sequence():
+    """Canonical deltas are not replacement-safe, so the placeholder is not one.
+
+    The client closes the connection on an ``epoch``/``sequence`` gap by design.
+    A placeholder that dropped those fields would trip that check and kill the
+    connection this guard exists to save, so only the oversized BODY is shed.
+    """
+    from local_operator.session.runtime.server import (
+        _MAX_LINE_BYTES,
+        relay_frame_or_degraded,
+    )
+
+    frame = {
+        "op": "frontend_update",
+        "data": {
+            "epoch": "epoch-1",
+            "sequence": 42,
+            "snapshot": {"jobs": "y" * (_MAX_LINE_BYTES + 10_000)},
+        },
+    }
+
+    sendable = relay_frame_or_degraded(frame, _MAX_LINE_BYTES)
+
+    assert len(json.dumps(sendable).encode()) + 1 <= _MAX_LINE_BYTES
+    assert sendable["data"]["epoch"] == "epoch-1"
+    assert sendable["data"]["sequence"] == 42
+    assert sendable["data"]["degraded"] is True
+
+
+def test_ordinary_relay_frames_pass_through_untouched():
+    """The guard is on the hot path, so the common case must not rewrite."""
+    from local_operator.session.runtime.server import (
+        _MAX_LINE_BYTES,
+        relay_frame_or_degraded,
+    )
+
+    frame = {"op": "event", "data": {"type": "notice", "text": "hello", "kind": "note"}}
+    assert relay_frame_or_degraded(frame, _MAX_LINE_BYTES) is frame

--- a/tests/unit/session/test_attach_frame_size.py
+++ b/tests/unit/session/test_attach_frame_size.py
@@ -1454,6 +1454,8 @@ async def test_compaction_never_assembles_an_unreadable_frame() -> None:
     for frame in list(conn.event_queue._queue):
         assert len(json.dumps(frame).encode()) + 1 <= _MAX_LINE_BYTES
 
+    before = "".join(str(f["data"]["delta"]) for f in list(conn.event_queue._queue))
+
     server = RuntimeServer.__new__(RuntimeServer)
     server._compact_event_queue(cast(Any, conn))
 
@@ -1463,3 +1465,9 @@ async def test_compaction_never_assembles_an_unreadable_frame() -> None:
     for frame in out:
         size = len(json.dumps(frame).encode()) + 1
         assert size <= _MAX_LINE_BYTES, f"compaction emitted an unreadable {size}-byte frame"
+
+    # LOSSLESSNESS is the property that makes refusing (rather than degrading)
+    # defensible, and without this assertion the test above still passes
+    # against a compaction that keeps the first frame and discards 63 deltas.
+    # The delta stream is append-only, so concatenating it must be unchanged.
+    assert "".join(str(f["data"]["delta"]) for f in out) == before

--- a/tests/unit/session/test_attach_frame_size.py
+++ b/tests/unit/session/test_attach_frame_size.py
@@ -20,11 +20,12 @@ import json
 import uuid
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
 from local_operator.harness.types import ModelSpec, Usage
+from local_operator.mobile.attach_client import _READ_LIMIT_BYTES
 from local_operator.session.attention import AttentionStore
 from local_operator.session.frontend_state import (
     _MODEL_CATALOGUE_LINE_LIMIT,
@@ -1264,6 +1265,21 @@ def test_the_catalogue_budget_tracks_the_socket_line_limit() -> None:
     assert _MODEL_CATALOGUE_LINE_LIMIT == _MAX_LINE_BYTES
 
 
+def test_the_client_read_limit_tracks_the_socket_line_limit() -> None:
+    """The reader's limit must equal the writer's, or one side is wrong.
+
+    Same pin as the catalogue budget above, for the third copy of this value.
+    ``attach_client`` declares its own ``_READ_LIMIT_BYTES`` because the
+    transport is deliberately import-light, so nothing but this assertion keeps
+    the two honest. Drift IS caught today, but only incidentally, by e2e tests
+    whose failure message never names the cause: a client limit BELOW the
+    server's turns a legal frame into "owner sent a frame too large to read",
+    and one ABOVE it means the guard this module tests stops matching what the
+    reader will actually refuse.
+    """
+    assert _READ_LIMIT_BYTES == _MAX_LINE_BYTES
+
+
 @pytest.mark.asyncio
 async def test_attach_succeeds_against_an_owner_offering_thousands_of_models(
     tmp_path: Path, monkeypatch
@@ -1394,3 +1410,56 @@ def test_ordinary_relay_frames_pass_through_untouched():
 
     frame = {"op": "event", "data": {"type": "notice", "text": "hello", "kind": "note"}}
     assert relay_frame_or_degraded(frame, _MAX_LINE_BYTES) is frame
+
+
+@pytest.mark.asyncio
+async def test_compaction_never_assembles_an_unreadable_frame() -> None:
+    """Merging individually-legal frames must not produce an oversized one.
+
+    The guard runs at ``_enqueue_client_frame``, but ``_compact_event_queue``
+    runs AFTER it and is the one operation that makes a frame bigger than
+    anything the guard was shown: it concatenates ``delta`` fields and
+    re-queues the result, which ``_send_to`` then writes with no size re-check.
+    Measured on the real path, 20 frames of 908,157 B — every one legal on its
+    own — merged to 1,060,157 B and killed a real pump with the precise failure
+    the relay guard exists to prevent.
+
+    The merge is refused rather than degraded because refusing is lossless:
+    both frames are individually sendable.
+    """
+    from local_operator.session.runtime.server import _EVENT_QUEUE_MAX
+
+    conn = SimpleNamespace(event_queue=asyncio.Queue(maxsize=_EVENT_QUEUE_MAX))
+
+    # Ordinary streaming shape: a near-limit accumulated message with small
+    # deltas, which is exactly the burst compaction exists to absorb.
+    chunk = "z" * 1024
+    # Near the limit but under it: a long assistant message still streaming.
+    # Each frame is legal; 64 concatenated deltas are what push the merge over.
+    accumulated = "y" * 1_020_000
+    for _ in range(_EVENT_QUEUE_MAX):
+        conn.event_queue.put_nowait(
+            {
+                "op": "event",
+                "data": {
+                    "type": "message_update",
+                    "message": {"id": "m1", "role": "assistant", "text": accumulated},
+                    "delta": chunk,
+                },
+            }
+        )
+
+    # Precondition: every input frame is individually legal, so the guard at
+    # the chokepoint passes all of them and cannot be what saves us here.
+    for frame in list(conn.event_queue._queue):
+        assert len(json.dumps(frame).encode()) + 1 <= _MAX_LINE_BYTES
+
+    server = RuntimeServer.__new__(RuntimeServer)
+    server._compact_event_queue(cast(Any, conn))
+
+    # Whatever came out, every frame must be readable by the client.
+    out = list(conn.event_queue._queue)
+    assert out, "compaction must not empty the queue"
+    for frame in out:
+        size = len(json.dumps(frame).encode()) + 1
+        assert size <= _MAX_LINE_BYTES, f"compaction emitted an unreadable {size}-byte frame"

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -41,6 +41,7 @@ from local_operator.harness.types import (
 from local_operator.harness.wake import WAKE_PROMPT_MESSAGE_TYPE
 from local_operator.providers.failover import ProviderError
 from local_operator.session.session import (
+    _PRE_ABORT_DROP_NOTICE_AT,
     IMAGE_DROPPED_NOTICE,
     IMAGE_OMITTED_TEXT_ONLY_NOTICE,
     SESSION_CREDENTIAL_MESSAGE_TYPE,
@@ -4335,4 +4336,104 @@ async def test_in_gap_abort_still_stops_a_continuation(tmp_path):
 
     assert len(stream.requests) == spent_before, "the stopped continuation ran"
     assert session._continuation_queue == []
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_dropped_plain_message_is_persisted_exactly_once(tmp_path):
+    """The drop path must not double-write a plain ``Message``.
+
+    The two parking paths have opposite persistence contracts:
+    ``_append_or_park_journal`` (CustomMessage) only touches live context, so
+    the durable write is owed at the drop; the steering queue's consumer
+    (``_drain_steering``) persists whatever it drains, so appending there too
+    wrote the row twice. The duplicate survived into replayed history, so a
+    resumed session showed the message twice and sent it to the model twice.
+    """
+    stream = ScriptedStream([[StreamEndEvent(stop_reason="stop")] for _ in range(4)])
+    session = make_session(tmp_path, stream)
+    await session.prompt("warm up")
+
+    marker = "held-plain-message"
+    session.abort("interrupted")
+    async with session._turn_lock:
+        await session._run_turn([Message.user(marker)])
+
+    # The drain is the single writer, so the next real turn is what persists it.
+    session._abort_requested = False
+    await session.prompt("next turn")
+
+    rows = [
+        entry
+        for entry in Transcript(tmp_path / "sess").entries()
+        if entry.type == "message"
+        for block in entry.payload.get("content", []) or []
+        if isinstance(block, dict) and marker in str(block.get("text", ""))
+    ]
+    assert len(rows) == 1, f"the held message was persisted {len(rows)} times"
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_typed_prompt_is_never_dropped_silently(tmp_path):
+    """A prompt caught by an abort mid-pipeline is interrupted, not swallowed.
+
+    ``prompt()`` clears the flag under the lock, but the pipeline awaits twice
+    before ``_run_turn`` reads it. An abort landing in that window (submit,
+    then immediately Esc) would otherwise send the user's OWN prompt down the
+    silent drop path: no start/end pair, and ``prompt()`` returning success for
+    work that never ran. Arriving work may drop because nobody is waiting on
+    it; a synchronous caller may not.
+    """
+    stream = ScriptedStream([[StreamEndEvent(stop_reason="stop")] for _ in range(3)])
+    session = make_session(tmp_path, stream)
+    events: list[AgentEvent] = []
+    session.subscribe(events.append)
+
+    # Fire the abort inside the pipeline gap the race opens.
+    original = session._refresh_context_metadata
+    fired = False
+
+    async def racing_refresh(*args, **kwargs):
+        nonlocal fired
+        result = await original(*args, **kwargs)
+        if not fired:
+            fired = True
+            session.abort("interrupted")
+        return result
+
+    session._refresh_context_metadata = racing_refresh  # type: ignore[method-assign]
+
+    await session.prompt("my typed prompt")
+
+    # The turn is VISIBLY interrupted: the UI gets its pair, not silence.
+    assert [e for e in events if isinstance(e, AgentStartEvent)]
+    ends = [e for e in events if isinstance(e, AgentEndEvent)]
+    assert ends and ends[-1].aborted is True
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_drop_notice_fires_once_across_a_stuttering_run(tmp_path):
+    """One notice per run, held by a latch rather than counter equality.
+
+    With ``==`` a run interrupted by a real turn at count 2 restarts the
+    counter, so a long stuttering run could clear the threshold repeatedly and
+    still never say anything.
+    """
+    stream = ScriptedStream([[StreamEndEvent(stop_reason="stop")] for _ in range(6)])
+    session = make_session(tmp_path, stream)
+    await session.prompt("warm up")
+    notices: list[NoticeEvent] = []
+    session.subscribe(lambda e: notices.append(e) if isinstance(e, NoticeEvent) else None)
+
+    session.abort("interrupted")
+    for index in range(_PRE_ABORT_DROP_NOTICE_AT + 3):
+        async with session._turn_lock:
+            await session._run_turn([Message.user(f"held {index}")])
+
+    assert len(notices) == 1, f"expected one notice for the run, got {len(notices)}"
+    # ...and the text does not tell the user to act, because a new arrival
+    # clears the abort on its own.
+    assert "send a message" not in notices[0].text.lower()
     await session.dispose()

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -17,6 +17,7 @@ from local_operator.harness.types import (
     AbortSignal,
     AgentEndEvent,
     AgentEvent,
+    AgentMessage,
     AgentStartEvent,
     AgentTool,
     ChatRequest,
@@ -4436,4 +4437,82 @@ async def test_the_drop_notice_fires_once_across_a_stuttering_run(tmp_path):
     # ...and the text does not tell the user to act, because a new arrival
     # clears the abort on its own.
     assert "send a message" not in notices[0].text.lower()
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["plain", "custom"])
+async def test_a_held_message_survives_dispose(tmp_path, kind):
+    """A dropped turn's message must be durable BEFORE the next turn.
+
+    Round 1 removed the duplicate row by letting the steering drain be the only
+    writer — but the drain runs on the next turn, and ``dispose()`` consumes
+    the same queue and rejects without persisting. A session ending while a
+    message was held therefore destroyed it: exactly-once had become
+    exactly-zero for the peer/wake traffic this path exists to hold safely.
+
+    Both message kinds are covered because they take different branches of the
+    drop and only one of them regressed.
+    """
+    message: AgentMessage = (
+        Message.user("held work")
+        if kind == "plain"
+        else CustomMessage(
+            custom_type=WAKE_PROMPT_MESSAGE_TYPE,
+            attribution="user",
+            details={"text": "held work", "schedule_id": "w1"},
+        )
+    )
+    stream = ScriptedStream([[StreamEndEvent(stop_reason="stop")] for _ in range(3)])
+    session = make_session(tmp_path, stream)
+    await session.prompt("warm up")
+
+    session.abort("interrupted")
+    async with session._turn_lock:
+        await session._run_turn([message])
+
+    # Durable while merely HELD — before any later turn, and before dispose.
+    assert Transcript(tmp_path / "sess").has_entry(message.id)
+
+    await session.dispose()
+
+    # ...and still there after the session ends without ever running a turn.
+    assert Transcript(tmp_path / "sess").has_entry(message.id), "the held message was lost"
+
+
+@pytest.mark.asyncio
+async def test_a_held_message_is_still_persisted_only_once(tmp_path):
+    """The M4 fix must not reintroduce M1's duplicate row.
+
+    The drop persists, so the steering drain must skip what the transcript
+    already holds rather than writing it a second time.
+    """
+    stream = ScriptedStream([[StreamEndEvent(stop_reason="stop")] for _ in range(4)])
+    session = make_session(tmp_path, stream)
+    await session.prompt("warm up")
+
+    marker = "held-then-drained"
+    session.abort("interrupted")
+    async with session._turn_lock:
+        await session._run_turn([Message.user(marker)])
+
+    # A later turn drains the queue; the row must not be written again.
+    session._abort_requested = False
+    await session.prompt("next turn")
+
+    rows = [
+        entry
+        for entry in Transcript(tmp_path / "sess").entries()
+        if entry.type == "message"
+        for block in entry.payload.get("content", []) or []
+        if isinstance(block, dict) and marker in str(block.get("text", ""))
+    ]
+    assert len(rows) == 1, f"the held message was persisted {len(rows)} times"
+    # ...and the model sees it exactly once on replay.
+    replayed = [
+        message
+        for message in Transcript(tmp_path / "sess").build_llm_history()
+        if marker in str(getattr(message, "text", ""))
+    ]
+    assert len(replayed) == 1
     await session.dispose()

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -38,6 +38,7 @@ from local_operator.harness.types import (
     ToolResult,
     Usage,
 )
+from local_operator.harness.wake import WAKE_PROMPT_MESSAGE_TYPE
 from local_operator.providers.failover import ProviderError
 from local_operator.session.session import (
     IMAGE_DROPPED_NOTICE,
@@ -4192,4 +4193,146 @@ async def test_the_offered_count_and_the_stopped_count_agree(tmp_path):
     assert offered == 2, "a queued child is still a child the user asked to stop"
     assert stopped == offered, "the confirmation must not contradict the offer"
     await asyncio.sleep(0.3)
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_arriving_work_clears_a_stale_abort(tmp_path):
+    """A peer message or wake arriving AFTER an abort is fresh intent.
+
+    The regression: ``_abort_requested`` is sticky and was cleared only by
+    ``prompt()``, so one abort left every later wake/peer/catch-up turn
+    pre-aborted forever. Each arrival opened a turn that died before doing
+    anything and spent a provider call doing it — observed live as `wait`/`jobs`
+    pairs ending ``interrupted`` at sub-second cadence.
+    """
+    stream = ScriptedStream([[StreamEndEvent(stop_reason="stop")] for _ in range(4)])
+    session = make_session(tmp_path, stream)
+
+    await session.prompt("hello")
+    spent_before = len(stream.requests)
+
+    session.abort("interrupted")
+    assert session._abort_requested is True
+
+    await session.receive_peer_message(
+        "child reporting in",
+        mode="mailbox",
+        wake=True,
+        sender={"pid": 42, "conversation_name": "child"},
+    )
+    # The delivery is spawned in the background, so wait for the turn it opens
+    # rather than for idleness — which is already true before it starts.
+    await wait_for(lambda: len(stream.requests) > spent_before)
+    await wait_for(lambda: not session.is_streaming and not session._turn_lock.locked())
+
+    # The arrival ran a real turn, and cleared the stale stop while doing it.
+    assert len(stream.requests) == spent_before + 1
+    assert session._abort_requested is False
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_abort_stops_work_already_queued_behind_the_turn(tmp_path):
+    """One Esc stops the running turn AND the arrivals queued behind it.
+
+    Arrivals wait on ``_turn_lock``. Treating each as unconditionally fresh
+    intent would clear the abort N times and run all N, so the user had to
+    press Esc once per queued item and the loop looked unstoppable. Work that
+    arrived BEFORE the abort is part of what the user is stopping; the abort
+    epoch is what distinguishes it from work arriving after.
+    """
+    releases: list[asyncio.Event] = []
+
+    async def slow_stream(request, signal):
+        gate = asyncio.Event()
+        releases.append(gate)
+        await asyncio.wait([asyncio.ensure_future(gate.wait())], timeout=2.0)
+        yield StreamEndEvent(stop_reason="stop")
+
+    session = make_session(tmp_path, slow_stream)
+    prompt_task = asyncio.ensure_future(session.prompt("start working"))
+    await wait_for(lambda: bool(releases))
+
+    # Three units of work arrive and queue behind the running turn.
+    for n in range(3):
+        message = CustomMessage(
+            custom_type=WAKE_PROMPT_MESSAGE_TYPE,
+            attribution="user",
+            details={"text": f"arrival {n}", "schedule_id": f"w{n}"},
+        )
+        session._spawn_background(session._prompt_messages([message]))
+    await asyncio.sleep(0.05)
+    queued_at_abort = len(releases)
+
+    session.abort("interrupted")
+    releases[0].set()
+    await prompt_task
+    await wait_for(lambda: not session.is_streaming and not session._turn_lock.locked())
+
+    # None of the queued arrivals opened a model call.
+    assert len(releases) == queued_at_abort
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_pre_aborted_turn_is_dropped_and_its_message_kept(tmp_path):
+    """A turn born pre-aborted is not run — and its message is not lost.
+
+    Running it spends a provider request for an ``aborted`` end with no output:
+    a paid no-op. Dropping it must still persist the arriving row, so the
+    message reaches the model on the session's next real turn (the same
+    guarantee the record-only delivery path gives a busy session).
+    """
+    stream = ScriptedStream([[StreamEndEvent(stop_reason="stop")] for _ in range(3)])
+    session = make_session(tmp_path, stream)
+
+    await session.prompt("hello")
+    spent_before = len(stream.requests)
+    events: list[AgentEvent] = []
+    session.subscribe(events.append)
+
+    session.abort("interrupted")
+    message = CustomMessage(
+        custom_type=WAKE_PROMPT_MESSAGE_TYPE,
+        attribution="user",
+        details={"text": "held work", "schedule_id": "w1"},
+    )
+    # Straight to _run_turn: the arrival path clears the flag by design, so the
+    # drop is exercised where a continuation-shaped caller would reach it.
+    async with session._turn_lock:
+        await session._run_turn([message])
+
+    # No provider call, and no start/end pair painted for a turn that never ran.
+    assert len(stream.requests) == spent_before
+    assert not [e for e in events if isinstance(e, (AgentStartEvent, AgentEndEvent))]
+    # The message is durable, so the next turn still reads it.
+    assert any(
+        entry.payload.get("custom_type") == WAKE_PROMPT_MESSAGE_TYPE
+        for entry in session._transcript.entries()
+        if entry.type == "message"
+    )
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_in_gap_abort_still_stops_a_continuation(tmp_path):
+    """The case the sticky flag EXISTS for, guarded against the fix above.
+
+    A Ctrl+C between a turn and its post-compaction continuation has no live
+    signal to fire, so only the flag carries it. Clearing the flag for arriving
+    work must not clear it for a continuation of the turn being stopped.
+    """
+    stream = ScriptedStream([[StreamEndEvent(stop_reason="stop")] for _ in range(3)])
+    session = make_session(tmp_path, stream)
+
+    await session.prompt("hello")
+    spent_before = len(stream.requests)
+
+    session._continuation_queue.append(Message.user("continue"))
+    session.abort("interrupted")
+    await session._drain_continuation()
+
+    assert len(stream.requests) == spent_before, "the stopped continuation ran"
+    assert session._continuation_queue == []
     await session.dispose()


### PR DESCRIPTION
## Summary

Observed live on the operator's real session `835fbcafdc27` (~$2119 spent): the TUI showed `wait`/`jobs` pairs each ending `interrupted` after 0.1–1.8s, repeating indefinitely, a new turn every ~0.7s, with the runtime projection reading `streaming=True, stop_reason=aborted`. Every one of those turns was a **paid no-op** — a real provider call for a turn that was born aborted and produced nothing. Pressing Esc made it worse.

Three defects, one incident.

## Defect 1 (blocker) — a stale abort pre-aborted every later turn

`Session._abort_requested` is sticky and was cleared in **exactly one place**: `prompt()`. Every other turn entry point goes through `_prompt_messages` — peer messages, wake deliveries, resume catch-up, background job results — which never cleared it. So one abort left every subsequent arrival pre-aborted **forever**: each arrival opened a turn, `_run_turn` fired `signal.abort("interrupted")` on the fresh signal, and the turn died having spent a request. With subagent hub messages arriving continuously, that is a model call per iteration at sub-second cadence.

**The sticky flag is not the bug** and is preserved. It exists because a Ctrl+C in the gap between a turn and its post-compaction continuation has no live signal to fire, so only the flag carries it. A continuation reaches `_run_turn` directly via `_drain_continuation` and never passes through the new clear — verified by a dedicated test.

What was wrong is that the flag had no stated owner. Now: **an arriving unit of work is fresh intent and clears the abort exactly as `prompt()` does** — clearing *after* acquiring `_turn_lock`, the same ordering `prompt()` uses, so an abort aimed at the previous turn is not eaten.

## Defect 2(a) — one Esc could not stop the backlog

Clearing unconditionally on arrival would have been wrong, and the repro proves it. Arrivals **queue on `_turn_lock`** behind a running turn, so when the user presses Esc there may be N waiting. Those arrived *before* the stop and are part of what the user is stopping; clearing per-arrival runs all N and forces one Esc per queued item — the "I pressed Esc twice and it kept going" report, and a worse loop than Defect 1 since each item runs a *full* turn.

An **abort epoch** distinguishes them. `abort()` bumps it; `_prompt_messages` samples it *before* the lock wait, so it dates the work's arrival rather than when it reached the front of the queue. Unchanged ⇒ any pending abort predates this work and does not apply (run). Bumped ⇒ an abort landed while this sat queued, aimed at the backlog it was in (hold).

```
Before: 5 arrivals queued, then one Esc: provider calls spent afterwards = 5
After:  5 arrivals queued, then one Esc: provider calls spent afterwards = 0
        a NEW arrival after the abort:   provider calls = 1   ← still responsive
```

## Defect 1, observability half — drop the turn, don't spin

A turn that would be born pre-aborted is now **dropped rather than run**. Running it bills a request for an `aborted` end with no output. The arriving message is **still persisted and still reaches the model on the next real turn** — the same guarantee the record-only delivery path gives a busy session — so nothing is lost; only the call the user already stopped is skipped. No `agent_start`/`agent_end` pair is emitted for a turn that never ran, which is what was painting N identical `interrupted` rows. A *run* of drops emits **one** notice naming the remedy rather than N silent rows.

## Defect 3 (major) — `event`/`frontend_update` relay had no size guard

`frontend_sync` has been guarded since it caused this exact failure; `frontend_update` and `event` were not. Measured on the operator's real transcript: a single **1,039,374-byte** row produces an `event` frame of **1,129,319 bytes** against the reader's 1 MiB limit. `readline` then raises `LimitOverrunError` — and critically **does not consume the buffer**, so every later read re-raises on the same bytes. The pump dies and the viewer paints `owner connection lost: owner sent a frame too large to read`, which is what the operator hit.

Guarded at `_enqueue_client_frame`, the chokepoint **both** relay frame types pass through. Degrading one delta is safe (the viewer recovers through `frontend_sync` + durable history); killing the socket is not.

> **Corrected in round 1.** This section originally claimed the chokepoint placement meant "no future relay caller can bypass it". That was **false as written**: `_compact_event_queue` runs *after* the guard and is the one operation that makes a frame bigger than anything the guard was shown — it concatenates `delta` fields and re-queues with a bare `put_nowait`. Reviewer and QA found it independently, and QA killed a real pump with it. It is now fixed (the merge is measured and refused when it would not fit), so the claim holds — but it did not hold when first written.

The placeholder stays a **valid frame of its own op**, which is why it is not one generic marker:
- **`event`** → degrades to a `notice`. The payload is deserialized by `deserialize_event`, which requires `type`; a bare marker raises there and (since the client swallows callback failures) would be silently dropped with nothing said.
- **`frontend_update`** → keeps `epoch`/`sequence`, shedding only the oversized body. Canonical deltas are not replacement-safe and the client **closes the connection on a sequence gap by design** — a placeholder without them would trip that check and kill the very connection this guard exists to save.

## Testing evidence

Repros driving a **real `Session`** and the **real `AttachClient._pump`** over a **real socket** at the server's limit — actual output, before and after:

**Defect 1**, abort then deliver a peer message / a wake:
```
BEFORE  peer message:  ended aborted=True,  output=[''],   _abort_requested still set=True
        wake delivery: ended aborted=True,  output=[''],   _abort_requested still set=True
AFTER   peer message:  ended aborted=False, output=['ok'], _abort_requested still set=False
        wake delivery: ended aborted=False, output=['ok'], _abort_requested still set=False
```

**The continuation case the sticky flag exists for**, guarded against the fix:
```
AFTER   continuation after an in-gap abort: provider calls=0, queue left=0, _abort_requested=True
        PASS: the continuation the user stopped did not run.
```

**Defect 3**, real socket, frame sized to the measured 1,129,319 bytes:
```
BEFORE  pump disconnect reason = 'owner sent a frame too large to read'; later frames delivered = 0
AFTER   pump disconnect reason = '';                                     later frames delivered = 2
```
The before-case log line is the operator's exact symptom:
```
attach client: owner sent a frame larger than the 1048576-byte line limit; the connection cannot continue
```

Seven regression tests added (`test_session.py`, `test_attach_frame_size.py`) covering: arriving work clears a stale abort; one abort stops the queued backlog; a pre-aborted turn is dropped *and its message kept*; an in-gap abort still stops a continuation; oversized `event` degrades to a deserializable notice; oversized `frontend_update` keeps its sequence; ordinary frames pass through untouched (identity-asserted — the guard is on the hot path).

## Gates

Whole tree, exactly as CI:

| Gate | Exact command | Result |
|---|---|---|
| flake8 | `.venv/bin/python -m flake8 .` | clean |
| black | `uvx --from black==26.1.0 black --check .` | 986 files unchanged |
| isort | `uvx isort==5.13.2 --check .` | clean |
| pyright | `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | 0 errors, 0 warnings |
| unit suite | `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q` | **14995 passed, 18 skipped** (1031s) |

The exact commands are now spelled out because round 1 could not reproduce the pyright row. The cause was the invocation, not the tree: **`--pythonpath .venv/bin/python` is what AGENTS.md and CI specify**, and without it pyright cannot see the worktree venv and reports 1334 phantom `reportMissingImports` errors. Both numbers reproduce exactly on this head — `python -m pyright .` → 1334 errors, `python -m pyright --pythonpath .venv/bin/python .` → 0. Likewise `black`/`isort` are deliberately **not** installed in the worktree venv, so they must go through `uvx` at the pinned versions; `.venv/bin/black` does not exist here.

Isolated worktree venv (`/tmp/lop-abort-loop`), verified resolving its own tree. No `~/.local-operator` or live session was touched. No `pyproject.toml` bump.

## Not addressed

**Defect 2(b) — the TUI indicator not settling when the runtime is idle** — `deferred — viewer/owner turn-state divergence, owned by PR #711 (fix/viewer-transient-disconnect)`.

It is the same underlying viewer/owner turn-state divergence, and #711 covers it explicitly: a rebind with `streaming=False` + `last_turn_outcome="completed"` posts `TurnEnded(aborted=False)` so the band cannot stay `working`/`thinking` after the runtime goes idle (`test_rebind_after_an_idle_runtime_posts_turn_ended`). Fixing it here would be a second implementation of one defect. (Round 1 correctly flagged that the branch had no remote PR when this was first written; it does now.)

