### PR TITLE
feat(tui): /move changes a session's working directory

### DIFF
--- a/local_operator/mobile/attach_client.py
+++ b/local_operator/mobile/attach_client.py
@@ -642,6 +642,26 @@ class AttachClient:
         """
         return await self._request("refresh_if_idle")
 
+    async def retire_now(self) -> str:
+        """Ask an IDLE owner to retire so a successor can start elsewhere.
+
+        ``/move``'s transport. The session's working directory is fixed when
+        its runtime is spawned, so changing it means retiring the current
+        runtime and engaging one at the new path — and the runtime leaves by
+        the ``retiring`` route rather than the ``stopping`` one, which is the
+        whole reason this is a distinct op. A stop tells the viewer the SESSION
+        ended (it parks, and ``/resume`` is the way back); ``retiring`` tells it
+        a successor is owed and it should engage one, which is exactly what a
+        move wants and what the build-refresh path already does.
+
+        As with ``retire_if_pristine`` and ``request_refresh`` the answer is the
+        runtime's own ("retiring", or "kept: …"): it re-asks its idle predicate
+        and refuses if work arrived. An owner too old to know the op answers the
+        standard unknown-op error, which the caller surfaces as a refusal to
+        move rather than moving anyway.
+        """
+        return await self._request("retire_now")
+
     async def job_trajectory(self, job_id: str, offset: int = 0, limit: int = 120) -> Any:
         """Fetch one page of a child job's retained events from the owner.
 

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -662,6 +662,13 @@ _FRONTEND_LOCAL_SLASHES = {
     "reload",
     "update",
     "resume",
+    # The picker draws on THIS terminal, its suggestions are read from THIS
+    # machine's session records and wake index, and the directory a user means
+    # is one on the machine they are sitting at — the same argument `/settings`
+    # and `/theme` make about config.yml. Routed to the owner it would offer a
+    # remote host's directories to someone who cannot see them, and move a
+    # session into a path that may not exist here at all.
+    "move",
     # A fork opens a window on THIS machine and reads THIS machine's config.yml
     # for where to put it — the same argument `/settings` and `/theme` make. On a
     # follower attached to a remote owner, forking must open a window here, not

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -1117,8 +1117,57 @@ class RemoteSession:
             return await client.ask_answer(request_id, value, question_index=question_index)
         raise ValueError("the answer does not match the current question")
 
+    def move_will_wait(self) -> bool:
+        """Whether :meth:`set_working_directory` is about to make the user wait.
+
+        The frontend needs this to decide whether to narrate before the move,
+        and it must NOT reconstruct the answer from ``is_cold``. That predicate
+        means "no synchronised runtime is attached", which this class already
+        establishes is a different question — and a viewer with an engage in
+        flight reads cold while the move joins that engage and then retires the
+        runtime it produces, taking seconds. Gating narration on ``is_cold``
+        therefore stayed silent for exactly the case the narration exists for:
+        `/move` as the first action of a session (review MAJOR-1, design U6).
+
+        The two waiting shapes are the two this method reports, and they are
+        the same two ``set_working_directory`` branches on:
+
+        * a live client — the runtime has to be asked to retire; and
+        * an engage already in flight — the move joins it first.
+
+        A genuinely cold viewer with nothing running returns False, because
+        that move is a field assignment that settles within the frame and an
+        in-flight line would be contradicted by its own receipt a moment later.
+
+        A RECOVERING viewer also returns False, because its move does not wait
+        either — ``set_working_directory`` refuses it outright, and promising a
+        restart one line before refusing to move at all is worse than silence.
+        """
+        if self._recovering:
+            return False
+        client = self._client
+        if client is not None and client.connected:
+            return True
+        return self._engage_in_flight()
+
+    def _engage_in_flight(self) -> bool:
+        """Whether an engage is running that a move would have to join.
+
+        ONE definition, read by both the decision to join and the decision to
+        narrate it. Two copies would let the frontend promise a wait the move
+        does not take, or stay silent through one it does — which is the
+        divergence this whole feature exists to prevent, in miniature.
+        """
+        return self._can_go_cold and self._bind_lock.locked() and not self._recovering
+
     async def set_working_directory(self, cwd: str) -> str:
         """Point this session at ``cwd``; returns what happened, for the receipt.
+
+        TRUSTS ITS CALLER on the target. ``cwd`` is not checked for existence
+        or permission here: the frontend validates through ``validate_target``
+        BEFORE calling, so a bad path costs the user one line and never a
+        half-applied state. Validating again here would put the user-facing
+        sentences in two places, which is how they drift (QA Q6).
 
         THE CWD IS BAKED IN AT SPAWN. ``_spawn_runtime`` passes it as
         ``LOP_MOBILE_CHILD_CWD`` and the child reads it once in ``amain``,
@@ -1172,7 +1221,20 @@ class RemoteSession:
         reads is set. If the retire is refused the field is put back: a viewer
         whose ``_cwd`` says one thing while its runtime works in another is
         precisely the divergence this method exists to avoid.
+
+        DURING OWNER RECOVERY it refuses, in the same words and for the same
+        reason as ``route_shared_slash`` one seam over. A recovering viewer is
+        chasing a successor that ``_recover_owner`` will bind at whatever cwd
+        the owner's record names, so a "cold move" reported here is silently
+        undone the moment that bind lands — the viewer would say it moved and
+        then work somewhere else, which is the one divergence this method
+        exists to prevent. Refusing keeps the whole seam consistent: every
+        request/response operation on this class (routed slash, compaction,
+        the answer gates) declines while ``_recovering`` rather than reporting
+        an outcome the replacement owner has not agreed to (review MINOR-1).
         """
+        if self._recovering:
+            raise ConnectionError(_RECONNECTING_SLASH_NOTICE.format(command="move"))
         previous = self._cwd
         # UNDER ``_bind_lock``, and that is the correctness fix rather than a
         # precaution. ``_ensure_bound`` reads ``self._cwd`` INSIDE this lock and
@@ -1206,27 +1268,37 @@ class RemoteSession:
         # bind inherits its timeouts, its ``ConnectionError`` and its vetted
         # startup sentences, and returns a viewer that is either bound or
         # honestly cold.
-        joined = self._can_go_cold and self._bind_lock.locked() and not self._recovering
-        if joined:
-            try:
-                await self._ensure_bound()
-            except Exception:  # noqa: BLE001 — a failed engage still leaves a movable cold viewer
-                # The engage failed, which is its own reported problem. The
-                # session is then genuinely cold, and the assignment above is
-                # already the whole move: the NEXT engage uses the new path.
-                logger.debug("joining the in-flight engage before a move failed", exc_info=True)
-        async with self._bind_lock:
-            try:
+        try:
+            if self._engage_in_flight():
+                try:
+                    await self._ensure_bound()
+                except Exception:  # noqa: BLE001 — a failed engage still leaves a movable viewer
+                    # The engage failed, which is its own reported problem. The
+                    # session is then genuinely cold, and the assignment above
+                    # is already the whole move: the NEXT engage uses the new
+                    # path. Deliberately narrower than the rollback below —
+                    # ``Exception`` here so a cancellation still unwinds.
+                    logger.debug("joining the in-flight engage before a move failed", exc_info=True)
+            async with self._bind_lock:
                 return await self._apply_working_directory(cwd, previous=previous)
-            except Exception:
-                # ONE rollback for every refusal, here rather than at each
-                # raise: the optimistic assignment above must not outlive a
-                # move that did not happen, and a viewer whose ``_cwd`` says
-                # one thing while its runtime works in another is exactly the
-                # divergence this method exists to prevent. Restoring in the
-                # caller means a refusal added later cannot forget to.
-                self._cwd = previous
-                raise
+        except BaseException:
+            # ONE rollback for every non-return exit, here rather than at each
+            # raise: the optimistic assignment above must not outlive a move
+            # that did not happen, and a viewer whose ``_cwd`` says one thing
+            # while its runtime works in another is exactly the divergence this
+            # method exists to prevent. Restoring in the caller means a refusal
+            # added later cannot forget to.
+            #
+            # ``BaseException``, not ``Exception``: ``asyncio.CancelledError``
+            # does not derive from ``Exception``, so an ``Exception`` clause
+            # let a cancelled move — the session worker being torn down, a
+            # transition superseded — escape with ``_cwd`` at the new value and
+            # no move performed, which is the divergence in its quietest form
+            # (review MINOR-2). The join is inside the guarded region for the
+            # same reason: a cancel while joining the engage is the wider of
+            # the two windows, not the narrower one.
+            self._cwd = previous
+            raise
 
     async def _apply_working_directory(self, cwd: str, *, previous: str) -> str:
         """The move itself, with ``_bind_lock`` already held by the caller.

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -1174,8 +1174,82 @@ class RemoteSession:
         precisely the divergence this method exists to avoid.
         """
         previous = self._cwd
-        if self.is_cold:
+        # UNDER ``_bind_lock``, and that is the correctness fix rather than a
+        # precaution. ``_ensure_bound`` reads ``self._cwd`` INSIDE this lock and
+        # hands it to ``engage_runtime``, whose spawn is a 1-3 s await; the TUI
+        # starts that engage eagerly at mount. A move that only assigned the
+        # field would therefore land AFTER the value had been read, and the
+        # runtime would be spawned at the old path while the user was told it
+        # moved — silently, permanently, and in the feature's PRIMARY case
+        # ("change directory at the start of a session"), because that is
+        # exactly when the mount engage is in flight. Measured at a median
+        # 1.26 s window, losing 5/5 first-action moves (review BLOCKER-1 / QA
+        # Q1). Joining that engage makes the two orderings the only two
+        # possible: the move lands before the engage reads the field, or it
+        # waits for the engage and then finds a bound runtime and retires it.
+        #
+        # The field is set FIRST, before joining, and that ordering is what
+        # makes the in-flight engage harmless. A spawn already under way has
+        # read the OLD value and cannot be recalled, so the move cannot be
+        # honoured by waiting alone — the runtime that arrives is at the old
+        # path, which is the bug in its second form. Setting ``_cwd`` up front
+        # means every LATER read (this engage's retry, the successor's spawn,
+        # the wake index) sees the new value, and the stale runtime is then
+        # retired by the normal bound path below.
+        self._cwd = cwd
+        # JOINED by awaiting ``_ensure_bound`` rather than by blocking on the
+        # lock directly — the same construction ``run_slash_authoritative``
+        # uses for the same reason (remote.py, "Join its lock before mutating").
+        # Waiting on the raw lock would park this coroutine for as long as the
+        # engage takes with no bound on failure, so a spawn that never
+        # completes would hang the command instead of refusing it; awaiting the
+        # bind inherits its timeouts, its ``ConnectionError`` and its vetted
+        # startup sentences, and returns a viewer that is either bound or
+        # honestly cold.
+        joined = self._can_go_cold and self._bind_lock.locked() and not self._recovering
+        if joined:
+            try:
+                await self._ensure_bound()
+            except Exception:  # noqa: BLE001 — a failed engage still leaves a movable cold viewer
+                # The engage failed, which is its own reported problem. The
+                # session is then genuinely cold, and the assignment above is
+                # already the whole move: the NEXT engage uses the new path.
+                logger.debug("joining the in-flight engage before a move failed", exc_info=True)
+        async with self._bind_lock:
+            try:
+                return await self._apply_working_directory(cwd, previous=previous)
+            except Exception:
+                # ONE rollback for every refusal, here rather than at each
+                # raise: the optimistic assignment above must not outlive a
+                # move that did not happen, and a viewer whose ``_cwd`` says
+                # one thing while its runtime works in another is exactly the
+                # divergence this method exists to prevent. Restoring in the
+                # caller means a refusal added later cannot forget to.
+                self._cwd = previous
+                raise
+
+    async def _apply_working_directory(self, cwd: str, *, previous: str) -> str:
+        """The move itself, with ``_bind_lock`` already held by the caller.
+
+        ``previous`` is the directory to restore on a refusal. It is passed in
+        rather than re-read because the caller has already applied ``cwd``
+        optimistically, so ``self._cwd`` is no longer the value to roll back to.
+        """
+        # NOT ``is_cold``. That predicate means "no SYNCHRONISED runtime is
+        # attached right now", which is a different question from "does a
+        # runtime exist to retire". ``_refresh_display_history`` clears
+        # ``_ready_for_events`` while the client stays connected and the
+        # runtime keeps serving, so an ``is_cold`` test routes a live runtime
+        # into the free-field-assignment branch and silently skips the retire
+        # (review MAJOR-1), and a second move during a rebind does the same
+        # (QA Q2). Liveness of the socket is the honest term: if a client is
+        # connected there is a runtime that must be asked to go, and the
+        # runtime's own ``may_refresh`` re-check stays the authority on
+        # whether it may.
+        client = self._client
+        if client is None or not client.connected:
             self._cwd = cwd
+            self._repoint_armed_wakes(cwd)
             return "cold"
         # ``owner_idle`` is the SAME reading the build-refresh seam uses, and
         # it already covers every term that matters here — streaming, a parked
@@ -1187,8 +1261,7 @@ class RemoteSession:
             raise RuntimeError(
                 "this session is working right now — /move again when the turn finishes"
             )
-        client = self._client
-        ask = getattr(client, "retire_now", None) if client is not None else None
+        ask = getattr(client, "retire_now", None)
         if not callable(ask):
             raise RuntimeError("this session's runtime is too old to be moved; /reload first")
         self._cwd = cwd
@@ -1196,6 +1269,16 @@ class RemoteSession:
             detail = str(await cast(Callable[[], Awaitable[str]], ask)())
         except Exception as error:  # noqa: BLE001 — the refusal IS the receipt
             self._cwd = previous
+            # A runtime older than this build answers the wire's own
+            # ``unknown op`` error. The vetted sentence above cannot fire for
+            # it — the viewer always carries THIS build's ``AttachClient``, so
+            # the method is always present — which left the reachable path
+            # showing a user an internal op name (review MINOR-1 / QA Q4).
+            # Mapped here, where the skew actually surfaces.
+            if "unknown op" in str(error) and "retire_now" in str(error):
+                raise RuntimeError(
+                    "this session's runtime is too old to be moved; /reload first"
+                ) from error
             raise RuntimeError(f"could not move: {error}") from error
         if detail != "retiring":
             # The runtime kept itself — work arrived between this viewer's idle
@@ -1204,7 +1287,51 @@ class RemoteSession:
             # the directory goes back because nothing moved.
             self._cwd = previous
             raise RuntimeError(f"could not move: {detail.removeprefix('kept: ')}")
+        self._repoint_armed_wakes(cwd)
         return "rebound"
+
+    def _repoint_armed_wakes(self, cwd: str) -> None:
+        """Rewrite this session's wake-index ``cwd`` after a successful move.
+
+        The index carries a per-session ``cwd`` that the SUPERVISOR spawns an
+        unattended runtime with, so a wake armed before the move fires in the
+        old directory (review MAJOR-2). The bound path self-heals — the
+        successor rewrites the entry when it opens — but the cold path spawns
+        nothing to heal it, and a wake is the one mechanism designed to run
+        without the user present to notice, so the divergence survives until
+        the next manual prompt.
+
+        Rewritten for BOTH paths rather than only the cold one: the bound
+        path's self-heal happens whenever its successor opens, which is after
+        an arbitrary delay, and a wake due inside that gap would still fire at
+        the old path. Writing here makes the index correct at the moment the
+        move is reported.
+
+        Best-effort by construction. Every failure is logged and swallowed:
+        the move itself has already succeeded and is what the user was told
+        about, so a wake index that could not be rewritten must not turn a
+        completed move into an error.
+        """
+        try:
+            from local_operator.wakes.store import read_index, write_entry
+
+            entry = (read_index(self._config_dir) or {}).get(self._session_id)
+            if not isinstance(entry, dict):
+                return  # no wakes armed: nothing to repoint
+            schedules = entry.get("schedules") or []
+            if not schedules:
+                return
+            write_entry(
+                self._config_dir,
+                self._session_id,
+                cwd=cwd,
+                schedules=schedules,
+                # The existing entry rides along so a key this code does not
+                # know about (``stopped_at`` today) is not dropped by a move.
+                preserve=entry,
+            )
+        except Exception:  # noqa: BLE001 — a completed move must not fail on its index
+            logger.debug("could not repoint armed wakes after a move", exc_info=True)
 
     async def _ensure_bound(self) -> None:
         """Attach to a runtime, starting one if none exists. Idempotent.

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -1117,6 +1117,95 @@ class RemoteSession:
             return await client.ask_answer(request_id, value, question_index=question_index)
         raise ValueError("the answer does not match the current question")
 
+    async def set_working_directory(self, cwd: str) -> str:
+        """Point this session at ``cwd``; returns what happened, for the receipt.
+
+        THE CWD IS BAKED IN AT SPAWN. ``_spawn_runtime`` passes it as
+        ``LOP_MOBILE_CHILD_CWD`` and the child reads it once in ``amain``,
+        which is then the session's ``_cwd`` for the rest of that runtime's
+        life — it reaches the system prompt's environment block, every tool
+        call's ``ToolContext.cwd``, skill discovery and MCP config resolution.
+        There is no live setter to call and adding one would be wrong: those
+        consumers read the value at different moments, so a mid-flight change
+        would leave one turn's prompt disagreeing with the tools that turn
+        actually ran.
+
+        So the honest implementations are exactly two, and which one applies is
+        a property of the viewer rather than a choice:
+
+        * COLD — no runtime yet. The directory is simply the one the next
+          engage will spawn with, so this is a field assignment and costs
+          nothing. This is the "at the start of a session" case, and it is the
+          common one: ``lop`` opens cold.
+        * BOUND — a runtime is already serving. It is retired and a fresh one
+          is engaged at the new directory. That is a REBIND, not a new
+          conversation: the session id, the transcript and everything on screen
+          are untouched, and the successor replays the same durable history the
+          predecessor wrote. It is the same shape as the build-refresh path
+          (``_go_cold(refresh=True)`` → re-engage), which exists precisely
+          because retiring an idle runtime and starting its successor is a
+          housekeeping event rather than an ending.
+
+        A BUSY runtime is REFUSED rather than rebuilt. Retiring mid-turn would
+        abort a model call the user is paying for and did not ask to lose, and
+        "apply it to the next turn" is the option that produces exactly the
+        divergence AGENTS.md calls out for ``/reload``: the band would show the
+        new directory while the running turn's tools still resolve against the
+        old one. Refusing states the situation and leaves both surfaces
+        agreeing.
+
+        It leaves by the RETIRING route (``retire_now``), never the stopping
+        one, and that distinction is the whole correctness argument for the
+        bound path. ``stop`` announces ``stopping``, which latches
+        ``_deliberate_stop`` in ``_on_disconnected`` and parks this viewer in
+        the stopped state — the right answer for a session the user ENDED and
+        the wrong one for a move, which ends a runtime while the conversation
+        continues. ``retiring`` already means "a successor is owed; engage
+        one": it goes cold with ``refresh=True`` and fires the refresh callback
+        the app re-engages on. So a move reuses the mechanism the build refresh
+        established rather than issuing a stop and then trying to un-latch it —
+        which cannot work anyway, since the disconnect that sets the flag
+        arrives AFTER this method's ack has returned.
+
+        The move is applied to ``_cwd`` FIRST and only then is the runtime
+        asked to go, so the successor cannot be engaged before the field it
+        reads is set. If the retire is refused the field is put back: a viewer
+        whose ``_cwd`` says one thing while its runtime works in another is
+        precisely the divergence this method exists to avoid.
+        """
+        previous = self._cwd
+        if self.is_cold:
+            self._cwd = cwd
+            return "cold"
+        # ``owner_idle`` is the SAME reading the build-refresh seam uses, and
+        # it already covers every term that matters here — streaming, a parked
+        # approval/ask gate, and a running background job — so this asks one
+        # question rather than reassembling the predicate and drifting from it.
+        # The runtime re-checks on its own side anyway (``may_refresh``): a
+        # retire that races work arriving is refused there and surfaces below.
+        if not self.owner_idle():
+            raise RuntimeError(
+                "this session is working right now — /move again when the turn finishes"
+            )
+        client = self._client
+        ask = getattr(client, "retire_now", None) if client is not None else None
+        if not callable(ask):
+            raise RuntimeError("this session's runtime is too old to be moved; /reload first")
+        self._cwd = cwd
+        try:
+            detail = str(await cast(Callable[[], Awaitable[str]], ask)())
+        except Exception as error:  # noqa: BLE001 — the refusal IS the receipt
+            self._cwd = previous
+            raise RuntimeError(f"could not move: {error}") from error
+        if detail != "retiring":
+            # The runtime kept itself — work arrived between this viewer's idle
+            # read and the runtime's own re-check, which is the race the
+            # re-check exists to catch. Its reason is the honest receipt, and
+            # the directory goes back because nothing moved.
+            self._cwd = previous
+            raise RuntimeError(f"could not move: {detail.removeprefix('kept: ')}")
+        return "rebound"
+
     async def _ensure_bound(self) -> None:
         """Attach to a runtime, starting one if none exists. Idempotent.
 

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -1600,6 +1600,28 @@ class RuntimeServer:
                     detail = f"kept: {observers} viewer(s) still attached"
                 else:
                     detail = await self._retire_if_pristine(leaving=conn)
+            elif op == "retire_now":
+                # ``/move``: the viewer changed the directory this session
+                # works in, and the cwd is baked in at spawn
+                # (``LOP_MOBILE_CHILD_CWD``), so the only way to honour it is
+                # to retire and let the viewer engage a successor at the new
+                # path.
+                #
+                # A SIBLING of ``refresh_if_idle`` rather than a reuse of it,
+                # because the two differ in exactly one term and it is the
+                # gating one: a refresh is owed only when the build on disk has
+                # moved, whereas a move is owed whenever the user asked for it.
+                # Everything downstream is deliberately identical — the same
+                # idle predicate, the same ``retiring`` announcement, the same
+                # re-check after it — so a moved runtime and a refreshed one
+                # leave by one path and a viewer needs no new frame to
+                # understand either.
+                #
+                # Handled HERE rather than in ``_dispatch`` for the same reason
+                # its two siblings are: these are lifecycle ops that must not
+                # trigger the post-ack refresh (the exemption list below), and
+                # a dispatcher that has no ``conn`` cannot make that call.
+                detail = await self._retire_for("moved")
             elif op == "refresh_if_idle":
                 # The viewer-side belt for the runtime's own self-refresh
                 # (design-runtime-autorefresh §3.3): a `lop --resume` in the
@@ -1669,6 +1691,10 @@ class RuntimeServer:
                 "stop",
                 "retire_if_pristine",
                 "refresh_if_idle",
+                # Same exemption, same reason: it either retired (nothing to
+                # push, and the handle is mid-dispose) or refused (nothing
+                # changed, so there is nothing to push).
+                "retire_now",
             ):
                 await self._handle.refresh()
                 await self._push()
@@ -1767,15 +1793,37 @@ class RuntimeServer:
         but costs the user a cold start they did not need, a wrong "keep"
         costs the reaper's next check.
         """
-        h = self._handle
-        may_refresh = getattr(h, "may_refresh", None)
-        if not callable(may_refresh):
-            return "kept: this runtime cannot judge itself idle"
         from local_operator.session.runtime import process as process_mod
 
         newer = process_mod._build_changed(self._boot_build)
         if newer is None:
             return "kept: build on disk matches (or has not settled)"
+        logger.info(
+            "session runtime: viewer asked for a refresh; build on disk is %s, loaded %s",
+            newer.label(),
+            self._boot_build.label(),
+        )
+        return await self._retire_for("stale-build", to=newer.label())
+
+    async def _retire_for(self, reason_label: str, *, to: str = "") -> str:
+        """Retire this runtime iff it is idle, announcing ``reason_label``.
+
+        The shared body of the two viewer-driven retirements — a stale build
+        (``refresh_if_idle``) and a directory change (``retire_now``). They
+        differ only in what makes the retirement OWED, which each caller
+        establishes before calling; everything after that decision is the same
+        ordering and must stay so, because a second copy of it is how one path
+        grows a re-check the other lacks.
+
+        Every failure path RETURNS ``kept: …`` rather than raising, and every
+        one keeps the runtime alive. The asymmetry ``_retire_if_pristine``
+        records holds here too: a wrong "retire" costs a cold start nobody
+        asked for, a wrong "keep" costs one more check.
+        """
+        h = self._handle
+        may_refresh = getattr(h, "may_refresh", None)
+        if not callable(may_refresh):
+            return "kept: this runtime cannot judge itself idle"
         try:
             reason = str(may_refresh() or "")
         except Exception as exc:  # noqa: BLE001 — uncertainty keeps the runtime
@@ -1785,7 +1833,7 @@ class RuntimeServer:
         request_stop = getattr(h, "request_stop", None)
         if not callable(request_stop):
             return "kept: this runtime cannot stop itself gracefully"
-        await self.announce_retiring("stale-build", to=newer.label())
+        await self.announce_retiring(reason_label, to=to)
         # The one await between decision and stop; re-ask, as
         # ``_retire_if_pristine`` does after its broadcast.
         try:
@@ -1794,11 +1842,7 @@ class RuntimeServer:
             return f"kept: idle probe failed ({exc})"
         if reason:
             return f"kept: {reason} (arrived while retiring was announced)"
-        logger.info(
-            "session runtime: viewer asked for a refresh; build on disk is %s, loaded %s; retiring",
-            newer.label(),
-            self._boot_build.label(),
-        )
+        logger.info("session runtime: retiring (%s)", reason_label)
         result = request_stop()
         if inspect.isawaitable(result):
             await result

--- a/local_operator/slash_commands.py
+++ b/local_operator/slash_commands.py
@@ -120,6 +120,32 @@ SLASH_COMMANDS: list[SlashCommand] = [
         aliases=("recall",),
         desktop_destination="sessions.resume",
     ),
+    # Beside the session-transition family because it changes the same session
+    # rather than replacing it: `/new` discards the conversation, `/resume`
+    # moves to another, and this one keeps the conversation and changes WHERE
+    # it works. Placed after `/resume` and before `/rename` because those two
+    # are the other commands that alter a session in place.
+    #
+    # NOT an echo, the rule `/approvals` and `/rename` follow: the argument is
+    # a setting rather than words the model is given, and the receipt names the
+    # directory that ended up in force — strictly more than the typed words,
+    # which may have been `~/x` or a relative path the app resolved.
+    SlashCommand(
+        "move",
+        # Names the two ways to answer it, because the argument form is the
+        # half a picker cannot teach: a user who has only ever seen the list
+        # will not guess that a path can be typed straight in. 44 cells, inside
+        # the ~55 at which the description column wraps (see `/model`, where a
+        # wrapping row renders a phantom command name in `/help`).
+        "Change this session's working directory",
+        # OPTIONAL: a bare `/move` opens the picker, which is the discoverable
+        # route, and the space offers the same suggestions for a user who would
+        # rather type. Enter on the bare command still does something useful,
+        # which is exactly the distinction `/approvals` and `/effort` draw
+        # against `/login`'s REQUIRED.
+        arguments=ArgumentMode.OPTIONAL,
+        desktop_destination="session.move",
+    ),
     # Beside `/resume` because it names the thing the picker lists. NOT an echo:
     # the argument is the conversation's own label — it goes on the band and the
     # terminal tab, never into anything the model is told — and the receipt

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -15172,7 +15172,11 @@ class OperatorApp(App[None]):
             return
 
         from local_operator.paths import config_dir
-        from local_operator.tui.move_targets import complete_path, suggest_targets
+        from local_operator.tui.move_targets import (
+            complete_path,
+            resolve_self,
+            suggest_targets,
+        )
 
         cwd = self._session_cwd()
         try:
@@ -15186,15 +15190,25 @@ class OperatorApp(App[None]):
             # relative path completes from where the band says the session is.
             return complete_path(query, cwd=cwd)
 
+        def _self_target(query: str):
+            # Lets a directory with no subdirectories still be chosen, instead
+            # of completing to nothing and reporting "no directory matches"
+            # for a path the user just walked to (D1/U1). Same cwd binding.
+            return resolve_self(query, cwd=cwd)
+
         def _move_choice(path: str | None) -> None:
             # Dismissed with Esc — the session is left exactly where it was,
             # with nothing said: a cancelled picker is not an event worth a
             # transcript line (the rule `_cmd_resume` states).
             if path:
-                self._apply_move(path, notice, typed=False)
+                # ``typed=True`` even from the picker, so choosing the row
+                # labelled `current` says `already in ~/x` instead of closing
+                # in silence — which was byte-identical to Esc on the one row
+                # whose whole purpose is to answer "where am I?" (UX U4).
+                self._apply_move(path, notice, typed=True)
 
         self.push_screen(
-            MovePickerScreen(targets, current=cwd, complete=_complete),
+            MovePickerScreen(targets, current=cwd, complete=_complete, self_target=_self_target),
             _move_choice,
         )
 
@@ -15239,6 +15253,18 @@ class OperatorApp(App[None]):
             if typed:
                 notice(f"already in {format_label(destination)}")
             return
+        # NARRATED BEFORE the transition, exactly as `/resume` does one method
+        # above, and only when a runtime actually has to be replaced. That
+        # retire is an RPC to a child process that must finish draining —
+        # ~600 ms measured — during which the picker has closed, the band still
+        # reads the old directory, and `_session_transition_pending` swallows a
+        # typed Enter without replaying it. With no line printed the app simply
+        # looked like it had ignored the user (UX U2). The cold path needs no
+        # such line: it settles within the frame, so an in-flight notice would
+        # be immediately contradicted by its own receipt.
+        session = self._session
+        if session is not None and not getattr(session, "is_cold", True):
+            notice(f"moving to {format_label(destination)}… restarting the runtime there")
         self._run_session_transition(self._move_session(destination, notice))
 
     async def _move_session(self, destination: str, notice: NoticeFn) -> None:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -15337,9 +15337,56 @@ class OperatorApp(App[None]):
             # callback this app already installs — `_on_runtime_refreshed` —
             # engages the successor eagerly. Starting a second engage from here
             # would race that one for the same session's lease.
+            #
+            # THE EVAL KERNEL DOES NOT SURVIVE THE REBIND, and the user is told
+            # so rather than discovering it from a `NameError` two turns later.
+            # `tools/eval.py` caches one interpreter per session in `_KERNELS`
+            # and `Session` registers `close_session_kernel` as a dispose hook,
+            # so retiring the runtime disposes the session and takes every
+            # variable, import and function the user built up with it — while
+            # the conversation, the transcript and the session id all survive,
+            # which is exactly what makes the loss surprising. Narrated, not
+            # refused: losing it is a real consequence of a move the user asked
+            # for, not a reason to decline the move.
+            if self._session_used_eval():
+                notice(
+                    f"moved to {label} — this session's runtime restarted there,"
+                    " so the eval kernel's variables were lost"
+                )
+                return
             notice(f"moved to {label} — this session's runtime restarted there")
             return
         notice(f"moved to {label}")
+
+    def _session_used_eval(self) -> bool:
+        """Whether this conversation has run `eval`, so a rebind loses state.
+
+        READ FROM THE TRANSCRIPT, which is the only honest source available in
+        THIS process. The registry that actually holds the interpreters
+        (`tools/eval.py:_KERNELS`) is a module global in the runtime CHILD —
+        `Session` is built by `process.amain` over the socket, never here — so
+        the viewer cannot ask "is a kernel resident" without inventing a wire
+        op, which is a great deal of machinery for one clause of one receipt.
+
+        The transcript answers a slightly different question — "did a call to
+        `eval` happen in this conversation" rather than "is an interpreter
+        resident right now" — and the difference is deliberately in the
+        direction that cannot mislead. An idle kernel can have been reaped
+        (`_reap_idle`) or evicted (`_remember`) before the move, in which case
+        this warns about state that was already gone; the eval tool's own
+        stale-namespace receipt covers that case and the user has still lost
+        nothing they had. The reverse error — staying silent for a user who
+        does have a live kernel — is the one that costs work, and it cannot
+        happen: no `eval` call in the transcript means no kernel for this
+        session was ever created here.
+        """
+        transcript = self._transcript
+        if transcript is None:
+            return False
+        return any(
+            isinstance(block, ToolCard) and block.tool_name == "eval"
+            for block in transcript.blocks()
+        )
 
     def _push_cwd_to_band(self, cwd: str) -> None:
         """Repaint the band's directory segment for ``cwd``.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1951,10 +1951,17 @@ class OperatorApp(App[None]):
         #: runtime destroys the namespace it built up. Latched when the call is
         #: drawn rather than re-derived from the transcript, because `/clear`
         #: and a bounded resume both edit the VIEW while the kernel lives on
-        #: (see `_session_used_eval`). Reset when the session is replaced —
-        #: the successor has its own kernel, and inheriting the flag would warn
-        #: about a loss that belongs to a conversation the user has left.
+        #: (see `_session_used_eval`).
         self._session_used_eval_latch = False
+        #: The session the latch above was stamped for. KEYED rather than
+        #: cleared at each swap: the conversation is replaced under the viewer
+        #: by three different paths, and a reset installed at only the one
+        #: being edited leaked the flag across the other two — telling a
+        #: conversation that never ran `eval` that its namespace was destroyed
+        #: (review MAJOR-4.1). A key makes a stale latch structurally unable to
+        #: answer, so a swap site added later cannot reintroduce the leak by
+        #: forgetting to clear.
+        self._eval_latch_session_id = ""
         #: A show `_set_welcome_visible` withheld during a swap. Applied by
         #: `_reload_session` once the answer is settled, which is what still
         #: puts the splash up for a swap onto a genuinely empty session.
@@ -4755,6 +4762,23 @@ class OperatorApp(App[None]):
         # cold session that never started a runtime, leaving exactly the
         # half-empty band this change exists to remove.
         self._warm_engage_started = False
+        # THE EVAL LATCH IS KEYED TO THE SESSION, and re-keyed here for the
+        # same reason `_warm_engage_started` is reset here: it belongs to the
+        # BINDING, not to the app. Round 4 reset it in `_reload_session` only,
+        # which is one of three paths that replace the conversation under the
+        # viewer — `_apply_sidebar_presentation` rebinds `_transcript` to the
+        # incoming view and `_attach_or_refuse` adopts a successor, and neither
+        # went through that reset. The latch leaked across both, so a
+        # conversation that never ran `eval` was told its namespace had been
+        # destroyed (review MAJOR-4.1).
+        #
+        # Keyed rather than cleared because clearing has to be REMEMBERED at
+        # every future swap site, and the same defect appearing at a third site
+        # later is the same defect. Adoption is the one edge where the identity
+        # is known, so a latch stamped with another session's id is
+        # structurally unable to answer for this one.
+        self._session_used_eval_latch = False
+        self._eval_latch_session_id = self._adopted_session_id
         # The user can type `/team lop` while the boot worker is still building
         # the session. Its one opening fill then sees no registry, so adoption is
         # the second authoritative edge that must refill the CURRENT query and
@@ -6647,10 +6671,6 @@ class OperatorApp(App[None]):
         async with self._turn_provider_lock:
             pass
         self._session = None
