### PR TITLE
fix(tui): make a resumed transcript scrollable and stop page-mount jitter

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -786,6 +786,22 @@ RESUME_PAGE_MESSAGES = 60
 #: sees nothing arrive for a frame, and concludes the conversation starts there.
 RESUME_PAGE_TRIGGER_ROWS = 4
 
+#: How many older pages the initial resume may mount to make the first frame
+#: SCROLLABLE. A hard cap, not a target: the fill loop below stops the moment
+#: the content exceeds the viewport, and this only bounds the pathological
+#: case (a history of rows that each render to nothing measurable) so it
+#: cannot spin. Three pages is 180 messages on top of the initial bound, which
+#: is still inside the render budget's measured envelope.
+RESUME_FILL_MAX_PAGES = 3
+
+#: Rows of content beyond the viewport the initial fill aims for. A frame that
+#: is scrollable by one row technically has a scrollbar, but the reader has
+#: nothing to travel through and the page-back trigger
+#: (:data:`RESUME_PAGE_TRIGGER_ROWS`) sits at row 4 — so the fill would leave a
+#: transcript whose trigger is unreachable in practice. One trigger zone plus a
+#: margin is the smallest overshoot that makes "scroll up" a real gesture.
+RESUME_FILL_SLACK_ROWS = RESUME_PAGE_TRIGGER_ROWS + 4
+
 #: The row that stands in for the un-rendered head of a resumed conversation.
 #: It exists because the failure mode of a display bound is a user believing
 #: history was LOST — so the transcript says, in its own voice, that the older
@@ -796,6 +812,14 @@ RESUME_OLDER_NOTICE = "older messages above — scroll up to load"
 #: of the transcript states the conversation's real beginning rather than
 #: leaving a promise of more that will never arrive.
 RESUME_START_NOTICE = "start of conversation"
+
+#: Shown when older messages exist but this frame cannot be scrolled to reach
+#: them — the fill hit its cap, or the remaining rows measure to no height.
+#: Deliberately NOT "start of conversation" (which would be false) and not the
+#: "scroll up to load" instruction (which the reader cannot carry out): it
+#: states what is true, and names the key that still works, because `ctrl+home`
+#: reaches the page-back path without needing an offset to travel.
+RESUME_UNREACHABLE_NOTICE = "older messages above — press ctrl+home to load"
 
 
 def _resume_tail_start(history: list[Any], bound: int) -> int:
@@ -808,16 +832,39 @@ def _resume_tail_start(history: list[Any], bound: int) -> int:
     reply with no question, which reads as a broken resume rather than a
     bounded one.
 
