### PR TITLE
ci: a release PR must actually bump, and only ever forward

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,22 +186,56 @@ jobs:
             'chore(release):'*)
               echo "Release PR, version change allowed:"
               echo "$changed"
-              # The new version must sort ABOVE the newest release tag. A
-              # published version cannot be corrected: PyPI refuses to reuse a
-              # filename even after a yank, and a number that sorts below what
-              # a source installer already holds means `pip install -U`
-              # silently declines to move them onto the real release. Numbers
-              # consumed by an unreleased in-PR bump are skipped, never reused.
-              new=$(printf '%s\n' "$changed" | sed -n 's/^+version[[:space:]]*=[[:space:]]*"\(.*\)"$/\1/p')
-              last=$(git describe --tags --abbrev=0 --match 'v[0-9]*' HEAD^1 2>/dev/null | sed 's/^v//') || last=""
-              if [ -n "$new" ] && [ -n "$last" ]; then
+              # The new version must sort ABOVE the highest existing release
+              # tag. A published version cannot be corrected: PyPI refuses to
+              # reuse a filename even after a yank, and a number that sorts
+              # below what a source installer already holds means
+              # `pip install -U` silently declines to move them onto the real
+              # release. Numbers consumed by an unreleased in-PR bump are
+              # skipped, never reused.
+              #
+              # The tag comes from `ls-remote`, NOT `git describe`, and that is
+              # load-bearing rather than a preference. `actions/checkout@v4`
+              # passes `--no-tags` unless `fetch-tags: true` (its default is
+              # false), so this shallow checkout carries ZERO tags and
+              # `git describe` exits 128 on every real run — a first draft of
+              # this check used it and was dead code that passed a backward
+              # bump green. `fetch-tags: true` does not fix it either: at
+              # depth 2 the tag object arrives but is not REACHABLE in the
+              # truncated history, so `describe` still fails whenever the base
+              # has moved past the tag, which is the normal state during a
+              # release window. `ls-remote` asks the forge instead of the local
+              # object store, in one network call, and needs no history at all.
+              #
+              # It is therefore the highest tag REPO-WIDE rather than the
+              # newest reachable one. That is the stricter reading and the
+              # right one here: a release must be forward of everything ever
+              # published, not merely of its own ancestry.
+              new=$(printf '%s\n' "$changed" \
+                | sed -n 's/^+version[[:space:]]*=[[:space:]]*["'"'"']\{0,1\}\([0-9][^"'"'"' 	]*\).*/\1/p')
+              if [ -z "$new" ]; then
+                echo "::error file=pyproject.toml::Could not parse the new version."
+                echo "The diff adds a version line this job cannot read:"
+                printf '%s\n' "$changed"
+                echo "Expected: version = \"X.Y.Z\". Fix the line, or update this"
+                echo "job if the project's version syntax has genuinely changed;"
+                echo "an unparsable version must never pass unchecked."
+                exit 1
+              fi
+              last=$(git ls-remote --tags --refs origin 'v[0-9]*' \
+                | sed 's#.*refs/tags/v##' | sort -V | tail -1)
+              if [ -n "$last" ]; then
                 highest=$(printf '%s\n%s\n' "$new" "$last" | sort -V | tail -1)
                 if [ "$new" = "$last" ] || [ "$highest" != "$new" ]; then
-                  echo "::error file=pyproject.toml::Release version must be above the last tag."
-                  echo "New version '$new' does not sort above the newest tag 'v$last'."
+                  echo "::error file=pyproject.toml::Release version must be above the highest tag."
+                  echo "New version '$new' does not sort above the highest release tag 'v$last'."
+                  echo "A published version cannot be corrected, so pick the next unused"
+                  echo "number above v$last rather than reusing or rewinding one."
                   exit 1
                 fi
-                echo "Version $new sorts above the last tag v$last."
+                echo "Version $new sorts above the highest release tag v$last."
+              else
+                echo "No release tags found on the remote; skipping the ordering check."
               fi
               ;;
             *)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,39 @@ jobs:
           # match" is exit 1 and must stay non-fatal, so the two are separated.
           changed=$(printf '%s\n' "$diff" | { grep -E '^[+-]version[[:space:]]*=' || true; })
           if [ -z "$changed" ]; then
