### PR TITLE
fix(tui): restore the splash and reset the band on a sidebar switch

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -4011,6 +4011,20 @@ class OperatorApp(App[None]):
             factory = self._resume_factory
             if factory is not None:
                 self._session_factory = lambda: factory(session_id)
+            # A sidebar switch IS a conversation swap, so the band's
+            # session-scoped segments are blanked here rather than being left to
+            # the incoming snapshot to overwrite. That repaint is leave-alone on
+            # absent values, and a conversation that has never had a turn
+            # legitimately supplies none: `cumulative_cost` is None until spend
+            # exists and `context_tokens` defaults to None. So switching away
+            # from a `/new` conversation to a busy one and back left the BUSY
+            # session's cost and context window painted over the fresh one, with
+            # nothing arriving to correct them until its first turn ended.
+            #
+            # Immediately BEFORE the adopt, never after: the incoming snapshot
+            # is what puts a real figure back, so a session with genuine spend
+            # still lands on its own number rather than on zero.
+            self._reset_band_for_swap()
             self._adopt_session(session, replay_history=False, reuse_controller=True)
             self._mark_pending_tool_rows(incoming.replay.view.blocks(), session)
             history = session.display_history_window()
@@ -6844,6 +6858,39 @@ class OperatorApp(App[None]):
         # dead conversation's already-billed calls from its own turn total and
         # under-report that turn by exactly that much.
         self._turn_accrued_cost = 0.0
+        self._reset_band_for_swap()
+        return (*carried_spend, was_floor)
+
+    def _reset_band_for_swap(self) -> None:
+        """Blank the session-scoped BAND segments, without touching the transcript.
+
+        The band half of :meth:`_reset_ledger_for_swap`, split out because the
+        sidebar's switch path is a conversation swap that must NOT tear the
+        transcript down: it substitutes a prepared presentation rather than
+        rebuilding one, so the steer notices, tool cards, fork receipts and
+        resume state its sibling clears are all state the sidebar deliberately
+        preserves. Calling the whole of `_reset_ledger_for_swap` from there
+        would destroy the presentation the switch just spent a frame preparing.
+
+        Everything reset here is APP-SCOPED — it lives on the band widget, on
+        the dock, or on the app — which is exactly what makes it the half the
+        sidebar needs. The ledger figures themselves (`_total_cost`,
+        `_spend_is_floor`, the naming bookkeeping) are properties of
+        ``self._interaction`` and are therefore already per-conversation: on the
+        sidebar path ``_adopt_session`` swaps the interaction, so those come back
+        correct on their own, and zeroing them HERE would blank the outgoing
+        conversation's real spend — which, unlike a reload's, is parked and
+        returned to rather than retired.
+
+        ORDERING: call this BEFORE ``_adopt_session``, never after. The incoming
+        snapshot's repaint is leave-alone on absent values (`cumulative_cost` is
+        None until a session has had a turn, `context_tokens` defaults to None),
+        so a reset afterwards would erase a real figure, and no reset at all
+        left the previous conversation's cost and context painted over a fresh
+        `/new` — the reported bug. Resetting first means a session with genuine
+        spend still lands on its own number, because its snapshot carries it.
+        """
+        assert self._status is not None
         # The splash notice describes the session being replaced. Left
         # standing, a `/new` would open on the dead session's quota warning.
         self._splash_notice = None
@@ -6886,7 +6933,6 @@ class OperatorApp(App[None]):
         # ones (#525 design §2).
         if self._subagent_panel is not None:
             self._subagent_panel.reset_density()
-        return (*carried_spend, was_floor)
 
     def _conversation_id(self) -> str:
         """Which conversation is open, or "" when none is."""
@@ -13012,6 +13058,17 @@ class OperatorApp(App[None]):
         if visible == self._welcome_visible:
             return
         self._welcome_visible = visible
+        if visible:
+            # The splash is composed ONCE into the boot transcript, but sidebar
+            # navigation mounts a whole new `TranscriptView` per target and only
+            # gives it an empty state when the target had no history — so after a
+            # switch onto a conversation with messages, `self._welcome` is None
+            # (or points at a view parked off screen) and this call had nothing
+            # to show. The boot layout still applied, so `/new` landed on a
+            # centred, EMPTY card: the reported bug. Materialise the empty state
+            # on the view that is on screen now instead of adding a second
+            # "should the splash show" rule beside this one.
+            self._welcome = self._ensure_welcome_view()
         if self._welcome is not None:
             self._welcome.set_visible(visible)
         self._sync_boot_layout_class()
@@ -13023,6 +13080,54 @@ class OperatorApp(App[None]):
             self.screen.remove_class(BOOT_CARD_CLASS)
             self._sync_boot_column_width(max(0, self.size.width - SCREEN_INSET))
         self._sync_boot_layout()
+
+    def _ensure_welcome_view(self) -> WelcomeView | None:
+        """The CURRENT transcript's empty state, mounting one if it has none.
+
+        Identity, not construction, is the point: the splash lives inside the
+        transcript (see :meth:`compose`), so "the splash" is whichever view the
+        transcript on screen owns. A handle to a view parked in another
+        conversation's viewport is worse than no handle at all — it is a widget
+        that reports `display=True` from one viewport to the right of the screen
+        — so a stale `self._welcome` is REPLACED here rather than reused.
+
+        At most one is ever mounted per transcript: the existing child is
+        adopted when there is one, which is what stops a splash accumulating per
+        sidebar switch. The mount is deliberately not awaited — every caller is
+        synchronous, and the swap path's whole ordering argument (see
+        :meth:`_adopt_session`) is that nothing between the clear and the replay
+        may yield to the event loop.
+
+        Returns None only before the transcript is composed, which is the one
+        state where there is no empty state to own.
+        """
+        try:
+            view = self._transcript_view()
+        except Exception:  # pragma: no cover - only before compose
+            logger.debug("transcript is not mounted yet", exc_info=True)
+            return None
+        existing = next((child for child in view.children if isinstance(child, WelcomeView)), None)
+        if existing is not None:
+            return existing
+        # Same closure as `compose` and as the sidebar's prepare path, so the
+        # splash renders the same info rows wherever it is materialised. It is a
+        # closure rather than a snapshot because the notice, the setup state and
+        # the update banner all resolve AFTER the view is built.
+        welcome = WelcomeView(
+            lambda: session_welcome_info(
+                self._session,
+                self._providers,
+                notice=self._splash_notice,
+                setup=self._setup_state,
+                update_available=self._update_available,
+            )
+        )
+        # The splash is the empty state, so it goes ABOVE the blocks — the same
+        # position `compose` gives it. `mount(before=0)` rather than a plain
+        # mount because a transcript that already holds rows (a `/clear` receipt,
+        # a boot notice) would otherwise get its empty state underneath them.
+        view.mount(welcome, before=0)
+        return welcome
 
     def _sync_row_density_class(self) -> None:
         """Put ``Screen.comfortable-rows`` on iff the setting says so.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -282,6 +282,7 @@ from local_operator.tui.widgets.transcript import (
     UserBlock,
     WakeBlock,
     WorkingBlock,
+    conversation_started,
 )
 from local_operator.tui.widgets.usage_panel import (
     UsageDismissed,
@@ -1950,8 +1951,12 @@ class OperatorApp(App[None]):
         #: not started — a quota fallback, a provider that is missing. The
         #: splash is the empty state, and treating one of these as a
         #: transcript block retired it for an empty message view. Latest
-        #: one only: the splash is one row. Cleared on a session swap
-        #: because it describes the session that just died.
+        #: one only: the splash is one row. Cleared on a swap that RETIRES
+        #: the conversation (`/new`, `/resume`, `/reload`) because it
+        #: describes the session that just died — but NOT on a sidebar
+        #: switch, which parks that conversation and can return to it with
+        #: the warning still the only account of why it cannot answer
+        #: (see :meth:`_reset_band_for_swap`).
         self._splash_notice: str | None = None
         #: PyPI version strictly newer than this install, filled by the
         #: one-shot mount worker. ``None`` until then AND when current —
@@ -3387,7 +3392,11 @@ class OperatorApp(App[None]):
             conversation = self.query_one("#session-conversation")
             conversation.styles.layers = "session-cache default"
             await conversation.mount(replay.view)
-            if not replay.blocks:
+            # The same predicate the commit path applies on the return leg. Two
+            # tests of "is this conversation empty" on the two halves of one
+            # switch would eventually disagree, and the visible failure is a
+            # target that arrives with no empty state and no way to grow one.
+            if not conversation_started(replay.blocks):
                 welcome = WelcomeView(
                     lambda: session_welcome_info(
                         session,
@@ -4024,7 +4033,12 @@ class OperatorApp(App[None]):
             # Immediately BEFORE the adopt, never after: the incoming snapshot
             # is what puts a real figure back, so a session with genuine spend
             # still lands on its own number rather than on zero.
-            self._reset_band_for_swap()
+            #
+            # `retire=False`: the outgoing conversation is PARKED, not destroyed.
+            # The splash notice and the dock density are the two pieces of state
+            # in there that nothing on this path restores, and both belong to the
+            # conversation the user can click straight back to.
+            self._reset_band_for_swap(retire=False)
             self._adopt_session(session, replay_history=False, reuse_controller=True)
             self._mark_pending_tool_rows(incoming.replay.view.blocks(), session)
             history = session.display_history_window()
@@ -4089,7 +4103,12 @@ class OperatorApp(App[None]):
                 editor.focus()
         finally:
             self._swapping_session = False
-        self._set_welcome_visible(not bool(incoming.replay.view.blocks()))
+        # `conversation_started`, not `bool(blocks())`: the infrastructure
+        # notices `_adopt_session` re-emits on EVERY swap (build skew, a failed
+        # MCP server) are blocks that deliberately do not end the empty state,
+        # and counting them retired the splash on the return leg — a `/new`
+        # conversation lost its empty state just by being glanced away from.
+        self._set_welcome_visible(not incoming.replay.view.conversation_started())
         if outgoing_presentation is not None:
             self.run_worker(self._release_sidebar_preparation((outgoing, outgoing_presentation)))
         if displaced is not None and displaced is not incoming:
@@ -6861,7 +6880,7 @@ class OperatorApp(App[None]):
         self._reset_band_for_swap()
         return (*carried_spend, was_floor)
 
-    def _reset_band_for_swap(self) -> None:
+    def _reset_band_for_swap(self, *, retire: bool = True) -> None:
         """Blank the session-scoped BAND segments, without touching the transcript.
 
         The band half of :meth:`_reset_ledger_for_swap`, split out because the
