### PR TITLE
fix(runtime): keep viewers bound across transient socket drops

### DIFF
--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -1932,10 +1932,21 @@ def _live_row_cost(value: Any) -> int:
     """
     try:
         return len(json.dumps(value, default=str))
-    except (TypeError, ValueError):
+    except Exception:  # noqa: BLE001 — see below; narrowing this reopens the hole
         # A payload that will not serialize cannot be sized, so it is treated
         # as too big to keep rather than waved through unmeasured — the exact
         # mistake this function exists to stop making.
+        #
+        # Deliberately EVERY exception, not the `TypeError`/`ValueError` that
+        # `json.dumps` documents. `default=str` calls `str()` on whatever it
+        # does not recognise, so the failure mode is the payload's own
+        # `__str__`, which may raise anything at all; a narrower clause lets
+        # that propagate out of `sync_wire_payload` and fail the whole attach
+        # over one unmeasurable block. Unreachable today — rows are built from
+        # `event.model_dump(mode="json")` and are JSON-safe by construction —
+        # but this function's entire contract is that nothing passes it
+        # unmeasured, and a contract with a gap for "raised something
+        # unexpected" is not that contract (round-4 MINOR-1).
         return LIVE_EVENT_TEXT_FRAME_BUDGET_CHARS + 1
 
 
@@ -1968,6 +1979,19 @@ def _bound_live_result_in_place(result: dict[str, Any], *, share: int) -> None:
         result["details"] = None
     blocks = [block for block in (result.get("content") or []) if isinstance(block, dict)]
     remaining = share
+    # Per ROW, not per block: a result of many blocks would otherwise multiply
+    # its own share and reinstate the unbounded shape one level further down.
+    # The floor is a promise that the CARD stays legible, so it is spent once —
+    # granting it to every block turns a shared ceiling into a per-block
+    # entitlement, and N blocks then cost N x floor with no ceiling at all.
+    # Measured when this guard was briefly lost in a rewrite: at the 100-row
+    # cap the crossover was 42 text blocks per row, 1,102,743 B against a
+    # 1,048,576 B limit, while the per-row form stays flat. ``content`` is
+    # typed ``list[dict[str, Any]]`` and this module deliberately does not
+    # enumerate what rides in it, so COUNT has to be bounded here for the same
+    # reason SIZE is — a producer emitting many blocks is a change in data,
+    # not a change in this file.
+    floor_spent = False
     for block in blocks:
         cost = _live_row_cost(block)
         if cost <= remaining:
@@ -1979,7 +2003,11 @@ def _bound_live_result_in_place(result: dict[str, Any], *, share: int) -> None:
             # overhead of the block's own envelope, so a clipped block lands
             # under the share rather than merely smaller than it was.
             envelope = cost - len(text)
-            allowance = max(LIVE_EVENT_TEXT_FLOOR_CHARS, remaining - envelope)
+            allowance = remaining - envelope
+            if not floor_spent:
+                allowance = max(LIVE_EVENT_TEXT_FLOOR_CHARS, allowance)
+                floor_spent = True
+            allowance = max(0, allowance)
             if len(text) > allowance:
                 block["text"] = text[:allowance] + "…"
         else:

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -233,8 +233,32 @@ _SHAREABLE_STATE_FIELDS = frozenset(
 #: total" is the same defect one level up, and call count per turn has no cap.
 #: The floor keeps every retained end legible — a card that says how it ended
 #: is what stops the retirement pass marking it interrupted.
+#:
+#: The budget is spent against each row's MEASURED serialized size, not against
+#: the length of the fields this module happens to know about. The first cut of
+#: this bound clipped ``content[].text`` and so was blind to every payload that
+#: carries no ``text`` key: an ``ImageContent`` block holds base64 in ``data``
+#: (one permitted image is ~1.4 MB encoded — larger than the whole line limit
+#: by itself, and 3 image ``read`` calls measured a 1,524,116-byte frame), and
+#: ``result.details`` holds the MCP bridge's full ``server_result`` dump (50
+#: calls measured 2,619,443 B). Both sailed through a bound that was looking at
+#: a different key. Measuring the row is what makes the NEXT payload-bearing
+#: field bounded on the day it is added rather than on the day it overflows.
 LIVE_EVENT_TEXT_FRAME_BUDGET_CHARS = 60_000
 LIVE_EVENT_TEXT_FLOOR_CHARS = 200
+
+#: Placeholder for a result block too big to ride the reconnect seed.
+#:
+#: A dropped block still leaves the card settleable — ``on_tool_ended`` needs
+#: the id and outcome, not the payload — but a block that VANISHES reads as a
+#: tool that returned nothing. The stand-in keeps the block's own shape (a
+#: valid ``TextContent``) so the viewer renders it as an ordinary row, and says
+#: what happened, because "the reconnect dropped this" and "the tool returned
+#: nothing" are different facts and only one of them is about the tool.
+#:
+#: The full payload is never lost: it is in the durable transcript, and a
+#: viewer that stayed connected received it untouched over the live relay.
+LIVE_EVENT_BLOCK_ELIDED_PLACEHOLDER = "[dropped from the reconnect snapshot — see the transcript]"
 
 #: Cap on retained ``tool_execution_end`` rows in the seed, newest kept.
 #:
@@ -1886,33 +1910,86 @@ def _bound_live_events_in_place(snapshot: dict[str, Any]) -> None:
     # Only ``tool_execution_end`` retains a payload; starts and message rows
     # are already small and are folded by phase, so they are not counted into
     # the share they would otherwise dilute.
-    texts: list[tuple[dict[str, Any], list[dict[str, Any]]]] = []
-    for item in events:
-        if not isinstance(item, dict) or item.get("type") != "tool_execution_end":
-            continue
-        result = item.get("result")
-        if not isinstance(result, dict):
-            continue
-        blocks = [
-            block
-            for block in (result.get("content") or [])
-            if isinstance(block, dict) and isinstance(block.get("text"), str)
-        ]
-        if blocks:
-            texts.append((result, blocks))
-    if not texts:
+    results = [
+        result
+        for item in events
+        if isinstance(item, dict) and item.get("type") == "tool_execution_end"
+        if isinstance(result := item.get("result"), dict)
+    ]
+    if not results:
         return
-    share = max(LIVE_EVENT_TEXT_FLOOR_CHARS, LIVE_EVENT_TEXT_FRAME_BUDGET_CHARS // len(texts))
-    for _result, blocks in texts:
-        # Per ROW, not per block: a result of many blocks would otherwise
-        # multiply its own share and reinstate the unbounded shape one level
-        # further down.
-        remaining = share
-        for block in blocks:
-            text = block["text"]
-            if len(text) > remaining:
-                block["text"] = text[:remaining] + "…" if remaining > 0 else "…"
-            remaining = max(0, remaining - len(text))
+    share = max(LIVE_EVENT_TEXT_FLOOR_CHARS, LIVE_EVENT_TEXT_FRAME_BUDGET_CHARS // len(results))
+    for result in results:
+        _bound_live_result_in_place(result, share=share)
+
+
+def _live_row_cost(value: Any) -> int:
+    """Serialized size of one payload, which is the only honest unit here.
+
+    ``len(str)`` was the round-3 defect: it measures the fields this module
+    thought to look at, so a payload under a different key was not "small", it
+    was UNMEASURED. Serializing is what makes the budget total.
+    """
+    try:
+        return len(json.dumps(value, default=str))
+    except (TypeError, ValueError):
+        # A payload that will not serialize cannot be sized, so it is treated
+        # as too big to keep rather than waved through unmeasured — the exact
+        # mistake this function exists to stop making.
+        return LIVE_EVENT_TEXT_FRAME_BUDGET_CHARS + 1
+
+
+def _bound_live_result_in_place(result: dict[str, Any], *, share: int) -> None:
+    """Spend one retained end's share across everything it actually carries.
+
+    Driven by MEASURED cost rather than by key names, so a payload-bearing
+    field cannot escape by not being a string (see
+    :data:`LIVE_EVENT_TEXT_FRAME_BUDGET_CHARS` for the two that did).
+
+    Order matters and is deliberate. ``details`` goes first: it is machine
+    detail for a card the viewer is only settling, so it is the cheapest thing
+    to lose and dropping it often buys the whole share back. Text is clipped
+    next, because a clipped preview still tells the user what the tool said.
+    Whole blocks are dropped last and only when they still do not fit, since a
+    dropped block is the biggest loss of the three.
+
+    Every branch keeps the row itself, and the row is what settles the card —
+    dropping the row would strand the card live and re-open the
+    ``⊘ interrupted`` artefact this retention exists to close.
+    """
+    if _live_row_cost(result) <= share:
+        return
+    # ``details`` is not rendered on the card at all (``on_tool_ended`` reads
+    # it only for the write/edit counters), so an oversized one is pure weight
+    # on a frame that must fit. The MCP bridge's ``server_result`` dump reached
+    # 2.6 MB across 50 calls.
+    details = result.get("details")
+    if details is not None and _live_row_cost(details) > share // 4:
+        result["details"] = None
+    blocks = [block for block in (result.get("content") or []) if isinstance(block, dict)]
+    remaining = share
+    for block in blocks:
+        cost = _live_row_cost(block)
+        if cost <= remaining:
+            remaining -= cost
+            continue
+        text = block.get("text")
+        if isinstance(text, str):
+            # Clip in CHARACTERS against the remaining budget, less the fixed
+            # overhead of the block's own envelope, so a clipped block lands
+            # under the share rather than merely smaller than it was.
+            envelope = cost - len(text)
+            allowance = max(LIVE_EVENT_TEXT_FLOOR_CHARS, remaining - envelope)
+            if len(text) > allowance:
+                block["text"] = text[:allowance] + "…"
+        else:
+            # No text to clip — an image's base64, or any future block whose
+            # payload lives under a key this function has never heard of. It is
+            # replaced rather than emptied so the row still reads as a block.
+            block.clear()
+            block["type"] = "text"
+            block["text"] = LIVE_EVENT_BLOCK_ELIDED_PLACEHOLDER
+        remaining = max(0, remaining - _live_row_cost(block))
 
 
 def _bound_job_text_in_place(job: dict[str, Any], *, share: int) -> None:

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -201,6 +201,65 @@ _SHAREABLE_STATE_FIELDS = frozenset(
         "cumulative_parent_cost",
     }
 )
+#: Wire budget for the in-flight seed's retained tool results.
+#:
+#: ``live_events`` used to bound itself: every ``tool_execution_end`` ERASED its
+#: call's row, so a turn of completed calls left zero rows behind and the field
+#: could not grow. Retaining the end (so a viewer that reconnects mid-turn can
+#: settle a card for work that finished while it was away) removed that bound
+#: and made the field accumulate one whole tool result per completed call —
+#: measured at 2,028,680 B over 100 calls, putting the ``frontend_sync`` frame
+#: at 2,029,839 B against the socket's 1,048,576-byte line limit. Overflow
+#: began at ~18 completed calls returning 60 KB each, which is an ordinary
+#: heavy turn rather than a pathological one.
+#:
+#: This is the third instance of the shape :func:`sync_wire_payload` documents
+#: after trajectories and ``usage_components``, and the consequence is the one
+#: ``server.py`` records: an oversized sync is UNREADABLE rather than merely
+#: large, so the viewer waits out its sync timeout and degrades to a cold
+#: session with no roster and no todos.
+#:
+#: Bounded by TRUNCATING result text rather than by dropping rows, because the
+#: seed's job is to say WHICH calls ended and HOW — ``on_tool_ended`` needs
+#: ``tool_call_id``, ``is_error`` and a first line to settle the card, and
+#: dropping a row would strand the card live and re-open the very
+#: ``⊘ interrupted`` artefact the retention exists to close. The full result is
+#: never lost: it is in the durable transcript, and the live relay delivers it
+#: untouched to a viewer that stayed connected. Only the RECONNECT seed is
+#: clipped, and only its text.
+#:
+#: A shared frame budget rather than a per-row cap, for the reason
+#: :data:`JOB_TEXT_FRAME_BUDGET_CHARS` gives: "bounded per row, unbounded in
+#: total" is the same defect one level up, and call count per turn has no cap.
+#: The floor keeps every retained end legible — a card that says how it ended
+#: is what stops the retirement pass marking it interrupted.
+LIVE_EVENT_TEXT_FRAME_BUDGET_CHARS = 60_000
+LIVE_EVENT_TEXT_FLOOR_CHARS = 200
+
+#: Cap on retained ``tool_execution_end`` rows in the seed, newest kept.
+#:
+#: The text budget above bounds what a row COSTS; it does not bound how many
+#: rows there are, and "bounded per row, unbounded in total" is exactly the
+#: defect the budget exists to answer. The floor makes that gap reachable: at
+#: :data:`LIVE_EVENT_TEXT_FLOOR_CHARS` every row still costs ~500 B, and even
+#: stripped to bare identity a row is ~300 B, so 5,000 completed calls in one
+#: turn measured 2,528,943 B — back over the line limit with the text budget
+#: fully applied. A cap is the only thing that closes it.
+#:
+#: 100 holds the field's worst case to ~71 KB — the same order as
+#: ``usage_components`` (69 KB), and a fair share of a frame whose roster alone
+#: can run to 620 KB. The all-year fixture is what set the number, and it had
+#: to be set twice: at 400 the seed took 255 KB and at 150 it took 107 KB, both
+#: of which put the frame back over the limit once stacked on that roster. With
+#: every other field at its own maximum the fixture leaves ~99 KB here, so
+#: "bounded" is not sufficient on its own — the bound has to be small enough to
+#: COEXIST. A viewer needs the seed only for the CURRENT turn's unsettled
+#: cards, and 100 completed calls in one turn is already far beyond that.
+#:
+#: Dropping OLDEST-first is what makes the cap safe: the newest calls are the
+#: ones most likely to still be on screen unsettled, and a dropped row costs
+#: nothing durable — the transcript replay repaints those cards regardless.
+LIVE_EVENT_END_ROWS_MAX = 100
 
 #: Smallest catalogue the wire will clip to, however little the frame has left.
 #:
@@ -1649,6 +1708,12 @@ def sync_wire_payload(sync: FrontendSync) -> dict[str, Any]:
       undercount money, while folding is lossless. See
       :func:`_folded_components`.
 
+    * ``snapshot.live_events`` — the in-flight seed. It bounded itself while a
+      ``tool_execution_end`` erased its call's row; once the end is RETAINED so
+      a reconnecting viewer can settle the card, one whole tool result per
+      completed call accumulates for the turn. See
+      :data:`LIVE_EVENT_TEXT_FRAME_BUDGET_CHARS`.
+
     :func:`assert_frame_fits` is the guard that fails CI when a THIRD such
     field appears.
     """
@@ -1658,6 +1723,7 @@ def sync_wire_payload(sync: FrontendSync) -> dict[str, Any]:
         components = snapshot.get("usage_components")
         if isinstance(components, list) and len(components) > USAGE_COMPONENT_CAP:
             snapshot["usage_components"] = _capped_components(components)
+        _bound_live_events_in_place(snapshot)
         jobs = snapshot.get("jobs")
         if isinstance(jobs, list):
             # Share one text budget across the roster so the frame does not grow