-    Walk back from the naive cut to the nearest user (or wake/peer) row so the
-    viewport always opens on a turn boundary. The walk is bounded by ``bound``
-    itself: if the last ``bound`` messages contain no such row, the naive cut
-    stands, because inventing an earlier start would spend the budget we just
-    measured.
+    So the cut is snapped to a turn boundary — a user, wake or peer row. The
+    direction of that snap is the whole point, and it is BACKWARD, toward
+    older messages.
+
+    Snapping FORWARD is what this function used to do, and it silently
+    inverted the bound from a floor into a ceiling: the nearest boundary
+    *after* the naive cut can be arbitrarily far down the conversation, so the
+    frame rendered arbitrarily FEWER than ``bound`` messages. On the shape
+    this harness produces most — one prompt, then a long run of assistant and
+    tool rows, then a short recent follow-up — a 404-message history rendered
+    **4 blocks**. That is not merely a short frame: the content then fits
+    inside the viewport, Textual shows no scrollbar and pins ``scroll_y`` at
+    0, and the page-back trigger (which only fires on a scroll INTO the top
+    rows) can never be reached. The deferred head becomes permanently
+    unreachable while the transcript's first row promises the reader it is
+    one scroll away.
+
+    Walking backward cannot do that: the result is never later than the naive
+    cut, so the frame is always at least ``bound`` messages.
+
+    The walk is bounded by ``bound`` again, so the frame is at most ``2 *
+    bound`` messages. That ceiling is the render budget
+    (:data:`RESUME_RENDER_MESSAGES`) doing its job — 160 messages measured at
+    251 ms against 139 ms for 80 and 1022 ms for a whole 716-message session,
+    so overshooting by up to one budget stays far from the cost this bound
+    exists to remove. A conversation with no boundary within that window is
+    one long turn; the naive cut stands, and it still renders ``bound``.
     """
     naive = max(0, len(history) - bound)
     if naive == 0:
         return 0
-    for index in range(naive, len(history)):
+    floor = max(0, naive - bound)
+    for index in range(naive, floor - 1, -1):
         message = history[index]
         role = getattr(message, "role", None)
         custom = getattr(message, "custom_type", None)
@@ -5830,6 +5877,132 @@ class OperatorApp(App[None]):
         # first arrival at the top owes a page (see `_resume_in_zone`).
         self._resume_in_zone = True
         self._project_settled_rows(history, bound=RESUME_RENDER_MESSAGES)
+        # A message budget is a PROXY for height, and a poor one. Whether the
+        # first frame can be scrolled is a question about ROWS, and only the
+        # laid-out widgets can answer it — so ask them, once the mount has
+        # settled, and top up if the answer is "no".
+        self._transcript_view().call_after_refresh(self._fill_resume_until_scrollable)
+
+    def _fill_resume_until_scrollable(self, _attempt: int = 0) -> None:
+        """Mount older pages until the first resume frame is actually scrollable.
+
+        The render bound is counted in MESSAGES, but "can the reader scroll up
+        to reach the rest" is decided in ROWS: 80 one-line messages in a 60-row
+        terminal still fit inside the viewport, and a transcript whose content
+        fits has no scrollbar and no offset to travel. ``_check_resume_page``
+        only ever fires on a scroll INTO the trigger zone, so on such a frame
+        the deferred head and the server's ``history_before_token`` pages are
+        unreachable forever while the head notice tells the reader to scroll up
+        for them.
+
+        So the geometry is measured after the mount settles, and while the
+        content does not exceed the viewport AND more history exists, the next
+        older page is mounted. Recursive-by-refresh rather than a loop: each
+        page's blocks only author their real heights on a later layout pass
+        (``_set_authored_height``), so measuring again in the same frame would
+        read the extent this mount has not finished growing.
+
+        NOT A GESTURE. This runs outside the page-back latch entirely: it must
+        neither arm ``_resume_in_zone`` (which would hand a free page to the
+        reader's first real scroll) nor consume it (which would swallow that
+        scroll's legitimate page). It cooperates with ``_resume_paging`` only
+        as a mutex — if a genuine gesture is mid-mount, this stands down and
+        lets the gesture own the frame, because a reader who is already
+        scrolling does not need the fill.
+
+        ``RESUME_FILL_MAX_PAGES`` bounds it hard. The loop's own exit condition
+        is the geometry, which terminates on any real history; the cap is for
+        the case where it cannot — a head of rows that measure to zero height
+        would otherwise mount the entire conversation one page at a time,
+        which is the unbounded render cost the budget exists to remove.
+        """
+        if _attempt >= RESUME_FILL_MAX_PAGES:
+            self._reconcile_head_notice()
+            return
+        view = self._transcript_view()
+        if view.parent is None:
+            return
+        # A real gesture owns the mount seam right now. Stand down: the reader
+        # is scrolling, which is the condition this fill exists to make possible.
+        if self._resume_paging:
+            return
+        # Content already exceeds the viewport by enough for the trigger zone
+        # to be reachable — the frame is scrollable and the fill is done.
+        viewport = view.container_size.height or view.size.height
+        if not viewport:
+            return
+        if view.virtual_size.height > viewport + RESUME_FILL_SLACK_ROWS:
+            # Scrollable, so "scroll up to load" is a gesture the reader can
+            # actually perform. The notice keeps its promise.
+            return
+
+        session = self._session
+        if self._resume_pending_head:
+            self._mount_older_resume_page()
+            # Re-measure after the page has settled, not now: see the docstring.
+            view.call_after_refresh(self._fill_resume_until_scrollable, _attempt + 1)
+            return
+        if session is not None and getattr(session, "history_before_token", None):
+            # The remote/server-paged case: nothing is held locally, but the
+            # conversation continues on the server. Same gate, so this cannot
+            # race a gesture's own fetch.
+            #
+            # The continuation is chained to the WORKER, not to the next
+            # refresh: the fetch is a network round trip, so a refresh-scheduled
+            # re-measure would run while it is still in flight, see the gate
+            # held and stand down — leaving the fill one page short on exactly
+            # the sessions (remote, long) it is most needed for.
+            self._resume_paging = True
+
+            async def fetch_then_refill() -> None:
+                await self._fetch_older_display_page(self._interaction)
+                if self._transcript_view() is view:
+                    self._fill_resume_until_scrollable(_attempt + 1)
+
+            self.run_worker(
+                fetch_then_refill(),
+                group=self._interaction.worker_group("history-page"),
+            )
+            return
+        # No more history in either direction. The frame is as tall as the
+        # conversation allows.
+        self._reconcile_head_notice()
+
+    def _reconcile_head_notice(self) -> None:
+        """Never promise history the reader cannot actually reach.
+
+        "older messages above — scroll up to load" is an INSTRUCTION, and it is
+        only honest while scrolling up can carry it out. Two ways it can stop
+        being true, and both must be caught here because neither goes through
+        ``_mount_older_resume_page``'s own exhaustion branch:
+
+        * the head really is exhausted (the fill drained it), and the notice
+          should now state where the conversation begins rather than point at
+          nothing;
+        * the head is NOT exhausted but the transcript still does not exceed
+          its viewport — the fill hit its cap, or the remaining rows measure to
+          nothing. There is no offset to travel and no trigger to reach, so the
+          instruction cannot be followed. Saying "start of conversation" would
+          be a lie in the other direction, so the notice is restated to name
+          what is actually true: more exists, and it is not reachable by
+          scrolling here.
+
+        Idempotent, and safe to call from every fill exit.
+        """
+        notice = self._resume_head_notice
+        if notice is None:
+            return
+        view = self._transcript_view()
+        viewport = view.container_size.height or view.size.height
+        scrollable = bool(viewport) and view.virtual_size.height > viewport
+        session = self._session
+        more = bool(self._resume_pending_head) or bool(
+            session is not None and getattr(session, "history_before_token", None)
+        )
+        if not more:
+            notice.restate(RESUME_START_NOTICE, "info")
+        elif not scrollable:
+            notice.restate(RESUME_UNREACHABLE_NOTICE, "info")
 
     @staticmethod
     def _mark_pending_tool_rows(blocks: list[Any], session: Any) -> None:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2265,6 +2265,17 @@ class OperatorApp(App[None]):
         #: unbounded render cost this bound exists to remove. Cleared by the
         #: settle callback `insert_blocks` schedules, never synchronously.
         self._resume_paging = False
+        #: Whether the INITIAL fill still has an attempt to make. Distinct from
+        #: `_resume_paging`, which is a mutex over the mount seam: this asks
+        #: "is the geometry on screen still provisional?", and it stays set
+        #: across the gaps between attempts where the gate is open.
+        #:
+        #: Read only by `_reconcile_head_notice`, to withhold the pessimistic
+        #: "select to load" copy while the fill is still working. Stating it
+        #: from intermediate geometry made the row round-trip its own copy on
+        #: painted frames — `scroll up` -> `select` -> `scroll up` — which
+        #: reads as the notice changing its mind (review round 2, R6).
+        self._resume_fill_active = False
         #: SINGLE-FLIGHT guard for the deferred page check: while set, a check
         #: is already scheduled and `_transcript_scrolled` must not queue a
         #: second. See that method for why unbounded requeues were a cascade.
@@ -3305,6 +3316,7 @@ class OperatorApp(App[None]):
         self._welcome_visible = None
         # Gesture tasks belong to the abandoned viewport, not its history.
         self._resume_paging = False
+        self._resume_fill_active = False
         self._resume_check_pending = False
         self._resume_in_zone = False
         self._stop_offered_at = None
@@ -4062,6 +4074,7 @@ class OperatorApp(App[None]):
             self._welcome.set_navigation_visible(False)
         old_view.set_on_user_scroll(None)
         old_view.set_on_tail_requested(None)
+        old_view.set_on_extent_changed(None)
         old_view.set_on_clear(None)
         old_view.styles.layer = "session-cache"
         old_view.styles.overlay = "screen"
@@ -4081,6 +4094,7 @@ class OperatorApp(App[None]):
         incoming.replay.view.set_on_clear(self._on_transcript_cleared)
         incoming.replay.view.set_on_user_scroll(self._transcript_scrolled)
         incoming.replay.view.set_on_tail_requested(self._jump_newer_resume_tail)
+        incoming.replay.view.set_on_extent_changed(self._transcript_extent_changed)
         self._swapping_session = True
         try:
             factory = self._resume_factory
@@ -4667,6 +4681,12 @@ class OperatorApp(App[None]):
         # rest-guard in `_check_resume_page` is what collapses the many
         # firings of one animated gesture into ONE page (M1/U1).
         transcript.set_on_user_scroll(self._transcript_scrolled)
+        # The head notice describes GEOMETRY, and geometry changes for reasons
+        # that are not gestures and not mounts — a terminal resize, a live turn
+        # lengthening the content. Neither passes through a fill exit or a page
+        # settle, which is why the copy went stale on resize while every
+        # activation path was correct (design review round 2, D1; QA Q5).
+        transcript.set_on_extent_changed(self._transcript_extent_changed)
         # Cached: every appended block asks the splash to hide, and that path
         # should not pay for a DOM query per block.
         self._welcome = self.query_one(WelcomeView)
@@ -5905,6 +5925,12 @@ class OperatorApp(App[None]):
         # first frame can be scrolled is a question about ROWS, and only the
         # laid-out widgets can answer it — so ask them, once the mount has
         # settled, and top up if the answer is "no".
+        #
+        # Marked active BEFORE the first attempt is scheduled, not inside it:
+        # the frames between this mount and that callback are the earliest
+        # ones a reader sees, and they are exactly as provisional as the ones
+        # between attempts.
+        self._resume_fill_active = True
         self._transcript_view().call_after_refresh(self._fill_resume_until_scrollable)
 
     def _fill_resume_until_scrollable(self, _attempt: int = 0) -> None:
@@ -5964,11 +5990,17 @@ class OperatorApp(App[None]):
         would otherwise mount the entire conversation one page at a time,
         which is the unbounded render cost the budget exists to remove.
         """
+        # EVERY exit below is terminal for the fill, so each clears the
+        # provisional-geometry flag before reconciling: the notice is entitled
+        # to state the pessimistic case once the fill has actually given up,
+        # and only then (R6).
         if _attempt >= RESUME_FILL_MAX_PAGES:
+            self._resume_fill_active = False
             self._reconcile_head_notice()
             return
         view = self._transcript_view()
         if view.parent is None:
+            self._resume_fill_active = False
             return
         # A real gesture owns the mount seam right now. Stand down: the reader
         # is scrolling, which is the condition this fill exists to make
@@ -5977,12 +6009,14 @@ class OperatorApp(App[None]):
         # reconcile is how the head notice came to promise history the frame
         # could not reach.
         if self._resume_paging:
+            self._resume_fill_active = False
             self._reconcile_head_notice()
             return
         # Content already exceeds the viewport by enough for the trigger zone
         # to be reachable — the frame is scrollable and the fill is done.
         viewport = view.container_size.height or view.size.height
         if not viewport:
+            self._resume_fill_active = False
             return
         if view.virtual_size.height > viewport + RESUME_FILL_SLACK_ROWS:
             # Scrollable, so "scroll up to load" is a gesture the reader can
@@ -5990,6 +6024,7 @@ class OperatorApp(App[None]):
             # anyway, because this is also the exit taken when a page mounted
             # by an earlier attempt exhausted the head, and the notice would
             # otherwise still be promising more.
+            self._resume_fill_active = False
             self._reconcile_head_notice()
             return
 
@@ -6045,6 +6080,15 @@ class OperatorApp(App[None]):
                     # fetch's own mount must not spend the reader's latch.
                     self._resume_in_zone = armed
                     self._fill_resume_until_scrollable(_attempt + 1)
+                elif self._is_current(source):
+                    # The reader moved on mid-fetch, so this fill is abandoned
+                    # and no later exit will clear the flag. Cleared here so a
+                    # conversation cannot be left permanently "filling", which
+                    # would suppress the unreachable copy forever. Guarded on
+                    # `_is_current` so an abandoned fetch does not reach into
+                    # the state of the conversation the reader moved TO, which
+                    # is running its own fill.
+                    self._resume_fill_active = False
 
             self.run_worker(
                 fetch_then_refill(),
@@ -6053,6 +6097,7 @@ class OperatorApp(App[None]):
             return
         # No more history in either direction. The frame is as tall as the
         # conversation allows.
+        self._resume_fill_active = False
         self._reconcile_head_notice()
 
     def _reconcile_head_notice(self) -> None:
@@ -6084,7 +6129,15 @@ class OperatorApp(App[None]):
         of travel and the top row still said "press ctrl+home to load". That
         is the failure `NoticeBlock.restate`'s own docstring is written about.
 
-        Idempotent, and safe to call from every fill exit and every settle.
+        Idempotent, and safe to call from every fill exit, every settle and
+        every extent change. Cheaply idempotent: the restate is SKIPPED when
+        the copy is already the one this geometry implies. ``restate`` re-runs
+        the build, re-measures and asks the container to re-decide the gaps
+        around the row, and 1-3 of the calls per resume were no-ops asking for
+        all of that to reach the text already on screen (review round 2, R8).
+        That was merely wasteful while the only callers were fill exits; it is
+        load-bearing now that the extent hook calls this on every geometry
+        change, which is once per resize frame while a window is being dragged.
         """
         notice = self._resume_head_notice
         if notice is None:
@@ -6097,7 +6150,18 @@ class OperatorApp(App[None]):
             session is not None and getattr(session, "history_before_token", None)
         )
         if not more:
-            notice.restate(RESUME_START_NOTICE, "info")
+            self._restate_head_notice(notice, RESUME_START_NOTICE, "info")
+        elif not scrollable and self._resume_fill_active:
+            # A fill attempt is still in flight, and the frame it is about to
+            # produce is the one worth describing. Stating "unreachable" from
+            # intermediate geometry the fill is on its way to invalidating made
+            # the row ROUND-TRIP its copy on painted frames — `scroll up` ->
+            # `select` -> `scroll up` at 120x300, which a reader sees as the
+            # notice changing its mind and changing it back (review round 2,
+            # R6). The pessimistic state is worth stating once the fill has
+            # actually given up, and the fill's own exits do exactly that:
+            # every one of them clears this flag before reconciling.
+            return
         elif not scrollable:
             # `note`, not `info`: this is the answer to "where did my history
             # go", which is the role `NoticeBlock` reserves `note` for, and it
@@ -6105,12 +6169,50 @@ class OperatorApp(App[None]):
             # on. `info` maps to `dim`, which measures 3.77:1 on the light
             # theme — below the 4.5:1 AA floor — so the row got quieter
             # exactly as it got more important.
-            notice.restate(RESUME_UNREACHABLE_NOTICE, "note")
+            self._restate_head_notice(notice, RESUME_UNREACHABLE_NOTICE, "note")
         else:
             # The way BACK. More history exists and the frame can now reach it,
             # so the instruction is followable again and the notice returns to
             # stating the promise it can keep.
-            notice.restate(RESUME_OLDER_NOTICE, "note")
+            self._restate_head_notice(notice, RESUME_OLDER_NOTICE, "note")
+
+    @staticmethod
+    def _restate_head_notice(notice: NoticeBlock, text: str, kind: NoticeKind) -> None:
+        """Restate the head notice, and keep its INTERACTIVITY honest too.
+
+        Two jobs, both about not lying, which is why they share one funnel
+        rather than sitting at each of the three call sites above.
+
+        First, restating to the text already on the row is skipped. See
+        :meth:`_reconcile_head_notice` for why that matters now (R8).
+
+        Second, the row stops being a control when it stops having an action.
+        Once the head is exhausted the copy becomes ``start of conversation``
+        and the handler correctly returns early \u2014 but the row went on carrying
+        ``interactive-notice``, staying focusable, sitting two Tabs into the
+        focus chain and painting the full-width focus band, so Enter on it was
+        a guess whose answer was "nothing happens" (design review round 2, D7).
+        The tail twin solves this by REMOVING itself when its direction is
+        exhausted; the head cannot, because removing the first row shifts every
+        row below it and undoes the anchor an insert just held. So it keeps its
+        position and drops the affordances instead.
+
+        Reversible, not a latch, for the same reason the copy is: the head is
+        only empty until a remote page arrives or the reader switches
+        conversations, and a row that permanently stopped being a control after
+        one transient exhaustion would be the D1 defect wearing different
+        clothes.
+        """
+        if notice.text() != text:
+            notice.restate(text, kind)
+        # Typed as the base `NoticeBlock` because that is what the app holds:
+        # a reduced presentation can seat a plain notice here. Only the control
+        # has interactivity to correct, and only it needs this.
+        if isinstance(notice, OlderHistoryNotice):
+            # Set unconditionally: `restate` may have been skipped as a no-op
+            # while the interactivity still needs correcting (a reader who
+            # activated the exhausted row, then received a remote page).
+            notice.set_interactive(text != RESUME_START_NOTICE)
 
     @staticmethod
     def _mark_pending_tool_rows(blocks: list[Any], session: Any) -> None:
@@ -6161,9 +6263,17 @@ class OperatorApp(App[None]):
             if self._resume_paging:
                 return
             self._resume_paging = True
+            # Pinned once and passed through, for the reason the fill's remote
+            # branch states at length: `self._interaction` read twice can be
+            # two different conversations if the reader switches between the
+            # reads. Narrower here than in the fill — nothing awaits between
+            # them — but the two twins running the same fetch through the same
+            # worker group must not disagree about the rule, or a later reader
+            # fixes whichever one they find second (review round 2, R7).
+            source = self._interaction
             self.run_worker(
-                self._fetch_older_display_page(self._interaction),
-                group=self._interaction.worker_group("history-page"),
+                self._fetch_older_display_page(source),
+                group=source.worker_group("history-page"),
             )
 
     def _jump_newer_resume_tail(self) -> None:
@@ -6259,6 +6369,37 @@ class OperatorApp(App[None]):
         finally:
             if self._is_current(source):
                 self._resume_paging = False
+
+    def _transcript_extent_changed(self) -> None:
+        """Re-decide the head notice whenever the geometry it describes moves.
+
+        The head notice is decided from two terms: whether more history is
+        held, and whether this frame can reach it. Every path that changes the
+        FIRST term reconciles it already — the fill's exits and the page
+        mount's settle. Nothing was telling it about the second, because a
+        terminal resize and a live turn's appended rows change the geometry
+        without going through either. So the copy was correct on every path a
+        test drove and wrong on the one a reader takes most often: the notice
+        told a reader to scroll up in a frame with no scrollbar after the
+        window grew, and went on offering `select to load` after it shrank back
+        into a scrollable frame (design review round 2, D1; QA Q5).
+
+        Keyed on the EXTENT rather than on a resize event, which is the same
+        reasoning ``TranscriptView._size_updated`` gives for the tail anchor:
+        a rule keyed on the measurement holds for growth nobody enumerated.
+        Measured on both triggers — a resize reports one `changed` call, and
+        400 appended rows report one — so this covers the general case Q5
+        named, not just the resize instance D1 reproduced.
+
+        Cheap enough to run on every extent change: `_reconcile_head_notice`
+        returns immediately when no resume notice is mounted (the common case
+        — an ordinary session never has one), and skips the restate when the
+        copy already matches (R8), so a window drag pays two integer
+        comparisons per frame rather than a rebuild and a spacing pass.
+        """
+        if self._resume_head_notice is None:
+            return
+        self._reconcile_head_notice()
 
     def _transcript_scrolled(self, *_args: Any, continuous: bool = False) -> None:
         """Mount the next older page when the reader reaches the top.
@@ -6491,7 +6632,10 @@ class OperatorApp(App[None]):
             # statement of where the conversation begins. Restated in place
             # rather than removed: removing it would shift every row above
             # the viewport by one and undo the anchor the insert just held.
-            notice.restate(RESUME_START_NOTICE, "info")
+            # Through the shared funnel so the row also stops advertising the
+            # action it no longer has (D7) — a local exhaustion reaches here
+            # rather than through the reconcile.
+            self._restate_head_notice(notice, RESUME_START_NOTICE, "info")
 
     def _collect_resume_page_blocks(self, page: list[Any]) -> list[Any]:
         """Build the blocks for one deferred page WITHOUT mounting them.
@@ -24492,8 +24636,21 @@ class OperatorApp(App[None]):
         # resume notice that appears when the reader is already stuck. One row
         # for both ends, naming what each is FOR rather than the direction:
         # "top" is where a resumed conversation's older history is loaded from.
-        # 61 composed cells against the 74-cell ceiling this block documents.
+        # 64 composed cells against the 74-cell ceiling this block documents.
         lines.append(_key_row("ctrl+home", "jump to the transcript top; ctrl+end returns"))
+        # The second row is the KEYBOARD half of the head notice's offer, and
+        # it is here rather than in the notice for a reason both the design and
+        # UX rounds endorsed: the copy must not recite a chord, and `ctrl+home`
+        # is itself a chord (`fn+ctrl+←`) on most Mac keyboards.
+        #
+        # It says "loads" because that is the part a reader cannot guess. On a
+        # frame too tall to scroll, `select to load` is followable with a mouse
+        # in one click, while `pageup` and `home` are no-ops (there is no
+        # offset to travel) and reaching the notice by arrow traversal costs
+        # ~129 presses — so the only practical keyboard route was a key whose
+        # only documented effect was "jump", in a state where jumping does
+        # nothing visible (ux review round 2, U6). 71 composed cells.
+        lines.append(_key_more("loads older history when there is no more to scroll"))
         lines.append(_key_row("ctrl+t", "expand or collapse the todo panel"))
         # 46 cells (66 composed) against the 74-cell ceiling: names the three
         # stops so a user who only ever saw "expand/collapse" learns the panel

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -5934,6 +5934,35 @@ class OperatorApp(App[None]):
         self._transcript_view().call_after_refresh(self._fill_resume_until_scrollable)
 
     def _fill_resume_until_scrollable(self, _attempt: int = 0) -> None:
+        """Run one fill attempt, and never leave the fill flagged active if it raises.
+
+        ``_resume_fill_active`` SUPPRESSES the pessimistic "not reachable by
+        scrolling" copy while the geometry is still provisional (R6), so a flag
+        stuck ``True`` is not inert — it permanently silences the correction
+        and leaves the notice promising a gesture the frame cannot perform,
+        which is the defect this whole feature exists to remove. The attempt
+        body clears the flag at each of its terminal exits, but those are
+        statement sites: a raise between the ``True`` in ``_render_resume`` and
+        any of them skips every one (measured: ``fill_active`` stayed ``True``
+        across a subsequent resize, with the copy frozen).
+
+        Only the ABNORMAL path is cleared here. A `finally` would be wrong:
+        the two continuation branches return with the flag deliberately still
+        ``True`` because the fill is genuinely still running, and clearing it
+        there would hand the reader the pessimistic copy mid-fill.
+
+        ``_resume_paging``, the flag this one is contrasted with in the body's
+        own commentary, is protected the same way by the ``finally`` in
+        :meth:`_fetch_older_display_page`; the two siblings must not disagree
+        about who guarantees their invariant (review round 3, R10).
+        """
+        try:
+            self._fill_resume_attempt(_attempt)
+        except BaseException:
+            self._resume_fill_active = False
+            raise
+
+    def _fill_resume_attempt(self, _attempt: int) -> None:
         """Mount older pages until the first resume frame is actually scrollable.
 
         The render bound is counted in MESSAGES, but "can the reader scroll up
@@ -6208,6 +6237,14 @@ class OperatorApp(App[None]):
         # Typed as the base `NoticeBlock` because that is what the app holds:
         # a reduced presentation can seat a plain notice here. Only the control
         # has interactivity to correct, and only it needs this.
+        #
+        # This `isinstance` is the ONLY thing keeping the correction attached
+        # to the rows that need it, so a future interactive head notice that is
+        # not an `OlderHistoryNotice` would silently skip it and re-introduce
+        # the stale-affordance bug with no test failing (review round 3, R11).
+        # A new head-notice class must therefore either subclass
+        # `OlderHistoryNotice` or grow a shared `set_interactive` protocol that
+        # this branch tests for instead of a concrete type.
         if isinstance(notice, OlderHistoryNotice):
             # Set unconditionally: `restate` may have been skipped as a no-op
             # while the interactivity still needs correcting (a reader who
@@ -24652,7 +24689,7 @@ class OperatorApp(App[None]):
         # nothing visible (ux review round 2, U6). 71 composed cells.
         lines.append(_key_more("loads older history when there is no more to scroll"))
         lines.append(_key_row("ctrl+t", "expand or collapse the todo panel"))
-        # 46 cells (66 composed) against the 74-cell ceiling: names the three
+        # 67 composed cells against the 74-cell ceiling: names the three
         # stops so a user who only ever saw "expand/collapse" learns the panel
         # can now shrink to a row or go away (#525).
         lines.append(_key_row("ctrl+g", "cycle the subagent panel: full, summary, hidden"))

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -175,6 +175,7 @@ from local_operator.tui.session_navigation import SessionNavigation
 from local_operator.tui.session_presentation import (
     DraftRecoveryNotice,
     HistoryPageNotice,
+    OlderHistoryNotice,
     PreparedReplay,
     SessionPresentation,
 )
@@ -792,6 +793,15 @@ RESUME_PAGE_TRIGGER_ROWS = 4
 #: case (a history of rows that each render to nothing measurable) so it
 #: cannot spin. Three pages is 180 messages on top of the initial bound, which
 #: is still inside the render budget's measured envelope.
+#:
+#: The cap is genuinely reachable, which it was not when it was first written:
+#: the fill chained its re-measure to the next refresh while the paging gate
+#: was released a settle later, so attempt 1 always stood down and the
+#: effective cap was ONE. Measured after the chaining fix, a 401-message
+#: agentic history reaches attempt 2 at 120x300 and mounts two pages. Anything
+#: taller than roughly 600 rows still exhausts the cap and lands in
+#: :data:`RESUME_UNREACHABLE_NOTICE`, which is why that notice is a control
+#: rather than a dead end.
 RESUME_FILL_MAX_PAGES = 3
 
 #: Rows of content beyond the viewport the initial fill aims for. A frame that
@@ -805,7 +815,8 @@ RESUME_FILL_SLACK_ROWS = RESUME_PAGE_TRIGGER_ROWS + 4
 #: The row that stands in for the un-rendered head of a resumed conversation.
 #: It exists because the failure mode of a display bound is a user believing
 #: history was LOST — so the transcript says, in its own voice, that the older
-#: messages are still there and how to reach them.
+#: messages are still there and how to reach them. Scrolling up is the primary
+#: gesture; the row is also a control, so it can be clicked or activated.
 RESUME_OLDER_NOTICE = "older messages above — scroll up to load"
 
 #: Replaces the notice once every deferred message has been mounted, so the top
@@ -815,11 +826,17 @@ RESUME_START_NOTICE = "start of conversation"
 
 #: Shown when older messages exist but this frame cannot be scrolled to reach
 #: them — the fill hit its cap, or the remaining rows measure to no height.
+#: Reachable in practice only on a very tall viewport (measured: a 401-message
+#: agentic history needs ~600 rows before three filled pages still fit inside
+#: the screen), which is a large display at a small font rather than an exotic
+#: case.
+#:
 #: Deliberately NOT "start of conversation" (which would be false) and not the
-#: "scroll up to load" instruction (which the reader cannot carry out): it
-#: states what is true, and names the key that still works, because `ctrl+home`
-#: reaches the page-back path without needing an offset to travel.
-RESUME_UNREACHABLE_NOTICE = "older messages above — press ctrl+home to load"
+#: "scroll up to load" instruction (which the reader cannot carry out here). It
+#: states what is true and offers the row itself as the way out: the notice is
+#: a control (:class:`OlderHistoryNotice`), so it does not have to recite a
+#: keyboard chord the product documents nowhere else.
+RESUME_UNREACHABLE_NOTICE = "older messages above — select to load"
 
 
 def _resume_tail_start(history: list[Any], bound: int) -> int:
@@ -864,7 +881,14 @@ def _resume_tail_start(history: list[Any], bound: int) -> int:
     if naive == 0:
         return 0
     floor = max(0, naive - bound)
-    for index in range(naive, floor - 1, -1):
+    # Clamped because `bound=0` puts `naive` at `len(history)`, one past the
+    # last index: the old forward walk was an empty range and returned safely,
+    # so the backward walk must not turn a degenerate budget into an
+    # `IndexError`. Not reachable from either call site today (both pass a
+    # positive constant), but this function is otherwise total and should stay
+    # that way.
+    start = min(naive, len(history) - 1)
+    for index in range(start, floor - 1, -1):
         message = history[index]
         role = getattr(message, "role", None)
         custom = getattr(message, "custom_type", None)
@@ -5897,10 +5921,22 @@ class OperatorApp(App[None]):
 
         So the geometry is measured after the mount settles, and while the
         content does not exceed the viewport AND more history exists, the next
-        older page is mounted. Recursive-by-refresh rather than a loop: each
+        older page is mounted. Recursive-by-SETTLE rather than a loop: each
         page's blocks only author their real heights on a later layout pass
         (``_set_authored_height``), so measuring again in the same frame would
         read the extent this mount has not finished growing.
+
+        The continuation is chained to the mount's own settle seam, never to
+        ``call_after_refresh``. The paging gate is released from the settle
+        callback ``insert_blocks`` schedules, which is strictly LATER than the
+        next refresh, so a refresh-chained re-measure arrived while the gate
+        was still held, took the stand-down return below, and nothing ever
+        rescheduled it: :data:`RESUME_FILL_MAX_PAGES` was unreachable and the
+        effective cap was ONE page. On a viewport tall enough to need two, the
+        resume stayed unscrollable with its head unreachable — the exact defect
+        this method exists to remove (measured at 120x300: `max_scroll_y=0`,
+        no scrollbar, 261 messages pending, and the head notice still telling
+        the reader to scroll up for them).
 
         NOT A GESTURE. This runs outside the page-back latch entirely: it must
         neither arm ``_resume_in_zone`` (which would hand a free page to the
@@ -5909,6 +5945,18 @@ class OperatorApp(App[None]):
         as a mutex — if a genuine gesture is mid-mount, this stands down and
         lets the gesture own the frame, because a reader who is already
         scrolling does not need the fill.
+
+        That neutrality is ENFORCED here, not merely intended. The fill does
+        not touch the latch itself, but its mount lands the reader at y=0 and
+        the settle that follows drives the same page-back hook a reader's
+        scroll does; the latch was spent that way, and because the hook re-arms
+        only on a discrete act or outside the trigger zone, a wheel reader
+        clamped at the top could never earn another page (measured: 60 notches
+        at y=0 mounted nothing). The offset leak behind it is fixed at source
+        in ``TranscriptView.insert_blocks``'s restore, but this method saves
+        and restores the latch around its own mount regardless — the
+        guarantee is this method's to keep, and it should not silently depend
+        on another widget's scroll bookkeeping staying correct.
 
         ``RESUME_FILL_MAX_PAGES`` bounds it hard. The loop's own exit condition
         is the geometry, which terminates on any real history; the cap is for
@@ -5923,8 +5971,13 @@ class OperatorApp(App[None]):
         if view.parent is None:
             return
         # A real gesture owns the mount seam right now. Stand down: the reader
-        # is scrolling, which is the condition this fill exists to make possible.
+        # is scrolling, which is the condition this fill exists to make
+        # possible. Reconcile on the way out — EVERY exit from this method
+        # leaves a frame the reader looks at, and one that skipped the
+        # reconcile is how the head notice came to promise history the frame
+        # could not reach.
         if self._resume_paging:
+            self._reconcile_head_notice()
             return
         # Content already exceeds the viewport by enough for the trigger zone
         # to be reachable — the frame is scrollable and the fill is done.
@@ -5933,14 +5986,29 @@ class OperatorApp(App[None]):
             return
         if view.virtual_size.height > viewport + RESUME_FILL_SLACK_ROWS:
             # Scrollable, so "scroll up to load" is a gesture the reader can
-            # actually perform. The notice keeps its promise.
+            # actually perform. The notice keeps its promise — reconciled
+            # anyway, because this is also the exit taken when a page mounted
+            # by an earlier attempt exhausted the head, and the notice would
+            # otherwise still be promising more.
+            self._reconcile_head_notice()
             return
 
         session = self._session
         if self._resume_pending_head:
-            self._mount_older_resume_page()
-            # Re-measure after the page has settled, not now: see the docstring.
-            view.call_after_refresh(self._fill_resume_until_scrollable, _attempt + 1)
+            # Save and restore the latch across the mount: whatever the settle
+            # does with it, the reader's first real scroll still owns the page
+            # it is entitled to. See the docstring — this guarantee is kept
+            # structurally rather than inherited.
+            armed = self._resume_in_zone
+
+            def settled() -> None:
+                self._resume_in_zone = armed
+                self._fill_resume_until_scrollable(_attempt + 1)
+
+            # Chained to the SETTLE, not to the next refresh: see the
+            # docstring. `_attempt` is carried through so the cap still bounds
+            # a head whose rows measure to no height.
+            self._mount_older_resume_page(on_settled=settled)
             return
         if session is not None and getattr(session, "history_before_token", None):
             # The remote/server-paged case: nothing is held locally, but the
@@ -5953,15 +6021,34 @@ class OperatorApp(App[None]):
             # held and stand down — leaving the fill one page short on exactly
             # the sessions (remote, long) it is most needed for.
             self._resume_paging = True
+            armed = self._resume_in_zone
+            # Pinned BEFORE the round trip, and checked after it: the identity
+            # test below is close to a tautology on its own, because
+            # `_transcript_view` is the main transcript and is never removed or
+            # reparented. The generation is what actually answers "is this
+            # still the conversation that asked?" — without it, a sidebar
+            # switch during the fetch runs an unrequested fill against the
+            # conversation the reader moved TO. Every other async continuation
+            # in this file pins it the same way (`_mount_newer_resume_page`,
+            # `_transcript_scrolled`).
+            generation = self._sidebar_navigation.generation
+            source = self._interaction
 
             async def fetch_then_refill() -> None:
-                await self._fetch_older_display_page(self._interaction)
-                if self._transcript_view() is view:
+                await self._fetch_older_display_page(source)
+                if (
+                    self._transcript_view() is view
+                    and self._is_current(source)
+                    and self._sidebar_navigation.generation == generation
+                ):
+                    # Restored for the same reason as the local branch: the
+                    # fetch's own mount must not spend the reader's latch.
+                    self._resume_in_zone = armed
                     self._fill_resume_until_scrollable(_attempt + 1)
 
             self.run_worker(
                 fetch_then_refill(),
-                group=self._interaction.worker_group("history-page"),
+                group=source.worker_group("history-page"),
             )
             return
         # No more history in either direction. The frame is as tall as the
@@ -5987,7 +6074,17 @@ class OperatorApp(App[None]):
           what is actually true: more exists, and it is not reachable by
           scrolling here.
 
-        Idempotent, and safe to call from every fill exit.
+        TOTAL, not a one-way latch. Every one of these states can be left
+        again — `ctrl+home` mounts a page, a resize grows the viewport, a
+        streaming turn lengthens the content — so each call decides the text
+        from the CURRENT geometry rather than only ever darkening it. A
+        one-directional version shipped briefly and reintroduced exactly the
+        bug this notice exists to prevent, one state over: after the reader
+        pressed the key the copy named, the frame had a scrollbar and 120 rows
+        of travel and the top row still said "press ctrl+home to load". That
+        is the failure `NoticeBlock.restate`'s own docstring is written about.
+
+        Idempotent, and safe to call from every fill exit and every settle.
         """
         notice = self._resume_head_notice
         if notice is None:
@@ -6002,7 +6099,18 @@ class OperatorApp(App[None]):
         if not more:
             notice.restate(RESUME_START_NOTICE, "info")
         elif not scrollable:
-            notice.restate(RESUME_UNREACHABLE_NOTICE, "info")
+            # `note`, not `info`: this is the answer to "where did my history
+            # go", which is the role `NoticeBlock` reserves `note` for, and it
+            # carries an instruction the reader must be able to READ to act
+            # on. `info` maps to `dim`, which measures 3.77:1 on the light
+            # theme — below the 4.5:1 AA floor — so the row got quieter
+            # exactly as it got more important.
+            notice.restate(RESUME_UNREACHABLE_NOTICE, "note")
+        else:
+            # The way BACK. More history exists and the frame can now reach it,
+            # so the instruction is followable again and the notice returns to
+            # stating the promise it can keep.
+            notice.restate(RESUME_OLDER_NOTICE, "note")
 
     @staticmethod
     def _mark_pending_tool_rows(blocks: list[Any], session: Any) -> None:
@@ -6027,6 +6135,36 @@ class OperatorApp(App[None]):
         message.stop()
         if message.notice is self._resume_tail_notice:
             self._mount_newer_resume_page()
+
+    def on_older_history_notice_requested(self, message: OlderHistoryNotice.Requested) -> None:
+        """Activating the head notice loads the next older page.
+
+        The head twin of the handler above. Routed through the same mount the
+        scroll trigger uses, so a click and a scroll-to-top earn exactly one
+        page each and share the single-flight gate — an activation arriving
+        while a page is still settling is dropped by `_mount_older_resume_page`
+        rather than queued, which is the same contract a keypress gets.
+
+        This is the ONLY way out of the unreachable state
+        (:data:`RESUME_UNREACHABLE_NOTICE`), where by construction there is no
+        offset to travel and the scroll trigger can never fire.
+        """
+        message.stop()
+        if message.notice is not self._resume_head_notice:
+            return
+        if self._resume_pending_head:
+            self._mount_older_resume_page()
+            return
+        session = self._session
+        if session is not None and getattr(session, "history_before_token", None):
+            # Remote/server-paged: the same fetch the scroll trigger runs.
+            if self._resume_paging:
+                return
+            self._resume_paging = True
+            self.run_worker(
+                self._fetch_older_display_page(self._interaction),
+                group=self._interaction.worker_group("history-page"),
+            )
 
     def _jump_newer_resume_tail(self) -> None:
         if not self._resume_pending_tail:
@@ -6260,8 +6398,17 @@ class OperatorApp(App[None]):
             self._resume_in_zone = False
             self._mount_older_resume_page()
 
-    def _mount_older_resume_page(self) -> None:
+    def _mount_older_resume_page(self, on_settled: Callable[[], None] | None = None) -> None:
         """Mount the next older page of a bounded resume, at the top.
+
+        ``on_settled`` runs once this page is fully answered and the paging
+        gate has been released — the seam the initial fill chains its next
+        re-measure to. It exists because "after the gate releases" and "after
+        the next refresh" are different moments: the gate is cleared from the
+        settle callback ``insert_blocks`` schedules, which is two refresh hops
+        deep, so a re-measure scheduled with ``call_after_refresh`` always
+        observed the gate still held and stood down (see
+        :meth:`_fill_resume_until_scrollable`).
 
         The reader reached the top of what was rendered, so the oldest
         :data:`RESUME_PAGE_MESSAGES` still held are projected and inserted
@@ -6319,6 +6466,16 @@ class OperatorApp(App[None]):
             # is still crossing the trigger row, and the next animation frame
             # mounts another page.
             self._resume_paging = False
+            # This page changed both terms the head notice is decided from —
+            # how much history is left, and whether the frame can reach it —
+            # so restate it from the geometry this mount just produced. Without
+            # this the notice was decided once, at the fill's exit, and a
+            # reader who obeyed it went on being told to obey it.
+            self._reconcile_head_notice()
+            # AFTER the release, so a continuation that wants to mount another
+            # page finds the gate open rather than standing down against it.
+            if on_settled is not None:
+                on_settled()
 
         if blocks:
             # Index 1 when the notice heads the list: the page goes BELOW
@@ -24330,6 +24487,13 @@ class OperatorApp(App[None]):
         lines.append(_key_row("option+up/down", "same as up/down (history, lists)"))
         lines.append(_key_row("shift+tab", "cycle reasoning effort"))
         lines.append(_key_row("ctrl+l", "clear the transcript (history stays)"))
+        # The transcript-navigation pair was bound `show=False` and listed
+        # nowhere, so the ONLY place the product mentioned `ctrl+home` was a
+        # resume notice that appears when the reader is already stuck. One row
+        # for both ends, naming what each is FOR rather than the direction:
+        # "top" is where a resumed conversation's older history is loaded from.
+        # 61 composed cells against the 74-cell ceiling this block documents.
+        lines.append(_key_row("ctrl+home", "jump to the transcript top; ctrl+end returns"))
         lines.append(_key_row("ctrl+t", "expand or collapse the todo panel"))
         # 46 cells (66 composed) against the 74-cell ceiling: names the three
         # stops so a user who only ever saw "expand/collapse" learns the panel

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -46,6 +46,44 @@ class HistoryPageNotice(NoticeBlock, can_focus=True):
         self.action_more()
 
 
+class OlderHistoryNotice(NoticeBlock, can_focus=True):
+    """The HEAD notice, and the twin of :class:`HistoryPageNotice` above it.
+
+    The two ends of one transcript solve the same problem — "there is more
+    conversation off this edge of the screen" — and they must not solve it in
+    opposite ways. The tail notice has always been a control: focusable,
+    clickable, `enter`-bound, with the `interactive-notice` styling that gives
+    it hover and focus affordances. The head notice was a bare label that
+    recited a keyboard chord (`ctrl+home`) which appears NOWHERE else in the
+    product — not in the footer hints, not in the `?` help screen — and which
+    on most Mac keyboards is itself a chord (`fn+ctrl+←`). A reader who had
+    learned to click the bottom notice would click this one and get nothing.
+
+    Making it a control is what lets the copy stay a plain statement: the row
+    no longer has to explain how to operate it, because it IS the thing you
+    operate. That matters most in the state this notice exists for — a frame
+    too tall to scroll, where the history is otherwise a dead end.
+    """
+
+    BINDINGS = [Binding("enter", "older", "Older messages", show=False)]
+
+    class Requested(Message):
+        def __init__(self, notice: OlderHistoryNotice) -> None:
+            super().__init__()
+            self.notice = notice
+
+    def __init__(self, text: str) -> None:
+        super().__init__(text, "note")
+        self.add_class("interactive-notice")
+
+    def action_older(self) -> None:
+        self.post_message(self.Requested(self))
+
+    def on_click(self, event: events.Click) -> None:
+        event.stop()
+        self.action_older()
+
+
 class DraftRecoveryNotice(NoticeBlock, can_focus=True):
     BINDINGS = [Binding("enter", "restore", "Restore unsent prompt", show=False)]
 
@@ -175,7 +213,7 @@ class PreparedReplay(ReplayState):
         if self._resume_pending_head:
             from local_operator.tui.app import RESUME_OLDER_NOTICE
 
-            self._resume_head_notice = NoticeBlock(RESUME_OLDER_NOTICE, "note")
+            self._resume_head_notice = OlderHistoryNotice(RESUME_OLDER_NOTICE)
             self.blocks.insert(0, self._resume_head_notice)
         if self._resume_pending_tail:
             self._resume_tail_notice = HistoryPageNotice()
@@ -394,7 +432,7 @@ def project_settled_rows(
     # #451/#452 exist to prevent. One extra mount of a one-line notice is
     # not the cost this bound is avoiding.
     if self._block_sink is None and self._resume_pending_head and self._resume_head_notice is None:
-        notice = NoticeBlock(RESUME_OLDER_NOTICE, "note")
+        notice = OlderHistoryNotice(RESUME_OLDER_NOTICE)
         self._resume_head_notice = notice
         self._append_block(notice)
         appended = True

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -74,13 +74,49 @@ class OlderHistoryNotice(NoticeBlock, can_focus=True):
 
     def __init__(self, text: str) -> None:
         super().__init__(text, "note")
+        self._interactive = True
         self.add_class("interactive-notice")
+
+    def set_interactive(self, interactive: bool) -> None:
+        """Advertise an action only while there is one to take.
+
+        The head notice restates rather than removing itself when the history
+        runs out (removing the first row would shift every row below it and
+        undo the anchor an insert just held), so unlike its tail twin it
+        outlives its own action. A row that keeps `interactive-notice`, keeps
+        `can_focus`, and paints the full-width focus band while activating it
+        does nothing is a focus stop that answers Enter with silence.
+
+        `can_focus` is an instance attribute here, shadowing the class-level
+        value Textual's `can_focus=True` keyword set. Textual reads
+        `allow_focus()` -> `can_focus` per widget at focus time, so flipping it
+        removes the row from the focus chain without touching the class or the
+        twin.
+
+        Idempotent, and reversible in both directions: a remote page can refill
+        an exhausted head, and a control that only ever went one way would be
+        the same stale-state defect the copy already guards against.
+        """
+        if interactive == self._interactive:
+            return
+        self._interactive = interactive
+        self.can_focus = interactive
+        self.set_class(interactive, "interactive-notice")
+        if not interactive and self.has_focus:
+            # Focus cannot rest on a row that just left the focus chain: it
+            # would keep the band painted and keep swallowing Enter.
+            self.blur()
 
     def action_older(self) -> None:
         self.post_message(self.Requested(self))
 
     def on_click(self, event: events.Click) -> None:
         event.stop()
+        if not self._interactive:
+            # Stopped anyway: the row still occupies its cells, and letting the
+            # click fall through to the transcript beneath would scroll a
+            # surface the reader was pointing at, not aiming past.
+            return
         self.action_older()
 
 

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -100,12 +100,24 @@ class OlderHistoryNotice(NoticeBlock, can_focus=True):
         if interactive == self._interactive:
             return
         self._interactive = interactive
-        self.can_focus = interactive
-        self.set_class(interactive, "interactive-notice")
         if not interactive and self.has_focus:
             # Focus cannot rest on a row that just left the focus chain: it
             # would keep the band painted and keep swallowing Enter.
+            #
+            # ORDER IS LOAD-BEARING: blur BEFORE `can_focus` is cleared.
+            # `blur()` -> `Screen._reset_focus(self)` locates this widget in
+            # the focus chain to hand focus to an ordered NEIGHBOUR. Clearing
+            # `can_focus` first removes the row from that chain, so the lookup
+            # raises and Textual takes its "widget was made invisible" fallback
+            # instead: the first focusable VISIBLE SIBLING, which in a
+            # transcript is the topmost `ToolCard` — measured ~770 rows above a
+            # reader sitting at the tail, with the reader's next `enter`
+            # silently expanding a card they cannot see (review round 3, R9).
+            # Blurring while still in the chain lands focus on `TranscriptView`,
+            # which is on screen and answers `enter` with nothing.
             self.blur()
+        self.can_focus = interactive
+        self.set_class(interactive, "interactive-notice")
 
     def action_older(self) -> None:
         self.post_message(self.Requested(self))

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -2374,6 +2374,13 @@ class TranscriptView(ScrollableContainer):
         #: in one call. `None` outside one, which is how `append_block` tells
         #: the two modes apart.
         self._pending_mounts: list[TranscriptBlock] | None = None
+        #: The reader's position through an in-flight top insert, as
+        #: ``(anchor_block, gap)`` where ``gap`` is the distance from the
+        #: anchor's top to the viewport's top. Held for the whole settle, not
+        #: just its last frame, and honoured by :meth:`_size_updated` — see
+        #: :meth:`insert_blocks` for why a single late restore is not enough.
+        #: ``None`` when no insert is settling.
+        self._insert_anchor: tuple[TranscriptBlock, float] | None = None
 
     def on_mount(self) -> None:
         """Give the system vertical scrollbar an open-hand hover cursor.
@@ -2552,11 +2559,33 @@ class TranscriptView(ScrollableContainer):
         AND the anchor restore's own non-animated scroll has landed — which is
         the earliest moment a caller that gates work on "the reader is back
         where they were" can safely re-open that gate. Running it from the
-        anchor restore rather than the settle itself is load-bearing: between
-        the two, the offset still sits where the inserted rows pushed it. It
-        runs INSIDE the restore's programmatic-scroll guard so the gate never
-        opens on a frame where this widget's own scroll could still be
-        reported as a reader's (see ``restore_anchor``).
+        anchor restore rather than the settle itself is load-bearing: the
+        restore is the last thing that touches the offset. It runs INSIDE the
+        restore's programmatic-scroll guard so the gate never opens on a frame
+        where this widget's own scroll could still be reported as a reader's
+        (see ``restore_anchor``).
+
+        THE INVARIANT, and why the restore alone did not deliver it: mounting
+        rows ABOVE the viewport moves the reader's content down the virtual
+        canvas by the inserted extent, so the offset must move by exactly the
+        same amount for the content under the reader's eyes to stay still.
+        Those two happen at different times. The extent grows as each mounted
+        block authors its height (``_set_authored_height``), over SEVERAL
+        layout passes; a restore scheduled for the end of that sequence leaves
+        every intermediate frame painted at the old offset against a taller
+        canvas — the reader watches the transcript lurch down and snap back.
+        Measured on a 401-message resume before this change: the anchor gap
+        (anchor top minus ``scroll_y``, invariant under a correct insert)
+        excursed to **120 rows on a 31-row viewport** — nearly four screens —
+        across three painted frames before the restore returned it to 0.
+
+        So the anchor is held for the WHOLE settle in ``_insert_anchor`` and
+        re-applied by :meth:`_size_updated` on every extent change, which is
+        the same frame the growth lands in. The deferred restore is kept as
+        the final correction (and as the ``on_settled`` seam), but by the time
+        it runs the offset is already right and it is a no-op. This is the
+        same class of bug ``_land_on_tail`` documents for the tail direction:
+        one late correction against an extent that is still moving.
         """
         additions = list(blocks)
         if not additions:
@@ -2568,6 +2597,10 @@ class TranscriptView(ScrollableContainer):
             self._blocks[-1] if self._blocks else None,
         )
         anchor_gap = anchor_block.virtual_region.y - old_scroll if anchor_block is not None else 0.0
+        # Armed BEFORE the mount so the very first extent change this insert
+        # causes is already corrected; `_size_updated` fires during mount.
+        if anchor_block is not None:
+            self._insert_anchor = (anchor_block, anchor_gap)
         before = self._blocks[index] if index < len(self._blocks) else None
         if before is None:
             self.mount(*additions)
@@ -2575,12 +2608,20 @@ class TranscriptView(ScrollableContainer):
             self.mount(*additions, before=before)
         self._blocks[index:index] = additions
         self._name_col_cache = None
+        # The mount itself may not have triggered a resize yet; correct now so
+        # no frame can be painted at the displaced offset even once.
+        self._reanchor_insert()
 
         def settle_then_restore() -> None:
             self._settle_gaps(additions)
             self._remeasure_empty_state()
 
             def restore_anchor() -> None:
+                # Release the held anchor whatever happens next: the settle is
+                # over, and leaving it armed would have `_size_updated` pin the
+                # reader against ordinary later growth (a streaming message, a
+                # card unfolding) that has nothing to do with this insert.
+                self._insert_anchor = None
                 if anchor_block is None or anchor_block.parent is not self:
                     if on_settled is not None:
                         on_settled()
@@ -2965,6 +3006,11 @@ class TranscriptView(ScrollableContainer):
         # working line is mounted again.
         self._name_col_cache = None
         self._tail = None
+        # An insert settling into the transcript that just went away has no
+        # reader to hold. `_reanchor_insert` would notice the anchor is
+        # unparented and drop it anyway, but clearing at the source keeps the
+        # invariant local to the thing that broke it.
+        self._insert_anchor = None
         # A cleared transcript IS at its own end, so the anchor re-arms: the
         # next turn streams into a reader who is, by construction, at the
         # bottom of an empty column.
@@ -3141,7 +3187,53 @@ class TranscriptView(ScrollableContainer):
         changed = super()._size_updated(size, virtual_size, container_size, layout)
         if changed and self._tail_anchor.following:
             self._scroll_to_tail()
+        elif changed:
+            # A top insert is settling: the extent just grew under the reader,
+            # so move the offset by the same amount IN THIS FRAME. Only when
+            # not following — a reader at the tail wants the tail, and the
+            # branch above already gave it to them.
+            self._reanchor_insert()
         return changed
+
+    def _reanchor_insert(self) -> None:
+        """Re-pin the reader to the block they were on, if an insert is settling.
+
+        The one line that holds :meth:`insert_blocks`'s invariant: rows mounted
+        above the viewport change the scroll EXTENT and the reader's absolute
+        offset by the same amount, so the content under their eyes does not
+        move. Called from the mount and from every extent change until the
+        settle's restore disarms it, so there is no painted frame in between
+        where only the extent has moved.
+
+        Silent no-op when no insert is in flight, which is the common case —
+        this must not touch the offset for ordinary appends.
+        """
+        held = self._insert_anchor
+        if held is None:
+            return
+        anchor_block, anchor_gap = held
+        if anchor_block.parent is not self:
+            # The anchor was removed mid-settle (a clear, a mode switch).
+            # Nothing to hold the reader to; drop it rather than guess.
+            self._insert_anchor = None
+            return
+        target = max(0.0, anchor_block.virtual_region.y - anchor_gap)
+        if abs(self.scroll_y - target) < 0.5:
+            return
+        # Programmatic: this is the widget's own correction, not a reader's
+        # scroll, so it must neither release the tail anchor nor be reported
+        # to the resume page-back hook as an arrival at the top.
+        #
+        # `immediate=True` is the whole point and not a micro-optimisation.
+        # Textual's `scroll_to` defaults to `immediate=False`, which defers the
+        # offset change with `call_after_refresh` — i.e. until AFTER the next
+        # compositor refresh. That refresh is a real paint, and it would be
+        # painted with the extent already grown and the offset not yet moved:
+        # exactly the displaced frame this method exists to remove. Measured
+        # against the deferred form on a 401-message resume, the deferred
+        # correction still left 3 painted frames at a 60-row excursion.
+        with self._tail_anchor.programmatic_scroll():
+            self.scroll_to(y=target, animate=False, immediate=True)
 
     # -- user scroll gestures ------------------------------------------------
     # Enumerated rather than funnelled through `scroll_to`, because the funnel

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -2350,6 +2350,24 @@ class TranscriptView(ScrollableContainer):
         #: clamped against it.
         self._on_user_scroll: UserScrollHook | None = None
         self._on_tail_requested: Callable[[], None] | None = None
+        #: Fired from :meth:`_size_updated` whenever the scrollable EXTENT or
+        #: the viewport changes. Same shape as ``on_clear``: optional,
+        #: app-owned, never required for the widget.
+        #:
+        #: It exists because a copy that describes GEOMETRY goes stale for
+        #: reasons that are not events anyone thought to instrument. The
+        #: resume head notice is decided from two terms — is more history
+        #: held, and can this frame reach it — and the second one moves when
+        #: the terminal is resized or a live turn lengthens the content,
+        #: neither of which passes through a fill exit or a page mount. So the
+        #: app was told about the mounts it caused and never about the
+        #: geometry it did not, and the row went on telling a reader to scroll
+        #: up in a frame with no scrollbar (design review round 2, D1).
+        #:
+        #: Keyed on the extent for exactly the reason :meth:`_size_updated`
+        #: gives for the tail anchor: a rule keyed on the measurement rather
+        #: than on a particular event holds for growth nobody enumerated.
+        self._on_extent_changed: Callable[[], None] | None = None
         # The ledger's shared name column, recomputed lazily. Cached because it
         # is read once per card per repaint and only changes when the set of tool
         # names on screen does.
@@ -2420,6 +2438,15 @@ class TranscriptView(ScrollableContainer):
         mount cannot re-acquire following for a reader who just left the tail.
         """
         self._on_user_scroll = hook
+
+    def set_on_extent_changed(self, hook: Callable[[], None] | None) -> None:
+        """Install the hook fired whenever the scrollable extent changes.
+
+        Installed and cleared alongside the other transcript hooks, so a
+        cached view that has been swapped out of the layout stops reporting
+        geometry the app is no longer showing.
+        """
+        self._on_extent_changed = hook
 
     def set_on_tail_requested(self, callback: Callable[[], None] | None) -> None:
         """Let a bounded history window materialize its latest rows on End."""
@@ -3241,6 +3268,12 @@ class TranscriptView(ScrollableContainer):
         line as the user types, the terminal being resized.
         """
         changed = super()._size_updated(size, virtual_size, container_size, layout)
+        if changed and self._on_extent_changed is not None:
+            # Announced BEFORE the anchor work below, and unconditionally on
+            # every extent change: a listener describing the geometry has to
+            # hear about the frame it is describing whether or not the reader
+            # is following the tail.
+            self._on_extent_changed()
         if changed and self._tail_anchor.following:
             self._scroll_to_tail()
         elif changed:

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -2597,9 +2597,26 @@ class TranscriptView(ScrollableContainer):
             self._blocks[-1] if self._blocks else None,
         )
         anchor_gap = anchor_block.virtual_region.y - old_scroll if anchor_block is not None else 0.0
+        # A reader who is FOLLOWING THE TAIL is not holding a position for this
+        # insert to preserve — they are holding the END, and `_size_updated`'s
+        # first branch already carries them there on every extent change. Two
+        # rules for one offset is one too many, and this is the direction that
+        # loses: the held anchor targets `max(0, anchor_y - gap)`, so an insert
+        # that lands while the frame is not yet scrollable (`scroll_y` and
+        # `max_scroll_y` both 0, which is exactly the initial resume fill) pins
+        # the reader to row 0 and keeps re-pinning them there as the extent
+        # grows beneath them. Measured before this guard: a resumed 401-message
+        # conversation at 120x200 settled at `scroll_y=0` against
+        # `max_scroll_y=210` — the reader opened ~120 messages BEHIND the
+        # newest, on a session they opened to see the latest state.
+        #
+        # Anchoring only when NOT following keeps the jitter fix exactly where
+        # it was written for (a reader who scrolled up to read history) and
+        # hands the tail case back to the one rule that owns it.
+        following_tail = self._tail_anchor.following
         # Armed BEFORE the mount so the very first extent change this insert
         # causes is already corrected; `_size_updated` fires during mount.
-        if anchor_block is not None:
+        if anchor_block is not None and not following_tail:
             self._insert_anchor = (anchor_block, anchor_gap)
         before = self._blocks[index] if index < len(self._blocks) else None
         if before is None:
@@ -2611,6 +2628,11 @@ class TranscriptView(ScrollableContainer):
         # The mount itself may not have triggered a resize yet; correct now so
         # no frame can be painted at the displaced offset even once.
         self._reanchor_insert()
+        if following_tail:
+            # Same reasoning in the tail direction, and for the same frame: the
+            # extent grew above the reader, so the end moved, and a follower is
+            # entitled to it on THIS frame rather than one refresh later.
+            self._scroll_to_tail()
 
         def settle_then_restore() -> None:
             self._settle_gaps(additions)
@@ -2626,6 +2648,15 @@ class TranscriptView(ScrollableContainer):
                     if on_settled is not None:
                         on_settled()
                     return
+                if self._tail_anchor.following:
+                    # The reader is on the tail (see the arming guard above):
+                    # restoring a held offset here would drag them off the end
+                    # they never left. Land them on it instead, and only then
+                    # hand the gate back.
+                    self._scroll_to_tail()
+                    if on_settled is not None:
+                        on_settled()
+                    return
                 # Inside the programmatic guard: this scroll is the insert's
                 # own, not a reader's, so it must not release the tail anchor
                 # (`watch_scroll_y` skips the resync) — and, for the resume
@@ -2634,9 +2665,34 @@ class TranscriptView(ScrollableContainer):
                 # zone by construction: the rows above were just inserted, so
                 # the anchor lands where it was, which was the top.
                 with self._tail_anchor.programmatic_scroll():
+                    # `immediate=True` for the SAME reason `_reanchor_insert`
+                    # needs it, and its omission here was the deeper half of
+                    # that defect. Textual's `scroll_to` defers the offset
+                    # change with `call_after_refresh` unless `immediate`, so
+                    # the deferred `_scroll_to` runs AFTER this `with` block
+                    # has exited — outside the very guard that marks the
+                    # scroll as this widget's own. `watch_scroll_y` then reads
+                    # `programmatic == False` and treats the insert's own
+                    # restore as a READER's scroll, with two measured
+                    # consequences: it resyncs the tail anchor to
+                    # `at_end=False` (so a resume whose fill inserted at y=0
+                    # stops following the tail and lands the reader on the
+                    # OLDEST row instead of the newest), and it drives the
+                    # resume page-back hook, which spends `_resume_in_zone` on
+                    # a scroll no human made and leaves a wheel reader parked
+                    # at the top unable to earn another page.
+                    #
+                    # Traced on a 401-message resume at 120x200:
+                    #   scroll_to y=0 programmatic=True   <- inside the guard
+                    #   APPLY     y=0 programmatic=False  <- deferred, outside
+                    #
+                    # Applying inside the guard makes that window not exist
+                    # rather than not matter — the same trade the `on_settled`
+                    # placement below already documents.
                     self.scroll_to(
                         y=max(0, anchor_block.virtual_region.y - anchor_gap),
                         animate=False,
+                        immediate=True,
                     )
                     # INSIDE the guard, not after it: `on_settled` re-opens the
                     # caller's page gate, and the guard is what keeps THIS

--- a/scripts/resume_paging_probe.py
+++ b/scripts/resume_paging_probe.py
@@ -1,0 +1,393 @@
+"""Measure resume transcript geometry and page-mount jitter.
+
+Evidence tool for the "resumed transcript cannot be scrolled up" defect. It
+answers two questions the stills alone cannot:
+
+1. Is the FIRST frame of a resumed conversation scrollable at all? Prints the
+   block count, ``virtual_size`` vs ``container_size``, ``show_vertical_scrollbar``
+   and whether the head notice is promising history the reader can reach.
+2. Does mounting an older page move the rows under the reader's eyes? Records
+   ``scroll_y`` and the visible row strip on every painted frame across the
+   mount, so a displaced frame shows up as a row-strip that differs from the
+   settled one.
+
+Usage:
+    python scripts/resume_paging_probe.py geometry [SHAPE] [COLSxROWS]
+    python scripts/resume_paging_probe.py jitter   [SHAPE] [COLSxROWS]
+    python scripts/resume_paging_probe.py reader   [SHAPE] [COLSxROWS]
+
+``reader`` is the one to show a human: it prints, for every painted frame of a
+page mount, the TEXT of the block at the top of the viewport. A correct insert
+prints the same line on every frame; the pre-fix code prints three different
+lines and then returns to the first.
+
+SHAPE is one of the conversation shapes in ``SHAPES`` below; ``agentic`` is the
+operator's reported case (one prompt, a long run of assistant/tool rows).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.visual_capture import isolate_capture  # noqa: E402
+
+isolate_capture()
+
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.widgets.transcript import (  # noqa: E402
+    NoticeBlock,
+    TranscriptView,
+)
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+
+def _user(i: int) -> Any:
+    return SimpleNamespace(
+        role="user",
+        id=f"u-{i}",
+        text=f"turn {i:04d}: please check item {i}",
+        tool_calls=None,
+        content=[],
+        custom_type=None,
+    )
+
+
+def _assistant(i: int, k: int) -> Any:
+    return SimpleNamespace(
+        role="assistant",
+        id=f"a-{i}-{k}",
+        text=f"Step {k:03d} of turn {i:04d}: inspecting the next candidate row.",
+        tool_calls=[
+            SimpleNamespace(id=f"call-{i}-{k}", name="bash", arguments={"command": f"echo {k}"})
+        ],
+        custom_type=None,
+        stop_reason=None,
+        provider_payload=None,
+    )
+
+
+def _tool(i: int, k: int) -> Any:
+    return SimpleNamespace(
+        role="tool",
+        id=f"t-{i}-{k}",
+        tool_call_id=f"call-{i}-{k}",
+        text=f"exit code: 0\nitem-{i}-{k}",
+        is_error=False,
+        provider_payload=None,
+        content=[],
+        custom_type=None,
+    )
+
+
+def _shape(turns: int, steps: int) -> list[Any]:
+    """``turns`` prompts, each followed by ``steps`` assistant/tool pairs."""
+    rows: list[Any] = []
+    for i in range(turns):
+        rows.append(_user(i))
+        for k in range(steps):
+            rows.append(_assistant(i, k))
+            rows.append(_tool(i, k))
+    return rows
+
+
+#: The shapes worth measuring. ``agentic`` is the operator's screenshot: ONE
+#: prompt and a long run of tool work, which is the normal shape here.
+#:
+#: ``followup`` is the shape the forward walk in `_resume_tail_start` actually
+#: degenerates on, and it is not exotic: a long agentic turn, then a SHORT
+#: recent prompt ("thanks, now do X") whose user row lands INSIDE the last
+#: `bound` messages. The forward walk snaps to that late row and renders only
+#: the handful of messages after it.
+SHAPES = {
+    "agentic": lambda: _shape(1, 200),
+    "agentic-few": lambda: _shape(5, 100),
+    "followup": lambda: _shape(1, 200) + [_user(9), _assistant(9, 0), _tool(9, 0)],
+    "ordinary": lambda: _shape(60, 3),
+    "short": lambda: _shape(4, 2),
+}
+
+
+def _rows(app: OperatorApp, view: TranscriptView) -> list[str]:
+    """The PAINTED rows the transcript occupies on this frame.
+
+    Read from the compositor, not from ``render_lines``: the compositor is what
+    was actually put on the terminal, so a frame captured here is a frame the
+    reader's eyes saw. Sliced to the transcript's own region so composer and
+    status chrome cannot mask a transcript that moved.
+    """
+    strips = list(app.screen._compositor.render_strips())
+    region = view.region
+    top, bottom = max(0, region.y), min(len(strips), region.y + region.height)
+    return ["".join(seg.text for seg in strips[y]._segments) for y in range(top, bottom)]
+
+
+def _geometry(app: OperatorApp, view: TranscriptView) -> dict[str, Any]:
+    blocks = view.blocks()
+    notices = [b.text() for b in blocks if isinstance(b, NoticeBlock)]
+    return {
+        "blocks": len(blocks),
+        "virtual_h": view.virtual_size.height,
+        "container_h": view.container_size.height,
+        "size_h": view.size.height,
+        "max_scroll_y": view.max_scroll_y,
+        "scroll_y": view.scroll_y,
+        "scrollbar": bool(view.show_vertical_scrollbar),
+        "scrollable": view.virtual_size.height > view.container_size.height,
+        "pending_head": len(app._resume_pending_head),
+        "notices": notices,
+    }
+
+
+async def _boot(history: list[Any], size: tuple[int, int]):
+    session = FakeSession()
+    session._history = history
+    app = OperatorApp(lambda: _factory(session))
+    return app, session
+
+
+async def _settle(pilot, app: OperatorApp, view_holder: dict[str, Any]) -> TranscriptView:
+    for _ in range(80):
+        await pilot.pause()
+        view = app.query_one(TranscriptView)
+        if view.blocks():
+            view_holder["view"] = view
+            for _ in range(10):
+                await pilot.pause()
+            return view
+    raise AssertionError("resume never painted")
+
+
+async def run_geometry(shape: str, size: tuple[int, int]) -> None:
+    history = SHAPES[shape]()
+    app, _session = await _boot(history, size)
+    async with app.run_test(size=size) as pilot:
+        view = await _settle(pilot, app, {})
+        geo = _geometry(app, view)
+        geo["shape"] = shape
+        geo["history"] = len(history)
+        geo["grid"] = f"{size[0]}x{size[1]}"
+        print(json.dumps(geo, indent=2))
+
+
+async def run_jitter(shape: str, size: tuple[int, int]) -> None:
+    """Record the reader's ANCHOR GAP on every offset the viewport passes.
+
+    The jitter is not visible in a compositor strip diff, because the rows the
+    transcript paints between the mount and the restore are the SAME rows —
+    what changes is where they sit. The measurable quantity is therefore the
+    anchor gap: the distance from the top of the block the reader is looking at
+    to the top of the viewport (``anchor.virtual_region.y - scroll_y``). It is
+    invariant under a correct insert above the viewport, because the mount adds
+    the same amount to the block's absolute position and to the offset — and it
+    JUMPS by the inserted extent on any frame where only one of the two moved.
+
+    Sampled from the widget's own ``scroll_y`` watch and its extent hook, so
+    every offset the viewport actually rests at is recorded, not just the ones
+    a ``pause`` loop happens to land on.
+    """
+    history = SHAPES[shape]()
+    app, _session = await _boot(history, size)
+    async with app.run_test(size=size) as pilot:
+        view = await _settle(pilot, app, {})
+        if not app._resume_pending_head:
+            print(json.dumps({"error": "no deferred head to page", "shape": shape}))
+            return
+        # Park the reader just below the trigger so the mount is a real page.
+        # `note_user_scroll` FIRST: a bare `scroll_to` leaves the tail anchor
+        # following, and `_size_updated` then drags the viewport back to the
+        # end the moment the mount grows the extent — which measures the tail
+        # follow, not the insert. A reader who scrolled up has released it.
+        view.note_user_scroll()
+        view.scroll_to(y=6, animate=False)
+        for _ in range(8):
+            await pilot.pause()
+
+        # The block under the reader's eyes, identified BEFORE the mount and
+        # tracked by identity: its absolute position moves with the insert,
+        # and that movement is exactly what the offset must match.
+        anchor = next(
+            (b for b in view.blocks() if b.virtual_region.bottom > view.scroll_y),
+            None,
+        )
+        if anchor is None:
+            print(json.dumps({"error": "no anchor block", "shape": shape}))
+            return
+
+        samples: list[dict[str, Any]] = []
+
+        def sample(tag: str) -> None:
+            samples.append(
+                {
+                    "tag": tag,
+                    "scroll_y": round(float(view.scroll_y), 2),
+                    "anchor_y": int(anchor.virtual_region.y),
+                    "gap": round(float(anchor.virtual_region.y - view.scroll_y), 2),
+                    "virtual_h": view.virtual_size.height,
+                }
+            )
+
+        sample("baseline")
+        baseline_gap = samples[0]["gap"]
+
+        original_watch = view.watch_scroll_y
+        original_size = view._size_updated
+        screen = app.screen
+        original_refresh = screen._compositor_refresh
+
+        def watch_scroll_y(old: float, new: float) -> None:
+            original_watch(old, new)
+            sample("scroll")
+
+        def size_updated(*args: Any, **kwargs: Any) -> bool:
+            changed = original_size(*args, **kwargs)
+            if changed:
+                sample("extent")
+            return changed
+
+        def compositor_refresh() -> None:
+            # THE moment the terminal is written. Sampled here rather than
+            # after a `pause`, because a pause drains the whole callback queue
+            # and coalesces the entire settle into one observation — which
+            # reports every intermediate paint as if it never happened.
+            sample("paint")
+            original_refresh()
+
+        view.watch_scroll_y = watch_scroll_y  # type: ignore[method-assign]
+        view._size_updated = size_updated  # type: ignore[method-assign]
+        screen._compositor_refresh = compositor_refresh  # type: ignore[method-assign]
+        try:
+            app._mount_older_resume_page()
+            for _ in range(16):
+                await pilot.pause()
+                sample("frame")
+        finally:
+            view.watch_scroll_y = original_watch  # type: ignore[method-assign]
+            view._size_updated = original_size  # type: ignore[method-assign]
+            screen._compositor_refresh = original_refresh  # type: ignore[method-assign]
+
+        sample("settled")
+
+        # PAINTED frames are the ones that matter: a `frame` sample is taken
+        # after a `pause`, so the terminal has been written. `extent` samples
+        # are taken INSIDE `_size_updated`, before the same frame's re-anchor
+        # has run — they show the growth arriving, not a frame the reader saw,
+        # so they are reported separately rather than mixed into the verdict.
+        painted = [s for s in samples if s["tag"] in ("baseline", "paint", "frame", "settled")]
+        painted_excursion = max(abs(s["gap"] - baseline_gap) for s in painted) if painted else 0
+        displaced = [s for s in painted if abs(s["gap"] - baseline_gap) > 0.5]
+        print(
+            json.dumps(
+                {
+                    "shape": shape,
+                    "grid": f"{size[0]}x{size[1]}",
+                    "baseline_gap": baseline_gap,
+                    "samples": samples,
+                    "painted_frames": len(painted),
+                    "displaced_painted_frames": len(displaced),
+                    "painted_max_gap_excursion": painted_excursion,
+                    "all_sample_max_gap_excursion": (
+                        max(abs(s["gap"] - baseline_gap) for s in samples) if samples else 0
+                    ),
+                    "settled_gap": samples[-1]["gap"],
+                },
+                indent=2,
+            )
+        )
+
+
+async def run_reader(shape: str, size: tuple[int, int]) -> None:
+    """Print the block the reader is looking at, on every painted frame.
+
+    The human-legible form of the invariant. ``jitter`` measures the anchor gap
+    numerically; this names the row, which is what the reader actually notices
+    when it moves — and it needs no interpretation to read as right or wrong.
+    """
+    history = SHAPES[shape]()
+    app, _session = await _boot(history, size)
+    async with app.run_test(size=size) as pilot:
+        view = await _settle(pilot, app, {})
+        if not app._resume_pending_head:
+            print(json.dumps({"error": "no deferred head to page", "shape": shape}))
+            return
+        # Mid-transcript, not in the trigger zone: the zone is itself a gesture
+        # that would mount its own page and confound the baseline.
+        view.note_user_scroll()
+        view.scroll_to(y=max(8.0, view.max_scroll_y / 2), animate=False)
+        for _ in range(20):
+            await pilot.pause()
+
+        anchor = next((b for b in view.blocks() if b.virtual_region.bottom > view.scroll_y), None)
+        if anchor is None:
+            print(json.dumps({"error": "no anchor block", "shape": shape}))
+            return
+
+        def top_text() -> str:
+            top = next((b for b in view.blocks() if b.virtual_region.bottom > view.scroll_y), None)
+            text = getattr(top, "text", None)
+            if not callable(text):
+                return ""
+            return str(text())[:44]
+
+        baseline = top_text()
+        frames: list[dict[str, Any]] = []
+        screen = app.screen
+        original_refresh = screen._compositor_refresh
+
+        def compositor_refresh() -> None:
+            original_refresh()
+            frames.append(
+                {
+                    "paint": len(frames),
+                    "scroll_y": round(float(view.scroll_y), 1),
+                    "virtual_h": view.virtual_size.height,
+                    "top_row": top_text(),
+                    "holds": top_text() == baseline,
+                }
+            )
+
+        screen._compositor_refresh = compositor_refresh  # type: ignore[method-assign]
+        try:
+            app._mount_older_resume_page()
+            for _ in range(16):
+                await pilot.pause()
+        finally:
+            screen._compositor_refresh = original_refresh  # type: ignore[method-assign]
+
+        print(
+            json.dumps(
+                {
+                    "shape": shape,
+                    "grid": f"{size[0]}x{size[1]}",
+                    "baseline_top_row": baseline,
+                    "frames": frames,
+                    "frames_that_moved": sum(1 for f in frames if not f["holds"]),
+                },
+                indent=2,
+            )
+        )
+
+
+def main() -> None:
+    mode = sys.argv[1] if len(sys.argv) > 1 else "geometry"
+    shape = sys.argv[2] if len(sys.argv) > 2 else "agentic"
+    grid = sys.argv[3] if len(sys.argv) > 3 else "120x40"
+    columns, rows = (int(n) for n in grid.split("x"))
+    if mode == "geometry":
+        asyncio.run(run_geometry(shape, (columns, rows)))
+    elif mode == "jitter":
+        asyncio.run(run_jitter(shape, (columns, rows)))
+    elif mode == "reader":
+        asyncio.run(run_reader(shape, (columns, rows)))
+    else:
+        raise SystemExit(f"unknown mode {mode!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/resume_paging_probe.py
+++ b/scripts/resume_paging_probe.py
@@ -40,7 +40,13 @@ from scripts.visual_capture import isolate_capture  # noqa: E402
 
 isolate_capture()
 
-from local_operator.tui.app import OperatorApp  # noqa: E402
+from textual.events import MouseScrollUp  # noqa: E402
+
+from local_operator.tui.app import (  # noqa: E402
+    RESUME_PAGE_MESSAGES,
+    RESUME_PAGE_TRIGGER_ROWS,
+    OperatorApp,
+)
 from local_operator.tui.widgets.transcript import (  # noqa: E402
     NoticeBlock,
     TranscriptView,
@@ -112,6 +118,29 @@ SHAPES = {
     "ordinary": lambda: _shape(60, 3),
     "short": lambda: _shape(4, 2),
 }
+
+
+def _wheel_to_trigger(view: TranscriptView) -> None:
+    """Post ONE real wheel notch at the transcript.
+
+    The widget's own input surface, so it routes through `note_user_scroll`
+    and the page-back latch exactly as a hand on a mouse does. One notch is
+    enough when the reader is already parked inside the trigger zone, and one
+    is the point: the contract under test is "one arrival, one page".
+    """
+    view.post_message(
+        MouseScrollUp(
+            widget=view,
+            x=5,
+            y=5,
+            delta_x=0,
+            delta_y=-1,
+            button=0,
+            shift=False,
+            meta=False,
+            ctrl=False,
+        )
+    )
 
 
 def _rows(app: OperatorApp, view: TranscriptView) -> list[str]:
@@ -199,13 +228,19 @@ async def run_jitter(shape: str, size: tuple[int, int]) -> None:
         if not app._resume_pending_head:
             print(json.dumps({"error": "no deferred head to page", "shape": shape}))
             return
-        # Park the reader just below the trigger so the mount is a real page.
+        # Park the reader just below the trigger so the notch below lands
+        # INSIDE the trigger zone and earns a real page.
         # `note_user_scroll` FIRST: a bare `scroll_to` leaves the tail anchor
         # following, and `_size_updated` then drags the viewport back to the
         # end the moment the mount grows the extent — which measures the tail
         # follow, not the insert. A reader who scrolled up has released it.
         view.note_user_scroll()
-        view.scroll_to(y=6, animate=False)
+        # Just below the trigger row, measured from the CURRENT extent rather
+        # than assumed to be near 0: the fill now makes the first frame
+        # scrollable and lands the reader on the tail, so a hard-coded `y=6`
+        # parks them wherever the tail happens to be and the notch below earns
+        # nothing.
+        view.scroll_to(y=RESUME_PAGE_TRIGGER_ROWS + 2, animate=False)
         for _ in range(8):
             await pilot.pause()
 
@@ -233,6 +268,28 @@ async def run_jitter(shape: str, size: tuple[int, int]) -> None:
                 }
             )
 
+        # A REAL GESTURE, not `app._mount_older_resume_page()`.
+        #
+        # Calling the mount directly bypasses the three layers that sit between
+        # a reader and a page — the page-back latch (`_resume_in_zone`), the
+        # single-flight requeue, and the scroll animation — and every defect
+        # this probe was written to catch lived in exactly that bypassed layer:
+        # the fill spending the reader's latch, the cap that could not iterate,
+        # and the resume landing at the top instead of the tail. Measurements
+        # taken through the direct call were CORRECT and still could not see
+        # any of it — a blind spot in the instrument, not in the reading. So
+        # the page is earned the way a user earns it.
+        pending_before = len(app._resume_pending_head)
+        _wheel_to_trigger(view)
+
+        # The baseline is taken AFTER the notch's own travel has landed, and
+        # BEFORE the page it earned has mounted. A wheel notch legitimately
+        # moves the reader by its own delta — that is the scroll they asked
+        # for — and the invariant under test is that the MOUNT adds no motion
+        # on top of it. Sampling before the notch folds the gesture's own rows
+        # into the verdict and reports a correct insert as displaced.
+        for _ in range(2):
+            await pilot.pause()
         sample("baseline")
         baseline_gap = samples[0]["gap"]
 
@@ -263,7 +320,6 @@ async def run_jitter(shape: str, size: tuple[int, int]) -> None:
         view._size_updated = size_updated  # type: ignore[method-assign]
         screen._compositor_refresh = compositor_refresh  # type: ignore[method-assign]
         try:
-            app._mount_older_resume_page()
             for _ in range(16):
                 await pilot.pause()
                 sample("frame")
@@ -273,6 +329,7 @@ async def run_jitter(shape: str, size: tuple[int, int]) -> None:
             screen._compositor_refresh = original_refresh  # type: ignore[method-assign]
 
         sample("settled")
+        pages_mounted = (pending_before - len(app._resume_pending_head)) // RESUME_PAGE_MESSAGES
 
         # PAINTED frames are the ones that matter: a `frame` sample is taken
         # after a `pause`, so the terminal has been written. `extent` samples
@@ -289,6 +346,10 @@ async def run_jitter(shape: str, size: tuple[int, int]) -> None:
                     "grid": f"{size[0]}x{size[1]}",
                     "baseline_gap": baseline_gap,
                     "samples": samples,
+                    # Proof the gesture actually earned a page: a run where
+                    # nothing mounted measures an insert that never happened
+                    # and reports a flat, meaningless zero.
+                    "pages_mounted": pages_mounted,
                     "painted_frames": len(painted),
                     "displaced_painted_frames": len(displaced),
                     "painted_max_gap_excursion": painted_excursion,
@@ -354,7 +415,9 @@ async def run_reader(shape: str, size: tuple[int, int]) -> None:
 
         screen._compositor_refresh = compositor_refresh  # type: ignore[method-assign]
         try:
-            app._mount_older_resume_page()
+            # A real gesture, for the reason documented in `run_jitter`: the
+            # direct mount skips the latch, the requeue and the animation.
+            _wheel_to_trigger(view)
             for _ in range(16):
                 await pilot.pause()
         finally:

--- a/scripts/resume_paging_shot.py
+++ b/scripts/resume_paging_shot.py
@@ -1,0 +1,262 @@
+"""Capture the resumed-transcript paging frames in the production CSS host.
+
+Evidence for the "a resumed conversation cannot be scrolled up" defect. The
+lightweight test hosts declare no ``CSS_PATH``, so only the real
+:class:`OperatorApp` shows what the reader actually sees — see AGENTS.md,
+"Visual validation".
+
+Usage:
+    python scripts/resume_paging_shot.py OUT.svg FRAME [COLSxROWS]
+
+FRAME is one of:
+    resumed      the first frame of a resumed conversation (the bug frame:
+                 pre-fix this has no scrollbar and 4 blocks, while the top row
+                 promises "older messages above")
+    scrolled     the same conversation after scrolling to the top, i.e. what
+                 the notice is asking the reader to do
+    mount-0..3   consecutive frames across ONE older-page mount, sampled after
+                 a ``pause``
+    paint-0..3   the SAME mount sampled at the COMPOSITOR REFRESH, which is the
+                 moment the terminal is actually written. This is the frame
+                 pair that proves the jitter: a ``pause`` drains the whole
+                 callback queue and coalesces the entire settle into one
+                 observation, so the ``mount-*`` frames show a displaced paint
+                 as though it never happened. Pre-fix, ``paint-1`` sits a page
+                 below ``paint-0``; post-fix every paint is identical.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.visual_capture import isolate_capture, save_capture  # noqa: E402
+
+isolate_capture()
+
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.widgets.transcript import TranscriptView  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+FRAMES = [
+    "resumed",
+    "scrolled",
+    *[f"mount-{i}" for i in range(4)],
+    *[f"paint-{i}" for i in range(4)],
+]
+
+
+def _history(steps: int = 200, followups: int = 1) -> list[Any]:
+    """The operator's shape: one prompt, a long tool run, a short follow-up."""
+    rows: list[Any] = [
+        SimpleNamespace(
+            role="user",
+            id="u-0",
+            text="Audit every row in the export and tell me which ones fail validation.",
+            tool_calls=None,
+            content=[],
+            custom_type=None,
+        )
+    ]
+    for k in range(steps):
+        rows.append(
+            SimpleNamespace(
+                role="assistant",
+                id=f"a-0-{k}",
+                text=f"Checking record {k:03d} against the schema.",
+                tool_calls=[
+                    SimpleNamespace(
+                        id=f"call-0-{k}",
+                        name="bash",
+                        arguments={"command": f"validate --row {k}"},
+                    )
+                ],
+                custom_type=None,
+                stop_reason=None,
+                provider_payload=None,
+            )
+        )
+        rows.append(
+            SimpleNamespace(
+                role="tool",
+                id=f"t-0-{k}",
+                tool_call_id=f"call-0-{k}",
+                text=f"exit code: 0\nrow {k:03d}: ok",
+                is_error=False,
+                provider_payload=None,
+                content=[],
+                custom_type=None,
+            )
+        )
+    for f in range(followups):
+        rows.append(
+            SimpleNamespace(
+                role="user",
+                id=f"fu-{f}",
+                text="Thanks — now summarise the failures.",
+                tool_calls=None,
+                content=[],
+                custom_type=None,
+            )
+        )
+        rows.append(
+            SimpleNamespace(
+                role="assistant",
+                id=f"fa-{f}",
+                text="Three rows failed validation: 041, 118 and 176.",
+                tool_calls=None,
+                custom_type=None,
+                stop_reason=None,
+                provider_payload=None,
+            )
+        )
+    return rows
+
+
+def grid(value: str) -> tuple[int, int]:
+    try:
+        columns, rows = (int(n) for n in value.split("x"))
+        if not (20 <= columns <= 400 and 10 <= rows <= 150):
+            raise ValueError
+        return columns, rows
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "grid must be COLSxROWS within 20..400 by 10..150"
+        ) from exc
+
+
+async def capture(path: Path, frame: str, size: tuple[int, int]) -> None:
+    session: Any = FakeSession()
+    # The jitter frames drop the trailing follow-up on purpose. WITH it, the
+    # pre-fix tree cannot scroll at all (that is Defect 1), so a before/after
+    # mount pair would be comparing "no scrollbar" against "no jitter" and
+    # would prove neither. Without it both trees open on a scrollable frame,
+    # and the only difference across the pair is the insert's behaviour.
+    jitter = frame.startswith("mount-") or frame.startswith("paint-")
+    session._history = _history(followups=0 if jitter else 1)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=size) as pilot:
+        for _ in range(60):
+            await pilot.pause()
+            if app.query_one(TranscriptView).blocks():
+                break
+        # Let the initial mount AND any scrollability fill settle.
+        for _ in range(40):
+            await pilot.pause()
+        view = app.query_one(TranscriptView)
+
+        if frame == "scrolled":
+            view.note_user_scroll()
+            view.scroll_home(animate=False)
+            for _ in range(12):
+                await pilot.pause()
+        elif frame.startswith("paint-"):
+            # Same parking as `mount-*`, but the SVG is exported from inside
+            # the compositor refresh — the moment the terminal is written —
+            # rather than after a `pause`. Nothing else can see a displaced
+            # frame: a pause drains the callback queue, so by the time it
+            # returns the correction has already run.
+            view.note_user_scroll()
+            view.scroll_to(y=max(8.0, view.max_scroll_y / 2), animate=False)
+            for _ in range(20):
+                await pilot.pause()
+            # EVERY paint of the sequence is captured in THIS ONE run, and the
+            # requested index is written to ``path``. Capturing one index per
+            # process and comparing across processes is invalid: the parking
+            # offset depends on ``max_scroll_y`` at that instant, so two runs
+            # can legitimately park at different rows and the "difference"
+            # between their frames says nothing about the insert.
+            count = len(FRAMES) - FRAMES.index("paint-0")
+            wanted = int(frame.split("-")[1])
+            screen = app.screen
+            original_refresh = screen._compositor_refresh
+            seen = {"n": 0}
+
+            def compositor_refresh() -> None:
+                original_refresh()
+                index = seen["n"]
+                seen["n"] += 1
+                if index >= count:
+                    return
+                top = next(
+                    (b for b in view.blocks() if b.virtual_region.bottom > view.scroll_y),
+                    None,
+                )
+                g = (top.virtual_region.y - view.scroll_y) if top is not None else 0.0
+                out = (
+                    path
+                    if index == wanted
+                    else path.with_name(path.name.replace(f"paint-{wanted}", f"paint-{index}"))
+                )
+                save_capture(app, out)
+                print(
+                    f"{out}  PAINT#{index} blocks={len(view.blocks())} "
+                    f"virtual_h={view.virtual_size.height} scroll_y={view.scroll_y:.0f} "
+                    f"top_gap={g:.0f}"
+                )
+
+            screen._compositor_refresh = compositor_refresh  # type: ignore[method-assign]
+            try:
+                app._mount_older_resume_page()
+                for _ in range(16):
+                    await pilot.pause()
+            finally:
+                screen._compositor_refresh = original_refresh  # type: ignore[method-assign]
+            if seen["n"] <= wanted:
+                raise SystemExit(f"the mount painted fewer than {wanted + 1} frames")
+            return
+        elif frame.startswith("mount-"):
+            # Park the reader MID-transcript, then step one mount frame by frame.
+            #
+            # Mid-transcript, not in the trigger zone, for two reasons. The
+            # anchor restore in `insert_blocks` holds the reader wherever they
+            # are, so the jitter is visible at any offset — and parking inside
+            # the zone is itself a gesture that mounts a page, which would
+            # confound frame 0 with a mount already in flight. `note_user_scroll`
+            # still comes first: it releases the tail anchor, without which the
+            # mount legitimately drags the viewport to the end and the capture
+            # shows tail-following rather than the insert.
+            view.note_user_scroll()
+            view.scroll_to(y=max(8.0, view.max_scroll_y / 2), animate=False)
+            for _ in range(20):
+                await pilot.pause()
+            index = int(frame.split("-")[1])
+            if index:
+                app._mount_older_resume_page()
+                for _ in range(index):
+                    await pilot.pause()
+
+        # The first visible block and its distance to the viewport top: this is
+        # the quantity the jitter frames are about, so it is printed with them
+        # rather than left to be inferred from the picture.
+        top_block = next(
+            (b for b in view.blocks() if b.virtual_region.bottom > view.scroll_y), None
+        )
+        gap = (top_block.virtual_region.y - view.scroll_y) if top_block is not None else 0.0
+        geometry = (
+            f"blocks={len(view.blocks())} virtual_h={view.virtual_size.height} "
+            f"viewport={view.container_size.height} scroll_y={view.scroll_y:.0f} "
+            f"max_scroll_y={view.max_scroll_y} scrollbar={bool(view.show_vertical_scrollbar)} "
+            f"top_gap={gap:.0f} paging={app._resume_paging}"
+        )
+        save_capture(app, path)
+        print(f"{path}  {geometry}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("out", type=Path)
+    parser.add_argument("frame", choices=FRAMES)
+    parser.add_argument("grid", nargs="?", default="120x40", type=grid)
+    args = parser.parse_args()
+    asyncio.run(capture(args.out, args.frame, args.grid))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -376,6 +376,13 @@ class FakeSession:
         #: reads it: a switch made mid-turn says when it starts applying, and a
         #: hard-coded False could never exercise that branch.
         self.streaming = False
+        #: The server-paging cursor a `RemoteSession` exposes: non-None means
+        #: "older history continues on the server". Declared here (rather than
+        #: set ad hoc by the one test that needs it) because the resume fill
+        #: branches on it, and a fake that lacks the attribute silently sends
+        #: every test down the LOCAL path — which is how the remote branch
+        #: reached review with no coverage at all.
+        self.history_before_token: str | None = None
         # The REAL holder, not a bare string: `user_set` precedence (a human
         # rename outranks every generated title, forever) is behaviour the TUI
         # relies on, and a fake that reimplements it as a plain assignment

--- a/tests/unit/tui/test_resume_render.py
+++ b/tests/unit/tui/test_resume_render.py
@@ -1167,3 +1167,283 @@ async def test_the_fill_can_mount_more_than_one_page() -> None:
         f"{app_module.RESUME_FILL_MAX_PAGES} is unreachable, so it cannot "
         "iterate on a viewport that needs more than one"
     )