-        # The successor gets its own `eval` kernel, so the latch belongs to the
-        # session being disposed and must not outlive it — carrying it over
-        # would warn a NEW conversation about a namespace it never had.
-        self._session_used_eval_latch = False
         # THE WATCHED ID DELIBERATELY SURVIVES THIS WINDOW. It is the only
         # lever a stranded viewer has, and clearing it here disarmed the kill
         # switch on the exact path this feature exists to serve: if anything
@@ -15414,7 +15434,13 @@ class OperatorApp(App[None]):
         stated policy; deriving it from the screen quietly broke that policy in
         the one direction that costs the user work (review round 3, MAJOR-1).
         """
-        if self._session_used_eval_latch:
+        # The latch answers only for the session it was stamped for. A swap
+        # that rebinds the transcript or adopts a successor without going
+        # through `_adopt_session` leaves the flag set against a DIFFERENT id,
+        # and a stale key must not warn conversation B about conversation A's
+        # namespace (review MAJOR-4.1).
+        current_id = getattr(self._session, "session_id", "") or ""
+        if self._session_used_eval_latch and self._eval_latch_session_id == current_id:
             return True
         transcript = self._transcript
         if transcript is None:
@@ -15427,7 +15453,11 @@ class OperatorApp(App[None]):
             isinstance(block, ToolCard) and block.tool_name == "eval"
             for block in transcript.blocks()
         ):
+            # Memoised against the CURRENT session, not the one that was bound
+            # when the flag was last written: caching it under a stale key
+            # would make the answer unreadable on the very next call.
             self._session_used_eval_latch = True
+            self._eval_latch_session_id = current_id
             return True
         return False
 
@@ -16880,8 +16910,11 @@ class OperatorApp(App[None]):
         # view: `/clear` empties it and a bounded resume renders only the tail,
         # so re-deriving "did this session use eval" from the screen loses the
         # answer while the kernel is still alive (`_session_used_eval`).
+        # Stamped with the session it belongs to, so a later swap cannot make
+        # this fact answer for a conversation that never ran the call.
         if isinstance(block, ToolCard) and block.tool_name == "eval":
             self._session_used_eval_latch = True
+            self._eval_latch_session_id = getattr(self._session, "session_id", "") or ""
         if self._projection_message_id:
             if not block.navigation_anchor_id:
                 block.navigation_anchor_id = self._projection_message_id

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -15168,7 +15168,7 @@ class OperatorApp(App[None]):
             return
 
         if arg.strip():
-            self._apply_move(arg.strip(), notice, typed=True)
+            self._apply_move(arg.strip(), notice)
             return
 
         from local_operator.paths import config_dir
@@ -15201,18 +15201,18 @@ class OperatorApp(App[None]):
             # with nothing said: a cancelled picker is not an event worth a
             # transcript line (the rule `_cmd_resume` states).
             if path:
-                # ``typed=True`` even from the picker, so choosing the row
-                # labelled `current` says `already in ~/x` instead of closing
-                # in silence — which was byte-identical to Esc on the one row
-                # whose whole purpose is to answer "where am I?" (UX U4).
-                self._apply_move(path, notice, typed=True)
+                # The no-op receipt reaches the picker too, so choosing the
+                # row labelled `current` says `already in ~/x` instead of
+                # closing in silence — which was byte-identical to Esc on the
+                # one row whose whole purpose is to answer "where am I?" (U4).
+                self._apply_move(path, notice)
 
         self.push_screen(
             MovePickerScreen(targets, current=cwd, complete=_complete, self_target=_self_target),
             _move_choice,
         )
 
-    def _apply_move(self, raw: str, notice: NoticeFn, *, typed: bool) -> None:
+    def _apply_move(self, raw: str, notice: NoticeFn) -> None:
         """Validate ``raw`` and move the session to it, or say why not.
 
         Validation happens HERE, before anything is changed, so a bad target
@@ -15220,10 +15220,14 @@ class OperatorApp(App[None]):
         rejections (absent, not a directory, unenterable) are told apart
         because they call for three different next moves.
 
-        ``typed`` says whether the path came from the composer rather than the
-        picker. Only a typed path can be a no-op worth reporting — picking the
-        row you are already on is a deliberate "stay here" — so the two produce
-        different receipts for the same situation.
+        The no-op is reported for EVERY caller. This used to take a ``typed``
+        flag so that only a composer path said "already in …", on the argument
+        that choosing the row you are on is a deliberate "stay here" — but a
+        silent close there is byte-identical to Esc on the one row whose job is
+        to answer "where am I?" (UX U4), so the picker now reports it too.
+        With both callers passing the same value the flag was a distinction the
+        code no longer drew, and a flag with one value gets misread as still
+        meaning something (design D8).
         """
         from local_operator.tui.move_targets import (
             MoveError,
@@ -15250,20 +15254,30 @@ class OperatorApp(App[None]):
 
         destination = str(target)
         if destination == self._session_cwd():
-            if typed:
-                notice(f"already in {format_label(destination)}")
+            notice(f"already in {format_label(destination)}")
             return
         # NARRATED BEFORE the transition, exactly as `/resume` does one method
-        # above, and only when a runtime actually has to be replaced. That
-        # retire is an RPC to a child process that must finish draining —
-        # ~600 ms measured — during which the picker has closed, the band still
-        # reads the old directory, and `_session_transition_pending` swallows a
-        # typed Enter without replaying it. With no line printed the app simply
-        # looked like it had ignored the user (UX U2). The cold path needs no
-        # such line: it settles within the frame, so an in-flight notice would
-        # be immediately contradicted by its own receipt.
+        # above, and only when the move actually makes the user wait. That wait
+        # is an RPC to a child process that must finish draining, or a spawn
+        # already in flight that has to be joined first — during which the
+        # picker has closed, the band still reads the old directory, and
+        # `_session_transition_pending` swallows a typed Enter without
+        # replaying it. With no line printed the app simply looked like it had
+        # ignored the user (UX U2). A genuinely cold viewer needs no such line:
+        # it settles within the frame, so an in-flight notice would be
+        # contradicted by its own receipt a moment later.
+        #
+        # ASKED OF THE SESSION, never reconstructed here. Gating this on
+        # `is_cold` is what shipped in round 1 and it was silent for exactly
+        # the case the line exists for: a viewer with a mount engage in flight
+        # reads cold, while the move joins that engage and then retires the
+        # runtime — measured at 1.94 s of untouched boot splash on a move that
+        # printed "runtime restarted there". The predicate this PR's own
+        # blocker established as unsound must not decide a user-visible line
+        # one layer up (review MAJOR-1, design U6).
         session = self._session
-        if session is not None and not getattr(session, "is_cold", True):
+        will_wait = getattr(session, "move_will_wait", None) if session else None
+        if callable(will_wait) and will_wait():
             notice(f"moving to {format_label(destination)}… restarting the runtime there")
         self._run_session_transition(self._move_session(destination, notice))
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1947,21 +1947,25 @@ class OperatorApp(App[None]):
         # Keep the existing composer visually unchanged, but make its submit
         # boundary atomic so text cannot land in the conversation being left.
         self._session_transition_pending = False
-        #: Whether THIS session has run `eval`, so a `/move` that restarts the
-        #: runtime destroys the namespace it built up. Latched when the call is
-        #: drawn rather than re-derived from the transcript, because `/clear`
-        #: and a bounded resume both edit the VIEW while the kernel lives on
-        #: (see `_session_used_eval`).
-        self._session_used_eval_latch = False
-        #: The session the latch above was stamped for. KEYED rather than
-        #: cleared at each swap: the conversation is replaced under the viewer
-        #: by three different paths, and a reset installed at only the one
-        #: being edited leaked the flag across the other two — telling a
-        #: conversation that never ran `eval` that its namespace was destroyed
-        #: (review MAJOR-4.1). A key makes a stale latch structurally unable to
-        #: answer, so a swap site added later cannot reintroduce the leak by
-        #: forgetting to clear.
-        self._eval_latch_session_id = ""
+        #: Session ids that have run `eval`, so a `/move` restarting the
+        #: runtime destroys the namespace they built up. Recorded when the call
+        #: is drawn rather than re-derived from the transcript, because
+        #: `/clear` and a bounded resume both edit the VIEW while the kernel
+        #: lives on (see `_session_used_eval`).
+        #:
+        #: A SET, not a flag plus a key. Two rounds of review were spent on the
+        #: flag form because a single boolean cannot describe more than one
+        #: conversation, and this app holds several: clearing it on adoption
+        #: told a RETURNING session its live kernel was gone (MAJOR-5.1, the
+        #: sidebar re-adopts the same session), while not clearing it told an
+        #: INCOMING one its namespace had been destroyed (MAJOR-4.1). Stamping
+        #: an owner onto the flag cannot fix that — it only re-labels the last
+        #: writer, so whichever direction is closed opens the other.
+        #:
+        #: Keyed by identity, the question answers itself: a session finds its
+        #: own id or it does not, no swap site has to remember to clear, and a
+        #: path added later cannot reintroduce either direction by forgetting.
+        self._sessions_that_used_eval: set[str] = set()
         #: A show `_set_welcome_visible` withheld during a swap. Applied by
         #: `_reload_session` once the answer is settled, which is what still
         #: puts the splash up for a swap onto a genuinely empty session.
@@ -4762,23 +4766,16 @@ class OperatorApp(App[None]):
         # cold session that never started a runtime, leaving exactly the
         # half-empty band this change exists to remove.
         self._warm_engage_started = False
-        # THE EVAL LATCH IS KEYED TO THE SESSION, and re-keyed here for the
-        # same reason `_warm_engage_started` is reset here: it belongs to the
-        # BINDING, not to the app. Round 4 reset it in `_reload_session` only,
-        # which is one of three paths that replace the conversation under the
-        # viewer — `_apply_sidebar_presentation` rebinds `_transcript` to the
-        # incoming view and `_attach_or_refuse` adopts a successor, and neither
-        # went through that reset. The latch leaked across both, so a
-        # conversation that never ran `eval` was told its namespace had been
-        # destroyed (review MAJOR-4.1).
-        #
-        # Keyed rather than cleared because clearing has to be REMEMBERED at
-        # every future swap site, and the same defect appearing at a third site
-        # later is the same defect. Adoption is the one edge where the identity
-        # is known, so a latch stamped with another session's id is
-        # structurally unable to answer for this one.
-        self._session_used_eval_latch = False
-        self._eval_latch_session_id = self._adopted_session_id
+        # NOTHING HERE FOR THE EVAL RECORD, deliberately. It is keyed by
+        # session id (`_sessions_that_used_eval`), so adoption has no work to
+        # do: the arriving conversation is either in the set or it is not.
+        # Earlier rounds cleared a shared flag here, which is what told a
+        # RETURNING session its live kernel was gone — this method is
+        # re-entered for the SAME conversation by the sidebar return path
+        # (review MAJOR-5.1) — while removing the clear and keeping a stamp
+        # told an INCOMING one its namespace had been destroyed (MAJOR-4.1).
+        # Both were the single flag failing to hold per-session state; do not
+        # reintroduce a reset here.
         # The user can type `/team lop` while the boot worker is still building
         # the session. Its one opening fill then sees no registry, so adoption is
         # the second authoritative edge that must refill the CURRENT query and
@@ -15397,6 +15394,30 @@ class OperatorApp(App[None]):
             return
         notice(f"moved to {label}")
 
+    #: Ceiling on `_sessions_that_used_eval`. A viewer can walk through many
+    #: conversations in one process, and an unbounded set of ids is a slow leak
+    #: for a signal that only decorates one receipt. Sized well above any
+    #: plausible sidebar session count so eviction is unreachable in practice;
+    #: it exists so the growth is bounded at all, not as a working limit.
+    _EVAL_MEMORY_MAX = 512
+
+    def _remember_session_used_eval(self, session_id: str) -> None:
+        """Record that ``session_id`` has run `eval`, bounded.
+
+        Empty ids are dropped rather than stored: an unidentified session
+        cannot be matched back on read, so keeping one would grow the set
+        without ever answering a question. The transcript fallback still covers
+        that case, which is the honest place for it.
+        """
+        if not session_id:
+            return
+        if len(self._sessions_that_used_eval) >= self._EVAL_MEMORY_MAX:
+            # Evicting an arbitrary member only costs a warning the user would
+            # otherwise have seen, and the transcript fallback often still
+            # catches it. Growing without limit costs the process.
+            self._sessions_that_used_eval.pop()
+        self._sessions_that_used_eval.add(session_id)
+
     def _session_used_eval(self) -> bool:
         """Whether this conversation has run `eval`, so a rebind loses state.
 
@@ -15429,18 +15450,28 @@ class OperatorApp(App[None]):
           messages, so an `eval` call older than that is simply not in
           `blocks()` after a resume.
 
-        The latch records the fact when it happens, so nothing that edits the
+        The set records the fact when it happens, so nothing that edits the
         VIEW can retract it. Erring toward warning was always this signal's
         stated policy; deriving it from the screen quietly broke that policy in
         the one direction that costs the user work (review round 3, MAJOR-1).
+
+        RECORDED PER SESSION, and that shape is load-bearing. It was first
+        written as one boolean plus the id of whoever last wrote it, which
+        cannot describe a viewer holding several conversations: clearing on
+        adoption told a RETURNING session its live kernel was gone (MAJOR-5.1
+        — the sidebar re-adopts the same session), and not clearing told an
+        INCOMING one its namespace had been destroyed (MAJOR-4.1). Those are
+        not two bugs but one impossible constraint on a single flag, which is
+        why three rounds of closing one direction reopened the other. A set of
+        ids makes the storage match the state, and no swap site has to remember
+        to clear anything.
         """
-        # The latch answers only for the session it was stamped for. A swap
-        # that rebinds the transcript or adopts a successor without going
-        # through `_adopt_session` leaves the flag set against a DIFFERENT id,
-        # and a stale key must not warn conversation B about conversation A's
-        # namespace (review MAJOR-4.1).
+        # MEMBERSHIP, not a flag: this app holds several conversations and the
+        # answer differs per conversation, so the storage has to as well. A
+        # session finds its own id or it does not — a returning one still does
+        # (its kernel never died), an incoming one never did.
         current_id = getattr(self._session, "session_id", "") or ""
-        if self._session_used_eval_latch and self._eval_latch_session_id == current_id:
+        if current_id and current_id in self._sessions_that_used_eval:
             return True
         transcript = self._transcript
         if transcript is None:
@@ -15453,11 +15484,10 @@ class OperatorApp(App[None]):
             isinstance(block, ToolCard) and block.tool_name == "eval"
             for block in transcript.blocks()
         ):
-            # Memoised against the CURRENT session, not the one that was bound
-            # when the flag was last written: caching it under a stale key
-            # would make the answer unreadable on the very next call.
-            self._session_used_eval_latch = True
-            self._eval_latch_session_id = current_id
+            # Memoised against the CURRENT session, so a later `/clear` cannot
+            # take the answer away from the conversation the evidence was read
+            # for.
+            self._remember_session_used_eval(current_id)
             return True
         return False
 
@@ -16905,16 +16935,15 @@ class OperatorApp(App[None]):
         resume already retired it when it painted the tail, and a page mounted
         into the scrollback is not the edge that starts a conversation.
         """
-        # LATCHED HERE, at the moment the call is drawn, because this is the
+        # RECORDED HERE, at the moment the call is drawn, because this is the
         # last point where the fact is certain. Everything downstream is a
         # view: `/clear` empties it and a bounded resume renders only the tail,
         # so re-deriving "did this session use eval" from the screen loses the
         # answer while the kernel is still alive (`_session_used_eval`).
-        # Stamped with the session it belongs to, so a later swap cannot make
-        # this fact answer for a conversation that never ran the call.
+        # Recorded against the session that ran it, so the fact travels with
+        # that conversation across every swap instead of with the viewer.
         if isinstance(block, ToolCard) and block.tool_name == "eval":
-            self._session_used_eval_latch = True
-            self._eval_latch_session_id = getattr(self._session, "session_id", "") or ""
+            self._remember_session_used_eval(getattr(self._session, "session_id", "") or "")
         if self._projection_message_id:
             if not block.navigation_anchor_id:
                 block.navigation_anchor_id = self._projection_message_id

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1947,6 +1947,14 @@ class OperatorApp(App[None]):
         # Keep the existing composer visually unchanged, but make its submit
         # boundary atomic so text cannot land in the conversation being left.
         self._session_transition_pending = False
+        #: Whether THIS session has run `eval`, so a `/move` that restarts the
+        #: runtime destroys the namespace it built up. Latched when the call is
+        #: drawn rather than re-derived from the transcript, because `/clear`
+        #: and a bounded resume both edit the VIEW while the kernel lives on
+        #: (see `_session_used_eval`). Reset when the session is replaced —
+        #: the successor has its own kernel, and inheriting the flag would warn
+        #: about a loss that belongs to a conversation the user has left.
+        self._session_used_eval_latch = False
         #: A show `_set_welcome_visible` withheld during a swap. Applied by
         #: `_reload_session` once the answer is settled, which is what still
         #: puts the splash up for a swap onto a genuinely empty session.
@@ -6639,6 +6647,10 @@ class OperatorApp(App[None]):
         async with self._turn_provider_lock:
             pass
         self._session = None
+        # The successor gets its own `eval` kernel, so the latch belongs to the
+        # session being disposed and must not outlive it — carrying it over
+        # would warn a NEW conversation about a namespace it never had.
+        self._session_used_eval_latch = False
         # THE WATCHED ID DELIBERATELY SURVIVES THIS WINDOW. It is the only
         # lever a stranded viewer has, and clearing it here disarmed the kill
         # switch on the exact path this feature exists to serve: if anything
@@ -15349,9 +15361,16 @@ class OperatorApp(App[None]):
             # refused: losing it is a real consequence of a move the user asked
             # for, not a reason to decline the move.
             if self._session_used_eval():
+                # "everything you set up in eval", not "the eval kernel's
+                # variables": `kernel` is an implementation noun this surface
+                # never teaches, and it led the clause. `eval` is the one term
+                # the user has provably seen — it is the tool name on the card
+                # above — and the shorter phrasing also shortens the wrapped
+                # tail, which is where this warning always lands (design D11,
+                # D12).
                 notice(
                     f"moved to {label} — this session's runtime restarted there,"
-                    " so the eval kernel's variables were lost"
+                    " so everything you set up in eval was lost"
                 )
                 return
             notice(f"moved to {label} — this session's runtime restarted there")
@@ -15375,18 +15394,42 @@ class OperatorApp(App[None]):
         (`_reap_idle`) or evicted (`_remember`) before the move, in which case
         this warns about state that was already gone; the eval tool's own
         stale-namespace receipt covers that case and the user has still lost
-        nothing they had. The reverse error — staying silent for a user who
-        does have a live kernel — is the one that costs work, and it cannot
-        happen: no `eval` call in the transcript means no kernel for this
-        session was ever created here.
+        nothing they had.
+
+        LATCHED, because `blocks()` is a DISPLAY PROJECTION and not a ledger.
+        This method used to re-derive the answer from what was on screen and
+        its docstring claimed the silent direction could not happen. It can,
+        by two reachable routes, and both leave the kernel alive:
+
+        * `/clear` (`clear_blocks`) empties the view while the session, the
+          runtime and the kernel all survive — and `/clear`'s own receipt
+          promises "history is untouched", so that user has every reason to
+          believe their `eval` state is intact; and
+        * `_project_settled_rows` renders only the last `RESUME_RENDER_MESSAGES`
+          messages, so an `eval` call older than that is simply not in
+          `blocks()` after a resume.
+
+        The latch records the fact when it happens, so nothing that edits the
+        VIEW can retract it. Erring toward warning was always this signal's
+        stated policy; deriving it from the screen quietly broke that policy in
+        the one direction that costs the user work (review round 3, MAJOR-1).
         """
+        if self._session_used_eval_latch:
+            return True
         transcript = self._transcript
         if transcript is None:
             return False
-        return any(
+        # Still consulted as well as the latch: a session RESUMED into this
+        # app never saw the call happen, so its only evidence is what the
+        # replay put on screen. The latch covers the live session, the
+        # transcript covers the resumed one, and either being true is enough.
+        if any(
             isinstance(block, ToolCard) and block.tool_name == "eval"
             for block in transcript.blocks()
-        )
+        ):
+            self._session_used_eval_latch = True
+            return True
+        return False
 
     def _push_cwd_to_band(self, cwd: str) -> None:
         """Repaint the band's directory segment for ``cwd``.
@@ -16832,6 +16875,13 @@ class OperatorApp(App[None]):
         resume already retired it when it painted the tail, and a page mounted
         into the scrollback is not the edge that starts a conversation.
         """
+        # LATCHED HERE, at the moment the call is drawn, because this is the
+        # last point where the fact is certain. Everything downstream is a
+        # view: `/clear` empties it and a bounded resume renders only the tail,
+        # so re-deriving "did this session use eval" from the screen loses the
+        # answer while the kernel is still alive (`_session_used_eval`).
+        if isinstance(block, ToolCard) and block.tool_name == "eval":
+            self._session_used_eval_latch = True
         if self._projection_message_id:
             if not block.navigation_anchor_id:
                 block.navigation_anchor_id = self._projection_message_id

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -224,6 +224,7 @@ from local_operator.tui.widgets.editor import (
 )
 from local_operator.tui.widgets.image_block import ImageBlock
 from local_operator.tui.widgets.model_picker import ModelRow
+from local_operator.tui.widgets.move_picker import MovePickerScreen
 from local_operator.tui.widgets.org_chart_view import (
     OrgChartView,
     OrgChartViewDismissed,
@@ -15139,6 +15140,181 @@ class OperatorApp(App[None]):
             self._notify_mobile_title(stored)
         return stored
 
+    def _cmd_move(self, arg: str, notice: NoticeFn) -> None:
+        """``/move`` — pick a working directory; ``/move <path>`` — go straight there.
+
+        A bare ``/move`` opens :class:`MovePickerScreen`, because choosing a
+        directory is the same two-way question `/resume` answers with a card:
+        the app offers what it knows, the user picks one. An explicit path
+        skips it — a user who already knows where they are going should not be
+        made to answer a prompt — and is expanded (``~``, relative) against the
+        SESSION's directory rather than the process's, since a resumed session
+        routinely differs from the terminal's own cwd.
+
+        FRONTEND-LOCAL, and it must stay that way: the picker draws on this
+        terminal, the suggestions are read from THIS machine's session records,
+        and the directory a user means is one on the machine they are sitting
+        at. Routing it to the owner would offer a remote host's directories to
+        someone who cannot see them — the same argument ``/settings`` and
+        ``/theme`` make about config.yml.
+        """
+        session = self._session
+        if session is None:
+            # A rejected command changed nothing, so the boot composition must
+            # survive it: `_system_notice`, the rule every rejecting branch
+            # here follows.
+            body, kind = self._no_session_notice()
+            self._system_notice(body, kind)
+            return
+
+        if arg.strip():
+            self._apply_move(arg.strip(), notice, typed=True)
+            return
+
+        from local_operator.paths import config_dir
+        from local_operator.tui.move_targets import complete_path, suggest_targets
+
+        cwd = self._session_cwd()
+        try:
+            targets = suggest_targets(cwd, config_dir=config_dir())
+        except Exception:  # noqa: BLE001 — a picker that cannot suggest still opens
+            logger.debug("could not assemble move suggestions", exc_info=True)
+            targets = []
+
+        def _complete(query: str):
+            # Bound to the SESSION's cwd, not the process's, so a typed
+            # relative path completes from where the band says the session is.
+            return complete_path(query, cwd=cwd)
+
+        def _move_choice(path: str | None) -> None:
+            # Dismissed with Esc — the session is left exactly where it was,
+            # with nothing said: a cancelled picker is not an event worth a
+            # transcript line (the rule `_cmd_resume` states).
+            if path:
+                self._apply_move(path, notice, typed=False)
+
+        self.push_screen(
+            MovePickerScreen(targets, current=cwd, complete=_complete),
+            _move_choice,
+        )
+
+    def _apply_move(self, raw: str, notice: NoticeFn, *, typed: bool) -> None:
+        """Validate ``raw`` and move the session to it, or say why not.
+
+        Validation happens HERE, before anything is changed, so a bad target
+        costs the user one line and never a half-applied state: the three
+        rejections (absent, not a directory, unenterable) are told apart
+        because they call for three different next moves.
+
+        ``typed`` says whether the path came from the composer rather than the
+        picker. Only a typed path can be a no-op worth reporting — picking the
+        row you are already on is a deliberate "stay here" — so the two produce
+        different receipts for the same situation.
+        """
+        from local_operator.tui.move_targets import (
+            MoveError,
+            expand_path,
+            format_label,
+            validate_target,
+        )
+
+        session = self._session
+        if session is None:
+            body, kind = self._no_session_notice()
+            self._system_notice(body, kind)
+            return
+        try:
+            target = validate_target(expand_path(raw, cwd=self._session_cwd()))
+        except MoveError as error:
+            notice(str(error), "warning")
+            return
+        except OSError as error:
+            # A path on an unmounted volume, or a symlink loop: the same class
+            # of answer as a MoveError, and equally not a traceback's business.
+            notice(f"cannot move to {raw}: {error}", "warning")
+            return
+
+        destination = str(target)
+        if destination == self._session_cwd():
+            if typed:
+                notice(f"already in {format_label(destination)}")
+            return
+        self._run_session_transition(self._move_session(destination, notice))
+
+    async def _move_session(self, destination: str, notice: NoticeFn) -> None:
+        """Point the session at ``destination``, rebuilding its runtime if bound.
+
+        The two outcomes are the session's to decide, not this app's — see
+        ``RemoteSession.set_working_directory``, which owns the reasoning about
+        why a cold viewer is a field assignment and a bound one is a runtime
+        rebind. This method is the UI half: it reports what happened, keeps the
+        band in step, and re-engages the successor.
+
+        Run behind ``_run_session_transition`` because the bound path DOES
+        replace the runtime under the conversation, and Enter must not address
+        the outgoing one while that is in flight — the same boundary `/new` and
+        `/resume` use for the same reason.
+
+        THE BAND IS THE INVARIANT. It is repainted from the value the session
+        now holds, immediately and on both paths, because the failure this
+        feature must not have is the one AGENTS.md names for `/reload`: a
+        screen showing one directory while the agent works in another. On the
+        cold path nothing else would repaint it (there is no runtime to push a
+        snapshot), and on the bound path the successor's snapshot arrives
+        seconds later — so the push here is what makes the two agree at the
+        moment the receipt is printed rather than eventually.
+        """
+        session = self._session
+        move = getattr(session, "set_working_directory", None)
+        if not callable(move):
+            # A reduced facade (a test double, an embedder's host) that never
+            # grew the method. Refusing names the situation rather than
+            # silently doing nothing.
+            self._system_notice("this session cannot be moved", "warning")
+            return
+        from local_operator.tui.move_targets import format_label, remember_recent
+
+        label = format_label(destination)
+        try:
+            outcome = await cast(Callable[[str], Awaitable[str]], move)(destination)
+        except Exception as error:  # noqa: BLE001 — the refusal IS the receipt
+            notice(str(error), "warning")
+            return
+
+        # The band FIRST, before any await: it is the surface the user is
+        # looking at when the receipt lands, and the whole point is that it
+        # never disagrees with where the session works.
+        self._push_cwd_to_band(destination)
+
+        from local_operator.paths import config_dir
+
+        remember_recent(config_dir(), destination)
+
+        if outcome == "rebound":
+            # NOTHING to re-engage here. The runtime leaves by the `retiring`
+            # route (see `RemoteSession.set_working_directory`), which the
+            # facade turns into `_go_cold(refresh=True)` and the refresh
+            # callback this app already installs — `_on_runtime_refreshed` —
+            # engages the successor eagerly. Starting a second engage from here
+            # would race that one for the same session's lease.
+            notice(f"moved to {label} — this session's runtime restarted there")
+            return
+        notice(f"moved to {label}")
+
+    def _push_cwd_to_band(self, cwd: str) -> None:
+        """Repaint the band's directory segment for ``cwd``.
+
+        One call paints the band AND pushes the terminal title (see
+        ``StatusLine._sync_terminal_title``), so neither surface can lag the
+        other by a frame — the discipline `_cmd_rename` follows for the name.
+        The title matters here specifically: an unnamed conversation is
+        LABELLED by its directory (``terminal_title.cwd_label``), so a move
+        that did not push would leave the tab naming the old folder.
+        """
+        if self._status is None:
+            return
+        self._status.update(cwd=cwd)
+
     def _cmd_rename(self, arg: str, notice: NoticeFn) -> None:
         """``/rename`` — report the title; ``/rename <text>`` — set it by hand.
 
@@ -17799,6 +17975,8 @@ class OperatorApp(App[None]):
             self._cmd_resume(arg, notice)
         elif command == "/fork":
             self._cmd_fork(prompt_arg, notice)
+        elif command == "/move":
+            self._cmd_move(arg, notice)
         elif command == "/rename":
             self._cmd_rename(arg, notice)
         elif command == "/model":
@@ -22767,6 +22945,33 @@ class OperatorApp(App[None]):
             return
         if message.command == "analytics":
             picker.set_choices(self._analytics_choices())
+            picker.set_notice("")
+            return
+        if message.command == "move":
+            # The same suggestions the picker opens with, offered inline for a
+            # user who typed the space rather than pressing Enter — one
+            # vocabulary, two routes to it, so the list cannot propose a
+            # directory the picker would not. Free typing is unaffected: the
+            # editor's list RANKS what is typed and never filters what may be
+            # submitted, so an arbitrary path still reaches `_cmd_move`.
+            from local_operator.paths import config_dir
+            from local_operator.tui.move_targets import suggest_targets
+
+            try:
+                targets = suggest_targets(self._session_cwd(), config_dir=config_dir())
+            except Exception:  # noqa: BLE001 — an unreadable store is an empty list
+                logger.debug("could not assemble move argument rows", exc_info=True)
+                targets = []
+            picker.set_choices(
+                [
+                    ArgumentChoice(
+                        name=target.label,
+                        description=target.path,
+                        detail=target.detail,
+                    )
+                    for target in targets
+                ]
+            )
             picker.set_notice("")
             return
         if message.command == "mcp":

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -1851,6 +1851,40 @@ SessionPickerScreen .session-picker {
 }
 
 