@@ -1761,6 +1827,92 @@ def _frame_line_bytes(payload: dict[str, Any]) -> int:
     budget for a line nobody sends.
     """
     return len(json.dumps({"op": "frontend_sync", "data": payload}).encode()) + 1
+
+
+def _bound_live_events_in_place(snapshot: dict[str, Any]) -> None:
+    """Clip the in-flight seed's retained tool results to their wire bound.
+
+    See :data:`LIVE_EVENT_TEXT_FRAME_BUDGET_CHARS` for why the seed grew a
+    bound at all and why it clips TEXT instead of dropping rows: every retained
+    end must survive as a row, because the row is what settles the card.
+
+    The budget is shared only across the rows that actually carry result text,
+    for the reason :func:`_bound_job_text_in_place` gives — the common row
+    contributes nothing, and dividing by it would starve the few that do. The
+    floor wins over an arithmetically smaller share so a turn with very many
+    calls still hands each card a legible line rather than an empty one; that
+    trades an exactly-proportional budget for a guarantee the card can settle,
+    which is the property this field exists to provide.
+
+    Truncation is marked with an ellipsis, as the neighbouring text bounds do
+    it, so a reader can tell a clipped preview from a tool that really did
+    return that little.
+    """
+    events = snapshot.get("live_events")
+    if not isinstance(events, list):
+        return
+    # Row COUNT first, then per-row text: see :data:`LIVE_EVENT_END_ROWS_MAX`
+    # for why the text budget alone leaves the frame reachable.
+    #
+    # An evicted end takes its START with it. Evicting the end alone would
+    # leave the start behind as a card the viewer paints LIVE and can never
+    # settle — a stranded spinner, and then an `⊘ interrupted` at retirement on
+    # a call that succeeded. That is the precise artefact this retention was
+    # added to remove, so the cap must not reintroduce it by the back door.
+    # A start with no end is a call still RUNNING and is always kept: that card
+    # is the one the viewer most needs.
+    end_positions = [
+        index
+        for index, item in enumerate(events)
+        if isinstance(item, dict) and item.get("type") == "tool_execution_end"
+    ]
+    if len(end_positions) > LIVE_EVENT_END_ROWS_MAX:
+        evicted_ends = end_positions[: len(end_positions) - LIVE_EVENT_END_ROWS_MAX]
+        evicted = set(evicted_ends)
+        settled = {
+            str(events[index].get("tool_call_id") or "")
+            for index in evicted_ends
+            if events[index].get("tool_call_id")
+        }
+        for index, item in enumerate(events):
+            if (
+                isinstance(item, dict)
+                and item.get("type") == "tool_execution_start"
+                and str(item.get("tool_call_id") or "") in settled
+            ):
+                evicted.add(index)
+        events = [item for index, item in enumerate(events) if index not in evicted]
+        snapshot["live_events"] = events
+    # Only ``tool_execution_end`` retains a payload; starts and message rows
+    # are already small and are folded by phase, so they are not counted into
+    # the share they would otherwise dilute.
+    texts: list[tuple[dict[str, Any], list[dict[str, Any]]]] = []
+    for item in events:
+        if not isinstance(item, dict) or item.get("type") != "tool_execution_end":
+            continue
+        result = item.get("result")
+        if not isinstance(result, dict):
+            continue
+        blocks = [
+            block
+            for block in (result.get("content") or [])
+            if isinstance(block, dict) and isinstance(block.get("text"), str)
+        ]
+        if blocks:
+            texts.append((result, blocks))
+    if not texts:
+        return
+    share = max(LIVE_EVENT_TEXT_FLOOR_CHARS, LIVE_EVENT_TEXT_FRAME_BUDGET_CHARS // len(texts))
+    for _result, blocks in texts:
+        # Per ROW, not per block: a result of many blocks would otherwise
+        # multiply its own share and reinstate the unbounded shape one level
+        # further down.
+        remaining = share
+        for block in blocks:
+            text = block["text"]
+            if len(text) > remaining:
+                block["text"] = text[:remaining] + "…" if remaining > 0 else "…"
+            remaining = max(0, remaining - len(text))
 
 
 def _bound_job_text_in_place(job: dict[str, Any], *, share: int) -> None:

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -3028,7 +3028,16 @@ class FrontendStateStore:
             live.append(data)
         elif kind == "tool_execution_end":
             call_id = str(data.get("tool_call_id") or "")
+            # The END REPLACES the start rather than erasing the call. A
+            # frontend that joins mid-turn needs to learn the outcome of a
+            # call that finished while it was away: dropping the row left the
+            # viewer holding a card it had painted live with no way to settle
+            # it, so ``_retire_live_tool_cards`` marked it ``⊘ interrupted``
+            # at turn end — on a call that had SUCCEEDED (QA round 1, Q2).
+            # A joiner that never saw the start still renders correctly: the
+            # app buffers an unmatched end in ``_pending_tool_ends``.
             live = [item for item in live if str(item.get("tool_call_id") or "") != call_id]
+            live.append(data)
         # Shallow copy on purpose: this runs per streaming delta on the session
         # loop, and a deep copy re-clones a 500-event trajectory each token.
         # ``live`` is freshly built above, and every other field is replaced

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -258,7 +258,24 @@ LIVE_EVENT_TEXT_FLOOR_CHARS = 200
 #:
 #: The full payload is never lost: it is in the durable transcript, and a
 #: viewer that stayed connected received it untouched over the live relay.
+#:
+#: ``ToolResult.text`` joins content blocks with ``""``
+#: (``harness/types.py``), so a marker following a caption renders as
+#: ``screenshot of the page[dropped from the reconnect snapshot…]`` — the two
+#: run together and the marker reads as part of what the tool said. The
+#: separator is therefore carried by the marker itself, prepended only when an
+#: earlier block already contributed text (see
+#: :data:`LIVE_EVENT_BLOCK_ELIDED_SEPARATOR`); as the first block it would
+#: otherwise open the card with a blank line.
+#:
+#: Fixed here rather than at the join because ``ToolResult.text`` is a shared
+#: API with other consumers, and widening its separator to suit this one
+#: caller would change how every existing multi-block result renders. A marker
+#: this module injects is this module's to make well-formed.
 LIVE_EVENT_BLOCK_ELIDED_PLACEHOLDER = "[dropped from the reconnect snapshot — see the transcript]"
+
+#: Separates the elided-block marker from a preceding block's text.
+LIVE_EVENT_BLOCK_ELIDED_SEPARATOR = "\n"
 
 #: Cap on retained ``tool_execution_end`` rows in the seed, newest kept.
 #:
@@ -1992,10 +2009,17 @@ def _bound_live_result_in_place(result: dict[str, Any], *, share: int) -> None:
     # reason SIZE is — a producer emitting many blocks is a change in data,
     # not a change in this file.
     floor_spent = False
+    # Whether any block so far put text on the card, which is what a marker
+    # needs to know to separate itself from it.
+    emitted_text = False
     for block in blocks:
         cost = _live_row_cost(block)
         if cost <= remaining:
             remaining -= cost
+            # Tracked on the UNCLIPPED path too: the common shape is a small
+            # caption that fits, followed by an image that does not, and it is
+            # exactly that caption a marker must separate itself from.
+            emitted_text = emitted_text or bool(block.get("text"))
             continue
         text = block.get("text")
         if isinstance(text, str):
@@ -2014,9 +2038,21 @@ def _bound_live_result_in_place(result: dict[str, Any], *, share: int) -> None:
             # No text to clip — an image's base64, or any future block whose
             # payload lives under a key this function has never heard of. It is
             # replaced rather than emptied so the row still reads as a block.
+            #
+            # The marker separates itself from whatever precedes it, because
+            # ``ToolResult.text`` concatenates blocks with no delimiter and a
+            # caption would otherwise run straight into it (round-4 Q4-2). Led
+            # by the text ALREADY EMITTED rather than by block position: a
+            # marker after an image-only block has nothing to separate from,
+            # and would open the card with a blank line.
             block.clear()
             block["type"] = "text"
-            block["text"] = LIVE_EVENT_BLOCK_ELIDED_PLACEHOLDER
+            block["text"] = (
+                LIVE_EVENT_BLOCK_ELIDED_SEPARATOR + LIVE_EVENT_BLOCK_ELIDED_PLACEHOLDER
+                if emitted_text
+                else LIVE_EVENT_BLOCK_ELIDED_PLACEHOLDER
+            )
+        emitted_text = emitted_text or bool(block.get("text"))
         remaining = max(0, remaining - _live_row_cost(block))
 
 

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import (
     BaseModel,
@@ -1437,6 +1437,14 @@ class FrontendSessionState(BaseModel):
     cost_knowledge: CostKnowledge = CostKnowledge.UNKNOWN
     streaming: bool = False
     generation: int = 0
+    #: How the last logical turn ended, for a viewer that dropped mid-turn and
+    #: rebinds after it settled. ``live_events`` is emptied at ``agent_end``, so
+    #: the real end is not in the snapshot; without this a rebind cannot tell
+    #: aborted from completed and would synthesise ``aborted=True`` (today's
+    #: false "interrupted"). ``""`` is the wire default and the old-runtime
+    #: value — treat as aborted. Additive; extra="allow" keeps older readers
+    #: tolerant. One value per user prompt, not per compaction continuation.
+    last_turn_outcome: Literal["completed", "aborted", "error", ""] = ""
     activity_started_at: float | None = None
     active_duration_s: float = 0.0
     current_turn_accrued_cost: float = 0.0
@@ -2733,6 +2741,7 @@ class FrontendStateStore:
             cost_knowledge=knowledge,
             streaming=bool(getattr(session, "is_streaming", False)),
             generation=int(getattr(session, "_generation", current.generation) or 0),
+            last_turn_outcome=_last_turn_outcome_from(session, current.last_turn_outcome),
             activity_started_at=(
                 current.activity_started_at
                 if bool(getattr(session, "is_streaming", False))
@@ -2874,7 +2883,18 @@ class FrontendStateStore:
             duration = state.active_duration_s
             if state.activity_started_at is not None:
                 duration += max(0.0, now - state.activity_started_at)
-            changes.update(streaming=False, activity_started_at=None, active_duration_s=duration)
+            if event.error:
+                outcome: Literal["completed", "aborted", "error", ""] = "error"
+            elif event.aborted:
+                outcome = "aborted"
+            else:
+                outcome = "completed"
+            changes.update(
+                streaming=False,
+                activity_started_at=None,
+                active_duration_s=duration,
+                last_turn_outcome=outcome,
+            )
             # Reconcile the whole turn once. Per-call receipts are retained so a
             # mixed-provider aggregate never loses which call owned which price.
             usages = [
@@ -3301,6 +3321,21 @@ def _job_subtree_cost(job: Any, *, default_model_label: str) -> float | None:
             return None
         descendant += cost
     return (direct or 0.0) + descendant
+
+
+def _last_turn_outcome_from(session: Any, current: str) -> str:
+    """Prefer the session's published outcome; keep the store's if it has none.
+
+    ``observe_event`` writes ``last_turn_outcome`` onto the store from the
+    emitted ``AgentEndEvent``. ``refresh_from_session`` then copies the
+    session's fields over the store — and a reduced test double (or a
+    runtime that has not yet grown the attribute) would wipe a just-written
+    value back to ``""``, which a rebinding viewer treats as aborted.
+    """
+    if not hasattr(session, "_last_turn_outcome"):
+        return current if current in ("completed", "aborted", "error") else ""
+    raw = str(getattr(session, "_last_turn_outcome", "") or "")
+    return raw if raw in ("completed", "aborted", "error") else ""
 
 
 def _label(spec: Any) -> str:

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -363,6 +363,17 @@ class RemoteSession:
         self._disposed = False
         self._recovering = False
         self._recovery_task: asyncio.Task[None] | None = None
+        #: Generation of the turn that was live when the socket dropped, or
+        #: ``None`` when nothing was streaming. Recovery uses this to decide
+        #: whether to synthesise an ``AgentEndEvent``: a rebind to the same
+        #: live generation must not, or the ledger paints a false
+        #: "interrupted" on a turn the runtime is still running.
+        self._suspect_generation: int | None = None
+        #: Set by ``_settle_suspect_turn`` when recovery rebound to the same
+        #: live generation. ``_finish_sync`` then seeds only ``AgentStartEvent``
+        #: — replaying ``live_events`` would duplicate tool cards the ledger
+        #: already holds (test 16: "seeded start only").
+        self._same_live_turn = False
         self._takeover_callback: Callable[[Any], Any] | None = None
         # Input submitted while the owner rotates waits here instead of failing
         # out of the composer's turn worker. On reattach it goes over the fresh
@@ -2316,10 +2327,21 @@ class RemoteSession:
             return
         self._recovering = True
         self._owner_ready.clear()
-        self._end_turn_locally()
+        # Do NOT end the turn here. A dropped socket says nothing about the
+        # turn: the runtime is usually still running it (a send timeout under
+        # a stalled TUI loop is the common cause). Recovery decides — see
+        # ``_settle_suspect_turn``.
+        self._suspect_generation = self._generation if self._streaming else None
         self._recovery_task = asyncio.create_task(self._recover_owner())
 
-    def _end_turn_locally(self, *, direct: bool = False) -> None:
+    def _end_turn_locally(
+        self,
+        *,
+        direct: bool = False,
+        aborted: bool = True,
+        error: str | None = None,
+        force: bool = False,
+    ) -> None:
         """End an in-flight turn the owner can no longer end itself.
 
         All three terminal outcomes need it and none can get it from the