+
+
+@pytest.mark.asyncio
+async def test_the_head_notice_tracks_a_resize_in_both_directions() -> None:
+    """The copy describes GEOMETRY, so it must follow geometry it did not cause.
+
+    Every path that reconciled this notice was a fill exit or a page-mount
+    settle — i.e. a change the app itself made. A terminal resize changes the
+    other term the copy is decided from, the viewport, and goes through
+    neither. So the notice was correct on every path a test drove and wrong on
+    the one a reader takes most often, in BOTH directions (design review round
+    2, D1; QA Q5):
+
+    * grow past the point where three filled pages still fit, and the row went
+      on saying "scroll up to load" on a frame with no scrollbar at all — the
+      unfollowable instruction this whole file exists to remove, reached by
+      dragging a window instead of by pressing a key;
+    * shrink back into a scrollable frame, and it went on offering "select to
+      load" — true, since the control still works, but it names the wrong
+      gesture and hides the one that now works.
+
+    PINNED AT THE HEIGHTS THE DEFECT WAS REPRODUCED AT. 450 is where a filled
+    frame first stops being scrollable on this shape, and 300 is a height that
+    is comfortably scrollable again; both were measured on the real app rather
+    than guessed. There was no ``resize_terminal`` anywhere in this file, which
+    is exactly why the round-1 guard passed while the defect shipped.
+    """
+    session = FakeSession()
+    session._history = _agentic_history(200, followups=1)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 200)) as pilot:
+        await _wait_for_resume(pilot, app)
+        for _ in range(80):
+            await pilot.pause()
+        view = app.query_one(TranscriptView)
+
+        def notices() -> list[str]:
+            return [b.text() for b in view.blocks() if isinstance(b, NoticeBlock)]
+
+        def scrollable() -> bool:
+            viewport = view.container_size.height or view.size.height
+            return bool(viewport) and view.virtual_size.height > viewport
+
+        # Precondition: a scrollable frame whose notice keeps its promise.
+        assert scrollable()
+        assert RESUME_OLDER_NOTICE in notices()
+        assert app._resume_pending_head
+
+        # GROW out of it. The frame can no longer be scrolled, so the
+        # instruction can no longer be followed.
+        await pilot.resize_terminal(120, 450)
+        for _ in range(80):
+            await pilot.pause()
+        assert not scrollable(), "expected 120x450 to swallow the filled frame"
+        assert RESUME_OLDER_NOTICE not in notices(), (
+            "the frame has no scrollbar after the resize, but the notice still "
+            "tells the reader to scroll up for history"
+        )
+        assert app_module.RESUME_UNREACHABLE_NOTICE in notices()
+
+        # SHRINK back. The gesture works again, so the copy must name it
+        # again — this is the direction a one-way latch would fail.
+        await pilot.resize_terminal(120, 300)
+        for _ in range(80):
+            await pilot.pause()
+        assert scrollable(), "expected 120x300 to be scrollable again"
+        assert app_module.RESUME_UNREACHABLE_NOTICE not in notices(), (
+            "the frame is scrollable again after the resize, but the notice "
+            "still says the history cannot be reached by scrolling"
+        )
+        assert RESUME_OLDER_NOTICE in notices()
+
+
+@pytest.mark.asyncio
+async def test_the_head_notice_tracks_content_growth_without_a_resize() -> None:
+    """The general case the resize is one instance of (QA Q5).
+
+    A live turn appending rows makes an unscrollable frame scrollable without
+    any resize and without any page mount, so a seam keyed on the resize EVENT
+    would leave this stale. The seam is keyed on the extent instead, which is
+    the same reasoning ``TranscriptView._size_updated`` gives for the tail
+    anchor: a rule keyed on the measurement holds for growth nobody enumerated.
+    """
+    session = FakeSession()
+    session._history = _agentic_history(200, followups=1)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 600)) as pilot:
+        await _wait_for_resume(pilot, app)
+        for _ in range(120):
+            await pilot.pause()
+        view = app.query_one(TranscriptView)
+
+        def notices() -> list[str]:
+            return [b.text() for b in view.blocks() if isinstance(b, NoticeBlock)]
+
+        viewport = view.container_size.height or view.size.height
+        assert view.virtual_size.height <= viewport, "expected the unreachable state"
+        assert app_module.RESUME_UNREACHABLE_NOTICE in notices()
+
+        # A turn's worth of output, appended the way live output arrives.
+        for i in range(400):
+            view.append_block(NoticeBlock(f"live row {i}", "info"))
+        for _ in range(80):
+            await pilot.pause()
+
+        viewport = view.container_size.height or view.size.height
+        assert view.virtual_size.height > viewport, "expected the appends to overflow"
+        assert app_module.RESUME_UNREACHABLE_NOTICE not in notices(), (
+            "content growth made the frame scrollable, but the head notice "
+            "still says the history cannot be reached by scrolling"
+        )
+        assert RESUME_OLDER_NOTICE in notices()
+
+
+@pytest.mark.asyncio
+async def test_the_head_notice_stops_being_a_control_once_it_is_inert() -> None:
+    """A focus stop must not answer Enter with silence (design round 2, D7).
+
+    The head notice restates rather than removing itself when the history runs
+    out — removing the first row would shift every row below it and undo the
+    anchor an insert just held — so unlike its tail twin it outlives its own
+    action. It went on carrying ``interactive-notice``, staying focusable and
+    painting the full-width focus band while activating it did nothing.
+
+    Asserted on the widget's own state rather than on a rendered band, because
+    what makes the row a control is `can_focus` and the class; the paint is
+    downstream of both.
+    """
+    session = FakeSession()
+    session._history = _agentic_history(200, followups=1)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 600)) as pilot:
+        await _wait_for_resume(pilot, app)
+        for _ in range(120):
+            await pilot.pause()
+        notice = app._resume_head_notice
+        assert isinstance(notice, OlderHistoryNotice)
+
+        # While there IS an action, the row advertises it.
+        assert notice.can_focus
+        assert notice.has_class("interactive-notice")
+
+        # Drain the head through the control itself, which is the route a
+        # reader in this state takes.
+        for _ in range(12):
+            if not app._resume_pending_head:
+                break
+            notice.action_older()
+            for _ in range(80):
+                await pilot.pause()
+        assert not app._resume_pending_head, "the head never drained"
+        assert notice.text() == RESUME_START_NOTICE
+
+        # Now it has none, so it must stop advertising one.
+        assert not notice.can_focus, (
+            "the exhausted notice is still focusable, so it sits in the focus "
+            "chain painting a focus band for an Enter that does nothing"
+        )
+        assert not notice.has_class("interactive-notice")
+        assert not notice.focusable
+
+
+@pytest.mark.asyncio
+async def test_the_insert_restore_is_applied_inside_the_programmatic_guard() -> None:
+    """Pin the ``immediate=True`` half of the landing fix ON ITS OWN (QA Q6).
+
+    Mutation testing found that either half of the landing fix could be
+    reverted alone with the suite green: the guards pinned the DEFECT (a resume
+    that opens away from the tail) but not which line prevents it, so a future
+    refactor could delete one and learn nothing until both were gone.
+
+    This pins half A by its defining STRUCTURAL property rather than by the
+    landing, which is what makes it independent of half B: EVERY ``scroll_to``
+    issued inside a ``programmatic_scroll()`` guard must be ``immediate``.
+    Textual defers the offset write with ``call_after_refresh`` otherwise, so
+    the write lands after the ``with`` block has exited, outside the very guard
+    that marks it as the widget's own — and ``watch_scroll_y`` then scores the
+    insert's own restore as a reader's scroll.
+
+    Asserted on the CALL rather than on the landing, and that choice is what
+    makes it work. Watching for a misread offset write finds nothing even with
+    the mutation applied, because ``_reanchor_insert`` has usually already put
+    the offset where the restore wants it, so the deferred write is a no-op
+    that changes no value and fires no watch. The defect is real regardless —
+    the guarantee is that the correction is applied in-frame, not that it
+    happened to be unnecessary this time — and the argument is where that
+    guarantee lives. Measured: 1 deferred in-guard call with half A reverted,
+    0 with it in place.
+
+    It cannot flake: it is a fact about which arguments were passed, with no
+    clock and no frame count in it.
+    """
+    session = FakeSession()
+    session._history = _agentic_history(200, followups=1)
+    app = OperatorApp(lambda: _factory(session))
+    deferred: list[Any] = []
+    async with app.run_test(size=(120, 200)) as pilot:
+        await _wait_for_resume(pilot, app)
+        for _ in range(60):
+            await pilot.pause()
+        view = app.query_one(TranscriptView)
+        original_scroll_to = view.scroll_to
+
+        def watching(*args: Any, **kwargs: Any) -> None:
+            if view._tail_anchor.programmatic and not kwargs.get("immediate", False):
+                deferred.append(kwargs.get("y"))
+            original_scroll_to(*args, **kwargs)
+
+        view.scroll_to = watching  # type: ignore[method-assign]
+        # A real gesture, so a genuine insert settles under the probe.
+        await _press_and_settle(pilot, view, "ctrl+home")
+        for _ in range(120):
+            await pilot.pause()
+        view.scroll_to = original_scroll_to  # type: ignore[method-assign]
+
+    assert not deferred, (
+        f"{len(deferred)} scroll(s) inside `programmatic_scroll()` were issued "
+        f"without `immediate=True` (targets {deferred[:3]}): the offset write "
+        "is deferred past the guard that marks it as this widget's own, so "
+        "`watch_scroll_y` resyncs the tail anchor and spends the page-back "
+        "latch on a scroll no human made"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_tail_following_insert_holds_no_anchor() -> None:
+    """Pin the ``not following_tail`` half of the landing fix ON ITS OWN (Q6).
+
+    Half B's defining property is not the landing either — it is that a reader
+    who is FOLLOWING holds no insert anchor, because they are holding the end
+    and ``_size_updated``'s first branch already carries them there. Two rules
+    for one offset is one too many, and the held anchor is the one that loses:
+    it targets ``max(0, anchor_y - gap)``, which pins a not-yet-scrollable
+    frame to row 0 and keeps re-pinning it as the extent grows.
+
+    Read at insert time, so it is a fact about the arming decision rather than
+    about where the frame settled. Together with the test above, each half of
+    the fix now has a guard that fails for that half alone.
+
+    Instrumented on the APP's mount rather than on the view's ``insert_blocks``,
+    for the reason ``test_the_fill_can_mount_more_than_one_page`` gives: the
+    fill runs off the initial mount's settle, so a probe installed after
+    querying the view races it and misses the insert entirely on roughly one
+    run in three (observed on both the fixed and the pre-fix tree). The app
+    method exists before the app boots, so wrapping it cannot be raced.
+    """
+    session = FakeSession()
+    session._history = _agentic_history(200, followups=1)
+    app = OperatorApp(lambda: _factory(session))
+    samples: list[tuple[bool, bool]] = []
+    original_mount = app._mount_older_resume_page
+
+    def instrumented(*args: Any, **kwargs: Any) -> None:
+        view = app.query_one(TranscriptView)
+        following = view._tail_anchor.following
+        original_mount(*args, **kwargs)
+        # Read straight after the mount: `insert_blocks` arms the anchor
+        # inside it and holds it for the whole settle, so this is the arming
+        # decision rather than where the frame ended up.
+        samples.append((following, view._insert_anchor is not None))
+
+    app._mount_older_resume_page = instrumented  # type: ignore[assignment]
+    async with app.run_test(size=(120, 200)) as pilot:
+        await _wait_for_resume(pilot, app)
+        for _ in range(200):
+            await pilot.pause()
+            if samples:
+                break
+        for _ in range(60):
+            await pilot.pause()
+    app._mount_older_resume_page = original_mount  # type: ignore[assignment]
+
+    assert samples, "the fill mounted no page, so this pins nothing"
+    held_while_following = [s for s in samples if s[0] and s[1]]
+    assert not held_while_following, (
+        f"{len(held_while_following)} of {len(samples)} insert(s) armed an "
+        "anchor while the reader was following the tail; the held anchor "
+        "clamps a not-yet-scrollable frame to row 0 and the resume opens on "
+        "the OLDEST row instead of the newest"
+    )

--- a/tests/unit/tui/test_resume_render.py
+++ b/tests/unit/tui/test_resume_render.py
@@ -14,6 +14,7 @@ from typing import Any
 import pytest
 from textual.events import Key, MouseScrollUp
 
+import local_operator.tui.app as app_module
 from local_operator.tui.app import (
     RESUME_OLDER_NOTICE,
     RESUME_PAGE_MESSAGES,
@@ -121,15 +122,69 @@ async def _wait_for_resume(pilot, app: OperatorApp, *, min_blocks: int = 1) -> N
     )
 
 
-def test_resume_tail_start_snaps_to_the_nearest_user_row() -> None:
+def test_resume_tail_start_snaps_back_to_the_nearest_user_row() -> None:
     """A naive ``len - bound`` cut can land on a tool result; the viewport
-    must open on a turn, not on a reply with no question."""
+    must open on a turn, not on a reply with no question — and the snap goes
+    BACKWARD, so the frame is never shorter than the budget.
+
+    This test previously asserted 12 (a FORWARD snap). That direction is the
+    defect: the nearest boundary after the cut can be arbitrarily far down the
+    conversation, so the "budget" silently became a ceiling and the frame
+    rendered fewer messages than asked for. See
+    ``test_resume_tail_start_never_renders_fewer_than_the_bound`` for the
+    pathological shape that produced 2 rendered messages out of 1007.
+    """
     history = _history(5)
-    # 15 messages, bound 4 would land on the last turn's assistant (index 11)
-    # without the snap; the user row of that turn is index 12.
-    assert _resume_tail_start(history, 4) == 12
+    # 15 messages, bound 4: the naive cut is index 11, turn 3's tool result.
+    # Backward lands on turn 3's user row at index 9 — a turn boundary, and a
+    # frame of 6 messages, which is >= the bound rather than < it.
+    assert _resume_tail_start(history, 4) == 9
     assert _resume_tail_start(history, 80) == 0
     assert _resume_tail_start(history, 15) == 0
+
+
+def test_resume_tail_start_never_renders_fewer_than_the_bound() -> None:
+    """The budget is a FLOOR on what gets painted, on every history shape.
+
+    The shape that broke it is the normal one for this harness: ONE prompt,
+    a long run of assistant/tool rows, then a short recent follow-up whose
+    user row sits inside the last ``bound`` messages. A forward snap jumps to
+    that late row and paints only the handful of messages after it — measured
+    at **2 of 1007** on the first shape below.
+
+    Rendering that little is not merely a short frame. The content then fits
+    inside the viewport, so there is no scrollbar and no offset to travel, and
+    the page-back trigger (which only fires on a scroll INTO the top rows) can
+    never be reached — the deferred head is unreachable forever while the top
+    row promises the reader it is one scroll up.
+    """
+    bound = RESUME_RENDER_MESSAGES
+
+    def shape(turns: int, steps: int, followups: int = 0) -> list[Any]:
+        rows: list[Any] = []
+        for i in range(turns):
+            rows.append(SimpleNamespace(role="user", custom_type=None, id=f"u-{i}"))
+            for k in range(steps):
+                rows.append(SimpleNamespace(role="assistant", custom_type=None, id=f"a-{i}-{k}"))
+        for f in range(followups):
+            rows.append(SimpleNamespace(role="user", custom_type=None, id=f"fu-{f}"))
+            rows.append(SimpleNamespace(role="assistant", custom_type=None, id=f"fa-{f}"))
+        return rows
+
+    cases = {
+        "long turns then a follow-up": shape(5, 200, followups=1),
+        "one very long turn": shape(1, 400),
+        "one long turn then a follow-up": shape(1, 400, followups=1),
+        "ordinary turns": shape(30, 39),
+        "many tiny turns": shape(200, 1),
+    }
+    for name, history in cases.items():
+        start = _resume_tail_start(history, bound)
+        rendered = len(history) - start
+        assert rendered >= bound, f"{name}: rendered {rendered} of {len(history)}, bound {bound}"
+        # And still bounded: the backward walk is capped at one more budget, so
+        # the render cost the bound exists to control stays controlled.
+        assert rendered <= 2 * bound, f"{name}: rendered {rendered}, over the 2x ceiling"
 
 
 @pytest.mark.asyncio
@@ -569,3 +624,282 @@ async def test_assistant_and_tool_rows_stay_paired_across_a_page() -> None:
             assert isinstance(body[i + 2], ToolCard)
         # Silence unused import if _transcript_text is handy for debug.
         assert "turn 0000" in _transcript_text(app)
+
+
+def _agentic_history(steps: int, followups: int = 0) -> list[Any]:
+    """ONE prompt, then ``steps`` assistant/tool pairs, then short follow-ups.
+
+    The shape the operator reported and the shape this harness produces most:
+    a single instruction followed by a long run of tool work. A follow-up
+    ("thanks, now do X") puts a user row inside the last ``bound`` messages,
+    which is what the old forward snap collapsed onto.
+    """
+    rows: list[Any] = [
+        SimpleNamespace(
+            role="user",
+            id="u-0",
+            text="turn 0000: please check every item",
+            tool_calls=None,
+            content=[],
+            custom_type=None,
+        )
+    ]
+    for k in range(steps):
+        rows.append(
+            SimpleNamespace(
+                role="assistant",
+                id=f"a-0-{k}",
+                text=f"Step {k:03d}: inspecting the next candidate row.",
+                tool_calls=[
+                    SimpleNamespace(
+                        id=f"call-0-{k}", name="bash", arguments={"command": f"echo {k}"}
+                    )
+                ],
+                custom_type=None,
+                stop_reason=None,
+                provider_payload=None,
+            )
+        )
+        rows.append(
+            SimpleNamespace(
+                role="tool",
+                id=f"t-0-{k}",
+                tool_call_id=f"call-0-{k}",
+                text=f"exit code: 0\nitem-{k}",
+                is_error=False,
+                provider_payload=None,
+                content=[],
+                custom_type=None,
+            )
+        )
+    for f in range(followups):
+        rows.extend(_turn(900 + f))
+    return rows
+
+
+@pytest.mark.asyncio
+async def test_a_resumed_long_single_turn_transcript_is_scrollable() -> None:
+    """The first frame of a resume must be scrollable when history remains.
+
+    This is the operator's report: a resumed conversation whose transcript had
+    NO scrollbar and could not be scrolled up, while its top row read "older
+    messages above — scroll up to load". Two separate causes, both asserted
+    here because either one alone reproduces it:
+
+    * the tail cut snapped FORWARD onto the late follow-up prompt and painted
+      4 blocks of a 404-message history (see the ``_resume_tail_start`` tests);
+    * a message-count budget is a proxy for HEIGHT, so even a correct 80-message
+      frame can fit inside a tall viewport.
+
+    The consequence is the same and is what makes it a defect rather than a
+    short frame: ``_check_resume_page`` only fires on a scroll INTO the trigger
+    zone, so a transcript that cannot scroll can never mount its deferred head.
+    The notice then promises history the reader physically cannot reach.
+    """
+    session = FakeSession()
+    session._history = _agentic_history(200, followups=1)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _wait_for_resume(pilot, app)
+        view = app.query_one(TranscriptView)
+        # Let the geometry-driven fill settle. It runs after the initial mount
+        # and may mount pages of its own, each with its own settle pass.
+        for _ in range(40):
+            await pilot.pause()
+
+        viewport = view.container_size.height or view.size.height
+        assert viewport, "the transcript has no viewport to measure against"
+        # THE assertion: content taller than the viewport, so there is an
+        # offset to travel and a scrollbar to travel it with.
+        assert view.virtual_size.height > viewport, (
+            f"resumed transcript is not scrollable: virtual={view.virtual_size.height} "
+            f"viewport={viewport} blocks={len(view.blocks())}"
+        )
+        assert view.max_scroll_y > 0
+        assert view.show_vertical_scrollbar
+
+        # And the promise is actionable: scrolling to the top really does mount
+        # the deferred head, which is the whole point of being scrollable.
+        assert app._resume_pending_head
+        before = len(app._resume_pending_head)
+        view.scroll_home(animate=False)
+        view.note_user_scroll()
+        for _ in range(10):
+            await pilot.pause()
+        assert len(app._resume_pending_head) < before
+
+
+@pytest.mark.asyncio
+async def test_the_fill_does_not_arm_or_consume_the_page_back_latch() -> None:
+    """The scrollability fill is not a gesture and must not spend one.
+
+    It runs outside the page-back latch by construction. If it armed
+    ``_resume_in_zone`` the reader's first scroll would collect a free extra
+    page; if it consumed one, that scroll's legitimate page would be swallowed.
+    Either way the hard-won "ONE page per user gesture" contract breaks, so it
+    is pinned rather than trusted.
+    """
+    session = FakeSession()
+    session._history = _agentic_history(200, followups=1)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _wait_for_resume(pilot, app)
+        view = app.query_one(TranscriptView)
+        for _ in range(40):
+            await pilot.pause()
+        # The latch is still armed: no gesture has happened yet, so the
+        # reader's first arrival at the top is still owed a page.
+        assert app._resume_in_zone is True
+        assert app._resume_paging is False
+
+        # And that first gesture mounts exactly ONE page, not the cascade.
+        before = len(app._resume_pending_head)
+        assert before
+        await _press_and_settle(pilot, view, "ctrl+home")
+        assert len(app._resume_pending_head) == before - RESUME_PAGE_MESSAGES
+
+
+@pytest.mark.asyncio
+async def test_mounting_an_older_page_never_moves_the_rows_under_the_reader() -> None:
+    """The insert invariant, asserted on every PAINTED frame of the mount.
+
+    Mounting rows ABOVE the viewport changes the scroll EXTENT and the reader's
+    absolute offset by the same amount, so the content under their eyes must
+    not move. The measurable form is the ANCHOR GAP — the distance from the top
+    of the block the reader is on to the top of the viewport — which is
+    invariant under a correct insert and jumps by the inserted extent on any
+    frame where only one of the two has moved.
+
+    Sampled from the compositor refresh, which is the moment the terminal is
+    actually written; sampling after a ``pause`` instead drains the whole
+    callback queue and coalesces the entire settle into one observation, which
+    reports every intermediate paint as though it never happened. Before this
+    was fixed the gap excursed to 120 rows on a 31-row viewport across 5
+    painted frames — the reader saw the transcript lurch down ~4 screens and
+    snap back.
+    """
+    session = FakeSession()
+    session._history = _agentic_history(200)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _wait_for_resume(pilot, app)
+        view = app.query_one(TranscriptView)
+        for _ in range(40):
+            await pilot.pause()
+        assert app._resume_pending_head
+
+        # Park the reader inside the trigger zone. `note_user_scroll` first:
+        # a bare scroll leaves the tail anchor following, and the mount would
+        # then legitimately drag the viewport to the end — which measures tail
+        # following, not the insert.
+        view.note_user_scroll()
+        view.scroll_to(y=6, animate=False)
+        for _ in range(8):
+            await pilot.pause()
+
+        anchor = next((b for b in view.blocks() if b.virtual_region.bottom > view.scroll_y), None)
+        assert anchor is not None
+        baseline_gap = anchor.virtual_region.y - view.scroll_y
+
+        gaps: list[float] = []
+        screen = app.screen
+        original_refresh = screen._compositor_refresh
+
+        def compositor_refresh() -> None:
+            gaps.append(anchor.virtual_region.y - view.scroll_y)
+            original_refresh()
+
+        screen._compositor_refresh = compositor_refresh  # type: ignore[method-assign]
+        try:
+            app._mount_older_resume_page()
+            for _ in range(16):
+                await pilot.pause()
+        finally:
+            screen._compositor_refresh = original_refresh  # type: ignore[method-assign]
+
+        assert gaps, "the mount painted no frames to measure"
+        displaced = [g for g in gaps if abs(g - baseline_gap) > 0.5]
+        assert not displaced, (
+            f"the reader's rows moved on {len(displaced)} painted frame(s); "
+            f"max excursion {max(abs(g - baseline_gap) for g in gaps)} rows "
+            f"(baseline gap {baseline_gap})"
+        )
+        # And it settled where it started, so the correction is a hold rather
+        # than a drift that happened to end in the right place.
+        assert abs((anchor.virtual_region.y - view.scroll_y) - baseline_gap) <= 0.5
+
+
+@pytest.mark.asyncio
+async def test_an_unreachable_head_never_says_scroll_up_to_load() -> None:
+    """The head notice is an instruction; it must only appear when it works.
+
+    "older messages above — scroll up to load" is what the operator's frame
+    showed while the transcript could not be scrolled at all. Even with the
+    fill in place a frame can legitimately end up unscrollable — a very tall
+    terminal, a head of rows that measure to almost nothing, or the fill's own
+    iteration cap — and in that state the instruction is still unfollowable.
+
+    The cap is forced to zero here rather than contriving such a history: it is
+    the honest way to reach the state on demand, and it exercises exactly the
+    branch that runs when the real cap is hit.
+    """
+    session = FakeSession()
+    session._history = _agentic_history(200, followups=1)
+    app = OperatorApp(lambda: _factory(session))
+    monkey = pytest.MonkeyPatch()
+    # A tall viewport plus no fill: 80 short messages cannot exceed 161 rows.
+    monkey.setattr(app_module, "RESUME_FILL_MAX_PAGES", 0)
+    try:
+        async with app.run_test(size=(120, 170)) as pilot:
+            await _wait_for_resume(pilot, app)
+            for _ in range(40):
+                await pilot.pause()
+            view = app.query_one(TranscriptView)
+            viewport = view.container_size.height or view.size.height
+            # Precondition: this really is the unreachable state.
+            assert view.virtual_size.height <= viewport
+            assert app._resume_pending_head
+
+            notices = [b.text() for b in view.blocks() if isinstance(b, NoticeBlock)]
+            assert notices, "the head notice vanished"
+            assert (
+                app_module.RESUME_OLDER_NOTICE not in notices
+            ), "the transcript cannot be scrolled, but still tells the reader to scroll up"
+            # And it does not claim the conversation starts here either — more
+            # history genuinely exists.
+            assert app_module.RESUME_START_NOTICE not in notices
+            assert app_module.RESUME_UNREACHABLE_NOTICE in notices
+    finally:
+        monkey.undo()
+
+
+@pytest.mark.asyncio
+async def test_the_fill_makes_a_tall_terminal_scrollable() -> None:
+    """A message budget is a proxy for HEIGHT, and on a tall terminal a bad one.
+
+    80 short messages are ~161 rows; a 170-row terminal swallows them whole, so
+    the count-bounded frame is not scrollable even though the tail cut is
+    perfectly correct. This is the layer that has to catch it, and it is
+    separate from the ``_resume_tail_start`` fix — the cut is right here and
+    the frame is still wrong without the fill.
+    """
+    session = FakeSession()
+    session._history = _agentic_history(300)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 170)) as pilot:
+        await _wait_for_resume(pilot, app)
+        for _ in range(60):
+            await pilot.pause()
+        view = app.query_one(TranscriptView)
+        viewport = view.container_size.height or view.size.height
+        assert view.virtual_size.height > viewport, (
+            f"tall terminal not scrollable: virtual={view.virtual_size.height} "
+            f"viewport={viewport} blocks={len(view.blocks())}"
+        )
+        # Bounded: the fill stops as soon as it is scrollable, so the render
+        # cost the budget exists to control is still controlled.
+        assert (
+            len(view.blocks())
+            <= (RESUME_RENDER_MESSAGES + app_module.RESUME_FILL_MAX_PAGES * RESUME_PAGE_MESSAGES)
+            * 2
+        )

--- a/tests/unit/tui/test_resume_render.py
+++ b/tests/unit/tui/test_resume_render.py
@@ -1330,6 +1330,138 @@ async def test_the_head_notice_stops_being_a_control_once_it_is_inert() -> None:
 
 
 @pytest.mark.asyncio
+async def test_exhausting_the_focused_notice_lands_focus_on_the_visible_transcript() -> None:
+    """Say WHERE focus goes when the control retires, not merely that it left.
+
+    The sibling guard above asserts the NEGATIVE — the exhausted row is no
+    longer focusable — and that shape passed while the row handed focus to the
+    topmost ``ToolCard``, roughly 770 rows above a reader sitting at the tail.
+    Their next ``enter`` expanded a card off screen: D7 removed a focus stop
+    that answered ``enter`` with silence and replaced it with one that answered
+    with an invisible side effect, which is strictly harder to attribute
+    (review round 3, R9).
+
+    So this asserts the positive landing, and the two properties that make it
+    the right one: the widget focus moved to is ON SCREEN, and ``enter`` on it
+    changes nothing the reader would have to explain. Both are read from the
+    live app rather than from ``set_interactive``'s intent, because the defect
+    lived entirely in Textual's fallback branch — ``blur()`` after ``can_focus``
+    was cleared cannot find the row in the focus chain and falls back to the
+    first focusable visible SIBLING instead of an ordered neighbour.
+
+    Drained through the control WITH FOCUS ON IT, which is the mouse route
+    (focus-then-activate) and the only state in which the blur runs at all.
+    """
+    session = FakeSession()
+    session._history = _agentic_history(200, followups=1)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _wait_for_resume(pilot, app)
+        for _ in range(120):
+            await pilot.pause()
+        notice = app._resume_head_notice
+        assert isinstance(notice, OlderHistoryNotice)
+        view = app._transcript_view()
+
+        for _ in range(14):
+            if not app._resume_pending_head:
+                break
+            notice.focus()
+            for _ in range(10):
+                await pilot.pause()
+            assert notice.has_focus, "the live notice refused focus"
+            notice.action_older()
+            for _ in range(80):
+                await pilot.pause()
+        assert not app._resume_pending_head, "the head never drained"
+        assert notice.text() == RESUME_START_NOTICE
+        for _ in range(40):
+            await pilot.pause()
+
+        focused = app.focused
+        assert focused is not None, "focus was dropped entirely"
+        assert focused is view, (
+            "focus left the exhausted notice for "
+            f"{type(focused).__name__}, not the transcript the reader is "
+            "looking at; a widget reached through Textual's visible-sibling "
+            "fallback can sit far outside the viewport"
+        )
+
+        # On screen, not merely non-None: the fallback branch produced a
+        # perfectly valid focus target whose region was ~210 rows above the
+        # screen at 120x600.
+        region = focused.region
+        assert region.height > 0
+        assert 0 <= region.y < app.screen.size.height, (
+            f"focus landed off screen at y={region.y} for a " f"{app.screen.size.height}-row screen"
+        )
+
+        # And the stray keypress a reader makes next must do nothing visible.
+        before = (view.virtual_size.height, view.scroll_offset.y)
+        await pilot.press("enter")
+        for _ in range(60):
+            await pilot.pause()
+        after = (view.virtual_size.height, view.scroll_offset.y)
+        assert after == before, (
+            f"enter after exhausting the notice changed the transcript: "
+            f"extent/offset {before} -> {after}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_raising_fill_does_not_leave_the_pessimistic_copy_suppressed() -> None:
+    """A crashed fill must not silence the correction it was suppressing (R10).
+
+    ``_resume_fill_active`` exists to hold back the "not reachable by
+    scrolling" copy while the geometry is still provisional, so a flag left
+    ``True`` is not inert bookkeeping: it permanently suppresses the very
+    correction this feature adds, and the notice goes on promising a gesture
+    the frame cannot perform. Its eight clear sites are statement sites, so a
+    raise between arming the flag and reaching one of them skipped all eight.
+
+    ``_resume_paging``, the sibling flag, is protected by a ``finally`` in
+    ``_fetch_older_display_page``; this pins the same guarantee here so the two
+    cannot drift apart.
+    """
+    session = FakeSession()
+    session._history = _agentic_history(200, followups=1)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 300)) as pilot:
+        await _wait_for_resume(pilot, app)
+        for _ in range(120):
+            await pilot.pause()
+
+        def explode(*_args: Any, **_kwargs: Any) -> None:
+            raise RuntimeError("synthetic mount failure")
+
+        app._mount_older_resume_page = explode  # type: ignore[assignment]
+        # The attempt body reads only these four geometry terms before it
+        # reaches the mount, and by now the real transcript is scrollable and
+        # would take an earlier exit. Pinning them keeps the test on the branch
+        # under examination instead of on whatever the fill happened to settle
+        # to — the flag's LIFETIME is what is being pinned, not the conditions
+        # that normally arm it.
+        unscrollable = SimpleNamespace(
+            parent=app,
+            container_size=SimpleNamespace(height=40),
+            size=SimpleNamespace(height=40),
+            virtual_size=SimpleNamespace(height=10),
+        )
+        app._transcript_view = lambda: unscrollable  # type: ignore[assignment]
+        app._resume_paging = False
+        app._resume_pending_head = list(_history(4))
+        app._resume_fill_active = True
+
+        with pytest.raises(RuntimeError):
+            app._fill_resume_until_scrollable()
+
+        assert app._resume_fill_active is False, (
+            "a raising fill left itself flagged active, which suppresses the "
+            "unreachable-head copy for the rest of the session"
+        )
+
+
+@pytest.mark.asyncio
 async def test_the_insert_restore_is_applied_inside_the_programmatic_guard() -> None:
     """Pin the ``immediate=True`` half of the landing fix ON ITS OWN (QA Q6).
 

--- a/tests/unit/tui/test_resume_render.py
+++ b/tests/unit/tui/test_resume_render.py
@@ -24,6 +24,7 @@ from local_operator.tui.app import (
     OperatorApp,
     _resume_tail_start,
 )
+from local_operator.tui.session_presentation import OlderHistoryNotice
 from local_operator.tui.widgets.assistant import AssistantBlock
 from local_operator.tui.widgets.tool_card import ToolCard
 from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView, UserBlock
@@ -738,17 +739,45 @@ async def test_the_fill_does_not_arm_or_consume_the_page_back_latch() -> None:
     page; if it consumed one, that scroll's legitimate page would be swallowed.
     Either way the hard-won "ONE page per user gesture" contract breaks, so it
     is pinned rather than trusted.
+
+    PINNED AT 120x170, NOT 120x40, and that is the whole value of this test.
+    At 40 rows the frame is already scrollable, the fill returns at its
+    scrollable-exit having mounted NOTHING, and the assertion below reads back
+    a value no code touched — it passed while the latch was in fact being
+    consumed on every taller frame. A guard that cannot go red is worse than
+    no guard, so the size is chosen to be one where the fill really mounts.
     """
     session = FakeSession()
     session._history = _agentic_history(200, followups=1)
     app = OperatorApp(lambda: _factory(session))
-    async with app.run_test(size=(120, 40)) as pilot:
+    # Counted by instrumenting the mount, NOT by sampling a "pending before"
+    # after `_wait_for_resume`: the fill starts as soon as the initial mount
+    # settles, so by the time the first frame paints it may already have run
+    # and a before/after comparison silently reads zero.
+    fill_mounts = 0
+    async with app.run_test(size=(120, 170)) as pilot:
+        original_mount = app._mount_older_resume_page
+
+        def counting_mount(*args: Any, **kwargs: Any) -> None:
+            nonlocal fill_mounts
+            fill_mounts += 1
+            original_mount(*args, **kwargs)
+
+        app._mount_older_resume_page = counting_mount  # type: ignore[assignment]
         await _wait_for_resume(pilot, app)
         view = app.query_one(TranscriptView)
-        for _ in range(40):
+        for _ in range(60):
             await pilot.pause()
-        # The latch is still armed: no gesture has happened yet, so the
-        # reader's first arrival at the top is still owed a page.
+        app._mount_older_resume_page = original_mount  # type: ignore[assignment]
+
+        # PRECONDITION, asserted rather than assumed: the fill actually did
+        # the thing whose side effects this test is about.
+        assert fill_mounts, (
+            "the fill mounted no pages at this size, so the latch assertion "
+            "below would pin a value nothing touched"
+        )
+        # The latch is still armed: the fill is not a gesture, so the reader's
+        # first arrival at the top is still owed a page.
         assert app._resume_in_zone is True
         assert app._resume_paging is False
 
@@ -757,6 +786,60 @@ async def test_the_fill_does_not_arm_or_consume_the_page_back_latch() -> None:
         assert before
         await _press_and_settle(pilot, view, "ctrl+home")
         assert len(app._resume_pending_head) == before - RESUME_PAGE_MESSAGES
+
+
+@pytest.mark.asyncio
+async def test_a_wheel_reader_at_the_top_can_still_page_after_the_fill() -> None:
+    """The latch guarantee, from the READER's side rather than the flag's.
+
+    The flag assertion above says the fill left the latch armed. This says what
+    that is FOR, through the only input that cannot re-arm it: a wheel notch
+    arriving while the viewport is already clamped at the top moves nothing, so
+    it is not evidence the reader left and came back, so it never re-arms. If
+    the fill spends the latch, such a reader is stuck forever — measured before
+    the fix as 60 settled notches at y=0 mounting exactly nothing, while the
+    first row of that transcript told them to scroll up.
+
+    A wheel gesture rather than a keypress on purpose: `pageup`, `home` and
+    `ctrl+home` are discrete acts and re-arm unconditionally, so they cannot
+    observe this defect at all.
+    """
+    session = FakeSession()
+    session._history = _agentic_history(200, followups=1)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 170)) as pilot:
+        await _wait_for_resume(pilot, app)
+        view = app.query_one(TranscriptView)
+        for _ in range(60):
+            await pilot.pause()
+        before = len(app._resume_pending_head)
+        assert before, "no deferred head to page"
+
+        # Real wheel events through the widget's own input surface, which is
+        # what routes through `note_user_scroll` and the latch. Enough notches
+        # to travel the whole frame and sit clamped at the top afterwards.
+        for _ in range(40):
+            view.post_message(
+                MouseScrollUp(
+                    widget=view,
+                    x=5,
+                    y=5,
+                    delta_x=0,
+                    delta_y=-1,
+                    button=0,
+                    shift=False,
+                    meta=False,
+                    ctrl=False,
+                )
+            )
+            for _ in range(14):
+                await pilot.pause()
+
+        assert len(app._resume_pending_head) < before, (
+            "a wheel reader scrolling to the top of a filled resume earned no "
+            f"page: pending {before} -> {len(app._resume_pending_head)} at "
+            f"y={view.scroll_y}"
+        )
 
 
 @pytest.mark.asyncio
@@ -839,38 +922,89 @@ async def test_an_unreachable_head_never_says_scroll_up_to_load() -> None:
     terminal, a head of rows that measure to almost nothing, or the fill's own
     iteration cap — and in that state the instruction is still unfollowable.
 
-    The cap is forced to zero here rather than contriving such a history: it is
-    the honest way to reach the state on demand, and it exercises exactly the
-    branch that runs when the real cap is hit.
+    REACHED THROUGH GEOMETRY, not by monkeypatching the cap to 0. The earlier
+    version did that, which routed past the stand-down return that was blocking
+    this branch in production: the test was green while the notice fired in 0
+    of 35 real frames. 600 rows is where three genuinely-mounted fill pages
+    still fit inside the viewport, so this reaches the state the same way a
+    reader on a large display at a small font does.
     """
     session = FakeSession()
     session._history = _agentic_history(200, followups=1)
     app = OperatorApp(lambda: _factory(session))
-    monkey = pytest.MonkeyPatch()
-    # A tall viewport plus no fill: 80 short messages cannot exceed 161 rows.
-    monkey.setattr(app_module, "RESUME_FILL_MAX_PAGES", 0)
-    try:
-        async with app.run_test(size=(120, 170)) as pilot:
-            await _wait_for_resume(pilot, app)
-            for _ in range(40):
-                await pilot.pause()
-            view = app.query_one(TranscriptView)
-            viewport = view.container_size.height or view.size.height
-            # Precondition: this really is the unreachable state.
-            assert view.virtual_size.height <= viewport
-            assert app._resume_pending_head
+    async with app.run_test(size=(120, 600)) as pilot:
+        await _wait_for_resume(pilot, app)
+        for _ in range(80):
+            await pilot.pause()
+        view = app.query_one(TranscriptView)
+        viewport = view.container_size.height or view.size.height
+        # Precondition: this really is the unreachable state, reached by
+        # geometry alone.
+        assert view.virtual_size.height <= viewport
+        assert app._resume_pending_head
 
-            notices = [b.text() for b in view.blocks() if isinstance(b, NoticeBlock)]
-            assert notices, "the head notice vanished"
-            assert (
-                app_module.RESUME_OLDER_NOTICE not in notices
-            ), "the transcript cannot be scrolled, but still tells the reader to scroll up"
-            # And it does not claim the conversation starts here either — more
-            # history genuinely exists.
-            assert app_module.RESUME_START_NOTICE not in notices
-            assert app_module.RESUME_UNREACHABLE_NOTICE in notices
-    finally:
-        monkey.undo()
+        notices = [b.text() for b in view.blocks() if isinstance(b, NoticeBlock)]
+        assert notices, "the head notice vanished"
+        assert (
+            app_module.RESUME_OLDER_NOTICE not in notices
+        ), "the transcript cannot be scrolled, but still tells the reader to scroll up"
+        # And it does not claim the conversation starts here either — more
+        # history genuinely exists.
+        assert app_module.RESUME_START_NOTICE not in notices
+        assert app_module.RESUME_UNREACHABLE_NOTICE in notices
+
+        # The state is a dead end for SCROLLING by construction, so the notice
+        # itself has to be the way out: it is a control, and activating it
+        # loads the page no gesture could reach.
+        notice = app._resume_head_notice
+        assert isinstance(notice, OlderHistoryNotice)
+        assert notice.focusable
+        before = len(app._resume_pending_head)
+        notice.action_older()
+        for _ in range(60):
+            await pilot.pause()
+        assert len(app._resume_pending_head) < before, (
+            "activating the head notice in the unreachable state loaded " "nothing"
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_head_notice_stops_saying_unreachable_once_it_is_reachable() -> None:
+    """The notice must restate BOTH ways, not latch on its darkest state.
+
+    ``_reconcile_head_notice`` only ever demoted: there was no path from
+    "unreachable" back to "scroll up to load", so after the reader activated
+    the notice — with a scrollbar now on screen and rows of travel available —
+    the top row still told them it could not be scrolled to. That is precisely
+    the stale-copy failure `NoticeBlock.restate` exists to prevent, one state
+    over from the one this file fixes.
+    """
+    session = FakeSession()
+    session._history = _agentic_history(200, followups=1)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 600)) as pilot:
+        await _wait_for_resume(pilot, app)
+        for _ in range(80):
+            await pilot.pause()
+        view = app.query_one(TranscriptView)
+
+        def notices() -> list[str]:
+            return [b.text() for b in view.blocks() if isinstance(b, NoticeBlock)]
+
+        assert app_module.RESUME_UNREACHABLE_NOTICE in notices()
+
+        # Obey the notice. The frame becomes scrollable, so the copy must go
+        # back to the promise it can now keep.
+        app._resume_head_notice.action_older()  # type: ignore[union-attr]
+        for _ in range(80):
+            await pilot.pause()
+        viewport = view.container_size.height or view.size.height
+        assert view.virtual_size.height > viewport, "expected the frame to become scrollable"
+        assert app_module.RESUME_UNREACHABLE_NOTICE not in notices(), (
+            "the frame is scrollable again but the notice still tells the "
+            "reader it cannot be reached by scrolling"
+        )
+        assert app_module.RESUME_OLDER_NOTICE in notices()
 
 
 @pytest.mark.asyncio
