### PR TITLE
chore(release): bump version to 0.51.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.0"
+version = "0.51.1"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release bump for the post-v0.51.0 window. `pyproject.toml` only — one line.

## Window contents

| PR | Merge | Impact |
|---|---|---|
| #711 | `49c476b78` | A transient socket drop no longer paints a false `interrupted` on a live turn. Also bounds `live_events` on the attach frame by **measured cost** rather than key shape — images and MCP `details` were escaping a `text`-shaped filter and producing 2–4 MB frames against a 1 MiB line limit, killing the viewer's pump with `owner sent a frame too large to read`. |
| #718 | `3081d0986` | **A working stop button.** `abort` acked `"stopping"` while live subagents kept billing — 39 paid provider calls in the 2 s after the ack, plus 117 child-side; now 0. Also fixes `/stop` refusing with "session is still starting…" on a visibly looping session, and a path where `/stop` could resolve by **substring** (name, id, *or cwd basename*, plus an all-digit id coerced to a PID) and stop the **wrong live session**. |
| #720 | `78c20295e` | The sidebar's activity indicator reflects real conversation activity: a finished conversation holding a background job no longer animates a spinner, sessions with armed schedules show the wake symbol, and the list widens on roomy terminals. The sidebar had published the reaper's *residency* predicate as its "working" bit, so any session that had ever backgrounded a job wore a spinner forever — 12 of 12 live sessions on this host reported busy, one idle for 34 minutes. Activity and residency are now separate predicates. |

## Bump class: PATCH

All three are defect fixes on existing surfaces — no new surface, no API change, and none clears the step-function bar on its own (#720 adds a small responsive-width tweak alongside its fix). Eight lop-dev peers were polled; all yielded the window and all concurred with PATCH.

## Verification

- `git diff v0.51.0..origin/main -- pyproject.toml` is **empty** — no PR in this window carried a stray bump, so 0.51.1 is the next unconsumed number. (This repo has been bitten before: #701 and #706 each carried a bump, silently consuming 0.50.1 and 0.50.2.)
- #711 and #718 merged with reviewer TERMINAL + QA PASS fresh on their exact merge heads (`c42abc552`, `06c79f3e0`), CI green on both.
- #720 was a latecomer, squash-merged at 07:02 UTC after this branch was first cut; the bump has been **rebased onto it** and is included rather than deferred, since the tag had not yet been created.

C0 scope: one file, one line.