### PR TITLE
fix(tui): sidebar activity indicator reflects real conversation activity

### DIFF
--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -692,6 +692,73 @@ class OwnedSessionHandle(SessionHandle):
             return True
         return False
 
+    def is_conversationally_active(self) -> bool:
+        """True while the CONVERSATION itself is moving — the spinner's signal.
+
+        Deliberately narrower than :meth:`is_busy`, and the difference is the
+        whole point. The two answer different questions:
+
+        * :meth:`is_busy` asks *may this runtime exit?* and must be maximally
+          inclusive, because exiting under live work destroys it. A detached
+          background job, a running subagent, a retained background task all
+          forbid an exit and are all counted there.
+        * This asks *is this conversation working right now?*, which is what an
+          animated indicator claims to a user. Somebody reading a spinner
+          expects tokens to be moving and a reply to be coming.
+
+        Publishing the residency answer as the activity bit made every session
+        that had ever backgrounded a job look permanently busy. Measured on the
+        reporter's host: 8 of 8 live sessions published ``busy=True``, one of
+        them idle for 25.6 minutes with a completed final turn — the runtime
+        was correctly resident (a `bash` job was still running) and the sidebar
+        was incorrectly claiming it was working. A spinner that is always on is
+        not a status; the user's report ("still shows that it's active … even
+        though the task is done") is exactly that indicator having become
+        meaningless.
+
+        The terms kept here are the ones a user would call "it is working on my
+        conversation": a live provider stream, a compaction, a held turn lock,
+        a queued or draining prompt, a running goal loop, and a parked gate.
+        The gate is included because a parked approval IS a running turn — the
+        tool slot is held mid-flight — and the surfaces then draw it with the
+        needs-you marker, which outranks the spinner in ``row_state_mark``.
+
+        The terms dropped are the work-RETENTION ones: background jobs,
+        subagents, MCP grant/reload tasks and retained background tasks. Each
+        is real work the runtime must stay alive for, and none of it means the
+        conversation is mid-reply — a `background=true` job exists precisely to
+        outlive its turn, so animating a row for it contradicts the flag's
+        purpose. Those sessions still render as live (the idle glyph), and
+        `lop sessions` still reports them resident.
+
+        Fails CLOSED (True) on an unreadable probe, matching :meth:`is_busy`:
+        a spurious spinner is a cosmetic fault, while a missed one would hide a
+        session that genuinely is working.
+        """
+        if self._disposing:
+            return False
+        session = self._session
+        if self._goal_loop is not None and self._goal_loop.running:
+            return True
+        try:
+            if getattr(session, "is_streaming", False):
+                return True
+            if getattr(session, "_compacting", False):
+                return True
+            lock = getattr(session, "_turn_lock", None)
+            if lock is not None and lock.locked():
+                return True
+        except Exception:  # noqa: BLE001 — an unreadable session is assumed active
+            return True
+        if self._prompt_queue or (
+            self._prompt_drain_task is not None and not self._prompt_drain_task.done()
+        ):
+            return True
+        if self._pending_futures:
+            # A gate parked on a person belongs to a turn that has not ended.
+            return True
+        return False
+
     def is_pristine(self) -> bool:
         """True when nothing has ever happened in this session.
 
@@ -3265,16 +3332,26 @@ class OwnedSessionHandle(SessionHandle):
         de-duplicates, so the republish costs one comparison per event and a
         staged write only on an actual transition.
 
-        `is_busy()` is the authority rather than a second flag: it is the same
-        predicate the reaper uses to decide whether this runtime may exit, so
-        the marker and the residency decision can never disagree.
+        The authority is :meth:`is_conversationally_active`, NOT ``is_busy()``.
+        The record's ``busy`` field is read by exactly one kind of consumer —
+        surfaces that render "this session is working" (the sidebar's spinner,
+        the picker's marker, `lop sessions`) — and residency is a different
+        question that no surface asks. Publishing ``is_busy()`` here meant a
+        session holding a background job wore a spinner forever; see
+        :meth:`is_conversationally_active` for the measurement.
+
+        This deliberately DOES let the marker and the residency decision
+        disagree, which the previous note here forbade. That coupling was the
+        defect: a runtime may quite correctly be un-exitable while its
+        conversation is finished, and the record has a separate field for each
+        fact a reader needs.
         """
         server = self._registrant
         setter = getattr(server, "set_busy", None)
         if not callable(setter):
             return
         try:
-            setter(self.is_busy())
+            setter(self.is_conversationally_active())
         except Exception:  # noqa: BLE001 — a stale marker is not worth a turn
             logger.debug("could not publish the busy state", exc_info=True)
 

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -995,9 +995,20 @@ class RuntimeServer:
                 # missed publish can get to one heartbeat. A 15 s-stale bit is
                 # still wrong for the picker; it is right for a `lop sessions`
                 # run hours later, which is the case the hook's absence cost.
-                is_busy = getattr(self._handle, "is_busy", None)
-                if callable(is_busy):
-                    self.set_busy(bool(is_busy()))
+                #
+                # Reads the same predicate the handle publishes
+                # (``is_conversationally_active``) rather than ``is_busy``:
+                # this loop runs every 15 s forever, so a floor that disagreed
+                # with the turn-boundary publisher would not merely be stale,
+                # it would OVERWRITE the correct value within one heartbeat and
+                # re-pin the spinner on every idle session holding a background
+                # job. Falls back to ``is_busy`` only for a handle predating the
+                # split, where the older answer is the only one available.
+                probe = getattr(self._handle, "is_conversationally_active", None)
+                if not callable(probe):
+                    probe = getattr(self._handle, "is_busy", None)
+                if callable(probe):
+                    self.set_busy(bool(probe()))
                 # A dead renderer can leave its main-process socket alive.
                 # Expiring the lease must reroute a parked gate even when no
                 # TCP disconnect arrives to trigger the ordinary detach path.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -238,6 +238,7 @@ from local_operator.tui.widgets.session_sidebar import (
     SIDEBAR_MIN_CONTENT_WIDTH,
     SIDEBAR_WIDTH,
     SessionSidebar,
