### PR TITLE
docs(agents): read the committed ref, not the shared working tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,12 +303,22 @@ was `0.50.3`, with no error. It bites hardest on "is this documented?"
 questions, because anything added recently is invisible on an older ref.
 
 And `origin/main` is not always the ref you mean. Asking whether *a PR's* tree
-contains something means reading that PR's head, not `main`:
+contains something means reading that PR's head, not `main`. Fetch it into a
+**named ref** and delete that ref afterwards:
 
 ```sh
-git -C ~/local-operator fetch origin pull/713/head --quiet
-git -C ~/local-operator show FETCH_HEAD:AGENTS.md | grep -n 'thing you are checking'
+git -C ~/local-operator fetch origin pull/713/head:refs/lo-read/pr713 --force --quiet
+git -C ~/local-operator show refs/lo-read/pr713:AGENTS.md | grep -n 'thing you are checking'
+git -C ~/local-operator update-ref -d refs/lo-read/pr713
 ```
+
+**Not `FETCH_HEAD`.** There is one `FETCH_HEAD` per gitdir, rewritten by every
+fetch, and the `-C ~/local-operator` above means every session on this machine
+shares the root checkout's copy. A peer fetching between your fetch and your
+read silently redirects it: measured at **0 successes in 20 interleaved
+trials**, returning `main`'s tree with no error, where the named-ref form
+succeeded 8/8. That is this section's own failure — a confident wrong answer —
+reappearing inside the command meant to prevent it.
 
 Several agents routinely hold uncommitted work in the root checkout at the
 same time, so a tracked file there is whatever the last writer left mid-task —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,6 +280,50 @@ listing out of a catalogue cache that the same session's own earlier live calls
 had written into the real home. Any cell whose point is a cold cache needs a
 **fresh** `HOME` per cell, not merely a fresh config dir.
 
+### Read the committed ref, not the working tree
+
+The section above is about not *writing* into a checkout other agents are
+using. This is the same hazard in the other direction, and it is easier to
+fall into because nothing fails: **when you want to know what the repository
+says, read the ref, not the files on disk.**
+
+```sh
+git -C ~/local-operator show origin/main:AGENTS.md | grep -n 'thing you are checking'
+grep -n 'thing you are checking' ~/local-operator/AGENTS.md   # answers about SOMEONE'S DRAFT
+```
+
+Several agents routinely hold uncommitted work in the root checkout at the
+same time, so a tracked file there is whatever the last writer left mid-task —
+a half-finished edit, a section not yet written, or a revision from a branch
+nobody merged. `grep` reports that state with no indication that it is not the
+repository's.
+
+The failure mode is a **confident false negative**: `grep` finds nothing, and
+"nothing" reads like an answer rather than like a question about which tree you
+just searched. It has already produced a wrong finding on a PR. A reviewer
+checking whether the release procedure was documented grepped the working copy,
+found no match, and reported that the procedure "does not exist in the repo's
+markdown" — while `git show origin/main:AGENTS.md` matched it immediately at
+`### What the release owner does`. A peer session was holding the file 398
+lines shorter than `main`. The claim was reported, believed, and escalated to
+the operator before anyone checked the ref, and the fix it implied was to write
+a section that was already there.
+
+So an absence found in the working tree is not evidence. Confirm it against the
+ref before acting on it, and say which you read when you report it:
+
+```sh
+git -C ~/local-operator status --porcelain AGENTS.md   # 'M'/'MM' => on-disk copy is not main's
+```
+
+This applies to any question about repository content — whether a rule is
+written down, whether a helper exists, whether a test covers a case, what a
+config declares. It does not apply to your own uncommitted work, which is the
+one thing the working tree is authoritative about. When you need several files
+or a whole tree at a known revision, take a throwaway worktree
+(`git worktree add --detach /tmp/lo-read origin/main`) rather than reading the
+shared checkout and hoping it is clean.
+
 ## Releasing the stable `lop` runtime
 
 Development and the global launcher deliberately use different installations:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,14 +282,32 @@ had written into the real home. Any cell whose point is a cold cache needs a
 
 ### Read the committed ref, not the working tree
 
-The section above is about not *writing* into a checkout other agents are
-using. This is the same hazard in the other direction, and it is easier to
-fall into because nothing fails: **when you want to know what the repository
-says, read the ref, not the files on disk.**
+"Never `git stash` to get a before-frame" (in the visual-validation section
+below) is about not *writing* into a checkout other agents are using. This is
+the same hazard in the other direction, and it is easier to fall into because
+nothing fails: **when you want to know what the repository says, read a ref,
+not the files on disk.**
 
 ```sh
+git -C ~/local-operator fetch origin main --quiet          # REQUIRED: see below
 git -C ~/local-operator show origin/main:AGENTS.md | grep -n 'thing you are checking'
 grep -n 'thing you are checking' ~/local-operator/AGENTS.md   # answers about SOMEONE'S DRAFT
+```
+
+**Fetch first, and pick the right ref.** `origin/main` is a local tracking
+ref that only moves when something fetches, so reading it without fetching has
+the *same* failure this section exists to prevent — a silent, plausible, stale
+answer. Reproduced: against a tracking ref left where it was a few hours
+earlier, `git show origin/main:pyproject.toml` reported `0.50.2` while `main`
+was `0.50.3`, with no error. It bites hardest on "is this documented?"
+questions, because anything added recently is invisible on an older ref.
+
+And `origin/main` is not always the ref you mean. Asking whether *a PR's* tree
+contains something means reading that PR's head, not `main`:
+
+```sh
+git -C ~/local-operator fetch origin pull/713/head --quiet
+git -C ~/local-operator show FETCH_HEAD:AGENTS.md | grep -n 'thing you are checking'
 ```
 
 Several agents routinely hold uncommitted work in the root checkout at the