@@ -6872,15 +6891,30 @@ class OperatorApp(App[None]):
         preserves. Calling the whole of `_reset_ledger_for_swap` from there
         would destroy the presentation the switch just spent a frame preparing.
 
-        Everything reset here is APP-SCOPED — it lives on the band widget, on
-        the dock, or on the app — which is exactly what makes it the half the
-        sidebar needs. The ledger figures themselves (`_total_cost`,
-        `_spend_is_floor`, the naming bookkeeping) are properties of
-        ``self._interaction`` and are therefore already per-conversation: on the
-        sidebar path ``_adopt_session`` swaps the interaction, so those come back
-        correct on their own, and zeroing them HERE would blank the outgoing
-        conversation's real spend — which, unlike a reload's, is parked and
-        returned to rather than retired.
+        RETIRE vs PARK is the distinction that decides what may be blanked, and
+        it is the concept to carry away from this method. ``/new``, ``/resume``
+        and ``/reload`` RETIRE the conversation they leave: it is gone, and
+        state describing it is correctly discarded with it. The sidebar PARKS
+        one and returns to it, so ``retire=False`` — state that no path puts
+        back must survive.
+
+        Most of what is cleared here does not care, because ``_adopt_session``
+        unconditionally repaints it from the incoming snapshot: the cost, the
+        context reading, the MCP segment and the model label are all overwritten
+        a few lines later whichever path called this, so blanking them costs a
+        park nothing and is what stops a never-used conversation inheriting the
+        previous one's figures. Only TWO things here have nobody to restore them
+        on the sidebar path — the splash notice and the dock density — and both
+        are therefore gated on ``retire``. They were not, and a park-and-return
+        silently discarded a standing setup warning and a user's ``ctrl+g``.
+
+        The ledger figures themselves (`_total_cost`, `_spend_is_floor`, the
+        naming bookkeeping) are properties of ``self._interaction`` and are
+        therefore already per-conversation: on the sidebar path
+        ``_adopt_session`` swaps the interaction, so those come back correct on
+        their own, and zeroing them HERE would blank the outgoing conversation's
+        real spend — which, unlike a reload's, is parked and returned to rather
+        than retired.
 
         ORDERING: call this BEFORE ``_adopt_session``, never after. The incoming
         snapshot's repaint is leave-alone on absent values (`cumulative_cost` is
@@ -6891,11 +6925,22 @@ class OperatorApp(App[None]):
         spend still lands on its own number, because its snapshot carries it.
         """
         assert self._status is not None
-        # The splash notice describes the session being replaced. Left
-        # standing, a `/new` would open on the dead session's quota warning.
-        self._splash_notice = None
-        for toast in self.query(Toast):
-            toast.withdraw(SPLASH_NOTICE)
+        if retire:
+            # The splash notice describes the session being replaced. Left
+            # standing, a `/new` would open on the dead session's quota warning.
+            #
+            # Retire-only: it describes ONE conversation's empty state (the
+            # `/login`, unknown-provider and no-model-set warnings
+            # `_announce_on_splash` raises), and nothing on the sidebar path puts
+            # it back. Clearing it on a park lost it in the worst way — silently
+            # and LATE, because `WelcomeView` reads the notice through a closure,
+            # so the row survived the switch frame and vanished at the next
+            # `refresh_info()`. A user parking an unconfigured session and
+            # returning watched the only explanation of why it cannot answer
+            # disappear on its own.
+            self._splash_notice = None
+            for toast in self.query(Toast):
+                toast.withdraw(SPLASH_NOTICE)
         # The MCP segment is cleared too: the old session's manager is gone, so
         # a lingering count would describe servers nothing is connected to any
         # more. `_adopt_session` repaints it from the new session's manager.
@@ -6931,7 +6976,11 @@ class OperatorApp(App[None]):
         # replacement session re-reads `display.dock` on its first roster and
         # a `ctrl+g` pressed against the old children does not pin the new
         # ones (#525 design §2).
-        if self._subagent_panel is not None:
+        #
+        # Retire-only for the mirror-image reason: on the sidebar path the "old
+        # children" ARE the ones the user is coming back to, so their explicit
+        # `ctrl+g` still applies and nothing would re-seed it.
+        if retire and self._subagent_panel is not None:
             self._subagent_panel.reset_density()
 
     def _conversation_id(self) -> str:
@@ -16615,6 +16664,12 @@ class OperatorApp(App[None]):
                 block.navigation_anchor_id = self._projection_message_id
                 block.navigation_anchor_part = self._projection_part
             self._projection_part += 1
+        # Recorded on the BLOCK, not merely acted on here, because the sidebar
+        # parks a transcript and comes back to it: the return leg has to ask the
+        # same "has this conversation started" question this call is answering,
+        # long after the append that answered it. See
+        # `transcript.conversation_started`.
+        block.ends_empty_state = ends_empty_state
         if self._block_sink is not None:
             self._block_sink.append(block)
             return

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -4041,6 +4041,20 @@ class OperatorApp(App[None]):
             # straight back to.
             self._reset_band_for_swap(retire=False)
             self._adopt_session(session, replay_history=False, reuse_controller=True)
+            # Re-derive the fork indicator from the session now in front of the
+            # user. `fork_pending` is app-scoped with no `FrontendSessionState`
+            # field, so no snapshot repaints it and the park leg deliberately
+            # leaves it alone (nothing else restores a live fork on the return).
+            # Both halves of that are correct and neither resolves the flag for
+            # the INCOMING conversation, so an adoption that changes conversation
+            # has to ask the new session itself — otherwise the outgoing
+            # conversation's `forking` stays painted here, advertising an `esc`
+            # that `action_stop` routes to `self._session` and so can never
+            # reach the fork it names. That is the lie `_schedule_fork_report`
+            # forbids, one conversation over. AFTER the adopt, never before:
+            # `_sync_fork_pending` reads `self._session`, which the line above
+            # has just swapped.
+            self._sync_fork_pending()
             self._mark_pending_tool_rows(incoming.replay.view.blocks(), session)
             history = session.display_history_window()
             total = session.history_message_count
@@ -6916,10 +6930,17 @@ class OperatorApp(App[None]):
         ``_apply_frontend_state``'s snapshot repaint) and all ten come back.
         ``fork_pending`` is the sole structural exception, which is why it needs
         the gate rather than a restore: ``FrontendSessionState`` carries no
-        fork-pending field, so no snapshot can repaint it, and the only writer of
-        the truth — :meth:`_sync_fork_pending` — is called from neither
-        ``_adopt_session`` nor ``_commit_sidebar_session``. A clear on the park
-        leg is therefore permanent for the lifetime of the pending request.
+        fork-pending field, so no snapshot can repaint it. A clear on the park
+        leg is therefore permanent for the lifetime of the pending request,
+        which is what ``retire=False`` prevents.
+
+        That gate answers the RETURN leg only. Leaving the flag alone also
+        leaves the OUTGOING conversation's value standing over the session
+        switched TO, so ``_commit_sidebar_session`` pairs this call with a
+        :meth:`_sync_fork_pending` after its adopt to re-derive the flag from
+        the incoming session. The two are a pair: neither alone gets both legs
+        right, and this method must not try to do the incoming half itself
+        because it runs BEFORE ``_adopt_session`` swaps ``self._session``.
 
         The ledger figures themselves (`_total_cost`, `_spend_is_floor`, the
         naming bookkeeping) are properties of ``self._interaction`` and are
@@ -7966,10 +7987,11 @@ class OperatorApp(App[None]):
 
         Read from the session rather than tracked here, so the band can never
         disagree with the fact that actually governs the drain. Called at the
-        three moments the answer can change — the request, the receipt, and a
-        cancel — rather than polled, because the band repaints at 12.5 Hz during
-        a turn and a poll would be doing this work eighty times a second to
-        observe a flag that changes twice a session.
+        moments the answer can change — the request, the receipt, a cancel, and
+        a sidebar switch, which changes the session the flag is read FROM rather
+        than the fork itself — rather than polled, because the band repaints at
+        12.5 Hz during a turn and a poll would be doing this work eighty times a
+        second to observe a flag that changes twice a session.
 
         Defensive on both sides: a host whose session has no ``has_pending_fork``
         (the lightweight facades, ``RemoteSession``) simply never lights the

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -4035,9 +4035,10 @@ class OperatorApp(App[None]):
             # still lands on its own number rather than on zero.
             #
             # `retire=False`: the outgoing conversation is PARKED, not destroyed.
-            # The splash notice and the dock density are the two pieces of state
-            # in there that nothing on this path restores, and both belong to the
-            # conversation the user can click straight back to.
+            # The splash notice, the dock density and the band's fork indicator
+            # are the three pieces of state in there that nothing on this path
+            # restores, and all belong to the conversation the user can click
+            # straight back to.
             self._reset_band_for_swap(retire=False)
             self._adopt_session(session, replay_history=False, reuse_controller=True)
             self._mark_pending_tool_rows(incoming.replay.view.blocks(), session)
@@ -6903,10 +6904,22 @@ class OperatorApp(App[None]):
         context reading, the MCP segment and the model label are all overwritten
         a few lines later whichever path called this, so blanking them costs a
         park nothing and is what stops a never-used conversation inheriting the
-        previous one's figures. Only TWO things here have nobody to restore them
-        on the sidebar path — the splash notice and the dock density — and both
-        are therefore gated on ``retire``. They were not, and a park-and-return
-        silently discarded a standing setup warning and a user's ``ctrl+g``.
+        previous one's figures. THREE things here have nobody to restore them on
+        the sidebar path — the splash notice, the dock density and the band's
+        fork indicator — and all three are therefore gated on ``retire``. They
+        were not, and a park-and-return silently discarded a standing setup
+        warning, a user's ``ctrl+g``, and the ``forking`` segment of a request
+        that was still live and still cancellable.
+
+        Every other field the ungated ``status.update`` below writes was audited
+        against both restore paths (``_adopt_session``'s explicit repaint and
+        ``_apply_frontend_state``'s snapshot repaint) and all ten come back.
+        ``fork_pending`` is the sole structural exception, which is why it needs
+        the gate rather than a restore: ``FrontendSessionState`` carries no
+        fork-pending field, so no snapshot can repaint it, and the only writer of
+        the truth — :meth:`_sync_fork_pending` — is called from neither
+        ``_adopt_session`` nor ``_commit_sidebar_session``. A clear on the park
+        leg is therefore permanent for the lifetime of the pending request.
 
         The ledger figures themselves (`_total_cost`, `_spend_is_floor`, the
         naming bookkeeping) are properties of ``self._interaction`` and are
@@ -6939,8 +6952,17 @@ class OperatorApp(App[None]):
             # returning watched the only explanation of why it cannot answer
             # disappear on its own.
             self._splash_notice = None
-            for toast in self.query(Toast):
-                toast.withdraw(SPLASH_NOTICE)
+        # The TOAST goes on both legs, unlike the notice it was raised for. They
+        # are different objects with different lifetimes, as `_announce_on_splash`
+        # says: "The toast is the interruption; the splash row is what is still
+        # there after the toast dismisses." The row is the parked conversation's
+        # own empty-state content and must survive the round trip; the toast is a
+        # transient overlay ABOUT the conversation being left, and gating it with
+        # the notice made a park carry it onto the session switched TO — "No
+        # provider configured" sitting over a working session with real spend
+        # (design round 2, D2).
+        for toast in self.query(Toast):
+            toast.withdraw(SPLASH_NOTICE)
         # The MCP segment is cleared too: the old session's manager is gone, so
         # a lingering count would describe servers nothing is connected to any
         # more. `_adopt_session` repaints it from the new session's manager.
@@ -6963,7 +6985,15 @@ class OperatorApp(App[None]):
             # Cleared with the name it qualifies: the dead session's fork tag
             # must not describe the conversation replacing it.
             forked=False,
-            fork_pending=False,
+            # Retire-only, and `None` here means leave-alone rather than clear.
+            # Unlike its ten siblings in this call, nothing repaints this one:
+            # see the docstring's audit. A `/fork` deferred to a turn boundary
+            # stays live and cancellable across a park, so blanking the segment
+            # on that leg is the inverse of the lie `_schedule_fork_report`
+            # forbids — the band stops saying `forking` while the request the
+            # user could still Ctrl+C is pending, and the fork lands later with
+            # no cue that it was coming.
+            fork_pending=False if retire else None,
             mcp=McpStatus(),
             context_tokens=0,
             context_is_estimate=False,

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -130,6 +130,10 @@ class PreparedReplay(ReplayState):
     def _append_block(
         self, block: Any, *, ends_empty_state: bool = True, pin_tail: bool = False
     ) -> None:
+        # Same recording as the live appender: a prepared replay decides its own
+        # empty state from these blocks (`prepare` below), and the commit path
+        # asks the mounted view the same question afterwards.
+        block.ends_empty_state = ends_empty_state
         if not block.navigation_anchor_id:
             block.navigation_anchor_id = self._projection_message_id
             block.navigation_anchor_part = self._projection_part

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -32,7 +32,16 @@ import os
 import time
 import unicodedata
 from contextlib import contextmanager
-from typing import Any, Callable, ClassVar, Iterator, Literal, Protocol, Sequence
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Iterable,
+    Iterator,
+    Literal,
+    Protocol,
+    Sequence,
+)
 
 from rich.cells import cell_len
 from rich.console import Console, RenderableType
@@ -243,6 +252,30 @@ GAP_CLASS = "gap-above"
 BOOT_COLUMN_CLASS = "boot-column"
 
 
+def conversation_started(blocks: Iterable[TranscriptBlock]) -> bool:
+    """Does ``blocks`` contain anything that ENDS the transcript's empty state?
+
+    THE authority for "has this conversation started", shared by every caller
+    that has to decide whether the splash belongs on screen. It is a free
+    function over an iterable rather than a method, because the two shapes a
+    transcript takes here are a mounted ``TranscriptView`` and the plain
+    ``list`` a ``PreparedReplay`` builds off screen, and one predicate over both
+    is the point: a second copy would eventually disagree with the first, and
+    the way that failure looks is a splash centred over a populated transcript.
+
+    The distinction is the one ``OperatorApp._append_block`` already makes and
+    ``_system_notice`` already relies on: "the CONVERSATION has started" is not
+    "something got drawn". A notice about infrastructure the user did not ask
+    about \u2014 an MCP server that failed to connect, a build-skew warning \u2014 is
+    appended with ``ends_empty_state=False`` so it lands UNDER the splash. So
+    ``bool(view.blocks())`` is the WRONG test: it counts those, and the sidebar's
+    commit path used it, which is why returning to an untouched ``/new``
+    conversation showed no empty state at all whenever any such notice was
+    present \u2014 i.e. always on a skewed build or with one broken MCP server.
+    """
+    return any(block.ends_empty_state for block in blocks)
+
+
 class TranscriptBlock(Static):
     """Base class for one transcript entry (assistant, tool, user, notice).
 
