### PR TITLE
feat(tui): notify when a background session completes

### DIFF
--- a/local_operator/session/attention.py
+++ b/local_operator/session/attention.py
@@ -5,12 +5,21 @@ completion token advances the watermark. Tokens are conversation-bound and do
 not depend on a process epoch, a wall clock, or transcript modification time.
 SQLite serializes the short transactions across TUI, relay and server processes;
 callers on an event loop run these operations in a worker thread.
+
+TWO WATERMARKS, DELIBERATELY SEPARATE. ``receipts.acknowledged`` says a human
+demonstrably READ a result; ``deliveries.delivered`` says somebody already
+NOTIFIED them about it. They ride the same monotonic ``completions.sequence``
+but must never be conflated: notifying is cheap and reversible, marking-read is
+destructive, and ``docs/SESSION_SIDEBAR.md`` pins the rule that routing a
+notification never marks anything read. A session can be delivered-and-unread
+forever, which is correct — the sidebar's checkmark stays until it is opened.
 """
 
 from __future__ import annotations
 
 import json
 import sqlite3
+import time
 import uuid
 from collections.abc import Iterable
 from contextlib import closing
@@ -21,6 +30,30 @@ from local_operator.paths import config_dir
 
 ATTENTION_CAPABILITY = "completion-ack-v1"
 ATTENTION_CUSTOM_TYPE = "completion_attention"
+
+#: The delivery watermark. `delivered` is a highwater mark on the SAME
+#: `completions.sequence` that `receipts.acknowledged` uses, which is what makes
+#: the two comparable and the arbitration clock-free: sequence is assigned by
+#: SQLite AUTOINCREMENT under BEGIN IMMEDIATE, so it is a total order across
+#: every process on this machine. `delivered_at` and `backend` are DIAGNOSTICS
+#: ONLY and no decision may read them \u2014 in particular, a wall clock must never
+#: enter the claim, or two observers whose clocks disagree would both deliver.
+_CREATE_DELIVERIES = (
+    "CREATE TABLE deliveries ("
+    "conversation TEXT PRIMARY KEY, delivered INTEGER NOT NULL, "
+    "delivered_at REAL NOT NULL, backend TEXT NOT NULL)"
+)
+
+#: The no-flood rule, as one statement: everything already published counts as
+#: already delivered. Runs once, inside the transaction that creates the table
+#: (see `_connect`), so a machine upgrading into background-completion
+#: notifications starts from "nothing outstanding" rather than announcing its
+#: entire history.
+_BASELINE_DELIVERIES = (
+    "INSERT INTO deliveries(conversation,delivered,delivered_at,backend) "
+    "SELECT conversation, MAX(sequence), ?, 'baseline' FROM completions "
+    "GROUP BY conversation"
+)
 
 
 def conversation_identity(directory: Path) -> str:
@@ -114,13 +147,41 @@ class AttentionStore:
                         "CREATE TABLE receipts ("
                         "conversation TEXT PRIMARY KEY, acknowledged INTEGER NOT NULL)"
                     )
+                    # A store being created here has no completions yet, so
+                    # there is no backlog to baseline against — an empty
+                    # delivery watermark IS the correct starting point.
+                    conn.execute(_CREATE_DELIVERIES)
                 else:
                     # Missing tables/columns in an established database are
                     # corruption, not permission to rebuild an empty watermark.
+                    #
+                    # `deliveries` IS DELIBERATELY ABSENT FROM THIS PROBE, and
+                    # adding it is the one "tidy-up" that would brick every
+                    # existing machine: a database written by any release
+                    # before the background-completion notifier legitimately
+                    # lacks the table, so probing for it would read every one
+                    # of them as corrupt. The probe stays byte-identical to
+                    # what shipped, which is what keeps the meaning of an
+                    # established database unchanged.
                     conn.execute(
                         "SELECT sequence,conversation,token,anchor,kind FROM completions LIMIT 0"
                     )
                     conn.execute("SELECT conversation,acknowledged FROM receipts LIMIT 0")
+                    # Additive migration, and the baseline rides the SAME
+                    # transaction as the CREATE so no concurrent reader can
+                    # ever observe an unbaselined table. `unseen` is a LEVEL,
+                    # not an edge: without this, the first observer to upgrade
+                    # would claim every historical completion still unread and
+                    # fire a banner for each one (measured: 8 on this machine's
+                    # live store). Baselining at creation also means the
+                    # eleventh observer to start INHERITS the baseline rather
+                    # than re-deriving one of its own — the watermark is a
+                    # property of the database, not of a process.
+                    if not conn.execute(
+                        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='deliveries'"
+                    ).fetchone():
+                        conn.execute(_CREATE_DELIVERIES)
+                        conn.execute(_BASELINE_DELIVERIES, (time.time(),))
             return conn
         except BaseException:
             conn.close()
@@ -285,3 +346,95 @@ class AttentionStore:
                 (conversation, row[0]),
             )
             return self._state(conn, conversation)
+
+    def claim_delivery(self, conversation: str, token: str, backend: str) -> bool:
+        """True iff THIS caller may notify about ``token``. Exactly one ever wins.
+
+        The arbitration point for N observer processes watching one shared
+        store. Every frontend polls attention for every session, so without a
+        claim, eleven running sessions would each announce the same completion
+        eleven times. `BEGIN IMMEDIATE` is the serialization: both racers take
+        the write lock, and the loser reads the winner's already-advanced
+        watermark from inside its own transaction. This is the identical
+        argument `receipts` already rests on, which is why the table lives here
+        rather than beside the store in a lock file of its own.
+
+        NEVER ACKNOWLEDGES. Delivering a toast about a session says nothing
+        about whether the human read it, so this touches `deliveries` only and
+        the sidebar's unseen mark survives untouched.
+
+        CLAIM-THEN-DELIVER, deliberately. A process dying between the claim and
+        the spawn loses that one toast; delivering first and claiming after
+        would instead give a crash-looping process a repeating banner. The lost
+        signal is only the transient nudge \u2014 `unseen` stays true, the checkmark
+        stays in the sidebar, and `lop sessions` still reports it \u2014 whereas a
+        duplicate is visible and repeats. Backends that can report their own
+        failure hand the claim back through :meth:`release_delivery`.
+
+        A store that does not exist yet holds no completion to claim, so this
+        never creates one: an arbitration read must not be the thing that
+        materialises the database.
+        """
+        if not self.path.exists():
+            return False
+        with closing(self._connect()) as conn, conn:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT sequence FROM completions WHERE conversation=? AND token=?",
+                (conversation, token),
+            ).fetchone()
+            if row is None:
+                # An unknown token is never invented into the watermark: a
+                # caller racing a store that was cleared behind it must not be
+                # able to write a sequence no completion ever had.
+                return False
+            sequence = int(row[0])
+            current = conn.execute(
+                "SELECT delivered FROM deliveries WHERE conversation=?", (conversation,)
+            ).fetchone()
+            if current is not None and int(current[0]) >= sequence:
+                return False
+            conn.execute(
+                "INSERT INTO deliveries(conversation,delivered,delivered_at,backend) "
+                "VALUES(?,?,?,?) ON CONFLICT(conversation) DO UPDATE SET "
+                "delivered=MAX(deliveries.delivered,excluded.delivered), "
+                "delivered_at=excluded.delivered_at, backend=excluded.backend",
+                (conversation, sequence, time.time(), backend),
+            )
+            # MAX on conflict mirrors `acknowledge` exactly, so reordered
+            # writes converge upward instead of regressing the watermark.
+            return True
+
+    def release_delivery(self, conversation: str, token: str) -> bool:
+        """Hand a claim back when the backend that took it delivered nothing.
+
+        Without this, a backend failing AFTER the claim (notifications turned
+        off between the two, `osascript` missing, a spawn refused) leaves the
+        watermark asserting a toast that never reached anyone \u2014 a silent hole
+        of exactly the kind this feature exists to close.
+
+        Compare-and-swap, not `MAX`: rolling a watermark BACK is the one
+        operation monotonic convergence cannot express. The update fires only
+        while `delivered` is still the sequence this caller claimed, so an
+        observer that has since claimed something newer is never clobbered.
+        Rolling back to ``sequence - 1`` rather than deleting the row keeps
+        every OLDER completion of this conversation delivered (their sequences
+        are lower still), so a released claim re-opens exactly one event.
+        """
+        if not self.path.exists():
+            return False
+        with closing(self._connect()) as conn, conn:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT sequence FROM completions WHERE conversation=? AND token=?",
+                (conversation, token),
+            ).fetchone()
+            if row is None:
+                return False
+            sequence = int(row[0])
+            cursor = conn.execute(
+                "UPDATE deliveries SET delivered=?, delivered_at=?, backend='released' "
+                "WHERE conversation=? AND delivered=?",
+                (sequence - 1, time.time(), conversation, sequence),
+            )
+            return cursor.rowcount > 0

--- a/local_operator/session/attention.py
+++ b/local_operator/session/attention.py
@@ -172,8 +172,12 @@ class AttentionStore:
                     # ever observe an unbaselined table. `unseen` is a LEVEL,
                     # not an edge: without this, the first observer to upgrade
                     # would claim every historical completion still unread and
-                    # fire a banner for each one (measured: 8 on this machine's
-                    # live store). Baselining at creation also means the
+                    # fire a banner for each one (measured on the maintainer's
+                    # live store: 171 unseen conversations out of 332
+                    # completions; the "8" an earlier draft of this comment
+                    # cited was the test fixture's count, not a live
+                    # measurement — review round 1, n1). Baselining at creation
+                    # also means the
                     # eleventh observer to start INHERITS the baseline rather
                     # than re-deriving one of its own — the watermark is a
                     # property of the database, not of a process.
@@ -370,6 +374,20 @@ class AttentionStore:
         stays in the sidebar, and `lop sessions` still reports it \u2014 whereas a
         duplicate is visible and repeats. Backends that can report their own
         failure hand the claim back through :meth:`release_delivery`.
+
+        THE ACCEPTED RISK, stated plainly so the next reader does not have to
+        rediscover it: a claimant killed between the claim and the spawn leaves
+        that completion delivered-but-unannounced FOREVER. There is no lease,
+        no owner pid and no expiry \u2014 a re-claim returns False for good, and
+        nothing sweeps it. That is bounded in CONSEQUENCE (one transient toast,
+        for one completion, on a process that crashed) and unbounded in TIME,
+        and it is accepted here because the alternative trade is worse: a lease
+        needs a clock, and a clock in this predicate is what lets two observers
+        with disagreeing time both deliver. The durable signal survives
+        regardless, which is what makes the transient one safe to lose. A lease
+        carrying an owner pid is the natural fix if this ever stops being
+        acceptable; the schema has no room for one today (review round 1 m1,
+        QA round 1 Q3 \u2014 both judged the trade correct).
 
         A store that does not exist yet holds no completion to claim, so this
         never creates one: an arbitration read must not be the thing that

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -1708,10 +1708,12 @@ class OwnedSessionHandle(SessionHandle):
             return
         try:
             from local_operator.tui.notify import (
+                APP_NAME,
                 BODIES,
                 CONTEXTS,
                 detached_notify,
                 sanitize_text,
+                session_names_in_notifications,
             )
 
             # TITLE IS THE SESSION NAME ONLY. " needs you" used to be appended
@@ -1724,7 +1726,15 @@ class OwnedSessionHandle(SessionHandle):
             #
             # `sanitize_text` for the same reason every other path does it:
             # the name is model-written and reaches argv (D16).
-            name = sanitize_text(getattr(self._session, "conversation_name", "") or "lop")
+            #
+            # `display.notification_session_name` gates this leg too. The flag
+            # exists to keep a model-written name off a screen other people can
+            # see, and a detached runtime's gate toast reaches the same lock
+            # screen as every other banner — a flag that governed only some of
+            # them would make its own settings copy false (review round 1, M2).
+            name = APP_NAME
+            if session_names_in_notifications():
+                name = sanitize_text(getattr(self._session, "conversation_name", "") or "lop")
             # The body names the ACTION when there is one, and otherwise falls
             # back to the shared vocabulary — an `ask` with no text used to
             # render as the bare word "question" with no hint it was a

--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -796,6 +796,28 @@ SETTINGS: tuple[Setting, ...] = (
         choices=_bool_choices("notify when unfocused", "never notify"),
     ),
     Setting(
+        # The observer path (a background session finishing while you are
+        # looking at a DIFFERENT one) widens where a session name appears: the
+        # toast is about a conversation the terminal is not showing, so its
+        # name is the only thing that identifies it, and macOS repeats banner
+        # titles on the lock screen. Session names are model-written and can
+        # quote the work, so this is the opt-out for anyone who does not want
+        # that on a screen other people can see. Default TRUE because it
+        # matches what every existing notification already does; off falls back
+        # to the brand name, which still says a session finished.
+        key="display.notification_session_name",
+        path=("display.notification_session_name",),
+        section="appearance",
+        # Fits the row's label column at 100 columns. "Name sessions in
+        # notifications" elided to "…notificatio…", losing the one word that
+        # says what the row governs.
+        label="Notification session names",
+        kind=Kind.BOOL,
+        default=True,
+        help="Off titles toasts with the app name instead, for a shared screen.",
+        choices=_bool_choices("name the session", "app name only"),
+    ),
+    Setting(
         # The session's INITIAL dock density, not a hard override: `ctrl+g`
         # cycles freely from it and never writes it back (the same split as
         # `tool_approval_mode` vs `/approvals`). A hard override would make

--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -814,8 +814,28 @@ SETTINGS: tuple[Setting, ...] = (
         label="Notification session names",
         kind=Kind.BOOL,
         default=True,
-        help="Off titles toasts with the app name instead, for a shared screen.",
-        choices=_bool_choices("name the session", "app name only"),
+        # Leads with the CONSEQUENCE, not the mechanism: the decision being
+        # asked for is whether a model-written session name appears on a lock
+        # screen, which is the one fact that changes someone's answer. The
+        # neighbours ("Fires only while the terminal is unfocused.") are worded
+        # the same way (design round 1, D6).
+        help="A session's name appears on banners, including the lock screen.",
+        # `off` no longer means "app name only" on every route — a background
+        # session with no stored title is titled "A session finished" — so the
+        # label names what the user gets rather than a fallback that is now one
+        # of two (design round 1, D7, folded into D2).
+        choices=_bool_choices("name the session", "keep names off banners"),
+        # Without this the row renders `on` while `display.notifications` is
+        # off, describing a banner that cannot fire — the "page states
+        # something untrue about its own effect" class (#431). The detail line
+        # now reads `inert: Desktop notifications is off` through the mechanism
+        # four `session.cleanup.*` rows already use (design round 1, D4).
+        gated_by="display.notifications",
+        # Without this the row renders `on` while `display.notifications` is
+        # off, describing a banner that cannot fire — the "page states
+        # something untrue about its own effect" class (#431). The detail line
+        # now reads `inert: Desktop notifications is off` through the mechanism
+        # four `session.cleanup.*` rows already use (design round 1, D4).
     ),
     Setting(
         # The session's INITIAL dock density, not a hard override: `ctrl+g`

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -13603,7 +13603,7 @@ class OperatorApp(App[None]):
 
         return conversation_identity(config_dir() / "sessions" / session_id)
 
-    def _announce_background_digest(self, kinds: Sequence[str], announced: int) -> bool:
+    def _announce_background_digest(self, kinds: Sequence[str]) -> bool:
         """One line standing in for the completions the per-tick cap held back.
 
         The cap exists to stop a backlog flooding the notification centre; on
@@ -13616,15 +13616,31 @@ class OperatorApp(App[None]):
         D8. The remainder is whatever the cap did not reach and the catalog
         ranks by `(tier, -mtime, id)` rather than by kind, so this line was
         asserting `Complete` over sets that were entirely errors. The caller
-        already holds each held-back row's `completion_kind` at no extra cost,
-        so the honest subtitle is a derivation rather than new mechanism — see
-        `digest_subtitle`, which says a state only when every session held back
+        already holds each row's `completion_kind` at no extra cost, so the
+        honest subtitle is a derivation rather than new mechanism — see
+        `digest_subtitle`, which says a state only when every session in the set
         is in it.
 
-        `announced` is the number of banners that DID go out this tick, so the
-        title can carry the absolute total. "N more" is relative to a cap the
-        user may never have seen — a lock screen or a coalesce loses the three
-        banners it counts from (D11) — while "27 sessions finished" stands on
+        ONE SEQUENCE, COVERING THE WHOLE TICK — every completion this tick
+        handled, ANNOUNCED AND HELD BACK ALIKE — and the single parameter is
+        the fix, not an incidental shape. It arrived here as `(kinds,
+        announced)`, and the title counted `announced + len(kinds)` while the
+        subtitle read `kinds` alone: two scopes, moved apart by two independent
+        remediations, so `5 complete + 3 interrupted` rendered
+        `8 sessions finished` over `Complete` — D8's exact sentence one line up
+        (design round 3, D12). Ordinary data, not an edge: the cap is 3 and the
+        catalog ranks by `(tier, -mtime, id)` rather than by kind, so any tick
+        with a non-uniform backlog produced it.
+
+        THE SCOPE IS THE WHOLE TICK, and collapsing the two arguments into one
+        is what makes the title and the subtitle structurally incapable of
+        disagreeing about it — there is no second set for either line to drift
+        onto. The alternative, deriving both from the remainder, would reopen
+        D11.
+
+        That absolute count is the other half of D11: "N more" is relative to a
+        cap the user may never have seen — a lock screen or a coalesce loses the
+        three banners it counts from — while "27 sessions finished" stands on
         its own.
 
         REPORTS WHETHER THE BANNER WENT OUT, exactly like
@@ -13662,9 +13678,11 @@ class OperatorApp(App[None]):
             digest_subtitle,
         )
 
-        # The TOTAL, not the remainder: the title is the line that survives
-        # macOS's clip, and an absolute count needs no knowledge of the cap.
-        title = background_digest_title(announced + len(kinds))
+        # ONE SET, READ TWICE. The title is the line that survives macOS's clip
+        # and an absolute count needs no knowledge of the cap; the subtitle is
+        # the line that carries the state claim. Both describe `kinds`, so the
+        # count and the claim have the same denominator by construction (D12).
+        title = background_digest_title(len(kinds))
         subtitle = digest_subtitle(kinds)
         try:
             surface = cmux_surface_id()
@@ -13928,6 +13946,15 @@ class OperatorApp(App[None]):
             self._background_notify_revision = revision
             current = str(getattr(self._session, "session_id", "") or "")
             announced = 0
+            # The kinds of the rows that DID get a banner this tick. Collected
+            # for one reason: the digest's title counts the whole tick, so its
+            # subtitle must describe the whole tick too, or the frame states an
+            # outcome about sessions it counted but did not look at — `5
+            # complete + 3 interrupted` read `8 sessions finished` over
+            # `Complete` (design round 3, D12). `entry.completion_kind` is
+            # already in hand here, where `announced` is incremented, so this is
+            # a second read of a value already loaded rather than new plumbing.
+            announced_kinds: list[str] = []
             # The rows the cap held back, kept as `(identity, token, kind)`
             # rather than counted: their claims are already taken, so if the
             # digest standing in for them fails to send they have to be handed
@@ -13988,6 +14015,11 @@ class OperatorApp(App[None]):
                         entry, self._background_completion_identity(entry.id)
                     ):
                         announced += 1
+                        # Only a DELIVERED banner counts, exactly as `announced`
+                        # does: a released row is not part of the tick the
+                        # digest speaks for, so it must not reach the title's
+                        # count or the subtitle's claim.
+                        announced_kinds.append(entry.completion_kind)
                     else:
                         released = True
                 except Exception:  # noqa: BLE001 — one bad row must not mute the rest
@@ -14001,7 +14033,7 @@ class OperatorApp(App[None]):
                     logger.debug("background completion row skipped", exc_info=True)
                     released = True
             if claimed_silently and not self._announce_background_digest(
-                [kind for _, _, kind in claimed_silently], announced
+                announced_kinds + [kind for _, _, kind in claimed_silently]
             ):
                 # THE DIGEST IS THE ONLY THING THAT WAS EVER GOING TO SPEAK FOR
                 # THESE ROWS. Each was claimed above with backend `"digest"`, so

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -506,6 +506,24 @@ _SUBAGENT_DOCK_ROWS = 10
 #: number.
 _BAND_SETTLE_PASSES = 3
 
+#: Background-completion banners one observer tick may SPAWN. Everything past
+#: the cap is still claimed — the arbitration is unchanged — and collapsed into
+#: a single "N more sessions finished" digest.
+#:
+#: The no-flood baseline only covers the tick that CREATES the deliveries
+#: table. A store already migrated, with no observer running while background
+#: sessions finish, has an unbounded backlog on the next open: measured at 30
+#: banners on one tick from a store at rest (review round 1, B1), which is the
+#: overnight case — close every window, let daemons finish, open one TUI in the
+#: morning.
+#:
+#: Three, because a macOS banner stack shows about that many before it starts
+#: collapsing them itself, and the digest carries the remainder losslessly. It
+#: bounds a BACKLOG and nothing else: coalescing several sessions finishing
+#: within seconds of each other is a separate mechanism on a separate PR, and
+#: deliberately not half-built here.
+_BACKGROUND_NOTIFY_MAX_PER_TICK = 3
+
 
 # The registry, its policy commentary and `slash_command_for` live in
 # `local_operator.slash_commands`, which the server front ends import too; both
@@ -13489,6 +13507,95 @@ class OperatorApp(App[None]):
 
         return conversation_identity(config_dir() / "sessions" / session_id)
 