@@ -319,10 +337,28 @@ git -C ~/local-operator status --porcelain AGENTS.md   # 'M'/'MM' => on-disk cop
 This applies to any question about repository content — whether a rule is
 written down, whether a helper exists, whether a test covers a case, what a
 config declares. It does not apply to your own uncommitted work, which is the
-one thing the working tree is authoritative about. When you need several files
-or a whole tree at a known revision, take a throwaway worktree
-(`git worktree add --detach /tmp/lo-read origin/main`) rather than reading the
-shared checkout and hoping it is clean.
+one thing the working tree is authoritative about, and it is not only about
+`grep`: a subprocess launched with the wrong cwd resolves the root checkout's
+copy of a module rather than its own worktree's, which surfaces as failures
+that look environmental and are.
+
+When you need several files or a whole tree at a known revision, take a
+throwaway worktree rather than reading the shared checkout and hoping it is
+clean — and **remove it in the same task**, on a unique path, because a
+leftover either blocks the next agent or gets silently reused at a stale
+revision (`git worktree list` presently shows dozens of abandoned ones):
+
+```sh
+read=$(mktemp -d /tmp/lo-read.XXXXXX)
+git -C ~/local-operator fetch origin main --quiet
+git -C ~/local-operator worktree add --detach "$read" origin/main --quiet
+grep -n 'thing you are checking' "$read/AGENTS.md"
+git -C ~/local-operator worktree remove --force "$read"
+```
+
+The `-C ~/local-operator` is load-bearing on every command here: you are
+usually standing somewhere else when you ask these questions, and without it
+`git` fails with `not a git repository`.
 
 ## Releasing the stable `lop` runtime
 


### PR DESCRIPTION
## Summary

Adds an AGENTS.md subsection: when you want to know what the repository says, read the committed ref, not the files on disk in the shared root checkout.

**Change class: C1 (standard, pre-authorized).** Documentation only, no runtime path.

## Why this exists, and why it is not the change I was asked for

I was asked to document the release-owner/window procedure, on the strength of a finding I reported to the operator: that the procedure I had just followed to cut v0.50.3 was not written down anywhere.

**That finding was wrong, and this PR is the actual defect behind it.**

The procedure *is* documented on `main`, and has been since #655:

```
$ git show origin/main:AGENTS.md | grep -n '^### What the release owner does'
402:### What the release owner does
```

What happened is that the reviewer and I both grepped the **working tree** of `~/local-operator`, where a peer session was holding `AGENTS.md` **398 lines shorter** than `main`:

```
$ git show origin/main:AGENTS.md | wc -l      # 1313
$ wc -l < ~/local-operator/AGENTS.md          #  915
$ git status --porcelain AGENTS.md            #  MM
```

`grep` found nothing, nothing failed, and "nothing" read like an answer instead of a question about which tree had just been searched. The claim was reported, believed, escalated to the operator, and the remedy it implied was to write a section that already existed. Writing it would have produced a duplicate, drifting copy of a procedure the file already carried, which is materially worse than the imaginary gap.

AGENTS.md already warns against **writing** into a checkout other agents are using (`stash`/`restore`/`reset` in the visual-validation section). It said nothing about **reading** one, which is the easier mistake precisely because there is no error to notice.

## What the section says

- Read `git show origin/main:<file>` rather than the path on disk, with the trap command shown beside the correct one.
- An absence found in the working tree is not evidence; confirm against the ref before acting on it, and say which you read when you report it.
- `git status --porcelain <file>` reveals a dirty copy before you trust it.
- The working tree remains authoritative for exactly one thing: your own uncommitted work.
- For several files or a whole tree at a known revision, take a throwaway worktree instead of hoping the shared checkout is clean.

Placed immediately after the `LOCAL_OPERATOR_CONFIG_DIR` isolation note, which is the same class of defect: a silent, plausible wrong answer rather than an error.

## Testing Evidence

No runtime path — this is documentation. What I validated instead is that **every factual claim in the text is true** and **every command in it does what the text says**, checked against the live repository rather than from memory, since the whole point of the section is not trusting an unverified read.

Claims:

```
=== CLAIM 1: origin/main HAS the section, working tree does NOT ===
  origin/main: 1
  working tree: 0
=== CLAIM 2: heading text is exactly '### What the release owner does' ===
402:### What the release owner does
=== CLAIM 3: line-count delta is 398 ===
  main=1313 wt=915 delta=398
=== CLAIM 4: status porcelain shows M/MM ===
MM AGENTS.md
```

Commands, run from outside the repo exactly as written:

```
=== the RECOMMENDED command (reads the ref) ===
402:### What the release owner does
=== the TRAP command (reads the working tree) ===
  (no match — the confident false negative)
=== the porcelain check ===
MM AGENTS.md
=== the throwaway-worktree escape hatch ===
1
  worktree hatch works, removed
```

The trap reproduces live: the same grep that produced the false finding still produces it, and the ref-first command still resolves the section. Both are in the diff as written.

## Scope

`AGENTS.md` only, +44/-0. `pyproject.toml` untouched at `0.50.3` — `version-bump-guard` (#710) should report no version change on this run.

Release: patch — AGENTS.md documents reading the committed ref rather than the shared working tree, so an agent grepping a checkout a peer is mid-edit in no longer gets a confident false negative.
