### PR TITLE
fix(session): make a stop actually stop a runaway, and stop lying about it

### DIFF
--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -1335,11 +1335,92 @@ class OwnedSessionHandle(SessionHandle):
         return detail
 
     async def abort(self) -> str:
+        """Stop this session's turn AND its children, and say what was stopped.
+
+        THE CONTROL OP HAS NO SECOND RUNG. The keyboard's Esc ladder can afford
+        a narrow first press because a second press within
+        ``DOUBLE_STOP_WINDOW_S`` is right there, offered on screen, and stops
+        the children. Nothing on this path has that: the mobile relay, a
+        supervisor and ``lop`` peers all send ``abort`` once into a session
+        they cannot see, and there is no gesture that escalates. Reusing the
+        keyboard's narrow semantics here therefore gave callers a stop that
+        could NEVER reach a runaway — the operator sent ``abort``, was acked
+        ``stopping``, and watched 39 paid provider calls land in the next two
+        seconds while their children kept reporting in (QA Q-1). Escalating is
+        what makes "a user must always be able to halt a runaway" true on the
+        surface that has no ladder to climb.
+
+        THE RECEIPT MUST NOT OVERSTATE. It previously returned the literal
+        ``"stopping"`` whatever survived, which is how the operator was told
+        the problem was handled while the meter ran. It now names what was
+        actually stopped, and — because backgrounded ``bash`` jobs deliberately
+        outlive a stop (``background=true`` exists so a build survives the turn
+        that started it) — names what is still running and how to reach it.
+        """
         self._check_loop_thread()
         if self._goal_loop is not None:
             await self._goal_loop.cancel()
+        # THE PARENT FIRST, THEN THE CHILDREN. A child settling hands its
+        # result back to the parent, and a parent still accepting work would
+        # open a turn on it — so stopping the parent first is what makes the
+        # children's teardown quiet instead of one last round of arrivals.
         self._session.abort("stopped from mobile")
-        return "stopping"
+        # `cancel_subagents` reports how many it acted on, counted at cancel
+        # time: the receipt describes THIS abort, not a roster that has since
+        # moved.
+        stopped_children = self._cancel_children("stopped from mobile")
+        return self._abort_receipt(stopped_children)
+
+    def _cancel_children(self, reason: str) -> int:
+        """Cancel this session's subagents, tolerating a host that has none.
+
+        ``getattr``-probed like every other optional capability in this file: a
+        reduced handle or a test double need not implement the subagent
+        protocol, and a stop must not fail because the thing it was asked to
+        stop does not exist.
+        """
+        cancel = getattr(self._session, "cancel_subagents", None)
+        if not callable(cancel):
+            return 0
+        try:
+            return int(cast(int, cancel(reason)))
+        except Exception:  # noqa: BLE001 — a stop must never fail on its children
+            logger.warning("cancelling subagents during abort failed", exc_info=True)
+            return 0
+
+    def _abort_receipt(self, stopped_children: int) -> str:
+        """What the abort actually did, including what it deliberately left.
+
+        Survivors are named only when there ARE any: unconditional, it is noise
+        on the overwhelmingly common stop that had nothing else running.
+        """
+        parts = ["stopping this turn"]
+        if stopped_children:
+            plural = "s" if stopped_children != 1 else ""
+            parts.append(f"stopped {stopped_children} subagent{plural}")
+        spared = self._background_bash_jobs()
+        if spared:
+            plural = "s" if spared != 1 else ""
+            parts.append(f"{spared} background job{plural} still running — jobs cancel to stop")
+        return "; ".join(parts)
+
+    def _background_bash_jobs(self) -> int:
+        """Backgrounded ``bash`` jobs, which a stop never touches.
+
+        Deliberately spared (see ``Session.cancel_subagents``) and genuinely
+        surprising to someone who just asked for everything to stop, so the
+        receipt names them. Never raises: this runs inside a kill switch.
+        """
+        try:
+            jobs = self._session.jobs.list()
+        except Exception:  # noqa: BLE001 — an unreadable ledger must not break a stop
+            logger.warning("listing background jobs during abort failed", exc_info=True)
+            return 0
+        return sum(
+            1
+            for job in jobs
+            if getattr(job, "type", "") == "bash" and getattr(job, "status", "") == "running"
+        )
 
     async def cancel_gracefully(self, reason: str = "cancelled by supervisor") -> str:
         """Stop at the next post-tool boundary, leaving in-flight work intact.

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -24,6 +24,7 @@ import asyncio
 import inspect
 import logging
 import secrets
+import time
 import uuid
 from asyncio import InvalidStateError
 from collections import deque
@@ -62,6 +63,17 @@ logger = logging.getLogger(__name__)
 #: another await to that prelude. Turns, not seconds — see
 #: ``_admit_without_waiting_for_the_turn``.
 _ADMISSION_PRELUDE_TURNS = 3
+
+#: How long the ``abort`` op waits for cancelled children to actually go before
+#: it reports what is left. Cancellation is one fire-and-forget task per child,
+#: so a count taken at dispatch describes intent rather than outcome — the
+#: overstatement review round 1 (MAJOR-1) measured. A child normally settles in
+#: well under a tick, and the poll exits the moment the roster drains, so this
+#: is a CEILING for the wedged case rather than a cost every stop pays. Kept
+#: short because the caller (a phone, a supervisor) is blocked on the ack: a
+#: child that will not die must delay the receipt by a beat, never hold it.
+_ABORT_SETTLE_BUDGET_S = 1.0
+_ABORT_SETTLE_POLL_S = 0.02
 
 
 def _log_detached_admission(task: "asyncio.Task[str]") -> None:
@@ -1350,12 +1362,23 @@ class OwnedSessionHandle(SessionHandle):
         what makes "a user must always be able to halt a runaway" true on the
         surface that has no ladder to climb.
 
-        THE RECEIPT MUST NOT OVERSTATE. It previously returned the literal
-        ``"stopping"`` whatever survived, which is how the operator was told
-        the problem was handled while the meter ran. It now names what was
-        actually stopped, and — because backgrounded ``bash`` jobs deliberately
-        outlive a stop (``background=true`` exists so a build survives the turn
-        that started it) — names what is still running and how to reach it.
+        THE RECEIPT MUST NOT OVERSTATE, AND IT IS COUNTED AFTER THE FACT.
+        It previously returned the literal ``"stopping"`` whatever survived,
+        which is how the operator was told the problem was handled while the
+        meter ran. Reporting ``cancel_subagents()``'s return value instead
+        would only move the lie: that number is ``len(running)`` sampled at
+        DISPATCH time, before any child has actually gone, and per-child
+        cancellation is fire-and-forget with failures swallowed by design. A
+        child that refuses to die was therefore counted as stopped — measured
+        with two of three cancels raising, the receipt still said "stopped 3
+        subagents" while two kept running and spending (review round 1,
+        MAJOR-1).
+
+        So the count is taken from the session's own live predicate once the
+        cancellations have had a chance to land, and anything still standing is
+        named as still running. Backgrounded ``bash`` jobs deliberately outlive
+        a stop (``background=true`` exists so a build survives the turn that
+        started it), so they are named too rather than implied stopped.
         """
         self._check_loop_thread()
         if self._goal_loop is not None:
@@ -1365,11 +1388,10 @@ class OwnedSessionHandle(SessionHandle):
         # open a turn on it — so stopping the parent first is what makes the
         # children's teardown quiet instead of one last round of arrivals.
         self._session.abort("stopped from mobile")
-        # `cancel_subagents` reports how many it acted on, counted at cancel
-        # time: the receipt describes THIS abort, not a roster that has since
-        # moved.
-        stopped_children = self._cancel_children("stopped from mobile")
-        return self._abort_receipt(stopped_children)
+        before = self._running_children()
+        self._cancel_children("stopped from mobile")
+        remaining = await self._settled_children(before)
+        return self._abort_receipt(stopped=max(before - remaining, 0), still_running=remaining)
 
     def _cancel_children(self, reason: str) -> int:
         """Cancel this session's subagents, tolerating a host that has none.
@@ -1378,6 +1400,10 @@ class OwnedSessionHandle(SessionHandle):
         reduced handle or a test double need not implement the subagent
         protocol, and a stop must not fail because the thing it was asked to
         stop does not exist.
+
+        The return is the DISPATCH count and must not be reported as an
+        outcome — see :meth:`abort`. Callers wanting the truth ask
+        :meth:`_running_children` after the cancellations have settled.
         """
         cancel = getattr(self._session, "cancel_subagents", None)
         if not callable(cancel):
@@ -1388,16 +1414,66 @@ class OwnedSessionHandle(SessionHandle):
             logger.warning("cancelling subagents during abort failed", exc_info=True)
             return 0
 
-    def _abort_receipt(self, stopped_children: int) -> str:
+    def _running_children(self) -> int:
+        """Children still running RIGHT NOW, via the session's own predicate.
+
+        ``running_subagents`` is the one predicate the ladder and its counts
+        share, so the receipt cannot disagree with what a later Esc would
+        offer. Probed and non-raising for the same reasons as
+        :meth:`_cancel_children`.
+        """
+        counter = getattr(self._session, "running_subagents", None)
+        if not callable(counter):
+            return 0
+        try:
+            return int(cast(int, counter()))
+        except Exception:  # noqa: BLE001 — a stop must never fail on its count
+            logger.warning("counting subagents during abort failed", exc_info=True)
+            return 0
+
+    async def _settled_children(self, before: int) -> int:
+        """Wait briefly for the cancellations to land, then count what is left.
+
+        Cancellation is one fire-and-forget task per child, so the roster is
+        still full the instant after dispatch and an immediate count would
+        report every child as surviving — the mirror image of the overstatement
+        this exists to fix. Polling rather than awaiting the tasks because the
+        handle does not own them (the session tracks them for ``dispose``), and
+        the loop exits the moment the roster drains, so the healthy case costs
+        one tick rather than the whole budget.
+
+        BOUNDED, and short. This runs inside a kill switch whose caller is a
+        phone or a supervisor waiting on the ack: a child wedged in an
+        uninterruptible await must delay the receipt by a beat, never hold it.
+        Whatever has not gone by then is reported as still running, which is
+        the honest answer and the one that tells the user to escalate.
+        """
+        if before <= 0:
+            return 0
+        deadline = time.monotonic() + _ABORT_SETTLE_BUDGET_S
+        remaining = self._running_children()
+        while remaining > 0 and time.monotonic() < deadline:
+            await asyncio.sleep(_ABORT_SETTLE_POLL_S)
+            remaining = self._running_children()
+        return remaining
+
+    def _abort_receipt(self, *, stopped: int, still_running: int) -> str:
         """What the abort actually did, including what it deliberately left.
 
         Survivors are named only when there ARE any: unconditional, it is noise
         on the overwhelmingly common stop that had nothing else running.
         """
         parts = ["stopping this turn"]