+            # A release PR that changes NOTHING is the mirror-image failure,
+            # and it is the more dangerous direction. The feature-PR case below
+            # burns a number nobody released; this one ships the PREVIOUS
+            # release's CODE under a new number, so
+            # `pip install local-operator==X.Y.Z` delivers the version before
+            # it, and the tag, the Release and PyPI all agree with each other
+            # about the wrong tree.
+            #
+            # It was nearly shipped as v0.50.4. The owner amended the bump onto
+            # a DETACHED HEAD, so the branch ref never followed the amend, and
+            # every signal said it had worked: `push --force-with-lease`
+            # reported success (honestly — nothing needed overwriting, so the
+            # lease was never violated), the retitle and un-draft applied
+            # because PR metadata is independent of the ref, CI went green, and
+            # THIS JOB PASSED through the early exit below. Four green signals
+            # on a broken state, because each answered a question about a
+            # different object than the one being released.
+            case "$PR_TITLE" in
+              'chore(release): bump version to '*)
+                echo "::error file=pyproject.toml::A release PR must actually change the version."
+                echo "This PR is titled '$PR_TITLE' but its diff does not touch"
+                echo "the version line in pyproject.toml, so the release would carry"
+                echo "the previous version's code under a new number."
+                echo
+                echo "The usual cause is an amend made on a detached HEAD: the branch"
+                echo "ref never moved, and --force-with-lease still reports success"
+                echo "because nothing needed overwriting. Check what the FORGE has,"
+                echo "not what your local clone has:"
+                echo "  gh pr view <n> --json headRefOid --jq .headRefOid"
+                echo "  git show <that-sha>:pyproject.toml | grep '^version'"
+                exit 1
+                ;;
+            esac
             echo "No version change in pyproject.toml."
             exit 0
           fi
@@ -153,6 +186,23 @@ jobs:
             'chore(release):'*)
               echo "Release PR, version change allowed:"
               echo "$changed"
+              # The new version must sort ABOVE the newest release tag. A
+              # published version cannot be corrected: PyPI refuses to reuse a
+              # filename even after a yank, and a number that sorts below what
+              # a source installer already holds means `pip install -U`
+              # silently declines to move them onto the real release. Numbers
+              # consumed by an unreleased in-PR bump are skipped, never reused.
+              new=$(printf '%s\n' "$changed" | sed -n 's/^+version[[:space:]]*=[[:space:]]*"\(.*\)"$/\1/p')
+              last=$(git describe --tags --abbrev=0 --match 'v[0-9]*' HEAD^1 2>/dev/null | sed 's/^v//') || last=""
+              if [ -n "$new" ] && [ -n "$last" ]; then
+                highest=$(printf '%s\n%s\n' "$new" "$last" | sort -V | tail -1)
+                if [ "$new" = "$last" ] || [ "$highest" != "$new" ]; then
+                  echo "::error file=pyproject.toml::Release version must be above the last tag."
+                  echo "New version '$new' does not sort above the newest tag 'v$last'."
+                  exit 1
+                fi
+                echo "Version $new sorts above the last tag v$last."
+              fi
               ;;
             *)
               echo "::error file=pyproject.toml::A feature PR must not change the project version."


### PR DESCRIPTION
## Summary

Closes the other half of #710's guard. That job checks that a PR **touching** the version line is titled `chore(release):`. It says nothing about a PR **so titled** that changes nothing, nor about a bump that goes backwards.

**Change class: C1 (standard, pre-authorized).** CI config only, no runtime path.

## Why — a near-miss on v0.50.4

The release owner amended the bump onto a **detached HEAD**, so the branch ref never followed the amend. The tag was nearly cut against a tree that still said `0.50.3`.

What makes this worth a CI check rather than a note is that **every signal said it had worked**:

| Signal | Why it lied |
| --- | --- |
| `git push --force-with-lease` reported success | Honestly. Nothing needed overwriting, so the lease was never violated |
| The PR retitle and un-draft applied | PR metadata is independent of the ref |
| CI went green | It tested the tree that was actually there |
| **`version-bump-guard` passed** | It took the "No version change" early exit |

Four green ticks on a broken state, each answering a question about a different object than the one being released. A reviewer caught it by reading the PR head **from the forge** rather than from a local clone, and found the head was not even the claim commit.

This is the mirror image of the failure #710 was written for, and the worse direction. Burning a number publishes nothing; this publishes **the previous release's code under a new number**, so `pip install local-operator==X.Y.Z` delivers the version before it while the tag, the GitHub Release and PyPI all agree with each other about the wrong tree. Unlike a burned number, it is not correctable after publication.

## What it adds

1. **A release PR must actually bump.** A PR titled `chore(release): bump version to ...` whose diff does not touch the version line fails, and the error names the detached-HEAD cause plus the forge-side commands that reveal it (`gh pr view <n> --json headRefOid`, then `git show <sha>:pyproject.toml`).

   The claim PR that takes the window lock is titled `chore(release): claim release window` — no `bump version to` — so it still passes with no bump. That is deliberate: the lock is opened *before* the number is known, and breaking it would break the window protocol in AGENTS.md.

2. **A bump may only go forward.** The new version must sort strictly above the newest reachable tag. A published version cannot be corrected: PyPI refuses to reuse a filename even after a yank, and a number sorting below what a source installer already holds means `pip install -U` silently declines to move them onto the real release. This is the rule that made v0.50.3 skip the burned `0.50.1`/`0.50.2` rather than reuse them.

## Testing Evidence

CI-config change, so its runtime path is the workflow. I extracted the job's shell with `yaml.safe_load` and drove it against **real commits and simulated `refs/pull/N/merge` refs** built with `commit-tree`, which is the shape Actions checks out.

```
NEW: release title, no actual bump           expect=REJECT got=REJECT OK
claim-window PR, no bump yet                 expect=PASS   got=PASS   OK
docs PR, no version change                   expect=PASS   got=PASS   OK
smuggled bump (#701)                         expect=REJECT got=REJECT OK
smuggled bump (#706)                         expect=REJECT got=REJECT OK
real forward release bump                    expect=PASS   got=PASS   OK
```

Version ordering, against the live tag set (newest `v0.50.4`):

```
forward bump 0.50.5      PASS   Version 0.50.5 sorts above the last tag v0.50.4.
forward minor 0.51.0     PASS   Version 0.51.0 sorts above the last tag v0.50.4.
REWIND to burned 0.50.1  REJECT Release version must be above the last tag.
REWIND below tag 0.49.9  REJECT Release version must be above the last tag.
```

Exact reuse, tested against a tag reachable from the base:

```
reachable tag: v9.9.9 ; PR sets version to 9.9.9 (EXACT REUSE)
::error file=pyproject.toml::Release version must be above the last tag.
New version '9.9.9' does not sort above the newest tag 'v9.9.9'.
exit=1
```

**The shallow-checkout case, which is what CI actually runs.** The job uses `fetch-depth: 2`, so `git describe` may find no tags. Verified the fallback skips the comparison rather than failing the job, under `set -euo pipefail`:

```
tags present: 0
  new=0.50.5 last=[]
  SKIPPED comparison, job continues
  survived pipefail: yes
exit=0
```

**Negative control:** this PR touches only `ci.yml`, so `version-bump-guard` must report no version change on its own run — and because its title is not `chore(release): bump version to ...`, the new check must not fire either.

## Impact

No runtime behaviour, no dependencies. Same single PR-event job, a few seconds. Attributed to the session that owns #714/#697, who found the near-miss, verified it, and deliberately did **not** bolt the fix onto their own release — they would have been author, reviewer's subject and release owner at once.

Release: patch — a release PR that does not actually change the version, or that moves it backwards, now fails CI instead of shipping the previous release's code under a new number.