+    def _announce_background_digest(self, count: int) -> None:
+        """One line standing in for the completions the per-tick cap held back.
+
+        The cap exists to stop a backlog flooding the notification centre; on
+        its own it would silently drop 25 of 30 finished sessions, which is a
+        second defect rather than a fix. This says how many, so the count is
+        never lost — the sidebar still carries every row's `✓`, and the user
+        now knows to go and look at it.
+
+        Titled with the neutral sentence rather than any session's name: it is
+        about several sessions, so naming one of them would be wrong, and it
+        also costs nothing to a user who has opted out of names entirely.
+
+        Same best-effort contract as every other delivery here — this runs off
+        the loop inside `collect()`, and a digest that failed to send must not
+        take the scan down with it.
+        """
+        from local_operator.proc import spawn_detached
+        from local_operator.tui.notify import (
+            BACKGROUND_FALLBACK_TITLE,
+            CONTEXT_COMPLETE,
+            cmux_command,
+            cmux_surface_id,
+            detached_notify,
+        )
+
+        body = f"{count} more session{'s' if count != 1 else ''} finished"
+        try:
+            surface = cmux_surface_id()
+            if surface is not None:
+                spawn_detached(
+                    cmux_command(surface, BACKGROUND_FALLBACK_TITLE, CONTEXT_COMPLETE, body)
+                )
+            else:
+                # No `session_id`: a digest covers several sessions, so there is
+                # no single transcript for a click to reopen. The banner is
+                # informational and the sidebar is where the user goes next.
+                detached_notify(BACKGROUND_FALLBACK_TITLE, body, subtitle=CONTEXT_COMPLETE)
+        except Exception:  # noqa: BLE001 — a toast must never affect the poll
+            logger.debug("background completion digest failed", exc_info=True)
+
+    def _background_completion_title(self, entry: CatalogEntry) -> str:
+        """The banner title for a background session: its STORED name, or a sentence.
+
+        Deliberately NOT ``entry.row.name``. That is the picker's display name,
+        which falls back to the session's opening user message when no
+        ``title.json`` exists — and macOS clips a banner title at ~43
+        characters, while an agent-spawned session's opener begins with its
+        role preamble. Measured on the maintainer's store: 15 of 67 rows have
+        no stored title, and 11 of 67 are not uniquely identifiable at the
+        clip, producing banners like ``[team: lopdev] You are reviewer on this
+        te…`` where every discriminating word is past the cut (design round 1,
+        D1). Those are disproportionately the BACKGROUND sessions this feature
+        exists to announce, so the fallback has to be the one that fails
+        gracefully rather than the one that fails silently.
+
+        The sidebar keeps using the opener because its row is on screen beside
+        the others and one keypress from the transcript; a lock-screen banner
+        has neither, so the two surfaces answer the same question differently
+        on purpose.
+
+        Reads the sidecar directly rather than through ``session_name`` because
+        that helper's whole contract is the opener fallback this must not take.
+        Tolerant like every other call on this path: an unreadable directory
+        yields the neutral sentence rather than raising into the poll.
+        """
+        from local_operator.paths import config_dir
+        from local_operator.resume import stored_session_title
+        from local_operator.tui.notify import (
+            BACKGROUND_FALLBACK_TITLE,
+            sanitize_text,
+            session_names_in_notifications,
+        )
+
+        if not session_names_in_notifications():
+            # The opt-out keeps the BRAND, which is what a user who turned this
+            # off is asking for: no statement about their sessions at all. The
+            # nameless case below is a different meaning and gets a different
+            # sentence, so the two banners are no longer identical (D2).
+            from local_operator.tui.notify import APP_NAME
+
+            return APP_NAME
+        try:
+            stored = stored_session_title(config_dir() / "sessions" / entry.id)
+        except Exception:  # noqa: BLE001 — a title is chrome; delivery is not
+            logger.debug("background completion title unavailable", exc_info=True)
+            stored = ""
+        return sanitize_text(stored) or BACKGROUND_FALLBACK_TITLE
+
     def _deliver_background_completion(self, entry: CatalogEntry, identity: str) -> bool:
         """Announce one finished background session; report whether a toast went out.
 
@@ -13522,41 +13629,51 @@ class OperatorApp(App[None]):
         from local_operator.proc import spawn_detached
         from local_operator.session.attention import AttentionStore
         from local_operator.tui.notify import (
-            APP_NAME,
-            BODIES,
+            BODY_BACKGROUND,
             CONTEXTS,
+            argv_safe,
             cmux_command,
             cmux_surface_id,
             detached_notify,
-            sanitize_text,
-            session_names_in_notifications,
         )
 
-        # `interrupted` folds to `error` for the same reason the sidebar paints
-        # both with `✗`: the user's question is "did it finish or not", and a
-        # third word on a banner they read in under a second does not answer it.
-        kind = "error" if entry.completion_kind in ("error", "interrupted") else "complete"
+        # THREE STATES, THREE SENTENCES. `interrupted` is not folded into
+        # `error`: the store constrains a kind to exactly complete/error/
+        # interrupted, and the maintainer's real store holds 318 complete, 14
+        # interrupted and 0 error — so a fold made every non-success banner
+        # this can raise today say a session failed when it did not (design
+        # round 1, D3). The sidebar's shared `✗` does not justify it either: a
+        # glyph is a pointer one keypress from the row, while banner prose is
+        # read once on a lock screen with nothing to check it against. Note the
+        # sidebar's own `CatalogEntry.state_description` keeps the two distinct
+        # as well — it is only the GLYPH that folds.
+        kind = entry.completion_kind if entry.completion_kind in CONTEXTS else "complete"
         surface = cmux_surface_id()
         backend = "cmux" if surface is not None else "detached"
         store = AttentionStore(config_dir() / "attention.db")
         if not store.claim_delivery(identity, entry.completion_token, backend):
             return False
-        # Falls back to the brand rather than to a bare directory name: the
-        # point of the title is that the user can tell WHICH session finished,
-        # and a name they opted out of showing is not improved by a worse one.
-        title = sanitize_text(entry.row.name) if session_names_in_notifications() else ""
-        title = title or APP_NAME
+        title = self._background_completion_title(entry)
+        # The body says why this banner exists — the session that finished is
+        # not the one on screen — because the subtitle already carries the
+        # state and repeating it there spent both lines on one word (D5).
+        body = BODY_BACKGROUND
         try:
             if surface is not None:
                 delivered = bool(
-                    spawn_detached(
-                        cmux_command(surface, title, CONTEXTS.get(kind, ""), BODIES.get(kind, ""))
-                    )
+                    spawn_detached(cmux_command(surface, title, CONTEXTS.get(kind, ""), body))
                 )
             else:
                 delivered = detached_notify(
-                    title,
-                    BODIES.get(kind, ""),
+                    # `argv_safe` for parity with the cmux branch above, which
+                    # applies it inside `cmux_command`. A model-written name can
+                    # begin with `-`; this title lands in argv slot 1 of the
+                    # signed bundle, where it is positional and so not misparsed
+                    # today — the wrap exists so the two branches cannot drift
+                    # into disagreeing about whether a title is shape-safe
+                    # (review round 1, m2).
+                    argv_safe(title),
+                    body,
                     session_id=entry.id,
                     subtitle=CONTEXTS.get(kind, ""),
                 )
@@ -13604,8 +13721,20 @@ class OperatorApp(App[None]):
         in-app `Notifier` on `TurnEnded`), which is what stops one completion
         being announced twice by one process.
 
+        A row ATTACHED IN ANOTHER WINDOW is skipped by the same rule, not by a
+        different one: `live_state == "attached"` means some other TUI holds
+        that session open and its own `Notifier` already owns the toast, so the
+        only thing this process would add is a duplicate (B2).
+
+        BOUNDED PER TICK. At most `_BACKGROUND_NOTIFY_MAX_PER_TICK` banners are
+        spawned in one scan; the rest are still claimed and reported as one
+        digest line, so a backlog cannot flood the notification centre and
+        cannot be silently swallowed either (B1).
+
         Never raises and never blocks the loop: a notification is chrome, and
         the work below is a SQLite read plus a directory scan plus a spawn.
+        Every row is delivered under its own guard, so one unreadable row
+        cannot mute its siblings (Q2).
         """
         if getattr(self, "_background_notify_pending", False):
             return
@@ -13633,21 +13762,88 @@ class OperatorApp(App[None]):
             # value afterwards would skip the next poll and lose that event.
             self._background_notify_revision = revision
             current = str(getattr(self._session, "session_id", "") or "")
+            announced = 0
+            claimed_silently = 0
+            released = False
             for entry in load_catalog(directory):
                 if (
                     not entry.unseen
                     or not entry.completion_token
                     or entry.row.pending
                     or entry.id == current
+                    or entry.row.live_state == "attached"
                 ):
                     # A pending row is a GATE, not a finished turn: the runtime
                     # already announces those itself (`_announce_pending`), and
                     # a second toast for one parked question is the duplicate
                     # that routing was built to avoid.
+                    #
+                    # `live_state == "attached"` is the SAME rule as the
+                    # `entry.id == current` skip beside it, applied to a window
+                    # this process cannot see. It means another TUI has that
+                    # session open, and that TUI's own in-app `Notifier` owns
+                    # its completion toast — so announcing it here is the
+                    # double notification the routing design forbids (X8/X9;
+                    # review round 1, B2). The operator runs ~11 concurrent
+                    # sessions, so attached-elsewhere is the NORMAL state of
+                    # their catalog rather than an edge case. Delivering
+                    # THROUGH the attached surface is a later PR; suppressing
+                    # is the correct behaviour to ship here.
+                    #
+                    # Reading `live_state` and not `busy`: #720 re-pointed
+                    # `busy` at a conversational-activity predicate but left
+                    # `attached` meaning exactly what it did — a record whose
+                    # runtime reports a watching surface.
                     continue
-                self._deliver_background_completion(
-                    entry, self._background_completion_identity(entry.id)
-                )
+                try:
+                    if announced >= _BACKGROUND_NOTIFY_MAX_PER_TICK:
+                        # OVER THE CAP: claim it and stay quiet. The claim must
+                        # still be taken or the backlog re-floods on the next
+                        # revision change, and the digest below tells the user
+                        # the count rather than silently dropping it.
+                        if store.claim_delivery(
+                            self._background_completion_identity(entry.id),
+                            entry.completion_token,
+                            "digest",
+                        ):
+                            claimed_silently += 1
+                        continue
+                    if self._deliver_background_completion(
+                        entry, self._background_completion_identity(entry.id)
+                    ):
+                        announced += 1
+                    else:
+                        released = True
+                except Exception:  # noqa: BLE001 — one bad row must not mute the rest
+                    # PER-ROW, deliberately. `claim_delivery` sits outside the
+                    # delivery helper's own try/except and touches SQLite, so a
+                    # corrupt store (`DatabaseError`) or a read-only one
+                    # (`OperationalError`) raised straight out of the first row
+                    # and dropped every remaining session that tick — measured
+                    # at 0 of 5 toasts (QA round 1, Q2). A notification is
+                    # chrome; it may lose itself, never its siblings.
+                    logger.debug("background completion row skipped", exc_info=True)
+                    released = True
+            if claimed_silently:
+                self._announce_background_digest(claimed_silently)
+            if released:
+                # A RELEASED CLAIM MUST BE RE-EXAMINED, and `revision()` cannot
+                # see that it was: it reads `completions` and `receipts` only,
+                # so claiming and handing back leaves it byte-identical and the
+                # gate above short-circuits every later tick until some
+                # unrelated completion moves it — measured at 0 retries across
+                # 60 ticks with the backend healthy again (review M1 / QA Q1).
+                # On a one-session machine that is silence, which is the exact
+                # hole `release_delivery` exists to close.
+                #
+                # Forgetting the revision rather than widening `revision()` to
+                # read `deliveries`: the store's change detector is consumed by
+                # the mobile attention API and by the acknowledgement path, and
+                # a delivery — a purely local, per-observer concern — has no
+                # business moving a number those read as "something happened to
+                # this conversation". The retry is this observer's problem, so
+                # it is fixed in this observer's state.
+                self._background_notify_revision = None
 
         async def run() -> None:
             try:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1846,6 +1846,18 @@ class OperatorApp(App[None]):
         #: swap: the row belongs to the PANE and the process, and a ``/new``
         #: only changes the session-id metadata it carries.
         self._herdr_reporter: HerdrReporter | None = None
+        #: Latch and change-detector for the OBSERVER notification leg — the
+        #: one that announces OTHER sessions finishing (see
+        #: `_notify_background_completions`). The latch keeps one off-loop scan
+        #: in flight at a time; the revision is the attention store's own cheap
+        #: `(max_sequence, sum_acknowledged)` detector, so the 1 s poll does a
+        #: catalog scan only when something actually changed. ``None`` rather
+        #: than ``(0, 0)`` so the FIRST tick always scans: an empty store
+        #: genuinely reads ``(0, 0)``, and seeding with it would make a
+        #: completion published before this app started invisible until the
+        #: next unrelated change.
+        self._background_notify_pending = False
+        self._background_notify_revision: tuple[int, int] | None = None
         #: Desktop notifications for the user who is looking at another app —
         #: the surface one step beyond the window title (see `tui/notify.py`).
         #: Held by the app rather than by the band because, unlike the title,
@@ -13464,9 +13476,197 @@ class OperatorApp(App[None]):
                 return top is block or block in top.ancestors
         return False
 
+    def _background_completion_identity(self, session_id: str) -> str:
+        """The attention-store key for another session's directory.
+
+        Goes through ``conversation_identity`` rather than formatting the
+        string here, because that helper encodes the agent-vs-session
+        namespace split that keeps an agent profile from aliasing a session's
+        conversation.
+        """
+        from local_operator.paths import config_dir
+        from local_operator.session.attention import conversation_identity
+
+        return conversation_identity(config_dir() / "sessions" / session_id)
+
+    def _deliver_background_completion(self, entry: CatalogEntry, identity: str) -> bool:
+        """Announce one finished background session; report whether a toast went out.
+
+        Runs OFF the event loop (see :meth:`_notify_background_completions`):
+        every route here spawns a process, and the cmux route shells out.
+
+        THE CLAIM COMES FIRST. Every running frontend polls attention for every
+        session, so eleven windows would otherwise announce one completion
+        eleven times. ``claim_delivery`` is the cross-process arbitration and
+        exactly one caller wins it; a route that then fails to deliver hands
+        the claim back rather than leaving the watermark asserting a toast
+        nobody received.
+
+        ``detached_notify`` rather than an in-band escape, even though this app
+        has a terminal to write into. Two reasons, and the second is the
+        operator's actual request:
+
+        - The toast is about a session this terminal is NOT showing, so
+          attributing it to this pane is simply wrong.
+        - It has to be CLICKABLE. ``detached_notify`` carries ``session_id``
+          through the signed macOS bundle to ``lop resume-click``, which
+          replays that transcript and idles. The in-band alternative cannot:
+          Ghostty implements no OSC 99 at all, and its OSC 9 is title-only with
+          no id, action or payload — an in-band toast for another session would
+          be unclickable, which is the opposite of what was asked for.
+
+        cmux stays first where a cmux surface genuinely exists, matching the
+        precedence every other delivery path here uses.
+        """
+        from local_operator.paths import config_dir
+        from local_operator.proc import spawn_detached
+        from local_operator.session.attention import AttentionStore
+        from local_operator.tui.notify import (
+            APP_NAME,
+            BODIES,
+            CONTEXTS,
+            cmux_command,
+            cmux_surface_id,
+            detached_notify,
+            sanitize_text,
+            session_names_in_notifications,
+        )
+
+        # `interrupted` folds to `error` for the same reason the sidebar paints
+        # both with `✗`: the user's question is "did it finish or not", and a
+        # third word on a banner they read in under a second does not answer it.
+        kind = "error" if entry.completion_kind in ("error", "interrupted") else "complete"
+        surface = cmux_surface_id()
+        backend = "cmux" if surface is not None else "detached"
+        store = AttentionStore(config_dir() / "attention.db")
+        if not store.claim_delivery(identity, entry.completion_token, backend):
+            return False
+        # Falls back to the brand rather than to a bare directory name: the
+        # point of the title is that the user can tell WHICH session finished,
+        # and a name they opted out of showing is not improved by a worse one.
+        title = sanitize_text(entry.row.name) if session_names_in_notifications() else ""
+        title = title or APP_NAME
+        try:
+            if surface is not None:
+                delivered = bool(
+                    spawn_detached(
+                        cmux_command(surface, title, CONTEXTS.get(kind, ""), BODIES.get(kind, ""))
+                    )
+                )
+            else:
+                delivered = detached_notify(
+                    title,
+                    BODIES.get(kind, ""),
+                    session_id=entry.id,
+                    subtitle=CONTEXTS.get(kind, ""),
+                )
+        except Exception:  # noqa: BLE001 — a toast must never affect the poll
+            logger.debug("background completion notification failed", exc_info=True)
+            delivered = False
+        if not delivered:
+            # The backend reported nothing went out (notifications disabled
+            # between the two calls, no notifier on PATH, a refused spawn).
+            # Give the claim back so the next observer, or the next poll, can
+            # try again — a watermark that lies about a delivered toast is a
+            # silent hole of exactly the kind this feature exists to close.
+            store.release_delivery(identity, entry.completion_token)
+        return delivered
+
+    def _notify_background_completions(self) -> None:
+        """Tell the user about sessions that finished while they were elsewhere.
+
+        THE GAP THIS CLOSES. A completion published by a detached
+        ``kind=daemon`` runtime already crosses the process boundary correctly
+        (`AttentionStore`) and is already read by this process on every catalog
+        poll — the sidebar paints its `✓` from exactly that. Nothing converted
+        the fact into a notification, so a background session finishing while
+        the operator watched a different session in the same window produced no
+        signal of any kind. The fact was held, rendered, and discarded.
+
+        RIDES THE POLL THAT ALREADY RUNS. No new timer, no new IPC: this is
+        called from `_poll_completion_attention`'s 1 s tick and gated on
+        `AttentionStore.revision()`, the store's documented cheap change
+        detector, so the catalog scan behind it happens only when a completion
+        was actually published or acknowledged — not once a second.
+
+        THE FOCUS GATE IS THE ATTACHED-SESSION CHECK, and that is the whole
+        point of the fix rather than an omission. OS terminal focus is the
+        wrong predicate at this granularity: the operator WAS looking at their
+        terminal, just at another session, and suppressing on that is precisely
+        the bug. The correct rule — suppress only when the user is demonstrably
+        looking at the session that PRODUCED the event — is the conjunction the
+        acknowledgement path below already applies (`terminal_is_foreground`
+        AND `_completion_anchor_visible`), and for a row that is not the
+        attached session that conjunction is false by construction: this app
+        renders one session's transcript, so another session's completion
+        anchor is not on screen and cannot be. So the attached-session skip IS
+        that rule, evaluated. The attached row keeps its existing owner (the
+        in-app `Notifier` on `TurnEnded`), which is what stops one completion
+        being announced twice by one process.
+
+        Never raises and never blocks the loop: a notification is chrome, and
+        the work below is a SQLite read plus a directory scan plus a spawn.
+        """
+        if getattr(self, "_background_notify_pending", False):
+            return
+        from local_operator.tui.notify import notifications_enabled
+
+        if not notifications_enabled():
+            return
+        self._background_notify_pending = True
+
+        def collect() -> None:
+            from local_operator.paths import config_dir
+            from local_operator.session.attention import AttentionStore
+            from local_operator.tui.session_catalog import load_catalog
+
+            directory = config_dir()
+            store = AttentionStore(directory / "attention.db")
+            revision = store.revision()
+            if revision == self._background_notify_revision:
+                # Nothing published or acknowledged anywhere on this machine
+                # since the last look, so no row's unseen state can have
+                # changed and the catalog scan is pure waste.
+                return
+            # Recorded BEFORE the scan, not after: a completion published while
+            # this scan runs bumps the revision again, and recording the newer
+            # value afterwards would skip the next poll and lose that event.
+            self._background_notify_revision = revision
+            current = str(getattr(self._session, "session_id", "") or "")
+            for entry in load_catalog(directory):
+                if (
+                    not entry.unseen
+                    or not entry.completion_token
+                    or entry.row.pending
+                    or entry.id == current
+                ):
+                    # A pending row is a GATE, not a finished turn: the runtime
+                    # already announces those itself (`_announce_pending`), and
+                    # a second toast for one parked question is the duplicate
+                    # that routing was built to avoid.
+                    continue
+                self._deliver_background_completion(
+                    entry, self._background_completion_identity(entry.id)
+                )
+
+        async def run() -> None:
+            try:
+                await asyncio.to_thread(collect)
+            except Exception:
+                logger.debug("background completion notification skipped", exc_info=True)
+            finally:
+                self._background_notify_pending = False
+
+        self.run_worker(run(), group="background-notify")
+
     async def _poll_completion_attention(self) -> None:
         from local_operator.tui.attention import terminal_is_foreground
 
+        # BEFORE the guards below, which are about the ATTACHED session's read
+        # receipt: a session that has no attention API, or a poll already in
+        # flight for it, must not also silence every other session's
+        # completion. This leg has a pending latch of its own.
+        self._notify_background_completions()
         if getattr(self, "_attention_poll_pending", False):
             return
         session = self._session

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -524,6 +524,87 @@ _BAND_SETTLE_PASSES = 3
 #: deliberately not half-built here.
 _BACKGROUND_NOTIFY_MAX_PER_TICK = 3
 
+#: Longest gap, in observer ticks (~1 s each), between two retries of a
+#: completion whose delivery failed. The retry interval starts at one tick and
+#: DOUBLES after every barren attempt until it reaches this.
+#:
+#: TWO INVARIANTS PULL AGAINST EACH OTHER HERE, and this is the shape that holds
+#: both. Neither may be traded for the other:
+#:
+#: 1. A RELEASED CLAIM MUST BE RE-EXAMINED, EVENTUALLY, WITHOUT AN UNRELATED
+#:    COMPLETION — for as long as the process runs. `revision()` reads
+#:    `completions` and `receipts` only, so claiming and handing back leaves it
+#:    byte-identical and the observer's own gate short-circuits forever; on a
+#:    one-session machine that is silence (review round 1 M1 / QA Q1).
+#: 2. A HOST THAT CANNOT DELIVER AT ALL MUST NOT RESCAN AT 1 Hz FOREVER. Retried
+#:    every tick, (1) degenerates on any machine with no notifier backend — no
+#:    `notify-send` on Linux, no `osascript`, or the macOS bundle not yet built
+#:    — into a permanent `load_catalog` directory scan plus two `BEGIN
+#:    IMMEDIATE` writes per unread row per tick, against a store where by
+#:    construction nothing has changed: measured at 23 scans and 138 writes over
+#:    20 ticks on 3 unread rows (review round 2, M2).
+#:
+#: BACKOFF RATHER THAN A CAP, and the difference is not cosmetic. Round 2
+#: proposed capping the consecutive retries and then waiting for a genuine
+#: revision change. That was implemented first and REGRESSED (1): with the cap
+#: at 3, a backend down for four ticks and then healthy never delivered again,
+#: which `…a_released_claim_is_retried_without_an_unrelated_completion` caught
+#: immediately. A cap converts a rare permanent hole into a common one — any
+#: outage longer than the cap — whereas doubling makes the steady-state cost
+#: O(log T) over T ticks while the retry itself never stops. Under this the same
+#: 20-tick window above costs 5 scans instead of 23, and an hour of a dead
+#: backend costs about 12 rather than 3,600.
+#:
+#: A CACHED "this host has no notifier" FLAG WAS ALSO REJECTED. `detached_notify`
+#: returns False for one durable fact (nothing on PATH) and for two transient
+#: ones (notifications disabled between the two calls, a refused spawn) without
+#: distinguishing them — and on macOS the bundle case is transient BY DESIGN:
+#: `ensure_bundle` returns None on a cold machine and starts the build in the
+#: background, so the very next attempt may succeed. Latching would latch at
+#: exactly the cold-start moment a backlog exists, and would then need an
+#: invalidation path to unlatch. Backoff is self-healing and needs none.
+#:
+#: Counted in TICKS, never in seconds: the poll's own cadence is the only clock
+#: this needs, and a tick count cannot drift with machine load the way a
+#: wall-clock deadline does (AGENTS.md §"Timing, flakes").
+#:
+#: 64 ticks ≈ a minute between attempts at the ceiling — negligible load, and
+#: still far inside the window where a user who has just installed `notify-send`
+#: or whose bundle has finished building would call it responsive.
+_BACKGROUND_NOTIFY_MAX_RETRY_TICKS = 64
+
+#: The `SessionRow.live_state` values this observer may announce a completion
+#: for. An ALLOW-LIST, deliberately, and the inversion is the finding: the skip
+#: shipped as `live_state == "attached"`, which is the narrowest of the three
+#: states that all mean the same thing (review round 2, M3).
+#:
+#: THE RULE IS RESIDENCY, NOT A LABEL: "some other TUI holds this session open
+#: and its own in-app `Notifier` already owns its completion toast, so anything
+#: this process sends is a duplicate" (X8/X9; review round 1, B2). `live_state`
+#: is a single-slot field whose branches are mutually exclusive and ordered
+#: `wedged` > `busy` > `attached` > `idle` (`session_catalog.decorate_rows`), so
+#: an attached window that is running a turn reports `busy` and never
+#: `attached` — and post-#720 `busy` means conversational activity, which a
+#: session whose previous turn completed unread reaches the moment the user
+#: sends it a new prompt in another window. `wedged` is likewise an ATTACHED
+#: window whose heartbeat went stale, not an absence of one. All three were
+#: reproduced double-notifying.
+#:
+#: An allow-list rather than a deny-list because the failure directions are not
+#: symmetric. A new `live_state` added later defaults, under a deny-list, to
+#: NOTIFYING — the duplicate this exists to prevent, and silent. Under this it
+#: defaults to staying quiet, which loses at most a transient nudge while
+#: `unseen` stays true, the sidebar keeps its `✓` and `lop sessions` still
+#: reports it. That is the same trade `claim_delivery` documents, made the same
+#: way.
+#:
+#: `""` is a COLD session — no runtime record at all — and `"idle"` is a
+#: resident runtime with nobody watching. Both are precisely the reported bug's
+#: own scenario (a background runtime finishing with no attached surface), so
+#: both must stay in this set; `test_an_idle_background_session_is_still_
+#: announced` guards that direction.
+_BACKGROUND_NOTIFY_ANNOUNCEABLE_STATES = frozenset({"", "idle"})
+
 
 # The registry, its policy commentary and `slash_command_for` live in
 # `local_operator.slash_commands`, which the server front ends import too; both