@@ -903,3 +1037,133 @@ async def test_the_fill_makes_a_tall_terminal_scrollable() -> None:
             <= (RESUME_RENDER_MESSAGES + app_module.RESUME_FILL_MAX_PAGES * RESUME_PAGE_MESSAGES)
             * 2
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("rows", [40, 170, 200, 250, 300])
+async def test_a_resumed_conversation_opens_on_its_newest_message(rows: int) -> None:
+    """A resume must land on the TAIL, at every viewport height.
+
+    The bounded-resume feature exists to make the HEAD cheap; it must never
+    move the tail. This is parametrized across the band where the fill mounts
+    because the regression it guards lived only there: the fill's insert ran
+    while the frame was still unscrollable (`scroll_y` and `max_scroll_y` both
+    0), the held insert anchor clamped the target to row 0, and the offset
+    change released tail-following so nothing recovered it. The reader opened a
+    resumed conversation ~120 messages BEHIND its newest message, on a session
+    they opened to see the latest state — a worse outcome than the missing
+    scrollbar this file repairs.
+
+    40 rows is included as the control: the fill mounts nothing there, so this
+    height passed throughout and is what made the defect look absent.
+    """
+    session = FakeSession()
+    session._history = _agentic_history(200, followups=1)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, rows)) as pilot:
+        await _wait_for_resume(pilot, app)
+        for _ in range(80):
+            await pilot.pause()
+        view = app.query_one(TranscriptView)
+        assert view.is_near_bottom(), (
+            f"resume opened away from the newest message at 120x{rows}: "
+            f"scroll_y={view.scroll_y} max_scroll_y={view.max_scroll_y} "
+            f"blocks={len(view.blocks())}"
+        )
+        # Following, not merely parked at the end by luck: the next thing the
+        # conversation appends must carry the viewport with it.
+        assert view.is_following_tail
+
+
+@pytest.mark.asyncio
+async def test_the_fill_pages_a_remote_session_through_its_fetch_worker() -> None:
+    """The remote/``history_before_token`` branch, which nothing reached before.
+
+    This is the riskiest path in the fill: it is the only one that sets the
+    paging gate by hand, spawns a worker, and re-enters itself from that
+    worker's completion across a network round trip. Every other test in this
+    file uses a local ``FakeSession`` with no token, so the branch had zero
+    coverage while carrying the generation guard and the latch restore.
+
+    The fetch itself is stubbed — the point is the fill's control flow around
+    it (does it terminate, does it re-enter, does it leave the gate closed),
+    not ``RemoteSession``'s wire format.
+    """
+    session = FakeSession()
+    session._history = _agentic_history(200, followups=1)
+    # A token means "the conversation continues on the server", which is the
+    # condition the remote branch keys on.
+    session.history_before_token = "cursor-0"
+    app = OperatorApp(lambda: _factory(session))
+    fetches = 0
+
+    async def fake_fetch(source: Any) -> None:
+        # Stands in for the round trip: prepend a page's worth of history and
+        # release the gate, exactly as the real fetch does on success.
+        nonlocal fetches
+        fetches += 1
+        app._resume_pending_head = _agentic_history(30) + app._resume_pending_head
+        if fetches >= 2:
+            session.history_before_token = None
+        app._resume_paging = False
+
+    async with app.run_test(size=(120, 600)) as pilot:
+        await _wait_for_resume(pilot, app)
+        for _ in range(60):
+            await pilot.pause()
+        app._fetch_older_display_page = fake_fetch  # type: ignore[assignment]
+        # Drain the local head so the fill must take the REMOTE branch.
+        app._resume_pending_head = []
+        app._fill_resume_until_scrollable()
+        for _ in range(120):
+            await pilot.pause()
+
+    assert fetches, "the fill never took the remote branch"
+    # Terminates rather than spinning: the cap still bounds a branch whose
+    # geometry never improves.
+    assert fetches <= app_module.RESUME_FILL_MAX_PAGES
+    # And it leaves the gate open, so a real gesture is not locked out.
+    assert app._resume_paging is False
+    # The latch is untouched by the fetch's own mount, same as the local path.
+    assert app._resume_in_zone is True
+
+
+@pytest.mark.asyncio
+async def test_the_fill_can_mount_more_than_one_page() -> None:
+    """``RESUME_FILL_MAX_PAGES`` must be reachable, not decorative.
+
+    The fill chained its re-measure with ``call_after_refresh`` while the
+    paging gate is released from the settle callback ``insert_blocks``
+    schedules — which runs strictly later. So attempt 1 always found the gate
+    held, took the stand-down return, and nothing rescheduled it: the effective
+    cap was ONE page regardless of the constant, and on a viewport needing two
+    the resume stayed unscrollable with its head unreachable.
+
+    600 rows needs more than one page here, so a single-page fill cannot
+    satisfy the assertion.
+    """
+    session = FakeSession()
+    session._history = _agentic_history(300)
+    app = OperatorApp(lambda: _factory(session))
+    fill_mounts = 0
+    async with app.run_test(size=(120, 600)) as pilot:
+        original_mount = app._mount_older_resume_page
+
+        def counting_mount(*args: Any, **kwargs: Any) -> None:
+            nonlocal fill_mounts
+            fill_mounts += 1
+            original_mount(*args, **kwargs)
+
+        # Instrumented before the resume paints, because the fill runs off the
+        # initial mount's settle and a before/after count misses it entirely.
+        app._mount_older_resume_page = counting_mount  # type: ignore[assignment]
+        await _wait_for_resume(pilot, app)
+        for _ in range(120):
+            await pilot.pause()
+        app._mount_older_resume_page = original_mount  # type: ignore[assignment]
+
+    assert fill_mounts > 1, (
+        f"the fill mounted {fill_mounts} page(s): the cap of "
+        f"{app_module.RESUME_FILL_MAX_PAGES} is unreachable, so it cannot "
+        "iterate on a viewport that needs more than one"
+    )


