### PR TITLE
ci: fail any feature PR that changes the project version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,9 +109,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # The three-dot diff below needs both branches, which the default
-          # single-commit fetch does not provide.
-          fetch-depth: 0
+          # Two commits is all the diff below needs, but the checkout is the
+          # `refs/pull/N/merge` commit, so HEAD^1 (the base side) and HEAD^2
+          # (the PR side) must both be present.
+          fetch-depth: 2
 
       - name: Reject a version bump outside a release PR
         env:
@@ -119,13 +120,31 @@ jobs:
           # script: a PR title is attacker-controlled text, and inlining it
           # directly would let a crafted title inject shell.
           PR_TITLE: ${{ github.event.pull_request.title }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
-          # Three-dot: compare against the MERGE BASE, so a branch that is
-          # merely behind a release does not look like it reverted the version.
-          changed=$(git diff "$BASE_SHA"...HEAD -- pyproject.toml \
-            | grep -E '^[+-]version[[:space:]]*=' || true)
+          # `HEAD^1 HEAD` and NOT a three-dot diff against
+          # `github.event.pull_request.base.sha`. Actions checks out the
+          # RECOMPUTED `refs/pull/N/merge`, whose first parent is the base
+          # branch as of this run, while `base.sha` is frozen when the event
+          # fires. Once `main` moves, the frozen SHA becomes an ancestor of
+          # HEAD, `merge-base` returns it unchanged, and the three-dot form
+          # silently degrades to two-dot — sweeping in every version bump
+          # `main` itself landed in the meantime and failing an innocent PR
+          # for a diff it never wrote. Measured on the six PRs before this
+          # one, `base.sha` was already stale for four of them (#700, #704,
+          # #706, #708), and it goes stale precisely during the busy release
+          # window this guard exists to protect. The first person failed by a
+          # version diff they did not write is the person who disables the
+          # guard.
+          #
+          # The merge commit's own diff against its base parent is exactly
+          # "what this PR would introduce", which is the question being asked.
+          diff=$(git diff HEAD^1 HEAD -- pyproject.toml)
+          # Not `|| true` on the grep: that discards git's exit status too, so
+          # a failed diff would report "no version change" and the guard would
+          # fail OPEN on a head that carries a real bump. grep's own "no
+          # match" is exit 1 and must stay non-fatal, so the two are separated.
+          changed=$(printf '%s\n' "$diff" | { grep -E '^[+-]version[[:space:]]*=' || true; })
           if [ -z "$changed" ]; then
             echo "No version change in pyproject.toml."
             exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,73 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # A feature PR must never carry a version bump. Releases are cut as ONE
+  # deliberate `chore(release):` PR per window by that window's owner, so a
+  # bump riding a feature diff silently consumes a version number that is
+  # never tagged, never built and never published.
+  #
+  # This is not hypothetical and it is why the check is machine-checked rather
+  # than left to review. Two feature PRs (#701, #706) each smuggled a bump, so
+  # `main` advertised 0.50.2 while the newest tag, GitHub Release and PyPI
+  # artifact were all still 0.50.0: 0.50.1 and 0.50.2 were burned, and anyone
+  # reading pyproject.toml got a version PyPI had never heard of. The v0.50.3
+  # window had to skip both numbers, because two artifacts believing they are
+  # the same version is unrecoverable once published.
+  #
+  # AGENTS.md already stated the rule AND told reviewers to treat a version
+  # change in a feature PR as a finding. Both review rounds passed anyway. The
+  # defect was that the rule existed only in prose, so it depended on each
+  # reviewer remembering to look; this job is that rule with teeth.
+  #
+  # PR-only: a `push` run on `main` has no PR title to read, and by then the
+  # commit is already in. The release PR is exempted by its conventional-commit
+  # title, which is the same string the release procedure already requires.
+  version-bump-guard:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The three-dot diff below needs both branches, which the default
+          # single-commit fetch does not provide.
+          fetch-depth: 0
+
+      - name: Reject a version bump outside a release PR
+        env:
+          # Read through the environment rather than interpolated into the
+          # script: a PR title is attacker-controlled text, and inlining it
+          # directly would let a crafted title inject shell.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          # Three-dot: compare against the MERGE BASE, so a branch that is
+          # merely behind a release does not look like it reverted the version.
+          changed=$(git diff "$BASE_SHA"...HEAD -- pyproject.toml \
+            | grep -E '^[+-]version[[:space:]]*=' || true)
+          if [ -z "$changed" ]; then
+            echo "No version change in pyproject.toml."
+            exit 0
+          fi
+          case "$PR_TITLE" in
+            'chore(release):'*)
+              echo "Release PR, version change allowed:"
+              echo "$changed"
+              ;;
+            *)
+              echo "::error file=pyproject.toml::A feature PR must not change the project version."
+              echo "This PR changes the version line in pyproject.toml:"
+              echo "$changed"
+              echo
+              echo "Versions are bumped only by a dedicated release PR whose title"
+              echo "starts with 'chore(release):', cut by the release window owner."
+              echo "Drop the bump from this branch; pyproject.toml stays at the last"
+              echo "released version on every feature branch."
+              exit 1
+              ;;
+          esac
+
   lint:
     runs-on: ubuntu-latest
     # Generous against the ~30 s this takes; it exists so a wedged install step

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,11 +306,19 @@ changes the `version =` line fails unless its title starts with
 `chore(release):`. Dependency and metadata edits to `pyproject.toml` are
 unaffected — the guard reads the version line, not the file.
 
