### PR TITLE
fix(osworld): derive the guest's command deadline from our socket deadline

### DIFF
--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/aws.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/aws.py
@@ -50,6 +50,7 @@ import asyncio
 import json
 import logging
 import os
+import signal
 import time
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -67,7 +68,7 @@ from lop_osworld_v2_adapter.cleanup import (
     EVIDENCE_TERMINATE_DENIED,
     EVIDENCE_TERMINATE_UNCONFIRMED,
 )
-from lop_osworld_v2_adapter.providers.base import GUEST_COMMAND_TIMEOUT_S
+from lop_osworld_v2_adapter.providers.base import GUEST_COMMAND_TIMEOUT_S, guest_deadline_for
 from lop_osworld_v2_adapter.provisioning import ProvisioningPlan
 from lop_osworld_v2_adapter.taskfile import TaskDescriptor
 
@@ -116,6 +117,37 @@ class AllocationError(RuntimeError):
 
 class GuestExecutionError(RuntimeError):
     """Input may have partially committed; never replay the failed batch."""
+
+
+def _exit_description(returncode: int) -> str:
+    """Describe a guest exit status: an ordinary code, or death by signal.
+
+    ``subprocess`` reports a signal-killed child as a NEGATIVE returncode, so
+    ``exit -15`` in a diagnostic is really "SIGTERM killed it" wearing a
+    misleading costume. A reader who does not know that convention reads -15 as
+    an exit code and looks for a program that returned one; naming the signal
+    removes a research step that has already cost a full investigation.
+
+    Deliberately says WHAT happened and not WHY. A signal death has many
+    possible originators — the OS, a supervisor, another process, or the
+    command's own actions — and this layer cannot distinguish them. Naming a
+    specific cause here would encode a guess into every future incident report,
+    which is the failure mode that made the last one expensive.
+
+    Leaks nothing: the output is a signal NAME from the stdlib's fixed
+    enumeration or a bare integer, never command text, guest stdout, or stderr.
+    That is the same discipline ``execute`` applies to transport errors.
+    """
+
+    if returncode >= 0:
+        return f"exit {returncode}"
+    try:
+        name = signal.Signals(-returncode).name
+    except ValueError:
+        # An unrecognised signal number is still worth reporting as a signal
+        # rather than as a negative exit code.
+        return f"terminated by signal {-returncode}"
+    return f"terminated by signal {name}"
 
 
 class ReadinessTimeout(AllocationError):
