### PR TITLE
feat(tui): scroll the /copy picker, and let the mouse drive it

### DIFF
--- a/local_operator/tui/copy_targets.py
+++ b/local_operator/tui/copy_targets.py
@@ -104,6 +104,13 @@ class CopyTarget:
     children: tuple["CopyTarget", ...] = ()
     #: Ours, not the reference's. The answer was cut off before it finished.
     truncated: bool = False
+    #: An aggregate (`All N code blocks`) rather than something that exists in
+    #: the message. The picker paints it one ramp step down, which is the
+    #: quietest way to say "derived" without adding a glyph (design round 1,
+    #: D4). A FIELD rather than an `id.endswith(":all")` test in the renderer:
+    #: the id's shape is an identity detail, and a renderer that pattern-
+    #: matches on it turns every future id into a rendering decision.
+    derived: bool = False
 
 
 def extract_blocks(text: str) -> list[MessageBlock]:
@@ -226,8 +233,21 @@ def first_line(text: str) -> str:
     return _WHITESPACE_RUN_RE.sub(" ", text.strip())
 
 
+#: Hint for a block with nothing in it, in place of the ``0 lines`` a plain
+#: count produces. A closed-on-the-next-line fence is a real block of the
+#: message, so it keeps its row (``action_choose`` explains why removing it
+#: would make the remaining numbers disagree with what the user is reading) —
+#: but Enter REFUSES it, and refusing silently reads as a broken key. Saying
+#: ``empty`` in the hint column predicts the refusal in the frame, which is
+#: better than explaining it afterwards: a row visibly marked empty does not
+#: invite the Enter or the double-click in the first place. ``0 lines`` could
+#: not do that job — it is a statistic, and the column beside it is full of
+#: statistics.
+EMPTY_BLOCK_HINT = "empty"
+
+
 def _block_hint(block: MessageBlock) -> str:
-    lines = plural_lines(block.body)
+    lines = EMPTY_BLOCK_HINT if not block.body else plural_lines(block.body)
     return f"{block.lang} · {lines}" if block.lang else lines
 
 
@@ -275,43 +295,61 @@ def _message_target(text: str, rank: int, truncated: bool) -> CopyTarget:
     # message, not that block — so marking it would be a false claim about
     # what is on the clipboard. A genuinely half-written trailing fence never
     # becomes a block at all (see `extract_blocks`).