+    sidebar_content_width,
 )
 from local_operator.tui.widgets.settings_view import (
     SettingsChanged,
@@ -4301,8 +4302,18 @@ class OperatorApp(App[None]):
         # right edge when docked left, left edge when docked right. Applied as
         # padding on the widget rather than a margin on the main lane so the
         # overlay case (where nothing is displaced) gets the same separation.
-        total_width = SIDEBAR_WIDTH + SIDEBAR_GUTTER
-        narrow = size.width < total_width + SIDEBAR_MAIN_MIN_WIDTH + 2
+        #
+        # The list grows on a roomy terminal and stays at its base width
+        # otherwise; `sidebar_content_width` owns that rule so the docked width
+        # and anything predicting it cannot drift apart.
+        content_width = sidebar_content_width(size.width)
+        total_width = content_width + SIDEBAR_GUTTER
+        # The OVERLAY threshold is deliberately measured against the BASE width,
+        # not the grown one. Growth only happens well above this threshold (it
+        # needs a comfortable main lane before it takes a single column), so
+        # feeding the grown width in here could only move the dock/overlay
+        # switch — a behaviour change at small sizes this has no business making.
+        narrow = size.width < SIDEBAR_WIDTH + SIDEBAR_GUTTER + SIDEBAR_MAIN_MIN_WIDTH + 2
         workspace = self.query_one("#session-workspace")
         workspace.set_class(narrow, "sidebar-overlay")
         sidebar.styles.dock = position

--- a/local_operator/tui/session_catalog.py
+++ b/local_operator/tui/session_catalog.py
@@ -68,18 +68,30 @@ class CatalogEntry:
             return "Not responding"
         if self.row.live_state == "busy":
             return "Working"
-        # Follows ``row_state_mark``'s precedence exactly, so the tooltip can
-        # never name a different state from the glyph beside it: an armed wake
-        # outranks mere presence, a dormant one does not. The glyph is a single
-        # character and the description is where a user finds out what it meant,
-        # so the two disagreeing is worse than either being terse.
+        # Follows ``row_state_mark``'s precedence EXACTLY, so the tooltip can
+        # never name a different state from the glyph beside it. The glyph is a
+        # single character and the description is where a user finds out what it
+        # meant, so the two disagreeing is worse than either being terse.
+        #
+        # Every branch below mirrors one in ``row_state_mark``, in its order:
+        # attached outranks an armed wake, which outranks idle, and a DORMANT
+        # wake falls through to the cold case — where it is still the glyph, so
+        # it must still be the words (round 1, D1: a cold row with a stopped
+        # schedule drew the wake mark while the tooltip said "Recent").
+        if self.row.live_state == "attached":
+            return "Open"
         if self.row.wakes and not self.row.wakes_dormant:
             count = self.row.wakes
             return f"Scheduled ({count} wake{'s' if count != 1 else ''})"
-        return {
-            "idle": "Ready",
-            "attached": "Open",
-        }.get(self.row.live_state, "Recent")
+        if self.row.live_state == "idle":
+            return "Ready"
+        if self.row.wakes:
+            # Dormant: the schedule exists but the session was stopped, so it is
+            # not going to fire. Named rather than hidden — a user who sees the
+            # glyph needs to know why it is not going to act.
+            count = self.row.wakes
+            return f"Stopped ({count} wake{'s' if count != 1 else ''} paused)"
+        return "Recent"
 
 
 def rank_entries(entries: Sequence[CatalogEntry]) -> tuple[CatalogEntry, ...]:

--- a/local_operator/tui/session_catalog.py
+++ b/local_operator/tui/session_catalog.py
@@ -64,11 +64,21 @@ class CatalogEntry:
             return {"error": "Unseen error", "interrupted": "Unseen interruption"}.get(
                 self.completion_kind, "Unseen completion"
             )
+        if self.row.live_state == "wedged":
+            return "Not responding"
+        if self.row.live_state == "busy":
+            return "Working"
+        # Follows ``row_state_mark``'s precedence exactly, so the tooltip can
+        # never name a different state from the glyph beside it: an armed wake
+        # outranks mere presence, a dormant one does not. The glyph is a single
+        # character and the description is where a user finds out what it meant,
+        # so the two disagreeing is worse than either being terse.
+        if self.row.wakes and not self.row.wakes_dormant:
+            count = self.row.wakes
+            return f"Scheduled ({count} wake{'s' if count != 1 else ''})"
         return {
-            "busy": "Working",
             "idle": "Ready",
             "attached": "Open",
-            "wedged": "Not responding",
         }.get(self.row.live_state, "Recent")
 
 

--- a/local_operator/tui/session_catalog.py
+++ b/local_operator/tui/session_catalog.py
@@ -89,8 +89,16 @@ class CatalogEntry:
             # Dormant: the schedule exists but the session was stopped, so it is
             # not going to fire. Named rather than hidden — a user who sees the
             # glyph needs to know why it is not going to act.
+            #
+            # "dormant" rather than a fresh adjective, because the stop receipt
+            # this state comes FROM already says "N wakes dormant until you
+            # reopen it" (``control.py`` / ``app.py``). Design review round 2
+            # (D5) flagged that an earlier draft here said "paused" and split
+            # the vocabulary for one fact across two surfaces; the receipt's
+            # word is the established one, so this follows it rather than
+            # asking the receipt to move.
             count = self.row.wakes
-            return f"Stopped ({count} wake{'s' if count != 1 else ''} paused)"
+            return f"Stopped ({count} wake{'s' if count != 1 else ''} dormant)"
         return "Recent"
 
 

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -428,16 +428,22 @@ def row_state_mark(row: SessionRow, frame: int) -> tuple[str, str]:
     needs-you outranks everything (a person is blocked), then wedged (broken),
     then busy, then an ARMED wake, then the runtime's own presence.
 
-    **An armed wake outranks the presence glyphs**, which is a change from the
+    **An armed wake outranks the IDLE glyph**, which is a change from the
     original ordering and is what the user asked for: "show the wake symbol if
     it's just scheduled wakes, or the circle icon that there's a runtime but no
-    activity". Presence (``○``/``●``) is the least informative thing true of a
-    row — every resident session has it — while "this one will act on its own
-    at some point" is a fact about the future that nothing else on the row
-    conveys. Under the old order the wake glyph was unreachable for any live
-    session, because a session with a wake armed is by definition resident and
+    activity". ``●`` idle is the least informative thing true of a row — every
+    resident session has it — while "this one will act on its own at some
+    point" is a fact about the future that nothing else on the row conveys.
+    Under the old order the wake glyph was unreachable for any live session,
+    because a session with a wake armed is by definition resident and
     ``idle``/``attached`` matched first; it could only ever appear on a COLD
     row, i.e. one whose wake had no runtime to fire in.
+
+    **``attached`` stays ABOVE the wake**, because the "least informative"
+    argument does not extend to it (round 1, D2). ``○`` does not mean merely
+    "resident"; it means *a terminal is watching this session*, which on a list
+    the user is scanning is the one mark that answers "where am I?". A wake is
+    worth more than bare residency and less than presence.
 
     **A DORMANT wake does not**, and stays below presence. ``wakes_dormant``
     means the session was deliberately stopped, so the schedule is not going to
@@ -460,10 +466,10 @@ def row_state_mark(row: SessionRow, frame: int) -> tuple[str, str]:
         return WEDGED_MARKER, "danger"
     if row.live_state == "busy":
         return SPINNER_FRAMES[frame % len(SPINNER_FRAMES)], "accent"
-    if row.wakes and not row.wakes_dormant:
-        return WAKE_MARKER, "muted"
     if row.live_state == "attached":
         return ATTACHED_MARKER, "muted"
+    if row.wakes and not row.wakes_dormant:
+        return WAKE_MARKER, "muted"
     if row.live_state == "idle":
         return IDLE_MARKER, "muted"
     if row.wakes:

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -426,11 +426,33 @@ def row_state_mark(row: SessionRow, frame: int) -> tuple[str, str]:
     "which of these is actually running, and which one wants me" has to be
     answerable at a glance. Precedence is by URGENCY, not by state machine:
     needs-you outranks everything (a person is blocked), then wedged (broken),
-    then busy, then attached, then wakes.
+    then busy, then an ARMED wake, then the runtime's own presence.
+
+    **An armed wake outranks the presence glyphs**, which is a change from the
+    original ordering and is what the user asked for: "show the wake symbol if
+    it's just scheduled wakes, or the circle icon that there's a runtime but no
+    activity". Presence (``○``/``●``) is the least informative thing true of a
+    row — every resident session has it — while "this one will act on its own
+    at some point" is a fact about the future that nothing else on the row
+    conveys. Under the old order the wake glyph was unreachable for any live
+    session, because a session with a wake armed is by definition resident and
+    ``idle``/``attached`` matched first; it could only ever appear on a COLD
+    row, i.e. one whose wake had no runtime to fire in.
+
+    **A DORMANT wake does not**, and stays below presence. ``wakes_dormant``
+    means the session was deliberately stopped, so the schedule is not going to
+    fire; promoting it would advertise a future that is not coming, over a
+    runtime that is genuinely here. On a cold row it still renders (dimmed) as
+    the last thing worth saying about the session.
 
     The spinner reuses ``terminal_title.SPINNER_FRAMES`` rather than a second
     animation vocabulary — the same glyphs the band and the terminal title
     already animate with, so "this is working" looks the same everywhere.
+
+    ``live_state == "busy"`` is now the CONVERSATION's activity rather than the
+    runtime's residency (see ``OwnedSessionHandle.is_conversationally_active``),
+    which is what makes the spinner honest: it had been pinned on by any
+    background job or subagent the session had ever launched.
     """
     if row.pending:
         return NEEDS_YOU_MARKER, "warning"
@@ -438,12 +460,14 @@ def row_state_mark(row: SessionRow, frame: int) -> tuple[str, str]:
         return WEDGED_MARKER, "danger"
     if row.live_state == "busy":
         return SPINNER_FRAMES[frame % len(SPINNER_FRAMES)], "accent"
+    if row.wakes and not row.wakes_dormant:
+        return WAKE_MARKER, "muted"
     if row.live_state == "attached":
         return ATTACHED_MARKER, "muted"
     if row.live_state == "idle":
         return IDLE_MARKER, "muted"
     if row.wakes:
-        return WAKE_MARKER, "dim" if row.wakes_dormant else "muted"
+        return WAKE_MARKER, "dim"
     return "", "dim"
 
 

--- a/local_operator/tui/widgets/session_sidebar.py
+++ b/local_operator/tui/widgets/session_sidebar.py
@@ -57,7 +57,20 @@ SIDEBAR_MAX_WIDTH = 44
 #: every size and the list simply stays at its base width when there is nothing
 #: spare. 80 is the conventional readable measure and the width the transcript's
 #: own wrapping is tuned around.
+#:
+#: Measured against the TERMINAL, not against the conversation widget, and the
+#: two differ by :data:`APP_SCREEN_INSET` (code review round 1, M1: the lane
+#: was measured at 78 cells where a naive reading of this constant promises
+#: 80). The inset is subtracted explicitly in :func:`sidebar_content_width` so
+#: the guarantee this constant names is the one the layout actually delivers.
 SIDEBAR_MAIN_COMFORT_WIDTH = 80
+
+#: Cells the app's own chrome takes out of the terminal before any lane is
+#: measured — the outer inset the stylesheet puts on the workspace (one cell
+#: each side). Named rather than inlined because it is the difference between
+#: "terminal width" and "width the lanes divide up", and a growth rule that
+#: forgets it over-promises by exactly this much.
+APP_SCREEN_INSET = 2
 
 #: How long a requested row waits before its state mark becomes a spinner.
 #: The tint itself is immediate — it is the acknowledgement that the click
@@ -104,8 +117,8 @@ def sidebar_content_width(terminal_width: int) -> int:
     to predict it.
 
     The rule, in one sentence: **start at the base width and spend only
-    surplus.** Surplus is whatever the terminal has beyond the base sidebar,
-    its gutter and a comfortable main lane
+    surplus.** Surplus is whatever the terminal has beyond the app's own inset,
+    the base sidebar, its gutter and a comfortable main lane
     (:data:`SIDEBAR_MAIN_COMFORT_WIDTH`); the list takes it up to
     :data:`SIDEBAR_MAX_WIDTH` and never more. Consequences worth stating
     because they are the safety argument:
@@ -113,12 +126,23 @@ def sidebar_content_width(terminal_width: int) -> int:
     * A terminal at or below the comfort threshold gets exactly today's
       layout — this cannot regress a narrow window, and the overlay behaviour
       at genuinely small sizes is untouched.
-    * The main lane never drops below its comfort width because of growth: the
-      sidebar is only ever handed columns the conversation did not need.
+    * The conversation never drops below :data:`SIDEBAR_MAIN_COMFORT_WIDTH`
+      *because of growth*: the sidebar is only ever handed columns the
+      conversation did not need. Below the threshold the lane can of course be
+      narrower — that is the terminal being small, not the list taking
+      anything.
     * Growth is monotonic in terminal width, so dragging a window wider never
       makes the list narrower.
+
+    :data:`APP_SCREEN_INSET` is subtracted because the lanes divide the
+    terminal MINUS the app's outer inset, not the terminal. Omitting it made
+    the promise wrong by two cells at every size where growth is active (code
+    review round 1, M1) — a real measurement of 78 against a documented 80,
+    which is the kind of quiet drift that makes a stated invariant untrustable
+    even when nothing visibly breaks.
     """
-    surplus = terminal_width - (SIDEBAR_WIDTH + SIDEBAR_GUTTER + SIDEBAR_MAIN_COMFORT_WIDTH)
+    reserved = APP_SCREEN_INSET + SIDEBAR_WIDTH + SIDEBAR_GUTTER + SIDEBAR_MAIN_COMFORT_WIDTH
+    surplus = terminal_width - reserved
     if surplus <= 0:
         return SIDEBAR_WIDTH
     return min(SIDEBAR_MAX_WIDTH, SIDEBAR_WIDTH + surplus)

--- a/local_operator/tui/widgets/session_sidebar.py
+++ b/local_operator/tui/widgets/session_sidebar.py
@@ -30,6 +30,35 @@ from local_operator.tui.widgets.tool_card import truncate_cells
 
 SIDEBAR_WIDTH = 30
 
+#: The widest the list may grow on a roomy terminal, in the same units as
+#: :data:`SIDEBAR_WIDTH` (content, before the gutter is added).
+#:
+#: At the base 30 the title column is about 20 cells once the caret, the state
+#: mark and the age have taken theirs, and real conversation names are longer
+#: than that: the reporter's own frame showed "Article-search-svc s…",
+#: "Add Flavia's Adverse Med…", "Update Provider Onbo…" — eleven of twelve rows
+#: ellipsized, several of them cut before the word that distinguishes them from
+#: their neighbour. A list whose whole job is "recognise your own conversation"
+#: cannot do it at that budget, and a wide terminal has the cells to spare.
+#:
+#: 44 gives about 34 title cells, which fits the great majority of generated
+#: titles outright. It is a CAP rather than a target: growth is paid for out of
+#: surplus only (see :data:`SIDEBAR_MAIN_COMFORT_WIDTH`), so a narrow terminal
+#: is unaffected and nothing here can squeeze the conversation.
+SIDEBAR_MAX_WIDTH = 44
+
+#: The main lane's COMFORT width, which growth may not eat into.
+#:
+#: Distinct from :data:`SIDEBAR_MAIN_MIN_WIDTH`, and the distinction is what
+#: makes widening safe. That constant is a HARD floor — below it the drawer
+#: stops displacing the conversation and becomes an overlay. This one is the
+#: point past which extra columns are surplus: the sidebar grows only into
+#: terminal width beyond it, so the transcript keeps a comfortable measure at
+#: every size and the list simply stays at its base width when there is nothing
+#: spare. 80 is the conventional readable measure and the width the transcript's
+#: own wrapping is tuned around.
+SIDEBAR_MAIN_COMFORT_WIDTH = 80
+
 #: How long a requested row waits before its state mark becomes a spinner.
 #: The tint itself is immediate — it is the acknowledgement that the click
 #: landed. The spinner is only for a switch that is genuinely taking a while,
@@ -64,6 +93,36 @@ SIDEBAR_GUTTER = 3
 #: the separation the gutter buys.
 SIDEBAR_MIN_CONTENT_WIDTH = 24
 SIDEBAR_MAIN_MIN_WIDTH = 60
+
+
+def sidebar_content_width(terminal_width: int) -> int:
+    """How wide the list's CONTENT should be in a terminal this wide.
+
+    One pure function so the width the app docks and the width any test or
+    capture reasons about are the same number, derived the same way — the
+    layout used to compute it inline, which is fine until a second caller needs
+    to predict it.
+
+    The rule, in one sentence: **start at the base width and spend only
+    surplus.** Surplus is whatever the terminal has beyond the base sidebar,
+    its gutter and a comfortable main lane
+    (:data:`SIDEBAR_MAIN_COMFORT_WIDTH`); the list takes it up to
+    :data:`SIDEBAR_MAX_WIDTH` and never more. Consequences worth stating
+    because they are the safety argument:
+
+    * A terminal at or below the comfort threshold gets exactly today's
+      layout — this cannot regress a narrow window, and the overlay behaviour
+      at genuinely small sizes is untouched.
+    * The main lane never drops below its comfort width because of growth: the
+      sidebar is only ever handed columns the conversation did not need.
+    * Growth is monotonic in terminal width, so dragging a window wider never
+      makes the list narrower.
+    """
+    surplus = terminal_width - (SIDEBAR_WIDTH + SIDEBAR_GUTTER + SIDEBAR_MAIN_COMFORT_WIDTH)
+    if surplus <= 0:
+        return SIDEBAR_WIDTH
+    return min(SIDEBAR_MAX_WIDTH, SIDEBAR_WIDTH + surplus)
+
 
 #: The list's own spinner cadence, deliberately slower than
 #: :data:`terminal_title.SPINNER_INTERVAL_S` that the band and the panels use.

--- a/scripts/sidebar_shot.py
+++ b/scripts/sidebar_shot.py
@@ -75,6 +75,17 @@ ROWS = [
     ("aaaaaaaaaaa5", "OSWorld benchmark evaluation (subagent)", 8, HOLDING_WORK, None, 0, False),
     ("aaaaaaaaaaa6", "Auto-update inactive session runtimes", 13, "idle", None, 2, False),
     ("aaaaaaaaaaa7", "Debugging session cost and naming drift", 43, "idle", None, 1, True),
+    # The two states the round-1 design findings were about. Neither was in the
+    # fixture when those findings were raised, so the frames could not show the
+    # bugs OR their fixes and the reviewer had to build a scratch harness to
+    # see them (round 2). A capture script that cannot frame the states it was
+    # reviewed for is the same defect as D3 in a different place.
+    #
+    #   attached + armed wake -> must draw the ATTACHED mark, not the wake (D2)
+    #   cold + dormant wake   -> draws the wake mark, so the words must follow
+    #                            it: "Stopped (N wakes paused)" (D1)
+    ("aaaaaaaaaab4", "Review provider onboarding copy", 7, "attached", None, 2, False),
+    ("aaaaaaaaaab5", "Stopped nightly catalogue refresh", 120, "", None, 1, True),
     ("aaaaaaaaaaa8", "Add Flavia's Adverse Media Case", 3, "idle", "approval", 0, False),
     ("aaaaaaaaaaa9", "Review and merge open provider MRs", 52, "wedged", None, 0, False),
     ("aaaaaaaaaab1", "Toggleable Sidebar for Session Switching", 49, "", None, 3, False),
@@ -132,12 +143,28 @@ async def main() -> None:
         sidebar.cursor_id = "aaaaaaaaaaa1"
         # Pin the animation: a capture is only comparable frame-to-frame if the
         # spinner is at a known phase in both.
+        #
+        # Pausing the timer is NOT enough, and a frame pinned that way was in
+        # fact unstable across runs (design review round 2, D6: six runs, two
+        # distinct glyphs). `_sync_animation()` runs from `set_entries` and from
+        # several other paths, and it RE-RESUMES the timer whenever any visible
+        # row is busy — so a tick can still land during the settling pauses
+        # below and advance `_frame` out from under the pin.
+        #
+        # Stopping the timer outright and clearing the handle is what actually
+        # holds: `_sync_animation` returns early when `_timer is None`, so
+        # nothing can restart it, and `_frame` stays exactly where it is put.
         if sidebar._timer is not None:
-            sidebar._timer.pause()
+            sidebar._timer.stop()
+            sidebar._timer = None
         sidebar._frame = 2
         sidebar.refresh()
         await pilot.pause()
         await pilot.pause()
+        # Assert the pin rather than trusting it: a capture script whose
+        # determinism claim is false silently poisons every future comparison
+        # captured from it.
+        assert sidebar._frame == 2, f"spinner phase drifted to {sidebar._frame}"
 
         save_capture(app, out)
         conversation = app.query_one("#session-conversation")

--- a/scripts/sidebar_shot.py
+++ b/scripts/sidebar_shot.py
@@ -1,0 +1,137 @@
+"""Capture the session sidebar over a populated transcript, for visual validation.
+
+Run from the worktree root:
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python scripts/sidebar_shot.py OUT.svg [COLSxROWS]
+
+Seeds ONE fixed catalog covering every state the list can draw — a live turn,
+an idle runtime, an attached viewer, an armed wake, a dormant wake, a parked
+gate, a wedged runtime and cold rows — so a single frame answers both questions
+this change is about:
+
+* **Which rows animate.** Only a session whose CONVERSATION is working may
+  carry the spinner. The rows named "…(bg job)" and "…(subagent)" are the
+  regression under test: they hold work that keeps the runtime resident while
+  the conversation itself is finished, and before the fix they were
+  indistinguishable from a live turn.
+* **How much of a title survives.** The names here are real-length generated
+  titles, so the frame shows the title budget rather than a curated short one.
+
+The frame is deterministic: the spinner is pinned to a known frame and the
+catalog is fixed, so before/after captures differ only where the change does.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.visual_capture import isolate_capture, save_capture  # noqa: E402
+
+isolate_capture()
+
+from local_operator.resume import SessionRow  # noqa: E402
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.session_catalog import (  # noqa: E402
+    CatalogEntry,
+    SidebarSettings,
+)
+from local_operator.tui.widgets.assistant import AssistantBlock  # noqa: E402
+from local_operator.tui.widgets.transcript import UserBlock  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+NOW = time.time()
+
+#: ``(id, title, age_minutes, live_state, pending, wakes, dormant)``.
+#: Titles are real generated-length names, several of them sharing a prefix,
+#: because "Article-search-svc s…" vs "Article search servi…" is exactly the
+#: discrimination the list failed to support at the base width.
+ROWS = [
+    ("aaaaaaaaaaa1", "Fix sidebar activity indicator accuracy", 1, "busy", None, 0, False),
+    ("aaaaaaaaaaa2", "Update Provider Onboarding and OAuth UX", 4, "attached", None, 0, False),
+    ("aaaaaaaaaaa3", "Article-search-svc schema review (bg job)", 11, "idle", None, 0, False),
+    ("aaaaaaaaaaa4", "Article search service integration rollout", 6, "idle", None, 0, False),
+    ("aaaaaaaaaaa5", "OSWorld benchmark evaluation (subagent)", 8, "idle", None, 0, False),
+    ("aaaaaaaaaaa6", "Auto-update inactive session runtimes", 13, "idle", None, 2, False),
+    ("aaaaaaaaaaa7", "Debugging session cost and naming drift", 43, "idle", None, 1, True),
+    ("aaaaaaaaaaa8", "Add Flavia's Adverse Media Case", 3, "idle", "approval", 0, False),
+    ("aaaaaaaaaaa9", "Review and merge open provider MRs", 52, "wedged", None, 0, False),
+    ("aaaaaaaaaab1", "Toggleable Sidebar for Session Switching", 49, "", None, 3, False),
+    ("aaaaaaaaaab2", "Mark Focused TUI Session as Read", 300, "", None, 0, False),
+    ("aaaaaaaaaab3", "Address Local Operator packaging review", 35, "", None, 0, False),
+]
+
+
+def _entries() -> list[CatalogEntry]:
+    return [
+        CatalogEntry(
+            SessionRow(
+                id=session_id,
+                mtime=NOW - age * 60,
+                name=name,
+                live_state=state,
+                pending=pending,
+                wakes=wakes,
+                wakes_dormant=dormant,
+            )
+        )
+        for session_id, name, age, state, pending, wakes, dormant in ROWS
+    ]
+
+
+async def main() -> None:
+    out = sys.argv[1]
+    size = (100, 30)
+    if len(sys.argv) > 2:
+        cols, rows = sys.argv[2].split("x")
+        size = (int(cols), int(rows))
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=size) as pilot:
+        await pilot.pause()
+        app._sidebar_settings = SidebarSettings(False, "left")
+        # Seed a conversation so the frame shows the list BESIDE something,
+        # which is the only way the width trade-off is visible at all.
+        for turn in range(1, 7):
+            app._append_block(UserBlock(f"Turn {turn}: what should we do about the stale rows?"))
+            prose = AssistantBlock()
+            prose.update_text(
+                f"Answer {turn}: the audit log still has every row, so a backfill "
+                "is possible. Nothing else reads that column today, which is why "
+                "dropping it is on the table at all."
+            )
+            app._append_block(prose)
+        await pilot.pause()
+
+        await pilot.press("ctrl+b")
+        await pilot.pause()
+        sidebar = app._session_sidebar
+        sidebar.set_entries(_entries())
+        sidebar.current_id = "aaaaaaaaaaa1"
+        sidebar.cursor_id = "aaaaaaaaaaa1"
+        # Pin the animation: a capture is only comparable frame-to-frame if the
+        # spinner is at a known phase in both.
+        if sidebar._timer is not None:
+            sidebar._timer.pause()
+        sidebar._frame = 2
+        sidebar.refresh()
+        await pilot.pause()
+        await pilot.pause()
+
+        save_capture(app, out)
+        conversation = app.query_one("#session-conversation")
+        print(
+            f"terminal={size[0]}x{size[1]} "
+            f"sidebar_outer={sidebar.region.width} "
+            f"sidebar_content={sidebar.content_region.width} "
+            f"conversation={conversation.size.width} "
+            f"virtual={app.screen.virtual_size} actual={app.screen.size} "
+            f"scrollbar={app.screen.show_vertical_scrollbar}"
+        )
+
+
+asyncio.run(main())

--- a/scripts/sidebar_shot.py
+++ b/scripts/sidebar_shot.py
@@ -83,7 +83,7 @@ ROWS = [
     #
     #   attached + armed wake -> must draw the ATTACHED mark, not the wake (D2)
     #   cold + dormant wake   -> draws the wake mark, so the words must follow
-    #                            it: "Stopped (N wakes paused)" (D1)
+    #                            it: "Stopped (N wakes dormant)" (D1)
     ("aaaaaaaaaab4", "Review provider onboarding copy", 7, "attached", None, 2, False),
     ("aaaaaaaaaab5", "Stopped nightly catalogue refresh", 120, "", None, 1, True),
     ("aaaaaaaaaaa8", "Add Flavia's Adverse Media Case", 3, "idle", "approval", 0, False),

--- a/scripts/sidebar_shot.py
+++ b/scripts/sidebar_shot.py
@@ -9,13 +9,22 @@ an idle runtime, an attached viewer, an armed wake, a dormant wake, a parked
 gate, a wedged runtime and cold rows — so a single frame answers both questions
 this change is about:
 
-* **Which rows animate.** Only a session whose CONVERSATION is working may
-  carry the spinner. The rows named "…(bg job)" and "…(subagent)" are the
-  regression under test: they hold work that keeps the runtime resident while
-  the conversation itself is finished, and before the fix they were
-  indistinguishable from a live turn.
+* **Which glyph each state draws**, across every mark the list can produce.
 * **How much of a title survives.** The names here are real-length generated
   titles, so the frame shows the title budget rather than a curated short one.
+
+**What this script can and cannot prove.** It renders from a FIXED catalog of
+``SessionRow``s, so it exercises the display layer only. The rows named
+"…(bg job)" and "…(subagent)" carry ``live_state="idle"`` because that is what
+the fixed runtime now publishes for them — which means they render ``●`` in
+this script against BOTH trees, and a before/after pair of these frames is not
+evidence for the activity fix (round 1, D3). The change those rows stand for
+happens upstream, where ``OwnedSessionHandle`` decides whether to publish
+``busy`` at all; it is proven by
+``tests/unit/session/runtime/test_activity_vs_residency.py`` and by the live
+probe described on the PR, not here. To see the pre-fix rendering of those
+rows, set ``LO_SIDEBAR_SHOT_STALE_BUSY=1``, which restores the state the OLD
+record would have published for a session holding background work.
 
 The frame is deterministic: the spinner is pinned to a known frame and the
 catalog is fixed, so before/after captures differ only where the change does.
@@ -24,6 +33,7 @@ catalog is fixed, so before/after captures differ only where the change does.
 from __future__ import annotations
 
 import asyncio
+import os
 import sys
 import time
 from pathlib import Path
@@ -50,12 +60,19 @@ NOW = time.time()
 #: Titles are real generated-length names, several of them sharing a prefix,
 #: because "Article-search-svc s…" vs "Article search servi…" is exactly the
 #: discrimination the list failed to support at the base width.
+#: Rows whose live_state models a session HOLDING BACKGROUND WORK with a
+#: finished conversation. Under the old runtime these published ``busy``; under
+#: the fixed one they publish idle. ``LO_SIDEBAR_SHOT_STALE_BUSY=1`` renders
+#: them the old way so the two can be compared in one tree.
+STALE_BUSY = os.environ.get("LO_SIDEBAR_SHOT_STALE_BUSY") == "1"
+HOLDING_WORK = "busy" if STALE_BUSY else "idle"
+
 ROWS = [
     ("aaaaaaaaaaa1", "Fix sidebar activity indicator accuracy", 1, "busy", None, 0, False),
     ("aaaaaaaaaaa2", "Update Provider Onboarding and OAuth UX", 4, "attached", None, 0, False),
-    ("aaaaaaaaaaa3", "Article-search-svc schema review (bg job)", 11, "idle", None, 0, False),
+    ("aaaaaaaaaaa3", "Article-search-svc schema review (bg job)", 11, HOLDING_WORK, None, 0, False),
     ("aaaaaaaaaaa4", "Article search service integration rollout", 6, "idle", None, 0, False),
-    ("aaaaaaaaaaa5", "OSWorld benchmark evaluation (subagent)", 8, "idle", None, 0, False),
+    ("aaaaaaaaaaa5", "OSWorld benchmark evaluation (subagent)", 8, HOLDING_WORK, None, 0, False),
     ("aaaaaaaaaaa6", "Auto-update inactive session runtimes", 13, "idle", None, 2, False),
     ("aaaaaaaaaaa7", "Debugging session cost and naming drift", 43, "idle", None, 1, True),
     ("aaaaaaaaaaa8", "Add Flavia's Adverse Media Case", 3, "idle", "approval", 0, False),

--- a/scripts/visual_gallery.py
+++ b/scripts/visual_gallery.py
@@ -50,6 +50,11 @@ def cases() -> list[dict[str, Any]]:
                 args += ["100x30", variant]
             elif script in {"fallback_shot.py", "nerd_glyph_shot.py"}:
                 args += [variant]
+            elif script == "sidebar_shot.py":
+                # Two widths, because the whole point of the sample is the
+                # trade-off between them: "base" is the size at which the list
+                # does not grow at all, "wide" the size at which it does.
+                args += ["160x40" if variant == "wide" else "100x30"]
             elif script == "stop_ladder_shot.py":
                 args += [variant, "100x30"]
             elif script == "org_chart_shot.py":

--- a/scripts/visual_inventory.json
+++ b/scripts/visual_inventory.json
@@ -125,6 +125,10 @@
       "custom",
       "provider-windowed"
     ],
+    "sidebar_shot.py": [
+      "base",
+      "wide"
+    ],
     "shot_login.py": [
       "prompt",
       "empty-submit",

--- a/tests/unit/session/runtime/test_activity_vs_residency.py
+++ b/tests/unit/session/runtime/test_activity_vs_residency.py
@@ -1,0 +1,214 @@
+"""The record's activity bit is about the CONVERSATION, not about residency.
+
+**This file exists because a session that had finished talking still wore a
+spinner in the sidebar.** The reported symptom was a "done" conversation
+("Article-search-svc…") that kept showing the working indicator; the measured
+cause was that `OwnedSessionHandle.is_busy()` — the *reaper's* residency
+predicate — was published verbatim as `SessionRecord.busy`, which every
+surface renders as "a turn is running".
+
+Those are two different questions and they were answered by one predicate:
+
+* **Residency** ("may this runtime exit?") must be MAXIMALLY inclusive. A
+  backgrounded `bash` job, a still-running subagent, a queued prompt and a
+  parked gate all forbid exit, because exiting would destroy work. Fail-closed
+  is correct there: an over-broad residency answer costs an idle process.
+* **Activity** ("is this conversation working right now?") is what a spinner
+  claims. A user who reads a spinner expects tokens to be moving. A detached
+  background job the user themself launched with `background=true` is
+  deliberately outliving its turn, so it is exactly the thing that must NOT
+  animate a row.
+
+Measured on this host before the fix: 8 of 8 live sessions published
+`busy=True`, including one idle for 25.6 minutes whose transcript's last entry
+was a completed turn — because a background `bash` job and a stale subagent row
+each held `is_busy()` True forever. The bit was not stale; it was answering the
+wrong question, so no amount of republishing could have fixed it.
+
+The split introduced here is `is_conversationally_active()`: the terms of
+`is_busy()` that mean "the conversation itself is moving", with the
+work-retention terms (background jobs, subagents, background tasks) removed.
+`is_busy()` is untouched, because the reaper's fail-closed behaviour is
+correct and this must not make a runtime exit under live work.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.session.runtime.owned import OwnedSessionHandle
+from local_operator.session.runtime.server import RuntimeServer
+from tests.e2e.harness import ScriptedStream, build_session, text_turn
+
+
+async def _rig(directory: Path, replies: int = 2) -> tuple[Any, OwnedSessionHandle, RuntimeServer]:
+    """A real Session under the production handle and server.
+
+    Same rig as ``test_busy_settles``: the seam under test is the one
+    production runs, so the handle and the server are the real classes and only
+    the provider stream is scripted.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    stream = ScriptedStream([text_turn(f"reply {i}") for i in range(replies)])
+    session = build_session(directory, stream)
+    handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd=str(directory))
+    server = RuntimeServer(handle, kind="daemon")
+    handle.subscribe(server._schedule_push)
+    return session, handle, server
+
+
+async def _running_job(session: Any, job_type: str) -> str:
+    """Register a REAL job on the session's own manager and leave it running.
+
+    Deliberately not a manager double. The predicate under test reads job rows
+    through ``session.jobs.list()``, and a double would let the test agree with
+    an implementation that production data never produces — the shape of a
+    running row (``status``, ``type``, ``queued``) is exactly what is being
+    asserted about. The runner parks on an Event the caller never sets, which
+    is what a backgrounded `bash` job or a live subagent looks like to the
+    manager: admitted, started, and not finished.
+    """
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def run(job_id: str, signal: Any, emit: Any) -> str:
+        # The manager's ``JobRunFn`` contract: (job_id, abort signal, emit).
+        started.set()
+        await release.wait()
+        return "done"
+
+    job_id = session.jobs.register(job_type, f"{job_type}-job", run)
+    await asyncio.wait_for(started.wait(), 5.0)
+    _RELEASES.append(release)
+    return job_id
+
+
+#: Every parked runner, released in teardown so no test leaves a pending task
+#: behind for the next one to trip over.
+_RELEASES: list[asyncio.Event] = []
+
+
+@pytest.fixture(autouse=True)
+def _release_parked_jobs():
+    _RELEASES.clear()
+    yield
+    for event in _RELEASES:
+        event.set()
+    _RELEASES.clear()
+
+
+@pytest.mark.asyncio
+async def test_a_background_job_holds_residency_but_is_not_conversation_activity(
+    tmp_path: Path,
+) -> None:
+    """THE REPORTED BUG, as an assertion.
+
+    A backgrounded `bash` job is running; the conversation has said everything
+    it is going to say. The runtime must stay resident (the job's output would
+    be destroyed by an exit) and the row must NOT animate.
+
+    On the unfixed tree ``is_conversationally_active`` does not exist and the
+    published bit is ``is_busy()``, which is True here.
+    """
+    session, handle, server = await _rig(tmp_path / "sess")
+    try:
+        await _running_job(session, "bash")
+        assert handle.is_busy() is True, "a running job must still pin residency"
+        assert handle.is_conversationally_active() is False
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_running_subagent_holds_residency_but_is_not_conversation_activity(
+    tmp_path: Path,
+) -> None:
+    """Delegated work is the same case as a background job.
+
+    A `task` subagent outlives the turn that launched it by design — the parent
+    is explicitly free to keep talking, or to say nothing at all. Measured on
+    this host: three live sessions carried a `running` roster row with the
+    parent idle for 8-25 minutes, and all three wore the spinner.
+    """
+    session, handle, server = await _rig(tmp_path / "sess")
+    try:
+        await _running_job(session, "task")
+        assert handle.is_busy() is True
+        assert handle.is_conversationally_active() is False
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_live_turn_is_conversation_activity(tmp_path: Path) -> None:
+    """The signal must still be TRUE for the case the spinner exists for.
+
+    The guard against fixing the false positive by making the bit always False:
+    while a turn streams, both predicates hold.
+    """
+    session, handle, server = await _rig(tmp_path / "sess")
+    seen: list[bool] = []
+
+    def on_event(event: Any) -> None:
+        # Sampled from INSIDE the turn: after it settles the predicate is False
+        # again, so a sample taken afterwards would prove nothing. Guarded
+        # because the session logs and swallows a raising handler, which would
+        # otherwise turn "the predicate does not exist yet" into the much less
+        # informative "no events were produced".
+        probe = getattr(handle, "is_conversationally_active", None)
+        seen.append(bool(probe()) if callable(probe) else False)
+
+    session.subscribe(on_event)
+    try:
+        await handle.prompt("hello", wait_complete=True)
+        assert seen, "the turn produced no events to sample"
+        assert any(seen), "a streaming turn must read as conversation activity"
+        # And it must SETTLE: a predicate stuck True is the bug in the other
+        # direction, and is exactly what shipped.
+        await asyncio.sleep(0)
+        assert handle.is_conversationally_active() is False
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_parked_gate_is_conversation_activity(tmp_path: Path) -> None:
+    """A gate waiting on a person belongs to a turn that is mid-flight.
+
+    It renders as the needs-you marker rather than the spinner (that
+    precedence lives in ``row_state_mark``), but the underlying turn IS
+    running: the tool slot is held and the conversation is not finished. So
+    the activity predicate says True and the marker layer decides what to draw.
+    """
+    session, handle, server = await _rig(tmp_path / "sess")
+    try:
+        future: asyncio.Future[Any] = asyncio.get_running_loop().create_future()
+        handle._pending_futures["req-1"] = future
+        assert handle.is_conversationally_active() is True
+    finally:
+        handle._pending_futures.clear()
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_published_record_bit_follows_activity_not_residency(
+    tmp_path: Path,
+) -> None:
+    """End to end: what a background job does to the RECORD the sidebar reads.
+
+    ``_publish_busy`` is the one seam between the handle and the record, so
+    this asserts the thing the user actually sees rather than the predicate
+    behind it.
+    """
+    session, handle, server = await _rig(tmp_path / "sess")
+    try:
+        await _running_job(session, "bash")
+        handle._publish_busy()
+        assert server._busy is False, "an idle conversation must not publish busy"
+        assert handle.is_busy() is True, "residency must be unaffected by the split"
+    finally:
+        await session.dispose()

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -1858,9 +1858,7 @@ def test_an_armed_wake_outranks_idle_but_not_attached() -> None:
     idle = _row("wake00000001", "armed")._replace(live_state="idle", wakes=2)
     assert row_state_mark(idle, 0)[0] == WAKE_MARKER
 
-    watched = _row("wake00000003", "armed and watched")._replace(
-        live_state="attached", wakes=2
-    )
+    watched = _row("wake00000003", "armed and watched")._replace(live_state="attached", wakes=2)
     assert row_state_mark(watched, 0)[0] == ATTACHED_MARKER
 
     # A cold row with an armed wake still shows it — that never regressed.

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -1830,7 +1830,7 @@ def test_the_signature_names_only_real_row_fields() -> None:
     assert "id" in SessionPickerScreen._SIGNATURE_FIELDS
 
 
-def test_an_armed_wake_outranks_mere_presence() -> None:
+def test_an_armed_wake_outranks_idle_but_not_attached() -> None:
     """The reported ask: "show the wake symbol if it's just scheduled wakes".
 
     Under the original precedence the wake glyph was UNREACHABLE for any live
@@ -1839,19 +1839,33 @@ def test_an_armed_wake_outranks_mere_presence() -> None:
     cold row — one with no runtime to fire it. That is backwards, because the
     cold row is the one where the schedule means least.
 
-    Presence is the least informative thing true of a row (every resident
-    session has it); "this will act on its own later" is a fact nothing else on
-    the row conveys.
+    `idle` is the least informative thing true of a row (every resident session
+    has it); "this will act on its own later" is a fact nothing else conveys.
+
+    `attached` is NOT that, and this test asserts the distinction because the
+    first cut of the change got it wrong (round 1, D2): `○` means *a terminal
+    is watching this session*, which on a list the user is scanning is the one
+    mark that answers "where am I?". A wake outranks bare residency and loses
+    to presence.
     """
     from local_operator.tui.widgets.session_picker import (
+        ATTACHED_MARKER,
         IDLE_MARKER,
         WAKE_MARKER,
         row_state_mark,
     )
 
-    for state in ("idle", "attached"):
-        row = _row("wake00000001", "armed")._replace(live_state=state, wakes=2)
-        assert row_state_mark(row, 0)[0] == WAKE_MARKER, state
+    idle = _row("wake00000001", "armed")._replace(live_state="idle", wakes=2)
+    assert row_state_mark(idle, 0)[0] == WAKE_MARKER
+
+    watched = _row("wake00000003", "armed and watched")._replace(
+        live_state="attached", wakes=2
+    )
+    assert row_state_mark(watched, 0)[0] == ATTACHED_MARKER
+
+    # A cold row with an armed wake still shows it — that never regressed.
+    cold = _row("wake00000004", "cold armed")._replace(wakes=1)
+    assert row_state_mark(cold, 0)[0] == WAKE_MARKER
 
     # And with no wake armed, presence still renders exactly as before.
     plain = _row("idle00000002", "no wake")._replace(live_state="idle")

--- a/tests/unit/tui/test_session_picker.py
+++ b/tests/unit/tui/test_session_picker.py
@@ -1828,3 +1828,79 @@ def test_the_signature_names_only_real_row_fields() -> None:
     assert not unknown, f"signature names fields SessionRow does not have: {sorted(unknown)}"
     # Identity must be in it, or a pure reorder compares equal.
     assert "id" in SessionPickerScreen._SIGNATURE_FIELDS
+
+
+def test_an_armed_wake_outranks_mere_presence() -> None:
+    """The reported ask: "show the wake symbol if it's just scheduled wakes".
+
+    Under the original precedence the wake glyph was UNREACHABLE for any live
+    session: a session with a wake armed is by definition resident, so
+    `idle`/`attached` matched first and the wake was only ever visible on a
+    cold row — one with no runtime to fire it. That is backwards, because the
+    cold row is the one where the schedule means least.
+
+    Presence is the least informative thing true of a row (every resident
+    session has it); "this will act on its own later" is a fact nothing else on
+    the row conveys.
+    """
+    from local_operator.tui.widgets.session_picker import (
+        IDLE_MARKER,
+        WAKE_MARKER,
+        row_state_mark,
+    )
+
+    for state in ("idle", "attached"):
+        row = _row("wake00000001", "armed")._replace(live_state=state, wakes=2)
+        assert row_state_mark(row, 0)[0] == WAKE_MARKER, state
+
+    # And with no wake armed, presence still renders exactly as before.
+    plain = _row("idle00000002", "no wake")._replace(live_state="idle")
+    assert row_state_mark(plain, 0)[0] == IDLE_MARKER
+
+
+def test_a_dormant_wake_stays_below_presence() -> None:
+    """A stopped session's schedule is not going to fire, so it must not win.
+
+    Promoting it would advertise a future that is not coming over a runtime
+    that is genuinely here. On a COLD row it still renders, dimmed, because
+    there it is the last thing worth saying about the session.
+    """
+    from local_operator.tui.widgets.session_picker import (
+        IDLE_MARKER,
+        WAKE_MARKER,
+        row_state_mark,
+    )
+
+    live = _row("dorm00000001", "stopped but resident")._replace(
+        live_state="idle", wakes=1, wakes_dormant=True
+    )
+    assert row_state_mark(live, 0)[0] == IDLE_MARKER
+
+    cold = _row("dorm00000002", "cold")._replace(wakes=1, wakes_dormant=True)
+    glyph, ink = row_state_mark(cold, 0)
+    assert glyph == WAKE_MARKER
+    assert ink == "dim", "a dormant wake must read as quieter than an armed one"
+
+
+def test_urgency_still_outranks_an_armed_wake() -> None:
+    """Promoting wakes must not have demoted anything above them.
+
+    A person waiting and a broken runtime are both more urgent than a schedule,
+    and a live turn is what the spinner exists for.
+    """
+    from local_operator.tui.terminal_title import SPINNER_FRAMES
+    from local_operator.tui.widgets.session_picker import (
+        NEEDS_YOU_MARKER,
+        WEDGED_MARKER,
+        row_state_mark,
+    )
+
+    base = dict(wakes=3, wakes_dormant=False)
+    pending = _row("urg000000001", "waiting")._replace(pending="approval", **base)
+    assert row_state_mark(pending, 0)[0] == NEEDS_YOU_MARKER
+
+    wedged = _row("urg000000002", "broken")._replace(live_state="wedged", **base)
+    assert row_state_mark(wedged, 0)[0] == WEDGED_MARKER
+
+    busy = _row("urg000000003", "working")._replace(live_state="busy", **base)
+    assert row_state_mark(busy, 0)[0] in set(SPINNER_FRAMES)

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -21,6 +21,7 @@ from local_operator.tui.session_catalog import (
 )
 from local_operator.tui.widgets.editor import Editor
 from local_operator.tui.widgets.session_sidebar import (
+    APP_SCREEN_INSET,
     SIDEBAR_GUTTER,
     SIDEBAR_MAIN_COMFORT_WIDTH,
     SIDEBAR_MAIN_MIN_WIDTH,
@@ -1050,14 +1051,14 @@ def test_a_narrow_terminal_is_left_exactly_as_it_was():
     the layout, the overlay switch and every existing geometry test describe the
     same app they did before.
     """
-    threshold = SIDEBAR_WIDTH + SIDEBAR_GUTTER + SIDEBAR_MAIN_COMFORT_WIDTH
+    threshold = APP_SCREEN_INSET + SIDEBAR_WIDTH + SIDEBAR_GUTTER + SIDEBAR_MAIN_COMFORT_WIDTH
     for width in (60, 80, 100, threshold - 1, threshold):
         assert sidebar_content_width(width) == SIDEBAR_WIDTH, width
 
 
 def test_growth_spends_only_surplus_and_stops_at_the_cap():
     """One column of terminal buys at most one column of list, up to the cap."""
-    threshold = SIDEBAR_WIDTH + SIDEBAR_GUTTER + SIDEBAR_MAIN_COMFORT_WIDTH
+    threshold = APP_SCREEN_INSET + SIDEBAR_WIDTH + SIDEBAR_GUTTER + SIDEBAR_MAIN_COMFORT_WIDTH
     assert sidebar_content_width(threshold + 1) == SIDEBAR_WIDTH + 1
     assert sidebar_content_width(threshold + 5) == SIDEBAR_WIDTH + 5
     assert sidebar_content_width(threshold + 500) == SIDEBAR_MAX_WIDTH
@@ -1067,18 +1068,53 @@ def test_growth_spends_only_surplus_and_stops_at_the_cap():
 
 
 def test_the_conversation_never_pays_for_the_list_getting_wider():
-    """The structural invariant, asserted as arithmetic rather than as a frame.
+    """The structural invariant, as arithmetic over the whole width range.
 
     At every terminal width, whatever the sidebar and its gutter take must
-    leave the main lane at least its comfort width. This is the property that
-    makes the feature safe, so it is checked across the whole range rather than
-    at the two sizes a screenshot happens to use.
+    leave the main lane at least its comfort width. Checked across the range
+    rather than at the two sizes a screenshot happens to use.
+
+    The app's own outer inset is part of the sum. Leaving it out is what made
+    the documented guarantee wrong by two cells (code review round 1, M1) while
+    this test still passed — arithmetic that models the layout inaccurately
+    proves only that the arithmetic is self-consistent, which is why the
+    companion test below measures the REAL widget instead.
     """
     for width in range(40, 400):
         content = sidebar_content_width(width)
         if content == SIDEBAR_WIDTH:
             continue  # not growing: the pre-existing floors govern
-        assert width - (content + SIDEBAR_GUTTER) >= SIDEBAR_MAIN_COMFORT_WIDTH, width
+        lane = width - APP_SCREEN_INSET - (content + SIDEBAR_GUTTER)
+        assert lane >= SIDEBAR_MAIN_COMFORT_WIDTH, (width, lane)
+
+
+@pytest.mark.asyncio
+async def test_the_measured_conversation_lane_matches_the_documented_guarantee():
+    """The same invariant, MEASURED, across the sizes where growth is active.
+
+    The arithmetic test above cannot catch a wrong model of the layout, and did
+    not: it agreed with a helper that ignored the app's inset, so the lane sat
+    at 78 cells while the constant promised 80 (M1). This drives the real app
+    and reads the real widget at every width across the growth band and past
+    the cap, which is the only assertion that can fail when the model drifts
+    from the layout again.
+
+    Sampled every third column rather than every column: each size boots a
+    Textual app, and the property is continuous in width, so the sampling
+    catches a systematic error without making the file's runtime unreasonable
+    on a loaded machine.
+    """
+    threshold = APP_SCREEN_INSET + SIDEBAR_WIDTH + SIDEBAR_GUTTER + SIDEBAR_MAIN_COMFORT_WIDTH
+    for width in range(threshold, threshold + 40, 3):
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(width, 30)) as pilot:
+            await pilot.pause()
+            await pilot.press("ctrl+b")
+            await pilot.pause()
+            lane = app.query_one("#session-conversation").size.width
+            assert lane >= SIDEBAR_MAIN_COMFORT_WIDTH, (width, lane)
+            assert app.screen.virtual_size == app.screen.size, width
+            assert not app.screen.show_vertical_scrollbar, width
 
 
 @pytest.mark.asyncio
@@ -1223,6 +1259,14 @@ def test_no_reachable_row_state_pairs_a_glyph_with_the_wrong_words():
     the pairing one hand-picked row at a time is what let that through, so this
     enumerates the product of every live state, wake count and dormancy and
     asserts the two renderings agree by construction.
+
+    ``unseen`` is a fourth dimension and is covered SEPARATELY, below, rather
+    than folded in here (code review round 1, M2). It short-circuits ``status``
+    ahead of every branch this function enumerates, and the sidebar likewise
+    overrides the glyph for an unseen row — so the pair that actually reaches a
+    user is neither the one ``row_state_mark`` returns nor the one this table
+    describes. Enumerating it here would assert a pairing no surface renders;
+    the companion test drives the real render path instead.
     """
     from local_operator.tui.terminal_title import SPINNER_FRAMES
     from local_operator.tui.widgets.session_picker import (
@@ -1270,3 +1314,57 @@ def test_no_reachable_row_state_pairs_a_glyph_with_the_wrong_words():
                     )
                 checked += 1
     assert checked == 75, checked
+
+
+@pytest.mark.asyncio
+async def test_an_unseen_row_pairs_its_completion_mark_with_completion_words():
+    """The ``unseen`` dimension, asserted on the RENDERED row.
+
+    Raised as M2 in code review round 1: `CatalogEntry.status` returns "Unseen
+    completion" ahead of every state branch, so pairing it with
+    ``row_state_mark``'s answer would show `◷` beside those words. That pairing
+    never reaches a user — the sidebar substitutes its own `✓`/`✗` for an
+    unseen row — but the only thing establishing that is the render, so the
+    render is what this test reads.
+
+    Written as a pilot test rather than as a call to ``row_state_mark`` for
+    exactly that reason: the helper's answer is not what is painted here, and a
+    unit-level assertion would describe a surface that does not exist.
+    """
+    from textual.geometry import Region
+
+    now = time.time()
+    cases = [
+        ("complete", "✓", "Unseen completion"),
+        ("error", "✗", "Unseen error"),
+        ("interrupted", "✗", "Unseen interruption"),
+    ]
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        await pilot.press("ctrl+b")
+        await pilot.pause()
+        sidebar = app._session_sidebar
+        for kind, glyph, words in cases:
+            # An ARMED WAKE on the row is the case M2 names: without the
+            # override this row would draw the wake glyph beside "Unseen …".
+            entry = CatalogEntry(
+                SessionRow("u" * 12, now, f"unseen {kind}", live_state="idle", wakes=2),
+                unseen=True,
+                completion_kind=kind,
+            )
+            sidebar.set_entries([entry])
+            if sidebar._timer is not None:
+                sidebar._timer.pause()
+            await pilot.pause()
+            painted = [
+                "".join(segment.text for segment in line)
+                for line in sidebar.render_lines(
+                    Region(0, 0, sidebar.size.width, sidebar.size.height)
+                )
+            ]
+            row = next(line for line in painted if f"unseen {kind}" in line)
+            assert glyph in row, (kind, row)
+            assert entry.status == words, (kind, entry.status)
+            # The wake glyph must NOT be what a user sees on an unseen row.
+            assert "◷" not in row, (kind, row)

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -1111,13 +1111,19 @@ async def test_the_measured_conversation_lane_matches_the_documented_guarantee()
             await pilot.pause()
             await pilot.press("ctrl+b")
             await pilot.pause()
-            # Pause the 2 s catalog poll that `ctrl+b` resumes. Without this
-            # the poll fires mid-test, calls `set_entries` with the empty
-            # isolated catalog and wipes the hand-built rows below — a load
-            # -dependent flake, and a departure from every sibling pilot test
-            # in this file (code review round 2, M3).
+            # Quiesce BOTH catalog refresh paths that `ctrl+b` starts, or the
+            # hand-built rows below get replaced by the empty isolated catalog
+            # mid-test and the row lookup raises.
+            #
+            # The timer is the 2 s poll (code review round 2, M3). The
+            # generation bump retires the ONE-SHOT worker `_set_sidebar_open`
+            # launches on the very next line after resuming that timer (round
+            # 3, M4): its `set_entries` is gated only on this counter, so
+            # pausing the timer alone leaves the identical race on the sibling
+            # path — reproduced by slowing the off-loop read.
             assert app._sidebar_timer is not None
             app._sidebar_timer.pause()
+            app._sidebar_refresh_generation += 1
             lane = app.query_one("#session-conversation").size.width
             assert lane >= SIDEBAR_MAIN_COMFORT_WIDTH, (width, lane)
             assert app.screen.virtual_size == app.screen.size, width
@@ -1144,13 +1150,19 @@ async def test_a_wide_terminal_actually_shows_more_of_the_title():
             await pilot.pause()
             await pilot.press("ctrl+b")
             await pilot.pause()
-            # Pause the 2 s catalog poll that `ctrl+b` resumes. Without this
-            # the poll fires mid-test, calls `set_entries` with the empty
-            # isolated catalog and wipes the hand-built rows below — a load
-            # -dependent flake, and a departure from every sibling pilot test
-            # in this file (code review round 2, M3).
+            # Quiesce BOTH catalog refresh paths that `ctrl+b` starts, or the
+            # hand-built rows below get replaced by the empty isolated catalog
+            # mid-test and the row lookup raises.
+            #
+            # The timer is the 2 s poll (code review round 2, M3). The
+            # generation bump retires the ONE-SHOT worker `_set_sidebar_open`
+            # launches on the very next line after resuming that timer (round
+            # 3, M4): its `set_entries` is gated only on this counter, so
+            # pausing the timer alone leaves the identical race on the sibling
+            # path — reproduced by slowing the off-loop read.
             assert app._sidebar_timer is not None
             app._sidebar_timer.pause()
+            app._sidebar_refresh_generation += 1
             sidebar = app._session_sidebar
             sidebar.set_entries(entries)
             if sidebar._timer is not None:
@@ -1199,13 +1211,19 @@ async def test_the_grown_list_still_leaves_the_conversation_its_lane():
         await pilot.pause()
         await pilot.press("ctrl+b")
         await pilot.pause()
-        # Pause the 2 s catalog poll that `ctrl+b` resumes. Without this
-        # the poll fires mid-test, calls `set_entries` with the empty
-        # isolated catalog and wipes the hand-built rows below — a load
-        # -dependent flake, and a departure from every sibling pilot test
-        # in this file (code review round 2, M3).
+        # Quiesce BOTH catalog refresh paths that `ctrl+b` starts, or the
+        # hand-built rows below get replaced by the empty isolated catalog
+        # mid-test and the row lookup raises.
+        #
+        # The timer is the 2 s poll (code review round 2, M3). The
+        # generation bump retires the ONE-SHOT worker `_set_sidebar_open`
+        # launches on the very next line after resuming that timer (round
+        # 3, M4): its `set_entries` is gated only on this counter, so
+        # pausing the timer alone leaves the identical race on the sibling
+        # path — reproduced by slowing the off-loop read.
         assert app._sidebar_timer is not None
         app._sidebar_timer.pause()
+        app._sidebar_refresh_generation += 1
         sidebar = app._session_sidebar
         assert sidebar.content_region.width > SIDEBAR_WIDTH - SIDEBAR_GUTTER
         assert app.query_one("#session-conversation").size.width >= SIDEBAR_MAIN_COMFORT_WIDTH
@@ -1365,13 +1383,19 @@ async def test_an_unseen_row_pairs_its_completion_mark_with_completion_words():
         await pilot.pause()
         await pilot.press("ctrl+b")
         await pilot.pause()
-        # Pause the 2 s catalog poll that `ctrl+b` resumes. Without this
-        # the poll fires mid-test, calls `set_entries` with the empty
-        # isolated catalog and wipes the hand-built rows below — a load
-        # -dependent flake, and a departure from every sibling pilot test
-        # in this file (code review round 2, M3).
+        # Quiesce BOTH catalog refresh paths that `ctrl+b` starts, or the
+        # hand-built rows below get replaced by the empty isolated catalog
+        # mid-test and the row lookup raises.
+        #
+        # The timer is the 2 s poll (code review round 2, M3). The
+        # generation bump retires the ONE-SHOT worker `_set_sidebar_open`
+        # launches on the very next line after resuming that timer (round
+        # 3, M4): its `set_entries` is gated only on this counter, so
+        # pausing the timer alone leaves the identical race on the sibling
+        # path — reproduced by slowing the off-loop read.
         assert app._sidebar_timer is not None
         app._sidebar_timer.pause()
+        app._sidebar_refresh_generation += 1
         sidebar = app._session_sidebar
         for kind, glyph, words in cases:
             # An ARMED WAKE on the row is the case M2 names: without the

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -1167,6 +1167,7 @@ def test_the_tooltip_never_names_a_different_state_from_the_glyph():
     wake glyph.
     """
     from local_operator.tui.widgets.session_picker import (
+        ATTACHED_MARKER,
         IDLE_MARKER,
         WAKE_MARKER,
         row_state_mark,
@@ -1180,12 +1181,28 @@ def test_the_tooltip_never_names_a_different_state_from_the_glyph():
     single = CatalogEntry(SessionRow("wake00000002", now, "one", live_state="idle", wakes=1))
     assert single.status == "Scheduled (1 wake)", "the count must not be pluralised at 1"
 
-    # A dormant wake does not win the glyph, so it must not win the words.
+    # A dormant wake does not win the glyph on a LIVE row, so it must not win
+    # the words there either.
     dormant = CatalogEntry(
         SessionRow("dorm00000001", now, "stopped", live_state="idle", wakes=1, wakes_dormant=True)
     )
     assert row_state_mark(dormant.row, 0)[0] == IDLE_MARKER
     assert dormant.status == "Ready"
+
+    # ...but on a COLD row it IS the glyph, so it must be the words (D1).
+    cold_dormant = CatalogEntry(
+        SessionRow("dorm00000002", now, "cold+stopped", wakes=1, wakes_dormant=True)
+    )
+    assert row_state_mark(cold_dormant.row, 0)[0] == WAKE_MARKER
+    assert cold_dormant.status == "Stopped (1 wake paused)"
+
+    # Presence outranks an armed wake: "a terminal is watching this" answers
+    # "where am I?", which bare residency does not (D2).
+    watched = CatalogEntry(
+        SessionRow("att000000001", now, "watched", live_state="attached", wakes=2)
+    )
+    assert row_state_mark(watched.row, 0)[0] == ATTACHED_MARKER
+    assert watched.status == "Open"
 
     # And the states above wakes are unchanged.
     busy = CatalogEntry(SessionRow("busy00000001", now, "working", live_state="busy", wakes=4))
@@ -1194,3 +1211,62 @@ def test_the_tooltip_never_names_a_different_state_from_the_glyph():
         SessionRow("gate00000001", now, "waiting", live_state="idle", pending="approval", wakes=4)
     )
     assert gate.status == "Approval needed"
+
+
+def test_no_reachable_row_state_pairs_a_glyph_with_the_wrong_words():
+    """The invariant itself, over EVERY reachable combination.
+
+    The two round-1 design findings were both a glyph and its description
+    disagreeing in a state no frame happened to cover: a cold row with a
+    stopped schedule drew the wake mark while the tooltip said "Recent" (D1),
+    and the individual glyph and status assertions above each passed. Testing
+    the pairing one hand-picked row at a time is what let that through, so this
+    enumerates the product of every live state, wake count and dormancy and
+    asserts the two renderings agree by construction.
+    """
+    from local_operator.tui.terminal_title import SPINNER_FRAMES
+    from local_operator.tui.widgets.session_picker import (
+        ATTACHED_MARKER,
+        IDLE_MARKER,
+        NEEDS_YOU_MARKER,
+        WAKE_MARKER,
+        WEDGED_MARKER,
+        row_state_mark,
+    )
+
+    #: Which descriptions may accompany each glyph. A status not listed for the
+    #: glyph a row drew is a contradiction the user would have to resolve.
+    ALLOWED = {
+        NEEDS_YOU_MARKER: {"Approval needed", "Answer needed"},
+        WEDGED_MARKER: {"Not responding"},
+        ATTACHED_MARKER: {"Open"},
+        IDLE_MARKER: {"Ready"},
+        WAKE_MARKER: {"Scheduled", "Stopped"},
+        "": {"Recent"},
+    }
+    now = time.time()
+    checked = 0
+    for state in ("", "idle", "attached", "busy", "wedged"):
+        for pending in (None, "approval", "ask"):
+            for wakes, dormant in ((0, False), (1, False), (3, False), (1, True), (2, True)):
+                row = SessionRow(
+                    "x" * 12,
+                    now,
+                    "a conversation",
+                    live_state=state,
+                    pending=pending,
+                    wakes=wakes,
+                    wakes_dormant=dormant,
+                )
+                glyph = row_state_mark(row, 0)[0]
+                status = CatalogEntry(row).status
+                if glyph in SPINNER_FRAMES:
+                    assert status == "Working", (state, pending, wakes, dormant, status)
+                else:
+                    allowed = ALLOWED[glyph]
+                    assert any(status.startswith(prefix) for prefix in allowed), (
+                        f"glyph {glyph!r} paired with {status!r} "
+                        f"(state={state!r} pending={pending!r} wakes={wakes} dormant={dormant})"
+                    )
+                checked += 1
+    assert checked == 75, checked

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -22,8 +22,12 @@ from local_operator.tui.session_catalog import (
 from local_operator.tui.widgets.editor import Editor
 from local_operator.tui.widgets.session_sidebar import (
     SIDEBAR_GUTTER,
+    SIDEBAR_MAIN_COMFORT_WIDTH,
     SIDEBAR_MAIN_MIN_WIDTH,
+    SIDEBAR_MAX_WIDTH,
     SIDEBAR_SPINNER_INTERVAL_S,
+    SIDEBAR_WIDTH,
+    sidebar_content_width,
 )
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
 
@@ -1025,3 +1029,168 @@ async def test_the_outer_title_yields_to_section_headers_but_survives_quiet_stat
     ):
         quiet = await first_lines(setup)
         assert quiet[0] == "Sessions", quiet[:2]
+
+
+# ---------------------------------------------------------------------------
+# Responsive width
+#
+# The list is the one surface whose whole job is "recognise your own
+# conversation", and at the fixed base width it could not do it: the reported
+# frame ellipsized eleven of twelve titles, several of them before the word
+# that told them apart from the row above. These pin the growth rule and, more
+# importantly, the two ways widening a docked panel usually goes wrong — eating
+# the conversation, and regressing narrow terminals.
+# ---------------------------------------------------------------------------
+
+
+def test_a_narrow_terminal_is_left_exactly_as_it_was():
+    """Growth must be unable to regress the sizes that already worked.
+
+    Everything at or below the comfort threshold resolves to the base width, so
+    the layout, the overlay switch and every existing geometry test describe the
+    same app they did before.
+    """
+    threshold = SIDEBAR_WIDTH + SIDEBAR_GUTTER + SIDEBAR_MAIN_COMFORT_WIDTH
+    for width in (60, 80, 100, threshold - 1, threshold):
+        assert sidebar_content_width(width) == SIDEBAR_WIDTH, width
+
+
+def test_growth_spends_only_surplus_and_stops_at_the_cap():
+    """One column of terminal buys at most one column of list, up to the cap."""
+    threshold = SIDEBAR_WIDTH + SIDEBAR_GUTTER + SIDEBAR_MAIN_COMFORT_WIDTH
+    assert sidebar_content_width(threshold + 1) == SIDEBAR_WIDTH + 1
+    assert sidebar_content_width(threshold + 5) == SIDEBAR_WIDTH + 5
+    assert sidebar_content_width(threshold + 500) == SIDEBAR_MAX_WIDTH
+    # Monotonic: dragging a window wider never narrows the list.
+    widths = [sidebar_content_width(w) for w in range(40, 400)]
+    assert widths == sorted(widths)
+
+
+def test_the_conversation_never_pays_for_the_list_getting_wider():
+    """The structural invariant, asserted as arithmetic rather than as a frame.
+
+    At every terminal width, whatever the sidebar and its gutter take must
+    leave the main lane at least its comfort width. This is the property that
+    makes the feature safe, so it is checked across the whole range rather than
+    at the two sizes a screenshot happens to use.
+    """
+    for width in range(40, 400):
+        content = sidebar_content_width(width)
+        if content == SIDEBAR_WIDTH:
+            continue  # not growing: the pre-existing floors govern
+        assert width - (content + SIDEBAR_GUTTER) >= SIDEBAR_MAIN_COMFORT_WIDTH, width
+
+
+@pytest.mark.asyncio
+async def test_a_wide_terminal_actually_shows_more_of_the_title():
+    """The user-visible payoff, measured on the RENDERED rows.
+
+    The arithmetic above proves the budget; this proves the budget reaches the
+    text. A long title is rendered at a base-width terminal and a wide one, and
+    the wide frame must carry strictly more of it — otherwise the extra cells
+    went to padding somewhere and the report would be unfixed.
+    """
+    name = "Article-search-svc schema review and rollout plan"
+    entries = [
+        CatalogEntry(SessionRow(id="aaaaaaaaaaa1", mtime=time.time(), name=name, live_state="idle"))
+    ]
+
+    async def rendered(size) -> str:
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=size) as pilot:
+            await pilot.pause()
+            await pilot.press("ctrl+b")
+            await pilot.pause()
+            sidebar = app._session_sidebar
+            sidebar.set_entries(entries)
+            if sidebar._timer is not None:
+                sidebar._timer.pause()
+            await pilot.pause()
+            from textual.geometry import Region
+
+            lines = [
+                "".join(segment.text for segment in line)
+                for line in sidebar.render_lines(
+                    Region(0, 0, sidebar.size.width, sidebar.size.height)
+                )
+            ]
+            return next(line for line in lines if "Article" in line)
+
+    narrow = await rendered((100, 30))
+    wide = await rendered((160, 40))
+
+    def visible_title(line: str) -> str:
+        # Everything up to the ellipsis is what the user can actually read,
+        # minus the leading chrome (cursor cells and the state glyph) which is
+        # fixed-width and not part of the title budget under test.
+        text = line.split("…")[0]
+        return text[text.index("Article") :].strip() if "Article" in text else text.strip()
+
+    narrow_title, wide_title = visible_title(narrow), visible_title(wide)
+    assert len(wide_title) > len(narrow_title), (narrow, wide)
+    # Numbers, not just "more": the base width shows about 20 cells of title
+    # and the cap about 38, so the gain is worth the change rather than
+    # cosmetic. Asserted as a floor so a future tweak to the chrome does not
+    # fail the test for being one cell off.
+    assert len(narrow_title) < 25, narrow_title
+    assert len(wide_title) >= 35, wide_title
+    # A title that FITS the grown budget is shown outright, with no ellipsis:
+    # the previous frame ellipsized even short names.
+    short = "Article-search-svc schema review"
+    assert len(short) <= len(wide_title)
+    assert wide_title.startswith(short), wide_title
+
+
+@pytest.mark.asyncio
+async def test_the_grown_list_still_leaves_the_conversation_its_lane():
+    """The same invariant, through the real layout rather than the helper."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(200, 40)) as pilot:
+        await pilot.pause()
+        await pilot.press("ctrl+b")
+        await pilot.pause()
+        sidebar = app._session_sidebar
+        assert sidebar.content_region.width > SIDEBAR_WIDTH - SIDEBAR_GUTTER
+        assert app.query_one("#session-conversation").size.width >= SIDEBAR_MAIN_COMFORT_WIDTH
+        # A wider list must not introduce a scrollbar or a reflow.
+        assert app.screen.virtual_size == app.screen.size
+        assert not app.screen.show_vertical_scrollbar
+
+
+def test_the_tooltip_never_names_a_different_state_from_the_glyph():
+    """Description and marker are two renderings of one precedence.
+
+    The glyph is a single character, so the description is where a user finds
+    out what it meant; the two disagreeing is worse than either being terse.
+    When wakes were promoted above presence in ``row_state_mark``, a status map
+    keyed only on ``live_state`` would have gone on saying "Ready" beside a
+    wake glyph.
+    """
+    from local_operator.tui.widgets.session_picker import (
+        IDLE_MARKER,
+        WAKE_MARKER,
+        row_state_mark,
+    )
+
+    now = time.time()
+    armed = CatalogEntry(SessionRow("wake00000001", now, "armed", live_state="idle", wakes=2))
+    assert row_state_mark(armed.row, 0)[0] == WAKE_MARKER
+    assert armed.status == "Scheduled (2 wakes)"
+
+    single = CatalogEntry(SessionRow("wake00000002", now, "one", live_state="idle", wakes=1))
+    assert single.status == "Scheduled (1 wake)", "the count must not be pluralised at 1"
+
+    # A dormant wake does not win the glyph, so it must not win the words.
+    dormant = CatalogEntry(
+        SessionRow("dorm00000001", now, "stopped", live_state="idle", wakes=1, wakes_dormant=True)
+    )
+    assert row_state_mark(dormant.row, 0)[0] == IDLE_MARKER
+    assert dormant.status == "Ready"
+
+    # And the states above wakes are unchanged.
+    busy = CatalogEntry(SessionRow("busy00000001", now, "working", live_state="busy", wakes=4))
+    assert busy.status == "Working"
+    gate = CatalogEntry(
+        SessionRow("gate00000001", now, "waiting", live_state="idle", pending="approval", wakes=4)
+    )
+    assert gate.status == "Approval needed"

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -1111,6 +1111,13 @@ async def test_the_measured_conversation_lane_matches_the_documented_guarantee()
             await pilot.pause()
             await pilot.press("ctrl+b")
             await pilot.pause()
+            # Pause the 2 s catalog poll that `ctrl+b` resumes. Without this
+            # the poll fires mid-test, calls `set_entries` with the empty
+            # isolated catalog and wipes the hand-built rows below — a load
+            # -dependent flake, and a departure from every sibling pilot test
+            # in this file (code review round 2, M3).
+            assert app._sidebar_timer is not None
+            app._sidebar_timer.pause()
             lane = app.query_one("#session-conversation").size.width
             assert lane >= SIDEBAR_MAIN_COMFORT_WIDTH, (width, lane)
             assert app.screen.virtual_size == app.screen.size, width
@@ -1137,6 +1144,13 @@ async def test_a_wide_terminal_actually_shows_more_of_the_title():
             await pilot.pause()
             await pilot.press("ctrl+b")
             await pilot.pause()
+            # Pause the 2 s catalog poll that `ctrl+b` resumes. Without this
+            # the poll fires mid-test, calls `set_entries` with the empty
+            # isolated catalog and wipes the hand-built rows below — a load
+            # -dependent flake, and a departure from every sibling pilot test
+            # in this file (code review round 2, M3).
+            assert app._sidebar_timer is not None
+            app._sidebar_timer.pause()
             sidebar = app._session_sidebar
             sidebar.set_entries(entries)
             if sidebar._timer is not None:
@@ -1185,6 +1199,13 @@ async def test_the_grown_list_still_leaves_the_conversation_its_lane():
         await pilot.pause()
         await pilot.press("ctrl+b")
         await pilot.pause()
+        # Pause the 2 s catalog poll that `ctrl+b` resumes. Without this
+        # the poll fires mid-test, calls `set_entries` with the empty
+        # isolated catalog and wipes the hand-built rows below — a load
+        # -dependent flake, and a departure from every sibling pilot test
+        # in this file (code review round 2, M3).
+        assert app._sidebar_timer is not None
+        app._sidebar_timer.pause()
         sidebar = app._session_sidebar
         assert sidebar.content_region.width > SIDEBAR_WIDTH - SIDEBAR_GUTTER
         assert app.query_one("#session-conversation").size.width >= SIDEBAR_MAIN_COMFORT_WIDTH
@@ -1230,7 +1251,7 @@ def test_the_tooltip_never_names_a_different_state_from_the_glyph():
         SessionRow("dorm00000002", now, "cold+stopped", wakes=1, wakes_dormant=True)
     )
     assert row_state_mark(cold_dormant.row, 0)[0] == WAKE_MARKER
-    assert cold_dormant.status == "Stopped (1 wake paused)"
+    assert cold_dormant.status == "Stopped (1 wake dormant)"
 
     # Presence outranks an armed wake: "a terminal is watching this" answers
     # "where am I?", which bare residency does not (D2).
@@ -1344,6 +1365,13 @@ async def test_an_unseen_row_pairs_its_completion_mark_with_completion_words():
         await pilot.pause()
         await pilot.press("ctrl+b")
         await pilot.pause()
+        # Pause the 2 s catalog poll that `ctrl+b` resumes. Without this
+        # the poll fires mid-test, calls `set_entries` with the empty
+        # isolated catalog and wipes the hand-built rows below — a load
+        # -dependent flake, and a departure from every sibling pilot test
+        # in this file (code review round 2, M3).
+        assert app._sidebar_timer is not None
+        app._sidebar_timer.pause()
         sidebar = app._session_sidebar
         for kind, glyph, words in cases:
             # An ARMED WAKE on the row is the case M2 names: without the

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -46,6 +46,37 @@ def isolated_sidebar(tmp_path, monkeypatch):
     monkeypatch.setattr(OperatorApp, "_check_for_update", lambda self: None)
 
 
+def _quiesce_sidebar_refresh(app) -> None:
+    """Stop both catalog-refresh paths that opening the sidebar starts.
+
+    Every pilot test that hands the list its OWN rows needs this, or the real
+    catalog lands on top of them mid-test. `ctrl+b` starts two refreshes, and
+    closing one and missing the other is a mistake this file has now made twice
+    (code review rounds 2 and 3):
+
+    * ``app._sidebar_timer`` — the 2 s poll, resumed by ``_set_sidebar_open``.
+    * the ONE-SHOT worker ``_set_sidebar_open`` launches on the very next line.
+      Its ``set_entries`` is gated only on ``_sidebar_refresh_generation``, so
+      bumping the counter is what retires a read already in flight; there is no
+      worker handle to cancel.
+
+    What goes wrong differs by test, which is why this lives in one place
+    rather than being restated at each call site: a test that looks a row up by
+    name raises when the empty catalog replaces its rows, while a test that
+    only measures geometry sees the list's HEIGHT change under it and can read
+    a different ``virtual_size``. Both are the same cause.
+
+    **The bump retires the CURRENT read, not future ones** — ``_refresh_sidebar``
+    bumps the counter itself on entry, so anything that starts a refresh AFTER
+    this call (a second ``ctrl+b``, a re-open, an explicit ``_refresh_sidebar()``)
+    wins the gate and repaints. Call this after the last thing that could start
+    one.
+    """
+    assert app._sidebar_timer is not None
+    app._sidebar_timer.pause()
+    app._sidebar_refresh_generation += 1
+
+
 def test_urgency_ranking_keeps_gates_independent_of_acknowledgement():
     rows = [
         CatalogEntry(SessionRow("recent", 100, "Recent")),
@@ -1111,19 +1142,7 @@ async def test_the_measured_conversation_lane_matches_the_documented_guarantee()
             await pilot.pause()
             await pilot.press("ctrl+b")
             await pilot.pause()
-            # Quiesce BOTH catalog refresh paths that `ctrl+b` starts, or the
-            # hand-built rows below get replaced by the empty isolated catalog
-            # mid-test and the row lookup raises.
-            #
-            # The timer is the 2 s poll (code review round 2, M3). The
-            # generation bump retires the ONE-SHOT worker `_set_sidebar_open`
-            # launches on the very next line after resuming that timer (round
-            # 3, M4): its `set_entries` is gated only on this counter, so
-            # pausing the timer alone leaves the identical race on the sibling
-            # path — reproduced by slowing the off-loop read.
-            assert app._sidebar_timer is not None
-            app._sidebar_timer.pause()
-            app._sidebar_refresh_generation += 1
+            _quiesce_sidebar_refresh(app)
             lane = app.query_one("#session-conversation").size.width
             assert lane >= SIDEBAR_MAIN_COMFORT_WIDTH, (width, lane)
             assert app.screen.virtual_size == app.screen.size, width
@@ -1150,19 +1169,7 @@ async def test_a_wide_terminal_actually_shows_more_of_the_title():
             await pilot.pause()
             await pilot.press("ctrl+b")
             await pilot.pause()
-            # Quiesce BOTH catalog refresh paths that `ctrl+b` starts, or the
-            # hand-built rows below get replaced by the empty isolated catalog
-            # mid-test and the row lookup raises.
-            #
-            # The timer is the 2 s poll (code review round 2, M3). The
-            # generation bump retires the ONE-SHOT worker `_set_sidebar_open`
-            # launches on the very next line after resuming that timer (round
-            # 3, M4): its `set_entries` is gated only on this counter, so
-            # pausing the timer alone leaves the identical race on the sibling
-            # path — reproduced by slowing the off-loop read.
-            assert app._sidebar_timer is not None
-            app._sidebar_timer.pause()
-            app._sidebar_refresh_generation += 1
+            _quiesce_sidebar_refresh(app)
             sidebar = app._session_sidebar
             sidebar.set_entries(entries)
             if sidebar._timer is not None:
@@ -1211,19 +1218,7 @@ async def test_the_grown_list_still_leaves_the_conversation_its_lane():
         await pilot.pause()
         await pilot.press("ctrl+b")
         await pilot.pause()
-        # Quiesce BOTH catalog refresh paths that `ctrl+b` starts, or the
-        # hand-built rows below get replaced by the empty isolated catalog
-        # mid-test and the row lookup raises.
-        #
-        # The timer is the 2 s poll (code review round 2, M3). The
-        # generation bump retires the ONE-SHOT worker `_set_sidebar_open`
-        # launches on the very next line after resuming that timer (round
-        # 3, M4): its `set_entries` is gated only on this counter, so
-        # pausing the timer alone leaves the identical race on the sibling
-        # path — reproduced by slowing the off-loop read.
-        assert app._sidebar_timer is not None
-        app._sidebar_timer.pause()
-        app._sidebar_refresh_generation += 1
+        _quiesce_sidebar_refresh(app)
         sidebar = app._session_sidebar
         assert sidebar.content_region.width > SIDEBAR_WIDTH - SIDEBAR_GUTTER
         assert app.query_one("#session-conversation").size.width >= SIDEBAR_MAIN_COMFORT_WIDTH
@@ -1383,19 +1378,7 @@ async def test_an_unseen_row_pairs_its_completion_mark_with_completion_words():
         await pilot.pause()
         await pilot.press("ctrl+b")
         await pilot.pause()
-        # Quiesce BOTH catalog refresh paths that `ctrl+b` starts, or the
-        # hand-built rows below get replaced by the empty isolated catalog
-        # mid-test and the row lookup raises.
-        #
-        # The timer is the 2 s poll (code review round 2, M3). The
-        # generation bump retires the ONE-SHOT worker `_set_sidebar_open`
-        # launches on the very next line after resuming that timer (round
-        # 3, M4): its `set_entries` is gated only on this counter, so
-        # pausing the timer alone leaves the identical race on the sibling
-        # path — reproduced by slowing the off-loop read.
-        assert app._sidebar_timer is not None
-        app._sidebar_timer.pause()
-        app._sidebar_refresh_generation += 1
+        _quiesce_sidebar_refresh(app)
         sidebar = app._session_sidebar
         for kind, glyph, words in cases:
             # An ARMED WAKE on the row is the case M2 names: without the

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -46,7 +46,7 @@ def isolated_sidebar(tmp_path, monkeypatch):
     monkeypatch.setattr(OperatorApp, "_check_for_update", lambda self: None)
 
 
-def _quiesce_sidebar_refresh(app) -> None:
+def _quiesce_sidebar_refresh(app: OperatorApp) -> None:
     """Stop both catalog-refresh paths that opening the sidebar starts.
 
     Every pilot test that hands the list its OWN rows needs this, or the real
@@ -60,11 +60,18 @@ def _quiesce_sidebar_refresh(app) -> None:
       bumping the counter is what retires a read already in flight; there is no
       worker handle to cancel.
 
-    What goes wrong differs by test, which is why this lives in one place
-    rather than being restated at each call site: a test that looks a row up by
-    name raises when the empty catalog replaces its rows, while a test that
-    only measures geometry sees the list's HEIGHT change under it and can read
-    a different ``virtual_size``. Both are the same cause.
+    The observed failure is a test that looks a row up by name raising when the
+    empty catalog replaces its rows. The two geometry tests here call it as
+    well, but as PROPHYLAXIS rather than against a demonstrated failure: what
+    they assert (the docked width, the conversation lane, ``virtual_size``) is a
+    pure function of terminal width and does not move with the row count — tested
+    directly, by landing 300 rows at this exact point with the quiesce disabled,
+    which changed neither assertion in 15 samples (code review round 5).
+
+    Kept at those sites anyway, and stated rather than quietly dropped: a
+    catalog arriving mid-assertion is a variable the test does not control, and
+    the next person to add a row-reading assertion there should not have to
+    rediscover why the other two tests needed it.
 
     **The bump retires the CURRENT read, not future ones** — ``_refresh_sidebar``
     bumps the counter itself on entry, so anything that starts a refresh AFTER


### PR DESCRIPTION
## Summary

The sidebar animated a "working" spinner on conversations that had finished. The reported case was a done session (`Article-search-svc…`) still showing activity; on the reporter's host **12 of 12 live sessions published `busy=True`**, one of them idle for 34 minutes with a completed final turn.

Two user-visible changes, plus the width follow-up requested on the same report:

1. **The activity indicator now means activity.** A row animates only while the conversation itself is working.
2. **An armed wake shows `◷` instead of `●`.** An idle session with a schedule now says so.
3. **The list widens on a roomy terminal**, spending only surplus columns.

## The bug was a wrong question, not a stale value

`SessionRecord.busy` was published from `OwnedSessionHandle.is_busy()` — the **reaper's residency predicate**, "may this runtime exit?" — while every surface renders that field as "a turn is running".

Residency is deliberately maximally inclusive: a backgrounded `bash` job, a running subagent or a retained background task all forbid an exit, because exiting would destroy work. That is correct for the reaper and wrong for a spinner. So any session that had ever backgrounded a job wore a spinner **forever**, and the indicator stopped carrying information. Republishing more often could never have fixed it.

This PR adds `is_conversationally_active()`: the terms of `is_busy()` that mean the conversation is moving — live provider stream, compaction, held turn lock, queued/draining prompt, running goal loop, parked gate — with the work-retention terms removed.

- `is_busy()` is **untouched**. The reaper's fail-closed behaviour is correct and nothing here may let a runtime exit under live work.
- **Both** publishers now read the activity predicate: the turn-boundary hook and the 15 s heartbeat floor. Had only one changed, the floor would have overwritten the correct value within one heartbeat and re-pinned every spinner.
- Sessions holding background work still render as live (the idle glyph) and `lop sessions` still reports them resident.

### Wake precedence

Under the old ordering the wake glyph was **unreachable for any live session**: a session with a wake armed is by definition resident, so `idle`/`attached` always matched first, and `◷` could only appear on a cold row — one with no runtime to fire it. Armed wakes now outrank the presence glyphs.

A **dormant** wake (the session was deliberately stopped) deliberately stays *below* presence: it is not going to fire, so it must not advertise a future over a runtime that is genuinely here. The sidebar tooltip follows the identical precedence, so the words beside a glyph can never name a different state.

### Width

Growth spends **only surplus**: whatever the terminal has beyond the base sidebar, its gutter and an 80-column comfortable main lane, capped at 44. Consequences, all asserted as tests: a terminal at or below the threshold resolves to today's exact layout, the main lane never pays for the list, and growth is monotonic in terminal width. The overlay threshold is still measured against the base width, so the dock/overlay switch at small sizes is unchanged.

## Testing evidence

### Live QA — the real path, not a unit rig

A real `Session` behind the production `OwnedSessionHandle` + `RuntimeServer`, a genuine registered background job, and the **record file on disk read back through `registry.scan()`** (the same call the sidebar's catalog makes). Run against this branch and against `origin/main` with an isolated `HOME` and config dir:

| probe | `origin/main` | this branch |
|---|---|---|
| `is_busy()` (bg job running, conversation finished) | `True` | `True` — residency unchanged |
| `is_conversationally_active()` | n/a | **`False`** |
| **`record.busy` on disk** | **`True`** | **`False`** |
| sidebar glyph / status derived from that record | `⣾` "Working" | **`●` "Ready"** |
| idle runtime + 2 armed wakes | `●` "Ready" | **`◷` "Scheduled (2 wakes)"** |
| during a live turn | active | **active** (still animates) |

The last row is the guard against "fixing" a false positive by making the signal always false.

### Field reproduction

Correlating each published record against its transcript's last write, before the fix:

```
pid= 99576 busy=True  idle=  33.8m Auto-update inactive session runti
pid= 66964 busy=True  idle=  26.9m Fixing Ghostty background session
pid=  3894 busy=True  idle=  20.2m OSWorld benchmark evaluation and a
pid= 88846 busy=True  idle=  16.2m Debugging session cost and naming
...  12 of 12 live sessions reported busy=True
```

The 25-minute-idle session's roster showed **zero running jobs** and its transcript's final entry was a completed turn with a `completion_attention` marker — so the bit was not merely lagging.

### Rendered frames

Captured with the faithful developer helper (`scripts/sidebar_shot.py`, new, registered in the visual gallery as `sidebar_shot-base` / `sidebar_shot-wide`) over a seeded transcript, spinner pinned to a fixed phase so frames are comparable. The before-frame comes from a throwaway `origin/main` worktree.

Rows reconstructed from the two SVGs at 160×40:

```
before                                    after
"● Auto-update inactive… 13m"      ->     "◷ Auto-update inactive session runti… 13m"   armed wake now visible
"● Debugging session co… 43m"      ->     "● Debugging session cost and naming…  43m"   dormant wake correctly NOT promoted
"○ Update Provider Onboa… 4m"      ->     "○ Update Provider Onboarding and OAut… 4m"   +14 cells of title
"! Add Flavia's Adverse…  3m"      ->     "! Add Flavia's Adverse Media Case      3m"   fits outright
```

**Narrow terminals are provably untouched:** the 100×30 before/after frames render **byte-identical text** (`diff` of every `<text>` element: no output).

Geometry behind the pixels:

| terminal | sidebar outer | sidebar content | conversation | virtual == actual | scrollbar |
|---|---|---|---|---|---|
| 100×30 before | 33 | 29 | 65 | yes | no |
| 100×30 after | 33 | 29 | 65 | yes | no |
| 160×40 before | 33 | 29 | 125 | yes | no |
| 160×40 after | **47** | **43** | 111 | yes | no |

No scrollbar appears and virtual size never exceeds actual size at either width, so the wider list introduces no reflow.

### Automated

| gate | result |
|---|---|
| `.venv/bin/python -m flake8 .` | PASS |
| `uvx --from black==26.1.0 black --check .` | PASS, 1012 files unchanged |
| `uvx isort==5.13.2 --check .` | PASS |
| `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | 0 errors, 0 warnings |
| `pytest tests/unit/session/runtime tests/unit/tui/test_session_sidebar.py tests/unit/tui/test_session_picker.py tests/unit/tui/test_sidebar_source_state.py` | **445 passed** |

New tests, each written to fail on the unfixed tree first (verified — all five activity tests failed with `AttributeError: no attribute 'is_conversationally_active'` and `AssertionError: an idle conversation must not publish busy` before the change):

- `tests/unit/session/runtime/test_activity_vs_residency.py` — background job and subagent hold residency but not activity; a live turn and a parked gate *are* activity; the published record follows activity. Drives the **real** `AsyncJobManager` rather than a double, so the row shapes are production's.
- `test_session_picker.py` — armed wake outranks presence; dormant wake does not; needs-you/wedged/busy still outrank wakes.
- `test_session_sidebar.py` — narrow terminals unchanged; growth spends only surplus and is monotonic; the conversation never pays, asserted across widths 40–400; a wide terminal shows measurably more title (≥35 cells vs <25); tooltip and glyph cannot disagree.

## Risk

Behavioural change is confined to what the `busy` field *means* to display surfaces. Residency, the reaper, `may_refresh` and `/fork`'s busy check all still read `is_busy()` and are unaffected. The one deliberate loosening is that the marker and the residency decision may now disagree — which was the defect: a runtime can correctly be un-exitable while its conversation is finished.

Release: patch — the sidebar's activity indicator now reflects real conversation activity, shows the wake symbol for scheduled sessions, and the list widens on roomy terminals.
