### PR TITLE
chore(release): bump version to 0.50.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.50.2"
+version = "0.50.3"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window claimed and cut. Owner session pid: 29080 (lopdev manager, "Review and merge open PRs").

**This window must skip 0.50.1 and 0.50.2.** Both were consumed by version bumps smuggled inside feature PRs (#701 at `6a3bf4777`, #706 at `ec5aa3db0`) and neither was ever tagged, built or published: the newest tag, GitHub Release and PyPI artifact are all `v0.50.0`, while `main` advertises `0.50.2`. Reusing either number would publish a different artifact under a number `main` has already claimed, and would sort *below* the tree anyone who installed from source is already holding, so `pip install -U` would decline to move them onto the real release. Cutting **v0.50.3**.

#710 (merged, in this window) adds the `version-bump-guard` CI job so this cannot recur. This PR is the first live test of its `chore(release):` exemption, and the job passed here in 7s while failing feature PRs that change the version.

Window — every PR merged to `main` since `v0.50.0`:

- [x] #700 — patch — the code-owner rule on `main` can be satisfied by a review instead of an admin bypass
- [x] #701 — patch — a provider refusal or content filter in the evaluation runner is attributed to the provider instead of being reported as malformed JSON the model never emitted
- [x] #703 — patch — fixes the repo's dominant CI flake (`test_blur_slows`, 7 of 11 failures over 40 runs) plus a double-click flake and an e2e read-after-write
- [x] #704 — patch — AGENTS.md states the intended two-tier merge policy correctly
- [x] #705 — patch — README reframed as an agent-organization hub; subscription pooling, cache efficiency and always-on get dedicated sections
- [x] #706 — patch — OSWorld types at upstream's speed, so long typing actions no longer exhaust the 90s guest deadline
- [x] #707 — patch — idle runtimes refresh themselves onto the build on disk; resume never shows `/stop, then send again`
- [x] #708 — patch — README copy pass: em dashes replaced, AI-isms removed
- [x] #710 — patch — CI fails any feature PR that changes the project version
- [x] #602 — patch — QwenCloud Token Plan models use prompt caching, and the missing `qwen3.8-flash` row stops a 1M-context model being compacted at 128k
- [x] #604 — patch — a message beginning with a path (`/tmp/test`) can be sent instead of being rejected as an unknown command and discarded
- [x] #613 — patch — lop reads a user-scope `~/.agents/AGENTS.md` alongside `system_prompt.md`

**Bump class: patch**, ruled by the independent reviewer rather than by me. I had written `Release: minor` on #613 and the reviewer overruled it: the feature is inert for anyone without `~/.agents/AGENTS.md` (the loader catches `OSError` and returns `""`), so the population whose behaviour changes is exactly the population that keeps that file and wants it read. No single PR clears the step-function bar on its own.

## Scope

One line in one file:

```
-version = "0.50.2"
+version = "0.50.3"
```

No dependency pin, script or entry point moved beside the bump.