-    code_index = 0
-    quote_index = 0
-    for block in blocks:
-        if block.kind == "code":
-            children.append(
-                CopyTarget(
-                    id=f"{node_id}:code:{code_index}",
-                    label=f"Block {code_index + 1}",
-                    hint=_block_hint(block),
-                    preview=block.body,
-                    content=block.body,
-                    copy_message=f"Copied code block {code_index + 1} to clipboard",
-                    language=block.lang or None,
-                )
+    #
+    # Grouped BY KIND (every `Block`, then every `Quote`), not in document
+    # order. Document order interleaved them, so a message alternating fences
+    # and quotes drew `Block 1 / Quote 1 / Block 2 / Quote 2` above an
+    # `All 2 code blocks` row that covers the first and third of those — the
+    # aggregate's members were not adjacent to it and nothing in the frame
+    # said which rows it stood for. Grouping puts each aggregate directly
+    # under the run it summarises (design round 1, D4). The NUMBERING is
+    # unchanged: `Block N` still counts fences in document order, so the label
+    # keeps matching the order the user read them in.
+    for code_index, block in enumerate(code):
+        children.append(
+            CopyTarget(
+                id=f"{node_id}:code:{code_index}",
+                label=f"Block {code_index + 1}",
+                hint=_block_hint(block),
+                preview=block.body,
+                content=block.body,
+                copy_message=f"Copied code block {code_index + 1} to clipboard",
+                language=block.lang or None,
             )
-            code_index += 1
-        else:
-            children.append(
-                CopyTarget(
-                    id=f"{node_id}:quote:{quote_index}",
-                    label=f"Quote {quote_index + 1}",
-                    hint=plural_lines(block.body),
-                    preview=block.body,
-                    content=block.body,
-                    copy_message=f"Copied quote block {quote_index + 1} to clipboard",
-                )
+        )
+    for quote_index, block in enumerate(quotes):
+        children.append(
+            CopyTarget(
+                id=f"{node_id}:quote:{quote_index}",
+                label=f"Quote {quote_index + 1}",
+                # `_block_hint`, not a bare `plural_lines`: a quote whose body
+                # is empty must read `empty` for the same reason a fence does.
+                hint=_block_hint(block),
+                preview=block.body,
+                content=block.body,
+                copy_message=f"Copied quote block {quote_index + 1} to clipboard",
             )
-            quote_index += 1
+        )
 
     # "All N" only when there is more than one of a kind: with a single block
     # it would be a second row copying byte-for-byte what the first one does.
+    #
+    # The label names the KIND (`All 2 code blocks`, not `All 2 blocks`). The
+    # aggregate is built from `len(code)` alone, but it is drawn as the last
+    # sibling of a list that can also contain quotes, with the identical
+    # `├─`/`└─` connector treatment — so a frame reading
+    # `Block 1 / Block 2 / Quote 1 / All 2 blocks` says it copies the three
+    # rows above it, and it does not. That is the frame answering a
+    # correctness question wrongly, which is why the five cells are worth
+    # spending (design round 1, D4). The quote aggregate already named its
+    # kind; only the code one was under-specified.
     if len(code) > 1:
         combined = "\n\n".join(block.body for block in code)
         children.append(
             CopyTarget(
                 id=f"{node_id}:all",
-                label=f"All {len(code)} blocks",
+                label=f"All {len(code)} code blocks",
+                derived=True,
                 hint=plural_lines(combined),
                 preview=combined,
                 content=combined,
@@ -324,6 +362,7 @@ def _message_target(text: str, rank: int, truncated: bool) -> CopyTarget:
             CopyTarget(
                 id=f"{node_id}:all-quotes",
                 label=f"All {len(quotes)} quotes",
+                derived=True,
                 hint=plural_lines(combined),
                 preview=combined,
                 content=combined,

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -1819,6 +1819,20 @@ CopyPickerScreen .copy-picker {
     overflow: hidden;
 }
 
+/* Shown in place of the card on a terminal too small to draw one, where the
+ * alternative is a dimmed screen that says nothing at all. A SIBLING of the
+ * card rather than a row inside it, so the card's pinned "either the footer
+ * is on screen or nothing drew" contract is untouched: one row, no ground of
+ * its own, and `dim` because it is an explanation of a degraded frame rather
+ * than anything to act on. */
+#copy-picker-too-small {
+    width: 100%;
+    height: 1;
+    content-align: center middle;
+    text-align: center;
+    color: $lo-dim;
+}
+
 
 /* ── /resume session picker ────────────────────────────────────────────── *
  *

--- a/local_operator/tui/widgets/copy_picker.py
+++ b/local_operator/tui/widgets/copy_picker.py
@@ -16,6 +16,8 @@ The tree itself is a SNAPSHOT taken when the screen was built. See
 
 from __future__ import annotations
 
+from typing import NamedTuple
+
 from rich.cells import cell_len
 from rich.console import Console
 from rich.style import Style
@@ -93,6 +95,12 @@ GUTTER_THUMB_CELLS = 2
 #: on terminals that draw one today. It is shed instead, the discipline
 #: :meth:`CopyPickerScreen._footer_text` already applies to hints.
 GUTTER_SHED_HEADROOM = 4
+#: Shortest track that can carry a PROPORTION. On one or two rows the thumb
+#: either fills the track — the visual language for "everything fits", beside
+#: a `↓ N more` cue saying it does not — or occupies half of it regardless of
+#: where the window sits. Three rows is the first height at which a thumb has
+#: somewhere to be that is neither of those. See `_gutter_drawn`.
+MIN_GUTTER_TRACK_ROWS = 3
 #: Footer hints, widest first, paired with the order they are SHED in. The
 #: footer is the only statement of how to leave, so a narrow card drops the
 #: movement hints rather than the whole row — `esc quit` is eight cells and
@@ -136,6 +144,29 @@ MIN_CARD_INNER_ROWS = 7
 #: clipboard": that string is what the pinned tests use to assert the card is
 #: absent, and a notice that tripped it would make the guard unable to fail.
 TOO_SMALL_NOTICE = "terminal too small for /copy · esc"
+#: The same notice for a card too narrow to hold the full one. `esc` is the
+#: ACTIONABLE half and it used to shed FIRST, leaving `terminal too small for
+#: /copy ·` — a dangling separator that reads as a rendering fault — and then
+#: dropping the one word that tells the user how to leave (round 1, U8). The
+#: footer already solves this by shedding hints and keeping `esc quit` last;
+#: this is the same discipline in two forms rather than a truncation, because
+#: there is only one thing here worth keeping. 14 cells against 34.
+TOO_SMALL_NOTICE_SHORT = "too small · esc"
+
+
+class _PointerAt(NamedTuple):
+    """A bare screen coordinate with the two attributes the hit-tests read.
+
+    :meth:`CopyPickerScreen._index_at` and :meth:`_pointer_row_of` take an
+    "event" but use only ``screen_x``/``screen_y``. Re-resolving the hover
+    after the window moved has a coordinate and no event — synthesising a real
+    ``events.MouseMove`` for it would mean inventing a widget, a button state
+    and deltas that no hit-test reads, and posting it would re-enter the
+    handler. This is the coordinate, and nothing else.
+    """
+
+    screen_x: int
+    screen_y: int
 
 
 class CopyPickerScreen(ModalScreen[CopyTarget | None]):
@@ -208,6 +239,17 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         # `_selected`: hover says "clickable", the cursor says "Enter takes
         # this", and painting them identically would show two selected rows.
         self._hovered: int | None = None
+        # Last pointer position seen on this screen, in SCREEN coordinates.
+        # Kept because `_hovered` is an index into `_flat` and the window
+        # moves under a resting pointer: a real terminal sends no MouseMove
+        # while only the wheel turns, so the highlight has to be recomputed
+        # from the coordinate rather than carried (round 1, U4/Q3).
+        self._pointer_at: tuple[int, int] | None = None
+        # `(index, screen coordinate)` the current click chain is bound to.
+        # A double-click copies THIS row rather than re-resolving the
+        # coordinate, because the first click recentres the tree under the
+        # pointer — see `on_click` (round 1, U1/Q1).
+        self._click_anchor: tuple[int, tuple[int, int]] | None = None
         # Wrapped preview rows, keyed `(target.id, width)`. See
         # `_wrap_preview` for why that key is total and why the cache exists.
         self._wrap_cache: dict[tuple[str, int, int], tuple[list[Text], list[int]]] = {}
@@ -302,12 +344,17 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         visible, which reads as the key being broken rather than as the
         document being short — and it spends cells a narrow card needs for the
         hints that do apply.
+
+        The gate reads :meth:`_preview_overflows`, the SAME fact the pane's
+        `… N more lines` marker is drawn from. It used to compare
+        ``_preview_source_lines() > _preview_rows``, which is source lines
+        against wrapped rows: on ordinary prose (one long source line per
+        paragraph) the pane overflowed with FEWER source lines than rows, so
+        the frame drew the marker while the footer — the only place
+        `shift+↑↓` is ever named — declined to say the preview scrolled, in
+        one screenshot (round 1, MAJOR-1). One overflow fact, two cues.
         """
-        hints = [
-            hint
-            for hint in FOOTER_HINTS
-            if hint != PREVIEW_HINT or self._preview_source_lines() > self._preview_rows
-        ]
+        hints = [hint for hint in FOOTER_HINTS if hint != PREVIEW_HINT or self._preview_overflows()]
         while len(hints) > 1 and cell_len(" · ".join(hints)) > width:
             hints.pop(0)
         return " · ".join(hints)
@@ -403,18 +450,32 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         only choice that leaves one uniform rule on the page. `home`/`end` are
         the better answer to "take me to the other end" anyway.
         """
-        # The preview is a DIFFERENT DOCUMENT once the selection changes, so
-        # the offset resets on every cursor move — including one that lands
-        # where it already was, which costs nothing and removes a state where
-        # the reset depends on whether the clamp happened to move anything.
-        # Carrying an offset across targets would open the next preview
-        # part-way down a document the user never scrolled.
-        self._preview_offset = 0
         if not self._flat:
             self._selected = 0
+            self._preview_offset = 0
             self._repaint()
             return
-        self._selected = max(0, min(len(self._flat) - 1, index))
+        clamped = max(0, min(len(self._flat) - 1, index))
+        # The preview is a DIFFERENT DOCUMENT once the selection changes, so
+        # the offset resets — but ONLY when the index actually changed.
+        # Resetting unconditionally meant a movement that is a complete visual
+        # no-op (`up`/`home`/`pageup` already at the top row, `down`/`end` at
+        # the last, or a wheel notch at either end) still threw away the
+        # user's reading position, with no history and no way back: 90
+        # `shift+down` to recover a place lost to a key that moved nothing
+        # (round 1, U2). It bites hardest on this surface's own best case, a
+        # single long answer, where the tree is ONE row so every arrow press
+        # is such a no-op. The old comment argued the unconditional form
+        # "removes a state where the reset depends on whether the clamp
+        # happened to move anything" — but that state is exactly what a user
+        # expects: nothing moved, so nothing should have changed.
+        if clamped != self._selected:
+            self._preview_offset = 0
+        self._selected = clamped
+        # The cursor move may have scrolled the window under a resting
+        # pointer, which is what left the highlight on a row the pointer was
+        # not over. Resolved before the repaint so one paint carries both.
+        self._refresh_hover()
         self._repaint()
 
     def _preview_source_lines(self) -> int:
@@ -428,20 +489,94 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
             return 0
         return len(target.preview.splitlines())
 
+    def _preview_tail_offset(self) -> int:
+        """The LAST useful offset: the one whose pane ends on the last line.
+
+        This is the single definition of "the preview overflows" that the
+        whole surface derives from — the footer's `shift+↑↓ preview` hint, the
+        `… N more lines` marker's existence, and the scroll clamp all read it,
+        so the frame cannot contradict itself in the way review round 1 found
+        it doing (MAJOR-1: the pane drew `… 4 more lines` while the footer
+        declined to say the preview scrolled, because the two were computed in
+        DIFFERENT UNITS — source lines against wrapped rows — on ordinary
+        prose that wraps, which is most assistant answers).
+
+        Returning **0** when the document already fits is the other half of
+        that fix (MAJOR-2/U5). The previous ceiling was ``source_lines - 1``
+        unconditionally, so a three-line preview in a sixteen-row pane still
+        scrolled, pushing content it had room for off the top of the frame and
+        leaving blank rows behind — the `less` contract, and the tree's own
+        `down` contract, are both that scrolling stops with the last line at
+        the bottom.
+
+        The count walks ``rows_per_source`` BACKWARDS from the end, because
+        the two units only convert through that map: filling a pane of
+        ``content_rows`` wrapped rows consumes however many source lines those
+        rows came from, which varies per line. Walking from the end asks the
+        question the clamp actually has — "what is the first source line whose
+        remainder still fills the pane?" — and answers it exactly, at any
+        width, without ever subtracting a row count from a line count. That
+        subtraction is the defect `_preview_lines` documents at length and the
+        one this method exists not to re-introduce.
+        """
+        target = self.selected_target()
+        source_total = self._preview_source_lines()
+        if target is None or source_total <= 0:
+            return 0
+        # `_preview_rows` is already the pane's CONTENT height — `_card_text`
+        # stores it net of the header row — and the tail is the offset whose
+        # remainder fills exactly that, with no marker row needed because
+        # there is nothing left to announce.
+        content_rows = max(0, self._preview_rows)
+        if content_rows <= 0:
+            return max(0, source_total - 1)
+
+        # Wrapped from the LAST window, so a long document costs one wrap of
+        # the tail rather than of the whole body: only the final rows can
+        # decide where the tail begins. The cache makes a repeat free.
+        window_start = self._wrap_window_start(max(0, source_total - 1))
+        width = max(1, self._card_width() - 2)
+        _, rows_per_source = self._wrap_preview(target, width, window_start)
+        if not rows_per_source:
+            return max(0, source_total - 1)
+
+        # Lines below the mapped window are not wrapped here (the map covers
+        # at most PREVIEW_WRAP_BUDGET); they cannot be part of a tail that
+        # begins inside the window, so the ceiling stays the last line.
+        mapped_end = window_start + len(rows_per_source)
+        if mapped_end < source_total:
+            return max(0, source_total - 1)
+
+        rows = 0
+        for back, count in enumerate(reversed(rows_per_source), start=1):
+            rows += count
+            if rows >= content_rows:
+                # `back` source lines fill the pane, so the tail starts at the
+                # first of them. One earlier line would overflow it.
+                return max(0, source_total - back)
+        # The whole mapped window fits the pane. Only a window that starts at
+        # line 0 proves the DOCUMENT fits; otherwise the tail is the window.
+        return window_start
+
+    def _preview_overflows(self) -> bool:
+        """Whether the preview has anything the pane is not already showing.
+
+        The one fact both cues are gated on. See :meth:`_preview_tail_offset`.
+        """
+        return self._preview_tail_offset() > 0
+
     def _scroll_preview_to(self, offset: int) -> None:
         """Move the preview, CLAMPED at both ends — never wrapped.
 
-        Clamped for the same reason `_move_to` is, and the ceiling is the LAST
-        SOURCE LINE rather than ``total - preview_rows``: the pane's row count
-        is in wrapped rows and the offset is in source lines, so subtracting
-        one from the other would over- or under-shoot by however much the
-        document wraps. Stopping at the last line means a fully scrolled
-        preview can show a single line above blank rows, which is the honest
-        frame — the remainder marker has vanished by then, so the blank space
-        reads as "that is the end" rather than as a rendering fault.
+        Clamped for the same reason `_move_to` is. The ceiling is
+        :meth:`_preview_tail_offset` — the offset whose pane ends on the last
+        source line — rather than ``source_lines - 1``, so scrolling stops
+        with the document's end at the bottom of the pane instead of sliding
+        it up into blank rows (round 1, MAJOR-2/U5). It is deliberately NOT
+        ``total - preview_rows``: that subtracts wrapped rows from source
+        lines, the unit confusion this file documents throughout.
         """
-        ceiling = max(0, self._preview_source_lines() - 1)
-        clamped = max(0, min(ceiling, offset))
+        clamped = max(0, min(self._preview_tail_offset(), offset))
         if clamped == self._preview_offset:
             return
         self._preview_offset = clamped
@@ -509,9 +644,21 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         Refusing here rather than dropping the empty child from the tree: the
         block IS in the message, and a `Block 2` that vanishes from the list
         makes the remaining numbers disagree with what the user is reading.
+
+        The refusal RINGS. Marking the row (`py · empty` in the hint column,
+        and `Preview · py · empty` in the header) predicts the refusal, and
+        that prediction does real work — but a user who did not read the hint
+        column pressed Enter and got nothing at all: no notice, no bell, no
+        frame change, which is an application that appears to have stopped
+        responding to the key (round 1, U6). `App.bell` is the right register
+        for it — a toast would demand a dismissal for a keypress the user can
+        simply repeat elsewhere, and this screen deliberately raises no
+        notices of its own. On a terminal with the bell disabled the marking
+        is still there, which is why both halves exist.
         """
         target = self.selected_target()
         if target is None or not target.content:
+            self.app.bell()
             return
         self._dismiss_result(target)
 
@@ -560,13 +707,28 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         routing on stale state would send the first notch to the wrong pane.
         """
         row = self._pointer_row_of(event)
-        if row is not None and row >= self._preview_top_row:
+        # OFF THE CARD IS INERT, exactly as it is for the click. The notch
+        # used to fall through to `action_move`, so a pointer ONE COLUMN
+        # outside the card did something categorically different and
+        # destructive: it moved the cursor and discarded the reading position
+        # (round 1, U3/Q2). At 100x30 that zone is three cells left of the
+        # preview text the user is reading, and trackpad drift of three cells
+        # while scrolling is routine rather than adversarial; on a
+        # single-node tree it was a PURE loss, since nothing moved and the
+        # page was simply gone.
+        #
+        # The old justification — "movement is clamped, reversible and
+        # visible" — is true of the cursor and false of the offset it silently
+        # discarded. `_index_at` had already decided the backdrop is inert to
+        # clicks, and one gesture map per surface is easier to learn than two.
+        if row is None:
+            return
+        if row >= self._preview_top_row:
             self._scroll_preview_to(self._preview_offset + direction * self._wheel_step())
             return
-        # Anywhere else on the card — including the chrome and the backdrop —
-        # moves the cursor. That is the generous reading and it is safe:
-        # movement is clamped, reversible and visible, unlike the click, which
-        # is why only the click carries `_index_at`'s three guards.
+        # The tree pane and its own chrome (title and rules) move the cursor:
+        # inside the card the generous reading is right, and it is the pane
+        # the pointer is visibly over.
         self.action_move(direction * self._wheel_step())
 
     def on_mouse_scroll_down(self, event) -> None:  # type: ignore[no-untyped-def]
@@ -603,28 +765,55 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         Button 1 only, and the button is tested BEFORE any state changes: a
         right-click asking for a context menu is measured to arrive here, and
         it must not move the cursor on its way to being ignored.
+
+        **The copy is bound to the row the FIRST click resolved, not to a
+        fresh hit-test on the second.** `_window_start` centres the cursor, so
+        click 1 recentres the tree UNDER A STATIONARY POINTER and the same
+        screen coordinate then names a different row: measured at ~41% of the
+        pane on any overflowing tree, and it copied `Answer 10` when the user
+        aimed at `Quote 1` (round 1, U1/Q1 — the clipboard bytes were
+        captured). Two clicks of one gesture must mean one row, so the chain
+        remembers which. This does not re-open the arbitration that made a
+        double-click the copy gesture; it is what makes that gesture honest.
         """
         if getattr(event, "button", 1) != 1:
             return
         index = self._index_at(event)
         if index is None:
+            # A chain broken off the tree cannot be continued onto it: the
+            # next click on a row must read as a fresh first click.
+            self._click_anchor = None
             return
         event.stop()
-        if index != self._selected:
-            self._move_to(index)
         # `Click.chain` is Textual's own double-click count (0.5 s threshold),
-        # so the contract needs no timing invented here.
-        if getattr(event, "chain", 1) >= 2:
+        # so the contract needs no timing invented here. Textual only
+        # increments the chain while the pointer stays on ONE screen offset,
+        # which is what makes the anchor safe: a chained click is by
+        # definition the same physical spot, so the row the user aimed at is
+        # the row the first click bound.
+        chain = getattr(event, "chain", 1)
+        anchor = self._click_anchor
+        coordinate = (event.screen_x, event.screen_y)
+        if chain >= 2 and anchor is not None and anchor[1] == coordinate:
+            target_index = anchor[0]
+        else:
+            target_index = index
+            self._click_anchor = (index, coordinate)
+        if target_index != self._selected:
+            self._move_to(target_index)
+        if chain >= 2:
             self.action_choose()
 
     def on_mouse_move(self, event) -> None:  # type: ignore[no-untyped-def]
+        self._pointer_at = (event.screen_x, event.screen_y)
         index = self._index_at(event)
         if index != self._hovered:
             self._hovered = index
-            # Tree rows only: `_tree_lines` is 0.07 ms against the preview's
-            # 31 ms, and a hover changes nothing the preview draws. Repainting
-            # the whole card per row the pointer crosses is what made a mouse
-            # sweep cost 365 ms of loop CPU.
+            # Tree rows only: the tree is roughly two orders of magnitude
+            # cheaper to draw than the preview (see `_wrap_preview`), and a
+            # hover changes nothing the preview draws. Repainting the whole
+            # card per row the pointer crosses is what made a mouse sweep
+            # dominate the loop before the wrap was memoised.
             self._repaint()
         # A hand over a tree row, the default shape everywhere else INCLUDING
         # the preview: the preview is scrollable, not clickable, and a hand
@@ -633,7 +822,46 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         # property's own observer and no-ops when the shape did not change.
         self.styles.pointer = "pointer" if index is not None else "default"
 
+    def _refresh_hover(self) -> bool:
+        """Re-resolve the highlight against the LAST KNOWN pointer position.
+
+        `_hovered` is an index into `_flat`, but the window moves under a
+        resting pointer — the wheel scrolls the tree and a click recentres it
+        — and a real terminal sends NO `MouseMove` while only the wheel turns.
+        So the highlight was left painted on a row the pointer was not over,
+        and six notches scrolled it off the pane entirely while the hand
+        cursor stayed (round 1, U4/Q3).
+
+        That matters more here than it looks: the hover highlight is the
+        ENTIRE affordance for the mouse on this screen, deliberately — the
+        footer does not advertise the click — so a highlight that is not under
+        the pointer undermines the one thing teaching the feature. It also hid
+        U1 in the exact frame where it was still catchable, by confirming an
+        aim the second click did not honour.
+
+        Called from every path that can move the window without a pointer
+        event. Cheap: it is one hit-test plus the repaint the caller was
+        already doing, and it no-ops when the row did not change.
+
+        `session_picker` has the identical staleness and is NOT fixed here —
+        that is its own change, deliberately out of this PR's scope.
+
+        Returns whether the highlight moved, so a caller that is about to
+        repaint anyway does not pay for a second one.
+        """
+        if self._pointer_at is None:
+            return False
+        index = self._index_at(_PointerAt(*self._pointer_at))
+        self.styles.pointer = "pointer" if index is not None else "default"
+        if index == self._hovered:
+            return False
+        self._hovered = index
+        return True
+
     def on_leave(self, event) -> None:  # type: ignore[no-untyped-def]
+        self._pointer_at = None
+        # A chain cannot survive the pointer leaving the card.
+        self._click_anchor = None
         if self._hovered is not None:
             self._hovered = None
             self._repaint()
@@ -647,19 +875,30 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         relative to the whole block — title, rules, preview and footer
         included.
 
-        Three guards, all load-bearing, and all three are `session_picker`'s.
-        Its docstring records that its first cut without them resolved a click
-        on the footer to session #12 and the dimmed backdrop to row 0, and
-        BOTH of those coordinates were re-measured as still delivered here —
-        so these are mandatory rather than defensive:
+        Three guards, all three `session_picker`'s. Its docstring records that
+        its first cut without them resolved a click on the footer to session
+        #12 and the dimmed backdrop to row 0, and BOTH of those coordinates
+        were re-measured as still delivered here:
 
         - the point must be inside the body's region (the modal's backdrop
           covers the whole screen and bubbles events from well outside the
           card, including the columns to its left where ``y`` alone still
-          looks valid);
+          looks valid). **Mandatory**: without it those measured coordinates
+          resolve to real rows;
         - the row must be inside the DRAWN page, not merely inside ``_flat`` —
           a short tree caps the pane at the rows that exist, and the blank
-          remainder below them would otherwise resolve to real targets;
+          remainder below them would otherwise resolve to real targets.
+          **Defensive on this screen, not mandatory.** Review round 1
+          brute-forced the reachable state space (``_flat`` 0-39 x
+          ``available`` 1-39 x every cursor position) and found NO state where
+          it changes the outcome: ``_window_start``'s clamp to
+          ``len(_flat) - tree_rows`` and ``_split_rows``' ``min(len(_flat), …)``
+          cap already guarantee ``start + tree_rows <= len(_flat)``, so the
+          third guard subsumes it. It is kept as defence against a future
+          change to either invariant — both live in other methods — and this
+          note replaces an earlier one calling all three "mandatory rather
+          than defensive", which sent a reader hunting for a case that cannot
+          occur (MINOR-2);
         - and the resulting index must still be a row that exists.
 
         Title, rules, preview, footer, card padding and backdrop are therefore
@@ -744,11 +983,16 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         position the document no longer has would paint blank.
         """
         self._wrap_cache.clear()
-        # Before `_move_to`, which resets the offset to 0 anyway — the clamp
-        # is here so the invariant holds even if that reset is ever narrowed
-        # to "only when the index actually changed".
-        self._scroll_preview_to(self._preview_offset)
+        # `_move_to` first, so the split and the window are re-derived at the
+        # new size, and it no longer resets the offset for a resize (the index
+        # does not change, U2). Then the clamp, which now OBSERVABLY does what
+        # its docstring always claimed: the position is kept and clamped
+        # rather than dropped, so widening the terminal to read a long block
+        # more comfortably no longer throws the reader back to line 1
+        # (round 1, U7). The order matters — the clamp reads `_preview_rows`,
+        # which `_card_text` only refreshes during that repaint.
         self._move_to(self._selected)
+        self._scroll_preview_to(self._preview_offset)
 
     def _repaint(self) -> None:
         body = getattr(self, "_body", None)
@@ -769,6 +1013,19 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         notice = getattr(self, "_too_small", None)
         if notice is not None and notice.is_mounted:
             notice.display = not drawable
+            if not drawable:
+                # The notice is pinned to ONE row in the stylesheet, so a
+                # string wider than the screen wraps and the pin clips it —
+                # the notice that exists to explain a degraded frame becoming
+                # degraded itself. Choosing the form that fits keeps `esc`
+                # down to fourteen columns instead of shedding it first (U8,
+                # NIT-1).
+                columns = self._screen_size()[0]
+                notice.update(
+                    TOO_SMALL_NOTICE
+                    if cell_len(TOO_SMALL_NOTICE) <= columns
+                    else TOO_SMALL_NOTICE_SHORT
+                )
 
     def render_lines_for_test(self) -> list[str]:
         """The card as plain strings — what a user reads.
@@ -830,7 +1087,13 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         # overflows costs no row to say so — which matters because the row
         # budget is exactly what the split above is fighting to recover, and
         # at 80x24 the tree is six rows, two of which would have been signage.
-        self._append_rule(out, width, rule, f"↑ {above}" if above else "")
+        # `↑ N more`, not `↑ N`: a bare number reads as an ordinal ("row 6")
+        # rather than as a remainder, which is the exact hazard that ruled out
+        # an `N of M` position indicator on this card. `↓ N more` cannot be
+        # misread that way, so the asymmetry was worth closing rather than
+        # preserving (design round 1, D12). It is free — the slot below is
+        # already sized on the wider `↓` form.
+        self._append_rule(out, width, rule, self._cue("↑", above) if above else "")
         out.append("\n")
 
         for line in self._tree_lines(width, tree_rows):
@@ -845,7 +1108,7 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         # clipped at both ends at once, and a down-only cue would then be
         # actively misleading — it would say the list continues below while
         # silently hiding the rows above.
-        self._append_rule(out, width, rule, f"↓ {below} more" if below else "")
+        self._append_rule(out, width, rule, self._cue("↓", below) if below else "")
         out.append("\n")
 
         target = self.selected_target()
@@ -857,6 +1120,25 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         out.append("\n")
         out.append(self._footer_text(width), style=dim)
         return out
+
+    def _cue(self, arrow: str, count: int) -> str:
+        """A remainder cue whose COLUMNS do not move as its digits change.
+
+        The count is right-aligned in a field as wide as the largest it can
+        ever reach (``len(_flat)``), so `↑  3 more` and `↑ 14 more` occupy the
+        same cells and the digits line up under each other. Reserving the
+        rule's slot alone was not enough: the cue is right-aligned into it, so
+        a one-digit value started a column further right than a two-digit one
+        and the text visibly stepped sideways as the user crossed 9→10 while
+        merely scrolling (round 1, U9). That is precisely what item C1 asked
+        to avoid, and `todo_panel`'s U1 is the same lesson.
+
+        The field is sized from the row count rather than from the current
+        value for the same reason the rule's slot is: a width that tracks the
+        present number is a width that changes.
+        """
+        digits = len(str(max(1, len(self._flat))))
+        return f"{arrow} {count:>{digits}} more"
 
     def _append_rule(self, out: Text, width: int, rule: Style, cue: str) -> None:
         """A full-width rule, with ``cue`` right-aligned into its last cells.
@@ -874,7 +1156,7 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
             return
         # Widest rendering: every row hidden in that direction, in the longer
         # of the two cue shapes.
-        slot = cell_len(f"↓ {max(1, len(self._flat))} more")
+        slot = cell_len(self._cue("↓", max(1, len(self._flat))))
         keep = max(0, width - slot - 1)
         out.append("─" * keep, style=rule)
         pad = max(0, width - keep - cell_len(cue))
@@ -891,6 +1173,17 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         cannot scroll is a scrollbar for a document that fits, and it makes
         the cue's absence stop meaning "this is everything".
 
+        A track shorter than :data:`MIN_GUTTER_TRACK_ROWS` is dropped for the
+        same reason, one step further on. At 100x14 the split gives the tree
+        ONE row with eighteen hidden, and a one-row track can only paint a
+        thumb that fills it — the visual language for "everything fits", while
+        `↓ 18 more` on the rule says the opposite (design round 1, D14). The
+        contradiction is forced by geometry rather than by the anchor, so
+        fixing D11 does not fix it: below three rows no thumb can express a
+        proportion at all. The card at that height is a degraded frame either
+        way; dropping the gutter removes the one element in it that is
+        actively wrong and leaves `↓ N more` to do the work alone.
+
         And it is a SHED, not an optional decoration. The gutter costs
         :data:`GUTTER_THUMB_CELLS` off every tree row, which raises the
         narrowest row the card can lay out — so drawing it unconditionally
@@ -902,6 +1195,8 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         if rows is None:
             rows = self._tree_rows
         if len(self._flat) <= rows:
+            return False
+        if rows < MIN_GUTTER_TRACK_ROWS:
             return False
         return width - self._min_flat_width() >= GUTTER_SHED_HEADROOM
 
@@ -1020,16 +1315,39 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         thumb is the only CONTINUOUS signal on this surface — the `↓ N more`
         cue says how much is left, the thumb says WHERE you are and moves as
         you go — which is why both exist and neither replaces the other.
+
+        The top is anchored on SCROLL PROGRESS (``start / max_start``) across
+        the track's free travel, not on the window's fraction of the list.
+        Those are two different mappings, and the earlier
+        ``min(rows - span, round(start * rows / total))`` let the clamp win one
+        window position early: the thumb bottomed out at ``start=2`` of 3 while
+        the rule still read `↓ 1 more`, so two distinct list positions painted
+        an IDENTICAL gutter and the user's final arrow press moved the
+        continuous signal not at all (design round 1, D11). This is the model
+        `ask_picker._scrollbar_thumb` and `usage_panel._scrollbar_thumb`
+        already use — span from the viewport fraction, top from the offset's
+        fraction of its own range — so the app's three bars agree.
+
+        The division FLOORS rather than rounds, and that is the part carrying
+        the invariant. ``floor(start * travel / max_start) == travel`` exactly
+        when ``start == max_start``, so **"thumb at the bottom of the track"
+        means "no `↓ N more`" at every shape**. Rounding is very nearly right
+        and fails the same way the original did on shapes where the fraction
+        crosses ``travel - 0.5`` early: at 32 rows in a 12-row pane
+        (``span=4``, ``travel=8``, ``max_start=20``) ``round(19*8/20) = 8``
+        bottoms the thumb at ``start=19``, one window before the end, exactly
+        the defect being fixed. Verified over every ``start`` for both that
+        shape and the 19-row one D11 was reported against.
         """
         total = len(self._flat)
         if total <= rows:
             return range(0)
         span = max(1, round(rows * rows / total))
-        # Anchored on the window rather than the cursor, since the window is
-        # what the track represents. Clamped so a thumb at the end of the list
-        # cannot be drawn past the bottom of the track.
-        top = min(rows - span, round(start * rows / total))
-        return range(max(0, top), max(0, top) + span)
+        travel = rows - span
+        max_start = total - rows
+        top = (start * travel) // max_start if travel > 0 and max_start > 0 else 0
+        top = max(0, min(travel, top))
+        return range(top, top + span)
 
     @staticmethod
     def _append_gutter(line: Text, on_thumb: bool, row_bg: Style) -> None:
@@ -1184,14 +1502,42 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         frozen, the tree is a snapshot taken when the screen was pushed and
         cannot change while it is open, and width and window are the only
         other inputs — so a hit is byte-identical to a recomputation by
-        construction. The cost of not caching is not theoretical either. Every
-        repaint re-wrapped the whole preview through ``rich.Syntax``: measured
-        at 31 ms against ``_tree_lines``' 0.07 ms, so one mouse sweep across
-        the tree spent 365 ms of loop CPU with the loop frozen throughout, and
-        the same sweep warm costs 2 ms. Hover made that trivial to hit without
-        meaning to press anything, which is what turned a pre-existing
-        inefficiency into a blocker for the mouse work. Cleared on resize,
-        where width changes wholesale.
+        construction.
+
+        The cost of not caching is not theoretical either. Every repaint
+        re-wrapped the preview through ``rich.Syntax``, which is two orders of
+        magnitude dearer than the tree beside it. Measured with
+        ``time.thread_time`` (CPU, not wall — AGENTS.md), median of 9, on an
+        M-series laptop at 100x30, so treat the RATIO as the durable fact and
+        the absolute numbers as this machine's:
+
+        ===============================  =========  =========  =========
+        preview shape                    wrap cold  wrap warm  _tree_lines
+        ===============================  =========  =========  =========
+        plain, 121 lines                   3.40 ms   0.00025 ms   0.015 ms
+        plain, 3002 lines                  3.58 ms   0.00025 ms   0.014 ms
+        python block, 499 lines            4.19 ms   0.00025 ms   0.024 ms
+        python block, 499 lines @200col    4.31 ms   0.00025 ms   0.023 ms
+        ===============================  =========  =========  =========
+
+        Note what the third column says: the wrap is ~200x the tree's cost,
+        and a hover changes ONLY what the tree draws — which is why
+        `on_mouse_move` repaints without touching the preview, and why the
+        memo exists at all. `_card_text` as a whole goes from ~4.06 ms cold to
+        ~0.10 ms warm on the 121-line answer, so a mouse sweep across the tree
+        costs one wrap rather than one per row.
+
+        The figures are also flat in the document's length, which is
+        :data:`PREVIEW_WRAP_BUDGET` doing its job: a 3002-line answer wraps no
+        more source than a 121-line one, so neither the cache entry nor the
+        wrap grows with the message. An earlier revision of this comment
+        quoted 31 ms / 0.07 ms / a 365 ms sweep; those do not reproduce at the
+        shapes described here (QA round 1, Q4), and 31 ms was only reachable
+        on a wide card before the budget bounded the work. An unqualified
+        number that does not reproduce is worse than no number, so the shape,
+        the clock and the machine are stated above.
+
+        Cleared on resize, where width changes wholesale.
         """
         key = (target.id, width, window_start)
         cached = self._wrap_cache.get(key)

--- a/local_operator/tui/widgets/copy_picker.py
+++ b/local_operator/tui/widgets/copy_picker.py
@@ -250,6 +250,13 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         # coordinate, because the first click recentres the tree under the
         # pointer — see `on_click` (round 1, U1/Q1).
         self._click_anchor: tuple[int, tuple[int, int]] | None = None
+        # Set when something moved the window while an anchor was live, which
+        # Textual's chain cannot see: it breaks a chain on a changed screen
+        # offset or the clock, and a wheel notch or an arrow key is neither
+        # (round 2, U10). `on_click` reads it to refuse a copy for a chain
+        # that is no longer one gesture, rather than copying a row the frame
+        # stopped showing.
+        self._anchor_disturbed = False
         # Wrapped preview rows, keyed `(target.id, width)`. See
         # `_wrap_preview` for why that key is total and why the cache exists.
         self._wrap_cache: dict[tuple[str, int, int], tuple[list[Text], list[int]]] = {}
@@ -456,6 +463,22 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
             self._repaint()
             return
         clamped = max(0, min(len(self._flat) - 1, index))
+        # ANY movement DISTURBS a live double-click anchor. Textual breaks a
+        # click chain on only two things — a changed screen offset and the
+        # clock — and a wheel notch or an arrow key changes neither, so the
+        # second click still arrived as `chain=2` and copied the PRE-WHEEL row
+        # while the caret and the preview had moved on (round 2, U10: 5/5
+        # frame/clipboard disagreements with a wheel between the clicks, 5/5
+        # with a key, 0/5 plain). That is the same silent wrong-clipboard
+        # failure U1 was filed for, through a narrower but entirely natural
+        # gesture: click a row, realise it is not the one, nudge the wheel,
+        # click again. This is the single path every gesture and key moves
+        # through, so it is the one place that can see them all; `on_click`
+        # re-arms after its own call, so a click cannot erase the anchor it is
+        # establishing.
+        if self._click_anchor is not None:
+            self._anchor_disturbed = True
+        self._click_anchor = None
         # The preview is a DIFFERENT DOCUMENT once the selection changes, so
         # the offset resets — but ONLY when the index actually changed.
         # Resetting unconditionally meant a movement that is a complete visual
@@ -518,6 +541,26 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         width, without ever subtracting a row count from a line count. That
         subtraction is the defect `_preview_lines` documents at length and the
         one this method exists not to re-introduce.
+
+        The walk crosses WRAP WINDOWS rather than stopping at the last one,
+        and that is what makes the ceiling hold on long documents.
+        `_wrap_window_start` snaps to :data:`PREVIEW_WRAP_STRIDE`, so a
+        document of ``100k + 1 … 100k + content_rows`` lines has a final
+        window holding fewer lines than the pane draws: walking only that
+        window ran out of MAP before it ran out of PANE and returned
+        ``window_start``, which for that band is exactly the
+        ``source_lines - 1`` ceiling MAJOR-2 removed — a fully scrolled
+        205-line answer ended on five lines above eleven blank rows at 100x30
+        (round 2, BLOCKER-1/U11). The band is ``content_rows`` wide, so it
+        grew with the terminal: 17/60 sampled lengths at 80x24, 30/60 at
+        100x30, 43/60 at 140x44. Stepping to the previous window and
+        continuing costs one further wrap (cached, and only on documents past
+        the stride) and makes the ceiling independent of where the document's
+        length happens to fall against it.
+
+        Reaching ``window_start == 0`` with the pane still unfilled is the
+        only proof the DOCUMENT fits, and it returns **0** — the "does not
+        overflow" answer the whole surface gates on.
         """
         target = self.selected_target()
         source_total = self._preview_source_lines()
@@ -534,29 +577,30 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         # Wrapped from the LAST window, so a long document costs one wrap of
         # the tail rather than of the whole body: only the final rows can
         # decide where the tail begins. The cache makes a repeat free.
-        window_start = self._wrap_window_start(max(0, source_total - 1))
         width = max(1, self._card_width() - 2)
-        _, rows_per_source = self._wrap_preview(target, width, window_start)
-        if not rows_per_source:
-            return max(0, source_total - 1)
-
-        # Lines below the mapped window are not wrapped here (the map covers
-        # at most PREVIEW_WRAP_BUDGET); they cannot be part of a tail that
-        # begins inside the window, so the ceiling stays the last line.
-        mapped_end = window_start + len(rows_per_source)
-        if mapped_end < source_total:
-            return max(0, source_total - 1)
-
+        line = max(0, source_total - 1)
+        window_start = self._wrap_window_start(line)
         rows = 0
-        for back, count in enumerate(reversed(rows_per_source), start=1):
-            rows += count
-            if rows >= content_rows:
-                # `back` source lines fill the pane, so the tail starts at the
-                # first of them. One earlier line would overflow it.
-                return max(0, source_total - back)
-        # The whole mapped window fits the pane. Only a window that starts at
-        # line 0 proves the DOCUMENT fits; otherwise the tail is the window.
-        return window_start
+        while True:
+            _, rows_per_source = self._wrap_preview(target, width, window_start)
+            if not rows_per_source:
+                return max(0, source_total - 1)
+            # The map covers at most PREVIEW_WRAP_BUDGET lines from
+            # `window_start`, and `line` is the highest one this pass may
+            # consume, so a window the budget truncated is walked over the
+            # part it does cover rather than trusted past its end.
+            top = min(line, window_start + len(rows_per_source) - 1)
+            for index in range(top, window_start - 1, -1):
+                rows += rows_per_source[index - window_start]
+                if rows >= content_rows:
+                    # The lines from `index` to the last one fill the pane, so
+                    # the tail starts at `index`; one line earlier overflows it.
+                    return index
+            if window_start <= 0:
+                # Walked to the document's first line without filling the pane.
+                return 0
+            line = window_start - 1
+            window_start = self._wrap_window_start(line)
 
     def _preview_overflows(self) -> bool:
         """Whether the preview has anything the pane is not already showing.
@@ -775,33 +819,69 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         captured). Two clicks of one gesture must mean one row, so the chain
         remembers which. This does not re-open the arbitration that made a
         double-click the copy gesture; it is what makes that gesture honest.
+
+        The anchor binds only while the chain is UNDISTURBED. A chained click
+        is by definition the same physical spot, but a spot is not a row: the
+        window can move under a still pointer, so anything that moves it
+        clears the anchor in `_move_to` and the second click SELECTS WITHOUT
+        COPYING (round 2, U10). What survives is the case the anchor was built for —
+        the app moved the row under a hand that did not move — and what no
+        longer survives is the case where the USER moved it, where the frame
+        they are looking at is the honest answer. QA round 2 (Q6) noted this
+        boundary while it still cut the other way and recommended documenting
+        rather than changing it; the UX round measured the same mechanism
+        destroying the clipboard silently, so it is a fix here and not a note.
         """
         if getattr(event, "button", 1) != 1:
             return
         index = self._index_at(event)
         if index is None:
             # A chain broken off the tree cannot be continued onto it: the
-            # next click on a row must read as a fresh first click.
+            # next click on a row must read as a fresh first click — which is
+            # why the disturbance flag clears with it rather than surviving to
+            # refuse that click.
             self._click_anchor = None
+            self._anchor_disturbed = False
             return
         event.stop()
-        # `Click.chain` is Textual's own double-click count (0.5 s threshold),
-        # so the contract needs no timing invented here. Textual only
-        # increments the chain while the pointer stays on ONE screen offset,
-        # which is what makes the anchor safe: a chained click is by
-        # definition the same physical spot, so the row the user aimed at is
-        # the row the first click bound.
+        # `Click.chain` is Textual's own double-click count, so the contract
+        # needs no timing invented here. The window is `App.CLICK_CHAIN_TIME_
+        # THRESHOLD`, which this app deliberately widens to **0.9 s** (see the
+        # constant's own rationale in `app.py`); round 2 corrected a "0.5 s"
+        # written here, which understated the exposure by 80%. Cited rather
+        # than restated so a Textual upgrade cannot make this comment false.
+        #
+        # Textual increments the chain only while the pointer stays on ONE
+        # screen offset, so a chained click is the same physical SPOT. That is
+        # not the same as the same ROW: the window can move under a still
+        # pointer, which is why `_move_to` clears the anchor and why the fall
+        # back below re-hit-tests rather than trusting a stale one (U10).
         chain = getattr(event, "chain", 1)
         anchor = self._click_anchor
         coordinate = (event.screen_x, event.screen_y)
-        if chain >= 2 and anchor is not None and anchor[1] == coordinate:
-            target_index = anchor[0]
-        else:
-            target_index = index
-            self._click_anchor = (index, coordinate)
+        chained = chain >= 2 and anchor is not None and anchor[1] == coordinate
+        # A chain the window moved under is no longer ONE gesture, so it does
+        # not copy — it selects and previews, exactly as a chain broken by the
+        # clock already does (verified in round 2 as "the right refusal").
+        # Re-hit-testing instead was considered and measured: because a wheel
+        # over the tree moves the CURSOR and `_window_start` recentres it, the
+        # row under the pointer equals the row the preview is showing in only
+        # **1 of 9** pane positions, so that fallback copies a third row that
+        # is neither aimed at nor displayed. Refusing is the conservative
+        # direction for the reason this docstring already gives: a wrong copy
+        # is silent and destroys the clipboard, a refusal is visible in the
+        # frame and one more click away from the right answer.
+        disturbed = chain >= 2 and not chained and self._anchor_disturbed
+        target_index = anchor[0] if chained and anchor is not None else index
         if target_index != self._selected:
             self._move_to(target_index)
-        if chain >= 2:
+        if not chained:
+            # Re-armed AFTER the move, which disturbs any anchor: this click is
+            # the one binding the chain, so its anchor must outlive the
+            # movement it causes.
+            self._click_anchor = (index, coordinate)
+            self._anchor_disturbed = False
+        if chain >= 2 and not disturbed:
             self.action_choose()
 
     def on_mouse_move(self, event) -> None:  # type: ignore[no-untyped-def]
@@ -860,8 +940,11 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
 
     def on_leave(self, event) -> None:  # type: ignore[no-untyped-def]
         self._pointer_at = None
-        # A chain cannot survive the pointer leaving the card.
+        # A chain cannot survive the pointer leaving the card. Cleared as a
+        # pair: the next click is a fresh first click, so it must not inherit
+        # a disturbance recorded against the anchor being dropped here.
         self._click_anchor = None
+        self._anchor_disturbed = False
         if self._hovered is not None:
             self._hovered = None
             self._repaint()
@@ -989,8 +1072,17 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         # its docstring always claimed: the position is kept and clamped
         # rather than dropped, so widening the terminal to read a long block
         # more comfortably no longer throws the reader back to line 1
-        # (round 1, U7). The order matters — the clamp reads `_preview_rows`,
-        # which `_card_text` only refreshes during that repaint.
+        # (round 1, U7).
+        #
+        # The order is DEFENSIVE, not load-bearing. The reasoning for it — the
+        # clamp reads `_preview_rows`, which `_card_text` only refreshes
+        # during that repaint — is sound, but review round 2 (MINOR-1) swapped
+        # the two statements and found no frame where it shows: identical
+        # rows, tail, offset and painted output at 140x44, 100x30, 80x24 and
+        # 90x14 with the offset at the tail, and the whole file green. It is
+        # kept in this order because deriving geometry before reading it is
+        # the right dependency, and recorded as unobservable so the next
+        # reader does not go looking for the frame that needs it.
         self._move_to(self._selected)
         self._scroll_preview_to(self._preview_offset)
 
@@ -1015,12 +1107,34 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
             notice.display = not drawable
             if not drawable:
                 # The notice is pinned to ONE row in the stylesheet, so a
-                # string wider than the screen wraps and the pin clips it —
-                # the notice that exists to explain a degraded frame becoming
-                # degraded itself. Choosing the form that fits keeps `esc`
-                # down to fourteen columns instead of shedding it first (U8,
-                # NIT-1).
-                columns = self._screen_size()[0]
+                # string wider than the box it lands in wraps and the pin
+                # clips it — the notice that exists to explain a degraded
+                # frame becoming degraded itself. Choosing the form that fits
+                # keeps `esc` down to fourteen columns instead of shedding it
+                # first (U8, NIT-1).
+                #
+                # Measured against the NOTICE'S OWN box, not the screen's.
+                # `_screen_size` agrees with it once laid out, but its two
+                # fallbacks do not: it answers `self.app.size` before layout
+                # and a hardcoded (80, 24) on exception, both of which report
+                # the terminal rather than the content box `Screen
+                # { padding: 1 }` insets by two cells — so a 34- or 35-column
+                # terminal could be told it had room for the 34-cell long form
+                # and clip it back to `terminal too small for /copy ·`, the
+                # exact dangling separator U8 removed. Design round 2 (D17)
+                # kept a captured frame of that rendering but could not
+                # reproduce it on demand across 22 repeats, so this closes the
+                # question rather than chasing the race: take the NARROWEST
+                # width any resolved source reports, and when nothing is
+                # resolved prefer the short form — it fits everywhere the long
+                # one does, so an uncertain measurement must not select the
+                # one that can clip.
+                candidates = [
+                    size.width
+                    for size in (getattr(notice, "size", None), getattr(self, "size", None))
+                    if size is not None and size.width
+                ]
+                columns = min(candidates) if candidates else 0
                 notice.update(
                     TOO_SMALL_NOTICE
                     if cell_len(TOO_SMALL_NOTICE) <= columns
@@ -1328,16 +1442,48 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         already use — span from the viewport fraction, top from the offset's
         fraction of its own range — so the app's three bars agree.
 
-        The division FLOORS rather than rounds, and that is the part carrying
-        the invariant. ``floor(start * travel / max_start) == travel`` exactly
-        when ``start == max_start``, so **"thumb at the bottom of the track"
-        means "no `↓ N more`" at every shape**. Rounding is very nearly right
-        and fails the same way the original did on shapes where the fraction
-        crosses ``travel - 0.5`` early: at 32 rows in a 12-row pane
-        (``span=4``, ``travel=8``, ``max_start=20``) ``round(19*8/20) = 8``
-        bottoms the thumb at ``start=19``, one window before the end, exactly
-        the defect being fixed. Verified over every ``start`` for both that
-        shape and the 19-row one D11 was reported against.
+        The invariant is SYMMETRIC, and both halves are load-bearing:
+
+            thumb flush with the bottom of the track ⟺ nothing below
+            thumb flush with the top of the track    ⟺ nothing above
+
+        Round 2 (reviewer MAJOR-1, design D16) found that a bare floored
+        proportion holds the first and breaks the second. ``floor`` puts
+        ``top == travel`` exactly at ``start == max_start`` — the bottom
+        invariant, and why round 1 chose it over ``round`` — but it also
+        yields ``top == 0`` for a RANGE of early windows, so the thumb sat
+        pinned at the top of the track while `↑ N more` said rows were hidden
+        above. That is verbatim D11's own defect, mirrored: at the 19-row
+        shape D11 was filed against, ``start=0`` and ``start=1`` painted an
+        identical gutter while the cue changed, and at 80x24 three
+        consecutive positions did. Enumerated over ``total`` 2–399 ×
+        ``rows`` 1–59, floor scored 0 bottom contradictions and 427,381 top
+        ones.
+
+        So the extremes of the track are RESERVED for the extremes of the
+        list, and the interior is mapped over the interior cells only. Over
+        the same space, restricted to shapes that actually draw a gutter
+        (``rows >= MIN_GUTTER_TRACK_ROWS``): **0 contradictions at either end
+        across 3,898,762 window positions**, bar the five noted below.
+
+        The interior mapping spreads ``1 … max_start-1`` over
+        ``1 … travel-1`` rather than re-flooring the full-range proportion.
+        Both forms satisfy the invariant identically — the difference is only
+        how evenly interior windows land on interior cells, where this one
+        measures 1.17x the ideal crowding against 1.78x for a clamped
+        full-range floor, i.e. the thumb tracks the list more faithfully in
+        the middle where the user is actually reading.
+
+        The five residuals are all ``travel == 1`` with ``max_start > 1``
+        (only ``rows``/``total`` of 3/5, 3/6, 4/6, 5/7): a one-cell travel has
+        two expressible positions for three or more states, so by pigeonhole
+        SOME window must share a cell with an extreme. It is a geometric
+        limit, not a formula defect, and it is resolved deliberately in favour
+        of the BOTTOM — an interior window shares the top cell rather than the
+        bottom one — because the bottom is where the list ends and where the
+        user stops, and because `↑`/`↓` cues carry the fine signal at sizes
+        that small (see ``MIN_GUTTER_TRACK_ROWS``, which sheds the track
+        entirely once it cannot say anything true at all).
         """
         total = len(self._flat)
         if total <= rows:
@@ -1345,8 +1491,20 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         span = max(1, round(rows * rows / total))
         travel = rows - span
         max_start = total - rows
-        top = (start * travel) // max_start if travel > 0 and max_start > 0 else 0
-        top = max(0, min(travel, top))
+        if travel <= 0 or max_start <= 0:
+            top = 0
+        elif start <= 0:
+            top = 0
+        elif start >= max_start:
+            top = travel
+        elif travel < 2:
+            # One cell of travel cannot express an interior at all. Share the
+            # TOP cell, so "flush with the bottom" keeps meaning "nothing
+            # below" — see the docstring on which end this forfeits and why.
+            top = 0
+        else:
+            top = 1 + ((start - 1) * (travel - 2)) // max(1, max_start - 2)
+            top = max(1, min(travel - 1, top))
         return range(top, top + span)
 
     @staticmethod
@@ -1495,6 +1653,18 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         scroll. The caller compares the windowed map against the true source
         length, so budgeting changes how much is WRAPPED and never the number
         the user is shown.
+
+        Two entries are live on the paint path of a long preview, not one:
+        `_preview_lines` wraps the window holding the CURRENT offset while
+        `_footer_text` → `_preview_overflows` → `_preview_tail_offset` walks
+        the window(s) holding the document's END, and on a document scrolled
+        to its middle those are different keys (review round 2, MINOR-2). So
+        the first paint of a long preview pays two cold wraps rather than one,
+        and the walk added for BLOCKER-1 can touch a third on the band of
+        lengths that straddles a stride boundary. The memo absorbs the repeats
+        — warm hits are ~0.00025 ms below — and the cold cost is bounded by
+        the same per-window budget, so the ratio the table reports still holds
+        per entry; the count of entries is what changed.
 
         **Memoised on ``(target.id, width, window_start)``**, which supersedes
         this method's former "no per-target cache" note. That note's objection

--- a/local_operator/tui/widgets/copy_picker.py
+++ b/local_operator/tui/widgets/copy_picker.py
@@ -195,7 +195,50 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
     other pane's version of this key" and needs no mode. `j/k`, `space` and
     `/` are deliberately not bound: this app is not modal-vim anywhere, and
     there is no filter here to open.
+
+    **The card is CHROME, so it is out of the text-selection walk.** See
+    ``ALLOW_SELECT`` below.
     """
+
+    # The card is chrome, not content: `app.Chrome` and
+    # `settings_view._ChromeStatic` state that rule in full and this surface is
+    # the same shape. Its content is reachable through the picker's own copy —
+    # a drag-select of the rules, gutter and footer is meaningless — so the
+    # selection machinery has nothing to offer here and one thing to take.
+    #
+    # WHAT IT TAKES, measured (round 3, Q8/U12, found independently by QA and
+    # the UX round). `Widget._on_click` calls `text_select_all()` on EVERY
+    # `chain == 2` click on a selectable widget; this app turns the resulting
+    # `TextSelected` into a real clipboard write plus a receipt
+    # (`app.on_text_selected` -> `_copy_selection` -> `_put_on_clipboard`). The
+    # card is one `Static`, so a double-click anywhere on it put ~1,450
+    # characters of the picker's own interface on the clipboard and toasted
+    # `copied 23 lines` to say it had worked.
+    #
+    # That write was always there and was always immediately OVERWRITTEN,
+    # because until the U10 refusal every chained click on a row dismissed and
+    # copied. The refusal created the first chained click that does neither, so
+    # the chrome write became the last one standing: the gesture the refusal
+    # exists to protect — click a row, nudge the wheel, click again — destroyed
+    # the user's clipboard and told them it had succeeded, which is a worse
+    # outcome than the wrong-row copy U10 was filed for. `ALLOW_SELECT = False`
+    # is what makes "refuses to copy" mean the clipboard is untouched.
+    #
+    # It closes a second, older doorway with it: double-clicking an EMPTY block
+    # (which `action_choose` refuses with a bell) leaked the card identically
+    # and has done since round 1, as did double-clicking the title, footer,
+    # preview or backdrop — pre-existing on every head and never noticed,
+    # because nobody had reason to look at the clipboard after a click that
+    # copied nothing.
+    #
+    # Set on the SCREEN rather than the card widget: `Screen._forward_event`
+    # arms the drag on `select_widget.allow_select AND self.screen.allow_select`,
+    # so the screen attribute gates the backdrop and any future child at once
+    # rather than needing each to remember. It gates ONLY selection — click
+    # delivery, `on_click`, hover and the picker's own copy are all untouched
+    # (verified: the plain double-click still copies the aimed row and
+    # dismisses).
+    ALLOW_SELECT = False
 
     BINDINGS = [
         Binding("escape", "cancel", "Cancel", show=False),
@@ -463,22 +506,49 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
             self._repaint()
             return
         clamped = max(0, min(len(self._flat) - 1, index))
-        # ANY movement DISTURBS a live double-click anchor. Textual breaks a
-        # click chain on only two things — a changed screen offset and the
-        # clock — and a wheel notch or an arrow key changes neither, so the
-        # second click still arrived as `chain=2` and copied the PRE-WHEEL row
-        # while the caret and the preview had moved on (round 2, U10: 5/5
-        # frame/clipboard disagreements with a wheel between the clicks, 5/5
-        # with a key, 0/5 plain). That is the same silent wrong-clipboard
-        # failure U1 was filed for, through a narrower but entirely natural
-        # gesture: click a row, realise it is not the one, nudge the wheel,
-        # click again. This is the single path every gesture and key moves
-        # through, so it is the one place that can see them all; `on_click`
-        # re-arms after its own call, so a click cannot erase the anchor it is
-        # establishing.
-        if self._click_anchor is not None:
-            self._anchor_disturbed = True
-        self._click_anchor = None
+        # A movement that MOVED SOMETHING disturbs a live double-click anchor.
+        # Textual breaks a click chain on only two things — a changed screen
+        # offset and the clock — and a wheel notch or an arrow key changes
+        # neither, so the second click still arrived as `chain=2` and copied
+        # the PRE-WHEEL row while the caret and the preview had moved on
+        # (round 2, U10: 5/5 frame/clipboard disagreements with a wheel between
+        # the clicks, 5/5 with a key, 0/5 plain). That is the same silent
+        # wrong-clipboard failure U1 was filed for, through a narrower but
+        # entirely natural gesture: click a row, realise it is not the one,
+        # nudge the wheel, click again. This is the single path every gesture
+        # and key moves through, so it is the one place that can see them all;
+        # `on_click` re-arms after its own call, so a click cannot erase the
+        # anchor it is establishing.
+        #
+        # GATED ON THE CLAMP, exactly as the preview offset below is (round 3,
+        # D19, and the reviewer's own MAJOR by a different route). Disturbing
+        # unconditionally meant a movement that is a complete visual NO-OP —
+        # `up`/`home` already at the top row, `down`/`end` at the last, a wheel
+        # notch at either end — armed the refusal anyway, so the second click
+        # declined to copy against a frame that was byte-identical at all three
+        # points: three gestures, one unchanged picture, nothing copied and
+        # nothing on screen saying why. The refusal's whole defence is that it
+        # is legible — "visible in the frame and one more click from the right
+        # answer", stated in `on_click` — and that defence is only true when
+        # the refusal actually changed the frame.
+        #
+        # It bites hardest on this surface's HEADLINE case, a single long
+        # answer: the tree is ONE row, so 100% of wheel notches and arrow keys
+        # over it are clamped no-ops and any stray notch poisoned the
+        # double-click with no way for the user to see it. Same principle, same
+        # clamp, same file as `test_a_move_that_changes_nothing_keeps_the_
+        # reading_position` (round 1, U2) already pins for the reading
+        # position: nothing moved, so nothing should have changed.
+        #
+        # The ANCHOR ITSELF is preserved too, not merely the flag. Clearing it
+        # on a no-op would send the second click down the fresh-hit-test path,
+        # and `_window_start` recentres the tree under a stationary pointer, so
+        # that path names a different row than the one the gesture aimed at —
+        # U1 returning through the back door.
+        if clamped != self._selected:
+            if self._click_anchor is not None:
+                self._anchor_disturbed = True
+            self._click_anchor = None
         # The preview is a DIFFERENT DOCUMENT once the selection changes, so
         # the offset resets — but ONLY when the index actually changed.
         # Resetting unconditionally meant a movement that is a complete visual
@@ -822,8 +892,8 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
 
         The anchor binds only while the chain is UNDISTURBED. A chained click
         is by definition the same physical spot, but a spot is not a row: the
-        window can move under a still pointer, so anything that moves it
-        clears the anchor in `_move_to` and the second click SELECTS WITHOUT
+        window can move under a still pointer, so anything that ACTUALLY MOVES
+        it clears the anchor in `_move_to` and the second click SELECTS WITHOUT
         COPYING (round 2, U10). What survives is the case the anchor was built for —
         the app moved the row under a hand that did not move — and what no
         longer survives is the case where the USER moved it, where the frame
@@ -831,6 +901,11 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         boundary while it still cut the other way and recommended documenting
         rather than changing it; the UX round measured the same mechanism
         destroying the clipboard silently, so it is a fix here and not a note.
+
+        "Actually moves it" is load-bearing and is the clamp's job: a movement
+        that changes nothing leaves the anchor alone, so the refusal never
+        fires against a frame it did not change (round 3, D19 — see `_move_to`,
+        which owns that condition and the measurement behind it).
         """
         if getattr(event, "button", 1) != 1:
             return
@@ -870,7 +945,10 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         # is neither aimed at nor displayed. Refusing is the conservative
         # direction for the reason this docstring already gives: a wrong copy
         # is silent and destroys the clipboard, a refusal is visible in the
-        # frame and one more click away from the right answer.
+        # frame and one more click away from the right answer. That second
+        # half is only true because `_move_to` disturbs on a real move only
+        # (D19) and because `ALLOW_SELECT = False` keeps the refusing click
+        # from writing the card to the clipboard behind the refusal (Q8/U12).
         disturbed = chain >= 2 and not chained and self._anchor_disturbed
         target_index = anchor[0] if chained and anchor is not None else index
         if target_index != self._selected:
@@ -1464,7 +1542,8 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         list, and the interior is mapped over the interior cells only. Over
         the same space, restricted to shapes that actually draw a gutter
         (``rows >= MIN_GUTTER_TRACK_ROWS``): **0 contradictions at either end
-        across 3,898,762 window positions**, bar the five noted below.
+        across 3,898,762 window positions**, with no exceptions once the
+        one-cell-travel shapes below are handled.
 
         The interior mapping spreads ``1 … max_start-1`` over
         ``1 … travel-1`` rather than re-flooring the full-range proportion.
@@ -1474,16 +1553,33 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         full-range floor, i.e. the thumb tracks the list more faithfully in
         the middle where the user is actually reading.
 
-        The five residuals are all ``travel == 1`` with ``max_start > 1``
-        (only ``rows``/``total`` of 3/5, 3/6, 4/6, 5/7): a one-cell travel has
-        two expressible positions for three or more states, so by pigeonhole
-        SOME window must share a cell with an extreme. It is a geometric
-        limit, not a formula defect, and it is resolved deliberately in favour
-        of the BOTTOM — an interior window shares the top cell rather than the
-        bottom one — because the bottom is where the list ends and where the
-        user stops, and because `↑`/`↓` cues carry the fine signal at sizes
-        that small (see ``MIN_GUTTER_TRACK_ROWS``, which sheds the track
-        entirely once it cannot say anything true at all).
+        A one-cell travel cannot express an interior at all: two expressible
+        positions for three or more window states means, by pigeonhole, that
+        some interior window shares a cell with an extreme and contradicts its
+        own cue. Round 2 forfeited those five shapes (``rows``/``total`` of
+        3/5, 3/6, 4/6, 5/7) as "a geometric limit", **which was wrong** — the
+        pigeonhole argument is valid only for a FIXED span, and the span is a
+        free parameter (round 3, D20). All four shapes are reachable at real
+        terminal sizes: the shipped split yields them at 100x20 with a 5- or
+        6-node tree and 100x23 with a 6- or 7-node one, where the frame painted
+        the thumb flush with the top of the track while `↑ 1 more` sat on the
+        rule above it.
+
+        So when the track has no interior to give, one cell of SPAN buys the
+        cell of travel that the invariant needs. Measured over the same
+        3,898,762 states: **5 top contradictions → 0, bottom stays 0, no cue
+        goes missing**, for a cumulative span error of 6724.5 against 6723.4 —
+        1.1 cells spread across the whole space, i.e. the span is one cell off
+        the ideal proportion on four shapes and exact everywhere else. Trading
+        a cell of thumb LENGTH (which says how much of the list you can see,
+        already rounded) for a cell of thumb POSITION (which is the invariant
+        this method exists to hold) is the right direction, and it is only ever
+        taken where the alternative is a frame that contradicts itself.
+
+        Guarded by ``span > 1`` so the floor that keeps a very long tree marked
+        at all is never spent, and by ``max_start > 1`` so a track with only
+        two window states — which a one-cell travel expresses exactly — keeps
+        its full proportional span.
         """
         total = len(self._flat)
         if total <= rows:
@@ -1491,17 +1587,18 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         span = max(1, round(rows * rows / total))
         travel = rows - span
         max_start = total - rows
+        if travel == 1 and max_start > 1 and span > 1:
+            # No interior cell to land an interior window on. Give up a cell of
+            # span for a second cell of travel — see the docstring for the
+            # measurement and for why length is the cheaper of the two.
+            span -= 1
+            travel = rows - span
         if travel <= 0 or max_start <= 0:
             top = 0
         elif start <= 0:
             top = 0
         elif start >= max_start:
             top = travel
-        elif travel < 2:
-            # One cell of travel cannot express an interior at all. Share the
-            # TOP cell, so "flush with the bottom" keeps meaning "nothing
-            # below" — see the docstring on which end this forfeits and why.
-            top = 0
         else:
             top = 1 + ((start - 1) * (travel - 2)) // max(1, max_start - 2)
             top = max(1, min(travel - 1, top))

--- a/local_operator/tui/widgets/copy_picker.py
+++ b/local_operator/tui/widgets/copy_picker.py
@@ -55,19 +55,73 @@ CARD_HEIGHT_FRACTION = 0.9
 GUTTER_CELLS = 3
 #: Cells the `❯ ` cursor column costs on every row, selected or not.
 CURSOR_CELLS = 2
-#: Cap on source lines wrapped for the preview. A 500-line answer would
-#: otherwise fold thousands of rows to display about fifteen. The overflow
-#: marker is computed from the SOURCE line count, never from the wrapped rows,
-#: so budgeting the wrap cannot change the number the user is shown.
+#: Source lines wrapped around the preview's current offset. A 20,000-line
+#: answer costs 2.8 s of loop CPU to wrap whole (measured), which is why a
+#: budget exists at all; 200 lines costs 23 ms.
+#:
+#: It is a WINDOW, not a prefix. It used to cap the wrap at the first 200
+#: source lines, which was invisible while only ~15 rows were ever shown —
+#: but the moment the preview scrolls, a prefix budget becomes a dead end the
+#: user walks into: scrolling a 600-line answer stops at source line 200 with
+#: a remainder that will not go down, and the surface looks broken. Sliding
+#: the window with the offset keeps the same bounded cost while every line
+#: stays reachable. The overflow marker is still computed from the true SOURCE
+#: line count, never from the wrapped rows, so the budget remains an
+#: optimisation the user cannot observe.
 PREVIEW_WRAP_BUDGET = 200
+#: Granularity the wrap window's start is snapped to. Half the budget, so
+#: every reachable offset has at least this many lines wrapped below it —
+#: more than any terminal draws — while the memo holds one entry per stride
+#: rather than one per scrolled line. See
+#: :meth:`CopyPickerScreen._wrap_window_start`.
+PREVIEW_WRAP_STRIDE = PREVIEW_WRAP_BUDGET // 2
+#: Content rows the preview keeps whatever the tree would like to have, plus
+#: its header row. The tree used to take ``available // 2`` unconditionally
+#: while the preview's cap-at-``len`` generosity only ever ran downward, so a
+#: 19-row tree at 100x30 hid ten rows while SEVEN preview rows sat empty under
+#: a one-line preview (design round 1, D1). Reserving the preview a floor and
+#: giving the tree the rest inverts that: five content rows is enough to judge
+#: "is this the block I meant" (the preview's whole job), and the tree gets
+#: every row it can actually fill.
+MIN_PREVIEW_ROWS = 6
+#: Cells the scroll gutter costs a tree row: the track column plus one cell of
+#: gap so the thumb does not touch the hint.
+GUTTER_THUMB_CELLS = 2
+#: Spare cells above :meth:`CopyPickerScreen._min_flat_width` before the gutter
+#: is drawn at all. The gutter widens the narrowest drawable row, so drawing it
+#: unconditionally would move the drawability threshold and newly HIDE the card
+#: on terminals that draw one today. It is shed instead, the discipline
+#: :meth:`CopyPickerScreen._footer_text` already applies to hints.
+GUTTER_SHED_HEADROOM = 4
 #: Footer hints, widest first, paired with the order they are SHED in. The
 #: footer is the only statement of how to leave, so a narrow card drops the
 #: movement hints rather than the whole row — `esc quit` is eight cells and
-#: fits terminals the full thirty-one-cell footer does not. This mirrors
+#: fits terminals the full forty-five-cell footer does not. This mirrors
 #: `session_picker._shed_to_width`, which drops hints in a fixed order for the
 #: same reason; hiding the card over a footer that merely needed shortening
 #: would blank a modal the user is looking at.
-FOOTER_HINTS = ("↑↓ move", "enter copy", "esc quit")
+#:
+#: `shift+↑↓ preview` sits at index 1 deliberately: `_footer_text` sheds from
+#: the FRONT, so the ladder is `↑↓ move` → `shift+↑↓ preview` → `enter copy`,
+#: which is the order these earn their cells. A user on a card narrow enough
+#: to shed has a smaller preview to scroll, and the arrows are the thing a
+#: list surface is assumed to have anyway.
+#:
+#: The MOUSE is deliberately absent. `↑↓/click move · enter/dblclick copy` is
+#: 46 cells spent on something a mouse user does not need to be told: the
+#: hover highlight and the hand pointer ARE the affordance and they
+#: demonstrate themselves the instant the pointer crosses a row. Neither
+#: `session_picker` nor `command_picker` advertises its click either. The
+#: scarce cells go to the preview scroll, which is genuinely undiscoverable
+#: (design round 1, D8; UX round 1, §3.3).
+#:
+#: `shift+↑↓`, not `⇧↑↓`: `settings_view` spells this modifier out in both of
+#: its footers (`shift+↑↓ reorder · d delete`), and one glyph style per app
+#: beats a shorter row. At 50 cells it still fits the 50-cell card a 60-column
+#: terminal draws.
+#: Named because it is the one hint that is CONDITIONAL — see `_footer_text`.
+PREVIEW_HINT = "shift+↑↓ preview"
+FOOTER_HINTS = ("↑↓ move", PREVIEW_HINT, "enter copy", "esc quit")
 #: Never shed: without it the card cannot say how to leave.
 FOOTER_ESSENTIAL = "esc quit"
 #: Rows the card cannot do without: title, rule, one tree row, rule, the
@@ -75,6 +129,13 @@ FOOTER_ESSENTIAL = "esc quit"
 #: than laying out rows the box cannot hold — `overflow: hidden` clips from
 #: the bottom, so a card one row too tall loses the footer specifically.
 MIN_CARD_INNER_ROWS = 7
+#: Shown INSTEAD of the card when the terminal cannot hold one. It names the
+#: command so the frame explains itself, and `esc` because that is the only
+#: thing the user can do from here — the same two facts the footer carries,
+#: in the cells that remain. Deliberately does not contain "Copy to
+#: clipboard": that string is what the pinned tests use to assert the card is
+#: absent, and a notice that tripped it would make the guard unable to fail.
+TOO_SMALL_NOTICE = "terminal too small for /copy · esc"
 
 
 class CopyPickerScreen(ModalScreen[CopyTarget | None]):
@@ -93,6 +154,16 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
     means depending on whether an overlay happened to be open. Both existing
     modals (`SessionPickerScreen`, `AnalyticsScreen`) dismiss on Esc alone, so
     Esc alone is also the consistent answer.
+
+    ``shift+↑↓`` scrolls the PREVIEW. It is the one shape that gives the
+    second pane a keyboard without giving this screen a focus model: `left`,
+    `right` and `tab` are all free, and all three plausible uses of them
+    ("move focus to the preview") would create a mode in which `up`/`down`
+    mean two different things depending on state nothing in the frame shows —
+    the user presses `down` and sees nothing move. `shift+↑↓` reads as "the
+    other pane's version of this key" and needs no mode. `j/k`, `space` and
+    `/` are deliberately not bound: this app is not modal-vim anywhere, and
+    there is no filter here to open.
     """
 
     BINDINGS = [
@@ -104,6 +175,13 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         Binding("pagedown", "page(1)", "Page down", show=False),
         Binding("home", "jump(0)", "First", show=False),
         Binding("end", "jump(1)", "Last", show=False),
+        # Keyboard parity for the preview wheel. Every mouse capability needs
+        # a key or the mouse becomes the only way to do something, which on a
+        # terminal UI is a regression rather than a feature.
+        Binding("shift+up", "scroll_preview(-1)", "Preview up", show=False),
+        Binding("shift+down", "scroll_preview(1)", "Preview down", show=False),
+        Binding("shift+pageup", "page_preview(-1)", "Preview page up", show=False),
+        Binding("shift+pagedown", "page_preview(1)", "Preview page down", show=False),
     ]
 
     def __init__(self, targets: list[CopyTarget]) -> None:
@@ -116,7 +194,25 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         # so pageDown moves by exactly what the user can see. Seeded with the
         # floor so a page key pressed before the first paint still moves.
         self._tree_rows = MIN_TREE_ROWS
+        # Rows the preview drew last paint, reused as its page step for the
+        # same reason `_tree_rows` is.
+        self._preview_rows = MIN_PREVIEW_ROWS
+        # First SOURCE line of the preview on screen. Source lines, not
+        # wrapped rows: everything the user is shown about the preview (the
+        # header total, the `… N more lines` remainder) is counted in source
+        # lines, and an offset in the other unit would make the remainder
+        # disagree with the header at every width — the exact defect
+        # `_preview_lines` documents.
+        self._preview_offset = 0
+        # Row index under the pointer, in `_flat` coordinates. Distinct from
+        # `_selected`: hover says "clickable", the cursor says "Enter takes
+        # this", and painting them identically would show two selected rows.
+        self._hovered: int | None = None
+        # Wrapped preview rows, keyed `(target.id, width)`. See
+        # `_wrap_preview` for why that key is total and why the cache exists.
+        self._wrap_cache: dict[tuple[str, int, int], tuple[list[Text], list[int]]] = {}
         self._body: Static
+        self._too_small: Static
 
     # -- state ---------------------------------------------------------------
     # `visible_rows`/`_card_text`, not `visible`/`_render`: both short names
@@ -199,8 +295,19 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         Hints come off the front (movement first, then Enter) because the last
         one standing has to be ``esc quit``: a card that cannot say how to
         leave is the defect the whole drawability check exists to prevent.
+
+        The preview hint is GATED on the preview actually overflowing, the same
+        rule the `↓ N more` cue follows. Advertising a scroll on a preview that
+        is entirely on screen sends the user to press a key that does nothing
+        visible, which reads as the key being broken rather than as the
+        document being short — and it spends cells a narrow card needs for the
+        hints that do apply.
         """
-        hints = list(FOOTER_HINTS)
+        hints = [
+            hint
+            for hint in FOOTER_HINTS
+            if hint != PREVIEW_HINT or self._preview_source_lines() > self._preview_rows
+        ]
         while len(hints) > 1 and cell_len(" · ".join(hints)) > width:
             hints.pop(0)
         return " · ".join(hints)
@@ -251,9 +358,30 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         ``tree_rows`` is capped at the number of rows that EXIST, so a two-node
         tree takes two rows and donates the remainder to the preview rather
         than sitting in a half-height pane padded with blanks.
+
+        The other cap is :data:`MIN_PREVIEW_ROWS`, and it replaced an
+        unconditional ``available // 2``. The half share only ever LOST rows to
+        the preview — the ``min(len)`` cap donates downward and nothing donated
+        back — so a tree longer than half the budget was starved while the
+        preview sat padded with blanks: measured at 100x30 mixed, ten of
+        nineteen tree rows hidden under SEVEN empty preview rows (design round
+        1, D1). Reserving the preview its floor and giving the tree the rest
+        recovers those rows in exactly the cases that were wasting them; five
+        of the seven measured shapes (mixed@80x24, mixed@100x14, short, code,
+        long) render byte-identically, because there the ``min(len)`` cap and
+        the ``max(1, …)`` floor still do all the work.
+
+        **The expression must not read the cursor or the selected target.**
+        Only ``len(self._flat)`` and ``available`` appear here, and both are
+        invariant while the screen is open. Sizing the preview from the
+        selected target's own line count would look tempting — it would fill
+        the pane exactly — and it would change the tree's height on every
+        arrow press, shifting rows sideways under a cursor the user is aiming
+        at. That is `session_picker.render_rows`' documented column defect
+        moved onto the time axis, where it is worse: motion draws the eye.
         """
         available = self._row_budget()
-        tree_rows = max(1, min(len(self._flat), available // 2))
+        tree_rows = max(1, min(len(self._flat), available - MIN_PREVIEW_ROWS))
         preview_rows = max(1, available - tree_rows)
         return tree_rows, preview_rows
 
@@ -275,11 +403,48 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         only choice that leaves one uniform rule on the page. `home`/`end` are
         the better answer to "take me to the other end" anyway.
         """
+        # The preview is a DIFFERENT DOCUMENT once the selection changes, so
+        # the offset resets on every cursor move — including one that lands
+        # where it already was, which costs nothing and removes a state where
+        # the reset depends on whether the clamp happened to move anything.
+        # Carrying an offset across targets would open the next preview
+        # part-way down a document the user never scrolled.
+        self._preview_offset = 0
         if not self._flat:
             self._selected = 0
             self._repaint()
             return
         self._selected = max(0, min(len(self._flat) - 1, index))
+        self._repaint()
+
+    def _preview_source_lines(self) -> int:
+        """Source lines in the selected target's preview.
+
+        The unit `_preview_offset` is measured in, and the unit the header
+        total and the `… N more lines` remainder are both counted in.
+        """
+        target = self.selected_target()
+        if target is None or not target.preview:
+            return 0
+        return len(target.preview.splitlines())
+
+    def _scroll_preview_to(self, offset: int) -> None:
+        """Move the preview, CLAMPED at both ends — never wrapped.
+
+        Clamped for the same reason `_move_to` is, and the ceiling is the LAST
+        SOURCE LINE rather than ``total - preview_rows``: the pane's row count
+        is in wrapped rows and the offset is in source lines, so subtracting
+        one from the other would over- or under-shoot by however much the
+        document wraps. Stopping at the last line means a fully scrolled
+        preview can show a single line above blank rows, which is the honest
+        frame — the remainder marker has vanished by then, so the blank space
+        reads as "that is the end" rather than as a rendering fault.
+        """
+        ceiling = max(0, self._preview_source_lines() - 1)
+        clamped = max(0, min(ceiling, offset))
+        if clamped == self._preview_offset:
+            return
+        self._preview_offset = clamped
         self._repaint()
 
     def action_move(self, delta: int) -> None:
@@ -291,8 +456,44 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
     def action_jump(self, to_end: int) -> None:
         self._move_to(len(self._flat) - 1 if to_end else 0)
 
+    def action_scroll_preview(self, delta: int) -> None:
+        self._scroll_preview_to(self._preview_offset + delta)
+
+    def action_page_preview(self, delta: int) -> None:
+        # By the preview's own drawn height, so a page moves by what the user
+        # can see — the same rule `action_page` follows for the tree.
+        self._scroll_preview_to(self._preview_offset + delta * max(1, self._preview_rows))
+
+    def _dismiss_result(self, result: CopyTarget | None) -> None:
+        """Dismiss once, releasing a hovered row's pointer shape first.
+
+        Two guards in three lines, both load-bearing.
+
+        ``is_active`` is the dismiss-race guard. Two dismissals with no event
+        loop turn between them — a fast double-click on a busy machine, or a
+        user hammering Enter — reach ``dismiss`` after the screen has already
+        popped, and Textual raises ``ScreenStackError: Can't pop screen``.
+        Reproduced on both paths before this existed: two queued ``Click``
+        messages crash, and so do two bare ``action_choose()`` calls and a
+        choose-then-cancel, which means the KEYBOARD path could crash the app
+        without a mouse anywhere near it. Guarding only the mouse handler
+        would have left that in place, so the guard lives here, where both
+        paths pass through. (``pilot.click(times=2)`` does NOT reproduce it —
+        it pauses between clicks — which is why the regression test posts the
+        messages itself.)
+
+        The pointer reset is the other half: the modal leaves without another
+        mouse move, so the inline-rule assignment has to restore OSC 22 while
+        this screen still owns the pointer. Without it a user who clicks to
+        copy is left with a hand cursor over their transcript.
+        """
+        if not self.is_active:
+            return
+        self.styles.pointer = "default"
+        self.dismiss(result)
+
     def action_cancel(self) -> None:
-        self.dismiss(None)
+        self._dismiss_result(None)
 
     def action_choose(self) -> None:
         """Copy the highlighted node.
@@ -312,19 +513,241 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         target = self.selected_target()
         if target is None or not target.content:
             return
-        self.dismiss(target)
+        self._dismiss_result(target)
 
     # -- rendering -----------------------------------------------------------
+    # -- mouse ---------------------------------------------------------------
+    # Handler names are PUBLIC (`on_click`, `on_mouse_move`, `on_leave`,
+    # `on_mouse_scroll_*`), per `command_picker`'s note: Textual's own `Widget`
+    # hover bookkeeping runs off these names, and a private one would take the
+    # events without letting it keep its state.
+    #
+    # Every handler stops its event. The wheel is measured NOT to bubble to the
+    # transcript today — the modal already absorbs it — so this fixes nothing
+    # observable; it is what keeps a future change to the transcript's own
+    # scrolling from re-opening the one-gesture-two-surfaces defect, which is
+    # why both sibling pickers do it too.
+
+    def _wheel_step(self) -> int:
+        """Rows per wheel notch, read LIVE from the app.
+
+        Not a hardcoded 1, though both sibling pickers step by one: it is a
+        per-instance attribute set in `App.__init__` (measured at 2.0 here), so
+        a constant silently desynchronises the moment anything changes it and
+        one gesture then travels at two speeds depending on where the pointer
+        sat. `settings_view` records the same reasoning and the measurement
+        behind it.
+        """
+        try:
+            return max(1, int(self.app.scroll_sensitivity_y))
+        except Exception:
+            return 1
+
+    def _wheel(self, event, direction: int) -> None:  # type: ignore[no-untyped-def]
+        """Route a notch by WHERE THE POINTER IS, not by which widget saw it.
+
+        The card is one `Static`, so the event's widget is identical over both
+        panes and cannot discriminate them — the pointer's row against the
+        card's own layout is the only thing that can. Over the tree the notch
+        moves the cursor through `_move_to`, the single movement path every
+        other gesture and key already uses; over the preview it moves the
+        preview and leaves the cursor alone, because a wheel over text you are
+        reading must not change what is selected under you.
+
+        The row comes off the EVENT rather than off the last remembered
+        pointer position: a wheel can arrive without a preceding mouse move
+        (the pointer is already resting where the user wants to scroll), and
+        routing on stale state would send the first notch to the wrong pane.
+        """
+        row = self._pointer_row_of(event)
+        if row is not None and row >= self._preview_top_row:
+            self._scroll_preview_to(self._preview_offset + direction * self._wheel_step())
+            return
+        # Anywhere else on the card — including the chrome and the backdrop —
+        # moves the cursor. That is the generous reading and it is safe:
+        # movement is clamped, reversible and visible, unlike the click, which
+        # is why only the click carries `_index_at`'s three guards.
+        self.action_move(direction * self._wheel_step())
+
+    def on_mouse_scroll_down(self, event) -> None:  # type: ignore[no-untyped-def]
+        event.stop()
+        self._wheel(event, 1)
+
+    def on_mouse_scroll_up(self, event) -> None:  # type: ignore[no-untyped-def]
+        event.stop()
+        self._wheel(event, -1)
+
+    def on_click(self, event) -> None:  # type: ignore[no-untyped-def]
+        """Click selects and previews; DOUBLE-click copies and dismisses.
+
+        **A deliberate divergence from `session_picker`, where a single click
+        acts immediately.** That shape is right there because its list has no
+        preview — the row text is all the information that exists, so a click
+        cannot rob the user of anything. Here the preview pane is the picker's
+        entire reason to exist: it is how you confirm you have the right block
+        before overwriting your clipboard. A click that copied would remove
+        the confirmation step FROM THE MOUSE PATH ONLY, handing the mouse user
+        a less careful version of the feature than the keyboard user gets —
+        backwards, since the mouse was invited in to make this easier.
+
+        The two mistakes also differ in how they fail. Resuming the wrong
+        session is loud and recoverable: you see the wrong conversation.
+        Copying the wrong thing is SILENT — the clipboard is overwritten, the
+        modal is gone, and the user finds out at the paste site with the prior
+        contents already destroyed.
+
+        "Click the already-selected row copies" was considered and rejected:
+        it makes one physical gesture mean two different things depending on
+        invisible prior state.
+
+        Button 1 only, and the button is tested BEFORE any state changes: a
+        right-click asking for a context menu is measured to arrive here, and
+        it must not move the cursor on its way to being ignored.
+        """
+        if getattr(event, "button", 1) != 1:
+            return
+        index = self._index_at(event)
+        if index is None:
+            return
+        event.stop()
+        if index != self._selected:
+            self._move_to(index)
+        # `Click.chain` is Textual's own double-click count (0.5 s threshold),
+        # so the contract needs no timing invented here.
+        if getattr(event, "chain", 1) >= 2:
+            self.action_choose()
+
+    def on_mouse_move(self, event) -> None:  # type: ignore[no-untyped-def]
+        index = self._index_at(event)
+        if index != self._hovered:
+            self._hovered = index
+            # Tree rows only: `_tree_lines` is 0.07 ms against the preview's
+            # 31 ms, and a hover changes nothing the preview draws. Repainting
+            # the whole card per row the pointer crosses is what made a mouse
+            # sweep cost 365 ms of loop CPU.
+            self._repaint()
+        # A hand over a tree row, the default shape everywhere else INCLUDING
+        # the preview: the preview is scrollable, not clickable, and a hand
+        # there would promise a click it does not keep. The inline-rule
+        # assignment drives `Screen.update_pointer_shape()` through the
+        # property's own observer and no-ops when the shape did not change.
+        self.styles.pointer = "pointer" if index is not None else "default"
+
+    def on_leave(self, event) -> None:  # type: ignore[no-untyped-def]
+        if self._hovered is not None:
+            self._hovered = None
+            self._repaint()
+        self.styles.pointer = "default"
+
+    def _index_at(self, event) -> int | None:  # type: ignore[no-untyped-def]
+        """Tree row under a mouse event, or ``None`` anywhere else.
+
+        Measured against the BODY's region rather than the event's own widget:
+        the card is one ``Static``, so an event anywhere in it reports a ``y``
+        relative to the whole block — title, rules, preview and footer
+        included.
+
+        Three guards, all load-bearing, and all three are `session_picker`'s.
+        Its docstring records that its first cut without them resolved a click
+        on the footer to session #12 and the dimmed backdrop to row 0, and
+        BOTH of those coordinates were re-measured as still delivered here —
+        so these are mandatory rather than defensive:
+
+        - the point must be inside the body's region (the modal's backdrop
+          covers the whole screen and bubbles events from well outside the
+          card, including the columns to its left where ``y`` alone still
+          looks valid);
+        - the row must be inside the DRAWN page, not merely inside ``_flat`` —
+          a short tree caps the pane at the rows that exist, and the blank
+          remainder below them would otherwise resolve to real targets;
+        - and the resulting index must still be a row that exists.
+
+        Title, rules, preview, footer, card padding and backdrop are therefore
+        all inert. The backdrop deliberately does NOT dismiss: the app's other
+        two modals have no mouse handling at all, so backdrop-dismissal would
+        exist on exactly one of three and a user who learned it here would get
+        stuck on `/resume`. If the app wants it, it lands on all three.
+        """
+        row = self._pointer_row_of(event)
+        if row is None:
+            return None
+        tree_rows, _ = self._split_rows()
+        offset = row - HEADER_ROWS
+        start = self._window_start(tree_rows)
+        drawn = min(tree_rows, max(0, len(self._flat) - start))
+        if not 0 <= offset < drawn:
+            return None
+        index = start + offset
+        return index if 0 <= index < len(self._flat) else None
+
+    def _pointer_row_of(self, event) -> int | None:  # type: ignore[no-untyped-def]
+        """Row of the CARD under the event, or ``None`` outside the card.
+
+        Kept separate from `_index_at` because the wheel and the click ask
+        different questions of the same coordinate: the wheel needs to know
+        which PANE the pointer is over (including its chrome), the click needs
+        an exact tree row.
+        """
+        body = getattr(self, "_body", None)
+        if body is None or not body.is_mounted:
+            return None
+        region = body.region
+        if not region.contains(event.screen_x, event.screen_y):
+            return None
+        return event.screen_y - region.y
+
+    @property
+    def _preview_top_row(self) -> int:
+        """First card row belonging to the preview pane, its header included.
+
+        Derived from the same split the paint uses, so the routing boundary
+        cannot drift from the drawn one.
+        """
+        tree_rows, _ = self._split_rows()
+        # title + rule + tree + rule
+        return HEADER_ROWS + tree_rows + 1
+
     def compose(self) -> ComposeResult:
         with Container(classes="copy-picker"):
             self._body = Static(self._card_text(), id="copy-picker-body")
             yield self._body
+        # A SIBLING of the card, not a row inside it, and that placement is
+        # the whole trick. The card's contract is two-sided and pinned — either
+        # its footer is on screen or it drew nothing — so the notice must not
+        # be able to satisfy "the card drew something". Outside the card it
+        # cannot: `render_lines_for_test` reads the card body and still
+        # reports `[]`, `is_drawable` is untouched, and "Copy to clipboard"
+        # stays out of a frame too small to hold the card.
+        #
+        # It exists because the hidden card is correct and unexplained. From
+        # the user's chair, `/copy` on a small terminal is "I typed a command
+        # and my screen went dim and blank": the dimmed backdrop is the only
+        # sign anything happened, and nothing says why or what to do. One dim
+        # line fits widths the card does not (8 cells of `esc` against a
+        # 32-cell narrowest row), so the degraded frame becomes legible
+        # without laying out a single row the box cannot hold.
+        self._too_small = Static(TOO_SMALL_NOTICE, id="copy-picker-too-small")
+        yield self._too_small
 
     def on_mount(self) -> None:
         self._repaint()
 
     def on_resize(self, event) -> None:  # type: ignore[no-untyped-def]
-        """Re-measure: the row split and every column come from the screen."""
+        """Re-measure: the row split and every column come from the screen.
+
+        The wrap cache and the preview offset join that re-derivation because
+        both are width-dependent. The cache is keyed on width so a stale entry
+        cannot be *read*, but the old-width entries would sit there for the
+        life of the screen; dropping them keeps the cache the size of one
+        layout. The offset is clamped rather than kept, because a narrower
+        card wraps the same source into more rows and a preview scrolled to a
+        position the document no longer has would paint blank.
+        """
+        self._wrap_cache.clear()
+        # Before `_move_to`, which resets the offset to 0 anyway — the clamp
+        # is here so the invariant holds even if that reset is ever narrowed
+        # to "only when the index actually changed".
+        self._scroll_preview_to(self._preview_offset)
         self._move_to(self._selected)
 
     def _repaint(self) -> None:
@@ -343,6 +766,9 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         card = body.parent
         if card is not None:
             card.display = drawable
+        notice = getattr(self, "_too_small", None)
+        if notice is not None and notice.is_mounted:
+            notice.display = not drawable
 
     def render_lines_for_test(self) -> list[str]:
         """The card as plain strings — what a user reads.
@@ -387,23 +813,39 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         width = self._card_width()
         tree_rows, preview_rows = self._split_rows()
         # Remembered for the page step, which must move by what the user can
-        # actually see rather than by an uncapped half-height.
+        # actually see rather than by an uncapped half-height. The preview's
+        # height is remembered for the same reason, by `shift+pageup/down`.
         self._tree_rows = tree_rows
+        self._preview_rows = max(1, preview_rows - 1)
+
+        rule = Style(color=theme_mod.semantic_color("edge"))
+        start = self._window_start(tree_rows)
+        above = start
+        below = max(0, len(self._flat) - start - tree_rows)
 
         out = Text(no_wrap=True, overflow="ellipsis")
         out.append("Copy to clipboard", style=label_style)
         out.append("\n")
-        out.append("─" * width, style=Style(color=theme_mod.semantic_color("edge")))
+        # The two cues ride the rules that already exist, so a tree that
+        # overflows costs no row to say so — which matters because the row
+        # budget is exactly what the split above is fighting to recover, and
+        # at 80x24 the tree is six rows, two of which would have been signage.
+        self._append_rule(out, width, rule, f"↑ {above}" if above else "")
         out.append("\n")
 
-        rule = Style(color=theme_mod.semantic_color("edge"))
         for line in self._tree_lines(width, tree_rows):
             out.append_text(line)
             out.append("\n")
 
         # A rule, not a blank row: without it the preview's header sat directly
         # under the last tree row and read as one more row of the tree.
-        out.append("─" * width, style=rule)
+        #
+        # BOTH directions are cued, unlike `todo_panel`'s single remainder,
+        # because `_window_start` centres the cursor: this list is very often
+        # clipped at both ends at once, and a down-only cue would then be
+        # actively misleading — it would say the list continues below while
+        # silently hiding the rows above.
+        self._append_rule(out, width, rule, f"↓ {below} more" if below else "")
         out.append("\n")
 
         target = self.selected_target()
@@ -416,12 +858,78 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         out.append(self._footer_text(width), style=dim)
         return out
 
+    def _append_rule(self, out: Text, width: int, rule: Style, cue: str) -> None:
+        """A full-width rule, with ``cue`` right-aligned into its last cells.
+
+        The cue's SLOT is sized on the widest value the cue can ever take, not
+        on the value it has now. Sizing it on the current text makes the rule
+        change length as the digit count does, so a user who is only scrolling
+        watches the divider twitch under them for no reason they can see —
+        `todo_panel`'s U1, worth not re-learning. Reserving the slot costs
+        nothing: what is not cue is rule, and the rule is the same glyph
+        either way.
+        """
+        if not cue:
+            out.append("─" * width, style=rule)
+            return
+        # Widest rendering: every row hidden in that direction, in the longer
+        # of the two cue shapes.
+        slot = cell_len(f"↓ {max(1, len(self._flat))} more")
+        keep = max(0, width - slot - 1)
+        out.append("─" * keep, style=rule)
+        pad = max(0, width - keep - cell_len(cue))
+        out.append("─" * pad, style=rule)
+        out.append(cue, style=Style(color=theme_mod.semantic_color("dim")))
+
+    def _gutter_drawn(self, width: int, rows: int | None = None) -> bool:
+        """Whether the scroll gutter is drawn at this width and tree height.
+
+        Two gates, for two different reasons.
+
+        It is drawn only when the tree ACTUALLY OVERFLOWS, the same rule the
+        `↑ N`/`↓ N more` cues follow: a track with no thumb on a list that
+        cannot scroll is a scrollbar for a document that fits, and it makes
+        the cue's absence stop meaning "this is everything".
+
+        And it is a SHED, not an optional decoration. The gutter costs
+        :data:`GUTTER_THUMB_CELLS` off every tree row, which raises the
+        narrowest row the card can lay out — so drawing it unconditionally
+        would push :meth:`is_drawable`'s width limb up and newly HIDE the card
+        on terminals that draw one today. Dropping the gutter instead is the
+        same discipline :meth:`_footer_text` applies to hints: a card that
+        merely needed narrowing must not be blanked.
+        """
+        if rows is None:
+            rows = self._tree_rows
+        if len(self._flat) <= rows:
+            return False
+        return width - self._min_flat_width() >= GUTTER_SHED_HEADROOM
+
     def _tree_lines(self, width: int, rows: int) -> list[Text]:
-        """The windowed tree: cursor, ancestor gutter, connector, label, hint."""
+        """The windowed tree: cursor, ancestor gutter, connector, label, hint.
+
+        Each row is painted on a GROUND spanning the full card width, in
+        `session_picker.render_rows`' exact three-way shape — selected,
+        hovered, or neither — rather than a fourth state invented here. A bare
+        caret is adequate for a keyboard user and inadequate the moment the
+        mouse arrives: hover has to say a row is live BEFORE the click, and a
+        caret gives it nothing to lift. Hover and selection share
+        ``tint-select`` and **the caret discriminates them**, which is this
+        app's established convention: if hover painted like selection the user
+        would see two selected rows and could not tell which one Enter takes.
+        """
         accent = Style(color=theme_mod.semantic_color("accent"))
         dim = Style(color=theme_mod.semantic_color("dim"))
         fg = Style(color=theme_mod.semantic_color("fg"))
+        # The caret is MUTED, not accent: once the ground says "selected", the
+        # mark only has to point. Two signals competing for the same fact is
+        # what `command_picker`'s D17 and `session_picker`'s D5 both record.
+        muted = Style(color=theme_mod.semantic_color("muted"))
+        warning = Style(color=theme_mod.semantic_color("warning"))
         start = self._window_start(rows)
+        gutter = self._gutter_drawn(width, rows)
+        row_width = width - GUTTER_THUMB_CELLS if gutter else width
+        thumb = self._thumb_span(rows, start) if gutter else range(0)
 
         lines: list[Text] = []
         for offset in range(rows):
@@ -432,6 +940,14 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
                 continue
             node = self._flat[index]
             selected = index == self._selected
+            hovered = index == self._hovered
+            if selected:
+                ground = theme_mod.semantic_color("tint-select-hi" if hovered else "tint-select")
+            elif hovered:
+                ground = theme_mod.semantic_color("tint-select")
+            else:
+                ground = theme_mod.semantic_color("overlay")
+            row_bg = Style(bgcolor=ground)
 
             prefix = ""
             for level in range(max(0, node.depth - 1)):
@@ -448,24 +964,95 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
             # a narrow terminal must not lose. Two cells of gap minimum.
             hint_cells = cell_len(hint) + 2 if hint else 0
             used = CURSOR_CELLS + cell_len(prefix)
-            label = truncate_cells(node.target.label, max(1, width - used - hint_cells))
+            label = truncate_cells(node.target.label, max(1, row_width - used - hint_cells))
 
-            line.append("❯ " if selected else "  ", style=accent if selected else fg)
-            line.append(prefix, style=dim)
-            line.append(label, style=accent + Style(bold=True) if selected else fg)
+            line.append("❯ " if selected else "  ", style=row_bg + (muted if selected else fg))
+            line.append(prefix, style=row_bg + dim)
+            # An aggregate row is DERIVED — it copies a join of rows listed
+            # above it rather than something that exists in the message — and
+            # one ramp step down is the quietest way to say so without adding
+            # a glyph (design round 1, D4).
+            if selected:
+                label_ink = accent + Style(bold=True)
+            elif node.target.derived:
+                label_ink = muted
+            else:
+                label_ink = fg
+            line.append(label, style=row_bg + label_ink)
             if hint:
-                gap = max(1, width - used - cell_len(label) - cell_len(hint))
-                line.append(" " * gap)
-                line.append(hint, style=dim)
+                gap = max(1, row_width - used - cell_len(label) - cell_len(hint))
+                line.append(" " * gap, style=row_bg)
+                self._append_hint(line, hint, row_bg, dim, warning)
+            # The ground spans the FULL card width. A highlight that stops at
+            # the text is ragged, and on a mouse surface it also lies about
+            # where the row's click target ends.
+            painted = cell_len(line.plain)
+            if painted < row_width:
+                line.append(" " * (row_width - painted), style=row_bg)
+            if gutter:
+                self._append_gutter(line, offset in thumb, row_bg)
             lines.append(line)
         return lines
 
-    def _preview_lines(self, width: int, target: CopyTarget | None, rows: int) -> list[Text]:
-        """The highlighted node's text, wrapped — never hard-truncated.
+    @staticmethod
+    def _append_hint(line: Text, hint: str, row_bg: Style, dim: Style, warning: Style) -> None:
+        """The hint, with `truncated` lifted out of the count ink.
 
-        Overflow is reported as `… N more lines` on the last row, which COSTS
-        a row: showing one more line and hiding the fact that more exist is
-        the failure this marker prevents.
+        `truncated` is a caveat about the payload — the app raises a `warning`
+        notice about it after the copy — and the whole hint was `dim`, which
+        styled it as though it were one more statistic in a column full of
+        statistics. The counts stay `dim`; only the caveat moves. `_message_hint`
+        puts `truncated` first for its own reason, which is what makes it
+        separable with a prefix test rather than a parse.
+        """
+        marker = "truncated"
+        if hint.startswith(marker):
+            line.append(marker, style=row_bg + warning)
+            line.append(hint[len(marker) :], style=row_bg + dim)
+            return
+        line.append(hint, style=row_bg + dim)
+
+    def _thumb_span(self, rows: int, start: int) -> range:
+        """Rows of the drawn page the scroll thumb covers.
+
+        Proportional: the thumb is as much of the track as the page is of the
+        list, floored at one row so a very long tree still shows a mark. The
+        thumb is the only CONTINUOUS signal on this surface — the `↓ N more`
+        cue says how much is left, the thumb says WHERE you are and moves as
+        you go — which is why both exist and neither replaces the other.
+        """
+        total = len(self._flat)
+        if total <= rows:
+            return range(0)
+        span = max(1, round(rows * rows / total))
+        # Anchored on the window rather than the cursor, since the window is
+        # what the track represents. Clamped so a thumb at the end of the list
+        # cannot be drawn past the bottom of the track.
+        top = min(rows - span, round(start * rows / total))
+        return range(max(0, top), max(0, top) + span)
+
+    @staticmethod
+    def _append_gutter(line: Text, on_thumb: bool, row_bg: Style) -> None:
+        """One cell of gap, then the track cell for this row."""
+        track_ink = theme_mod.semantic_color("dim" if on_thumb else "edge-hi")
+        line.append(" ", style=row_bg)
+        line.append("█" if on_thumb else "│", style=row_bg + Style(color=track_ink))
+
+    def _preview_lines(self, width: int, target: CopyTarget | None, rows: int) -> list[Text]:
+        """The highlighted node's text from ``_preview_offset``, wrapped.
+
+        Never hard-truncated. What is BELOW the pane is reported as
+        `… N more lines` on the last row, which COSTS a row: showing one more
+        line and hiding the fact that more exist is the failure this marker
+        prevents. What is ABOVE it is reported in the header, which already
+        carries the total and so costs no row at all.
+
+        Both cues are LIVE — they are recomputed from the offset every paint
+        and they VANISH at their ends, so the absence of the marker means
+        "this is the end of the document" and the absence of the header's
+        position means "you are at the top". That is `todo_panel`'s rule, and
+        it is what makes a remainder self-checking without ordinals: scroll,
+        and the number goes down.
         """
         dim = Style(color=theme_mod.semantic_color("dim"))
         muted = Style(color=theme_mod.semantic_color("muted"))
@@ -481,42 +1068,101 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
                 lines.append(Text())
             return lines
 
-        wrapped, rows_per_source = self._wrap_preview(target, max(1, width - 2))
         source_total = len(target.preview.split("\n"))
-        has_more = len(wrapped) > content_rows or len(rows_per_source) < source_total
-        shown = content_rows - 1 if has_more else min(len(wrapped), content_rows)
+        # Clamped HERE as well as in `_scroll_preview_to` because the pane's
+        # height is a paint-time fact: a resize that shrinks the document's
+        # room reaches paint before any gesture can re-clamp.
+        offset = max(0, min(self._preview_offset, max(0, source_total - 1)))
+        window_start = self._wrap_window_start(offset)
+        wrapped, rows_per_source = self._wrap_preview(target, max(1, width - 2), window_start)
 
-        # Counted in SOURCE lines, not wrapped rows. The header beside it
-        # reports the source line count, so a marker counting rows contradicted
-        # it in the same pane — at 100 cols a 79-line answer claimed "144 more
-        # lines", more than the document has. It also saturated: the wrap
-        # budget capped the rows, so a 600-line and a 1000-line answer both
-        # reported the same 183. Both numbers now measure the same thing, and
-        # the budget stays an optimisation the user cannot observe.
-        consumed = 0
-        source_shown = 0
-        for count in rows_per_source:
-            if consumed + count > shown:
-                break
-            consumed += count
-            source_shown += 1
-        remaining = max(0, source_total - source_shown)
+        # Rows are dropped, not re-wrapped, to reach the offset: the wrap
+        # window starts at a stride boundary, so the offset is usually some
+        # lines into it. `rows_per_source` is the map from source lines to the
+        # rows they produced, which is exactly what converts one unit to the
+        # other.
+        skipped_rows = sum(rows_per_source[: offset - window_start])
+        visible = wrapped[skipped_rows:]
+        # Source lines still wrapped below the window (the map covers at most
+        # PREVIEW_WRAP_BUDGET of them), plus the ones the window never reached.
+        mapped_from_offset = rows_per_source[offset - window_start :]
+
+        below_window = source_total - (window_start + len(rows_per_source))
+        has_more = len(visible) > content_rows or below_window > 0
+        shown = content_rows - 1 if has_more else min(len(visible), content_rows)
+
+        def _remaining_below(shown_rows: int) -> int:
+            """Source lines below the pane when ``shown_rows`` rows are drawn.
+
+            Counted in SOURCE lines, not wrapped rows. The header beside it
+            reports the source line count, so a marker counting rows
+            contradicted it in the same pane — at 100 cols a 79-line answer
+            claimed "144 more lines", more than the document has. It also
+            saturated: the wrap budget capped the rows, so a 600-line and a
+            1000-line answer both reported the same 183. An OFFSET-AWARE
+            marker can re-introduce that defect in one line, which is why the
+            conversion runs through ``rows_per_source`` — the row-to-line map —
+            rather than subtracting row counts from a row total.
+            """
+            consumed = 0
+            source_shown = 0
+            for count in mapped_from_offset:
+                if consumed + count > shown_rows:
+                    break
+                consumed += count
+                source_shown += 1
+            return max(0, source_total - offset - source_shown)
+
+        # Reserving the marker's row is only right if the marker has something
+        # to say. A pane whose last drawn row completes the document leaves
+        # `remaining` at 0, and spending a row on a marker that will not be
+        # painted would hide a line for nothing — the inverse of the defect
+        # the marker exists to prevent.
+        if has_more and _remaining_below(shown) == 0:
+            has_more = False
+            shown = min(len(visible), content_rows)
+
+        remaining = _remaining_below(shown)
+
+        # The header says where the pane sits once it is not at the top. It is
+        # the symmetric cue to the foot marker: without it a scrolled preview
+        # looks like a document that simply starts at "line 40", and the user
+        # has no way to tell there is anything above. Free — the header row
+        # already exists and carries only the total.
+        if offset > 0:
+            header.append(f" · from line {offset + 1}", style=dim)
 
         for row in range(content_rows):
             if row < shown:
-                line = wrapped[row]
+                line = visible[row]
                 # Highlighted code keeps its own colours; prose is muted so the
                 # tree above stays the brighter surface.
                 lines.append(line if target.language else Text(line.plain, style=muted))
-            elif row == shown and has_more:
+            elif row == shown and has_more and remaining > 0:
                 plural = "line" if remaining == 1 else "lines"
                 lines.append(Text(f"… {remaining} more {plural}", style=dim))
             else:
                 lines.append(Text())
         return lines
 
-    def _wrap_preview(self, target: CopyTarget, width: int) -> tuple[list[Text], list[int]]:
-        """``(wrapped rows, rows each source line produced)``.
+    def _wrap_window_start(self, offset: int) -> int:
+        """First source line of the wrap window holding ``offset``.
+
+        Snapped to :data:`PREVIEW_WRAP_STRIDE` rather than taken as the offset
+        itself, purely to bound the cache: keying on the raw offset would give
+        a 20,000-line answer 20,000 entries, each holding up to
+        :data:`PREVIEW_WRAP_BUDGET` rows, as the user scrolls it. Snapping caps
+        it at ``ceil(lines / STRIDE)`` per target per width, and because the
+        stride is half the budget, every offset in the window still has at
+        least a stride's worth of lines wrapped BELOW it — far more than any
+        terminal can draw at once, so the snapping is invisible.
+        """
+        return (max(0, offset) // PREVIEW_WRAP_STRIDE) * PREVIEW_WRAP_STRIDE
+
+    def _wrap_preview(
+        self, target: CopyTarget, width: int, window_start: int = 0
+    ) -> tuple[list[Text], list[int]]:
+        """``(wrapped rows, rows each source line produced)`` from ``window_start``.
 
         The second list is what lets the overflow marker be quoted in SOURCE
         lines: it maps a row cutoff back to the line the user would count. It
@@ -525,18 +1171,35 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         widths 20-100 for prose, long words, unicode and highlighted code
         before this was relied on.
 
-        Only the first :data:`PREVIEW_WRAP_BUDGET` source lines are wrapped: a
-        long answer would otherwise fold thousands of rows to display about
-        fifteen. The caller compares the budgeted map against the true source
+        :data:`PREVIEW_WRAP_BUDGET` source lines are wrapped, starting at
+        ``window_start`` — a WINDOW, not a prefix; see the constant for why
+        that distinction became user-visible the moment the preview could
+        scroll. The caller compares the windowed map against the true source
         length, so budgeting changes how much is WRAPPED and never the number
         the user is shown.
 
-        No per-target cache. The reference caches because it re-renders on
-        every frame; Textual repaints on state change, so a cache here would
-        buy nothing measurable and could serve a stale preview.
+        **Memoised on ``(target.id, width, window_start)``**, which supersedes
+        this method's former "no per-target cache" note. That note's objection
+        was staleness, and it does not survive the key: ``CopyTarget`` is
+        frozen, the tree is a snapshot taken when the screen was pushed and
+        cannot change while it is open, and width and window are the only
+        other inputs — so a hit is byte-identical to a recomputation by
+        construction. The cost of not caching is not theoretical either. Every
+        repaint re-wrapped the whole preview through ``rich.Syntax``: measured
+        at 31 ms against ``_tree_lines``' 0.07 ms, so one mouse sweep across
+        the tree spent 365 ms of loop CPU with the loop frozen throughout, and
+        the same sweep warm costs 2 ms. Hover made that trivial to hit without
+        meaning to press anything, which is what turned a pre-existing
+        inefficiency into a blocker for the mouse work. Cleared on resize,
+        where width changes wholesale.
         """
+        key = (target.id, width, window_start)
+        cached = self._wrap_cache.get(key)
+        if cached is not None:
+            return cached
+
         source = target.preview.expandtabs(4)
-        budgeted = source.split("\n")[:PREVIEW_WRAP_BUDGET]
+        budgeted = source.split("\n")[window_start : window_start + PREVIEW_WRAP_BUDGET]
         text = "\n".join(budgeted)
 
         console = Console(width=width, no_color=False)
@@ -569,4 +1232,5 @@ class CopyPickerScreen(ModalScreen[CopyTarget | None]):
         rows_per_source = [
             len(console.render_lines(Text(entry), options, pad=False)) for entry in budgeted
         ]
+        self._wrap_cache[key] = (lines, rows_per_source)
         return lines, rows_per_source

--- a/scripts/copy_shot.py
+++ b/scripts/copy_shot.py
@@ -5,6 +5,14 @@ Run from the worktree root:
     env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
         scripts/copy_shot.py OUT.svg [COLSxROWS] [SHAPE]
 
+``STATE`` (optional, after SHAPE) drives the picker before the frame is taken:
+
+    rest   (default)  as opened
+    hover             pointer over a row that is not the selected one
+    preview           the preview scrolled down, for its position cues
+    tree              the tree window clipped at BOTH ends, for `↑ N`/`↓ N more`
+    moved             one row past `tree`, to diff a frame against it
+
 ``SHAPE`` selects the tree the picker is opened over, because the layout maths
 differ by case and each one has its own way of looking wrong:
 
@@ -22,6 +30,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+from textual import events  # noqa: E402
+
 from scripts.visual_capture import isolate_capture, save_capture  # noqa: E402
 
 isolate_capture()
@@ -29,7 +39,10 @@ isolate_capture()
 from local_operator.tui.app import OperatorApp  # noqa: E402
 from local_operator.tui.copy_targets import build_copy_targets  # noqa: E402
 from local_operator.tui.widgets.assistant import AssistantBlock  # noqa: E402
-from local_operator.tui.widgets.copy_picker import CopyPickerScreen  # noqa: E402
+from local_operator.tui.widgets.copy_picker import (  # noqa: E402
+    HEADER_ROWS,
+    CopyPickerScreen,
+)
 from local_operator.tui.widgets.transcript import UserBlock  # noqa: E402
 from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
 
@@ -105,6 +118,47 @@ def _seed(app: OperatorApp, shape: str) -> None:
     app._append_block(cut)
 
 
+async def _drive(screen: CopyPickerScreen, state: str, pilot) -> None:
+    """Put the picker in ``state`` before the frame is taken.
+
+    Hover is posted as a `MouseMove` rather than driven through a pilot helper
+    because the card is ONE `Static`: the coordinate has to be computed against
+    the body's region and the screen's own row map, which is the same routing
+    the widget itself does.
+    """
+    if state == "hover":
+        # A row that is NOT the selected one, so the frame carries both states
+        # at once — the contrast is the thing under review.
+        region = screen._body.region
+        screen.post_message(
+            events.MouseMove(
+                widget=screen._body,
+                x=0,
+                y=0,
+                delta_x=0,
+                delta_y=0,
+                button=0,
+                shift=False,
+                meta=False,
+                ctrl=False,
+                screen_x=region.x + 6,
+                screen_y=region.y + HEADER_ROWS + 2,
+            )
+        )
+    elif state == "preview":
+        for _ in range(8):
+            await pilot.press("shift+down")
+    elif state in ("tree", "moved"):
+        # Far enough in that the window is clipped at BOTH ends, which is the
+        # case a down-only cue would misreport.
+        for _ in range(12):
+            await pilot.press("down")
+        if state == "moved":
+            await pilot.press("down")
+    await pilot.pause()
+    await pilot.pause()
+
+
 async def main() -> None:
     out = sys.argv[1]
     size = (100, 30)
@@ -112,6 +166,7 @@ async def main() -> None:
         cols, rows = sys.argv[2].split("x")
         size = (int(cols), int(rows))
     shape = sys.argv[3] if len(sys.argv) > 3 else "mixed"
+    state = sys.argv[4] if len(sys.argv) > 4 else "rest"
 
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=size) as pilot:
@@ -120,10 +175,26 @@ async def main() -> None:
         await pilot.pause()
 
         targets = build_copy_targets(app._transcript_view().blocks())
-        app.push_screen(CopyPickerScreen(targets))
+        screen = CopyPickerScreen(targets)
+        app.push_screen(screen)
         await pilot.pause()
         await pilot.pause()
+        await _drive(screen, state, pilot)
         save_capture(app, out)
+
+        # The numbers behind the pixels: a still shows the symptom, these show
+        # the cause. Two of them are this app's standing invariants — a
+        # scrollable Screen is always a bug here, and a scrollbar silently
+        # costs two cells of width and reflows the transcript behind.
+        print(
+            f"{Path(out).name}: size={tuple(app.screen.size)} "
+            f"virtual={tuple(app.screen.virtual_size)} "
+            f"vscroll={app.screen.show_vertical_scrollbar} "
+            f"drawable={screen.is_drawable} split={screen._split_rows()} "
+            f"card_w={screen._card_width()} min_flat={screen._min_flat_width()} "
+            f"gutter={screen._gutter_drawn(screen._card_width())} "
+            f"sel={screen._selected} preview_off={screen._preview_offset}"
+        )
 
 
 asyncio.run(main())

--- a/tests/unit/tui/test_copy_picker.py
+++ b/tests/unit/tui/test_copy_picker.py
@@ -24,6 +24,7 @@ from local_operator.tui.copy_targets import (
 from local_operator.tui.widgets.assistant import AssistantBlock
 from local_operator.tui.widgets.copy_picker import (
     CARD_PADDING_ROWS,
+    MIN_PREVIEW_ROWS,
     MIN_TREE_ROWS,
     CopyPickerScreen,
 )
@@ -80,15 +81,53 @@ async def test_a_short_tree_takes_only_the_rows_it_has() -> None:
 
 
 @pytest.mark.asyncio
-async def test_a_long_tree_splits_the_budget_in_half() -> None:
+async def test_a_long_tree_takes_every_row_the_preview_does_not_need() -> None:
+    """The tree used to take `available // 2` unconditionally, and this test
+    asserted that. The half share only ever LOST rows: the preview's
+    `min(len)` cap donates downward and nothing donated back, so a tree longer
+    than half the budget was starved while the preview sat padded with blanks
+    — measured at 100x30 mixed, ten of nineteen tree rows hidden under SEVEN
+    empty preview rows (design round 1, D1). Reserving the preview a floor and
+    giving the tree the rest is what recovers them.
+
+    Pinned both ways: the tree gets everything above the floor, AND the
+    preview keeps its floor rather than the tree taking the lot.
+    """
     app = _real_app()
     async with app.run_test(size=(100, 40)) as pilot:
         await pilot.pause()
         screen = await _open(app, _targets(*[f"answer {i}" for i in range(40)]), pilot)
         available = screen._row_budget()
         tree_rows, preview_rows = screen._split_rows()
-        assert tree_rows == available // 2
-        assert preview_rows == available - tree_rows
+        assert tree_rows == available - MIN_PREVIEW_ROWS
+        assert preview_rows == MIN_PREVIEW_ROWS
+        # The recovered rows are real: strictly more tree than the old split.
+        assert tree_rows > available // 2
+
+
+@pytest.mark.asyncio
+async def test_the_split_does_not_move_when_the_cursor_does() -> None:
+    """The hard constraint on D1's fix. Sizing the preview from the selected
+    target's own line count would fill the pane exactly and would change the
+    TREE's height on every arrow press, shifting rows sideways under a cursor
+    the user is aiming at — `session_picker.render_rows`' documented column
+    defect moved onto the time axis, where motion draws the eye.
+
+    So the split is built only from `len(_flat)` and the row budget, and the
+    test walks the cursor across targets whose previews differ by two orders
+    of magnitude.
+    """
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        long_answer = "\n".join(f"line {index}" for index in range(300))
+        screen = await _open(app, _targets("one line", long_answer, CODE_ANSWER), pilot)
+        splits = set()
+        for _ in range(len(screen.visible_rows)):
+            splits.add(screen._split_rows())
+            await pilot.press("down")
+            await pilot.pause()
+        assert len(splits) == 1, splits
 
 
 @pytest.mark.asyncio
@@ -205,13 +244,33 @@ async def test_esc_still_leaves_a_card_too_small_to_draw() -> None:
 
 @pytest.mark.asyncio
 async def test_the_footer_is_always_the_last_drawn_row() -> None:
-    """It is the only statement of how to leave the screen."""
+    """It is the only statement of how to leave the screen.
+
+    The preview hint is CONDITIONAL and both sides are asserted here. It is
+    advertised only when the preview actually overflows, on the same rule the
+    `… N more lines` remainder follows: pointing a user at a key that does
+    nothing visible reads as the key being broken rather than as the document
+    being short.
+    """
+    fits = "↑↓ move · enter copy · esc quit"
+    overflows = "↑↓ move · shift+↑↓ preview · enter copy · esc quit"
+    long_answer = "\n".join(f"line {index}" for index in range(200))
+    seen = set()
     for height in (14, 20, 30, 50):
-        app = _real_app()
-        async with app.run_test(size=(100, height)) as pilot:
-            await pilot.pause()
-            screen = await _open(app, _targets(CODE_ANSWER), pilot)
-            assert screen.render_lines_for_test()[-1] == "↑↓ move · enter copy · esc quit"
+        for body in (CODE_ANSWER, long_answer):
+            app = _real_app()
+            async with app.run_test(size=(100, height)) as pilot:
+                await pilot.pause()
+                screen = await _open(app, _targets(body), pilot)
+                # Whether the hint belongs is the pane's question, not the
+                # fixture's: a short answer overflows a 14-row card's preview
+                # too, and asserting otherwise would pin the fixture rather
+                # than the rule.
+                scrollable = screen._preview_source_lines() > screen._preview_rows
+                expected = overflows if scrollable else fits
+                assert screen.render_lines_for_test()[-1] == expected, (height, scrollable)
+                seen.add(scrollable)
+    assert seen == {True, False}, f"both sides of the gate must be exercised: {seen}"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_copy_picker.py
+++ b/tests/unit/tui/test_copy_picker.py
@@ -266,9 +266,19 @@ async def test_the_footer_is_always_the_last_drawn_row() -> None:
                 # fixture's: a short answer overflows a 14-row card's preview
                 # too, and asserting otherwise would pin the fixture rather
                 # than the rule.
-                scrollable = screen._preview_source_lines() > screen._preview_rows
+                #
+                # Read off the PAINTED FRAME — whether the pane drew a `… N
+                # more lines` marker — and not from the predicate under test.
+                # Round 1 (MAJOR-1) found this test deriving `expected` from
+                # the very expression the footer used, so it asserted the
+                # implementation against itself and passed for ANY predicate,
+                # including the one that was wrong. The marker is the user's
+                # evidence that the preview overflows, so it is the right
+                # thing for the footer to be checked against.
+                lines = screen.render_lines_for_test()
+                scrollable = any("more lines" in line for line in lines)
                 expected = overflows if scrollable else fits
-                assert screen.render_lines_for_test()[-1] == expected, (height, scrollable)
+                assert lines[-1] == expected, (height, scrollable, lines[-1])
                 seen.add(scrollable)
     assert seen == {True, False}, f"both sides of the gate must be exercised: {seen}"
 

--- a/tests/unit/tui/test_copy_picker_mouse.py
+++ b/tests/unit/tui/test_copy_picker_mouse.py
@@ -18,6 +18,7 @@ machine delivers and what used to crash the app.
 from __future__ import annotations
 
 import pytest
+from rich.cells import cell_len
 from textual import events
 from textual.binding import Binding
 
@@ -25,6 +26,7 @@ from local_operator.tui.copy_targets import CopyTarget, build_copy_targets
 from local_operator.tui.widgets.assistant import AssistantBlock
 from local_operator.tui.widgets.copy_picker import (
     HEADER_ROWS,
+    PREVIEW_HINT,
     PREVIEW_WRAP_BUDGET,
     TOO_SMALL_NOTICE,
     CopyPickerScreen,
@@ -207,6 +209,18 @@ async def test_the_wheel_over_the_preview_scrolls_it_and_leaves_the_cursor_alone
 
 @pytest.mark.asyncio
 async def test_the_preview_offset_clamps_at_both_ends() -> None:
+    """Clamped, never wrapped — and the DOWN ceiling is the offset whose pane
+    ends on the last source line, not the last source line itself.
+
+    This test previously asserted `== 39` on a 40-line document, i.e. the
+    document scrolled until only its final line remained above a pane of blank
+    rows. Review round 1 (MAJOR-2, and U5 independently) rejected that
+    ceiling: it pushed up to 33 rows of already-read text off the top of a
+    document the user was still reading, where `less` and this card's own tree
+    both stop with the last line at the bottom. The assertion is rewritten to
+    the corrected contract rather than relaxed — the last line must be ON
+    SCREEN at the ceiling, and nothing may remain below it.
+    """
     app = _real_app()
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
@@ -216,7 +230,13 @@ async def test_the_preview_offset_clamps_at_both_ends() -> None:
         for _ in range(200):
             screen.post_message(_wheel(screen, *_preview_row(screen), down=True))
         await pilot.pause()
-        assert screen._preview_offset == 39, "stops on the last source line"
+        ceiling = screen._preview_offset
+        assert (
+            0 < ceiling < 39
+        ), f"stops with the document's end at the foot, not past it: {ceiling}"
+        lines = screen.render_lines_for_test()
+        assert any("line 39" in line for line in lines), "the last line is on screen"
+        assert not any("more lines" in line for line in lines), "and nothing is below it"
 
         for _ in range(200):
             screen.post_message(_wheel(screen, *_preview_row(screen), down=False))
@@ -479,11 +499,26 @@ async def test_the_keyboard_path_cannot_crash_by_dismissing_twice() -> None:
 async def test_the_pointer_shape_is_released_before_the_screen_leaves() -> None:
     """The modal goes without another mouse move, so OSC 22 has to be restored
     while this screen still owns the pointer. Without it a user who clicks to
-    copy is left with a hand cursor over their transcript."""
+    copy is left with a hand cursor over their transcript.
+
+    Observed AT DISMISS TIME, in the dismiss callback, rather than after the
+    screen has left the stack. Round 1 (MINOR-1) showed the after-the-fact
+    assertion was vacuous: `styles.pointer` reads `"default"` once the screen
+    is off the stack whether or not the code resets it, so deleting the line
+    under test left all 127 tests green. The callback runs while the screen is
+    still the one that owns the pointer, which is the only moment at which the
+    reset is observable — and is exactly the moment the terminal is being told.
+    """
     app = _real_app()
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
-        screen = await _open(app, _targets("first", "second"), pilot)
+        at_dismiss: list[str] = []
+        screen = await _open(
+            app,
+            _targets("first", "second"),
+            pilot,
+            lambda _result: at_dismiss.append(str(screen.styles.pointer)),
+        )
         screen.post_message(_move(screen, *_tree_row(screen, 0)))
         await pilot.pause()
         assert screen.styles.pointer == "pointer"
@@ -491,7 +526,10 @@ async def test_the_pointer_shape_is_released_before_the_screen_leaves() -> None:
         screen.post_message(_click(screen, *_tree_row(screen, 0), chain=2))
         await pilot.pause()
         await pilot.pause()
-        assert screen.styles.pointer == "default"
+        assert at_dismiss == ["default"], (
+            "the hand cursor was still set as the screen left, so it would "
+            f"outlive the modal: {at_dismiss}"
+        )
 
 
 # --- preview scrolling -------------------------------------------------------
@@ -687,11 +725,17 @@ async def test_the_wrap_budget_is_a_window_and_not_a_dead_end() -> None:
         shown = sum(1 for line in lines if line.startswith("line "))
         assert int(marker.strip().split()[1]) == total - beyond - shown
 
-        # And the far end is reachable rather than floored at the budget.
+        # And the far end is reachable rather than floored at the budget. The
+        # ceiling is the offset whose pane ENDS on the last line (MAJOR-2/U5),
+        # so the property that matters is that the last line is drawn — not
+        # that the offset equals `total - 1`, which was the old ceiling that
+        # scrolled the document off its own pane.
         screen._scroll_preview_to(total)
         await pilot.pause()
-        assert screen._preview_offset == total - 1
-        assert any(f"line {total - 1}" in line for line in screen.render_lines_for_test())
+        assert screen._preview_offset > PREVIEW_WRAP_BUDGET, "far past the budget"
+        lines = screen.render_lines_for_test()
+        assert any(f"line {total - 1}" in line for line in lines)
+        assert not any("more lines" in line for line in lines), "nothing left below"
 
 
 # --- the scroll cues ---------------------------------------------------------
@@ -710,10 +754,13 @@ async def test_the_tree_cues_appear_only_in_the_direction_that_overflows() -> No
         screen = await _open(app, _targets(*[f"answer {i}" for i in range(30)]), pilot)
 
         def _cues() -> tuple[bool, bool]:
+            # Keyed on the ARROW, not on the word "more": both cues carry
+            # `more` since D12 made the up cue a remainder rather than the
+            # bare `↑ 6`, which reads as an ordinal.
             lines = screen.render_lines_for_test()
             return (
-                any("↑ " in line and "─" in line for line in lines),
-                any("more" in line and "─" in line for line in lines),
+                any("↑" in line and "─" in line for line in lines),
+                any("↓" in line and "─" in line for line in lines),
             )
 
         assert _cues() == (False, True), "at the top: only the down cue"
@@ -933,3 +980,450 @@ async def test_the_wrap_cache_serves_the_same_rows_it_would_have_computed() -> N
         fresh_rows, fresh_map = screen._wrap_preview(target, 88, 0)
         assert [row.plain for row in cached_rows] == [row.plain for row in fresh_rows]
         assert cached_map == fresh_map
+
+
+# --- review round 1 regressions ----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_double_click_copies_the_row_the_first_click_selected() -> None:
+    """The BLOCKER from round 1 (U1/Q1), and the one that put wrong bytes on a
+    real clipboard: aimed at `Quote 1`, received `Answer 10 body text.`
+
+    `_window_start` centres the cursor, so click 1 recentres the tree UNDER A
+    STATIONARY POINTER and click 2 resolves the same screen coordinate against
+    a different window. It covered ~41% of the pane on any overflowing tree —
+    the lower half, which is exactly where a user clicks after scanning a list
+    top to bottom.
+
+    Driven through Textual's own `pilot.click(times=2)` rather than posted
+    messages, because the pilot is what produces a real chained click, and
+    aimed BELOW `tree_rows / 2` on an overflowing tree: a version of this test
+    that clicks row 0 passes against the broken code.
+    """
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        bodies = [f"Answer {i} body text.\n\n> Quote of answer {i}." for i in range(16, 0, -1)]
+        chosen: list[CopyTarget | None] = []
+        screen = await _open(app, _targets(*bodies), pilot, chosen.append)
+
+        tree_rows, _ = screen._split_rows()
+        assert len(screen.visible_rows) > tree_rows, "the tree must overflow to recentre"
+        pane_row = tree_rows - 3
+        assert pane_row > tree_rows // 2, "aimed in the band that used to copy the wrong row"
+
+        start = screen._window_start(tree_rows)
+        aimed = screen.visible_rows[start + pane_row].target
+        x, y = _tree_row(screen, pane_row)
+
+        await pilot.click(offset=(x, y), times=2)
+        await pilot.pause()
+        await pilot.pause()
+
+        assert len(chosen) == 1
+        assert chosen[0] is not None
+        assert (
+            chosen[0].id == aimed.id
+        ), f"copied {chosen[0].label!r}, user aimed at {aimed.label!r}"
+
+
+@pytest.mark.asyncio
+async def test_a_wheel_off_the_card_does_nothing_at_all() -> None:
+    """Round 1, U3/Q2. `_pointer_row_of` returns `None` off the body and the
+    notch used to fall through to `action_move`, which reset the preview — so
+    a pointer ONE COLUMN outside the card moved the cursor and silently
+    discarded the reading position. At 100x30 that zone is three cells left of
+    the preview text being read, and trackpad drift of three cells is routine.
+
+    Off the card is now inert, exactly as it already was for the click.
+    """
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        body = "\n".join(f"line {index}" for index in range(200))
+        # Seeded LAST so the long answer is row 0 (most-recent-first), which is
+        # what makes a preview offset reachable at all.
+        screen = await _open(app, _targets("second answer", body), pilot)
+
+        screen._scroll_preview_to(60)
+        await pilot.pause()
+        assert screen._preview_offset == 60
+
+        region = screen._body.region
+        row = region.y + screen._preview_top_row + 1
+        outside = [
+            (region.x - 1, row),
+            (region.x + region.width, row),
+            (region.x + 4, region.y + region.height),
+        ]
+        for x, y in outside:
+            screen.post_message(_wheel(screen, x, y, down=True))
+            await pilot.pause()
+            assert screen._preview_offset == 60, f"the page was lost at {(x, y)}"
+            assert screen._selected == 0, f"the cursor moved at {(x, y)}"
+
+
+@pytest.mark.asyncio
+async def test_a_move_that_changes_nothing_keeps_the_reading_position() -> None:
+    """Round 1, U2 — the one KEYBOARD-ONLY regression against main. The offset
+    was reset BEFORE the clamp, so `up`/`home`/`pageup` at the top row (a total
+    visual no-op) threw away the reading position with no way back: 90
+    `shift+down` to recover. On a single long answer the tree is ONE row, so
+    every arrow press was such a no-op.
+
+    A move that DOES change the selection still resets, because the preview is
+    then a different document — that contract is unchanged and is pinned by
+    `test_the_preview_offset_resets_on_every_cursor_move`.
+    """
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        body = "\n".join(f"line {index}" for index in range(200))
+        screen = await _open(app, _targets(body), pilot)
+        assert len(screen.visible_rows) == 1, "the single-node case U2 bites hardest on"
+
+        screen._scroll_preview_to(60)
+        await pilot.pause()
+        assert screen._preview_offset == 60
+
+        for key in ("up", "home", "pageup", "down", "end", "pagedown"):
+            await pilot.press(key)
+            await pilot.pause()
+            assert screen._selected == 0, f"{key} moved the cursor on a one-row tree"
+            assert screen._preview_offset == 60, f"{key} moved nothing but lost the page"
+
+
+@pytest.mark.asyncio
+async def test_the_footer_advertises_the_scroll_whenever_the_pane_overflows() -> None:
+    """Round 1, MAJOR-1: the footer's gate and the pane's marker were computed
+    in DIFFERENT UNITS — source lines against wrapped rows. On ordinary prose
+    (one long source line per paragraph, the normal shape of an answer) the
+    pane overflowed with FEWER source lines than rows, so the frame drew
+    `… N more lines` while the footer — the only place `shift+↑↓` is ever
+    named — declined to say the preview scrolled, in one screenshot.
+
+    The fixture is deliberately one whose two units DISAGREE: 11 source lines
+    wrapping to 17 rows in a 16-row pane. A fixture of short lines passes
+    against the broken predicate.
+    """
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        prose = "\n\n".join(
+            "This is a long paragraph of ordinary assistant prose written as one "
+            "single source line, which therefore wraps across several rows of the "
+            f"preview pane when it is painted at the card's width. Paragraph {i}."
+            for i in range(6)
+        )
+        screen = await _open(app, _targets(prose), pilot)
+
+        assert screen._preview_source_lines() <= screen._preview_rows, (
+            "the fixture must have FEWER source lines than rows, or the old "
+            "source-line predicate would have been right by accident"
+        )
+        lines = screen.render_lines_for_test()
+        assert any("more lines" in line for line in lines), "the pane overflows"
+        assert (
+            PREVIEW_HINT in lines[-1]
+        ), f"the pane says it overflows and the footer disagrees: {lines[-1]!r}"
+
+
+@pytest.mark.asyncio
+async def test_a_preview_that_fits_does_not_scroll_at_all() -> None:
+    """Round 1, MAJOR-2/U5. The clamp ceilinged at `source_lines - 1`
+    regardless of whether the document already fitted, so a 3-line preview in a
+    16-row pane scrolled its own content off the top and left blank rows — the
+    "a scroll gesture that teleports reads as the list resetting itself"
+    failure AGENTS.md warns about. `less` stops with the last line at the
+    bottom; so does the tree's own `down`; so does this now.
+    """
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets("alpha\nbeta\ngamma"), pilot)
+        assert screen._preview_source_lines() < screen._preview_rows, "it fits"
+
+        before = screen.render_lines_for_test()
+        for _ in range(6):
+            await pilot.press("shift+down")
+        await pilot.pause()
+        for _ in range(6):
+            screen.post_message(_wheel(screen, *_preview_row(screen), down=True))
+        await pilot.pause()
+
+        assert screen._preview_offset == 0, "a document that fits has nowhere to go"
+        assert screen.render_lines_for_test() == before
+        assert PREVIEW_HINT not in before[-1], "and the footer does not advertise it"
+
+
+@pytest.mark.asyncio
+async def test_a_long_preview_stops_with_its_last_line_at_the_foot() -> None:
+    """The other end of the same clamp: scrolling a document that DOES overflow
+    still reaches its last line, and stops there rather than sliding the text
+    up into blank rows (round 1, U5 measured 33 rows of read text pushed off
+    screen at 200x50)."""
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        body = "\n".join(f"line {index}" for index in range(121))
+        screen = await _open(app, _targets(body), pilot)
+
+        for _ in range(300):
+            await pilot.press("shift+down")
+        await pilot.pause()
+
+        lines = screen.render_lines_for_test()
+        assert any("line 120" in line for line in lines), "the last line is on screen"
+        assert not any("more lines" in line for line in lines), "and nothing remains below"
+
+        # The pane must still be FULL. This is the assertion the finding turns
+        # on: the old ceiling reached the same last line but with fifteen of
+        # sixteen rows blank beneath it, having pushed everything already read
+        # off the top. `less` leaves the screen full; so does this.
+        top = screen._preview_top_row
+        pane = lines[top + 1 : top + 1 + screen._preview_rows]
+        blank = sum(1 for line in pane if not line.strip())
+        assert blank <= 1, (
+            f"{blank} of {len(pane)} preview rows are empty — the document was "
+            f"scrolled off its own pane"
+        )
+        assert sum(1 for line in pane if line.strip()) >= screen._preview_rows - 1
+
+
+@pytest.mark.asyncio
+async def test_the_hover_highlight_follows_the_window_under_a_resting_pointer() -> None:
+    """Round 1, U4/Q3. `on_mouse_move` was the only thing that updated
+    `_hovered`, but the wheel and the click move rows under a stationary
+    pointer and a real terminal sends NO `MouseMove` while only the wheel
+    turns — so the highlight was left on a row the pointer was not over, and
+    enough notches scrolled it off the pane entirely while the hand remained.
+
+    Cosmetic in isolation (the click resolves by coordinate, not by the
+    highlight), but the hover highlight is the ENTIRE affordance for the mouse
+    here by design, and a stale one confirmed the wrong aim in the exact frame
+    where U1 was still catchable.
+    """
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        bodies = [f"Answer {i} body text.\n\n> Quote of answer {i}." for i in range(16, 0, -1)]
+        screen = await _open(app, _targets(*bodies), pilot)
+
+        pane_row = 3
+        x, y = _tree_row(screen, pane_row)
+        screen.post_message(_move(screen, x, y))
+        await pilot.pause()
+
+        def _row_under_pointer() -> int:
+            tree_rows, _ = screen._split_rows()
+            return screen._window_start(tree_rows) + pane_row
+
+        assert screen._hovered == _row_under_pointer()
+
+        for notch in range(8):
+            screen.post_message(_wheel(screen, x, y, down=True))
+            await pilot.pause()
+            assert (
+                screen._hovered == _row_under_pointer()
+            ), f"after notch {notch + 1} the highlight is on a row the pointer is not over"
+
+        # And the same under a click that recentres the tree.
+        screen.post_message(_click(screen, x, y))
+        await pilot.pause()
+        assert screen._hovered == _row_under_pointer()
+
+
+@pytest.mark.asyncio
+async def test_the_thumb_reaches_the_bottom_exactly_when_the_cue_goes() -> None:
+    """Round 1, D11. `_thumb_span` anchored on the window's fraction of the
+    LIST and then clamped, so the clamp won one window position early: the
+    thumb sat at the bottom of the track while the rule still read `↓ 1 more`,
+    two distinct positions painted an identical gutter, and the user's final
+    arrow press moved the one CONTINUOUS signal not at all.
+
+    The invariant asserted here is the whole point of the component: thumb at
+    the bottom of the track if and only if there is nothing below.
+
+    **The row counts are chosen because they DISCRIMINATE.** The old formula
+    is accidentally correct at many shapes — at 32 rows in a 12-row pane it
+    has no violation at all — so a single convenient fixture passes against
+    the broken code. 19 is the shape D11 was reported against (it bottoms out
+    one window early, at `start=6` of 7); 15, 26 and 40 are the other
+    published failures, 40 breaking at three consecutive positions. A test
+    that pinned only one shape here would be a guard that cannot go red.
+    """
+    for total_rows in (15, 19, 26, 40):
+        app = _real_app()
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            bodies = [f"answer {i}" for i in range(total_rows)]
+            screen = await _open(app, _targets(*bodies), pilot)
+            tree_rows = screen._tree_rows
+            total = len(screen.visible_rows)
+            max_start = total - tree_rows
+            assert max_start > 0, f"{total_rows} must overflow the pane"
+
+            for start in range(max_start + 1):
+                span = screen._thumb_span(tree_rows, start)
+                at_bottom = span.stop == tree_rows
+                nothing_below = start == max_start
+                assert at_bottom == nothing_below, (
+                    f"{total} rows in {tree_rows}: start={start}/{max_start} thumb "
+                    f"{span.start}..{span.stop}, {total - start - tree_rows} rows still below"
+                )
+            # And it actually travels rather than sitting still.
+            first = screen._thumb_span(tree_rows, 0)
+            last = screen._thumb_span(tree_rows, max_start)
+            assert first.start < last.start, f"the thumb never moved at {total} rows"
+
+
+@pytest.mark.asyncio
+async def test_a_track_too_short_to_hold_a_proportion_is_shed() -> None:
+    """Round 1, D14. At 100x14 the split gives the tree ONE row with eighteen
+    hidden, and a one-row track can only paint a thumb that FILLS it — the
+    visual language for "everything fits" — beside a `↓ 18 more` cue saying
+    the opposite. Forced by geometry rather than by D11's anchor, so fixing
+    D11 does not fix it. The cue does the work alone instead."""
+    app = _real_app()
+    async with app.run_test(size=(100, 14)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets(*[f"answer {i}" for i in range(19)]), pilot)
+        assert screen._tree_rows < 3, "the geometry D14 was reported against"
+        assert not screen._gutter_drawn(screen._card_width())
+
+        lines = screen.render_lines_for_test()
+        assert not any("█" in line or "│" in line for line in lines), "no contradictory thumb"
+        assert any("more" in line and "─" in line for line in lines), "the cue still says so"
+
+
+@pytest.mark.asyncio
+async def test_both_tree_cues_read_as_remainders_and_hold_their_column() -> None:
+    """Round 1, D12 and U9, which are one shape between them.
+
+    D12: `↑ 6` is a bare number where `↓ 7 more` is a remainder, and a bare N
+    reads as an ordinal ("row 6") — the exact hazard that ruled out an `N of M`
+    indicator on this card. `↑ N more` fits the slot already reserved.
+
+    U9: the cue moved COLUMN as its digit count changed (measured stepping at
+    9→10 on a 39-row tree), which is precisely what brief item C1 asked to
+    avoid. The count is now right-aligned in a field sized on the largest value
+    it can reach, so the digits line up and nothing twitches under a user who
+    is only scrolling.
+    """
+    app = _real_app()
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets(*[f"answer {i}" for i in range(39)]), pilot)
+
+        columns: set[int] = set()
+        seen_up = False
+        for index in range(len(screen.visible_rows)):
+            screen._move_to(index)
+            await pilot.pause()
+            for line in screen.render_lines_for_test():
+                if "↑" in line and "─" in line:
+                    seen_up = True
+                    assert "more" in line, f"the up cue reads as an ordinal: {line.strip()[-12:]!r}"
+                    columns.add(line.index("↑"))
+                if "↓" in line and "─" in line:
+                    columns.add(line.index("↓"))
+
+        assert seen_up, "the fixture must scroll far enough to raise the up cue"
+        assert len(columns) == 1, f"the cue changed column as its digits did: {columns}"
+
+
+@pytest.mark.asyncio
+async def test_enter_on_an_empty_block_is_audible_rather_than_silent() -> None:
+    """Round 1, U6. Marking the row shipped and does real work — the refusal is
+    PREDICTED by the frame — but the audible half did not, so a user who had
+    not read the hint column pressed Enter and got nothing at all: no notice,
+    no bell, no frame change, which is an application that appears to have
+    stopped responding to the key. That was the original complaint.
+
+    `bell` rather than a toast: a toast would demand a dismissal for a keypress
+    the user can simply repeat elsewhere, and this screen raises no notices of
+    its own.
+    """
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chosen: list[CopyTarget | None] = []
+        screen = await _open(app, _targets("Here:\n\n```py\n```\n"), pilot, chosen.append)
+
+        rings: list[int] = []
+        app.bell = lambda: rings.append(1)  # type: ignore[method-assign]
+
+        empty = next(
+            index for index, node in enumerate(screen.visible_rows) if not node.target.content
+        )
+        screen._move_to(empty)
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert rings == [1], "the refusal is audible"
+        assert chosen == [], "and it is still a refusal"
+        assert screen.is_active
+
+        # A row with content copies, and does NOT ring.
+        screen._move_to(0)
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.pause()
+        assert rings == [1], "a successful copy is not an error"
+        assert len(chosen) == 1
+
+
+@pytest.mark.asyncio
+async def test_the_too_small_notice_keeps_esc_when_it_cannot_keep_the_rest() -> None:
+    """Round 1, U8 and NIT-1. The notice is pinned to ONE row in the
+    stylesheet, so below its own width it wrapped and the pin clipped it: `esc`
+    — the ACTIONABLE half — sheds first, leaving `terminal too small for /copy
+    ·`, a dangling separator that reads as a rendering fault. The footer
+    already solves this by keeping `esc quit` last; the notice now does the
+    same with two forms.
+    """
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chosen: list[CopyTarget | None] = []
+        screen = await _open(app, _targets("first", "second"), pilot, chosen.append)
+
+        for width in (40, 30, 20, 16):
+            await pilot.resize_terminal(width, 8)
+            await pilot.pause()
+            await pilot.pause()
+            assert not screen.is_drawable, f"{width} columns must be too small"
+            text = str(screen._too_small.content)
+            assert "esc" in text, f"the way out was shed at {width} columns: {text!r}"
+            assert cell_len(text) <= width, f"the notice wraps at {width}: {text!r}"
+            assert not text.rstrip().endswith("·"), f"dangling separator at {width}"
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert chosen == [None], "and esc really does work throughout"
+
+
+@pytest.mark.asyncio
+async def test_a_resize_keeps_the_reading_position_instead_of_dropping_it() -> None:
+    """Round 1, U7. `on_resize` clamped the offset and then called `_move_to`,
+    which reset it to 0 regardless, so the clamp could not be observed and
+    someone widening their terminal to read a long block more comfortably was
+    thrown back to line 1. Falls out of the U2 fix; asserted so it stays out.
+    """
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        body = "\n".join(f"line {index}" for index in range(201))
+        screen = await _open(app, _targets(body), pilot)
+
+        screen._scroll_preview_to(40)
+        await pilot.pause()
+        assert screen._preview_offset == 40
+
+        for size in ((80, 24), (140, 40), (100, 30)):
+            await pilot.resize_terminal(*size)
+            await pilot.pause()
+            await pilot.pause()
+            assert screen._preview_offset > 0, f"the position was dropped resizing to {size}"
+            assert screen._preview_offset <= 40

--- a/tests/unit/tui/test_copy_picker_mouse.py
+++ b/tests/unit/tui/test_copy_picker_mouse.py
@@ -1,0 +1,935 @@
+"""The `/copy` picker's mouse gestures, preview scrolling and scroll cues.
+
+Separate from `test_copy_picker.py` (layout and navigation) and
+`test_copy_picker_qa.py` (the target grammar and the clipboard payload)
+because this file asks a different question: does the surface behave when it
+is DRIVEN rather than merely drawn. Everything here goes through the real app
+and the real stylesheet — the lightweight hosts elsewhere in this suite
+declare no `CSS_PATH`, so a card sized by percentage rules is not sized at all
+under one, and a mouse coordinate against an unsized card means nothing.
+
+Mouse events are posted as messages rather than driven through
+``pilot.click``. That is not a shortcut: the pilot pauses between clicks, so
+it cannot produce the case that matters most here — two events queued with no
+event loop turn between them, which is what a fast double-click on a busy
+machine delivers and what used to crash the app.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual import events
+from textual.binding import Binding
+
+from local_operator.tui.copy_targets import CopyTarget, build_copy_targets
+from local_operator.tui.widgets.assistant import AssistantBlock
+from local_operator.tui.widgets.copy_picker import (
+    HEADER_ROWS,
+    PREVIEW_WRAP_BUDGET,
+    TOO_SMALL_NOTICE,
+    CopyPickerScreen,
+)
+
+CODE_ANSWER = "Here it is.\n\n```python\ndef f():\n    return 1\n```\n\n> and a quote"
+
+
+def _answer(text: str, truncated: bool = False) -> AssistantBlock:
+    block = AssistantBlock()
+    block.update_text(text)
+    block.finalize_text()
+    if truncated:
+        block.mark_truncated()
+    return block
+
+
+def _targets(*texts: str) -> list[CopyTarget]:
+    return build_copy_targets([_answer(text) for text in texts])
+
+
+def _real_app():
+    from local_operator.tui.app import OperatorApp
+    from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+    return OperatorApp(lambda: _factory(FakeSession()))
+
+
+async def _open(app, targets: list[CopyTarget], pilot, callback=None) -> CopyPickerScreen:
+    screen = CopyPickerScreen(targets)
+    if callback is None:
+        app.push_screen(screen)
+    else:
+        app.push_screen(screen, callback)
+    await pilot.pause()
+    await pilot.pause()
+    return screen
+
+
+def _card_row(screen: CopyPickerScreen, row: int) -> tuple[int, int]:
+    """Screen coordinates of card row ``row``, a few cells in from its left."""
+    region = screen._body.region
+    return region.x + 4, region.y + row
+
+
+def _tree_row(screen: CopyPickerScreen, offset: int) -> tuple[int, int]:
+    """Screen coordinates of the ``offset``-th DRAWN tree row."""
+    return _card_row(screen, HEADER_ROWS + offset)
+
+
+def _preview_row(screen: CopyPickerScreen, offset: int = 1) -> tuple[int, int]:
+    """Screen coordinates inside the preview pane (``offset`` past its header)."""
+    tree_rows, _ = screen._split_rows()
+    return _card_row(screen, HEADER_ROWS + tree_rows + 1 + offset)
+
+
+def _click(screen: CopyPickerScreen, x: int, y: int, button: int = 1, chain: int = 1):
+    return events.Click(
+        widget=screen._body,
+        x=0,
+        y=0,
+        delta_x=0,
+        delta_y=0,
+        button=button,
+        shift=False,
+        meta=False,
+        ctrl=False,
+        screen_x=x,
+        screen_y=y,
+        chain=chain,
+    )
+
+
+def _move(screen: CopyPickerScreen, x: int, y: int) -> events.MouseMove:
+    return events.MouseMove(
+        widget=screen._body,
+        x=0,
+        y=0,
+        delta_x=0,
+        delta_y=0,
+        button=0,
+        shift=False,
+        meta=False,
+        ctrl=False,
+        screen_x=x,
+        screen_y=y,
+    )
+
+
+def _wheel(screen: CopyPickerScreen, x: int, y: int, down: bool):
+    kind = events.MouseScrollDown if down else events.MouseScrollUp
+    return kind(
+        widget=screen._body,
+        x=0,
+        y=0,
+        delta_x=0,
+        delta_y=1 if down else -1,
+        button=0,
+        shift=False,
+        meta=False,
+        ctrl=False,
+        screen_x=x,
+        screen_y=y,
+    )
+
+
+# --- the wheel ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_wheel_over_the_tree_moves_the_cursor_by_the_app_sensitivity() -> None:
+    """Stepped by the LIVE `App.scroll_sensitivity_y`, not a hardcoded 1.
+
+    It is a per-instance attribute set in `App.__init__` (2.0 here), so a
+    constant would silently desynchronise the moment anything changed it and
+    one gesture would then travel at two speeds depending on where the pointer
+    sat — the position-dependence `settings_view` records the measurement for.
+    """
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets(*[f"answer {i}" for i in range(20)]), pilot)
+        step = max(1, int(app.scroll_sensitivity_y))
+        assert step > 1, "this test is vacuous if the app steps by one"
+
+        screen.post_message(_wheel(screen, *_tree_row(screen, 0), down=True))
+        await pilot.pause()
+        assert screen._selected == step
+
+        app.scroll_sensitivity_y = 5.0
+        screen.post_message(_wheel(screen, *_tree_row(screen, 0), down=True))
+        await pilot.pause()
+        assert screen._selected == step + 5, "the step is read live, not cached"
+
+
+@pytest.mark.asyncio
+async def test_the_wheel_over_the_tree_clamps_rather_than_wrapping() -> None:
+    """This screen's documented rule for every gesture: a scroll that came
+    round to the other end of the list would read as the picker resetting
+    itself."""
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets(*[f"answer {i}" for i in range(8)]), pilot)
+        for _ in range(20):
+            screen.post_message(_wheel(screen, *_tree_row(screen, 0), down=False))
+        await pilot.pause()
+        assert screen._selected == 0
+
+        for _ in range(40):
+            screen.post_message(_wheel(screen, *_tree_row(screen, 0), down=True))
+        await pilot.pause()
+        assert screen._selected == len(screen.visible_rows) - 1
+
+
+@pytest.mark.asyncio
+async def test_the_wheel_over_the_preview_scrolls_it_and_leaves_the_cursor_alone() -> None:
+    """The two panes are ONE `Static`, so the event's widget is identical over
+    both and cannot discriminate them — the routing is by screen row against
+    the card's own layout. A wheel over text the user is reading must not
+    change what is selected under them."""
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        # Most-recent-FIRST: `build_copy_targets` walks the transcript in
+        # reverse, so the long answer has to be seeded last to sit at row 0.
+        body = "\n".join(f"line {index}" for index in range(120))
+        screen = await _open(app, _targets("second answer", body), pilot)
+        before = screen._selected
+
+        screen.post_message(_wheel(screen, *_preview_row(screen), down=True))
+        await pilot.pause()
+        assert screen._preview_offset == max(1, int(app.scroll_sensitivity_y))
+        assert screen._selected == before, "the cursor must not move with the preview"
+
+        screen.post_message(_wheel(screen, *_tree_row(screen, 0), down=True))
+        await pilot.pause()
+        assert screen._selected != before, "the tree still takes its own notches"
+
+
+@pytest.mark.asyncio
+async def test_the_preview_offset_clamps_at_both_ends() -> None:
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        body = "\n".join(f"line {index}" for index in range(40))
+        screen = await _open(app, _targets(body), pilot)
+
+        for _ in range(200):
+            screen.post_message(_wheel(screen, *_preview_row(screen), down=True))
+        await pilot.pause()
+        assert screen._preview_offset == 39, "stops on the last source line"
+
+        for _ in range(200):
+            screen.post_message(_wheel(screen, *_preview_row(screen), down=False))
+        await pilot.pause()
+        assert screen._preview_offset == 0
+
+
+# --- clicks ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_single_click_selects_and_previews_without_copying() -> None:
+    """The deliberate divergence from `session_picker`, whose click acts
+    immediately. That shape is right there because its list has no preview: the
+    row text is all the information that exists. Here the preview IS the
+    picker's reason to exist, so a click that copied would remove the
+    confirmation step from the mouse path only — handing the mouse user a less
+    careful version of the feature than the keyboard user gets, and the mistake
+    it enables is silent (the clipboard is overwritten and the modal is gone).
+    """
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chosen: list[CopyTarget | None] = []
+        screen = await _open(app, _targets("first", "second", "third"), pilot, chosen.append)
+
+        screen.post_message(_click(screen, *_tree_row(screen, 2)))
+        await pilot.pause()
+        assert screen._selected == 2
+        assert chosen == [], "a single click must not copy"
+        assert screen.is_active, "a single click must not dismiss"
+        preview = screen.render_lines_for_test()
+        assert any(line.startswith("Preview · ") for line in preview)
+
+
+@pytest.mark.asyncio
+async def test_a_double_click_copies_the_row_it_landed_on() -> None:
+    """`Click.chain` is Textual's own double-click count (0.5 s threshold), so
+    the contract needs no timing invented here."""
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chosen: list[CopyTarget | None] = []
+        screen = await _open(app, _targets("first", "second", "third"), pilot, chosen.append)
+
+        screen.post_message(_click(screen, *_tree_row(screen, 1), chain=2))
+        await pilot.pause()
+        await pilot.pause()
+        assert len(chosen) == 1
+        assert chosen[0] is not None and chosen[0].label == "second"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("button", [2, 3])
+async def test_the_other_buttons_are_ignored_before_any_state_changes(button: int) -> None:
+    """A right-click asking for a context menu is measured to arrive here, and
+    a middle-click paste with it. Neither may move the cursor on its way to
+    being ignored, which is why the button is tested first."""
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chosen: list[CopyTarget | None] = []
+        screen = await _open(app, _targets("first", "second", "third"), pilot, chosen.append)
+
+        screen.post_message(_click(screen, *_tree_row(screen, 2), button=button))
+        screen.post_message(_click(screen, *_tree_row(screen, 2), button=button, chain=2))
+        await pilot.pause()
+        assert screen._selected == 0
+        assert chosen == []
+        assert screen.is_active
+
+
+@pytest.mark.asyncio
+async def test_the_chrome_and_the_backdrop_are_inert() -> None:
+    """`session_picker`'s three guards, and its docstring records why they are
+    mandatory rather than defensive: its first cut without them resolved a
+    click on the footer to session #12 and the dimmed backdrop to row 0. Both
+    coordinates were re-measured as still delivered here.
+
+    The backdrop deliberately does NOT dismiss. The app's other two modals
+    have no mouse handling at all, so backdrop-dismissal would exist on
+    exactly one of three and a user who learned it here would be stuck on
+    `/resume`.
+
+    The tree is deliberately LONGER than the pane. On a short tree the third
+    guard ("the index must exist") catches the footer on its own, so the
+    second one looks redundant — it is only load-bearing when rows exist below
+    the drawn page, which is precisely session_picker's documented case of a
+    footer click resolving to session #12. Measured here at 100x30: without
+    the drawn-page cap, the footer's offset is 29 against a 40-row list and
+    selects row 29.
+    """
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chosen: list[CopyTarget | None] = []
+        screen = await _open(
+            app, _targets(*[f"answer {i}" for i in range(40)]), pilot, chosen.append
+        )
+        screen._move_to(3)
+        await pilot.pause()
+
+        region = screen._body.region
+        tree_rows, preview_rows = screen._split_rows()
+        assert len(screen.visible_rows) > tree_rows + preview_rows + 2, (
+            "the fixture must have rows below the drawn page, or the drawn-page "
+            "guard is not exercised"
+        )
+        elsewhere = [
+            ("title", (region.x + 4, region.y)),
+            ("rule under title", (region.x + 4, region.y + 1)),
+            ("rule under tree", (region.x + 4, region.y + HEADER_ROWS + tree_rows)),
+            ("preview header", (region.x + 4, region.y + HEADER_ROWS + tree_rows + 1)),
+            ("preview body", _preview_row(screen)),
+            ("footer", (region.x + 4, region.y + HEADER_ROWS + tree_rows + preview_rows + 2)),
+            ("card padding", (region.x - 1, region.y + 3)),
+            ("backdrop left", (0, region.y + 3)),
+            ("backdrop above", (region.x + 4, 0)),
+        ]
+        for name, (x, y) in elsewhere:
+            screen.post_message(_click(screen, x, y))
+            screen.post_message(_click(screen, x, y, chain=2))
+            await pilot.pause()
+            assert screen._selected == 3, f"{name} moved the cursor"
+            assert chosen == [], f"{name} copied"
+            assert screen.is_active, f"{name} dismissed the modal"
+
+
+@pytest.mark.asyncio
+async def test_a_short_tree_leaves_no_clickable_blank_below_its_rows() -> None:
+    """A short tree's pane is capped at the rows that EXIST, so the space under
+    them belongs to the preview rather than to a blank tail of the tree — and
+    the region below the last row must select nothing whatever the cause.
+
+    Asserted as an invariant of the layout rather than of one coordinate: the
+    drawn page and the row list are the same length here, which is what makes
+    `_index_at`'s second guard non-binding on THIS shape (the third catches
+    the overshoot). The long-tree case, where the second guard is the only
+    thing standing between a footer click and row 29, is covered by
+    `test_the_chrome_and_the_backdrop_are_inert`.
+    """
+    app = _real_app()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets("only answer"), pilot)
+        tree_rows, _ = screen._split_rows()
+        rows = len(screen.visible_rows)
+        assert tree_rows == rows, "the pane is capped at the rows that exist"
+
+        # Every row from the end of the tree to the bottom of the card.
+        for offset in range(rows, screen._row_budget()):
+            screen.post_message(_click(screen, *_tree_row(screen, offset), chain=2))
+        await pilot.pause()
+        assert screen.is_active
+        assert screen._selected == 0
+
+
+# --- hover -------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hover_highlights_a_row_without_looking_like_the_selection() -> None:
+    """Hover and selection share the ground and the CARET discriminates them.
+    If hover painted like selection the user would see two selected rows and
+    could not tell which one Enter takes."""
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets("first", "second", "third"), pilot)
+
+        screen.post_message(_move(screen, *_tree_row(screen, 2)))
+        await pilot.pause()
+        assert screen._hovered == 2
+        assert screen._selected == 0, "hovering must not select"
+
+        lines = screen.render_lines_for_test()
+        carets = [line for line in lines if line.startswith("❯")]
+        assert len(carets) == 1, "exactly one row may carry the cursor mark"
+        assert screen.styles.pointer == "pointer"
+
+
+@pytest.mark.asyncio
+async def test_the_pointer_is_a_hand_only_over_a_tree_row() -> None:
+    """Including NOT over the preview: it is scrollable, not clickable, and a
+    hand there would promise a click it does not keep."""
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        body = "\n".join(f"line {index}" for index in range(60))
+        screen = await _open(app, _targets("second", body), pilot)
+
+        screen.post_message(_move(screen, *_tree_row(screen, 0)))
+        await pilot.pause()
+        assert screen.styles.pointer == "pointer"
+
+        screen.post_message(_move(screen, *_preview_row(screen)))
+        await pilot.pause()
+        assert screen.styles.pointer == "default"
+        assert screen._hovered is None
+
+        screen.post_message(_move(screen, *_tree_row(screen, 0)))
+        await pilot.pause()
+        screen.post_message(events.Leave(screen._body))
+        await pilot.pause()
+        assert screen._hovered is None
+        assert screen.styles.pointer == "default"
+
+
+# --- the dismiss race --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_two_queued_clicks_dismiss_once_instead_of_crashing() -> None:
+    """The regression this guard exists for. Two `Click` events with no event
+    loop turn between them — a fast double-click on a busy machine — reached
+    `dismiss` after the screen had already popped, and Textual raised
+    `ScreenStackError: Can't pop screen`. Reproduced on the unguarded code
+    before the guard was written.
+
+    Posted rather than driven through `pilot.click(times=2)`, which pauses
+    between clicks and therefore CANNOT reproduce it — a test written that way
+    would pass against the crashing code.
+    """
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chosen: list[CopyTarget | None] = []
+        screen = await _open(app, _targets("first", "second"), pilot, chosen.append)
+
+        x, y = _tree_row(screen, 0)
+        screen.post_message(_click(screen, x, y, chain=2))
+        screen.post_message(_click(screen, x, y, chain=3))
+        await pilot.pause()
+        await pilot.pause()
+        assert len(chosen) == 1, "one gesture, one clipboard write"
+
+
+@pytest.mark.asyncio
+async def test_the_keyboard_path_cannot_crash_by_dismissing_twice() -> None:
+    """The same race exists WITHOUT a mouse: two `action_choose()` calls, and
+    choose-then-cancel, both raised `ScreenStackError` on the unguarded code,
+    so a user hammering Enter could crash the app. Guarding only the click
+    handler would have left that in place, which is why the guard lives in
+    `_dismiss_result` where both paths pass through."""
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chosen: list[CopyTarget | None] = []
+        screen = await _open(app, _targets("first", "second"), pilot, chosen.append)
+        screen.action_choose()
+        screen.action_choose()
+        screen.action_cancel()
+        await pilot.pause()
+        await pilot.pause()
+        assert len(chosen) == 1
+        assert chosen[0] is not None
+
+
+@pytest.mark.asyncio
+async def test_the_pointer_shape_is_released_before_the_screen_leaves() -> None:
+    """The modal goes without another mouse move, so OSC 22 has to be restored
+    while this screen still owns the pointer. Without it a user who clicks to
+    copy is left with a hand cursor over their transcript."""
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets("first", "second"), pilot)
+        screen.post_message(_move(screen, *_tree_row(screen, 0)))
+        await pilot.pause()
+        assert screen.styles.pointer == "pointer"
+
+        screen.post_message(_click(screen, *_tree_row(screen, 0), chain=2))
+        await pilot.pause()
+        await pilot.pause()
+        assert screen.styles.pointer == "default"
+
+
+# --- preview scrolling -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_shift_arrows_scroll_the_preview_for_keyboard_parity() -> None:
+    """Every mouse capability needs a key, or the mouse becomes the only way to
+    do something — on a terminal UI that is a regression, not a feature."""
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        body = "\n".join(f"line {index}" for index in range(120))
+        screen = await _open(app, _targets(body), pilot)
+
+        await pilot.press("shift+down", "shift+down", "shift+down")
+        await pilot.pause()
+        assert screen._preview_offset == 3
+        assert screen._selected == 0
+
+        await pilot.press("shift+up")
+        await pilot.pause()
+        assert screen._preview_offset == 2
+
+        await pilot.press("shift+pagedown")
+        await pilot.pause()
+        assert screen._preview_offset > 2, "a page moves by more than a line"
+
+
+@pytest.mark.asyncio
+async def test_left_right_and_tab_stay_unbound() -> None:
+    """Both plausible uses are wrong here. Focus-swapping would give a screen
+    with no focus model a MODE, in which `up`/`down` mean two different things
+    depending on state nothing in the frame shows; collapse/expand is a
+    different feature. `shift+↑↓` scrolls the preview without a mode, which is
+    why it is the right shape."""
+    keys = {
+        binding.key if isinstance(binding, Binding) else binding[0]
+        for binding in CopyPickerScreen.BINDINGS
+    }
+    assert keys, "bindings must not be empty"
+    for key in ("left", "right", "tab", "space", "j", "k", "slash"):
+        assert key not in keys, f"{key} is bound"
+    # The preview keys ARE bound, so the assertions above are about restraint
+    # rather than about an empty table.
+    assert {"shift+up", "shift+down"} <= keys
+    # `ctrl+c` stays the global interrupt: a modal claiming it would change
+    # what stopping a turn means depending on whether an overlay is open.
+    assert "ctrl+c" not in keys
+
+
+@pytest.mark.asyncio
+async def test_the_preview_offset_resets_on_every_cursor_move() -> None:
+    """The preview is a DIFFERENT DOCUMENT once the selection changes.
+    Carrying an offset across targets would open the next preview part-way
+    down a document the user never scrolled."""
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        # Seeded last so the long answer is row 0 (most-recent-first).
+        long_body = "\n".join(f"line {index}" for index in range(120))
+        screen = await _open(app, _targets("second answer", long_body), pilot)
+
+        await pilot.press("shift+down", "shift+down", "shift+down")
+        await pilot.pause()
+        assert screen._preview_offset == 3
+
+        await pilot.press("down")
+        await pilot.pause()
+        assert screen._preview_offset == 0
+
+        await pilot.press("up")
+        await pilot.pause()
+        assert screen._preview_offset == 0
+
+
+@pytest.mark.asyncio
+async def test_the_remainder_counts_down_as_the_preview_scrolls() -> None:
+    """A LIVE remainder, which is what makes it self-checking without ordinals:
+    scroll, and the number goes down. It is counted in SOURCE lines — the unit
+    the header beside it reports — because a marker counting wrapped rows
+    contradicted the header in the same pane."""
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        total = 120
+        # Each source line WRAPS to several rows, which is what makes this test
+        # able to tell the two units apart at all. With short lines the counts
+        # coincide and a row-counting implementation passes — measured: a
+        # 79-line answer of 43-cell lines produces exactly 79 rows in an
+        # 88-cell pane, so the units are indistinguishable there.
+        body = "\n".join(f"line {index} " + "padding " * 20 for index in range(total))
+        screen = await _open(app, _targets(body), pilot)
+
+        target = screen.selected_target()
+        assert target is not None
+        _, rows_per_source = screen._wrap_preview(target, max(1, screen._card_width() - 2), 0)
+        assert max(rows_per_source) > 1, "the fixture must wrap or this test is vacuous"
+
+        def _claim() -> int:
+            marker = next(line for line in screen.render_lines_for_test() if "more lines" in line)
+            return int(marker.strip().split()[1])
+
+        first = _claim()
+        # Every source line WHOLLY on screen is one the marker must not count.
+        # A line only partly drawn still counts as remaining — the user cannot
+        # read it, and claiming otherwise is the same over-count in miniature.
+        drawn = screen.render_lines_for_test()
+        rows_on_screen = sum(1 for line in drawn if line.startswith(("line ", "padding")))
+        consumed = 0
+        whole_lines = 0
+        for rows in rows_per_source:
+            if consumed + rows > rows_on_screen:
+                break
+            consumed += rows
+            whole_lines += 1
+        assert first == total - whole_lines
+
+        # And it is genuinely in the other unit: a row-counting implementation
+        # would quote a bigger number here, which is the contradiction the
+        # header made visible in the same pane.
+        assert first < len(rows_per_source) * max(rows_per_source) - rows_on_screen
+
+        await pilot.press("shift+down", "shift+down", "shift+down", "shift+down", "shift+down")
+        await pilot.pause()
+        assert _claim() == first - 5
+
+
+@pytest.mark.asyncio
+async def test_the_remainder_vanishes_at_the_end_of_the_document() -> None:
+    """Its ABSENCE has to mean "this is everything" — `todo_panel`'s rule. A
+    marker that stayed at `… 0 more lines`, or that kept a stale count at the
+    bottom, would make the presence of the marker meaningless."""
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        body = "\n".join(f"line {index}" for index in range(40))
+        screen = await _open(app, _targets(body), pilot)
+        assert any("more lines" in line for line in screen.render_lines_for_test())
+
+        for _ in range(60):
+            await pilot.press("shift+down")
+        await pilot.pause()
+        lines = screen.render_lines_for_test()
+        assert not any("more lines" in line for line in lines)
+        assert any("line 39" in line for line in lines), "the last line must be reachable"
+
+
+@pytest.mark.asyncio
+async def test_the_header_says_where_a_scrolled_preview_starts() -> None:
+    """The symmetric cue to the foot marker, and free: the header row already
+    exists and carries only the total. Without it a scrolled preview looks
+    like a document that simply starts at "line 40"."""
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        body = "\n".join(f"line {index}" for index in range(120))
+        screen = await _open(app, _targets(body), pilot)
+        header = next(line for line in screen.render_lines_for_test() if line.startswith("Preview"))
+        assert "from line" not in header, "an unscrolled preview claims no position"
+
+        await pilot.press("shift+down", "shift+down")
+        await pilot.pause()
+        header = next(line for line in screen.render_lines_for_test() if line.startswith("Preview"))
+        assert "from line 3" in header
+
+
+@pytest.mark.asyncio
+async def test_the_wrap_budget_is_a_window_and_not_a_dead_end() -> None:
+    """`PREVIEW_WRAP_BUDGET` was a PREFIX cap: it wrapped the first 200 source
+    lines and no more. That was invisible while only ~15 rows were ever shown,
+    and became a visible dead end the moment the preview could scroll —
+    scrolling a 600-line answer stopped at source line 200 with a remainder
+    that would not go down, which reads as a broken surface.
+
+    Deliberately walks PAST the budget in one jump and then reads the frame:
+    the lines beyond it must be drawn and the remainder must still be honest.
+    """
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        total = 600
+        body = "\n".join(f"line {index}" for index in range(total))
+        screen = await _open(app, _targets(body), pilot)
+
+        beyond = PREVIEW_WRAP_BUDGET + 50
+        screen._scroll_preview_to(beyond)
+        await pilot.pause()
+        lines = screen.render_lines_for_test()
+        assert any(f"line {beyond}" in line for line in lines), "past the budget, still drawn"
+
+        marker = next(line for line in lines if "more lines" in line)
+        shown = sum(1 for line in lines if line.startswith("line "))
+        assert int(marker.strip().split()[1]) == total - beyond - shown
+
+        # And the far end is reachable rather than floored at the budget.
+        screen._scroll_preview_to(total)
+        await pilot.pause()
+        assert screen._preview_offset == total - 1
+        assert any(f"line {total - 1}" in line for line in screen.render_lines_for_test())
+
+
+# --- the scroll cues ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_tree_cues_appear_only_in_the_direction_that_overflows() -> None:
+    """`↓ N more` and `↑ N` ride the rules that already exist, so they cost no
+    row. BOTH directions are cued, unlike `todo_panel`'s single remainder,
+    because `_window_start` centres the cursor: this list is very often clipped
+    at both ends at once, and a down-only cue would say the list continues
+    below while silently hiding the rows above."""
+    app = _real_app()
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets(*[f"answer {i}" for i in range(30)]), pilot)
+
+        def _cues() -> tuple[bool, bool]:
+            lines = screen.render_lines_for_test()
+            return (
+                any("↑ " in line and "─" in line for line in lines),
+                any("more" in line and "─" in line for line in lines),
+            )
+
+        assert _cues() == (False, True), "at the top: only the down cue"
+
+        await pilot.press("end")
+        await pilot.pause()
+        assert _cues() == (True, False), "at the bottom: only the up cue"
+
+        await pilot.press("home")
+        for _ in range(12):
+            await pilot.press("down")
+        await pilot.pause()
+        assert _cues() == (True, True), "windowed from the middle: both at once"
+
+
+@pytest.mark.asyncio
+async def test_a_tree_that_fits_advertises_no_paging() -> None:
+    """The cue's absence has to mean "this is everything", so a short tree must
+    not carry one."""
+    app = _real_app()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets("only answer"), pilot)
+        lines = screen.render_lines_for_test()
+        assert not any("more" in line and "─" in line for line in lines)
+        assert not any("↑ " in line and "─" in line for line in lines)
+
+
+@pytest.mark.asyncio
+async def test_the_cue_slot_does_not_resize_as_its_digits_change() -> None:
+    """Sized on the WIDEST rendering, not the current value. Sizing it on the
+    current text makes the rule change length as the digit count does, so a
+    user who is only scrolling watches the divider twitch under them for no
+    reason they can see (todo_panel's U1)."""
+    app = _real_app()
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets(*[f"answer {i}" for i in range(30)]), pilot)
+        widths = set()
+        for _ in range(len(screen.visible_rows)):
+            rules = [line for line in screen.render_lines_for_test() if "─" in line]
+            widths.update(len(line) for line in rules)
+            await pilot.press("down")
+            await pilot.pause()
+        assert len(widths) == 1, f"the rules changed width as the cue did: {widths}"
+
+
+@pytest.mark.asyncio
+async def test_the_gutter_thumb_tracks_the_window_and_is_shed_when_narrow() -> None:
+    """The only CONTINUOUS signal here — the remainder says how much is left,
+    the thumb says where you are and moves as you go.
+
+    It is a SHED, not a decoration: it widens every tree row, so drawing it
+    unconditionally would raise the drawability floor and newly HIDE the card
+    on terminals that draw one today."""
+    app = _real_app()
+    async with app.run_test(size=(100, 24)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets(*[f"answer {i}" for i in range(30)]), pilot)
+        assert screen._gutter_drawn(screen._card_width())
+
+        top = screen._thumb_span(screen._tree_rows, screen._window_start(screen._tree_rows))
+        await pilot.press("end")
+        await pilot.pause()
+        bottom = screen._thumb_span(screen._tree_rows, screen._window_start(screen._tree_rows))
+        assert top.start < bottom.start, "the thumb moves down with the window"
+        assert len(top) == len(bottom) >= 1, "the span is proportional and never empty"
+
+    # A tree that FITS carries no track. A gutter drawn on a list that cannot
+    # scroll is a scrollbar for a document that fits, and it would break the
+    # same rule the remainder cues keep: the absence of the signal has to mean
+    # "this is everything".
+    app = _real_app()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets("only answer"), pilot)
+        assert not screen._gutter_drawn(screen._card_width())
+        assert not any("│" in line or "█" in line for line in screen.render_lines_for_test())
+
+    # A card wide enough to draw but not to spare the gutter's two cells. The
+    # hint is what sets the floor (it never truncates), so the shed case needs
+    # rows carrying real hints rather than bare labels.
+    blocky = "An answer.\n\n" + "\n".join(f"```py\nx{i}\n```\n" for i in range(4)) + "\n> quote\n"
+    app = _real_app()
+    async with app.run_test(size=(44, 24)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets(blocky), pilot)
+        assert screen.is_drawable, "shedding the gutter, not hiding the card"
+        assert not screen._gutter_drawn(screen._card_width(), rows=1)
+        assert "esc quit" in "\n".join(screen.render_lines_for_test())
+
+
+# --- resize ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_resize_clamps_the_preview_offset_and_drops_the_wrap_cache() -> None:
+    """Both are width-dependent. A stale offset would show the preview at a
+    position the document no longer has, and old-width cache entries would sit
+    there for the life of the screen."""
+    app = _real_app()
+    async with app.run_test(size=(100, 40)) as pilot:
+        await pilot.pause()
+        body = "\n".join(f"line {index}" for index in range(120))
+        screen = await _open(app, _targets(body), pilot)
+        screen._scroll_preview_to(100)
+        await pilot.pause()
+        assert screen._wrap_cache, "the preview was wrapped at least once"
+
+        app.post_message(events.Resize(screen.size, screen.size))
+        await pilot.resize_terminal(70, 20)
+        await pilot.pause()
+        await pilot.pause()
+
+        assert screen._preview_offset <= max(0, 120 - 1)
+        keys = {key[1] for key in screen._wrap_cache}
+        assert len(keys) <= 1, f"entries from more than one width survived: {keys}"
+        # And the frame is still coherent at the new size.
+        assert screen.render_lines_for_test()
+
+
+@pytest.mark.asyncio
+async def test_nothing_here_makes_the_screen_scrollable() -> None:
+    """A scrollbar on this app is always a bug and silently costs two cells of
+    width, reflowing the transcript behind the overlay. Everything the cues,
+    the gutter and the preview scroll add is drawn INSIDE the one existing
+    `Static`; the preview "scroll" is an offset into a `Text`, not a
+    container."""
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        body = "\n".join(f"line {index}" for index in range(300))
+        screen = await _open(app, _targets(body, *[f"answer {i}" for i in range(30)]), pilot)
+        for keys in (("down",), ("shift+down",), ("end",), ("home",)):
+            await pilot.press(*keys)
+            await pilot.pause()
+            assert screen.virtual_size.height <= screen.size.height, keys
+            assert not screen.show_vertical_scrollbar, keys
+
+
+# --- honesty in the frame ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_empty_block_says_so_rather_than_refusing_silently() -> None:
+    """Enter REFUSES an empty block, and that refusal is right — but refusing
+    silently reads as a broken key, and the reasoning behind the refusal is
+    itself that a deliberate action which does nothing and says nothing is the
+    failure to avoid.
+
+    Marking the row is the better fix than a message: the refusal becomes
+    PREDICTED by the frame rather than explained after the fact, and a row
+    visibly marked `empty` does not invite the double-click either. The
+    refusal itself is unchanged.
+    """
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        chosen: list[CopyTarget | None] = []
+        screen = await _open(app, _targets("Here:\n\n```py\n```\n"), pilot, chosen.append)
+        row = next(line for line in screen.render_lines_for_test() if "Block 1" in line)
+        assert "empty" in row and "0 lines" not in row
+
+        screen._move_to(1)
+        await pilot.press("enter")
+        await pilot.pause()
+        assert chosen == [], "the refusal still stands"
+        assert screen.is_active
+
+
+@pytest.mark.asyncio
+async def test_a_terminal_too_small_for_the_card_says_so() -> None:
+    """From the user's chair, `/copy` on a small terminal was "I typed a
+    command and my screen went dim and blank".
+
+    The card's two-sided contract is untouched and is asserted here too: the
+    notice is a SIBLING of the card, so `render_lines_for_test` still reports
+    `[]`, `Copy to clipboard` is still absent, and `esc` still works.
+    """
+    app = _real_app()
+    async with app.run_test(size=(40, 20)) as pilot:
+        await pilot.pause()
+        chosen: list[CopyTarget | None] = []
+        screen = await _open(app, _targets(CODE_ANSWER), pilot, chosen.append)
+        assert not screen.is_drawable
+        assert screen.render_lines_for_test() == []
+
+        strips = app.screen._compositor.render_strips()
+        frame = "\n".join("".join(segment.text for segment in strip) for strip in strips)
+        assert TOO_SMALL_NOTICE in frame
+        assert "Copy to clipboard" not in frame
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert chosen == [None]
+
+
+@pytest.mark.asyncio
+async def test_the_wrap_cache_serves_the_same_rows_it_would_have_computed() -> None:
+    """The memo's key is `(target.id, width, window_start)` and the claim is
+    that it is TOTAL: `CopyTarget` is frozen, the tree is a snapshot that
+    cannot change while the screen is open, and those three are the only other
+    inputs. So a hit must be byte-identical to a recomputation — asserted
+    rather than assumed, because the cost of being wrong is a stale preview
+    beside an honest header.
+    """
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        body = "\n".join(f"line {index}" for index in range(80))
+        screen = await _open(app, _targets(body), pilot)
+        target = screen.selected_target()
+        assert target is not None
+
+        cached_rows, cached_map = screen._wrap_preview(target, 88, 0)
+        screen._wrap_cache.clear()
+        fresh_rows, fresh_map = screen._wrap_preview(target, 88, 0)
+        assert [row.plain for row in cached_rows] == [row.plain for row in fresh_rows]
+        assert cached_map == fresh_map

--- a/tests/unit/tui/test_copy_picker_mouse.py
+++ b/tests/unit/tui/test_copy_picker_mouse.py
@@ -13,6 +13,16 @@ Mouse events are posted as messages rather than driven through
 it cannot produce the case that matters most here — two events queued with no
 event loop turn between them, which is what a fast double-click on a busy
 machine delivers and what used to crash the app.
+
+**But a posted `Click` cannot see everything.** It reaches the screen's own
+``on_click`` and nothing else, so ``Widget._on_click`` — Textual's own
+handler, which starts a TEXT SELECTION on a `chain == 2` click — never runs.
+A whole class of defect lives there and was invisible to every test in this
+file until round 3 (Q8/U12: the refusing click wrote the card to the
+clipboard). ``_full_click`` below drives real ``MouseDown``/``MouseUp`` pairs
+through ``App.on_event`` for the tests that need that path; ``pilot.click``
+is NOT the alternative, since it fabricates the chain per call, so two calls
+both arrive as ``chain=1`` and never double-click at all.
 """
 
 from __future__ import annotations
@@ -135,6 +145,71 @@ def _wheel(screen: CopyPickerScreen, x: int, y: int, down: bool):
         screen_x=x,
         screen_y=y,
     )
+
+
+async def _full_click(app, x: int, y: int) -> None:
+    """A REAL press and release at ``(x, y)``, with Textual computing the chain.
+
+    Fed to ``App.on_event`` rather than posted to the screen, because that is
+    the only entry point that synthesises the ``Click`` (chain and all) and
+    then routes it through ``Widget._on_click`` — where Textual's select-all
+    lives. The tests that assert on the CLIPBOARD need that path; the tests
+    that assert on the picker's own row arithmetic do not, and keep using the
+    posted `_click` for the no-loop-turn case it exists to reach.
+    """
+    for kind in (events.MouseDown, events.MouseUp):
+        # Spelled out per event rather than splatted from a shared dict: a
+        # `dict(...)` literal widens every value to the union of its types, so
+        # `**common` type-checks as `int | None` against every parameter.
+        await app.on_event(
+            kind(
+                widget=None,
+                x=x,
+                y=y,
+                delta_x=0,
+                delta_y=0,
+                button=1,
+                shift=False,
+                meta=False,
+                ctrl=False,
+                screen_x=x,
+                screen_y=y,
+            )
+        )
+
+
+async def _full_wheel(app, x: int, y: int, down: bool) -> None:
+    """A real wheel notch through ``App.on_event``, to pair with `_full_click`."""
+    kind = events.MouseScrollDown if down else events.MouseScrollUp
+    await app.on_event(
+        kind(
+            widget=None,
+            x=x,
+            y=y,
+            delta_x=0,
+            delta_y=1 if down else -1,
+            button=0,
+            shift=False,
+            meta=False,
+            ctrl=False,
+            screen_x=x,
+            screen_y=y,
+        )
+    )
+
+
+def _reset_click_chain(app) -> None:
+    """Forget any chain in progress.
+
+    Textual's counter lives on the APP (`_chained_clicks`,
+    `_click_chain_last_offset`, `_click_chain_last_time`), so it OUTLIVES a
+    screen pop: without this a case inherits the previous case's chain and
+    reports the wrong verdict. Found while writing the round-3 probe, where it
+    silently turned a first click into a `chain=2`.
+    """
+    app._chained_clicks = 1
+    app._click_chain_last_offset = None
+    app._click_chain_last_time = None
 
 
 # --- the wheel ---------------------------------------------------------------
@@ -1468,12 +1543,22 @@ async def test_the_thumb_holds_both_ends_across_every_shape_it_can_draw() -> Non
     gutter is SHED rather than drawn (round 1, D14) and an undrawn thumb
     cannot contradict a cue.
 
-    The five residuals are `travel == 1` with `max_start > 1` — a one-cell
-    travel has two expressible positions for three or more window states, so
-    by pigeonhole one must share a cell with an extreme. They are asserted
-    EXACTLY rather than tolerated: the set is pinned by shape, so a formula
-    that regressed a sixth position would fail here even though the count is
-    non-zero, and the forfeited end is asserted to be the top.
+    Round 2 left five `travel == 1` residuals and called them a geometric
+    limit. Round 3 (D20) showed the shapes are REACHABLE at real terminal
+    sizes — 100x20 and 100x23 with 5-to-7-node trees — and that the pigeonhole
+    argument only holds for a fixed span, which is a free parameter. Spending
+    one cell of span to buy a second cell of travel removes all five, so the
+    expectation here is now ZERO at both ends.
+
+    **The end invariants alone are not a sufficient guard, which is the second
+    half of this test.** Collapsing the thumb's whole interior to a constant
+    (`top = 1`) satisfies both of them and passed every test in this file,
+    while destroying the continuity the thumb exists to provide: at 300 rows in
+    30 it takes 28 distinct positions down to 3. So the sweep also asserts that
+    every cell the track can express is actually USED, and that the thumb never
+    travels backwards — properties a constant interior cannot satisfy
+    (measured: the mutant fails 20,452 of 20,976 shapes, worst case 3 of 51
+    cells).
     """
     app = _real_app()
     async with app.run_test(size=(100, 30)) as pilot:
@@ -1482,28 +1567,41 @@ async def test_the_thumb_holds_both_ends_across_every_shape_it_can_draw() -> Non
 
         top_bad: list[tuple[int, int, int]] = []
         bottom_bad: list[tuple[int, int, int]] = []
+        crushed: list[tuple[int, int, int, int]] = []
+        backwards: list[tuple[int, int]] = []
         states = 0
         for rows in range(MIN_GUTTER_TRACK_ROWS, 60):
             for total in range(rows + 1, 400):
                 screen._flat = [None] * total  # type: ignore[assignment]
                 max_start = total - rows
+                tops: list[int] = []
                 for start in range(max_start + 1):
                     span = screen._thumb_span(rows, start)
                     states += 1
+                    tops.append(span.start)
                     if (span.stop == rows) != (start == max_start):
                         bottom_bad.append((rows, total, start))
                     if (span.start == 0) != (start == 0):
                         top_bad.append((rows, total, start))
+                # CONTINUITY. The track's cells run 0..max(tops); every one of
+                # them should carry a window, unless there are fewer windows
+                # than cells to spend on them.
+                reachable = min(max(tops) + 1, max_start + 1)
+                if len(set(tops)) < reachable:
+                    crushed.append((rows, total, len(set(tops)), reachable))
+                if any(later < earlier for earlier, later in zip(tops, tops[1:])):
+                    backwards.append((rows, total))
 
         assert states > 3_800_000, f"the sweep must be a sweep: {states} states"
         assert bottom_bad == [], f"the thumb bottoms out away from the list's end: {bottom_bad[:5]}"
-        assert top_bad == [
-            (3, 5, 1),
-            (3, 6, 1),
-            (3, 6, 2),
-            (4, 6, 1),
-            (5, 7, 1),
-        ], f"unexpected top-end residual: {top_bad[:8]}"
+        assert top_bad == [], f"the thumb sits at the top with rows above it: {top_bad[:8]}"
+        assert crushed == [], (
+            "the thumb's interior collapsed — cells the track can express carry no window, "
+            f"so the continuous signal is lost: {crushed[:5]}"
+        )
+        assert (
+            backwards == []
+        ), f"the thumb travelled backwards as the window advanced: {backwards[:5]}"
 
 
 @pytest.mark.parametrize("size", [(80, 24), (100, 30), (140, 44)])
@@ -1735,3 +1833,245 @@ async def test_the_too_small_notice_never_picks_a_form_wider_than_its_box() -> N
         assert (
             str(screen._too_small.content) == TOO_SMALL_NOTICE_SHORT
         ), "with no resolved width the notice chose the form that can clip"
+
+
+@pytest.mark.asyncio
+async def test_a_refused_click_leaves_the_clipboard_exactly_as_it_found_it() -> None:
+    """Round 3, Q8/U12 — found independently by the QA and UX rounds.
+
+    The U10 refusal made the picker DECLINE to copy on a disturbed chain. It
+    did not make the click harmless: `Widget._on_click` calls
+    `text_select_all()` on every `chain == 2` click on a selectable widget,
+    and this app turns the resulting `TextSelected` into a real clipboard
+    write plus a `copied N lines` receipt. The card is one `Static`, so the
+    refusing click put ~1,450 characters of the picker's own chrome — rules,
+    gutter, footer — on the clipboard and told the user it had worked.
+
+    **The refusal did not introduce that write; it removed what was masking
+    it.** Every chained click on a row used to dismiss and copy, so the
+    picker's own copy always overwrote the chrome a moment later. The refusal
+    is the first chained click that does neither, so the chrome write became
+    the last one standing. That is why this test asserts the CLIPBOARD IS
+    UNTOUCHED rather than that the picker stayed open: "refuses to copy" has
+    to mean the user's prior clipboard survives, and the round-2 shape of this
+    file's tests could not tell the difference.
+
+    **Driven through `App.on_event` with real MouseDown/MouseUp pairs, and
+    that is the whole point.** The neighbouring test posts a synthetic `Click`
+    straight to the screen, which never reaches `Widget._on_click`, so it
+    cannot observe this at all — measured: the same gesture reports a clean
+    clipboard when driven that way. `pilot.click` is no better; it fabricates
+    the chain per call, so two calls both arrive as `chain=1`.
+
+    Also covers the pre-existing doorway the same mechanism opened: a
+    double-click on the card's INERT regions (title, footer) leaked the card
+    identically on every earlier head, and an empty block — which
+    `action_choose` refuses with a bell — has leaked since round 1.
+    """
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        bodies = [f"Answer {index} unique body." for index in range(20, 0, -1)]
+        prior = "PRECIOUS-PRIOR-CLIPBOARD-CONTENTS"
+
+        def _choose(target: CopyTarget | None, sink: list[CopyTarget | None]) -> None:
+            """`_cmd_copy._copy_choice`, which is what closes the loop on the real
+            command: the picker only RETURNS a target, the app writes it. Without
+            the write the control case below cannot tell a working copy from a
+            clipboard nobody touched."""
+            sink.append(target)
+            if target is not None and target.content is not None:
+                app._put_on_clipboard(target.content)
+
+        async def _drive(interlude: str, pane_row: int) -> tuple[str, bool, CopyTarget | None]:
+            got: list[CopyTarget | None] = []
+            screen = await _open(app, _targets(*bodies), pilot, lambda t: _choose(t, got))
+            _reset_click_chain(app)
+            app.copy_to_clipboard(prior)
+            x, y = _tree_row(screen, pane_row)
+
+            await _full_click(app, x, y)
+            await pilot.pause()
+            if interlude == "wheel":
+                await _full_wheel(app, x, y, down=True)
+                await pilot.pause()
+            elif interlude == "key":
+                await pilot.press("down")
+                await pilot.pause()
+            await _full_click(app, x, y)
+            await pilot.pause()
+            await pilot.pause()
+
+            clipboard = app._clipboard
+            copied = got[0] if got else None
+            if screen.is_attached:
+                app.pop_screen()
+                await pilot.pause()
+            return clipboard, screen.is_attached, copied
+
+        # The instrument must be able to see a copy at all, or every assertion
+        # below passes vacuously against an app that never writes anything.
+        clipboard, _still_open, copied = await _drive("none", 4)
+        assert copied is not None, "a plain double-click must still copy"
+        assert clipboard == copied.content, (
+            "the plain double-click left something other than the chosen block on the "
+            f"clipboard: {clipboard[:60]!r}"
+        )
+
+        for interlude in ("wheel", "key"):
+            for pane_row in (0, 4, 8):
+                clipboard, _still_open, copied = await _drive(interlude, pane_row)
+                assert copied is None, f"a {interlude} between the clicks copied a row"
+                assert clipboard == prior, (
+                    f"a {interlude} between the clicks REFUSED to copy but still wrote "
+                    f"{len(clipboard)} characters to the clipboard: {clipboard[:60]!r}"
+                )
+
+        # The inert regions of the card, and the empty-block refusal: both are
+        # the same select-all mechanism through a doorway that predates this
+        # change, and both must also leave the clipboard alone.
+        screen = await _open(app, _targets(*bodies), pilot)
+        region = screen._body.region
+        inert = {
+            "title": (region.x + 4, region.y + 1),
+            "footer": (region.x + 4, region.y + region.height - 2),
+            "preview": _preview_row(screen, 1),
+            "backdrop": (1, 1),
+        }
+        for label, (x, y) in inert.items():
+            _reset_click_chain(app)
+            app.copy_to_clipboard(prior)
+            await _full_click(app, x, y)
+            await pilot.pause()
+            await _full_click(app, x, y)
+            await pilot.pause()
+            await pilot.pause()
+            assert app._clipboard == prior, (
+                f"double-clicking the {label} wrote {len(app._clipboard)} characters of "
+                f"card chrome to the clipboard: {app._clipboard[:60]!r}"
+            )
+        if screen.is_attached:
+            app.pop_screen()
+            await pilot.pause()
+
+        # `super+c` is bound on `Screen` beside `ctrl+c` and copies the live
+        # SELECTION, so it is the same leak by another key. With the card out
+        # of the selection walk there is nothing for it to take.
+        screen = await _open(app, _targets(*bodies), pilot)
+        _reset_click_chain(app)
+        app.copy_to_clipboard(prior)
+        x, y = _tree_row(screen, 4)
+        await _full_click(app, x, y)
+        await pilot.pause()
+        await pilot.press("super+c")
+        await pilot.pause()
+        assert app._clipboard == prior, "super+c copied the card's own chrome"
+        assert (
+            not screen.allow_select
+        ), "the card is chrome: it must stay out of Textual's selection walk"
+        if screen.is_attached:
+            app.pop_screen()
+            await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_a_movement_that_moves_nothing_does_not_disarm_the_double_click() -> None:
+    """Round 3, D19 — and the reviewer's own MAJOR, found by a different route.
+
+    `_move_to` armed the U10 refusal BEFORE comparing the clamp, so a wheel
+    notch, an arrow key or `end` that is a complete visual NO-OP disarmed the
+    double-click anyway. The user clicks a row, nudges, clicks again: the
+    frame is byte-identical at all three points, nothing is copied, and
+    nothing on screen says why. The refusal's entire defence is that it is
+    legible — "visible in the frame and one more click from the right answer"
+    — and that defence was true in 8 of 9 pane positions and false in exactly
+    these.
+
+    **It is worst on this surface's headline case.** With one long answer the
+    tree is ONE row, so 100% of wheel notches and arrow keys over it are
+    clamped no-ops and every nudge poisoned the double-click.
+
+    The fix is the same clamp comparison the preview offset two lines below
+    already uses, and the principle
+    `test_a_move_that_changes_nothing_keeps_the_reading_position` already pins
+    for the reading position.
+
+    Asserted on the CLIPBOARD, not on `_anchor_disturbed`: the defect is what
+    the user got, and the round-2 fixture missed this entirely because it uses
+    20 targets with the cursor mid-list — no clamped no-op is in its matrix at
+    all. The `noop` assertion below is what makes the fixture discriminating:
+    the frame really must be unchanged, or the case is not the one D19 named.
+    """
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        many = [f"Answer {index} unique body." for index in range(16, 0, -1)]
+        # The headline case: one long answer, so the tree is a single row and
+        # every tree movement is a no-op by construction.
+        one = ["A single long answer.\n" * 40]
+
+        async def _drive(
+            bodies: list[str], interlude: str, pre_key: str | None
+        ) -> tuple[CopyTarget | None, bool]:
+            got: list[CopyTarget | None] = []
+            screen = await _open(app, _targets(*bodies), pilot, got.append)
+            _reset_click_chain(app)
+            if pre_key is not None:
+                await pilot.press(pre_key)
+                await pilot.pause()
+            tree_rows, _ = screen._split_rows()
+            # Aim at whichever pane row is painting the cursor, so the FIRST
+            # click is itself a no-op and the interlude is the only variable.
+            pane_row = screen._selected - screen._window_start(tree_rows)
+            x, y = _tree_row(screen, pane_row)
+
+            before = screen.render_lines_for_test()
+            await _full_click(app, x, y)
+            await pilot.pause()
+            middle = screen.render_lines_for_test()
+            if interlude == "wheel-down":
+                await _full_wheel(app, x, y, down=True)
+                await pilot.pause()
+            elif interlude == "wheel-up":
+                await _full_wheel(app, x, y, down=False)
+                await pilot.pause()
+            else:
+                await pilot.press(interlude)
+                await pilot.pause()
+            after = screen.render_lines_for_test()
+            await _full_click(app, x, y)
+            await pilot.pause()
+            await pilot.pause()
+
+            copied = got[0] if got else None
+            if screen.is_attached:
+                app.pop_screen()
+                await pilot.pause()
+            return copied, before == middle == after
+
+        cases = [
+            (many, "wheel-up", "home", "wheel up at the first row"),
+            (many, "up", "home", "`up` at the first row"),
+            (many, "home", "home", "`home` at the first row"),
+            (many, "wheel-down", "end", "wheel down at the last row"),
+            (many, "down", "end", "`down` at the last row"),
+            (many, "end", "end", "`end` at the last row"),
+            (one, "wheel-down", None, "wheel over a one-row tree"),
+            (one, "down", None, "`down` on a one-row tree"),
+        ]
+        for bodies, interlude, pre_key, label in cases:
+            copied, noop = await _drive(bodies, interlude, pre_key)
+            assert noop, f"{label}: the fixture's premise — the frame must be unchanged"
+            assert copied is not None, (
+                f"{label} moved nothing, yet the double-click was refused against a frame "
+                "that never changed"
+            )
+
+        # And the refusal STILL fires when something really moved, or this
+        # test's fix would simply be "never refuse" — which is U10 reopened.
+        for interlude, pre_key in (("wheel-down", "home"), ("down", "home")):
+            copied, noop = await _drive(many, interlude, pre_key)
+            assert not noop, "the control's premise: this movement must change the frame"
+            assert (
+                copied is None
+            ), f"a {interlude} that MOVED the cursor no longer refuses — U10 is back"

--- a/tests/unit/tui/test_copy_picker_mouse.py
+++ b/tests/unit/tui/test_copy_picker_mouse.py
@@ -21,14 +21,18 @@ import pytest
 from rich.cells import cell_len
 from textual import events
 from textual.binding import Binding
+from textual.geometry import Size
 
 from local_operator.tui.copy_targets import CopyTarget, build_copy_targets
 from local_operator.tui.widgets.assistant import AssistantBlock
 from local_operator.tui.widgets.copy_picker import (
     HEADER_ROWS,
+    MIN_GUTTER_TRACK_ROWS,
     PREVIEW_HINT,
     PREVIEW_WRAP_BUDGET,
+    PREVIEW_WRAP_STRIDE,
     TOO_SMALL_NOTICE,
+    TOO_SMALL_NOTICE_SHORT,
     CopyPickerScreen,
 )
 
@@ -1235,23 +1239,38 @@ async def test_the_hover_highlight_follows_the_window_under_a_resting_pointer() 
 
 
 @pytest.mark.asyncio
-async def test_the_thumb_reaches_the_bottom_exactly_when_the_cue_goes() -> None:
-    """Round 1, D11. `_thumb_span` anchored on the window's fraction of the
-    LIST and then clamped, so the clamp won one window position early: the
-    thumb sat at the bottom of the track while the rule still read `↓ 1 more`,
-    two distinct positions painted an identical gutter, and the user's final
-    arrow press moved the one CONTINUOUS signal not at all.
+async def test_the_thumb_reaches_each_end_exactly_when_that_cue_goes() -> None:
+    """Round 1 D11, and round 2 MAJOR-1/D16 — the SAME invariant at both ends.
 
-    The invariant asserted here is the whole point of the component: thumb at
-    the bottom of the track if and only if there is nothing below.
+    D11: `_thumb_span` anchored on the window's fraction of the LIST and then
+    clamped, so the clamp won one window position early — the thumb sat at the
+    bottom of the track while the rule still read `↓ 1 more`, two distinct
+    positions painted an identical gutter, and the user's final arrow press
+    moved the one CONTINUOUS signal not at all.
 
-    **The row counts are chosen because they DISCRIMINATE.** The old formula
-    is accidentally correct at many shapes — at 32 rows in a 12-row pane it
-    has no violation at all — so a single convenient fixture passes against
-    the broken code. 19 is the shape D11 was reported against (it bottoms out
-    one window early, at `start=6` of 7); 15, 26 and 40 are the other
-    published failures, 40 breaking at three consecutive positions. A test
-    that pinned only one shape here would be a guard that cannot go red.
+    Round 1 fixed that with a floored proportion and asserted only the bottom
+    half. **That is why this test had to change shape rather than gain a
+    fixture.** The floor moved the contradiction to the TOP — `top == 0` for a
+    RANGE of early windows, so at the very 19-row shape D11 was filed against,
+    `start=0` and `start=1` painted an identical gutter while the cue changed
+    from `↓ 7 more` to `↑ 1 more ↓ 6 more`. Enumerated, floor scored 0 bottom
+    contradictions and 427,381 top ones. The round-1 guard could not see any
+    of it: it asserted `at_bottom == nothing_below` and nothing else, and all
+    four of its fixtures VIOLATE the top invariant on the code they pass
+    against. A guard that structurally cannot observe the defect it is named
+    for is worse than no guard, so both directions are pinned here now:
+
+        thumb flush with the bottom of the track ⟺ nothing below
+        thumb flush with the top of the track    ⟺ nothing above
+
+    **The row counts are chosen because they DISCRIMINATE.** The round-1
+    formula is accidentally correct at many shapes — at 32 rows in a 12-row
+    pane it has no violation at all — so a single convenient fixture passes
+    against broken code. 19 is the shape D11 and D16 were both reported
+    against; 15, 26 and 40 are the other published failures, 40 breaking at
+    three consecutive positions. Each of the four also fails the TOP assertion
+    on the round-1 floor (at `start=1`; 26 at 1–2 and 40 at 1–3), so the same
+    fixtures discriminate in the new direction — verified by reverting.
     """
     for total_rows in (15, 19, 26, 40):
         app = _real_app()
@@ -1271,6 +1290,12 @@ async def test_the_thumb_reaches_the_bottom_exactly_when_the_cue_goes() -> None:
                 assert at_bottom == nothing_below, (
                     f"{total} rows in {tree_rows}: start={start}/{max_start} thumb "
                     f"{span.start}..{span.stop}, {total - start - tree_rows} rows still below"
+                )
+                at_top = span.start == 0
+                nothing_above = start == 0
+                assert at_top == nothing_above, (
+                    f"{total} rows in {tree_rows}: start={start}/{max_start} thumb "
+                    f"{span.start}..{span.stop}, {start} rows still above"
                 )
             # And it actually travels rather than sitting still.
             first = screen._thumb_span(tree_rows, 0)
@@ -1427,3 +1452,286 @@ async def test_a_resize_keeps_the_reading_position_instead_of_dropping_it() -> N
             await pilot.pause()
             assert screen._preview_offset > 0, f"the position was dropped resizing to {size}"
             assert screen._preview_offset <= 40
+
+
+@pytest.mark.asyncio
+async def test_the_thumb_holds_both_ends_across_every_shape_it_can_draw() -> None:
+    """Round 2, MAJOR-1/D16 — the same invariant as the test above, ENUMERATED.
+
+    The test above drives the real app, so it can afford four shapes; this one
+    calls `_thumb_span` directly and sweeps the whole space both reviewers
+    scored, which is what turns "0 violations" from a claim into a measurement.
+    Both are kept: the four-shape version proves the invariant holds on a card
+    that is actually laid out and painted, this one proves no shape escapes it.
+
+    Restricted to `rows >= MIN_GUTTER_TRACK_ROWS`, because below that the
+    gutter is SHED rather than drawn (round 1, D14) and an undrawn thumb
+    cannot contradict a cue.
+
+    The five residuals are `travel == 1` with `max_start > 1` — a one-cell
+    travel has two expressible positions for three or more window states, so
+    by pigeonhole one must share a cell with an extreme. They are asserted
+    EXACTLY rather than tolerated: the set is pinned by shape, so a formula
+    that regressed a sixth position would fail here even though the count is
+    non-zero, and the forfeited end is asserted to be the top.
+    """
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets("a", "b"), pilot)
+
+        top_bad: list[tuple[int, int, int]] = []
+        bottom_bad: list[tuple[int, int, int]] = []
+        states = 0
+        for rows in range(MIN_GUTTER_TRACK_ROWS, 60):
+            for total in range(rows + 1, 400):
+                screen._flat = [None] * total  # type: ignore[assignment]
+                max_start = total - rows
+                for start in range(max_start + 1):
+                    span = screen._thumb_span(rows, start)
+                    states += 1
+                    if (span.stop == rows) != (start == max_start):
+                        bottom_bad.append((rows, total, start))
+                    if (span.start == 0) != (start == 0):
+                        top_bad.append((rows, total, start))
+
+        assert states > 3_800_000, f"the sweep must be a sweep: {states} states"
+        assert bottom_bad == [], f"the thumb bottoms out away from the list's end: {bottom_bad[:5]}"
+        assert top_bad == [
+            (3, 5, 1),
+            (3, 6, 1),
+            (3, 6, 2),
+            (4, 6, 1),
+            (5, 7, 1),
+        ], f"unexpected top-end residual: {top_bad[:8]}"
+
+
+@pytest.mark.parametrize("size", [(80, 24), (100, 30), (140, 44)])
+@pytest.mark.asyncio
+async def test_a_fully_scrolled_preview_ends_on_a_full_pane_at_every_length(size) -> None:
+    """Round 2, BLOCKER-1/U11 — MAJOR-2's clamp did not survive the wrap budget.
+
+    `_preview_tail_offset` walked only the LAST wrap window. `_wrap_window_start`
+    snaps to `PREVIEW_WRAP_STRIDE`, so a document of `100k + 1 … 100k + rows`
+    lines has a final window holding fewer lines than the pane draws: the walk
+    ran out of MAP before it ran out of PANE and fell through to `window_start`,
+    which for that band IS the `source_lines - 1` ceiling round 1 removed. A
+    fully scrolled 205-line answer ended on five lines of text above eleven
+    blank rows — the exact frame MAJOR-2 was filed against, restored by its own
+    fix, on this surface's headline case (one long answer).
+
+    **Enumerated across lengths AND sizes because both reviewers found it that
+    way and neither found it by spot-checking.** The band is `preview_rows`
+    wide, so it widens with the terminal — measured on the pre-fix code at
+    17/60 sampled lengths at 80x24, 30/60 at 100x30 and 43/60 at 140x44 — and
+    a fixture at one size and one length is exactly the guard that missed it.
+    The round-1 tests used 40- and 201-line documents and asserted `0 < offset
+    <= 40`, never that the end frame was FULL, which is why this asserts the
+    painted pane rather than the offset.
+
+    The lengths deliberately straddle two stride boundaries and include the
+    lengths either side, so a fix that merely special-cased one boundary fails.
+    """
+    lengths = (
+        [PREVIEW_WRAP_BUDGET - 1, PREVIEW_WRAP_BUDGET]
+        + list(range(PREVIEW_WRAP_BUDGET + 1, PREVIEW_WRAP_BUDGET + 32))
+        + [3 * PREVIEW_WRAP_STRIDE + 1, 3 * PREVIEW_WRAP_STRIDE + 6, 4 * PREVIEW_WRAP_STRIDE + 1]
+    )
+    app = _real_app()
+    async with app.run_test(size=size) as pilot:
+        await pilot.pause()
+        drained = []
+        for length in lengths:
+            body = "\n".join(f"line {index}" for index in range(length))
+            screen = await _open(app, _targets(body), pilot)
+
+            # Past any reachable end, so this is the CEILING and not a stop.
+            screen._scroll_preview_to(10**6)
+            await pilot.pause()
+
+            lines = screen.render_lines_for_test()
+            top = screen._preview_top_row
+            pane = lines[top + 1 : top + 1 + screen._preview_rows]
+            blank = sum(1 for line in pane if not line.strip())
+            if blank > 1:
+                drained.append((length, screen._preview_offset, blank, len(pane)))
+            assert any(
+                f"line {length - 1}" in line for line in pane
+            ), f"{length} lines: the last line is not on screen"
+            app.pop_screen()
+            await pilot.pause()
+
+        assert not drained, "a fully scrolled preview drained its own pane at " + ", ".join(
+            f"{n} lines (offset {o}, {b}/{p} rows blank)" for n, o, b, p in drained
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_wheel_or_a_key_between_the_clicks_refuses_rather_than_copying() -> None:
+    """Round 2, U10. The U1 anchor binds the copy to the row the FIRST click
+    resolved, which is right while nothing moves in between. But Textual breaks
+    a click chain on only two things — a changed screen offset and the clock —
+    and a wheel notch changes neither, nor does a keypress. So the second click
+    still arrived as `chain=2`, the anchor fired, and the CLIPBOARD got the
+    pre-wheel row while the caret and preview had moved on: measured 5/5
+    disagreements with a wheel between the clicks, 5/5 with a key, 0/5 plain.
+
+    That is the same silent failure U1 was filed for — the clipboard receives
+    something other than what the frame promised — through a narrower but
+    entirely natural gesture: click a row, realise it is not the one, nudge the
+    wheel, click again.
+
+    **The refusal is the fix, not a re-hit-test.** Re-resolving the row under
+    the pointer was measured first: because a wheel over the tree moves the
+    cursor and `_window_start` recentres it, the pointer's row equals the
+    previewed row in only 1 of 9 pane positions, so that fallback copies a
+    third row that is neither aimed at nor shown. A disturbed chain therefore
+    selects and previews without copying, exactly as a chain broken by the
+    clock already does.
+
+    Asserted on the CLIPBOARD PAYLOAD, not on the anchor attribute: the defect
+    was what the user got, and an attribute assertion would pass against a
+    fix that cleared the anchor and copied the wrong row anyway.
+    """
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        bodies = [f"Answer {index} unique body." for index in range(20, 0, -1)]
+
+        async def _drive(interlude: str, pane_row: int) -> tuple[CopyTarget, CopyTarget | None]:
+            got: list[CopyTarget | None] = []
+            screen = await _open(app, _targets(*bodies), pilot, got.append)
+            x, y = _tree_row(screen, pane_row)
+
+            screen.post_message(_click(screen, x, y, chain=1))
+            await pilot.pause()
+            if interlude == "wheel":
+                screen.post_message(_wheel(screen, x, y, down=True))
+                await pilot.pause()
+            elif interlude == "key":
+                await pilot.press("down")
+                await pilot.pause()
+
+            framed = screen.selected_target()
+            assert framed is not None, "the frame must be previewing something to disagree with"
+            screen.post_message(_click(screen, x, y, chain=2))
+            await pilot.pause()
+            await pilot.pause()
+            copied = got[0] if got else None
+            if screen.is_attached:
+                app.pop_screen()
+                await pilot.pause()
+            return framed, copied
+
+        # The plain double-click still copies, and copies what it aimed at.
+        # Without this the "fix" could be `never copy`, which passes the rest.
+        for pane_row in (0, 4, 8):
+            framed, copied = await _drive("none", pane_row)
+            assert copied is not None, f"a plain double-click at row {pane_row} did not copy"
+            assert copied.content == framed.content, "the plain double-click copied a stale row"
+
+        for interlude in ("wheel", "key"):
+            for pane_row in (0, 2, 4, 6, 8):
+                framed, copied = await _drive(interlude, pane_row)
+                if copied is None:
+                    continue  # refused, which is the fix's chosen behaviour
+                got, shown = copied.content or "", framed.content or ""
+                assert got == shown, (
+                    f"a {interlude} between the clicks copied {got.splitlines()[0]!r} "
+                    f"while the frame showed {shown.splitlines()[0]!r}"
+                )
+
+
+@pytest.mark.asyncio
+async def test_the_too_small_notice_never_picks_a_form_wider_than_its_box() -> None:
+    """Round 2, D17. `_repaint` chose the notice's form against
+    `self._screen_size()[0]`, but the notice is laid out in the SCREEN'S
+    CONTENT BOX, which `Screen { padding: 1 }` makes two cells narrower. Those
+    agree once laid out; `_screen_size`'s two fallbacks do not — it answers
+    `self.app.size` before layout resolves and a hardcoded (80, 24) on
+    exception, both reporting more room than the notice has. At 34 and 35
+    columns that selects the 34-cell long form for a 32- or 33-cell box, and
+    it clips back to `terminal too small for /copy ·` — the dangling separator
+    U8 removed.
+
+    The design round kept a captured frame of that rendering but could not
+    reproduce it across 22 repeats, so this asserts the PROPERTY rather than
+    the race: whatever form is chosen must fit the box it is laid out in, at
+    every width, and an unresolved measurement must fall back to the short
+    form because it fits everywhere the long one does.
+    """
+    app = _real_app()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        screen = await _open(app, _targets("body"), pilot)
+
+        # Down to 17 columns, where the SHORT form still fits its box. Below
+        # that neither form does and the notice truncates whatever it is given
+        # — the 13–16 column residue UX round 2 recorded as a follow-up under
+        # U8, which is about the short form's own width and not about D17's
+        # choice between the two.
+        for columns in (60, 40, 37, 36, 35, 34, 33, 32, 30, 24, 20, 18, 17):
+            await pilot.resize_terminal(columns, 10)
+            await pilot.pause()
+            await pilot.pause()
+            assert not screen.is_drawable, f"{columns} cols must be too small for the card"
+            notice = screen._too_small
+            painted = str(notice.content)
+            box = notice.size.width
+            assert box, f"{columns} cols: the notice has no resolved width"
+            assert cell_len(painted) <= box, (
+                f"{columns} cols: the notice is {cell_len(painted)} cells in a {box}-cell box "
+                f"and will clip: {painted!r}"
+            )
+            assert not painted.rstrip().endswith("·"), f"dangling separator at {columns}"
+            assert "esc" in painted, f"the way out was shed at {columns} columns"
+            # And the widest form that FITS is the one chosen — the fix must
+            # not degrade to "always short", which would pass everything above.
+            if cell_len(TOO_SMALL_NOTICE) <= box:
+                assert (
+                    painted == TOO_SMALL_NOTICE
+                ), f"{columns} cols: short form in a box that fits the long one"
+
+        # THE DISCRIMINATING FIXTURE, and the reason this test exists at all.
+        # On the laid-out path every source agrees (`app.size` 34 → `self.size`
+        # 32 → the notice's box 32, measured at every width above), so no
+        # resize can tell the old code from the new one: a test that only
+        # swept widths would be exactly the guard that cannot see its own
+        # defect. The discrepancy is `_screen_size`'s FALLBACK — with
+        # `self.size` unresolved it answers `self.app.size`, the terminal,
+        # which is two cells wider than the box `Screen { padding: 1 }` leaves
+        # the notice.
+        #
+        # 34x8, not 34x10, and that is load-bearing: the same fallback feeds
+        # `is_drawable`, and at height 10 the patched screen reports itself
+        # DRAWABLE, so `_repaint` skips the notice branch and the assertion
+        # reads a stale string that passes against either code. Height 8 is
+        # below `MIN_CARD_INNER_ROWS` however the width is measured, so the
+        # notice branch really runs. Verified: the pre-fix expression paints
+        # the 34-cell long form into the 32-cell box here.
+        await pilot.resize_terminal(34, 8)
+        await pilot.pause()
+        await pilot.pause()
+        assert screen._too_small.size.width == 32, "the fixture's premise: a 32-cell box at 34 cols"
+        with pytest.MonkeyPatch.context() as patch:
+            patch.setattr(type(screen), "size", property(lambda self: Size(0, 0)))
+            assert screen._screen_size()[0] == 34, "the fallback reports the terminal, not the box"
+            assert not screen.is_drawable, "the notice branch must actually run"
+            screen._repaint()
+            painted = str(screen._too_small.content)
+        assert cell_len(painted) <= 32, (
+            f"the unresolved-layout path chose a {cell_len(painted)}-cell form for a "
+            f"32-cell box, which clips to a dangling separator: {painted!r}"
+        )
+        assert painted == TOO_SMALL_NOTICE_SHORT
+
+        # And with NOTHING resolved it must still prefer the short form: it
+        # fits everywhere the long one does, so an uncertain measurement must
+        # not select the one that can clip.
+        with pytest.MonkeyPatch.context() as patch:
+            patch.setattr(type(screen._too_small), "size", property(lambda self: Size(0, 0)))
+            patch.setattr(type(screen), "size", property(lambda self: Size(0, 0)))
+            screen._repaint()
+        assert (
+            str(screen._too_small.content) == TOO_SMALL_NOTICE_SHORT
+        ), "with no resolved width the notice chose the form that can clip"

--- a/tests/unit/tui/test_copy_picker_qa.py
+++ b/tests/unit/tui/test_copy_picker_qa.py
@@ -35,7 +35,11 @@ import re
 import pytest
 
 from local_operator.tui.app import OperatorApp
-from local_operator.tui.copy_targets import MAX_MESSAGES, build_copy_targets
+from local_operator.tui.copy_targets import (
+    MAX_MESSAGES,
+    build_copy_targets,
+    extract_blocks,
+)
 from local_operator.tui.events import (
     AssistantDelta,
     AssistantMessageEnd,
@@ -205,7 +209,15 @@ def test_the_all_rows_appear_only_above_more_than_one_block_of_that_kind() -> No
     """`All N` is a convenience over several blocks; above one it would be a
     second row copying byte-for-byte what the row above copies. The two kinds
     are counted INDEPENDENTLY, so a message with two fences and one quote gets
-    `All 2 blocks` and no `All N quotes`."""
+    `All 2 code blocks` and no `All N quotes`.
+
+    The label names the KIND. `All 2 blocks` was built from `len(code)` alone
+    but drawn as the last sibling of a list that also held a quote, with the
+    identical connector treatment — so the frame said it copied the three rows
+    above it, and it did not. That is the frame answering a correctness
+    question wrongly (design round 1, D4), which is why five cells buy a fix
+    rather than a nicety.
+    """
     one_code_two_quotes = build_copy_targets([_answer("```py\na\n```\n\n> q1\n\ntext\n\n> q2\n")])[
         0
     ]
@@ -223,8 +235,13 @@ def test_the_all_rows_appear_only_above_more_than_one_block_of_that_kind() -> No
         "Block 1",
         "Block 2",
         "Quote 1",
-        "All 2 blocks",
+        "All 2 code blocks",
     ]
+    # The aggregate is marked as DERIVED, which is what earns it a dimmer ink
+    # in the tree: it copies a join of the rows above it rather than anything
+    # that exists in the message. A flag rather than an `id.endswith(':all')`
+    # test, so the id's shape stays an identity detail.
+    assert [c.label for c in two_code_one_quote.children if c.derived] == ["All 2 code blocks"]
 
 
 def test_the_all_blocks_row_joins_bodies_with_one_blank_line() -> None:
@@ -232,7 +249,7 @@ def test_the_all_blocks_row_joins_bodies_with_one_blank_line() -> None:
     `.join("\\n\\n")`. A single newline would weld the last line of one block
     onto the first of the next when the payload is pasted into a file."""
     target = build_copy_targets([_answer("```py\na\nb\n```\n\n```js\nc\n```\n")])[0]
-    combined = next(c for c in target.children if c.label == "All 2 blocks")
+    combined = next(c for c in target.children if c.label == "All 2 code blocks")
 
     assert combined.content == "a\nb\n\nc"
 
@@ -256,8 +273,11 @@ def test_the_all_blocks_row_joins_bodies_with_one_blank_line() -> None:
         ("unclosed", "before\n```py\nhalf written\n", []),
         # Fences mask their bodies: this `>` is code, not a quote.
         ("quote in fence", "```\n> not a quote\n```\n", [("code", "> not a quote")]),
-        # A quote run ends where the fence begins; both survive, in order.
-        ("quote then fence", "> q\n```py\nc\n```\n", [("quote", "q"), ("code", "c")]),
+        # A quote run ends where the fence begins; both survive. Listed here
+        # code-first because the CHILD ROWS are grouped by kind (see the
+        # docstring); the grammar's own document order is asserted separately
+        # below, against `extract_blocks`.
+        ("quote then fence", "> q\n```py\nc\n```\n", [("code", "c"), ("quote", "q")]),
         # `>` plus at most ONE space comes off, so a bare `>foo` de-prefixes.
         ("no space after gt", ">tight\n", [("quote", "tight")]),
         # Only one optional space: further indentation is the quote's own.
@@ -276,7 +296,21 @@ def test_the_block_grammar_holds_on_its_edges(
     block presented as whole — so the body is what distinguishes them, not an
     exception. Asserted through `build_copy_targets` rather than
     `extract_blocks` so the child `content` (what is actually copied) is what
-    is checked, not an intermediate."""
+    is checked, not an intermediate.
+
+    ``expected`` is in CHILD ROW order, which groups every `Block` before
+    every `Quote`. It used to be document order, because the two coincided:
+    children were emitted as the grammar found them, which drew
+    `Block 1 / Quote 1 / Block 2 / Quote 2` above an `All 2 code blocks` row
+    covering the first and third of those, with nothing in the frame saying
+    which rows the aggregate stood for (design round 1, D4). Grouping puts
+    each aggregate under the run it summarises.
+
+    The grammar's own document order did not change and is not abandoned
+    here: it is asserted directly against `extract_blocks`, which is where
+    that fact actually lives — the numbering the user reads (`Block 1`,
+    `Block 2`) still counts fences in the order they appear.
+    """
     target = build_copy_targets([_answer(message)])[0]
     got = [
         ("code" if child.id.split(":")[2] == "code" else "quote", child.content)
@@ -285,6 +319,14 @@ def test_the_block_grammar_holds_on_its_edges(
     ]
 
     assert got == expected, f"{name}: {got}"
+    # Same bodies, in the order the message presents them.
+    assert sorted(got) == sorted(
+        (block.kind, block.body) for block in extract_blocks(message)
+    ), f"{name}: rows and grammar disagree on the bodies"
+    assert [block.kind for block in extract_blocks("> q\n```py\nc\n```\n")] == [
+        "quote",
+        "code",
+    ], "the grammar itself still walks the message in document order"
 
 
 def test_twenty_code_blocks_all_become_rows_and_the_all_row_counts_them() -> None:
@@ -299,7 +341,7 @@ def test_twenty_code_blocks_all_become_rows_and_the_all_row_counts_them() -> Non
     assert len(blocks) == 20
     assert blocks[0].id == "msg:1:code:0" and blocks[0].label == "Block 1"
     assert blocks[-1].id == "msg:1:code:19" and blocks[-1].label == "Block 20"
-    assert combined.label == "All 20 blocks"
+    assert combined.label == "All 20 code blocks"
     assert combined.content == "\n\n".join(f"block {index}" for index in range(20))
 
 

--- a/tests/unit/tui/test_copy_targets.py
+++ b/tests/unit/tui/test_copy_targets.py
@@ -185,16 +185,35 @@ def test_a_group_node_still_copies_the_whole_message() -> None:
     assert targets[0].content == text
 
 
-def test_children_are_the_blocks_then_the_all_rows() -> None:
+def test_children_are_the_blocks_then_the_quotes_then_the_all_rows() -> None:
+    """Grouped by KIND, not interleaved in document order.
+
+    Document order put `Block 1 / Quote 1 / Block 2 / Quote 2` above an
+    `All 2 code blocks` row that covers the first and third of those, drawn
+    with the identical `├─`/`└─` connector — so nothing in the frame said
+    which rows the aggregate stood for, and the reasonable reading was that it
+    copied all four (design round 1, D4). Grouping puts each aggregate
+    directly under the run it summarises.
+
+    The NUMBERING is unchanged and is the thing to keep an eye on here:
+    `Block N` still counts fences in the order the message presents them, so
+    the labels still match the order the user read them in.
+    """
     text = "intro\n\n```py\na\n```\n\n> q1\n\n```py\nb\n```\n\n> q2"
     targets = build_copy_targets([_Assistant(text)])
     assert [child.label for child in targets[0].children] == [
         "Block 1",
-        "Quote 1",
         "Block 2",
+        "Quote 1",
         "Quote 2",
-        "All 2 blocks",
+        "All 2 code blocks",
         "All 2 quotes",
+    ]
+    # Grouping reordered the ROWS, not the bodies behind them.
+    assert [child.content for child in targets[0].children if ":code:" in child.id] == ["a", "b"]
+    assert [child.content for child in targets[0].children if ":quote:" in child.id] == [
+        "q1",
+        "q2",
     ]
 
 


### PR DESCRIPTION
## Summary

The `/copy` picker can now be scrolled, and the mouse drives it. This is the operator's ask: *"make it so that the /copy page can be scrolled and add more UX improvements to make that section more intuitive. I noticed that you can't hover and click on the copy lines, that would make operating easier as well."*

**Change class: C2 (standard, pre-authorized).** One TUI screen plus its target builder; no runtime, protocol or release surface.

Release: patch — the `/copy` picker scrolls its preview and tree, responds to hover, click and the wheel, and shows how much is off-screen.

Measured on `origin/main` before touching anything, which is what makes this a fix rather than a polish pass:

- a 121-line answer showed **15 lines with 92% unreachable** by any key or gesture;
- **27 hidden tree rows announced by nothing at all** — no scrollbar, no remainder, no position;
- every click, hover and wheel event **inert** (`has on_click: False`, `has on_mouse_move: False`);
- **10 of 19 tree rows hidden while 7 preview rows sat empty** under a one-line preview.

### Why patch, not minor

`AGENTS.md` reserves a minor for a step-function capability a user would notice and adopt — a new surface or subsystem. This makes an existing surface work properly: no new command, no new screen, no new subsystem. It is a substantial improvement to one modal, which is what the patch class is for, and the release title test settles it — there is no `X.Y.0: <the new thing>` sentence to write here.

## What changed

**Mouse.** The wheel over the tree moves the cursor through the existing `_move_to`, stepped by the live `App.scroll_sensitivity_y` (2.0 on this app) rather than a hardcoded 1; over the preview it scrolls the preview and leaves the cursor alone. Routing is by screen row against the card's own layout, because the card is one `Static` and the event's widget is identical over both panes.

A single click **selects and previews**; a **double-click** copies (Textual's own `Click.chain`, whose window is `App.CLICK_CHAIN_TIME_THRESHOLD` — **0.9 s** in this app, not the 0.5 s an earlier revision of this body and the handler comment both claimed; corrected in round 2, UX U10). That diverges from `session_picker`, where a click acts immediately, and the divergence is commented at the handler: this picker's whole value is the preview pane, so click-to-copy would hand the mouse user a *less* careful path than the keyboard user, and its mistake is silent — the clipboard is overwritten and the modal is gone before you find out at the paste site. `session_picker`'s mistake (wrong session resumed) is loud and recoverable.

Buttons 2/3 return before any state change. `_index_at` carries all three of `session_picker`'s guards, whose absence there once resolved a footer click to session #12 and the backdrop to row 0 — both coordinates re-measured as still delivered here. The backdrop deliberately does **not** dismiss: the app's other two modals have no mouse handling at all, so it would exist on exactly one of three.

**Scrolling.** A `_preview_offset`, reset on every cursor move (a different selection is a different document) and clamped at both ends, with `shift+↑↓` and `shift+pageup/pagedown` for keyboard parity — every mouse capability needs a key, or the mouse becomes the only way to do something. `left`/`right`/`tab` stay unbound: focus-swapping would give a screen with no focus model a mode in which `up`/`down` mean two different things depending on invisible state.

**`PREVIEW_WRAP_BUDGET` had to be resolved in the same commit.** As a prefix cap it was an invisible optimisation only because ~15 rows were ever shown; the moment the preview scrolls it becomes a dead end at source line 200 with a remainder that stops going down. It is now a sliding **window** around the offset, snapped to a stride so the memo stays bounded. Shipping the scroll without this would have converted an optimisation into a bug.

**The `… N more lines` marker is now live** — counted from the current offset and vanishing at the end of the document, so its absence means "this is everything". It is still counted in **SOURCE lines** through the existing `rows_per_source` map, which is the single highest-risk regression in this change: a row-counting version once made a 79-line answer claim `… 144 more lines`. Three existing tests pin it and all three still pass; the new test uses deliberately *wrapping* content, because with short lines the two units coincide and a row-counting implementation passes (measured: 79 43-cell lines produce exactly 79 rows in an 88-cell pane).

**Making the hidden scroll visible.** `↑ N` and `↓ N more` ride the two rules that already exist, so an overflowing tree costs no row to say so. Both directions are cued because `_window_start` centres the cursor, so the list is very often clipped at both ends at once and a down-only cue would actively mislead. The cue slot is sized on its widest rendering so the rule does not twitch as the digit count changes. A one-cell gutter thumb adds the *continuous* signal a remainder cannot give — and it is **shed**, not allowed to raise the drawability floor, so no terminal that draws a card today stops drawing one.

**The split.** `_split_rows` gave the tree `available // 2` unconditionally while the preview's `min(len)` cap only ever donated downward. It now reserves the preview a floor and gives the tree the rest. **The expression reads only `len(_flat)` and the row budget** — never the cursor or the selected target's line count, which would change the tree's height on every arrow press and shift rows sideways under a cursor the user is aiming at.

**Rows carry `session_picker`'s three-way ground** so hover has something to lift, with the caret (`accent` → `muted`) as the discriminator between hover and selection.

## Two defects found on the way, both fixed here

**The dismiss race crashes on `main` today, without a mouse.** Two dismissals with no event-loop turn between them reach `dismiss` after the screen popped:

```
$ .venv/bin/python /tmp/copyux/probe7.py          # on origin/main, keyboard only
second action_choose() raised: ScreenStackError Can't pop screen; there must be at least one screen on the stack
cancel after choose raised: ScreenStackError Can't pop screen; there must be at least one screen on the stack

$ .venv/bin/python /tmp/copyux/probe12u.py        # a naively-ported on_click, two queued Clicks
textual.app.ScreenStackError: Can't pop screen; there must be at least one screen on the stack
```

So a user hammering Enter could crash the app on `main` right now. Guarding only `on_click` would have left that in place, so `action_choose`/`action_cancel` route through a `_dismiss_result` helper guarding on `is_active`. After the fix, on this branch:

```
MOUSE  two queued clicks: survived, callbacks=1
KEYS   choose/choose/cancel: survived, callbacks=1
pointer after dismiss: default
```

`pilot.click(times=2)` does **not** reproduce this — it pauses between clicks — so the regression test posts the messages itself. The helper also resets `styles.pointer` before dismissing, or a mouse user who copies is left with a hand cursor over their transcript.

**Every repaint re-wrapped the whole preview** through `rich.Syntax`, which is roughly **200x** the cost of drawing the tree beside it — measured with `time.thread_time` (CPU, not wall), median of 9, at 100x30: `_wrap_preview` 3.40 ms cold against `_tree_lines`' 0.015 ms on a 121-line answer, and 4.19 ms against 0.024 ms on a 499-line highlighted block. `_card_text` as a whole goes 4.06 ms cold to 0.10 ms warm, so a mouse sweep costs one wrap rather than one per row. *(Corrected in round 1, Q4: this section previously quoted 31 ms / 0.07 ms / a 365 ms sweep. Those do not reproduce — the figures are flat in document length because `PREVIEW_WRAP_BUDGET` bounds the work, so 31 ms was only ever reachable before that budget applied.)* Hover makes that trivial to hit without meaning to press anything. `_wrap_preview` is memoised on `(target.id, width, window_start)` — a total key, since `CopyTarget` is frozen and the tree is a snapshot that cannot change while the screen is open — and the method's former "No per-target cache" comment is **updated** rather than worked around, since its staleness objection does not survive that key.

Measured on this branch:

| | loop CPU |
|---|---|
| 20-row sweep, cold | 244 ms |
| 20-row sweep, warm | **3 ms (72x)** |
| 20 hover-only repaints | 4 ms (cache grew by 0 entries) |
| 20,000-line preview, first paint | 0.7 ms |
| 20,000-line preview, 20 scrolled paints | 90 ms |

That last row is the wrap window doing its job: wrapping such a document whole measures 2.8 s.

## Smaller honesty fixes

- **`All 2 blocks` → `All 2 code blocks`, and children group by kind.** The aggregate is built from `len(code)` but was drawn as the last sibling of a list containing a quote, with identical connector treatment — so the frame said it copied the three rows above it, and it did not. Aggregates also render one ramp step down (`muted`), since they are derived targets.
- **`truncated` moves from `dim` to `warning`.** The whole hint was `dim`, styling a caveat as a statistic, while the app raises a `warning` notice about it after the copy.
- **An empty block reads `empty`, not `0 lines`, and Enter's refusal rings.** Enter refuses it (unchanged, still pinned); marking the row means the frame predicts the refusal instead of explaining it afterwards, and `app.bell()` means a user who did not read the hint column gets an answer rather than an application that appears to have stopped responding to the key. *(The audible half landed in round 1, U6; before that only the marking shipped and this bullet overstated it.)*
- **A terminal too small for the card now says so.** It rendered nothing at all: from the user's chair, "I typed a command and my screen went dim and blank". The notice is a **sibling** of the card, so `render_lines_for_test()` still reports `[]`, `"Copy to clipboard"` is still absent from the frame, and `esc` still works — the pinned two-sided contract is untouched, not weakened.
- **Footer:** `↑↓ move · shift+↑↓ preview · enter copy · esc quit`, with `shift+↑↓` spelled out to match `settings_view` rather than introducing a `⇧` glyph style. The mouse is deliberately **not** advertised — hover plus the hand pointer is self-demonstrating, and neither sibling picker advertises its click either; the scarce cells go to the genuinely undiscoverable thing. The preview hint is gated on the preview actually overflowing, and sheds second.

## Testing Evidence

### Gates, over the whole tree exactly as CI

| Command | Result |
|---|---|
| `.venv/bin/python -m flake8 .` | PASS |
| `uvx --from black==26.1.0 black --check .` | PASS |
| `uvx isort==5.13.2 --check .` | PASS |
| `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | **0 errors, 0 warnings, 0 informations** |
| `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit/tui/test_copy_picker*.py tests/unit/tui/test_copy_targets.py -q -n0` | **PASS** |
| `.venv/bin/python -m pytest tests/unit -q` | **15232 passed, 18 skipped, 0 failed** in 2507 s |

The only file either formatter flags is `scripts/bench_runtime_attach.py`, which is untracked, pre-existing and not part of this branch.

An earlier full-suite run on this same head reported **one** failure, `tests/unit/tools/test_task_wait_jobs.py::test_wait_and_jobs_coercion_and_label_resolution` (`unknown job [78070e674242]` — a job-registry lookup). It was classified rather than waved off, per AGENTS.md's rule that a standing "known environmental" failure is an unverified claim, and it is **a flake, confirmed three independent ways**: the clean 15232-passed run above, the isolation runs below, and green CI including all five test shards.

```
# in isolation, on this branch
26 passed in 3.74s
# the whole tools suite on this branch, 4 consecutive runs under -n auto
715 passed / 715 passed / 715 passed / 715 passed
# the same file on the base commit (8738b9495) in a throwaway worktree
26 passed in 1.44s
# the whole tools suite on base, 3 consecutive runs
715 passed / 715 passed / 715 passed
```

It reproduced neither on the branch nor on base, this diff touches no job, task or registry code, and the re-run of the identical head passed all 15232. The host was under load average 27-63 from sibling worktrees at the time. Recorded here rather than hidden.

### The tests prove they can still fail

A guard that cannot go red is worse than none, so each new one was re-run against a reintroduced regression:

| Mutation | Test | Result |
|---|---|---|
| wrap budget back to a prefix | `..._the_wrap_budget_is_a_window_and_not_a_dead_end` | **FAILED** ✓ |
| remove the `is_active` guard | `..._two_queued_clicks_dismiss_once_instead_of_crashing` | **FAILED** ✓ |
| remove the `is_active` guard | `..._the_keyboard_path_cannot_crash_by_dismissing_twice` | **FAILED** ✓ |
| wheel step hardcoded to 1 | `..._the_wheel_over_the_tree_moves_the_cursor_by_the_app_sensitivity` | **FAILED** ✓ |
| click acts immediately | `..._a_single_click_selects_and_previews_without_copying` | **FAILED** ✓ |
| drop `_index_at`'s drawn-page limb | `..._the_chrome_and_the_backdrop_are_inert` | **FAILED** ✓ |
| drop `_index_at`'s `region.contains` | `..._the_chrome_and_the_backdrop_are_inert` | **FAILED** ✓ |
| marker counts wrapped rows | `..._the_remainder_counts_down_as_the_preview_scrolls` | **FAILED** ✓ |

Two of these initially **survived** and both were real gaps in my tests, not in the code: the remainder fixture did not wrap (so source lines and rows coincided), and the chrome fixture's tree was shorter than the pane (so the third guard masked the second). Both fixtures were fixed to discriminate, and the assertions now say why in their docstrings.

### Tests that encoded the old behaviour were rewritten, not deleted

- `test_a_long_tree_splits_the_budget_in_half` → `test_a_long_tree_takes_every_row_the_preview_does_not_need`, plus a new `test_the_split_does_not_move_when_the_cursor_does` pinning D1's hard constraint.
- `test_children_are_the_blocks_then_the_all_rows` → `..._then_the_quotes_then_the_all_rows`, asserting the bodies are unchanged and that `Block N` still numbers fences in document order.
- `test_the_block_grammar_holds_on_its_edges` now asserts row order *and* checks the grammar's own document order directly against `extract_blocks`, so grouping the rows did not quietly abandon that fact.
- `test_the_footer_is_always_the_last_drawn_row` derives its expectation from the gate rather than pinning a fixture, and asserts both sides were exercised.

### Rendered frames

Every frame is a native-size capture from the real `OperatorApp` with the production stylesheet, via `scripts/copy_shot.py` (extended here with the drive states) and `scripts.visual_capture.save_capture`. Rasterized and viewed, not merely produced.

**mixed @ 100x30 — the case the split was starving.** Tree 9 → **12 rows**, hidden 10 → 7, and the seven blank preview rows are gone. `↓ 7 more`, the gutter thumb, the amber `truncated`, `All 2 code blocks` and the new footer are all visible.

| before | after |
|---|---|
| ![before mixed](https://gist.githubusercontent.com/damianvtran/c693af6a2223be599f9f5f63d061f759/raw/09b01b87ac770e71241ec247fcd6060eb89ce370/before-mixed.svg) | ![after mixed](https://gist.githubusercontent.com/damianvtran/c693af6a2223be599f9f5f63d061f759/raw/b4a0cc9a6cf6022506ea300df99102a7cdb8f71d/after-mixed.svg) |

**short — the two-node tree, byte-identical layout.** No cue and no gutter, because the tree does not overflow: the signal's absence has to mean "this is everything".

| before | after |
|---|---|
| ![before short](https://gist.githubusercontent.com/damianvtran/c693af6a2223be599f9f5f63d061f759/raw/ea878d701c6dc8fbc7c3896eb6a482c10182e41c/before-short.svg) | ![after short](https://gist.githubusercontent.com/damianvtran/c693af6a2223be599f9f5f63d061f759/raw/fad96a67b97f94c13ad8a7d8fac26f182c993454/after-short.svg) |

**code and long — the split is unchanged** (5,13) and (1,17); only the aggregate label and the footer differ.

| before | after |
|---|---|
| ![before code](https://gist.githubusercontent.com/damianvtran/c693af6a2223be599f9f5f63d061f759/raw/259e73c0cda5dab01fd2c60db282d9578b3c4b94/before-code.svg) | ![after code](https://gist.githubusercontent.com/damianvtran/c693af6a2223be599f9f5f63d061f759/raw/e5f5f7714510a694fee9dea415ee8ec609c570d3/after-code.svg) |
| ![before long](https://gist.githubusercontent.com/damianvtran/c693af6a2223be599f9f5f63d061f759/raw/5c6193de82c1c42954d6e423bdc82c5c6cacff69/before-long.svg) | ![after long](https://gist.githubusercontent.com/damianvtran/c693af6a2223be599f9f5f63d061f759/raw/075995344f05c65d85d66aaf47f5d782a1e5f254/after-long.svg) |

**mixed @ 80x24 — the narrow case.** Split (6,6) identical to before; the hints move two cells left for the gutter and `↓ 13 more` appears. The 50-cell footer still fits the 70-cell card.

| before | after |
|---|---|
| ![before 80x24](https://gist.githubusercontent.com/damianvtran/c693af6a2223be599f9f5f63d061f759/raw/7c33e18bab45bf7c879cd76c62e880676d867890/before-mixed-80x24.svg) | ![after 80x24](https://gist.githubusercontent.com/damianvtran/c693af6a2223be599f9f5f63d061f759/raw/a0250b5bfdf99fc5195ab53a03eea745188e2645/after-mixed-80x24.svg) |

**The states the change adds:**

| hovered (not selected) | preview scrolled | tree clipped both ends |
|---|---|---|
| ![hover](https://gist.githubusercontent.com/damianvtran/c693af6a2223be599f9f5f63d061f759/raw/9b1a8fbc8aaa5c29e0116c9badb3d1c1a32c78f7/after-hover.svg) | ![preview scrolled](https://gist.githubusercontent.com/damianvtran/c693af6a2223be599f9f5f63d061f759/raw/0a307604813b31e9f000622a96db07b74b9e0bca/after-preview.svg) | ![tree scrolled](https://gist.githubusercontent.com/damianvtran/c693af6a2223be599f9f5f63d061f759/raw/0e0141e5bcb53317428dba640f455a8e1543ec17/after-tree.svg) |

- **hover** — `Block 1` under the pointer takes the ground with *no* caret while the selected row keeps caret + accent: the two states are distinguishable in one glance, which is the whole point of the caret-as-discriminator rule.
- **preview scrolled** — header reads `Preview · 121 lines · from line 9`, foot reads `… 98 more lines`. 121 − 8 − 15 = 98: the two numbers agree, in source lines.
- **tree scrolled** — `↑ 6` on the upper rule and `↓ 1 more` on the lower rule **at once**, which is the case a down-only cue would have misreported.

**A terminal too small for the card**, where the frame was previously blank:

![too small](https://gist.githubusercontent.com/damianvtran/c693af6a2223be599f9f5f63d061f759/raw/d4eb2ebb04d9328ea2b1e0bf5b6f834853b24e55/after-toosmall.svg)

**Two consecutive frames across one arrow press** (`down` from row 12 to row 13), proving the tree does not change height even though the preview's content goes from 1 line to 2:

| before the press | after the press |
|---|---|
| ![arrow frame 1](https://gist.githubusercontent.com/damianvtran/c693af6a2223be599f9f5f63d061f759/raw/0e0141e5bcb53317428dba640f455a8e1543ec17/after-arrow1.svg) | ![arrow frame 2](https://gist.githubusercontent.com/damianvtran/c693af6a2223be599f9f5f63d061f759/raw/7eb3b78105ce4b5d48c5205656c2e0f852bd1ef3/after-arrow2.svg) |

### The numbers behind the pixels

`app.screen.virtual_size` equals `app.screen.size` in **every** frame and no scrollbar ever appears — the standing invariant for this app, where a scrollbar silently costs two cells of width and reflows the transcript behind the overlay.

```
after-mixed         size=(98,28) virtual=(98,28) vscroll=False split=(12,6) card_w=90 gutter=True
after-short         size=(98,28) virtual=(98,28) vscroll=False split=(2,16)  card_w=90 gutter=False
after-code          size=(98,28) virtual=(98,28) vscroll=False split=(5,13)  card_w=90 gutter=False
after-long          size=(98,28) virtual=(98,28) vscroll=False split=(1,17)  card_w=90 gutter=False
after-mixed-80x24   size=(78,22) virtual=(78,22) vscroll=False split=(6,6)   card_w=70 gutter=True
after-preview       size=(98,28) virtual=(98,28) vscroll=False split=(1,17)  preview_off=8
after-tree          size=(98,28) virtual=(98,28) vscroll=False split=(12,6)  sel=12
after-arrow1        size=(98,28) virtual=(98,28) vscroll=False split=(12,6)  sel=12
after-arrow2        size=(98,28) virtual=(98,28) vscroll=False split=(12,6)  sel=13   <- split unchanged
after-toosmall      size=(38,18) virtual=(38,18) vscroll=False drawable=False
```

Measured footer shed ladder, confirming `esc quit` never sheds:

```
width 90 -> 50 cells  '↑↓ move · shift+↑↓ preview · enter copy · esc quit'
width 50 -> 50 cells  '↑↓ move · shift+↑↓ preview · enter copy · esc quit'
width 40 -> 40 cells  'shift+↑↓ preview · enter copy · esc quit'
width 30 -> 21 cells  'enter copy · esc quit'
width 20 ->  8 cells  'esc quit'
```

## Deferred — recorded here, no issues opened

- **Collapse/expand of message rows.** A real want on a 36-row tree, but a different feature: the flatten is pinned and `_window_start`, `_page_rows`, `_min_flat_width` and `is_drawable`'s width limb all read `_flat` directly. Scoping it in would risk the mouse work; the `↓ N more` cue addresses the underlying "the tree is too long" complaint cheaply.
- **Content-sizing the card** (designer D10). `before-short` is a 27-row card holding 6 rows. Genuinely wasteful, but the safe version needs a snapshot-invariant demand measure and changes the height model.
- **`esc close` vs `esc quit`.** Both reviewers raised that "quit" risks reading as "quit the app". The string is pinned in two places; left as-is.
- **Dotted leaders / the label→hint gap** (designer D5). Measured at 60-70 cells of void on child rows; looks alarming in isolation and reads fine in the frame, since the hints form a clean right-aligned column. Recorded so a later round does not rediscover it.
- **Backdrop-to-dismiss.** All three modals or none.

## Deviations from the brief

One, and it makes the rule stricter rather than looser: the **gutter is additionally gated on the tree actually overflowing**. The brief gated it only on width. Drawing a track on a list that cannot scroll is a scrollbar for a document that fits, and it breaks the same rule the remainder cues keep — the absence of the signal has to mean "this is everything". Caught by looking at `after-short`, not by a test.

## Review

Agent review round to follow on this PR. Opened as a **draft**: remediation rounds are expected, and the auto-requested code owner should not spend attention until the rounds are clean.