+/* ── /move directory picker ────────────────────────────────────────────── *
+ *
+ * The `/resume` picker's twin, and deliberately identical to it: both answer
+ * a "read a list, pick a row" question with a cursor and hand a value back,
+ * so giving them different visual language would make one more screen look
+ * like a different app.
+ *
+ * `max-width` rather than a fixed width so an 80-column terminal gets the
+ * card it can hold; the widget measures its own columns against
+ * PICKER_MAX_WIDTH and truncates the path from the LEFT, which is the one
+ * column that can give up cells. Content-sized in both axes like `/resume`,
+ * because the row budget is computed in Python (`_page_rows`) and a second
+ * cap in the sheet is how a card loses its footer to a clip from the outside. */
+MovePickerScreen {
+    align: center middle;
+    background: $lo-sunken;
+}
+
+MovePickerScreen .move-picker {
+    width: auto;
+    height: auto;
+    max-width: 86;
+    max-height: 80%;
+    background: $lo-overlay;
+    padding: 1 2;
+}
+
+#move-picker-body {
+    width: auto;
+    height: auto;
+    color: $lo-fg;
+}
+
+
 /* ── /analytics /usage: the aggregated token-consumption screen ────────── *
  *
  * The same centred card over a dimmed transcript as `/resume`, because it is

--- a/local_operator/tui/move_targets.py
+++ b/local_operator/tui/move_targets.py
@@ -1,0 +1,494 @@
+"""Directory suggestions and validation behind ``/move``.
+
+Kept free of widget imports for the reason
+:mod:`local_operator.tui.copy_targets` is: the assembly rules are pure
+functions over a directory and a config root, so they are testable — and
+reusable by a non-Textual frontend — without importing Textual to learn what
+``/move`` would offer.
+
+WHY A PICKER NEEDS SUGGESTIONS AT ALL. The reported problem was a session
+started in the wrong folder, which means the user does not want to *type* a
+path: they want to recognise the one they meant. So the list leads with places
+the user has actually been (this session's directory, then other sessions'),
+and only then with the structural fallbacks — home, ``/tmp``, the parent, and
+the children that make the picker a navigator rather than a bookmark list.
+
+WHERE "RECENT" COMES FROM, and why there is a small file for it. Three sources,
+cheapest first, deduplicated in this order:
+
+* the LIVE runtime records (``session/runtime/registry.scan``), which carry
+  ``cwd`` and are the other ``lop`` sessions running right now. This is the
+  most valuable source and it costs one directory listing.
+* the wake index, whose entries also carry ``cwd`` — sessions that are not
+  running but have work armed.
+* :data:`RECENTS_FILE`, this module's own tiny list of directories ``/move``
+  has been used to reach.
+
+The third exists because the first two are both LIVE state: quit every session
+and the recents list goes empty, so the second use of the feature on a fresh
+morning would offer nothing the first use taught it. It is deliberately the
+smallest durable thing that fixes that — a capped JSON array of strings,
+atomically replaced, best-effort at both ends (an unreadable or malformed file
+is treated as empty and a failed write costs the user nothing but a missing
+row). Notably it is NOT a general "directory history": nothing writes it but a
+completed move, so it cannot grow without the user having chosen each entry.
+
+The session TRANSCRIPT also records a cwd (the durable frontend checkpoint),
+and it is deliberately not read here: the picker opens synchronously and those
+files reach 100 MB, so mining them per open would trade a directory listing for
+a multi-hundred-megabyte parse to learn something the two live sources already
+answer for every session that matters.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: Where the durable half of "recent directories" lives, under the config root
+#: beside the other small derived indexes (``wakes/``, ``mobile-seen.json``).
+RECENTS_FILE = "move-recents.json"
+
+#: How many directories the durable list keeps. A picker is scanned, not paged
+#: through, and the live sources already contribute the sessions that matter
+#: right now — so this is a memory of where the user has deliberately gone,
+#: not a shell history. Small enough that the file stays a single short read.
+RECENTS_LIMIT = 20
+
+#: Immediate subdirectories of the current directory offered as rows. Bounded
+#: because a node_modules-shaped directory has thousands and the card can draw
+#: about ten: past this the rows stop being suggestions and become noise the
+#: user has to filter anyway, which is what TYPING is for.
+CHILD_LIMIT = 12
+
+#: Suggestion rows in total. The card scrolls, so this is not a display cap —
+#: it bounds the WORK an open costs, and it sits well past what fits on screen
+#: so the filter still has material to narrow.
+SUGGESTION_LIMIT = 60
+
+
+@dataclass(frozen=True)
+class MoveTarget:
+    """One directory ``/move`` can go to, with why it is being offered.
+
+    ``path`` is absolute and normalised, because it is what the session's cwd
+    is set to; ``label`` is the home-relative rendering the user reads. Keeping
+    both means the row a user recognises (``~/workspace/repos/x``) and the
+    value the runtime is spawned with can never drift apart.
+    """
+
+    path: str
+    label: str
+    #: ``current`` | ``recent`` | ``home`` | ``tmp`` | ``parent`` | ``child``.
+    #: Drives the row's note and nothing else; the picker does not branch on it.
+    kind: str
+    #: The short right-hand note ("current", "session", "home", …). Carried on
+    #: the target rather than derived in the widget so the ordering rationale
+    #: and the label the user reads live in one place.
+    detail: str = ""
+
+
+class MoveError(ValueError):
+    """A target that cannot be moved to, carrying the sentence to show.
+
+    A distinct type rather than a returned string so a caller cannot forget to
+    check: every rejection reaches the user as one vetted line, and the three
+    reasons (absent, not a directory, unreadable) are told apart because they
+    call for different actions.
+    """
+
+
+def format_label(path: str | Path, *, home: Path | None = None) -> str:
+    """``~/rel/path`` inside the home tree, the absolute path outside it.
+
+    The same rendering :func:`local_operator.tui.widgets.status_line.format_cwd`
+    gives the band, and deliberately so: the row the user picks and the segment
+    they then read on the band must be the same string, or the move looks like
+    it landed somewhere else.
+    """
+    text = str(path)
+    if not text:
+        return ""
+    root = home if home is not None else Path.home()
+    try:
+        relative = Path(text).relative_to(root)
+    except ValueError:
+        return text
+    return "~" if str(relative) == "." else f"~/{relative}"
+
+
+def expand_path(text: str, *, cwd: str | Path) -> Path:
+    """A typed path as an absolute one: ``~`` expanded, relative resolved.
+
+    Resolved against the SESSION's directory rather than the process's, because
+    those differ routinely — a resumed conversation carries its own cwd while
+    the terminal was launched somewhere else — and ``/move ../sibling`` has to
+    mean the sibling of the directory the band is showing.
+
+    Symlinks are deliberately NOT resolved (``absolute()``, not ``resolve()``):
+    a user who moves into ``~/current-project`` means the symlink, and printing
+    its target back at them on the band would read as the move having gone
+    somewhere else.
+    """
+    raw = os.path.expanduser(text.strip())
+    candidate = Path(raw)
+    if not candidate.is_absolute():
+        candidate = Path(cwd) / candidate
+    return Path(os.path.normpath(candidate))
+
+
+def validate_target(path: str | Path) -> Path:
+    """``path`` as a usable working directory, or raise :class:`MoveError`.
+
+    Three distinct rejections because they call for three different next
+    moves, and a single "invalid directory" told the user none of them. The
+    executable bit is checked as well as existence: a directory that cannot be
+    entered would let the move "succeed" and then fail every tool call made
+    inside it, which is the half-applied state this exists to prevent.
+    """
+    candidate = Path(path)
+    if not candidate.exists():
+        raise MoveError(f"no such directory: {format_label(candidate)}")
+    if not candidate.is_dir():
+        raise MoveError(f"not a directory: {format_label(candidate)}")
+    if not os.access(candidate, os.R_OK | os.X_OK):
+        raise MoveError(f"cannot enter {format_label(candidate)}: permission denied")
+    return candidate
+
+
+def _readable_dir(path: str | Path) -> bool:
+    """Whether ``path`` is a directory this process could actually work in.
+
+    The suggestion assembler's filter. Never raises: a source can name a
+    directory on a volume that has since been unmounted, and a picker that
+    cannot open because one stale row's ``stat`` failed is worse than a row
+    that is quietly not offered.
+    """
+    try:
+        return validate_target(path) is not None
+    except (MoveError, OSError):
+        return False
+
+
+def read_recents(config_dir: Path) -> list[str]:
+    """The durable recent-directory list, newest first; ``[]`` when unreadable.
+
+    Best-effort by contract. This file is an enhancement to a list that has two
+    live sources already, so every failure mode — absent, truncated, holding a
+    JSON object instead of an array, holding non-strings — degrades to "no
+    remembered directories" rather than costing the user the picker.
+    """
+    path = Path(config_dir) / RECENTS_FILE
+    try:
+        raw = json.loads(path.read_text())
+    except FileNotFoundError:
+        return []
+    except (OSError, ValueError):
+        logger.debug("move recents unreadable; continuing without them", exc_info=True)
+        return []
+    if not isinstance(raw, list):
+        return []
+    return [item for item in raw if isinstance(item, str) and item]
+
+
+def remember_recent(config_dir: Path, path: str | Path) -> None:
+    """Record ``path`` as the newest entry, deduplicated and capped.
+
+    Written to a temporary file in the SAME directory and ``os.replace``d over
+    the target, the discipline every small index here uses
+    (``config.py``, ``multiplexer/markers.py``): a torn read of this file would
+    silently empty a user's remembered directories, and same-directory replace
+    is the only form that is atomic.
+
+    Never raises. This runs immediately after a move the user has already been
+    told succeeded, so a read-only config directory must cost them the memory
+    of the move and not the move itself.
+    """
+    directory = Path(config_dir)
+    text = str(path)
+    entries = [item for item in read_recents(directory) if item != text]
+    entries.insert(0, text)
+    del entries[RECENTS_LIMIT:]
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+        handle_fd, temporary = tempfile.mkstemp(dir=directory, prefix=".move-recents-")
+        try:
+            with os.fdopen(handle_fd, "w") as handle:
+                json.dump(entries, handle)
+            os.replace(temporary, directory / RECENTS_FILE)
+        except BaseException:
+            Path(temporary).unlink(missing_ok=True)
+            raise
+    except OSError:
+        logger.debug("could not record the move in recents", exc_info=True)
+
+
+def live_session_dirs(config_dir: Path) -> list[str]:
+    """Directories other ``lop`` sessions are working in, newest session first.
+
+    The most valuable recents source and the cheapest: one records listing
+    answers it for every running session, which is exactly the "take me to
+    where my other work is" case ``/move`` was asked for. Sessions are ordered
+    by start time so the one the user most recently opened leads.
+
+    Best-effort, like every other consumer of the registry here
+    (``session_catalog.decorate_rows``): an unreadable run directory costs the
+    picker its liveness rows, never its ability to open.
+    """
+    out: list[str] = []
+    try:
+        from local_operator.session.runtime import registry
+
+        scanned = registry.scan(Path(config_dir))
+    except Exception:  # noqa: BLE001 — suggestions are an enhancement, never a gate
+        logger.debug("could not scan session records for directories", exc_info=True)
+        scanned = []
+    rows = [record for record, state in scanned if state != "stale"]
+    rows.sort(key=lambda record: float(getattr(record, "started_at", 0.0) or 0.0), reverse=True)
+    for record in rows:
+        cwd = str(getattr(record, "cwd", "") or "")
+        if cwd:
+            out.append(cwd)
+    return out
+
+
+def wake_session_dirs(config_dir: Path) -> list[str]:
+    """Directories of sessions that are not running but have wakes armed.
+
+    The second live source. A session with a wake is one the user expects to
+    come back to, so its directory belongs in the same tier as a running
+    session's — and the index already carries ``cwd`` for the supervisor's own
+    use, so reading it costs one small file.
+    """
+    try:
+        from local_operator.wakes.store import read_index
+
+        index = read_index(Path(config_dir))
+    except Exception:  # noqa: BLE001
+        logger.debug("could not read the wake index for directories", exc_info=True)
+        return []
+    out: list[str] = []
+    for entry in (index or {}).values():
+        if not isinstance(entry, dict):
+            continue
+        cwd = str(entry.get("cwd") or "")
+        if cwd:
+            out.append(cwd)
+    return out
+
+
+def child_dirs(cwd: str | Path, *, limit: int = CHILD_LIMIT) -> list[str]:
+    """Immediate subdirectories of ``cwd``, alphabetical, hidden ones omitted.
+
+    What makes the picker a navigator instead of a bookmark list. Hidden
+    directories are skipped because ``.git``/``.venv``/``.mypy_cache`` would
+    otherwise crowd out every real child on any checkout — a user who wants one
+    can type it, and typing is the path that reaches ANY directory.
+    """
+    try:
+        entries = sorted(Path(cwd).iterdir(), key=lambda item: item.name.lower())
+    except OSError:
+        return []
+    out: list[str] = []
+    for entry in entries:
+        if entry.name.startswith("."):
+            continue
+        try:
+            if not entry.is_dir():
+                continue
+        except OSError:
+            continue
+        out.append(str(entry))
+        if len(out) >= limit:
+            break
+    return out
+
+
+def suggest_targets(
+    cwd: str | Path,
+    *,
+    config_dir: Path,
+    home: Path | None = None,
+    limit: int = SUGGESTION_LIMIT,
+) -> list[MoveTarget]:
+    """The rows ``/move`` opens with, in order of usefulness and deduplicated.
+
+    The ORDER is the feature, so it is stated once here rather than being an
+    accident of how the sources are concatenated:
+
+    1. the current directory, always first and always present — a picker that
+       does not show where you are makes "did that work?" unanswerable, and it
+       is also the row that makes Esc-equivalent (pick where you already are) a
+       visible option rather than a thing you have to know;
+    2. recent directories — other sessions', then remembered ones. These are
+       places the user has demonstrably worked, which beats anything structural;
+    3. home and ``/tmp``, the two destinations that need no memory at all;
+    4. the parent, then the children — the navigator tier, last because they
+       are one step each where the tiers above are whole destinations.
+
+    Deduplicated by resolved path with the FIRST occurrence winning, so a
+    directory that is both the home directory and a running session's cwd is
+    offered once, in the higher tier, with that tier's note. Only directories
+    that exist and can be entered are offered: a suggestion that fails
+    validation the moment it is chosen is worse than no suggestion.
+    """
+    root = home if home is not None else Path.home()
+    current = Path(os.path.normpath(Path(cwd)))
+    config_root = Path(config_dir)
+
+    # (path, kind, detail), in the tiers documented above. Built as one flat
+    # list so the dedup below sees them in exactly the offered order.
+    candidates: list[tuple[str, str, str]] = [(str(current), "current", "current")]
+    for path in live_session_dirs(config_root):
+        candidates.append((path, "recent", "session"))
+    for path in wake_session_dirs(config_root):
+        candidates.append((path, "recent", "wake armed"))
+    for path in read_recents(config_root):
+        candidates.append((path, "recent", "recent"))
+    candidates.append((str(root), "home", "home"))
+    # Noted like every other row. A blank note read as a missing value in the
+    # rendered frame — every neighbour carries one, so the gap looked like the
+    # row had failed to resolve rather than like a row that needed no
+    # explanation. "scratch" is what the directory is FOR, which is the same
+    # kind of statement "home" and "parent" make.
+    candidates.append((os.path.normpath("/tmp"), "tmp", "scratch"))
+    parent = current.parent
+    if parent != current:
+        candidates.append((str(parent), "parent", "parent"))
+    for path in child_dirs(current):
+        candidates.append((path, "child", "in this folder"))
+
+    out: list[MoveTarget] = []
+    seen: set[str] = set()
+    for raw, kind, detail in candidates:
+        path = os.path.normpath(os.path.expanduser(raw))
+        # Deduplicated on the RESOLVED path, offered as the un-resolved one.
+        # On macOS `/tmp` is a symlink to `/private/tmp`, and a running
+        # session reports the resolved form while this module's own `/tmp`
+        # row does not — so a plain string dedup offered the same directory
+        # twice, in two spellings, in the same list (observed on the real
+        # store). Resolution decides identity; the label still shows the path
+        # the user asked for, because `expand_path` deliberately keeps
+        # symlinks unresolved.
+        try:
+            identity = os.path.realpath(path)
+        except OSError:
+            identity = path
+        if identity in seen:
+            continue
+        seen.add(identity)
+        # The CURRENT directory is offered even when it fails validation: a
+        # session whose directory was deleted underneath it is exactly when a
+        # user reaches for `/move`, and hiding the row would leave the picker
+        # silently disagreeing with the band about where the session is.
+        if kind != "current" and not _readable_dir(path):
+            continue
+        out.append(
+            MoveTarget(path=path, label=format_label(path, home=root), kind=kind, detail=detail)
+        )
+        if len(out) >= limit:
+            break
+    return out
+
+
+def complete_path(
+    text: str, *, cwd: str | Path, home: Path | None = None, limit: int = 40
+) -> list[MoveTarget]:
+    """Directories matching a typed PATH prefix, for the completion tier.
+
+    The half of the picker that reaches an arbitrary directory. A list of
+    suggestions can only ever offer what it guessed; a filter that also
+    completes paths means no directory on the machine is unreachable, which is
+    the difference between a picker people use and one they abandon.
+
+    The prefix is split the way a shell splits it — everything up to the last
+    separator is the directory to list, the remainder is the fragment to match
+    — so ``~/work`` lists ``~`` for names starting ``work`` while ``~/work/``
+    lists inside the directory itself. Matching is case-insensitive because the
+    common filesystem here is, and a case-sensitive filter over a
+    case-insensitive filesystem reports "no matches" for a directory the user
+    can see.
+
+    Hidden directories are offered ONLY when the fragment itself starts with a
+    dot: the same rule :func:`child_dirs` uses, with the escape hatch that
+    makes a typed ``~/.config`` reachable.
+    """
+    raw = text.strip()
+    if not raw:
+        return []
+    expanded = os.path.expanduser(raw)
+    # A trailing separator means "inside this directory", so the fragment is
+    # empty and the whole of it is the base.
+    if expanded.endswith(os.sep):
+        base_text, fragment = expanded, ""
+    else:
+        base_text, _, fragment = expanded.rpartition(os.sep)
+        if not base_text:
+            # A bare relative word ("src"): complete inside the session's own
+            # directory rather than treating it as a filesystem root.
+            base_text = str(cwd) if not expanded.startswith(os.sep) else os.sep
+    base = Path(base_text) if base_text else Path(cwd)
+    if not base.is_absolute():
+        base = Path(cwd) / base
+    root = home if home is not None else Path.home()
+    needle = fragment.lower()
+    try:
+        entries = sorted(base.iterdir(), key=lambda item: item.name.lower())
+    except OSError:
+        return []
+    out: list[MoveTarget] = []
+    for entry in entries:
+        name = entry.name
+        if name.startswith(".") and not fragment.startswith("."):
+            continue
+        if needle and not name.lower().startswith(needle):
+            continue
+        path = os.path.normpath(str(entry))
+        if not _readable_dir(path):
+            continue
+        out.append(
+            MoveTarget(path=path, label=format_label(path, home=root), kind="typed", detail="")
+        )
+        if len(out) >= limit:
+            break
+    return out
+
+
+def looks_like_path(text: str) -> bool:
+    """Whether ``text`` should be COMPLETED as a path rather than used to filter.
+
+    The picker has one input and two jobs, so the rule that splits them has to
+    be one a user can predict without being told: anything with a separator, or
+    anchored at ``~``, ``/`` or ``.``, is a path. Everything else is a filter
+    over the suggestions — which is what a user typing ``repos`` means, and
+    completing that as a relative directory would answer an empty list because
+    no such child exists.
+    """
+    stripped = text.strip()
+    if not stripped:
+        return False
+    return stripped.startswith(("~", "/", ".")) or os.sep in stripped
+
+
+def filter_targets(targets: list[MoveTarget], query: str) -> list[MoveTarget]:
+    """``targets`` whose label or path contains ``query``, order preserved.
+
+    Narrowing NEVER reorders, matching ``session_picker.filter_rows``' contract
+    for a fixed query: the tier order above is the picker's whole argument for
+    what to offer first, and re-ranking on each keystroke would move a row out
+    from under a cursor that is aiming at it.
+    """
+    needle = query.strip().lower()
+    if not needle:
+        return list(targets)
+    return [
+        target
+        for target in targets
+        if needle in target.label.lower() or needle in target.path.lower()
+    ]

--- a/local_operator/tui/move_targets.py
+++ b/local_operator/tui/move_targets.py
@@ -509,6 +509,18 @@ def resolve_self(text: str, *, cwd: str | Path, home: Path | None = None) -> Mov
     path = os.path.normpath(str(candidate))
     if not _readable_dir(path):
         return None
+    # Walking or typing your way BACK to where you already are must read the
+    # same as arriving there from the suggestion list, or the one row whose
+    # job is to answer "where am I?" says something different depending on how
+    # you reached it (design D9). `current` also earns the note-pinning that
+    # `render_rows` gives that tier, which `typed` does not get.
+    if os.path.normpath(str(cwd)) == path:
+        return MoveTarget(
+            path=path,
+            label=format_label(path, home=root),
+            kind="current",
+            detail="current",
+        )
     return MoveTarget(
         path=path,
         label=format_label(path, home=root),

--- a/local_operator/tui/move_targets.py
+++ b/local_operator/tui/move_targets.py
@@ -107,10 +107,17 @@ class MoveError(ValueError):
 def format_label(path: str | Path, *, home: Path | None = None) -> str:
     """``~/rel/path`` inside the home tree, the absolute path outside it.
 
-    The same rendering :func:`local_operator.tui.widgets.status_line.format_cwd`
-    gives the band, and deliberately so: the row the user picks and the segment
-    they then read on the band must be the same string, or the move looks like
-    it landed somewhere else.
+    Matches :func:`local_operator.tui.widgets.status_line.format_cwd`
+    deliberately: the row the user picks and the segment they then read on the
+    band should be the same string, or the move looks like it landed somewhere
+    else.
+
+    ONE case diverges, and the claim is narrowed rather than overstated because
+    the difference is real. For the home directory ITSELF this renders ``~``
+    while the band renders ``~/.``. They name the same directory, and the band
+    has rendered it that way for every surface since long before ``/move``
+    existed, so correcting it belongs in ``format_cwd`` — where every other
+    caller would be affected — and not here (QA Q3).
     """
     text = str(path)
     if not text:

--- a/local_operator/tui/move_targets.py
+++ b/local_operator/tui/move_targets.py
@@ -460,6 +460,56 @@ def complete_path(
     return out
 
 
+def resolve_self(text: str, *, cwd: str | Path, home: Path | None = None) -> MoveTarget | None:
+    """``text`` as a row for ITSELF when it names a directory you can move to.
+
+    The completion tier lists what is INSIDE a path, so a directory with no
+    subdirectories completes to nothing and was reported as "no directory
+    matches that path" — for a directory the user had just selected, one
+    keystroke earlier, from this same card. Enter there chose nothing and the
+    picker closed silently (design D1 / UX U1, found independently).
+
+    Offering the resolved directory as its own row makes the walk terminate
+    where a walk naturally ends: at the directory you were walking to. Returns
+    ``None`` when the path does not exist or cannot be entered — those really
+    are "no match" and keep that sentence.
+
+    ``detail`` states why the row is there, in the vocabulary the other tiers
+    use, because at that moment it is the only row on the card and "this
+    folder" is what distinguishes it from the children it does not have.
+    """
+    raw = text.strip()
+    if not raw:
+        return None
+    root = home if home is not None else Path.home()
+    # ``~`` is expanded against the SAME root the labels are written against,
+    # not the process's ``$HOME``. ``os.path.expanduser`` reads the environment,
+    # so a caller that passes ``home=`` (every test, and any embedder with a
+    # relocated home) would have its ``~`` rows resolve somewhere the labels
+    # never point — the row would render and then refuse to resolve.
+    if raw == "~":
+        expanded = str(root)
+    elif raw.startswith("~" + os.sep):
+        expanded = str(root / raw[2:])
+    else:
+        expanded = os.path.expanduser(raw)
+    # A trailing separator is how ``action_complete`` marks "descend into
+    # this", and it is exactly the state that produces an empty completion, so
+    # it must resolve to the directory itself rather than be rejected.
+    candidate = Path(expanded.rstrip(os.sep) or os.sep)
+    if not candidate.is_absolute():
+        candidate = Path(cwd) / candidate
+    path = os.path.normpath(str(candidate))
+    if not _readable_dir(path):
+        return None
+    return MoveTarget(
+        path=path,
+        label=format_label(path, home=root),
+        kind="typed",
+        detail="this folder",
+    )
+
+
 def looks_like_path(text: str) -> bool:
     """Whether ``text`` should be COMPLETED as a path rather than used to filter.
 
@@ -473,7 +523,16 @@ def looks_like_path(text: str) -> bool:
     stripped = text.strip()
     if not stripped:
         return False
-    return stripped.startswith(("~", "/", ".")) or os.sep in stripped
+    # ``~`` anchors a path only when it is the whole string or is followed by a
+    # separator. ``~x`` is a filter word: routing it to completion returned
+    # nothing instead of narrowing the suggestions to labels containing ``x``
+    # (review MINOR-3). ``/`` and ``.`` need no such qualification — both are
+    # legal path starts on their own and neither begins an ordinary word.
+    if stripped in ("~", "."):
+        return True
+    if stripped.startswith("~"):
+        return stripped[1:2] == os.sep
+    return stripped.startswith(("/", ".")) or os.sep in stripped
 
 
 def filter_targets(targets: list[MoveTarget], query: str) -> list[MoveTarget]:

--- a/local_operator/tui/widgets/move_picker.py
+++ b/local_operator/tui/widgets/move_picker.py
@@ -1,0 +1,660 @@
+"""The ``/move`` picker: choose the directory this session works in.
+
+A sibling of :class:`~local_operator.tui.widgets.session_picker.SessionPickerScreen`
+and deliberately built to its pattern rather than to a new one: a modal over
+the dimmed transcript, a cursor the screen owns, a filter every printable key
+types into, and a dismissal that hands the caller a value or ``None``. The
+answer is an absolute PATH (``str``), the way the resume picker's answer is a
+session id — the caller decides what to do with it.
+
+WHY IT ALSO COMPLETES PATHS. Every other picker in this app chooses from a
+closed set: the sessions on disk, the models a provider lists, the blocks in a
+message. A directory list is not closed — the destination the user wants may be
+anywhere on the filesystem — so a card that could only filter its suggestions
+would be abandoned the first time someone wanted a directory it had not
+guessed. The input therefore has two modes, split by
+:func:`~local_operator.tui.move_targets.looks_like_path`: anything anchored at
+``~``/``/``/``.`` or containing a separator COMPLETES against the filesystem,
+and anything else FILTERS the suggestions. One input, and the mode is
+predictable from what the user typed rather than from a key they have to know.
+
+The card states which mode it is in (the header says ``filter`` or ``path``)
+because the two answer differently to the same keystroke, and a user who cannot
+tell which one they are in cannot tell whether an empty list means "no such
+directory" or "no such suggestion".
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from rich.cells import cell_len
+from rich.style import Style
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Container
+from textual.screen import ModalScreen
+from textual.widgets import Static
+
+from local_operator.tui import theme as theme_mod
+from local_operator.tui.move_targets import MoveTarget, filter_targets, looks_like_path
+from local_operator.tui.widgets.tool_card import truncate_cells
+
+#: Width the card takes when the terminal allows it, and the floor it will not
+#: go below. Both are CELL counts of the card's content, inside its padding.
+#: Wider than the resume picker's 74 because a path is the whole row here where
+#: a session name shares its row with an age and an id — and a truncated path,
+#: unlike a truncated name, is not recognisable at all.
+PICKER_MAX_WIDTH = 80
+PICKER_MIN_WIDTH = 30
+
+#: Cells between the card and the terminal edges, on top of its own padding, so
+#: it reads as floating. Same value and same reason as the resume picker's.
+PICKER_WIDTH_MARGIN = 6
+
+#: Cells of the card's own padding on EACH side, mirroring ``padding: 1 2``.
+PICKER_PADDING_CELLS = 2
+
+#: Rows of directories shown before the list scrolls, when there is room. A
+#: CEILING, not the page size — see :meth:`MovePickerScreen._page_rows`.
+PAGE_ROWS_MAX = 10
+
+#: Fraction of the screen height the card may occupy, mirroring the stylesheet.
+CARD_MAX_HEIGHT_FRACTION = 0.8
+
+#: Rows the card spends on things that are not directories: the header, the
+#: rule under it, the blank spacer and the footer. Reserved FIRST so a short
+#: terminal loses list rows (which scroll) rather than the footer (which is the
+#: only statement of how to leave) — the discipline `session_picker` records.
+CARD_CHROME_ROWS = 4
+
+#: Rows of the card's own padding, mirroring the vertical half of ``padding: 1 2``.
+CARD_PADDING_ROWS = 2
+
+#: The cursor column, present on every row so a selection cannot shift the text.
+CURSOR_CELLS = 2
+
+#: What the card says when the filter admits nothing. Distinct sentences for
+#: the two modes because they mean different things and imply different fixes:
+#: a filter that matches nothing is a typo in a word, a path that matches
+#: nothing is a directory that is not there.
+NO_MATCH_NOTICE = "no suggestion matches that"
+NO_PATH_NOTICE = "no directory matches that path"
+
+
+def render_rows(
+    targets: list[MoveTarget],
+    selected: int,
+    width: int,
+    hovered: int | None = None,
+) -> list[Text]:
+    """One line per directory: cursor, label, and the note saying why.
+
+    The note is right-aligned and DROPPED before the label is cut: the label is
+    the thing being chosen and the note is only the reason it was offered, so
+    on a narrow card the reason goes first. The label is then truncated from
+    the LEFT (``…/repos/lo-move-cmd``) rather than the right, because the tail
+    of a path is what distinguishes two siblings while the head is the part
+    every row shares.
+    """
+    dim = Style(color=theme_mod.semantic_color("dim"))
+    faint = Style(color=theme_mod.semantic_color("faint"))
+    accent = Style(color=theme_mod.semantic_color("accent"))
+    fg = Style(color=theme_mod.semantic_color("fg"))
+
+    out: list[Text] = []
+    for index, target in enumerate(targets):
+        is_selected = index == selected
+        line = Text(no_wrap=True, overflow="ellipsis")
+        line.append("❯ " if is_selected else "  ", style=accent if is_selected else faint)
+        room = max(1, width - CURSOR_CELLS)
+        note = target.detail
+        # The note only earns its cells when the label still fits beside it.
+        note_cells = cell_len(note) + 2 if note else 0
+        if note and cell_len(target.label) + note_cells > room:
+            note, note_cells = "", 0
+        label = _truncate_head(target.label, max(1, room - note_cells))
+        line.append(label, style=fg if is_selected else dim)
+        if note:
+            pad = room - cell_len(label) - cell_len(note)
+            if pad > 0:
+                line.append(" " * pad)
+            line.append(note, style=faint)
+        if hovered is not None and index == hovered and not is_selected:
+            line.stylize(Style(bgcolor=theme_mod.semantic_color("raised")))
+        out.append(line)
+    return out
+
+
+def _truncate_head(text: str, width: int) -> str:
+    """``text`` cut from the LEFT to ``width`` cells, marked with an ellipsis.
+
+    ``truncate_cells`` cuts the tail, which is right for a sentence and wrong
+    for a path: two rows under the same parent differ only in their last
+    segment, so a tail cut renders them as the same string.
+    """
+    if cell_len(text) <= width:
+        return text
+    if width <= 1:
+        return "…"
+    kept = text
+    while kept and cell_len(kept) > width - 1:
+        kept = kept[1:]
+    return f"…{kept}"
+
+
+class MovePickerScreen(ModalScreen[str | None]):
+    """Pick a working directory; dismisses with its absolute path, or ``None``.
+
+    Two-way like the resume picker: the caller pushes it and acts on what comes
+    back, so this screen owns navigation and the caller owns the move. Esc
+    answers ``None`` and the session is left exactly where it was.
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel", show=False),
+        Binding("enter", "choose", "Move", show=False),
+        Binding("up", "move(-1)", "Up", show=False),
+        Binding("down", "move(1)", "Down", show=False),
+        # The readline pair as well as the arrows, for the reason the resume
+        # picker carries them: every printable key belongs to the filter, so
+        # these are the only other way to move a hand that is already typing.
+        Binding("ctrl+p", "move(-1)", "Up", show=False),
+        Binding("ctrl+n", "move(1)", "Down", show=False),
+        Binding("pageup", "page(-1)", "Page up", show=False),
+        Binding("pagedown", "page(1)", "Page down", show=False),
+        Binding("home", "jump(0)", "First", show=False),
+        Binding("end", "jump(1)", "Last", show=False),
+        Binding("backspace", "backspace", "Edit filter", show=False),
+        # Tab COMPLETES the highlighted row into the query rather than choosing
+        # it, which is what makes the card a navigator: completing
+        # `~/workspace` and pressing tab again lists inside it, so a user can
+        # walk down a tree without knowing the full path. Enter still chooses,
+        # so tab never costs a keystroke that Enter would have finished.
+        Binding("tab", "complete", "Complete", show=False),
+    ]
+
+    def __init__(
+        self,
+        targets: list[MoveTarget],
+        current: str = "",
+        *,
+        complete: Callable[[str], list[MoveTarget]] | None = None,
+    ) -> None:
+        super().__init__()
+        self._all = list(targets)
+        self._current = current
+        self._query = ""
+        self._selected = 0
+        self._offset = 0
+        self._hovered: int | None = None
+        # Supplied by the host, which knows the session's cwd to resolve
+        # relative paths against. Optional so the widget stays testable — and
+        # usable by an embedder — without one: no completer means the card
+        # filters its suggestions and nothing more, which is a smaller feature
+        # rather than an error.
+        self._complete = complete
+        # Filtering runs on every keystroke and again on every paint, so the
+        # result is cached against the query that produced it. The path tier
+        # is cached on the SAME key because it is the same keystroke's work,
+        # and it is filesystem I/O — re-listing a directory per repaint is
+        # exactly the cost this cache exists to avoid.
+        self._rows: list[MoveTarget] = list(targets)
+        self._rows_for = "\x00 never a real query"
+        self._body: Static
+
+    # -- state ---------------------------------------------------------------
+    # ``visible_rows``/``filter_query``/``_card_text``, not ``visible``/``query``/
+    # ``_render``: all three shorter names are Textual's own (``Widget.visible``,
+    # ``DOMNode.query``, ``Widget._render``) and shadowing them breaks focus,
+    # query and paint from inside the screen.
+    @property
+    def visible_rows(self) -> list[MoveTarget]:
+        """The rows the current query admits, in the order they are offered.
+
+        Two tiers, chosen by what was typed (see the module docstring): a path
+        completes against the filesystem, anything else filters the
+        suggestions. Order is never re-ranked for a fixed query, so a row
+        cannot move out from under the cursor between repaints.
+        """
+        if self._rows_for != self._query:
+            self._rows = self._resolve_rows(self._query)
+            self._rows_for = self._query
+        return self._rows
+
+    def _resolve_rows(self, query: str) -> list[MoveTarget]:
+        if query and looks_like_path(query) and self._complete is not None:
+            try:
+                return list(self._complete(query))
+            except Exception:  # noqa: BLE001 — a failed listing is an empty one
+                return []
+        return filter_targets(self._all, query)
+
+    @property
+    def is_path_query(self) -> bool:
+        """Whether the typed text is being COMPLETED rather than filtered."""
+        return bool(self._query) and looks_like_path(self._query)
+
+    @property
+    def filter_query(self) -> str:
+        return self._query
+
+    @property
+    def selected_index(self) -> int:
+        return self._selected
+
+    def selected_path(self) -> str | None:
+        """The highlighted directory's absolute path, or ``None`` when empty."""
+        rows = self.visible_rows
+        if not rows:
+            return None
+        return rows[min(self._selected, len(rows) - 1)].path
+
+    # -- actions -------------------------------------------------------------
+    def _dismiss_result(self, result: str | None) -> None:
+        """Dismiss after releasing a hovered row's pointer shape."""
+        self.styles.pointer = "default"
+        self.dismiss(result)
+
+    def action_cancel(self) -> None:
+        self._dismiss_result(None)
+
+    def action_choose(self) -> None:
+        # Enter on an empty result set is not a choice, but it still CLOSES the
+        # picker — which is what a user who has typed a bad filter expects, and
+        # what the resume picker does.
+        self._dismiss_result(self.selected_path())
+
+    def action_complete(self) -> None:
+        """Put the highlighted row's path into the query, ready to descend.
+
+        A trailing separator is appended so the very next keystroke — or an
+        immediate second tab — lists INSIDE the completed directory rather than
+        re-matching it among its siblings. That is the whole walking gesture,
+        and without the separator tab would appear to do nothing on the second
+        press.
+        """
+        target = self.selected_path()
+        if target is None:
+            return
+        self.set_query(target.rstrip("/") + "/")
+
+    def action_move(self, delta: int) -> None:
+        self._move_to(self._selected + delta)
+
+    def action_page(self, delta: int) -> None:
+        self._move_to(self._selected + delta * self._page_rows())
+
+    def action_jump(self, to_end: int) -> None:
+        self._move_to(len(self.visible_rows) - 1 if to_end else 0)
+
+    def action_backspace(self) -> None:
+        if self._query:
+            self.set_query(self._query[:-1])
+
+    def on_key(self, event) -> None:  # type: ignore[no-untyped-def]
+        """Printable keys type into the query.
+
+        Handled here rather than as bindings for the reason the resume picker
+        gives: the query accepts every character, and a binding per key is a
+        table of ninety-five entries that still misses the ninety-sixth.
+        """
+        char = event.character
+        if char is not None and char.isprintable() and len(char) == 1:
+            event.stop()
+            event.prevent_default()
+            self.set_query(self._query + char)
+
+    # -- mouse ---------------------------------------------------------------
+    # The wheel moves the cursor a row at a time, which scrolls the window with
+    # it. CLAMPED, like every other movement here: a scroll gesture that
+    # wrapped to the other end would read as the list resetting itself. Every
+    # handler stops the event so one gesture does not also scroll the
+    # transcript behind the card.
+    def on_mouse_scroll_down(self, event) -> None:  # type: ignore[no-untyped-def]
+        event.stop()
+        self.action_move(1)
+
+    def on_mouse_scroll_up(self, event) -> None:  # type: ignore[no-untyped-def]
+        event.stop()
+        self.action_move(-1)
+
+    def on_click(self, event) -> None:  # type: ignore[no-untyped-def]
+        """Primary-button click on a row moves to it.
+
+        Button 1 only, the guard the resume picker documents: the action behind
+        this rebuilds the session's runtime, which is not something a
+        right-click asking for a context menu should trigger.
+        """
+        if getattr(event, "button", 1) != 1:
+            return
+        index = self._index_at(event)
+        if index is None:
+            return
+        event.stop()
+        rows = self.visible_rows
+        if 0 <= index < len(rows):
+            self._selected = index
+            self._dismiss_result(rows[index].path)
+
+    def on_mouse_move(self, event) -> None:  # type: ignore[no-untyped-def]
+        index = self._index_at(event)
+        if index != self._hovered:
+            self._hovered = index
+            self._repaint()
+        self.styles.pointer = "pointer" if index is not None else "default"
+
+    def on_leave(self, event) -> None:  # type: ignore[no-untyped-def]
+        if self._hovered is not None:
+            self._hovered = None
+            self._repaint()
+        self.styles.pointer = "default"
+
+    def _index_at(self, event) -> int | None:  # type: ignore[no-untyped-def]
+        """List index under a mouse event, or ``None`` anywhere else.
+
+        The same three guards ``session_picker._index_at`` documents, and they
+        are load-bearing for the same reason: the modal's backdrop covers the
+        whole screen and bubbles clicks from outside the card, the footer and
+        spacer sit below the last row at offsets that resolve to real rows, and
+        a false positive here MOVES THE SESSION.
+        """
+        body = getattr(self, "_body", None)
+        if body is None or not body.is_mounted:
+            return None
+        region = body.region
+        if not region.contains(event.screen_x, event.screen_y):
+            return None
+        row = event.screen_y - region.y - self._header_rows()
+        rows = self.visible_rows
+        drawn = min(self._page_rows(), max(0, len(rows) - self._offset))
+        if not 0 <= row < drawn:
+            return None
+        index = self._offset + row
+        return index if 0 <= index < len(rows) else None
+
+    # -- geometry ------------------------------------------------------------
+    def _screen_size(self) -> tuple[int, int]:
+        """The box the card's percentage sizes actually resolve in.
+
+        ``self.size`` (this Screen's CONTENT box), not ``self.app.size``:
+        ``Screen { padding: 1 }`` insets the content box, and percentage
+        heights resolve against that box — so measuring the terminal
+        over-counts the room and Textual clips the difference silently, off the
+        bottom, taking the footer with it. Reported honestly, with the width
+        floor applied where the preference is (``_card_width``) rather than in
+        the measurement it is applied to.
+        """
+        try:
+            size = self.size
+            if not size.width or not size.height:  # not laid out yet
+                size = self.app.size
+        except Exception:  # pragma: no cover - only before the app has a screen
+            return 80, 24
+        return max(1, size.width), max(8, size.height)
+
+    def _card_width(self) -> int:
+        """Content cells the card may use, measured against the terminal.
+
+        The floor applies only while it FITS: a minimum width is a preference
+        and the terminal is not, so below it the card gives up the breathing
+        margin before it gives up content.
+        """
+        width, _ = self._screen_size()
+        padding = PICKER_PADDING_CELLS * 2
+        room = width - PICKER_WIDTH_MARGIN - padding
+        if room < PICKER_MIN_WIDTH:
+            return max(1, width - padding)
+        return min(PICKER_MAX_WIDTH, room)
+
+    def _page_rows(self) -> int:
+        """Directory rows the card can actually DRAW right now.
+
+        Chrome is reserved FIRST and the list takes what is left, so the cursor
+        can never sit on a row the card did not render — Enter on one would
+        move somewhere the user could not see.
+        """
+        _, height = self._screen_size()
+        budget = int(height * CARD_MAX_HEIGHT_FRACTION) - CARD_PADDING_ROWS - CARD_CHROME_ROWS
+        return max(1, min(PAGE_ROWS_MAX, budget))
+
+    def _header_rows(self) -> int:
+        """Rows above the first directory row: the header and its rule."""
+        return 2
+
+    # -- internals -----------------------------------------------------------
+    def set_query(self, query: str) -> None:
+        """Apply a query and put the cursor on the FIRST match.
+
+        Not the nearest surviving row: clamping the old index means narrowing a
+        list usually lands the cursor on the LAST match, so the row Enter would
+        take is the least related one still standing. Every finder the user has
+        met — and this app's own command, ask and resume pickers — answers a
+        narrowing query with its best match at the top.
+        """
+        if query == self._query:
+            return
+        self._query = query
+        self._selected = 0
+        self._offset = 0
+        self._repaint()
+
+    def _move_to(self, index: int) -> None:
+        rows = self.visible_rows
+        if not rows:
+            self._selected = 0
+            self._offset = 0
+            self._repaint()
+            return
+        # CLAMPED, never wrapping. `session_picker._move_to` clamps and
+        # AGENTS.md's exception covers a full surface like this one; a Down at
+        # the bottom that silently returned to the top reads as the list having
+        # reset itself.
+        self._selected = max(0, min(len(rows) - 1, index))
+        # Scroll only far enough to keep the cursor on screen, so the list is
+        # stable while paging through the middle of it.
+        page = self._page_rows()
+        if self._selected < self._offset:
+            self._offset = self._selected
+        elif self._selected >= self._offset + page:
+            self._offset = self._selected - page + 1
+        self._offset = max(0, min(self._offset, max(0, len(rows) - page)))
+        self._repaint()
+
+    # -- rendering -----------------------------------------------------------
+    def compose(self) -> ComposeResult:
+        with Container(classes="move-picker"):
+            self._body = Static(self._card_text(), id="move-picker-body")
+            yield self._body
+
+    def on_mount(self) -> None:
+        self._repaint()
+
+    def on_resize(self, event) -> None:  # type: ignore[no-untyped-def]
+        """Re-measure: every column and the page size come from the screen."""
+        self._move_to(self._selected)
+
+    def _repaint(self) -> None:
+        body = getattr(self, "_body", None)
+        if body is None or not body.is_mounted:
+            return
+        body.update(self._card_text())
+
+    def render_lines_for_test(self) -> list[str]:
+        """The card as plain strings — what a user reads."""
+        return [line.plain for line in self._card_text().split("\n")]
+
+    def _card_text(self) -> Text:
+        dim = Style(color=theme_mod.semantic_color("dim"))
+        faint = Style(color=theme_mod.semantic_color("faint"))
+        label_style = Style(color=theme_mod.semantic_color("label"))
+        fg = Style(color=theme_mod.semantic_color("fg"))
+        width = self._card_width()
+        rows = self.visible_rows
+
+        # The typed query is the user's only receipt that typing reached this
+        # modal, so a narrow card sheds the title before it sheds the query —
+        # truncating the assembled line does the opposite. The MODE word
+        # ("filter"/"path") rides with it because the two answer the same
+        # keystroke differently, and an empty list means different things in
+        # each.
+        title = "Move to a directory"
+        header = Text(no_wrap=True, overflow="ellipsis")
+        if self._query:
+            lead = "  path " if self.is_path_query else "  filter "
+            compact_lead = lead.strip() + " "
+
+            # A long PATH is cut from the LEFT, a long filter word from the
+            # right. The reason is the same one the rows use: the end of a path
+            # is the fragment the user is currently typing and the part the
+            # completion is matching on, so a tail cut hides the only characters
+            # that are changing — measured on a real capture, where a deep path
+            # rendered as `…/ho…` and the user could not see what they had
+            # typed. A filter word has its meaning at the front instead.
+            def _fit(text: str, room: int) -> str:
+                return (
+                    _truncate_head(text, room) if self.is_path_query else truncate_cells(text, room)
+                )
+
+            titled = cell_len(title) + cell_len(lead) + cell_len(self._query)
+            if titled <= width:
+                header.append(title, style=fg)
+                header.append(lead, style=faint)
+                header.append(self._query, style=label_style)
+            elif cell_len(compact_lead) < width:
+                header.append(compact_lead, style=faint)
+                header.append(
+                    _fit(self._query, width - cell_len(compact_lead)),
+                    style=label_style,
+                )
+            else:
+                header.append(_fit(self._query, width), style=label_style)
+        else:
+            header.append(title, style=fg)
+
+        out = Text()
+        out.append_text(header)
+        out.append("\n")
+        out.append("─" * width, style=faint)
+        out.append("\n")
+
+        page = self._page_rows()
+        counter: tuple[int, int, int] | None = None
+        if not rows:
+            # Two sentences for two situations: a filter that matched nothing
+            # is a mistyped word, a path that matched nothing is a directory
+            # that does not exist. The header already echoes the query, so
+            # neither repeats it.
+            out.append(NO_PATH_NOTICE if self.is_path_query else NO_MATCH_NOTICE, style=dim)
+        else:
+            window = rows[self._offset : self._offset + page]
+            for index, line in enumerate(
+                render_rows(
+                    window,
+                    self._selected - self._offset,
+                    width,
+                    None if self._hovered is None else self._hovered - self._offset,
+                )
+            ):
+                if index:
+                    out.append("\n")
+                out.append_text(line)
+            if len(rows) > page:
+                counter = (self._offset + 1, self._offset + len(window), len(rows))
+
+        # Body, one quiet row, then the card's META — the position and the key
+        # hints, which are statements ABOUT the list rather than entries in it,
+        # so they travel together at the bottom. This is the usage and resume
+        # cards' grammar. The counter is emitted ONLY when the list scrolls:
+        # printing an empty line in its place leaves two blank rows and pushes
+        # the keys away from the block they belong to.
+        out.append("\n\n")
+        if counter is not None:
+            first, last, total = counter
+            out.append("showing ", style=faint)
+            out.append(f"{first:,}–{last:,}", style=dim)
+            out.append(" of ", style=faint)
+            out.append(f"{total:,}", style=dim)
+            out.append("\n")
+        for index, (key, what) in enumerate(
+            _footer_hints(width, scrolls=counter is not None, empty=not rows)
+        ):
+            if index:
+                out.append(" · ", style=faint)
+            out.append(key, style=dim)
+            if what:
+                out.append(f" {what}", style=faint)
+        return out
+
+
+#: Footer hints, MOST disposable first. ``enter``/``esc`` are never dropped:
+#: between them they are how the card is used and how it is left. ``tab`` sits
+#: above them because completion is the half of this picker that reaches a
+#: directory the suggestions never guessed — a user who does not know it exists
+#: cannot discover it from the list.
+_FOOTER_HINTS: tuple[tuple[str, str], ...] = (
+    ("↑↓", "move"),
+    ("pgup/pgdn", "page"),
+    ("type", "to filter or path"),
+    ("tab", "complete"),
+    ("enter", "move"),
+    ("esc", "cancel"),
+)
+_FOOTER_DROP_ORDER = ("pgup/pgdn", "type", "tab", "↑↓")
+
+#: Drop order for a list that SCROLLS. ``pgup/pgdn`` is the first thing shed by
+#: the order above, which is right for a list that fits on one page and wrong
+#: for one that does not — the card would advertise paging where paging is a
+#: no-op and withdraw it where it is the fastest way through the list. The same
+#: correction ``session_picker`` makes, for the same reason.
+_FOOTER_DROP_ORDER_SCROLLING = ("type", "pgup/pgdn", "tab", "↑↓")
+
+
+#: The footer for a query that matched nothing. Movement, paging, completion
+#: and `enter move` all describe a list that is not there, so the only honest
+#: thing the row can say is how to get back to one. `backspace` is the key that
+#: widens the query and the one a user in this state is already reaching for.
+#: Stated as a hint pair like every other so it sheds and renders identically —
+#: the same correction `session_picker._EMPTY_HINT` records.
+_EMPTY_HINT: tuple[str, str] = ("backspace", "to widen")
+
+
+def _footer_hints(
+    width: int, *, scrolls: bool = False, empty: bool = False
+) -> list[tuple[str, str]]:
+    """The key hints that fit in ``width`` cells, dropping the least needed."""
+    if empty:
+        # Offering movement and `enter move` for an empty list advertises
+        # actions that do nothing, and `tab complete` promises to complete a
+        # row that is not there. `esc` stays: leaving is still available and is
+        # the other thing a user wants here.
+        return _shed_to_width([_EMPTY_HINT, ("esc", "cancel")], (_EMPTY_HINT[0],), width)
+    hints = list(_FOOTER_HINTS)
+    drop_order = _FOOTER_DROP_ORDER_SCROLLING if scrolls else _FOOTER_DROP_ORDER
+    return _shed_to_width(hints, drop_order, width)
+
+
+def _shed_to_width(
+    hints: list[tuple[str, str]], drop_order: tuple[str, ...], width: int
+) -> list[tuple[str, str]]:
+    """``hints`` reduced to fit ``width`` cells, dropping in ``drop_order``.
+
+    The last resort drops the LABELS and keeps the keys: two bare keys still
+    say which keys exist, which is more than a clipped row says. Mirrors
+    ``session_picker._shed_to_width`` so the two footers cannot drift into two
+    shed policies.
+    """
+
+    def cells(pairs: list[tuple[str, str]]) -> int:
+        return sum(cell_len(f"{key} {what}".strip()) for key, what in pairs) + 3 * max(
+            0, len(pairs) - 1
+        )
+
+    for droppable in drop_order:
+        if cells(hints) <= width:
+            return hints
+        hints = [pair for pair in hints if pair[0] != droppable]
+    if cells(hints) <= width:
+        return hints
+    return [(key, "") for key, _ in hints]

--- a/local_operator/tui/widgets/move_picker.py
+++ b/local_operator/tui/widgets/move_picker.py
@@ -716,21 +716,30 @@ _FOOTER_HINTS: tuple[tuple[str, str], ...] = (
 #: ``tab`` instead spends 75 to keep paging and lose completion, which is how
 #: the opening frame briefly lost ``tab complete`` everywhere (design D7).
 #:
-#: THE NUMBERS ABOVE ARE CARD CELLS, AND THE CARD IS TEN CELLS NARROWER THAN
-#: THE TERMINAL — ``_card_width`` subtracts screen padding (2),
-#: ``PICKER_WIDTH_MARGIN`` (6) and its own padding (4). So 73 card cells is an
-#: **86-column terminal**, and at the very common 80-column terminal (68 card
-#: cells) ``tab`` is still given up. That is a deliberate trade, not an
-#: oversight: keeping both there would need ``type to filter or path``
-#: shortened to ``type filter/path`` to reach 67 cells, and a copy regression
-#: on the hint round 1 fought to keep is worse than losing ``tab`` at one
-#: width. ``tab`` is the one dropped because the header already names the mode
-#: the instant you type, while nothing announces ``tab``.
+#: THE NUMBERS ABOVE ARE CARD CELLS, AND THE CARD IS TWELVE CELLS NARROWER
+#: THAN THE TERMINAL. Two of those are spent before ``_card_width`` runs at
+#: all: it measures ``_screen_size()``, which is the Screen CONTENT box and is
+#: already inset by ``Screen { padding: 1 }`` (terminal - 2). It then subtracts
+#: ``PICKER_WIDTH_MARGIN`` (6) and its own padding (``PICKER_PADDING_CELLS``
+#: x2 = 4). So 2 + 6 + 4 = 12, and 73 card cells is an **85-column terminal** —
+#: measured end to end, not derived: 84 columns (72 cells) is the last width
+#: without ``tab`` and 85 (73 cells) the first with it.
+#:
+#: At the very common 80-column terminal (68 card cells) ``tab`` is still
+#: given up. That is a deliberate trade, not an oversight: keeping both there
+#: would need ``type to filter or path`` shortened to ``type filter/path`` to
+#: reach 67 cells, and a copy regression on the hint round 1 fought to keep is
+#: worse than losing ``tab`` at one width. ``tab`` is the one dropped because
+#: the header already names the mode the instant you type, while nothing
+#: announces ``tab``.
 #:
 #: Stated in terminal columns because that is the unit a reader has: quoting
 #: card cells with the terminal in parentheses is exactly how the guard for
 #: D7 came to assert 80 CARD cells while claiming to test an 80-column
-#: terminal (design D10).
+#: terminal (design D10) — and getting the offset wrong is how the fix for
+#: THAT then named 86 as the boundary when it is 85 (review MAJOR-4.3). The
+#: derivation is written out above so the next reader checks it rather than
+#: trusting a total.
 #:
 #: ONE order for both list shapes. A second constant existed to protect
 #: paging on a scrolling list, and paging is precisely what should shed first

--- a/local_operator/tui/widgets/move_picker.py
+++ b/local_operator/tui/widgets/move_picker.py
@@ -83,6 +83,12 @@ NO_MATCH_NOTICE = "no suggestion matches that"
 NO_PATH_NOTICE = "no directory matches that path"
 
 
+#: Tiers whose note states WHAT THE ROW IS rather than why it was offered.
+#: Rendered at the paths' own weight so the grouping reads as structure; the
+#: structural tiers stay faint. See ``render_rows`` (design D5).
+_IDENTITY_KINDS = frozenset({"current", "recent"})
+
+
 def render_rows(
     targets: list[MoveTarget],
     selected: int,
@@ -110,9 +116,16 @@ def render_rows(
         line.append("❯ " if is_selected else "  ", style=accent if is_selected else faint)
         room = max(1, width - CURSOR_CELLS)
         note = target.detail
-        # The note only earns its cells when the label still fits beside it.
+        # ``current`` is EXEMPT from the note drop, unlike every other note.
+        # The others say why a row was offered and are expendable beside the
+        # label being chosen; `current` answers a different question — "where
+        # am I now?" — and it was dropped first on exactly the deep paths this
+        # machine is full of, so the marker vanished for the users most likely
+        # to need it (design D4). It costs 7 cells and the label is truncated
+        # to pay for them.
+        pinned = target.kind == "current"
         note_cells = cell_len(note) + 2 if note else 0
-        if note and cell_len(target.label) + note_cells > room:
+        if note and not pinned and cell_len(target.label) + note_cells > room:
             note, note_cells = "", 0
         label = _truncate_head(target.label, max(1, room - note_cells))
         line.append(label, style=fg if is_selected else dim)
@@ -120,7 +133,14 @@ def render_rows(
             pad = room - cell_len(label) - cell_len(note)
             if pad > 0:
                 line.append(" " * pad)
-            line.append(note, style=faint)
+            # The IDENTITY notes (`current`, `recent`) are lifted to `dim`,
+            # the weight the paths carry; the structural ones (`home`,
+            # `parent`, `in this folder`) stay `faint`. The tiers were legible
+            # only through the notes, and the notes were the lowest-contrast
+            # thing on the row, so the ordering's meaning was invisible
+            # (design D5). A gradient gives the grouping without spending rows
+            # on separators, which a 10-row budget cannot afford.
+            line.append(note, style=dim if target.kind in _IDENTITY_KINDS else faint)
         if hovered is not None and index == hovered and not is_selected:
             line.stylize(Style(bgcolor=theme_mod.semantic_color("raised")))
         out.append(line)
@@ -167,6 +187,13 @@ class MovePickerScreen(ModalScreen[str | None]):
         Binding("home", "jump(0)", "First", show=False),
         Binding("end", "jump(1)", "Last", show=False),
         Binding("backspace", "backspace", "Edit filter", show=False),
+        # A PATH is long, so the readline word/line kills are not a nicety
+        # here: backing out of a completed path one character at a time cost 15
+        # backspaces in the UX walk, and they were the only editing key bound.
+        # `ctrl+w` deletes the last path SEGMENT rather than the last word,
+        # which is what "back up one directory" means on this card.
+        Binding("ctrl+w", "kill_segment", "Delete segment", show=False),
+        Binding("ctrl+u", "kill_query", "Clear", show=False),
         # Tab COMPLETES the highlighted row into the query rather than choosing
         # it, which is what makes the card a navigator: completing
         # `~/workspace` and pressing tab again lists inside it, so a user can
@@ -181,6 +208,7 @@ class MovePickerScreen(ModalScreen[str | None]):
         current: str = "",
         *,
         complete: Callable[[str], list[MoveTarget]] | None = None,
+        self_target: Callable[[str], MoveTarget | None] | None = None,
     ) -> None:
         super().__init__()
         self._all = list(targets)
@@ -195,6 +223,11 @@ class MovePickerScreen(ModalScreen[str | None]):
         # filters its suggestions and nothing more, which is a smaller feature
         # rather than an error.
         self._complete = complete
+        # Resolves a typed path to ITSELF when it names a usable directory, so
+        # a directory with no subdirectories is still selectable rather than
+        # reported as "no match" (D1/U1). Supplied by the host for the same
+        # reason ``complete`` is: it needs the session's cwd for relative paths.
+        self._self_target = self_target
         # Filtering runs on every keystroke and again on every paint, so the
         # result is cached against the query that produced it. The path tier
         # is cached on the SAME key because it is the same keystroke's work,
@@ -226,10 +259,42 @@ class MovePickerScreen(ModalScreen[str | None]):
     def _resolve_rows(self, query: str) -> list[MoveTarget]:
         if query and looks_like_path(query) and self._complete is not None:
             try:
-                return list(self._complete(query))
+                rows = list(self._complete(query))
             except Exception:  # noqa: BLE001 — a failed listing is an empty one
-                return []
+                rows = []
+            if rows:
+                return rows
+            # NO CHILDREN IS NOT NO MATCH. ``action_complete`` appends a
+            # separator so the next tab descends, and completing INSIDE a
+            # directory with no subdirectories returns nothing — so the
+            # directory the user just walked to rendered as "no directory
+            # matches that path", one keystroke after being a selectable row,
+            # and Enter there dismissed with ``None`` (read by the caller as
+            # Esc: no move, no notice). That is the dead end design D1 and UX
+            # U1 found independently, and it made the picker strictly weaker
+            # than the typed-path route it fronts.
+            #
+            # A query that RESOLVES to a readable directory is offered as
+            # itself, so Enter moves there. Typing the path by hand lands here
+            # too, which is why this sits in row resolution rather than in
+            # ``action_complete``.
+            here = self._resolve_self(query)
+            if here is not None:
+                return [here]
         return filter_targets(self._all, query)
+
+    def _resolve_self(self, query: str) -> MoveTarget | None:
+        """``query`` as its own row when it names a usable directory.
+
+        Returns ``None`` for a path that does not exist or cannot be entered —
+        those are genuinely "no match" and keep the existing sentence.
+        """
+        if self._self_target is None:
+            return None
+        try:
+            return self._self_target(query)
+        except Exception:  # noqa: BLE001 — an unresolvable path is simply not offered
+            return None
 
     @property
     def is_path_query(self) -> bool:
@@ -275,10 +340,17 @@ class MovePickerScreen(ModalScreen[str | None]):
         and without the separator tab would appear to do nothing on the second
         press.
         """
-        target = self.selected_path()
-        if target is None:
+        rows = self.visible_rows
+        if not rows:
             return
-        self.set_query(target.rstrip("/") + "/")
+        row = rows[min(self._selected, len(rows) - 1)]
+        # The LABEL, not the absolute path. The row the user pressed tab on
+        # reads ``~/workspace/repos/x``; inserting ``path`` put a long absolute
+        # string in the header, which then head-truncated into something that
+        # did not resemble the row they had just chosen (design D3).
+        # ``complete_path`` expands ``~`` itself, so the tidy form round-trips.
+        text = row.label or row.path
+        self.set_query(text.rstrip("/") + "/")
 
     def action_move(self, delta: int) -> None:
         self._move_to(self._selected + delta)
@@ -292,6 +364,24 @@ class MovePickerScreen(ModalScreen[str | None]):
     def action_backspace(self) -> None:
         if self._query:
             self.set_query(self._query[:-1])
+
+    def action_kill_segment(self) -> None:
+        """Drop the last path segment — "back up one directory".
+
+        A trailing separator is dropped with the segment it closes, so a query
+        left at ``~/a/b/`` by ``tab`` goes to ``~/a/`` in one press rather than
+        stripping the separator and leaving the user where they were.
+        """
+        if not self._query:
+            return
+        trimmed = self._query.rstrip("/")
+        head, sep, _ = trimmed.rpartition("/")
+        self.set_query(head + sep if sep else "")
+
+    def action_kill_query(self) -> None:
+        """Clear the query, returning the card to its suggestions."""
+        if self._query:
+            self.set_query("")
 
     def on_key(self, event) -> None:  # type: ignore[no-untyped-def]
         """Printable keys type into the query.
@@ -447,9 +537,13 @@ class MovePickerScreen(ModalScreen[str | None]):
             self._offset = 0
             self._repaint()
             return
-        # CLAMPED, never wrapping. `session_picker._move_to` clamps and
-        # AGENTS.md's exception covers a full surface like this one; a Down at
-        # the bottom that silently returned to the top reads as the list having
+        # CLAMPED, never wrapping, because `session_picker._move_to` clamps and
+        # this card is its twin down to the CSS — AGENTS.md names that picker
+        # explicitly ("`session_picker._move_to` already clamps, and it is a
+        # full surface too"). NOT on the `/settings` exception, which is about
+        # a full PAGE and would equally license clamping `/model` and
+        # `/command` — the same paragraph forbids those by name. A Down at the
+        # bottom that silently returned to the top reads as the list having
         # reset itself.
         self._selected = max(0, min(len(rows) - 1, index))
         # Scroll only far enough to keep the cursor on screen, so the list is
@@ -546,6 +640,13 @@ class MovePickerScreen(ModalScreen[str | None]):
             # is a mistyped word, a path that matched nothing is a directory
             # that does not exist. The header already echoes the query, so
             # neither repeats it.
+            #
+            # A path that RESOLVES is no longer one of these cases: it comes
+            # back as its own row from ``_resolve_rows``, so "no directory
+            # matches that path" is now only said about a path that genuinely
+            # does not resolve — which is what made the sentence false before
+            # (design D1, UX U3: it was shown for a directory the user had
+            # just selected).
             out.append(NO_PATH_NOTICE if self.is_path_query else NO_MATCH_NOTICE, style=dim)
         else:
             window = rows[self._offset : self._offset + page]
@@ -601,14 +702,24 @@ _FOOTER_HINTS: tuple[tuple[str, str], ...] = (
     ("enter", "move"),
     ("esc", "cancel"),
 )
-_FOOTER_DROP_ORDER = ("pgup/pgdn", "type", "tab", "↑↓")
+#: ``type to filter or path`` sheds LATE, and that is the whole of design D2.
+#: It is the only thing anywhere on this card that says a second input mode
+#: exists, and path completion is the half of the feature that makes any
+#: directory on the machine reachable. Shedding it first meant the mode was
+#: advertised only to users who had already found it.
+#:
+#: Paging is inferable from a scrollbar-less list with a `showing N–M of T`
+#: counter; a hidden second input mode is not inferable from anything. So
+#: ``pgup/pgdn`` goes first in both orders and ``type`` outlives ``tab``.
+_FOOTER_DROP_ORDER = ("pgup/pgdn", "tab", "type", "↑↓")
 
-#: Drop order for a list that SCROLLS. ``pgup/pgdn`` is the first thing shed by
-#: the order above, which is right for a list that fits on one page and wrong
-#: for one that does not — the card would advertise paging where paging is a
-#: no-op and withdraw it where it is the fastest way through the list. The same
-#: correction ``session_picker`` makes, for the same reason.
-_FOOTER_DROP_ORDER_SCROLLING = ("type", "pgup/pgdn", "tab", "↑↓")
+#: Drop order for a list that SCROLLS — which a freshly opened picker almost
+#: always is: ``PAGE_ROWS_MAX`` is 10 and the default suggestion set runs to
+#: 11-12 rows, so this is the order the OPENING frame uses at every width.
+#: That is precisely why ``type`` may not lead it. ``pgup/pgdn`` is kept ahead
+#: of ``tab`` here (the reverse of the non-scrolling order) because paging is
+#: real on a scrolling list and is the fastest way through it.
+_FOOTER_DROP_ORDER_SCROLLING = ("tab", "pgup/pgdn", "type", "↑↓")
 
 
 #: The footer for a query that matched nothing. Movement, paging, completion

--- a/local_operator/tui/widgets/move_picker.py
+++ b/local_operator/tui/widgets/move_picker.py
@@ -678,9 +678,7 @@ class MovePickerScreen(ModalScreen[str | None]):
             out.append(" of ", style=faint)
             out.append(f"{total:,}", style=dim)
             out.append("\n")
-        for index, (key, what) in enumerate(
-            _footer_hints(width, scrolls=counter is not None, empty=not rows)
-        ):
+        for index, (key, what) in enumerate(_footer_hints(width, empty=not rows)):
             if index:
                 out.append(" · ", style=faint)
             out.append(key, style=dim)
@@ -702,24 +700,29 @@ _FOOTER_HINTS: tuple[tuple[str, str], ...] = (
     ("enter", "move"),
     ("esc", "cancel"),
 )
-#: ``type to filter or path`` sheds LATE, and that is the whole of design D2.
-#: It is the only thing anywhere on this card that says a second input mode
-#: exists, and path completion is the half of the feature that makes any
-#: directory on the machine reachable. Shedding it first meant the mode was
-#: advertised only to users who had already found it.
+#: ``pgup/pgdn`` sheds FIRST, and the two disclosures that nobody infers —
+#: ``type to filter or path`` and ``tab complete`` — both outlive it.
 #:
-#: Paging is inferable from a scrollbar-less list with a `showing N–M of T`
-#: counter; a hidden second input mode is not inferable from anything. So
-#: ``pgup/pgdn`` goes first in both orders and ``type`` outlives ``tab``.
+#: Paging is the one hint on this card a user does not need told: a
+#: ``showing N–M of T`` counter sits directly above it saying the list is
+#: paged, and PageUp/PageDown are the keys everyone already tries on a long
+#: list. The other two are discovered from nothing. ``type`` is the only
+#: statement anywhere that the input has two modes (design D2), and ``tab`` is
+#: the gesture that makes this a NAVIGATOR rather than a filter box — the
+#: subject of the module docstring, of the self-row that lets a walk
+#: terminate, and of the binding comment below.
+#:
+#: Shedding ``pgup/pgdn`` alone leaves 73 cells and keeps BOTH; shedding
+#: ``tab`` instead spends 75 to keep paging and lose completion, which is how
+#: the opening frame briefly lost ``tab complete`` at every width the picker
+#: opens at (design D7). Only the genuinely cramped 68-cell card has to give
+#: one up, and there ``tab`` goes because the header already names the mode
+#: the instant you type while nothing announces ``tab``.
+#:
+#: ONE order for both list shapes. A second constant existed to protect
+#: paging on a scrolling list, and paging is precisely what should shed first
+#: in either — so there is nothing left for it to say.
 _FOOTER_DROP_ORDER = ("pgup/pgdn", "tab", "type", "↑↓")
-
-#: Drop order for a list that SCROLLS — which a freshly opened picker almost
-#: always is: ``PAGE_ROWS_MAX`` is 10 and the default suggestion set runs to
-#: 11-12 rows, so this is the order the OPENING frame uses at every width.
-#: That is precisely why ``type`` may not lead it. ``pgup/pgdn`` is kept ahead
-#: of ``tab`` here (the reverse of the non-scrolling order) because paging is
-#: real on a scrolling list and is the fastest way through it.
-_FOOTER_DROP_ORDER_SCROLLING = ("tab", "pgup/pgdn", "type", "↑↓")
 
 
 #: The footer for a query that matched nothing. Movement, paging, completion
@@ -731,19 +734,21 @@ _FOOTER_DROP_ORDER_SCROLLING = ("tab", "pgup/pgdn", "type", "↑↓")
 _EMPTY_HINT: tuple[str, str] = ("backspace", "to widen")
 
 
-def _footer_hints(
-    width: int, *, scrolls: bool = False, empty: bool = False
-) -> list[tuple[str, str]]:
-    """The key hints that fit in ``width`` cells, dropping the least needed."""
+def _footer_hints(width: int, *, empty: bool = False) -> list[tuple[str, str]]:
+    """The key hints that fit in ``width`` cells, dropping the least needed.
+
+    Takes no ``scrolls`` flag, unlike ``session_picker``'s: this card sheds in
+    one order whether or not the list pages, because ``pgup/pgdn`` is the
+    first thing to go in both. A parameter with one reachable value reads as a
+    distinction the code still draws, and this one no longer does.
+    """
     if empty:
         # Offering movement and `enter move` for an empty list advertises
         # actions that do nothing, and `tab complete` promises to complete a
         # row that is not there. `esc` stays: leaving is still available and is
         # the other thing a user wants here.
         return _shed_to_width([_EMPTY_HINT, ("esc", "cancel")], (_EMPTY_HINT[0],), width)
-    hints = list(_FOOTER_HINTS)
-    drop_order = _FOOTER_DROP_ORDER_SCROLLING if scrolls else _FOOTER_DROP_ORDER
-    return _shed_to_width(hints, drop_order, width)
+    return _shed_to_width(list(_FOOTER_HINTS), _FOOTER_DROP_ORDER, width)
 
 
 def _shed_to_width(

--- a/local_operator/tui/widgets/move_picker.py
+++ b/local_operator/tui/widgets/move_picker.py
@@ -714,10 +714,23 @@ _FOOTER_HINTS: tuple[tuple[str, str], ...] = (
 #:
 #: Shedding ``pgup/pgdn`` alone leaves 73 cells and keeps BOTH; shedding
 #: ``tab`` instead spends 75 to keep paging and lose completion, which is how
-#: the opening frame briefly lost ``tab complete`` at every width the picker
-#: opens at (design D7). Only the genuinely cramped 68-cell card has to give
-#: one up, and there ``tab`` goes because the header already names the mode
-#: the instant you type while nothing announces ``tab``.
+#: the opening frame briefly lost ``tab complete`` everywhere (design D7).
+#:
+#: THE NUMBERS ABOVE ARE CARD CELLS, AND THE CARD IS TEN CELLS NARROWER THAN
+#: THE TERMINAL — ``_card_width`` subtracts screen padding (2),
+#: ``PICKER_WIDTH_MARGIN`` (6) and its own padding (4). So 73 card cells is an
+#: **86-column terminal**, and at the very common 80-column terminal (68 card
+#: cells) ``tab`` is still given up. That is a deliberate trade, not an
+#: oversight: keeping both there would need ``type to filter or path``
+#: shortened to ``type filter/path`` to reach 67 cells, and a copy regression
+#: on the hint round 1 fought to keep is worse than losing ``tab`` at one
+#: width. ``tab`` is the one dropped because the header already names the mode
+#: the instant you type, while nothing announces ``tab``.
+#:
+#: Stated in terminal columns because that is the unit a reader has: quoting
+#: card cells with the terminal in parentheses is exactly how the guard for
+#: D7 came to assert 80 CARD cells while claiming to test an 80-column
+#: terminal (design D10).
 #:
 #: ONE order for both list shapes. A second constant existed to protect
 #: paging on a scrolling list, and paging is precisely what should shed first

--- a/scripts/move_shot.py
+++ b/scripts/move_shot.py
@@ -1,0 +1,172 @@
+"""Capture the `/move` picker and the band it changes, for visual validation.
+
+Run from the worktree root:
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/move_shot.py OUT.svg [COLSxROWS] [STATE]
+
+``STATE`` selects the frame:
+
+* ``open`` (default) — the picker as `/move` opens it: the current directory
+  marked, recents, home, /tmp, the parent, then the children.
+* ``filter`` — a word typed, narrowing the suggestions.
+* ``path`` — a path typed, COMPLETING against the filesystem. This is the
+  frame worth looking at hardest: the header has to say which of the two modes
+  is in force, because an empty list means different things in each.
+* ``empty`` — a path that matches nothing, so the "no directory matches" state
+  is judgeable rather than inferred.
+* ``band-before`` / ``band-after`` — the status band on either side of a move.
+  The pair is the point: the band is the surface that must never disagree with
+  where the session actually works, so a single "looks fine" frame cannot show
+  the property under test.
+
+Drives the real ``OperatorApp`` rather than a bare widget host on purpose: the
+lightweight hosts in the test files declare no ``CSS_PATH``, so
+``local_operator.tcss`` never applies to them and a still captured from one
+cannot show what the user sees (AGENTS.md, "Visual validation").
+
+The directory tree is SYNTHETIC and built under a temporary root, so the frames
+are stable across machines and do not leak the operator's real paths into an
+image attached to a PR. The suggestions are assembled by the real
+``suggest_targets`` over that tree, which is what makes the frame evidence
+rather than decoration: only the code under test can change what it shows.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.visual_capture import isolate_capture, save_capture  # noqa: E402
+
+isolate_capture()
+
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.move_targets import (  # noqa: E402
+    complete_path,
+    remember_recent,
+    suggest_targets,
+)
+from local_operator.tui.widgets.assistant import AssistantBlock  # noqa: E402
+from local_operator.tui.widgets.move_picker import MovePickerScreen  # noqa: E402
+from local_operator.tui.widgets.transcript import UserBlock  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+
+def build_tree(root: Path) -> tuple[Path, Path]:
+    """A believable working tree: a home, two checkouts, and some children."""
+    home = root / "home"
+    workspace = home / "workspace" / "repos"
+    project = workspace / "lo-move-cmd"
+    for name in ("local_operator", "tests", "scripts", "docs", "benchmarks"):
+        (project / name).mkdir(parents=True, exist_ok=True)
+    (workspace / "lo-session-sidebar").mkdir(parents=True, exist_ok=True)
+    (home / "oss" / "oh-my-pi").mkdir(parents=True, exist_ok=True)
+    config = root / "config"
+    config.mkdir(exist_ok=True)
+    # Two remembered directories, so the `recent` tier is populated and its
+    # ordering against home/tmp/parent is visible in the frame.
+    remember_recent(config, str(home / "oss" / "oh-my-pi"))
+    remember_recent(config, str(workspace / "lo-session-sidebar"))
+    return project, config
+
+
+def seed_conversation(app: OperatorApp) -> None:
+    """So "does this overlay still let me read the conversation?" is an
+    answerable question rather than a screenshot of an empty app."""
+    for turn in range(1, 6):
+        app._append_block(UserBlock(f"Turn {turn}: can you check the migration script?"))
+        prose = AssistantBlock()
+        prose.update_text(
+            f"Answer {turn}: the script reads every row once and writes the"
+            " backfill in batches, so it is safe to re-run."
+        )
+        app._append_block(prose)
+
+
+async def main() -> None:
+    out = sys.argv[1]
+    size = (100, 30)
+    if len(sys.argv) > 2:
+        cols, rows = sys.argv[2].split("x")
+        size = (int(cols), int(rows))
+    state = sys.argv[3] if len(sys.argv) > 3 else "open"
+
+    with tempfile.TemporaryDirectory(prefix="lop-move-shot-") as raw_root:
+        root = Path(raw_root)
+        project, config = build_tree(root)
+        home = root / "home"
+
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=size) as pilot:
+            await pilot.pause()
+            seed_conversation(app)
+            await pilot.pause()
+
+            if state in ("band-before", "band-after"):
+                # The band pair. `_push_cwd_to_band` is the one call the move
+                # makes to keep the band honest, so driving it directly is
+                # exactly the surface under test.
+                app._push_cwd_to_band(str(project))
+                if state == "band-after":
+                    for _ in range(2):
+                        await pilot.pause()
+                    app._push_cwd_to_band(str(home / "oss" / "oh-my-pi"))
+                for _ in range(4):
+                    await pilot.pause()
+                assert app._status is not None
+                print(f"band: {app._status.render_text(size[0]).plain}", file=sys.stderr)
+                save_capture(app, out)
+                return
+
+            targets = suggest_targets(project, config_dir=config, home=home)
+            screen = MovePickerScreen(
+                targets,
+                current=str(project),
+                complete=lambda query: complete_path(query, cwd=project, home=home),
+            )
+            app.push_screen(screen)
+            # Let the overlay's layout SETTLE before the capture: the first
+            # painted frame is still sized to the pre-push geometry, and rows
+            # come out truncated in a way the running app never shows.
+            for _ in range(6):
+                await pilot.pause()
+
+            if state == "filter":
+                screen.set_query("repos")
+            elif state == "path":
+                screen.set_query(f"{project}/")
+            elif state == "empty":
+                screen.set_query(f"{project}/zzz")
+            for _ in range(4):
+                await pilot.pause()
+            await pilot.wait_for_scheduled_animations()
+            screen._repaint()
+            await pilot.pause()
+
+            # The numbers behind the frame: the stills show the symptom, the
+            # geometry shows the cause. A card whose virtual height exceeds the
+            # screen's own size has made the screen scrollable, which silently
+            # costs two cells of width and reflows the transcript behind it.
+            print(f"state={state} size={size}", file=sys.stderr)
+            print(
+                f"  card_width={screen._card_width()} page_rows={screen._page_rows()} "
+                f"rows={len(screen.visible_rows)} path_mode={screen.is_path_query}",
+                file=sys.stderr,
+            )
+            print(
+                f"  screen.size={screen.size} virtual_size={screen.virtual_size} "
+                f"scrollbar={screen.show_vertical_scrollbar}",
+                file=sys.stderr,
+            )
+            for line in screen.render_lines_for_test():
+                print(f"  |{line}|", file=sys.stderr)
+            save_capture(app, out)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/move_shot.py
+++ b/scripts/move_shot.py
@@ -13,6 +13,8 @@ Run from the worktree root:
 * ``path`` — a path typed, COMPLETING against the filesystem. This is the
   frame worth looking at hardest: the header has to say which of the two modes
   is in force, because an empty list means different things in each.
+* ``kernel-lost`` — the receipt of a rebind in a session that has used
+  ``eval``, whose persistent namespace the restart destroys.
 * ``in-flight`` — the transcript WHILE a move that has to wait is waiting.
   The frame that shows whether the user was told anything at all during the
   join+retire gap; a property read cannot answer that, only a painted frame.
@@ -58,6 +60,7 @@ from local_operator.tui.move_targets import (  # noqa: E402
 )
 from local_operator.tui.widgets.assistant import AssistantBlock  # noqa: E402
 from local_operator.tui.widgets.move_picker import MovePickerScreen  # noqa: E402
+from local_operator.tui.widgets.tool_card import ToolCard  # noqa: E402
 from local_operator.tui.widgets.transcript import UserBlock  # noqa: E402
 from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
 
@@ -154,6 +157,41 @@ async def main() -> None:
                 app._push_cwd_to_band(str(project))
                 app._apply_move(str(target), app._system_notice)
                 for _ in range(6):
+                    await pilot.pause()
+                save_capture(app, out)
+                return
+
+            if state == "kernel-lost":
+                # The RECEIPT of a rebind in a session that has used `eval`.
+                # Retiring the runtime disposes the session, whose dispose hook
+                # closes the cached interpreter, so every variable the user
+                # built up is gone while the transcript above it survives
+                # untouched — which is what makes the loss surprising and why
+                # it is said out loud. Only a painted frame shows whether the
+                # sentence still reads as one receipt rather than two.
+                os.environ["HOME"] = str(home)
+                target = home / "oss" / "oh-my-pi"
+
+                class _Rebinding:
+                    is_cold = False
+
+                    async def dispose(self) -> None:
+                        return None
+
+                    def move_will_wait(self) -> bool:
+                        return True
+
+                    async def set_working_directory(self, cwd: str) -> str:
+                        return "rebound"
+
+                app._session = _Rebinding()  # type: ignore[assignment]
+                app._push_cwd_to_band(str(project))
+                # A real `eval` card in the transcript is the signal the
+                # receipt reads, so the frame exercises the same predicate the
+                # running app does rather than a flag set for the capture.
+                app._append_block(ToolCard(tool_call_id="shot-eval", tool_name="eval"))
+                app._apply_move(str(target), app._system_notice)
+                for _ in range(8):
                     await pilot.pause()
                 save_capture(app, out)
                 return

--- a/scripts/move_shot.py
+++ b/scripts/move_shot.py
@@ -13,6 +13,9 @@ Run from the worktree root:
 * ``path`` — a path typed, COMPLETING against the filesystem. This is the
   frame worth looking at hardest: the header has to say which of the two modes
   is in force, because an empty list means different things in each.
+* ``in-flight`` — the transcript WHILE a move that has to wait is waiting.
+  The frame that shows whether the user was told anything at all during the
+  join+retire gap; a property read cannot answer that, only a painted frame.
 * ``empty`` — a path that matches nothing, so the "no directory matches" state
   is judgeable rather than inferred.
 * ``band-before`` / ``band-after`` — the status band on either side of a move.
@@ -35,6 +38,7 @@ rather than decoration: only the code under test can change what it shows.
 from __future__ import annotations
 
 import asyncio
+import os
 import sys
 import tempfile
 from pathlib import Path
@@ -107,6 +111,52 @@ async def main() -> None:
             await pilot.pause()
             seed_conversation(app)
             await pilot.pause()
+
+            if state == "in-flight":
+                # The MID-GAP frame: what the user is looking at while a move
+                # that has to wait is still waiting. The line is gated on the
+                # session's own `move_will_wait`, and gating it on `is_cold`
+                # instead left a joined mount engage silent for ~2 s on the
+                # feature's primary case — visible only in a painted frame,
+                # which is why this state exists (design U6).
+                #
+                # `is_cold` is deliberately left TRUE here: this is the
+                # in-flight engage, the exact reading that used to suppress
+                # the line, so the frame is evidence rather than decoration.
+                target = home / "oss" / "oh-my-pi"
+                # POINT HOME AT THE SYNTHETIC TREE for this state only. The
+                # picker states pass `home=` explicitly into `suggest_targets`
+                # and friends, but the notice `_apply_move` prints goes through
+                # `format_label` with no `home`, which reads `Path.home()` — so
+                # the frame rendered the sandbox's raw `/var/folders/...` path
+                # where a user sees `~/oss/oh-my-pi`. That is the one string
+                # this frame exists to be read, and a raw temp path in it makes
+                # the capture look like a bug it is not.
+                os.environ["HOME"] = str(home)
+
+                class _Joining:
+                    is_cold = True
+                    disposed = False
+
+                    async def dispose(self) -> None:
+                        # The app disposes its session at teardown; without
+                        # this the shot ends in a traceback after the capture.
+                        self.disposed = True
+
+                    def move_will_wait(self) -> bool:
+                        return True
+
+                    async def set_working_directory(self, cwd: str) -> str:
+                        await asyncio.sleep(30)  # never settles within the shot
+                        return "rebound"
+
+                app._session = _Joining()  # type: ignore[assignment]
+                app._push_cwd_to_band(str(project))
+                app._apply_move(str(target), app._system_notice)
+                for _ in range(6):
+                    await pilot.pause()
+                save_capture(app, out)
+                return
 
             if state in ("band-before", "band-after"):
                 # The band pair. `_push_cwd_to_band` is the one call the move

--- a/scripts/move_shot.py
+++ b/scripts/move_shot.py
@@ -49,6 +49,7 @@ from local_operator.tui.app import OperatorApp  # noqa: E402
 from local_operator.tui.move_targets import (  # noqa: E402
     complete_path,
     remember_recent,
+    resolve_self,
     suggest_targets,
 )
 from local_operator.tui.widgets.assistant import AssistantBlock  # noqa: E402
@@ -128,6 +129,7 @@ async def main() -> None:
                 targets,
                 current=str(project),
                 complete=lambda query: complete_path(query, cwd=project, home=home),
+                self_target=lambda query: resolve_self(query, cwd=project, home=home),
             )
             app.push_screen(screen)
             # Let the overlay's layout SETTLE before the capture: the first
@@ -142,6 +144,22 @@ async def main() -> None:
                 screen.set_query(f"{project}/")
             elif state == "empty":
                 screen.set_query(f"{project}/zzz")
+            elif state == "leaf":
+                # The D1/U1 frame: `tab` onto a directory with no
+                # subdirectories. This used to render "no directory matches
+                # that path" for a directory the user had just selected, with
+                # `enter move` shed from the footer.
+                index = next(
+                    (
+                        i
+                        for i, r in enumerate(screen.visible_rows)
+                        if r.path == str(project / "scripts")
+                    ),
+                    None,
+                )
+                if index is not None:
+                    screen._move_to(index)
+                screen.action_complete()
             for _ in range(4):
                 await pilot.pause()
             await pilot.wait_for_scheduled_animations()

--- a/tests/unit/session/runtime/test_server_move.py
+++ b/tests/unit/session/runtime/test_server_move.py
@@ -1,0 +1,154 @@
+"""``retire_now`` on the RuntimeServer — `/move`'s side of the wire.
+
+A sibling of ``refresh_if_idle`` (see ``test_server_refresh``) differing in one
+term, and the tests here exist to pin exactly that difference: a refresh is
+owed only when the build on disk has moved, whereas a move is owed whenever the
+user asked for it. Everything after that decision is deliberately shared, so
+these also check that a move leaves by the same ``retiring`` announcement — the
+frame a viewer already knows means "a successor is owed; engage one".
+
+Every uncertain answer is ``kept``, the asymmetry the whole file family
+records: a wrong "retire" costs a cold start nobody asked for, a wrong "keep"
+costs one more check.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from local_operator import update as update_mod
+from local_operator.session.runtime.server import RuntimeServer, _ClientConn
+from local_operator.update import BuildStamp
+from tests.unit.session.runtime.test_server import FakeHandle
+
+BOOT = BuildStamp(version="0.51.0", source_ref="abc1234567890")
+
+
+class MovableHandle(FakeHandle):
+    def __init__(self, *, reason: str = "") -> None:
+        super().__init__()
+        self.reason = reason
+        self.stopped = False
+        self.probes = 0
+
+    def may_refresh(self) -> str:
+        self.probes += 1
+        return self.reason
+
+    def request_stop(self) -> None:
+        self.stopped = True
+
+
+def _conn(kind: str = "attach") -> _ClientConn:
+    return _ClientConn(writer=cast(Any, object()), kind=cast(Any, kind))
+
+
+def _rig(handle: Any) -> tuple[RuntimeServer, list[dict[str, Any]]]:
+    server = RuntimeServer(handle, kind="tui")
+    server._boot_build = BOOT
+    sent: list[dict[str, Any]] = []
+
+    async def capture(target, frame):  # noqa: ANN001
+        sent.append({"_recipient": target.kind, **frame})
+
+    server._send_to = capture  # type: ignore[assignment]
+    return server, sent
+
+
+async def _ask(server: RuntimeServer, sent: list[dict[str, Any]], conn: _ClientConn) -> str:
+    await server._on_request({"op": "retire_now", "req": 1}, conn)
+    replies = [f for f in sent if f.get("op") in ("ack", "error")]
+    assert replies, "the op never replied"
+    reply = replies[-1]
+    assert reply.get("op") == "ack", f"unexpected reply: {reply}"
+    return str(reply.get("detail", ""))
+
+
+@pytest.mark.asyncio
+async def test_an_idle_runtime_announces_retiring_and_stops() -> None:
+    handle = MovableHandle(reason="")
+    server, sent = _rig(handle)
+    viewer = _conn("attach")
+    server._clients[id(viewer.writer)] = viewer
+
+    assert await _ask(server, sent, viewer) == "retiring"
+    assert handle.stopped is True
+    announced = [f for f in sent if f.get("op") == "retiring"]
+    assert [f["_recipient"] for f in announced] == ["attach"]
+    assert announced[0]["reason"] == "moved"
+
+
+@pytest.mark.asyncio
+async def test_a_move_does_NOT_require_a_newer_build_on_disk(monkeypatch) -> None:
+    """The one term this op drops, and the whole reason it is not a reuse of
+    ``refresh_if_idle`` — which would answer "kept: build on disk matches"."""
+    monkeypatch.setattr(update_mod, "installed_build", lambda *_a, **_k: BOOT)
+    handle = MovableHandle(reason="")
+    server, sent = _rig(handle)
+    viewer = _conn("attach")
+    server._clients[id(viewer.writer)] = viewer
+
+    assert await _ask(server, sent, viewer) == "retiring"
+    assert handle.stopped is True
+
+
+@pytest.mark.asyncio
+async def test_a_busy_runtime_keeps_itself_and_says_why() -> None:
+    handle = MovableHandle(reason="busy")
+    server, sent = _rig(handle)
+    viewer = _conn("attach")
+    server._clients[id(viewer.writer)] = viewer
+
+    assert await _ask(server, sent, viewer) == "kept: busy"
+    assert handle.stopped is False
+    assert not [f for f in sent if f.get("op") == "retiring"]
+
+
+@pytest.mark.asyncio
+async def test_work_arriving_while_retiring_was_announced_keeps_the_runtime() -> None:
+    """The re-check after the one await between decision and stop — the same
+    guard ``_retire_if_pristine`` documents, and the race the viewer's own
+    idle read cannot close."""
+
+    class Racing(MovableHandle):
+        def may_refresh(self) -> str:
+            self.probes += 1
+            # Idle on the first probe, busy by the second: a turn opened while
+            # the announcement was draining.
+            return "" if self.probes == 1 else "busy"
+
+    handle = Racing()
+    server, sent = _rig(handle)
+    viewer = _conn("attach")
+    server._clients[id(viewer.writer)] = viewer
+
+    detail = await _ask(server, sent, viewer)
+    assert detail == "kept: busy (arrived while retiring was announced)"
+    assert handle.stopped is False
+
+
+@pytest.mark.asyncio
+async def test_a_handle_that_cannot_judge_itself_is_kept() -> None:
+    """Unknown state is not an invitation to stop a runtime."""
+    server, sent = _rig(FakeHandle())
+    viewer = _conn("attach")
+    server._clients[id(viewer.writer)] = viewer
+
+    assert (await _ask(server, sent, viewer)).startswith("kept:")
+
+
+@pytest.mark.asyncio
+async def test_a_failing_idle_probe_keeps_the_runtime() -> None:
+    class Broken(MovableHandle):
+        def may_refresh(self) -> str:
+            raise RuntimeError("probe exploded")
+
+    handle = Broken()
+    server, sent = _rig(handle)
+    viewer = _conn("attach")
+    server._clients[id(viewer.writer)] = viewer
+
+    assert "idle probe failed" in await _ask(server, sent, viewer)
+    assert handle.stopped is False

--- a/tests/unit/session/test_no_session_deletion.py
+++ b/tests/unit/session/test_no_session_deletion.py
@@ -92,6 +92,23 @@ _ALLOWED_ROWS: tuple[tuple[str | int, ...], ...] = (
         "os.unlink",
         "Removes only its named temporary draft file after a failed atomic replacement",
     ),
+    # `/move`'s recent-directory list, and the same shape as the draft store
+    # above: one named FILE at `<config_dir>/move-recents.json`, written to a
+    # tempfile in that same directory and replaced over. The destination is a
+    # literal filename joined to the config root, so it can never name a
+    # directory and never resolve under sessions/ — and the value written is a
+    # list of path STRINGS, never a path this code opens or removes.
+    (
+        "local_operator/tui/move_targets.py::remember_recent",
+        "os.replace",
+        "Atomic replacement of the single move-recents.json file in the config dir, "
+        "never a directory and never under sessions/",
+    ),
+    (
+        "local_operator/tui/move_targets.py::remember_recent",
+        "<path>.unlink",
+        "Removes only its own named temporary file after a failed atomic replacement",
+    ),
     # -- the one legitimate remover -----------------------------------------
     (
         "local_operator/session/cleanup.py::remove_session_dir",

--- a/tests/unit/session/test_remote_move.py
+++ b/tests/unit/session/test_remote_move.py
@@ -1,0 +1,143 @@
+"""``RemoteSession.set_working_directory`` — the three honest outcomes of `/move`.
+
+The cwd is fixed when a runtime is spawned (``LOP_MOBILE_CHILD_CWD``), so there
+are exactly two ways to honour a change and one situation where neither is
+safe. What these tests pin is that the facade never ends up in the state the
+feature exists to prevent: its ``_cwd`` saying one thing while its runtime
+works in another.
+
+The RETIRING route is the load-bearing detail. A move must not leave by the
+``stopping`` route, because that latches ``_deliberate_stop`` and parks the
+viewer in the stopped state — the right answer for a session the user ENDED and
+the wrong one for a move, after which the conversation continues.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from local_operator.session.remote import RemoteSession
+
+
+@pytest.fixture
+def cold_session(tmp_path):
+    async def _build(cwd: str = "/tmp") -> RemoteSession:
+        return await RemoteSession.cold(
+            "session-under-test",
+            config_dir=tmp_path,
+            cwd=cwd,
+            takeover_factory=lambda *_a, **_k: None,
+        )
+
+    return _build
+
+
+class FakeClient:
+    """The attach client's move-relevant surface, and nothing else."""
+
+    def __init__(self, answer: str = "retiring", error: Exception | None = None) -> None:
+        self.answer = answer
+        self.error = error
+        self.ops: list[str] = []
+        #: ``is_cold`` reads this — a bound facade is one whose client is up.
+        self.connected = True
+
+    async def retire_now(self) -> str:
+        self.ops.append("retire_now")
+        if self.error is not None:
+            raise self.error
+        return self.answer
+
+
+def _bind(session: RemoteSession, client: object) -> None:
+    """Make ``session`` look bound, the way ``is_cold`` actually reads it."""
+    session._client = client  # type: ignore[assignment]
+    session._ready_for_events = True
+
+
+@pytest.mark.asyncio
+async def test_a_cold_session_just_changes_the_directory_it_will_spawn_with(
+    cold_session,
+) -> None:
+    """The "at the start of a session" case the feature was asked for, and the
+    common one: `lop` opens cold. It is a field assignment and costs nothing."""
+    session = await cold_session("/tmp")
+    assert session.is_cold
+    assert await session.set_working_directory("/usr") == "cold"
+    assert session._cwd == "/usr"
+
+
+@pytest.mark.asyncio
+async def test_a_bound_idle_session_retires_its_runtime_and_rebinds(cold_session) -> None:
+    session = await cold_session("/tmp")
+    client = FakeClient()
+    _bind(session, client)
+    session.owner_idle = lambda: True  # type: ignore[method-assign]
+    assert await session.set_working_directory("/usr") == "rebound"
+    assert client.ops == ["retire_now"]
+    assert session._cwd == "/usr"
+
+
+@pytest.mark.asyncio
+async def test_a_move_does_NOT_park_the_viewer_in_the_stopped_state(cold_session) -> None:
+    """The reason `/move` uses `retire_now` rather than `stop`. Left latched,
+    the next prompt would route to the stopped notice for a conversation that
+    is deliberately still alive — and the flag could not be cleared here
+    anyway, because the disconnect that sets it arrives after this returns."""
+    session = await cold_session("/tmp")
+    _bind(session, FakeClient())
+    session.owner_idle = lambda: True  # type: ignore[method-assign]
+    await session.set_working_directory("/usr")
+    assert session._deliberate_stop is False
+
+
+@pytest.mark.asyncio
+async def test_a_busy_session_is_REFUSED_and_does_not_move(cold_session) -> None:
+    """Retiring mid-turn would abort a model call the user is paying for, and
+    "apply it next turn" is exactly the divergence AGENTS.md names for
+    `/reload`: the band showing one directory while the running turn's tools
+    resolve against another."""
+    session = await cold_session("/tmp")
+    client = FakeClient()
+    _bind(session, client)
+    session.owner_idle = lambda: False  # type: ignore[method-assign]
+    with pytest.raises(RuntimeError, match="working right now"):
+        await session.set_working_directory("/usr")
+    assert session._cwd == "/tmp"
+    assert client.ops == []
+
+
+@pytest.mark.asyncio
+async def test_a_runtime_that_keeps_itself_rolls_the_directory_back(cold_session) -> None:
+    """Work can arrive between this viewer's idle read and the runtime's own
+    re-check. The runtime is the authority; its reason is the receipt, and
+    nothing moved so nothing is recorded as moved."""
+    session = await cold_session("/tmp")
+    _bind(session, FakeClient(answer="kept: busy"))
+    session.owner_idle = lambda: True  # type: ignore[method-assign]
+    with pytest.raises(RuntimeError, match="busy"):
+        await session.set_working_directory("/usr")
+    assert session._cwd == "/tmp"
+
+
+@pytest.mark.asyncio
+async def test_a_refused_op_rolls_the_directory_back(cold_session) -> None:
+    session = await cold_session("/tmp")
+    _bind(session, FakeClient(error=RuntimeError("unknown op: 'retire_now'")))
+    session.owner_idle = lambda: True  # type: ignore[method-assign]
+    with pytest.raises(RuntimeError, match="could not move"):
+        await session.set_working_directory("/usr")
+    assert session._cwd == "/tmp"
+
+
+@pytest.mark.asyncio
+async def test_a_runtime_too_old_to_know_the_op_refuses_cleanly(cold_session) -> None:
+    """Rather than moving anyway and leaving the runtime in the old directory."""
+    session = await cold_session("/tmp")
+    _bind(session, SimpleNamespace(connected=True))
+    session.owner_idle = lambda: True  # type: ignore[method-assign]
+    with pytest.raises(RuntimeError, match="too old"):
+        await session.set_working_directory("/usr")
+    assert session._cwd == "/tmp"

--- a/tests/unit/session/test_remote_move.py
+++ b/tests/unit/session/test_remote_move.py
@@ -38,7 +38,11 @@ def cold_session(tmp_path):
 class FakeClient:
     """The attach client's move-relevant surface, and nothing else."""
 
-    def __init__(self, answer: str = "retiring", error: Exception | None = None) -> None:
+    # ``BaseException``, not ``Exception``: the retire RPC can be CANCELLED as
+    # well as fail, and cancellation is the case the caller-level rollback got
+    # wrong (review MINOR-2). Typing this narrowly would make the defect
+    # unrepresentable in the double while remaining reachable in production.
+    def __init__(self, answer: str = "retiring", error: BaseException | None = None) -> None:
         self.answer = answer
         self.error = error
         self.ops: list[str] = []

--- a/tests/unit/session/test_remote_move.py
+++ b/tests/unit/session/test_remote_move.py
@@ -270,3 +270,127 @@ async def test_a_move_repoints_an_armed_wake_at_the_new_directory(
         "spawn the unattended runtime there"
     )
     assert [s["id"] for s in entry["schedules"]] == ["w1"], "the schedule must survive"
+
+
+@pytest.mark.asyncio
+async def test_move_will_wait_answers_for_an_engage_in_flight(cold_session) -> None:
+    """``is_cold`` and "will this move make me wait" are DIFFERENT questions,
+    and the frontend must ask the second one.
+
+    They disagree on exactly one reachable input — a client connected while
+    ``_ready_for_events`` is clear, and a viewer whose engage is still in
+    flight — which is the mount engage, i.e. `/move` as the first action of a
+    session. Gating the in-flight notice on ``is_cold`` therefore stayed
+    silent for the case the notice exists for (review MAJOR-1, design U6).
+    """
+    session = await cold_session("/tmp")
+
+    # Nothing running: the move is a field assignment that settles in-frame.
+    assert session.is_cold is True
+    assert session.move_will_wait() is False
+
+    # A settled bound runtime: it has to be asked to retire.
+    client = FakeClient()
+    _bind(session, client)
+    assert session.move_will_wait() is True
+
+    # THE MISMATCH: connected but not synchronised. `is_cold` says cold; the
+    # move still retires a live runtime.
+    session._ready_for_events = False
+    assert session.is_cold is True
+    assert session.move_will_wait() is True
+
+    # A socket that is down is not a runtime to wait for.
+    client.connected = False
+    assert session.move_will_wait() is False
+
+    # THE PRIMARY CASE: no client yet, but an engage holds the bind lock, so
+    # the move joins it before doing anything.
+    session._client = None
+    await session._bind_lock.acquire()
+    try:
+        assert session.is_cold is True
+        assert session.move_will_wait() is True
+    finally:
+        session._bind_lock.release()
+
+
+@pytest.mark.asyncio
+async def test_a_move_while_the_owner_is_recovering_is_REFUSED(cold_session) -> None:
+    """The seam refuses uniformly while ``_recovering``, and a move is no
+    exception.
+
+    ``route_shared_slash`` in the same file declines during recovery because a
+    request/response command that blocks until a replacement owner arrives
+    answers a question the user has stopped asking. A move that reported
+    success here would be worse than slow: ``_recover_owner`` binds the
+    successor at whatever cwd the owner's RECORD names, so the "cold move"
+    is silently undone and the viewer works somewhere it said it had left
+    (review MINOR-1).
+    """
+    session = await cold_session("/tmp")
+    session._recovering = True
+
+    # Nothing running: the tempting case, because the cold path looks free.
+    with pytest.raises(ConnectionError, match="reconnecting"):
+        await session.set_working_directory("/usr")
+    assert session._cwd == "/tmp", "a refused move must not leave the directory moved"
+
+    # And with a connected client, which the round-2 delta had reporting
+    # `rebound` and issuing a real retire while recovery was in progress.
+    client = FakeClient()
+    _bind(session, client)
+    session.owner_idle = lambda: True  # type: ignore[method-assign]
+    with pytest.raises(ConnectionError, match="reconnecting"):
+        await session.set_working_directory("/usr")
+    assert session._cwd == "/tmp"
+    assert client.ops == [], "no runtime may be retired for a move that was refused"
+
+    # The narration must not promise a wait for a move that will not happen.
+    assert session.move_will_wait() is False
+
+
+@pytest.mark.asyncio
+async def test_a_CANCELLED_move_rolls_the_directory_back(cold_session) -> None:
+    """``CancelledError`` is a ``BaseException``, so an ``except Exception``
+    rollback let it through.
+
+    The optimistic assignment happens before the runtime is asked to go, so a
+    move cancelled mid-flight — the session worker torn down, a transition
+    superseded — escaped with ``_cwd`` at the NEW value and no move performed.
+    That is the divergence this method exists to prevent, in its quietest
+    form: nothing raised, nothing logged, and the next engage spawns somewhere
+    the user never went (review MINOR-2).
+    """
+    session = await cold_session("/tmp")
+
+    # Cancelled inside the retire RPC: the widest window on the bound path.
+    _bind(session, FakeClient(error=asyncio.CancelledError()))
+    session.owner_idle = lambda: True  # type: ignore[method-assign]
+    with pytest.raises(asyncio.CancelledError):
+        await session.set_working_directory("/usr")
+    assert session._cwd == "/tmp", "a cancelled move left the directory moved"
+
+
+@pytest.mark.asyncio
+async def test_a_move_CANCELLED_while_joining_the_engage_rolls_back(cold_session) -> None:
+    """The other cancellation window, and the reason the join sits INSIDE the
+    guarded region rather than beside it.
+
+    Joining an in-flight engage is a 1-3 s await — by some margin the longest
+    a move spends anywhere — so it is the likeliest moment for a cancel to
+    land. A rollback that only wrapped the retire would miss it entirely.
+    """
+    session = await cold_session("/tmp")
+
+    async def _cancelled_join() -> None:
+        raise asyncio.CancelledError()
+
+    session._ensure_bound = _cancelled_join  # type: ignore[method-assign]
+    await session._bind_lock.acquire()  # an engage is in flight
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await session.set_working_directory("/usr")
+    finally:
+        session._bind_lock.release()
+    assert session._cwd == "/tmp", "a move cancelled while joining left the directory moved"

--- a/tests/unit/session/test_remote_move.py
+++ b/tests/unit/session/test_remote_move.py
@@ -14,6 +14,7 @@ the wrong one for a move, after which the conversation continues.
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -55,6 +56,80 @@ def _bind(session: RemoteSession, client: object) -> None:
     """Make ``session`` look bound, the way ``is_cold`` actually reads it."""
     session._client = client  # type: ignore[assignment]
     session._ready_for_events = True
+
+
+@pytest.mark.asyncio
+async def test_a_move_during_the_mount_engage_spawns_in_the_NEW_directory(
+    cold_session, monkeypatch
+) -> None:
+    """The blocker this feature shipped with, and its primary use case.
+
+    ``is_cold`` means "no SYNCHRONISED runtime is attached", NOT "no runtime
+    exists". The TUI engages eagerly at mount, so by the time a user can type
+    ``/move`` the engage has usually already read ``_cwd`` and handed it to
+    ``engage_runtime`` — a 1-3 s spawn. A move that only assigned the field
+    landed after that read: the runtime came up in the OLD directory while the
+    receipt and the band both said the new one, permanently and silently.
+
+    Asserts what the runtime is SPAWNED WITH, which is the property the feature
+    promises. The original cold test asserted the return value and ``_cwd``,
+    both of which were true throughout the bug — which is why 92 green tests
+    did not catch it.
+    """
+    from local_operator.session.runtime import launch as launch_mod
+
+    spawns: list[str] = []
+    engage_started = asyncio.Event()
+
+    async def slow_engage(session_id, cwd, work, *, config_dir, deadline_s=30.0):
+        engage_started.set()
+        await asyncio.sleep(0.05)  # the spawn window the move must not lose
+        spawns.append(str(cwd))
+
+    monkeypatch.setattr(launch_mod, "engage_runtime", slow_engage)
+
+    session = await cold_session("/tmp")
+    task = asyncio.create_task(session._ensure_bound())
+    await engage_started.wait()  # the engage has read _cwd and is in flight
+
+    assert session.is_cold, "the state a user types /move in at boot"
+    await asyncio.wait_for(session.set_working_directory("/usr"), timeout=10)
+    try:
+        await asyncio.wait_for(task, timeout=10)
+    except Exception:  # noqa: BLE001 — the bind's own outcome is not under test
+        pass
+
+    assert spawns, "no runtime was ever engaged"
+    assert spawns[-1] == "/usr", (
+        f"the surviving runtime was spawned at {spawns[-1]!r}, not the moved-to "
+        "directory — the band and the receipt would say /usr while every tool "
+        "call, the system prompt and skill discovery used the old path"
+    )
+    assert session._cwd == "/usr"
+
+
+@pytest.mark.asyncio
+async def test_a_move_while_a_live_runtime_is_resyncing_still_retires_it(
+    cold_session,
+) -> None:
+    """``_ready_for_events`` is False during a history refresh while the runtime
+    keeps serving, so an ``is_cold`` test routed a LIVE runtime into the
+    free-field-assignment branch: no retire, nothing rebound, and the user told
+    it worked (review MAJOR-1; QA Q2 is the same hole during a rebind).
+
+    Liveness of the socket is the honest term, and this pins it.
+    """
+    session = await cold_session("/tmp")
+    client = FakeClient()
+    _bind(session, client)
+    session._ready_for_events = False  # mid-resync: cold by the old predicate
+    session.owner_idle = lambda: True  # type: ignore[method-assign]
+
+    assert session.is_cold, "the predicate that used to decide the branch"
+    outcome = await session.set_working_directory("/usr")
+
+    assert outcome == "rebound", "a live runtime must be retired, not skipped"
+    assert client.ops == ["retire_now"]
 
 
 @pytest.mark.asyncio
@@ -123,9 +198,27 @@ async def test_a_runtime_that_keeps_itself_rolls_the_directory_back(cold_session
 
 
 @pytest.mark.asyncio
-async def test_a_refused_op_rolls_the_directory_back(cold_session) -> None:
+async def test_a_version_skewed_runtime_gets_the_vetted_sentence(cold_session) -> None:
+    """A runtime older than this build answers ``unknown op: 'retire_now'``.
+
+    This is the REACHABLE skew path: the viewer always carries this build's
+    ``AttachClient``, so the ``callable`` guard below can never fire in
+    production and the user was shown a raw wire internal instead of the
+    sentence written for them (review MINOR-1 / QA Q4).
+    """
     session = await cold_session("/tmp")
     _bind(session, FakeClient(error=RuntimeError("unknown op: 'retire_now'")))
+    session.owner_idle = lambda: True  # type: ignore[method-assign]
+    with pytest.raises(RuntimeError, match="too old to be moved"):
+        await session.set_working_directory("/usr")
+    assert session._cwd == "/tmp"
+
+
+@pytest.mark.asyncio
+async def test_any_other_transport_failure_rolls_the_directory_back(cold_session) -> None:
+    """A failure that is NOT version skew still refuses and restores the cwd."""
+    session = await cold_session("/tmp")
+    _bind(session, FakeClient(error=ConnectionError("socket closed")))
     session.owner_idle = lambda: True  # type: ignore[method-assign]
     with pytest.raises(RuntimeError, match="could not move"):
         await session.set_working_directory("/usr")
@@ -141,3 +234,39 @@ async def test_a_runtime_too_old_to_know_the_op_refuses_cleanly(cold_session) ->
     with pytest.raises(RuntimeError, match="too old"):
         await session.set_working_directory("/usr")
     assert session._cwd == "/tmp"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bound", [False, True])
+async def test_a_move_repoints_an_armed_wake_at_the_new_directory(
+    cold_session, tmp_path, bound
+) -> None:
+    """An armed wake spawns an UNATTENDED runtime from the index's own ``cwd``.
+
+    Nothing rewrote that entry, so a session moved with a wake armed fired it
+    in the old directory (review MAJOR-2). A wake is the one mechanism designed
+    to run without the user present to notice, so the divergence survived until
+    the next manual prompt. Checked on both paths: the bound path self-heals
+    only when its successor opens, which can be long after a wake is due.
+    """
+    from local_operator.wakes.store import read_index, write_entry
+
+    session = await cold_session("/tmp")
+    write_entry(
+        tmp_path,
+        session.session_id,
+        cwd="/tmp",
+        schedules=[{"id": "w1", "due_at_ms": 1, "note": "check the build"}],
+    )
+    if bound:
+        _bind(session, FakeClient())
+        session.owner_idle = lambda: True  # type: ignore[method-assign]
+
+    await session.set_working_directory("/usr")
+
+    entry = read_index(tmp_path)[session.session_id]
+    assert entry["cwd"] == "/usr", (
+        "the wake index still names the old directory, so the supervisor would "
+        "spawn the unattended runtime there"
+    )
+    assert [s["id"] for s in entry["schedules"]] == ["w1"], "the schedule must survive"

--- a/tests/unit/session/test_subagent_accounting.py
+++ b/tests/unit/session/test_subagent_accounting.py
@@ -20,6 +20,12 @@ from local_operator.session.frontend_state import (
 from local_operator.tui.costs import cost_summary, turn_cost
 from local_operator.tui.widgets.subagent_panel import job_stats
 
+#: Loop TURNS to allow the app's boot worker, not seconds. A turn count
+#: survives the contention a wall-clock budget does not (AGENTS.md, "Wait on
+#: the event, never on the clock"), and the only test here that drives a real
+#: ``OperatorApp`` needs the band mounted before it can assert on the ledger.
+MAX_BOOT_TURNS = 200
+
 
 @pytest.mark.parametrize("bad", [-1, float("nan"), float("inf")])
 def test_invalid_estimates_cannot_enter_durable_usage(bad):
@@ -199,7 +205,19 @@ async def test_rendered_footer_uses_whole_owner_ledger():
 
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.pause()
+        # Wait for the BAND to exist, not for a fixed number of pauses.
+        # ``_apply_frontend_state`` returns early while ``_status`` is None, so
+        # a single pause asserts nothing about the ledger on a machine where
+        # boot has not finished within one loop turn — the total simply stays
+        # 0.0 and the failure names the cost rather than the race. Idle, one
+        # pause is enough (measured); under CI shard load it is not, which is
+        # how this went red on a branch that only ever ADDED unrelated test
+        # files: file-index sharding moved this test to a busier shard.
+        for _ in range(MAX_BOOT_TURNS):
+            await pilot.pause()
+            if app._status is not None:
+                break
+        assert app._status is not None, "the band never mounted"
         state = FrontendSessionState(
             epoch="money",
             session_id="money",

--- a/tests/unit/tui/test_approvals_ux.py
+++ b/tests/unit/tui/test_approvals_ux.py
@@ -548,6 +548,12 @@ def test_the_registry_states_which_commands_offer_values() -> None:
         # OPTIONAL like `/approvals`: bare `/stop` stops THIS session; the
         # list offers the other sessions and `all`.
         "stop": ArgumentMode.OPTIONAL,
+        # OPTIONAL like `/stop`: bare `/move` opens the directory picker, which
+        # is the discoverable route, and the space offers the same suggestions
+        # inline for a user who would rather type. Deliberately not REQUIRED —
+        # Enter on the bare command does something useful, which is the line
+        # `/login` sits on the other side of.
+        "move": ArgumentMode.OPTIONAL,
         # OPTIONAL like `/mcp`: bare `/team` lists the teams, and the space
         # opens the team-name argument list with roster details.
         "team": ArgumentMode.OPTIONAL,

--- a/tests/unit/tui/test_command_picker.py
+++ b/tests/unit/tui/test_command_picker.py
@@ -459,7 +459,7 @@ async def test_typing_filters_to_the_matches() -> None:
         await pilot.pause()
         picker = app.editor.picker
         assert picker.is_open()
-        assert [name for name, _ in picker.suggestions()] == ["model", "mobile"]
+        assert [name for name, _ in picker.suggestions()] == ["move", "model", "mobile"]
 
 
 @pytest.mark.asyncio
@@ -851,7 +851,10 @@ async def test_click_on_the_overflow_row_does_nothing() -> None:
         # a registry move.
         ("c", ["clear", "copy", "config", "context", "compact", "credential"]),
         ("lo", ["loop", "login", "logout"]),
-        ("mo", ["model", "mobile"]),
+        # `move` leads on registry order, not on length: all three are flat 900
+        # prefix matches and `match_commands` breaks the tie on registry index,
+        # where `/move` sits beside `/resume` in the session-transition family.
+        ("mo", ["move", "model", "mobile"]),
     ],
 )
 def test_short_queries_keep_only_prefix_matches(query: str, expected: list[str]) -> None:

--- a/tests/unit/tui/test_move_command.py
+++ b/tests/unit/tui/test_move_command.py
@@ -1,0 +1,259 @@
+"""`/move` driven through the REAL app: the editor, the submit handler, the band.
+
+Calling ``_cmd_move`` directly would skip the editor and the submit handler,
+which is the pair a user actually goes through — so everything here types into
+the real composer and presses Enter.
+
+The band assertions are the load-bearing ones. The failure this feature must
+not have is the one AGENTS.md names for `/reload`: the screen showing one
+directory while the session works in another. So every path that changes the
+directory is checked against what the band says, and every path that refuses is
+checked against the band NOT having changed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.editor import Editor
+from local_operator.tui.widgets.move_picker import MovePickerScreen
+from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+class MovableSession(FakeSession):
+    """A session that can actually be moved, recording what it was asked.
+
+    ``FakeSession`` deliberately has no ``set_working_directory``: the app must
+    refuse a facade that cannot be moved rather than reporting a move that did
+    not happen, and that refusal is asserted below too.
+    """
+
+    def __init__(self, cwd: str = "/tmp", outcome: str = "cold") -> None:
+        super().__init__()
+        self._cwd = cwd
+        self._outcome = outcome
+        self.moves: list[str] = []
+        self.error: Exception | None = None
+
+    async def set_working_directory(self, cwd: str) -> str:
+        self.moves.append(cwd)
+        if self.error is not None:
+            raise self.error
+        self._cwd = cwd
+        return self._outcome
+
+
+def _notices(app: OperatorApp) -> list[str]:
+    return [
+        block._text
+        for block in app.query_one(TranscriptView).blocks()
+        if isinstance(block, NoticeBlock)
+    ]
+
+
+def _band(app: OperatorApp) -> str:
+    status = app._status
+    assert status is not None
+    return status.render_text(200).plain
+
+
+async def _boot(pilot, app: OperatorApp) -> None:
+    for _ in range(40):
+        await pilot.pause()
+        if app._session is not None:
+            return
+
+
+async def _submit(pilot, app: OperatorApp, text: str) -> None:
+    editor = app.query_one(Editor)
+    editor.text = text
+    await pilot.pause()
+    if editor._picker.is_open():
+        await pilot.press("escape")
+        await pilot.pause()
+    await pilot.press("enter")
+    for _ in range(6):
+        await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_moving_a_cold_session_updates_the_band_and_says_so(tmp_path: Path) -> None:
+    session = MovableSession(cwd=str(tmp_path))
+    app = OperatorApp(lambda: _factory(session))
+    destination = tmp_path / "elsewhere"
+    destination.mkdir()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, f"/move {destination}")
+
+        assert session.moves == [str(destination)]
+        assert str(destination) in _band(app)
+        assert any("moved to" in text for text in _notices(app))
+
+
+@pytest.mark.asyncio
+async def test_a_rebound_session_says_its_runtime_restarted(tmp_path: Path) -> None:
+    """The user must be told the runtime was replaced — it is a visible pause
+    and a real event, even though the conversation is untouched."""
+    session = MovableSession(cwd=str(tmp_path), outcome="rebound")
+    app = OperatorApp(lambda: _factory(session))
+    destination = tmp_path / "elsewhere"
+    destination.mkdir()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, f"/move {destination}")
+        assert any("runtime restarted" in text for text in _notices(app))
+
+
+@pytest.mark.asyncio
+async def test_a_tilde_path_is_expanded(monkeypatch, tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    (home / "project").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    session = MovableSession(cwd=str(tmp_path))
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/move ~/project")
+        assert session.moves == [str(home / "project")]
+
+
+@pytest.mark.asyncio
+async def test_a_relative_path_resolves_against_the_SESSIONS_directory(tmp_path: Path) -> None:
+    (tmp_path / "child").mkdir()
+    session = MovableSession(cwd=str(tmp_path))
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/move child")
+        assert session.moves == [str(tmp_path / "child")]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "suffix,expected",
+    [("nope", "no such directory"), ("file.txt", "not a directory")],
+)
+async def test_an_invalid_target_is_refused_without_moving(
+    tmp_path: Path, suffix: str, expected: str
+) -> None:
+    """A clear notice, never a traceback and never a half-applied state."""
+    (tmp_path / "file.txt").write_text("x")
+    session = MovableSession(cwd=str(tmp_path))
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        before = _band(app)
+        await _submit(pilot, app, f"/move {tmp_path / suffix}")
+
+        assert session.moves == []
+        assert any(expected in text for text in _notices(app))
+        assert _band(app) == before
+
+
+@pytest.mark.asyncio
+async def test_moving_to_the_directory_youre_already_in_is_a_no_op(tmp_path: Path) -> None:
+    session = MovableSession(cwd=str(tmp_path))
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, f"/move {tmp_path}")
+        assert session.moves == []
+        assert any("already in" in text for text in _notices(app))
+
+
+@pytest.mark.asyncio
+async def test_a_refusal_from_the_session_reaches_the_user_verbatim(tmp_path: Path) -> None:
+    """A busy session's refusal is the receipt; the band must not move."""
+    session = MovableSession(cwd=str(tmp_path))
+    session.error = RuntimeError("this session is working right now")
+    app = OperatorApp(lambda: _factory(session))
+    destination = tmp_path / "elsewhere"
+    destination.mkdir()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        before = _band(app)
+        await _submit(pilot, app, f"/move {destination}")
+
+        assert any("working right now" in text for text in _notices(app))
+        assert _band(app) == before
+
+
+@pytest.mark.asyncio
+async def test_a_session_that_cannot_be_moved_is_refused_not_silently_ignored() -> None:
+    """``FakeSession`` has no ``set_working_directory``; reporting success
+    would tell the user a move happened that did not."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/move /tmp")
+        assert any("cannot be moved" in text for text in _notices(app))
+
+
+@pytest.mark.asyncio
+async def test_a_bare_move_opens_the_picker_on_the_current_directory(tmp_path: Path) -> None:
+    session = MovableSession(cwd=str(tmp_path))
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/move")
+        for _ in range(4):
+            await pilot.pause()
+
+        screen = app.screen
+        assert isinstance(screen, MovePickerScreen)
+        assert screen.visible_rows
+        assert screen.visible_rows[0].path == str(tmp_path)
+        assert screen.visible_rows[0].kind == "current"
+
+
+@pytest.mark.asyncio
+async def test_escaping_the_picker_leaves_the_session_where_it_was(tmp_path: Path) -> None:
+    """A cancelled picker is not an event worth a transcript line."""
+    session = MovableSession(cwd=str(tmp_path))
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        before = _band(app)
+        await _submit(pilot, app, "/move")
+        for _ in range(4):
+            await pilot.pause()
+        await pilot.press("escape")
+        for _ in range(4):
+            await pilot.pause()
+
+        assert session.moves == []
+        assert _band(app) == before
+
+
+@pytest.mark.asyncio
+async def test_choosing_a_row_in_the_picker_moves_there(tmp_path: Path) -> None:
+    """The whole point of the card, driven the way a user drives it."""
+    child = tmp_path / "child"
+    child.mkdir()
+    session = MovableSession(cwd=str(tmp_path))
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/move")
+        for _ in range(4):
+            await pilot.pause()
+
+        screen = app.screen
+        assert isinstance(screen, MovePickerScreen)
+        # Row 0 is the current directory, so move down to a real destination.
+        index = next(i for i, row in enumerate(screen.visible_rows) if row.path != str(tmp_path))
+        for _ in range(index):
+            await pilot.press("down")
+            await pilot.pause()
+        chosen = screen.selected_path()
+        await pilot.press("enter")
+        for _ in range(6):
+            await pilot.pause()
+
+        assert session.moves == [chosen]
+        assert str(chosen) in _band(app)

--- a/tests/unit/tui/test_move_command.py
+++ b/tests/unit/tui/test_move_command.py
@@ -38,11 +38,26 @@ class MovableSession(FakeSession):
         self._outcome = outcome
         self.moves: list[str] = []
         self.error: Exception | None = None
-        #: The app reads this to decide whether a move has to WAIT for a
-        #: runtime to retire, and so whether to narrate before the transition
-        #: (UX U2). Declared here rather than set ad hoc so the two states a
-        #: test can put this double in are both part of its surface.
+        #: What ``is_cold`` reads. The app must NOT consult it to decide
+        #: whether to narrate a move — a viewer with an engage in flight reads
+        #: cold while its move joins that engage and then retires the runtime
+        #: it produces (review MAJOR-1, design U6). It stays on this double
+        #: precisely so a test can set it to the reading that used to suppress
+        #: the line and prove the app is indifferent to it.
         self.is_cold: bool = True
+
+    def move_will_wait(self) -> bool:
+        """DERIVED from the outcome, so this double cannot lie about the wait.
+
+        The round-1 guard let the gate's input and the move's outcome be set
+        independently, so a gate reading an unrelated predicate could disagree
+        with what the move actually did and the test still passed — which is
+        how the ``is_cold`` gate shipped green beside the blocker that
+        established ``is_cold`` is unsound. Tying the two together here makes
+        the disagreement unrepresentable: a rebind is exactly the move that
+        retires a runtime, which is exactly the move that makes the user wait.
+        """
+        return self._outcome == "rebound"
 
     async def set_working_directory(self, cwd: str) -> str:
         self.moves.append(cwd)
@@ -265,15 +280,62 @@ async def test_choosing_a_row_in_the_picker_moves_there(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_a_bound_move_narrates_before_the_runtime_restarts(tmp_path: Path) -> None:
-    """The retire is an RPC to a child that must drain — ~600 ms measured —
-    during which the picker has closed, the band still reads the old directory
-    and `_session_transition_pending` swallows a typed Enter without replaying
-    it. With nothing printed the app looked like it had ignored the user
-    (UX U2). `/resume` prints its receipt BEFORE the transition; this matches.
+@pytest.mark.parametrize(
+    "is_cold",
+    [
+        # A settled bound runtime: the case that already worked.
+        False,
+        # An engage IN FLIGHT: reads cold, joins, retires, rebinds. The move
+        # takes seconds and the round-1 gate said nothing for all of them.
+        True,
+    ],
+)
+async def test_every_move_that_waits_says_so_before_it_waits(tmp_path: Path, is_cold: bool) -> None:
+    """THE INVARIANT, not the gate's input: a move that ends in ``rebound``
+    made the user wait, so it must have narrated before it did.
+
+    The round-1 guard set ``is_cold = False`` itself and asserted the line
+    appeared — so it pinned the branch that already worked and was
+    structurally incapable of seeing the one that shipped broken beside it.
+    The double returns ``rebound`` regardless of ``is_cold``, so the gate and
+    the outcome could disagree freely and the test still passed. Gating on
+    ``is_cold`` then left a joined mount engage silent for a measured 1.94 s —
+    the feature's primary case, and the same predicate this PR's own blocker
+    established is unsound (review MAJOR-1, design U6).
+
+    Parametrised over both readings of ``is_cold`` precisely because the
+    invariant must not depend on it: the double's ``move_will_wait`` is
+    derived from the outcome, so ``is_cold`` is free to say anything and a
+    gate that consults it goes red on the ``True`` case.
     """
     session = MovableSession(cwd=str(tmp_path), outcome="rebound")
-    session.is_cold = False  # a bound runtime: the path that has to wait
+    session.is_cold = is_cold
+    app = OperatorApp(lambda: _factory(session))
+    destination = tmp_path / "elsewhere"
+    destination.mkdir()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, f"/move {destination}")
+
+        assert session.moves == [str(destination)], "the move must actually have run"
+        texts = _notices(app)
+        assert any("restarting the runtime" in t for t in texts), (
+            f"a move that returned 'rebound' (is_cold={is_cold}) never told the "
+            f"user it was going to wait: {texts}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_move_that_does_not_wait_stays_quiet(tmp_path: Path) -> None:
+    """The other half of the invariant, so the fix cannot be "always narrate".
+
+    A genuinely cold viewer settles within the frame, so an in-flight line
+    would be contradicted by its own receipt a moment later. ``is_cold`` is
+    left FALSE here — the reading that used to force the line — so this half
+    is red for an "always narrate" fix and for the old gate alike.
+    """
+    session = MovableSession(cwd=str(tmp_path), outcome="cold")
+    session.is_cold = False
     app = OperatorApp(lambda: _factory(session))
     destination = tmp_path / "elsewhere"
     destination.mkdir()
@@ -282,9 +344,8 @@ async def test_a_bound_move_narrates_before_the_runtime_restarts(tmp_path: Path)
         await _submit(pilot, app, f"/move {destination}")
 
         texts = _notices(app)
-        assert any(
-            "restarting the runtime" in t for t in texts
-        ), f"no in-flight line before the rebind: {texts}"
+        assert not any("restarting the runtime" in t for t in texts), texts
+        assert any("moved to" in t for t in texts), texts
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_move_command.py
+++ b/tests/unit/tui/test_move_command.py
@@ -38,6 +38,11 @@ class MovableSession(FakeSession):
         self._outcome = outcome
         self.moves: list[str] = []
         self.error: Exception | None = None
+        #: The app reads this to decide whether a move has to WAIT for a
+        #: runtime to retire, and so whether to narrate before the transition
+        #: (UX U2). Declared here rather than set ad hoc so the two states a
+        #: test can put this double in are both part of its surface.
+        self.is_cold: bool = True
 
     async def set_working_directory(self, cwd: str) -> str:
         self.moves.append(cwd)
@@ -257,3 +262,49 @@ async def test_choosing_a_row_in_the_picker_moves_there(tmp_path: Path) -> None:
 
         assert session.moves == [chosen]
         assert str(chosen) in _band(app)
+
+
+@pytest.mark.asyncio
+async def test_a_bound_move_narrates_before_the_runtime_restarts(tmp_path: Path) -> None:
+    """The retire is an RPC to a child that must drain — ~600 ms measured —
+    during which the picker has closed, the band still reads the old directory
+    and `_session_transition_pending` swallows a typed Enter without replaying
+    it. With nothing printed the app looked like it had ignored the user
+    (UX U2). `/resume` prints its receipt BEFORE the transition; this matches.
+    """
+    session = MovableSession(cwd=str(tmp_path), outcome="rebound")
+    session.is_cold = False  # a bound runtime: the path that has to wait
+    app = OperatorApp(lambda: _factory(session))
+    destination = tmp_path / "elsewhere"
+    destination.mkdir()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, f"/move {destination}")
+
+        texts = _notices(app)
+        assert any(
+            "restarting the runtime" in t for t in texts
+        ), f"no in-flight line before the rebind: {texts}"
+
+
+@pytest.mark.asyncio
+async def test_choosing_the_current_row_says_you_are_already_there(tmp_path: Path) -> None:
+    """Selecting the row labelled `current` closed the picker in silence —
+    byte-identical to Esc, on the one row whose purpose is to answer "where am
+    I?" — while typing the same path said `already in …` (UX U4)."""
+    session = MovableSession(cwd=str(tmp_path))
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/move")
+        for _ in range(4):
+            await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, MovePickerScreen)
+        assert screen.visible_rows[0].kind == "current"
+        await pilot.press("enter")
+        for _ in range(6):
+            await pilot.pause()
+
+        assert session.moves == [], "the current row must not issue a move"
+        assert any("already in" in t for t in _notices(app)), _notices(app)

--- a/tests/unit/tui/test_move_command.py
+++ b/tests/unit/tui/test_move_command.py
@@ -39,6 +39,12 @@ class MovableSession(FakeSession):
         self._outcome = outcome
         self.moves: list[str] = []
         self.error: Exception | None = None
+        # ``FakeSession`` pins ``session_id`` to a constant, but the eval-latch
+        # guards need TWO distinguishable conversations to drive a real
+        # replacement through ``_adopt_session`` — one id for every double
+        # cannot express a swap. Overridden as a property (not a plain
+        # attribute) so it stays type-compatible with the base.
+        self._session_id = "sess"
         #: What ``is_cold`` reads. The app must NOT consult it to decide
         #: whether to narrate a move — a viewer with an engage in flight reads
         #: cold while its move joins that engage and then retires the runtime
@@ -59,6 +65,14 @@ class MovableSession(FakeSession):
         retires a runtime, which is exactly the move that makes the user wait.
         """
         return self._outcome == "rebound"
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+    @session_id.setter
+    def session_id(self, value: str) -> None:
+        self._session_id = value
 
     async def set_working_directory(self, cwd: str) -> str:
         self.moves.append(cwd)
@@ -487,25 +501,70 @@ async def test_the_eval_warning_survives_a_cleared_transcript(tmp_path: Path) ->
 
 @pytest.mark.asyncio
 async def test_a_replaced_session_does_not_inherit_the_eval_latch(tmp_path: Path) -> None:
-    """The latch belongs to the session that ran `eval`.
+    """The eval warning belongs to the conversation that ran `eval`.
 
-    A successor has its own kernel, so carrying the flag across a session
-    swap would warn a NEW conversation about a namespace it never had — the
-    opposite error, and just as untrue.
+    DRIVES A REAL REPLACEMENT through `_adopt_session` — the funnel every
+    swap path reaches — instead of performing the reset itself. The previous
+    version of this guard assigned `_session_used_eval_latch = False` by hand
+    and then asserted `False` stayed `False`, so it passed with the production
+    reset deleted and was structurally unable to notice that two of the three
+    session-replacement paths never reset at all (review MAJOR-4.1/4.2).
+
+    That is why the leak shipped: `_reload_session` reset the flag, but
+    `_apply_sidebar_presentation` rebinds `_transcript` to the incoming view
+    and `_attach_or_refuse` adopts a successor, and a conversation that never
+    ran `eval` was told its namespace had been destroyed.
     """
-    session = MovableSession(cwd=str(tmp_path), outcome="rebound")
-    app = OperatorApp(lambda: _factory(session))
+    session_a = MovableSession(cwd=str(tmp_path), outcome="rebound")
+    session_a.session_id = "conversation-a"
+    app = OperatorApp(lambda: _factory(session_a))
     async with app.run_test(size=(100, 30)) as pilot:
         await _boot(pilot, app)
         app._append_block(ToolCard(tool_call_id="c1", tool_name="eval"))
         for _ in range(3):
             await pilot.pause()
-        assert app._session_used_eval()
+        assert app._session_used_eval(), "the session that ran eval is not flagged"
 
-        # What `_reload_session` does when it drops the outgoing session.
-        app._session_used_eval_latch = False
+        # THE REAL SWAP: adopt a different conversation, exactly as every
+        # replacement path does, and give it its own empty transcript — which
+        # is what makes the transcript half unable to retract a leaked latch.
+        session_b = MovableSession(cwd=str(tmp_path), outcome="rebound")
+        session_b.session_id = "conversation-b"
+        app._adopt_session(session_b)
         app._transcript_view().clear_blocks()
         for _ in range(3):
             await pilot.pause()
 
-        assert not app._session_used_eval(), "a fresh session inherited the warning"
+        assert not app._session_used_eval(), (
+            "conversation B inherited A's eval latch and would be warned about "
+            "a namespace it never had"
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_latch_answers_only_for_the_session_it_was_stamped_for(
+    tmp_path: Path,
+) -> None:
+    """The key, asserted directly rather than through a swap's side effects.
+
+    A latch left set against another session's id must be structurally unable
+    to answer for the current one — that is what makes a swap site added later
+    unable to reintroduce the leak by forgetting to clear.
+    """
+    session = MovableSession(cwd=str(tmp_path), outcome="rebound")
+    session.session_id = "the-current-one"
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        app._transcript_view().clear_blocks()
+        for _ in range(3):
+            await pilot.pause()
+
+        # Set, but stamped for somebody else: the shape a leak takes.
+        app._session_used_eval_latch = True
+        app._eval_latch_session_id = "a-conversation-the-user-left"
+        assert not app._session_used_eval(), "a stale-keyed latch answered"
+
+        # The same flag, correctly stamped, does answer.
+        app._eval_latch_session_id = "the-current-one"
+        assert app._session_used_eval()

--- a/tests/unit/tui/test_move_command.py
+++ b/tests/unit/tui/test_move_command.py
@@ -20,6 +20,7 @@ import pytest
 from local_operator.tui.app import OperatorApp
 from local_operator.tui.widgets.editor import Editor
 from local_operator.tui.widgets.move_picker import MovePickerScreen
+from local_operator.tui.widgets.tool_card import ToolCard
 from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
 
@@ -369,3 +370,77 @@ async def test_choosing_the_current_row_says_you_are_already_there(tmp_path: Pat
 
         assert session.moves == [], "the current row must not issue a move"
         assert any("already in" in t for t in _notices(app)), _notices(app)
+
+
+@pytest.mark.asyncio
+async def test_a_rebind_warns_that_the_eval_kernel_was_lost(tmp_path: Path) -> None:
+    """A move that restarts the runtime destroys the persistent `eval`
+    namespace, and the user must be TOLD rather than find out from a
+    `NameError` two turns later.
+
+    `tools/eval.py` caches one interpreter per session in `_KERNELS`, and
+    `Session` registers `close_session_kernel` as a dispose hook — so retiring
+    the runtime takes every variable, import and function built up in `eval`
+    with it, while the conversation, transcript and session id all survive.
+    That survival is exactly what makes the loss surprising: nothing else on
+    screen changes. Reported by a peer session during round 3, verified in
+    source.
+    """
+    session = MovableSession(cwd=str(tmp_path), outcome="rebound")
+    app = OperatorApp(lambda: _factory(session))
+    destination = tmp_path / "elsewhere"
+    destination.mkdir()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        # A real `eval` call in the conversation: the signal the receipt reads.
+        app._append_block(ToolCard(tool_call_id="c1", tool_name="eval"))
+        await pilot.pause()
+        await _submit(pilot, app, f"/move {destination}")
+
+        texts = _notices(app)
+        assert any(
+            "eval kernel" in t for t in texts
+        ), f"a rebind destroyed the eval namespace without saying so: {texts}"
+        # The move still HAPPENS: this is narration, not a refusal.
+        assert session.moves == [str(destination)]
+        assert str(destination) in _band(app)
+
+
+@pytest.mark.asyncio
+async def test_a_session_that_never_used_eval_is_not_warned_about_it(tmp_path: Path) -> None:
+    """The other half, so the warning cannot become noise on every rebind.
+
+    A user who has never touched `eval` has no kernel to lose, and a receipt
+    that mentions one invents a consequence that did not happen.
+    """
+    session = MovableSession(cwd=str(tmp_path), outcome="rebound")
+    app = OperatorApp(lambda: _factory(session))
+    destination = tmp_path / "elsewhere"
+    destination.mkdir()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, f"/move {destination}")
+
+        texts = _notices(app)
+        assert any("runtime restarted" in t for t in texts), texts
+        assert not any("eval kernel" in t for t in texts), texts
+
+
+@pytest.mark.asyncio
+async def test_a_COLD_move_never_mentions_the_eval_kernel(tmp_path: Path) -> None:
+    """A cold move retires nothing, so no kernel is disposed — even in a
+    session that has used `eval`. Warning there would be a lie about a loss
+    that did not occur."""
+    session = MovableSession(cwd=str(tmp_path), outcome="cold")
+    app = OperatorApp(lambda: _factory(session))
+    destination = tmp_path / "elsewhere"
+    destination.mkdir()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        app._append_block(ToolCard(tool_call_id="c1", tool_name="eval"))
+        await pilot.pause()
+        await _submit(pilot, app, f"/move {destination}")
+
+        texts = _notices(app)
+        assert any("moved to" in t for t in texts), texts
+        assert not any("eval kernel" in t for t in texts), texts

--- a/tests/unit/tui/test_move_command.py
+++ b/tests/unit/tui/test_move_command.py
@@ -500,56 +500,69 @@ async def test_the_eval_warning_survives_a_cleared_transcript(tmp_path: Path) ->
 
 
 @pytest.mark.asyncio
-async def test_a_replaced_session_does_not_inherit_the_eval_latch(tmp_path: Path) -> None:
-    """The eval warning belongs to the conversation that ran `eval`.
+async def test_the_eval_record_follows_the_conversation_across_a_round_trip(
+    tmp_path: Path,
+) -> None:
+    """A -> B -> A: the record belongs to the conversation, not the viewer.
 
-    DRIVES A REAL REPLACEMENT through `_adopt_session` — the funnel every
-    swap path reaches — instead of performing the reset itself. The previous
-    version of this guard assigned `_session_used_eval_latch = False` by hand
-    and then asserted `False` stayed `False`, so it passed with the production
-    reset deleted and was structurally unable to notice that two of the three
-    session-replacement paths never reset at all (review MAJOR-4.1/4.2).
+    THE THREE STATES IN ONE WALK, because closing either direction alone is
+    what three review rounds each did. Leaving A must not carry its record to
+    B (a conversation told its namespace was destroyed when it never had one,
+    MAJOR-4.1); returning to A must not have lost it (a live kernel destroyed
+    in silence, MAJOR-5.1 — the sidebar return path re-adopts the SAME
+    session, whose kernel never died). A single flag cannot satisfy both, which
+    is why the record is keyed by session id.
 
-    That is why the leak shipped: `_reload_session` reset the flag, but
-    `_apply_sidebar_presentation` rebinds `_transcript` to the incoming view
-    and `_attach_or_refuse` adopts a successor, and a conversation that never
-    ran `eval` was told its namespace had been destroyed.
+    EVERY ADOPTED SESSION GETS ITS OWN EMPTY VIEW, and that is load-bearing
+    rather than tidiness: `_session_used_eval` falls back to the transcript,
+    so a probe that adopts B while A's `eval` card is still on screen has the
+    fallback answer for it and passes over a broken record. That masking is
+    what made a simulation of the round-5 remedy report success — and what made
+    an earlier repro of MAJOR-5.1 fail to reproduce it.
     """
     session_a = MovableSession(cwd=str(tmp_path), outcome="rebound")
     session_a.session_id = "conversation-a"
+    session_b = MovableSession(cwd=str(tmp_path), outcome="rebound")
+    session_b.session_id = "conversation-b"
     app = OperatorApp(lambda: _factory(session_a))
     async with app.run_test(size=(100, 30)) as pilot:
         await _boot(pilot, app)
         app._append_block(ToolCard(tool_call_id="c1", tool_name="eval"))
         for _ in range(3):
             await pilot.pause()
-        assert app._session_used_eval(), "the session that ran eval is not flagged"
+        assert app._session_used_eval(), "the session that ran eval is not recorded"
 
-        # THE REAL SWAP: adopt a different conversation, exactly as every
-        # replacement path does, and give it its own empty transcript — which
-        # is what makes the transcript half unable to retract a leaked latch.
-        session_b = MovableSession(cwd=str(tmp_path), outcome="rebound")
-        session_b.session_id = "conversation-b"
-        app._adopt_session(session_b)
+        # A -> B, with B on its own empty view as production gives it.
+        app._adopt_session(session_b, replay_history=False, reuse_controller=True)
         app._transcript_view().clear_blocks()
         for _ in range(3):
             await pilot.pause()
-
         assert not app._session_used_eval(), (
-            "conversation B inherited A's eval latch and would be warned about "
-            "a namespace it never had"
+            "conversation B inherited A's eval record and would be warned "
+            "about a namespace it never had"
+        )
+
+        # B -> A. The same live session returns; its kernel never died, so the
+        # warning it is owed must still be there.
+        app._adopt_session(session_a, replay_history=False, reuse_controller=True)
+        for _ in range(3):
+            await pilot.pause()
+        assert app._session_used_eval(), (
+            "returning to conversation A lost its eval record, so a move would "
+            "destroy a live kernel in silence"
         )
 
 
 @pytest.mark.asyncio
-async def test_the_latch_answers_only_for_the_session_it_was_stamped_for(
+async def test_the_eval_record_answers_only_for_the_session_that_ran_it(
     tmp_path: Path,
 ) -> None:
-    """The key, asserted directly rather than through a swap's side effects.
+    """Membership, asserted directly rather than through a swap's side effects.
 
-    A latch left set against another session's id must be structurally unable
-    to answer for the current one — that is what makes a swap site added later
-    unable to reintroduce the leak by forgetting to clear.
+    The state is per conversation, so the storage is too: another session's id
+    in the record cannot answer for this one. That is the property which makes
+    a swap path added later unable to reintroduce either direction — there is
+    nothing for it to remember to clear.
     """
     session = MovableSession(cwd=str(tmp_path), outcome="rebound")
     session.session_id = "the-current-one"
@@ -560,11 +573,33 @@ async def test_the_latch_answers_only_for_the_session_it_was_stamped_for(
         for _ in range(3):
             await pilot.pause()
 
-        # Set, but stamped for somebody else: the shape a leak takes.
-        app._session_used_eval_latch = True
-        app._eval_latch_session_id = "a-conversation-the-user-left"
-        assert not app._session_used_eval(), "a stale-keyed latch answered"
+        # Somebody else's conversation is recorded: the shape a leak takes.
+        app._sessions_that_used_eval.add("a-conversation-the-user-left")
+        assert not app._session_used_eval(), "another session's record answered"
 
-        # The same flag, correctly stamped, does answer.
-        app._eval_latch_session_id = "the-current-one"
+        # This conversation's own id does answer.
+        app._sessions_that_used_eval.add("the-current-one")
         assert app._session_used_eval()
+
+
+def test_the_eval_record_is_bounded() -> None:
+    """The set is capped: a viewer can walk through many conversations in one
+    process, and an unbounded id set is a slow leak for a signal that only
+    decorates one receipt.
+
+    Asserted through the recorder rather than by reading the constant, so the
+    bound is checked where it is enforced. The empty-id case is here too: an
+    unidentified session cannot be matched on read, so storing one would grow
+    the set without ever answering a question.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+
+    app._remember_session_used_eval("")
+    assert not app._sessions_that_used_eval, "an unidentifiable session was stored"
+
+    for index in range(app._EVAL_MEMORY_MAX + 50):
+        app._remember_session_used_eval(f"session-{index}")
+    assert len(app._sessions_that_used_eval) <= app._EVAL_MEMORY_MAX
+    # The most recent writer is always present: eviction may drop an older id,
+    # never the one being recorded.
+    assert f"session-{app._EVAL_MEMORY_MAX + 49}" in app._sessions_that_used_eval

--- a/tests/unit/tui/test_move_command.py
+++ b/tests/unit/tui/test_move_command.py
@@ -399,7 +399,7 @@ async def test_a_rebind_warns_that_the_eval_kernel_was_lost(tmp_path: Path) -> N
 
         texts = _notices(app)
         assert any(
-            "eval kernel" in t for t in texts
+            "set up in eval" in t for t in texts
         ), f"a rebind destroyed the eval namespace without saying so: {texts}"
         # The move still HAPPENS: this is narration, not a refusal.
         assert session.moves == [str(destination)]
@@ -423,7 +423,7 @@ async def test_a_session_that_never_used_eval_is_not_warned_about_it(tmp_path: P
 
         texts = _notices(app)
         assert any("runtime restarted" in t for t in texts), texts
-        assert not any("eval kernel" in t for t in texts), texts
+        assert not any("set up in eval" in t for t in texts), texts
 
 
 @pytest.mark.asyncio
@@ -443,4 +443,69 @@ async def test_a_COLD_move_never_mentions_the_eval_kernel(tmp_path: Path) -> Non
 
         texts = _notices(app)
         assert any("moved to" in t for t in texts), texts
-        assert not any("eval kernel" in t for t in texts), texts
+        assert not any("set up in eval" in t for t in texts), texts
+
+
+@pytest.mark.asyncio
+async def test_the_eval_warning_survives_a_cleared_transcript(tmp_path: Path) -> None:
+    """`/clear` empties the VIEW while the session, the runtime and the `eval`
+    kernel all survive — and `/clear`'s own receipt promises "history is
+    untouched", so that user has every reason to believe their state is
+    intact. Deriving "did this session use eval" from `blocks()` therefore
+    lost the answer in the one direction that costs work, which the original
+    docstring ruled out as impossible (review round 3, MAJOR-1).
+
+    CLEARS THE TRANSCRIPT and still expects the warning. The three guards that
+    shipped with the feature all pass while the defect is live, because none
+    of them clears or bounds the transcript — the decoration shape AGENTS.md
+    names.
+    """
+    session = MovableSession(cwd=str(tmp_path), outcome="rebound")
+    session.is_cold = False
+    app = OperatorApp(lambda: _factory(session))
+    destination = tmp_path / "elsewhere"
+    destination.mkdir()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        app._append_block(ToolCard(tool_call_id="c1", tool_name="eval"))
+        for _ in range(3):
+            await pilot.pause()
+
+        # The kernel is untouched by this; only the screen is emptied.
+        app._transcript_view().clear_blocks()
+        for _ in range(3):
+            await pilot.pause()
+        assert app._session_used_eval(), "the latch did not survive /clear"
+
+        await _submit(pilot, app, f"/move {destination}")
+        texts = _notices(app)
+
+    assert any(
+        "set up in eval" in t for t in texts
+    ), f"a rebind destroyed the eval namespace with no warning after /clear: {texts}"
+
+
+@pytest.mark.asyncio
+async def test_a_replaced_session_does_not_inherit_the_eval_latch(tmp_path: Path) -> None:
+    """The latch belongs to the session that ran `eval`.
+
+    A successor has its own kernel, so carrying the flag across a session
+    swap would warn a NEW conversation about a namespace it never had — the
+    opposite error, and just as untrue.
+    """
+    session = MovableSession(cwd=str(tmp_path), outcome="rebound")
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        app._append_block(ToolCard(tool_call_id="c1", tool_name="eval"))
+        for _ in range(3):
+            await pilot.pause()
+        assert app._session_used_eval()
+
+        # What `_reload_session` does when it drops the outgoing session.
+        app._session_used_eval_latch = False
+        app._transcript_view().clear_blocks()
+        for _ in range(3):
+            await pilot.pause()
+
+        assert not app._session_used_eval(), "a fresh session inherited the warning"

--- a/tests/unit/tui/test_move_picker.py
+++ b/tests/unit/tui/test_move_picker.py
@@ -1,0 +1,284 @@
+"""The `/move` picker screen: navigation, the two input modes, and geometry.
+
+Geometry is asserted against the REAL app and the real stylesheet: the
+lightweight hosts elsewhere in this suite declare no `CSS_PATH`, so a card
+sized by percentage rules would not be sized at all under one — the same
+reason `test_copy_picker` gives.
+
+The mode tests are the load-bearing ones. This card has one input and two jobs
+(filter the suggestions, complete a path), and the whole design rests on the
+split being predictable from what was typed rather than from a key the user has
+to know.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.move_targets import MoveTarget
+from local_operator.tui.widgets.move_picker import (
+    NO_MATCH_NOTICE,
+    NO_PATH_NOTICE,
+    PAGE_ROWS_MAX,
+    MovePickerScreen,
+    _truncate_head,
+    render_rows,
+)
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+def _target(path: str, kind: str = "recent", detail: str = "") -> MoveTarget:
+    return MoveTarget(path=path, label=path, kind=kind, detail=detail)
+
+
+def _targets(count: int = 4) -> list[MoveTarget]:
+    rows = [_target("/here", "current", "current")]
+    rows += [_target(f"/dir{index}", "recent", "session") for index in range(count - 1)]
+    return rows
+
+
+# -- pure rendering ----------------------------------------------------------
+
+
+def test_a_long_path_is_truncated_from_the_LEFT() -> None:
+    """The tail distinguishes two siblings; the head is what every row shares,
+    so a tail cut renders two different directories as the same string."""
+    cut = _truncate_head("/Users/damian/workspace/repos/lo-move-cmd", 20)
+    assert cut.startswith("…")
+    assert cut.endswith("lo-move-cmd")
+
+
+def test_a_short_path_is_left_alone() -> None:
+    assert _truncate_head("/tmp", 20) == "/tmp"
+
+
+def test_the_note_is_dropped_before_the_path_is_cut() -> None:
+    """The path is the thing being chosen; the note is only why it was
+    offered, so on a narrow card the reason goes first."""
+    wide = render_rows([_target("/a/very/long/directory/name", detail="session")], 0, 60)
+    narrow = render_rows([_target("/a/very/long/directory/name", detail="session")], 0, 24)
+    assert "session" in wide[0].plain
+    assert "session" not in narrow[0].plain
+    assert "name" in narrow[0].plain
+
+
+def test_every_row_reserves_the_cursor_column() -> None:
+    """So selecting a row cannot shift its text sideways."""
+    rows = render_rows(_targets(3), 1, 60)
+    assert rows[0].plain.startswith("  ")
+    assert rows[1].plain.startswith("❯ ")
+
+
+# -- navigation --------------------------------------------------------------
+
+
+def test_movement_clamps_at_both_ends() -> None:
+    """`session_picker._move_to` clamps and AGENTS.md's exception covers a full
+    surface like this one: a Down at the bottom that returned to the top reads
+    as the list having reset itself."""
+    screen = MovePickerScreen(_targets(4))
+    screen._move_to(99)
+    assert screen.selected_index == 3
+    screen.action_move(1)
+    assert screen.selected_index == 3
+    screen.action_move(-99)
+    assert screen.selected_index == 0
+    screen.action_move(-1)
+    assert screen.selected_index == 0
+
+
+def test_a_new_query_homes_the_cursor_on_the_first_match() -> None:
+    """Not the nearest surviving row: clamping lands the cursor on the LAST
+    match, so Enter would take the least related row still standing."""
+    screen = MovePickerScreen(_targets(6))
+    screen._move_to(4)
+    screen.set_query("dir")
+    assert screen.selected_index == 0
+    assert screen.selected_path() == screen.visible_rows[0].path
+
+
+def test_selecting_from_an_empty_result_set_answers_nothing() -> None:
+    screen = MovePickerScreen(_targets(3))
+    screen.set_query("nothing matches this")
+    assert screen.visible_rows == []
+    assert screen.selected_path() is None
+
+
+def test_printable_keys_type_into_the_query() -> None:
+    screen = MovePickerScreen(_targets(3))
+
+    class _Key:
+        character = "d"
+        stopped = False
+
+        def stop(self) -> None:
+            self.stopped = True
+
+        def prevent_default(self) -> None:
+            pass
+
+    screen.on_key(_Key())
+    assert screen.filter_query == "d"
+
+
+def test_backspace_edits_the_query_and_stops_at_empty() -> None:
+    screen = MovePickerScreen(_targets(3))
+    screen.set_query("ab")
+    screen.action_backspace()
+    assert screen.filter_query == "a"
+    screen.action_backspace()
+    screen.action_backspace()
+    assert screen.filter_query == ""
+
+
+# -- the two input modes -----------------------------------------------------
+
+
+def test_a_plain_word_FILTERS_the_suggestions() -> None:
+    screen = MovePickerScreen(_targets(4))
+    screen.set_query("dir1")
+    assert screen.is_path_query is False
+    assert [row.path for row in screen.visible_rows] == ["/dir1"]
+
+
+def test_a_path_COMPLETES_against_the_filesystem(tmp_path: Path) -> None:
+    """The half of the picker that reaches a directory the suggestions never
+    guessed — without it the card is abandoned the first time someone wants
+    one it did not offer."""
+    (tmp_path / "alpha").mkdir()
+    (tmp_path / "beta").mkdir()
+    asked: list[str] = []
+
+    def complete(query: str) -> list[MoveTarget]:
+        asked.append(query)
+        return [_target(str(tmp_path / "alpha"), "typed")]
+
+    screen = MovePickerScreen(_targets(3), complete=complete)
+    screen.set_query(f"{tmp_path}/al")
+    assert screen.is_path_query is True
+    # Reading the rows is what runs the tier: the result is cached against the
+    # query, so the filesystem is touched once per keystroke and not per paint.
+    assert [row.path for row in screen.visible_rows] == [str(tmp_path / "alpha")]
+    assert asked == [f"{tmp_path}/al"]
+    # Cached: a repaint must not re-list the directory.
+    assert [row.path for row in screen.visible_rows] == [str(tmp_path / "alpha")]
+    assert asked == [f"{tmp_path}/al"]
+
+
+def test_a_failing_completer_yields_an_empty_list_not_an_error() -> None:
+    def boom(_query: str) -> list[MoveTarget]:
+        raise OSError("gone")
+
+    screen = MovePickerScreen(_targets(3), complete=boom)
+    screen.set_query("/nowhere/x")
+    assert screen.visible_rows == []
+
+
+def test_without_a_completer_a_path_falls_back_to_FILTERING() -> None:
+    """A smaller feature rather than an error, so the widget stays testable
+    and usable by an embedder that has no session to resolve against. The
+    fallback filters rather than answering empty: a host with no completer
+    should still be able to reach the rows it WAS given, and an empty list
+    would make the card look broken instead of merely less capable."""
+    screen = MovePickerScreen(_targets(3))
+    screen.set_query("/dir1")
+    assert [row.path for row in screen.visible_rows] == ["/dir1"]
+
+
+def test_tab_completes_the_highlighted_row_and_descends(tmp_path: Path) -> None:
+    """The trailing separator is what makes a second tab list INSIDE the
+    directory rather than re-matching it among its siblings."""
+    screen = MovePickerScreen(_targets(3), complete=lambda _q: [])
+    screen.action_complete()
+    assert screen.filter_query == "/here/"
+    assert screen.is_path_query is True
+
+
+def test_tab_on_an_empty_list_does_nothing() -> None:
+    screen = MovePickerScreen(_targets(3), complete=lambda _q: [])
+    screen.set_query("/no/such")
+    screen.action_complete()
+    assert screen.filter_query == "/no/such"
+
+
+# -- the card's own text -----------------------------------------------------
+
+
+def test_the_header_names_which_mode_is_in_force() -> None:
+    """An empty list means different things in the two modes, so a user who
+    cannot tell which they are in cannot read the answer."""
+    screen = MovePickerScreen(_targets(3), complete=lambda _q: [])
+    screen.set_query("dir")
+    assert "filter dir" in "\n".join(screen.render_lines_for_test())
+    screen.set_query("/dir")
+    assert "path /dir" in "\n".join(screen.render_lines_for_test())
+
+
+def test_the_two_empty_states_say_different_things() -> None:
+    screen = MovePickerScreen(_targets(3), complete=lambda _q: [])
+    screen.set_query("zzz")
+    assert NO_MATCH_NOTICE in "\n".join(screen.render_lines_for_test())
+    screen.set_query("/zzz")
+    assert NO_PATH_NOTICE in "\n".join(screen.render_lines_for_test())
+
+
+def test_the_footer_always_says_how_to_leave() -> None:
+    """It is the only statement of how to get out, so it is never shed."""
+    for width in (100, 60, 40, 26):
+        screen = MovePickerScreen(_targets(3))
+        lines = screen._card_text().split("\n")
+        assert "esc" in lines[-1].plain
+
+
+def test_the_position_row_appears_only_when_the_list_scrolls() -> None:
+    """Printing an empty line in its place leaves two blank rows and pushes
+    the keys away from the block they belong to."""
+    short = MovePickerScreen(_targets(3))
+    assert "showing" not in "\n".join(short.render_lines_for_test())
+    long = MovePickerScreen(_targets(PAGE_ROWS_MAX + 5))
+    assert "showing" in "\n".join(long.render_lines_for_test())
+
+
+# -- geometry, against the real app and stylesheet ---------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(100, 30), (150, 40), (80, 24), (60, 16)])
+async def test_the_card_never_makes_the_screen_scrollable(size) -> None:
+    """A tall overlay that pushes virtual height past the screen's own size
+    silently costs two cells of width and reflows the transcript behind it —
+    a defect this repo has hit before."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=size) as pilot:
+        await pilot.pause()
+        app.push_screen(MovePickerScreen(_targets(PAGE_ROWS_MAX + 10)))
+        for _ in range(4):
+            await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, MovePickerScreen)
+        assert screen.virtual_size.height <= screen.size.height
+        assert screen.show_vertical_scrollbar is False
+
+
+@pytest.mark.asyncio
+async def test_the_cursor_can_only_sit_on_a_row_the_card_drew() -> None:
+    """A fixed page let the cursor sit on a row the card never rendered —
+    Enter then moved somewhere the user could not see."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 16)) as pilot:
+        await pilot.pause()
+        screen = MovePickerScreen(_targets(30))
+        app.push_screen(screen)
+        for _ in range(4):
+            await pilot.pause()
+        drawn = [line for line in screen.render_lines_for_test() if line.startswith(("❯ ", "  /"))]
+        assert len(drawn) <= screen._page_rows()
+        screen.action_jump(1)
+        for _ in range(2):
+            await pilot.pause()
+        painted = "\n".join(screen.render_lines_for_test())
+        assert screen.selected_path() is not None
+        assert str(screen.selected_path()) in painted

--- a/tests/unit/tui/test_move_picker.py
+++ b/tests/unit/tui/test_move_picker.py
@@ -354,25 +354,59 @@ def test_tab_completes_into_the_tidy_label_not_a_raw_absolute_path(tmp_path: Pat
     assert screen.filter_query == "~/scripts/"
 
 
-def test_both_undiscoverable_hints_survive_on_the_opening_card() -> None:
-    """`type to filter or path` and `tab complete` are the two hints nobody
-    infers, and the card must not trade one for the other.
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("terminal_cols", "expect_tab"),
+    [
+        # Measured against the REAL app, not computed: `_card_width` subtracts
+        # ten cells (screen padding 2 + PICKER_WIDTH_MARGIN 6 + card padding 4)
+        # before the footer sees anything, so the 73 cells that carry both
+        # hints need an 86-column TERMINAL.
+        (80, False),  # the standard terminal — documented to give `tab` up
+        (84, False),  # last width without it
+        (86, True),  # first width with it
+        (100, True),
+    ],
+)
+async def test_the_footer_boundary_stated_in_TERMINAL_columns(
+    tmp_path: Path, terminal_cols: int, expect_tab: bool
+) -> None:
+    """Where `tab complete` actually appears, measured end to end.
 
-    D2: `type` is the only statement that a second input mode exists, and it
-    was shed FIRST on a scrolling list — which a freshly opened picker almost
-    always is (11-12 rows against PAGE_ROWS_MAX=10), so the opening frame
-    never carried it. D7: fixing that by shedding `tab` instead swapped the
-    navigator's own gesture off the frame at every width the picker opens at,
-    which is a worse trade — `pgup/pgdn` fits in 73 cells and keeps both,
-    while dropping `tab` spends 75 to keep paging.
+    `type to filter or path` and `tab complete` are the two hints nobody
+    infers. D2: `type` was shed first, so the opening frame never carried it.
+    D7: fixing that by shedding `tab` instead swapped the navigator's own
+    gesture off the frame — a worse trade, since `pgup/pgdn` is the one hint a
+    `showing N-M of T` counter already implies.
 
-    80 cells is the card at a 100- and 150-column terminal, i.e. the width the
-    picker actually opens at. Only the cramped 68-cell card gives one up.
+    D10 is why this test drives the app rather than calling `_footer_hints`
+    with a number. The previous version passed `80` — which is 80 CARD cells,
+    a 100-column terminal — while its docstring claimed that was "the width
+    the picker actually opens at". Literally true and thoroughly misleading:
+    it never asked about an 80-column terminal, where `tab` is still absent.
+    The shed ORDER is correct and is not changed; what was wrong was the unit
+    the guard and its comment were written in.
+
+    So the boundary is pinned in the unit a user has: terminal columns.
     """
-    hints = [key for key, _ in _footer_hints(80)]
-    assert "type" in hints, f"the mode hint was shed at the opening width: {hints}"
-    assert "tab" in hints, f"the navigator gesture was shed at the opening width: {hints}"
-    assert "pgup/pgdn" not in hints, "paging should shed before either disclosure"
+    from local_operator.tui.app import OperatorApp
+    from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(terminal_cols, 30)) as pilot:
+        await pilot.pause()
+        screen = _walking_screen(tmp_path)
+        app.push_screen(screen)
+        for _ in range(6):
+            await pilot.pause()
+        footer = screen.render_lines_for_test()[-1]
+
+    assert ("tab" in footer) is expect_tab, (
+        f"at a {terminal_cols}-column terminal (card {screen._card_width()}) the "
+        f"footer reads {footer!r}"
+    )
+    # The mode hint is never the one given up: it outlives `tab` at every width.
+    assert "type" in footer, f"the mode hint was shed at {terminal_cols} columns"
 
 
 def test_the_footer_sheds_paging_first_and_tab_only_when_truly_cramped() -> None:

--- a/tests/unit/tui/test_move_picker.py
+++ b/tests/unit/tui/test_move_picker.py
@@ -354,14 +354,69 @@ def test_tab_completes_into_the_tidy_label_not_a_raw_absolute_path(tmp_path: Pat
     assert screen.filter_query == "~/scripts/"
 
 
-def test_the_mode_hint_survives_on_a_scrolling_card(tmp_path: Path) -> None:
-    """`type to filter or path` is the ONLY disclosure that a second input mode
-    exists, and it was shed FIRST when the list scrolls — which a freshly
-    opened picker almost always does (11-12 rows against PAGE_ROWS_MAX=10), so
-    the opening frame never carried it at any width (D2)."""
-    for width in (100, 80, 68):
-        hints = [key for key, _ in _footer_hints(width, scrolls=True)]
-        assert "type" in hints, f"the mode hint was shed at width={width}"
+def test_both_undiscoverable_hints_survive_on_the_opening_card() -> None:
+    """`type to filter or path` and `tab complete` are the two hints nobody
+    infers, and the card must not trade one for the other.
+
+    D2: `type` is the only statement that a second input mode exists, and it
+    was shed FIRST on a scrolling list — which a freshly opened picker almost
+    always is (11-12 rows against PAGE_ROWS_MAX=10), so the opening frame
+    never carried it. D7: fixing that by shedding `tab` instead swapped the
+    navigator's own gesture off the frame at every width the picker opens at,
+    which is a worse trade — `pgup/pgdn` fits in 73 cells and keeps both,
+    while dropping `tab` spends 75 to keep paging.
+
+    80 cells is the card at a 100- and 150-column terminal, i.e. the width the
+    picker actually opens at. Only the cramped 68-cell card gives one up.
+    """
+    hints = [key for key, _ in _footer_hints(80)]
+    assert "type" in hints, f"the mode hint was shed at the opening width: {hints}"
+    assert "tab" in hints, f"the navigator gesture was shed at the opening width: {hints}"
+    assert "pgup/pgdn" not in hints, "paging should shed before either disclosure"
+
+
+def test_the_footer_sheds_paging_first_and_tab_only_when_truly_cramped() -> None:
+    """The whole shed sequence, pinned at the measured boundaries.
+
+    The previous test pins the opening width; this one pins the ORDER, so a
+    future reorder cannot pass by happening to fit at 80. The numbers are
+    measured from `_shed_to_width`, not chosen: the full row is 90 cells,
+    dropping `pgup/pgdn` leaves 73, and dropping `tab` as well leaves 58 — so
+    73 is the widest card that must still carry everything but paging, and 72
+    is the first that has to give up `tab` (design D7).
+
+    `↑↓`, `enter` and `esc` are never shed while any label survives: between
+    them they are how the card is moved through, used and left.
+    """
+    assert [k for k, _ in _footer_hints(90)] == [
+        "↑↓",
+        "pgup/pgdn",
+        "type",
+        "tab",
+        "enter",
+        "esc",
+    ], "the full row must fit at its own measured width"
+    # The card at every terminal the picker realistically opens at.
+    for width in (89, 80, 73):
+        assert [k for k, _ in _footer_hints(width)] == [
+            "↑↓",
+            "type",
+            "tab",
+            "enter",
+            "esc",
+        ], f"paging must be the only thing shed at width={width}"
+    # The cramped card: `tab` goes, and only here. The header already names
+    # the mode the instant you type, while nothing else announces `tab`.
+    for width in (72, 68, 58):
+        assert [k for k, _ in _footer_hints(width)] == [
+            "↑↓",
+            "type",
+            "enter",
+            "esc",
+        ], f"`tab` should be the second and last disclosure shed, at width={width}"
+    # Narrower still: the mode hint goes, then the labels — never the three
+    # keys that make the card usable at all.
+    assert [k for k, _ in _footer_hints(40)] == ["↑↓", "enter", "esc"]
 
 
 def test_ctrl_w_backs_out_one_path_segment(tmp_path: Path) -> None:

--- a/tests/unit/tui/test_move_picker.py
+++ b/tests/unit/tui/test_move_picker.py
@@ -358,13 +358,18 @@ def test_tab_completes_into_the_tidy_label_not_a_raw_absolute_path(tmp_path: Pat
 @pytest.mark.parametrize(
     ("terminal_cols", "expect_tab"),
     [
-        # Measured against the REAL app, not computed: `_card_width` subtracts
-        # ten cells (screen padding 2 + PICKER_WIDTH_MARGIN 6 + card padding 4)
-        # before the footer sees anything, so the 73 cells that carry both
-        # hints need an 86-column TERMINAL.
+        # Measured against the REAL app, not computed: the card is TWELVE
+        # cells narrower than the terminal — `_screen_size()` is already inset
+        # by `Screen { padding: 1 }` (2), then `_card_width` subtracts
+        # PICKER_WIDTH_MARGIN (6) and its own padding (4). So the 73 cells that
+        # carry both hints need an 85-column TERMINAL. 84 and 85 are pinned as
+        # a PAIR so the boundary is guarded rather than straddled: an earlier
+        # version pinned 84 and 86 and named 86 as "first width with it", which
+        # is off by one (review MAJOR-4.3).
         (80, False),  # the standard terminal — documented to give `tab` up
         (84, False),  # last width without it
-        (86, True),  # first width with it
+        (85, True),  # THE BOUNDARY: 73 card cells, measured end to end
+        (86, True),
         (100, True),
     ],
 )

--- a/tests/unit/tui/test_move_picker.py
+++ b/tests/unit/tui/test_move_picker.py
@@ -24,6 +24,7 @@ from local_operator.tui.widgets.move_picker import (
     NO_PATH_NOTICE,
     PAGE_ROWS_MAX,
     MovePickerScreen,
+    _footer_hints,
     _truncate_head,
     render_rows,
 )
@@ -282,3 +283,105 @@ async def test_the_cursor_can_only_sit_on_a_row_the_card_drew() -> None:
         painted = "\n".join(screen.render_lines_for_test())
         assert screen.selected_path() is not None
         assert str(screen.selected_path()) in painted
+
+
+# -- the completion dead end (design D1 / UX U1) -----------------------------
+
+
+def _leaf_tree(tmp_path: Path) -> Path:
+    """A directory that exists, is readable, and has no SUBdirectories."""
+    leaf = tmp_path / "scripts"
+    leaf.mkdir()
+    (leaf / "a_file.py").write_text("files are not subdirectories")
+    return leaf
+
+
+def _walking_screen(tmp_path: Path) -> MovePickerScreen:
+    from local_operator.tui.move_targets import (
+        complete_path,
+        resolve_self,
+        suggest_targets,
+    )
+
+    targets = suggest_targets(tmp_path, config_dir=tmp_path / "cfg", home=tmp_path)
+    return MovePickerScreen(
+        targets,
+        current=str(tmp_path),
+        complete=lambda q: complete_path(q, cwd=tmp_path, home=tmp_path),
+        self_target=lambda q: resolve_self(q, cwd=tmp_path, home=tmp_path),
+    )
+
+
+def test_tab_onto_a_childless_directory_leaves_it_selectable(tmp_path: Path) -> None:
+    """`tab` appends a separator and completing INSIDE a directory with no
+    subdirectories returns nothing — so the directory the user had just walked
+    to rendered as "no directory matches that path", and `enter` there
+    dismissed with `None`, which the caller reads as Esc: picker closed, no
+    move, no notice. Found independently by design (D1) and UX (U1), and it
+    made the picker strictly weaker than the typed path it fronts.
+    """
+    leaf = _leaf_tree(tmp_path)
+    screen = _walking_screen(tmp_path)
+    index = next(i for i, r in enumerate(screen.visible_rows) if r.path == str(leaf))
+    screen._move_to(index)
+    screen.action_complete()
+
+    assert screen.visible_rows, "the directory the user walked to vanished from the card"
+    assert screen.selected_path() == str(leaf), "enter would not move to that directory"
+    painted = "\n".join(screen.render_lines_for_test())
+    assert NO_PATH_NOTICE not in painted, "a real directory reported as no match"
+    assert "enter" in painted.splitlines()[-1], "the footer dropped `enter move`"
+
+
+def test_a_path_that_does_not_resolve_still_reports_no_match(tmp_path: Path) -> None:
+    """The fix must not make the empty state unreachable: a path that genuinely
+    does not exist is still a no-match, and keeps that sentence."""
+    _leaf_tree(tmp_path)
+    screen = _walking_screen(tmp_path)
+    screen.set_query("~/nope/")
+    assert screen.visible_rows == []
+    assert NO_PATH_NOTICE in "\n".join(screen.render_lines_for_test())
+
+
+def test_tab_completes_into_the_tidy_label_not_a_raw_absolute_path(tmp_path: Path) -> None:
+    """The row reads `~/scripts`; inserting the absolute path made the header
+    jump to a long string that did not resemble the row just chosen (D3)."""
+    leaf = _leaf_tree(tmp_path)
+    screen = _walking_screen(tmp_path)
+    index = next(i for i, r in enumerate(screen.visible_rows) if r.path == str(leaf))
+    screen._move_to(index)
+    screen.action_complete()
+    assert screen.filter_query == "~/scripts/"
+
+
+def test_the_mode_hint_survives_on_a_scrolling_card(tmp_path: Path) -> None:
+    """`type to filter or path` is the ONLY disclosure that a second input mode
+    exists, and it was shed FIRST when the list scrolls — which a freshly
+    opened picker almost always does (11-12 rows against PAGE_ROWS_MAX=10), so
+    the opening frame never carried it at any width (D2)."""
+    for width in (100, 80, 68):
+        hints = [key for key, _ in _footer_hints(width, scrolls=True)]
+        assert "type" in hints, f"the mode hint was shed at width={width}"
+
+
+def test_ctrl_w_backs_out_one_path_segment(tmp_path: Path) -> None:
+    """Backing out of a completed path cost 15 backspaces — the only editing
+    key bound — which is why walking in felt one-way (U1)."""
+    screen = _walking_screen(tmp_path)
+    screen.set_query("~/a/b/c/")
+    screen.action_kill_segment()
+    assert screen.filter_query == "~/a/b/"
+    screen.action_kill_segment()
+    assert screen.filter_query == "~/a/"
+    screen.action_kill_query()
+    assert screen.filter_query == ""
+
+
+def test_the_current_marker_survives_a_long_path(tmp_path: Path) -> None:
+    """`current` answers "where am I?", not "why is this offered", so unlike
+    every other note it is not dropped to buy label cells — it disappeared on
+    exactly the deep paths this machine is full of (D4)."""
+    deep = "~/workspace/repos/minerva-data-agent-service-integration-v2"
+    row = MoveTarget(path=deep, label=deep, kind="current", detail="current")
+    painted = render_rows([row], 0, 68)[0].plain
+    assert "current" in painted

--- a/tests/unit/tui/test_move_targets.py
+++ b/tests/unit/tui/test_move_targets.py
@@ -1,0 +1,348 @@
+"""Suggestion assembly, path expansion and validation behind ``/move``.
+
+The ordering tests are the load-bearing ones. The tier order IS the feature —
+a picker that led with `/tmp` and buried the directory the user's other session
+is in would technically list everything and help with nothing — so the order is
+pinned rather than left to the order the sources happen to be concatenated in.
+
+Everything here runs against a real temporary filesystem rather than mocks:
+these functions exist to answer questions about directories (does it exist, can
+it be entered, what is inside it), and a mocked filesystem would assert that
+the code calls the functions it calls rather than that it gives right answers.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from local_operator.tui.move_targets import (
+    RECENTS_FILE,
+    RECENTS_LIMIT,
+    MoveError,
+    child_dirs,
+    complete_path,
+    expand_path,
+    filter_targets,
+    format_label,
+    looks_like_path,
+    read_recents,
+    remember_recent,
+    suggest_targets,
+    validate_target,
+)
+
+
+@pytest.fixture
+def tree(tmp_path: Path) -> Path:
+    """A small directory tree: a home, a project with children, and a config."""
+    (tmp_path / "home").mkdir()
+    project = tmp_path / "home" / "project"
+    project.mkdir()
+    for name in ("alpha", "beta", ".hidden"):
+        (project / name).mkdir()
+    (project / "readme.md").write_text("not a directory")
+    (tmp_path / "config").mkdir()
+    return tmp_path
+
+
+# -- labels and expansion ----------------------------------------------------
+
+
+def test_a_directory_inside_home_is_labelled_relative_to_it(tree: Path) -> None:
+    home = tree / "home"
+    assert format_label(home / "project", home=home) == "~/project"
+    assert format_label(home, home=home) == "~"
+
+
+def test_a_directory_outside_home_keeps_its_absolute_path(tree: Path) -> None:
+    """The absolute path is already the shortest honest rendering there."""
+    assert format_label(tree / "config", home=tree / "home") == str(tree / "config")
+
+
+def test_a_tilde_path_expands_to_the_users_home(monkeypatch, tree: Path) -> None:
+    monkeypatch.setenv("HOME", str(tree / "home"))
+    assert expand_path("~/project", cwd="/nowhere") == tree / "home" / "project"
+
+
+def test_a_relative_path_resolves_against_the_SESSIONS_directory(tree: Path) -> None:
+    """Not the process's cwd: a resumed session routinely differs from it, and
+    `/move ../sibling` has to mean the sibling of what the band is showing."""
+    project = tree / "home" / "project"
+    assert expand_path("alpha", cwd=project) == project / "alpha"
+    assert expand_path("..", cwd=project) == tree / "home"
+
+
+def test_expansion_does_not_resolve_symlinks(tree: Path) -> None:
+    """A user who moves into a symlink means the symlink; printing its target
+    back on the band would read as the move having gone somewhere else."""
+    link = tree / "home" / "current"
+    link.symlink_to(tree / "home" / "project")
+    assert expand_path(str(link), cwd=tree) == link
+
+
+# -- validation --------------------------------------------------------------
+
+
+def test_a_missing_directory_is_refused_by_name(tree: Path) -> None:
+    with pytest.raises(MoveError, match="no such directory"):
+        validate_target(tree / "nope")
+
+
+def test_a_file_is_refused_as_not_a_directory(tree: Path) -> None:
+    """A distinct sentence from "missing": the fix is different."""
+    with pytest.raises(MoveError, match="not a directory"):
+        validate_target(tree / "home" / "project" / "readme.md")
+
+
+def test_an_unenterable_directory_is_refused_before_the_move(tree: Path) -> None:
+    """Checked as well as existence: a directory that cannot be entered would
+    let the move "succeed" and then fail every tool call made inside it."""
+    locked = tree / "locked"
+    locked.mkdir(mode=0o000)
+    try:
+        if os.access(locked, os.R_OK | os.X_OK):  # pragma: no cover - running as root
+            pytest.skip("this user can enter a 0o000 directory")
+        with pytest.raises(MoveError, match="permission denied"):
+            validate_target(locked)
+    finally:
+        locked.chmod(0o755)
+
+
+def test_a_usable_directory_validates_to_itself(tree: Path) -> None:
+    assert validate_target(tree / "home") == tree / "home"
+
+
+# -- recents -----------------------------------------------------------------
+
+
+def test_recents_start_empty_and_round_trip(tree: Path) -> None:
+    config = tree / "config"
+    assert read_recents(config) == []
+    remember_recent(config, "/one")
+    remember_recent(config, "/two")
+    assert read_recents(config) == ["/two", "/one"]
+
+
+def test_remembering_a_directory_again_moves_it_to_the_front(tree: Path) -> None:
+    config = tree / "config"
+    for path in ("/one", "/two", "/one"):
+        remember_recent(config, path)
+    assert read_recents(config) == ["/one", "/two"]
+
+
+def test_recents_are_capped(tree: Path) -> None:
+    config = tree / "config"
+    for index in range(RECENTS_LIMIT + 5):
+        remember_recent(config, f"/dir{index}")
+    assert len(read_recents(config)) == RECENTS_LIMIT
+
+
+@pytest.mark.parametrize("body", ["not json at all", '{"not": "a list"}', "[1, 2, 3]"])
+def test_a_corrupt_recents_file_reads_as_empty(tree: Path, body: str) -> None:
+    """Best-effort by contract: this list has two live sources besides it, so
+    every failure degrades to "nothing remembered" rather than to an error."""
+    config = tree / "config"
+    (config / RECENTS_FILE).write_text(body)
+    assert read_recents(config) == []
+
+
+def test_recents_are_written_atomically(tree: Path) -> None:
+    """Same-directory temp then replace: a torn read would silently empty the
+    list. Asserted by proving no temp file survives a successful write."""
+    config = tree / "config"
+    remember_recent(config, "/one")
+    leftovers = [p.name for p in config.iterdir() if p.name != RECENTS_FILE]
+    assert leftovers == []
+    assert json.loads((config / RECENTS_FILE).read_text()) == ["/one"]
+
+
+def test_an_unwritable_config_dir_costs_the_memory_not_the_move(tree: Path) -> None:
+    """This runs after the user has been told the move succeeded."""
+    config = tree / "readonly"
+    config.mkdir(mode=0o500)
+    try:
+        remember_recent(config, "/one")  # must not raise
+    finally:
+        config.chmod(0o755)
+
+
+# -- children ----------------------------------------------------------------
+
+
+def test_children_are_directories_only_alphabetical_and_unhidden(tree: Path) -> None:
+    """Hidden ones would otherwise crowd out every real child on a checkout."""
+    project = tree / "home" / "project"
+    assert [Path(p).name for p in child_dirs(project)] == ["alpha", "beta"]
+
+
+def test_children_are_bounded(tree: Path) -> None:
+    wide = tree / "wide"
+    wide.mkdir()
+    for index in range(40):
+        (wide / f"d{index:02d}").mkdir()
+    assert len(child_dirs(wide, limit=5)) == 5
+
+
+def test_an_unreadable_directory_yields_no_children(tree: Path) -> None:
+    assert child_dirs(tree / "nope") == []
+
+
+# -- suggestion assembly -----------------------------------------------------
+
+
+def test_the_current_directory_always_leads_and_is_marked(tree: Path) -> None:
+    """A picker that does not show where you are makes "did that work?"
+    unanswerable."""
+    project = tree / "home" / "project"
+    rows = suggest_targets(project, config_dir=tree / "config", home=tree / "home")
+    assert rows[0].path == str(project)
+    assert rows[0].kind == "current"
+    assert rows[0].detail == "current"
+
+
+def test_the_tiers_are_offered_in_order(tree: Path) -> None:
+    """current -> recent -> home -> tmp -> parent -> children. The order IS the
+    feature: places the user has worked beat structural fallbacks."""
+    config = tree / "config"
+    remember_recent(config, str(tree / "config"))
+    rows = suggest_targets(tree / "home" / "project", config_dir=config, home=tree / "home")
+    kinds = [row.kind for row in rows]
+    assert kinds[0] == "current"
+    assert "recent" in kinds
+    # Every tier appears no earlier than the one before it.
+    order = ["current", "recent", "home", "tmp", "parent", "child"]
+    positions = [order.index(kind) for kind in kinds]
+    assert positions == sorted(positions), kinds
+
+
+def test_a_directory_offered_by_two_tiers_appears_once_in_the_higher_one(
+    tree: Path,
+) -> None:
+    home = tree / "home"
+    remember_recent(tree / "config", str(home))
+    rows = suggest_targets(home / "project", config_dir=tree / "config", home=home)
+    matching = [row for row in rows if row.path == str(home)]
+    assert len(matching) == 1
+    assert matching[0].kind == "recent"
+
+
+def test_dedup_is_by_RESOLVED_path_not_by_spelling(tree: Path) -> None:
+    """`/tmp` is a symlink to `/private/tmp` on macOS, so a running session
+    reports the resolved form while the built-in row does not — a string dedup
+    offered the same directory twice, in two spellings (seen on the real store).
+    """
+    real = tree / "home" / "project"
+    link = tree / "home" / "alias"
+    link.symlink_to(real)
+    remember_recent(tree / "config", str(link))
+    rows = suggest_targets(real, config_dir=tree / "config", home=tree / "home")
+    resolved = [os.path.realpath(row.path) for row in rows]
+    assert len(resolved) == len(set(resolved))
+
+
+def test_a_remembered_directory_that_is_gone_is_not_offered(tree: Path) -> None:
+    """A suggestion that fails validation the moment it is chosen is worse
+    than no suggestion."""
+    remember_recent(tree / "config", str(tree / "deleted"))
+    rows = suggest_targets(tree / "home", config_dir=tree / "config", home=tree / "home")
+    assert all(row.path != str(tree / "deleted") for row in rows)
+
+
+def test_the_current_directory_is_offered_even_when_it_is_gone(tree: Path) -> None:
+    """The one exception, and the case a user most needs `/move` for: hiding
+    the row would leave the picker silently disagreeing with the band."""
+    missing = tree / "home" / "vanished"
+    rows = suggest_targets(missing, config_dir=tree / "config", home=tree / "home")
+    assert rows[0].path == str(missing)
+
+
+def test_suggestions_are_bounded(tree: Path) -> None:
+    wide = tree / "wide"
+    wide.mkdir()
+    for index in range(50):
+        (wide / f"d{index:02d}").mkdir()
+    rows = suggest_targets(wide, config_dir=tree / "config", home=tree / "home", limit=6)
+    assert len(rows) == 6
+
+
+# -- filtering and completion ------------------------------------------------
+
+
+def test_filtering_narrows_without_reordering(tree: Path) -> None:
+    """A fixed query must not move a row out from under the cursor."""
+    rows = suggest_targets(
+        tree / "home" / "project", config_dir=tree / "config", home=tree / "home"
+    )
+    filtered = filter_targets(rows, "a")
+    assert filtered == [row for row in rows if "a" in row.label.lower() or "a" in row.path.lower()]
+
+
+def test_an_empty_filter_admits_everything(tree: Path) -> None:
+    rows = suggest_targets(tree / "home", config_dir=tree / "config", home=tree / "home")
+    assert filter_targets(rows, "   ") == rows
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("~/x", True),
+        ("/etc", True),
+        ("./here", True),
+        ("../up", True),
+        ("a/b", True),
+        ("repos", False),
+        ("", False),
+    ],
+)
+def test_the_path_and_filter_modes_split_predictably(text: str, expected: bool) -> None:
+    """One input, two jobs — so the rule has to be one a user can predict."""
+    assert looks_like_path(text) is expected
+
+
+def test_completion_lists_directories_under_a_typed_prefix(tree: Path) -> None:
+    project = tree / "home" / "project"
+    rows = complete_path(f"{project}/al", cwd=tree, home=tree / "home")
+    assert [row.path for row in rows] == [str(project / "alpha")]
+
+
+def test_a_trailing_separator_lists_inside_the_directory(tree: Path) -> None:
+    """What makes a second tab descend rather than re-match siblings."""
+    project = tree / "home" / "project"
+    rows = complete_path(f"{project}/", cwd=tree, home=tree / "home")
+    assert [Path(row.path).name for row in rows] == ["alpha", "beta"]
+
+
+def test_completion_matches_case_insensitively(tree: Path) -> None:
+    """A case-sensitive filter over a case-insensitive filesystem reports "no
+    matches" for a directory the user can see."""
+    project = tree / "home" / "project"
+    rows = complete_path(f"{project}/AL", cwd=tree, home=tree / "home")
+    assert [Path(row.path).name for row in rows] == ["alpha"]
+
+
+def test_completion_hides_dotted_directories_unless_asked_for(tree: Path) -> None:
+    project = tree / "home" / "project"
+    assert not [r for r in complete_path(f"{project}/", cwd=tree) if ".hidden" in r.path]
+    dotted = complete_path(f"{project}/.h", cwd=tree)
+    assert [Path(row.path).name for row in dotted] == [".hidden"]
+
+
+def test_completion_never_offers_a_file(tree: Path) -> None:
+    project = tree / "home" / "project"
+    rows = complete_path(f"{project}/read", cwd=tree, home=tree / "home")
+    assert rows == []
+
+
+def test_completing_a_missing_directory_is_empty_not_an_error(tree: Path) -> None:
+    assert complete_path(f"{tree}/nowhere/x", cwd=tree) == []
+
+
+def test_a_bare_word_completes_inside_the_sessions_directory(tree: Path) -> None:
+    """Rather than being treated as a filesystem root."""
+    project = tree / "home" / "project"
+    rows = complete_path("alp", cwd=project, home=tree / "home")
+    assert [row.path for row in rows] == [str(project / "alpha")]

--- a/tests/unit/tui/test_slash_echo.py
+++ b/tests/unit/tui/test_slash_echo.py
@@ -60,6 +60,11 @@ ECHO_POLICY = {
     # without the echo the only record of what the branch was asked to do is in
     # another window entirely.
     "fork": True,
+    # A setting (WHERE the session works), not words the model is told. The
+    # receipt names the directory that ended up in force, which is strictly
+    # more than the typed words: `~/x`, a relative path, or nothing typed at
+    # all when the picker was used.
+    "move": False,
     # The label of the conversation, not words the model is told: the receipt
     # quotes the title that ended up in force, which is more than what was typed.
     "rename": False,
@@ -140,6 +145,10 @@ PROMPT_POLICY = {
     # Free text destined for a model, so an inline `/fork` reassembles to the
     # front of the composer rather than splicing into the middle of a sentence.
     "fork": True,
+    # A DIRECTORY, not a prompt: `/move ~/x` names where the session works, so
+    # an inline engage splices-and-runs like `/rename` rather than reassembling
+    # to the front and handing the model the rest of the draft.
+    "move": False,
     "rename": False,
     "model": False,
     "effort": False,


### PR DESCRIPTION
## Summary

A session's working directory was fixed at launch. Starting `lop` in the wrong folder meant quitting and starting again, and a resumed conversation was stuck wherever it began. `/move` changes it in place — with a picker, because the reported problem is not "I want to type a path", it is "I ended up somewhere weird and want to get where I meant".

**Change class: C2.** New user-facing command; one new runtime op, additive on the wire.

```
/move                 # opens the picker
/move ~/some/dir      # goes straight there (~ expanded, relative resolved)
```

## The picker

Follows `/resume`'s pattern rather than inventing a second dialect: a modal over the dimmed transcript, a cursor the screen owns, every printable key typing into the query, arrows/wheel **clamping** (`session_picker._move_to`'s rule, and AGENTS.md's documented exception for a list that is the whole surface).

Suggestions, in tier order — places the user has demonstrably worked beat structural fallbacks:

1. **the current directory**, always present and marked. A picker that does not show where you are makes "did that work?" unanswerable, and it is the row that keeps the card from silently disagreeing with the band.
2. **recents** — other sessions' cwds from the live runtime records, then sessions with wakes armed, then a small remembered list.
3. **home** and **/tmp**.
4. **the parent and the children**, so it navigates rather than just bookmarking.

