### PR TITLE
perf(runtime): poll densely while a spawned runtime is constructing

### DIFF
--- a/local_operator/session/runtime/launch.py
+++ b/local_operator/session/runtime/launch.py
@@ -92,10 +92,23 @@ _CONSTRUCTING_POLL_S = 0.01
 #: wedged, slow, or a contender doing something we cannot see — and continuing
 #: to poll it 100 times a second for the rest of a 30-second deadline would be
 #: a spin. Sized at ~2.5x the ~1.2 s a full cold session construction takes
-#: **as measured on an M-series dev box**; a slower host lapses the window
-#: mid-construction and degrades to the open-ended grid, which is exactly
-#: ``main``'s behaviour, so the failure mode is one-sided. Nothing asserts on
-#: this value — it is a poll-frequency heuristic, not a correctness bound.
+#: **as measured on an M-series dev box**.
+#:
+#: The one-sidedness of that calibration was MEASURED, not argued: modelling a
+#: slower host by lengthening the construction, dead time is 11.1/11.7/7.4 ms
+#: at 0.4/1.2/2.5 s (window covers it), 67.0 ms at 3.5 s (window lapses
+#: mid-construction), and 716.3 vs 726.2 ms at 5.0 s and 726.1 vs 778.6 ms at
+#: 8.0 s (fully degraded). Past the window the new shape CONVERGES to the old
+#: one and never exceeds it, because the fallback restarts the exponential
+#: from ``_POLL_INITIAL_S`` rather than from a value that decayed while we
+#: were watching (QA round 1, Q2). So a host 3x slower than this one gets
+#: today's behaviour, not a regression.
+#:
+#: Deliberately NOT structural. Deriving it from an observed construction time
+#: needs a measurement the loop does not have on a process's first ``/new``,
+#: and buys nothing over a heuristic whose worst case is the status quo.
+#: Nothing asserts on this value — it is a poll-frequency heuristic, not a
+#: correctness bound.
 _CONSTRUCTING_WINDOW_S = 3.0
 #: How many runtimes one engage may spawn before it stops trying. Only the
 #: FIRST spawn is ordinary; the rest are respawns after a candidate proved to