@@ -2355,9 +2377,9 @@ class RemoteSession:
         wants. It applies to the buffered path for the same reason: neither
         delivery has standing to speak for the successor's numbering.
         """
-        if not self._streaming:
+        if not self._streaming and not force:
             return
-        end = AgentEndEvent(aborted=True, generation=0, error=None)
+        end = AgentEndEvent(aborted=aborted, generation=0, error=error)
         # THE STATE CHANGE IS THE CONTRACT; ONLY THE NOTIFICATION IS
         # BEST-EFFORT (review round 2, MAJOR-2). `_deliver` calls handlers
         # synchronously with no guard of its own, and
@@ -2379,6 +2401,53 @@ class RemoteSession:
                 self._emit_or_buffer(end)
         finally:
             self._streaming = False
+            self._suspect_generation = None
+
+    def _settle_suspect_turn(self) -> None:
+        """Decide what a mid-turn disconnect meant, now that recovery rebound.
+
+        A dropped socket is not an abort: the runtime is usually still running
+        the turn. Called after ``_install_frontend`` has overwritten
+        ``_streaming`` / ``_generation`` from the snapshot.
+
+        * same generation still streaming — nothing to synthesise, and
+          ``_finish_sync`` skips the live-event seed so in-flight tool cards
+          are not duplicated. Deviation from the design's "seed
+          AgentStartEvent": that handler clears ``_started_tools``, so a
+          later real tool_end would miss the card and paint ⊘ interrupted.
+        * generation moved, or streaming False — the turn ended while we were
+          away. ``live_events`` is emptied at ``agent_end``, so synthesise
+          from ``last_turn_outcome`` (additive; ``""`` from an old runtime
+          keeps today's aborted synthesis).
+        """
+        suspect = self._suspect_generation
+        self._suspect_generation = None
+        if suspect is None:
+            return
+        snapshot_streaming = self._streaming
+        snapshot_generation = self._generation
+        if snapshot_streaming and snapshot_generation == suspect:
+            self._same_live_turn = True
+            return
+        outcome = ""
+        store = self._frontend_store
+        if store is not None:
+            outcome = str(getattr(store.state, "last_turn_outcome", "") or "")
+        # ``force`` because ``_apply_frontend_facades`` already cleared
+        # ``_streaming`` when the snapshot says the turn ended, and the
+        # usual early-return would swallow the synthesised end.
+        self._end_turn_locally(
+            direct=True,
+            aborted=outcome in ("aborted", ""),
+            error="turn failed" if outcome == "error" else None,
+            force=True,
+        )
+        # A successor turn may already be live (generation moved). The
+        # synthesised end is for the *suspect* turn; do not clear the
+        # successor's streaming bit — ``_end_turn_locally`` always does.
+        if snapshot_streaming:
+            self._streaming = True
+            self._generation = snapshot_generation
 
     async def _session_was_stopped(self) -> bool:
         """True when the disconnect's cause is a DELIBERATE stop, not owner death.
@@ -2444,10 +2513,12 @@ class RemoteSession:
         facade the turn was over while the app — which holds its working line,
         band and title open until an ``AgentEndEvent`` reaches it — was never
         told anything, so a viewer that went cold mid-turn held a spinner
-        forever with no toast and no notice. On the common path this is a
-        no-op: ``_on_disconnected`` already ended the turn before
-        ``_recover_owner`` started. The case it exists for is a SUCCESSOR
-        dying mid-reattach — ``_on_disconnected`` returns early while
+        forever with no toast and no notice. On the common path this is the
+        settlement of a *suspect* turn: ``_on_disconnected`` no longer
+        synthesises an abort (a dropped socket is usually a stalled viewer,
+        not a dead runtime), so go-cold is the verdict that the runtime is
+        actually gone. The other case it exists for is a SUCCESSOR dying
+        mid-reattach — ``_on_disconnected`` returns early while
         ``_recovering``, and ``_apply_frontend_facades`` has just re-marked
         the turn live from the successor's snapshot — which leaves
         ``_streaming`` True with nothing else on the way to clear it.
@@ -2483,11 +2554,20 @@ class RemoteSession:
             # die, goes cold rather than taking over. The `lop --resume` TUI
             # is exactly this case (design-runtime-autorefresh §1.1).
             self._can_go_cold = True
+            # ``_suspect_generation`` is deliberately LEFT SET here. A refresh
+            # is not a death, so an in-flight turn (which should not exist —
+            # the warning above) must not be aborted: the successor's snapshot
+            # is the honest repair, and ``_settle_suspect_turn`` decides on
+            # rebind exactly as it does after a transient drop.
         else:
             try:
                 self._end_turn_locally(direct=True)
             except Exception:  # noqa: BLE001 — a viewer notice must not break teardown
                 logger.debug("ending the in-flight turn on go-cold failed", exc_info=True)
+            # Belt for the case ``_end_turn_locally`` early-returns on
+            # ``not _streaming``: a suspect recorded at the drop must not
+            # outlive the verdict that the runtime is gone.
+            self._suspect_generation = None
         self._owner_ready.set()
         callback = self._refresh_callback if refresh else self._went_cold_callback
         if callback is None:
@@ -2567,6 +2647,10 @@ class RemoteSession:
         if self._stopped_announced:
             return
         self._stopped_announced = True
+        # A stop found during recovery (the on-disk marker, not the
+        # ``stopping`` frame) never went through ``_on_disconnected``'s
+        # deliberate-stop branch, so the suspect turn is still open.
+        self._end_turn_locally(direct=True)
         callback = self._stopped_callback
         if callback is None:
             return
@@ -2678,6 +2762,14 @@ class RemoteSession:
                                 frontend.live_cursor,
                                 drop_history_duplicates=False,
                             )
+                        # After the snapshot is installed AND the bind held:
+                        # ``_apply_frontend_facades`` overwrote ``_streaming``
+                        # / ``_generation`` from the snapshot, so the
+                        # comparison is against the runtime's current turn.
+                        # Must run AFTER the transcript bind — a raise above
+                        # would otherwise consume ``_suspect_generation`` and
+                        # the next retry would have nothing to settle.
+                        self._settle_suspect_turn()
                         self._finish_sync()
                         return
                     except (ConnectionError, OSError, TimeoutError):
@@ -2701,6 +2793,10 @@ class RemoteSession:
                     else:
                         callback = self._takeover_callback
                         if callback is not None:
+                            # Takeover means the owner is gone: the turn did
+                            # abort. Synthesise before the app disposes this
+                            # facade, or the working line never learns.
+                            self._end_turn_locally(direct=True)
                             result = callback(local)
                             if inspect.isawaitable(result):
                                 await result
@@ -3422,8 +3518,11 @@ class RemoteSession:
         return True
 
     def abort(self, reason: str = "interrupted") -> None:
-        if self._client is not None:
-            asyncio.create_task(self._client.abort())
+        client = self._client
+        if client is None or not client.connected:
+            return  # nothing to abort on; the local end is what the app shows
+        task = asyncio.create_task(client.abort())
+        task.add_done_callback(_log_abort_failure)
 
     async def request_stop(self) -> str:
         """Stop the session this follower is watching — deliberately.
@@ -3609,6 +3708,22 @@ class RemoteSession:
             # A pending snapshot owns the final close, including failure and
             # cancellation. No new socket, create retry, or owner restart occurs.
             self._client = None
+
+
+def _log_abort_failure(task: asyncio.Task[Any]) -> None:
+    """A mid-recovery abort raises ``ConnectionError("not attached")``.
+
+    ``asyncio.create_task`` without a done-callback left that as "Task
+    exception was never retrieved" in the operator log (12 rows in one
+    morning). DEBUG, not ERROR: the local turn end is already what the
+    app shows, and a detached client has nothing to abort on.
+    """
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is None:
+        return
+    logger.debug("remote abort failed", exc_info=exc)
 
 
 async def _await_handler(result: Any) -> None:

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -1799,6 +1799,13 @@ class RemoteSession:
         here rather than painted twice.
         """
         seeded = []
+        # The seed loop runs on EVERY path, including a same-live-turn rebind:
+        # ``live_events`` is the turn AS IT IS NOW, so it carries whatever the
+        # runtime produced while the socket was down. Dropping it lost a tool
+        # that started during the gap (its real end then arrives orphaned and
+        # is discarded unrendered at ``agent_end``) and any gap assistant text
+        # outright — review round 1, MAJOR-1. ``_is_duplicate``/``_track``
+        # below already make re-seeding safe for rows the ledger holds.
         for data in self.frontend_state.live_events:
             event = deserialize_event(data)
             if self._is_duplicate(event):
@@ -1809,7 +1816,15 @@ class RemoteSession:
                 continue
             self._track(event)
             seeded.append(event)
-        if self.frontend_state.streaming:
+        # ONLY the synthetic start is suppressed on a same-live-turn rebind.
+        # ``_handle_agent_start`` clears ``_started_tools``, so a later real
+        # tool_end would miss its card and ``_finalize_turn`` would paint
+        # ⊘ interrupted — the artefact this PR exists to remove. The
+        # controller already holds this generation, applied from the
+        # snapshot, so nothing needs re-stamping. Deviation from the
+        # design's "seed as today", proven by the reviewer's counterfactual.
+        same_live_turn, self._same_live_turn = self._same_live_turn, False
+        if self.frontend_state.streaming and not same_live_turn:
             seeded.insert(0, AgentStartEvent(generation=self.frontend_state.generation))
         # Durable-before-live is the transcript's paint invariant. On
         # reconnect the buffer's head can hold the gap's HistoryDeltaEvent