Because a list of guesses can never be complete, the one input has two modes, split by what was typed (`looks_like_path`): anything anchored at `~`, `/`, `.` or containing a separator **completes against the filesystem**; anything else **filters the suggestions**. `tab` completes the highlighted row and appends a separator, so the card walks down a tree. The header says which mode is in force, because an empty list means different things in each. Without the completion tier this is a picker people abandon the first time they want a directory it did not guess.

### On recents, and why there is a small file

Two of the three sources are **live** state — quit every session and the list goes empty, so the second use of the feature on a fresh morning would offer nothing the first use taught it. `<config_dir>/move-recents.json` is the smallest durable fix: a capped array of strings, tempfile + `os.replace` in the same directory, best-effort at both ends. Nothing writes it but a completed move, so it cannot grow without the user having chosen each entry.

The session **transcript** also records a cwd and is deliberately not read: the picker opens synchronously and those files reach 100 MB, so mining them per open would trade a directory listing for a multi-hundred-megabyte parse to learn what the live sources already answer.

## Semantics for a running runtime — the part that needed deciding

**The cwd is baked in at spawn.** `_spawn_runtime` passes it as `LOP_MOBILE_CHILD_CWD`, the child reads it once in `amain`, and it is then the session's `_cwd` for that runtime's life — reaching the system prompt's environment block, every `ToolContext.cwd`, skill discovery and MCP config resolution. There is no live setter, and adding one would be wrong: those consumers read at different moments, so a mid-flight change leaves one turn's prompt disagreeing with the tools that turn actually ran.

