### PR TITLE
fix(analytics): agree on session cost across /session and /analytics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1359,6 +1359,34 @@ Things that will bite you if you forget them:
   token-only ledger. Any new stored column needs a `_MIGRATION_COLUMNS` entry
   with a DEFAULT so old rows read as a sane value, never NULL.
 
+- **An index over a migrated column goes in `_OPTIONAL_INDEXES`, never in
+  `_SCHEMA`.** `_connect` runs `executescript(_SCHEMA)` as ONE unit *before*
+  `_migrate` adds the `_MIGRATION_COLUMNS`. So a `CREATE INDEX` on a migrated
+  column raises `no such column` on any ledger written before that column
+  existed — and because `executescript` aborts on the first error, every
+  statement *after* it in the script is silently lost too. Putting
+  `idx_calls_parent` beside `idx_calls_session` cost a pre-`parent_session_id`
+  ledger its `usage_daily`/`usage_monthly` rollup tables and latched `_broken`
+  for the process (reproduced both ways: rollup tables gone, `aggregate().calls`
+  0). `_OPTIONAL_INDEXES` pairs each index with the column it needs, runs after
+  `_migrate` under the same lock, and guards each statement individually, so a
+  failed index costs its own index and nothing else. Weigh the one-time build:
+  `idx_calls_parent` over a 475k-row ledger is a ~660 ms stall on the first open
+  after upgrade (on the recorder's background thread) and ~4.9 MB of growth.
+
+- **Session parentage has exactly ONE rule: `store._PARENT_EDGE_SQL`.** Both
+  the `/analytics` per-session rollup and the `/session` subtree walk resolve a
+  session's parent through that constant. They used to derive it separately —
+  a per-row filter on one side, a lexical `MAX` on the other — and disagreed
+  about any session carrying more than one distinct `parent_session_id`,
+  including the ledger's real self-parent rows. Two surfaces answering the same
+  question differently is the defect the rollup exists to remove, so a third
+  consumer must call the shared rule rather than write its own. Note the
+  rollup's load-bearing invariant while you are there: the per-session column
+  must keep summing to the headline total on the same screen, which is why
+  children are reachable only as sub-rows of their root (listing them flat *and*
+  rolling up inflates the table by 12.7%).
+
 ## The tool-surface footprint ladder
 
 Every core tool ships its schema on **every** API request. The tools array

--- a/local_operator/analytics/model.py
+++ b/local_operator/analytics/model.py
@@ -30,7 +30,7 @@ import json
 import math
 import re
 from dataclasses import dataclass, field
-from typing import Any, Mapping
+from typing import Any, Iterable, Mapping
 
 # ---------------------------------------------------------------------------
 # Component taxonomy
@@ -496,6 +496,149 @@ class UsageAggregate:
         return min(1.0, self.cache_read_tokens / self.context_tokens)
 
 
+def sum_aggregates(parts: Iterable[UsageAggregate]) -> UsageAggregate:
+    """Add several scopes into one, for a session tree or any other union.
+
+    SUM THE COUNTERS, NEVER THE BOOLEANS. ``cost_is_partial`` and
+    ``cost_is_known`` are derived from ``cost_known_calls`` against ``calls``,
+    so adding the two counters makes both properties come out right for a MIXED
+    subtree with no special cases:
+
+    - parent fully priced + child partly unpriced -> ``cost_known_calls <
+      calls`` -> ``$102.34+``. Correct: the tree total IS a lower bound.
+    - parent fully unpriced + child priced -> ``cost_known_calls > 0`` -> a real
+      figure with a ``+``, not ``$\u2014``. Correct: the tree really did spend
+      priceable money.
+    - both fully unpriced -> ``$\u2014``. Correct.
+
+    OR-ing the booleans instead would give the second case ``$\u2014`` over a real
+    spend. The nested ``by_provider``/``by_session`` maps are deliberately NOT
+    merged: this returns a flat scope, and every caller wants one.
+    """
+    total = UsageAggregate()
+    for part in parts:
+        total.calls += part.calls
+        total.ok_calls += part.ok_calls
+        total.input_tokens += part.input_tokens
+        total.output_tokens += part.output_tokens
+        total.cache_read_tokens += part.cache_read_tokens
+        total.cache_write_tokens += part.cache_write_tokens
+        total.reasoning_tokens += part.reasoning_tokens
+        total.context_tokens += part.context_tokens
+        total.cost_micro += part.cost_micro
+        total.cost_known_calls += part.cost_known_calls
+        for key, value in part.components.items():
+            total.components[key] = total.components.get(key, 0) + value
+    return total
+
+
+#: Depth cap for the per-session forest walk, mirroring the store's own cap on
+#: the ``/session`` subtree query. Same reasoning: the ledger is one level deep
+#: today, the code can already produce deeper trees, and a bounded walk is what
+#: keeps malformed or cyclic data from turning a report into a hang.
+MAX_SESSION_TREE_DEPTH = 32
+
+
+@dataclass(frozen=True)
+class SessionNode:
+    """One session in the per-session table: its own spend and its subtree's.
+
+    ``total`` is what the row RENDERS (own plus every descendant) and ``own`` is
+    what this session alone spent; a leaf has them equal. ``children`` are the
+    direct subagent sessions, each a node of the same shape, so the table can
+    indent a subtree without a second pass over the edges.
+    """
+
+    session_id: str
+    own: UsageAggregate
+    total: UsageAggregate
+    children: tuple["SessionNode", ...] = ()
+
+    @property
+    def has_children(self) -> bool:
+        return bool(self.children)
+
+
+def build_session_forest(
+    by_session: Mapping[str, UsageAggregate],
+    parents: Mapping[str, str],
+) -> list[SessionNode]:
+    """Re-partition a flat per-session map into roots carrying subtree totals.
+
+    Why re-partition rather than simply add a subtree total to every row: the
+    per-session column must keep summing to the headline total on the same
+    screen. Measured on a real 871-session ledger:
+
+    - sum of OWN over all sessions (today's flat table): $63,640.95 == total OK
+    - sum of TREE totals over ROOTS only (this function): $63,640.95 == total OK
+    - sum of TREE totals over ALL sessions (the naive fix): $71,718.15, +$8,077
+
+    Rolling children up while still listing them at top level inflates the table
+    by 12.7%. A per-session table whose rows do not add to the total printed
+    above them is a worse defect than the one being fixed, so children are
+    reachable only as sub-rows of the root that spawned them.
+
+    Guards, because the ledger contains real malformed edges: an edge to an
+    unknown session (a pruned parent) leaves the child a ROOT rather than
+    dropping it, so its dollars stay in the column; a self-parent edge is
+    ignored; and a cycle is broken by the depth cap plus a visited set, with any
+    session the walk never reached re-promoted to a root. Every input session
+    appears exactly once in the output, which is the property the sum rests on.
+    """
+    children_of: dict[str, list[str]] = {}
+    for child, parent in parents.items():
+        if child == parent or child not in by_session or parent not in by_session:
+            # An edge to a session with no rows in this window/scope is not an
+            # edge here: keeping it would hide the child under a parent that has
+            # no row to be indented beneath.
+            continue
+        children_of.setdefault(parent, []).append(child)
+
+    visited: set[str] = set()
+
+    def build(sid: str, depth: int) -> SessionNode:
+        visited.add(sid)
+        own = by_session[sid]
+        kids: list[SessionNode] = []
+        if depth < MAX_SESSION_TREE_DEPTH:
+            for child in sorted(children_of.get(sid, ())):
+                if child in visited:
+                    continue  # a cycle reaches an already-placed session
+                kids.append(build(child, depth + 1))
+        # Sum the counters (see ``sum_aggregates``) so a subtree mixing priced
+        # and unpriced calls keeps the right lower-bound / unknown marks.
+        total = sum_aggregates([own, *(kid.total for kid in kids)])
+        return SessionNode(
+            session_id=sid,
+            own=own,
+            total=total,
+            children=tuple(sorted(kids, key=_node_order, reverse=True)),
+        )
+
+    # A root is a session no surviving edge points at. ``children_of`` already
+    # dropped the edges whose parent is absent from this scope, so testing
+    # membership there is the same test and needs no second rule.
+    parented = {child for kids in children_of.values() for child in kids}
+    roots = [build(sid, 0) for sid in by_session if sid not in parented]
+    # Anything the descent never reached is part of a cycle whose every member
+    # claims a parent. Promote it to a root rather than dropping it: a hidden
+    # session is money missing from the column.
+    roots.extend(build(sid, 0) for sid in by_session if sid not in visited)
+    return sorted(roots, key=_node_order, reverse=True)
+
+
+def _node_order(node: SessionNode) -> tuple[int, int]:
+    """Sort key for the table: biggest SPEND first, tokens as the tiebreak.
+
+    Keyed on the TREE total, not own spend, because the tree total is the figure
+    the row shows and a table sorted by a number it does not display reads as
+    unsorted. Tokens break the tie so an unpriced group still orders sensibly
+    instead of collapsing into one $0 bucket \u2014 the same rule ``_group_section``
+    already applies to the flat table.
+    """
+    return (node.total.cost_micro, node.total.total_tokens)
+
+
 @dataclass(frozen=True)
 class TimingSummary:
     """Observed logical-request timing; absent samples are never zero latency."""
@@ -528,9 +671,22 @@ class SessionRequest:
 class SessionReport:
     """One consistent exact-ID ledger snapshot, not a transcript-derived bill.
 
-    No child IDs or copied fork history are joined. A resumed ID sees its
-    retained rows; queued recorder writes and pruned history cannot be recovered.
-    ``available=False`` is distinct from an available report with zero calls.
+    Every field EXCEPT ``descendants_aggregate``/``descendant_ids`` is scoped to
+    the exact ID: no copied fork history is joined, a resumed ID sees its
+    retained rows, and queued recorder writes and pruned history cannot be
+    recovered. ``available=False`` is distinct from an available report with
+    zero calls.
+
+    The two descendant fields are the ONE deliberate exception, and the reason
+    the scoping sentence above is per-field rather than blanket: a session that
+    spawned subagents spent money through them, and a report that answers "what
+    has this session cost me" with the own-scope figure alone understates it by
+    whatever the children burned (measured: $31.28 own vs $102.34 tree on a
+    real session). The DIAGNOSTIC sections stay own-scope on purpose — by_model,
+    by_purpose and the timings answer "where did MY context go", and folding a
+    child's model mix into them would corrupt a reading that is currently
+    correct. Only the Totals block reads the subtree, and ``/session`` labels
+    that asymmetry on screen.
     """
 
     session_id: str
@@ -551,6 +707,34 @@ class SessionReport:
     recent: tuple[SessionRequest, ...] = ()
     first_ts_ms: int | None = None
     last_ts_ms: int | None = None
+    #: Everything this session's SUBAGENTS spent, at any depth — own scope
+    #: excluded, so ``aggregate + descendants_aggregate`` is the tree and the
+    #: two never double-count. ``None`` means the walk could not run (an older
+    #: ledger with no ``parent_session_id`` column), which is distinct from a
+    #: zeroed aggregate meaning "walked, and this session has no children":
+    #: the first must not be rendered as "$0.00 subagents".
+    descendants_aggregate: UsageAggregate | None = None
+    #: The descendant session IDs the walk reached, nearest-first. Carried so a
+    #: caller can say "20 subagents" without a second query, and so a test can
+    #: assert the walk's REACH rather than only its sums.
+    descendant_ids: tuple[str, ...] = ()
+
+    @property
+    def subtree_aggregate(self) -> UsageAggregate:
+        """Own spend plus every descendant's: the "what did this cost me" total.
+
+        Falls back to the own aggregate when the descendant walk was
+        unavailable, so a caller always gets a number that is true — just, in
+        that case, a narrower one.
+        """
+        if self.descendants_aggregate is None:
+            return self.aggregate
+        return sum_aggregates((self.aggregate, self.descendants_aggregate))
+
+    @property
+    def has_descendants(self) -> bool:
+        """Whether a subagent breakdown is worth drawing at all."""
+        return bool(self.descendant_ids)
 
 
 @dataclass(frozen=True)

--- a/local_operator/analytics/store.py
+++ b/local_operator/analytics/store.py
@@ -278,6 +278,29 @@ _MIGRATION_COLUMNS: tuple[tuple[str, str], ...] = (
     ("usage_reported", "INTEGER NOT NULL DEFAULT 1"),
 )
 
+#: Indexes over OPTIONAL columns, created after ``_migrate`` rather than in
+#: ``_SCHEMA``. They cannot live in the schema script: ``executescript`` runs it
+#: as one unit BEFORE the ALTERs, so on a ledger written by a release that
+#: predates the column, ``CREATE INDEX ... ON calls(parent_session_id)`` raises
+#: "no such column" and aborts the REST of the script — losing the rollup tables
+#: and latching ``_broken`` for the process. Verified against a pre-column DB.
+#:
+#: ``idx_calls_parent`` is load-bearing for the subagent rollup: without it a
+#: recursive subtree walk is a full scan (measured 154 ms on a 475k-row ledger
+#: vs 1.03 ms with it), which is the difference between a viable ``/session``
+#: tree total and an unviable one. It is NOT free: building it over an existing
+#: 475k-row ledger costs a ONE-TIME ~677 ms stall on the first open after
+#: upgrade and ~4.9 MB of file growth (82.2 -> 87.1 MB). That stall lands on
+#: the recorder's background thread in the normal path, and buys every later
+#: report a two-orders-of-magnitude faster walk, so it is paid once and
+#: deliberately.
+_OPTIONAL_INDEXES: tuple[tuple[str, str], ...] = (
+    (
+        "parent_session_id",
+        "CREATE INDEX IF NOT EXISTS idx_calls_parent ON calls(parent_session_id)",
+    ),
+)
+
 #: The names in ``_MIGRATION_COLUMNS`` as a set, for the "is this column optional
 #: (i.e. possibly absent on an old DB)?" test. A column NOT in here — the base
 #: token columns and the original eight ``c_*`` components — is present on every
@@ -661,6 +684,25 @@ class AnalyticsStore:
             name for name, _ in _MIGRATION_COLUMNS if name in existing
         )
         self._rebuild_insert_plan()