@@ -425,8 +457,22 @@ class AwsProvider:
         """
 
         url = f"http://{self._public_ip}:{GUEST_PORT}{_EXECUTE_PATH}"
+        # ``timeout`` is sent in the BODY as well as applied to the socket, and
+        # the two are deliberately NOT the same number. The body value is the
+        # guest's own ``subprocess.run`` deadline; omitting it let the guest
+        # default to 120 s, outside our socket deadline, so a slow command
+        # expired on our side while still running on the guest's — an unknown
+        # outcome the no-retry policy can only turn into a dead episode.
+        # ``guest_deadline_for`` keeps the guest strictly first for whatever
+        # socket deadline this caller actually passed.
         body = self._clients.http_post_json(
-            url, {"command": list(command), "shell": False}, timeout
+            url,
+            {
+                "command": list(command),
+                "shell": False,
+                "timeout": guest_deadline_for(timeout),
+            },
+            timeout,
         )
         returncode = body.get("returncode")
         return guest_disk.CommandResult(
@@ -789,7 +835,7 @@ class AwsProvider:
                     ) from None
                 if result.returncode != 0:
                     raise GuestExecutionError(
-                        f"guest action {index + 1} failed (exit {result.returncode}); "
+                        f"guest action {index + 1} failed ({_exit_description(result.returncode)}); "
                         "input may be partial; batch not retried"
                     )
             # Let the desktop settle after the batch, exactly as OSWorld's

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/aws.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/aws.py
@@ -68,7 +68,10 @@ from lop_osworld_v2_adapter.cleanup import (
     EVIDENCE_TERMINATE_DENIED,
     EVIDENCE_TERMINATE_UNCONFIRMED,
 )
-from lop_osworld_v2_adapter.providers.base import GUEST_COMMAND_TIMEOUT_S, guest_deadline_for
+from lop_osworld_v2_adapter.providers.base import (
+    GUEST_COMMAND_TIMEOUT_S,
+    guest_deadline_for,
+)
 from lop_osworld_v2_adapter.provisioning import ProvisioningPlan
 from lop_osworld_v2_adapter.taskfile import TaskDescriptor
 
@@ -835,7 +838,8 @@ class AwsProvider:
                     ) from None
                 if result.returncode != 0:
                     raise GuestExecutionError(
-                        f"guest action {index + 1} failed ({_exit_description(result.returncode)}); "
+                        f"guest action {index + 1} failed "
+                        f"({_exit_description(result.returncode)}); "
                         "input may be partial; batch not retried"
                     )
             # Let the desktop settle after the batch, exactly as OSWorld's

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/base.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/base.py
@@ -28,6 +28,85 @@ from lop_osworld_v2_adapter.taskfile import TaskDescriptor
 # drifting apart is precisely the defect that cost two episodes.
 GUEST_COMMAND_TIMEOUT_S = 90.0
 
+# Transport margin between OUR socket deadline and the GUEST's own subprocess
+# deadline, and the reason the two must be ordered rather than merely close.
+#
+# The guest's ``/execute`` route reads ``timeout`` from the request body and
+# defaults it to 120 (osworld-server @ a3cc3f0, ``execute_command``). Sending no
+# ``timeout`` therefore put the guest's deadline (120 s) OUTSIDE our socket read
+# deadline (90 s) — two deadlines governing one command with nothing relating
+# them. In that ordering a slow command always resolves the WRONG way: our
+# socket expires first, ``requests`` raises a ReadTimeout, and the command is
+# STILL RUNNING in the guest. That branch is unrecoverable by construction — a
+# transport error cannot distinguish "never started" from "half-applied", so
+# ``execute`` can only report an unknown outcome, and the no-retry policy that
+# correctly refuses to replay a possibly-committed batch then ends the episode.
+# Those ReadTimeouts are an observed episode-killer, not a hypothesis.
+#
+# Putting the guest's deadline strictly INSIDE ours inverts the race so it
+# resolves the RIGHT way: the guest reaches its own deadline first and ANSWERS.
+# ``execute_command`` catches the resulting ``TimeoutExpired`` and returns an
+# HTTP 500 error body, so a command that outlives its budget becomes a definite,
+# attributable failure rather than an ambiguous silence. Converting an unknown
+# outcome into a known one is the entire point: the episode still fails, but it
+# fails legibly and without the no-retry policy having to assume the worst.
+#
+# The margin pays for the round trip that answer still has to make — request
+# transmission, the guest's Flask dispatch, and the error response coming back —
+# so it is sized for TRANSPORT, not for command work. 10 s against the same
+# regression that measured 3.6 s of fixed per-command overhead (see
+# ``GUEST_TYPE_DEADLINE_FRACTION``) is ~2.8x that figure, deliberately generous
+# because the AMI is burstable and the margin only has to be big enough to carry
+# a small error response home. Too small and a loaded guest's answer misses our
+# socket anyway, losing the very determinism this ordering buys.
+GUEST_TRANSPORT_MARGIN_S = 10.0
+
+# Floor below which subtracting the full margin stops making sense, and the
+# share of an already-tight socket deadline the guest gets instead. Both exist
+# only for the squeezed tail: they keep the derived deadline positive AND
+# strictly inside the socket deadline when the caller's remaining budget is
+# smaller than the margin itself. The fraction is well under 1 so the ordering
+# survives; its exact value matters little because a command with under a second
+# of budget is failing regardless.
+_MIN_GUEST_DEADLINE_S = 1.0
+_SQUEEZED_DEADLINE_FRACTION = 0.5
+
+
+def guest_deadline_for(socket_timeout_s: float) -> float:
+    """The guest's subprocess deadline for a command we wait ``socket_timeout_s`` on.
+
+    The relationship, not a constant, because callers do not all wait the same
+    time: ``guest_disk`` shrinks its socket deadline as its own budget drains,
+    and the guest's deadline has to stay inside WHICHEVER deadline actually
+    applies. Expressing it as a function is what stops a second literal being
+    written next to the first.
+
+    The result is ALWAYS strictly less than ``socket_timeout_s``, which is the
+    invariant the whole fix rests on — a guest deadline at or beyond ours
+    restores the ambiguous ordering this function exists to prevent.
+
+    Subtracting the margin is the normal case. A caller whose socket deadline is
+    already at or under the margin (``guest_disk`` shrinks its own toward zero as
+    its budget drains) would derive a non-positive deadline, which the guest
+    reads as "kill this immediately". Such a call is close to doomed either way,
+    but it must not be converted into a guaranteed instant kill, so it falls back
+    to a fraction of the socket deadline: still strictly inside, still positive,
+    and it degrades smoothly instead of stepping off a cliff.
+    """
+
+    inner = socket_timeout_s - GUEST_TRANSPORT_MARGIN_S
+    if inner < _MIN_GUEST_DEADLINE_S:
+        return min(_MIN_GUEST_DEADLINE_S, socket_timeout_s * _SQUEEZED_DEADLINE_FRACTION)
+    return inner
+
+
+# The deadline sent with a command run at the DEFAULT socket timeout, named so
+# the canonical pair is greppable and the ordering invariant is assertable.
+# DERIVED, never written as a literal: the invariant this file exists to hold is
+# ``GUEST_EXECUTE_TIMEOUT_S < GUEST_COMMAND_TIMEOUT_S``, and a hand-written
+# second number is exactly how that invariant was lost the first time.
+GUEST_EXECUTE_TIMEOUT_S = guest_deadline_for(GUEST_COMMAND_TIMEOUT_S)
+
 # Budgeted cost of delivering ONE character through the guest's X11 synthetic
 # key path, with pyautogui's default (zero) inter-key interval.
 #

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/base.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/base.py
@@ -46,10 +46,20 @@ GUEST_COMMAND_TIMEOUT_S = 90.0
 # Putting the guest's deadline strictly INSIDE ours inverts the race so it
 # resolves the RIGHT way: the guest reaches its own deadline first and ANSWERS.
 # ``execute_command`` catches the resulting ``TimeoutExpired`` and returns an
-# HTTP 500 error body, so a command that outlives its budget becomes a definite,
-# attributable failure rather than an ambiguous silence. Converting an unknown
-# outcome into a known one is the entire point: the episode still fails, but it
-# fails legibly and without the no-retry policy having to assume the worst.
+# HTTP 500 error body.
+#
+# Be precise about what that buys, because it is less than it first appears.
+# ``http_post_json`` calls ``raise_for_status()``, so that 500 raises
+# ``HTTPError``, and ``execute``'s blanket ``except Exception`` still reports
+# "outcome is unknown" — the SAME branch a ``ReadTimeout`` produced, and the
+# no-retry policy still ends the episode. What the ordering actually changes is
+# WHEN and WHY the answer arrives: the guest gives up first and replies, so the
+# failure lands promptly and is attributable to the command outrunning its
+# budget, instead of our socket expiring while the command is still running and
+# leaving a half-applied batch nobody can characterise. Turning that into a
+# genuinely DEFINITE outcome needs the 500's timeout shape distinguished from a
+# transport error before the blanket handler; this module does not do that yet,
+# and claiming otherwise would misdescribe the code.
 #
 # The margin pays for the round trip that answer still has to make — request
 # transmission, the guest's Flask dispatch, and the error response coming back —
@@ -71,6 +81,18 @@ GUEST_TRANSPORT_MARGIN_S = 10.0
 _MIN_GUEST_DEADLINE_S = 1.0
 _SQUEEZED_DEADLINE_FRACTION = 0.5
 
+# The strictly positive floor under EVERY derived guest deadline. A body
+# ``timeout`` of 0 -- or a negative one -- is not "no deadline", it is
+# "kill immediately", which is the exact outcome this whole module exists to
+# prevent. The squeezed branch alone does not rule it out: a caller that has
+# already exhausted its budget can reach here with ``socket_timeout_s`` at or
+# below zero (``guest_disk`` samples its remaining budget at the guard and
+# again at the call, so a value positive at the guard can be ~0 by the call),
+# and a fraction of zero is still zero. Clamping keeps the guest's deadline
+# positive so a doomed-either-way call still gets a real, if tiny, chance to
+# run rather than a guaranteed instant kill.
+_ABSOLUTE_FLOOR_S = 0.05
+
 
 def guest_deadline_for(socket_timeout_s: float) -> float:
     """The guest's subprocess deadline for a command we wait ``socket_timeout_s`` on.