So there are exactly two honest implementations and one situation where neither is safe:

| state | behaviour | why |
|---|---|---|
| **cold** (no runtime yet) | the directory the next engage spawns with | the "at the start of a session" case; a field assignment, free |
| **bound + idle** | the runtime retires; a successor is engaged at the new path | conversation, transcript and session id untouched |
| **bound + busy** | **refused**, with a reason | see below |

**Busy is refused, not queued.** Retiring mid-turn would abort a model call the user is paying for and did not ask to lose. And "apply it to the next turn" is precisely the divergence AGENTS.md calls out for `/reload` — the band showing one directory while the running turn's tools resolve against another. Refusing states the situation and leaves both surfaces agreeing.

**It leaves by the `retiring` route, never `stopping`, and that is the correctness argument.** A `stop` announces `stopping`, which latches `_deliberate_stop` in `_on_disconnected` and parks the viewer in the ended state — right for a session the user ENDED, wrong for a move, after which the conversation continues. `retiring` already means *"a successor is owed; engage one"*: the facade goes cold with `refresh=True` and the app's existing `_on_runtime_refreshed` engages the successor. So this reuses the mechanism the build-refresh path established.

That is not a stylistic preference — I built the `stop`-then-unlatch version first and it **cannot work**: the disconnect that sets the flag arrives *after* the op's ack returns, so there is no moment at which the viewer could clear it. Hence the new op.

