### PR TITLE
chore(release): bump version to 0.50.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.50.3"
+version = "0.50.4"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
# Release window claim

**Owner session pid: 4951** (`Mark Focused TUI Session as Viewed`).

This draft PR **is the lock** on the current release window, per `AGENTS.md`
(*One release owner per window*): a `send` is not observable to a session that
was not listening, so an open `chore(release):` PR is what makes ownership
discoverable through the forge.

This commit is intentionally empty. Once the window's bump is decided it is
amended into the `pyproject.toml` change and this PR is retitled
`chore(release): bump version to X.Y.Z` — the PR number, and so the lock,
never changes.

## Window contents

- [x] #713 — `docs(agents)`: read the committed ref, not the shared working tree
- [x] #697 — `feat(desktop)`: acknowledge viewed completions across the TUI, mobile relay and desktop app
- [x] `local-operator-ui#85` — desktop app keeps viewed-completion state in sync (separate repo, not versioned here)

Contributors: `send` your PR number, merge SHA and `Release:` line to pid 4951
rather than opening a second release.
