### PR TITLE
chore(release): bump version to 0.51.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.50.4"
+version = "0.51.0"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
One-file release bump for the v0.51.0 window. C0 scope: `pyproject.toml` only, no product change.

**Window contents** (v0.50.4..main):
- #694 `bf7020399` — toggleable session sidebar: ranked Active/Previous session list, click and keyboard switching with all sessions left running, plus the viewer-leak drain, bounded catalog poll and hover-repaint fixes it required
- #709 `d37edd32b` — a stale abort no longer pre-aborts every later turn, and the compaction bypass that could kill a viewer's pump is closed
- #715 `408a0385c` — CI guard: a release PR must actually bump, and only ever forward

**Bump class: MINOR.** #694 adds a new user-facing TUI surface with its own hotkeys and settings, which clears the step-function bar on its own. #709 and #715 are patch-class and ride along.