-        if stopped_children:
-            plural = "s" if stopped_children != 1 else ""
-            parts.append(f"stopped {stopped_children} subagent{plural}")
+        if stopped:
+            parts.append(f"stopped {stopped} subagent{'s' if stopped != 1 else ''}")
+        if still_running:
+            # The whole point of the change: a child that would not die is the
+            # one fact the user must have, and it names the stronger lever
+            # rather than leaving them to discover the meter still running.
+            parts.append(
+                f"{still_running} subagent{'s' if still_running != 1 else ''} "
+                "did NOT stop — lop stop ends the process"
+            )
         spared = self._background_bash_jobs()
         if spared:
             plural = "s" if spared != 1 else ""

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -254,6 +254,29 @@ _MAX_CONTINUATIONS = 8
 #: at sub-second cadence is the noise this replaced.
 _PRE_ABORT_DROP_NOTICE_AT = 3
 
+#: Arrivals that are the RESIDUE of work a stop was aimed at, not fresh intent.
+#:
+#: ``_prompt_messages`` clears a sticky abort for arriving work because a new
+#: unit of work is normally a new intent — a peer's message or the user's own
+#: wake genuinely means "do this now", and PR #709 made that clearing the cure
+#: for the paid-no-op loop. But a SUBAGENT reporting in is not a new intent: it
+#: is the echo of the very work the user just stopped. Letting it clear the
+#: abort is what kept the meter running after a stop acked — measured at 39
+#: paid provider calls in the 2 s after an abort, one per child report, because
+#: each report cleared the flag and bought a full turn (QA Q-1).
+#:
+#: These types are therefore held rather than run while a stop is pending: the
+#: message is still persisted and still reaches the model on the next real
+#: turn, so nothing is lost — only the model call the user already said to stop
+#: is skipped. A typed prompt, a peer message or a wake still clears the flag,
+#: which is what keeps a stopped session recoverable without a restart.
+#:
+#: ``job_result`` is in the set for both job kinds deliberately. A background
+#: job's completion is the finish of work the stopped turn launched, never a
+#: fresh instruction from the user, so it may not re-open a turn on a session
+#: that has been stopped.
+_STOPPED_WORK_RESIDUE_TYPES = frozenset({HUB_MESSAGE_TYPE, JOB_RESULT_MESSAGE_TYPE})
+
 #: The builtin tools whose createIf gate reads a field only a SESSION can fill
 #: (``subagent_launcher``, ``jobs``, ``wake_scheduler``, ``subagent_comms``, the
 #: ask hook). Named here rather than inline in
@@ -5052,6 +5075,16 @@ class Session:
         opens minutes later is the surprise this closes — see
         :meth:`cancel_fork`. The host reports it; ``abort`` returns nothing, so
         the caller asks the session what it cancelled.
+
+        SUBAGENTS ARE NOT STOPPED HERE, and that stays deliberate: the
+        keyboard's first press must not destroy a child minutes into useful
+        work (see :meth:`cancel_subagents`). What changed is that the first
+        rung is now CHEAP as well as narrow — a child reporting into a stopped
+        parent no longer clears the abort and buys a turn (see
+        ``_STOPPED_WORK_RESIDUE_TYPES``), so a stop that leaves children
+        running no longer leaves a meter running with them. A caller with no
+        second rung to offer must still reach the children itself, which is
+        what the ``abort`` control op now does.
         """
         self._abort_requested = True
         # Bumped on EVERY abort, before the signal fires. Work already queued
@@ -5739,6 +5772,28 @@ class Session:
 
     # -- turn machinery --------------------------------------------------------
 
+    @staticmethod
+    def _is_stopped_work_residue(initial: list[AgentMessage]) -> bool:
+        """Whether this arrival is the echo of stopped work rather than new intent.
+
+        Read only while an abort is pending, to decide whether the arrival may
+        clear it (see ``_STOPPED_WORK_RESIDUE_TYPES`` for the reasoning and the
+        measured cost of getting it wrong).
+
+        ALL of the batch must be residue. A batch that mixes a child's report
+        with a real user-driven arrival contains fresh intent, and the safe
+        reading of a mixed batch is the one that still lets the user's work
+        through — holding it would be the "Esc broke my session" failure in
+        place of the money one.
+        """
+        if not initial:
+            return False
+        return all(
+            isinstance(message, CustomMessage)
+            and message.custom_type in _STOPPED_WORK_RESIDUE_TYPES
+            for message in initial
+        )
+
     async def _prompt_messages(self, initial: list[AgentMessage]) -> None:
         """Shared turn runner for wake deliveries (prompt() owns its own lock
         handling so it can REJECT reentrants instead of queueing)."""
@@ -5792,7 +5847,17 @@ class Session:
             # the flag. Bumped means an abort landed while this sat in the
             # queue, aimed at the backlog it was in: leave the flag set and let
             # ``_run_turn`` hold the message instead of running it.
-            if self._abort_epoch == arrived_at_epoch:
+            #
+            # AND THE ARRIVAL MUST BE FRESH INTENT, NOT RESIDUE. The epoch test
+            # alone asks only "did the abort predate this work", which is the
+            # wrong question for a subagent still reporting in: its report
+            # always arrives after the stop, so it always looked fresh, cleared
+            # the flag and bought a turn. With children reporting at sub-second
+            # cadence that is an unstoppable meter — 39 paid calls in the 2 s
+            # after an acked abort (QA Q-1). See
+            # ``_STOPPED_WORK_RESIDUE_TYPES`` for why these types are the echo
+            # of the stopped work rather than a new instruction.
+            if self._abort_epoch == arrived_at_epoch and not self._is_stopped_work_residue(initial):
                 self._abort_requested = False
                 # ...and the boundary cancel, for the reason ``prompt()``
                 # gives: the request applied to the turn the caller was

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -274,7 +274,37 @@ _PRE_ABORT_DROP_NOTICE_AT = 3
 #: ``job_result`` is in the set for both job kinds deliberately. A background
 #: job's completion is the finish of work the stopped turn launched, never a
 #: fresh instruction from the user, so it may not re-open a turn on a session
-#: that has been stopped.
+#: that has been stopped. It is also the type that carries the fix in
+#: PRODUCTION: every live ``hub_message`` producer routes through
+#: :meth:`Session.queue_aside`, so ``HUB_MESSAGE_TYPE`` is defensive here
+#: rather than load-bearing (review round 1, MINOR-1) — kept because a future
+#: producer reaching ``_prompt_messages`` with one would otherwise reopen the
+#: money loop silently.
+#:
+#: THE BOUNDARY, STATED (review round 1, MAJOR-2). Everything NOT in this set
+#: — a typed prompt, a wake, a peer message, a resume catch-up — still clears a
+#: pending abort and may buy a turn on a stopped session. That is deliberate
+#: and it is what "stopped" means here: this session's own work is halted, but
+#: the session stays REACHABLE, so a human (or their own reminder) can revive
+#: it without restarting the process. Adding those types would make one Esc
+#: mean "ignore the user until they restart me", which is a worse failure than
+#: the one this set fixes.
+#:
+#: What keeps that carve-out safe is that none of it is a SELF-SUSTAINING loop
+#: the session can drive on its own:
+#:
+#: * a wake is rate-limited by ``MIN_WAKE_INTERVAL_MS`` (60 s), so the worst
+#:   case is a turn a minute from a schedule the user can see and cancel, not
+#:   an unbounded burn;
+#: * a peer message needs another session or a human to send it, and mailbox
+#:   mode (the default) spends nothing at all;
+#: * a typed prompt is the user asking for work.
+#:
+#: The residue types are the ones the STOPPED SESSION'S OWN CHILDREN generate,
+#: at whatever cadence they choose, with no floor and no human in the loop —
+#: which is exactly why they are the ones that must not clear a stop. A caller
+#: that needs everything to stop regardless has the stronger rung: the ``abort``
+#: control op cancels the children, and ``lop stop`` ends the process.
 _STOPPED_WORK_RESIDUE_TYPES = frozenset({HUB_MESSAGE_TYPE, JOB_RESULT_MESSAGE_TYPE})
 
 #: The builtin tools whose createIf gate reads a field only a SESSION can fill

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1714,6 +1714,9 @@ class OperatorApp(App[None]):
         #: than tell them to wait for a session that is never arriving.
         #: Cleared the moment another session transition starts.
         self._stopped_session_id = ""
+        #: See `_adopt_session`: the session this viewer is looking at, which
+        #: outlives the `_session` binding so `/stop` can still address it.
+        self._adopted_session_id = ""
         self._watched_stop_notice_shown = False
         #: Whether THIS app issued the stop it is about to be told about, so
         #: the notice can attribute it correctly (see _paint_watched_stop_notice).
@@ -2761,6 +2764,14 @@ class OperatorApp(App[None]):
         """
         self._invalidate_pending_frontend_state()
         self._session = session
+        # The id of the session this VIEWER is looking at, kept beside the
+        # binding rather than derived from it. `self._session` is dropped by
+        # every swap/reload/reconnect path while the underlying session keeps
+        # running, and the kill switch must still be able to name a target in
+        # that window — a `/stop` that refuses because the viewer is unbound is
+        # a runaway nobody can halt (see `_cmd_stop`, QA Q-2). Recorded on
+        # adoption because that is the one edge where the identity is known.
+        self._adopted_session_id = getattr(session, "session_id", "") or ""
         # The latch belongs to the BINDING, not to the app: a swapped-in
         # session is cold again and owes its own engage. Its declaration has
         # always said a swap resets it, but nothing did — harmless while the
@@ -6455,6 +6466,18 @@ class OperatorApp(App[None]):
             )
         if self._boot_failed:
             return ("session failed to start — /login to reconfigure or restart lop", failed)
+        if self._adopted_session_id:
+            # ADOPTED, then unbound. "Still starting" is false here and its
+            # advice — wait — is the most expensive thing a user can do when
+            # the session they cannot reach is spending money (QA Q-2). This is
+            # the residual state after `_cmd_stop`'s fallback could not address
+            # the session, so the copy names what is actually true and points
+            # at the lever that works from outside this viewer.
+            return (
+                f"this viewer lost its link to session {self._adopted_session_id}; "
+                f"it may still be running — lop stop {self._adopted_session_id} ends it",
+                failed,
+            )
         return ("session is still starting…", starting)
 
     def _retire_name_list_reserve(self) -> None:
@@ -15935,6 +15958,25 @@ class OperatorApp(App[None]):
             return
         if not target:
             if session is None:
+                # GATED ON WHETHER A SESSION EXISTS TO STOP, not on whether
+                # THIS VIEWER happens to hold one. The two are different, and
+                # conflating them broke the kill switch in exactly the state it
+                # is needed: with the session adopted, alive and undisposed but
+                # the viewer's reference dropped (a swap, a reload, a reconnect
+                # race), `/stop` answered "session is still starting…" for a
+                # session that was visibly burning money — and told the user to
+                # WAIT, the single most expensive thing they can do (QA Q-2).
+                #
+                # An unbound viewer can still stop the session it is LOOKING
+                # at: `_resumable_session_id` carries that id, and the runtime
+                # stop ladder addresses a session by id rather than by object.
+                # So the refusal is now the genuinely unstoppable case only.
+                watched = self._adopted_session_id
+                if watched and not self._stopped_session_id:
+                    self.run_worker(
+                        self._stop_unbound_worker(watched), thread=False, group="session"
+                    )
+                    return
                 # ``_system_notice``: nothing ran, so the boot composition
                 # must survive it — the rule every rejecting branch follows.
                 # Through the shared no-session helper so a second /stop
@@ -15980,6 +16022,10 @@ class OperatorApp(App[None]):
         # and no stopped id and answers "session is still starting…" — the
         # boot wording — for a session the user just stopped on purpose.
         self._stopped_session_id = resumable_id
+        # This viewer is no longer looking at a live session, so the unbound
+        # `/stop` fallback must not offer to stop it again through the socket
+        # ladder — it is already ending here.
+        self._adopted_session_id = ""
         name = getattr(session, "conversation_name", "") or resumable_id
         wakes = self._mark_own_wakes_dormant(session)
         # Retire any paint the dying session already queued: its
@@ -16157,6 +16203,41 @@ class OperatorApp(App[None]):
         # stop that arrives as an announcement came from another terminal or
         # from the runtime's own ladder, and that is what the user needs.
         self._system_notice(detail or "stop requested from another terminal")
+
+    async def _stop_unbound_worker(self, session_id: str) -> None:
+        """Bare ``/stop`` when the viewer lost its binding but the session lives.
+
+        Deliberately NOT ``_stop_target_worker``. That worker's self-pid branch
+        routes back into :meth:`_cmd_stop`, which — with no bound session —
+        would take the unbound fallback again and dispatch another worker,
+        forever. Measured while building this path: the recursion spawned
+        workers until teardown and painted nothing at all, which is a quieter
+        version of the very defect being fixed.
+
+        The two outcomes are genuinely different and must read differently:
+
+        * the session is in ANOTHER process — the socket ladder owns it, and
+          the shared worker's receipt is the right one, so this delegates;
+        * the session is in THIS process — nothing here can reach it, because
+          the object that would be asked is exactly the reference this viewer
+          lost. Saying so, and naming the out-of-process lever, is the honest
+          answer; "still starting" was not.
+        """
+        from local_operator.mobile.peer_send import resolve_peer_target
+
+        record, candidates, _error = resolve_peer_target(
+            target=session_id,
+            pid=None,
+            session=None,
+            pid_hint="a pid",
+            session_hint="a session id",
+            include_wedged=True,  # a wedged agent is the one a user most needs to stop
+        )
+        if record is not None and not candidates and record.pid != os.getpid():
+            await self._stop_target_worker(session_id)
+            return
+        body, kind = self._no_session_notice()
+        self._system_notice(body, kind)
 
     async def _stop_target_worker(self, target: str) -> None:
         """``/stop <target>``: resolve with the `send` vocabulary, stop it.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -4823,6 +4823,11 @@ class OperatorApp(App[None]):
         async with self._turn_provider_lock:
             pass
         self._session = None
+        # The watched id dies WITH the binding. It exists so an unbound viewer
+        # can still stop what it is looking at; a session being deliberately
+        # replaced is not that, and a stale id here made an ordinary /reload
+        # take the unbound branch (review round 1, BLOCKER-2).
+        self._adopted_session_id = ""
         # The pending approval belonged to the session that just died. Left
         # set, the NEW session's first write/exec approval queued behind a
         # question that is no longer on screen and nothing could answer it.
@@ -5843,6 +5848,10 @@ class OperatorApp(App[None]):
             except Exception:
                 pass
         self._session = None
+        # Same reason as `_reload_session`: the id is a lever for a viewer that
+        # LOST its session, never for one deliberately swapping to another.
+        # `_adopt_session` re-stamps it for the incoming session below.
+        self._adopted_session_id = ""
         self._swapping_session = True
         try:
             self._reset_ledger_for_swap()
@@ -6466,13 +6475,22 @@ class OperatorApp(App[None]):
             )
         if self._boot_failed:
             return ("session failed to start — /login to reconfigure or restart lop", failed)
-        if self._adopted_session_id:
+        if self._adopted_session_id and not self._session_transition_pending:
             # ADOPTED, then unbound. "Still starting" is false here and its
             # advice — wait — is the most expensive thing a user can do when
             # the session they cannot reach is spending money (QA Q-2). This is
             # the residual state after `_cmd_stop`'s fallback could not address
             # the session, so the copy names what is actually true and points
             # at the lever that works from outside this viewer.
+            #
+            # EXCLUDED DURING A TRANSITION, and this helper is shared by ~15
+            # call sites (`/team`, `/agent`, the prompt path), so the exclusion
+            # is not a `/stop` detail. A /reload nulls the binding deliberately
+            # and boots a replacement; telling the user their viewer "lost its
+            # link" and that a session "may still be running" — in the error
+            # weight — during a transition they themselves started is false and
+            # alarming (review round 1, BLOCKER-2). "Still starting" is the true
+            # answer there: a session really is on its way.
             return (
                 f"this viewer lost its link to session {self._adopted_session_id}; "
                 f"it may still be running — lop stop {self._adopted_session_id} ends it",
@@ -15968,11 +15986,27 @@ class OperatorApp(App[None]):
                 # WAIT, the single most expensive thing they can do (QA Q-2).
                 #
                 # An unbound viewer can still stop the session it is LOOKING
-                # at: `_resumable_session_id` carries that id, and the runtime
-                # stop ladder addresses a session by id rather than by object.
-                # So the refusal is now the genuinely unstoppable case only.
+                # at: `_adopted_session_id` carries that id (stamped in
+                # `_adopt_session`, and NOT the same thing as the
+                # `_resumable_session_id()` method, which answers a different
+                # question about transcripts on disk), and the runtime stop
+                # ladder addresses a session by id rather than by object. So
+                # the refusal is now the genuinely unstoppable case only.
+                #
+                # NOT DURING A TRANSITION. A /reload, /new, /resume or attach
+                # nulls the binding on purpose and boots a replacement, so the
+                # viewer is legitimately sessionless for that window and the
+                # id it holds names a session that is being REPLACED, not one
+                # that ran away. Clearing the id at each unbind closes most of
+                # the window; this guard closes the rest of it, including the
+                # gap before the new session is adopted (review round 1,
+                # BLOCKER-2).
                 watched = self._adopted_session_id
-                if watched and not self._stopped_session_id:
+                if (
+                    watched
+                    and not self._stopped_session_id
+                    and not self._session_transition_pending
+                ):
                     self.run_worker(
                         self._stop_unbound_worker(watched), thread=False, group="session"
                     )
@@ -16225,16 +16259,36 @@ class OperatorApp(App[None]):
         """
         from local_operator.mobile.peer_send import resolve_peer_target
 