@@ -660,17 +673,35 @@ def _poll_delay(backoff: float, constructing_for_s: float | None) -> tuple[float
     The totals clustered bimodally at ~540 ms and ~990 ms precisely because
     they were quantized to that grid.
 
+    **What this change controls is the dead time, and only that.** An
+    independent QA round reproduced the collapse in every one of three
+    interleaved A/B runs (~94-136 ms down to ~10-16 ms) but measured the
+    TOTAL attach improving by 2.1%, 15.0% and 16.6% \u2014 not the 34.9% an idle
+    box shows. The child's own construction dominates the total and varies far
+    more than the dead time removed here, so the percentage is a property of
+    how loaded the machine is, not of this code. State the dead time when
+    quoting this change; the total is a consequence, and a variable one.
+
     WHY DENSE POLLING IS AFFORDABLE HERE
     ====================================
     The backoff was protecting against a cost that does not exist at these
-    timescales. One full poll iteration — ``find_owner_record`` (a miss scan
-    over a run directory holding 11 records), ``_lease_holder``, and
-    ``Popen.poll`` — measures a median of 339 µs. At 10 ms that is a 3.4%
+    timescales. One full poll iteration — ``find_owner_record`` (a miss scan),
+    ``_lease_holder``, and ``Popen.poll`` — measures 23-30 µs against a run
+    directory of 200 real records, and is FLAT from 0 to 200 because
+    ``find_owner_record`` returns before ``scan()`` when there is no owner
+    marker (QA round 1, Q3; an earlier author estimate of 339 µs on an
+    11-record dir was pessimistic). At a 10 ms interval that is a 0.2-0.3%
     duty cycle on one thread, for at most ``_CONSTRUCTING_WINDOW_S``, and only
-    while a session is genuinely starting. The dense window is bounded rather
-    than open-ended for exactly the reason the backoff exists: a construction
-    still unfinished after 3 s is not about to publish, so the loop stops
-    guessing and falls back to the open-ended shape.
+    while a session is genuinely starting.
+
+    The nominal 100 Hz is also not what the loop achieves: real work per
+    iteration plus scheduling put the measured rate at ~42 Hz (126 dense wakes
+    in 3033 ms), so "10 ms" overstates how often the parent actually looks.
+
+    The dense window is bounded rather than open-ended for exactly the reason
+    the backoff exists: a construction still unfinished after 3 s is not about
+    to publish, so the loop stops guessing and falls back to the open-ended
+    shape.
 
     **That 339 µs assumes a tidy run directory, and record COUNT is not what
     threatens it.** ``scan()`` forks ``ps`` for any record whose heartbeat is

--- a/local_operator/session/runtime/launch.py
+++ b/local_operator/session/runtime/launch.py
@@ -43,12 +43,15 @@ subtree: given ``session_factory`` (the composition root the child imports
 regardless), its marginal cost is 2.2 ms. Deferring it would move ~2 ms.
 
 **The poll shape has two regimes, because the loop has two waits.** When a
-construction is KNOWN to be in flight — a candidate we spawned is still
-alive, or a contender holds the lease — we have a strong prior on when a
-record will appear (~0.4 s here, ~1.2 s for a full cold session), so the grid
-is DENSE and flat. When nothing is known to be constructing, the wait is
-open-ended and the exponential backoff takes over. See
-:func:`_poll_delay` for the measurements behind the constants.
+construction is KNOWN to be in flight — no record exists yet, AND either a
+candidate we spawned is still alive or a contender holds the lease — we have
+a strong prior on when a record will appear (~0.4 s for a deferred warm
+start, ~1.2 s for a full cold session; both measured on an M-series dev box
+via ``scripts/bench_runtime_attach.py``), so the grid is DENSE and flat.
+When nothing is known to be constructing the wait is open-ended and the
+exponential backoff takes over — and that includes retrying a record which
+already exists but will not answer the dial, a slow path that must stay one.
+See :func:`_poll_delay` for the measurements behind the constants.
 """
 
 from __future__ import annotations
@@ -88,7 +91,11 @@ _CONSTRUCTING_POLL_S = 0.01
 #: A construction still unfinished after this is not "about to publish" — it is
 #: wedged, slow, or a contender doing something we cannot see — and continuing
 #: to poll it 100 times a second for the rest of a 30-second deadline would be
-#: a spin. Sized at ~2.5x the ~1.2 s a full cold session construction takes.
+#: a spin. Sized at ~2.5x the ~1.2 s a full cold session construction takes
+#: **as measured on an M-series dev box**; a slower host lapses the window
+#: mid-construction and degrades to the open-ended grid, which is exactly
+#: ``main``'s behaviour, so the failure mode is one-sided. Nothing asserts on
+#: this value — it is a poll-frequency heuristic, not a correctness bound.
 _CONSTRUCTING_WINDOW_S = 3.0
 #: How many runtimes one engage may spawn before it stops trying. Only the
 #: FIRST spawn is ordinary; the rest are respawns after a candidate proved to
@@ -565,12 +572,32 @@ async def engage_runtime(
                 actionable=spawn_actionable,
             ) from last_error
 
-        # Is a construction KNOWN to be in flight? Either a contender holds the
-        # lease, or the candidate we spawned is still alive — a live candidate
-        # is by definition still constructing (see the respawn branch above).
-        # Both mean a record is expected soon, which is what earns the dense
-        # poll regime; anything else is the open-ended wait.
-        constructing = holder is not None or (candidate is not None and candidate.poll() is None)
+        # Is a construction KNOWN to be in flight? It requires BOTH that no
+        # record exists yet AND that someone is working on one — a contender
+        # holding the lease, or the candidate we spawned still being alive.
+        #
+        # ``record is None`` is load-bearing, not belt-and-braces. The lease is
+        # NOT a construction signal on its own: ``session_factory`` registers
+        # its release as a dispose hook, so a fully constructed, happily
+        # serving runtime holds its lease for its entire life. Without this
+        # term, a runtime that has published a record but refuses the dial
+        # (wedged control socket, port exhaustion) takes the ``ConnectionError``
+        # retry path above and is read as "constructing" on every pass — which
+        # turned a slow retry into a hot spin: measured at 301 dial attempts in
+        # a 3 s window against 8 under the open-ended grid (review round 1,
+        # MAJOR-1). A record that already exists means construction is over,
+        # whatever the lease says, so the wait for that runtime to become
+        # dialable is open-ended and belongs on the backoff.
+        #
+        # It also bounds the scan cost the dense interval assumes. A quiet
+        # record makes `scan()` fork `ps`, but `find_owner_record` only reaches
+        # `scan()` once an owner marker exists; requiring `record is None`
+        # keeps the dense regime off the marker-plus-record case entirely. See
+        # `_poll_delay` for the measured table and the one overlap that
+        # remains.
+        constructing = record is None and (
+            holder is not None or (candidate is not None and candidate.poll() is None)
+        )
         now = time.monotonic()
         if constructing:
             if constructing_since is None:
@@ -594,9 +621,14 @@ def _poll_delay(backoff: float, constructing_for_s: float | None) -> tuple[float
     """Pick the next poll interval, and the backoff to carry forward.
 
     ``constructing_for_s`` is how long a construction has been KNOWN to be in
-    flight (a candidate we spawned is alive, or a contender holds the lease),
-    or ``None`` when nothing is known to be constructing. Returns
-    ``(sleep_for, next_backoff)``.
+    flight — no record has been published yet, and either a candidate we
+    spawned is alive or a contender holds the lease — or ``None`` when nothing
+    is known to be constructing. Returns ``(sleep_for, next_backoff)``.
+
+    The "no record yet" half is not redundant: a held lease alone does not mean
+    construction, because it is released only on session disposal. See the
+    caller's comment on ``constructing`` for the retry storm that omitting it
+    caused.
 
     WHY TWO REGIMES
     ===============
@@ -604,16 +636,17 @@ def _poll_delay(backoff: float, constructing_for_s: float | None) -> tuple[float
     but they are not the same wait and the shape that suits one is wrong for
     the other:
 
-    * **Known construction.** We have a live ``Popen`` (or a lease naming a
-      live pid) and a good prior on when the record lands — measured at
-      ~0.4 s on this machine for a deferred warm start, ~1.2 s for a full
-      cold session. The record's arrival is an EVENT we are already close to;
-      the only question is how soon after it we look. A flat, dense grid
-      answers within one interval.
+    * **Known construction.** No record exists yet, and we have a live
+      ``Popen`` (or a lease naming a live pid) plus a good prior on when the
+      record lands — measured at ~0.4 s for a deferred warm start and ~1.2 s
+      for a full cold session, on an M-series dev box. The record's arrival is
+      an EVENT we are already close to; the only question is how soon after it
+      we look. A flat, dense grid answers within one interval.
     * **Open-ended wait.** Nothing is known to be constructing. There is no
       prior at all, the wait may run the whole 30-second deadline, and
       polling it densely is a spin that buys nothing. That is the wait the
-      exponential backoff was written for, and it keeps it unchanged.
+      exponential backoff was written for, and it keeps it unchanged. A
+      published record that refuses the dial lives HERE, not above.
 
     THE MEASUREMENT THAT FORCED THIS
     ================================
@@ -638,6 +671,39 @@ def _poll_delay(backoff: float, constructing_for_s: float | None) -> tuple[float
     than open-ended for exactly the reason the backoff exists: a construction
     still unfinished after 3 s is not about to publish, so the loop stops
     guessing and falls back to the open-ended shape.
+
+    **That 339 µs assumes a tidy run directory, and record COUNT is not what
+    threatens it.** ``scan()`` forks ``ps`` for any record whose heartbeat is
+    older than ``HEARTBEAT_INTERVAL_S * 1.5``, and such a record is not reaped,
+    so it pays that fork on every scan (review round 1, MINOR-1).
+
+    Where that lands is narrower than it first appears, because
+    ``find_owner_record`` returns BEFORE ``scan()`` when the session has no
+    ``.session.pid`` owner marker. Measured on this host, 8 fresh records plus
+    N quiet ones:
+
+    ====================  ===========  ===========  ===========
+    owner marker          0 quiet      1 quiet      3 quiet
+    ====================  ===========  ===========  ===========
+    absent (no owner)     0.01 ms      0.01 ms      0.01 ms
+    present               0.48 ms      14.02 ms     32.13 ms
+    ====================  ===========  ===========  ===========
+
+    So the expensive column needs an owner marker, and the cheap row is the
+    ordinary ``/new`` dense window — a freshly minted session has no owner, so
+    it never reaches ``scan()`` at all and the 339 µs figure holds.
+
+    The requirement that no record exists retires the WORST case (a marker
+    plus a dialable record is now always coarse), but one reachable overlap
+    remains and is stated here rather than glossed: a marker present with no
+    usable record yet — the genuine pre-publish window — can pay ~14 ms per
+    poll against a 10 ms interval. That is accepted rather than floored,
+    because it is SELF-LIMITING: the scans run sequentially on a ``to_thread``
+    worker, so a scan slower than its interval simply yields fewer scans
+    instead of a growing backlog, and the loop degrades toward the coarse
+    grid's own frequency. A minimum-interval floor would not help — the cost
+    is in the scan, not in the sleep — and the window is bounded by
+    ``_CONSTRUCTING_WINDOW_S`` regardless.
     """
     if constructing_for_s is not None and constructing_for_s < _CONSTRUCTING_WINDOW_S:
         # Hold the backoff where it is: if the dense window expires, the

--- a/local_operator/session/runtime/launch.py
+++ b/local_operator/session/runtime/launch.py
@@ -29,9 +29,26 @@ an error (``process.py`` logs the loss and returns 0 for that reason).
    from the same caller cannot help — if the first is still constructing, (2)
    now covers it — and would just be another loser to reap.
 
-The backoff (``0.05 → ×1.7 → cap 1.0``) is shaped for step 2's wait: fast
-enough that a warm start feels immediate, and backing off to seconds so a
-30-second deadline does not become a spin.
+**What the parent's dead time is NOT.** Two other suspects were measured and
+acquitted, so nobody re-derives them. (1) The first ``find_owner_record``
+scan is a guaranteed miss for a freshly minted ``/new`` session, which looks
+like serialized latency ahead of the spawn — but in the warm parent that
+actually runs ``/new`` (a long-lived TUI) engage-entry to fork measures a
+median of 2.1 ms. The ~24 ms a cold process shows is function-local import
+cost the TUI has already paid, so skipping the scan would buy single-digit
+milliseconds while weakening the lease arbitration this module exists to
+protect. (2) The child's import graph is dominated by
+``local_operator.harness.jobs`` at 99 ms cumulative, but that is a SHARED
+subtree: given ``session_factory`` (the composition root the child imports
+regardless), its marginal cost is 2.2 ms. Deferring it would move ~2 ms.
+
+**The poll shape has two regimes, because the loop has two waits.** When a
+construction is KNOWN to be in flight — a candidate we spawned is still
+alive, or a contender holds the lease — we have a strong prior on when a
+record will appear (~0.4 s here, ~1.2 s for a full cold session), so the grid
+is DENSE and flat. When nothing is known to be constructing, the wait is
+open-ended and the exponential backoff takes over. See
+:func:`_poll_delay` for the measurements behind the constants.
 """
 
 from __future__ import annotations
@@ -56,10 +73,23 @@ logger = logging.getLogger(__name__)
 #: message went nowhere.
 DEFAULT_DEADLINE_S = 30.0
 
-#: Poll shape while waiting for a contender's runtime to publish its record.
+#: Poll shape for an OPEN-ENDED wait — nothing is known to be constructing, so
+#: there is no prior on when a record might appear and a spin would be pure
+#: waste against a 30-second deadline.
 _POLL_INITIAL_S = 0.05
 _POLL_FACTOR = 1.7
 _POLL_CAP_S = 1.0
+
+#: Poll interval while a construction is KNOWN to be in flight. Flat, not
+#: exponential: see :func:`_poll_delay` for why the two waits get two shapes.
+_CONSTRUCTING_POLL_S = 0.01
+
+#: How long the dense regime may last before the open-ended backoff takes over.
+#: A construction still unfinished after this is not "about to publish" — it is
+#: wedged, slow, or a contender doing something we cannot see — and continuing
+#: to poll it 100 times a second for the rest of a 30-second deadline would be
+#: a spin. Sized at ~2.5x the ~1.2 s a full cold session construction takes.
+_CONSTRUCTING_WINDOW_S = 3.0
 #: How many runtimes one engage may spawn before it stops trying. Only the
 #: FIRST spawn is ordinary; the rest are respawns after a candidate proved to
 #: have died during construction. Three is enough to ride out a transient
@@ -400,6 +430,10 @@ async def engage_runtime(
         work = type(work)(**{**_fields(work), "command_id": new_command_id()})
 
     deadline = time.monotonic() + deadline_s
+    # The open-ended wait's exponential state. ``delay`` is what we actually
+    # sleep on a given pass, which the dense regime overrides without
+    # disturbing ``backoff``.
+    backoff = _POLL_INITIAL_S
     delay = _POLL_INITIAL_S
     spawned = False
     # The Popen of the most recent candidate, so the respawn branch can tell
@@ -417,6 +451,11 @@ async def engage_runtime(
     # only the retries need a cap. See the respawn branch below.
     spawns = 0
     last_error: Exception | None = None
+    # When the current construction episode was first OBSERVED, which is what
+    # selects the dense poll regime (see ``_poll_delay``). Reset to None the
+    # moment nothing is known to be constructing, so a respawned candidate
+    # gets its own fresh dense window rather than inheriting a spent one.
+    constructing_since: float | None = None
     # Deferred materialisation is exactly the speculative case: a warm engage
     # must not create a session directory for a draft the user may abandon.
     # A wake engage is NOT speculative — the session already exists on disk.
@@ -444,6 +483,7 @@ async def engage_runtime(
                 last_error = exc
                 logger.debug("engage: dial failed for %s; retrying", session_id, exc_info=True)
 
+        holder: int | None = None
         if not spawned or spawns < _MAX_SPAWNS:
             holder = await asyncio.to_thread(_lease_holder, config_dir, session_id)
             if holder is not None:
@@ -525,14 +565,86 @@ async def engage_runtime(
                 actionable=spawn_actionable,
             ) from last_error
 
+        # Is a construction KNOWN to be in flight? Either a contender holds the
+        # lease, or the candidate we spawned is still alive — a live candidate
+        # is by definition still constructing (see the respawn branch above).
+        # Both mean a record is expected soon, which is what earns the dense
+        # poll regime; anything else is the open-ended wait.
+        constructing = holder is not None or (candidate is not None and candidate.poll() is None)
+        now = time.monotonic()
+        if constructing:
+            if constructing_since is None:
+                constructing_since = now
+        else:
+            constructing_since = None
+
+        delay, backoff = _poll_delay(
+            backoff, None if constructing_since is None else now - constructing_since
+        )
         await asyncio.sleep(min(delay, max(0.0, deadline - time.monotonic())))
-        delay = min(delay * _POLL_FACTOR, _POLL_CAP_S)
 
     if capture is not None:
         capture.unlink(missing_ok=True)
     raise TimeoutError(
         f"could not reach a runtime for session {session_id} within {deadline_s:.0f}s"
     ) from last_error
+
+
+def _poll_delay(backoff: float, constructing_for_s: float | None) -> tuple[float, float]:
+    """Pick the next poll interval, and the backoff to carry forward.
+
+    ``constructing_for_s`` is how long a construction has been KNOWN to be in
+    flight (a candidate we spawned is alive, or a contender holds the lease),
+    or ``None`` when nothing is known to be constructing. Returns
+    ``(sleep_for, next_backoff)``.
+
+    WHY TWO REGIMES
+    ===============
+    The single exponential grid this replaces served both of the loop's waits,
+    but they are not the same wait and the shape that suits one is wrong for
+    the other:
+
+    * **Known construction.** We have a live ``Popen`` (or a lease naming a
+      live pid) and a good prior on when the record lands — measured at
+      ~0.4 s on this machine for a deferred warm start, ~1.2 s for a full
+      cold session. The record's arrival is an EVENT we are already close to;
+      the only question is how soon after it we look. A flat, dense grid
+      answers within one interval.
+    * **Open-ended wait.** Nothing is known to be constructing. There is no
+      prior at all, the wait may run the whole 30-second deadline, and
+      polling it densely is a spin that buys nothing. That is the wait the
+      exponential backoff was written for, and it keeps it unchanged.
+
+    THE MEASUREMENT THAT FORCED THIS
+    ================================
+    Under one grid (``0.05 → ×1.7 → cap 1.0``) the polls fire at 50, 135,
+    280, 525, 943 ms. A warm ``/new`` child publishes its record at ~400 ms,
+    which falls between the 280 ms and 525 ms wakes — so the parent slept
+    ~145 ms past a runtime that was already serving, and a child landing just
+    after 525 ms waited until 943 ms. Measured over 7 isolated runs
+    (``scripts/bench_runtime_attach.py``): child ready at a median of 401 ms,
+    parent noticed at 538 ms, **144 ms median dead time and 318 ms at worst**.
+    The totals clustered bimodally at ~540 ms and ~990 ms precisely because
+    they were quantized to that grid.
+
+    WHY DENSE POLLING IS AFFORDABLE HERE
+    ====================================
+    The backoff was protecting against a cost that does not exist at these
+    timescales. One full poll iteration — ``find_owner_record`` (a miss scan
+    over a run directory holding 11 records), ``_lease_holder``, and
+    ``Popen.poll`` — measures a median of 339 µs. At 10 ms that is a 3.4%
+    duty cycle on one thread, for at most ``_CONSTRUCTING_WINDOW_S``, and only
+    while a session is genuinely starting. The dense window is bounded rather
+    than open-ended for exactly the reason the backoff exists: a construction
+    still unfinished after 3 s is not about to publish, so the loop stops
+    guessing and falls back to the open-ended shape.
+    """
+    if constructing_for_s is not None and constructing_for_s < _CONSTRUCTING_WINDOW_S:
+        # Hold the backoff where it is: if the dense window expires, the
+        # open-ended wait starts from the top rather than from a value that
+        # decayed while we were watching a healthy construction.
+        return _CONSTRUCTING_POLL_S, backoff
+    return backoff, min(backoff * _POLL_FACTOR, _POLL_CAP_S)
 
 
 def _fields(work: Errand) -> dict[str, Any]:

--- a/scripts/bench_runtime_attach.py
+++ b/scripts/bench_runtime_attach.py
@@ -1,0 +1,230 @@
+"""Measure how long `/new` takes to produce a usable runtime.
+
+WHAT THIS MEASURES, AND WHY IT IS THE RIGHT THING
+=================================================
+The user-visible complaint is that `/new` sits on "starting…" for a long
+time. That indicator is raised by `OperatorApp._set_starting(True)` in
+`_engage_runtime_eagerly` and lowered when `RemoteSession._ensure_bound()`
+returns, so the number a user actually feels is exactly the wall time of
+`_ensure_bound`, which decomposes into:
+
+    engage_runtime()            spawn a child + poll until it publishes
+      └─ _spawn_runtime()         fork/exec `python -m ...runtime.process`
+      └─ child: import           the composition root's import graph
+      └─ child: spawn_owned_session()  build the session
+      └─ child: RuntimeServer.start_in_process()  bind + publish record
+      └─ parent poll loop        find_owner_record() every _POLL_* seconds
+    find_owner_record()         one more scan once the errand is delivered
+    _bind_to(record)            dial the socket, await the frontend snapshot,
+                                load history, install state
+
+Two of those phases are pure latency the parent adds on top of the child's
+real work: the **poll grid** (the parent only notices the record on a poll
+boundary, so up to one full backoff step is dead time) and the **serialized
+spawn** (nothing is started until the first `find_owner_record` scan has
+already come back empty). This benchmark reports every phase separately so a
+change can be shown to move the phase it claims to move, rather than showing
+one aggregate number that improved for unknown reasons.
+
+ISOLATION
+=========
+Every run gets a fresh `HOME` *and* a fresh `LOCAL_OPERATOR_CONFIG_DIR`.
+`AGENTS.md` is explicit that the config dir alone is not enough — the model
+catalogue cache derives its root from the home directory independently, so a
+run with only the config dir redirected reads the operator's real cache and
+reports a warm number as a cold one. The harness therefore never touches the
+operator's live sessions, and a benchmark run cannot spawn a runtime that
+attaches to a real conversation.
+
+USAGE
+=====
+    .venv/bin/python scripts/bench_runtime_attach.py --runs 7
+    .venv/bin/python scripts/bench_runtime_attach.py --runs 7 --json out.json
+
+Report the MEDIAN, not the mean: the distribution has a long right tail (the
+first run in a process pays for the OS page cache being cold on the
+interpreter and on site-packages), and a mean over seven runs is dominated by
+whichever one happened to land during a Spotlight sweep.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import shutil
+import statistics
+import sys
+import tempfile
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+# A benchmark under scripts/ must read the tree it lives in, not whatever tree
+# the venv was installed from (AGENTS.md, "Every feature worktree owns its own
+# venv"). Without this a benchmark run in a worktree silently measures main.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+class Phase:
+    """One timed span, recorded in milliseconds."""
+
+    __slots__ = ("name", "started", "elapsed_ms")
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.started = time.perf_counter()
+        self.elapsed_ms = 0.0
+
+    def stop(self) -> float:
+        self.elapsed_ms = (time.perf_counter() - self.started) * 1000.0
+        return self.elapsed_ms
+
+
+async def _one_run(config_dir: Path) -> dict[str, float]:
+    """Spawn one runtime and attach to it, timing each phase.
+
+    Returns a mapping of phase name to milliseconds. `total` is the number the
+    user feels — the whole of `_ensure_bound`.
+    """
+    from local_operator.mobile.attach_client import find_owner_record
+    from local_operator.session.runtime.launch import WarmErrand, engage_runtime
+
+    session_id = f"bench-{uuid.uuid4().hex[:12]}"
+    cwd = str(config_dir)
+    out: dict[str, float] = {}
+
+    total = Phase("total")
+
+    engage = Phase("engage")
+    await engage_runtime(session_id, cwd, WarmErrand(), config_dir=config_dir)
+    out["engage_ms"] = engage.stop()
+
+    lookup = Phase("lookup")
+    record, _owner = await asyncio.to_thread(find_owner_record, config_dir, session_id)
+    out["lookup_ms"] = lookup.stop()
+
+    out["total_ms"] = total.stop()
+    out["found"] = 1.0 if record is not None else 0.0
+
+    # Tear the child down: a benchmark that leaves seven runtimes resident
+    # measures the eighth against a machine it degraded itself.
+    if record is not None:
+        pid = getattr(record, "pid", None)
+        if isinstance(pid, int) and pid > 0:
+            try:
+                os.kill(pid, 15)
+            except (ProcessLookupError, PermissionError, OSError):
+                pass
+    return out
+
+
+def _seed_config(config_dir: Path) -> None:
+    """Write the minimum config a runtime needs to construct.
+
+    The `test` provider is used deliberately: `create_session` raises
+    `HostingNotConfiguredError` before doing any of the work this benchmark
+    measures unless `hosting` resolves, and every real provider would put a
+    network client construction (and possibly a live credential check) inside
+    the span. `test` resolves through the same `get_provider_definition`
+    lookup the engine uses, so the composition root runs its full ordinary
+    path — imports, registry, engine, tool wiring — with nothing reaching the
+    network. That keeps the measurement about startup rather than about the
+    operator's connectivity.
+
+    `model_name` is set explicitly because `default_model_for("test")` is
+    None, and a missing model raises `ModelNotConfiguredError` at the same
+    preflight.
+
+    Written through `ConfigManager` rather than as hand-rolled YAML: the
+    metadata block carries fields (`last_modified`) that the loader requires
+    and that a hand-written file silently omits, which surfaces as a
+    `KeyError` from inside the child and reads like a startup regression
+    rather than a broken fixture.
+    """
+    from local_operator.config import ConfigManager
+
+    manager = ConfigManager(config_dir=config_dir)
+    manager.update_config({"hosting": "test", "model_name": "test-model"})
+
+
+def _run_isolated(runs: int) -> list[dict[str, float]]:
+    """Run the benchmark `runs` times, each in a fresh HOME + config dir."""
+    results: list[dict[str, float]] = []
+    for index in range(runs):
+        root = Path(tempfile.mkdtemp(prefix="lop-bench-"))
+        config_dir = root / ".local-operator"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        _seed_config(config_dir)
+        saved = {key: os.environ.get(key) for key in ("HOME", "LOCAL_OPERATOR_CONFIG_DIR")}
+        os.environ["HOME"] = str(root)
+        os.environ["LOCAL_OPERATOR_CONFIG_DIR"] = str(config_dir)
+        try:
+            result = asyncio.run(_one_run(config_dir))
+            result["run"] = float(index)
+            results.append(result)
+            print(
+                f"  run {index + 1}/{runs}: total={result['total_ms']:.0f}ms "
+                f"engage={result['engage_ms']:.0f}ms lookup={result['lookup_ms']:.0f}ms "
+                f"{'ok' if result['found'] else 'NO RECORD'}",
+                flush=True,
+            )
+        finally:
+            for key, value in saved.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+            shutil.rmtree(root, ignore_errors=True)
+    return results
+
+
+def _summarize(results: list[dict[str, float]]) -> dict[str, Any]:
+    """Median and spread per phase. Median, because the tail is not the signal."""
+    summary: dict[str, Any] = {"runs": len(results)}
+    for key in ("total_ms", "engage_ms", "lookup_ms"):
+        values = [r[key] for r in results if key in r]
+        if not values:
+            continue
+        summary[key] = {
+            "median": round(statistics.median(values), 1),
+            "min": round(min(values), 1),
+            "max": round(max(values), 1),
+        }
+    summary["records_found"] = sum(int(r.get("found", 0)) for r in results)
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--runs", type=int, default=7, help="how many spawns to time")
+    parser.add_argument("--json", type=str, default="", help="write raw results here")
+    args = parser.parse_args()
+
+    print(f"benchmarking runtime attach: {args.runs} isolated runs", flush=True)
+    results = _run_isolated(args.runs)
+    summary = _summarize(results)
+
+    print("\n--- summary (ms) ---")
+    for key in ("total_ms", "engage_ms", "lookup_ms"):
+        if key in summary:
+            stat = summary[key]
+            print(
+                f"  {key:<12} median={stat['median']:>7}  "
+                f"min={stat['min']:>7}  max={stat['max']:>7}"
+            )
+    print(f"  records found: {summary['records_found']}/{summary['runs']}")
+
+    if args.json:
+        Path(args.json).write_text(
+            json.dumps({"summary": summary, "results": results}, indent=2),
+            encoding="utf-8",
+        )
+        print(f"\nwrote {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/session/runtime/test_launch_arbitration.py
+++ b/tests/unit/session/runtime/test_launch_arbitration.py
@@ -559,6 +559,59 @@ def test_spawn_capture_is_private_and_anonymous(tmp_path, monkeypatch) -> None:
 # ---------------------------------------------------------------------------
 
 
+class _sleep_recorder:
+    """A stand-in for ``launch``'s ``asyncio`` that records what it was asked to sleep.
+
+    WHY A PROXY OBJECT AND NOT ``setattr(launch_module.asyncio, "sleep", ...)``
+    ==========================================================================
+    ``launch_module.asyncio`` is not a per-module copy -- it is THE shared
+    ``asyncio`` module object, so setting an attribute on it patches
+    ``asyncio.sleep`` for every module in the process. Under ``-n auto`` the
+    recorder then captures sleeps from whatever else is running in the same
+    worker, and the assertion reports another test's timings as this one's
+    (observed: 0.2 and 1.0 leaking in from ``tests/unit/tui/test_stop_command.py``,
+    which failed a poll-shape test that passes in isolation).
+
+    Rebinding the NAME on the module under test keeps the patch where the test
+    can reason about it: only ``launch``'s own ``asyncio.sleep`` calls are
+    recorded, and nothing outside this module is affected.
+    """
+
+    def __init__(self, slept: list[float], clock: dict[str, float] | None = None) -> None:
+        self._slept = slept
+        self._clock = clock
+
+    async def sleep(self, duration: float) -> None:
+        self._slept.append(duration)
+        # When a virtual clock is in play, the loop's own deadline arithmetic
+        # advances by exactly the sleeps it asked for -- time is DATA here,
+        # never a measurement, so a 3 s window costs no real seconds.
+        if self._clock is not None:
+            self._clock["now"] += duration
+
+    def __getattr__(self, name: str) -> Any:
+        # Anything the module reaches for other than `sleep` is the real thing.
+        return getattr(asyncio, name)
+
+
+class _virtual_clock:
+    """A stand-in for ``launch``'s ``time``, driven by the sleeps it requests.
+
+    Scoped for the same reason as :class:`_sleep_recorder`: ``time`` is a shared
+    module object, and a process-wide ``monotonic`` would be considerably worse
+    than a process-wide ``sleep``.
+    """
+
+    def __init__(self, clock: dict[str, float]) -> None:
+        self._clock = clock
+
+    def monotonic(self) -> float:
+        return self._clock["now"]
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(time, name)
+
+
 def test_poll_delay_is_dense_while_a_construction_is_known_to_be_in_flight() -> None:
     """The unit fact: a known construction polls flat and dense, and the
     open-ended backoff is preserved rather than decayed underneath it.
@@ -629,10 +682,12 @@ async def test_engage_polls_densely_while_its_own_candidate_constructs(
 
     slept: list[float] = []
 
-    async def record_sleep(duration: float) -> None:
-        slept.append(duration)
-
-    monkeypatch.setattr(launch_module.asyncio, "sleep", record_sleep)
+    # Scoped to a PRIVATE asyncio proxy for this module, never to the shared
+    # `asyncio` module object. `launch_module.asyncio` IS the global module, so
+    # `setattr(launch_module.asyncio, "sleep", ...)` patches it for the whole
+    # process and this recorder then captures unrelated sleeps from any test
+    # running beside it (observed: 0.2 and 1.0 leaking in from the TUI suite).
+    monkeypatch.setattr(launch_module, "asyncio", _sleep_recorder(slept))
 
     with pytest.raises(TimeoutError):
         await engage_runtime(
@@ -675,10 +730,12 @@ async def test_engage_uses_the_coarse_grid_when_nothing_is_constructing(
 
     slept: list[float] = []
 
-    async def record_sleep(duration: float) -> None:
-        slept.append(duration)
-
-    monkeypatch.setattr(launch_module.asyncio, "sleep", record_sleep)
+    # Scoped to a PRIVATE asyncio proxy for this module, never to the shared
+    # `asyncio` module object. `launch_module.asyncio` IS the global module, so
+    # `setattr(launch_module.asyncio, "sleep", ...)` patches it for the whole
+    # process and this recorder then captures unrelated sleeps from any test
+    # running beside it (observed: 0.2 and 1.0 leaking in from the TUI suite).
+    monkeypatch.setattr(launch_module, "asyncio", _sleep_recorder(slept))
 
     with pytest.raises(TimeoutError):
         await engage_runtime(
@@ -723,12 +780,10 @@ async def test_a_dense_window_does_not_outlive_its_welcome(tmp_path: Path, monke
     # waiting out three real seconds. Time is DATA here, never a measurement.
     clock = {"now": 0.0}
 
-    async def record_sleep(duration: float) -> None:
-        slept.append(duration)
-        clock["now"] += duration
-
-    monkeypatch.setattr(launch_module.asyncio, "sleep", record_sleep)
-    monkeypatch.setattr(launch_module.time, "monotonic", lambda: clock["now"])
+    # Same scoping as above, for both the sleep and the clock: `time` is a
+    # shared module object too, and a process-wide `monotonic` is far worse.
+    monkeypatch.setattr(launch_module, "asyncio", _sleep_recorder(slept, clock))
+    monkeypatch.setattr(launch_module, "time", _virtual_clock(clock))
 
     with pytest.raises(TimeoutError):
         await engage_runtime(

--- a/tests/unit/session/runtime/test_launch_arbitration.py
+++ b/tests/unit/session/runtime/test_launch_arbitration.py
@@ -800,3 +800,81 @@ async def test_a_dense_window_does_not_outlive_its_welcome(tmp_path: Path, monke
     # ...and the fallback restarts the backoff from the top rather than from a
     # value that decayed while the child looked healthy.
     assert coarse[0] == _POLL_INITIAL_S
+
+
+@pytest.mark.asyncio
+async def test_a_published_record_that_refuses_the_dial_is_not_polled_densely(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A live runtime that will not answer must stay on the SLOW path.
+
+    The lease is held for a session's whole life -- ``session_factory``
+    registers its release as a dispose hook -- so ``_lease_holder`` names a
+    live pid for a fully constructed, happily serving runtime, not merely one
+    that is starting. A runtime that has published a record but refuses the
+    dial (wedged control socket, port exhaustion) therefore takes the loop's
+    ``ConnectionError`` retry path with its lease still held.
+
+    Reading that as "constructing" turned a slow retry into a hot spin:
+    measured at 301 dial attempts inside a 3 s window against 8 under the
+    open-ended grid (review round 1, MAJOR-1). The guard is the shape of the
+    schedule -- no dense wake may be requested while a record exists -- which
+    is a fact about what the loop decided and cannot flake under load.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions").mkdir(parents=True, exist_ok=True)
+
+    record = SessionRecord(
+        pid=os.getpid(),
+        kind="daemon",
+        session_id=SESSION_ID,
+        conversation_name="wedged",
+        cwd=str(tmp_path),
+        model_label="test/model",
+        control_port=1,
+        control_key="k" * 16,
+    )
+    # A record IS present and the lease IS held by a live pid: construction is
+    # over and this runtime is simply unreachable. `find_owner_record` is a
+    # function-local import in the loop, so it is patched at its source module.
+    monkeypatch.setattr(
+        "local_operator.mobile.attach_client.find_owner_record",
+        lambda config_dir, session_id: (record, os.getpid()),
+    )
+    monkeypatch.setattr(launch_module, "_lease_holder", lambda config_dir, session_id: os.getpid())
+
+    dials = 0
+
+    async def refuses_the_dial(*args: Any, **kwargs: Any) -> tuple[str, bool]:
+        nonlocal dials
+        dials += 1
+        raise ConnectionError("control socket refuses")
+
+    monkeypatch.setattr(launch_module, "_deliver", refuses_the_dial)
+    # Nothing may be spawned: a record exists, so the loop must only be
+    # retrying the dial. A spawn here would be a separate (arbitration) bug.
+    monkeypatch.setattr(
+        "local_operator.session.runtime.launch._spawn_runtime",
+        lambda session_id, cwd, *, defer_materialise: pytest.fail("spawned despite a live record"),
+    )
+
+    slept: list[float] = []
+    clock = {"now": 0.0}
+    monkeypatch.setattr(launch_module, "asyncio", _sleep_recorder(slept, clock))
+    monkeypatch.setattr(launch_module, "time", _virtual_clock(clock))
+
+    with pytest.raises(TimeoutError):
+        await engage_runtime(
+            SESSION_ID, str(tmp_path), WarmErrand(), config_dir=tmp_path, deadline_s=3.0
+        )
+
+    assert dials > 0, "the dial was never attempted; the repro no longer exercises the retry path"
+    assert (
+        _CONSTRUCTING_POLL_S not in slept
+    ), f"a published record was polled at the dense interval: {sorted(set(slept))}"
+    # The open-ended shape is what should be running here, from the top.
+    assert slept[0] == _POLL_INITIAL_S
+    assert max(slept) > _CONSTRUCTING_POLL_S, "the schedule never backed off"
+    # Retries are bounded by the backoff, not by the poll floor: an order of
+    # magnitude fewer than the ~300 the dense regime produced over 3 s.
+    assert dials < 30, f"{dials} dial attempts in a 3 s window is a retry storm"

--- a/tests/unit/session/runtime/test_launch_arbitration.py
+++ b/tests/unit/session/runtime/test_launch_arbitration.py
@@ -26,12 +26,19 @@ from typing import Any
 
 import pytest
 
+import local_operator.session.runtime.launch as launch_module
 from local_operator.session.runtime.launch import (
+    _CONSTRUCTING_POLL_S,
+    _CONSTRUCTING_WINDOW_S,
     _MAX_SPAWNS,
+    _POLL_CAP_S,
+    _POLL_FACTOR,
+    _POLL_INITIAL_S,
     PeerMessageErrand,
     PromptErrand,
     RuntimeStartupError,
     WarmErrand,
+    _poll_delay,
     engage_runtime,
 )
 from local_operator.session.runtime.types import SessionRecord
@@ -528,3 +535,213 @@ def test_spawn_capture_is_private_and_anonymous(tmp_path, monkeypatch) -> None:
         assert capture.exists()
     finally:
         capture.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Poll shape
+#
+# WHY THESE ARE SCHEDULE-SHAPE ASSERTIONS AND NOT TIME BOUNDS
+# ===========================================================
+# The property under test is "the parent does not sleep past a runtime that is
+# already serving". The tempting way to assert that is to spawn a runtime and
+# bound the wall time, and AGENTS.md ("Timing, flakes, and how to assert that
+# something is fast") is emphatic that this repo has burned multiple PRs doing
+# exactly that: a bound calibrated on a dev box is not a bound on CI, and the
+# only honest conclusion at several sites was that no portable number exists.
+#
+# So these tests assert the SHAPE OF THE SCHEDULE the loop computes -- the
+# actual sleep durations it requests, captured from a stubbed `asyncio.sleep`.
+# That is a fact about what the code decided, not about how fast the machine
+# ran it, so it cannot flake under load: the recorded values are identical on
+# an idle laptop and a saturated 4-vCPU runner. It also fails deterministically
+# if someone restores the old single-grid constants, which is the regression
+# these guard.
+# ---------------------------------------------------------------------------
+
+
+def test_poll_delay_is_dense_while_a_construction_is_known_to_be_in_flight() -> None:
+    """The unit fact: a known construction polls flat and dense, and the
+    open-ended backoff is preserved rather than decayed underneath it.
+
+    Carrying the backoff forward untouched is what makes the fallback correct:
+    when the dense window expires the open-ended wait must start from the top,
+    not from a value that decayed while we were watching a healthy child.
+    """
+    backoff = _POLL_INITIAL_S
+    for elapsed in (0.0, 0.5, 1.2, _CONSTRUCTING_WINDOW_S - 0.001):
+        delay, backoff = _poll_delay(backoff, elapsed)
+        assert delay == _CONSTRUCTING_POLL_S
+        assert backoff == _POLL_INITIAL_S, "the open-ended backoff decayed during a dense window"
+
+
+def test_poll_delay_falls_back_to_the_open_ended_backoff() -> None:
+    """With nothing known to be constructing, the exponential shape is intact.
+
+    The backoff is what keeps a 30-second deadline from becoming a spin when
+    the wait is genuinely open-ended (a contender's contended lease, a session
+    that will never appear), so the dense regime must not have replaced it.
+    """
+    delay, backoff = _poll_delay(_POLL_INITIAL_S, None)
+    assert delay == _POLL_INITIAL_S
+    assert backoff == pytest.approx(_POLL_INITIAL_S * _POLL_FACTOR)
+
+    # It must still climb, and still cap.
+    for _ in range(40):
+        delay, backoff = _poll_delay(backoff, None)
+    assert delay == _POLL_CAP_S, "the open-ended backoff no longer reaches its cap"
+
+    # A construction that outlives the dense window is no longer 'about to
+    # publish', so it rejoins the open-ended shape rather than spinning.
+    delay, _ = _poll_delay(_POLL_INITIAL_S, _CONSTRUCTING_WINDOW_S)
+    assert delay == _POLL_INITIAL_S
+
+
+@pytest.mark.asyncio
+async def test_engage_polls_densely_while_its_own_candidate_constructs(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The integration fact, and the regression guard for the ~150 ms of dead time.
+
+    A candidate that we spawned and that is still alive is by definition still
+    constructing. Under the old single grid the loop slept 50, 135, 280, 525 ms
+    while waiting for it, so a child publishing at ~400 ms went unnoticed until
+    525 ms. Here the whole recorded schedule must be the dense interval.
+
+    The sleeps are RECORDED, not endured: `asyncio.sleep` is stubbed to a
+    no-op, so this test asserts the schedule the loop computed without waiting
+    for any of it.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions").mkdir(parents=True, exist_ok=True)
+
+    class _LiveCandidate:
+        """A spawned child that is alive and has published nothing yet."""
+
+        returncode = None
+
+        def poll(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "local_operator.session.runtime.launch._spawn_runtime",
+        lambda session_id, cwd, *, defer_materialise: _LiveCandidate(),
+    )
+
+    slept: list[float] = []
+
+    async def record_sleep(duration: float) -> None:
+        slept.append(duration)
+
+    monkeypatch.setattr(launch_module.asyncio, "sleep", record_sleep)
+
+    with pytest.raises(TimeoutError):
+        await engage_runtime(
+            SESSION_ID, str(tmp_path), WarmErrand(), config_dir=tmp_path, deadline_s=0.4
+        )
+
+    assert slept, "the loop never polled"
+    # No wake exceeds the dense interval. Stated as a ceiling rather than as
+    # equality because the loop clamps each sleep to the time left on the
+    # deadline (`min(delay, deadline - now)`), so the last few wakes of a
+    # short-deadline run are legitimately SMALLER than the interval.
+    assert max(slept) <= _CONSTRUCTING_POLL_S, f"not a dense grid: {sorted(set(slept))}"
+    # The unclamped body of the schedule is exactly the dense interval, and
+    # the old grid's signature is absent: under 0.05/x1.7 the loop would have
+    # slept 50, 85, 145, 246 ms and noticed a ~400 ms child only at 525 ms.
+    # Those values are precisely what this guards against.
+    assert _CONSTRUCTING_POLL_S in slept, "the dense interval was never requested"
+    assert not [d for d in slept if d > _CONSTRUCTING_POLL_S], "an exponential wake survived"
+
+
+@pytest.mark.asyncio
+async def test_engage_uses_the_coarse_grid_when_nothing_is_constructing(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The other half: an open-ended wait must NOT be polled densely.
+
+    Once every spawn we are allowed has been made and no candidate is alive,
+    there is no prior on when (or whether) a record appears. Polling that at
+    100 Hz for the rest of a 30-second deadline is the spin the backoff exists
+    to prevent, so the schedule here must climb rather than stay flat.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions").mkdir(parents=True, exist_ok=True)
+    # A spawn that starts nothing: no candidate handle, no lease, no record --
+    # so the loop can observe no construction in flight.
+    monkeypatch.setattr(
+        "local_operator.session.runtime.launch._spawn_runtime",
+        lambda session_id, cwd, *, defer_materialise: None,
+    )
+
+    slept: list[float] = []
+
+    async def record_sleep(duration: float) -> None:
+        slept.append(duration)
+
+    monkeypatch.setattr(launch_module.asyncio, "sleep", record_sleep)
+
+    with pytest.raises(TimeoutError):
+        await engage_runtime(
+            SESSION_ID, str(tmp_path), WarmErrand(), config_dir=tmp_path, deadline_s=5.0
+        )
+
+    assert len(slept) > 2
+    assert slept[0] == _POLL_INITIAL_S
+    # Strictly increasing until the cap: the exponential shape is intact.
+    assert slept[1] == pytest.approx(_POLL_INITIAL_S * _POLL_FACTOR)
+    assert _CONSTRUCTING_POLL_S not in slept, "an open-ended wait was polled at the dense interval"
+
+
+@pytest.mark.asyncio
+async def test_a_dense_window_does_not_outlive_its_welcome(tmp_path: Path, monkeypatch) -> None:
+    """A construction that never finishes must stop being polled densely.
+
+    The dense regime is a bet on a prior ("a record is about to appear"). A
+    candidate still alive and recordless after `_CONSTRUCTING_WINDOW_S` has
+    falsified that bet -- it is wedged or pathologically slow, not imminent --
+    and continuing at 100 Hz for the remaining ~27 s of the deadline would be
+    the spin the backoff exists to prevent. The schedule must therefore leave
+    the dense interval behind, on its own, with the child still alive.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    (tmp_path / "sessions").mkdir(parents=True, exist_ok=True)
+
+    class _WedgedCandidate:
+        returncode = None
+
+        def poll(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "local_operator.session.runtime.launch._spawn_runtime",
+        lambda session_id, cwd, *, defer_materialise: _WedgedCandidate(),
+    )
+
+    slept: list[float] = []
+    # A virtual clock: the loop's own deadline arithmetic advances by exactly
+    # the sleeps it asks for, so the dense window can expire without the test
+    # waiting out three real seconds. Time is DATA here, never a measurement.
+    clock = {"now": 0.0}
+
+    async def record_sleep(duration: float) -> None:
+        slept.append(duration)
+        clock["now"] += duration
+
+    monkeypatch.setattr(launch_module.asyncio, "sleep", record_sleep)
+    monkeypatch.setattr(launch_module.time, "monotonic", lambda: clock["now"])
+
+    with pytest.raises(TimeoutError):
+        await engage_runtime(
+            SESSION_ID, str(tmp_path), WarmErrand(), config_dir=tmp_path, deadline_s=10.0
+        )
+
+    dense = [d for d in slept if d == _CONSTRUCTING_POLL_S]
+    coarse = [d for d in slept if d > _CONSTRUCTING_POLL_S]
+    assert dense, "the dense regime never engaged"
+    assert coarse, "the dense window never expired; a wedged child is polled forever"
+    # The window is bounded by design, so the dense phase is ~_CONSTRUCTING_WINDOW_S
+    # of virtual time and not one poll more.
+    assert len(dense) == pytest.approx(_CONSTRUCTING_WINDOW_S / _CONSTRUCTING_POLL_S, rel=0.05)
+    # ...and the fallback restarts the backoff from the top rather than from a
+    # value that decayed while the child looked healthy.
+    assert coarse[0] == _POLL_INITIAL_S


### PR DESCRIPTION
## Summary

`/new` sat on the "starting…" indicator ~150 ms longer than it had to, and the wait was bimodal — sometimes ~540 ms, sometimes ~990 ms, for identical work. The cause was not the child being slow: it was the parent sleeping past a runtime that was **already serving**.

> **What this change controls: the dead time, and only that.** The parent's idle wait after the child is ready collapses from **~94–144 ms to ~10–16 ms**, reproducibly, in every run by two independent measurers. The *total* attach time improves by a **variable 2–17% under real load** (35% only on an idle box) because the child's own construction dominates the total and swings far more than the dead time removed here. **Read the dead-time figure as the result; the total is a consequence, and a load-dependent one.**

`engage_runtime`'s poll grid (`_POLL_INITIAL_S=0.05 → ×1.7 → cap 1.0`) fires at **50, 135, 280, 525, 943 ms**. A warm child publishes its record at ~400 ms, which falls between the 280 ms and 525 ms wakes, so the parent idled ~145 ms; a child landing just after 525 ms waited until 943 ms. The bimodality was the two grid points, not two different amounts of work.

The fix: **the loop has two different waits and was using one poll shape for both.**

| wait | prior on when a record appears | shape |
|---|---|---|
| A construction is KNOWN in flight — our own live `Popen`, or a contender holding the lease | strong (~0.4 s warm, ~1.2 s cold) | **flat and dense, 10 ms** |
| Open-ended — nothing known to be constructing | none; may run the full 30 s deadline | exponential backoff, **unchanged** |

The dense regime is bounded at `_CONSTRUCTING_WINDOW_S = 3.0` (~2.5× a full cold construction, measured on an M-series dev box). A candidate still recordless after that has falsified the prior — it is wedged, not imminent — so it rejoins the open-ended backoff. The backoff value is carried forward untouched during a dense window, so the fallback restarts from the top rather than from a decayed value.

**That one-sidedness was measured, not argued.** Modelling a slower host by lengthening the construction, dead time is 11.1 / 11.7 / 7.4 ms at 0.4 / 1.2 / 2.5 s (window covers it), 67.0 ms at 3.5 s (window lapses mid-construction), and at full degradation 716.3 vs 726.2 ms (5.0 s) and 726.1 vs 778.6 ms (8.0 s). **Past the window the new shape converges to the old one and never exceeds it** — a host 3× slower than this one gets today's behaviour, not a regression. Deliberately left non-structural: deriving the window from an observed construction time needs a measurement the loop does not have on a process's first `/new`, and buys nothing over a heuristic whose worst case is the status quo.

**Why dense polling is affordable.** The backoff was protecting against a cost that does not exist at these timescales. One full poll iteration — `find_owner_record`, `_lease_holder`, `Popen.poll` — measures **23–30 µs against a 200-record run dir, and is flat from 0 to 200 records**, because `find_owner_record` returns before `scan()` when there is no owner marker. That is a **0.2–0.3% duty cycle** on one thread, only while a session is genuinely starting. (My original estimate of 339 µs / 3.4%, from an 11-record dir, was pessimistic; the 23–30 µs figure is QA's independent measurement and supersedes it.) The nominal 100 Hz is also not achieved — measured **~42 Hz** (126 dense wakes in 3033 ms), since real work per iteration plus scheduling dominate.

**Lease arbitration is untouched.** The lease remains the sole arbiter, every contender may still spawn, and `_MAX_SPAWNS` plus the candidate-death respawn logic are unchanged. This PR changes *how often the parent looks*, never *who wins*.

## Measurements

All runs on macOS arm64 via `scripts/bench_runtime_attach.py` (landed here), which gives every run a fresh `HOME` **and** `LOCAL_OPERATOR_CONFIG_DIR`, seeds the `test` provider so nothing reaches the network, and SIGTERMs each child. It never touches the operator's real `~/.local-operator`. Medians, not means — the distribution has a long right tail.

### The dead time this PR removes

A separate tight-polling watcher records when the child *actually* publishes, independent of the parent's grid, so the two can be compared:

| | child ready | parent noticed | **dead time** |
|---|---|---|---|
| before | 401 ms | 538 ms | **144 ms** (318 ms worst) |
| after | — | — | **9.5 ms** (max 15 ms) |

Recorded sleep schedule before: `[50, 85, 145, 246]` ms. After: `[10, 10, 10, …]` ms. **This is the phase attribution**: the phase that moved is exactly the phase claimed — parent-side poll latency. Child-side construction is untouched and unchanged.

### End-to-end total attach — a range, not a number

Separate before/after invocations drift with machine state (this box is shared with ~10 sibling worktrees; load average ranged 33–393 across these rounds). So every figure below is an **interleaved** A/B alternating the old and new constants **within one process**, flipping which arm runs first each pair — the difference is attributable to the constants rather than to the weather.

**Author runs:**

| run | base | OLD | NEW | improvement |
|---|---|---|---|---|
| 9 pairs, idle box | v0.51.1 | 544.5 ms | 354.6 ms | 189.9 ms (**34.9%**) |
| 9 pairs, idle | 3081d0986 | 560.8 ms | 421.0 ms | 139.8 ms (24.9%) |
| 9 pairs, loaded | 0e673fffb | 1035.9 ms | 787.5 ms | 248.4 ms (24.0%) |

**Independent QA runs (three interleaved A/Bs, load 40–58):**

| run | OLD | NEW | improvement | dead time |
|---|---|---|---|---|
| 9 pairs, load ~42 | 550.2 ms | 538.5 ms | **2.1%** | 115.9 → 12.4 ms |
| 15 pairs, load ~40 | 567.5 ms | 482.6 ms | **15.0%** | 93.6 → 10.4 ms |
| 12 pairs, load ~58 | 806.9 ms | 673.1 ms | **16.6%** | 135.5 → 16.2 ms |

**The honest claim is the dead time.** It collapsed in *every* run by *both* measurers — 144→9.5, 115.9→12.4, 93.6→10.4, 135.5→16.2 ms — and it is the only quantity this change controls. The total is a different story: **~85–135 ms saved off a ~550–800 ms attach, i.e. 15–17% under typical contention, 2.1% at the floor when the child itself happened to be slow, and 34.9% only on an idle box.** That spread is the child's construction time varying, not the poll shape being inconsistent.

**35% is the best case, not the expected outcome.** A user on a loaded machine should expect the dead-time collapse reliably and a low-double-digit total improvement typically. This correction is QA finding Q1, and I agree with it — the earlier headline was measured on an idle box and was not what a user gets.

Recorded sleep schedule, before → after: `[50, 85, 145, 246]` → `[10, 10, 10, …]` ms. **This is the phase attribution**: the phase that moved is exactly the phase claimed. Child-side construction is untouched.

### Arbitration under real-process contention — and it forks *fewer* processes

The central risk of polling more often is that contenders spawn more candidates. QA tested this against **real spawned `python -m …runtime.process` children**, not mocks:

| test | result |
|---|---|
| 6-way × 10 trials | **every trial: records=1, distinct owners=1, engages 6/6, orphans=0, leaked=0** |
| 6-way × 8 trials on final head | **8/8: records=1, owners=1, orphans=0** |
| 12-way × 22 trials, load 155 | **invariant held 22/22** (failures symmetric across both arms — machine saturation, not arbitration) |
| **fork count** | **new forks FEWER: median 6 vs 8** |

The dense poll notices the winner's record *sooner*, so fewer contenders reach their own spawn. The change is not merely arbitration-neutral — it slightly reduces wasted process creation.

Fail-fast paths also improved rather than regressed: missing `hosting` 1813→**1601 ms**, unknown provider 2823→**1267 ms**, both still returning the actionable message rather than a 30 s timeout. Candidate-death respawn still caps at 3 (152 ms).

### Commands

```sh
.venv/bin/python scripts/bench_runtime_attach.py --runs 7 --json /tmp/attach-before.json
.venv/bin/python scripts/bench_runtime_attach.py --runs 7 --json /tmp/attach-after.json
```

## What I deliberately did NOT change, and why

Both were investigated on the task's suggestion, measured, and **acquitted**. Both findings are recorded in the module docstring so nobody re-derives them.

**1. Skipping the guaranteed-miss first scan for `/new`.** The first `find_owner_record` cannot possibly hit for a freshly minted session, so it looks like serialized latency ahead of the spawn. It is not, in the process that matters: in a **warm** parent — the long-lived TUI that actually runs `/new` — engage-entry to fork measures a **median of 2.1 ms** (n=14). The ~24 ms a cold process shows is function-local *import* cost the TUI has already paid. Racing the spawn ahead of the scan would buy single-digit milliseconds while adding a second path through the arbitration this module exists to protect. Not worth it.

**2. Deferring the child's `local_operator.harness.jobs` import.** It is the biggest single line in the child's `-X importtime` profile at **99 ms cumulative**, imported for one string constant (`TRAJECTORY_SEQ_KEY = '_lo_seq'`). But that 99 ms is a **shared subtree** (`harness.types`, pydantic). Given `session_factory` — the composition root the child imports regardless — `harness.jobs`'s **marginal cost is 2.2 ms**:

```
session_factory import: 162.8ms
harness.jobs already resident: False
harness.jobs MARGINAL import cost: 2.2ms
```

So deferring it moves ~2 ms, against a documented function-local import contract in `owned.py` whose comment explicitly asks not to be tidied. Not a trade worth making; the child-side cost is not safely reducible in this PR.

## Tests

`tests/unit/session/runtime/test_launch_arbitration.py`, +217 lines, 5 new tests.

**No wall-clock bounds.** Per AGENTS.md ("Timing, flakes, and how to assert that something is fast"), these assert the **shape of the schedule the loop computed**, captured from a stubbed `asyncio.sleep` — a fact about what the code decided, not about how fast the machine ran it. The recorded values are identical on an idle laptop and a saturated 4-vCPU runner, so they cannot flake under load. The wedged-child test drives a **virtual clock** (`time.monotonic` stubbed, advanced by exactly the sleeps requested), so a 3-second window is verified without waiting three real seconds.

- `test_poll_delay_is_dense_while_a_construction_is_known_to_be_in_flight`
- `test_poll_delay_falls_back_to_the_open_ended_backoff` — the exponential shape still climbs and still caps
- `test_engage_polls_densely_while_its_own_candidate_constructs` — the regression guard for the ~150 ms
- `test_engage_uses_the_coarse_grid_when_nothing_is_constructing` — the open-ended wait is *not* densely polled
- `test_a_dense_window_does_not_outlive_its_welcome` — a wedged child stops being polled densely

**Proved they can fail.** Reintroducing the old single-grid behaviour turns **3 of them red**, and the failure output prints the old grid's exact signature (`0.05, 0.085, 0.145, 0.246`):

```
FAILED ...::test_poll_delay_is_dense_while_a_construction_is_known_to_be_in_flight - assert 0.05 == 0.01
FAILED ...::test_engage_polls_densely_while_its_own_candidate_constructs - assert 0.362 <= 0.01
FAILED ...::test_a_dense_window_does_not_outlive_its_welcome - the dense regime never engaged
3 failed, 12 passed
```

Reverted, and green again.

## Review and QA

- **Agent review round 1** — one MAJOR (a held lease read as proof of construction, producing a 301-dial-in-3 s retry storm on the dial-failure path), fixed in `0e673fffb` with a structural guard that fails against the unfixed predicate. MINOR/NIT findings folded into the same commit.
- **QA round 1 — PASS**, independently on head `0e673fffb`: 28-row matrix, real spawned processes, `/new` driven on the assembled TUI, rendered frames, arbitration under 6- and 12-way contention. QA reproduced the MAJOR-1 bug (127 dial iterations in 3 s) and its fix (8) before accepting either. Its one finding, Q1, was that my headline speedup was an idle-box best case — corrected in `885bd965a`, which is a comments-and-claims change with **no executable line altered**.

## Gates

| Command | Result |
|---|---|
| `.venv/bin/python -m flake8 .` | **PASS** |
| `uvx --from black==26.1.0 black --check .` | **PASS** — 1011 files unchanged |
| `uvx isort==5.13.2 --check .` | **PASS** |
| `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | **0 errors, 0 warnings** |
| `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q -n 4` | **15269 passed, 18 skipped, 0 failed**, 1289.91s, rc=0 |
| `pytest tests/unit/session/runtime/test_launch_arbitration.py tests/unit/tui/test_stop_command.py -n0` | **50 passed** |

All gates above were re-run **on the rebased head**. No version bump: `pyproject.toml` is untouched at `0.51.1` (`version-bump-guard` passes).

## Rebase onto v0.51.1

Rebased from `8738b9495` onto `d017115dd` (v0.51.1) in two steps as main moved. **No conflicts**; main touched none of my three files.

```
$ git range-diff 3081d0986..a9c679f7c origin/main..HEAD
1:  30c1aa74c = 1:  6282b6264 perf(runtime): poll densely while a spawned runtime is constructing
2:  a9c679f7c = 2:  b6b5c2b0a test(runtime): scope the sleep recorder to the module under test
```

Both entries `=`. The product change (`launch.py`) is **byte-identical** to the version CI validated at the original head — verified by sorting the `+`/`-` line sets of both diffs, 569 changed lines, no difference.

**Semantic check against #718** (`/stop` no longer refuses with "session is still starting…"). That refusal is gated on *whether a session exists to stop* and on the transition window, **not** on any timing threshold, so shortening the binding window cannot invalidate it — and moves in the same direction as the fix. Confirmed by running `tests/unit/tui/test_stop_command.py` against this head: **50 passed** alongside the arbitration suite. `launch.py` was not touched by #711, #718 or #720.

### One real issue the rebase surfaced, and fixed

Running my new tests *beside* `test_stop_command.py` failed, while they passed in isolation. The cause was mine and it was a latent flake, not a product bug: `monkeypatch.setattr(launch_module.asyncio, "sleep", ...)` mutates the **shared** `asyncio` module object, so the recorder captured sleeps from any test running in the same worker (0.2 s and 1.0 s leaked in, reading as an exponential wake surviving into a dense window).

Commit `b6b5c2b0a` rebinds the *name* on the module under test via a small proxy that records `sleep` and delegates everything else, with the same treatment for the virtual clock (a process-wide `monotonic` would be worse still). The guards were re-verified against the old constants afterwards: still **3 failed, 12 passed**.

Pre-existing failures named by the release owner did not appear on this head. One unrelated TUI test (`test_band_panels.py`) failed once under load average 393 and passes both in isolation and in the clean full run above; it does not touch this diff.

Release: patch — `/new` stops idling ~100 ms after its runtime is already serving