@@ -292,6 +325,22 @@ class TranscriptBlock(Static):
     #: which also fires against the empty transcript's top edge because it
     #: marks a turn boundary; this one only separates neighbours.
     SPACING_AIRY: ClassVar[bool] = False
+
+    #: Did this block's arrival START THE CONVERSATION? Recorded per block by
+    #: the appenders (``OperatorApp._append_block`` and
+    #: ``PreparedReplay._append_block``, the two implementations of the
+    #: ``ReplayTarget`` protocol) from their ``ends_empty_state`` argument, so
+    #: that a reader asking "is this transcript still empty?" gets the same
+    #: answer the appender already acted on rather than a second rule beside it
+    #: — see :func:`conversation_started`.
+    #:
+    #: Deliberately an INSTANCE fact, not a class one: the same ``NoticeBlock``
+    #: type is conversation content as a ``/clear`` receipt and infrastructure
+    #: chatter as an MCP-connection warning. It defaults to True so a block
+    #: appended by any path that predates this attribute still counts, which is
+    #: the conservative direction: the failure it protects against is a splash
+    #: left standing over a populated transcript.
+    ends_empty_state: bool = True
 
     #: Set False once the block will never mutate again.
     _finalized: bool = False
@@ -2940,6 +2989,17 @@ class TranscriptView(ScrollableContainer):
     def blocks(self) -> list[TranscriptBlock]:
         """Blocks in append order (live and finalized)."""
         return list(self._blocks)
+
+    def conversation_started(self) -> bool:
+        """Has this transcript any content that ENDS the empty state?
+
+        The question ``bool(view.blocks())`` looks like it answers and does not:
+        a transcript can hold blocks and still be an unstarted conversation,
+        because an infrastructure notice is appended with ``ends_empty_state``
+        False precisely so it lands UNDER the splash. See
+        :func:`conversation_started` for why the two are different questions.
+        """
+        return conversation_started(self._blocks)
 
     def pinned_tail(self) -> TranscriptBlock | None:
         """The block held last by :meth:`pin_tail`, if a turn is in flight.

--- a/scripts/sidebar_new_shot.py
+++ b/scripts/sidebar_new_shot.py
@@ -1,0 +1,118 @@
+"""Capture `/new` and the band AFTER a sidebar switch, for visual validation.
+
+Run from the worktree root:
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/sidebar_new_shot.py OUT.svg [splash|band] [COLSxROWS]
+
+Both frames are only reachable through the sidebar's prepare/commit pair, which
+is why this drives that pair rather than `/new` alone: plain `/new` was never
+broken. ``splash`` switches onto a conversation WITH history and then runs
+`/new`; ``band`` parks on a conversation carrying cost and context, switches
+back to the untouched `/new` conversation, and captures the status band.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.visual_capture import isolate_capture, save_capture  # noqa: E402
+
+isolate_capture()
+
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from tests.unit.tui.test_app_pilot import _factory  # noqa: E402
+from tests.unit.tui.test_sidebar_swap_reset import SidebarRemote  # noqa: E402
+
+
+def _message(role: str, text: str):
+    return SimpleNamespace(role=role, text=text, tool_calls=None, content=text)
+
+
+async def _switch(app: OperatorApp, pilot, remote: SidebarRemote) -> None:
+    """The real prepare/commit pair, as `tests.unit.tui.test_sidebar_swap_reset`
+    drives it — kept in step with the tests so the frame shows what they assert."""
+    from local_operator.tui.session_interaction import SessionInteraction
+
+    source = app._sidebar_sources.get(remote.session_id)
+    if source is None:
+        source = SessionInteraction(remote)
+        app._sidebar_sources[remote.session_id] = source
+
+    async def lease(_session_id, *, speculative=False):
+        source.preparations += 1
+        return source
+
+    app._lease_sidebar_source = lease  # type: ignore[method-assign]
+    prepare = asyncio.ensure_future(app._prepare_sidebar_session(remote.session_id))
+    for _ in range(400):
+        if prepare.done():
+            break
+        await pilot.pause()
+    future = app._commit_sidebar_session(remote.session_id, prepare.result(), 0)
+    for _ in range(20):
+        await pilot.pause()
+    if future is not None and not future.done():
+        future.cancel()
+    for _ in range(10):
+        await pilot.pause()
+
+
+async def main() -> None:
+    out = sys.argv[1]
+    which = sys.argv[2] if len(sys.argv) > 2 else "splash"
+    size = sys.argv[3] if len(sys.argv) > 3 else "100x30"
+    columns, _, rows = size.partition("x")
+
+    fresh = SidebarRemote("fresh-session")
+    home = SidebarRemote("home-session")
+    busy = SidebarRemote(
+        "busy-session",
+        history=[
+            _message("user", "what does the sidebar switch preserve?"),
+            _message("assistant", "the prepared presentation, not the band."),
+        ],
+        cost=12.3456,
+        context=98_765,
+    )
+
+    async def resume_factory(_resume_id):
+        return fresh
+
+    app = OperatorApp(lambda: _factory(home), resume_factory=resume_factory)
+    with patch("local_operator.session.remote.RemoteSession", SidebarRemote):
+        async with app.run_test(size=(int(columns), int(rows))) as pilot:
+            for _ in range(20):
+                await pilot.pause()
+
+            await _switch(app, pilot, busy)
+            if which == "splash":
+                app._run_slash_command("/new")
+                for _ in range(80):
+                    await pilot.pause()
+                await asyncio.sleep(0.4)
+                for _ in range(40):
+                    await pilot.pause()
+            else:
+                # Away and back: the frame that carried the other conversation's
+                # money and context over a session that has never had a turn.
+                await _switch(app, pilot, fresh)
+
+            status = app._status
+            assert status is not None
+            view = app._transcript_view()
+            print(f"cost={status._cost!r} context_tokens={status._context_tokens}")
+            print(f"welcome={app._welcome!r} welcome_visible={app._welcome_visible}")
+            print(f"blocks={len(view.blocks())} boot_class={app.screen.has_class('boot')}")
+            print(f"screen size={tuple(app.screen.size)} virtual={tuple(app.screen.virtual_size)}")
+            print(f"scrollbar={app.screen.show_vertical_scrollbar}")
+            save_capture(app, out)
+
+
+asyncio.run(main())