### PR DESCRIPTION
## Summary

Two defects reported together from one screenshot: a resumed conversation whose transcript had **no scrollbar**, could not be scrolled up, and whose top row read `older messages above — scroll up to load` — an instruction the reader physically could not follow.

`Release: patch — a resumed conversation opens with scrollable history again, and loading older messages no longer jostles the rows you are reading.`

---

## Defect 1 — the first frame of a resumed conversation was often not scrollable at all

`_resume_tail_start(history, bound)` computed `naive = max(0, len(history) - bound)` and then snapped that cut to a turn boundary by walking **forward** (`for index in range(naive, len(history))`), while its docstring claimed it "walks back from the naive cut to the nearest user row".

The direction is the whole defect. The nearest boundary *after* the cut can be arbitrarily far down the conversation, so the render **budget silently became a ceiling**. Measured on the real function, pre-fix:

| shape | history | `_resume_tail_start` | messages rendered (bound 80) |
|---|---|---|---|
| 5 turns × 200 steps + follow-up | 1007 | 1005 | **2** |
| 1 turn × 400 steps + follow-up | 403 | 401 | **2** |
| 30 turns × 40 | 1200 | 1120 | 80 |

The pathological case is not exotic — it is the shape this harness produces most: one prompt, a long run of assistant/tool rows, then a short recent follow-up (*"thanks, now do X"*) whose user row lands inside the last `bound` messages.