@@ -81,9 +103,17 @@ def guest_deadline_for(socket_timeout_s: float) -> float:
     applies. Expressing it as a function is what stops a second literal being
     written next to the first.
 
-    The result is ALWAYS strictly less than ``socket_timeout_s``, which is the
+    The result is ALWAYS strictly positive, and strictly less than
+    ``socket_timeout_s`` for every socket deadline large enough for the ordering
+    to mean anything (anything above ``_ABSOLUTE_FLOOR_S``). That ordering is the
     invariant the whole fix rests on — a guest deadline at or beyond ours
     restores the ambiguous ordering this function exists to prevent.
+
+    Below that floor the two properties genuinely conflict: a caller whose budget
+    is already spent cannot be given a deadline that is both inside its own and
+    positive. Positivity wins, because a non-positive body ``timeout`` is an
+    instant kill while a deadline marginally outside an already-exhausted socket
+    budget merely returns the pre-existing behaviour.
 
     Subtracting the margin is the normal case. A caller whose socket deadline is
     already at or under the margin (``guest_disk`` shrinks its own toward zero as
@@ -96,7 +126,8 @@ def guest_deadline_for(socket_timeout_s: float) -> float:
 
     inner = socket_timeout_s - GUEST_TRANSPORT_MARGIN_S
     if inner < _MIN_GUEST_DEADLINE_S:
-        return min(_MIN_GUEST_DEADLINE_S, socket_timeout_s * _SQUEEZED_DEADLINE_FRACTION)
+        squeezed = min(_MIN_GUEST_DEADLINE_S, socket_timeout_s * _SQUEEZED_DEADLINE_FRACTION)
+        return max(squeezed, _ABSOLUTE_FLOOR_S)
     return inner
 
 

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/base.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/providers/base.py
@@ -84,13 +84,13 @@ _SQUEEZED_DEADLINE_FRACTION = 0.5
 # The strictly positive floor under EVERY derived guest deadline. A body
 # ``timeout`` of 0 -- or a negative one -- is not "no deadline", it is
 # "kill immediately", which is the exact outcome this whole module exists to
-# prevent. The squeezed branch alone does not rule it out: a caller that has
-# already exhausted its budget can reach here with ``socket_timeout_s`` at or
-# below zero (``guest_disk`` samples its remaining budget at the guard and
-# again at the call, so a value positive at the guard can be ~0 by the call),
-# and a fraction of zero is still zero. Clamping keeps the guest's deadline
-# positive so a doomed-either-way call still gets a real, if tiny, chance to
-# run rather than a guaranteed instant kill.
+# prevent. The squeezed branch alone does not rule it out, because a fraction
+# of a vanishingly small number is still vanishingly small: ``guest_disk``
+# guards on ``remaining > 0`` and passes ``min(COMMAND_TIMEOUT_S, remaining)``,
+# so a budget with nanoseconds left passes that guard and arrives here as a
+# positive value that rounds to nothing useful. Clamping keeps the guest's
+# deadline meaningfully positive, so a doomed-either-way call still gets a
+# real, if tiny, chance to run rather than a guaranteed instant kill.
 _ABSOLUTE_FLOOR_S = 0.05
 
 
@@ -110,10 +110,10 @@ def guest_deadline_for(socket_timeout_s: float) -> float:
     restores the ambiguous ordering this function exists to prevent.
 
     Below that floor the two properties genuinely conflict: a caller whose budget
-    is already spent cannot be given a deadline that is both inside its own and
-    positive. Positivity wins, because a non-positive body ``timeout`` is an
-    instant kill while a deadline marginally outside an already-exhausted socket
-    budget merely returns the pre-existing behaviour.
+    is all but spent cannot be given a deadline that is both inside its own and
+    usefully positive. Positivity wins, because a non-positive body ``timeout``
+    is an instant kill while a deadline marginally outside an already-exhausted
+    socket budget merely returns the pre-existing behaviour.
 
     Subtracting the margin is the normal case. A caller whose socket deadline is
     already at or under the margin (``guest_disk`` shrinks its own toward zero as

--- a/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
+++ b/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
@@ -37,6 +37,10 @@ from lop_osworld_v2_adapter.providers.aws import (
     _Clients,
     ttl_seconds_for,
 )
+from lop_osworld_v2_adapter.providers.base import (
+    GUEST_COMMAND_TIMEOUT_S,
+    guest_deadline_for,
+)
 
 from local_operator import computer_input
 from local_operator.evaluation.adapters.api import ScopedInfraValue
@@ -1351,11 +1355,25 @@ async def test_execute_settles_after_the_batch_and_respond_without_simulator_is_
         await provider.execute([])
         # The statement crosses as base64 (see ``python_source_argv``), so assert
         # the endpoint contract and decode the payload rather than pinning a
-        # literal argv -- the literal shape is the argv exposure this encoding
+        # literal argv -- the literal shape is the argv exposure that encoding
         # exists to remove.
+        #
+        # The body also carries the guest's OWN subprocess deadline alongside
+        # the command. It is derived from -- and strictly inside -- the socket
+        # deadline, so a slow command expires on the guest and comes back as a
+        # definite answer instead of expiring on our socket with the command
+        # still running. ``test_guest_deadline.py`` pins the derivation.
+        #
+        # Both properties are asserted here because they are independent and
+        # were introduced by separate changes: encoding removes the argv
+        # exposure, the deadline makes a slow command answerable. Asserting the
+        # dict wholesale would re-pin the literal argv this encoding removes,
+        # so the command is decoded and the remaining keys are pinned exactly.
         assert len(stubs.guest_posts) == 1
         post = stubs.guest_posts[0]
         assert post["shell"] is False
+        assert post["timeout"] == guest_deadline_for(GUEST_COMMAND_TIMEOUT_S)
+        assert set(post) == {"command", "shell", "timeout"}
         command = post["command"]
         assert command[:3] == ["python", "-c", computer_input._SOURCE_BOOTSTRAP]
         assert base64.b64decode("".join(command[3:])).decode("utf-8") == (

--- a/tests/unit/evaluation/adapters/osworld/test_guest_deadline.py
+++ b/tests/unit/evaluation/adapters/osworld/test_guest_deadline.py
@@ -1,0 +1,450 @@
+"""The guest's command deadline and our socket deadline are one relationship.
+
+Three deadlines govern one guest action: our HTTP socket read timeout
+(``GUEST_COMMAND_TIMEOUT_S``), the guest's own ``subprocess.run`` deadline
+inside its ``/execute`` route, and the parent step timeout. Nothing related the
+first two. The adapter posted ``{"command", "shell"}`` and never sent
+``timeout``, so the guest fell back to its route default of 120 s while our
+socket waited 90 s.
+
+That ordering resolves the WRONG way. With the guest's deadline outside ours, a
+command slower than our socket expires on OUR side while it is still running in
+the guest: ``requests`` raises, and a transport error cannot tell "never
+started" from "half-applied". ``execute`` can then only report an unknown
+outcome, and the no-retry policy — correct to refuse replaying a
+possibly-committed batch — ends the episode.
+
+The fix makes the guest's deadline a DERIVED function of ours, strictly inside
+it, so the guest reaches its deadline first and ANSWERS with a real response
+instead of leaving us to time out a still-running command. The tests below pin
+that ordering, pin the constants so neither can drift alone (the anti-drift
+property ``test_type_deadline.py`` establishes for the type bound), and prove
+the wire body actually carries the derived value — an invariant that holds in
+the module but never reaches the guest would fix nothing.
+
+The diagnostic tests cover a separate, deliberately NARROW improvement: a
+signal-killed guest command reports as a negative returncode, so ``exit -15``
+is really "SIGTERM killed it" in a misleading costume. The message now names
+the signal. It deliberately does NOT assert a CAUSE — many things kill a
+process, this layer cannot distinguish them, and guessing would encode a
+theory into every future incident report.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from threading import Thread
+from typing import Any
+
+import pytest
+from lop_osworld_v2_adapter.providers import aws as aws_mod
+from lop_osworld_v2_adapter.providers.aws import (
+    AwsProvider,
+    GuestExecutionError,
+    _exit_description,
+)
+from lop_osworld_v2_adapter.providers.base import (
+    GUEST_COMMAND_TIMEOUT_S,
+    GUEST_EXECUTE_TIMEOUT_S,
+    GUEST_TRANSPORT_MARGIN_S,
+    guest_deadline_for,
+)
+
+from tests.unit.evaluation.adapters.osworld.test_aws_provider import (
+    CREDS,
+    REGION,
+    _FakeEnv,
+    _Stubs,
+)
+
+# An autouse fixture is not inherited across modules, so the AWS scrub is
+# imported by name and re-registered here. Reused rather than re-written: a
+# second way of making these tests hermetic is how one of them later drifts.
+from tests.unit.evaluation.adapters.osworld.test_aws_provider import (  # noqa: F401  isort:skip
+    _hermetic_aws,
+)
+
+# Socket deadlines a caller can realistically pass. The default is the common
+# case; ``guest_disk`` shrinks its own toward zero as its budget drains, which
+# is why the squeezed tail is covered rather than assumed away.
+SOCKET_DEADLINES = (90.0, 60.0, 30.0, 12.0, 10.0, 9.0, 5.0, 1.0, 0.5, 0.01)
+
+
+# ----------------------------------------------------------------------------
+# The arithmetic: the two deadlines cannot drift apart
+# ----------------------------------------------------------------------------
+
+
+def test_the_guest_deadline_is_strictly_inside_the_socket_deadline() -> None:
+    """The ordering invariant the whole fix rests on.
+
+    Not "close to" and not "at most": STRICTLY less. A guest deadline equal to
+    ours is still a race we can lose, and losing it returns the ambiguous
+    unknown-outcome state that kills episodes.
+    """
+
+    assert GUEST_EXECUTE_TIMEOUT_S < GUEST_COMMAND_TIMEOUT_S
+
+
+def test_the_guest_deadline_is_derived_from_the_socket_deadline_and_the_margin() -> None:
+    """Recompute the derivation independently of the module that publishes it.
+
+    This is the test that prevents recurrence: it checks the two numbers are
+    still expressions of one another, which is the property whose absence let a
+    120 s guest default sit outside our 90 s socket.
+    """
+
+    assert GUEST_EXECUTE_TIMEOUT_S == GUEST_COMMAND_TIMEOUT_S - GUEST_TRANSPORT_MARGIN_S
+    assert GUEST_EXECUTE_TIMEOUT_S == guest_deadline_for(GUEST_COMMAND_TIMEOUT_S)
+
+
+@pytest.mark.parametrize("socket_timeout", SOCKET_DEADLINES)
+def test_every_caller_socket_deadline_yields_a_positive_inner_deadline(
+    socket_timeout: float,
+) -> None:
+    """The invariant must hold for EVERY caller, not just the default.
+
+    ``guest_disk`` passes ``min(COMMAND_TIMEOUT_S, remaining)``, so the socket
+    deadline shrinks toward zero over a preparation pass. Two failure modes are
+    excluded here: a non-positive deadline (which the guest reads as "kill this
+    immediately") and a deadline at or beyond the socket deadline (which
+    restores the ambiguous ordering).
+    """
+
+    derived = guest_deadline_for(socket_timeout)
+    assert derived > 0.0
+    assert derived < socket_timeout
+
+
+def test_the_deadline_constants_are_pinned_so_either_moving_is_deliberate() -> None:
+    """Pin both values, so changing EITHER lands here first.
+
+    The derivation above is invariant under a coordinated change, so it alone
+    would let someone halve the socket timeout and never notice the guest
+    deadline halving with it. Changing a value here is legitimate — update it,
+    and say in the commit which deadline moved and why the ordering still holds.
+    """
+
+    assert GUEST_COMMAND_TIMEOUT_S == 90.0
+    assert GUEST_TRANSPORT_MARGIN_S == 10.0
+    assert GUEST_EXECUTE_TIMEOUT_S == 80.0
+
+
+def test_the_margin_leaves_room_for_the_measured_per_command_overhead() -> None:
+    """The margin pays for transport, so it must exceed transport's real cost.
+
+    3.6 s of fixed per-command overhead was measured over 21 real batches (see
+    ``GUEST_TYPE_DEADLINE_FRACTION``). A margin below that would let the guest's
+    error response miss our socket, losing the determinism the ordering buys.
+    """
+
+    measured_overhead_s = 3.6
+    assert GUEST_TRANSPORT_MARGIN_S > measured_overhead_s
+
+
+# ----------------------------------------------------------------------------
+# The wire: the derived deadline actually reaches the guest
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_execute_body_carries_the_derived_timeout() -> None:
+    """An invariant that never reaches the guest fixes nothing.
+
+    The defect was not a wrong number, it was an ABSENT field: with no
+    ``timeout`` in the body the guest applies its own 120 s default no matter
+    what our constants say. This asserts the field is present and equal to the
+    derivation, so deleting it fails here rather than in a live run.
+    """
+
+    with _Stubs() as stubs:
+        provider = AwsProvider(
+            CREDS, region=REGION, lease_ref="lop-ttl-x", clients=stubs.clients, sleep=stubs.sleep
+        )
+        env = _FakeEnv()
+        env.pkgs_prefix = "{command}"
+        provider._env = env
+        provider._public_ip = "127.0.0.1"
+        await provider.execute(["pyautogui.click(1, 2)"])
+
+    assert len(stubs.guest_posts) == 1
+    posted = stubs.guest_posts[0]
+    assert posted["timeout"] == GUEST_EXECUTE_TIMEOUT_S
+    assert posted["timeout"] < GUEST_COMMAND_TIMEOUT_S
+    # The rest of the body shape is unchanged: ``shell`` false keeps the guest
+    # exec'ing argv directly rather than through a shell.
+    assert posted["shell"] is False
+
+
+def test_guest_disk_commands_also_carry_a_coherent_deadline() -> None:
+    """The disk-preparation path shares the transport and must share the rule.
+
+    It passes its own shrinking socket deadline, so this is where a fix applied
+    only to the canonical constant would silently not apply.
+    """
+
+    with _Stubs() as stubs:
+        provider = AwsProvider(
+            CREDS, region=REGION, lease_ref="lop-ttl-x", clients=stubs.clients, sleep=stubs.sleep
+        )
+        provider._public_ip = "127.0.0.1"
+        provider._run_guest_command(["bash", "-c", "df -B1 /"], 45.0)
+
+    posted = stubs.guest_posts[-1]
+    assert posted["timeout"] == guest_deadline_for(45.0)
+    assert posted["timeout"] < 45.0
+
+
+# ----------------------------------------------------------------------------
+# The diagnostic: a signal death is legible, and leaks nothing
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("returncode", "expected"),
+    [
+        (1, "exit 1"),
+        (7, "exit 7"),
+        (127, "exit 127"),
+        (-15, "terminated by signal SIGTERM"),
+        (-9, "terminated by signal SIGKILL"),
+        (-2, "terminated by signal SIGINT"),
+    ],
+)
+def test_a_signal_death_is_named_and_an_ordinary_exit_is_unchanged(
+    returncode: int, expected: str
+) -> None:
+    """``exit -15`` is a signal wearing a misleading costume.
+
+    A reader who does not know ``subprocess``'s negative-returncode convention
+    reads -15 as an exit code and hunts for a program that returned one. Naming
+    the signal removes that research step. Ordinary non-zero exits keep their
+    existing wording so nothing that reads them has to change.
+    """
+
+    assert _exit_description(returncode) == expected
+
+
+def test_an_unrecognised_signal_number_still_reads_as_a_signal() -> None:
+    """Signal numbers are platform-specific; an unknown one is still not an exit code.
+
+    Falling back to ``exit -64`` here would reintroduce exactly the confusion
+    this function exists to remove.
+    """
+
+    assert _exit_description(-64) == "terminated by signal 64"
+
+
+def test_the_diagnostic_does_not_assert_why_the_process_died() -> None:
+    """State WHAT happened, never WHY — this layer cannot know.
+
+    A SIGTERM can come from the OS, a supervisor, another process, or the
+    command's own actions. An earlier investigation was sent down the wrong path
+    by a confidently misattributed cause, so the message must not name one.
+    ``timeout`` in particular is a cause this layer cannot substantiate: the
+    guest's own timeout does not even surface here (its route returns HTTP 500,
+    which fails the transport branch instead).
+    """
+
+    described = " ".join(_exit_description(rc) for rc in (-15, -9, -2, -64, 1, 7))
+    for causal_claim in ("timeout", "timed out", "deadline", "killed by", "because", "guest-side"):
+        assert causal_claim not in described.lower()
+
+
+@pytest.mark.asyncio
+async def test_a_signal_killed_action_reports_the_signal_without_leaking_the_command() -> None:
+    """The end-to-end path: signal name in, command text out.
+
+    The existing code is deliberately careful that neither transport exceptions
+    nor guest stderr reach the message, because both can echo the command,
+    credentials or on-screen text. Improving the diagnostic must not widen that
+    surface, so this asserts the new wording AND the old silence together.
+    """
+
+    secret = "s3cret-passphrase-do-not-leak"
+    with _Stubs() as stubs:
+        stubs.guest_default = {
+            "returncode": -15,
+            "output": f"stdout containing {secret}",
+            "error": f"stderr containing {secret}",
+        }
+        provider = AwsProvider(
+            CREDS, region=REGION, lease_ref="lop-ttl-x", clients=stubs.clients, sleep=stubs.sleep
+        )
+        env = _FakeEnv()
+        env.pkgs_prefix = "{command}"
+        provider._env = env
+        provider._public_ip = "127.0.0.1"
+        with pytest.raises(GuestExecutionError) as raised:
+            await provider.execute([f"pyautogui.typewrite({secret!r})"])
+
+    message = str(raised.value)
+    assert "terminated by signal SIGTERM" in message
+    # The unrecoverable-state wording is load-bearing and must survive.
+    assert "input may be partial" in message
+    assert "batch not retried" in message
+    # Nothing from the command, its stdout or its stderr appears.
+    assert secret not in message
+    assert "typewrite" not in message
+    assert "stdout containing" not in message
+    assert "stderr containing" not in message
+
+
+@pytest.mark.asyncio
+async def test_no_error_path_leaks_command_text() -> None:
+    """Both failure branches stay silent about the payload.
+
+    The transport branch (unknown outcome) and the non-zero-exit branch (partial
+    input) are the only two ways ``execute`` raises, and neither may echo what it
+    was asked to run.
+    """
+
+    secret = "another-s3cret-value"
+    statement = f"pyautogui.typewrite({secret!r})"
+
+    for guest_reply in (
+        RuntimeError(f"connection refused while posting {secret}"),
+        {"returncode": 3, "output": secret, "error": secret},
+        {"returncode": -9, "output": secret, "error": secret},
+    ):
+        with _Stubs() as stubs:
+            stubs.guest_default = guest_reply
+            provider = AwsProvider(
+                CREDS,
+                region=REGION,
+                lease_ref="lop-ttl-x",
+                clients=stubs.clients,
+                sleep=stubs.sleep,
+            )
+            env = _FakeEnv()
+            env.pkgs_prefix = "{command}"
+            provider._env = env
+            provider._public_ip = "127.0.0.1"
+            with pytest.raises(GuestExecutionError) as raised:
+                await provider.execute([statement])
+
+        message = str(raised.value)
+        assert secret not in message
+        assert "typewrite" not in message
+
+
+# ----------------------------------------------------------------------------
+# The real control boundary: a guest that honours the deadline we send
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_real_guest_honours_the_posted_deadline_and_answers_in_time(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Exercise the property end-to-end against upstream's own route logic.
+
+    This is the point of the fix, so it is proven over real HTTP rather than
+    asserted from constants. The handler mirrors ``execute_command``
+    (osworld-server @ a3cc3f0): it reads ``timeout`` from the BODY, passes it to
+    ``subprocess.run``, and on ``TimeoutExpired`` returns HTTP 500 exactly as
+    upstream does.
+
+    A command that outruns the guest's deadline must therefore come back as a
+    definite answer WITHIN our socket deadline — the ambiguity the fix removes.
+    The numbers are scaled down so the test costs a second, but the ordering
+    (guest strictly inside socket) is the deployed one.
+    """
+
+    import subprocess
+    import sys
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    bodies_seen: list[dict[str, Any]] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, format: str, *args: Any) -> None:
+            pass
+
+        def do_POST(self) -> None:
+            payload = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            bodies_seen.append(payload)
+            # Upstream reads the deadline from the body, defaulting to 120.
+            # Sending it is the entire fix; the default is the defect.
+            timeout = payload.get("timeout", 120)
+            try:
+                completed = subprocess.run(
+                    [sys.executable, *payload["command"][1:]],
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                )
+                body = json.dumps(
+                    {
+                        "returncode": completed.returncode,
+                        "output": completed.stdout,
+                        "error": completed.stderr,
+                    }
+                ).encode()
+                status = 200
+            except subprocess.TimeoutExpired:
+                # Upstream's own shape: HTTP 500 and no returncode.
+                body = json.dumps({"status": "error", "message": "timed out"}).encode()
+                status = 500
+            self.send_response(status)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    monkeypatch.setattr(aws_mod, "GUEST_PORT", server.server_port)
+    # A socket deadline whose derived inner deadline is short enough to fire
+    # quickly, while keeping the deployed strict ordering.
+    socket_timeout = GUEST_TRANSPORT_MARGIN_S + 1.0
+    inner = guest_deadline_for(socket_timeout)
+    assert 0.0 < inner < socket_timeout
+    try:
+        with _Stubs() as stubs:
+            stubs.clients.http_post_json = aws_mod.build_clients(CREDS, REGION).http_post_json
+            provider = AwsProvider(
+                CREDS,
+                region=REGION,
+                lease_ref="lop-ttl-x",
+                clients=stubs.clients,
+                sleep=stubs.sleep,
+            )
+            provider._public_ip = "127.0.0.1"
+
+            # A command that finishes inside the guest deadline returns normally.
+            quick = provider._run_guest_command(["python", "-c", "print('done')"], socket_timeout)
+            assert quick.returncode == 0
+
+            # A command that outruns the guest deadline is ANSWERED by the guest
+            # (HTTP 500) rather than expiring our socket. ``raise_for_status``
+            # turns that into the transport branch, which is the honest
+            # unknown-outcome report — and crucially it arrives promptly.
+            sleeper = ["python", "-c", f"import time; time.sleep({socket_timeout * 4:.1f})"]
+            with pytest.raises(Exception) as raised:
+                provider._run_guest_command(sleeper, socket_timeout)
+            # It was the guest's answer, not our socket giving up.
+            assert "500" in str(raised.value) or "Server Error" in str(raised.value)
+
+        assert bodies_seen[-1]["timeout"] == inner
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+def test_the_adapter_never_relies_on_the_guest_route_default() -> None:
+    """Guard the specific regression: a body without ``timeout``.
+
+    The guest's default is 120 s, outside our 90 s socket. If a refactor ever
+    drops the field, the module constants would still agree with each other and
+    every arithmetic test above would still pass — only this one fails.
+    """
+
+    source = Path(aws_mod.__file__).read_text()
+    posted_body = re.search(r"\{\s*\"command\": list\(command\).*?\}", source, re.DOTALL)
+    assert posted_body is not None, "the /execute body literal moved; update this guard"
+    assert "timeout" in posted_body.group(0)
+    assert "guest_deadline_for" in posted_body.group(0)

--- a/tests/unit/evaluation/adapters/osworld/test_guest_deadline.py
+++ b/tests/unit/evaluation/adapters/osworld/test_guest_deadline.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import json
 import re
+import signal
 from pathlib import Path
 from threading import Thread
 from typing import Any
@@ -46,6 +47,9 @@ from lop_osworld_v2_adapter.providers.aws import (
     _exit_description,
 )
 from lop_osworld_v2_adapter.providers.base import (
+    _ABSOLUTE_FLOOR_S,
+    _MIN_GUEST_DEADLINE_S,
+    _SQUEEZED_DEADLINE_FRACTION,
     GUEST_COMMAND_TIMEOUT_S,
     GUEST_EXECUTE_TIMEOUT_S,
     GUEST_TRANSPORT_MARGIN_S,
@@ -69,7 +73,12 @@ from tests.unit.evaluation.adapters.osworld.test_aws_provider import (  # noqa: 
 # Socket deadlines a caller can realistically pass. The default is the common
 # case; ``guest_disk`` shrinks its own toward zero as its budget drains, which
 # is why the squeezed tail is covered rather than assumed away.
-SOCKET_DEADLINES = (90.0, 60.0, 30.0, 12.0, 10.0, 9.0, 5.0, 1.0, 0.5, 0.01)
+# Includes 0.0 and a negative value on purpose: ``guest_disk`` samples its
+# remaining budget at its guard and again at the call, so a caller CAN arrive
+# here with nothing left. The old tuple stopped at 0.01 and never reached the
+# boundary, which is how a derivation returning 0.0 and -2.5 passed a test named
+# for positivity.
+SOCKET_DEADLINES = (90.0, 60.0, 30.0, 12.0, 10.0, 9.0, 5.0, 1.0, 0.5, 0.01, 0.0, -5.0)
 
 
 # ----------------------------------------------------------------------------
@@ -114,8 +123,17 @@ def test_every_caller_socket_deadline_yields_a_positive_inner_deadline(
     """
 
     derived = guest_deadline_for(socket_timeout)
+
+    # Positivity holds for EVERY caller: a non-positive body ``timeout`` is an
+    # instant kill, never "no deadline".
     assert derived > 0.0
-    assert derived < socket_timeout
+
+    # Strict ordering holds wherever it is achievable. Below the absolute floor
+    # the two properties genuinely conflict -- a spent budget cannot yield a
+    # deadline both inside it and positive -- and positivity wins, because the
+    # alternative is a guaranteed instant kill.
+    if socket_timeout > _ABSOLUTE_FLOOR_S:
+        assert derived < socket_timeout
 
 
 def test_the_deadline_constants_are_pinned_so_either_moving_is_deliberate() -> None:
@@ -131,6 +149,13 @@ def test_the_deadline_constants_are_pinned_so_either_moving_is_deliberate() -> N
     assert GUEST_TRANSPORT_MARGIN_S == 10.0
     assert GUEST_EXECUTE_TIMEOUT_S == 80.0
 
+    # The squeezed branch governs the exhausted-budget tail, where the ordering
+    # invariant is weakest and a silent drift is hardest to notice. Pinned for
+    # the same reason as the pair above.
+    assert _MIN_GUEST_DEADLINE_S == 1.0
+    assert _SQUEEZED_DEADLINE_FRACTION == 0.5
+    assert _ABSOLUTE_FLOOR_S == 0.05
+
 
 def test_the_margin_leaves_room_for_the_measured_per_command_overhead() -> None:
     """The margin pays for transport, so it must exceed transport's real cost.
@@ -142,6 +167,13 @@ def test_the_margin_leaves_room_for_the_measured_per_command_overhead() -> None:
 
     measured_overhead_s = 3.6
     assert GUEST_TRANSPORT_MARGIN_S > measured_overhead_s
+
+    # Scope: this is a property of the SUBTRACT branch. In the squeezed tail the
+    # margin is whatever the caller had left -- ``guest_deadline_for(1.0)`` keeps
+    # 0.5 s, well under the measured overhead -- because a caller with a nearly
+    # spent budget has nothing to pay transport with. That call is close to
+    # doomed either way; the branch exists so it is not made CERTAINLY doomed.
+    assert guest_deadline_for(1.0) == 0.5
 
 
 # ----------------------------------------------------------------------------
@@ -227,14 +259,40 @@ def test_a_signal_death_is_named_and_an_ordinary_exit_is_unchanged(
     assert _exit_description(returncode) == expected
 
 
+def _unrecognised_signal_number() -> int | None:
+    """A signal number this platform does not name, or None if there is none.
+
+    Signal assignments differ per platform (64 is unassigned on macOS and
+    ``SIGRTMAX`` on Linux), so the fallback's test input must be discovered on
+    the host rather than hard-coded, or the test asserts a property of the
+    developer's laptop instead of the code.
+    """
+
+    for candidate in range(100, 128):
+        try:
+            signal.Signals(candidate)
+        except ValueError:
+            return candidate
+    return None
+
+
 def test_an_unrecognised_signal_number_still_reads_as_a_signal() -> None:
     """Signal numbers are platform-specific; an unknown one is still not an exit code.
 
-    Falling back to ``exit -64`` here would reintroduce exactly the confusion
+    Falling back to ``exit -100`` here would reintroduce exactly the confusion
     this function exists to remove.
+
+    The number matters. 64 is unassigned on macOS but IS ``SIGRTMAX`` on Linux,
+    so asserting it reads as "signal 64" passes on a developer's machine and
+    fails in CI \u2014 which is exactly what happened. 100 sits above the
+    real-time range on both, so the assertion tests the fallback rather than the
+    host it happens to run on. The guard below keeps it that way if a future
+    platform assigns it.
     """
 
-    assert _exit_description(-64) == "terminated by signal 64"
+    number = _unrecognised_signal_number()
+    assert number is not None, "no unassigned signal number found on this platform"
+    assert _exit_description(-number) == f"terminated by signal {number}"
 
 
 def test_the_diagnostic_does_not_assert_why_the_process_died() -> None:


### PR DESCRIPTION
## Summary

Two independent deadlines governed one guest command, and nothing related them. The guest's `/execute` route reads `timeout` from the request body and **defaults it to 120 s** (pinned guest server `xlang-ai/osworld-server @ a3cc3f0`, `execute_command`). We sent no `timeout`, so the guest's deadline sat *outside* our 90 s socket read deadline.

In that ordering a slow command always resolves the wrong way: our socket expires first, `requests` raises a `ReadTimeout`, and the command is **still running in the guest**. That branch is unrecoverable by construction — a transport error cannot distinguish "never started" from "half-applied" — so `execute` can only report an unknown outcome, and the no-retry policy that correctly refuses to replay a possibly-committed batch then ends the episode.

This derives the guest's deadline from whatever socket deadline the caller actually passed, keeping it strictly inside. The race now resolves the right way: the guest reaches its own deadline first and **answers**.

Be precise about what that buys, because round 1 review showed the original wording here overclaimed. The guest's HTTP 500 raises `HTTPError` through `raise_for_status()`, which `execute`'s blanket handler still reports as an unknown outcome — the same branch a `ReadTimeout` produced. What changes is **when and why** the answer arrives: the failure lands promptly and is attributable to the command outrunning its budget, instead of our socket expiring while the command is still running and leaving a half-applied batch nobody can characterise. Making it a genuinely *definite* outcome needs the 500's timeout shape distinguished from a transport error before that blanket handler, which is a separate change.

## Change class

C1 — standard, pre-authorized. Defect fix in the benchmark adapter's guest transport. No new surface, no API change.

## What changed

- `providers/base.py` — `guest_deadline_for(socket_timeout_s)` plus the reasoning for why the two deadlines must be *ordered*, not merely close.
- `providers/aws.py` — the execute body now carries that derived deadline.

## Evidence

The ordering property is pinned by tests rather than asserted in prose, including anti-drift coverage: mutating the socket timeout, the margin, or the derivation each fails a test, so the two numbers cannot silently drift apart again.

```
tests/unit/evaluation/adapters/osworld/test_guest_deadline.py  28 passed
tests/unit/evaluation/adapters/osworld/  (whole dir)          414 passed, 1 skipped
```

One pre-existing test pinned the exact execute body from before this contract existed; its expectation is updated to include the derived deadline, with a comment pointing at the file that pins the derivation.

**Gates (whole tree, as CI runs them, `build/` removed first):** flake8 clean · black 26.1.0 clean · isort 5.13.2 clean · pyright `0 errors, 0 warnings`.

Round 1 review correctly noted that this list originally omitted a red unit shard: a new test asserted a macOS-specific signal fact and failed on Linux. Fixed, and the lesson is that a gate list naming only lint/format/type is not evidence the suite is green.

**No runtime path exercised against a live guest.** This is a request-body contract change verified against the pinned guest server's source (`a3cc3f0`) and by unit coverage of the derivation; standing an AWS guest up was out of scope for this branch. The failure it addresses was observed in a live run — a `ReadTimeout` on a guest command that was still executing — which is what motivated it.

## Known pre-existing failures, not from this branch

Verified by checking out clean `origin/main` in a scratch worktree and running them there:

- `tests/unit/harness/test_efficiency.py` — 4 tests
- `tests/unit/tools/test_eval_tool.py::test_eval_tool_bridge_uses_this_calls_dispatch`
- `tests/unit/tui/test_steering_approval.py::test_empty_assistant_message_mounts_no_block`

## Version

No bump. `pyproject.toml` stays at the last released version (`0.51.1`) per the release policy.