--- a/scripts/sidebar_new_shot.py
+++ b/scripts/sidebar_new_shot.py
@@ -3,7 +3,7 @@
 Run from the worktree root:
 
     env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
-        scripts/sidebar_new_shot.py OUT.svg [splash|band|return|notice] [COLSxROWS]
+        scripts/sidebar_new_shot.py OUT.svg [splash|band|return|notice|toast] [COLSxROWS]
 
 Every frame here is only reachable through the sidebar's prepare/commit pair,
 which is why this drives that pair rather than `/new` alone: plain `/new` was
@@ -24,6 +24,13 @@ the conversation it left instead of retiring it:
   returns, and drives the `refresh_info()` repaint that used to take the row
   away — so the captured frame is the one AFTER the poll that exposed the loss,
   not the stale frame that survived the switch.
+* ``toast`` stops HALFWAY through ``notice``'s journey, on the session switched
+  TO, which is where the notice's toast used to follow the user (design round 2,
+  D2). The notice and the toast are raised together and have opposite lifetimes:
+  the splash ROW is the parked conversation's own empty-state content and must
+  come back, the TOAST is a transient overlay about the conversation being LEFT
+  and must not travel. This frame is the second half of that pair — read it
+  beside ``notice``, which shows the row surviving the return.
 """
 
 from __future__ import annotations
@@ -105,7 +112,19 @@ async def main() -> None:
             for _ in range(20):
                 await pilot.pause()
 
-            if which == "notice":
+            if which == "toast":
+                # Same setup as `notice`, captured one leg earlier: the toast is
+                # still up when the conversation is parked, so the frame shows
+                # what the session switched TO is wearing.
+                app._announce_on_splash(
+                    "/login openai to get started - no provider configured.", "warning"
+                )
+                for _ in range(10):
+                    await pilot.pause()
+                await _switch(app, pilot, busy)
+                for _ in range(20):
+                    await pilot.pause()
+            elif which == "notice":
                 # The warning belongs to the conversation being PARKED, so it is
                 # raised before the switch and read back after the return.
                 app._announce_on_splash(
@@ -168,6 +187,12 @@ async def main() -> None:
             started = getattr(view, "conversation_started", None)
             print(f"conversation_started={started() if started else 'n/a'}")
             print(f"splash_notice={app._splash_notice!r}")
+            # Counted from `display`, not from the owner tag: what the user sees
+            # is a card on screen, and a hidden toast still holding a tag is
+            # invisible. This is the D2 measurement.
+            from local_operator.tui.widgets.toast import Toast
+
+            print(f"live_toasts={len([t for t in app.query(Toast) if t.display])}")
             print(f"screen size={tuple(app.screen.size)} virtual={tuple(app.screen.virtual_size)}")
             print(f"scrollbar={app.screen.show_vertical_scrollbar}")
             save_capture(app, out)

--- a/scripts/sidebar_new_shot.py
+++ b/scripts/sidebar_new_shot.py
@@ -31,6 +31,20 @@ the conversation it left instead of retiring it:
   come back, the TOAST is a transient overlay about the conversation being LEFT
   and must not travel. This frame is the second half of that pair — read it
   beside ``notice``, which shows the row surviving the return.
+
+``fork_parked`` and ``fork_return`` are the two legs of the band's ``forking``
+segment (design round 3, D3), and are only meaningful as a PAIR — each one alone
+is satisfied by a fix that breaks the other:
+
+* ``fork_parked`` parks a conversation whose ``/fork`` is still waiting for a
+  turn boundary and captures the session switched TO, which has no fork. The
+  segment must be ABSENT: it advertises ``esc``, and ``action_stop`` probes
+  ``self._session``, so a segment left standing here offers a cancel that cannot
+  reach the fork it names.
+* ``fork_return`` completes the round trip and captures the conversation that
+  owns the fork, where the segment must be PRESENT — the request is still live
+  and still cancellable, and blanking it on the park leg is what review round 2
+  raised as MAJOR-3.
 """
 
 from __future__ import annotations
@@ -92,7 +106,11 @@ async def main() -> None:
     columns, _, rows = size.partition("x")
 
     fresh = SidebarRemote("fresh-session")