**Why it is a defect and not just a short frame.** Too few blocks → content height ≤ viewport height → Textual shows no scrollbar and pins `scroll_y` at 0 → `_transcript_scrolled` / `_check_resume_page` (which only fire on a scroll *into* the trigger zone) can never observe the trigger → the deferred head and the server's `history_before_token` pages are **unreachable forever**, while the top row promises they are one scroll away.

Reproduced in the production-CSS host at 120×40 (the operator's exact frame):

| | before | after |
|---|---|---|
| blocks rendered | **3** | **81** |
| `virtual_size.height` | 31 | 161 |
| `container_size.height` (viewport) | 31 | 31 |
| `max_scroll_y` | **0** | **130** |
| `show_vertical_scrollbar` | **False** | **True** |
| `_resume_pending_head` | 401 | 321 |
| head notice | `older messages above — scroll up to load` | `older messages above — scroll up to load` |

### Fixed in three layers — the first alone does not hold

**1. The snap walks backward.** Bounded by one further `bound`, so the frame is `>= bound` and `<= 2 * bound`. That ceiling keeps the render budget's intent: 160 messages measure at 251 ms against 139 ms for 80 and 1022 ms for a whole 716-message session, so overshooting by at most one budget stays far from the cost the bound exists to remove. The docstring now describes what the code does, and says why the direction matters.

**2. A message count is a proxy for height, and a poor one.** 80 short messages are ~161 rows; a 170-row terminal swallows them whole, so a *perfectly correct* cut still yields an unscrollable frame. After the initial mount settles, the real geometry is measured and older pages are mounted while the content does not exceed the viewport **and** history remains — capped by `RESUME_FILL_MAX_PAGES`, and re-measured after each page settles (blocks author their heights over later layout passes, so measuring in the same frame reads an extent that is still growing).

This also covers the remote/server-paged case where `_resume_pending_head` is empty but `history_before_token` is set. That branch chains its re-measure to the **fetch worker**, not to the next refresh: the fetch is a network round trip, so a refresh-scheduled re-measure would run mid-flight, see the gate held, and stand down — leaving the fill a page short on exactly the sessions it is most needed for.

Measured with the fill, at 120×170 (a tall terminal, where layer 1 is not enough):

| | fill disabled | fill enabled |
|---|---|---|
| blocks | 81 | **201** |
| `virtual_size.height` | 161 | **401** |
| viewport | 161 | 161 |
| scrollbar | **False** | **True** |

**The fill runs outside the gesture latch.** It is not a user gesture, so it must neither arm `_resume_in_zone` (which would hand a free page to the reader's first real scroll) nor consume it (which would swallow that scroll's legitimate page). It cooperates with `_resume_paging` only as a mutex — if a genuine gesture is mid-mount it stands down, because a reader who is already scrolling does not need the fill. Pinned by `test_the_fill_does_not_arm_or_consume_the_page_back_latch`.

**3. The notice never promises what the reader cannot reach.** `_reconcile_head_notice` restates it to `start of conversation` when the head is exhausted, and to `older messages above — press ctrl+home to load` when history genuinely remains but the frame still cannot be scrolled (fill cap hit, or rows that measure to no height). Saying "start of conversation" there would be false in the other direction; `ctrl+home` is named because it reaches the page-back path without needing an offset to travel.

Verified by forcing `RESUME_FILL_MAX_PAGES = 0` at 120×170:

```
cap=0  blocks=81  vh=161 vp=161 scrollbar=False pend=520
   notice: ['older messages above — press ctrl+home to load']
cap=3  blocks=201 vh=401 vp=161 scrollbar=True  pend=400
   notice: ['older messages above — scroll up to load']
```

---

## Defect 2 — the page mount jostled the rows in view

> "the scroll trigger is a bit janky … the messages in view generally stay in view without being jostled around and we just load the new messages up above and off screen and update the scroll height without moving the scroll pane."

`insert_blocks` deferred its anchor restore **two refresh passes** past the mount (`call_after_refresh(settle_then_restore)` → `_settle_gaps` → `call_after_refresh(restore_anchor)` → `scroll_to`). Blocks author their own heights over several layout passes (`_set_authored_height`), so the **extent grew while the offset did not**, and real frames were painted at the displaced offset. The code's own comment conceded it: *"between the two, the offset still sits where the inserted rows pushed it."*

**The invariant, now stated in the code:** mounting older rows above the viewport changes the scroll *extent* and the reader's absolute *offset* by the same amount, so the content under the reader's eyes does not move on any painted frame.

The measurable form is the **anchor gap** — `anchor.virtual_region.y - scroll_y` — which is invariant under a correct insert and jumps by the inserted extent on any frame where only one of the two has moved. Sampled at the **compositor refresh** (the moment the terminal is written); sampling after `await pilot.pause()` instead drains the whole callback queue and coalesces the entire settle into one observation, which reports every intermediate paint as though it never happened. That measurement subtlety is why an earlier pass of this investigation read "0 displaced frames" on the broken code.

The human-legible form — the text of the block at the top of the viewport, on every painted frame of one page mount (`scripts/resume_paging_probe.py reader agentic 120x40`):

**Before**
```
baseline: 'Step 176 of turn 0000: inspecting the next c'
  paint#0 y= 65.0 vh=221 holds=False top='Step 161 …'
  paint#1 y= 65.0 vh=221 holds=False top='Step 161 …'
  paint#2 y= 65.0 vh=281 holds=False top='Step 146 …'
  paint#3 y= 65.0 vh=281 holds=False top='Step 146 …'
  paint#4 y=185.0 vh=281 holds=True  top='Step 176 …'
frames_that_moved = 4
```

**After**
```
baseline: 'Step 176 of turn 0000: inspecting the next c'
  paint#0 y=125.0 vh=221 holds=True top='Step 176 …'
  paint#1 y=125.0 vh=221 holds=True top='Step 176 …'
  paint#2 y=185.0 vh=281 holds=True top='Step 176 …'
  paint#3 y=185.0 vh=281 holds=True top='Step 176 …'
frames_that_moved = 0
```

The reader's row scrolled away for four frames and snapped back — a **120-row excursion on a 31-row viewport**, nearly four screens.

### The fix

The anchor is held for the **whole settle** in `_insert_anchor` and re-applied by `_size_updated` on every extent change — the same frame the growth lands in — rather than once at the end. This is the same class of bug `_land_on_tail` documents for the tail direction: one late correction computed against an extent that is still moving.

`immediate=True` on that `scroll_to` is load-bearing, not a micro-optimisation: Textual's default is `immediate=False`, which defers the offset change with `call_after_refresh`, i.e. until *after* the next compositor refresh — itself a painted frame, with the extent grown and the offset not yet moved. With the deferred form the fix still left **3 painted frames at a 60-row excursion**; with `immediate=True` it is 0.

Anchor-gap excursion across shapes and grids, post-fix — displaced painted frames / max excursion:

| shape | 100×30 | 120×40 | 160×50 |
|---|---|---|---|
| agentic | 0 / 0.0 | 0 / 0.0 | 0 / 0.0 |
| followup | 0 / 0.0 | 0 / 0.0 | 0 / 0.0 |
| ordinary | 0 / 0.0 | 0 / 0.0 | 0 / 0.0 |

### The paging contract is preserved

Read in full before touching, and unchanged: **one page per user gesture**, the `_resume_in_zone` edge latch, `_resume_paging` held until the settle callback (never a synchronous `finally`), `_resume_check_pending` single-flight, `continuous=` re-arm semantics, and the `programmatic_scroll()` guard around every correction — including the new `_reanchor_insert`, so the widget's own scroll is never reported to the page-back hook as a reader arriving at the top. `test_page_back_latch.py` and the existing cascade tests pass unchanged (one animated Home still mounts exactly one page).

`clear_blocks` drops the held anchor at the source, so an insert settling into a transcript that just went away has no stale reader to hold.

**`_settle_gaps` was left alone.** It was listed as a jitter suspect (it walks to the end of the ledger, invalidating every row below the insert). The measurements above show the displacement was entirely the deferred restore: with the re-anchor in place, every painted frame holds at gap 0 *while `_settle_gaps` still walks the full ledger*. Narrowing that walk is a real optimisation but it is not this bug, and changing it here would be an unrequested change to hard-won spacing logic — noted, not done.

---

## Frames

Production-CSS host (`scripts/resume_paging_shot.py`), real `OperatorApp`, 120×40. The lightweight test hosts declare no `CSS_PATH` and would not show a stylesheet change at all.

Rendered from the exported SVGs as text so the frames are readable inline and diffable; the SVG originals were viewed as images during validation.

### Before — the reported bug: 3 rows, no scrollbar, an unfollowable instruction
<details open>
<summary><b>BEFORE — resumed conversation: 3 rows, no scrollbar, unfollowable instruction</b></summary>

```text
    · older messages above — scroll up to load

  ▌ Thanks — now summarise the failures.

  Three rows failed validation: 041, 118 and 176.

  ❯   Message Local Operator…
```

</details>

### After — full transcript, scrollbar present, 130 rows of travel
<details open>
<summary><b>AFTER — resumed conversation: full transcript, scrollbar, 130 rows of travel</b></summary>

```text
  Checking record 193 against the schema.

   bash     validate --row 193                                                                              ✓

  Checking record 194 against the schema.

   bash     validate --row 194                                                                              ✓

  Checking record 195 against the schema.

   bash     validate --row 195                                                                              ✓

  Checking record 196 against the schema.

   bash     validate --row 196                                                                              ✓

  Checking record 197 against the schema.

   bash     validate --row 197                                                                              ✓

  Checking record 198 against the schema.

   bash     validate --row 198                                                                              ✓

  Checking record 199 against the schema.

   bash     validate --row 199                                                                              ✓

  ▌ Thanks — now summarise the failures.

  Three rows failed validation: 041, 118 and 176.

  ❯   Message Local Operator…
```

</details>

### Before — scrolled to top (only reachable because this capture forces it)
<details open>
<summary><b>BEFORE — scrolled to top (reachable only because the capture forces it)</b></summary>

```text
    · older messages above — scroll up to load

  Checking record 170 against the schema.

   bash     validate --row 170                                                                              ✓

  Checking record 171 against the schema.
                                                                                                                      ▂
   bash     validate --row 171                                                                              ✓

  Checking record 172 against the schema.

   bash     validate --row 172                                                                              ✓

  Checking record 173 against the schema.

   bash     validate --row 173                                                                              ✓

  Checking record 174 against the schema.

   bash     validate --row 174                                                                              ✓

  Checking record 175 against the schema.

   bash     validate --row 175                                                                              ✓

  Checking record 176 against the schema.

   bash     validate --row 176                                                                              ✓

  Checking record 177 against the schema.

  ❯   Message Local Operator…
```

</details>

### After — scrolling up mounts a page and holds position
<details open>
<summary><b>AFTER — scrolling up mounts a page and holds position</b></summary>

```text
    · older messages above — scroll up to load

  Checking record 131 against the schema.
                                                                                                                      ▄
   bash     validate --row 131                                                                              ✓

  Checking record 132 against the schema.

   bash     validate --row 132                                                                              ✓

  Checking record 133 against the schema.

   bash     validate --row 133                                                                              ✓

  Checking record 134 against the schema.

   bash     validate --row 134                                                                              ✓

  Checking record 135 against the schema.

   bash     validate --row 135                                                                              ✓

  Checking record 136 against the schema.

   bash     validate --row 136                                                                              ✓

  Checking record 137 against the schema.

   bash     validate --row 137                                                                              ✓

  Checking record 138 against the schema.

  ❯   Message Local Operator…
```

</details>

---

## Geometry table

Post-fix, 120×40, across conversation shapes:

| shape | history | blocks | virtual_h | viewport | max_scroll_y | scrollbar | pending head |
|---|---|---|---|---|---|---|---|
| followup (1×200 + follow-up) | 404 | 80 | 159 | 31 | 128 | ✅ | 324 |
| agentic (1×200) | 401 | 81 | 161 | 31 | 130 | ✅ | 321 |
| agentic-few (5×100) | 1005 | 81 | 161 | 31 | 130 | ✅ | 925 |
| ordinary (60×3) | 420 | 85 | 169 | 31 | 138 | ✅ | 336 |
| short (4×2) | 24 | 20 | 39 | 31 | 8 | ✅ | 0 |

Pre-fix, the `followup` row read `blocks=4  virtual_h=31  max_scroll_y=0  scrollbar=False  pending=401` — and identically at 120×60 and 200×50, so it was not a terminal-size accident.

---

## Regression tests

Four new guards, **each proven to fail on the pre-fix tree** (run from a throwaway worktree at `origin/main` with the new tests copied in):

```
FAILED test_resume_tail_start_snaps_back_to_the_nearest_user_row
        AssertionError: assert 12 == 9
FAILED test_resume_tail_start_never_renders_fewer_than_the_bound
        long turns then a follow-up: rendered 2 of 1007, bound 80
FAILED test_a_resumed_long_single_turn_transcript_is_scrollable
        resumed transcript is not scrollable: virtual=31 viewport=31 blocks=4
FAILED test_mounting_an_older_page_never_moves_the_rows_under_the_reader
        the reader's rows moved on 4 painted frame(s); max excursion 120 rows
```

Plus `test_the_fill_does_not_arm_or_consume_the_page_back_latch`, `test_the_fill_makes_a_tall_terminal_scrollable`, and `test_an_unreachable_head_never_says_scroll_up_to_load`. The existing `test_resume_tail_start_snaps_to_the_nearest_user_row` asserted `== 12`, pinning the forward direction; it is updated to `== 9` with the reason recorded in its docstring.

## Gates

Run over the whole tree, exactly as CI:

| gate | result |
|---|---|
| `.venv/bin/python -m flake8 .` | ✅ clean |
| `uvx --from black==26.1.0 black --check .` | ✅ 1012 files unchanged |
| `uvx isort==5.13.2 --check .` | ✅ clean |
| `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | ✅ 0 errors |
| `pytest tests/unit -q` | ✅ **15203 passed**, 18 skipped, 3 unrelated |
| `pytest tests/e2e -m e2e -n0 -q` | ✅ **45 passed** |
| `pytest tests/unit/tui/test_resume_render.py` | ✅ 19 passed |
| anchor/scroll neighbours (`test_stream_anchor`, `test_subagent_view`, `test_page_back_latch`, `test_transcript_scrollbar_grab`, `test_resume_render`) | ✅ 190 passed |

The 3 unit failures were `tests/unit/tui/test_startup_attachment.py` `TimeoutError`s recorded while the shared host was at **load average 400+** from sibling worktrees. That file is untouched by this diff (0 matches for its symbols), and all **46 tests in it pass** when re-run serially (`-n0`, 75 s). Per AGENTS.md, classified as load-induced rather than written off as weather.

## Evidence tooling

Two reusable scripts under `scripts/` (frames themselves stay on the PR, per AGENTS.md "Evidence goes on the PR"):

- **`resume_paging_probe.py`** — `geometry` (block count, virtual vs container height, scrollbar, pending head, notices), `jitter` (anchor-gap excursion sampled at the compositor refresh), `reader` (the top row's text on every painted frame — the human-legible invariant).
- **`resume_paging_shot.py`** — production-CSS captures: `resumed`, `scrolled`, `mount-0..3`, and `paint-0..3` (SVG exported from inside the compositor refresh). Both call `isolate_capture()` before app imports, so a developer's own config cannot reach the frame.

## Not addressed

- **`_settle_gaps` still walks to the end of the ledger.** Investigated as a jitter suspect and measured out — every painted frame holds at gap 0 with the walk unchanged. A real optimisation, but a separate change to spacing logic that was not asked for.
- The `test_startup_attachment.py` timeouts above are environmental (host load), not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