@@ -1876,6 +1957,21 @@ class OperatorApp(App[None]):
         #: next unrelated change.
         self._background_notify_pending = False
         self._background_notify_revision: tuple[int, int] | None = None
+        #: Retry backoff for a delivery that failed: how many ticks to wait
+        #: before the next attempt, and how many of those are still owed. The
+        #: interval doubles per barren attempt so the revision-forgetting retry
+        #: (M1/Q1) cannot become a permanent 1 Hz rescan on a host with no
+        #: notifier backend (M2), while still never giving up — see
+        #: `_BACKGROUND_NOTIFY_MAX_RETRY_TICKS` for why backoff and not a cap.
+        self._background_notify_retry_ticks = 0
+        self._background_notify_retry_wait = 0
+        #: The last revision this observer actually SCANNED, kept separately
+        #: from `_background_notify_revision` because the retry sets that one to
+        #: None on purpose. Comparing against this is what tells a genuine
+        #: publish or acknowledgement apart from the observer's own retry coming
+        #: back round — without it, a real completion arriving mid-backoff would
+        #: be made to wait out the backoff it had nothing to do with.
+        self._background_notify_seen_revision: tuple[int, int] | None = None
         #: Desktop notifications for the user who is looking at another app —
         #: the surface one step beyond the window title (see `tui/notify.py`).
         #: Held by the app rather than by the band because, unlike the title,
@@ -13507,7 +13603,7 @@ class OperatorApp(App[None]):
 
         return conversation_identity(config_dir() / "sessions" / session_id)
 
-    def _announce_background_digest(self, count: int) -> None:
+    def _announce_background_digest(self, count: int) -> bool:
         """One line standing in for the completions the per-tick cap held back.
 
         The cap exists to stop a backlog flooding the notification centre; on
@@ -13516,9 +13612,26 @@ class OperatorApp(App[None]):
         never lost — the sidebar still carries every row's `✓`, and the user
         now knows to go and look at it.
 
-        Titled with the neutral sentence rather than any session's name: it is
-        about several sessions, so naming one of them would be wrong, and it
-        also costs nothing to a user who has opted out of names entirely.
+        REPORTS WHETHER THE BANNER WENT OUT, exactly like
+        `_deliver_background_completion` beside it, and for the same reason: the
+        rows this line stands for were already CLAIMED with backend `"digest"`,
+        so a digest that silently fails takes every one of those claims with it
+        and nothing re-fires them. Measured at 9 of 12 completions the user is
+        never told about, on both failure modes (review round 2, M1). That is
+        strictly worse than the flood B1 replaced — a flood is noisy and
+        self-correcting; this is silent while the claim asserts delivery. The
+        caller hands the claims back when this returns False.
+
+        NAME-FREE BY CONSTRUCTION, AND IT MUST STAY SO. The title is the
+        `BACKGROUND_FALLBACK_TITLE` constant and the body is a bare count, so
+        `session_names_in_notifications()` is not consulted — not because the
+        flag does not apply, but because there is nothing here for it to
+        govern. A digest is ABOUT several sessions, so naming one of them would
+        be wrong on its own terms; the useful-looking improvement ("Overnight 3
+        and 8 others finished") is therefore also the one that would silently
+        defeat that privacy flag on this leg, since nothing on this path reads
+        it. Any change that puts session-derived text in this banner must gate
+        it on `session_names_in_notifications()` first (review round 2, minor).
 
         Same best-effort contract as every other delivery here — this runs off
         the loop inside `collect()`, and a digest that failed to send must not
@@ -13537,16 +13650,21 @@ class OperatorApp(App[None]):
         try:
             surface = cmux_surface_id()
             if surface is not None:
-                spawn_detached(
-                    cmux_command(surface, BACKGROUND_FALLBACK_TITLE, CONTEXT_COMPLETE, body)
+                return bool(
+                    spawn_detached(
+                        cmux_command(surface, BACKGROUND_FALLBACK_TITLE, CONTEXT_COMPLETE, body)
+                    )
                 )
-            else:
-                # No `session_id`: a digest covers several sessions, so there is
-                # no single transcript for a click to reopen. The banner is
-                # informational and the sidebar is where the user goes next.
-                detached_notify(BACKGROUND_FALLBACK_TITLE, body, subtitle=CONTEXT_COMPLETE)
+            # No `session_id`: a digest covers several sessions, so there is no
+            # single transcript for a click to reopen. The banner is
+            # informational and the sidebar is where the user goes next.
+            return detached_notify(BACKGROUND_FALLBACK_TITLE, body, subtitle=CONTEXT_COMPLETE)
         except Exception:  # noqa: BLE001 — a toast must never affect the poll
             logger.debug("background completion digest failed", exc_info=True)
+            # A RAISE IS A FAILED DELIVERY, not a swallowed one: this return is
+            # what makes the caller hand the digest's claims back rather than
+            # leaving them asserting a banner nobody received.
+            return False
 
     def _background_completion_title(self, entry: CatalogEntry) -> str:
         """The banner title for a background session: its STORED name, or a sentence.
@@ -13704,7 +13822,11 @@ class OperatorApp(App[None]):
         called from `_poll_completion_attention`'s 1 s tick and gated on
         `AttentionStore.revision()`, the store's documented cheap change
         detector, so the catalog scan behind it happens only when a completion
-        was actually published or acknowledged — not once a second.
+        was actually published or acknowledged — not once a second. The one
+        deliberate exception is the retry after a failed delivery, which forgets
+        that gate for at most `_BACKGROUND_NOTIFY_MAX_BARREN_RETRIES` ticks per
+        store change; that bound is what stops a host with no notifier backend
+        from rescanning and rewriting forever (M2).
 
         THE FOCUS GATE IS THE ATTACHED-SESSION CHECK, and that is the whole
         point of the fix rather than an omission. OS terminal focus is the
@@ -13721,15 +13843,19 @@ class OperatorApp(App[None]):
         in-app `Notifier` on `TurnEnded`), which is what stops one completion
         being announced twice by one process.
 
-        A row ATTACHED IN ANOTHER WINDOW is skipped by the same rule, not by a
-        different one: `live_state == "attached"` means some other TUI holds
-        that session open and its own `Notifier` already owns the toast, so the
-        only thing this process would add is a duplicate (B2).
+        A row RESIDENT IN ANOTHER WINDOW is skipped by the same rule, not by a
+        different one: a `live_state` outside
+        `_BACKGROUND_NOTIFY_ANNOUNCEABLE_STATES` means some other TUI holds that
+        session open — attached, busy running a turn, or wedged — and its own
+        `Notifier` already owns the toast, so the only thing this process would
+        add is a duplicate (B2, widened past `attached` in M3).
 
         BOUNDED PER TICK. At most `_BACKGROUND_NOTIFY_MAX_PER_TICK` banners are
         spawned in one scan; the rest are still claimed and reported as one
         digest line, so a backlog cannot flood the notification centre and
-        cannot be silently swallowed either (B1).
+        cannot be silently swallowed either (B1). If that digest fails to send,
+        every claim it stood for is handed back, because otherwise the digest
+        loses N completions where a single failed row loses one (M1).
 
         Never raises and never blocks the loop: a notification is chrome, and
         the work below is a SQLite read plus a directory scan plus a spawn.
@@ -13757,13 +13883,38 @@ class OperatorApp(App[None]):
                 # since the last look, so no row's unseen state can have
                 # changed and the catalog scan is pure waste.
                 return
+            if revision == self._background_notify_seen_revision:
+                # THE STORE HAS NOT MOVED SINCE THE LAST SCAN, so the only
+                # reason this tick got past the gate above is that a previous
+                # one forgot the gate after a failed delivery: this is our own
+                # retry coming back round, not new activity.
+                if self._background_notify_retry_ticks > 0:
+                    # Not due yet. Spend one tick of the backoff and scan
+                    # nothing — without this the retry runs every tick and a
+                    # host that can never deliver rescans and rewrites forever
+                    # (M2). `_background_notify_revision` stays None so the next
+                    # tick reaches this same branch.
+                    self._background_notify_retry_ticks -= 1
+                    self._background_notify_revision = None
+                    return
+            else:
+                # A GENUINE publish or acknowledgement. It never waits out a
+                # backoff it had nothing to do with, and it resets the interval:
+                # whatever made delivery fail last time, there is new work now
+                # and it deserves a full-speed attempt.
+                self._background_notify_seen_revision = revision
+                self._background_notify_retry_wait = 0
             # Recorded BEFORE the scan, not after: a completion published while
             # this scan runs bumps the revision again, and recording the newer
             # value afterwards would skip the next poll and lose that event.
             self._background_notify_revision = revision
             current = str(getattr(self._session, "session_id", "") or "")
             announced = 0
-            claimed_silently = 0
+            # The rows the cap held back, kept as `(identity, token)` rather
+            # than counted: their claims are already taken, so if the digest
+            # standing in for them fails to send they have to be handed BACK,
+            # and `release_delivery` needs both halves to do it (M1).
+            claimed_silently: list[tuple[str, str]] = []
             released = False
             for entry in load_catalog(directory):
                 if (
@@ -13771,29 +13922,31 @@ class OperatorApp(App[None]):
                     or not entry.completion_token
                     or entry.row.pending
                     or entry.id == current
-                    or entry.row.live_state == "attached"
+                    or entry.row.live_state not in _BACKGROUND_NOTIFY_ANNOUNCEABLE_STATES
                 ):
                     # A pending row is a GATE, not a finished turn: the runtime
                     # already announces those itself (`_announce_pending`), and
                     # a second toast for one parked question is the duplicate
                     # that routing was built to avoid.
                     #
-                    # `live_state == "attached"` is the SAME rule as the
+                    # The `live_state` test is the SAME rule as the
                     # `entry.id == current` skip beside it, applied to a window
-                    # this process cannot see. It means another TUI has that
-                    # session open, and that TUI's own in-app `Notifier` owns
-                    # its completion toast — so announcing it here is the
-                    # double notification the routing design forbids (X8/X9;
-                    # review round 1, B2). The operator runs ~11 concurrent
-                    # sessions, so attached-elsewhere is the NORMAL state of
-                    # their catalog rather than an edge case. Delivering
-                    # THROUGH the attached surface is a later PR; suppressing
-                    # is the correct behaviour to ship here.
+                    # this process cannot see: another TUI has that session
+                    # open, and that TUI's own in-app `Notifier` owns its
+                    # completion toast, so announcing it here is the double
+                    # notification the routing design forbids (X8/X9; review
+                    # round 1, B2). The operator runs ~11 concurrent sessions,
+                    # so resident-elsewhere is the NORMAL state of their
+                    # catalog rather than an edge case. Delivering THROUGH the
+                    # attached surface is a later PR; suppressing is the
+                    # correct behaviour to ship here.
                     #
-                    # Reading `live_state` and not `busy`: #720 re-pointed
-                    # `busy` at a conversational-activity predicate but left
-                    # `attached` meaning exactly what it did — a record whose
-                    # runtime reports a watching surface.
+                    # It reads an ALLOW-LIST of the states with no other owner
+                    # rather than naming the states to skip — see
+                    # `_BACKGROUND_NOTIFY_ANNOUNCEABLE_STATES` for why the
+                    # `attached`-only form this shipped as still double-notified
+                    # a busy or wedged window (review round 2, M3), and why a
+                    # future state must default to quiet rather than to noisy.
                     continue
                 try:
                     if announced >= _BACKGROUND_NOTIFY_MAX_PER_TICK:
@@ -13801,12 +13954,9 @@ class OperatorApp(App[None]):
                         # still be taken or the backlog re-floods on the next
                         # revision change, and the digest below tells the user
                         # the count rather than silently dropping it.