-    home = SidebarRemote("home-session")
+    # The fork legs need the home conversation to REPORT a pending fork, because
+    # the band reads `has_pending_fork()` off the session rather than tracking
+    # it — which is the property the D3 frames are about: whose answer is being
+    # painted, not whether a flag was set.
+    home = SidebarRemote("home-session", pending_fork=which in ("fork_parked", "fork_return"))
     busy = SidebarRemote(
         "busy-session",
         history=[
@@ -112,7 +130,19 @@ async def main() -> None:
             for _ in range(20):
                 await pilot.pause()
 
-            if which == "toast":
+            if which in ("fork_parked", "fork_return"):
+                # The request, as `/fork` on a streaming session makes it: the
+                # session defers to a turn boundary and the band is synced from
+                # it, so the fork stays live and cancellable across the park.
+                app._sync_fork_pending()
+                for _ in range(10):
+                    await pilot.pause()
+                await _switch(app, pilot, busy)
+                if which == "fork_return":
+                    await _switch(app, pilot, home)
+                for _ in range(20):
+                    await pilot.pause()
+            elif which == "toast":
                 # Same setup as `notice`, captured one leg earlier: the toast is
                 # still up when the conversation is parked, so the frame shows
                 # what the session switched TO is wearing.
@@ -195,6 +225,15 @@ async def main() -> None:
             print(f"live_toasts={len([t for t in app.query(Toast) if t.display])}")
             print(f"screen size={tuple(app.screen.size)} virtual={tuple(app.screen.virtual_size)}")
             print(f"scrollbar={app.screen.show_vertical_scrollbar}")
+            # The D3 measurement, read off the RENDERED band rather than the
+            # flag: a code check can confirm the leave-alone is correct and
+            # still miss that the frame describes the wrong conversation.
+            from local_operator.tui.widgets.status_line import FORK_PENDING_TEXT
+
+            session = app._session
+            probe = getattr(session, "has_pending_fork", None) if session is not None else None
+            print(f"band_says_forking={FORK_PENDING_TEXT in status.render_text(100).plain}")
+            print(f"session_has_pending_fork={probe() if callable(probe) else 'n/a'}")
             save_capture(app, out)
 
 

--- a/scripts/sidebar_new_shot.py
+++ b/scripts/sidebar_new_shot.py
@@ -3,13 +3,27 @@
 Run from the worktree root:
 
     env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
-        scripts/sidebar_new_shot.py OUT.svg [splash|band] [COLSxROWS]
+        scripts/sidebar_new_shot.py OUT.svg [splash|band|return|notice] [COLSxROWS]
 
-Both frames are only reachable through the sidebar's prepare/commit pair, which
-is why this drives that pair rather than `/new` alone: plain `/new` was never
-broken. ``splash`` switches onto a conversation WITH history and then runs
+Every frame here is only reachable through the sidebar's prepare/commit pair,
+which is why this drives that pair rather than `/new` alone: plain `/new` was
+never broken. ``splash`` switches onto a conversation WITH history and then runs
 `/new`; ``band`` parks on a conversation carrying cost and context, switches
 back to the untouched `/new` conversation, and captures the status band.
+
+``return`` and ``notice`` are the PARK-AND-RETURN frames — the leg where the
+sidebar differs from `/new`, `/resume` and `/reload`, because it comes back to
+the conversation it left instead of retiring it:
+
+* ``return`` is the operator's reported flow with an infrastructure notice
+  present (`/new`, switch to a busy session, switch back). The notice is posted
+  through the production `_system_notice`, the same call `_check_build_skew`
+  makes on every swap, so the frame shows the splash standing UNDER it rather
+  than being retired by it.
+* ``notice`` raises a real setup warning on the splash, parks the conversation,
+  returns, and drives the `refresh_info()` repaint that used to take the row
+  away — so the captured frame is the one AFTER the poll that exposed the loss,
+  not the stale frame that survived the switch.
 """
 
 from __future__ import annotations
@@ -91,8 +105,46 @@ async def main() -> None:
             for _ in range(20):
                 await pilot.pause()
 
-            await _switch(app, pilot, busy)
-            if which == "splash":
+            if which == "notice":
+                # The warning belongs to the conversation being PARKED, so it is
+                # raised before the switch and read back after the return.
+                app._announce_on_splash(
+                    "/login openai to get started - no provider configured.", "warning"
+                )
+                for _ in range(10):
+                    await pilot.pause()
+                await _switch(app, pilot, busy)
+                await _switch(app, pilot, home)
+                if app._welcome is not None:
+                    # The repaint that exposed the loss: the splash reads its
+                    # facts through a closure, so a cleared notice left the drawn
+                    # row standing and removed it at the next poll.
+                    app._welcome.refresh_info()
+                for _ in range(20):
+                    await pilot.pause()
+            elif which == "return":
+                app._run_slash_command("/new")
+                for _ in range(80):
+                    await pilot.pause()
+                await asyncio.sleep(0.4)
+                for _ in range(40):
+                    await pilot.pause()
+                # The notice `_adopt_session` re-emits on every swap, posted the
+                # way the product posts it. Counting it as conversation content
+                # is what retired the splash on the return leg.
+                app._system_notice(
+                    "this session is running an older version than this window — it will "
+                    "move to the new version when its current work finishes.",
+                    "note",
+                )
+                for _ in range(10):
+                    await pilot.pause()
+                await _switch(app, pilot, busy)
+                await _switch(app, pilot, fresh)
+                for _ in range(20):
+                    await pilot.pause()
+            elif which == "splash":
+                await _switch(app, pilot, busy)
                 app._run_slash_command("/new")
                 for _ in range(80):
                     await pilot.pause()
@@ -102,6 +154,7 @@ async def main() -> None:
             else:
                 # Away and back: the frame that carried the other conversation's
                 # money and context over a session that has never had a turn.
+                await _switch(app, pilot, busy)
                 await _switch(app, pilot, fresh)
 
             status = app._status
@@ -110,6 +163,11 @@ async def main() -> None:
             print(f"cost={status._cost!r} context_tokens={status._context_tokens}")
             print(f"welcome={app._welcome!r} welcome_visible={app._welcome_visible}")
             print(f"blocks={len(view.blocks())} boot_class={app.screen.has_class('boot')}")
+            # Defensive so this script can also be run from a pre-fix checkout to
+            # capture a before-frame, where the predicate does not exist yet.
+            started = getattr(view, "conversation_started", None)
+            print(f"conversation_started={started() if started else 'n/a'}")
+            print(f"splash_notice={app._splash_notice!r}")
             print(f"screen size={tuple(app.screen.size)} virtual={tuple(app.screen.virtual_size)}")
             print(f"scrollbar={app.screen.show_vertical_scrollbar}")
             save_capture(app, out)

--- a/tests/unit/tui/test_sidebar_swap_reset.py
+++ b/tests/unit/tui/test_sidebar_swap_reset.py
@@ -1,0 +1,267 @@
+"""The sidebar's switch path is a conversation SWAP, and must reset like one.
+
+Two regressions the session sidebar introduced, both reported against `/new`
+and both only reachable THROUGH a sidebar switch — plain `/new` was never
+broken, which is why they survived the original round:
+
+* the splash did not come back on `/new`, because the prepared view for a
+  target WITH history carries no ``WelcomeView`` and `_welcome` became None;
+* the band kept the previous conversation's cost and context, because the
+  commit path reset neither and the incoming snapshot is leave-alone on the
+  absent values a never-used session legitimately reports.
+
+The over-fix guard is asserted in the same file and matters as much as the
+fixes: a switch BACK onto a conversation with real spend has to land on that
+spend, not on the zero the reset writes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from local_operator.session.frontend_state import (
+    FrontendModelSpec,
+    FrontendSessionState,
+    FrontendStateStore,
+)
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.session_interaction import SessionInteraction
+from local_operator.tui.widgets.welcome import WelcomeView
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+@pytest.fixture(autouse=True)
+def isolated_swap(tmp_path, monkeypatch):
+    # Headless apps must never rename the caller's real multiplexer workspace.
+    for key in tuple(os.environ):
+        if key.startswith("CMUX_"):
+            monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_NOTIFICATIONS", "1")
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_TERMINAL_TITLE", "1")
+    monkeypatch.setattr(OperatorApp, "_check_for_update", lambda _self: None)
+    monkeypatch.setattr(OperatorApp, "_start_terminal_title", lambda _self: None)
+    monkeypatch.setattr(OperatorApp, "_start_multiplexer_broadcast", lambda _self: None)
+    monkeypatch.setattr(OperatorApp, "_start_herdr_reporter", lambda _self: None)
+
+
+class SidebarRemote(FakeSession):
+    """A ``FakeSession`` wearing the owner-backed surface the sidebar requires.
+
+    A ``MagicMock(spec=RemoteSession)`` cannot stand in here: the commit path
+    renders the band and the splash from this object, and a mock's auto-created
+    attributes reach Rich as non-string values. Extending the suite's existing
+    fake keeps every protocol method real and adds only the navigation surface.
+
+    The frontend store is a REAL one so ``_adopt_session`` runs the production
+    repaint — which is precisely the leave-alone-on-None behaviour the band
+    regression turns on.
+    """
+
+    is_remote = True
+
+    def __init__(self, session_id: str, *, history=(), cost=None, context=None) -> None:
+        super().__init__()
+        self._id = session_id
+        self._history = list(history)
+        self._store = FrontendStateStore(
+            FrontendSessionState(
+                session_id=session_id,
+                epoch=f"epoch-{session_id}",
+                # `model_label` is DERIVED from this spec, not a field: the band
+                # and the splash both read the label, so a snapshot without a
+                # spec would repaint them empty and mask what is being asserted.
+                selected_model=FrontendModelSpec(provider="test", model_id="model"),
+                cumulative_parent_cost=cost,
+                context_tokens=context,
+                context_window=200_000 if context is not None else None,
+            )
+        )
+        self.is_cold = False
+        self.has_pending_gate_reply = False
+        self.display_history_current = True
+        self.display_history_revision = 1
+
+    @property
+    def session_id(self) -> str:
+        return self._id
+
+    @property
+    def frontend_state(self):
+        return self._store.state
+
+    def subscribe_frontend(self, handler):
+        return self._store.subscribe(handler)
+
+    def display_history_window(self):
+        return list(self._history)
+
+    def history(self):
+        return list(self._history)
+
+    @property
+    def history_message_count(self) -> int:
+        return len(self._history)
+
+    async def ensure_display_current(self) -> None:
+        return None
+
+    async def ensure_display_anchor(self, _anchor) -> bool:
+        return True
+
+    def resume_viewer_gates(self) -> None:
+        return None
+
+    def suspend_viewer_gates(self, *, auto_approve=False, keep_answer=False) -> None:
+        return None
+
+    def set_takeover_callback(self, _callback) -> None:
+        return None
+
+    def set_stopped_callback(self, _callback) -> None:
+        return None
+
+    def set_owner_gone_callback(self, _callback) -> None:
+        return None
+
+
+def _message(role: str, text: str):
+    return SimpleNamespace(role=role, text=text, tool_calls=None, content=text)
+
+
+async def _switch(app: OperatorApp, pilot, remote: SidebarRemote) -> None:
+    """Drive the REAL prepare/commit pair, the way a sidebar click does.
+
+    The lease is stubbed because leasing reaches for an owner record on disk;
+    everything after it — the prepared replay, the parked outgoing view, the
+    commit, the adopt — is production code, which is where both bugs lived.
+    """
+    source = app._sidebar_sources.get(remote.session_id)
+    if source is None:
+        source = SessionInteraction(remote)
+        app._sidebar_sources[remote.session_id] = source
+
+    async def lease(_session_id, *, speculative=False):
+        source.preparations += 1
+        return source
+
+    app._lease_sidebar_source = lease  # type: ignore[method-assign]
+    prepare = asyncio.ensure_future(app._prepare_sidebar_session(remote.session_id))
+    # Preparation waits on a laid-out frame, so the pilot has to keep pumping.
+    for _ in range(400):
+        if prepare.done():
+            break
+        await pilot.pause()
+    prepared = prepare.result()
+    future = app._commit_sidebar_session(remote.session_id, prepared, 0)
+    for _ in range(20):
+        await pilot.pause()
+    if future is not None and not future.done():
+        # The ready-frame future settles on a real paint; the pilot's frames are
+        # enough for the assertions here and the timer must not outlive the app.
+        future.cancel()
+    for _ in range(10):
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_new_after_a_sidebar_switch_still_shows_the_splash():
+    """`/new` must land on the splash even when the view came from the sidebar.
+
+    The splash is composed once, into the boot transcript. Sidebar navigation
+    mounts a NEW ``TranscriptView`` per target and gives it a ``WelcomeView``
+    only when the target has no history, so after a switch onto a conversation
+    with messages the app held no usable splash at all: `/new` applied the boot
+    layout over an empty transcript with nothing centred in it.
+    """
+    fresh = SidebarRemote("fresh-session")
+    home = SidebarRemote("home-session")
+    busy = SidebarRemote(
+        "busy-session",
+        history=[_message("user", "a question"), _message("assistant", "an answer")],
+    )
+
+    async def resume_factory(_resume_id):
+        return fresh
+
+    app = OperatorApp(lambda: _factory(home), resume_factory=resume_factory)
+    with patch("local_operator.session.remote.RemoteSession", SidebarRemote):
+        async with app.run_test(size=(100, 30)) as pilot:
+            for _ in range(20):
+                await pilot.pause()
+
+            await _switch(app, pilot, busy)
+            # The precondition, asserted so the test still describes the bug if
+            # the sidebar ever starts mounting an empty state unconditionally.
+            assert app._transcript_view().blocks()
+
+            app._run_slash_command("/new")
+            for _ in range(80):
+                await pilot.pause()
+            await asyncio.sleep(0.4)
+            for _ in range(40):
+                await pilot.pause()
+
+            view = app._transcript_view()
+            welcome = app._welcome
+            assert welcome is not None, "the app holds no splash after a sidebar switch"
+            assert welcome in list(view.children), "the splash is not in the visible transcript"
+            assert welcome.display, "the splash is mounted but hidden"
+            assert app._welcome_visible is True
+            assert app.screen.has_class("boot")
+            # One empty state per view, however many switches preceded it.
+            assert len([c for c in view.children if isinstance(c, WelcomeView)]) == 1
+
+
+@pytest.mark.asyncio
+async def test_sidebar_commit_clears_the_previous_conversations_cost_and_context():
+    """Switching back to an untouched `/new` must not show the other's spend.
+
+    ``_commit_sidebar_session`` used to reset none of the band and rely on the
+    incoming snapshot to repaint it. That snapshot is leave-alone on absent
+    values, and a conversation that has never had a turn reports exactly that
+    (`cumulative_cost` None, `context_tokens` None) — so the busy session's
+    figures stayed on screen over the fresh conversation.
+
+    The second half is the over-fix guard: the reset runs BEFORE the adopt, so a
+    conversation with real spend is repainted from its own snapshot rather than
+    left on the zero.
+    """
+    fresh = SidebarRemote("fresh-session")
+    home = SidebarRemote("home-session")
+    busy = SidebarRemote(
+        "busy-session",
+        history=[_message("user", "a question"), _message("assistant", "an answer")],
+        cost=12.3456,
+        context=98_765,
+    )
+
+    async def resume_factory(_resume_id):
+        return fresh
+
+    app = OperatorApp(lambda: _factory(home), resume_factory=resume_factory)
+    with patch("local_operator.session.remote.RemoteSession", SidebarRemote):
+        async with app.run_test(size=(100, 30)) as pilot:
+            for _ in range(20):
+                await pilot.pause()
+            assert app._status is not None
+
+            await _switch(app, pilot, busy)
+            assert app._status._cost == "$12.35"
+            assert app._status._context_tokens == 98_765
+
+            await _switch(app, pilot, fresh)
+            assert app._status._cost == "", "the previous conversation's cost is still painted"
+            assert not app._status._context_tokens, "the previous context reading is still painted"
+
+            # Back onto the conversation that genuinely spent it: the snapshot
+            # puts the real figure back, so the reset must not have cost it.
+            await _switch(app, pilot, busy)
+            assert app._status._cost == "$12.35", "restored spend was zeroed by the reset"
+            assert app._status._context_tokens == 98_765

--- a/tests/unit/tui/test_sidebar_swap_reset.py
+++ b/tests/unit/tui/test_sidebar_swap_reset.py
@@ -502,6 +502,77 @@ async def test_a_parked_conversation_keeps_its_pending_fork_indicator():
 
 
 @pytest.mark.asyncio
+async def test_the_fork_indicator_describes_the_session_the_user_is_looking_at():
+    """A parked conversation's `forking` must not be painted over another one.
+
+    The other half of the park gate above, and a defect that predates this PR:
+    on base, nothing on the sidebar path wrote `fork_pending` at all, so the
+    outgoing conversation's segment simply stayed lit over the session switched
+    TO. `retire=False` kept that behaviour rather than causing it — it fixed the
+    return leg — so both legs are only correct once `_commit_sidebar_session`
+    re-derives the flag from the incoming session after its adopt.
+
+    Why this is worse than a stale readout (design round 3, D3): the segment is
+    an AFFORDANCE. It advertises `esc`, and `action_stop` probes `self._session`
+    — now a different conversation — so the offered cancel cannot reach the fork
+    it names, and nothing ever clears it. That is precisely the lie
+    `_schedule_fork_report` brings the segment down to avoid, one session over.
+
+    Asserted on the RENDERED band, like its sibling, because `_fork_pending`
+    alone cannot see this: a code round can verify the `None` leave-alone is
+    correct and still miss that the resulting FRAME describes the wrong
+    conversation. Both legs live in one test because they are the pair a
+    one-sided fix breaks: clearing unconditionally would take the live
+    indicator back off the return leg (review round 2, MAJOR-3).
+    """
+    home = SidebarRemote("home-session", pending_fork=True)
+    busy = SidebarRemote(
+        "busy-session",
+        history=[_message("user", "a question"), _message("assistant", "an answer")],
+        cost=12.35,
+        context=98_765,
+    )
+
+    app = OperatorApp(lambda: _factory(home))
+    with patch("local_operator.session.remote.RemoteSession", SidebarRemote):
+        async with app.run_test(size=(100, 30)) as pilot:
+            for _ in range(20):
+                await pilot.pause()
+
+            app._sync_fork_pending()
+            for _ in range(5):
+                await pilot.pause()
+            assert app._status is not None
+            assert app._status.is_showing("fork"), "the band never showed `forking` to begin with"
+            assert FORK_PENDING_TEXT in app._status.render_text(100).plain
+
+            await _switch(app, pilot, busy)
+            for _ in range(10):
+                await pilot.pause()
+
+            # The park leg. `busy` has no fork of any kind, so the segment it
+            # would be offering `esc` for does not exist on this conversation.
+            assert busy.has_pending_fork() is False
+            assert FORK_PENDING_TEXT not in app._status.render_text(100).plain, (
+                "the parked conversation's `forking` is painted over the session "
+                "switched TO, advertising an `esc` that cannot reach that fork"
+            )
+
+            await _switch(app, pilot, home)
+            for _ in range(10):
+                await pilot.pause()
+
+            # The return leg, unchanged: the fork is still waiting for its
+            # boundary, so the segment it can still be cancelled from is back.
+            assert home.has_pending_fork() is True
+            assert app._status.is_showing("fork")
+            assert FORK_PENDING_TEXT in app._status.render_text(100).plain, (
+                "resolving the indicator for the incoming session cost the "
+                "live fork its indicator on the conversation that owns it"
+            )
+
+
+@pytest.mark.asyncio
 async def test_a_park_withdraws_the_splash_toast_but_keeps_the_notice():
     """The park drops the outgoing toast and keeps the outgoing splash row.
 

--- a/tests/unit/tui/test_sidebar_swap_reset.py
+++ b/tests/unit/tui/test_sidebar_swap_reset.py
@@ -31,6 +31,8 @@ from local_operator.session.frontend_state import (
 )
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.session_interaction import SessionInteraction
+from local_operator.tui.widgets.status_line import FORK_PENDING_TEXT
+from local_operator.tui.widgets.toast import Toast
 from local_operator.tui.widgets.welcome import WelcomeView
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
 
@@ -66,9 +68,22 @@ class SidebarRemote(FakeSession):
 
     is_remote = True
 
-    def __init__(self, session_id: str, *, history=(), cost=None, context=None) -> None:
+    def __init__(
+        self,
+        session_id: str,
+        *,
+        history=(),
+        cost=None,
+        context=None,
+        pending_fork: bool = False,
+    ) -> None:
         super().__init__()
         self._id = session_id
+        #: Opt-in, because `has_pending_fork` is the fact the band's `forking`
+        #: segment reads and only ONE test wants it true. A `/fork` issued on a
+        #: streaming session defers to a turn boundary (`owned.py:2208`), so the
+        #: request stays live — and cancellable — across a park.
+        self._pending_fork = pending_fork
         self._history = list(history)
         self._store = FrontendStateStore(
             FrontendSessionState(
@@ -91,6 +106,9 @@ class SidebarRemote(FakeSession):
     @property
     def session_id(self) -> str:
         return self._id
+
+    def has_pending_fork(self) -> bool:
+        return self._pending_fork
 
     @property
     def frontend_state(self):
@@ -423,3 +441,130 @@ async def test_returning_to_an_empty_conversation_shows_the_splash_under_a_notic
             assert welcome.display, "the splash is mounted but hidden"
             assert app._welcome_visible is True
             assert app.screen.has_class("boot")
+
+
+@pytest.mark.asyncio
+async def test_a_parked_conversation_keeps_its_pending_fork_indicator():
+    """A `/fork` still awaiting its boundary must survive a park-and-return.
+
+    The third RETIRE-only clear, found by the same audit that produced the other
+    two (review round 2, MAJOR-3). `fork_pending` is the one field the ungated
+    `status.update` writes that NEITHER restore path repaints: `_adopt_session`
+    does not touch it, `FrontendSessionState` carries no fork-pending field so a
+    snapshot cannot either, and the only writer of the truth
+    (`_sync_fork_pending`) is called from neither adoption path. So a clear on
+    the park leg is permanent for the lifetime of the request.
+
+    Why that matters more than a missing glyph: a deferred fork stays LIVE and
+    Ctrl+C-cancellable until the turn ends, so a band that stops saying `forking`
+    is the inverse of the lie `_schedule_fork_report` forbids — the user gets no
+    cue that a fork is coming and it lands minutes later out of nowhere.
+
+    Asserted on the RENDERED row, not on the flag: round 1's bug was state that
+    was set while the user saw nothing, so `_status._fork_pending` alone cannot
+    close this. `is_showing` confirms the drop ladder kept the segment at this
+    width, which is what makes reading the row a fair test rather than a
+    width-sensitive one.
+    """
+    home = SidebarRemote("home-session", pending_fork=True)
+    busy = SidebarRemote(
+        "busy-session",
+        history=[_message("user", "a question"), _message("assistant", "an answer")],
+    )
+
+    app = OperatorApp(lambda: _factory(home))
+    with patch("local_operator.session.remote.RemoteSession", SidebarRemote):
+        async with app.run_test(size=(100, 30)) as pilot:
+            for _ in range(20):
+                await pilot.pause()
+
+            # The request, as `/fork` on a streaming session makes it: the
+            # session reports the pending fork and the band is synced from it.
+            app._sync_fork_pending()
+            for _ in range(5):
+                await pilot.pause()
+            assert app._status is not None
+            assert app._status.is_showing("fork"), "the band never showed `forking` to begin with"
+            assert FORK_PENDING_TEXT in app._status.render_text(100).plain
+
+            await _switch(app, pilot, busy)
+            await _switch(app, pilot, home)
+            for _ in range(10):
+                await pilot.pause()
+
+            # The truth is unchanged — the fork is still waiting for a boundary.
+            assert home.has_pending_fork() is True
+            assert app._status.is_showing("fork")
+            assert FORK_PENDING_TEXT in app._status.render_text(100).plain, (
+                "the band stopped saying `forking` after a sidebar round trip, "
+                "while the request is still live and still cancellable"
+            )
+
+
+@pytest.mark.asyncio
+async def test_a_park_withdraws_the_splash_toast_but_keeps_the_notice():
+    """The park drops the outgoing toast and keeps the outgoing splash row.
+
+    The notice and the toast are raised together by `_announce_on_splash` and
+    have opposite lifetimes, which is the distinction this asserts (design round
+    2, D2). The NOTICE is the parked conversation's own empty-state content and
+    must survive the round trip — that is what this PR exists to deliver. The
+    TOAST is a transient overlay ABOUT the conversation being left, so gating it
+    with the notice made a park carry it onto the session switched TO: "No
+    provider configured" sitting over a working session with real spend.
+
+    Both halves are asserted in ONE test deliberately, because they are a pair
+    that can drift apart: withdrawing the toast must not cost the notice, and
+    keeping the notice must not keep the toast. Split across two tests, a fix
+    for either could silently break the other and still show green.
+    """
+    home = SidebarRemote("home-session")
+    busy = SidebarRemote(
+        "busy-session",
+        history=[_message("user", "a question"), _message("assistant", "an answer")],
+        cost=12.35,
+        context=98_765,
+    )
+
+    app = OperatorApp(lambda: _factory(home))
+    with patch("local_operator.session.remote.RemoteSession", SidebarRemote):
+        async with app.run_test(size=(100, 30)) as pilot:
+            for _ in range(20):
+                await pilot.pause()
+
+            warning = "/login openai to get started - no provider configured."
+            app._announce_on_splash(warning, "warning")
+            for _ in range(5):
+                await pilot.pause()
+
+            live = [toast for toast in app.query(Toast) if toast.display]
+            assert live, "no toast was raised — the park has nothing to withdraw"
+
+            await _switch(app, pilot, busy)
+            for _ in range(10):
+                await pilot.pause()
+
+            # ON the session switched TO: nothing of the parked conversation's
+            # interruption is left standing over it. Counted from `display`
+            # rather than from the owner, because what the user sees is a card
+            # on screen; a hidden toast still holding a tag is invisible.
+            assert (
+                len([toast for toast in app.query(Toast) if toast.display]) == 0
+            ), "the parked conversation's toast followed the user onto another session"
+
+            await _switch(app, pilot, home)
+            for _ in range(10):
+                await pilot.pause()
+
+            # And the row the toast was raised for is still there, past the
+            # repaint that exposes a late loss.
+            assert app._splash_notice == warning
+            assert app._welcome is not None
+            app._welcome.refresh_info()
+            for _ in range(5):
+                await pilot.pause()
+            assert (
+                app._welcome._info.notice == warning
+            ), "withdrawing the toast cost the splash notice it was raised for"
+            rendered = "\n".join(strip.text for strip in app.screen._compositor.render_strips())
+            assert warning in rendered, "the notice is on the app but not on the painted splash"

--- a/tests/unit/tui/test_sidebar_swap_reset.py
+++ b/tests/unit/tui/test_sidebar_swap_reset.py
@@ -265,3 +265,161 @@ async def test_sidebar_commit_clears_the_previous_conversations_cost_and_context
             await _switch(app, pilot, busy)
             assert app._status._cost == "$12.35", "restored spend was zeroed by the reset"
             assert app._status._context_tokens == 98_765
+
+
+@pytest.mark.asyncio
+async def test_a_parked_conversation_keeps_its_splash_notice():
+    """A sidebar round trip must not discard the setup warning on the splash.
+
+    `_splash_notice` describes ONE conversation's empty state — the `/login`,
+    unknown-provider and no-model-set warnings. `/new`, `/resume` and `/reload`
+    RETIRE the conversation they leave, so clearing it there is right; the
+    sidebar PARKS one and comes back to it, and nothing on that path puts the
+    notice back.
+
+    The loss was delayed rather than immediate, which is what made it worth a
+    guard: `WelcomeView` reads the notice through a closure, so the row survives
+    the switch frame and vanishes at the next `refresh_info()` — the 0.25 s poll
+    or any model change. Asserting the ATTRIBUTE rather than the painted row is
+    therefore deliberate: it is the state the next repaint reads, and it fails
+    at the moment of the loss instead of a quarter-second later.
+    """
+    home = SidebarRemote("home-session")
+    busy = SidebarRemote(
+        "busy-session",
+        history=[_message("user", "a question"), _message("assistant", "an answer")],
+    )
+
+    app = OperatorApp(lambda: _factory(home))
+    with patch("local_operator.session.remote.RemoteSession", SidebarRemote):
+        async with app.run_test(size=(100, 30)) as pilot:
+            for _ in range(20):
+                await pilot.pause()
+
+            warning = "/login openai to get started - no provider configured."
+            app._announce_on_splash(warning, "warning")
+            assert app._splash_notice == warning
+
+            await _switch(app, pilot, busy)
+            await _switch(app, pilot, home)
+
+            assert app._splash_notice == warning, (
+                "the parked conversation's setup warning was discarded by a " "sidebar round trip"
+            )
+            # And it must survive the repaint that exposes the loss. The splash
+            # reads its facts through a closure, so a cleared notice leaves the
+            # already-drawn row standing and takes it away at the next poll —
+            # this is that poll, driven explicitly rather than waited for.
+            assert app._welcome is not None
+            app._welcome.refresh_info()
+            for _ in range(5):
+                await pilot.pause()
+            assert (
+                app._welcome._info.notice == warning
+            ), "the warning survived on the app but the splash repainted without it"
+
+
+@pytest.mark.asyncio
+async def test_a_parked_conversation_keeps_its_dock_density():
+    """A `ctrl+g` set on the conversation the user returns to must survive.
+
+    `reset_density()` exists for a swap that retires: "a `ctrl+g` pressed
+    against the old children does not pin the new ones" (#525 design §2). On
+    the sidebar path the old children ARE the ones being returned to, and the
+    re-seed happens at the panel's next non-empty sync — so the user's explicit
+    choice was discarded by the act of glancing elsewhere.
+    """
+    home = SidebarRemote("home-session")
+    busy = SidebarRemote(
+        "busy-session",
+        history=[_message("user", "a question"), _message("assistant", "an answer")],
+    )
+
+    app = OperatorApp(lambda: _factory(home))
+    with patch("local_operator.session.remote.RemoteSession", SidebarRemote):
+        async with app.run_test(size=(100, 30)) as pilot:
+            for _ in range(20):
+                await pilot.pause()
+
+            panel = app._subagent_panel
+            assert panel is not None
+            # The state a `ctrl+g` leaves behind: seeded, and pinned by the user.
+            panel._density_seeded = True
+            panel._user_density = True
+
+            await _switch(app, pilot, busy)
+            await _switch(app, pilot, home)
+
+            assert panel._user_density, "the user's ctrl+g was discarded by a sidebar switch"
+            assert panel._density_seeded, "the dock density was re-seeded on a park"
+
+
+@pytest.mark.asyncio
+async def test_returning_to_an_empty_conversation_shows_the_splash_under_a_notice():
+    """The operator's reported flow, end to end, with an infrastructure notice.
+
+    `/new` → click a session with history → click back. The returned-to
+    conversation is the same untouched `/new` it was, so it must land on the
+    splash — but `_adopt_session` re-emits infrastructure notices (build skew, a
+    failed MCP server) on EVERY swap, and the commit path asked
+    `bool(view.blocks())`, which counts them. That is the wrong question: those
+    blocks are appended with `ends_empty_state=False` precisely so they land
+    UNDER the splash rather than retiring it, and a user on a skewed build or
+    with one broken MCP server therefore never got an empty state back.
+
+    The notice is raised through the production `_system_notice`, the same call
+    `_check_build_skew` makes, so this pins the predicate and not a fixture.
+    """
+    fresh = SidebarRemote("fresh-session")
+    home = SidebarRemote("home-session")
+    busy = SidebarRemote(
+        "busy-session",
+        history=[_message("user", "a question"), _message("assistant", "an answer")],
+        cost=12.3456,
+        context=98_765,
+    )
+
+    async def resume_factory(_resume_id):
+        return fresh
+
+    app = OperatorApp(lambda: _factory(home), resume_factory=resume_factory)
+    with patch("local_operator.session.remote.RemoteSession", SidebarRemote):
+        async with app.run_test(size=(100, 30)) as pilot:
+            for _ in range(20):
+                await pilot.pause()
+
+            app._run_slash_command("/new")
+            for _ in range(80):
+                await pilot.pause()
+            await asyncio.sleep(0.4)
+            for _ in range(40):
+                await pilot.pause()
+
+            # The infrastructure notice the swap re-emits, posted the way the
+            # product posts it. The splash stays up under it — that is the
+            # documented contract of `ends_empty_state=False`, asserted here so
+            # step 4 is compared against a step 2 that is known to be right.
+            app._system_notice("this session is running an older version than this window", "note")
+            for _ in range(10):
+                await pilot.pause()
+            assert app._transcript_view().blocks(), "the notice did not reach the transcript"
+            assert app._welcome_visible is True, "the notice retired the splash on `/new` itself"
+
+            await _switch(app, pilot, busy)
+            assert app._welcome_visible is not True
+
+            await _switch(app, pilot, fresh)
+            for _ in range(20):
+                await pilot.pause()
+
+            view = app._transcript_view()
+            # The precondition that made the old predicate wrong: the returned-to
+            # transcript is NOT empty, it just has not started a conversation.
+            assert view.blocks(), "no notice on the return leg — the flow is not reproduced"
+            assert not view.conversation_started()
+            welcome = app._welcome
+            assert welcome is not None, "no splash after returning to the `/new` conversation"
+            assert welcome in list(view.children), "the splash is not in the visible transcript"
+            assert welcome.display, "the splash is mounted but hidden"
+            assert app._welcome_visible is True
+            assert app.screen.has_class("boot")


### PR DESCRIPTION
## Summary

Two `/new` regressions reported by the operator, both introduced by the session sidebar (#694, merged as `bf7020399`, released in v0.51.0). Both are reachable **only through a sidebar switch** — plain `/new` was never broken, which is why they survived the original round and why the repros below drive `_prepare_sidebar_session` / `_commit_sidebar_session` rather than the command.

> 1. If starting from a resumed conversation, the splash is not appearing despite there being no messages
> 2. If moving to /new and clicking another session from the sidebar and then going back to my unnamed conversation, it doesn't clear the context window, cost, etc from the previous session

`Release: patch — /new shows its splash again and no longer inherits the previous conversation's cost and context after a sidebar switch.`

No version bump; `pyproject.toml` stays at `0.51.0`.

## Bug 1 — the splash widget did not exist after a sidebar switch

The splash is composed **exactly once**, inside the original `TranscriptView`, and cached at mount (`self._welcome = self.query_one(WelcomeView)`). Sidebar navigation builds a **brand new `TranscriptView` per target** and mounts a `WelcomeView` into it only `if not replay.blocks` — so a target with history gets none, and `_apply_sidebar_presentation` then sets `self._welcome = presentation.welcome`, i.e. `None`.

`/new` → `_reload_session()` → `_set_welcome_visible(True)` then flipped the flag and applied the boot layout, but its `if self._welcome is not None:` guard had nothing to show. The boot layout over an empty transcript with no splash content is exactly the reported frame.

**Fix.** `_set_welcome_visible` materialises the empty state on the view that is actually on screen, via `_ensure_welcome_view()`. That keeps the existing invariant — `_set_welcome_visible` remains the ONE condition driving the splash — rather than adding a second "should the splash show" rule that could disagree with it. The helper adopts an existing `WelcomeView` child when there is one (so no splash accumulates per switch), replaces a stale handle pointing at a parked view, and constructs with the same `session_welcome_info(...)` closure as `compose` so the info rows are identical.

## Bug 2 — the band's session-scoped segments were never reset on a sidebar commit

`_reset_ledger_for_swap` is the discipline "the ledger is only ever as old as the session on screen"; `/new`, `/resume` and `/reload` all go through it. `_commit_sidebar_session` went through none of it, relying on `_adopt_session` → `_apply_frontend_state` to repaint the band from the incoming session.

That repaint is **leave-alone on absent values**, in exactly the two segments the operator named:

- `FrontendState.cumulative_cost` returns `None` when `cumulative_parent_cost is None and children is None` — precisely a fresh `/new` session that has never had a turn — and `_apply_frontend_state` only assigns `if cost is not None`.
- `context_tokens` defaults to `None`, and `StatusLine.update` is explicitly leave-alone on `None`.

So sidebar → busy session → back to the fresh conversation left the busy session's figures painted, with nothing arriving to correct them.

**Fix.** The band half is split out of `_reset_ledger_for_swap` as `_reset_band_for_swap` and called from the sidebar commit. The **transcript teardown stays where it is**: the sidebar substitutes a prepared presentation rather than rebuilding one, so `clear_blocks()`, the steer notices, tool cards, fork receipts and resume state must not be torn down. `_reset_ledger_for_swap` is behaviour-identical for its existing callers — it now ends by calling the extracted half.

Traps handled, each commented at the site:

- **Ordering.** The reset runs immediately **before** `_adopt_session`, never after, so the incoming snapshot is what puts a real figure back and a session with genuine spend lands on its own number rather than on zero. Reversing the two lines makes the over-fix guard in the tests fail (verified — see below).
- **Per-session spend is not zeroed.** `_total_cost`, `_subagent_costs`, `_spend_is_floor` and the naming bookkeeping are properties of `self._interaction` and therefore already per-conversation; `_adopt_session` swaps the interaction on the sidebar path. Zeroing them in the band half would blank the **outgoing** conversation's real spend, which — unlike a reload's — is parked and returned to rather than retired. `_reconcile_reload`'s "same conversation restores carried spend" path is untouched.
- **`_splash_notice` and the subagent panel density** are in the band half deliberately: both are app-scoped (they live on the app and on the dock, not in the transcript), and both describe the conversation being left — a notice left standing would open the next `/new` on the previous session's quota warning.

## Reproduction — before and after

Headless, through the real prepare/commit pair, isolated `HOME` + `LOCAL_OPERATOR_CONFIG_DIR`, every `CMUX_*` scrubbed.

**On `origin/main` (`8738b9495`):**

```
=== BUG 1: /new after a sidebar switch ===
_welcome widget     : None
splash on screen    : False
EXPECT splash on screen == True -> FAIL (bug 1 reproduced)

=== BUG 2: back on the untouched /new conversation ===
band cost/context: ("'$12.35'", 98765)
EXPECT empty cost + zero context -> FAIL (bug 2 reproduced)
```

**On this branch:**

```
=== BUG 1: /new after a sidebar switch ===
_welcome widget     : WelcomeView(id='welcome')
splash on screen    : True
view children       : ['WelcomeView', 'NoticeBlock']
EXPECT splash on screen == True -> PASS

=== BUG 2: back on the untouched /new conversation ===
band cost/context: ("''", 0)
EXPECT empty cost + zero context -> PASS

=== GUARD: back on the busy session, spend must be RESTORED ===
band cost/context: ("'$12.35'", 98765)
EXPECT $12.35 / 98765 -> PASS
```

## Regression tests, and proof they can still fail

`tests/unit/tui/test_sidebar_swap_reset.py` — 2 tests, driving the production prepare/commit pair (only the on-disk owner lease is stubbed). Each was verified to go red on the exact reintroduced defect, then reverted:

| Defect reintroduced | Result |
|---|---|
| `_set_welcome_visible` no longer materialises the empty state | `FAILED … assert None is not None` — "the app holds no splash after a sidebar switch" |
| `_reset_band_for_swap()` removed from the commit path | `FAILED … AssertionError: the previous conversation's cost is still painted; assert '$12.35' == ''` |
| Reset moved to **after** `_adopt_session` (ordering trap) | `FAILED … assert '' == '$12.35'` — the over-fix guard catches it |

## Visual validation

Rendered before/after frames at 100x30, captured with `scripts/visual_capture.save_capture` (`isolate_capture()` before app imports), real `OperatorApp` with its production stylesheet. Before-frames taken from a throwaway detached worktree at `8738b9495`, since removed. A reusable capture script is added at `scripts/sidebar_new_shot.py`; the frames themselves are attached to this PR and **not** committed, per AGENTS.md.

Geometry behind the pixels — no scrollbar appears and virtual size never exceeds actual size in any of the four frames:

| frame | `_welcome` | `welcome_visible` | boot class | cost | context | screen / virtual | scrollbar |
|---|---|---|---|---|---|---|---|
| before, `/new` after switch | `None` | True | True | `''` | 0 | (98,28) / (98,28) | False |
| after, `/new` after switch | `WelcomeView` | True | True | `''` | 0 | (98,28) / (98,28) | False |
| before, band on return | — | False | False | `'$12.35'` | 98765 | (98,28) / (98,28) | False |
| after, band on return | — | False | False | `''` | 0 | (98,28) / (98,28) | False |

The before-splash frame shows the boot layout applied over a blank screen; the after-splash frame shows the full splash with its version, model, cwd and command rows. The before-band frame shows `98.8k/—` and `$12.35` on a conversation with no messages; the after-band frame shows both segments empty.

## Gates

Run over the whole tree from the worktree's own venv, exactly as CI (`python -m` / `uvx`, never the console scripts).

| Command | Result |
|---|---|
| `.venv/bin/python -m flake8 .` | PASS (rc=0) |
| `uvx --from black==26.1.0 black --check .` | PASS — 1012 files unchanged |
| `uvx isort==5.13.2 --check .` | PASS |
| `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | **0 errors, 0 warnings, 0 informations** |
| `.venv/bin/python -m pytest tests/unit -q` | **15201 passed, 18 skipped, 1 failed** in 43:01 — see below |
| `pytest tests/unit/tui/test_sidebar_swap_reset.py` + sidebar/navigation/source-state/boot-layout neighbours | **107 passed** |

The single full-suite failure is `tests/unit/tui/test_ask_picker.py::test_ctrl_e_is_live_at_the_sizes_the_user_reported`, an ask-picker footer assertion untouched by this diff. Classified rather than assumed: it passes **3/3 in isolation** and **122/122 when its own file is run** on this branch, and the whole file also passes on the base commit. It surfaced only under full-suite xdist contention while the machine was at load average 300+ from sibling worktrees. Not introduced here, and not silenced here.

One earlier full-suite run was discarded outright rather than reported: the host filled to 100% disk mid-run and produced 8625 `FileNotFoundError`/`OSError` pytest-tmpdir errors. That run was void; the table above is the clean re-run after space was reclaimed.

## Not addressed

- The prepare path still mounts a `WelcomeView` only `if not replay.blocks`. Left as-is deliberately: the on-demand path now covers the case it misses, and making preparation always mount a hidden splash would pay a widget per prepared view (including speculative prewarms that are never committed) to solve a problem the commit-time path already solves. Noted for the reviewer as the alternative that was weighed.
- The ask-picker flake above is reported, not fixed — it is outside this slice.