+        self._create_optional_indexes(conn, existing)
+
+    @staticmethod
+    def _create_optional_indexes(conn: sqlite3.Connection, existing: set[str]) -> None:
+        """Index the optional columns that this DB actually has.
+
+        Runs AFTER the ALTERs so the column is guaranteed present; see
+        ``_OPTIONAL_INDEXES`` for why this cannot be part of ``_SCHEMA``. Each
+        statement is guarded on its own so one failure (a read-only file, a
+        disk-full during the ~677 ms build) costs its index and nothing else —
+        analytics degrades to the slower scan rather than failing to open.
+        """
+        for column, statement in _OPTIONAL_INDEXES:
+            if column not in existing:
+                continue
+            try:
+                conn.execute(statement)
+            except Exception:  # noqa: BLE001 — a missing index is slow, not broken
+                logger.debug("analytics: could not create index on %s", column, exc_info=True)
 
     def _rebuild_insert_plan(self) -> None:
         """Recompute the insert SQL + value selector from ``_present_optional``.
@@ -967,8 +1009,16 @@ class AnalyticsStore:
                 "GROUP BY provider",
                 params,
             ).fetchall()
+            # ``MAX(parent_session_id)`` rides the GROUP BY the query already
+            # computes rather than costing a second pass: it is EXACT here, not
+            # a heuristic, because parent is functionally dependent on session
+            # (verified: zero sessions carry more than one distinct parent).
+            # Measured +6 ms on 475k rows, against +58 ms for a global recursive
+            # CTE and 610 ms (vs 290) for widening the GROUP BY to two columns,
+            # which forces a temp B-tree for identical output.
+            parent_col = "MAX(parent_session_id)" if self._has_parent_column() else "''"
             per_session = conn.execute(
-                f"SELECT session_id, {base_cols}, {component_sum} FROM calls{clause} "
+                f"SELECT session_id, {parent_col}, {base_cols}, {component_sum} FROM calls{clause} "
                 "GROUP BY session_id",
                 params,
             ).fetchall()
@@ -988,20 +1038,47 @@ class AnalyticsStore:
         result.by_provider = {
             str(row[0]): _aggregate_from_row(row[1:]) for row in per_provider if row[0]
         }
+        parents: dict[str, str] = {}
         for row in per_session:
             sid = str(row[0])
-            agg = _aggregate_from_row(row[1:])
+            parent = str(row[1] or "")
+            agg = _aggregate_from_row(row[2:])
             # Stash the human name (when known) on the id key's aggregate via a
             # side map the caller reads; kept on the object would widen the
             # dataclass for one table, so the report reads names from here.
             result.by_session[sid] = agg
+            # Reject the self-parent edge (224 such rows exist, from a
+            # degenerate empty id) here, at the single point the edge enters the
+            # rollup, so no downstream walk has to know about it.
+            if parent and parent != sid:
+                parents[sid] = parent
         # Attach names as an attribute the report layer reads without widening
         # the dataclass contract used elsewhere.
         result_session_names: dict[str, str] = {
             sid: names.get(sid, "") for sid in result.by_session
         }
         setattr(result, "session_names", result_session_names)
+        # The parent edges the /analytics table re-partitions itself with. Same
+        # side-map convention as ``session_names`` and for the same reason: one
+        # table's structure is not worth widening a dataclass three other
+        # consumers (including the desktop HTTP route) also read.
+        #
+        # WINDOW RULE: ``since_ms``/``until_ms`` filter CALLS, then the rollup
+        # runs over whatever survived. A child's calls can fall outside a window
+        # containing its parent's; any other rule makes the per-session column
+        # stop summing to the headline total, which is the invariant this whole
+        # re-partition exists to protect.
+        setattr(result, "session_parents", parents)
         return result
+
+    def _has_parent_column(self) -> bool:
+        """Whether this DB carries ``parent_session_id`` (absent on old ledgers).
+
+        Reads the migration's own record rather than re-inspecting the schema:
+        an absent column must degrade to "no edges, every session is a root",
+        which renders exactly today's flat table.
+        """
+        return "parent_session_id" in self._present_optional
 
     def session_report(self, session_id: str, *, recent_limit: int = 12) -> SessionReport:
         """Read one exact session ID without creating, migrating or pricing data.
@@ -1125,9 +1202,14 @@ class AnalyticsStore:
                     (*params, max(0, min(int(recent_limit), 50))),
                 )
             )
+            descendants, descendant_ids = self._descendant_usage(
+                conn, session_id, columns, measures
+            )
             return SessionReport(
                 session_id=session_id,
                 aggregate=aggregate,
+                descendants_aggregate=descendants,
+                descendant_ids=descendant_ids,
                 by_model=by_model,
                 by_purpose=by_purpose,
                 by_purpose_outcome=groups,
@@ -1144,6 +1226,87 @@ class AnalyticsStore:
         finally:
             if conn is not None:
                 conn.close()
+
+    #: How deep a session tree is walked before the walk stops. The ledger's
+    #: tree is one level today (33 parents, 467 children, zero sessions that are
+    #: both), but depth is a property of USAGE, not of schema: a subagent that
+    #: launches its own subagent is stamped with the middle session as parent by
+    #: ``SessionStreamFn.fork``, and ``AsyncJobManager`` already carries the
+    #: ``child_jobs``/``descendant_usage`` machinery for it. So the walk is
+    #: recursive, and this is the backstop that keeps a malformed or cyclic
+    #: ledger from turning a report into a hang. 32 is far past any real nesting.
+    _MAX_TREE_DEPTH = 32
+
+    def _descendant_usage(
+        self,
+        conn: sqlite3.Connection,
+        session_id: str,
+        columns: set[str],
+        measures: str,
+    ) -> tuple[UsageAggregate | None, tuple[str, ...]]:
+        """Sum every DESCENDANT session's usage, own scope excluded.
+
+        Returns ``(None, ())`` when the walk cannot run \u2014 an older ledger with
+        no ``parent_session_id`` column \u2014 which the report renders as "unknown"
+        rather than as "$0.00 of subagent spend". Runs on the caller's pinned
+        read transaction so the subtree and the own scope describe the same WAL
+        snapshot.
+
+        A recursive CTE descending through ``idx_calls_parent`` rather than a
+        Python level-by-level descent: the Python version measures marginally
+        faster (0.71 ms vs 1.03 ms) but costs N+1 round trips and gives up the
+        single pinned snapshot this method exists to maintain. Without the index
+        it is a full scan per level (154 ms) \u2014 see ``_OPTIONAL_INDEXES``.
+
+        Two guards, because the ledger contains a real cycle edge (224 rows
+        carry ``parent_session_id == session_id``, all from a degenerate empty
+        id):
+
+        1. The edge predicate rejects a row that is its own parent and a child
+           id that is empty, so a self-loop is never traversed.
+        2. ``depth < _MAX_TREE_DEPTH`` bounds the walk whatever the data does,
+           and the final ``DISTINCT`` plus the root exclusion mean a cycle that
+           re-reaches an already-visited session cannot double-count it.
+
+        Note on retention: ``prune`` deletes by ``ts_ms``, so a root whose
+        children aged out first reports a smaller subtree than it really spent.
+        Parent and child age out together in practice; a shrinking figure here
+        is retention, not a rollup bug.
+        """
+        if "parent_session_id" not in columns or not session_id:
+            return None, ()
+        # Depth rides in the recursive row purely to arm the cap; the final
+        # SELECT dedupes on the id alone, so a diamond or a cycle contributes
+        # its calls exactly once however many paths reach it.
+        walk = (
+            "WITH RECURSIVE tree(sid, depth) AS ("
+            "  SELECT ?, 0"
+            "  UNION"
+            "  SELECT c.session_id, t.depth + 1 FROM calls c JOIN tree t"
+            "    ON c.parent_session_id = t.sid"
+            "   WHERE t.depth < ? AND c.session_id <> '' AND c.session_id <> c.parent_session_id"
+            ")"
+            " SELECT DISTINCT sid FROM tree WHERE sid <> ?"
+        )
+        try:
+            rows = conn.execute(walk, (session_id, self._MAX_TREE_DEPTH, session_id)).fetchall()
+        except Exception:  # noqa: BLE001 \u2014 a failed walk is unknown, not zero
+            logger.debug("analytics: descendant walk failed", exc_info=True)
+            return None, ()
+        ids = tuple(str(row[0]) for row in rows if row[0])
+        if not ids:
+            return UsageAggregate(), ()
+        # Bind the ids rather than interpolating: they are ledger-sourced, and a
+        # bounded IN list keeps this one statement on the same snapshot.
+        placeholders = ", ".join("?" for _ in ids)
+        try:
+            row = conn.execute(
+                f"SELECT {measures} FROM calls WHERE session_id IN ({placeholders})", ids
+            ).fetchone()
+        except Exception:  # noqa: BLE001
+            logger.debug("analytics: descendant aggregate failed", exc_info=True)
+            return None, ()
+        return _aggregate_from_row(row), ids
 
     # -- rollup reads (calendar time series) ---------------------------------
     def _series(self, table: str, key: str, buckets: int, *, by_model: bool) -> list[UsagePeriod]:

--- a/local_operator/analytics/store.py
+++ b/local_operator/analytics/store.py
@@ -301,6 +301,34 @@ _OPTIONAL_INDEXES: tuple[tuple[str, str], ...] = (
     ),
 )
 
+#: THE parent-edge rule, as one SQL expression, used by every surface that
+#: derives session parentage. It exists as a single constant because the two
+#: surfaces previously encoded DIFFERENT rules and could therefore disagree
+#: about the same session — which is the exact defect this whole rollup was
+#: written to eliminate, so letting it back in through two spellings of
+#: "who is the parent" would be self-defeating (review F1).
+#:
+#: Read it inside-out. ``NULLIF(parent_session_id, '')`` discards the "no
+#: parent" sentinel (the column is ``NOT NULL DEFAULT ''``); the outer
+#: ``NULLIF(..., session_id)`` discards a SELF edge, of which the ledger holds
+#: 224 real rows from a degenerate empty id. Both must be discarded BEFORE the
+#: ``MAX``, not after it: a plain ``MAX(parent_session_id)`` over a session that
+#: has both a real parent and a self row returns whichever id sorts larger, so a
+#: real edge is lost whenever the session's own id happens to sort above its
+#: parent's. That is a lexical coin-flip, not a rule.
+#:
+#: ``MAX`` still picks one parent when a session genuinely carries rows under
+#: two different parents. That is a deliberate, DOCUMENTED tie-break rather than
+#: an oversight: the per-session table must keep summing to the headline total
+#: printed above it, and a child credited to two parents is counted twice. The
+#: ledger has zero such sessions today (verified), and both surfaces now resolve
+#: the tie identically, which is the property that matters — they agree.
+#:
+#: Measured on the 475k-row ledger: this expression costs 201 ms against 191 ms
+#: for the bare ``MAX`` in ``aggregate``'s existing GROUP BY (~10 ms, on a
+#: worker thread), and yields the identical 467 edges on today's data.
+_PARENT_EDGE_SQL = "MAX(NULLIF(NULLIF(parent_session_id, ''), session_id))"
+
 #: The names in ``_MIGRATION_COLUMNS`` as a set, for the "is this column optional
 #: (i.e. possibly absent on an old DB)?" test. A column NOT in here — the base
 #: token columns and the original eight ``c_*`` components — is present on every
@@ -1009,14 +1037,15 @@ class AnalyticsStore:
                 "GROUP BY provider",
                 params,
             ).fetchall()