**The new op is `retire_now`**, a sibling of `refresh_if_idle` differing in exactly one term — a refresh is owed only when the build on disk moved, a move whenever the user asked. Everything downstream is *shared code* (`RuntimeServer._retire_for`), not a copy: same idle predicate, same announcement, same re-check after the one await. Additive on the wire, so no `PROTOCOL_VERSION` bump; an older runtime answers the standard unknown-op error and the move is refused rather than half-applied.

**The band is the invariant.** It is pushed from the value the session now holds on every path that changes the directory, and rolled back on every path that does not. `_push_cwd_to_band` also drives the terminal title, which matters because an unnamed conversation is *labelled* by its directory.

## Screenshots

Captured with `scripts/move_shot.py` (new, reusable) over the real `OperatorApp` and the real stylesheet — the lightweight test hosts declare no `CSS_PATH` and cannot show styling at all. The tree is synthetic so frames are stable and leak no real paths.

| state | frame |
|---|---|
| picker as opened | ![open](https://gist.githubusercontent.com/damianvtran/a90022d048658067313e1d1e001cb4bd/raw/6507509b60d0286eae668cfd8d62e255d7492190/open-100x30.svg) |
| filtered (`repos`) | ![filter](https://gist.githubusercontent.com/damianvtran/a90022d048658067313e1d1e001cb4bd/raw/0dcfaabff4b1c71907ce53722f013fd05fb6a13a/filter-100x30.svg) |
| path completion | ![path](https://gist.githubusercontent.com/damianvtran/a90022d048658067313e1d1e001cb4bd/raw/30b8a053faad14686b4a471f0f5e9590d875a902/path-100x30.svg) |
| no match | ![empty](https://gist.githubusercontent.com/damianvtran/a90022d048658067313e1d1e001cb4bd/raw/d4cbd803b2f870ace20b111ac093798097654d42/empty-100x30.svg) |
| band **before** | ![before](https://gist.githubusercontent.com/damianvtran/a90022d048658067313e1d1e001cb4bd/raw/834027ed790896cfdeef8594905faa5b2c564c99/band-before-100x30.svg) |
| band **after** | ![after](https://gist.githubusercontent.com/damianvtran/a90022d048658067313e1d1e001cb4bd/raw/f28c1c2dd3f5176717089a83254d7a8753026d70/band-after-100x30.svg) |
| wide terminal (150x40) | ![wide](https://gist.githubusercontent.com/damianvtran/a90022d048658067313e1d1e001cb4bd/raw/22b0b2f04dd87016a2cef850f0332636d2cdd744/open-150x40.svg) |

**Two defects were found by looking at the frames and fixed**, neither visible in any test:

- a long **path** query truncated from the *right*, rendering as `…/ho…` — hiding the exact characters the user was typing and the completion was matching on. Paths now truncate from the **left** (filters still truncate right; the meaning of a word is at its front, of a path at its end).
- the **empty** state offered `↑↓ move · tab complete · enter move` for a list that was not there. It now shows `backspace to widen · esc cancel`, the correction `session_picker._EMPTY_HINT` already records.
- (also from the frames) `/tmp` was the only row with no note, which read as a *missing value* rather than a row needing no explanation. It says `scratch`.

**Geometry**, at 100x30, 150x40, 80x24 and 60x16 — `virtual_size.height <= size.height` and `show_vertical_scrollbar is False` on every one, asserted in the suite. A tall overlay pushing virtual height past the screen silently costs two cells of width and reflows the transcript behind it; this repo has hit that before.

## Testing evidence

Beyond the suite, every path was driven against real objects, not mocks.

**The three session outcomes**, against a real `RemoteSession` (`is_cold` reads the real client state):

```
cold outcome: cold          cwd now: /usr
bound outcome: rebound      cwd: /usr   ops: ['retire_now']
deliberate_stop after move: False          <- a move must NOT park the viewer
busy refused: this session is working right now — /move again when the turn finishes
busy cwd unchanged: /tmp
kept refused: could not move: busy         <- runtime kept itself; viewer rolled back
raced cwd rolled back: /tmp
old refused: this session's runtime is too old to be moved; /reload first
```

**The wire op**, against a real `RuntimeServer` over its real dispatch:

```
idle reply: ack 'retiring'   retiring frames: [('attach', 'moved')]   stopped: True
busy reply: 'kept: busy'     stopped: False   (no retiring frame sent)
retire_now ignores build staleness  <- the one term it drops vs refresh_if_idle
```

**Through the real app** (real editor, real submit handler, real band):

```
/move <dir>                 -> band updates, "moved to …"
/move /does/not/exist       -> "no such directory: …", band unchanged
/move /etc/hosts            -> "not a directory: /etc/hosts"
/move ~                     -> expands to $HOME
/move <current>             -> "already in …", no move issued
/move  (bare)               -> MovePickerScreen, 15 rows, current row first
```

**The guard was proved able to fail.** Deleting the `_push_cwd_to_band` call turns `test_moving_a_cold_session_updates_the_band_and_says_so` red with the band still naming the old directory — so the band assertion is a real guard, not a passing formality.

**92 new tests** across suggestion assembly/ordering/dedup, path expansion and the three validation refusals, the recents store (round-trip, cap, corrupt file, unwritable dir, atomicity), the picker (both modes, clamping, empty states, footer shedding, geometry) and the session/runtime semantics.

`tests/unit/session/test_no_session_deletion.py` flagged the atomic recents write, correctly. It is allow-listed with the reason, alongside the identical `SessionDraftStore._write` precedent: one named file joined to the config root, never a directory, never under `sessions/`.

## Round 1 remediation (head `7b44142e5`)

All four review streams reported on `d1eb03484`; every finding is answered in
one commit cycle. Per-finding replies:
[code](https://github.com/damianvtran/local-operator/pull/727#issuecomment-5569844704) ·
[QA](https://github.com/damianvtran/local-operator/pull/727#issuecomment-5570387185) ·
[design](https://github.com/damianvtran/local-operator/pull/727#issuecomment-5569695034) ·
[UX](https://github.com/damianvtran/local-operator/pull/727#issuecomment-5569716268)

**The blocker, found independently by the reviewer and QA from opposite
directions.** `is_cold` means "no SYNCHRONISED runtime is attached", not "no
runtime exists". The TUI engages eagerly at mount, so `_ensure_bound` had
usually already read `_cwd` and handed it to `engage_runtime` before the user
could type — and the cold branch was a bare field assignment taking no lock. A
`/move` in that window set the field *after* it had been read: the runtime came
up in the old directory while the band and the receipt both said the new one,
permanently and silently, in this feature's primary use case. QA measured a
median 1.26 s window and lost 5/5 first-action moves. The same predicate also
routed a *live* runtime into that branch whenever `_refresh_display_history`
had cleared `_ready_for_events`, which is how two successive moves left viewer
and runtime permanently disagreeing.

Fixed once at the root: `_cwd` is applied first (so every later read, including
the in-flight engage's own retry, sees it), any running engage is joined the
way `run_slash_authoritative` joins one, and the branch is chosen by the
client's **liveness** rather than by sync readiness. Taking the lock alone was
measurably *not* enough — a spawn already in flight has read the old value and
cannot be recalled — which the instrumented ordering showed before the fix
landed.

**Every new guard was watched failing against the unfixed code first**, and the
red output is quoted in the remediation comments. That standard is what my
original 92 green tests failed: they asserted the return value and `_cwd` (both
true throughout the bug) and never asserted what the runtime was *spawned
with*.

Also fixed: the wake index kept naming the old directory (an armed wake fires
unattended, so it self-corrects nowhere); the version-skew sentence was on an
unreachable branch while the reachable one showed `unknown op: 'retire_now'`;
`tab` onto a directory with no subdirectories rendered a real destination as
"no directory matches that path" and `enter` there silently cancelled the move;
the only disclosure of the second input mode was shed first in the state the
picker opens in; and `~x` was treated as a path.

### Re-captured frames

The card's copy changed, so the frames were retaken and **viewed as rendered
images**. Geometry re-checked at every width: `virtual_size == size`,
`scrollbar=False`.

| state | frame |
|---|---|
| open, 100x30 — the mode hint now survives | ![open](https://gist.githubusercontent.com/damianvtran/273195efd832207c4e6fb97c5034a9dc/raw/eedc58e2d7d3e2091c4f529ddf5f7d31bb7b06c1/open-100x30.svg) |
| walked-to leaf directory — was a dead end | ![leaf](https://gist.githubusercontent.com/damianvtran/273195efd832207c4e6fb97c5034a9dc/raw/da8fdc036fcb80e4c8e9865a7a1bfd902eb71c56/leaf-100x30.svg) |
| genuinely absent path — still says no match | ![empty](https://gist.githubusercontent.com/damianvtran/273195efd832207c4e6fb97c5034a9dc/raw/f9adf758e7ce7934282cf8228ddd3e3ce3bcc5c6/empty-100x30.svg) |
| open, 80x24 | ![open80](https://gist.githubusercontent.com/damianvtran/273195efd832207c4e6fb97c5034a9dc/raw/52f30a6574b4508c19fd5131f4a3c1489d29cf73/open-80x24.svg) |

All frames: https://gist.github.com/damianvtran/273195efd832207c4e6fb97c5034a9dc

### Gates on `7b44142e5`

```
flake8            clean
black 26.1.0      1021 files unchanged
isort 5.13.2      clean
pyright           0 errors, 0 warnings
pytest tests/unit 15370 passed, 18 skipped, 0 failed (31:10)
```

`/move` re-driven end to end through the real editor, submit handler and band:
`moved to …`, `no such directory: …`, `not a directory: …`, `already in …`,
`moved to ~`.

**Deferred, in-thread rather than as issues:** MINOR-2 (the warm-window refusal
is a change to `may_refresh`'s shared contract) and Q3 (`~` vs `~/.` lives in
the untouched band renderer; the overclaiming docstring is corrected instead).

## Round 2 remediation (head `5b1de59e1`)

QA **passed** on `7b44142e5` (50/50 moves honoured across 18 delay points,
verified from outside the app). Code review and design/UX found one defect
each, from opposite directions, with the same root cause. Replies:
[code](https://github.com/damianvtran/local-operator/pull/727#issuecomment-5571577322) ·
[design/UX](https://github.com/damianvtran/local-operator/pull/727#issuecomment-5571574224) ·
[QA](https://github.com/damianvtran/local-operator/pull/727#issuecomment-5572006949)

**The finding: I fixed the `is_cold` predicate in `remote.py` and then
reintroduced it one layer up in `app.py`**, as the gate for the in-flight
notice added in the same commit. The two disagree on exactly one input — a
client connected while `_ready_for_events` is clear — which is the mount
engage in flight, i.e. `/move` at the start of a session, the same case the
round-1 blocker was about. A move that joined that engage, retired the runtime
and printed "runtime restarted there" therefore said nothing for the seconds
it took: measured at 1.94 s of untouched boot splash, three times the 600 ms
that motivated the notice.

Fixed by asking the session whether the move **will wait** instead of what its
predecessor's state reads as. `move_will_wait()` reports the two waiting
shapes — a live client to retire, or an engage to join — and shares one
definition of the second with the join itself, so the promise and the wait
cannot drift apart.

**The old guard was structurally blind to this**: it set `is_cold = False`
itself and asserted the line appeared, so it pinned the branch that already
worked while the double returned `rebound` regardless. Replaced with the
invariant — *a move that returns `rebound` narrated before it waited* —
parametrised over both readings of `is_cold`, plus its converse so "always
narrate" does not pass. Red on the restored gate at `[True]` only.

Also: `pgup/pgdn` now sheds before `tab complete`, restoring the navigator's
own gesture to the opening frame at every width the picker opens at (fixing
D2 had traded it away); the dead `typed` flag on `_apply_move` is gone along
with the redundant scrolling drop-order and its `scrolls` parameter; the
resolved self-row reads `current` when it is the current directory; and
`set_working_directory` documents that it trusts its caller to validate.

### Re-captured frames

| state | frame |
|---|---|
| in-flight, 100x30 — the line now paints during the join | ![inflight](https://gist.githubusercontent.com/damianvtran/df6c88999b539509cbee48dd5539fcab/raw/11bfbab680f0a4e2d37d063325601a178abcc2ef/in-flight-100x30.svg) |
| open, 100x30 — `type` AND `tab` both survive | ![open100](https://gist.githubusercontent.com/damianvtran/df6c88999b539509cbee48dd5539fcab/raw/3a842fdc13923f3dca5f8ecad02f1264a187fe5a/open-100x30.svg) |
| open, 80x24 — byte-identical to round 1 | ![open80](https://gist.githubusercontent.com/damianvtran/df6c88999b539509cbee48dd5539fcab/raw/52f30a6574b4508c19fd5131f4a3c1489d29cf73/open-80x24.svg) |

Geometry re-checked: `virtual_size == size`, `scrollbar=False` at all three.
All frames: https://gist.github.com/damianvtran/df6c88999b539509cbee48dd5539fcab

### Gates on `5b1de59e1`

```
flake8            clean
black 26.1.0      1021 files unchanged
isort 5.13.2      clean
pyright           0 errors, 0 warnings
pytest tests/unit 15373 passed, 18 skipped, 0 failed (26:25)
```

**Pre-existing, recorded not fixed** (each re-probed at the round-1 head and
confirmed to predate this PR): the `_recovering` move reporting success where
`run_slash_authoritative` refuses; `CancelledError` escaping the `_cwd`
rollback; QA's Q5 (concurrent double-move, not reachable through the composer)
and Q6 (session-layer API trusts its caller — documented).

## Rebase onto the moved base (twice)

Cut from `8738b9495`. `main` moved twice mid-review — first to `3081d0986` (#711, #718), then to `d017115dd` (v0.51.1: #720, and the bump). Rebased onto the latest each time, and content proved unchanged against BOTH the original and the intermediate state:

```
$ git range-diff 8738b9495..04ef70689 origin/main..5b69623a0
1:  04ef70689 = 1:  5b69623a0 feat(tui): /move changes a session's working directory

$ git range-diff 3081d0986..45bf2563e origin/main..5b69623a0
1:  45bf2563e = 1:  5b69623a0 feat(tui): /move changes a session's working directory
```

`=` on both — **no hand-resolved conflicts**, no hunk changed by either rebase.

`pyproject.toml` is untouched at `0.51.1` (`git diff origin/main...HEAD -- pyproject.toml` is empty), and `version-bump-guard` passes.

Semantic check on the files `main` also touched, since a clean merge is not the same as a compatible one:

- **`remote.py` / #711** (a transient drop no longer paints a false `interrupted`). Its new `_suspect_generation` machinery governs a socket dropping *mid-turn*. `/move` retires only an **idle** runtime — `owner_idle()` is false while streaming, with a parked gate, or with a running job — so the "turn looked live" branch cannot fire from this path. Compatible by construction rather than by luck: the refresh path deliberately *leaves* `_suspect_generation` set for the successor's snapshot to settle, which is exactly the route a move takes.
- **`owned.py` / #720** (sidebar activity vs. the reaper's residency predicate). This is the one worth stating precisely, because it re-pointed a predicate near my idle gate. It **adds** a narrower `is_conversationally_active` for *display* and leaves `is_busy()` — which `may_refresh()` uses, and which is what actually gates `retire_now` — unchanged. My viewer-side gate reads the canonical snapshot (`owner_idle`), not either of them. So the runtime still refuses a move for a backgrounded job or a live subagent, which is the conservative answer a move wants. #720 touches **zero** `cwd` lines.
- **`app.py` / #718** (`/stop` no longer refuses on a looping session, no longer resolves by substring). No overlap: `/move` is frontend-local and never routes through the stop ladder. `tests/unit/tui/test_stop_command.py` passes on this head.
- **`frontend_state.py`** — my change adds one name to `_FRONTEND_LOCAL_SLASHES`, which can only make `_needs_runtime_first` answer *False* more often; `team`/`agent` are not in that set at all.

Every frame above and every execution trace below was **re-captured on this head**, not carried over from the pre-rebase run — #720 changes what the sidebar and band render, so a stale "after" frame would be evidence for a screen that no longer exists.

## CI: one real fix, one pre-existing failure

CI red on this branch resolved into two different things, and the first one **was** caused by this PR — indirectly, and worth stating plainly.

### Fixed here: `test_subagent_accounting.py::test_rendered_footer_uses_whole_owner_ledger`

CI shards by **file index modulo 5** (`ci.yml`, "Partition test suite"). Adding two test files shifted this test from **shard 1 to shard 3**, onto a busier runner:

```
on MAIN:      accounting is file index 236 -> shard 1
on THIS HEAD: accounting is file index 238 -> shard 3
```

It then failed twice in three runs with `assert 0.0 == 0.131`. The cause is not the cost: the test drove a real `OperatorApp` and asserted **one `pilot.pause()`** after `run_test`, but `_apply_frontend_state` **returns early while `_status` is None**, so under load the state was silently dropped and the total stayed `0.0`. Reproduced deterministically by clearing `_status` before the apply:

```
band NOT mounted -> spend_total=0.0    (reproduces CI: assert 0.0 == 0.131)
band mounted     -> spend_total=0.131
```

Idle it is green — the band is up after exactly 1 turn, 3/3 trials — which is why it sat unnoticed. Fixed in `d1eb03484` by waiting on the **event** (the band existing), bounded by loop **turns** not seconds per AGENTS.md, plus an assertion that the band mounted so a future starve fails by naming the race instead of the cost. **Shard 3 passes on CI with that commit**, and CI's exact shard-3 file set passes locally (3341 tests).

This is the whole of the fix: one test file, no product change. I did not touch the neighbouring tests.

### Not mine: `test_session_panel.py::test_disk_worker_is_off_loop_and_drops_stale_session`

Fails **3/3 locally, serially**, and — the decisive check — fails identically on **clean `origin/main`** with this branch absent:

```
$ git worktree add --detach /tmp/base origin/main     # d017115dd, my base
$ pytest tests/unit/tui/test_session_panel.py::test_disk_worker_is_off_loop_and_drops_stale_session -n0
FAILED …[new] - assert False
```

Its shard membership is **unchanged** by this PR (shard 0 on both main and here), so it is inherited, not surfaced. Left alone deliberately rather than expanded into: it is a real bug in someone else's area, and fixing it here would be an unrequested change riding a feature PR. **Recorded, not addressed.**

### The rest were genuine flakes

`test_task_wait_jobs.py::test_wait_and_jobs_coercion_and_label_resolution` and `test_stop_command.py::test_tui_handle_stop_op_acks_and_ends_the_session` each failed once and passed on re-run of the same commit; both pass locally (the latter 5/5, whole file 35/35). The `stop` one is answerable structurally as well as statistically: `retire_now` is a branch in `RuntimeServer._on_request` (~line 1603) while the `stop` op is handled in `RuntimeServer._dispatch` (~line 2016) — **different methods, no shared state** — and my diff adds no line to the `stop` path.

Locally on this head: `tests/unit` 15356 passed, `tests/unit/tui` 5764/5764 under xdist load, CI's shard 3 3341/3341.

## Gates (on the rebased head `45bf2563e`)

```
flake8 .                                  clean
black --check .    (26.1.0)               1019 files unchanged
isort --check .    (5.13.2)               clean
pyright                                   0 errors, 0 warnings
```

Full unit suite result appended below. `pyproject.toml` is untouched at `0.51.0` — no bump rides this PR.

Three registry pins needed `/move` added, each stating its reason next to the entry: `ECHO_POLICY`/`PROMPT_POLICY` (`test_slash_echo`), the `ArgumentMode` table (`test_approvals_ux`), and the `/mo` prefix ordering (`test_command_picker` — `move` leads on registry order, all three being flat 900 prefix matches).

Release: patch — `/move` changes a session's working directory without losing the conversation, with a directory picker and path completion.

```
$ .venv/bin/python -m pytest tests/unit -q          # on 5b69623a0
15356 passed, 1 failed, 18 skipped in 2556.99s
```

The one failure was `test_app_pilot.py::test_logout_offers_one_row_per_credential_not_per_provider`, and it is a **load flake, not this PR**. Established rather than assumed:

- it passes **6/6** in isolation on this head;
- the whole `tests/unit/tui` suite (5764 tests) passes on this head **under the same xdist load** with zero failures;
- clean `origin/main` runs the same 5685-test TUI suite green, so there is no pre-existing red to inherit — and
- **my diff cannot reach it.** The only argument-list code I add is gated `if message.command == "move":` and returns before the provider branch; `git diff origin/main...HEAD -- local_operator/tui/app.py | grep -c "logout\|login\|_provider_choices"` is `0`.

The test drives the list with a single `await pilot.pause()` after setting the editor line, and the rows are filled one message-loop tick later by `on_argument_query_opened` — so under contention the assertion can read the list before the refill lands. That is the same one-tick shape `set_choices`' own docstring describes.

```
$ .venv/bin/python -m pytest tests/unit/tui -q      # same head, same load
5764 passed, 12 skipped in 1390.43s
```