-        record, candidates, _error = resolve_peer_target(
-            target=session_id,
+        # THE EXACT SELECTOR, NEVER THE SUBSTRING VOCABULARY. `target=` matches
+        # case-insensitively against conversation_name, session_id AND the cwd
+        # basename of every live record, and the state this fallback exists for
+        # is precisely the one where the watched session is NOT resolvable — so
+        # the needle falls through to whatever else happens to contain it.
+        # Measured with the watched session absent and one decoy whose name
+        # contained its id: `target=` resolved to that unrelated live session
+        # with no error and no ambiguity candidates, and the kill switch would
+        # then have stopped it (review round 1, BLOCKER-1). `resolve_peer_target`
+        # names this class a wrong-recipient hazard in its own docstring, and a
+        # kill switch is the worst place to take it: the user asks to stop a
+        # runaway, a healthy peer dies, and the runaway keeps billing.
+        #
+        # `session=` is an exact `record.session_id ==` match, so a miss returns
+        # None and falls through to the honest notice below rather than to a
+        # neighbour.
+        record, _candidates, _error = resolve_peer_target(
+            target=None,
             pid=None,
-            session=None,
+            session=session_id,
             pid_hint="a pid",
             session_hint="a session id",
             include_wedged=True,  # a wedged agent is the one a user most needs to stop
         )
-        if record is not None and not candidates and record.pid != os.getpid():
-            await self._stop_target_worker(session_id)
+        if record is not None and record.pid != os.getpid():
+            # The RESOLVED RECORD is handed straight to the ladder. Re-entering
+            # `_stop_target_worker` with the id would resolve a second time
+            # through the substring vocabulary and hand back the very hazard
+            # the exact selector above just excluded.
+            await self._stop_resolved_record(record)
             return
         body, kind = self._no_session_notice()
         self._system_notice(body, kind)
@@ -16249,8 +16303,6 @@ class OperatorApp(App[None]):
         worker only surfaces them.
         """
         from local_operator.mobile.peer_send import resolve_peer_target
-        from local_operator.paths import config_dir
-        from local_operator.session.runtime import control
 
         record, candidates, error = resolve_peer_target(
             target=target,
@@ -16278,6 +16330,21 @@ class OperatorApp(App[None]):
         if record.pid == os.getpid():
             self._cmd_stop("", lambda body, kind="info": self._system_notice(body, kind))
             return
+        await self._stop_resolved_record(record)
+
+    async def _stop_resolved_record(self, record: Any) -> None:
+        """Run the stop ladder against a record that is ALREADY resolved.
+
+        Split from :meth:`_stop_target_worker` so a caller holding a record can
+        reach the ladder without resolving a second time. That matters for the
+        unbound `/stop`, which resolves by the EXACT session selector on
+        purpose: routing it back through the target worker would re-resolve the
+        id through the substring vocabulary and could land on a different live
+        session (review round 1, BLOCKER-1).
+        """
+        from local_operator.paths import config_dir
+        from local_operator.session.runtime import control
+
         # An acknowledgement the receipt then REPLACES: the ladder can take
         # seconds (a wedged runtime pays the graceful timeout, identity and
         # the SIGTERM grace), and a composer that accepts input while

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -4823,11 +4823,23 @@ class OperatorApp(App[None]):
         async with self._turn_provider_lock:
             pass
         self._session = None
-        # The watched id dies WITH the binding. It exists so an unbound viewer
-        # can still stop what it is looking at; a session being deliberately
-        # replaced is not that, and a stale id here made an ordinary /reload
-        # take the unbound branch (review round 1, BLOCKER-2).
-        self._adopted_session_id = ""
+        # THE WATCHED ID DELIBERATELY SURVIVES THIS WINDOW. It is the only
+        # lever a stranded viewer has, and clearing it here disarmed the kill
+        # switch on the exact path this feature exists to serve: if anything
+        # between the null above and `_adopt_session` below raises, the viewer
+        # is left unbound while the session it was watching keeps running — for
+        # a remote, in another process, still billing. Measured with the swap
+        # raising mid-window: cleared, `/stop` dispatched nothing and told the
+        # user to WAIT; left alone, it dispatched the stop (review round 2,
+        # BLOCKER-3).
+        #
+        # An ordinary transition stays honest WITHOUT clearing it, because
+        # `_session_transition_pending` already gates both the unbound dispatch
+        # and the notice for the whole window — including the gap before the
+        # replacement is adopted (see `_cmd_stop`). A real /reload sampled
+        # across the transition never observes an unbound viewer holding this
+        # id. `_adopt_session` re-stamps it on success, so the value is only
+        # ever stale on the failure path, which is precisely where it is needed.
         # The pending approval belonged to the session that just died. Left
         # set, the NEW session's first write/exec approval queued behind a
         # question that is no longer on screen and nothing could answer it.
@@ -5848,10 +5860,10 @@ class OperatorApp(App[None]):
             except Exception:
                 pass
         self._session = None
-        # Same reason as `_reload_session`: the id is a lever for a viewer that
-        # LOST its session, never for one deliberately swapping to another.
-        # `_adopt_session` re-stamps it for the incoming session below.
-        self._adopted_session_id = ""
+        # Same reason as `_reload_session`: the watched id must OUTLIVE this
+        # window. This is the strand path itself — the remote runs in another
+        # process, so a raise before the adopt below leaves it billing with the
+        # viewer unable to name it. `_adopt_session` re-stamps on success.
         self._swapping_session = True
         try:
             self._reset_ledger_for_swap()

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -16009,10 +16009,22 @@ class OperatorApp(App[None]):
                 # nulls the binding on purpose and boots a replacement, so the
                 # viewer is legitimately sessionless for that window and the
                 # id it holds names a session that is being REPLACED, not one
-                # that ran away. Clearing the id at each unbind closes most of
-                # the window; this guard closes the rest of it, including the
-                # gap before the new session is adopted (review round 1,
-                # BLOCKER-2).
+                # that ran away.
+                #
+                # THIS GUARD IS THE ONLY THING KEEPING THAT HONEST \u2014 do not
+                # delete it expecting a belt-and-braces id-clear to cover you.
+                # An earlier fix also cleared `_adopted_session_id` at each
+                # unbind, and that clear was REMOVED on purpose: it sat inside
+                # the null\u2192adopt window and disarmed the kill switch on the
+                # strand path, where the session keeps running (for a remote,
+                # in another process, still billing) and this id is the user's
+                # only lever. See `_reload_session`/`_attach_or_refuse` for why
+                # the id must outlive that window. So the id is deliberately
+                # live for the whole transition, and this flag is the sole
+                # reason a transition does not read as a strand \u2014 including
+                # the gap before the replacement is adopted, verified by firing
+                # `/stop` from inside that window (review rounds 1-3,
+                # BLOCKER-2/BLOCKER-3).
                 watched = self._adopted_session_id
                 if (
                     watched

--- a/tests/unit/session/runtime/test_owned.py
+++ b/tests/unit/session/runtime/test_owned.py
@@ -1466,3 +1466,62 @@ async def test_the_abort_op_survives_a_session_that_cannot_stop_children() -> No
     receipt = await handle.abort()
 
     assert "stopping this turn" in receipt
+
+
+@pytest.mark.asyncio
+async def test_the_abort_op_really_terminates_live_children(tmp_path) -> None:
+    """End to end on a REAL Session: the children are gone, not just counted.
+
+    The receipt naming stopped subagents is worth nothing if they keep running,
+    so this drives real jobs through the real job manager rather than a double
+    and asserts on their status afterwards. The children here would run for 30
+    seconds on their own, so a "cancelled" status cannot be them finishing.
+    """
+    from local_operator.harness.types import StreamEndEvent
+    from local_operator.session.session import ModelSpec, Session
+    from local_operator.session.transcript import Transcript
+
+    def stream(request, signal):  # noqa: ANN001, ANN202
+        async def gen():
+            await asyncio.sleep(0.01)
+            yield StreamEndEvent(stop_reason="stop")
+
+        return gen()
+
+    session = Session(
+        model=ModelSpec(
+            provider="test", model_id="T", context_window=100_000, supports_images=True
+        ),
+        stream_fn=stream,
+        tools=[],
+        transcript=Transcript(tmp_path / "sess"),
+        system_blocks_provider=lambda: ["stable", "env"],
+    )
+    started = asyncio.Event()
+
+    async def child(job_id, signal, report_progress):  # noqa: ANN001, ANN202
+        started.set()
+        await asyncio.sleep(30)
+        return "a child that never finishes on its own"
+
+    job_ids = [session.jobs.register("task", f"child-{n}", child) for n in range(3)]
+    await asyncio.wait_for(started.wait(), timeout=5)
+    await asyncio.sleep(0.2)
+    assert session.running_subagents() == 3
+
+    handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd=str(tmp_path))
+    receipt = await handle.abort()
+
+    def statuses() -> list[str]:
+        rows = [session.jobs.get(job_id) for job_id in job_ids]
+        assert all(row is not None for row in rows), "a registered job vanished"
+        return [row.status for row in rows if row is not None]
+
+    for _ in range(100):
+        await asyncio.sleep(0.02)
+        if all(status == "cancelled" for status in statuses()):
+            break
+    assert statuses() == ["cancelled"] * 3
+    assert session.running_subagents() == 0
+    assert "stopped 3 subagents" in receipt
+    await session.dispose()

--- a/tests/unit/session/runtime/test_owned.py
+++ b/tests/unit/session/runtime/test_owned.py
@@ -44,6 +44,9 @@ class FakeSession:
         self._complete_calls: list[tuple[str, str]] = []
         self.prompt_calls: list[str] = []
         self.steer_calls: list[str] = []
+        #: Reasons `abort` was called with, so a stop test can assert the turn
+        #: was stopped and not only the children.
+        self.aborts: list[str] = []
         self.prompt_release = asyncio.Event()
         #: The MCP manager the `/mcp` handlers read. ``None`` matches a real
         #: session before its servers connect; the grant tests substitute a
@@ -136,6 +139,12 @@ class FakeSession:
 
     def running_subagents(self) -> int:
         return 0
+
+    def abort(self, reason: str = "interrupted") -> None:
+        """Part of SessionProtocol, and the control op's first act. Recorded
+        rather than ignored so a test can prove the turn was stopped as well as
+        the children."""
+        self.aborts.append(reason)
 
     async def prompt(self, text: str, images=None) -> None:  # noqa: ANN001
         self.prompt_calls.append(text)
@@ -1390,3 +1399,70 @@ async def test_model_saved_with_no_configured_default_says_so(
     result = await handle._model_slash(session, "saved", SlashResult)
     assert "no boot default saved yet" in result.text
     assert "/model default <provider>/<model-id>" in result.text
+
+
+@pytest.mark.asyncio
+async def test_the_abort_op_stops_the_children_too() -> None:
+    """The control op has NO second rung, so its one press must reach children.
+
+    The keyboard's Esc ladder can afford a narrow first press because a second
+    press is offered on screen. Nothing on this path has that: the mobile
+    relay, a supervisor and `lop` peers send `abort` once into a session they
+    cannot see. Reusing the keyboard's narrow semantics gave those callers a
+    stop that could never end a runaway — the operator sent `abort`, was acked
+    "stopping", and watched the meter run (QA Q-1).
+    """
+    handle, session = make_handle()
+    cancelled: list[str] = []
+    session.cancel_subagents = lambda reason="interrupted": (  # type: ignore[attr-defined]
+        cancelled.append(reason),
+        3,
+    )[1]
+
+    receipt = await handle.abort()
+
+    assert session.aborts, "the turn itself must still be stopped"
+    assert cancelled, "the abort op must reach the children; it is the only rung it has"
+    assert "stopped 3 subagents" in receipt
+
+
+@pytest.mark.asyncio
+async def test_the_abort_receipt_does_not_claim_more_than_it_did() -> None:
+    """The ack must not say "stopping" while things keep running.
+
+    Returning the literal "stopping" whatever survived is how the operator was
+    told the problem was handled while the meter ran. Backgrounded `bash` jobs
+    are deliberately spared (`background=true` exists so a build outlives the
+    turn), so the receipt has to name them rather than imply they stopped.
+    """
+    handle, session = make_handle()
+    session.cancel_subagents = lambda reason="interrupted": 0  # type: ignore[attr-defined]
+
+    async def never(job_id, signal, report_progress):  # noqa: ANN001, ANN202
+        await asyncio.sleep(30)
+
+    session.jobs.register("bash", "a long build", never)
+    await asyncio.sleep(0.05)
+
+    receipt = await handle.abort()
+
+    assert "1 background job still running" in receipt
+    assert "jobs cancel" in receipt
+    # No children ran, so the receipt must not invent a number for them.
+    assert "subagent" not in receipt
+
+
+@pytest.mark.asyncio
+async def test_the_abort_op_survives_a_session_that_cannot_stop_children() -> None:
+    """A reduced host must get a stop, not an exception.
+
+    `cancel_subagents` is getattr-probed like every other optional capability
+    in this file: a stop must never fail because the thing it was asked to stop
+    is not implemented.
+    """
+    handle, session = make_handle()
+    assert not hasattr(session, "cancel_subagents")
+
+    receipt = await handle.abort()
+
+    assert "stopping this turn" in receipt

--- a/tests/unit/session/runtime/test_owned.py
+++ b/tests/unit/session/runtime/test_owned.py
@@ -137,8 +137,14 @@ class FakeSession:
         )
         self.emit(SteeringDeliveredEvent(count=1))
 
+    #: Children this double reports as live. A test that stages a cancel must
+    #: move this too: the abort receipt counts what the roster says SURVIVED,
+    #: not what `cancel_subagents` claims it dispatched, so a stub that returns
+    #: a number while this stays put proves only that a call was made.
+    running_children = 0
+
     def running_subagents(self) -> int:
-        return 0
+        return self.running_children
 
     def abort(self, reason: str = "interrupted") -> None:
         """Part of SessionProtocol, and the control op's first act. Recorded
@@ -1414,16 +1420,27 @@ async def test_the_abort_op_stops_the_children_too() -> None:
     """
     handle, session = make_handle()
     cancelled: list[str] = []
-    session.cancel_subagents = lambda reason="interrupted": (  # type: ignore[attr-defined]
-        cancelled.append(reason),
-        3,
-    )[1]
+    # The double reports its children through the SAME predicate the receipt
+    # reads, so "stopped" has to be earned by the roster emptying rather than
+    # by the stub's return value — the hole QA named in the first version of
+    # this test, where a stubbed count proved a call was made and nothing more.
+    session.running_children = 3  # type: ignore[attr-defined]
+
+    def _cancel(reason: str = "interrupted") -> int:
+        cancelled.append(reason)
+        dispatched = session.running_children  # type: ignore[attr-defined]
+        session.running_children = 0  # type: ignore[attr-defined]
+        return dispatched
+
+    session.cancel_subagents = _cancel  # type: ignore[attr-defined]
 
     receipt = await handle.abort()
 
     assert session.aborts, "the turn itself must still be stopped"
     assert cancelled, "the abort op must reach the children; it is the only rung it has"
+    assert session.running_subagents() == 0, "the roster must actually drain"
     assert "stopped 3 subagents" in receipt
+    assert "did NOT stop" not in receipt
 
 
 @pytest.mark.asyncio
@@ -1450,6 +1467,81 @@ async def test_the_abort_receipt_does_not_claim_more_than_it_did() -> None:
     assert "jobs cancel" in receipt
     # No children ran, so the receipt must not invent a number for them.
     assert "subagent" not in receipt
+
+
+@pytest.mark.asyncio
+async def test_the_receipt_names_children_that_refused_to_die(tmp_path) -> None:
+    """MAJOR-1: the count must be what DIED, not what was asked to die.
+
+    `cancel_subagents` returns `len(running)` sampled at DISPATCH time, and
+    per-child cancellation is fire-and-forget with failures swallowed by
+    design. Reporting that number said "stopped 3 subagents" while two children
+    were still running and spending — the exact overstatement this PR exists to
+    remove, reintroduced one layer up.
+
+    Deliberately driven against a REAL Session and real `task` rows, and
+    asserted on the ROSTER rather than on a stubbed return: a double that
+    reports its own count can only prove a call was made, never that anything
+    died.
+    """
+    from local_operator.harness.types import StreamEndEvent
+    from local_operator.session.session import ModelSpec, Session
+    from local_operator.session.transcript import Transcript
+
+    def stream(request, signal):  # noqa: ANN001, ANN202
+        async def gen():
+            await asyncio.sleep(0.01)
+            yield StreamEndEvent(stop_reason="stop")
+
+        return gen()
+
+    session = Session(
+        model=ModelSpec(
+            provider="test", model_id="T", context_window=100_000, supports_images=True
+        ),
+        stream_fn=stream,
+        tools=[],
+        transcript=Transcript(tmp_path / "sess"),
+        system_blocks_provider=lambda: ["stable", "env"],
+    )
+    started = asyncio.Event()
+
+    async def child(job_id, signal, report_progress):  # noqa: ANN001, ANN202
+        started.set()
+        await asyncio.sleep(30)
+        return "never"
+
+    ids = [session.jobs.register("task", f"c{n}", child) for n in range(3)]
+    await asyncio.wait_for(started.wait(), timeout=5)
+    await asyncio.sleep(0.2)
+
+    # Two of three children refuse to die: their cancel raises, which is the
+    # failure `_cancel_job_quietly` swallows by design.
+    real_cancel = session.jobs.cancel
+
+    async def flaky_cancel(job_id, *, owner_id=None):  # noqa: ANN001, ANN202
+        if job_id in (ids[1], ids[2]):
+            raise RuntimeError("child refuses to die")
+        return await real_cancel(job_id, owner_id=owner_id)
+
+    session.jobs.cancel = flaky_cancel  # type: ignore[assignment]
+
+    handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd=str(tmp_path))
+    receipt = await handle.abort()
+
+    # The rows are the ground truth, exactly as QA read them.
+    statuses = [session.jobs.get(job_id) for job_id in ids]
+    assert [row.status for row in statuses if row is not None] == [
+        "cancelled",
+        "running",
+        "running",
+    ]
+    assert "stopped 1 subagent" in receipt
+    assert "2 subagents did NOT stop" in receipt
+    assert "stopped 3 subagents" not in receipt, "the receipt must not claim the two that survived"
+
+    session.jobs.cancel = real_cancel  # type: ignore[assignment]
+    await session.dispose()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -13,6 +13,8 @@ from collections.abc import Awaitable, Callable, Sequence
 import pytest
 
 from local_operator.compaction.api import CompactionSettings
+from local_operator.harness.comms import HUB_MESSAGE_TYPE
+from local_operator.harness.jobs import JOB_RESULT_MESSAGE_TYPE
 from local_operator.harness.types import (
     AbortSignal,
     AgentEndEvent,
@@ -4229,6 +4231,153 @@ async def test_arriving_work_clears_a_stale_abort(tmp_path):
     await wait_for(lambda: not session.is_streaming and not session._turn_lock.locked())
 
     # The arrival ran a real turn, and cleared the stale stop while doing it.
+    assert len(stream.requests) == spent_before + 1
+    assert session._abort_requested is False
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_stopped_session_does_not_pay_for_its_children_reporting_in(tmp_path):
+    """THE MONEY TEST. A stop must stop the spend, not just the current turn.
+
+    The incident: the operator aborted, was acked, and the meter kept running
+    because live subagents kept reporting in. Each report looked like fresh
+    intent, cleared the sticky abort and bought a full provider call — measured
+    at 39 paid calls in the 2 s after an acked abort, one per child report.
+
+    A child's report is the ECHO of the work being stopped, not a new
+    instruction, so it must be held rather than run. Held, not dropped: the row
+    stays durable and the model reads it on the next real turn.
+    """
+    stream = ScriptedStream([[StreamEndEvent(stop_reason="stop")] for _ in range(12)])
+    session = make_session(tmp_path, stream)
+
+    await session.prompt("delegate some work")
+    spent_before = len(stream.requests)
+
+    session.abort("interrupted")
+
+    # Ten children reporting in after the stop, the incident's cadence.
+    for n in range(10):
+        message = CustomMessage(
+            custom_type=HUB_MESSAGE_TYPE,
+            attribution="user",
+            details={
+                "direction": "to_parent",
+                "job_id": "child",
+                "text": f"<subagent-message>progress {n}</subagent-message>",
+            },
+        )
+        await session._prompt_messages([message])
+
+    # NOT ONE provider call. This is the whole bar: a stop the user sent must
+    # end the spending, however many children are still talking.
+    assert len(stream.requests) == spent_before
+    # The stop is still in force, so the eleventh report is just as cheap.
+    assert session._abort_requested is True
+    # And nothing was lost on the way: every report is durable.
+    hub_rows = [
+        entry
+        for entry in session._transcript.entries()
+        if entry.type == "message" and entry.payload.get("custom_type") == HUB_MESSAGE_TYPE
+    ]
+    assert len(hub_rows) == 10
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_job_result_cannot_restart_a_stopped_session(tmp_path):
+    """A background job finishing is the end of stopped work, not a new order.
+
+    Same class as the hub report above and the other half of the producer set
+    QA measured: a `wait` returning on its own deadline re-opened a turn on a
+    session the user had stopped.
+    """
+    stream = ScriptedStream([[StreamEndEvent(stop_reason="stop")] for _ in range(4)])
+    session = make_session(tmp_path, stream)
+
+    await session.prompt("start a job")
+    spent_before = len(stream.requests)
+    session.abort("interrupted")
+
+    await session._prompt_messages(
+        [
+            CustomMessage(
+                custom_type=JOB_RESULT_MESSAGE_TYPE,
+                attribution="user",
+                details={"job_id": "j1", "text": "background job 'build' completed"},
+            )
+        ]
+    )
+
+    assert len(stream.requests) == spent_before
+    assert session._abort_requested is True
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_users_own_wake_still_revives_a_stopped_session(tmp_path):
+    """The guard against over-fixing the money bug.
+
+    Holding subagent residue must not make a stopped session unreachable. A
+    wake is the user's own "remind me" and a peer message is another human
+    reaching in: both are fresh intent, both must still clear the stop, or the
+    cure is a session that can only be recovered by restarting it — which is a
+    worse bug than the one being fixed.
+    """
+    stream = ScriptedStream([[StreamEndEvent(stop_reason="stop")] for _ in range(4)])
+    session = make_session(tmp_path, stream)
+
+    await session.prompt("hello")
+    spent_before = len(stream.requests)
+    session.abort("interrupted")
+
+    await session._prompt_messages(
+        [
+            CustomMessage(
+                custom_type=WAKE_PROMPT_MESSAGE_TYPE,
+                attribution="user",
+                details={"text": "the reminder you asked for", "schedule_id": "w1"},
+            )
+        ]
+    )
+
+    assert len(stream.requests) == spent_before + 1
+    assert session._abort_requested is False
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_mixed_batch_carrying_real_intent_is_not_held(tmp_path):
+    """Residue is an ALL-of test, and the asymmetry is deliberate.
+
+    A batch that mixes a child's report with a user-driven arrival contains
+    fresh intent. The safe reading of a mixed batch is the one that still lets
+    the user's work through: holding it would trade the money bug for an
+    "Esc broke my session" bug.
+    """
+    stream = ScriptedStream([[StreamEndEvent(stop_reason="stop")] for _ in range(4)])
+    session = make_session(tmp_path, stream)
+
+    await session.prompt("hello")
+    spent_before = len(stream.requests)
+    session.abort("interrupted")
+
+    await session._prompt_messages(
+        [
+            CustomMessage(
+                custom_type=HUB_MESSAGE_TYPE,
+                attribution="user",
+                details={"direction": "to_parent", "job_id": "c", "text": "progress"},
+            ),
+            CustomMessage(
+                custom_type=WAKE_PROMPT_MESSAGE_TYPE,
+                attribution="user",
+                details={"text": "and the user's own wake", "schedule_id": "w1"},
+            ),
+        ]
+    )
+
     assert len(stream.requests) == spent_before + 1
     assert session._abort_requested is False
     await session.dispose()

--- a/tests/unit/tui/test_stop_command.py
+++ b/tests/unit/tui/test_stop_command.py
@@ -1157,23 +1157,78 @@ async def test_an_ordinary_reload_does_not_take_the_unbound_branch() -> None:
 
 
 @pytest.mark.asyncio
-async def test_the_watched_id_is_dropped_when_a_reload_unbinds_the_session() -> None:
-    """The other half of BLOCKER-2: clear the id where the binding is nulled.
+async def test_a_strand_mid_swap_leaves_the_kill_switch_armed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """BLOCKER-3: the watched id must SURVIVE a failed swap.
 
-    The transition guard covers the window while a replacement is arriving; the
-    id itself must not outlive the session either, or a path that unbinds
-    without setting the transition flag leaves the same stale lever behind.
+    `_attach_or_refuse` (and `_reload_session`) null the binding and then adopt
+    a replacement. If anything in between raises, the viewer is stranded while
+    the session it was watching keeps running — for a remote, in another
+    process, still billing. That is the exact state this whole feature exists
+    to serve, and the round-2 remediation broke it by clearing the id inside
+    that window: `/stop` then dispatched nothing and told the user to WAIT,
+    which is the pre-PR failure mode with the pre-PR wording.
+
+    An ordinary transition is kept honest by `_session_transition_pending`
+    alone (pinned by the reload test above), so the id-clear bought nothing
+    there and cost the lever here.
     """
     session = FakeSession()
     app = OperatorApp(lambda: _factory(session))
+    dispatched: list[str] = []
+
+    async def spy(session_id: str) -> None:
+        dispatched.append(session_id)
+
     async with app.run_test(size=(100, 30)) as pilot:
         await _booted(app, pilot, session)
         assert app._adopted_session_id == "sess"
-        await app._reload_session()
+        app._stop_unbound_worker = spy  # type: ignore[assignment]
+
+        # Drive the REAL `_attach_or_refuse` rather than hand-rolling its
+        # sequence: the defect was one statement inside that window, so a test
+        # that reproduces the shape by hand would step straight over it. Its
+        # imports are function-local, so the record lookup and the connect are
+        # patched at their source modules and everything else is the real path.
+        remote_record = _record(90909, "the remote")
+        remote_record.protocol = 4
+
+        async def fake_find(_root: Any, _concrete: str):
+            return remote_record, 90909
+
+        async def fake_connect(*args: Any, **kwargs: Any):
+            return FakeSession()
+
+        # The failure lands in `_reset_ledger_for_swap`, which the source runs
+        # BETWEEN nulling the binding and adopting the replacement. That is the
+        # actual strand window: a raise later, inside `_adopt_session`, is
+        # harmless because it has already re-stamped the id by then.
+        def explode() -> Any:
+            raise RuntimeError("swap failed before the replacement was adopted")
+
+        monkeypatch.setattr(app, "_reset_ledger_for_swap", explode)
+
+        monkeypatch.setattr(
+            "local_operator.mobile.attach_client.find_owner_record",
+            lambda root, concrete: (remote_record, 90909),
+        )
+        monkeypatch.setattr("local_operator.session.remote.RemoteSession.connect", fake_connect)
+        app._resume_factory = fake_find  # type: ignore[assignment]
+
+        with pytest.raises(RuntimeError):
+            await app._attach_or_refuse(tmp_path, "remote-1", 90909)
+
+        assert app._session is None, "the viewer really is unbound"
+        assert app._adopted_session_id == "sess", "the only lever the user has must survive"
+
+        app._run_slash_command("/stop")
         for _ in range(20):
             await pilot.pause()
-            if app._session is not None:
+            if dispatched:
                 break
-        # Either cleared, or re-stamped by the session that replaced it —
-        # never left naming a session this viewer no longer watches.
-        assert app._adopted_session_id in ("", getattr(app._session, "session_id", ""))
+
+        assert dispatched == ["sess"], "a stranded viewer must still be able to stop what it sees"
+        assert "session is still starting…" not in _notices(
+            app
+        ), "telling a user to wait while a remote bills is the failure this PR removes"

--- a/tests/unit/tui/test_stop_command.py
+++ b/tests/unit/tui/test_stop_command.py
@@ -940,8 +940,10 @@ async def test_stop_reaches_a_live_session_the_viewer_lost_its_binding_to(
     """
     target = _record(77777, "the runaway")
     stopped: list[str] = []
+    selectors: list[dict[str, Any]] = []
 
     def fake_resolve(**kwargs: Any):
+        selectors.append(kwargs)
         return target, [], ""
 
     async def fake_stop(record, *, timeout_s=10.0, _root=None):  # noqa: ANN001, ANN202
@@ -967,6 +969,10 @@ async def test_stop_reaches_a_live_session_the_viewer_lost_its_binding_to(
                 break
         assert stopped, "an unbound viewer must still be able to stop what it is watching"
         assert "session is still starting…" not in _notices(app)
+        # The kill switch addresses the watched session by the EXACT selector,
+        # never the substring vocabulary — see the wrong-session test below.
+        assert selectors and selectors[0]["session"] == "sess"
+        assert not selectors[0]["target"]
 
 
 @pytest.mark.asyncio
@@ -1064,3 +1070,110 @@ async def test_an_unbound_stop_does_not_recurse_into_itself() -> None:
         # command: at most one delegation, and no unbounded growth.
         assert len(calls) == 0, calls
         assert any("lost its link" in text for text in _notices(app)), _notices(app)
+
+
+@pytest.mark.asyncio
+async def test_the_unbound_stop_never_reaches_a_look_alike_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BLOCKER-1: the kill switch must not stop a session it did not name.
+
+    The unbound fallback used the `target=` SUBSTRING vocabulary, which matches
+    against conversation_name, session_id AND the cwd basename of every live
+    record. The state this path exists for is precisely the one where the
+    watched session is not resolvable, so the needle fell through to whatever
+    else contained it — resolving to a different live session with no error and
+    no ambiguity candidates, which the ladder then stopped.
+
+    This is the operator's machine with several live sessions on it: stopping
+    the wrong one destroys someone's in-flight work while the runaway keeps
+    billing. Found independently by both the reviewer and QA.
+    """
+    watched = "00264921d0d9"
+    # The ONLY live record is an unrelated session whose NAME contains the
+    # watched id. The watched session itself is gone from the registry.
+    decoy = _record(4242, f"notes about {watched}")
+    stopped: list[str] = []
+
+    async def fake_stop(record, *, timeout_s=10.0, _root=None):  # noqa: ANN001, ANN202
+        stopped.append(record.session_id)
+        return control.StopOutcome(
+            record.pid, record.session_id, record.conversation_name, "socket", "stopped"
+        )
+
+    monkeypatch.setattr(
+        "local_operator.session.runtime.registry.scan", lambda *a, **k: [(decoy, "live")]
+    )
+    monkeypatch.setattr(control, "stop_session", fake_stop)
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _booted(app, pilot, session)
+        app._adopted_session_id = watched
+        app._session = None
+        await app._stop_unbound_worker(watched)
+        await pilot.pause()
+
+        assert stopped == [], f"the kill switch stopped a session it never named: {stopped}"
+        # And it says so honestly rather than silently doing nothing.
+        assert any("lost its link" in text for text in _notices(app)), _notices(app)
+
+
+@pytest.mark.asyncio
+async def test_an_ordinary_reload_does_not_take_the_unbound_branch() -> None:
+    """BLOCKER-2: a transition is not a lost binding.
+
+    `_adopted_session_id` was set on adopt but cleared in one place, while four
+    paths null `_session`. So for the whole window between "old session
+    disposed" and "replacement adopted" — an ordinary `/reload`, `/new`,
+    `/resume` or attach — the viewer was sessionless with a stale id, and a
+    bare `/stop` both painted "this viewer lost its link…" in the error weight
+    AND dispatched the stop worker against the session being replaced. That is
+    what made BLOCKER-1 reachable day to day rather than only in the rare
+    lost-binding state.
+    """
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    dispatched: list[str] = []
+
+    async def spy(session_id: str) -> None:
+        dispatched.append(session_id)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _booted(app, pilot, session)
+        app._stop_unbound_worker = spy  # type: ignore[assignment]
+        # Exactly what `_reload_session` does to the binding mid-transition.
+        app._session_transition_pending = True
+        app._session = None
+        app._run_slash_command("/stop")
+        for _ in range(10):
+            await pilot.pause()
+
+        assert dispatched == [], "a /reload must not dispatch a stop for the outgoing session"
+        notices = _notices(app)
+        # "Still starting" is TRUE here: a replacement really is on its way.
+        assert any("still starting" in text for text in notices), notices
+        assert not any("lost its link" in text for text in notices), notices
+
+
+@pytest.mark.asyncio
+async def test_the_watched_id_is_dropped_when_a_reload_unbinds_the_session() -> None:
+    """The other half of BLOCKER-2: clear the id where the binding is nulled.
+
+    The transition guard covers the window while a replacement is arriving; the
+    id itself must not outlive the session either, or a path that unbinds
+    without setting the transition flag leaves the same stale lever behind.
+    """
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _booted(app, pilot, session)
+        assert app._adopted_session_id == "sess"
+        await app._reload_session()
+        for _ in range(20):
+            await pilot.pause()
+            if app._session is not None:
+                break
+        # Either cleared, or re-stamped by the session that replaced it —
+        # never left naming a session this viewer no longer watches.
+        assert app._adopted_session_id in ("", getattr(app._session, "session_id", ""))

--- a/tests/unit/tui/test_stop_command.py
+++ b/tests/unit/tui/test_stop_command.py
@@ -90,16 +90,28 @@ async def test_bare_stop_ends_the_session_and_keeps_the_transcript() -> None:
 
 @pytest.mark.asyncio
 async def test_stop_with_no_session_is_a_warning() -> None:
-    class NeverBoots(FakeSession):
-        pass
+    """A session that has genuinely not arrived yet.
 
-    app = OperatorApp(lambda: _factory(NeverBoots()))
+    The factory is held open rather than adopting and then dropping
+    ``app._session``: those are two DIFFERENT states that used to share one
+    answer, and conflating them is what let `/stop` tell a user with a live,
+    spending session to wait for a boot that had already finished (QA Q-2).
+    The adopted-then-unbound state is pinned separately below.
+    """
+    release = asyncio.Event()
+
+    async def never_boots() -> Any:
+        await release.wait()
+        return FakeSession()
+
+    app = OperatorApp(never_boots)
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
-        app._session = None
+        assert app._session is None
         app._run_slash_command("/stop")
         await pilot.pause()
         assert "session is still starting…" in _notices(app)
+        release.set()
 
 
 @pytest.mark.asyncio
@@ -912,3 +924,143 @@ async def test_a_mid_turn_stop_does_not_add_a_bare_interrupted_row() -> None:
             await pilot.pause()
         bare = [b for b in app.query(NoticeBlock) if b._text == "interrupted"]
         assert not bare, "a bare interrupted row was added beside the per-card mark"
+
+
+@pytest.mark.asyncio
+async def test_stop_reaches_a_live_session_the_viewer_lost_its_binding_to(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """THE KILL SWITCH MUST WORK IN THE STATE IT IS NEEDED IN.
+
+    The refusal used to test the VIEWER's binding rather than whether a session
+    exists to stop. With the session adopted, alive and undisposed but the
+    viewer's reference dropped — a swap, a reload, a reconnect race — `/stop`
+    answered "session is still starting…" for a session that was visibly
+    burning money, and told the user to WAIT (QA Q-2).
+    """
+    target = _record(77777, "the runaway")
+    stopped: list[str] = []
+
+    def fake_resolve(**kwargs: Any):
+        return target, [], ""
+
+    async def fake_stop(record, *, timeout_s=10.0, _root=None):  # noqa: ANN001, ANN202
+        stopped.append(record.session_id)
+        return control.StopOutcome(
+            record.pid, record.session_id, "the runaway", "socket", 'stopped "the runaway"'
+        )
+
+    monkeypatch.setattr("local_operator.mobile.peer_send.resolve_peer_target", fake_resolve)
+    monkeypatch.setattr(control, "stop_session", fake_stop)
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _booted(app, pilot, session)
+        # The incident's shape: the session is ALIVE and spending; only the
+        # viewer's reference is gone.
+        app._session = None
+        assert session.disposed is False
+        app._run_slash_command("/stop")
+        for _ in range(20):
+            await pilot.pause()
+            if stopped:
+                break
+        assert stopped, "an unbound viewer must still be able to stop what it is watching"
+        assert "session is still starting…" not in _notices(app)
+
+
+@pytest.mark.asyncio
+async def test_a_lost_binding_never_tells_the_user_to_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the stop genuinely cannot be routed, the copy must still be honest.
+
+    "Still starting" is false for a session that has been adopted, and its
+    advice — wait — is the most expensive thing a user can do when the session
+    they cannot reach is spending money. The residual answer names the state
+    and points at the lever that works from outside this viewer.
+    """
+
+    def fake_resolve(**kwargs: Any):
+        return None, [], "no live session matches"
+
+    monkeypatch.setattr("local_operator.mobile.peer_send.resolve_peer_target", fake_resolve)
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _booted(app, pilot, session)
+        app._session = None
+        app._run_slash_command("/stop")
+        for _ in range(20):
+            await pilot.pause()
+            if any("lost its link" in text for text in _notices(app)):
+                break
+        notices = _notices(app)
+        assert any("lost its link" in text for text in notices), notices
+        assert any("lop stop" in text for text in notices), notices
+        assert "session is still starting…" not in notices
+
+
+@pytest.mark.asyncio
+async def test_a_booting_session_still_says_it_is_starting() -> None:
+    """The guard on the copy change: "still starting" is TRUE during boot.
+
+    The fix must narrow that message to the state it describes, not delete it —
+    a user who typed `/stop` a beat after launch should still be told the
+    session is on its way.
+    """
+    release = asyncio.Event()
+
+    async def delayed_factory():
+        await release.wait()
+        return FakeSession()
+
+    app = OperatorApp(delayed_factory)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        assert app._session is None
+        assert app._adopted_session_id == ""
+        app._run_slash_command("/stop")
+        await pilot.pause()
+        assert "session is still starting…" in _notices(app)
+        release.set()
+
+
+@pytest.mark.asyncio
+async def test_an_unbound_stop_does_not_recurse_into_itself() -> None:
+    """A regression guard found while building the fallback.
+
+    Routing the unbound case through `_stop_target_worker` looked right, but
+    that worker's self-pid branch calls back into `_cmd_stop` — which, with no
+    bound session, takes the unbound fallback again and dispatches another
+    worker, forever. It painted nothing at all, a quieter version of the defect
+    being fixed.
+    """
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _booted(app, pilot, session)
+        own_pid = os.getpid()
+        calls: list[str] = []
+        original = app._stop_target_worker
+
+        async def counting_worker(target: str) -> None:
+            calls.append(target)
+            await original(target)
+
+        app._stop_target_worker = counting_worker  # type: ignore[assignment]
+        # Resolve to THIS process, the branch that used to recurse.
+        own = _record(own_pid, "me")
+        app._session = None
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                "local_operator.mobile.peer_send.resolve_peer_target",
+                lambda **kwargs: (own, [], ""),
+            )
+            app._run_slash_command("/stop")
+            for _ in range(20):
+                await pilot.pause()
+        # The self-pid case is answered here, not bounced back into the
+        # command: at most one delegation, and no unbounded growth.
+        assert len(calls) == 0, calls
+        assert any("lost its link" in text for text in _notices(app)), _notices(app)


### PR DESCRIPTION
## Summary

The operator has now lost money **twice** to a runaway session they could not stop. PR #709 (`d37edd32b`) closed the paid-no-op class it named, but QA verified on merged `main` that it did **not** give them a working stop button: `abort` acks `"stopping"` while live subagents keep billing, and `/stop` refuses in exactly the state it is needed.

Both defects are fixed here, with QA's two deterministic repros as the A/B.

| | pre-fix (`408a0385c`) | this head |
|---|---|---|
| Q-1: paid provider calls in the 2 s after an acked abort | **38** | **0** |
| Q-2: `/stop` on an adopted, alive, undisposed session | `! session is still starting…` | stops it |

## Q-1 (blocker) — a stop must actually stop the spend

**Root cause.** The loop is producer-driven, not self-sustaining (QA's M13: one arrival → exactly one call → flat for 3 s). The money is spent **by the children**. Every subagent report arriving after the stop looked like *fresh intent*, so `_prompt_messages` cleared the sticky abort and bought a full turn — one paid call per child report, at sub-second cadence.

This is the fix's crux, and it is a semantic distinction rather than a new lever:

> **A subagent reporting in is not a new instruction. It is the echo of the very work the user just stopped.**

So `hub_message` and `job_result` arrivals no longer clear a pending abort. They are **held, not dropped** — still persisted, still read on the next real turn — exactly the guarantee #709 established for a queued backlog. A **wake or a peer message still clears it**, which is what keeps a stopped session recoverable without a restart, and a *mixed* batch carrying real intent runs, because trading the money bug for an "Esc broke my session" bug is not a fix.

> **Correction to an earlier version of this description (review round 1, MINOR-1).** It credited both types with the fix. On the real production path only **`job_result`** carries it: every live `hub_message` producer routes through `Session.queue_aside`, which cannot open a turn, so no production code reaches `_prompt_messages` with one. The `hub_message` half of the original A/B was synthetic — QA's repro calls `_prompt_messages` directly. The type stays in the set as a **defensive** guard (a future producer reaching that path would otherwise silently reopen the money loop), not as a load-bearing part of the fix.

**The Esc ladder is deliberately preserved.** I was asked not to collapse it blindly and did not: the first press still stops only the parent's turn, and a child minutes into useful work still survives a reflex keypress. What changed is that the first rung is now **cheap as well as narrow** — it no longer leaves a meter running.

**The control op is the case that genuinely differs, and it now escalates.** `abort` has **no second rung and no ladder**: the mobile relay, supervisors and peers send it once into a session they cannot see, with no gesture that escalates. Narrow semantics there meant a stop that could *never* reach a runaway. It now calls `cancel_subagents()` — which is what makes "a user must always be able to halt a runaway" true on the surface with nothing to climb.

**The receipt no longer lies.** It returned the literal `"stopping"` regardless of what survived, which is how the operator was told the problem was handled while the meter ran. Measured on the real handle:

```
children + a spared bash job : "stopping this turn; stopped 3 subagents; 1 background job still running — jobs cancel to stop"
one child                    : "stopping this turn; stopped 1 subagent"
nothing else running         : "stopping this turn"
```

Backgrounded `bash` is still spared on purpose (`background=true` exists so a build outlives the turn) — so the receipt **names** it rather than implying it stopped.

### The boundary this establishes, stated explicitly

`wake_prompt`, `peer_message` and a typed prompt **still** clear a stop and may buy a turn on a stopped session. That is deliberate: the alternative is a session recoverable only by restarting the process. It is safe because none of them is a loop the session can drive on its own — wakes are floored at 60 s by `MIN_WAKE_INTERVAL_MS`, mailbox peer messages spend nothing at all, and a typed prompt is the user asking for work. The residue types are the ones a stopped session's **own children** generate, at any cadence, with no human in the loop, which is exactly why only those may not clear a stop. A caller that needs everything stopped regardless has the stronger rungs: the `abort` control op cancels the children, and `lop stop` ends the process. The rule now lives in `_STOPPED_WORK_RESIDUE_TYPES`' own docstring rather than only in a PR description.

## Q-2 (major) — `/stop` refused because the *viewer* was unbound

`_cmd_stop` gated on `self._session is None` — the viewer's binding, not whether a session exists to stop. With the session adopted, alive and `underlying_session_disposed=false`, `/stop` answered `! session is still starting…`, and its wording told the user to **wait**: the single most expensive thing they can do while a session burns money.

The viewer now remembers the session it adopted (`_adopted_session_id`), so a bare `/stop` with no binding stops **the session this viewer is looking at**, by id, through the runtime stop ladder. When that genuinely cannot be routed, the copy is honest about the state it is actually in:

```
✗ this viewer lost its link to session <id>; it may still be running — lop stop <id> ends it
```

A genuinely booting session **still** says `session is still starting…` — the message was narrowed to the state it describes, not deleted (pinned by a test).

> **A defect I introduced and caught while building this.** Routing the unbound case through `_stop_target_worker` looked right, but that worker's self-pid branch calls back into `_cmd_stop`, which — with no bound session — takes the unbound fallback again and dispatches another worker, forever. It painted *nothing at all*: a quieter version of the very defect being fixed. It is now a dedicated `_stop_unbound_worker`, with a regression test pinning the non-recursion.

## The aside path — assessed, deliberately out of scope

QA flagged that `queue_aside`/`_drain_asides` never samples `_abort_epoch` and asked whether closing it is part of a correct Q-1 fix. **I measured it rather than reasoning about it**, and it is a separate concern:

```
requests_at_abort=1  requests_after=1  PAID_CALLS_AFTER_ABORT_VIA_ASIDE=0  undrained_thunks=10
```

Ten child notes queued as asides after an abort, into a turn deliberately held open: **zero** provider calls, all ten thunks left undrained. Asides inject at the loop's yield boundary *inside an already-running turn* — they cannot open a turn of their own, so they cannot spend on a stopped session. They were the *mechanism* by which children fed a parent turn, but the money was always bought at the **arrival** boundary, which is where the fix lands. Adding an epoch sample there would be an unmeasured change to a path that is not spending.

## Testing evidence

Every run pins `sys.path` and asserts `module.__file__` resolves under the tree under test — both arms print their resolved module, so neither can silently import the other (the trap that burned two reviewers).

**Q-1 — QA's `repro_runaway.py`, both arms, counting provider requests:**

```
=============== ARM: /tmp/sb/base (408a0385c) ===============
  import pin: /private/tmp/sb/base/local_operator/session/session.py
  aborts=1  PAID_CALLS_AFTER_ABORT=38  ends_completed=39  arrivals=49
  aborts=3  PAID_CALLS_AFTER_ABORT=37  ends_completed=38  arrivals=49
=============== ARM: this head ===============
  import pin: /private/tmp/lop-stop-button/local_operator/session/session.py
  aborts=1  PAID_CALLS_AFTER_ABORT=0   ends_completed=0   arrivals=49
  aborts=3  PAID_CALLS_AFTER_ABORT=0   ends_completed=0   arrivals=50
```

**Zero**, not merely fewer — while **49 arrivals were still delivered and held**, so nothing was lost to buy that.

**Q-1 — child-side spend, measured independently by QA** on the operator's exact incident shape (real `Session`, real `task` jobs, real control op):

```
                  pre-fix    head
receipt           "stopping" "stopping this turn; stopped 3 subagents"
roster            3 → 3      3 → 0  (cancelled)
parent paid       39         0
child paid        117        0
```

**Q-1 — children really terminate** (real `Session`, real job manager; these children would run 30 s on their own):

```
running_subagents_before : 3      child_status_before : running,   running,   running
running_subagents_after  : 0      child_status_after  : cancelled, cancelled, cancelled
receipt                  : "stopping this turn; stopped 3 subagents"
```

**#709's own behaviour is preserved**, not traded away — its full producer matrix on this head:

```
producer    mode     paid  noop  done   flag  persisted
hub         steady      0     0     0   True          6     ← residue held (was 6 paid)
hub         queued      0     0     0   True          6
job_result  steady      0     0     0   True          6     ← residue held (was 6 paid)
job_result  queued      0     0     0   True          6
wake        steady      6     0     6  False          6     ← user intent still runs
wake        queued      0     0     0   True          6
```

`persisted=6` in every cell: the paid-no-op class stays closed, subagent residue now costs nothing, and a user's own wake still revives the session.

**Q-2 — QA's `repro_stop_refusal.py`, driving the REAL TUI, both arms:**

```
=============== ARM: /tmp/sb/base (408a0385c) ===============
  A_boot_in_flight:               ! session is still starting…
  B_session_alive_viewer_unbound: ! session is still starting…      (disposed=False)
=============== ARM: this head ===============
  A_boot_in_flight:               ! session is still starting…      ← correctly unchanged
  B_session_alive_viewer_unbound: ✗ this viewer lost its link to session sess;
                                    it may still be running — lop stop sess ends it
```

A third real-TUI drive covers the state where the session **is** discoverable, confirming `/stop` dispatches a stop for the watched session (`stop_dispatched_for: ["sess"]`) instead of refusing.

### Tests added

- `test_a_stopped_session_does_not_pay_for_its_children_reporting_in` — the money test: 10 child reports after a stop, **0** provider calls, all 10 rows durable.
- `test_a_job_result_cannot_restart_a_stopped_session` — the other producer QA measured.
- `test_a_users_own_wake_still_revives_a_stopped_session` — the guard against over-fixing.
- `test_a_mixed_batch_carrying_real_intent_is_not_held` — the all-of asymmetry.
- `test_the_abort_op_stops_the_children_too` / `..._really_terminates_live_children` — escalation, and that children actually die.
- `test_the_abort_receipt_does_not_claim_more_than_it_did` — the receipt names survivors.
- `test_the_abort_op_survives_a_session_that_cannot_stop_children` — reduced hosts.
- `test_stop_reaches_a_live_session_the_viewer_lost_its_binding_to`, `test_a_lost_binding_never_tells_the_user_to_wait`, `test_a_booting_session_still_says_it_is_starting`, `test_an_unbound_stop_does_not_recurse_into_itself`.

`test_stop_with_no_session_is_a_warning` was **corrected, not deleted**: it claimed to test "no session" but faked it by nulling `app._session` *after* adoption — the exact conflation this PR fixes. It now holds the factory open so it tests the state its name promises.

### Gates — whole tree, exactly as CI

```
flake8 .                                        0
uvx --from black==26.1.0 black --check .        994 files unchanged
uvx isort==5.13.2 --check .                     0
pyright --pythonpath .venv/bin/python .         0 errors, 0 warnings
pytest tests/unit                               15117 passed, 18 skipped (23:24)
pytest tests/unit/session tests/unit/tui        7120 passed, 12 skipped (TUI env)
```

`pyproject.toml` is **not** bumped.

## Round 2 — review + QA remediation

Both streams independently found the same wrong-recipient defect; it leads.

**BLOCKER-1 / QA MAJOR — the unbound `/stop` could stop the WRONG session.** It passed the watched id as `target=`, the *substring* vocabulary, which matches conversation_name, session_id **and the cwd basename** of every live record — and the state this path exists for is precisely the one where the watched session is not resolvable. Reproduced through the real `_stop_unbound_worker` with the watched session absent and one decoy whose name contained its id:

```
BEFORE  sessions_actually_stopped: ['sid-4242']      ← a session the user never named
AFTER   sessions_actually_stopped: []
        notice: ✗ this viewer lost its link to session 00264921d0d9;
                  it may still be running — lop stop 00264921d0d9 ends it
```

Fixed with the exact `session=` selector. The **resolved record** is then handed to a new `_stop_resolved_record` rather than re-entering `_stop_target_worker` with the id — that would have resolved a second time by substring and handed the hazard straight back.

**BLOCKER-2 — the unbound branch fired on every ordinary `/reload`, `/new` and `/resume`,** which is what made BLOCKER-1 reachable day to day. Reproduced through the real command mid-transition:

```
BEFORE  unbound_worker_dispatched_with: ['sess']
        notices: ['this viewer lost its link to session sess; it may still be running…']
AFTER   unbound_worker_dispatched_with: []
        notices: ['! session is still starting…']        ← true: a replacement IS on its way
```

The id is now cleared wherever the binding is nulled, and both the dispatch and the shared `_no_session_notice` copy are gated on `not _session_transition_pending`. That helper backs ~15 call sites (`/team`, `/agent`, the prompt path), so the false "lost its link" in the error weight was never a `/stop` detail.

**MAJOR-1 — the receipt overstated, the exact class this PR exists to remove.** `cancel_subagents` returns `len(running)` sampled at *dispatch* time and per-child cancellation swallows failures by design, so a child that refused to die was still counted as stopped. Reproduced on a real `Session` with two of three cancels raising:

```
BEFORE  "stopping this turn; stopped 3 subagents"          ← two were still running
AFTER   "stopping this turn; stopped 1 subagent;
         2 subagents did NOT stop — lop stop ends the process"
rows:   c1=cancelled, c2=running, c3=running               (ground truth, both arms)
```

The count now comes from the session's own live predicate after a bounded settle (`_ABORT_SETTLE_BUDGET_S = 1.0`, polled, exits the moment the roster drains — a ceiling for the wedged case, not a cost every stop pays).

**Per QA's methodology note**, the receipt tests now assert on **roster rows** against a real `Session` with real `task` jobs, not on a stubbed return: a double that reports its own count proves a call was made, never that a child died. The `FakeSession` double's `running_subagents` was wired to a real field for the same reason.

**MAJOR-2** is answered as a documented boundary — see "The boundary this establishes" above; QA's INFO findings (60 s wake floor verified, mailbox spends 0) are the evidence that it is bounded. **MINOR-1** is corrected in the Q-1 section. **MINOR-2** fixed: a comment named `_resumable_session_id` for a value that is actually `_adopted_session_id`. **NIT-1** needed no action — both streams judged the modified pre-existing test a legitimate strengthening.

### The unbound-state entry path — now explained

Both streams listed this as unexplained, so I went looking rather than leaving it. `_attach_or_refuse` nulls `self._session` and *then* adopts a `RemoteSession`; anything raising between those two points leaves the viewer sessionless. For a **remote** session that matters, because the runtime is in another process and keeps running — and spending. Reproduced by making `subscribe_frontend` raise mid-adopt:

```
adopt_raised:                 RuntimeError: owner went away mid-attach
viewer_bound_after:           False
remote_still_alive_elsewhere: True
notice: this viewer lost its link to session remote-1; it may still be running
        — lop stop remote-1 ends it
```

That is the state this fallback was built for, reached without simulation. `_reload_session` is *not* such a path: it disposes the outgoing session first, so nothing is left billing (verified).

### New tests

`test_the_unbound_stop_never_reaches_a_look_alike_session`, `test_an_ordinary_reload_does_not_take_the_unbound_branch`, `test_the_watched_id_is_dropped_when_a_reload_unbinds_the_session`, `test_the_receipt_names_children_that_refused_to_die`, plus an exact-selector assertion added to the existing unbound-stop test. **Each was confirmed to fail on the pre-remediation source with the tests kept in place** — including `AssertionError: the kill switch stopped a session it never named: ['sid-4242']`.

### Gates re-run at `28d4f3da6`

```
flake8 .                                  0
uvx --from black==26.1.0 black --check .  994 files unchanged
uvx isort==5.13.2 --check .               0
pyright --pythonpath .venv/bin/python .   0 errors, 0 warnings
pytest tests/unit                         15122 passed, 18 skipped (24:46)
```

`pyproject.toml` still not bumped.

## Overlap with #711

#711 (`fix/viewer-transient-disconnect`) touches `session/session.py` and `tui/app.py`. I checked its diff before editing both. **No overlap:** its hunks are at `session.py` ~1993/5690/5733 and `app.py` ~24414 (the reconnect seed and live-card retirement); mine are at `session.py` 257/5078/5775/5850 and `app.py` 1717/2767/6469/15961/16025/16207 (the abort path and the stop command). `git merge-tree` against its head reports **zero conflict markers** in both files. Flagging rather than resolving: no action taken on its behalf.

## Not addressed

- The aside epoch gate — measured at 0 paid calls and argued above as a separate concern.
- ~~How the viewer reaches the unbound state is unexplained~~ — **resolved in round 2**: `_attach_or_refuse` nulls the binding before adopting the remote, and a raise in between strands the viewer while the remote keeps running in another process. Reproduced above. What is still not established is which *specific* failure stranded the operator's viewer on the night of the incident; that session ran 0.49.9 and is gone.
- No live-LLM arm: provider **request count** is the proxy for spend, same as QA's.