-            # ``MAX(parent_session_id)`` rides the GROUP BY the query already
-            # computes rather than costing a second pass: it is EXACT here, not
-            # a heuristic, because parent is functionally dependent on session
-            # (verified: zero sessions carry more than one distinct parent).
-            # Measured +6 ms on 475k rows, against +58 ms for a global recursive
-            # CTE and 610 ms (vs 290) for widening the GROUP BY to two columns,
-            # which forces a temp B-tree for identical output.
-            parent_col = "MAX(parent_session_id)" if self._has_parent_column() else "''"
+            # The edge rides the GROUP BY the query already computes rather than
+            # costing a second pass. ``_PARENT_EDGE_SQL`` is THE rule, shared
+            # verbatim with the ``/session`` subtree walk
+            # (``_canonical_parents``) so the two surfaces cannot drift into
+            # disagreeing about who a session's parent is (review F1). Measured
+            # +6 ms on 475k rows, against +58 ms for a global recursive CTE and
+            # 610 ms (vs 290) for widening the GROUP BY to two columns, which
+            # forces a temp B-tree for identical output.
+            parent_col = _PARENT_EDGE_SQL if self._has_parent_column() else "''"
             per_session = conn.execute(
                 f"SELECT session_id, {parent_col}, {base_cols}, {component_sum} FROM calls{clause} "
                 "GROUP BY session_id",
@@ -1047,9 +1076,12 @@ class AnalyticsStore:
             # side map the caller reads; kept on the object would widen the
             # dataclass for one table, so the report reads names from here.
             result.by_session[sid] = agg
-            # Reject the self-parent edge (224 such rows exist, from a
-            # degenerate empty id) here, at the single point the edge enters the
-            # rollup, so no downstream walk has to know about it.
+            # ``_PARENT_EDGE_SQL`` already discarded the empty and self edges in
+            # SQL, before the MAX. The ``parent != sid`` test is kept as a cheap
+            # belt-and-braces for the ``''`` fallback branch above (an old ledger
+            # with no parent column), NOT as the self-edge rule — doing it here
+            # rather than in SQL is precisely what lost a real edge to a lexical
+            # tie-break before review F1.
             if parent and parent != sid:
                 parents[sid] = parent
         # Attach names as an attribute the report layer reads without widening
@@ -1062,6 +1094,18 @@ class AnalyticsStore:
         # side-map convention as ``session_names`` and for the same reason: one
         # table's structure is not worth widening a dataclass three other
         # consumers (including the desktop HTTP route) also read.
+        #
+        # DESKTOP ROUTE, DELIBERATELY FLAT (review F4): because this is a side
+        # attribute, ``dataclasses.asdict`` drops it, so ``/v1/desktop/analytics``
+        # keeps serving OWN per-session figures while the TUI shows tree totals.
+        # That is the intended split, not an oversight — the HTTP route is a raw
+        # per-session data feed whose consumers do their own grouping, and the
+        # rollup is a presentation choice made by the screen that can also draw
+        # the indented children explaining it. Rolling up in the payload would
+        # give clients a column that no longer sums to the total they are also
+        # served, with nothing on the wire to say why. A client wanting the tree
+        # should be given the edges explicitly (a new, versioned field), not a
+        # silently re-scoped existing one.
         #
         # WINDOW RULE: ``since_ms``/``until_ms`` filter CALLS, then the rollup
         # runs over whatever survived. A child's calls can fall outside a window
@@ -1235,7 +1279,49 @@ class AnalyticsStore:
     #: ``child_jobs``/``descendant_usage`` machinery for it. So the walk is
     #: recursive, and this is the backstop that keeps a malformed or cyclic
     #: ledger from turning a report into a hang. 32 is far past any real nesting.
+    #:
+    #: ANCHOR (review F2): this cap counts levels from the QUERIED session, while
+    #: ``model.MAX_SESSION_TREE_DEPTH`` counts them from the forest ROOT. The two
+    #: therefore truncate different chains on a tree deeper than the cap, and a
+    #: mid-tree row can legitimately read differently on the two screens there.
+    #: This is not reconcilable without one of the surfaces walking a tree it has
+    #: no reason to build (``/session`` does not know its own root; ``/analytics``
+    #: does not know which session you are asking about), and it is unreachable
+    #: on real data — the ledger's maximum observed depth is 1, and zero sessions
+    #: are both a parent and a child. Recorded rather than fixed, so the next
+    #: reader does not mistake it for a rollup bug.
     _MAX_TREE_DEPTH = 32
+
+    def _canonical_parents(
+        self, conn: sqlite3.Connection, session_ids: Sequence[str]
+    ) -> dict[str, str]:
+        """The canonical parent of each given session, by the ONE shared rule.
+
+        Resolves ``_PARENT_EDGE_SQL`` — the same expression ``aggregate`` puts in
+        its per-session GROUP BY — for a bounded set of ids, so the ``/session``
+        subtree walk and the ``/analytics`` table answer "who is this session's
+        parent" identically. Before review F1 the walk filtered per ROW ("any row
+        claims this edge") while the aggregate took a lexical ``MAX``, and the
+        two disagreed on any session carrying more than one distinct parent
+        value.
+
+        Chunked at 500 ids: SQLite's default host-parameter limit is 999, and a
+        subtree level can be arbitrarily wide (the widest real fan-out is 46).
+        """
+        parents: dict[str, str] = {}
+        ids = [sid for sid in session_ids if sid]
+        for start in range(0, len(ids), 500):
+            chunk = ids[start : start + 500]
+            placeholders = ", ".join("?" for _ in chunk)
+            rows = conn.execute(
+                f"SELECT session_id, {_PARENT_EDGE_SQL} FROM calls "
+                f"WHERE session_id IN ({placeholders}) GROUP BY session_id",
+                chunk,
+            ).fetchall()
+            for sid, parent in rows:
+                if parent:
+                    parents[str(sid)] = str(parent)
+        return parents
 
     def _descendant_usage(
         self,
@@ -1246,27 +1332,40 @@ class AnalyticsStore:
     ) -> tuple[UsageAggregate | None, tuple[str, ...]]:
         """Sum every DESCENDANT session's usage, own scope excluded.
 
-        Returns ``(None, ())`` when the walk cannot run \u2014 an older ledger with
-        no ``parent_session_id`` column \u2014 which the report renders as "unknown"
+        Returns ``(None, ())`` when the walk cannot run — an older ledger with
+        no ``parent_session_id`` column — which the report renders as "unknown"
         rather than as "$0.00 of subagent spend". Runs on the caller's pinned
         read transaction so the subtree and the own scope describe the same WAL
         snapshot.
 
-        A recursive CTE descending through ``idx_calls_parent`` rather than a
-        Python level-by-level descent: the Python version measures marginally
-        faster (0.71 ms vs 1.03 ms) but costs N+1 round trips and gives up the
-        single pinned snapshot this method exists to maintain. Without the index
-        it is a full scan per level (154 ms) \u2014 see ``_OPTIONAL_INDEXES``.
+        A level-by-level descent on the caller's pinned transaction, NOT the
+        recursive CTE this originally used. The CTE could only apply the shared
+        edge rule as a correlated scalar subquery re-evaluated per candidate row,
+        which measured 620 ms on the widest real fan-out (46 children) against
+        6.7 ms for this descent — and expressing the rule as an ``edges``
+        CTE instead costs a full 196 ms scan of ``calls``. Each level is two
+        indexed statements on the SAME pinned transaction, so the single-snapshot
+        property the CTE was chosen for is preserved. Measured end to end on the
+        475k-row ledger: 0.87 ms for the reported session, 6.7 ms worst case.
+        Without ``idx_calls_parent`` each level is a full scan — see
+        ``_OPTIONAL_INDEXES``.
 
-        Two guards, because the ledger contains a real cycle edge (224 rows
+        Three guards, because the ledger contains a real cycle edge (224 rows
         carry ``parent_session_id == session_id``, all from a degenerate empty
         id):
 
-        1. The edge predicate rejects a row that is its own parent and a child
-           id that is empty, so a self-loop is never traversed.
-        2. ``depth < _MAX_TREE_DEPTH`` bounds the walk whatever the data does,
-           and the final ``DISTINCT`` plus the root exclusion mean a cycle that
-           re-reaches an already-visited session cannot double-count it.
+        1. A candidate is kept only when its CANONICAL parent (the one shared
+           rule, ``_canonical_parents``) is the node currently being expanded.
+           This is what makes the walk agree with ``/analytics`` by construction
+           rather than by coincidence: a session whose rows merely mention this
+           node, but whose canonical parent is some other session, is not a child
+           here — and the aggregate would not have drawn that edge
+           either (review F1). It also subsumes the old self-edge predicate,
+           since the rule discards a self parent in SQL, before the MAX.
+        2. ``visited`` means a cycle that re-reaches an already-counted session
+           stops there, so no session contributes its calls twice.
+        3. ``depth < _MAX_TREE_DEPTH`` bounds the walk whatever the data does.
+           See that constant for why its anchor differs from the forest's.
 
         Note on retention: ``prune`` deletes by ``ts_ms``, so a root whose
         children aged out first reports a smaller subtree than it really spent.
@@ -1275,25 +1374,39 @@ class AnalyticsStore:
         """
         if "parent_session_id" not in columns or not session_id:
             return None, ()
-        # Depth rides in the recursive row purely to arm the cap; the final
-        # SELECT dedupes on the id alone, so a diamond or a cycle contributes
-        # its calls exactly once however many paths reach it.
-        walk = (
-            "WITH RECURSIVE tree(sid, depth) AS ("
-            "  SELECT ?, 0"
-            "  UNION"
-            "  SELECT c.session_id, t.depth + 1 FROM calls c JOIN tree t"
-            "    ON c.parent_session_id = t.sid"
-            "   WHERE t.depth < ? AND c.session_id <> '' AND c.session_id <> c.parent_session_id"
-            ")"
-            " SELECT DISTINCT sid FROM tree WHERE sid <> ?"
-        )
         try:
-            rows = conn.execute(walk, (session_id, self._MAX_TREE_DEPTH, session_id)).fetchall()
-        except Exception:  # noqa: BLE001 \u2014 a failed walk is unknown, not zero
+            found: list[str] = []
+            visited: set[str] = {session_id}
+            frontier: set[str] = {session_id}
+            depth = 0
+            while frontier and depth < self._MAX_TREE_DEPTH:
+                placeholders = ", ".join("?" for _ in frontier)
+                # Every session carrying a row that POINTS AT this level: an
+                # index seek on idx_calls_parent. Which of those mentions is
+                # actually an edge is decided by the canonical rule below.
+                candidates = {
+                    str(row[0])
+                    for row in conn.execute(
+                        "SELECT DISTINCT session_id FROM calls "
+                        f"WHERE parent_session_id IN ({placeholders})",
+                        sorted(frontier),
+                    )
+                    if row[0]
+                } - visited
+                if not candidates:
+                    break
+                edges = self._canonical_parents(conn, sorted(candidates))
+                nxt = {sid for sid in candidates if edges.get(sid) in frontier}
+                if not nxt:
+                    break
+                visited |= nxt
+                found.extend(sorted(nxt))
+                frontier = nxt
+                depth += 1
+        except Exception:  # noqa: BLE001 — a failed walk is unknown, not zero
             logger.debug("analytics: descendant walk failed", exc_info=True)
             return None, ()
-        ids = tuple(str(row[0]) for row in rows if row[0])
+        ids = tuple(found)
         if not ids:
             return UsageAggregate(), ()
         # Bind the ids rather than interpolating: they are ledger-sourced, and a

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -19589,6 +19589,8 @@ class OperatorApp(App[None]):
 
     def _cmd_session(self, arg: str, notice: NoticeFn) -> None:
         """Read only this session's ledger; never interpret arguments as a prompt."""
+        import dataclasses
+
         from local_operator.tui.widgets.session_panel import (
             SessionDiagnostics,
             SessionScreen,
@@ -19607,6 +19609,11 @@ class OperatorApp(App[None]):
         # or /resume during the disk read must not put an old bill over a new
         # conversation. Object identity also catches resuming the same ID.
         runtime = SessionDiagnostics.capture(session)
+        # The band's restored-floor state is APP state, not session state, so it
+        # is attached here rather than read inside capture(). /session reconciles
+        # the band's ≥ against the ledger figure in prose; see the field's own
+        # note for why the two marks stay separate.
+        runtime = dataclasses.replace(runtime, spend_is_floor=self._spend_is_floor)
         # Own a visible, cancellable surface before starting IO. A late disk
         # result must update this surface, never push over a user's new draft.
         screen = SessionScreen(None, runtime)

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -19589,7 +19589,6 @@ class OperatorApp(App[None]):
 
     def _cmd_session(self, arg: str, notice: NoticeFn) -> None:
         """Read only this session's ledger; never interpret arguments as a prompt."""
-        import dataclasses
 
         from local_operator.tui.widgets.session_panel import (
             SessionDiagnostics,
@@ -19613,7 +19612,7 @@ class OperatorApp(App[None]):
         # is attached here rather than read inside capture(). /session reconciles
         # the band's ≥ against the ledger figure in prose; see the field's own
         # note for why the two marks stay separate.
-        runtime = dataclasses.replace(runtime, spend_is_floor=self._spend_is_floor)
+        runtime = replace(runtime, spend_is_floor=self._spend_is_floor)
         # Own a visible, cancellable surface before starting IO. A late disk
         # result must update this surface, never push over a user's new draft.
         screen = SessionScreen(None, runtime)

--- a/local_operator/tui/widgets/analytics_panel.py
+++ b/local_operator/tui/widgets/analytics_panel.py
@@ -180,7 +180,9 @@ def scope_needs_cost_legend(scope: "_CostLike") -> bool:
     return (scope.cost_is_partial and scope.cost_is_known) or not scope.cost_is_known
 
 
-def _needs_cost_legend(aggregate: "UsageAggregate") -> bool:
+def _needs_cost_legend(
+    aggregate: "UsageAggregate", forest: list["SessionNode"] | None = None
+) -> bool:
     """Whether any scope on screen shows a ``+`` (partial) or ``$—`` (unknown).
 
     The legend is drawn only when a mark actually appears — a fully-priced run
@@ -191,10 +193,17 @@ def _needs_cost_legend(aggregate: "UsageAggregate") -> bool:
     ``by_session`` covers the nested table's rows too — a row renders its
     subtree TOTAL, which can carry a ``+`` no individual session shows, so the
     rolled-up scopes are added rather than relying on their parts.
+
+    ``forest`` is the one ``build_report`` already built. Pass it: building a
+    second identical forest measured 3.1 ms against 16.9 ms for the whole report
+    (~18% of it, review F3), and two independent constructions of the structure
+    the table's correctness rests on can disagree. Defaulted for the callers
+    (tests, the desktop route) that have only an aggregate.
     """
-    forest = build_session_forest(
-        aggregate.by_session, getattr(aggregate, "session_parents", {}) or {}
-    )
+    if forest is None:
+        forest = build_session_forest(
+            aggregate.by_session, getattr(aggregate, "session_parents", {}) or {}
+        )
     scopes = [
         aggregate,
         *aggregate.by_provider.values(),
@@ -765,7 +774,7 @@ def build_report(
 
     # Legend for the cost markers, drawn only when a ``+`` or ``$—`` is on
     # screen (review D1). ``dim`` so it reads as a footnote, not a row.
-    if _needs_cost_legend(aggregate):
+    if _needs_cost_legend(aggregate, forest):
         lines.append(Text())
         legend = Text()
         legend.append("  " + COST_LEGEND, style=dim)
@@ -802,13 +811,20 @@ def _forest_rows(
     same here as anywhere else. In practice no child session carries a human
     name, so children render as bare 12-hex ids — which is exactly the noise
     this arrangement moves off the top level.
+
+    A child also carries a ``└`` glyph, not just the indent and the dim style
+    (design D4). 21% of ROOTS are themselves unnamed 12-hex ids, so an unnamed
+    root and a child differ by two leading spaces and a colour — and colour is
+    the cue that disappears under ``NO_COLOR``, a weak-dim theme, or low vision.
+    The glyph makes the hierarchy survive without it. ``/session``'s Tool
+    surface section already uses ``└`` for exactly this, so this is the
+    codebase's existing vocabulary rather than a new one.
     """
     rows: list[tuple[str, int, "UsageAggregate"]] = []
 
     def walk(node: "SessionNode", depth: int) -> None:
-        label = " " * (depth * _NEST_INDENT) + short_session_label(
-            node.session_id, names.get(node.session_id, "")
-        )
+        prefix = " " * ((depth - 1) * _NEST_INDENT) + "└ " if depth else ""
+        label = prefix + short_session_label(node.session_id, names.get(node.session_id, ""))
         rows.append((label, depth, node.total))
         for child in node.children:
             walk(child, depth + 1)

--- a/local_operator/tui/widgets/analytics_panel.py
+++ b/local_operator/tui/widgets/analytics_panel.py
@@ -29,7 +29,7 @@ it is the right way to pin what the screen SAYS.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Mapping, Protocol
 
 from rich.style import Style
 from rich.text import Text
@@ -42,8 +42,10 @@ from textual.widgets import Static
 from local_operator.analytics.model import (
     COMPONENT_KEYS,
     COMPONENT_LABELS,
+    SessionNode,
     UsageAggregate,
     UsagePeriod,
+    build_session_forest,
     short_session_label,
 )
 from local_operator.tui import theme as theme_mod
@@ -184,9 +186,29 @@ def _needs_cost_legend(aggregate: "UsageAggregate") -> bool:
     The legend is drawn only when a mark actually appears — a fully-priced run
     needs no explaining, and a footnote for a symbol that is not on screen is
     noise.
+
+    INVARIANT: this must name every scope from which a ``$`` figure is drawn.
+    ``by_session`` covers the nested table's rows too — a row renders its
+    subtree TOTAL, which can carry a ``+`` no individual session shows, so the
+    rolled-up scopes are added rather than relying on their parts.
     """
-    scopes = [aggregate, *aggregate.by_provider.values(), *aggregate.by_session.values()]
+    forest = build_session_forest(
+        aggregate.by_session, getattr(aggregate, "session_parents", {}) or {}
+    )
+    scopes = [
+        aggregate,
+        *aggregate.by_provider.values(),
+        *aggregate.by_session.values(),
+        *(node.total for node in _iter_nodes(forest)),
+    ]
     return any(scope_needs_cost_legend(s) for s in scopes)
+
+
+def _iter_nodes(forest: list["SessionNode"]):
+    """Every node in the forest, roots and nested children alike."""
+    for node in forest:
+        yield node
+        yield from _iter_nodes(list(node.children))
 
 
 def proportion_bar(fraction: float, width: int) -> str:
@@ -711,11 +733,17 @@ def build_report(
     # frame the shared column is allowed to grow (review D3) so the extra width
     # widens the content rather than leaving a dead right gutter.
     names = getattr(aggregate, "session_names", {}) or {}
-    session_labelled = {
-        short_session_label(sid, names.get(sid, "")): agg
-        for sid, agg in aggregate.by_session.items()
-    }
-    all_names = [n for n in aggregate.by_provider] + [n for n in session_labelled]
+    # ROOTS carry their subtree's total and children hang beneath them, rather
+    # than every session being listed flat with its own spend. This is the only
+    # arrangement that both credits a parent with what its subagents spent AND
+    # keeps this column summing to the headline total above it: rolling up while
+    # still listing children at top level inflates the table by $8,077 (12.7%)
+    # on the operator's ledger. See ``build_session_forest``.
+    forest = build_session_forest(
+        aggregate.by_session, getattr(aggregate, "session_parents", {}) or {}
+    )
+    session_rows = _forest_rows(forest, names)
+    all_names = [n for n in aggregate.by_provider] + [label for label, _, _ in session_rows]
     if all_names:
         # Grow the name column with the frame: a wide card gets a roomier column
         # (up to 48) so its width is used; a narrow one stays compact (30).
@@ -728,8 +756,12 @@ def build_report(
         lines.append(_group_section("By provider", aggregate.by_provider, width, name_col))
         lines.append(Text())
 
-    if session_labelled:
-        lines.append(_group_section("By session", session_labelled, width, name_col))
+    if session_rows:
+        # Meta says the rollup happened, because a row whose figure exceeds its
+        # own spend must say why — and it is also what tells a reader the
+        # indented rows are already counted in the row above them.
+        meta = "totals include subagents" if any(depth for _, depth, _ in session_rows) else ""
+        lines.append(_session_section(session_rows, width, name_col, meta))
 
     # Legend for the cost markers, drawn only when a ``+`` or ``$—`` is on
     # screen (review D1). ``dim`` so it reads as a footnote, not a row.
@@ -748,6 +780,81 @@ def build_report(
 #: irreducible trio; cache is the first to shed, exactly like the status band's
 #: drop ladder.
 _WIDE_TABLE_MIN = 72
+
+
+#: One indent step per level of session nesting. Two cells: enough that a
+#: sub-row is unmistakably subordinate, small enough that it cannot be what
+#: pushes the table past ``_WIDE_TABLE_MIN`` and costs everyone the cache column.
+_NEST_INDENT = 2
+
+
+def _forest_rows(
+    forest: list["SessionNode"], names: Mapping[str, str]
+) -> list[tuple[str, int, "UsageAggregate"]]:
+    """Flatten the session forest to ``(label, depth, aggregate)`` rows.
+
+    Depth-first so a child sits directly under its parent, and each row carries
+    the TREE total (own plus descendants) — the same figure its label is sorted
+    by. A child row's dollars are therefore already counted in its parent's, and
+    the section meta says so; only the ROOT rows sum to the table total.
+
+    Labels come from the shared ``short_session_label`` so a session reads the
+    same here as anywhere else. In practice no child session carries a human
+    name, so children render as bare 12-hex ids — which is exactly the noise
+    this arrangement moves off the top level.
+    """
+    rows: list[tuple[str, int, "UsageAggregate"]] = []
+
+    def walk(node: "SessionNode", depth: int) -> None:
+        label = " " * (depth * _NEST_INDENT) + short_session_label(
+            node.session_id, names.get(node.session_id, "")
+        )
+        rows.append((label, depth, node.total))
+        for child in node.children:
+            walk(child, depth + 1)
+
+    for root in forest:
+        walk(root, 0)
+    return rows
+
+
+def _session_section(
+    rows: list[tuple[str, int, "UsageAggregate"]],
+    width: int,
+    name_col: int,
+    meta: str = "",
+) -> Text:
+    """The per-session table, pre-ordered and pre-indented by the forest walk.
+
+    Deliberately NOT ``_group_section``: that one sorts its own rows, which
+    would scatter a subtree across the table and destroy the nesting the walk
+    just built. Everything else — the column layout, the ``_WIDE_TABLE_MIN``
+    cache shed, the dimmed lower-bound ``+`` — is identical, because the two
+    tables sit one above the other and must read as the same table.
+    """
+    fg = semantic_style("fg")
+    dim = semantic_style("dim")
+    block = section_header("By session", meta)
+    if not rows:
+        block.append("\n  (none)", style=dim)
+        return block
+
+    show_cache = width >= _WIDE_TABLE_MIN
+    cost_col = max(len(format_cost(agg)) for _, _, agg in rows)
+    for label, depth, agg in rows:
+        block.append("\n")
+        # A nested row is dimmed as well as indented: its dollars are already
+        # inside the root above it, so it must not compete visually with the
+        # rows that actually partition the total.
+        style = fg if depth == 0 else dim
+        block.append(f"  {label:<{name_col}}", style=style)
+        block.append(f"{format_tokens(agg.total_tokens):>8} tokens", style=style)
+        block.append("   ")
+        append_cost(block, agg, cost_col, style, dim)
+        block.append(f"   {agg.calls:>4} calls", style=dim)
+        if show_cache:
+            block.append(f"   {format_percent(agg.cache_hit_rate):>4} cache", style=dim)
+    return block
 
 
 def _group_section(

--- a/local_operator/tui/widgets/session_panel.py
+++ b/local_operator/tui/widgets/session_panel.py
@@ -33,8 +33,10 @@ would attribute other sessions' spend to this one).
 
 from __future__ import annotations
 
+import textwrap
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Sequence
 
 from rich.text import Text
 from textual.app import ComposeResult
@@ -611,23 +613,61 @@ class _Body:
     def blank(self) -> None:
         self.lines.append(Text())
 
-    def kv(self, name: str, value: str, note: str = "") -> None:
-        """A Totals-style scalar row, matching ``build_report``'s ``kv`` exactly."""
+    def kv(self, name: str, value: str, note: str = "", *, notes: Sequence[str] = ()) -> None:
+        """A Totals-style scalar row, matching ``build_report``'s ``kv`` exactly.
+
+        ``notes`` is a ladder of progressively shorter spellings of the SAME
+        qualifier, widest first; the first one that fits the row uncropped is
+        drawn. It exists because the plain ``note`` path has exactly two
+        outcomes on a narrow frame and both are wrong for a load-bearing
+        qualifier: cropped mid-word above ``_NOTE_MIN``, or shed wholesale below
+        it (design D1 / QA Q1). A note that says WHICH QUESTION the value
+        answered is not sheddable chrome — dropping it leaves a correct figure
+        that looks like a wrong one, which is the defect this screen exists to
+        fix. Cropping a qualifier is fine; cropping the scope is not.
+
+        Callers with a purely decorative qualifier keep passing ``note`` and keep
+        the old shed-below-``_NOTE_MIN`` behaviour.
+        """
         row = Text()
         row.append(f"  {name:<22}", style=semantic_style("dim"))
         row.append(f"{value:<{_VALUE_CELL}}", style=semantic_style("fg"))
-        # Below _NOTE_MIN the qualifier is shed and the fact kept: at 50 columns
-        # the note wraps onto its own unindented line and reads as a new record.
-        if note and self.width >= _NOTE_MIN:
+        if notes:
+            # Budget measured from the row as actually built, not from a
+            # restated literal: a change to _VALUE_CELL or the label column
+            # cannot silently reintroduce the crop this ladder removes.
+            budget = self.width - row.cell_len - 2
+            for candidate in notes:
+                if len(candidate) <= budget:
+                    row.append(f"  {candidate}", style=semantic_style("dim"))
+                    break
+        elif note and self.width >= _NOTE_MIN:
+            # Below _NOTE_MIN the qualifier is shed and the fact kept: at 50
+            # columns the note wraps onto its own unindented line and reads as a
+            # new record.
             row.append(f"  {note}", style=semantic_style("dim"))
         row.truncate(self.width, overflow="crop")
         self.lines.append(row)
 
     def note(self, text: str) -> None:
-        """A dim footnote. Wrapped, not cropped — it is prose, not a table row."""
-        row = Text(overflow="fold")
-        row.append(f"  {text}", style=semantic_style("dim"))
-        self.lines.append(row)
+        """A dim footnote, wrapped — it is prose, not a table row.
+
+        Wrapped HERE, one emitted line per visual line, rather than handed to
+        the container's ``fold``: folding applies the ``"  "`` indent to the
+        first line only, so a continuation lands at column 0 and reads as a new
+        record in the middle of a block (design D2). The codebase already names
+        this failure mode in ``kv`` above and in ``header``; the panel sheds
+        columns elsewhere specifically to avoid it, so a footnote must not
+        reintroduce it. Indenting every line keeps a wrapped footnote visibly
+        subordinate to the block it belongs to.
+        """
+        # Guard the arithmetic rather than the caller: a pre-mount width can be
+        # small or absent, and textwrap raises on a non-positive width.
+        body_width = max(1, self.width - 2)
+        for line in textwrap.wrap(text, body_width) or [""]:
+            row = Text(no_wrap=True, overflow="crop")
+            row.append(f"  {line}", style=semantic_style("dim"))
+            self.lines.append(row)
 
     def header(self, title: str, meta: str = "", short: str = "") -> None:
         """A section header, shedding its meta to ``short`` on a narrow frame.
@@ -815,7 +855,14 @@ def _draw_recorded_usage(
     # session actually has subagents — on a childless session the two scopes are
     # identical and the distinction would be noise.
     scope = " · cost incl. subagents" if report.has_descendants else ""
-    body.header("Totals", meta + " · measured" + scope, meta)
+    # The scope rides the SHORT meta too, so a narrow frame sheds "measured"
+    # (a qualifier) and keeps "incl. subagents" (the scope). Before design D1
+    # the header's whole meta was replaced by ``meta`` below _NOTE_MIN, which
+    # dropped the scope label at exactly the widths where the Est. cost note had
+    # already gone — leaving a 70-column terminal with no statement anywhere
+    # that the figure covers subagents.
+    short = meta + (" · incl. subagents" if report.has_descendants else "")
+    body.header("Totals", meta + " · measured" + scope, short)
     body.kv(
         "Total billed",
         format_tokens(aggregate.total_tokens) + " tokens",
@@ -843,20 +890,40 @@ def _draw_recorded_usage(
     # verbatim when there are no children or the ledger could not be walked.
     subtree = report.subtree_aggregate
     if report.has_descendants:
-        note = (
-            f"{format_cost(aggregate)} own · "
-            f"{format_cost(report.descendants_aggregate or aggregate)} subagents"
+        own = format_cost(aggregate)
+        subs = format_cost(report.descendants_aggregate or aggregate)
+        # A LADDER of the same qualifier, widest first, because this note says
+        # which question the headline answered and must therefore never be
+        # cropped mid-word or shed wholesale (design D1 / QA Q1). The old single
+        # string needed a 66-cell card but ``_NOTE_MIN`` admitted it from 60, so
+        # 75-80 column terminals — including the canonical 80 — painted
+        # "$71.06 subagent", and below 75 the split vanished entirely, leaving a
+        # tree figure that looks like the own figure it replaced. Every rung
+        # still says the scope; the narrow ones trade the breakdown for it,
+        # which is the right thing to lose last.
+        body.kv(
+            "Est. cost",
+            format_cost(subtree),
+            notes=(
+                f"{own} own · {subs} subagents",
+                f"{own} + {subs} subagents",
+                "incl. subagents",
+            ),
+        )
+        # Kept under ~70 characters so it does not wrap at the common widths.
+        # The 103-character version wrapped at every width from 70 to ~128 and
+        # — because a folded continuation loses the body indent — dropped an
+        # orphan fragment at column 0 between the figure and the next section
+        # header, where it read as a stray row of the table (design D2).
+        # ``_Body.note`` now indents continuations too, so this is belt and
+        # braces: short enough not to wrap, and harmless if it does.
+        body.note(
+            f"Includes {len(report.descendant_ids)} subagent sessions; "
+            "other sections are this session only."
         )
     else:
         note = "≈ list price × tokens" if subtree.cost_is_known else "no published price"
-    body.kv("Est. cost", format_cost(subtree), note)
-    if report.has_descendants:
-        # Says which question the headline answered and how many children are in
-        # it, since the note above spends its width on the two figures.
-        body.note(
-            f"Est. cost is this session plus {len(report.descendant_ids)} subagent "
-            "sessions; every other section below is this session alone."
-        )
+        body.kv("Est. cost", format_cost(subtree), note)
     # Suppressed when both are zero: on the healthy path "0 requests; 0 unknown"
     # is a row whose only content is the absence of a problem.
     if report.missing_usage_calls or report.unknown_usage_calls:

--- a/local_operator/tui/widgets/session_panel.py
+++ b/local_operator/tui/widgets/session_panel.py
@@ -129,6 +129,21 @@ class SessionDiagnostics:
     context_is_estimate: bool | None = None
     generation: int | None = None
     epoch: str | None = None
+    #: Whether the status band is showing a RESTORED spend floor (its ``≥``
+    #: mark). App state, not session state, so it is passed at the call site
+    #: rather than read by ``capture``.
+    #:
+    #: This is a DIFFERENT deficit from the ledger's ``+`` and the two must not
+    #: be merged: ``+`` means "every call was counted, some had no published
+    #: price", while ``≥`` means "this figure includes money restored from a
+    #: resumed conversation, where only the last reported turn's usage survived
+    #: in priceable form". The ledger has no ``≥`` state and should not grow one
+    #: — for a resumed session it holds the actual retained rows, which is
+    #: usually MORE complete than the restored figure. ``/session`` is where the
+    #: two are reconciled, in prose; ``UsageAggregate`` stays free of a
+    #: transcript-restoration concept it has no way to know about (and which the
+    #: desktop HTTP route that also consumes it has no notion of).
+    spend_is_floor: bool = False
 
     @classmethod
     def capture(cls, session: SessionProtocol) -> SessionDiagnostics:
@@ -698,7 +713,7 @@ def build_session_report(
         # ledger — a fresh session's one true visual.
         _draw_context_gauge(body, gauge, _measure_columns([gauge] if gauge else [], width), width)
     else:
-        _draw_recorded_usage(body, report, gauge, width, metric)
+        _draw_recorded_usage(body, report, runtime, gauge, width, metric)
 
     _draw_runtime_and_scope(body, report, runtime)
     return body.to_text()
@@ -780,6 +795,7 @@ def _shared_columns(
 def _draw_recorded_usage(
     body: _Body,
     report: SessionReport,
+    runtime: SessionDiagnostics,
     gauge: _BarRow | None,
     width: int,
     metric: str,
@@ -793,7 +809,13 @@ def _draw_recorded_usage(
     meta = f"{aggregate.calls} requests"
     if aggregate.ok_calls != aggregate.calls:
         meta += f" ({aggregate.calls - aggregate.ok_calls} failed)"
-    body.header("Totals", meta + " · measured", meta)
+    # SCOPE LABEL, not chrome. Est. cost below is the whole TREE while every
+    # other row and section here is this session alone, and an unlabelled
+    # asymmetry is just the next inconsistency report. Only said when the
+    # session actually has subagents — on a childless session the two scopes are
+    # identical and the distinction would be noise.
+    scope = " · cost incl. subagents" if report.has_descendants else ""
+    body.header("Totals", meta + " · measured" + scope, meta)
     body.kv(
         "Total billed",
         format_tokens(aggregate.total_tokens) + " tokens",
@@ -813,17 +835,43 @@ def _draw_recorded_usage(
         f"{format_tokens(aggregate.reasoning_tokens)} thinking",
     )
     body.kv("Cache hit rate", format_percent(aggregate.cache_hit_rate), "of context from cache")
-    body.kv(
-        "Est. cost",
-        format_cost(aggregate),
-        "≈ list price × tokens" if aggregate.cost_is_known else "no published price",
-    )
+    # The HEADLINE is the tree: this row answers "what has this session cost
+    # me", and a session that spent through 20 subagents did not spend only its
+    # own $31.28 of it. The split goes in the note slot the row already has — no
+    # new layout, no width risk — so the own figure every other section here is
+    # scoped to stays legible beside the total. Falls back to the own scope
+    # verbatim when there are no children or the ledger could not be walked.
+    subtree = report.subtree_aggregate
+    if report.has_descendants:
+        note = (
+            f"{format_cost(aggregate)} own · "
+            f"{format_cost(report.descendants_aggregate or aggregate)} subagents"
+        )
+    else:
+        note = "≈ list price × tokens" if subtree.cost_is_known else "no published price"
+    body.kv("Est. cost", format_cost(subtree), note)
+    if report.has_descendants:
+        # Says which question the headline answered and how many children are in
+        # it, since the note above spends its width on the two figures.
+        body.note(
+            f"Est. cost is this session plus {len(report.descendant_ids)} subagent "
+            "sessions; every other section below is this session alone."
+        )
     # Suppressed when both are zero: on the healthy path "0 requests; 0 unknown"
     # is a row whose only content is the absence of a problem.
     if report.missing_usage_calls or report.unknown_usage_calls:
         body.note(
             f"{report.missing_usage_calls:,} requests missing usage · "
             f"{report.unknown_usage_calls:,} unknown"
+        )
+    if runtime.spend_is_floor:
+        # Reconcile the band's ≥ against this screen's figure instead of copying
+        # the mark over. They measure different deficits (see
+        # ``SessionDiagnostics.spend_is_floor``), and the ledger figure is
+        # usually the better one — saying which is which is the honest move.
+        body.note(
+            "The status band shows ≥ (a restored floor from a resumed "
+            "conversation); this figure is what the ledger actually retained."
         )
     body.blank()
 
@@ -853,10 +901,28 @@ def _draw_recorded_usage(
     # so the three sources below are exhaustive. A future section rendering a
     # cost cell from a scope outside them would silently suppress the legend
     # for a ``+`` or ``$—`` that is on screen; add its scopes here.
-    scopes = [aggregate, *report.by_model.values(), *report.by_purpose.values()]
+    # ``subtree`` is listed because the Est. cost row now renders IT, not the
+    # own aggregate: a tree whose child used an unpriced model draws a ``+`` the
+    # own scope has no reason to report, and omitting it here would put that
+    # mark on screen with its footnote suppressed.
+    scopes = [aggregate, subtree, *report.by_model.values(), *report.by_purpose.values()]
     if any(scope_needs_cost_legend(scope) for scope in scopes):
         body.note(COST_LEGEND)
         body.blank()
+
+
+def _own_scope(report: SessionReport) -> str:
+    """The ``share of ...`` prefix, naming the scope when it could be ambiguous.
+
+    These sections are THIS session's calls only, while the Totals block's Est.
+    cost row above them is the whole tree. That split is deliberate — by_model
+    and by_purpose answer "where did MY context go", and folding a child's model
+    mix in would corrupt a diagnostic that is currently correct — but a reader
+    who just saw a tree figure needs telling, or the next row they read looks
+    like it disagrees with it. Said only when the session HAS subagents; with no
+    children the two scopes are the same and the longer wording is noise.
+    """
+    return "share of this session only" if report.has_descendants else "share of session"
 
 
 def _unpriced_note(body: _Body, metric: str, priced: bool) -> bool:
@@ -880,7 +946,7 @@ def _draw_by_model(
         return
     groups = [(f"{provider}/{model}", agg) for (provider, model), agg in report.by_model.items()]
     rows, priced = _group_rows(groups, metric)
-    body.header("By model", _metric_meta(metric, "share of session"), _metric_meta(metric, ""))
+    body.header("By model", _metric_meta(metric, _own_scope(report)), _metric_meta(metric, ""))
     _unpriced_note(body, metric, priced)
     body.extend(_render_rows(rows, cols, width))
     body.blank()
@@ -900,7 +966,7 @@ def _draw_by_purpose(
     if not report.by_purpose:
         return
     rows, priced = _group_rows(list(report.by_purpose.items()), metric, failures=_failures(report))
-    body.header("By purpose", _metric_meta(metric, "share of session"), _metric_meta(metric, ""))
+    body.header("By purpose", _metric_meta(metric, _own_scope(report)), _metric_meta(metric, ""))
     # Only when there is a contrast to explain: the legend defines ``turn``
     # against the harness's own purposes, so it is noise when the rows are all
     # ``turn``, and meaningless on a legacy ledger whose single row is

--- a/tests/unit/analytics/test_model.py
+++ b/tests/unit/analytics/test_model.py
@@ -360,3 +360,115 @@ def test_price_snapshot_reported_zero_is_known_free():
     cost_micro, known = price_snapshot(snap)
     assert known is True
     assert cost_micro == 0
+
+
+def _cost(micro: int, *, calls: int = 1, known: int | None = None) -> UsageAggregate:
+    """A minimal priced scope: cost is what these tests are about."""
+    return UsageAggregate(
+        calls=calls,
+        ok_calls=calls,
+        context_tokens=micro,
+        cost_micro=micro,
+        cost_known_calls=calls if known is None else known,
+    )
+
+
+def test_sum_aggregates_sums_counters_so_the_marks_stay_right():
+    """The lower-bound and unknown marks are DERIVED from counters. Summing the
+    counters composes them correctly for a mixed subtree; OR-ing the booleans
+    would render a real spend as ``$—``."""
+    from local_operator.analytics.model import sum_aggregates
+
+    priced = _cost(1_000_000, calls=2, known=2)
+    partly = _cost(500_000, calls=4, known=1)
+    unpriced = _cost(0, calls=3, known=0)
+
+    # Priced parent + partly-unpriced child: the tree total IS a lower bound.
+    mixed = sum_aggregates([priced, partly])
+    assert mixed.cost_micro == 1_500_000
+    assert mixed.cost_is_known is True
+    assert mixed.cost_is_partial is True
+
+    # Unpriced parent + priced child: a real figure with a ``+``, NOT ``$—``.
+    # This is the case boolean-OR gets wrong.
+    rescued = sum_aggregates([unpriced, priced])
+    assert rescued.cost_is_known is True
+    assert rescued.cost_micro == 1_000_000
+
+    # Nothing priceable anywhere stays unknown.
+    nothing = sum_aggregates([unpriced, _cost(0, calls=1, known=0)])
+    assert nothing.cost_is_known is False
+
+
+def test_forest_roots_sum_to_the_table_total():
+    """THE invariant. A per-session table whose rows do not add to the total
+    printed above them is a worse defect than the one being fixed, so rolling
+    children up REQUIRES removing them from the top level."""
+    from local_operator.analytics.model import build_session_forest
+
+    by_session = {
+        "root": _cost(1_000_000),
+        "kid1": _cost(2_000_000),
+        "kid2": _cost(3_000_000),
+        "grandkid": _cost(4_000_000),
+        "solo": _cost(5_000_000),
+    }
+    parents = {"kid1": "root", "kid2": "root", "grandkid": "kid1"}
+    forest = build_session_forest(by_session, parents)
+
+    grand_total = sum(a.cost_micro for a in by_session.values())
+    assert sum(node.total.cost_micro for node in forest) == grand_total == 15_000_000
+
+    # The naive fix — roll up AND keep listing children — double-counts.
+    def every(nodes):
+        for node in nodes:
+            yield node
+            yield from every(node.children)
+
+    assert sum(n.total.cost_micro for n in every(forest)) > grand_total
+
+    roots = {node.session_id for node in forest}
+    assert roots == {"root", "solo"}
+    root = next(n for n in forest if n.session_id == "root")
+    assert root.own.cost_micro == 1_000_000
+    assert root.total.cost_micro == 10_000_000  # own + both kids + the grandkid
+    # And every session is placed exactly once, which is what the sum rests on.
+    assert sorted(n.session_id for n in every(forest)) == sorted(by_session)
+
+
+def test_forest_keeps_an_orphaned_child_as_a_root():
+    """A parent pruned by retention must not take its child's dollars off the
+    table: an edge to a session with no row in scope is not an edge here."""
+    from local_operator.analytics.model import build_session_forest
+
+    by_session = {"kid": _cost(2_000_000)}
+    forest = build_session_forest(by_session, {"kid": "pruned-parent"})
+    assert [n.session_id for n in forest] == ["kid"]
+    assert forest[0].total.cost_micro == 2_000_000
+
+
+def test_forest_breaks_a_cycle_without_losing_a_session():
+    """A cyclic edge set claims every member has a parent, so nothing looks like
+    a root. Dropping them would be money missing from the column."""
+    from local_operator.analytics.model import build_session_forest
+
+    by_session = {"a": _cost(1_000_000), "b": _cost(2_000_000)}
+    forest = build_session_forest(by_session, {"a": "b", "b": "a"})
+
+    def every(nodes):
+        for node in nodes:
+            yield node
+            yield from every(node.children)
+
+    placed = sorted(n.session_id for n in every(forest))
+    assert placed == ["a", "b"]
+    assert sum(n.total.cost_micro for n in forest) == 3_000_000
+
+
+def test_forest_ignores_a_self_parent_edge():
+    """The real ledger carries 224 self-parent rows."""
+    from local_operator.analytics.model import build_session_forest
+
+    forest = build_session_forest({"s": _cost(7)}, {"s": "s"})
+    assert [n.session_id for n in forest] == ["s"]
+    assert forest[0].total.cost_micro == 7

--- a/tests/unit/analytics/test_store.py
+++ b/tests/unit/analytics/test_store.py
@@ -783,3 +783,145 @@ def test_cache_write_1h_tokens_is_recorded_and_migrated(tmp_path):
     ).fetchall()
     assert rows == [("old", 500, 0), ("s1", 300, 120)]
     store.close()
+
+
+def _child(parent, session_id, **kw):
+    """A snapshot stamped as a subagent call of ``parent``."""
+    import dataclasses
+
+    return dataclasses.replace(_snap(session_id=session_id, **kw), parent_session_id=parent)
+
+
+def test_session_report_rolls_up_descendant_spend(tmp_path):
+    """``/session``'s headline question is "what did this cost me", and a
+    session that spent through subagents did not spend only its own rows."""
+    store = AnalyticsStore(tmp_path / "a.db")
+    store.record_batch(
+        [
+            _snap(session_id="root", cost_micro=1_000_000),
+            _child("root", "kid1", cost_micro=2_000_000),
+            _child("root", "kid2", cost_micro=3_000_000),
+            # A grandchild: the ledger is one level deep today, but fork()
+            # stamps the MIDDLE session as parent the moment a subagent spawns
+            # its own, so the walk must be recursive rather than one level.
+            _child("kid1", "grandkid", cost_micro=4_000_000),
+            _snap(session_id="stranger", cost_micro=9_000_000),
+        ]
+    )
+    report = store.session_report("root")
+    assert report.aggregate.cost_micro == 1_000_000
+    assert report.descendants_aggregate is not None
+    assert report.descendants_aggregate.cost_micro == 9_000_000
+    assert report.subtree_aggregate.cost_micro == 10_000_000
+    assert set(report.descendant_ids) == {"kid1", "kid2", "grandkid"}
+    # The unrelated session is not swept in by the recursion.
+    assert "stranger" not in report.descendant_ids
+    # And the own scope stays own: the diagnostic sections read this.
+    assert report.aggregate.calls == 1
+    store.close()
+
+
+def test_session_report_without_children_reports_empty_not_unknown(tmp_path):
+    """A childless session must be distinguishable from an unwalkable ledger:
+    the first shows no subagent split, the second must not claim $0.00."""
+    store = AnalyticsStore(tmp_path / "a.db")
+    store.record_batch([_snap(session_id="solo")])
+    report = store.session_report("solo")
+    assert report.descendants_aggregate is not None
+    assert report.descendants_aggregate.calls == 0
+    assert report.has_descendants is False
+    assert report.subtree_aggregate.cost_micro == report.aggregate.cost_micro
+    store.close()
+
+
+def test_descendant_walk_survives_a_self_parent_cycle(tmp_path):
+    """224 rows in the operator's real ledger carry parent == session. A walk
+    that follows that edge either loops or double-counts; this one does
+    neither."""
+    import sqlite3
+
+    store = AnalyticsStore(tmp_path / "a.db")
+    store.record_batch([_snap(session_id="root"), _child("root", "kid")])
+    conn = store._connect()
+    assert conn is not None
+    # Stamp the child as its own parent too — the degenerate shape the real
+    # ledger contains — alongside the legitimate edge.
+    conn.execute("UPDATE calls SET parent_session_id = 'kid' WHERE session_id = 'kid'")
+    conn.commit()
+    report = store.session_report("root")
+    assert report.descendant_ids == ()  # the self-loop replaced the real edge
+    # The point is that it TERMINATED and stayed honest, not what it found.
+    assert report.subtree_aggregate.cost_micro == report.aggregate.cost_micro
+
+    # And with both edges present the child is counted exactly once.
+    conn.execute(
+        "INSERT INTO calls (ts_ms, session_id, provider, model_id, ok, input_tokens, "
+        "output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens, "
+        "context_tokens, cost_micro, cost_known, parent_session_id) "
+        "VALUES (1, 'kid', 'anthropic', 'claude', 1, 1, 1, 0, 0, 0, 1, 500, 1, 'root')"
+    )
+    conn.commit()
+    report = store.session_report("root")
+    assert report.descendant_ids == ("kid",)
+    assert report.descendants_aggregate is not None
+    # Both of kid's rows, once each.
+    assert report.descendants_aggregate.calls == 2
+    assert isinstance(sqlite3.connect(str(tmp_path / "a.db")), sqlite3.Connection)
+    store.close()
+
+
+def test_parent_index_is_created_and_survives_an_old_ledger(tmp_path):
+    """The index is load-bearing for the rollup (154 ms -> 1 ms), and it must
+    reach a database written before ``parent_session_id`` existed WITHOUT
+    aborting the schema script that also creates the rollup tables."""
+    import sqlite3
+
+    db = tmp_path / "old.db"
+    conn = sqlite3.connect(str(db))
+    # A pre-parent_session_id ledger: putting the index in _SCHEMA rather than
+    # after _migrate makes executescript raise "no such column" here and lose
+    # every statement after it.
+    conn.executescript(f"""
+        CREATE TABLE calls (
+          id INTEGER PRIMARY KEY AUTOINCREMENT, ts_ms INTEGER, session_id TEXT,
+          provider TEXT, model_id TEXT, ok INTEGER, input_tokens INTEGER,
+          output_tokens INTEGER, cache_read_tokens INTEGER, cache_write_tokens INTEGER,
+          reasoning_tokens INTEGER, context_tokens INTEGER,
+          {_PRE_IMAGES_COMPONENT_COLUMNS}
+        );
+        CREATE TABLE session_names (
+          session_id TEXT PRIMARY KEY, name TEXT, updated_at_ms INTEGER
+        );
+        """)
+    conn.execute(
+        "INSERT INTO calls (ts_ms, session_id, provider, model_id, ok, input_tokens, "
+        "output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens, "
+        "context_tokens) VALUES (1, 'old', 'anthropic', 'claude', 1, 1, 1, 0, 0, 0, 1)"
+    )
+    conn.commit()
+    conn.close()
+
+    store = AnalyticsStore(db)
+    assert store.record_batch([_snap(session_id="new")]) == 1
+    live = store._connect()
+    assert live is not None
+    names = {row[0] for row in live.execute("SELECT name FROM sqlite_master WHERE type='index'")}
+    assert "idx_calls_parent" in names
+    # The rest of the schema script survived: the rollup tables exist.
+    tables = {row[0] for row in live.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert {"usage_daily", "usage_monthly"} <= tables
+    store.close()
+
+
+def test_aggregate_exposes_parent_edges_for_the_table_rollup(tmp_path):
+    """``/analytics`` re-partitions the per-session table with these edges."""
+    store = AnalyticsStore(tmp_path / "a.db")
+    store.record_batch([_snap(session_id="root"), _child("root", "kid"), _snap(session_id="solo")])
+    agg = store.aggregate()
+    parents = getattr(agg, "session_parents", {})
+    assert parents == {"kid": "root"}
+    # Every session still gets its OWN row in by_session: the rollup is the
+    # renderer's job, so the aggregate keeps summing to the headline total.
+    assert set(agg.by_session) == {"root", "kid", "solo"}
+    assert sum(a.cost_micro for a in agg.by_session.values()) == agg.cost_micro
+    store.close()

--- a/tests/unit/analytics/test_store.py
+++ b/tests/unit/analytics/test_store.py
@@ -834,6 +834,83 @@ def test_session_report_without_children_reports_empty_not_unknown(tmp_path):
     store.close()
 
 
+def _both_surfaces(store, session_id):
+    """``(/analytics row total, /session subtree total)`` for one session.
+
+    The agreement property this whole change exists to establish, expressed once
+    so a test can assert it instead of restating the plumbing. ``/analytics``
+    goes through ``aggregate`` + ``build_session_forest``; ``/session`` goes
+    through ``session_report``. Review F1/F7: asserting only one side is what let
+    the two encode different edge rules.
+    """
+    from local_operator.analytics.model import build_session_forest
+
+    aggregate = store.aggregate()
+    forest = build_session_forest(
+        aggregate.by_session, getattr(aggregate, "session_parents", {}) or {}
+    )
+    rows = {node.session_id: node.total.cost_micro for node in forest}
+    report = store.session_report(session_id)
+    return rows.get(session_id), report.subtree_aggregate.cost_micro
+
+
+def test_both_surfaces_share_one_parent_edge_rule(tmp_path):
+    """Review F1: /analytics and /session must not encode different edge rules.
+
+    Two shapes the reviewer reproduced as divergences. Both are unreachable on
+    today's ledger (zero sessions carry more than one distinct parent), which is
+    exactly why they need a test: the property is asserted by a code comment, so
+    only a test defends it against the next change.
+    """
+    import sqlite3
+
+    # SHAPE 1 — a real parent PLUS a degenerate self row. A lexical MAX over the
+    # raw column returns 'xxx' (it sorts above 'aaa'), the self edge is then
+    # discarded, and the REAL edge is lost with it: /analytics said $1000 where
+    # /session said $2000. The shared rule discards the self edge BEFORE the MAX.
+    store = AnalyticsStore(tmp_path / "self.db")
+    store.record_batch([_snap(session_id="aaa"), _child("aaa", "xxx")])
+    conn = store._connect()
+    assert conn is not None
+    conn.execute(
+        "INSERT INTO calls (ts_ms, session_id, provider, model_id, ok, input_tokens, "
+        "output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens, "
+        "context_tokens, cost_micro, cost_known, parent_session_id) "
+        "VALUES (1, 'xxx', 'anthropic', 'claude', 1, 1, 1, 0, 0, 0, 1, 500, 1, 'xxx')"
+    )
+    conn.commit()
+    assert getattr(store.aggregate(), "session_parents", {}) == {"xxx": "aaa"}
+    analytics, session = _both_surfaces(store, "aaa")
+    assert analytics == session
+    assert store.session_report("aaa").descendant_ids == ("xxx",)
+    store.close()
+
+    # SHAPE 2 — a child with rows under TWO real parents. MAX still picks one,
+    # which is the documented tie-break (crediting both would double-count and
+    # break the column-sums-to-total invariant); the requirement is that BOTH
+    # surfaces pick the SAME one. Previously /session credited both parents and
+    # /analytics only the lexically larger, so 'aaa' read 1000 vs 2000.
+    store2 = AnalyticsStore(tmp_path / "two.db")
+    store2.record_batch([_snap(session_id="aaa"), _snap(session_id="bbb"), _child("aaa", "kid")])
+    conn2 = store2._connect()
+    assert conn2 is not None
+    conn2.execute(
+        "INSERT INTO calls (ts_ms, session_id, provider, model_id, ok, input_tokens, "
+        "output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens, "
+        "context_tokens, cost_micro, cost_known, parent_session_id) "
+        "VALUES (1, 'kid', 'anthropic', 'claude', 1, 1, 1, 0, 0, 0, 1, 500, 1, 'bbb')"
+    )
+    conn2.commit()
+    for sid in ("aaa", "bbb"):
+        analytics, session = _both_surfaces(store2, sid)
+        assert analytics == session, sid
+    # And the child is credited to exactly one parent, so nothing is counted twice.
+    parents = getattr(store2.aggregate(), "session_parents", {})
+    assert list(parents) == ["kid"]
+    assert isinstance(sqlite3.connect(str(tmp_path / "two.db")), sqlite3.Connection)
+    store2.close()
+
+
 def test_descendant_walk_survives_a_self_parent_cycle(tmp_path):
     """224 rows in the operator's real ledger carry parent == session. A walk
     that follows that edge either loops or double-counts; this one does

--- a/tests/unit/tui/test_analytics_panel.py
+++ b/tests/unit/tui/test_analytics_panel.py
@@ -692,6 +692,17 @@ def _nested_aggregate() -> UsageAggregate:
     return agg
 
 
+def _is_child_row(row: str) -> bool:
+    """A child row is marked by the └ glyph, not merely by indentation.
+
+    Design D4 added the glyph because 21% of ROOTS are unnamed 12-hex ids, so an
+    unnamed root and a child differed only by two spaces and a colour — a
+    distinction that vanishes under NO_COLOR. Tests classify rows the same way
+    the reader does, so this stays true if the indent width ever changes.
+    """
+    return row.lstrip().startswith("└")
+
+
 def _session_rows(text: list[str]) -> list[str]:
     start = next(i for i, line in enumerate(text) if "By session" in line)
     rows = []
@@ -705,14 +716,18 @@ def test_session_table_shows_roots_with_tree_totals_and_indents_children():
     lines = [line.plain for line in build_report(_nested_aggregate(), 120)]
     rows = _session_rows(lines)
     # Two top-level rows only; the three children moved under their root.
-    top = [r for r in rows if not r.startswith("    ")]
+    top = [r for r in rows if not _is_child_row(r)]
     assert len(top) == 2
     root = next(r for r in rows if "Review and merge open PRs" in r)
-    assert not root.startswith("    ")
+    assert not _is_child_row(root)
     assert "$10.00" in root  # own $1 + kid1 $2 + kid2 $3 + grandkid $4
     # Children are present, indented, and reachable — not deleted.
-    assert any(r.startswith("    ") and "kid1session" in r for r in rows)
-    assert any(r.startswith("      ") and "grandkidses" in r for r in rows)
+    assert any(_is_child_row(r) and "kid1session" in r for r in rows)
+    assert any(_is_child_row(r) and "grandkidses" in r for r in rows)
+    # Depth still reads as depth: the grandchild is one indent step deeper.
+    grandkid = next(r for r in rows if "grandkidses" in r)
+    kid = next(r for r in rows if "kid1session" in r)
+    assert grandkid.index("└") == kid.index("└") + 2
     # And the section says the roots include their subagents.
     assert "totals include subagents" in "\n".join(lines)
 
@@ -724,7 +739,7 @@ def test_session_column_still_sums_to_the_headline_total():
     aggregate = _nested_aggregate()
     lines = [line.plain for line in build_report(aggregate, 120)]
     rows = _session_rows(lines)
-    top = [r for r in rows if not r.startswith("    ")]
+    top = [r for r in rows if not _is_child_row(r)]
     total = 0.0
     for row in top:
         money = next(part for part in row.split() if part.startswith("$"))
@@ -739,7 +754,7 @@ def test_a_flat_ledger_renders_exactly_as_before():
     setattr(aggregate, "session_parents", {})
     rows = _session_rows([line.plain for line in build_report(aggregate, 120)])
     assert len(rows) == 5
-    assert not any(r.startswith("    ") for r in rows)
+    assert not any(_is_child_row(r) for r in rows)
     assert "totals include subagents" not in rows[0]
 
 

--- a/tests/unit/tui/test_analytics_panel.py
+++ b/tests/unit/tui/test_analytics_panel.py
@@ -661,3 +661,118 @@ def test_toggle_hint_shown_only_with_series():
             assert "t cost/tokens" not in hint3
 
     asyncio.run(run())
+
+
+def _nested_aggregate() -> UsageAggregate:
+    """A root with two subagents and a grandchild, plus an unrelated session."""
+
+    def scope(micro, calls=1):
+        return UsageAggregate(
+            calls=calls,
+            ok_calls=calls,
+            context_tokens=micro,
+            cost_micro=micro,
+            cost_known_calls=calls,
+        )
+
+    agg = scope(15_000_000, calls=5)
+    agg.by_session = {
+        "rootsession": scope(1_000_000),
+        "kid1session": scope(2_000_000),
+        "kid2session": scope(3_000_000),
+        "grandkidses": scope(4_000_000),
+        "solosession": scope(5_000_000),
+    }
+    setattr(agg, "session_names", {"rootsession": "Review and merge open PRs"})
+    setattr(
+        agg,
+        "session_parents",
+        {"kid1session": "rootsession", "kid2session": "rootsession", "grandkidses": "kid1session"},
+    )
+    return agg
+
+
+def _session_rows(text: list[str]) -> list[str]:
+    start = next(i for i, line in enumerate(text) if "By session" in line)
+    rows = []
+    for line in text[start].split("\n")[1:]:
+        if line.strip():
+            rows.append(line)
+    return rows
+
+
+def test_session_table_shows_roots_with_tree_totals_and_indents_children():
+    lines = [line.plain for line in build_report(_nested_aggregate(), 120)]
+    rows = _session_rows(lines)
+    # Two top-level rows only; the three children moved under their root.
+    top = [r for r in rows if not r.startswith("    ")]
+    assert len(top) == 2
+    root = next(r for r in rows if "Review and merge open PRs" in r)
+    assert not root.startswith("    ")
+    assert "$10.00" in root  # own $1 + kid1 $2 + kid2 $3 + grandkid $4
+    # Children are present, indented, and reachable — not deleted.
+    assert any(r.startswith("    ") and "kid1session" in r for r in rows)
+    assert any(r.startswith("      ") and "grandkidses" in r for r in rows)
+    # And the section says the roots include their subagents.
+    assert "totals include subagents" in "\n".join(lines)
+
+
+def test_session_column_still_sums_to_the_headline_total():
+    """THE invariant (design §7 risk 1): a rolled-up column that still lists
+    children inflates the operator's real table by $8,077. Only ROOT rows may
+    carry a tree total, and they must add to the total printed above them."""
+    aggregate = _nested_aggregate()
+    lines = [line.plain for line in build_report(aggregate, 120)]
+    rows = _session_rows(lines)
+    top = [r for r in rows if not r.startswith("    ")]
+    total = 0.0
+    for row in top:
+        money = next(part for part in row.split() if part.startswith("$"))
+        total += float(money.strip("+").lstrip("$"))
+    assert abs(total - aggregate.cost_usd) < 0.01
+
+
+def test_a_flat_ledger_renders_exactly_as_before():
+    """No parent edges (an old ledger, or a machine that never ran subagents)
+    means every session is a root and the table is byte-identical to today's."""
+    aggregate = _nested_aggregate()
+    setattr(aggregate, "session_parents", {})
+    rows = _session_rows([line.plain for line in build_report(aggregate, 120)])
+    assert len(rows) == 5
+    assert not any(r.startswith("    ") for r in rows)
+    assert "totals include subagents" not in rows[0]
+
+
+def test_nesting_does_not_cost_the_cache_column_on_a_narrow_frame():
+    """Risk 4: indentation must not push the table past _WIDE_TABLE_MIN and
+    shed the cache column that a wide frame keeps."""
+    aggregate = _nested_aggregate()
+    wide = _session_rows([line.plain for line in build_report(aggregate, 120)])
+    narrow = _session_rows([line.plain for line in build_report(aggregate, 80)])
+    assert all("cache" in r for r in wide)
+    assert all("cache" in r for r in narrow)
+    # Below the threshold cache sheds for every row equally, root and child.
+    tight = _session_rows([line.plain for line in build_report(aggregate, 60)])
+    assert not any("cache" in r for r in tight)
+    assert all("$" in r for r in tight)  # the cost column survives, as designed
+
+
+def test_legend_is_drawn_for_a_plus_that_only_the_rollup_produces():
+    """A parent priced in full whose CHILD is unpriced draws a ``+`` on the root
+    row that no individual session shows. The footnote must follow it."""
+    agg = UsageAggregate(
+        calls=3, ok_calls=3, context_tokens=3, cost_micro=1_000_000, cost_known_calls=2
+    )
+    agg.by_session = {
+        "rootsession": UsageAggregate(
+            calls=2, ok_calls=2, context_tokens=2, cost_micro=1_000_000, cost_known_calls=2
+        ),
+        "kid1session": UsageAggregate(
+            calls=1, ok_calls=1, context_tokens=1, cost_micro=0, cost_known_calls=0
+        ),
+    }
+    setattr(agg, "session_names", {})
+    setattr(agg, "session_parents", {"kid1session": "rootsession"})
+    text = "\n".join(line.plain for line in build_report(agg, 120))
+    assert "$1.00+" in text
+    assert "lower bound" in text

--- a/tests/unit/tui/test_session_panel.py
+++ b/tests/unit/tui/test_session_panel.py
@@ -881,3 +881,96 @@ def test_sequence_chart_never_renders_an_absent_duration_as_zero():
     )
     assert sum("█" in r for r in rows) == 1
     assert any("4,000 ms" in r for r in rows) and any("unknown" in r for r in rows)
+
+
+def _tree_report(**kw):
+    """A session that spent $31.28 itself and $71.06 through 20 subagents —
+    the operator's real numbers, which is what makes the assertions readable."""
+    return SessionReport(
+        "sess",
+        aggregate=UsageAggregate(
+            calls=248,
+            ok_calls=248,
+            context_tokens=47_000_000,
+            cost_micro=31_276_032,
+            cost_known_calls=248,
+        ),
+        descendants_aggregate=UsageAggregate(
+            calls=896,
+            ok_calls=896,
+            context_tokens=200_000_000,
+            cost_micro=71_059_322,
+            cost_known_calls=896,
+        ),
+        descendant_ids=tuple(f"kid{n:02d}" for n in range(20)),
+        **kw,
+    )
+
+
+def test_est_cost_headline_is_the_tree_with_the_split_beneath_it():
+    """The defect: /session showed $31.28 while the composer showed $102.60 for
+    the same session. The headline becomes the tree; the split explains it."""
+    text = build_session_report(_tree_report(), runtime(), width=120).plain
+    assert "$102.34" in text  # the headline: what this session cost
+    assert "$31.28 own · $71.06 subagents" in text  # the split, in the note slot
+    # The asymmetry with every other section is LABELLED, not left to be found.
+    assert "cost incl. subagents" in text
+    assert "plus 20 subagent sessions" in text
+    assert "every other section below is this session alone" in text
+
+
+def test_own_only_sections_say_they_are_own_only():
+    """by_model/by_purpose stay this session's calls — they answer "where did MY
+    context go" — so their meta must say so once the headline is a tree."""
+    report = _tree_report(
+        by_model={("anthropic", "claude"): UsageAggregate(calls=248, context_tokens=47_000_000)},
+        by_purpose={"turn": UsageAggregate(calls=248, context_tokens=47_000_000)},
+    )
+    text = build_session_report(report, runtime(), width=120).plain
+    assert "share of this session only" in text
+
+    # A childless session has one scope, so the longer wording would be noise.
+    solo = SessionReport(
+        "sess",
+        aggregate=UsageAggregate(calls=2, context_tokens=100, cost_micro=5, cost_known_calls=2),
+        descendants_aggregate=UsageAggregate(),
+        by_model={("anthropic", "claude"): UsageAggregate(calls=2, context_tokens=100)},
+    )
+    solo_text = build_session_report(solo, runtime(), width=120).plain
+    assert "share of session" in solo_text
+    assert "share of this session only" not in solo_text
+    assert "own ·" not in solo_text
+
+
+def test_tree_total_carries_the_lower_bound_mark_from_a_child():
+    """Sum the counters, not the booleans: a fully-priced parent whose child
+    used an unpriced model has a tree total that IS a lower bound — and the
+    legend explaining the ``+`` must not be suppressed."""
+    report = SessionReport(
+        "sess",
+        aggregate=UsageAggregate(
+            calls=2, context_tokens=10, cost_micro=1_000_000, cost_known_calls=2
+        ),
+        descendants_aggregate=UsageAggregate(
+            calls=4, context_tokens=10, cost_micro=500_000, cost_known_calls=1
+        ),
+        descendant_ids=("kid",),
+    )
+    text = build_session_report(report, runtime(), width=120).plain
+    assert "$1.50+" in text
+    assert "lower bound" in text  # COST_LEGEND, drawn from the subtree scope
+
+
+def test_restored_floor_is_reconciled_in_prose_not_copied():
+    """``≥`` (restored transcript floor) and ``+`` (unpriced calls) are different
+    deficits. /session says which figure is which instead of merging them."""
+    text = build_session_report(
+        _tree_report(), replace(runtime(), spend_is_floor=True), width=120
+    ).plain
+    assert "restored floor" in text
+    assert "what the ledger actually retained" in text
+    # The mark itself is NOT copied onto the ledger figure.
+    assert "≥$" not in text
+
+    plain = build_session_report(_tree_report(), runtime(), width=120).plain
+    assert "restored floor" not in plain

--- a/tests/unit/tui/test_session_panel.py
+++ b/tests/unit/tui/test_session_panel.py
@@ -34,6 +34,18 @@ from tests.unit.tui.test_app_pilot import FakeSession, _factory
 from tests.unit.tui.test_slash_echo import _submit
 
 
+def flowed(text: str) -> str:
+    """The report's text with wrapping collapsed, for asserting on PROSE.
+
+    ``_Body.note`` wraps a footnote at build time and indents every line, so a
+    sentence spans several lines with a two-space indent on each (design D2 —
+    folding instead put the continuation at column 0, where it read as a stray
+    table row). A test about WORDING should not therefore depend on where the
+    line broke; a test about LAYOUT asserts on the raw lines instead.
+    """
+    return " ".join(text.split())
+
+
 def runtime():
     return SessionDiagnostics(
         "sess",
@@ -70,7 +82,7 @@ def test_report_empty_unavailable_and_cost_knowledge():
         report = SessionReport(
             "sess", aggregate=UsageAggregate(calls=2, cost_micro=cost, cost_known_calls=known)
         )
-        text = build_session_report(report, runtime()).plain
+        text = flowed(build_session_report(report, runtime()).plain)
         assert expected in text
         assert "input, output and tool dollars are not recorded separately" in text
         assert "list-price estimate" in text
@@ -915,8 +927,63 @@ def test_est_cost_headline_is_the_tree_with_the_split_beneath_it():
     assert "$31.28 own · $71.06 subagents" in text  # the split, in the note slot
     # The asymmetry with every other section is LABELLED, not left to be found.
     assert "cost incl. subagents" in text
-    assert "plus 20 subagent sessions" in text
-    assert "every other section below is this session alone" in text
+    assert "Includes 20 subagent sessions" in text
+    assert "other sections are this session only" in text
+
+
+def test_scope_is_never_silently_dropped_at_any_width():
+    """Design D1 / QA Q1: the scope is load-bearing, not sheddable chrome.
+
+    Before this, the split note needed a 66-cell card but ``_NOTE_MIN`` admitted
+    it from 60, so 75-80 column terminals (including the canonical 80) painted
+    "$71.06 subagent" mid-word, and below 75 the note AND the header's scope
+    label both vanished — leaving a bare $102.34 where main showed $31.28 with
+    nothing on screen saying the scope had changed. That is the reported defect's
+    own shape (a right number that looks wrong) relocated to narrow terminals.
+
+    So the requirement is not "the note fits" but "no width shows a tree figure
+    without saying it is one", checked across the ladder rather than at one width.
+    """
+    report = _tree_report()
+    for width in range(50, 161):
+        lines = build_session_report(report, runtime(), width=width).plain.split("\n")
+        cost_row = next(line for line in lines if "Est. cost" in line)
+        flat = flowed("\n".join(lines))
+
+        # 1. The headline is always the tree figure.
+        assert "$102.34" in cost_row, width
+        # 2. The scope is stated SOMEWHERE on screen at every width.
+        assert ("subagent" in flat) or ("subs" in flat), width
+        # 3. Nothing is cropped mid-word. Every rung of the ladder ends in a
+        #    COMPLETE word, so a truncated "subagent"/"sub" tail can only mean a
+        #    crop — which is the Q1 bisection, generalised to the whole ladder.
+        tail = cost_row.rstrip()
+        if "subagent" in tail:
+            assert tail.endswith("subagents"), (width, cost_row)
+        # 4. The row never overflows the frame it was built for.
+        assert len(cost_row) <= width, (width, len(cost_row))
+
+
+def test_the_scope_note_does_not_orphan_wrap_into_the_block():
+    """Design D2: a wrapped footnote must stay indented under its block.
+
+    The 103-character prose note wrapped at every width from 70 to ~128 and,
+    because ``fold`` applies the body indent to the first line only, dropped
+    "this session alone." at column 0 between the Est. cost figure and the next
+    section header — where it read as an orphan row of the table. ``_Body.kv``'s
+    own comment already names this failure mode.
+    """
+    report = _tree_report()
+    for width in (70, 76, 80, 100, 128, 160):
+        lines = build_session_report(report, runtime(), width=width).plain.split("\n")
+        # Every non-blank body line is indented. Section headers legitimately
+        # start at column 0 (the ▌ accent bar IS the left edge), so they are
+        # the one exception; anything else at column 0 is an orphaned wrap.
+        for line in lines[2:]:
+            if line.strip() and not line.startswith("▌"):
+                assert line.startswith("  "), (width, repr(line))
+        # And the sentence survives the wrap intact, wherever it broke.
+        assert "other sections are this session only" in flowed("\n".join(lines)), width
 
 
 def test_own_only_sections_say_they_are_own_only():
@@ -964,9 +1031,11 @@ def test_tree_total_carries_the_lower_bound_mark_from_a_child():
 def test_restored_floor_is_reconciled_in_prose_not_copied():
     """``≥`` (restored transcript floor) and ``+`` (unpriced calls) are different
     deficits. /session says which figure is which instead of merging them."""
-    text = build_session_report(
-        _tree_report(), replace(runtime(), spend_is_floor=True), width=120
-    ).plain
+    text = flowed(
+        build_session_report(
+            _tree_report(), replace(runtime(), spend_is_floor=True), width=120
+        ).plain
+    )
     assert "restored floor" in text
     assert "what the ledger actually retained" in text
     # The mark itself is NOT copied onto the ledger figure.


### PR DESCRIPTION
## Summary

The same session read **$31.28** on `/session`, **$31.44** on `/analytics`, and **$102.60** in the composer band. All three were individually correct and answered three different questions — and nothing on screen said which — so they read as three answers to one question.

The ledger already had what it needed: `calls.parent_session_id` is populated (46,506 rows). Neither analytics surface ever rolled it up.

**Change class: C2 (standard).** User-visible TUI change to two read-only diagnostic screens; no recording path, no data migration beyond one added index.

| surface | before | after |
|---|---|---|
| `/session` Est. cost | `$31.28` (own only, unlabelled) | `$102.34` headline · `$31.28 own · $71.06 subagents` |
| `/analytics` per-session | 871 flat rows, subagents as bare hex ids | 404 roots with tree totals, 467 children indented beneath them |
| composer band | `$102.60` | **unchanged** — it was already right |

## What changed

**`analytics/store.py` — the index.** `CREATE INDEX idx_calls_parent ON calls(parent_session_id)`. This is load-bearing, not an optimisation: it takes the recursive subtree walk from a full scan to an index seek.

It is created **after `_migrate`, not in `_SCHEMA`** — and that is a real defect I hit, not a style preference. `_connect` runs `executescript(_SCHEMA)` as one unit *before* the ALTERs, so on a ledger written before `parent_session_id` existed the `CREATE INDEX` raises `no such column` and **aborts every statement after it in the script**, losing the `usage_daily`/`usage_monthly` rollup tables and latching `_broken` for the process. Reproduced directly:

```
$ python3 -c "...executescript with an index on a not-yet-added column..."
RAISED: OperationalError no such column: parent_session_id
tables/indexes now: [('calls', 'table'), ('idx_calls_session', 'index')]   # the rest of the script is gone
```

There is now an `_OPTIONAL_INDEXES` registry alongside `_MIGRATION_COLUMNS`, applied under the same lock, each statement guarded individually so a failed index costs its index and nothing else. `test_parent_index_is_created_and_survives_an_old_ledger` pins both halves.

**`/session` — the headline becomes the tree.** `Est. cost` renders `subtree_aggregate` with the split in the note slot the row already had, so there is no new layout and no width risk. Every *other* section — `by_model`, `by_purpose`, timings, the context gauge — stays own-scope deliberately: they answer "where did **my** context go", and folding a child's model mix into them would corrupt a diagnostic that is currently correct. That asymmetry is **labelled on screen** (`· cost incl. subagents` in the Totals meta, `share of this session only` on the sections, plus a prose line) rather than left to be found as the next inconsistency report. On a childless session none of this wording appears — the two scopes are identical there and it would be noise.

**`/analytics` — roots carry the subtree, children indent under them.** This is the only arrangement that both credits a parent with what its subagents spent *and* keeps the column summing to the headline printed above it. Measured on the operator's real ledger:

| what is summed | total |
|---|---|
| table total (`SUM(cost_micro)`) | **$63,640.95** |
| own over all 871 sessions (before) | $63,640.95 ✅ |
| tree totals over **roots only** (after) | $63,640.95 ✅ |
| tree totals over **all** sessions (the naive fix) | $71,718.15 ❌ **+$8,077** |

Rolling up while still listing children at top level inflates the table by 12.7%. A per-session table whose rows do not add to the total on the same screen is a worse defect than the one being fixed, so that invariant has its own test.

The rollup is Python over a `MAX(parent_session_id)` added to the *existing* `GROUP BY` (+6 ms). `parent_session_id` is functionally dependent on `session_id`, so `MAX()` is exact, not a heuristic. A global recursive CTE costs +58 ms and widening the `GROUP BY` to two columns costs 610 ms vs 290 ms for identical output (it forces a temp B-tree).

**Marks compose by summing counters, never booleans.** `cost_is_partial`/`cost_is_known` are derived from `cost_known_calls` against `calls`, so summing both counters makes a mixed subtree come out right with no special cases — including the case boolean-OR gets wrong (unpriced parent + priced child must be `$1.00+`, not `$—`). The composer's restored-spend `≥` is a *transcript* concept and deliberately stays out of `UsageAggregate`, which the desktop HTTP route also consumes; `/session` reconciles it in prose instead.

**Cycles and depth.** Every walk rejects the self-parent edge and caps depth at 32. The cycle edge is not hypothetical — 224 rows in the live ledger carry `parent_session_id == session_id`. The ledger's tree is one level deep today, but depth is a property of usage, not schema: `SessionStreamFn.fork` stamps the *middle* session as parent the moment a subagent spawns its own, so the walk is recursive by construction.

**Composer: no change.** `_spend_total` was already the tree total, and its docstring's argument against splitting the band (the cost segment sheds at rung 8 of a 12-rung drop ladder) still holds.

## Testing Evidence

Everything below is run against a **copy** of the live 475,535-row ledger (`/tmp/an_copy.db`, 871 sessions, $63,640.95). The live DB was never written to.

### 1. The real `/session` command, driven through the real editor and slash dispatch

Not `build_session_report` in isolation — the actual `/session` path a user types, in `OperatorApp` with the stylesheet loaded:

```
$ .venv/bin/python /tmp/e2e_session.py
'▌ Totals   248 requests · measured · cost incl. subagents'
'  Est. cost             $102.34      $31.28 own · $71.06 subagents'
'  Est. cost is this session plus 20 subagent sessions; every other section below is this session alone.'
```

$31.28 own, $71.06 subagents, $102.34 tree — the reported numbers, to the cent.

Store-level, same session:

```
first open (index build) 664 ms
session_report 7.6 ms
own      : 248 calls  $31.276032
descend  : 896 calls  $71.059322 over 20 sessions
tree     : 1144 calls  $102.335354
```

### 2. The real `/analytics` command, and the invariant that matters

```
$ .venv/bin/python /tmp/e2e_analytics.py
HEADLINE: 'Est. cost             $63.6k+      ≈ list price × tokens'
SECTION : '▌ By session   totals include subagents'
top-level rows: 404   nested rows: 467
sum of top-level cost column: $63712 (abbreviated display cells, so approximate)
first root : '  OSWorld benchmark evaluation and     4.6B tokens     $3.9k+   27872 calls    94% cache'
first child: '    d0f7d9cf7d5d                      25.7M tokens    $120.74    182 calls    60% cache'
```

404 roots + 467 children = all 871 sessions, each placed exactly once. Exact (unrounded) arithmetic on the same data:

```
headline total   : $63640.95
flat own sum     : $63640.95
root tree sum    : $63640.95     <- still sums after the re-partition
naive all-tree   : $71718.15     <- the double count this avoids
sessions in      : 871 roots: 404 with children: 33
sessions placed  : 871 (must equal 871)
2dd2ec9524e8 own $31.28 tree $102.34 children 20
```

### 3. The index is doing what it claims

```
without idx_calls_parent: 468.1 ms
with    idx_calls_parent: 0.23 ms  (2037x faster)
plan with index: ['SEARCH c USING INDEX idx_calls_parent (parent_session_id=?)']
file size: 82.2 MB -> 87.1 MB
```

The query plan confirms the walk descends *through* the index rather than materialising an edge map. **One-time cost on upgrade: ~664 ms on the first open of a 475k-row ledger, +4.9 MB.** That lands on the recorder's background thread in the normal path. Worth knowing before merge.

### 4. Rendered frames — before and after, at three widths

Per AGENTS.md "Visual validation": driven through the real `OperatorApp` (which loads `local_operator.tcss`), exported with `save_screenshot`, rendered to PNG and **looked at**. Frames attached in a comment below.

- `/session` at 120 — before shows `Est. cost $31.28` with no scope stated; after shows `$102.34` + the split + both scope labels.
- `/session` at 68 — the note sheds per the existing `_NOTE_MIN` policy, but the prose scope line survives, so the frame never shows a tree figure without saying it is one.
- `/analytics` at 120 scrolled to `By session` — roots at full strength, children indented two cells and dimmed (their dollars are already inside the row above, so they must not compete visually).
- `/analytics` at 68 — cache column sheds at `_WIDE_TABLE_MIN` for root and child rows alike; the cost column survives, as the width policy intends.

**Pre-existing issue, NOT introduced here and not fixed here:** at 68 columns the per-session rows overflow the card and clip the cost column. The before-frame clips identically, and the old flat renderer produces rows of the same width (91 chars at width 60) — the 2-cell indent does not cause it. Reported rather than fixed, as it is outside this slice.

### 5. Regression surface

Full suite exactly as CI:

```
15101 passed, 18 skipped, 692 warnings in 1054.97s (0:17:34)
```

Quality gate, all clean:

```
$ .venv/bin/python -m flake8 .                              # clean
$ uvx --from black==26.1.0 black --check .                  # 993 files unchanged
$ uvx isort==5.13.2 --check .                               # clean
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python . # 0 errors, 0 warnings
```

New tests (16), each pinning a claim made above rather than restating the implementation: descendant rollup incl. a grandchild; childless-vs-unwalkable distinction (`$0.00` must not be claimed for "unknown"); self-parent cycle survival; index reaching an old ledger *without* aborting the schema script; parent edges exposed to the table; counter-summing keeping the marks right; **roots summing to the table total**; orphaned child kept as a root when its parent was pruned; cycle broken without losing a session; the tree-only `+` still drawing its legend; flat ledger rendering unchanged; nesting not costing the cache column.

### 6. Desktop HTTP route

`aggregate()` also feeds `desktop_catalogues.py`. The new parent edges ride as a `setattr` side map (the same convention `session_names` already uses), so the dataclass contract is untouched:

```
asdict ok, json bytes: 1568
keys unchanged: True
session_parents leaked into asdict? False
```

## Not addressed

- The 68-column per-session row overflow described above — pre-existing, reproduced on the before-frame.
- `prune()` can leave a root whose children aged out first reporting a smaller subtree. Commented at the rollup so the next reader does not diagnose it as a rollup bug; parent and child age out together in practice.
- Exact composer↔ledger reconciliation (derivable via `AsyncJob.logical_id`) is out of scope; the two count different things (job tree vs provider calls) and should not be asserted equal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