-It makes the violation loud; it does not make it impossible. `main` has no
-branch protection, so no check is *required* and an `--admin` merge lands over
-a red guard. Treat a failing `version-bump-guard` as a stop signal rather than
-an obstacle to route around: the job is the reviewer's missing memory, not a
-lock.
+It makes the violation loud; it does not make it impossible. `main`'s ruleset
+requires a code-owner approval but configures **no required status checks**, and
+admins hold a configured bypass (see "Who may merge: two tiers, by code
+ownership"), so an `--admin` merge lands over a red guard. Treat a failing
+`version-bump-guard` as a stop signal rather than an obstacle to route around:
+the job is the reviewer's missing memory, not a lock.
+
+Note that `gh api repos/<owner>/<repo>/branches/main/protection` answers
+`404 Branch not protected` here. That endpoint reports only **legacy** branch
+protection and 404s even while a modern ruleset is actively enforcing the
+branch, so it is the wrong probe and reading it as "unprotected" is a mistake
+this paragraph made once already. Query
+`gh api repos/<owner>/<repo>/rules/branches/main` instead.
 
 The job exists because the prose above was not enough. It was already written,
 and it already told reviewers to treat a bump as a finding, when #701 and #706

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,6 +301,21 @@ releasing. The sections below say why, then how.
 fix branch. A PR never touches it, and the reviewer round treats a version
 change inside a feature PR as a finding.
 
+**CI enforces this**, in the `version-bump-guard` job. A pull request whose
+diff changes the `version =` line fails unless its title starts with
+`chore(release):`. Dependency and metadata edits to `pyproject.toml` are
+unaffected — the guard reads the version line, not the file.
+
+The job exists because the prose above was not enough. It was already written,
+and it already told reviewers to treat a bump as a finding, when #701 and #706
+each landed one inside a feature PR and both review rounds passed anyway. The
+result was that `main` advertised `0.50.2` while the newest tag, GitHub Release
+and PyPI artifact were all still `0.50.0`: `0.50.1` and `0.50.2` were consumed
+without ever being built or published, and the v0.50.3 window had to skip both
+numbers rather than reuse a version `main` had already claimed. A rule that
+depends on every reviewer remembering to look is a rule that fails on the day
+someone does not.
+
 This replaces the earlier practice of each PR bumping its own patch, which
 failed in a measurable way on 2026-09-05: with ten sessions each holding a
 reserved patch number, `0.47.1` → `0.48.0` took close to five hours of agents

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,10 +301,16 @@ releasing. The sections below say why, then how.
 fix branch. A PR never touches it, and the reviewer round treats a version
 change inside a feature PR as a finding.
 
-**CI enforces this**, in the `version-bump-guard` job. A pull request whose
-diff changes the `version =` line fails unless its title starts with
+**CI checks this**, in the `version-bump-guard` job. A pull request whose diff
+changes the `version =` line fails unless its title starts with
 `chore(release):`. Dependency and metadata edits to `pyproject.toml` are
 unaffected — the guard reads the version line, not the file.
+
+It makes the violation loud; it does not make it impossible. `main` has no
+branch protection, so no check is *required* and an `--admin` merge lands over
+a red guard. Treat a failing `version-bump-guard` as a stop signal rather than
+an obstacle to route around: the job is the reviewer's missing memory, not a
+lock.
 
 The job exists because the prose above was not enough. It was already written,
 and it already told reviewers to treat a bump as a finding, when #701 and #706


### PR DESCRIPTION
## Summary

Adds a `version-bump-guard` CI job that fails any pull request whose diff changes the `version =` line in `pyproject.toml`, unless the PR title starts with `chore(release):`.

**Change class: C1 (standard, pre-authorized).** CI/tooling config plus the AGENTS.md paragraph documenting it. No runtime path.

## Why

`AGENTS.md` already said PRs never carry a version bump, and already told the reviewer round to treat a version change in a feature PR as a finding. That rule was in force and it still failed:

| commit | PR | pyproject version |
|---|---|---|
| `52476a49a` | #700 | 0.50.0 |
| `6a3bf4777` | #701 | **0.50.1** — smuggled |
| `7efedc533` | #704 | 0.50.1 |
| `0a884c822` | #705 | 0.50.1 |
| `ec5aa3db0` | #706 | **0.50.2** — smuggled |

Both bumps rode the feature commit itself, and both review rounds passed anyway. Meanwhile:

```
$ git tag --list 'v0.50*'          -> v0.50.0
$ gh release list                  -> latest v0.50.0
$ curl -s https://pypi.org/pypi/local-operator/json | ...
   latest: 0.50.0    0.50.x present: ['0.50.0']
```

So `main` advertised a version that was never tagged, never built and never published. `0.50.1` and `0.50.2` are burned: the v0.50.3 window skips both rather than reuse a number `main` has already claimed, because two artifacts believing they are the same version cannot be untangled after publication.

The defect is not that anyone ignored the rule on purpose. It is that the rule existed **only in prose**, so it depended on each reviewer remembering to look. This job is that rule with teeth.

There is no version-writing automation to fix instead: no bumpversion/poetry/hatch config, no git hooks, and nothing in `.github/` or `scripts/` writes the version.

## Design notes

- **Reads the version LINE, not the file.** Dependency pins, scripts and metadata in `pyproject.toml` change freely; only `version =` is guarded.
- **Three-dot diff against the merge base**, so a branch that is merely behind a release does not look like it reverted the version.
- **PR-only** (`if: github.event_name == 'pull_request'`). A `push` run on `main` has no PR title to read, and by then the commit is already in.
- **Release PRs are exempt by title** — `chore(release):` is the same string the release procedure in AGENTS.md already requires, so this adds no new convention.
- **The title is passed through the environment**, not interpolated into the script. A PR title is attacker-controlled text and inlining it into `run:` would allow shell injection.

## Testing Evidence

This is a CI-config change, so its runtime path is the workflow itself. I extracted the exact shell the job runs and drove it against **real commits in this repository**, covering both directions plus the injection case.

```
### case 1: #706, the real smuggled bump (must REJECT)
REJECT: version changed
-version = "0.50.1"
+version = "0.50.2"
exit=1

### case 2: #701, the other smuggled bump (must REJECT)
REJECT: version changed
-version = "0.50.0"
+version = "0.50.1"
exit=1

### case 3b: real release diff WITH release title (must ALLOW)
ALLOW (release PR)
exit=0

### case 3c: same release diff with a FEATURE title (must REJECT)
REJECT: version changed
-version = "0.49.9"
+version = "0.50.0"
exit=1

### case 4: docs PR #708, no version change (must PASS)
PASS (no version change)
exit=0

### case 5: title injection attempt `evil"; echo PWNED; #` (must REJECT, not execute)
REJECT: version changed
-version = "0.50.1"
+version = "0.50.2"
exit=1

### case 6: pyproject dependency/metadata change, version line untouched (must PASS)
PASS (no version change)
exit=0
```

Case 5 rejects on the version change and never prints `PWNED`, confirming the environment indirection holds. Case 6 was produced by committing a real non-version edit to `pyproject.toml` and reverting it.

Workflow YAML parses, and the job wires up as intended:

```
$ python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/ci.yml')); ..."
job present, if = github.event_name == 'pull_request'
steps: ['checkout', 'Reject a version bump outside a release PR']
env: ['PR_TITLE', 'BASE_SHA']
```

**This PR is its own negative control**: it touches `AGENTS.md` and `ci.yml` but not `pyproject.toml`, so `version-bump-guard` must report no version change on this very run.

## Impact

No runtime behaviour, no dependencies. One added CI job (~10s, PR events only). The only workflow change for contributors is that a bump in a feature PR now fails CI instead of reaching review and, sometimes, `main`.

Found while cutting the v0.50.3 window; the root-cause trace came from the session that did the README work, and the version-state discovery from the session that owns #703.

Release: patch — CI now fails any feature PR that changes the project version, so a bump can no longer ride a feature diff and burn a release number.