@@ -2419,6 +2434,13 @@ class RemoteSession:
           away. ``live_events`` is emptied at ``agent_end``, so synthesise
           from ``last_turn_outcome`` (additive; ``""`` from an old runtime
           keeps today's aborted synthesis).
+
+        The ``error`` case synthesises the placeholder ``"turn failed"``.
+        ``last_turn_outcome`` is a four-value enum that deliberately carries
+        no message — transporting the owner's error text would mean a second,
+        unbounded field on every snapshot — so that string is a CLASS marker,
+        never the owner's actual diagnostic, and nothing downstream should
+        read it as authoritative (review round 1, MINOR-2).
         """
         suspect = self._suspect_generation
         self._suspect_generation = None
@@ -2647,9 +2669,15 @@ class RemoteSession:
         if self._stopped_announced:
             return
         self._stopped_announced = True
-        # A stop found during recovery (the on-disk marker, not the
-        # ``stopping`` frame) never went through ``_on_disconnected``'s
-        # deliberate-stop branch, so the suspect turn is still open.
+        # TWO ENTRY POINTS, and only one of them has already ended the turn.
+        # ``_on_disconnected``'s deliberate-stop branch calls
+        # ``_end_turn_locally()`` immediately before this, so the call here is
+        # a no-op for it (no ``force``, and ``_streaming`` is already False).
+        # The path this exists for is the wake-marker inference inside
+        # ``_recover_owner``, which never passed through that branch and would
+        # otherwise leave the suspect turn open forever. Do NOT add ``force``
+        # here without splitting the two callers: it would double-end the
+        # first one (review round 1, MINOR-1).
         self._end_turn_locally(direct=True)
         callback = self._stopped_callback
         if callback is None:
@@ -2681,14 +2709,36 @@ class RemoteSession:
         cold_deadline = time.monotonic() + COLD_FALLBACK_S
         try:
             while not self._disposed:
-                if self._can_go_cold and time.monotonic() >= cold_deadline:
-                    logger.info(
-                        "no runtime for %s after %.0fs; the viewer is going cold",
-                        self._session_id,
-                        COLD_FALLBACK_S,
-                    )
-                    self._go_cold()
-                    return
+                if time.monotonic() >= cold_deadline:
+                    if self._can_go_cold:
+                        logger.info(
+                            "no runtime for %s after %.0fs; the viewer is going cold",
+                            self._session_id,
+                            COLD_FALLBACK_S,
+                        )
+                        self._go_cold()
+                        return
+                    # The LEGACY attach surface has no cold state to fall into
+                    # (``_can_go_cold`` is desktop-only) and its contract is to
+                    # keep chasing a successor. But the turn must still reach a
+                    # verdict: with the abort deferred to recovery, a genuine
+                    # owner death whose takeover keeps failing (lease held by
+                    # another follower, or any raise — both retry forever by
+                    # design) left the working line spinning with nothing able
+                    # to clear it. That is strictly worse than the false
+                    # "interrupted" this PR removes — review round 1,
+                    # BLOCKER-1. The same ``COLD_FALLBACK_S`` bound applies:
+                    # after this long with no runtime, an in-flight turn is
+                    # honestly aborted. ``_end_turn_locally`` clears
+                    # ``_suspect_generation``, so this fires at most once and
+                    # the retry loop continues underneath it.
+                    if self._suspect_generation is not None:
+                        logger.info(
+                            "no runtime for %s after %.0fs; ending the in-flight turn",
+                            self._session_id,
+                            COLD_FALLBACK_S,
+                        )
+                        self._end_turn_locally(direct=True)
                 # A stop by someone else while we watched: the transcript's
                 # ``stopped_at`` marker plus no live owner is the deliberate
                 # shape. Read it once at the top of each pass — cheap (one

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -205,8 +205,12 @@ def relay_frame_or_degraded(frame: dict[str, Any], cap_bytes: int) -> dict[str, 
 
 # A projection is replaceable state. If a peer cannot accept one within this
 # bound, dropping that peer is safer than blocking authority-bearing ACKs for
-# every healthy front end.
+# every healthy front end. Daemon and legacy attach clients still receive
+# full projections; full-TUI clients (events + frontend_state) do not, so
+# they get a longer bound — a 1 s stall on a TUI reflow was dropping a
+# healthy viewer and synthesising a false "interrupted".
 _SEND_TIMEOUT_S = 1.0
+_TUI_SEND_TIMEOUT_S = 5.0
 # Raw events are lossless only while a follower keeps pace. One bounded FIFO per
 # event client prevents a non-reader from retaining an unbounded stream before
 # its active drain reaches the timeout; overflow drops that client so it can
@@ -938,7 +942,7 @@ class RuntimeServer:
             self._server.close()
         clients = list(self._clients.values())
         for conn in clients:
-            self._drop_client(conn)
+            self._drop_client(conn, reason="runtime shutdown")
         await self._await_push_shutdown()
         heartbeat = self._heartbeat_task
         if heartbeat is not None:
@@ -1084,7 +1088,7 @@ class RuntimeServer:
             for other in [
                 c for c in self._clients.values() if c.kind == "daemon" and c.writer is not writer
             ]:
-                self._drop_client(other)
+                self._drop_client(other, reason="daemon replaced")
         else:
             # Attach cap with LRU eviction: the least-recently-seen follower
             # goes. Sending on the evicted socket first (a goodbye) is not
@@ -1094,8 +1098,7 @@ class RuntimeServer:
             attaches = [c for c in self._clients.values() if c.kind == "attach"]
             if len(attaches) >= ATTACH_MAX_CLIENTS:
                 victim = min(attaches, key=lambda c: c.last_seen)
-                logger.info("mobile control: evicting attach client %s (cap)", peer)
-                self._drop_client(victim)
+                self._drop_client(victim, reason="attach cap")
 
         conn = _ClientConn(
             writer=writer,
@@ -1124,7 +1127,7 @@ class RuntimeServer:
         if conn.wants_frontend:
             subscribe_frontend = getattr(self._handle, "subscribe_frontend", None)
             if not callable(subscribe_frontend):
-                self._drop_client(conn)
+                self._drop_client(conn, reason="frontend requested but unsupported")
                 return
 
             def on_update(update: Any) -> None:
@@ -1198,6 +1201,7 @@ class RuntimeServer:
             while not self._closed.is_set():
                 line = await reader.readline()
                 if not line:
+                    self._drop_client(conn, reason="reader eof")
                     return  # client hung up
                 try:
                     frame = json.loads(line.decode("utf-8", "replace"))
@@ -1206,11 +1210,12 @@ class RuntimeServer:
                 conn.last_seen = time.monotonic()
                 await self._on_request(frame, conn)
         except (ConnectionResetError, BrokenPipeError):
+            self._drop_client(conn, reason="reader reset")
             return
         finally:
-            self._drop_client(conn)
+            self._drop_client(conn, reason="reader eof")
 
-    def _drop_client(self, conn: _ClientConn) -> None:
+    def _drop_client(self, conn: _ClientConn, *, reason: str = "unspecified") -> None:
         """Remove one connection from the registry and close its socket.
 
         The ONLY removal path: reader-loop exit, shutdown, daemon eviction,
@@ -1224,6 +1229,20 @@ class RuntimeServer:
         # SERVER-GLOBAL state has to honour that contract, or the late second
         # call reaches across to whatever connection replaced this one.
         was_registered = self._clients.pop(id(conn.writer), None) is not None
+        # One INFO per actual removal. The reader loop's ``finally`` always
+        # calls again after a send-path drop; that second call is a no-op and
+        # must not look like a second failure (DEBUG only).
+        peer = conn.writer.get_extra_info("peername")
+        log = logger.info if was_registered else logger.debug
+        log(
+            "session runtime: dropped %s client %s (events=%s frontend=%s surface=%s): %s",
+            conn.kind,
+            peer,
+            conn.wants_events,
+            conn.wants_frontend,
+            conn.surface,
+            reason,
+        )
         # The other half of the ``detached`` transition: the last terminal
         # leaving is precisely when the picker must start saying "nobody is
         # watching this". Published from the ONE removal path so no exit route
@@ -2206,7 +2225,7 @@ class RuntimeServer:
                 # A join that cannot install its boundary before this many
                 # canonical edges is already stale. Drop and let it reconnect
                 # to one fresh snapshot rather than retain an unbounded suffix.
-                self._drop_client(conn)
+                self._drop_client(conn, reason="frontend pending overflow before ready")
                 return
             conn.frontend_pending.append(data)
             return
@@ -2238,7 +2257,9 @@ class RuntimeServer:
                 except asyncio.QueueFull:
                     compacted = False
             if not compacted:
-                self._drop_client(conn)
+                self._drop_client(
+                    conn, reason="event queue overflow (%d frames)" % _EVENT_QUEUE_MAX
+                )
                 return
         if conn.event_writer_task is None:
             task = asyncio.create_task(self._drain_event_queue(conn))
@@ -2445,19 +2466,39 @@ class RuntimeServer:
         finally:
             self._push_scheduled = False
 
+    def _projection_recipients(self) -> list[_ClientConn]:
+        """Who still wants projection *repaints*.
+
+        A client that declared ``events`` AND ``frontend_state`` is a full-TUI
+        viewer: it consumes ``frontend_sync`` / ``frontend_update`` / ``event``
+        and discards projections (``RemoteSession._dial`` installs
+        ``lambda _projection: None``). Pushing 100–900 KB × ~20 Hz onto that
+        socket is what filled the kernel buffer and tripped ``_SEND_TIMEOUT_S``.
+        The welcome (``_push_to``) still goes to everyone — ``AttachClient.connect``
+        reads it as the identity check. Daemon and legacy v3/v4-only attach
+        clients keep receiving repaints byte-for-byte.
+
+        Desktop uses the same two flags and the same no-op projection
+        callback (confirmed: ``desktop_sessions.py`` consumes events +
+        frontend_state, nothing keys on ``op == "projection"`` after welcome).
+        """
+        return [
+            conn
+            for conn in self._clients.values()
+            if not (conn.wants_events and conn.wants_frontend)
+        ]
+
     async def _push(self) -> None:
         """Broadcast projection repaints, preserving daemon bytes exactly.
 
-        Event clients may need a follower-only gate overlay (currently a TUI
-        approval). Build the ordinary projection once for daemon and legacy
-        attach clients; only event subscribers get the overlaid copy. This is
-        the protocol-v4 promise that phone frames remain byte-identical.
+        Full-TUI attach clients are skipped (see ``_projection_recipients``).
+        Phone daemon frames stay byte-identical.
         """
         ordinary = self._projection_payload()
         await asyncio.gather(
             *(
                 self._send_to(conn, self._projection_frame(conn, ordinary))
-                for conn in list(self._clients.values())
+                for conn in self._projection_recipients()
             )
         )
 
@@ -2506,12 +2547,17 @@ class RuntimeServer:
         """One frame to one connection. A failed send drops ONLY that client
         from the registry (never retried — the reader loop will observe the
         close and its finally is a no-op second removal)."""
+        timeout = (
+            _TUI_SEND_TIMEOUT_S if conn.wants_events and conn.wants_frontend else _SEND_TIMEOUT_S
+        )
         async with conn.send_lock:
             try:
                 conn.writer.write(json.dumps(frame).encode() + b"\n")
-                await asyncio.wait_for(conn.writer.drain(), timeout=_SEND_TIMEOUT_S)
-            except (TimeoutError, ConnectionResetError, BrokenPipeError, OSError):
-                self._drop_client(conn)
+                await asyncio.wait_for(conn.writer.drain(), timeout=timeout)
+            except TimeoutError:
+                self._drop_client(conn, reason="send timeout (%.1fs)" % timeout)
+            except (ConnectionResetError, BrokenPipeError, OSError) as exc:
+                self._drop_client(conn, reason="send failed: %s" % type(exc).__name__)
 
     async def _send(self, frame: dict[str, Any]) -> None:
         """Broadcast alias kept for the pre-v2 call shape (tests, hosts that

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -2257,9 +2257,7 @@ class RuntimeServer:
                 except asyncio.QueueFull:
                     compacted = False
             if not compacted:
-                self._drop_client(
-                    conn, reason="event queue overflow (%d frames)" % _EVENT_QUEUE_MAX
-                )
+                self._drop_client(conn, reason=f"event queue overflow ({_EVENT_QUEUE_MAX} frames)")
                 return
         if conn.event_writer_task is None:
             task = asyncio.create_task(self._drain_event_queue(conn))
@@ -2555,9 +2553,9 @@ class RuntimeServer:
                 conn.writer.write(json.dumps(frame).encode() + b"\n")
                 await asyncio.wait_for(conn.writer.drain(), timeout=timeout)
             except TimeoutError:
-                self._drop_client(conn, reason="send timeout (%.1fs)" % timeout)
+                self._drop_client(conn, reason=f"send timeout ({timeout:.1f}s)")
             except (ConnectionResetError, BrokenPipeError, OSError) as exc:
-                self._drop_client(conn, reason="send failed: %s" % type(exc).__name__)
+                self._drop_client(conn, reason=f"send failed: {type(exc).__name__}")
 
     async def _send(self, frame: dict[str, Any]) -> None:
         """Broadcast alias kept for the pre-v2 call shape (tests, hosts that

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -5803,8 +5803,21 @@ class Session:
                 )
         # Fold before fan-out: a client joining from an event handler observes a
         # snapshot that already contains this event, never an off-by-one view.
+        #
+        # ``_is_streaming`` is the third term, and it is what makes a RECONNECT
+        # work. A headless runtime has ``_has_ui=False``, so when its only
+        # viewer's socket drops the server unsubscribes and ``has_subscribers``
+        # goes False — the fold then stops, and everything the runtime does for
+        # the rest of the turn is absent from ``live_events``. The viewer
+        # re-binds moments later to a snapshot that has forgotten the tool the
+        # runtime started while it was away: the card never paints and its real
+        # ``tool_execution_end`` arrives orphaned, to be discarded unrendered at
+        # ``agent_end``. That is the whole point of the bounded seed ("a
+        # frontend that joins mid-turn"), and a mid-turn drop is exactly when a
+        # frontend joins. Bounded to a live turn, so a genuinely unobserved
+        # idle session still does no work.
         store = getattr(self, "_frontend_state_store", None)
-        if store is not None and (self._has_ui or store.has_subscribers):
+        if store is not None and (self._has_ui or store.has_subscribers or self._is_streaming):
             # Replay-changing commits precede their public events. Publish the
             # scalar first so retained viewers cannot select a stale tail after
             # compaction, pruning, or a fold; unchanged events do no extra work.

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1992,6 +1992,15 @@ class Session:
         # whether the run continues, `_logical_generation` remembers which
         # agent_start the eventual end belongs to. Both are None outside a run.
         self._held_end: AgentEndEvent | None = None
+        #: How the last logical turn ended, published on the canonical snapshot
+        #: as ``last_turn_outcome``. A viewer that dropped mid-turn and rebinds
+        #: after the turn settled cannot recover this from ``live_events``
+        #: (cleared at ``agent_end``); without it it would synthesise
+        #: ``aborted=True`` and paint a false "interrupted". ``""`` until the
+        #: first turn ends. Set from the emitted end, which is one value per
+        #: user prompt (compaction continuations hold the end until the
+        #: pipeline flushes).
+        self._last_turn_outcome: Literal["completed", "aborted", "error", ""] = ""
         # The loop's held end owns billing, but a later post-turn compaction owns
         # occupancy. Carry that newer level to the boundary without rewriting the
         # usage objects that lifetime cost and analytics still need.
@@ -5751,6 +5760,16 @@ class Session:
     async def _emit(self, event: AgentEvent) -> None:
         if isinstance(event, AgentEndEvent):
             self._attention_outcome = event
+            # The emitted end is the logical turn's outcome (held ends flush
+            # here from the pipeline finally; abort/error skip the hold and
+            # emit immediately). The canonical snapshot copies this field so a
+            # rebinding viewer can synthesise the matching AgentEndEvent.
+            if event.error:
+                self._last_turn_outcome = "error"
+            elif event.aborted:
+                self._last_turn_outcome = "aborted"
+            else:
+                self._last_turn_outcome = "completed"
         if isinstance(event, ModelChangeEvent) and event.context_metadata:
             current = self.effective_model
             primary = (self._model.provider, self._model.model_id) == (

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -5816,6 +5816,14 @@ class Session:
         # frontend that joins mid-turn"), and a mid-turn drop is exactly when a
         # frontend joins. Bounded to a live turn, so a genuinely unobserved
         # idle session still does no work.
+        #
+        # This does mean the fold now also runs for a session NO viewer has
+        # ever attached to — every subagent — which is a real cost and the
+        # reason ``live_events`` needed its own wire bound (see
+        # ``LIVE_EVENT_END_ROWS_MAX``). Kept deliberately: "has a viewer right
+        # now" is not knowable at fold time in any useful way, since the whole
+        # point is to have the seed ready for a viewer that has not arrived
+        # yet. Bounded retention is the cheaper guarantee.
         store = getattr(self, "_frontend_state_store", None)
         if store is not None and (self._has_ui or store.has_subscribers or self._is_streaming):
             # Replay-changing commits precede their public events. Publish the

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -26531,6 +26531,17 @@ class OperatorApp(App[None]):
         obviously, ``_current_activity`` derives the working line's label from
         those cards, so the NEXT turn opened by announcing ``running bash`` for
         a bash call that had died with the previous session.
+
+        Deliberately UNCONDITIONAL: whatever is still live here has, by
+        definition, no outcome on this surface, so there is nothing to be
+        conditional on. What keeps that honest is upstream — the reconnect seed
+        retains each ``tool_execution_end`` (see
+        ``LIVE_EVENT_TEXT_FRAME_BUDGET_CHARS``), so a call that finished while
+        the viewer was away settles its card through the normal path BEFORE
+        retirement runs. A card reaching here really did stop mid-flight. If a
+        future change lets the seed drop an end again, this method will mark a
+        succeeded call ``⊘ interrupted`` — that was the round-1 Q2 bug, and the
+        fix belongs in the seed rather than in an outcome test here.
         """
         cards = list(self._tool_cards.values()) + list(self._composing_cards.values())
         for card in cards:

--- a/tests/e2e/test_viewer_attach_e2e.py
+++ b/tests/e2e/test_viewer_attach_e2e.py
@@ -807,3 +807,225 @@ async def test_a_transient_viewer_drop_mid_turn_does_not_paint_interrupted(
             await viewer.dispose()
         server.close()
         await handle.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_tool_started_during_the_gap_paints_and_completes_after_rebind(
+    headless_tui_env: Path, workspace: Path
+) -> None:
+    """Review round 1 MAJOR-1, deterministically: the gap's work is not lost.
+
+    ``_finish_sync`` once skipped the whole ``live_events`` seed on a
+    same-live-turn rebind, so a tool the runtime STARTED while the socket was
+    down never painted; its real ``tool_end`` then arrived orphaned and was
+    discarded unrendered at ``agent_end``, costing the user the card.
+
+    DETERMINISM, which is the point of this test — QA's equivalent cell raced
+    (``gap_tool_in_final`` flipped run to run) and so attributed nothing. Every
+    edge here is a happens-before on an ``asyncio.Event``, never a sleep:
+
+      1. ``first_running`` — tool A is executing, its card is painted LIVE.
+      2. the test drops the viewer's socket, then sets ``drop_done``.
+      3. tool A returns only after ``drop_done``, so the loop issues tool B
+         while the viewer is provably detached: B is a GAP tool by
+         construction, not by timing.
+      4. recovery is HELD OFF until B is running, by making the owner record
+         undiscoverable — the shape a viewer sees while a record is being
+         rewritten. Without this hold the viewer re-binds in ~100 ms, B
+         starts *after* the rebind, and the cell measures a completely
+         different path: that was the race that made QA's equivalent flip
+         run to run, and a probe confirmed it (B's start reached the viewer
+         neither live nor by seed, because the rebind had already happened).
+
+    So B's ``tool_execution_start`` is in ``live_events`` when the snapshot is
+    taken and can ONLY reach the viewer through the seed. If the seed is
+    skipped — the MAJOR-1 defect — B's card never exists.
+    """
+    import local_operator.session.remote as remote_module
+    from local_operator.harness.types import AgentTool, TextContent, ToolResult
+    from local_operator.session.remote import RemoteSession
+    from local_operator.tui.app import OperatorApp
+    from local_operator.tui.widgets.tool_card import ToolCard
+    from tests.e2e.harness import (
+        drain,
+        tool_call_turn,
+        transcript_text,
+        wait_for_adoption,
+    )
+
+    first_running = asyncio.Event()
+    drop_done = asyncio.Event()
+    second_running = asyncio.Event()
+    release_second = asyncio.Event()
+
+    async def execute_step(
+        tool_call_id: str,
+        args: dict[str, Any],
+        signal: Any = None,
+        on_update: Any = None,
+        context: Any = None,
+    ) -> ToolResult:
+        if str(args.get("which")) == "first":
+            first_running.set()
+            # Hold the turn open until the socket is provably gone, so the
+            # NEXT call is issued into the gap rather than racing it.
+            await drop_done.wait()
+            return ToolResult(
+                tool_call_id=tool_call_id,
+                tool_name="step",
+                content=[TextContent(text="first done")],
+            )
+        second_running.set()
+        await release_second.wait()
+        return ToolResult(
+            tool_call_id=tool_call_id,
+            tool_name="step",
+            content=[TextContent(text="second done")],
+        )
+
+    step = AgentTool(
+        name="step",
+        parameters={
+            "type": "object",
+            "properties": {"which": {"type": "string"}},
+        },
+        execute=execute_step,
+        interruptible=True,
+    )
+    directory = headless_tui_env / "sessions" / "gaptool01"
+    directory.mkdir(parents=True)
+    stream = ScriptedStream(
+        [
+            tool_call_turn(
+                text="First step.",
+                tool_name="step",
+                tool_call_id="gap-first",
+                arguments={"which": "first"},
+            ),
+            tool_call_turn(
+                text="Second step.",
+                tool_name="step",
+                tool_call_id="gap-second",
+                arguments={"which": "second"},
+            ),
+            text_turn("Both steps finished."),
+        ]
+    )
+    session = build_session(directory, stream, tools=[step], cwd=workspace)
+    handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd=str(workspace))
+    server = RuntimeServer(handle, kind="daemon")
+    await server.start_in_process()
+    import os
+
+    (directory / ".session.pid").write_text(str(os.getpid()), encoding="utf-8")
+
+    # The recovery hold (step 4). ``find_owner_record`` answering "no record
+    # yet" is a real transient the viewer already handles — the recovery loop
+    # polls until one appears — so this delays the rebind without touching the
+    # code under test.
+    real_find = remote_module.find_owner_record
+
+    def gated_find(*args: Any, **kwargs: Any) -> Any:
+        if not second_running.is_set():
+            return (None, None)
+        return real_find(*args, **kwargs)
+
+    viewer = None
+    try:
+        record = await _wait_for_record(headless_tui_env, session.session_id)
+        viewer = await RemoteSession.connect(
+            record,
+            session.session_id,
+            config_dir=headless_tui_env,
+            takeover_factory=_never_take_over,
+        )
+        pid_before = viewer.runtime_pid
+
+        async def factory() -> RemoteSession:
+            assert viewer is not None
+            return viewer
+
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 30)) as pilot:
+            await wait_for_adoption(app, pilot)
+            await drain(pilot)
+            owner_turn = asyncio.create_task(session.prompt("run both steps"))
+
+            # (1) tool A live and painted.
+            for _ in range(400):
+                await drain(pilot, cycles=2)
+                if first_running.is_set() and list(app.query(ToolCard)):
+                    break
+                await asyncio.sleep(0.05)
+            assert first_running.is_set(), "the first step never started"
+
+            # (2) drop the viewer's socket, then release A into the gap.
+            conns = [
+                conn
+                for conn in list(server._clients.values())
+                if conn.wants_events and conn.wants_frontend
+            ]
+            assert conns, "no full-TUI client to drop"
+            # Arm the hold BEFORE the drop, so the very first recovery poll
+            # already sees "no record yet".
+            remote_module.find_owner_record = gated_find
+            server._drop_client(conns[0], reason="test")
+            drop_done.set()
+
+            # (3)/(4) tool B starts while the viewer is detached.
+            for _ in range(400):
+                await drain(pilot, cycles=2)
+                if second_running.is_set():
+                    break
+                await asyncio.sleep(0.05)
+            assert second_running.is_set(), "the gap step never started"
+            # B's start is now in the owner's ``live_events``; releasing the
+            # hold lets recovery re-bind and take that snapshot.
+            remote_module.find_owner_record = real_find
+
+            # Let recovery rebind; B exists only in the snapshot seed.
+            rebound = False
+            for _ in range(400):
+                await drain(pilot, cycles=2)
+                if (
+                    viewer.runtime_pid == pid_before
+                    and not viewer._recovering
+                    and viewer._client is not None
+                    and viewer._client.connected
+                ):
+                    rebound = True
+                    break
+                await asyncio.sleep(0.05)
+            assert rebound, f"viewer never re-bound to pid {pid_before}"
+
+            card_ids = {card.tool_call_id for card in app.query(ToolCard)}
+            assert "gap-second" in card_ids, (
+                "the tool that started during the gap never painted — the "
+                f"live_events seed was dropped; cards on screen: {card_ids}"
+            )
+
+            release_second.set()
+            await asyncio.wait_for(owner_turn, timeout=20)
+            for _ in range(300):
+                await drain(pilot, cycles=2)
+                if "Both steps finished." in transcript_text(app):
+                    break
+                await asyncio.sleep(0.05)
+
+            painted = transcript_text(app)
+            assert "Both steps finished." in painted, painted
+            assert "interrupted" not in painted.lower(), painted
+            assert "\u2298" not in painted, painted
+            gap_cards = [card for card in app.query(ToolCard) if card.tool_call_id == "gap-second"]
+            assert gap_cards, "the gap tool's card vanished before the turn ended"
+            assert (
+                gap_cards[0]._state == "success"
+            ), f"the gap tool settled as {gap_cards[0]._state!r}, not success"
+    finally:
+        remote_module.find_owner_record = real_find
+        drop_done.set()
+        release_second.set()
+        if viewer is not None:
+            await viewer.dispose()
+        server.close()
+        await handle.dispose()

--- a/tests/e2e/test_viewer_attach_e2e.py
+++ b/tests/e2e/test_viewer_attach_e2e.py
@@ -663,3 +663,147 @@ async def test_the_record_carries_the_source_ref_when_lop_update_recorded_one(
     finally:
         server.close()
         await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_transient_viewer_drop_mid_turn_does_not_paint_interrupted(
+    headless_tui_env: Path, workspace: Path
+) -> None:
+    """Test 23: a server-side drop mid-turn must not paint ``interrupted``.
+
+    The runtime keeps working; the viewer re-binds to the same pid; the
+    ledger never gains an aborted artefact; the turn then completes and
+    paints the assistant row once.
+    """
+    from local_operator.harness.types import AgentTool, TextContent, ToolResult
+    from local_operator.session.remote import RemoteSession
+    from local_operator.tui.app import OperatorApp
+    from local_operator.tui.widgets.tool_card import ToolCard
+    from tests.e2e.harness import (
+        drain,
+        tool_call_turn,
+        transcript_text,
+        wait_for_adoption,
+    )
+
+    started = asyncio.Event()
+    released = asyncio.Event()
+
+    async def execute_hang(
+        tool_call_id: str,
+        args: dict[str, Any],
+        signal: Any = None,
+        on_update: Any = None,
+        context: Any = None,
+    ) -> ToolResult:
+        started.set()
+        await released.wait()
+        return ToolResult(
+            tool_call_id=tool_call_id,
+            tool_name="hang",
+            content=[TextContent(text="hung done")],
+        )
+
+    hang = AgentTool(
+        name="hang",
+        parameters={"type": "object", "properties": {}},
+        execute=execute_hang,
+        interruptible=True,
+    )
+    directory = headless_tui_env / "sessions" / "dropmidturn01"
+    directory.mkdir(parents=True)
+    stream = ScriptedStream(
+        [
+            tool_call_turn(
+                text="Hanging now.",
+                tool_name="hang",
+                tool_call_id="e2e-hang-1",
+                arguments={},
+            ),
+            text_turn("The hang finished normally."),
+        ]
+    )
+    session = build_session(directory, stream, tools=[hang], cwd=workspace)
+    handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd=str(workspace))
+    server = RuntimeServer(handle, kind="daemon")
+    await server.start_in_process()
+    import os
+
+    (directory / ".session.pid").write_text(str(os.getpid()), encoding="utf-8")
+    viewer = None
+    try:
+        record = await _wait_for_record(headless_tui_env, session.session_id)
+        viewer = await RemoteSession.connect(
+            record,
+            session.session_id,
+            config_dir=headless_tui_env,
+            takeover_factory=_never_take_over,
+        )
+        pid_before = viewer.runtime_pid
+
+        async def factory() -> RemoteSession:
+            assert viewer is not None
+            return viewer
+
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 30)) as pilot:
+            await wait_for_adoption(app, pilot)
+            await drain(pilot)
+            owner_turn = asyncio.create_task(session.prompt("please hang"))
+            for _ in range(400):
+                await drain(pilot, cycles=2)
+                if started.is_set() and list(app.query(ToolCard)):
+                    break
+                await asyncio.sleep(0.05)
+            assert started.is_set(), "the hang tool never started on the runtime"
+            painted = transcript_text(app)
+            assert "interrupted" not in painted.lower()
+
+            conns = [
+                conn
+                for conn in list(server._clients.values())
+                if conn.wants_events and conn.wants_frontend
+            ]
+            assert conns, "no full-TUI client to drop"
+            server._drop_client(conns[0], reason="test")
+
+            rebound = False
+            for _ in range(400):
+                await drain(pilot, cycles=2)
+                if (
+                    viewer.runtime_pid == pid_before
+                    and viewer.runtime_pid is not None
+                    and not viewer._recovering
+                    and viewer._client is not None
+                    and viewer._client.connected
+                ):
+                    rebound = True
+                    break
+                await asyncio.sleep(0.05)
+            painted = transcript_text(app)
+            assert rebound, (
+                f"viewer never re-bound to pid {pid_before}; "
+                f"now pid={viewer.runtime_pid} recovering={viewer._recovering} "
+                f"streaming={viewer.is_streaming}"
+            )
+            assert "interrupted" not in painted.lower(), painted
+            assert "\u2298" not in painted, painted
+
+            released.set()
+            await asyncio.wait_for(owner_turn, timeout=15)
+            for _ in range(200):
+                await drain(pilot, cycles=2)
+                painted = transcript_text(app)
+                if "The hang finished normally." in painted:
+                    break
+                await asyncio.sleep(0.05)
+            painted = transcript_text(app)
+            assert "interrupted" not in painted.lower(), painted
+            assert painted.count("The hang finished normally.") == 1, painted
+            assert session.is_streaming is False
+    finally:
+        released.set()
+        if viewer is not None:
+            await viewer.dispose()
+        server.close()
+        await handle.dispose()

--- a/tests/unit/session/runtime/test_server.py
+++ b/tests/unit/session/runtime/test_server.py
@@ -88,7 +88,13 @@ class FakeHandle:
         if event.type == "agent_start":
             self._frontend.mutate(streaming=True, generation=event.generation)
         elif event.type == "agent_end":
-            self._frontend.mutate(streaming=False)
+            if getattr(event, "error", None):
+                outcome = "error"
+            elif getattr(event, "aborted", False):
+                outcome = "aborted"
+            else:
+                outcome = "completed"
+            self._frontend.mutate(streaming=False, last_turn_outcome=outcome)
         if self._event_handler is not None:
             self._event_handler(event.model_dump(mode="json"))
 
@@ -1948,6 +1954,182 @@ async def test_a_credential_frame_with_a_non_string_value_is_refused() -> None:
         assert frame.get("op") == "error", f"a non-string value was accepted: {frame}"
         assert "value must be a string" in frame.get("message", ""), frame
         assert handle.verbs == []
+    finally:
+        if writer is not None:
+            writer.close()
+        runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_push_skips_full_tui_clients_but_keeps_welcome_and_daemon() -> None:
+    """Test 20: ``_push`` skips events+frontend clients; welcome still delivered.
+
+    Daemon and events-only attach clients keep receiving projection repaints
+    byte-for-byte. A full-TUI viewer (events AND frontend_state) got the
+    welcome as its identity check and then must not be flooded.
+    """
+    handle = FakeHandle()
+    runtime = RuntimeServer(handle, kind="tui")
+    runtime.start()
+    daemon_writer = events_writer = tui_writer = None
+    try:
+        record = await _wait_record()
+        daemon_reader, daemon_writer = await _dial(record)
+
+        events_reader, events_writer = await asyncio.open_connection(
+            "127.0.0.1", record.control_port, limit=1 << 20
+        )
+        events_writer.write(
+            json.dumps({"key": record.control_key, "client": "attach", "events": True}).encode()
+            + b"\n"
+        )
+        await events_writer.drain()
+        assert json.loads(await events_reader.readline())["op"] == "projection"
+
+        tui_reader, tui_writer = await asyncio.open_connection(
+            "127.0.0.1", record.control_port, limit=1 << 20
+        )
+        tui_writer.write(
+            json.dumps(
+                {
+                    "key": record.control_key,
+                    "client": "attach",
+                    "events": True,
+                    "frontend_state": True,
+                }
+            ).encode()
+            + b"\n"
+        )
+        await tui_writer.drain()
+        assert json.loads(await tui_reader.readline())["op"] == "projection"
+        seed = json.loads(await tui_reader.readline())
+        assert seed["op"] == "frontend_sync"
+
+        await runtime._push()
+        daemon_repaint = json.loads(await asyncio.wait_for(daemon_reader.readline(), timeout=2))
+        assert daemon_repaint["op"] == "projection"
+        events_repaint = json.loads(await asyncio.wait_for(events_reader.readline(), timeout=2))
+        assert events_repaint["op"] == "projection"
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(tui_reader.readline(), timeout=0.15)
+    finally:
+        for writer in (daemon_writer, events_writer, tui_writer):
+            if writer is not None:
+                writer.close()
+        runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_every_drop_logs_reason_once_at_info(caplog: pytest.LogCaptureFixture) -> None:
+    """Test 21: one INFO line per actual removal, naming the reason."""
+    import logging
+
+    handle = FakeHandle()
+    runtime = RuntimeServer(handle, kind="tui")
+    runtime.start()
+    writer = None
+    try:
+        record = await _wait_record()
+        _reader, writer = await _dial(record, client="attach")
+        conns = list(runtime._clients.values())
+        assert len(conns) == 1
+        caplog.set_level(logging.INFO, logger="local_operator.session.runtime.server")
+        runtime._drop_client(conns[0], reason="test")
+        infos = [
+            rec
+            for rec in caplog.records
+            if rec.levelno == logging.INFO and "dropped" in rec.getMessage()
+        ]
+        assert len(infos) == 1, [rec.getMessage() for rec in infos]
+        assert "dropped attach client" in infos[0].getMessage()
+        assert "events=" in infos[0].getMessage()
+        assert infos[0].getMessage().endswith(": test")
+        # Second call (reader-loop finally) must not INFO again.
+        runtime._drop_client(conns[0], reason="reader eof")
+        infos_after = [
+            rec
+            for rec in caplog.records
+            if rec.levelno == logging.INFO and "dropped" in rec.getMessage()
+        ]
+        assert len(infos_after) == 1
+    finally:
+        if writer is not None:
+            writer.close()
+        runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_attach_cap_drop_reason_is_logged(caplog: pytest.LogCaptureFixture) -> None:
+    import logging
+
+    handle = FakeHandle()
+    runtime = RuntimeServer(handle, kind="tui")
+    runtime.start()
+    writers: list[Any] = []
+    try:
+        record = await _wait_record()
+        caplog.set_level(logging.INFO, logger="local_operator.session.runtime.server")
+        for _ in range(ATTACH_MAX_CLIENTS + 1):
+            _reader, writer = await _dial(record, client="attach")
+            writers.append(writer)
+        await asyncio.sleep(0.1)
+        messages = [
+            rec.getMessage()
+            for rec in caplog.records
+            if rec.levelno == logging.INFO and "dropped" in rec.getMessage()
+        ]
+        assert any(msg.endswith(": attach cap") for msg in messages), messages
+    finally:
+        for writer in writers:
+            writer.close()
+        runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_tui_send_timeout_is_five_seconds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test 22: full-TUI clients use ``_TUI_SEND_TIMEOUT_S``, not the 1 s bound."""
+    from local_operator.session.runtime import server as server_mod
+
+    assert server_mod._SEND_TIMEOUT_S == 1.0
+    assert server_mod._TUI_SEND_TIMEOUT_S == 5.0
+
+    handle = FakeHandle()
+    runtime = RuntimeServer(handle, kind="tui")
+    seen: list[float] = []
+    original = asyncio.wait_for
+
+    async def spy_wait_for(awaitable: Any, timeout: float | None = None) -> Any:
+        seen.append(float(timeout) if timeout is not None else -1.0)
+        return await original(awaitable, timeout=timeout)
+
+    runtime.start()
+    writer = None
+    try:
+        record = await _wait_record()
+        _reader, writer = await asyncio.open_connection(
+            "127.0.0.1", record.control_port, limit=1 << 20
+        )
+        writer.write(
+            json.dumps(
+                {
+                    "key": record.control_key,
+                    "client": "attach",
+                    "events": True,
+                    "frontend_state": True,
+                }
+            ).encode()
+            + b"\n"
+        )
+        await writer.drain()
+        # Welcome + frontend_sync drain through _send_to.
+        await asyncio.sleep(0.2)
+        conns = [c for c in runtime._clients.values() if c.wants_events and c.wants_frontend]
+        assert conns, "full-TUI client never registered"
+        seen.clear()
+        monkeypatch.setattr(asyncio, "wait_for", spy_wait_for)
+        await runtime._send_to(conns[0], {"op": "ping"})
+        assert 5.0 in seen, f"TUI send bound was not 5.0 s; saw {seen}"
+        assert 1.0 not in seen, f"full-TUI client still used the 1 s bound; saw {seen}"
     finally:
         if writer is not None:
             writer.close()

--- a/tests/unit/session/test_attach_frame_size.py
+++ b/tests/unit/session/test_attach_frame_size.py
@@ -24,7 +24,7 @@ from typing import Any, cast
 
 import pytest
 
-from local_operator.harness.types import ModelSpec, Usage
+from local_operator.harness.types import ModelSpec, ToolResult, Usage
 from local_operator.mobile.attach_client import _READ_LIMIT_BYTES
 from local_operator.session.attention import AttentionStore
 from local_operator.session.frontend_state import (
@@ -1879,3 +1879,39 @@ def test_the_row_cost_of_many_blocks_does_not_grow_with_their_number() -> None:
     # Under the per-block floor this grew without limit, which is why the
     # COMPARISON is the assertion and neither number alone would serve.
     assert many < ten * 3, f"row cost scaled with block count: {ten} -> {many}"
+
+
+def test_the_elided_marker_separates_itself_from_a_caption() -> None:
+    """The marker must not run into the text of the block before it.
+
+    ``ToolResult.text`` joins content blocks with ``""``, so a caption
+    followed by a shed image rendered as
+    ``screenshot of the page[dropped from the reconnect snapshot…]`` — the
+    marker read as part of what the tool said (round-4 Q4-2, caught in a
+    rendered frame). Asserted through the real ``ToolResult.text`` rather
+    than on the block dict, because the join is where the defect lived.
+    """
+    row = _live_end("shot", text="screenshot of the page")
+    row["result"]["content"].append(
+        {"type": "image", "data": "A" * 1_400_000, "mime_type": "image/png"}
+    )
+
+    end = _bounded_live_events([row])[0]
+    rendered = ToolResult.model_validate(end["result"]).text
+
+    assert "page\n[dropped" in rendered
+    assert "page[dropped" not in rendered
+
+
+def test_a_lone_elided_marker_does_not_open_with_a_blank_line() -> None:
+    """The separator is conditional: nothing before it means nothing to separate.
+
+    An unconditional leading newline would open the card with an empty row
+    for the common single-image result, trading one cosmetic defect for
+    another.
+    """
+    end = _bounded_live_events([_live_image_end("img", b64="A" * 1_400_000)])[0]
+    rendered = ToolResult.model_validate(end["result"]).text
+
+    assert rendered == LIVE_EVENT_BLOCK_ELIDED_PLACEHOLDER
+    assert not rendered.startswith("\n")

--- a/tests/unit/session/test_attach_frame_size.py
+++ b/tests/unit/session/test_attach_frame_size.py
@@ -30,6 +30,7 @@ from local_operator.session.attention import AttentionStore
 from local_operator.session.frontend_state import (
     _MODEL_CATALOGUE_LINE_LIMIT,
     _SHAREABLE_STATE_FIELDS,
+    LIVE_EVENT_BLOCK_ELIDED_PLACEHOLDER,
     LIVE_EVENT_END_ROWS_MAX,
     LIVE_EVENT_TEXT_FLOOR_CHARS,
     LIVE_EVENT_TEXT_FRAME_BUDGET_CHARS,
@@ -649,6 +650,15 @@ def test_the_attach_frame_fits_for_a_session_that_ran_all_year(tmp_path: Path) -
         # contributing 2 MB to a 1 MiB frame. A retained `tool_execution_end`
         # is the row that grows one-per-call with a full tool result attached;
         # this fixture is what makes `assert_frame_fits` able to see it.
+        #
+        # Each row carries all THREE payload shapes a real turn produces, because
+        # a bound written against one of them silently misses the others. The
+        # first cut of this bound clipped `content[].text` and let both of the
+        # rest through: an image block keeps its base64 under `data` (one
+        # permitted image is ~1.4 MB encoded, over the whole line limit by
+        # itself) and `details` carries the MCP bridge's `server_result` dump
+        # (50 calls measured 2.6 MB). A fixture that only holds text can only
+        # ever catch the bug that was already fixed.
         "live_events": [
             row
             for index in range(1_000)
@@ -666,7 +676,15 @@ def test_the_attach_frame_fits_for_a_session_that_ran_all_year(tmp_path: Path) -
                     "result": {
                         "tool_call_id": f"call-{index}",
                         "tool_name": "read",
-                        "content": [{"type": "text", "text": "e" * 60_000}],
+                        "content": [
+                            {"type": "text", "text": "e" * 60_000},
+                            {
+                                "type": "image",
+                                "data": "A" * 1_400_000,
+                                "mime_type": "image/png",
+                            },
+                        ],
+                        "details": {"server_result": {"blob": "D" * 50_000}},
                         "is_error": False,
                     },
                 },
@@ -1673,7 +1691,15 @@ async def test_attach_succeeds_mid_turn_against_an_owner_with_a_heavy_seed(
     seed: list[dict[str, Any]] = []
     for index in range(600):
         seed.append(_live_start(f"call-{index}"))
-        seed.append(_live_end(f"call-{index}", text="R" * 20_000))
+        # Every payload shape a real turn produces, not just text: an image
+        # block alone is over the line limit, and `details` is what the MCP
+        # bridge fills. A seed of pure text cannot prove the socket survives.
+        end = _live_end(f"call-{index}", text="R" * 20_000)
+        end["result"]["content"].append(
+            {"type": "image", "data": "A" * 1_400_000, "mime_type": "image/png"}
+        )
+        end["result"]["details"] = {"server_result": {"blob": "D" * 50_000}}
+        seed.append(end)
     handle._frontend.mutate(jobs=_jobs(200, 500), live_events=seed)
 
     registrant = RuntimeServer(handle, kind="tui")
@@ -1696,3 +1722,95 @@ async def test_attach_succeeds_mid_turn_against_an_owner_with_a_heavy_seed(
         if remote is not None:
             await remote.dispose()
         registrant.close()
+
+
+def _live_image_end(call_id: str, *, b64: str) -> dict[str, Any]:
+    """A completed `read` of a PNG — the shape with no ``text`` key at all."""
+    return {
+        "type": "tool_execution_end",
+        "tool_call_id": call_id,
+        "tool_name": "read",
+        "is_error": False,
+        "result": {
+            "tool_call_id": call_id,
+            "tool_name": "read",
+            "content": [{"type": "image", "data": b64, "mime_type": "image/png"}],
+            "is_error": False,
+        },
+    }
+
+
+def test_an_image_result_cannot_ride_the_seed_verbatim() -> None:
+    """A block with no ``text`` key must still be bounded.
+
+    ``ImageContent`` carries base64 under ``data``. One permitted image is
+    ~1.4 MB encoded — larger than the whole socket line limit on its own — so
+    a bound that inspects ``text`` does not merely clip it badly, it never
+    sees it. The row survives (it is what settles the card) and the block is
+    replaced by a marker rather than deleted, so the card does not read as a
+    tool that returned nothing.
+    """
+    survivors = _bounded_live_events([_live_image_end("img", b64="A" * 1_400_000)])
+
+    end = survivors[0]
+    assert end["tool_call_id"] == "img" and end["is_error"] is False
+    block = end["result"]["content"][0]
+    assert LIVE_EVENT_BLOCK_ELIDED_PLACEHOLDER in block["text"]
+    assert "A" * 1_000 not in json.dumps(end), "the base64 payload must not reach the wire"
+    assert len(json.dumps(end)) < LIVE_EVENT_TEXT_FRAME_BUDGET_CHARS
+
+
+def test_fat_result_details_cannot_ride_the_seed_verbatim() -> None:
+    """``result.details`` is bounded too — the MCP bridge fills it.
+
+    ``details`` holds the bridge's whole ``server_result`` dump and is not
+    rendered on the card, so it is the cheapest thing to shed and the first
+    thing dropped. 50 such calls measured 2.6 MB before this.
+    """
+    row = _live_end("mcp", text="ok")
+    row["result"]["details"] = {"server_result": {"blob": "D" * 500_000}}
+
+    end = _bounded_live_events([row])[0]
+
+    assert end["result"]["details"] is None
+    assert "D" * 1_000 not in json.dumps(end)
+    # The card still settles and still shows what the tool said.
+    assert end["result"]["content"][0]["text"] == "ok"
+
+
+def test_a_small_ordinary_result_is_left_exactly_alone() -> None:
+    """The bound is a ceiling, not a rewrite: the common row must be untouched.
+
+    Worth asserting because every other test here drives the clipping paths;
+    without this, a bound that mangled ordinary results would look correct.
+    """
+    row = _live_end("ok", text="3 files changed")
+    row["result"]["details"] = {"added": 3, "removed": 1}
+
+    end = _bounded_live_events([row])[0]
+
+    assert end["result"]["content"][0]["text"] == "3 files changed"
+    assert end["result"]["details"] == {"added": 3, "removed": 1}
+
+
+def test_the_headline_of_a_clipped_result_survives_beside_an_image() -> None:
+    """A mixed result keeps its text preview AND settles, in one row.
+
+    The realistic shape after a browser screenshot or an image ``read``: text
+    the user wants to read, plus a payload that cannot ride. Both paths run on
+    the same row here, which is what the round-3 defect got wrong.
+    """
+    row = _live_end("mixed", text="HEADLINE. " + "z" * 300_000)
+    row["result"]["content"].append(
+        {"type": "image", "data": "B" * 1_400_000, "mime_type": "image/png"}
+    )
+    row["result"]["details"] = {"server_result": {"blob": "D" * 200_000}}
+
+    end = _bounded_live_events([row])[0]
+    text_block, image_block = end["result"]["content"]
+
+    assert text_block["text"].startswith("HEADLINE. ")
+    assert text_block["text"].endswith("…")
+    assert LIVE_EVENT_BLOCK_ELIDED_PLACEHOLDER in image_block["text"]
+    assert end["result"]["details"] is None
+    assert len(json.dumps(end)) < LIVE_EVENT_TEXT_FRAME_BUDGET_CHARS + 1_000

--- a/tests/unit/session/test_attach_frame_size.py
+++ b/tests/unit/session/test_attach_frame_size.py
@@ -1814,3 +1814,68 @@ def test_the_headline_of_a_clipped_result_survives_beside_an_image() -> None:
     assert LIVE_EVENT_BLOCK_ELIDED_PLACEHOLDER in image_block["text"]
     assert end["result"]["details"] is None
     assert len(json.dumps(end)) < LIVE_EVENT_TEXT_FRAME_BUDGET_CHARS + 1_000
+
+
+def test_block_count_is_bounded_the_way_block_size_is() -> None:
+    """Many blocks in one result must not multiply the row's share.
+
+    The floor is a promise that the CARD stays legible, so it is spent once
+    per row. Granted per block it becomes an entitlement instead of a ceiling:
+    N blocks cost N x floor and the row has no bound at all. That regression
+    was introduced once by moving the floor one loop level inward during a
+    rewrite, and it measured 1,102,743 B at the 100-row cap against a
+    1,048,576-byte limit while the per-row form stayed flat.
+
+    Pinned here because ``content`` is typed ``list[dict[str, Any]]`` and this
+    module deliberately does not enumerate what rides in it — a producer that
+    starts emitting many blocks is a change in DATA, which no test of block
+    SIZE would catch.
+    """
+    row = _live_end("many", text="a" * 5_000)
+    row["result"]["content"] = [{"type": "text", "text": "a" * 5_000} for _ in range(200)]
+
+    end = _bounded_live_events([row])[0]
+    cost = len(json.dumps(end))
+
+    # The whole row lands within one share plus its own envelope — NOT within
+    # 200 shares. The exact ceiling is not the assertion; not scaling with
+    # block count is.
+    assert cost < LIVE_EVENT_TEXT_FRAME_BUDGET_CHARS * 2
+    # The TEXT the row carries is one share's worth in total, spent in order
+    # until it runs out. Asserting the sum rather than any per-block length is
+    # the point: the defect was that each block could re-claim the floor, so
+    # the total is what distinguishes a shared ceiling from N entitlements.
+    total_text = sum(len(block.get("text") or "") for block in end["result"]["content"])
+    assert total_text <= LIVE_EVENT_TEXT_FRAME_BUDGET_CHARS
+    # Blocks past the budget are clipped to nothing rather than each keeping a
+    # floor's worth. Under the per-block floor all 200 sat at or above it.
+    starved = [
+        block
+        for block in end["result"]["content"]
+        if len(block.get("text") or "") < LIVE_EVENT_TEXT_FLOOR_CHARS
+    ]
+    assert len(starved) > 150, "the floor was granted per block, not per row"
+    # ...and the row still settles its card.
+    assert end["tool_call_id"] == "many" and end["is_error"] is False
+
+
+def test_the_row_cost_of_many_blocks_does_not_grow_with_their_number() -> None:
+    """The structural invariant behind the test above, stated as a comparison.
+
+    A ceiling that holds at 10 blocks and quietly scales at 2,000 is the
+    defect this pins; comparing the two is what distinguishes a real bound
+    from a number that merely happened to fit.
+    """
+    costs = []
+    for count in (10, 2_000):
+        row = _live_end(f"n{count}", text="a" * 5_000)
+        row["result"]["content"] = [{"type": "text", "text": "a" * 5_000} for _ in range(count)]
+        costs.append(len(json.dumps(_bounded_live_events([row])[0])))
+
+    ten, many = costs
+    # 200x the blocks must not mean anything like 200x the bytes. Only the
+    # extra blocks' fixed envelopes may grow; their TEXT comes out of the one
+    # shared budget, so the ratio stays near 1 rather than tracking the count.
+    # Under the per-block floor this grew without limit, which is why the
+    # COMPARISON is the assertion and neither number alone would serve.
+    assert many < ten * 3, f"row cost scaled with block count: {ten} -> {many}"

--- a/tests/unit/session/test_attach_frame_size.py
+++ b/tests/unit/session/test_attach_frame_size.py
@@ -30,10 +30,14 @@ from local_operator.session.attention import AttentionStore
 from local_operator.session.frontend_state import (
     _MODEL_CATALOGUE_LINE_LIMIT,
     _SHAREABLE_STATE_FIELDS,
+    LIVE_EVENT_END_ROWS_MAX,
+    LIVE_EVENT_TEXT_FLOOR_CHARS,
+    LIVE_EVENT_TEXT_FRAME_BUDGET_CHARS,
     MODEL_CATALOGUE_FLOOR_ROWS,
     USAGE_COMPONENT_CAP,
     FrontendSessionState,
     FrontendStateStore,
+    FrontendSync,
     FrontendUsage,
     JobState,
     McpServerState,
@@ -336,7 +340,16 @@ _BOUNDED_COLLECTION_FIELDS = {
     "context_breakdown": "one entry per tool; bounded by the tool inventory",
     "child_costs": "one float per job; O(1) bytes each",
     "queued_steering": "drains every turn",
-    "live_events": "explicitly bounded by _fold_live_event",
+    # Was "explicitly bounded by _fold_live_event", which stopped being true the
+    # moment a `tool_execution_end` began RETAINING its row instead of erasing
+    # it (so a viewer reconnecting mid-turn can settle a card for work that
+    # finished while it was away). The fold self-bounded only because completed
+    # calls left nothing behind; with the end retained the field accumulates one
+    # full tool result per call and measured 2 MB on a 1 MiB frame. Now bounded
+    # at the WIRE like `model_catalogue`: oldest ends evicted past
+    # LIVE_EVENT_END_ROWS_MAX, remaining result text clipped to a shared frame
+    # budget. Every retained row keeps the identity and outcome a card needs.
+    "live_events": "clipped at the wire: end rows capped newest-first, result text budgeted",
     "todos": "the user's own list, written by hand",
     "wakes": "the user's own schedules",
     "mcp_servers": "one row per configured server",
@@ -629,7 +642,36 @@ def test_the_attach_frame_fits_for_a_session_that_ran_all_year(tmp_path: Path) -
         "child_costs": {f"job{index}": 1.25 for index in range(2_000)},
         "context_breakdown": {f"tool_{index}": 1_000 for index in range(2_000)},
         "queued_steering": [{"id": str(index), "text": "q" * 200} for index in range(200)],
-        "live_events": [{"type": "message_update", "text": "e" * 200} for index in range(200)],
+        # COMPLETED TOOL CALLS, not `message_update` rows. The old fixture used
+        # 200 `message_update`s, which `_fold_live_event` dedupes to a single
+        # row by phase — so it could never exercise the shape that actually
+        # accumulates, and the whole suite passed while `live_events` was
+        # contributing 2 MB to a 1 MiB frame. A retained `tool_execution_end`
+        # is the row that grows one-per-call with a full tool result attached;
+        # this fixture is what makes `assert_frame_fits` able to see it.
+        "live_events": [
+            row
+            for index in range(1_000)
+            for row in (
+                {
+                    "type": "tool_execution_start",
+                    "tool_call_id": f"call-{index}",
+                    "tool_name": "read",
+                },
+                {
+                    "type": "tool_execution_end",
+                    "tool_call_id": f"call-{index}",
+                    "tool_name": "read",
+                    "is_error": False,
+                    "result": {
+                        "tool_call_id": f"call-{index}",
+                        "tool_name": "read",
+                        "content": [{"type": "text", "text": "e" * 60_000}],
+                        "is_error": False,
+                    },
+                },
+            )
+        ],
         "todos": [
             TodoPhaseState(
                 name=f"phase {index}",
@@ -1384,6 +1426,21 @@ def _oversized_event_frame() -> dict[str, Any]:
     }
 
 
+def _live_end(call_id: str, *, text: str) -> dict[str, Any]:
+    return {
+        "type": "tool_execution_end",
+        "tool_call_id": call_id,
+        "tool_name": "read",
+        "is_error": False,
+        "result": {
+            "tool_call_id": call_id,
+            "tool_name": "read",
+            "content": [{"type": "text", "text": text}],
+            "is_error": False,
+        },
+    }
+
+
 def test_oversized_event_frame_degrades_instead_of_killing_the_socket():
     """``event`` is guarded the way ``frontend_sync`` already was.
 
@@ -1513,3 +1570,129 @@ async def test_compaction_never_assembles_an_unreadable_frame() -> None:
     # against a compaction that keeps the first frame and discards 63 deltas.
     # The delta stream is append-only, so concatenating it must be unchanged.
     assert "".join(str(f["data"]["delta"]) for f in out) == before
+
+
+def _live_start(call_id: str) -> dict[str, Any]:
+    return {"type": "tool_execution_start", "tool_call_id": call_id, "tool_name": "read"}
+
+
+def _bounded_live_events(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Run rows through the real wire boundary and hand back what survived."""
+    state = FrontendSessionState(session_id="s1", epoch="e1", live_events=rows)
+    payload = sync_wire_payload(
+        FrontendSync(epoch=state.epoch, sequence=state.sequence, snapshot=state, live_cursor=None)
+    )
+    return payload["snapshot"]["live_events"]
+
+
+def test_a_retained_tool_end_keeps_what_settles_the_card() -> None:
+    """Truncation may take the payload, never the identity or the outcome.
+
+    The seed exists so a viewer that reconnects mid-turn can settle a card for
+    a call that finished while it was away. A bound that dropped ``is_error``
+    or the id would leave the card live and hand it back to the retirement
+    pass as ``⊘ interrupted`` — the artefact the retention removes.
+    """
+    survivors = _bounded_live_events([_live_start("c1"), _live_end("c1", text="R" * 500_000)])
+
+    ends = [row for row in survivors if row["type"] == "tool_execution_end"]
+    assert len(ends) == 1
+    assert ends[0]["tool_call_id"] == "c1"
+    assert ends[0]["is_error"] is False
+    text = ends[0]["result"]["content"][0]["text"]
+    assert text.endswith("…"), "a clipped preview must be marked as clipped"
+    # A lone row gets the WHOLE frame budget; the floor is the guarantee for a
+    # turn of many calls, not a ceiling for one.
+    assert len(text) <= LIVE_EVENT_TEXT_FRAME_BUDGET_CHARS + 1
+    assert text.startswith("RRR"), "the surviving preview must be the head of the result"
+
+
+def test_the_text_floor_holds_when_a_turn_has_very_many_calls() -> None:
+    """Every retained end stays legible however many calls the turn ran.
+
+    A share divided by call count alone would shrink to nothing on a long
+    turn, leaving cards that settle with an empty result. The floor is what
+    keeps a clipped card readable rather than merely present.
+    """
+    rows: list[dict[str, Any]] = []
+    for index in range(LIVE_EVENT_END_ROWS_MAX):
+        rows.append(_live_end(f"c{index}", text="y" * 50_000))
+
+    survivors = _bounded_live_events(rows)
+    lengths = [len(row["result"]["content"][0]["text"]) for row in survivors]
+
+    assert len(lengths) == LIVE_EVENT_END_ROWS_MAX
+    assert min(lengths) >= LIVE_EVENT_TEXT_FLOOR_CHARS
+
+
+def test_an_evicted_tool_end_takes_its_start_with_it() -> None:
+    """Never leave a start whose end was dropped: that is a stranded spinner.
+
+    Evicting the end alone would leave a card the viewer paints live and can
+    never settle, which is the same ``⊘ interrupted`` outcome by another route.
+    A start with NO end is a call still running and must always survive.
+    """
+    rows: list[dict[str, Any]] = []
+    for index in range(LIVE_EVENT_END_ROWS_MAX + 50):
+        rows.append(_live_start(f"done-{index}"))
+        rows.append(_live_end(f"done-{index}", text="x" * 100))
+    rows.append(_live_start("still-running"))
+
+    survivors = _bounded_live_events(rows)
+    ends = {row["tool_call_id"] for row in survivors if row["type"] == "tool_execution_end"}
+    starts = {row["tool_call_id"] for row in survivors if row["type"] == "tool_execution_start"}
+
+    assert len(ends) == LIVE_EVENT_END_ROWS_MAX
+    # Newest kept: those are the cards most likely still on screen unsettled.
+    assert "done-149" in ends and "done-0" not in ends
+    # No start outlives its own end...
+    assert starts - ends == {"still-running"}
+    # ...and the call that never ended keeps its card.
+    assert "still-running" in starts
+
+
+@pytest.mark.asyncio
+async def test_attach_succeeds_mid_turn_against_an_owner_with_a_heavy_seed(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """End to end over a real socket: a heavy in-flight seed still attaches.
+
+    The serialization tests above measure the frame; this one proves the claim
+    that matters. A viewer reconnecting into a long turn is the exact case the
+    retained ``tool_execution_end`` was added for, so it is the case that must
+    not be broken by the retention's own weight: without the wire bound this
+    ``frontend_sync`` runs to megabytes, the reader refuses the line, and the
+    connect degrades to the cold session the whole PR exists to prevent.
+
+    The surviving seed is asserted to be USABLE, not merely present — each end
+    keeps the id and outcome ``on_tool_ended`` needs to settle its card.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions" / "s1").mkdir(parents=True)
+    handle = FakeHandle()
+    seed: list[dict[str, Any]] = []
+    for index in range(600):
+        seed.append(_live_start(f"call-{index}"))
+        seed.append(_live_end(f"call-{index}", text="R" * 20_000))
+    handle._frontend.mutate(jobs=_jobs(200, 500), live_events=seed)
+
+    registrant = RuntimeServer(handle, kind="tui")
+    registrant.start()
+    remote = None
+    try:
+        record = await _record(tmp_path)
+        remote = await RemoteSession.connect(
+            record, "s1", config_dir=tmp_path, takeover_factory=_never
+        )
+        # Connecting at all is the assertion the bound exists to protect.
+        live = remote.frontend_state.live_events
+        ends = [row for row in live if row.get("type") == "tool_execution_end"]
+        assert 0 < len(ends) <= LIVE_EVENT_END_ROWS_MAX
+        # Newest survive: those are the cards still unsettled on screen.
+        assert ends[-1]["tool_call_id"] == "call-599"
+        # And every survivor can still settle its card.
+        assert all(row["tool_call_id"] and "is_error" in row for row in ends)
+    finally:
+        if remote is not None:
+            await remote.dispose()
+        registrant.close()

--- a/tests/unit/session/test_frontend_state.py
+++ b/tests/unit/session/test_frontend_state.py
@@ -1012,3 +1012,18 @@ def test_a_fork_of_a_fork_is_stamped_with_its_own_id_at_every_hop() -> None:
     second_fork = FrontendStateStore.from_checkpoint(_owner_over("fork20000001", first_fork)).state
     assert second_fork.session_id == "fork20000001"
     assert second_fork.jobs == ()
+
+
+def test_agent_end_records_last_turn_outcome() -> None:
+    """A rebinding viewer needs the logical-turn outcome after live_events clear."""
+    store = FrontendStateStore(_state())
+    session = SimpleNamespace(effective_model=_spec())
+    store.observe_event(session, AgentStartEvent(generation=3))
+    store.observe_event(session, AgentEndEvent(messages=[Message.assistant("ok")]))
+    assert store.state.last_turn_outcome == "completed"
+    store.observe_event(session, AgentStartEvent(generation=4))
+    store.observe_event(session, AgentEndEvent(aborted=True))
+    assert store.state.last_turn_outcome == "aborted"
+    store.observe_event(session, AgentStartEvent(generation=5))
+    store.observe_event(session, AgentEndEvent(error="boom"))
+    assert store.state.last_turn_outcome == "error"

--- a/tests/unit/session/test_remote_disconnect.py
+++ b/tests/unit/session/test_remote_disconnect.py
@@ -1,0 +1,243 @@
+"""Deferred abort on transient viewer disconnect (design §5.2 tests 16–19).
+
+A dropped socket is not an abort: the runtime is usually still running the
+turn. These pin that ``_on_disconnected`` no longer synthesises an
+``AgentEndEvent``, and that recovery's verdict is the only writer of one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+import local_operator.session.remote as remote_module
+from local_operator.harness.types import AgentEndEvent, AgentStartEvent
+from local_operator.session.frontend_state import FrontendSessionState
+from local_operator.session.remote import RemoteSession
+
+
+def _facade(tmp_path, monkeypatch, *, can_go_cold: bool = False) -> RemoteSession:
+    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    remote = RemoteSession(
+        config_dir=tmp_path,
+        session_id="s1",
+        takeover_factory=lambda: asyncio.sleep(0, result=None),
+    )
+    remote._can_go_cold = can_go_cold
+    remote._streaming = True
+    remote._generation = 7
+    remote._ready_for_events = True
+    return remote
+
+
+async def _cancel_recovery(remote: RemoteSession) -> None:
+    if remote._recovery_task is not None:
+        remote._recovery_task.cancel()
+        try:
+            await remote._recovery_task
+        except (asyncio.CancelledError, Exception):  # noqa: BLE001 — teardown only
+            pass
+
+
+@pytest.mark.asyncio
+async def test_mid_turn_socket_close_does_not_synthesise_an_end(tmp_path, monkeypatch) -> None:
+    """Test 16a: mid-turn socket close → no AgentEndEvent; ``_streaming`` stays True."""
+    remote = _facade(tmp_path, monkeypatch)
+    received: list[Any] = []
+    remote.subscribe(received.append)
+
+    remote._on_disconnected("send timeout")
+    ends = [event for event in received if isinstance(event, AgentEndEvent)]
+    assert ends == [], f"a dropped socket synthesised {ends}"
+    assert remote.is_streaming is True
+    assert remote._suspect_generation == 7
+    assert remote._recovering is True
+    await _cancel_recovery(remote)
+
+
+@pytest.mark.asyncio
+async def test_rebind_to_the_same_live_generation_synthesises_nothing(
+    tmp_path, monkeypatch
+) -> None:
+    """Test 16b: re-bind with streaming True and generation == suspect → no end.
+
+    Deviation from the design's "seed AgentStartEvent": re-seeding start
+    would run ``_handle_agent_start``, which clears ``_started_tools``. A
+    later real ``tool_end`` would then miss the live card and
+    ``_finalize_turn`` would paint ⊘ interrupted — the bug this PR exists
+    to stop. Generation is already applied from the snapshot; the ledger
+    is left untouched.
+    """
+    remote = _facade(tmp_path, monkeypatch)
+    received: list[Any] = []
+    remote.subscribe(received.append)
+    remote._on_disconnected("send timeout")
+    await _cancel_recovery(remote)
+
+    remote._install_frontend(
+        FrontendSessionState(
+            session_id="s1",
+            epoch="e1",
+            streaming=True,
+            generation=7,
+            live_events=[
+                {
+                    "type": "tool_execution_start",
+                    "tool_call_id": "t1",
+                    "tool_name": "hang",
+                    "args": {},
+                }
+            ],
+        )
+    )
+    remote._settle_suspect_turn()
+    remote._finish_sync()
+
+    ends = [event for event in received if isinstance(event, AgentEndEvent)]
+    starts = [event for event in received if isinstance(event, AgentStartEvent)]
+    assert ends == []
+    assert starts == [], f"same-live-turn rebind re-seeded starts {starts}"
+    assert remote.is_streaming is True
+    assert remote._suspect_generation is None
+    types = [getattr(event, "type", None) for event in received]
+    assert "tool_execution_start" not in types
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "outcome, aborted, error",
+    [
+        ("completed", False, None),
+        ("aborted", True, None),
+        ("error", False, "turn failed"),
+        ("", True, None),
+    ],
+    ids=["completed", "aborted", "error", "legacy-empty"],
+)
+async def test_rebind_after_the_turn_ended_synthesises_one_matching_end(
+    tmp_path, monkeypatch, outcome: str, aborted: bool, error: str | None
+) -> None:
+    """Test 17: re-bind with streaming False → exactly one end, aborted per outcome."""
+    remote = _facade(tmp_path, monkeypatch)
+    received: list[Any] = []
+    remote.subscribe(received.append)
+    remote._on_disconnected("send timeout")
+    await _cancel_recovery(remote)
+
+    remote._install_frontend(
+        FrontendSessionState(
+            session_id="s1",
+            epoch="e1",
+            streaming=False,
+            generation=7,
+            last_turn_outcome=outcome,  # type: ignore[arg-type]
+        )
+    )
+    remote._settle_suspect_turn()
+
+    ends = [event for event in received if isinstance(event, AgentEndEvent)]
+    assert len(ends) == 1, f"expected one end, got {ends}"
+    assert ends[0].aborted is aborted
+    assert ends[0].error == error
+    assert ends[0].generation == 0
+    assert remote.is_streaming is False
+    assert remote._suspect_generation is None
+
+
+@pytest.mark.asyncio
+async def test_rebind_to_a_newer_generation_ends_the_suspect_not_the_successor(
+    tmp_path, monkeypatch
+) -> None:
+    """Test 17 (generation moved): synthesise one end, keep the successor live."""
+    remote = _facade(tmp_path, monkeypatch)
+    received: list[Any] = []
+    remote.subscribe(received.append)
+    remote._on_disconnected("send timeout")
+    await _cancel_recovery(remote)
+
+    remote._install_frontend(
+        FrontendSessionState(
+            session_id="s1",
+            epoch="e1",
+            streaming=True,
+            generation=8,
+            last_turn_outcome="completed",
+        )
+    )
+    remote._settle_suspect_turn()
+
+    ends = [event for event in received if isinstance(event, AgentEndEvent)]
+    assert len(ends) == 1 and ends[0].aborted is False
+    assert remote.is_streaming is True
+    assert remote._generation == 8
+
+
+@pytest.mark.asyncio
+async def test_recovery_going_cold_emits_one_aborted_end(tmp_path, monkeypatch) -> None:
+    """Test 18: recovery goes cold → one aborted end (unchanged)."""
+    remote = _facade(tmp_path, monkeypatch, can_go_cold=True)
+    received: list[Any] = []
+    remote.subscribe(received.append)
+    remote._on_disconnected("owner exited")
+    await _cancel_recovery(remote)
+    remote._go_cold()
+
+    ends = [event for event in received if isinstance(event, AgentEndEvent)]
+    assert len(ends) == 1 and ends[0].aborted is True and ends[0].error is None
+    assert remote.is_streaming is False
+
+
+@pytest.mark.asyncio
+async def test_abort_while_detached_does_not_spawn_a_task(tmp_path, monkeypatch) -> None:
+    """Test 19: ``abort()`` while detached → no task, no 'never retrieved'."""
+    remote = _facade(tmp_path, monkeypatch)
+    remote._client = None
+    # ``connected`` False on a leftover client is the other half of the guard.
+    remote.abort("interrupted")
+    await asyncio.sleep(0)
+    # No unretrieved exception: the done-callback (or the early return) ate it.
+    assert remote._client is None
+
+
+@pytest.mark.asyncio
+async def test_rebind_after_an_idle_runtime_posts_turn_ended(tmp_path, monkeypatch) -> None:
+    """PR C deferred: TUI kept painting working after the runtime went idle.
+
+    Disconnect mid-turn, then rebind to a snapshot with ``streaming=False``
+    and ``last_turn_outcome="completed"``. The synthesised end must reach
+    EventController so the band can leave ``working``/``thinking``. An
+    unstamped end (generation=0) is what the controller accepts for the
+    open turn; a missing end is the stuck-indicator bug.
+    """
+    from local_operator.tui.events import EventController, TurnEnded, TurnStarted
+    from tests.unit.tui.test_events import FakeApp
+
+    remote = _facade(tmp_path, monkeypatch)
+    app = FakeApp()
+    controller = EventController(remote, app)  # type: ignore[arg-type]
+    app.controller = controller
+    controller.subscribe()
+    remote._on_wire_event(AgentStartEvent(generation=7).model_dump(mode="json"))
+    assert sum(isinstance(m, TurnStarted) for m in app.posted) == 1
+
+    remote._on_disconnected("send timeout")
+    await _cancel_recovery(remote)
+    assert not any(isinstance(m, TurnEnded) for m in app.posted)
+
+    remote._install_frontend(
+        FrontendSessionState(
+            session_id="s1",
+            epoch="e1",
+            streaming=False,
+            generation=7,
+            last_turn_outcome="completed",
+        )
+    )
+    remote._settle_suspect_turn()
+
+    ends = [m for m in app.posted if isinstance(m, TurnEnded)]
+    assert len(ends) == 1, f"band never learned the turn ended: {app.posted}"
+    assert ends[0].aborted is False
+    assert remote.is_streaming is False

--- a/tests/unit/session/test_remote_disconnect.py
+++ b/tests/unit/session/test_remote_disconnect.py
@@ -101,8 +101,12 @@ async def test_rebind_to_the_same_live_generation_synthesises_nothing(
     assert starts == [], f"same-live-turn rebind re-seeded starts {starts}"
     assert remote.is_streaming is True
     assert remote._suspect_generation is None
+    # The gap's own rows DO come through — only the synthetic start is
+    # suppressed (review round 1, MAJOR-1; the sibling test below pins the
+    # positive case). ``_is_duplicate`` keeps rows the ledger already holds
+    # from painting twice.
     types = [getattr(event, "type", None) for event in received]
-    assert "tool_execution_start" not in types
+    assert "agent_start" not in types
 
 
 @pytest.mark.asyncio
@@ -241,3 +245,153 @@ async def test_rebind_after_an_idle_runtime_posts_turn_ended(tmp_path, monkeypat
     assert len(ends) == 1, f"band never learned the turn ended: {app.posted}"
     assert ends[0].aborted is False
     assert remote.is_streaming is False
+
+
+@pytest.mark.asyncio
+async def test_the_real_recovery_loop_bounds_the_turn_on_a_terminal_viewer(
+    tmp_path, monkeypatch
+) -> None:
+    """Review round 1, BLOCKER-1: a real death must not spin forever on the TUI.
+
+    The 8 s cold deadline only fired for ``_can_go_cold`` (desktop). The
+    ordinary TUI attach viewer — ``tui/app.py`` calls ``connect()`` without
+    ``surface``, so ``surface == "terminal"`` and ``_can_go_cold`` is False —
+    could therefore never reach a verdict once the abort moved to recovery:
+    a takeover that keeps failing retries forever by design, so nothing was
+    left to end the turn.
+
+    THIS TEST LETS THE REAL LOOP RUN. Every other verdict test here hand-calls
+    ``_settle_suspect_turn`` / ``_go_cold``, and that test shape is what let
+    the blocker through — ``_facade`` defaults ``can_go_cold=False`` and no
+    test ever drove ``_recover_owner`` itself on that surface.
+
+    ``COLD_FALLBACK_S`` is monkeypatched so the bound is exercised in
+    milliseconds; the assertion is on the VERDICT, never on elapsed time.
+    """
+    monkeypatch.setattr(remote_module, "COLD_FALLBACK_S", 0.05)
+    takeover_attempts: list[int] = []
+
+    async def failing_takeover() -> Any:
+        takeover_attempts.append(1)
+        raise RuntimeError("the lease is held by another follower")
+
+    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    remote = RemoteSession(
+        config_dir=tmp_path,
+        session_id="s1",
+        takeover_factory=failing_takeover,
+    )
+    # The surface the operator actually uses: RemoteSession.connect defaults
+    # to "terminal", so this is what a real TUI viewer looks like.
+    assert remote._can_go_cold is False
+    remote._streaming = True
+    remote._generation = 7
+    remote._ready_for_events = True
+    received: list[Any] = []
+    remote.subscribe(received.append)
+    went_cold: list[str] = []
+    remote.set_went_cold_callback(lambda: went_cold.append("cold"))
+
+    remote._on_disconnected("owner exited")
+    assert remote._recovery_task is not None
+    # Wait on the PUBLICATION (the synthesised end), never on the clock.
+    for _ in range(400):
+        if any(isinstance(event, AgentEndEvent) for event in received):
+            break
+        await asyncio.sleep(0.01)
+    await _cancel_recovery(remote)
+
+    ends = [event for event in received if isinstance(event, AgentEndEvent)]
+    assert len(ends) == 1, (
+        "a dead runtime on the terminal surface left the turn spinning: "
+        f"ends={ends} attempts={len(takeover_attempts)}"
+    )
+    assert ends[0].aborted is True and ends[0].error is None
+    assert remote.is_streaming is False
+    assert remote._suspect_generation is None
+    # The legacy contract is preserved: the loop keeps CHASING a successor
+    # instead of taking the desktop-only cold exit, which would have stopped
+    # recovery and fired the went-cold callback.
+    assert went_cold == [], "the terminal surface took the desktop cold exit"
+    assert takeover_attempts, "the loop stopped retrying after ending the turn"
+
+
+@pytest.mark.asyncio
+async def test_the_terminal_bound_does_not_fire_when_no_turn_was_live(
+    tmp_path, monkeypatch
+) -> None:
+    """The bound ends a SUSPECT turn only: an idle viewer synthesises nothing."""
+    monkeypatch.setattr(remote_module, "COLD_FALLBACK_S", 0.05)
+
+    async def failing_takeover() -> Any:
+        raise RuntimeError("no successor yet")
+
+    monkeypatch.setattr(remote_module, "find_owner_record", lambda *args: (None, None))
+    remote = RemoteSession(
+        config_dir=tmp_path,
+        session_id="s1",
+        takeover_factory=failing_takeover,
+    )
+    remote._ready_for_events = True
+    remote._streaming = False  # nothing was running when the socket dropped
+    received: list[Any] = []
+    remote.subscribe(received.append)
+
+    remote._on_disconnected("owner exited")
+    for _ in range(30):
+        await asyncio.sleep(0.01)
+    await _cancel_recovery(remote)
+
+    assert [event for event in received if isinstance(event, AgentEndEvent)] == []
+    assert remote._suspect_generation is None
+
+
+@pytest.mark.asyncio
+async def test_a_same_live_turn_rebind_still_seeds_what_the_gap_produced(
+    tmp_path, monkeypatch
+) -> None:
+    """Review round 1, MAJOR-1: only the synthetic start is suppressed.
+
+    ``live_events`` is the turn AS IT IS NOW, so a tool that started while
+    the socket was down is in the snapshot and must paint. Dropping the whole
+    seed meant its later real ``tool_end`` arrived orphaned and was discarded
+    unrendered at ``agent_end`` — the user permanently lost that card.
+
+    The ⊘ interrupted trap the deviation identified is still covered: the
+    start event must NOT be re-seeded, because ``_handle_agent_start`` clears
+    ``_started_tools``. Both halves are asserted here.
+    """
+    remote = _facade(tmp_path, monkeypatch)
+    received: list[Any] = []
+    remote.subscribe(received.append)
+    remote._on_disconnected("send timeout")
+    await _cancel_recovery(remote)
+
+    remote._install_frontend(
+        FrontendSessionState(
+            session_id="s1",
+            epoch="e1",
+            streaming=True,
+            generation=7,
+            live_events=[
+                {
+                    "type": "tool_execution_start",
+                    "tool_call_id": "gap-tool",
+                    "tool_name": "hang",
+                    "args": {},
+                }
+            ],
+        )
+    )
+    remote._settle_suspect_turn()
+    remote._finish_sync()
+
+    types = [getattr(event, "type", None) for event in received]
+    assert (
+        "tool_execution_start" in types
+    ), f"the gap's tool was dropped instead of painted: {types}"
+    assert (
+        "agent_start" not in types
+    ), f"re-seeding the start clears _started_tools and orphans the card: {types}"
+    assert [event for event in received if isinstance(event, AgentEndEvent)] == []
+    assert remote.is_streaming is True

--- a/tests/unit/session/test_remote_takeover.py
+++ b/tests/unit/session/test_remote_takeover.py
@@ -461,12 +461,13 @@ async def test_going_cold_ends_an_in_flight_turn_directly(tmp_path, monkeypatch)
 async def test_a_disconnect_followed_by_going_cold_ends_the_turn_once(
     tmp_path, monkeypatch
 ) -> None:
-    """The common path: ``_on_disconnected`` already ended the turn, so the
-    go-cold end is a no-op rather than a second "interrupted" notice.
+    """A transient disconnect no longer synthesises an abort; go-cold does,
+    exactly once.
 
-    ``_end_turn_locally`` returns on ``not self._streaming``, which is what
-    makes the two callers safe to stack — pinned here so a later rewrite of
-    either does not turn one owner loss into two aborted ends on the app.
+    ``_on_disconnected`` marks the turn suspect and starts recovery. When
+    recovery gives up, ``_go_cold`` is the verdict that the runtime is
+    actually gone and emits the one aborted end. Stacking the two must not
+    produce a second "interrupted" notice.
     """
     from local_operator.harness.types import AgentEndEvent
 


### PR DESCRIPTION
## Summary of Changes

A dropped attach socket said nothing about the turn — the runtime was usually still running it — but `RemoteSession._on_disconnected` synthesised an aborted `AgentEndEvent` immediately. The ledger then painted `⊘ interrupted` / a standalone `interrupted` notice on a wait that never stopped; recovery re-bound to the same pid ~100 ms later and the band recovered, but the artefact stayed.

This is PR B of the runtime-autorefresh design (`docs/design-runtime-autorefresh.md` §4; that doc belongs to PR A and is **not** in this PR).

- **Defer the synthesised abort** until recovery's verdict. Mid-turn disconnect marks the turn *suspect* (`_suspect_generation`) and starts recovery; `_streaming` stays True so the band keeps `working`.
- **`last_turn_outcome`** (additive on `FrontendSessionState`): a rebind after the turn settled cannot recover the real end from `live_events` (cleared at `agent_end`). Set from the emitted end in `Session._emit` / `observe_event`. `""` from an old runtime keeps today's aborted synthesis.
- **Stop pushing projection repaints** to clients that declared `events` AND `frontend_state` (full-TUI / desktop). Welcome (`_push_to`) still goes to everyone — `AttachClient.connect` reads it as the identity check. Daemon and events-only attach clients keep receiving repaints byte-for-byte. Grepped: desktop consumes events + frontend_state, nothing keys on `op == "projection"` after welcome.
- **`_drop_client(reason=)`** — one INFO line per actual removal naming reason and client kind; the reader-loop `finally` no-op is DEBUG only.
- **`_TUI_SEND_TIMEOUT_S = 5.0`** for full-TUI clients now that projections are off that socket; daemon/legacy stay at 1.0 s.
- **`RemoteSession.abort`** — no task if detached; done-callback logs `ConnectionError("not attached")` at DEBUG instead of "Task exception was never retrieved".

**Deviation from the design:** same-live-turn rebind does **not** re-seed `AgentStartEvent`. That handler clears `_started_tools`, so a later real `tool_end` would miss the live card and `_finalize_turn` would paint `⊘ interrupted` — the bug this PR exists to stop. Generation is already applied from the snapshot; the ledger is left untouched. Test 16 pins this.

**PR C (#709) deferred item:** TUI kept painting `thinking`/`working` after the runtime went idle. Rebind with `streaming=False` + `last_turn_outcome="completed"` synthesises one unstamped `AgentEndEvent` that reaches `EventController` as `TurnEnded(aborted=False)` so the band can leave `working`. Pinned in `test_rebind_after_an_idle_runtime_posts_turn_ended`.

Did **not** touch `_enqueue_client_frame`'s size guard (#709 owns that). No `pyproject.toml` bump.

**Change class: C2.** No version bump; `pyproject.toml` stays at `0.50.0`.

Release: patch — viewers stay bound across a transient socket drop; a mid-wait stall no longer paints `interrupted`, and a rebind after the runtime went idle settles the band.

## Related Issue(s)

- Complements #709 (stale abort / oversized event frames); this PR does not duplicate its size guard.
- Covers the viewer/owner turn-state divergence #709 deferred: TUI stuck on `thinking` after the runtime is idle.

## Impact

**Breaking changes:** none. Additive snapshot field; older peers ignore it. Protocol version unchanged.

**User-visible:** removes a *false* `interrupted` notice; adds none. No copy / layout change.

## Testing Details

Gates (this worktree `.venv`, commands as CI):

```
.venv/bin/python -m flake8 .                         # 0
uvx --from black==26.1.0 black --check .             # 986 files unchanged
uvx isort==5.13.2 --check .                          # rc 0
.venv/bin/python -m pyright --pythonpath .venv/bin/python .  # 0 errors
```

Unit — design §5.2 tests 16–22 plus the #709 deferred band case:

```
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
  tests/unit/session/test_remote_disconnect.py \
  tests/unit/session/test_remote_takeover.py \
  tests/unit/session/runtime/test_server.py::test_push_skips_full_tui_clients_but_keeps_welcome_and_daemon \
  tests/unit/session/runtime/test_server.py::test_every_drop_logs_reason_once_at_info \
  tests/unit/session/runtime/test_server.py::test_attach_cap_drop_reason_is_logged \
  tests/unit/session/runtime/test_server.py::test_tui_send_timeout_is_five_seconds \
  tests/unit/session/test_frontend_state.py::test_agent_end_records_last_turn_outcome \
  -q -n0
# 30 passed (then 10 in test_remote_disconnect.py after the idle-band test)
```

```
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
  tests/unit/session/runtime tests/unit/session/test_frontend_state.py \
  tests/e2e/test_viewer_attach_e2e.py -q
# 301 passed
```

E2E test 23 (isolated `HOME`/`LOCAL_OPERATOR_CONFIG_DIR`, CMUX_* unset by the e2e autouse fixture):

```
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
  tests/e2e/test_viewer_attach_e2e.py::test_a_transient_viewer_drop_mid_turn_does_not_paint_interrupted \
  -m e2e -n0 -q
# 1 passed in 3.30s
```

Full `tests/e2e/test_viewer_attach_e2e.py`: **11 passed**.

Whole-tree `tests/unit` was started twice and killed at ~88% by host load (many sibling pytest runs); no failure was printed. CI is the remaining whole-tree proof.

### False-interrupt reproduction (event layer, isolated)

BEFORE (unfixed tree, `_on_disconnected` while `_streaming=True`, generation 7):

```
AgentEndEvents: [(True, 0, None)]
viewer._streaming: False
event types: ['agent_end']
```

AFTER (this branch, same call):

```
AgentEndEvents: []
viewer._streaming: True
viewer._suspect_generation: 7
event types: []
```

Same-generation rebind then synthesises nothing (streaming stays True).

E2E 23: hang tool live on the runtime → `_drop_client(conn, reason="test")` → viewer re-binds to the same pid → `transcript_text(app)` never contains `"interrupted"` → turn completes → assistant row once.

Desktop projection check (design §7 risk 4): `desktop_sessions.py` constructs `RemoteSession.cold(..., surface="desktop")` and subscribes to events + frontend_state. Nothing in `local_operator/server` or `tests/e2e/test_desktop_*.py` keys on `op == "projection"` after welcome. Recipient filter is therefore `wants_events and wants_frontend`, not `surface == "terminal"`.

## Non-goals (deliberate)

- No protocol bump.
- No `wait` tool changes.
- No runtime self-refresh / busy-bit (PR A).
- No `_enqueue_client_frame` size guard (#709).
- Design doc not committed here.