-                        if store.claim_delivery(
-                            self._background_completion_identity(entry.id),
-                            entry.completion_token,
-                            "digest",
-                        ):
-                            claimed_silently += 1
+                        identity = self._background_completion_identity(entry.id)
+                        if store.claim_delivery(identity, entry.completion_token, "digest"):
+                            claimed_silently.append((identity, entry.completion_token))
                         continue
                     if self._deliver_background_completion(
                         entry, self._background_completion_identity(entry.id)
@@ -13824,8 +13974,24 @@ class OperatorApp(App[None]):
                     # chrome; it may lose itself, never its siblings.
                     logger.debug("background completion row skipped", exc_info=True)
                     released = True
-            if claimed_silently:
-                self._announce_background_digest(claimed_silently)
+            if claimed_silently and not self._announce_background_digest(len(claimed_silently)):
+                # THE DIGEST IS THE ONLY THING THAT WAS EVER GOING TO SPEAK FOR
+                # THESE ROWS. Each was claimed above with backend `"digest"`, so
+                # a failed digest leaves N completions delivered-but-unannounced
+                # for good — the exact silent hole `release_delivery` exists to
+                # close, at N times the scale of a single row's (M1). Hand every
+                # one of them back, and let the `released` path below re-examine
+                # them: on the next tick they are unclaimed again, so whichever
+                # of them falls under the cap gets a real banner.
+                for identity, token in claimed_silently:
+                    try:
+                        store.release_delivery(identity, token)
+                    except Exception:  # noqa: BLE001 — per row, same rule as above
+                        # One unreleasable row must not strand its siblings'
+                        # claims; this loop is the recovery path, so it cannot
+                        # itself be all-or-nothing.
+                        logger.debug("background digest claim not released", exc_info=True)
+                released = True
             if released:
                 # A RELEASED CLAIM MUST BE RE-EXAMINED, and `revision()` cannot
                 # see that it was: it reads `completions` and `receipts` only,
@@ -13843,6 +14009,29 @@ class OperatorApp(App[None]):
                 # business moving a number those read as "something happened to
                 # this conversation". The retry is this observer's problem, so
                 # it is fixed in this observer's state.
+                #
+                # RATE-LIMITED, because retried every tick this is not a retry
+                # but a permanent 1 Hz rescan-and-write loop on any host that
+                # can never deliver (M2). The interval doubles per barren
+                # attempt up to `_BACKGROUND_NOTIFY_MAX_RETRY_TICKS` — see there
+                # for why backoff and not a cap, and why not a cached "this host
+                # has no notifier" flag.
+                #
+                # A tick that DELIVERED something is PROGRESS, not a barren
+                # retry, so it resets the interval: a partly-working backend
+                # (three banners out under the cap, the rest released) must keep
+                # draining a backlog at full speed rather than backing off
+                # through it. That cannot spin, because every delivered row
+                # consumes its own claim — progress is monotone and the backlog
+                # is finite.
+                if announced:
+                    self._background_notify_retry_wait = 0
+                else:
+                    self._background_notify_retry_wait = min(
+                        max(1, self._background_notify_retry_wait * 2),
+                        _BACKGROUND_NOTIFY_MAX_RETRY_TICKS,
+                    )
+                self._background_notify_retry_ticks = self._background_notify_retry_wait
                 self._background_notify_revision = None
 
         async def run() -> None:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -508,7 +508,7 @@ _BAND_SETTLE_PASSES = 3
 
 #: Background-completion banners one observer tick may SPAWN. Everything past
 #: the cap is still claimed — the arbitration is unchanged — and collapsed into
-#: a single "N more sessions finished" digest.
+#: a single "N sessions finished" digest carrying the tick's ABSOLUTE total.
 #:
 #: The no-flood baseline only covers the tick that CREATES the deliveries
 #: table. A store already migrated, with no observer running while background
@@ -13603,7 +13603,7 @@ class OperatorApp(App[None]):
 
         return conversation_identity(config_dir() / "sessions" / session_id)
 
-    def _announce_background_digest(self, count: int) -> bool:
+    def _announce_background_digest(self, kinds: Sequence[str], announced: int) -> bool:
         """One line standing in for the completions the per-tick cap held back.
 
         The cap exists to stop a backlog flooding the notification centre; on
@@ -13611,6 +13611,21 @@ class OperatorApp(App[None]):
         second defect rather than a fix. This says how many, so the count is
         never lost — the sidebar still carries every row's `✓`, and the user
         now knows to go and look at it.
+
+        TAKES THE KINDS, NOT A COUNT, and that is the whole of design round 2's
+        D8. The remainder is whatever the cap did not reach and the catalog
+        ranks by `(tier, -mtime, id)` rather than by kind, so this line was
+        asserting `Complete` over sets that were entirely errors. The caller
+        already holds each held-back row's `completion_kind` at no extra cost,
+        so the honest subtitle is a derivation rather than new mechanism — see
+        `digest_subtitle`, which says a state only when every session held back
+        is in it.
+
+        `announced` is the number of banners that DID go out this tick, so the
+        title can carry the absolute total. "N more" is relative to a cap the
+        user may never have seen — a lock screen or a coalesce loses the three
+        banners it counts from (D11) — while "27 sessions finished" stands on
+        its own.
 
         REPORTS WHETHER THE BANNER WENT OUT, exactly like
         `_deliver_background_completion` beside it, and for the same reason: the
@@ -13622,8 +13637,8 @@ class OperatorApp(App[None]):
         self-correcting; this is silent while the claim asserts delivery. The
         caller hands the claims back when this returns False.
 
-        NAME-FREE BY CONSTRUCTION, AND IT MUST STAY SO. The title is the
-        `BACKGROUND_FALLBACK_TITLE` constant and the body is a bare count, so
+        NAME-FREE BY CONSTRUCTION, AND IT MUST STAY SO. The title is a bare
+        count and the body is a fixed routing sentence, so
         `session_names_in_notifications()` is not consulted — not because the
         flag does not apply, but because there is nothing here for it to
         govern. A digest is ABOUT several sessions, so naming one of them would
@@ -13639,26 +13654,29 @@ class OperatorApp(App[None]):
         """
         from local_operator.proc import spawn_detached
         from local_operator.tui.notify import (
-            BACKGROUND_FALLBACK_TITLE,
-            CONTEXT_COMPLETE,
+            BODY_BACKGROUND_DIGEST,
+            background_digest_title,
             cmux_command,
             cmux_surface_id,
             detached_notify,
+            digest_subtitle,
         )
 
-        body = f"{count} more session{'s' if count != 1 else ''} finished"
+        # The TOTAL, not the remainder: the title is the line that survives
+        # macOS's clip, and an absolute count needs no knowledge of the cap.
+        title = background_digest_title(announced + len(kinds))
+        subtitle = digest_subtitle(kinds)
         try:
             surface = cmux_surface_id()
             if surface is not None:
                 return bool(
-                    spawn_detached(
-                        cmux_command(surface, BACKGROUND_FALLBACK_TITLE, CONTEXT_COMPLETE, body)
-                    )
+                    spawn_detached(cmux_command(surface, title, subtitle, BODY_BACKGROUND_DIGEST))
                 )
             # No `session_id`: a digest covers several sessions, so there is no
-            # single transcript for a click to reopen. The banner is
-            # informational and the sidebar is where the user goes next.
-            return detached_notify(BACKGROUND_FALLBACK_TITLE, body, subtitle=CONTEXT_COMPLETE)
+            # single transcript for a click to reopen — which is why the body
+            # names the sidebar rather than leaving the one inert banner in the
+            # stack silently inert (D10).
+            return detached_notify(title, BODY_BACKGROUND_DIGEST, subtitle=subtitle)
         except Exception:  # noqa: BLE001 — a toast must never affect the poll
             logger.debug("background completion digest failed", exc_info=True)
             # A RAISE IS A FAILED DELIVERY, not a swallowed one: this return is
@@ -13910,11 +13928,17 @@ class OperatorApp(App[None]):
             self._background_notify_revision = revision
             current = str(getattr(self._session, "session_id", "") or "")
             announced = 0
-            # The rows the cap held back, kept as `(identity, token)` rather
-            # than counted: their claims are already taken, so if the digest
-            # standing in for them fails to send they have to be handed BACK,
-            # and `release_delivery` needs both halves to do it (M1).
-            claimed_silently: list[tuple[str, str]] = []
+            # The rows the cap held back, kept as `(identity, token, kind)`
+            # rather than counted: their claims are already taken, so if the
+            # digest standing in for them fails to send they have to be handed
+            # BACK, and `release_delivery` needs both halves to do it (M1).
+            #
+            # The KIND rides along because the digest must not assert an
+            # outcome the remainder did not have — the catalog ranks by
+            # `(tier, -mtime, id)`, not by kind, so an over-cap set can be
+            # entirely errors (design round 2, D8). It is read here, where the
+            # entry is already in hand, rather than re-derived later.
+            claimed_silently: list[tuple[str, str, str]] = []
             released = False
             for entry in load_catalog(directory):
                 if (
@@ -13956,7 +13980,9 @@ class OperatorApp(App[None]):
                         # the count rather than silently dropping it.
                         identity = self._background_completion_identity(entry.id)
                         if store.claim_delivery(identity, entry.completion_token, "digest"):
-                            claimed_silently.append((identity, entry.completion_token))
+                            claimed_silently.append(
+                                (identity, entry.completion_token, entry.completion_kind)
+                            )
                         continue
                     if self._deliver_background_completion(
                         entry, self._background_completion_identity(entry.id)
@@ -13974,7 +14000,9 @@ class OperatorApp(App[None]):
                     # chrome; it may lose itself, never its siblings.
                     logger.debug("background completion row skipped", exc_info=True)
                     released = True
-            if claimed_silently and not self._announce_background_digest(len(claimed_silently)):
+            if claimed_silently and not self._announce_background_digest(
+                [kind for _, _, kind in claimed_silently], announced
+            ):
                 # THE DIGEST IS THE ONLY THING THAT WAS EVER GOING TO SPEAK FOR
                 # THESE ROWS. Each was claimed above with backend `"digest"`, so
                 # a failed digest leaves N completions delivered-but-unannounced
@@ -13983,7 +14011,7 @@ class OperatorApp(App[None]):
                 # one of them back, and let the `released` path below re-examine
                 # them: on the next tick they are unclaimed again, so whichever
                 # of them falls under the cap gets a real banner.
-                for identity, token in claimed_silently:
+                for identity, token, _ in claimed_silently:
                     try:
                         store.release_delivery(identity, token)
                     except Exception:  # noqa: BLE001 — per row, same rule as above

--- a/local_operator/tui/notify.py
+++ b/local_operator/tui/notify.py
@@ -206,6 +206,19 @@ def notifications_enabled() -> bool:
     return bool(settings_get("display.notifications", True))
 
 
+def session_names_in_notifications() -> bool:
+    """Whether a toast may be TITLED with the conversation's own name.
+
+    Separate from :func:`notifications_enabled` because it answers a different
+    question: not "may we interrupt" but "may we say what about". It exists for
+    the observer path, which announces a session the terminal is not currently
+    showing — so the name is the only thing distinguishing it, and it is also
+    the thing macOS repeats on a lock screen. Defaults to ``True``, which is
+    what every notification here has always done.
+    """
+    return bool(settings_get("display.notification_session_name", True))
+
+
 def sanitize_text(value: str | None, limit: int = MAX_TITLE_CHARS) -> str:
     """``value`` with control characters removed and whitespace collapsed.
 

--- a/local_operator/tui/notify.py
+++ b/local_operator/tui/notify.py
@@ -241,7 +241,16 @@ def background_digest_title(total: int) -> str:
 
     It is also ABSOLUTE, not relative: "3 more" is only meaningful to a user who
     noticed the three banners it counts from, which a lock screen or a coalesce
-    does not guarantee (design round 2, D11). The caller passes the TOTAL.
+    does not guarantee (design round 2, D11). The caller passes the TOTAL — the
+    whole tick, announced and held back alike, which is the same set the
+    subtitle beside it describes (round 3, D12).
+
+    THE SINGULAR IS DEFENSIVE, NOT REACHABLE. The digest fires only when the cap
+    held something back, which needs `_BACKGROUND_NOTIFY_MAX_PER_TICK` (3)
+    delivered banners first, so the smallest total production can reach is 4;
+    1-3 are test-only. Kept because a total is a count and a count that reads
+    "1 sessions" is wrong wherever it surfaces — but do not optimise the string
+    for a frame the user cannot receive (round 3, D13).
 
     NAME-FREE BY CONSTRUCTION, like the body beside it — a digest is about
     several sessions, so naming one would be wrong on its own terms, and nothing
@@ -261,7 +270,17 @@ def background_digest_title(total: int) -> str:
 #: pointed at the surface that CAN take them there — the docstring on
 #: ``_announce_background_digest`` already said the sidebar is where the user
 #: goes next; this is that sentence finally reaching the user.
-BODY_BACKGROUND_DIGEST = "Open the session sidebar to see them"
+#:
+#: IT NAMES THE KEY because ``tui.sidebar_visible`` defaults to ``False``, so
+#: for a default-configured user the sentence otherwise pointed at a surface
+#: that is not on screen and did not say how to summon it (round 3, D14).
+#: ``Ctrl+B`` and not ``Cmd+B``: the latter is bound only on darwin and only
+#: when the terminal delivers Super, while ``ctrl+b`` is unconditional on every
+#: platform — a banner cannot know which terminal is reading it, so it names the
+#: route that always exists. 45 characters, inside the ~43-char title clip that
+#: matters for the TITLE; bodies wrap rather than clip in Notification Centre,
+#: and the rendered captures confirm it lands whole.
+BODY_BACKGROUND_DIGEST = "Open the session sidebar (Ctrl+B) to see them"
 
 #: The observer path's body line, keyed by ROUTE rather than by state — which
 #: is why it is a single constant and not another entry in :data:`BODIES`.

--- a/local_operator/tui/notify.py
+++ b/local_operator/tui/notify.py
@@ -117,25 +117,37 @@ APP_NAME = "Local Operator"
 CONTEXT_COMPLETE = "Complete"
 CONTEXT_INPUT_REQUIRED = "Input required"
 CONTEXT_ATTENTION = "Needs attention"
+CONTEXT_INTERRUPTED = "Interrupted"
 BODY_COMPLETE = "Task complete"
 BODY_APPROVAL = "Waiting for approval"
 BODY_ASK = "Waiting for your answer"
 BODY_ERROR = "Stopped with an error"
+BODY_INTERRUPTED = "Stopped before finishing"
 
 #: Short state categories for notification surfaces with a title/subtitle/body
 #: split. Approval and ask intentionally share the category: both mean the turn
 #: cannot advance until the user returns, while the body says what it needs.
+#:
+#: ``interrupted`` is its OWN category, not a synonym for ``error``. The
+#: attention store constrains a completion's kind to exactly
+#: ``complete``/``error``/``interrupted``, and on the maintainer's real store
+#: those are 318 / 0 / 14 — so folding interrupted into error made EVERY
+#: non-success banner this feature can raise today assert that a session failed
+#: when it did not (design round 1, D3). A glyph may fold two states because it
+#: is a pointer that invites you to look; prose on a lock screen is an
+#: assertion read once, with nothing beside it to check it against.
 CONTEXTS: dict[str, str] = {
     "complete": CONTEXT_COMPLETE,
     "approval": CONTEXT_INPUT_REQUIRED,
     "ask": CONTEXT_INPUT_REQUIRED,
     "error": CONTEXT_ATTENTION,
+    "interrupted": CONTEXT_INTERRUPTED,
 }
 
 #: Notification kinds. ``complete`` is an edge the user may ignore; the two
 #: waiting kinds are edges the turn is BLOCKED on, which is why they are
 #: separated — see :func:`urgency_for`.
-NotifyKind = Literal["complete", "approval", "ask", "error"]
+NotifyKind = Literal["complete", "approval", "ask", "error", "interrupted"]
 
 #: Bodies keyed by kind, so a call site names the event rather than the prose.
 BODIES: dict[str, str] = {
@@ -143,7 +155,30 @@ BODIES: dict[str, str] = {
     "approval": BODY_APPROVAL,
     "ask": BODY_ASK,
     "error": BODY_ERROR,
+    "interrupted": BODY_INTERRUPTED,
 }
+
+#: Title for a background completion whose session has no STORED name, and the
+#: sentence the routing design specifies for exactly this case.
+#:
+#: Not :data:`APP_NAME`: macOS already attributes the banner to Local Operator
+#: by name and icon, so spending the title on the brand identifies nothing, and
+#: it rendered pixel-identical to the banner a user gets when they have opted
+#: OUT of session names — two different meanings in one frame (design round 1,
+#: D2). It also contradicted the sidebar, which paints these same rows as
+#: ``Untitled conversation``.
+BACKGROUND_FALLBACK_TITLE = "A session finished"
+
+#: The observer path's body line, keyed by ROUTE rather than by state — which
+#: is why it is a single constant and not another entry in :data:`BODIES`.
+#:
+#: The state already owns the subtitle (:data:`CONTEXTS`), so repeating it in
+#: the body spent the two most valuable lines under the title saying the same
+#: word twice — ``Complete`` over ``Task complete`` (design round 1, D5). What
+#: the body can say that the subtitle cannot is why this banner exists at all:
+#: the session that finished is not the one on screen. One string for all three
+#: kinds, because it describes the ROUTING decision, not the outcome.
+BODY_BACKGROUND = "You were in another session"
 
 #: BEL. Every terminal ever made honours it; it carries no text, but it is what
 #: raises tmux's ``monitor-bell``, Zellij's ``[!]`` flag and X11 urgency hints,
@@ -215,6 +250,14 @@ def session_names_in_notifications() -> bool:
     showing — so the name is the only thing distinguishing it, and it is also
     the thing macOS repeats on a lock screen. Defaults to ``True``, which is
     what every notification here has always done.
+
+    Governs BOTH notification legs — the observer path AND the attached
+    session's own :class:`Notifier` — so the promise the settings copy makes
+    ("a session's name appears on banners, including the lock screen") is true
+    of every banner and not merely of the newest one. Governing only the
+    observer path left the majority of a user's toasts still carrying the name
+    they had just opted out of showing, which is worse than a flag that is
+    clearly scoped, because the copy reads as a guarantee (review round 1, M2).
     """
     return bool(settings_get("display.notification_session_name", True))
 
@@ -896,7 +939,11 @@ class Notifier:
             return False
         if self._focused:
             return False
-        title = self._label or APP_NAME
+        # The privacy flag governs THIS leg too, not only the observer's. Read
+        # per send rather than cached at construction: `/settings` writes it
+        # live, and a notifier resolved once at boot would keep leaking the
+        # name for the rest of a session that had just turned it off.
+        title = (self._label if session_names_in_notifications() else "") or APP_NAME
         subtitle = CONTEXTS.get(kind, CONTEXT_COMPLETE)
         body = BODIES.get(kind, BODY_COMPLETE)
 

--- a/local_operator/tui/notify.py
+++ b/local_operator/tui/notify.py
@@ -88,6 +88,7 @@ import subprocess
 import sys
 import threading
 import uuid
+from collections.abc import Sequence
 from typing import Callable, Literal, Mapping
 
 from local_operator import terminals
@@ -144,6 +145,52 @@ CONTEXTS: dict[str, str] = {
     "interrupted": CONTEXT_INTERRUPTED,
 }
 
+#: The digest's subtitle when the sessions it stands for did NOT all end the
+#: same way. Deliberately not an entry in :data:`CONTEXTS`: that maps one
+#: session's kind to its category, and "mixed" is a property of a SET, not a
+#: kind any session can have. Keeping it out means no call site can accidentally
+#: resolve a single completion to it.
+CONTEXT_MIXED = "Mixed outcomes"
+
+
+def digest_subtitle(kinds: Sequence[str]) -> str:
+    """The honest state category for a set of completions, or ``""``.
+
+    The digest speaks for whatever the per-tick cap held back, and the catalog
+    ranks by ``(tier, -mtime, id)`` — **not** by kind — so ``error`` and
+    ``interrupted`` rows land in the overflow as readily as ``complete`` ones.
+    The digest hardcoded :data:`CONTEXT_COMPLETE` regardless, so a remainder
+    that was entirely failures was announced as "Complete · 5 more sessions
+    finished" on a lock screen, with the sidebar's ``✗`` the only thing
+    contradicting it (design round 2, D8). That is design round 1's D3 —
+    ``interrupted`` folded into a state it is not — reappearing at the scale of
+    an arbitrary number of sessions rather than one.
+
+    So the rule is: SAY A STATE ONLY WHEN EVERY SESSION HELD BACK IS IN IT.
+    A uniform set gets its real category out of the house vocabulary
+    (:data:`CONTEXTS`), so the digest reads exactly like the row banners beside
+    it when it honestly can. A MIXED set gets :data:`CONTEXT_MIXED` — not the
+    majority's category and not the first row's, either of which would assert
+    an outcome about sessions that did not have it, which is the defect. Three
+    complete and two errors is neither "Complete" nor "Needs attention"; it is
+    mixed, and that is a fact about the set rather than a guess about it.
+
+    An unrecognised kind counts as its own value, so a future kind makes a set
+    mixed rather than silently inheriting "Complete" — the same default-to-quiet
+    discipline ``_BACKGROUND_NOTIFY_ANNOUNCEABLE_STATES`` follows. An empty set
+    yields ``""``: no sessions is no claim, and both backends accept an empty
+    subtitle.
+
+    Pure, so the decision is testable without spawning or rendering anything.
+    """
+    distinct = set(kinds)
+    if not distinct:
+        return ""
+    if len(distinct) == 1:
+        return CONTEXTS.get(distinct.pop(), CONTEXT_MIXED)
+    return CONTEXT_MIXED
+
+
 #: Notification kinds. ``complete`` is an edge the user may ignore; the two
 #: waiting kinds are edges the turn is BLOCKED on, which is why they are
 #: separated — see :func:`urgency_for`.
@@ -168,6 +215,53 @@ BODIES: dict[str, str] = {
 #: D2). It also contradicted the sidebar, which paints these same rows as
 #: ``Untitled conversation``.
 BACKGROUND_FALLBACK_TITLE = "A session finished"
+
+
+def background_digest_title(total: int) -> str:
+    """``total`` sessions finished, as the DIGEST banner's title.
+
+    The digest is the one line standing in for the completions the per-tick cap
+    held back. A function rather than a constant because the count belongs in
+    the title, and this is the one place that decides so.
+
+    NOT :data:`BACKGROUND_FALLBACK_TITLE`, which it reused verbatim and which is
+    also the title every NAMELESS row banner carries. With a nameless over-cap
+    population — the overnight/agent-spawned case this feature exists for, 15 of
+    67 rows on the maintainer's store — that made the digest the fourth banner
+    in a stack of four with an IDENTICAL title AND subtitle, distinguished only
+    by the body, which is the line macOS truncates first (design round 2, D9).
+    At N=1 it also self-contradicted: "A session finished" over "1 more session
+    finished" describes two events in one frame.
+
+    THE COUNT MOVES INTO THE TITLE, and that is what makes the digest a
+    different KIND of object at a glance rather than a same-looking sibling.
+    macOS clips a title at ~43 characters and clips the body first, so the count
+    now sits in the line that survives; the string is 18-23 characters at every
+    count from 1 to 9999, far inside that clip.
+
+    It is also ABSOLUTE, not relative: "3 more" is only meaningful to a user who
+    noticed the three banners it counts from, which a lock screen or a coalesce
+    does not guarantee (design round 2, D11). The caller passes the TOTAL.
+
+    NAME-FREE BY CONSTRUCTION, like the body beside it — a digest is about
+    several sessions, so naming one would be wrong on its own terms, and nothing
+    on this leg consults :func:`session_names_in_notifications`.
+    """
+    return f"{total} sessions finished" if total != 1 else "1 session finished"
+
+
+#: The digest's body: where to go, since the banner itself cannot take you.
+#:
+#: The digest passes no ``session_id`` — it stands for several sessions, so
+#: there is no single transcript for a click to reopen — which makes it the one
+#: inert banner in a stack of otherwise-clickable ones, with nothing in the
+#: frame saying so (design round 2, D10). ``detached_notify``'s ``osascript``
+#: leg sets the precedent: it appends "— reopen with: lop --resume <id>" rather
+#: than letting a user learn by pressing (round 3, D14). This is that courtesy,
+#: pointed at the surface that CAN take them there — the docstring on
+#: ``_announce_background_digest`` already said the sidebar is where the user
+#: goes next; this is that sentence finally reaching the user.
+BODY_BACKGROUND_DIGEST = "Open the session sidebar to see them"
 
 #: The observer path's body line, keyed by ROUTE rather than by state — which
 #: is why it is a single constant and not another entry in :data:`BODIES`.

--- a/local_operator/tui/session_catalog.py
+++ b/local_operator/tui/session_catalog.py
@@ -44,6 +44,15 @@ class CatalogEntry:
     row: SessionRow
     unseen: bool = False
     completion_kind: str = ""
+    #: The token and anchor of this row's latest completion, straight from the
+    #: attention store. Carried because `unseen` alone is a LEVEL — true on
+    #: every poll until the session is read — and an observer that wants to
+    #: announce a background session's completion needs the identity of the
+    #: specific event to arbitrate on (`AttentionStore.claim_delivery`).
+    #: Defaulted so every existing construction site, and the sidebar tests
+    #: that build entries positionally, keep working unchanged.
+    completion_token: str = ""
+    anchor_id: str = ""
 
     @property
     def id(self) -> str:
@@ -266,6 +275,8 @@ def load_catalog(directory: Path) -> list[CatalogEntry]:
                     row,
                     bool(attention[identities[row.id]]["unseen"]),
                     str(attention[identities[row.id]]["kind"] or ""),
+                    str(attention[identities[row.id]]["completion_token"] or ""),
+                    str(attention[identities[row.id]]["anchor_id"] or ""),
                 )
                 for row in rows
             ]

--- a/local_operator/tui/settings.py
+++ b/local_operator/tui/settings.py
@@ -87,8 +87,11 @@ _DEFAULT_NOTES: dict[str, Any] = {
     # its own because the observer path (a BACKGROUND session finishing while
     # you are looking at a different one) widens where a model-written session
     # name appears — including on a lock screen, where macOS repeats banner
-    # titles. Off falls back to the brand name, which still says a session
-    # finished without saying which work it was.
+    # titles. Governs EVERY notification leg, not only the observer's: the
+    # attached session's own toasts and a detached runtime's gate toasts reach
+    # the same lock screen, and a flag that covered only some of them would
+    # make its own copy false (review round 1, M2). Off falls back to the brand
+    # name, which still says a session finished without saying which work.
     "display.notification_session_name": True,
     # The dock subagent panel's density when a session STARTS: `full` (one
     # row per child), `summary` (one row of counts) or `hidden`. Defaults to

--- a/local_operator/tui/settings.py
+++ b/local_operator/tui/settings.py
@@ -82,6 +82,14 @@ _DEFAULT_NOTES: dict[str, Any] = {
     # UNFOCUSED, so a user watching the session is never interrupted; the env
     # kill switch is `LOCAL_OPERATOR_NO_NOTIFICATIONS`.
     "display.notifications": True,
+    # Whether a toast is TITLED with the conversation's own name. Defaults ON,
+    # which is what every notification here has always done. It earns a flag of
+    # its own because the observer path (a BACKGROUND session finishing while
+    # you are looking at a different one) widens where a model-written session
+    # name appears — including on a lock screen, where macOS repeats banner
+    # titles. Off falls back to the brand name, which still says a session
+    # finished without saying which work it was.
+    "display.notification_session_name": True,
     # The dock subagent panel's density when a session STARTS: `full` (one
     # row per child), `summary` (one row of counts) or `hidden`. Defaults to
     # full, today's shape. It seeds the panel and nothing more — `ctrl+g`

--- a/scripts/settings_shot.py
+++ b/scripts/settings_shot.py
@@ -371,6 +371,45 @@ async def main() -> None:
             await pilot.pause()
             save_capture(app, out.replace(".svg", ".offdefault.svg"))
             geometry += f" || off-default hints={view.rendered_hints()!r}"
+        elif state == "notify-name":
+            # THREE frames, because the `display.notification_session_name` row
+            # makes three different claims and no single still shows more than
+            # one of them (design round 1, D4/D6/D7):
+            #
+            #   OUT.svg            resting, with the master ON — the help line
+            #                      that must name the LOCK-SCREEN consequence
+            #                      rather than the toggle's mechanism (D6)
+            #   OUT.open.svg       expanded, where the two choice labels must
+            #                      agree with the help about what `off` does —
+            #                      "app name only" stopped being true once a
+            #                      nameless session got its own title (D7/D2)
+            #   OUT.master-off.svg the same row with `display.notifications`
+            #                      OFF, which used to render `on` beside a dead
+            #                      master with a detail line describing a
+            #                      banner that cannot fire (D4)
+            #
+            # The cursor is left ON the row in every frame: the detail line
+            # describes the SELECTED row, so a capture taken with the cursor
+            # elsewhere photographs a different setting's sentence.
+            settings_io.write_setting(view._manager, _require("display.notifications"), True)
+            view._manager.reload()
+            view._repaint()
+            _select(view, "display.notification_session_name")
+            await pilot.pause()
+            save_capture(app, out)
+            geometry = _geometry(app, view, state, size)
+            view.action_activate()
+            await pilot.pause()
+            save_capture(app, out.replace(".svg", ".open.svg"))
+            await pilot.press("escape")
+            await pilot.pause()
+            settings_io.write_setting(view._manager, _require("display.notifications"), False)
+            view._manager.reload()
+            view._repaint()
+            _select(view, "display.notification_session_name")
+            await pilot.pause()
+            save_capture(app, out.replace(".svg", ".master-off.svg"))
+            geometry += f" || master off detail={view.render_lines_for_test()[-1]!r}"
         elif state == "bool-open":
             # TWO frames, for the reason `theme` and `cascade-row` take two:
             # the change is in what ACTIVATION does, not in how the row rests.

--- a/tests/unit/session/test_attention.py
+++ b/tests/unit/session/test_attention.py
@@ -214,3 +214,147 @@ def test_existing_database_damage_is_not_an_empty_read_state(tmp_path: Path, dam
 def test_agent_profiles_cannot_alias_session_conversations(tmp_path: Path) -> None:
     assert conversation_identity(tmp_path / "agents" / "same") == "agent/same"
     assert conversation_identity(tmp_path / "sessions" / "same") == "session/same"
+
+
+def test_delivery_claim_is_exactly_once_across_racing_processes(tmp_path: Path) -> None:
+    """Eleven frontends see one completion; exactly one of them may announce it.
+
+    The whole reason `deliveries` exists. Every running TUI polls attention for
+    every session, so without arbitration the operator's eleven sessions would
+    each fire a banner for one background completion.
+    """
+    path = tmp_path / "attention.db"
+    store = AttentionStore(path)
+    token = str(uuid.uuid4())
+    store.publish("session/a", token, "result", "complete")
+    # A separate AttentionStore per worker, which is what a separate PROCESS
+    # gets: no shared connection, no shared cache, only the file.
+    with ThreadPoolExecutor(max_workers=11) as pool:
+        claims = list(
+            pool.map(
+                lambda _: AttentionStore(path).claim_delivery("session/a", token, "test"),
+                range(11),
+            )
+        )
+    assert claims.count(True) == 1
+    # An observer starting later inherits the watermark rather than re-firing.
+    assert AttentionStore(path).claim_delivery("session/a", token, "test") is False
+
+
+def test_delivering_never_acknowledges(tmp_path: Path) -> None:
+    """Routing a notification must not mark a session read (SESSION_SIDEBAR.md)."""
+    path = tmp_path / "attention.db"
+    store = AttentionStore(path)
+    token = str(uuid.uuid4())
+    store.publish("session/a", token, "result", "complete")
+    before = store.state("session/a")
+    assert store.claim_delivery("session/a", token, "test") is True
+    after = store.state("session/a")
+    assert after["unseen"] is True
+    assert after["revision"] == before["revision"]
+    with sqlite3.connect(path) as conn:
+        assert conn.execute("SELECT count(*) FROM receipts").fetchone()[0] == 0
+
+
+def test_a_newer_completion_is_claimable_after_an_older_one_was_delivered(
+    tmp_path: Path,
+) -> None:
+    """The watermark is per-sequence, not per-conversation: new work still notifies."""
+    path = tmp_path / "attention.db"
+    store = AttentionStore(path)
+    first, second = str(uuid.uuid4()), str(uuid.uuid4())
+    store.publish("session/a", first, "one", "complete")
+    assert store.claim_delivery("session/a", first, "test") is True
+    assert store.claim_delivery("session/a", first, "test") is False
+    store.publish("session/a", second, "two", "complete")
+    assert store.claim_delivery("session/a", second, "test") is True
+
+
+def test_an_unknown_token_is_never_invented_into_the_watermark(tmp_path: Path) -> None:
+    path = tmp_path / "attention.db"
+    store = AttentionStore(path)
+    store.publish("session/a", str(uuid.uuid4()), "result", "complete")
+    assert store.claim_delivery("session/a", str(uuid.uuid4()), "test") is False
+    assert store.claim_delivery("session/missing", str(uuid.uuid4()), "test") is False
+    with sqlite3.connect(path) as conn:
+        assert conn.execute("SELECT count(*) FROM deliveries").fetchone()[0] == 0
+
+
+def test_claiming_does_not_create_the_store(tmp_path: Path) -> None:
+    """Arbitration is a read of published work; it cannot be what publishes it."""
+    path = tmp_path / "attention.db"
+    assert AttentionStore(path).claim_delivery("session/a", str(uuid.uuid4()), "test") is False
+    assert not path.exists()
+
+
+def test_a_released_claim_reopens_exactly_that_event(tmp_path: Path) -> None:
+    """A backend that delivered nothing hands the claim back, not a silent hole."""
+    path = tmp_path / "attention.db"
+    store = AttentionStore(path)
+    first, second = str(uuid.uuid4()), str(uuid.uuid4())
+    store.publish("session/a", first, "one", "complete")
+    store.publish("session/a", second, "two", "complete")
+    assert store.claim_delivery("session/a", second, "test") is True
+    assert store.release_delivery("session/a", second) is True
+    # Re-claimable, because the rollback returned the watermark to the state
+    # before this claim...
+    assert store.claim_delivery("session/a", second, "test") is True
+    # ...and the OLDER completion stays delivered rather than being re-armed.
+    assert store.claim_delivery("session/a", first, "test") is False
+    # A stale release cannot clobber a newer claim by another observer.
+    assert store.release_delivery("session/a", first) is False
+
+
+def test_upgrading_an_established_store_baselines_instead_of_flooding(tmp_path: Path) -> None:
+    """The no-flood rule, at the exact seam an upgrade crosses.
+
+    A database written before `deliveries` existed carries a backlog of unseen
+    completions. The first observer to open it must inherit them as already
+    delivered, or every one of them fires a banner at once.
+    """
+    path = tmp_path / "attention.db"
+    store = AttentionStore(path)
+    tokens = [str(uuid.uuid4()) for _ in range(8)]
+    for index, token in enumerate(tokens):
+        store.publish(f"session/{index}", token, f"result-{index}", "complete")
+    # Reproduce a pre-feature database exactly: the table simply is not there.
+    with sqlite3.connect(path) as conn:
+        conn.execute("DROP TABLE deliveries")
+    assert all(AttentionStore(path).state(f"session/{i}")["unseen"] for i in range(8))
+    upgraded = AttentionStore(path)
+    # Zero claims on first contact — the point of the whole test.
+    assert not any(
+        upgraded.claim_delivery(f"session/{index}", token, "test")
+        for index, token in enumerate(tokens)
+    )
+    # The backlog is still UNREAD; only its notifications are considered spent.
+    assert all(upgraded.state(f"session/{i}")["unseen"] for i in range(8))
+    # And work published after the upgrade still notifies.
+    fresh = str(uuid.uuid4())
+    upgraded.publish("session/0", fresh, "new", "complete")
+    assert upgraded.claim_delivery("session/0", fresh, "test") is True
+
+
+def test_a_missing_deliveries_table_is_not_read_as_corruption(tmp_path: Path) -> None:
+    """The migration hazard, pinned: an old database must stay fully usable.
+
+    `_uninitialized` treats missing tables in an established database as
+    corruption. Adding `deliveries` to that probe would make every database
+    written by an earlier release read as corrupt, so the probe deliberately
+    does not mention it — this test fails the moment someone "tidies" it.
+    """
+    path = tmp_path / "attention.db"
+    store = AttentionStore(path)
+    token = str(uuid.uuid4())
+    store.publish("session/a", token, "result", "complete")
+    with sqlite3.connect(path) as conn:
+        conn.execute("DROP TABLE deliveries")
+    reopened = AttentionStore(path)
+    assert reopened.state("session/a")["unseen"] is True
+    assert reopened.revision()[0] > 0
+    assert reopened.acknowledge("session/a", token)["unseen"] is False
+    # The two ORIGINAL tables are still corruption when absent.
+    with sqlite3.connect(path) as conn:
+        conn.execute("DROP TABLE receipts")
+    with pytest.raises(sqlite3.DatabaseError):
+        AttentionStore(path).publish("session/a", str(uuid.uuid4()), "result", "complete")

--- a/tests/unit/test_settings_io.py
+++ b/tests/unit/test_settings_io.py
@@ -155,6 +155,9 @@ _NO_SINGLE_VALUE_CONSUMER: dict[str, str] = {
     "display.terminal_title": "tui/settings.py derives its defaults from this registry",
     "display.images": "tui/settings.py derives its defaults from this registry",
     "display.notifications": "tui/settings.py derives its defaults from this registry",
+    "display.notification_session_name": (
+        "tui/settings.py derives its defaults from this registry"
+    ),
     "display.dock": "tui/settings.py derives its defaults from this registry",
     "subagents.models.lo": "free text; empty means 'keep the parent's model', no constant",
     "subagents.models.med": "free text; empty means 'keep the parent's model', no constant",

--- a/tests/unit/tui/test_background_completion_notify.py
+++ b/tests/unit/tui/test_background_completion_notify.py
@@ -381,3 +381,416 @@ async def test_a_failed_delivery_hands_the_claim_back(
         # The claim was released, so the event is still available to whoever
         # can actually deliver it.
         assert AttentionStore(store_root / "attention.db").claim_delivery(identity, token, "test")
+
+
+def _overlay(monkeypatch: pytest.MonkeyPatch, session_id: str, **fields: Any) -> None:
+    """Rewrite one catalog row's live fields, leaving every other row real.
+
+    The live state a row carries is published by a running runtime record, and
+    these tests have no second process to produce one. Patching the catalog
+    rather than faking the whole entry keeps the rest of the row — its name,
+    its completion token, its unseen level — coming from the real store.
+    """
+    import dataclasses
+
+    from local_operator.tui import session_catalog
+
+    real = session_catalog.load_catalog
+
+    def overlaid(directory: Path) -> Any:
+        return [
+            (
+                dataclasses.replace(entry, row=entry.row._replace(**fields))
+                if entry.id == session_id
+                else entry
+            )
+            for entry in real(directory)
+        ]
+
+    monkeypatch.setattr(session_catalog, "load_catalog", overlaid)
+
+
+@pytest.mark.asyncio
+async def test_a_session_attached_in_another_window_is_not_announced(
+    store_root: Path, spawned: list[list[str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``attached`` means ANOTHER TUI owns that session's toast (review B2).
+
+    The self-skip beside this one covers this process's own session. A row
+    whose ``live_state`` is ``attached`` belongs to a different window, whose
+    in-app ``Notifier`` already fires on ``TurnEnded`` — so announcing it here
+    is the double notification the routing design forbids (X8/X9). The
+    operator runs ~11 concurrent sessions, so this is the normal state of their
+    catalog rather than an edge case.
+
+    Fails without the filter: reintroducing it produced exactly one banner
+    titled with the attached session's name.
+    """
+    _make_session(store_root, "current", "Current conversation")
+    background = _make_session(store_root, "bg0000000001", "Attached elsewhere")
+    store = AttentionStore(store_root / "attention.db")
+    store.publish(conversation_identity(background), str(uuid.uuid4()), "fresh", "complete")
+    _overlay(monkeypatch, "bg0000000001", live_state="attached")
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot, rounds=8)
+        assert spawned == [], spawned
+
+
+@pytest.mark.asyncio
+async def test_an_idle_background_session_is_still_announced(
+    store_root: Path, spawned: list[list[str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The B2 filter must key on ``attached`` alone, not on liveness.
+
+    A resident-but-unattached session is exactly the case this feature exists
+    for — a background runtime finishing with nobody watching it — so a filter
+    written as "skip anything live" would suppress the reported bug's own
+    scenario. Guards the fix from being over-applied.
+    """
+    _make_session(store_root, "current", "Current conversation")
+    background = _make_session(store_root, "bg0000000001", "Idle background work")
+    store = AttentionStore(store_root / "attention.db")
+    store.publish(conversation_identity(background), str(uuid.uuid4()), "fresh", "complete")
+    _overlay(monkeypatch, "bg0000000001", live_state="idle")
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot, rounds=8)
+        assert len(spawned) == 1, spawned
+        assert "Idle background work" in " ".join(spawned[0])
+
+
+@pytest.mark.asyncio
+async def test_a_backlog_is_capped_and_the_remainder_is_summarised(
+    store_root: Path, spawned: list[list[str]]
+) -> None:
+    """A store AT REST with a backlog must not fire one banner per row (B1).
+
+    The baseline only covers the tick that CREATES the table. The overnight
+    case — an already-migrated store, no observer running while background
+    sessions finish — was measured at 30 banners on one tick. The cap bounds
+    the spawn; the digest is what stops the remainder being silently dropped,
+    which would be its own defect.
+
+    Every backlogged completion is still CLAIMED, so the flood cannot simply
+    return on the next revision change; the assertion below checks that too.
+    """
+    from local_operator.tui.app import _BACKGROUND_NOTIFY_MAX_PER_TICK
+
+    _make_session(store_root, "current", "Current conversation")
+    store = AttentionStore(store_root / "attention.db")
+    # Establish the table and its baseline FIRST, so the backlog below is
+    # published into a store that already has deliveries — the case the
+    # migration test cannot reach.
+    seed = _make_session(store_root, "bg0000000000", "Seed")
+    seed_token = str(uuid.uuid4())
+    store.publish(conversation_identity(seed), seed_token, "old", "complete")
+    store.acknowledge(conversation_identity(seed), seed_token)
+
+    backlog = 12
+    for index in range(backlog):
+        directory = _make_session(store_root, f"bg00000001{index:02d}", f"Overnight {index}")
+        store.publish(conversation_identity(directory), str(uuid.uuid4()), "fresh", "complete")
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot, rounds=8)
+
+    named = [call for call in spawned if "more session" not in " ".join(call)]
+    digests = [call for call in spawned if "more session" in " ".join(call)]
+    assert len(named) == _BACKGROUND_NOTIFY_MAX_PER_TICK, spawned
+    # The count is reported rather than lost: 12 backlogged, 3 named, 9 summarised.
+    assert len(digests) == 1, spawned
+    assert f"{backlog - _BACKGROUND_NOTIFY_MAX_PER_TICK} more sessions finished" in " ".join(
+        digests[0]
+    )
+    # Claimed, not merely skipped — otherwise the backlog re-floods next tick.
+    fresh = AttentionStore(store_root / "attention.db")
+    assert all(
+        not fresh.claim_delivery(
+            conversation_identity(store_root / "sessions" / f"bg00000001{index:02d}"),
+            str(
+                fresh.state(
+                    conversation_identity(store_root / "sessions" / f"bg00000001{index:02d}")
+                )["completion_token"]
+            ),
+            "test",
+        )
+        for index in range(backlog)
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_backlog_does_not_reflood_on_the_next_revision_change(
+    store_root: Path, spawned: list[list[str]]
+) -> None:
+    """The cap holds back a banner, not a claim (B1's other half).
+
+    A cap that skipped rows without claiming them would re-announce the whole
+    backlog the moment any unrelated completion moved the revision — turning a
+    one-tick flood into a recurring one.
+    """
+    _make_session(store_root, "current", "Current conversation")
+    store = AttentionStore(store_root / "attention.db")
+    seed = _make_session(store_root, "bg0000000000", "Seed")
+    seed_token = str(uuid.uuid4())
+    store.publish(conversation_identity(seed), seed_token, "old", "complete")
+    store.acknowledge(conversation_identity(seed), seed_token)
+    for index in range(10):
+        directory = _make_session(store_root, f"bg00000002{index:02d}", f"Overnight {index}")
+        store.publish(conversation_identity(directory), str(uuid.uuid4()), "fresh", "complete")
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot, rounds=8)
+        spawned.clear()
+        # An unrelated completion moves the revision, which is what re-opens
+        # the gate the observer holds.
+        latecomer = _make_session(store_root, "bg0000000999", "Latecomer")
+        store.publish(conversation_identity(latecomer), str(uuid.uuid4()), "fresh", "complete")
+        await _settle(app, pilot, rounds=8)
+
+    # Only the new one, never the backlog again.
+    assert len(spawned) == 1, spawned
+    assert "Latecomer" in " ".join(spawned[0])
+
+
+@pytest.mark.asyncio
+async def test_a_released_claim_is_retried_without_an_unrelated_completion(
+    store_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`release_delivery`'s promised retry actually happens (review M1 / QA Q1).
+
+    ``revision()`` reads ``completions`` and ``receipts`` only, so a claim taken
+    and handed back leaves it byte-identical and the observer's own gate
+    short-circuits forever. Measured at 0 retries across 60 ticks with the
+    backend healthy again — on a single-session machine, silence, which is the
+    exact hole ``release_delivery`` exists to close.
+
+    Asserts the RETRY, not the release: the pre-existing test already covers
+    the claim going back, and it passed throughout the defect.
+    """
+    monkeypatch.delenv("LOCAL_OPERATOR_NO_NOTIFICATIONS", raising=False)
+    _make_session(store_root, "current", "Current conversation")
+    background = _make_session(store_root, "bg0000000001", "Background work")
+    store = AttentionStore(store_root / "attention.db")
+    store.publish(conversation_identity(background), str(uuid.uuid4()), "fresh", "complete")
+
+    healthy = False
+    calls: list[list[str]] = []
+
+    def deliver(title: str, body: str, *, session_id: str = "", subtitle: str = "") -> bool:
+        # Fails while the backend is "down", succeeds once it recovers. Nothing
+        # else about the store changes in between, so the only thing that can
+        # produce a second attempt is the observer re-scanning on its own.
+        if not healthy:
+            return False
+        calls.append([title, body, session_id, subtitle])
+        return True
+
+    monkeypatch.setattr("local_operator.tui.notify.detached_notify", deliver)
+    monkeypatch.setattr(
+        "local_operator.proc.spawn_detached", lambda argv, **kwargs: calls.append(list(argv)) or 1
+    )
+    monkeypatch.setattr(
+        "local_operator.tui.notify.spawn_detached",
+        lambda argv, **kwargs: calls.append(list(argv)) or 1,
+    )
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot, rounds=6)
+        assert calls == [], "the backend was down; nothing should have been delivered"
+        healthy = True
+        # NOTHING is published here. Without the fix the revision is unchanged,
+        # the gate short-circuits, and this stays empty forever.
+        await _settle(app, pilot, rounds=6)
+        assert len(calls) == 1, calls
+        assert "Background work" in " ".join(calls[0])
+
+
+@pytest.mark.asyncio
+async def test_one_unreadable_row_does_not_mute_the_others(
+    store_root: Path, spawned: list[list[str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A raising row loses itself, never its siblings (QA Q2).
+
+    ``claim_delivery`` sits outside the delivery helper's own try/except and
+    touches SQLite, so a corrupt store (``DatabaseError``) or a read-only one
+    (``OperationalError``) raised straight out of the first row and dropped
+    every remaining session that tick — measured at 0 of 5 toasts. Reachable
+    without simulation, which is why the guard is per row.
+    """
+    import sqlite3
+
+    _make_session(store_root, "current", "Current conversation")
+    for index in range(4):
+        directory = _make_session(store_root, f"bg000000030{index}", f"Sibling {index}")
+        AttentionStore(store_root / "attention.db").publish(
+            conversation_identity(directory), str(uuid.uuid4()), "fresh", "complete"
+        )
+
+    # The catalog ranks by recency, so which row is scanned FIRST depends on
+    # directory mtimes the test does not control — and this test is only
+    # meaningful when the raising row precedes its siblings. Pin the order by
+    # id so the poisoned row is provably first; the ranking itself is asserted
+    # elsewhere and is not the property under test here.
+    from local_operator.tui import session_catalog
+
+    real_catalog = session_catalog.load_catalog
+    monkeypatch.setattr(
+        session_catalog,
+        "load_catalog",
+        lambda directory: sorted(real_catalog(directory), key=lambda entry: entry.id),
+    )
+
+    real_claim = AttentionStore.claim_delivery
+    poisoned = {"bg0000000300"}
+
+    def claim(self: Any, conversation: str, token: str, backend: str) -> bool:
+        if any(bad in conversation for bad in poisoned):
+            raise sqlite3.DatabaseError("file is not a database")
+        return real_claim(self, conversation, token, backend)
+
+    monkeypatch.setattr(AttentionStore, "claim_delivery", claim)
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot, rounds=8)
+
+    delivered = " ".join(" ".join(call) for call in spawned)
+    # The poisoned row is lost, and only it.
+    assert "Sibling 0" not in delivered, spawned
+    for index in range(1, 4):
+        assert f"Sibling {index}" in delivered, spawned
+
+
+@pytest.mark.asyncio
+async def test_an_interrupted_session_is_not_announced_as_an_error(
+    store_root: Path, spawned: list[list[str]]
+) -> None:
+    """`interrupted` gets its own sentence (design D3).
+
+    The store admits exactly complete/error/interrupted, and the maintainer's
+    real store holds 318 complete, 14 interrupted and 0 error — so folding
+    interrupted into error made every non-success banner the feature can raise
+    today assert a failure that did not happen.
+    """
+    from local_operator.tui.notify import (
+        BODY_ERROR,
+        CONTEXT_ATTENTION,
+        CONTEXT_INTERRUPTED,
+    )
+
+    _make_session(store_root, "current", "Current conversation")
+    background = _make_session(store_root, "bg0000000001", "Halted midway")
+    store = AttentionStore(store_root / "attention.db")
+    store.publish(conversation_identity(background), str(uuid.uuid4()), "fresh", "interrupted")
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot)
+        assert len(spawned) == 1, spawned
+        argv = " ".join(spawned[0])
+        assert CONTEXT_INTERRUPTED in argv
+        assert CONTEXT_ATTENTION not in argv
+        assert BODY_ERROR not in argv
+
+
+@pytest.mark.asyncio
+async def test_an_errored_session_still_says_it_errored(
+    store_root: Path, spawned: list[list[str]]
+) -> None:
+    """D3's other half: splitting the states must not lose the error wording."""
+    from local_operator.tui.notify import CONTEXT_ATTENTION
+
+    _make_session(store_root, "current", "Current conversation")
+    background = _make_session(store_root, "bg0000000001", "Broken run")
+    store = AttentionStore(store_root / "attention.db")
+    store.publish(conversation_identity(background), str(uuid.uuid4()), "fresh", "error")
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot)
+        assert len(spawned) == 1, spawned
+        assert CONTEXT_ATTENTION in " ".join(spawned[0])
+
+
+@pytest.mark.asyncio
+async def test_a_session_with_no_stored_title_is_not_titled_with_its_prompt(
+    store_root: Path, spawned: list[list[str]]
+) -> None:
+    """Role boilerplate must not eat the banner's identifying words (design D1/D2).
+
+    ``session_name`` falls back to the opening user message, and an
+    agent-spawned session's opener begins with its role preamble — so a banner
+    clipped at macOS's ~43 characters showed ``[team: lopdev] You are reviewer
+    on this te…`` with every discriminating word past the cut. 15 of 67 rows on
+    the maintainer's store have no stored title, and they are disproportionately
+    the background sessions this feature exists to announce.
+
+    The neutral sentence is also NOT the brand: ``Local Operator`` was
+    pixel-identical to the opt-out banner, two meanings in one frame (D2).
+    """
+    from local_operator.tui.notify import APP_NAME, BACKGROUND_FALLBACK_TITLE
+
+    _make_session(store_root, "current", "Current conversation")
+    # A session directory with a transcript but NO title.json — the shape
+    # `_make_session` produces before `write_session_title` runs.
+    directory = store_root / "sessions" / "bg0000000001"
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "transcript.jsonl").write_text(
+        '{"id":"e1","ts":1,"type":"message","payload":{"kind":"message","role":"user",'
+        '"content":[{"text":"[team: lopdev] You are reviewer on this team. '
+        'The manager is manager."}]}}\n'
+    )
+    store = AttentionStore(store_root / "attention.db")
+    store.publish(conversation_identity(directory), str(uuid.uuid4()), "fresh", "complete")
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot)
+        assert len(spawned) == 1, spawned
+        argv = " ".join(spawned[0])
+        assert BACKGROUND_FALLBACK_TITLE in argv
+        assert "team: lopdev" not in argv
+        assert "You are reviewer" not in argv
+        # Distinct from the opt-out banner, which keeps the brand.
+        assert APP_NAME not in argv
+        # Still clickable back into the session.
+        assert "bg0000000001" in argv
+
+
+@pytest.mark.asyncio
+async def test_the_opt_out_banner_is_distinguishable_from_the_nameless_one(
+    store_root: Path, spawned: list[list[str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two different meanings must not render as one frame (design D2)."""
+    from local_operator.tui.notify import APP_NAME, BACKGROUND_FALLBACK_TITLE
+
+    monkeypatch.setattr("local_operator.tui.notify.session_names_in_notifications", lambda: False)
+    _make_session(store_root, "current", "Current conversation")
+    background = _make_session(store_root, "bg0000000001", "Secret client migration")
+    store = AttentionStore(store_root / "attention.db")
+    store.publish(conversation_identity(background), str(uuid.uuid4()), "fresh", "complete")
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot)
+        assert len(spawned) == 1, spawned
+        argv = " ".join(spawned[0])
+        assert APP_NAME in argv
+        assert BACKGROUND_FALLBACK_TITLE not in argv
+        assert "Secret client migration" not in argv

--- a/tests/unit/tui/test_background_completion_notify.py
+++ b/tests/unit/tui/test_background_completion_notify.py
@@ -75,33 +75,48 @@ def store_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 @pytest.fixture
 def spawned(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
-    """Every argv the app would hand the OS, captured at the real boundary.
+    """Every notification the app decides to send, captured at ITS boundary.
 
     The visible, deliberate opt-in out of ``tests/conftest.py``'s suite-wide
     ``LOCAL_OPERATOR_NO_NOTIFICATIONS`` gate, which exists so no test can put a
     real banner in the maintainer's Notification Centre. Opting in is safe here
-    precisely because every spawn below is intercepted: this file asserts on the
-    argv a delivery WOULD hand the OS, and nothing is ever launched.
+    because nothing below is ever launched.
+
+    INTERCEPTED AT ``detached_notify``, NOT AT ``spawn_detached``, and the
+    distinction is a CI failure this file already paid for. What these tests
+    assert is the app's ROUTING DECISION — which session is announced, how
+    often, with what title, and whether the watermark moved. Which argv that
+    decision finally becomes is a property of the HOST: ``detached_notify``
+    resolves a signed bundle, then ``osascript``, then ``notify-send``, and on a
+    Linux CI runner with none of them installed it correctly delivers nothing
+    and returns False. Capturing spawns therefore made a green macOS run and a
+    red Linux run of identical, correct code (run 34091362532, shard 2).
+
+    The wire those argvs travel is not left untested — ``tui/test_notify.py``
+    already pins every backend's exact command as a pure function.
     """
     monkeypatch.delenv("LOCAL_OPERATOR_NO_NOTIFICATIONS", raising=False)
     calls: list[list[str]] = []
 
-    def capture(argv: list[str], **kwargs: Any) -> int:
-        calls.append(list(argv))
-        return 4242
+    def deliver(title: str, body: str, *, session_id: str = "", subtitle: str = "") -> bool:
+        # Recorded in the same flat shape the argv assertions used, so a test
+        # reads as "what did the user get told", not as a call signature.
+        calls.append([title, body, session_id, subtitle])
+        return True
 
-    # Patched at each name the delivery ladder actually calls, so a route that
-    # bypassed one of them would launch a real notifier and be noticed.
-    monkeypatch.setattr("local_operator.proc.spawn_detached", capture)
-    monkeypatch.setattr("local_operator.tui.notify.spawn_detached", capture)
-    monkeypatch.setattr("local_operator.tui.notify._spawn_detached", lambda argv: capture(argv))
+    monkeypatch.setattr("local_operator.tui.notify.detached_notify", deliver)
+    # The cmux route is a genuinely different backend, so it is captured too:
+    # this suite runs INSIDE cmux on the maintainer's machine, and the
+    # ``store_root`` fixture scrubs ``CMUX_*`` precisely so the bare-terminal
+    # path — the configuration the bug was reported in — is what is exercised.
+    # If that scrub ever regresses, this records the fact instead of launching.
     monkeypatch.setattr(
-        "local_operator.tui.notify._spawn_detached_ok", lambda argv: bool(capture(argv))
+        "local_operator.proc.spawn_detached", lambda argv, **kwargs: calls.append(list(argv)) or 1
     )
-    # The signed bundle is a compiled artifact that may or may not exist on the
-    # machine running this; forcing the plain route keeps the argv assertions
-    # deterministic without changing which DECISION is under test.
-    monkeypatch.setattr("local_operator.tui.notify._identity_notifier", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "local_operator.tui.notify.spawn_detached",
+        lambda argv, **kwargs: calls.append(list(argv)) or 1,
+    )
     return calls
 
 
@@ -346,7 +361,11 @@ async def test_a_failed_delivery_hands_the_claim_back(
 
     Otherwise a spawn refused once silences that completion permanently — the
     exact class of silent hole this feature exists to close.
+
+    Does not take the ``spawned`` fixture (it patches delivery itself), so it
+    opts out of the suite-wide notification gate on its own.
     """
+    monkeypatch.delenv("LOCAL_OPERATOR_NO_NOTIFICATIONS", raising=False)
     _make_session(store_root, "current", "Current conversation")
     background = _make_session(store_root, "bg0000000001", "Background work")
     store = AttentionStore(store_root / "attention.db")

--- a/tests/unit/tui/test_background_completion_notify.py
+++ b/tests/unit/tui/test_background_completion_notify.py
@@ -1,0 +1,364 @@
+"""A BACKGROUND session finishing, as the real app announces it.
+
+The reported bug this file guards: eleven concurrent sessions in one terminal
+window, a background session completes, the sidebar paints its checkmark, and no
+notification of any kind is delivered. The completion fact crossed the process
+boundary correctly and was rendered correctly — nothing converted it into a
+toast.
+
+These tests drive the real ``OperatorApp`` against a real ``AttentionStore`` and
+intercept at ``spawn_detached``, the actual process boundary a delivery crosses.
+That is deliberate: a test that called the delivery helper directly would pass
+with the observer leg wired to nothing, which is precisely the defect.
+
+The distinction that makes this feature correct is asserted throughout: DELIVERY
+and ACKNOWLEDGEMENT are separate watermarks. Announcing a session must never
+mark it read (``docs/SESSION_SIDEBAR.md``), or the checkmark the operator uses
+to find unread work would be cleared by the toast telling them about it.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.session.attention import AttentionStore, conversation_identity
+from local_operator.tui.app import OperatorApp
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+class AttachedSession(FakeSession):
+    """A session pinned to the id the operator is looking at."""
+
+    @property
+    def session_id(self) -> str:
+        return "current"
+
+
+def _make_session(root: Path, session_id: str, name: str) -> Path:
+    """A session directory the catalog can actually scan and name.
+
+    Uses ``write_session_title`` rather than hand-writing a sidecar, so the name
+    resolves through exactly the path the picker and sidebar use.
+    """
+    from local_operator.resume import write_session_title
+
+    directory = root / "sessions" / session_id
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "transcript.jsonl").write_text(
+        '{"id":"e1","ts":1,"type":"message",'
+        '"payload":{"kind":"message","role":"user","content":[{"text":"go"}]}}\n'
+    )
+    write_session_title(directory, name, user_set=False, past_names=[])
+    return directory
+
+
+@pytest.fixture
+def store_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """An isolated config root, with cmux scrubbed from the environment.
+
+    Every ``CMUX_*`` variable is removed because this suite runs inside cmux on
+    the maintainer's machine: an inherited ``CMUX_SURFACE_ID`` would route every
+    delivery down the cmux backend and silently stop testing the bare-terminal
+    path, which is the configuration the bug was reported in.
+    """
+    root = tmp_path / "config"
+    (root / "sessions").mkdir(parents=True)
+    for key in ("CMUX_SURFACE_ID", "CMUX_WORKSPACE_ID", "CMUX_SOCKET_PATH", "CMUX_PANE_ID"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr("local_operator.paths.config_dir", lambda: root)
+    return root
+
+
+@pytest.fixture
+def spawned(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
+    """Every argv the app would hand the OS, captured at the real boundary.
+
+    The visible, deliberate opt-in out of ``tests/conftest.py``'s suite-wide
+    ``LOCAL_OPERATOR_NO_NOTIFICATIONS`` gate, which exists so no test can put a
+    real banner in the maintainer's Notification Centre. Opting in is safe here
+    precisely because every spawn below is intercepted: this file asserts on the
+    argv a delivery WOULD hand the OS, and nothing is ever launched.
+    """
+    monkeypatch.delenv("LOCAL_OPERATOR_NO_NOTIFICATIONS", raising=False)
+    calls: list[list[str]] = []
+
+    def capture(argv: list[str], **kwargs: Any) -> int:
+        calls.append(list(argv))
+        return 4242
+
+    # Patched at each name the delivery ladder actually calls, so a route that
+    # bypassed one of them would launch a real notifier and be noticed.
+    monkeypatch.setattr("local_operator.proc.spawn_detached", capture)
+    monkeypatch.setattr("local_operator.tui.notify.spawn_detached", capture)
+    monkeypatch.setattr("local_operator.tui.notify._spawn_detached", lambda argv: capture(argv))
+    monkeypatch.setattr(
+        "local_operator.tui.notify._spawn_detached_ok", lambda argv: bool(capture(argv))
+    )
+    # The signed bundle is a compiled artifact that may or may not exist on the
+    # machine running this; forcing the plain route keeps the argv assertions
+    # deterministic without changing which DECISION is under test.
+    monkeypatch.setattr("local_operator.tui.notify._identity_notifier", lambda *a, **k: None)
+    return calls
+
+
+async def _settle(app: OperatorApp, pilot: Any, rounds: int = 6) -> None:
+    """Run the app's own attention poll to completion, several times."""
+    for _ in range(rounds):
+        await app._poll_completion_attention()
+        for _ in range(4):
+            await pilot.pause()
+
+
+async def _booted(app: OperatorApp, pilot: Any) -> None:
+    for _ in range(40):
+        await pilot.pause()
+        if app._session is not None:
+            return
+    raise AssertionError("the session worker never attached a session")
+
+
+@pytest.mark.asyncio
+async def test_a_background_session_completing_is_announced(
+    store_root: Path, spawned: list[list[str]]
+) -> None:
+    """The operator's exact report: attached to one session, another finishes."""
+    _make_session(store_root, "current", "Current conversation")
+    background = _make_session(store_root, "bg0000000001", "Article-search-svc schema review")
+    store = AttentionStore(store_root / "attention.db")
+    identity = conversation_identity(background)
+    # An ESTABLISHED store: a prior, already-read completion, so the baseline is
+    # installed and this is the steady state rather than a fresh machine.
+    first = str(uuid.uuid4())
+    store.publish(identity, first, "old", "complete")
+    store.acknowledge(identity, first)
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot)
+        spawned.clear()
+
+        store.publish(identity, str(uuid.uuid4()), "fresh", "complete")
+        await _settle(app, pilot)
+
+        assert len(spawned) == 1, spawned
+        argv = " ".join(spawned[0])
+        # Names the session, because with eleven open the name is the only
+        # thing that says WHICH one finished.
+        assert "Article-search-svc schema review" in argv
+        # Carries the session id, which is what makes the banner clickable
+        # back into the session (`lop resume-click`).
+        assert "bg0000000001" in argv
+
+
+@pytest.mark.asyncio
+async def test_the_announcement_does_not_repeat_on_later_polls(
+    store_root: Path, spawned: list[list[str]]
+) -> None:
+    """`unseen` is a LEVEL: without the watermark this fires once per second."""
+    _make_session(store_root, "current", "Current conversation")
+    background = _make_session(store_root, "bg0000000001", "Background work")
+    store = AttentionStore(store_root / "attention.db")
+    identity = conversation_identity(background)
+    store.publish(identity, str(uuid.uuid4()), "fresh", "complete")
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot, rounds=10)
+        assert len(spawned) == 1, spawned
+        # Still unread — the level is unchanged — and still silent.
+        assert store.state(identity)["unseen"] is True
+        await _settle(app, pilot, rounds=10)
+        assert len(spawned) == 1, spawned
+
+
+@pytest.mark.asyncio
+async def test_announcing_never_acknowledges_the_session(
+    store_root: Path, spawned: list[list[str]]
+) -> None:
+    """The invariant: a toast must not clear the sidebar's unread mark."""
+    _make_session(store_root, "current", "Current conversation")
+    background = _make_session(store_root, "bg0000000001", "Background work")
+    store = AttentionStore(store_root / "attention.db")
+    identity = conversation_identity(background)
+    store.publish(identity, str(uuid.uuid4()), "fresh", "complete")
+    before = store.state(identity)["revision"]
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot)
+        assert spawned
+        after = store.state(identity)
+        assert after["unseen"] is True
+        assert after["revision"] == before
+
+
+@pytest.mark.asyncio
+async def test_the_attached_session_is_not_announced_by_the_observer(
+    store_root: Path, spawned: list[list[str]]
+) -> None:
+    """The session on screen keeps its existing owner; two toasts would be wrong.
+
+    This is also the focus gate, evaluated: an event is suppressed only when the
+    user is demonstrably looking at the session that produced it, and for the
+    attached row the in-app ``Notifier`` on ``TurnEnded`` already answers.
+    """
+    current = _make_session(store_root, "current", "Current conversation")
+    store = AttentionStore(store_root / "attention.db")
+    store.publish(conversation_identity(current), str(uuid.uuid4()), "fresh", "complete")
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot, rounds=8)
+        assert spawned == []
+
+
+@pytest.mark.asyncio
+async def test_a_parked_gate_is_left_to_the_runtime(
+    store_root: Path, spawned: list[list[str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A row waiting for a person is announced by its own runtime, not here."""
+    _make_session(store_root, "current", "Current conversation")
+    background = _make_session(store_root, "bg0000000001", "Waiting on you")
+    store = AttentionStore(store_root / "attention.db")
+    identity = conversation_identity(background)
+    store.publish(identity, str(uuid.uuid4()), "fresh", "complete")
+
+    from local_operator.tui import session_catalog
+
+    real = session_catalog.load_catalog
+
+    def pending(directory: Path) -> Any:
+        # The pending mark is published by a live runtime record, which this
+        # test has no process to produce; the field is what the leg reads.
+        return [
+            entry if entry.id != "bg0000000001" else _with_pending(entry)
+            for entry in real(directory)
+        ]
+
+    def _with_pending(entry: Any) -> Any:
+        import dataclasses
+
+        return dataclasses.replace(entry, row=entry.row._replace(pending="approval"))
+
+    monkeypatch.setattr(session_catalog, "load_catalog", pending)
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot, rounds=8)
+        assert spawned == []
+
+
+@pytest.mark.asyncio
+async def test_an_upgrading_store_announces_nothing_on_the_first_tick(
+    store_root: Path, spawned: list[list[str]]
+) -> None:
+    """No-flood on upgrade, through the APP rather than the store alone.
+
+    A database written before this feature carries a backlog of unread
+    completions. The first app to open it must announce none of them: on the
+    maintainer's real store that backlog is 121 conversations, i.e. 121 banners
+    in one second.
+    """
+    import sqlite3
+
+    _make_session(store_root, "current", "Current conversation")
+    store = AttentionStore(store_root / "attention.db")
+    for index in range(8):
+        directory = _make_session(store_root, f"bg000000000{index}", f"Old work {index}")
+        store.publish(conversation_identity(directory), str(uuid.uuid4()), "old", "complete")
+    # Reproduce a pre-feature database exactly: the table is simply absent.
+    with sqlite3.connect(store_root / "attention.db") as conn:
+        conn.execute("DROP TABLE deliveries")
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot, rounds=8)
+        assert spawned == [], spawned
+        # The backlog is still UNREAD; only its notifications are spent.
+        assert all(
+            AttentionStore(store_root / "attention.db").state(
+                conversation_identity(store_root / "sessions" / f"bg000000000{i}")
+            )["unseen"]
+            for i in range(8)
+        )
+
+
+@pytest.mark.asyncio
+async def test_notifications_disabled_stays_silent(
+    store_root: Path, spawned: list[list[str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The existing kill switch governs this path too."""
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_NOTIFICATIONS", "1")
+    _make_session(store_root, "current", "Current conversation")
+    background = _make_session(store_root, "bg0000000001", "Background work")
+    store = AttentionStore(store_root / "attention.db")
+    store.publish(conversation_identity(background), str(uuid.uuid4()), "fresh", "complete")
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot, rounds=6)
+        assert spawned == []
+
+
+@pytest.mark.asyncio
+async def test_the_session_name_can_be_kept_off_the_banner(
+    store_root: Path, spawned: list[list[str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`display.notification_session_name` off titles with the brand instead.
+
+    The observer path widens where a model-written session name appears,
+    including on a lock screen; this is the opt-out.
+    """
+    monkeypatch.setattr("local_operator.tui.notify.session_names_in_notifications", lambda: False)
+    _make_session(store_root, "current", "Current conversation")
+    background = _make_session(store_root, "bg0000000001", "Secret client migration")
+    store = AttentionStore(store_root / "attention.db")
+    store.publish(conversation_identity(background), str(uuid.uuid4()), "fresh", "complete")
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot)
+        assert spawned
+        argv = " ".join(spawned[0])
+        assert "Secret client migration" not in argv
+        assert "Local Operator" in argv
+        # Still identifies the session for the click-through.
+        assert "bg0000000001" in argv
+
+
+@pytest.mark.asyncio
+async def test_a_failed_delivery_hands_the_claim_back(
+    store_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A backend that delivered nothing must not leave the watermark lying.
+
+    Otherwise a spawn refused once silences that completion permanently — the
+    exact class of silent hole this feature exists to close.
+    """
+    _make_session(store_root, "current", "Current conversation")
+    background = _make_session(store_root, "bg0000000001", "Background work")
+    store = AttentionStore(store_root / "attention.db")
+    identity = conversation_identity(background)
+    token = str(uuid.uuid4())
+    store.publish(identity, token, "fresh", "complete")
+    monkeypatch.setattr("local_operator.tui.notify.detached_notify", lambda *a, **k: False)
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot)
+        # The claim was released, so the event is still available to whoever
+        # can actually deliver it.
+        assert AttentionStore(store_root / "attention.db").claim_delivery(identity, token, "test")

--- a/tests/unit/tui/test_background_completion_notify.py
+++ b/tests/unit/tui/test_background_completion_notify.py
@@ -1157,3 +1157,133 @@ async def test_the_digest_never_asserts_an_outcome_the_remainder_did_not_have(
     assert all(title != call[0] for call in named), spawned
     # The one inert banner in the stack says where to go instead (D10).
     assert "sidebar" in body.lower(), digests
+
+
+@pytest.mark.parametrize(
+    ("announced_kind", "held_kind"),
+    [
+        # THE EXACT REPRODUCTION from design round 3: 5 complete held back
+        # behind 3 interrupted, which rendered `8 sessions finished` over
+        # `Complete` while three of those eight were interrupted.
+        ("interrupted", "complete"),
+        # The same seam in the other direction, where the held-back set is the
+        # alarming one: announcing 3 complete over 5 errors read
+        # `8 sessions finished` / `Needs attention` under the old subtitle
+        # scope and `Complete` under the old title's. Either way the two lines
+        # described different sets.
+        ("complete", "error"),
+    ],
+    ids=["interrupted-announced-complete-held", "complete-announced-error-held"],
+)
+@pytest.mark.asyncio
+async def test_the_digest_title_and_subtitle_describe_the_same_sessions(
+    store_root: Path,
+    spawned: list[list[str]],
+    announced_kind: str,
+    held_kind: str,
+) -> None:
+    """Title and subtitle must count the SAME set (design round 3, D12).
+
+    D8 moved the subtitle onto the remainder's real kinds; D11 moved the title
+    onto the tick's absolute total. Independently each was right, and together
+    they left the frame's two lines with different denominators — the title
+    naming the whole tick, the subtitle speaking only for the rows the cap held
+    back. So `5 complete + 3 interrupted` rendered `8 sessions finished` over
+    `Complete`: D8's exact sentence, one line up, reachable with ordinary data
+    because the cap is 3 and the catalog ranks by `(tier, -mtime, id)` rather
+    than by kind.
+
+    Asserted as a RELATION between the two lines rather than as an expected
+    string: the guard is that whatever set the title counts is the set the
+    subtitle describes, so it fails for a title scoped to the remainder just as
+    it fails for a subtitle scoped to it. A test pinning only `Mixed outcomes`
+    would pass a build that fixed the subtitle by shrinking the title, which
+    would silently reopen D11.
+
+    THE PRECONDITION IS ASSERTED, NOT ASSUMED. This PR has now shipped three
+    guards that passed against the defect they named because the catalog put
+    the interesting rows where the test did not expect (QA round 1's Q2; the
+    round-3 mixed case, where the cap announced all three errors and left an
+    all-complete remainder that `Complete` described correctly). A D12 case
+    whose announced and held-back sets happen to share a kind proves nothing at
+    all — the two scopes agree by accident and the old code passes. So the two
+    sets are derived from what actually went out and are required to differ in
+    kind before any assertion about the digest is trusted.
+    """
+    import os
+
+    from local_operator.tui.app import _BACKGROUND_NOTIFY_MAX_PER_TICK
+    from local_operator.tui.notify import (
+        CONTEXT_MIXED,
+        CONTEXTS,
+        background_digest_title,
+        digest_subtitle,
+    )
+
+    _make_session(store_root, "current", "Current conversation")
+    store = AttentionStore(store_root / "attention.db")
+    # An ESTABLISHED store, so this is the steady state rather than the tick
+    # that creates the deliveries table.
+    seed = _make_session(store_root, "bg0000000000", "Seed")
+    seed_token = str(uuid.uuid4())
+    store.publish(conversation_identity(seed), seed_token, "old", "complete")
+    store.acknowledge(conversation_identity(seed), seed_token)
+
+    # Held back first, announced last, with mtimes PINNED rather than left to
+    # creation order: the catalog ranks unseen rows by `-mtime`, so the newest
+    # rows are the ones that fit under the cap. Pinning is what makes "which
+    # kind gets announced" a property of the test rather than of how fast the
+    # filesystem clock ticks — and the precondition below still checks it.
+    held = [held_kind] * 5
+    announced = [announced_kind] * _BACKGROUND_NOTIFY_MAX_PER_TICK
+    for index, kind in enumerate(held + announced):
+        directory = _make_session(store_root, f"bg00000002{index:02d}", f"Overnight {index}")
+        os.utime(directory / "transcript.jsonl", (1_700_000_000 + index, 1_700_000_000 + index))
+        store.publish(conversation_identity(directory), str(uuid.uuid4()), "fresh", kind)
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot, rounds=8)
+
+    # Structural discriminator, not prose: the digest is the only delivery with
+    # no `session_id`, because it covers several sessions.
+    assert all(len(call) == 4 for call in spawned), spawned
+    digests = [call for call in spawned if not call[2]]
+    named = [call for call in spawned if call[2]]
+    assert len(digests) == 1, spawned
+    title, _, _, subtitle = digests[0]
+
+    # WHAT WAS ACTUALLY ANNOUNCED, read back off the banners rather than
+    # assumed from the parametrisation: each named banner's subtitle is its own
+    # kind's category, so inverting `CONTEXTS` recovers the announced set, and
+    # the rest of the published set is what the digest stood for.
+    by_context = {context: kind for kind, context in CONTEXTS.items()}
+    shown_kinds = [by_context[call[3]] for call in named]
+    remainder = list(held + announced)
+    for kind in shown_kinds:
+        remainder.remove(kind)
+
+    # THE PRECONDITION. If these two sets share a kind the case is vacuous: the
+    # title's scope and the subtitle's scope agree by accident and the defect
+    # passes. Everything below is only evidence because this holds.
+    assert len(shown_kinds) == _BACKGROUND_NOTIFY_MAX_PER_TICK, spawned
+    assert set(shown_kinds) == {announced_kind}, shown_kinds
+    assert set(remainder) == {held_kind}, remainder
+    assert set(shown_kinds).isdisjoint(remainder), (shown_kinds, remainder)
+
+    # THE DEFECT, as a relation between the two lines. The title counts the
+    # whole tick, so the subtitle must speak for the whole tick — a set holding
+    # two kinds, which is mixed. Under the defect this read `Complete` (or the
+    # held kind's own category) over a count that included sessions in neither.
+    whole_tick = shown_kinds + remainder
+    assert title == background_digest_title(len(whole_tick)), (title, whole_tick)
+    assert subtitle == digest_subtitle(whole_tick), (title, subtitle, whole_tick)
+    assert subtitle == CONTEXT_MIXED, (title, subtitle, whole_tick)
+    # Neither side's category may be asserted over a set only partly in it.
+    assert subtitle != CONTEXTS[announced_kind], (title, subtitle)
+    assert subtitle != CONTEXTS[held_kind], (title, subtitle)
+    # …and the title still carries the ABSOLUTE total, so a subtitle fixed by
+    # shrinking the title's scope fails here rather than silently reopening D11.
+    assert str(len(whole_tick)) in title, (title, whole_tick)
+    assert str(len(remainder)) not in title.split()[0], (title, remainder)

--- a/tests/unit/tui/test_background_completion_notify.py
+++ b/tests/unit/tui/test_background_completion_notify.py
@@ -410,33 +410,46 @@ def _overlay(monkeypatch: pytest.MonkeyPatch, session_id: str, **fields: Any) ->
     monkeypatch.setattr(session_catalog, "load_catalog", overlaid)
 
 
+# The round-1 `…attached_in_another_window…` test is subsumed here rather than
+# kept beside this one: it asserted exactly this, for exactly one of the three
+# states, and two tests spelling the same rule differently is how one of them
+# later gets updated alone. Its rationale is preserved in the docstring below.
+@pytest.mark.parametrize("live_state", ["attached", "busy", "wedged"])
 @pytest.mark.asyncio
-async def test_a_session_attached_in_another_window_is_not_announced(
-    store_root: Path, spawned: list[list[str]], monkeypatch: pytest.MonkeyPatch
+async def test_a_session_resident_in_another_window_is_not_announced(
+    store_root: Path,
+    spawned: list[list[str]],
+    monkeypatch: pytest.MonkeyPatch,
+    live_state: str,
 ) -> None:
-    """``attached`` means ANOTHER TUI owns that session's toast (review B2).
+    """EVERY state meaning "another window owns this row" suppresses (M3).
 
-    The self-skip beside this one covers this process's own session. A row
-    whose ``live_state`` is ``attached`` belongs to a different window, whose
-    in-app ``Notifier`` already fires on ``TurnEnded`` — so announcing it here
-    is the double notification the routing design forbids (X8/X9). The
-    operator runs ~11 concurrent sessions, so this is the normal state of their
-    catalog rather than an edge case.
+    B2 shipped as ``live_state == "attached"``, but ``live_state`` is a single
+    slot whose branches are mutually exclusive and ordered ``wedged`` > ``busy``
+    > ``attached`` > ``idle``: an attached window RUNNING A TURN reports
+    ``busy``, and one whose heartbeat went stale reports ``wedged``. Both still
+    have that session open, and both still fire their own ``Notifier`` — so the
+    ``attached``-only filter matched the narrowest of the three and let the
+    other two double-notify. Reproduced at 1 banner each before the fix.
 
-    Fails without the filter: reintroducing it produced exactly one banner
-    titled with the attached session's name.
+    ``busy`` is the reachable one post-#720: that PR re-pointed ``busy`` at
+    conversational activity, so a session whose last turn finished unread enters
+    it the moment the user sends a new prompt in another window.
+
+    Parametrised rather than written three times so a state added to the
+    suppressed set is one line here, and so the failure names which state broke.
     """
     _make_session(store_root, "current", "Current conversation")
-    background = _make_session(store_root, "bg0000000001", "Attached elsewhere")
+    background = _make_session(store_root, "bg0000000001", "Owned by another window")
     store = AttentionStore(store_root / "attention.db")
     store.publish(conversation_identity(background), str(uuid.uuid4()), "fresh", "complete")
-    _overlay(monkeypatch, "bg0000000001", live_state="attached")
+    _overlay(monkeypatch, "bg0000000001", live_state=live_state)
 
     app = OperatorApp(lambda: _factory(AttachedSession()))
     async with app.run_test(size=(120, 40)) as pilot:
         await _booted(app, pilot)
         await _settle(app, pilot, rounds=8)
-        assert spawned == [], spawned
+        assert spawned == [], f"{live_state} is resident elsewhere; its own window toasts it"
 
 
 @pytest.mark.asyncio
@@ -501,8 +514,18 @@ async def test_a_backlog_is_capped_and_the_remainder_is_summarised(
         await _booted(app, pilot)
         await _settle(app, pilot, rounds=8)
 
-    named = [call for call in spawned if "more session" not in " ".join(call)]
-    digests = [call for call in spawned if "more session" in " ".join(call)]
+    # Partitioned on the STRUCTURAL fact, not on the banner's prose: the digest
+    # is the only delivery that carries no `session_id`, by design and because
+    # it covers several sessions (there is no single transcript to reopen). A
+    # substring test on "more session" would sort a session literally named
+    # "…3 more sessions…" into the wrong bucket, and it breaks the moment a
+    # design round rewords the copy — which one already has (review round 2,
+    # nit). The `spawned` fixture records `[title, body, session_id, subtitle]`
+    # for every delivery, so slot 2 is the discriminator; a 4-slot shape on
+    # every call is also what proves no cmux argv leaked in to be mis-sorted.
+    assert all(len(call) == 4 for call in spawned), spawned
+    named = [call for call in spawned if call[2]]
+    digests = [call for call in spawned if not call[2]]
     assert len(named) == _BACKGROUND_NOTIFY_MAX_PER_TICK, spawned
     # The count is reported rather than lost: 12 backlogged, 3 named, 9 summarised.
     assert len(digests) == 1, spawned
@@ -523,6 +546,103 @@ async def test_a_backlog_is_capped_and_the_remainder_is_summarised(
         )
         for index in range(backlog)
     )
+
+
+@pytest.mark.parametrize("mode", ["returns_false", "raises"])
+@pytest.mark.asyncio
+async def test_a_failed_digest_does_not_consume_the_claims_it_stood_for(
+    store_root: Path, monkeypatch: pytest.MonkeyPatch, mode: str
+) -> None:
+    """A digest that fails hands back every claim it spoke for (review round 2, M1).
+
+    The cap CLAIMS the rows it holds back — it must, or the backlog re-floods —
+    and the digest is then the only thing that will ever speak for them. So a
+    digest that silently fails takes N completions with it permanently, where a
+    single failed row loses one: measured at 9 of 12 the user is never told
+    about. That is strictly worse than the flood B1 replaced, because a flood is
+    noisy and self-correcting while this is silent and the claim asserts the
+    banner went out.
+
+    Neither failure mode is exotic. ``detached_notify`` returns False by
+    contract on any host with no notifier on PATH — a Linux box without
+    ``notify-send`` — and on macOS before the signed bundle finishes building,
+    which is precisely the cold-start moment a backlog exists. The ``raises``
+    mode is what the helper's own ``except Exception`` swallows.
+
+    Asserts that NO COMPLETION IS PERMANENTLY LOST — every backlogged session is
+    eventually named to the user — rather than asserting the release call. That
+    is the property the user has, it is what the reviewer measured (9 of 12
+    never announced), and it cannot be satisfied by a release that rolled the
+    watermark somewhere useless. It is also why the released rows are followed
+    all the way to a banner: the digest fails on every tick here, so the only
+    way to reach 12 is for the released claims to keep coming back under the cap
+    until each has had a real one.
+    """
+    monkeypatch.delenv("LOCAL_OPERATOR_NO_NOTIFICATIONS", raising=False)
+    _make_session(store_root, "current", "Current conversation")
+    store = AttentionStore(store_root / "attention.db")
+    seed = _make_session(store_root, "bg0000000000", "Seed")
+    seed_token = str(uuid.uuid4())
+    store.publish(conversation_identity(seed), seed_token, "old", "complete")
+    store.acknowledge(conversation_identity(seed), seed_token)
+
+    backlog = 12
+    for index in range(backlog):
+        directory = _make_session(store_root, f"bg00000001{index:02d}", f"Overnight {index}")
+        store.publish(conversation_identity(directory), str(uuid.uuid4()), "fresh", "complete")
+
+    named: list[list[str]] = []
+
+    def deliver(title: str, body: str, *, session_id: str = "", subtitle: str = "") -> bool:
+        # ONLY the digest fails. A digest is the delivery with no `session_id`
+        # (it covers several sessions, so there is no transcript to reopen), so
+        # this splits on the same structural fact the cap test partitions on.
+        if not session_id:
+            if mode == "raises":
+                raise RuntimeError("notifier backend exploded")
+            return False
+        named.append([title, body, session_id, subtitle])
+        return True
+
+    monkeypatch.setattr("local_operator.tui.notify.detached_notify", deliver)
+    monkeypatch.setattr(
+        "local_operator.proc.spawn_detached", lambda argv, **kwargs: named.append(list(argv)) or 1
+    )
+    monkeypatch.setattr(
+        "local_operator.tui.notify.spawn_detached",
+        lambda argv, **kwargs: named.append(list(argv)) or 1,
+    )
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        # The cap lets `_BACKGROUND_NOTIFY_MAX_PER_TICK` through per scan, so
+        # draining 12 takes several scans however fast the machine is. Bounded
+        # by SCANS, not by a clock: `_settle` drives the poll directly.
+        await _settle(app, pilot, rounds=4 * backlog)
+
+    announced = {call[2] for call in named}
+    missing = {f"bg00000001{index:02d}" for index in range(backlog)} - announced
+    assert not missing, (
+        f"{len(missing)} completions were claimed by a digest that never reached the user and "
+        f"were never re-announced: {sorted(missing)}"
+    )
+    # And nothing is left holding a claim with nothing delivered.
+    fresh = AttentionStore(store_root / "attention.db")
+    stranded = [
+        index
+        for index in range(backlog)
+        if fresh.claim_delivery(
+            conversation_identity(store_root / "sessions" / f"bg00000001{index:02d}"),
+            str(
+                fresh.state(
+                    conversation_identity(store_root / "sessions" / f"bg00000001{index:02d}")
+                )["completion_token"]
+            ),
+            "test",
+        )
+    ]
+    assert not stranded, f"rows still unclaimed after every one was announced: {stranded}"
 
 
 @pytest.mark.asyncio
@@ -614,6 +734,136 @@ async def test_a_released_claim_is_retried_without_an_unrelated_completion(
         await _settle(app, pilot, rounds=6)
         assert len(calls) == 1, calls
         assert "Background work" in " ".join(calls[0])
+
+
+@pytest.mark.asyncio
+async def test_a_host_that_can_never_deliver_stops_rescanning(
+    store_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The retry is BOUNDED: a dead backend must not rescan forever (round 2, M2).
+
+    The M1/Q1 fix forgets the revision gate whenever a claim was released, so
+    the released row is re-examined without waiting for an unrelated completion.
+    Unbounded, that degenerates on a host where delivery ALWAYS fails — no
+    ``notify-send`` on Linux, no ``osascript``, the macOS bundle not yet built —
+    into a permanent 1 Hz loop: scan, claim, fail, release, forget, rescan.
+    Measured at 23 catalog scans and 138 SQLite writes over 20 ticks against a
+    store where nothing changed, on the same ``attention.db`` all of the
+    operator's sessions contend for.
+
+    STRUCTURAL, NOT TIMED. The assertion is that work per tick DECAYS — a later,
+    equally long run of idle ticks costs strictly fewer scans and writes than an
+    earlier one — rather than a bound on how long anything took. A per-tick
+    retry fails it by construction on any machine (every window costs the same),
+    and there is no clock reference anywhere in it. Ticks are counted by driving
+    `_poll_completion_attention` directly, so machine speed cannot enter.
+
+    Zero is deliberately NOT asserted: the retry must never stop entirely, which
+    is the invariant the third assertion below pins. A cap that stopped retrying
+    would make a backend outage longer than the cap a permanent silence — the
+    round-1 M1/Q1 hole, re-created. That is not hypothetical: capping was
+    implemented first here and `…a_released_claim_is_retried_without_an_
+    unrelated_completion` went red, which is why this is backoff.
+    """
+    monkeypatch.delenv("LOCAL_OPERATOR_NO_NOTIFICATIONS", raising=False)
+    _make_session(store_root, "current", "Current conversation")
+    for index in range(3):
+        directory = _make_session(store_root, f"bg00000003{index:02d}", f"Background {index}")
+        store = AttentionStore(store_root / "attention.db")
+        store.publish(conversation_identity(directory), str(uuid.uuid4()), "fresh", "complete")
+
+    from local_operator.session import attention as attention_module
+    from local_operator.tui import session_catalog
+
+    scans = 0
+    real_load = session_catalog.load_catalog
+
+    def counting_load(directory: Path) -> Any:
+        nonlocal scans
+        scans += 1
+        return real_load(directory)
+
+    writes = 0
+    real_claim = attention_module.AttentionStore.claim_delivery
+    real_release = attention_module.AttentionStore.release_delivery
+
+    def counting_claim(self: Any, conversation: str, token: str, backend: str) -> bool:
+        nonlocal writes
+        writes += 1
+        return real_claim(self, conversation, token, backend)
+
+    def counting_release(self: Any, conversation: str, token: str) -> bool:
+        nonlocal writes
+        writes += 1
+        return real_release(self, conversation, token)
+
+    monkeypatch.setattr(session_catalog, "load_catalog", counting_load)
+    monkeypatch.setattr(attention_module.AttentionStore, "claim_delivery", counting_claim)
+    monkeypatch.setattr(attention_module.AttentionStore, "release_delivery", counting_release)
+
+    delivered: list[str] = []
+    healthy = False
+
+    def deliver(title: str, body: str, *, session_id: str = "", subtitle: str = "") -> bool:
+        # The host with no notifier backend: `detached_notify`'s documented
+        # False, on every call, for as long as the backend is absent.
+        if not healthy:
+            return False
+        delivered.append(title)
+        return True
+
+    monkeypatch.setattr("local_operator.tui.notify.detached_notify", deliver)
+    monkeypatch.setattr(
+        "local_operator.proc.spawn_detached", lambda argv, **kwargs: delivered.append(argv[0]) or 1
+    )
+    monkeypatch.setattr(
+        "local_operator.tui.notify.spawn_detached",
+        lambda argv, **kwargs: delivered.append(argv[0]) or 1,
+    )
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        # Three EQUAL windows of idle ticks. Nothing is published in any of
+        # them, so every scan and every write is pure waste; with the retry
+        # rate-limited the later windows must cost strictly less than the first.
+        window = 12
+        await _settle(app, pilot, rounds=window)
+        assert delivered == [], "the backend is down; nothing should have gone out"
+        first_scans, first_writes = scans, writes
+
+        await _settle(app, pilot, rounds=window)
+        second_scans, second_writes = scans - first_scans, writes - first_writes
+
+        await _settle(app, pilot, rounds=window)
+        third_scans, third_writes = (
+            scans - first_scans - second_scans,
+            writes - first_writes - second_writes,
+        )
+
+        assert third_scans < first_scans, (
+            f"idle scans per {window}-tick window went {first_scans} -> {second_scans} -> "
+            f"{third_scans}: the retry is not backing off and this host rescans forever"
+        )
+        assert third_writes < first_writes, (
+            f"idle SQLite writes per {window}-tick window went {first_writes} -> "
+            f"{second_writes} -> {third_writes} against a store where nothing changed"
+        )
+        # A per-tick retry would scan on every one of them; the gate must hold
+        # for the large majority of an idle window.
+        assert (
+            third_scans * 2 < window
+        ), f"{third_scans} scans in {window} idle ticks — the revision gate is barely holding"
+
+        # ...and the budget is per STORE CHANGE, not per process: a real
+        # completion re-arms it, so the M1/Q1 retry it bounds still works.
+        healthy = True
+        latecomer = _make_session(store_root, "bg0000000999", "Latecomer")
+        AttentionStore(store_root / "attention.db").publish(
+            conversation_identity(latecomer), str(uuid.uuid4()), "fresh", "complete"
+        )
+        await _settle(app, pilot, rounds=8)
+        assert "Latecomer" in " ".join(delivered), delivered
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_background_completion_notify.py
+++ b/tests/unit/tui/test_background_completion_notify.py
@@ -527,11 +527,12 @@ async def test_a_backlog_is_capped_and_the_remainder_is_summarised(
     named = [call for call in spawned if call[2]]
     digests = [call for call in spawned if not call[2]]
     assert len(named) == _BACKGROUND_NOTIFY_MAX_PER_TICK, spawned
-    # The count is reported rather than lost: 12 backlogged, 3 named, 9 summarised.
+    # The count is reported rather than lost: 12 backlogged, 3 named, and the
+    # digest carries the ABSOLUTE total of 12 rather than the remainder of 9 —
+    # "9 more" is only meaningful to a user who noticed the three banners it
+    # counts from, which a lock screen does not guarantee (design round 2, D11).
     assert len(digests) == 1, spawned
-    assert f"{backlog - _BACKGROUND_NOTIFY_MAX_PER_TICK} more sessions finished" in " ".join(
-        digests[0]
-    )
+    assert f"{backlog} sessions finished" in " ".join(digests[0])
     # Claimed, not merely skipped — otherwise the backlog re-floods next tick.
     fresh = AttentionStore(store_root / "attention.db")
     assert all(
@@ -1044,3 +1045,115 @@ async def test_the_opt_out_banner_is_distinguishable_from_the_nameless_one(
         assert APP_NAME in argv
         assert BACKGROUND_FALLBACK_TITLE not in argv
         assert "Secret client migration" not in argv
+
+
+@pytest.mark.parametrize(
+    ("kinds", "expected_subtitle_key"),
+    [
+        # ALL-ERROR remainder. The catalog ranks by `(tier, -mtime, id)`, not by
+        # kind, so this is not a contrived shape — it is what the cap produces
+        # whenever a batch of failures finishes together.
+        (["error"] * 8, "error"),
+        (["interrupted"] * 8, "interrupted"),
+        # MIXED remainder, and mixed NO MATTER WHICH ROWS THE CAP ANNOUNCES.
+        # Both kinds exceed the cap, so at most one of them can be fully
+        # consumed by the three banners and the remainder always holds both.
+        # An earlier draft used 5 complete + 3 error and PASSED AGAINST THE
+        # DEFECT: the catalog announced the three errors, leaving an all-
+        # complete remainder that `Complete` described correctly. That is QA
+        # round 1's Q2 vacuity repeating, and this composition is what removes
+        # the dependency on an ordering the test does not control.
+        (["complete"] * 5 + ["error"] * 5, None),
+    ],
+    ids=["all-error", "all-interrupted", "mixed"],
+)
+@pytest.mark.asyncio
+async def test_the_digest_never_asserts_an_outcome_the_remainder_did_not_have(
+    store_root: Path,
+    spawned: list[list[str]],
+    kinds: list[str],
+    expected_subtitle_key: str | None,
+) -> None:
+    """The digest hardcoded `Complete` over whatever the cap held back (D8).
+
+    This is design round 1's D3 — `interrupted` folded into a state it is not —
+    reappearing at the scale of an arbitrary number of sessions rather than one.
+    A user reading "Complete · 5 more sessions finished" on a lock screen has
+    been told five things succeeded when all five failed, and the sidebar's `✗`
+    is the only thing that contradicts it.
+
+    Driven through the real observer against a real store, so what is asserted
+    is the banner the user would actually receive rather than a helper's return
+    value. Round 1 shipped a vacuous guard here once already (QA Q2, which
+    passed WITH the defect because catalog recency put the poisoned row last),
+    so every row in the over-cap remainder carries the kind under test: whatever
+    ordering the catalog chooses, the remainder's composition is the same.
+    """
+    from local_operator.tui.app import _BACKGROUND_NOTIFY_MAX_PER_TICK
+    from local_operator.tui.notify import CONTEXT_MIXED, CONTEXTS
+
+    _make_session(store_root, "current", "Current conversation")
+    store = AttentionStore(store_root / "attention.db")
+    # An ESTABLISHED store, so this is the steady state rather than the tick
+    # that creates the deliveries table.
+    seed = _make_session(store_root, "bg0000000000", "Seed")
+    seed_token = str(uuid.uuid4())
+    store.publish(conversation_identity(seed), seed_token, "old", "complete")
+    store.acknowledge(conversation_identity(seed), seed_token)
+
+    for index, kind in enumerate(kinds):
+        directory = _make_session(store_root, f"bg00000002{index:02d}", f"Overnight {index}")
+        store.publish(conversation_identity(directory), str(uuid.uuid4()), "fresh", kind)
+
+    app = OperatorApp(lambda: _factory(AttachedSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _booted(app, pilot)
+        await _settle(app, pilot, rounds=8)
+
+    # Structural discriminator, not prose: the digest is the only delivery with
+    # no `session_id`, because it covers several sessions.
+    assert all(len(call) == 4 for call in spawned), spawned
+    digests = [call for call in spawned if not call[2]]
+    assert len(digests) == 1, spawned
+    title, body, _, subtitle = digests[0]
+
+    # THE GUARD IS ONLY MEANINGFUL IF THE REMAINDER IS THE SHAPE UNDER TEST, so
+    # the remainder's composition is DERIVED from what actually went out rather
+    # than assumed from the parametrisation. Each named banner's subtitle is its
+    # own kind's category, so subtracting those from the published set leaves
+    # the kinds the digest really spoke for — which is the check the vacuous
+    # draft above was missing.
+    named = [call for call in spawned if call[2]]
+    remainder = list(kinds)
+    for shown in (call[3] for call in named):
+        for kind, context in CONTEXTS.items():
+            if context == shown and kind in remainder:
+                remainder.remove(kind)
+                break
+    assert len(remainder) == len(kinds) - _BACKGROUND_NOTIFY_MAX_PER_TICK, (spawned, remainder)
+
+    if expected_subtitle_key is None:
+        # Not vacuous: the set the digest stands for genuinely holds both kinds.
+        assert len(set(remainder)) > 1, remainder
+        assert subtitle == CONTEXT_MIXED, digests
+        # The exact failure: neither side's category may be asserted over a set
+        # that is only partly in it.
+        assert subtitle != CONTEXTS["complete"], digests
+        assert subtitle != CONTEXTS["error"], digests
+    else:
+        assert set(remainder) == {expected_subtitle_key}, remainder
+        assert subtitle == CONTEXTS[expected_subtitle_key], digests
+    # The defect in one line, for every case: a remainder that is not uniformly
+    # complete must never be announced as complete.
+    assert subtitle != CONTEXTS["complete"], digests
+
+    # The title carries the tick's ABSOLUTE total — banners shown plus the ones
+    # held back — so it means something to a user who never saw the cap (D11).
+    assert str(len(kinds)) in title, digests
+    assert f"{len(kinds) - _BACKGROUND_NOTIFY_MAX_PER_TICK} more" not in title, digests
+    # …and it is not the row banners' title, so the summary is a different kind
+    # of object at a glance rather than a fourth identical sibling (D9).
+    assert named, spawned
+    assert all(title != call[0] for call in named), spawned
+    # The one inert banner in the stack says where to go instead (D10).
+    assert "sidebar" in body.lower(), digests

--- a/tests/unit/tui/test_notify.py
+++ b/tests/unit/tui/test_notify.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 import subprocess
 from typing import Any
 
+import pytest
+
 from local_operator.tui.notify import (
     APP_NAME,
     BEL,
@@ -336,16 +338,25 @@ def test_a_parked_turn_notifies_even_with_children_running() -> None:
 
 
 def test_each_kind_says_which_state_it_is() -> None:
-    """Four states have distinct details and actionable context: completion is
-    unlike a blocked turn, while ask and approval share the need for input."""
+    """Five states have distinct details and actionable context: completion is
+    unlike a blocked turn, while ask and approval share the need for input.
+
+    ``interrupted`` is its own state rather than a synonym for ``error``. The
+    attention store admits exactly complete/error/interrupted, and on the
+    maintainer's real store the non-success completions are 14 interrupted and
+    0 error — so a fold made every non-success banner misreport (design round
+    1, D3). The distinct-bodies assertion is what pins that: it fails the
+    moment someone re-points ``interrupted`` at ``BODY_ERROR``.
+    """
     assert len(set(BODIES.values())) == len(BODIES)
     assert CONTEXTS == {
         "complete": "Complete",
         "approval": "Input required",
         "ask": "Input required",
         "error": "Needs attention",
+        "interrupted": "Interrupted",
     }
-    for kind in ("complete", "approval", "ask", "error"):
+    for kind in ("complete", "approval", "ask", "error", "interrupted"):
         notifier, sink = unfocused()
         notifier.send(kind)  # type: ignore[arg-type]
         assert BODIES[kind] in sink.joined
@@ -676,3 +687,40 @@ def test_the_built_click_command_actually_runs(tmp_path, monkeypatch) -> None:
 
     assert result.returncode == 0, result.stderr
     assert receipt.read_text().strip() == "resume-click abc123def456"
+
+
+def test_the_privacy_flag_governs_the_attached_session_toast_too(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`display.notification_session_name` off keeps the name off THIS leg too.
+
+    Review round 1, M2: the flag governed only the observer path, while the
+    attached session's own toasts title themselves from ``set_label`` and
+    ignored it — and those are the majority of a user's toasts. The settings
+    copy ("A session's name appears on banners, including the lock screen.") is
+    unqualified, so a flag that covered one leg made its own promise false. A
+    privacy control that half works is worse than one that is clearly scoped,
+    because the copy reads as a guarantee.
+    """
+    monkeypatch.setattr("local_operator.tui.notify.settings_get", lambda key, default: False)
+    notifier, sink = unfocused()
+    notifier.set_label("Secret client migration")
+    notifier.send("complete")
+    assert "Secret client migration" not in sink.joined
+    assert APP_NAME in sink.joined
+
+
+def test_the_privacy_flag_defaults_to_naming_the_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The widened gate must not change the DEFAULT, which is to name it.
+
+    Guards M2's fix from over-applying: a missing key resolves to True through
+    ``settings_get``'s default, exactly as every notification here has always
+    behaved.
+    """
+    monkeypatch.setattr("local_operator.tui.notify.settings_get", lambda key, default: default)
+    notifier, sink = unfocused()
+    notifier.set_label("Fix quota reporting")
+    notifier.send("complete")
+    assert "Fix quota reporting" in sink.joined

--- a/tests/unit/tui/test_notify.py
+++ b/tests/unit/tui/test_notify.py
@@ -28,8 +28,12 @@ import pytest
 
 from local_operator.tui.notify import (
     APP_NAME,
+    BACKGROUND_FALLBACK_TITLE,
     BEL,
     BODIES,
+    BODY_BACKGROUND,
+    BODY_BACKGROUND_DIGEST,
+    CONTEXT_MIXED,
     CONTEXTS,
     MAX_TITLE_CHARS,
     OSC9_PREFIX,
@@ -38,10 +42,12 @@ from local_operator.tui.notify import (
     Notifier,
     _spawn_detached,
     argv_safe,
+    background_digest_title,
     cmux_command,
     cmux_surface_id,
     desktop_notify_command,
     detect_protocol,
+    digest_subtitle,
     notification_sequence,
     notification_writes,
     notifications_enabled,
@@ -724,3 +730,85 @@ def test_the_privacy_flag_defaults_to_naming_the_session(
     notifier.set_label("Fix quota reporting")
     notifier.send("complete")
     assert "Fix quota reporting" in sink.joined
+
+
+def test_the_digest_says_a_state_only_when_every_session_is_in_it() -> None:
+    """A digest must not assert an outcome the remainder did not have (D8).
+
+    The digest speaks for whatever the per-tick cap held back, and the catalog
+    ranks by ``(tier, -mtime, id)`` rather than by kind — so an over-cap set can
+    be entirely ``error`` or entirely ``interrupted``. It hardcoded ``Complete``
+    regardless, which told a user on a lock screen that five failures had
+    succeeded.
+
+    Both halves matter and both are asserted here: a UNIFORM set keeps its real
+    category out of the house vocabulary, so the digest reads like the row
+    banners beside it when it honestly can; a MIXED set gets neither the
+    majority's category nor the first row's, because either would be the same
+    false assertion at a smaller scale.
+    """
+    assert digest_subtitle(["complete", "complete", "complete"]) == CONTEXTS["complete"]
+    assert digest_subtitle(["error", "error"]) == CONTEXTS["error"]
+    assert digest_subtitle(["interrupted"]) == CONTEXTS["interrupted"]
+
+    # 3 complete + 2 errors is neither "Complete" nor "Needs attention".
+    mixed = digest_subtitle(["complete", "complete", "complete", "error", "error"])
+    assert mixed == CONTEXT_MIXED
+    assert mixed not in (CONTEXTS["complete"], CONTEXTS["error"])
+    # Majority-of-one in the other direction, so a majority rule cannot pass.
+    assert digest_subtitle(["error", "error", "error", "complete"]) == CONTEXT_MIXED
+    # Order-independent: a "first row wins" rule cannot pass either.
+    assert digest_subtitle(["complete", "error"]) == digest_subtitle(["error", "complete"])
+
+    # No sessions is no claim; both backends accept an empty subtitle.
+    assert digest_subtitle([]) == ""
+    # An unrecognised kind makes the set mixed rather than inheriting Complete:
+    # a future kind defaults to quiet, never to a false success.
+    assert digest_subtitle(["complete", "abandoned"]) == CONTEXT_MIXED
+    assert digest_subtitle(["abandoned"]) == CONTEXT_MIXED
+    # "mixed" is a property of a SET, so no single completion can resolve to it.
+    assert CONTEXT_MIXED not in CONTEXTS.values()
+
+
+def test_the_digest_title_is_absolute_distinct_and_survives_the_clip() -> None:
+    """The digest must not look like the row banner beside it (D9/D11).
+
+    With nameless over-cap sessions the digest was the fourth banner in a stack
+    of four carrying ``BACKGROUND_FALLBACK_TITLE`` — identical title, identical
+    subtitle, differing only in the body, which is the line macOS truncates
+    first. At N=1 it also self-contradicted: "A session finished" over "1 more
+    session finished" describes two events in one frame.
+
+    Three properties are pinned: the title never collides with the row banner's,
+    it carries an ABSOLUTE count rather than one relative to a cap the user may
+    never have seen (D11), and it stays inside the ~43-character macOS clip at
+    every count so the number lands in the line that survives.
+    """
+    for total in (1, 2, 3, 4, 9, 25, 100, 9999):
+        title = background_digest_title(total)
+        assert str(total) in title
+        assert title != BACKGROUND_FALLBACK_TITLE
+        # The count is in the TITLE, which macOS clips last, and it fits.
+        assert len(title) <= 43, (total, title, len(title))
+    # Singular reads as one event, not two: no "more", no contradiction.
+    assert background_digest_title(1) == "1 session finished"
+    assert "more" not in background_digest_title(1)
+    assert background_digest_title(2) == "2 sessions finished"
+
+
+def test_the_digest_body_says_where_to_go_since_it_cannot_take_you() -> None:
+    """The digest is the one inert banner in a clickable stack (D10).
+
+    It passes no ``session_id`` — it stands for several sessions, so there is no
+    single transcript to reopen — and said nothing about it. ``detached_notify``
+    already sets this precedent for the ``osascript`` leg ("— reopen with: lop
+    --resume <id>"); this is the same courtesy pointed at the surface that CAN
+    take the user there.
+    """
+    assert "sidebar" in BODY_BACKGROUND_DIGEST.lower()
+    # Routing, not outcome: the body must not restate a state category, which
+    # is the subtitle's job and the tautology design round 1 removed (D5).
+    assert not any(
+        context.lower() in BODY_BACKGROUND_DIGEST.lower() for context in CONTEXTS.values()
+    )
+    assert BODY_BACKGROUND_DIGEST != BODY_BACKGROUND

--- a/tests/unit/tui/test_settings_view.py
+++ b/tests/unit/tui/test_settings_view.py
@@ -4996,3 +4996,53 @@ async def test_subagent_dock_row_renders_in_appearance_with_its_three_choices(
         await pilot.pause()
         assert _values(tmp_path)["display.dock"] == "hidden"
         assert "display" not in _values(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_the_session_name_row_is_inert_while_notifications_are_off() -> None:
+    """Design round 1, D4: the row must not read ``on`` for a toast that cannot fire.
+
+    ``display.notifications`` off means no notification of any kind is
+    delivered, so ``display.notification_session_name`` governs nothing — but
+    without a ``gated_by`` the row rendered its own ``on`` beside a master
+    reading ``off``, with a detail line explaining a behaviour that cannot
+    happen. That is the "page states something untrue about its own effect"
+    class this file already guards for the cleanup rows (#431).
+    """
+    from local_operator import settings_io
+    from local_operator.paths import config_dir
+    from local_operator.tui import theme as theme_mod
+
+    # Written through the SAME manager the page mounts (``ConfigManager(
+    # config_dir())``), not through ``tmp_path``: the suite already isolates
+    # HOME, so this is the isolated config the view actually reads. Writing
+    # elsewhere leaves the master at its ``True`` default and the row correctly
+    # renders as live — a test that would pass whether or not the gate exists.
+    #
+    # ``write_setting`` rather than ``update_config``: the registry owns the
+    # key's path, and it is the same writer the page's own toggle uses.
+    settings_io.write_setting(
+        ConfigManager(config_dir()), settings_io.BY_KEY["display.notifications"], False
+    )
+    dim = theme_mod.semantic_color("dim").lower()
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        view = await _open_page(pilot, app)
+        assert _value_ink(view, "display.notification_session_name") == dim
+        # The detail line describes the SELECTED row, so the clause is read
+        # with the cursor on the gated setting.
+        _select(view, "display.notification_session_name")
+        await pilot.pause()
+        assert "inert: Desktop notifications is off" in view.render_lines_for_test()[-1]
+        # Turning the master back ON must retract the clause, so the gate is a
+        # live reading of the master rather than a one-shot at mount. Asserted
+        # on the CLAUSE and not on the value ink: this child is still at its
+        # default, and a default renders dim whether or not it is gated — so an
+        # ink probe here would be measuring the wrong property.
+        _select(view, "display.notifications")
+        view.action_toggle_bool()
+        await pilot.pause()
+        _select(view, "display.notification_session_name")
+        await pilot.pause()
+        assert "inert:" not in view.render_lines_for_test()[-1]


### PR DESCRIPTION
## Summary

A background session completed, the sidebar painted its `✓`, and **no notification of any kind was delivered**. This is PR 1 of the notification-routing design and fixes that reported symptom.

The cause is not a bug in the notifier. It is a structural gap between two subsystems that are each correct in isolation: the completion fact **already** crosses the process boundary (the shared `AttentionStore`), and the observing TUI **already** reads it for every session on every catalog poll — `session_sidebar.py` paints the operator's checkmark from exactly that field. Nothing converted the fact into a toast. It was published, observed, rendered, and discarded.

**Change class: C2.** Adds a table to an existing database and a leg to an existing poll. No runtime change, no protocol change, no new IPC, no new polling loop, and no change to `local-operator serve`'s documented silence.

`Release: patch — a background session finishing now raises a clickable desktop notification naming the session, instead of only a sidebar checkmark.`

## What changed

| File | Change |
| --- | --- |
| `session/attention.py` | `deliveries` watermark + `claim_delivery()` / `release_delivery()`, on the same monotonic `completions.sequence` and the same `BEGIN IMMEDIATE` as `receipts` |
| `tui/session_catalog.py` | `CatalogEntry` carries `completion_token` / `anchor_id` (defaulted, so every existing construction site is unchanged) |
| `tui/app.py` | An observer leg on the attention poll that already runs, gated on the store's own `revision()` change detector |
| `settings_io.py`, `tui/settings.py`, `tui/notify.py` | `display.notification_session_name` (default `true`) |

### Why `detached_notify` rather than an in-band escape

The design said "cmux or in-band". In-band is wrong here on two counts, and the second is measurable:

- The toast is about a session **this terminal is not showing**, so attributing it to this pane is misleading.
- **It could not be clicked.** The operator asked to click through back into the session. Ghostty implements no OSC 99 at all (upstream #5634, still open), and its OSC 9 is title-only — no id, no action, no payload. `detached_notify` carries `session_id` through the signed bundle to `lop resume-click`, which replays the transcript and idles rather than resuming tool execution unattended.

cmux stays first where a cmux surface genuinely exists, matching the existing precedence.

### The focus gate

`Notifier._focused` (OS terminal focus) is the wrong predicate at this granularity — the operator **was** looking at their terminal, just at a different session, and suppressing on that is precisely the bug. An event is suppressed only when the user is demonstrably looking at the session that **produced** it, and for a non-attached row that is false by construction: this app renders one session's transcript, so another session's completion anchor cannot be on screen. The attached row keeps its existing owner (the in-app `Notifier` on `TurnEnded`), which is what stops one completion being announced twice.

### Two watermarks, deliberately separate

`docs/SESSION_SIDEBAR.md`: *"Preparation never acknowledges completion attention."* Delivering a toast advances `deliveries`; only a human demonstrably reading a rendered result advances `receipts`. A session stays delivered-and-unread, which is correct — **the checkmark survives the banner that told you about it.**

## The migration hazard

`_uninitialized()` deliberately treats missing tables in an *established* database as corruption. Adding `deliveries` to that probe would make **every existing database on every machine** read as corrupt. The probe is therefore left byte-identical, with a comment at the site saying why, because the next reader will otherwise "tidy" it. The table is created **and baselined in one transaction**, so no concurrent reader ever sees an unbaselined table and the eleventh observer inherits the baseline rather than re-deriving one.

# Testing evidence

All commands run in an isolated `HOME` + `LOCAL_OPERATOR_CONFIG_DIR`, with every inherited `CMUX_*` scrubbed — the reported configuration is **bare Ghostty, cmux not running**, and that is the acceptance case.

## 1. Before / after, the operator's exact scenario

Driven through the **real** `OperatorApp` with `run_test`, intercepting at `local_operator.proc.spawn_detached` — the actual process boundary a delivery crosses. Nothing above it is faked, so a leg wired to nothing shows up as zero captures.

**BEFORE** (the new leg disabled, everything else identical):

```
attached session: current   background session: bg000000aaaa
cmux in env: False
published completion for session/bg000000aaaa (token ddd38dfc…)

NOTIFICATIONS DELIVERED: 0

BEFORE: no notification of any kind — the reported bug. REPRODUCED
```

**AFTER**, same scenario, with the signed bundle built (the operator's real path):

```
NOTIFICATIONS DELIVERED: 1
  argv: ['/…/notifier/LocalOperator.app/Contents/MacOS/notifier',
         'Article-search-svc schema review',
         'Task complete',
         '/Users/damian/.local/bin/lop resume-click bg000000aaaa',
         'Complete']

AFTER: banner delivered
  names the session:      YES ('Article-search-svc schema review')
  carries session id:     YES (bg000000aaaa -> lop resume-click)
  re-fires on later polls: NO (level converted to edge)
  still unseen (✓ kept):   True — delivery did not acknowledge
  attached session:        not announced (its Notifier owns that)
```

A **real banner was also posted to Notification Centre** (no interception), confirming the whole chain including process attribution:

```
$ ps aux | grep notifier
… /…/LocalOperator.app/Contents/MacOS/notifier Article-search-svc schema review \
  Task complete /Users/damian/.local/bin/lop resume-click bg000000aaaa Complete
```

`lop resume-click` is a real subcommand on the installed runtime (`lop resume-click --help` → usage), so the click target is not hypothetical.

## 2. No-flood on upgrade — mandatory, blocker-class

Run against a **copy** of the maintainer's live `attention.db` (never the real file in write mode):

```
copied store: 265 completions, tables=['completions', 'receipts', 'sqlite_sequence']
conversations: 133, UNSEEN at first tick: 121
BANNERS THAT WOULD FIRE ON FIRST TICK: 0
still unseen after (checkmarks preserved): 121
post-upgrade completion claimable: True
RESULT: PASS — zero banners on first tick, backlog still unread
```

**121 unseen conversations**, not the 8 the briefing estimated. A naive implementation fires 121 banners in one second. This is also asserted twice in the suite — once at the store and once through the app.

## 3. Multi-observer exactly-once — real processes

`multiprocessing` with the `spawn` start method, so each claimant is a genuine process with its own SQLite connection (threads would share an interpreter and prove less):

```
11 real processes raced one completion -> True count: 1
```

## 4. `revision()` cost at N=11 — measured, not argued

The architect asserted this was negligible without measuring it. Against the real 265-completion store:

```
revision() median 0.064 ms, p95 0.130 ms, max 0.511 ms
N=11 observers at 1 Hz: 0.71 ms/s of wall work = 0.071% of one core
```

Settled: negligible. The catalog scan behind the gate runs only when the revision actually moves, so the common tick is one cheap read.

## 5. The guards can fail

A guard that cannot go red is worse than none, so each was reintroduced as a regression and observed failing:

| Regression reintroduced | Result |
| --- | --- |
| Remove the observer leg from the poll | **4 tests fail** (`assert 0 == 1`) |
| Remove the baseline, keep the migration | **2 tests fail**, the app-level one reporting a real flood of `osascript` argvs |

Both files were restored and re-verified afterwards.

## 6. Visual — `/settings`

The page gains one row. Geometry before/after at 100x30: `screen.virtual_size` 98x28 = `screen.size`, **no scrollbar appears**, and the list grows by exactly one row (97 → 98). Before-frame captured from a throwaway worktree at `origin/main` (never `git stash`).

First capture caught a real defect: the label elided to `Name sessions in notificatio…`, clipping the word that says what the row governs. Shortened to **"Notification session names"**, which fits.


## 7. Gates — whole tree, exactly as CI

```
.venv/bin/python -m flake8 .                             -> rc=0
uvx --from black==26.1.0 black --check .                 -> 1011 files unchanged
uvx isort==5.13.2 --check .                              -> clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python . -> 0 errors, 0 warnings
.venv/bin/python -m pytest tests/unit -q                 -> 15219 passed, 18 skipped (43:46)
```

`pyproject.toml` is untouched — the version stays at the last released value; a release owner bumps for the whole window.

## Deliberately not done

- **PRs 2-5 of the design**: the `notify/` router package, runtime-side completion emit for the `kind=daemon` mute (the secondary root cause), click-through hardening, and burst coalescing. All separate.
- **Burst coalescing.** Eleven sessions finishing inside two seconds is eleven banners today. Out of scope here (design §11 / PR 5); worth noting because this PR is what makes that reachable at all.
- **macOS click window stays 30 s** (`notifier_app/notifier.m`), per the design's Decision 2. A `local-operator://` scheme for durable clicks is PR 4.
- **The desktop-lease case falls through and delivers anyway**, per Decision 4 — an extra toast beats a silent hole until cross-repo behaviour is verified.

## One design note

The design's §10 specifies delivery "using the observer's own surface (cmux or **in-band**)". The in-band half is not viable for this path and should not be carried into PR 2: Ghostty has no OSC 99 and its OSC 9 carries no activation, so an in-band toast about another session would be unclickable — the opposite of the reported request. This PR uses `detached_notify` for that reason.


---

## Round 1 remediation (head `5e67a73d7`)

Two blockers, five majors, three minors and a nit were batched into one commit.
See the [remediation comment](https://github.com/damianvtran/local-operator/pull/724#issuecomment-round1) for the per-finding answers. In summary: the per-tick banner
fan-out is now capped at three with the remainder claimed and summarised as one
digest line (B1); rows attached in another window are skipped, since that
window's own `Notifier` already owns their toast (B2); a released claim now
forces a re-scan instead of waiting on an unrelated completion (M1/Q1); each row
is delivered under its own guard (Q2); `display.notification_session_name`
governs all three notification legs rather than one (M2); `interrupted` gets its
own banner wording (D3); a session with no stored title is titled `A session
finished` rather than with its role-prompt opener or the brand (D1/D2); and the
settings row is gated on its master with copy that names the lock-screen
consequence (D4/D6/D7).

## Known: your FIRST banner may not be clickable

**Pre-existing, not caused by this PR** (`notifier_app/` is untouched — 0 files),
but worth stating so it is not mistaken for a defect in this change. QA found the
bundle stamp at `~/.local-operator/notifier/.build-stamp` is `"1"` while
`notifier_app.BUILD_STAMP` is `"2"` on **both** `main` and this branch, so
`is_built()` returns False and the first delivery falls back to `osascript` —
which carries no activation. That banner therefore does nothing when clicked, and
looks identical to one that works. It self-heals after one build cycle: the
bundle rebuilds correctly when asked, and the next toast carries the identity and
the click action. The `osascript` route already appends `reopen with: lop
--resume <id>` to the body for exactly this window (round 3, D14).
