### PR TITLE
fix(evaluation): carry guest source as base64 so our argv cannot self-match

### DIFF
--- a/local_operator/computer_input.py
+++ b/local_operator/computer_input.py
@@ -161,19 +161,52 @@ def paste_text_source(text: str, keys: Sequence[str]) -> str:
     return f"exec({source!r})"
 
 
-def python_source_argv(source: str) -> list[str]:
-    """Keep one guest exec without exceeding Linux's per-argument byte limit.
+# The only program that ever reaches the guest's argv. It is a fixed constant:
+# it names no action, carries no agent text, and is byte-identical for every
+# statement we run, so nothing an agent writes can appear in it.
+_SOURCE_BOOTSTRAP = (
+    "import base64, sys; "
+    "exec(base64.b64decode(''.join(sys.argv[1:])).decode('utf-8'))"
+)
 
-    The clipboard accepts 100k Unicode characters (up to 400KB UTF-8), so even
-    one base64 payload exceeds MAX_ARG_STRLEN. Splitting *source*, not actions,
-    preserves the single-shot mutation boundary. Small legacy commands retain
-    their exact argv; each large-source chunk is at most 64KB in UTF-8.
+# Linux caps a single argv entry at MAX_ARG_STRLEN (32 pages = 128KB). Base64 is
+# ASCII, so one character is one byte and this character bound IS the byte bound.
+_MAX_ARGUMENT_CHARACTERS = 16_000
+
+
+def python_source_argv(source: str) -> list[str]:
+    """Carry one guest exec as base64, so our own argv never quotes the agent.
+
+    *source* is base64-encoded rather than passed literally because argv is a
+    PUBLIC channel: ``/proc/<pid>/cmdline`` is what ``pkill -f``, ``pgrep -f``
+    and ``ps | grep`` match against, and the guest process running a statement is
+    itself a running process. An agent cleaning up after itself with
+    ``pkill -f "ffmpeg -y -f x11grab"`` — routine, legitimate, and its own
+    recording to kill — used to match the very process typing that text and
+    SIGTERM it, which is the observed ``exit -15`` that killed ep-0ce67ac2d3a1.
+    Encoding removes the false match at its source; the alternative of screening
+    the agent's text for process-matching commands is both incomplete and not
+    ours to impose.
+
+    Base64 also subsumes the byte-limit problem this function already solved. The
+    clipboard accepts 100k Unicode characters (up to 400KB UTF-8, 533KB encoded),
+    which no single argv entry can hold, so the encoded form is split across
+    trailing arguments that the bootstrap rejoins. Splitting the *source*, never
+    the actions, is what preserves the single-shot mutation boundary: the guest
+    still performs exactly one exec, so a batch cannot half-commit.
+
+    There is deliberately no short-source fast path emitting ``python -c
+    <source>``. That shape is precisely the exposure, and a size threshold would
+    reinstate it for every statement small enough to fit — which is all of them
+    that matter here, since a ``pkill`` line is a few dozen characters.
     """
-    if len(source.encode("utf-8")) <= 64_000:
-        return ["python", "-c", source]
+    encoded = base64.b64encode(source.encode("utf-8")).decode("ascii")
     return [
         "python",
         "-c",
-        "import sys; exec(''.join(sys.argv[1:]))",
-        *(source[offset : offset + 16_000] for offset in range(0, len(source), 16_000)),
+        _SOURCE_BOOTSTRAP,
+        *(
+            encoded[offset : offset + _MAX_ARGUMENT_CHARACTERS]
+            for offset in range(0, len(encoded), _MAX_ARGUMENT_CHARACTERS)
+        ),
     ]

--- a/local_operator/computer_input.py
+++ b/local_operator/computer_input.py
@@ -163,11 +163,10 @@ def paste_text_source(text: str, keys: Sequence[str]) -> str:
 
 # The only program that ever reaches the guest's argv. It is a fixed constant:
 # it names no action, carries no agent text, and is byte-identical for every
-# statement we run, so nothing an agent writes can appear in it.
-_SOURCE_BOOTSTRAP = (
-    "import base64, sys; "
-    "exec(base64.b64decode(''.join(sys.argv[1:])).decode('utf-8'))"
-)
+# statement we run, so nothing an agent writes can appear in it. ``decode()``
+# takes no argument only because its default IS UTF-8, which is the encoding
+# ``python_source_argv`` encodes with; the two must not drift apart.
+_SOURCE_BOOTSTRAP = "import base64, sys; exec(base64.b64decode(''.join(sys.argv[1:])).decode())"
 
 # Linux caps a single argv entry at MAX_ARG_STRLEN (32 pages = 128KB). Base64 is
 # ASCII, so one character is one byte and this character bound IS the byte bound.

--- a/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
+++ b/tests/unit/evaluation/adapters/osworld/test_aws_provider.py
@@ -17,6 +17,7 @@ time (AGENTS.md "Timing, flakes").
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
 from pathlib import Path
@@ -37,6 +38,7 @@ from lop_osworld_v2_adapter.providers.aws import (
     ttl_seconds_for,
 )
 
+from local_operator import computer_input
 from local_operator.evaluation.adapters.api import ScopedInfraValue
 from tests.unit.evaluation.adapters.osworld import fixtures
 
@@ -1347,12 +1349,18 @@ async def test_execute_settles_after_the_batch_and_respond_without_simulator_is_
         provider._public_ip = "127.0.0.1"
         await provider.execute(["pyautogui.click(1, 2)"])
         await provider.execute([])
-        assert stubs.guest_posts == [
-            {
-                "command": ["python", "-c", "import pyautogui; pyautogui.click(1, 2)"],
-                "shell": False,
-            }
-        ]
+        # The statement crosses as base64 (see ``python_source_argv``), so assert
+        # the endpoint contract and decode the payload rather than pinning a
+        # literal argv -- the literal shape is the argv exposure this encoding
+        # exists to remove.
+        assert len(stubs.guest_posts) == 1
+        post = stubs.guest_posts[0]
+        assert post["shell"] is False
+        command = post["command"]
+        assert command[:3] == ["python", "-c", computer_input._SOURCE_BOOTSTRAP]
+        assert base64.b64decode("".join(command[3:])).decode("utf-8") == (
+            "import pyautogui; pyautogui.click(1, 2)"
+        )
         assert "executed" not in env.kwargs
         assert stubs.slept == [3.0, 3.0]
         assert await provider.respond("?") is None

--- a/tests/unit/evaluation/adapters/osworld/test_guest_argv_exposure.py
+++ b/tests/unit/evaluation/adapters/osworld/test_guest_argv_exposure.py
@@ -65,9 +65,7 @@ PKGS_PREFIX = "import pyautogui; import time; import platform; {command}"
 
 def _guest_argv_for(typed_text: str) -> list[str]:
     """The argv our provider would hand the guest for one ``type`` action."""
-    statement = actions.compile_action(
-        TypeAction(observation_id="o", text=typed_text), _geo()
-    )
+    statement = actions.compile_action(TypeAction(observation_id="o", text=typed_text), _geo())
     assert statement is not None
     return python_source_argv(PKGS_PREFIX.format(command=statement))
 
@@ -130,9 +128,7 @@ def test_a_pkill_shaped_payload_no_longer_matches_our_own_live_process() -> None
         else:
             pytest.fail("the guest-exec stand-in never became visible to pgrep")
 
-        matched = subprocess.run(
-            ["pgrep", "-f", FATAL_PATTERN], capture_output=True, text=True
-        )
+        matched = subprocess.run(["pgrep", "-f", FATAL_PATTERN], capture_output=True, text=True)
         pids = {int(pid) for pid in matched.stdout.split() if pid.isdigit()}
         assert process.pid not in pids
     finally:

--- a/tests/unit/evaluation/adapters/osworld/test_guest_argv_exposure.py
+++ b/tests/unit/evaluation/adapters/osworld/test_guest_argv_exposure.py
@@ -1,0 +1,304 @@
+"""Our guest-side process must not carry the agent's typed text in its argv.
+
+Episode ep-0ce67ac2d3a1 died with ``GuestExecutionError: guest action 1 failed
+(exit -15)``. An earlier step had legitimately started ``nohup ffmpeg -y -f
+x11grab ...`` to record the screen, and the model was correctly cleaning up
+after itself:
+
+    pkill -f "ffmpeg -y -f x11grab"; sleep 0.5; xdotool getactivewindow ...
+
+Nothing about that is wrong. The defect was ours: the statement was handed to
+the guest as a literal ``python -c <source>`` argv, and argv is a PUBLIC
+channel -- ``/proc/<pid>/cmdline`` is precisely what ``pkill -f``, ``pgrep -f``
+and ``ps | grep`` match against. The pattern was a substring of the command
+line of the process typing it, so ``pkill -f`` matched that process and
+SIGTERMed it. Exit -15 is SIGTERM; the step ran ~5.9 s against a 90 s deadline,
+which rules out any timeout explanation.
+
+These tests therefore assert the property, not a spelling: the agent's text is
+absent from our argv, and a real pattern matcher run against a real live
+process no longer selects it. They deliberately do NOT assert that we detect,
+sanitise or block ``pkill``/``killall``/``pgrep`` -- the agent's usage is
+legitimate and routine, and screening its text would be both incomplete and
+not ours to impose.
+"""
+
+from __future__ import annotations
+
+import base64
+import shutil
+import subprocess
+import sys
+import time
+from typing import Any
+
+import pytest
+from lop_osworld_v2_adapter import actions
+from lop_osworld_v2_adapter.providers.aws import AwsProvider, GuestExecutionError
+
+from local_operator import computer_input
+from local_operator.computer_input import python_source_argv
+from local_operator.evaluation.protocol import ClickAction, KeyAction, TypeAction
+from tests.unit.evaluation.adapters.osworld.test_actions import _geo
+from tests.unit.evaluation.adapters.osworld.test_aws_provider import (  # noqa: F401
+    CREDS,
+    REGION,
+    _FakeEnv,
+    _hermetic_aws,
+    _Stubs,
+)
+
+# The exact text from the failing episode's last model_response, and the
+# pattern inside it that ``pkill -f`` was given. Real evidence, not an invented
+# payload: a fix that does not clear THIS string has not fixed the incident.
+FATAL_TYPED_TEXT = (
+    'pkill -f "ffmpeg -y -f x11grab"; sleep 0.5; xdotool getactivewindow windowclose; '
+    "sleep 1; xdotool search --onlyvisible --class chrome windowactivate; sleep 0.5; "
+    "xdotool key F11\n"
+)
+FATAL_PATTERN = "ffmpeg -y -f x11grab"
+
+# Upstream's own controller prefix (python.py:37-45, condensed to the part that
+# matters here): whatever we wrap the statement in must not reintroduce the text.
+PKGS_PREFIX = "import pyautogui; import time; import platform; {command}"
+
+
+def _guest_argv_for(typed_text: str) -> list[str]:
+    """The argv our provider would hand the guest for one ``type`` action."""
+    statement = actions.compile_action(
+        TypeAction(observation_id="o", text=typed_text), _geo()
+    )
+    assert statement is not None
+    return python_source_argv(PKGS_PREFIX.format(command=statement))
+
+
+# ----------------------------------------------------------------------------
+# The exposure itself
+
+
+def test_the_typed_text_is_absent_from_the_guest_processes_argv() -> None:
+    argv = _guest_argv_for(FATAL_TYPED_TEXT)
+    joined = " ".join(argv)
+    assert FATAL_PATTERN not in joined
+    assert "pkill" not in joined
+    # Not merely the pattern: no fragment of what the agent typed survives.
+    for fragment in ("ffmpeg", "x11grab", "xdotool", "windowclose", "chrome"):
+        assert fragment not in joined
+
+
+def test_only_a_fixed_agent_independent_program_reaches_argv() -> None:
+    """Two unrelated payloads produce byte-identical argv up to the encoding.
+
+    This is the invariant that makes the property hold for text nobody has
+    thought of yet, rather than for the strings these tests happen to name.
+    """
+    first = _guest_argv_for(FATAL_TYPED_TEXT)
+    second = _guest_argv_for("echo something entirely different\n")
+    assert first[:3] == second[:3] == ["python", "-c", computer_input._SOURCE_BOOTSTRAP]
+    # The constant program mentions no action and no agent-supplied text.
+    assert "pyautogui" not in computer_input._SOURCE_BOOTSTRAP
+
+
+@pytest.mark.skipif(shutil.which("pgrep") is None, reason="needs pgrep")
+def test_a_pkill_shaped_payload_no_longer_matches_our_own_live_process() -> None:
+    """The real mechanism, against a real matcher and a real running process.
+
+    ``pgrep -f`` rather than ``pkill -f``: it is the same matcher over the same
+    ``/proc/<pid>/cmdline``, but it reports instead of signalling, so the test
+    observes the selection without depending on having killed something. The
+    guest runs ``pyautogui.typewrite``; the host has no GUI stack, so the
+    statement's runtime is stood in for by a sleep while the argv -- the thing
+    under test -- is built exactly as production builds it.
+    """
+    source = PKGS_PREFIX.replace("import pyautogui; ", "").format(
+        command="time.sleep(30); typed = %r" % FATAL_TYPED_TEXT
+    )
+    argv = python_source_argv(source)
+    process = subprocess.Popen(
+        [sys.executable, *argv[1:]],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        # Wait for the kernel to publish the command line, so a negative result
+        # cannot simply mean "the process had not started yet".
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            if subprocess.run(["pgrep", "-f", argv[3][:40]], capture_output=True).returncode == 0:
+                break
+            time.sleep(0.05)
+        else:
+            pytest.fail("the guest-exec stand-in never became visible to pgrep")
+
+        matched = subprocess.run(
+            ["pgrep", "-f", FATAL_PATTERN], capture_output=True, text=True
+        )
+        pids = {int(pid) for pid in matched.stdout.split() if pid.isdigit()}
+        assert process.pid not in pids
+    finally:
+        process.kill()
+        process.wait(timeout=10)
+
+
+# ----------------------------------------------------------------------------
+# The statement still arrives intact
+
+
+@pytest.mark.parametrize(
+    "typed",
+    [
+        FATAL_TYPED_TEXT,
+        "ordinary text",
+        "quotes ' \" and a backslash \\ and a #hash",
+        "a\tb\nnext\r\n",
+        "$(command_substitution) `backticks` ; rm -rf /",
+    ],
+    ids=["fatal-payload", "ordinary", "quoting", "whitespace", "shell-metacharacters"],
+)
+def test_the_guest_still_receives_the_exact_statement_it_used_to(typed: str) -> None:
+    """Encoding changes the transport, never the program the guest runs."""
+    argv = _guest_argv_for(typed)
+    decoded = base64.b64decode("".join(argv[3:])).decode("utf-8")
+    assert decoded == PKGS_PREFIX.format(command=f"pyautogui.typewrite({typed!r})")
+
+
+def test_the_decoded_source_executes_and_reproduces_the_text_verbatim(tmp_path: Any) -> None:
+    """End to end through a real interpreter: encode, split, exec, compare.
+
+    The guest's ``python -c`` is the only consumer of this argv, so the proof
+    that matters is that a real interpreter reconstructs the text byte for byte
+    -- including the newline and the embedded double quotes that a naive
+    quoting scheme would drop.
+    """
+    marker = tmp_path / "typed.txt"
+    source = (
+        "from pathlib import Path; "
+        f"Path({str(marker)!r}).write_text({FATAL_TYPED_TEXT!r}, encoding='utf-8')"
+    )
+    argv = python_source_argv(source)
+    completed = subprocess.run(
+        [sys.executable, *argv[1:]], capture_output=True, text=True, timeout=60
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert marker.read_text(encoding="utf-8") == FATAL_TYPED_TEXT
+
+
+def test_every_argument_stays_within_the_single_argument_byte_limit() -> None:
+    """Base64 is ASCII, so the character split is also the byte split.
+
+    Linux caps one argv entry at MAX_ARG_STRLEN; a 100k-character paste encodes
+    to ~533KB and must therefore still arrive in chunks the guest rejoins.
+    """
+    argv = python_source_argv("x = %r" % ("\N{SLIGHTLY SMILING FACE}" * 100_000))
+    assert len(argv) > 4, "a payload this large must still be split"
+    assert all(len(argument.encode("utf-8")) <= 64_000 for argument in argv[1:])
+
+
+# ----------------------------------------------------------------------------
+# Ordinary actions are unaffected
+
+
+@pytest.mark.parametrize(
+    "action, expected",
+    [
+        (
+            ClickAction(observation_id="o", frame_id="screen", x=100, y=200, button="left"),
+            "pyautogui.click(x=100, y=200, button='left')",
+        ),
+        (
+            KeyAction(observation_id="o", keys=("ctrl", "s")),
+            "pyautogui.hotkey('ctrl', 's')",
+        ),
+    ],
+    ids=["click", "key-chord"],
+)
+def test_ordinary_actions_compile_and_survive_the_encoding_unchanged(
+    action: Any, expected: str
+) -> None:
+    statement = actions.compile_action(action, _geo())
+    assert statement == expected
+    argv = python_source_argv(PKGS_PREFIX.format(command=statement))
+    assert base64.b64decode("".join(argv[3:])).decode("utf-8").endswith(expected)
+
+
+# ----------------------------------------------------------------------------
+# The properties the fix had to preserve
+
+
+@pytest.mark.asyncio
+async def test_the_transport_contract_and_single_exec_boundary_are_unchanged() -> None:
+    """One post, one exec, ``shell: false`` -- no new partial-commit boundary.
+
+    A fix that uploaded the source to the guest and then executed it would have
+    introduced a second round trip, and with it a state where the file landed
+    but the exec never ran. The batch must still commit in exactly one step.
+    """
+    with _Stubs() as stubs:
+        provider = AwsProvider(
+            CREDS, region=REGION, lease_ref="lop-ttl-x", clients=stubs.clients, sleep=stubs.sleep
+        )
+        provider._env = _FakeEnv()
+        provider._public_ip = "127.0.0.1"
+        await provider.execute([f"pyautogui.typewrite({FATAL_TYPED_TEXT!r})"])
+
+    assert len(stubs.guest_posts) == 1, "the batch must still commit in one post"
+    post = stubs.guest_posts[0]
+    assert post["shell"] is False
+    assert isinstance(post["command"], list)
+    assert FATAL_PATTERN not in " ".join(post["command"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "response",
+    [
+        {"returncode": 7, "error": "PRIVATE_PAYLOAD"},
+        RuntimeError("PRIVATE_PAYLOAD"),
+    ],
+    ids=["guest-stderr", "transport-exception"],
+)
+async def test_failures_still_redact_and_still_refuse_to_retry(
+    response: dict[str, Any] | Exception,
+) -> None:
+    """Neither guest stderr nor a transport exception may reach the caller.
+
+    Both can echo the command, credentials or UI text, and the outcome of a
+    failed action is unknown -- so the batch stops where it failed and is never
+    replayed. Encoding the source changed neither policy.
+    """
+    with _Stubs() as stubs:
+        provider = AwsProvider(
+            CREDS, region=REGION, lease_ref="lop-ttl-x", clients=stubs.clients, sleep=stubs.sleep
+        )
+        provider._env = _FakeEnv()
+        provider._public_ip = "127.0.0.1"
+        stubs.guest_default = response
+        with pytest.raises(GuestExecutionError) as raised:
+            await provider.execute(["first()", "must_not_run()"])
+
+    assert "PRIVATE_PAYLOAD" not in str(raised.value)
+    assert "batch not retried" in str(raised.value)
+    assert len(stubs.guest_posts) == 1, "the second action must not have run"
+    assert stubs.slept == [], "a failed batch does not settle"
+
+
+@pytest.mark.asyncio
+async def test_the_controllers_input_patch_still_wraps_every_statement() -> None:
+    """``pkgs_prefix`` is upstream's isShiftCharacter fix; it must still apply.
+
+    The encoding sits strictly below that wrapping -- we encode the already
+    prefixed script -- so the guest still runs the patched program.
+    """
+    with _Stubs() as stubs:
+        provider = AwsProvider(
+            CREDS, region=REGION, lease_ref="lop-ttl-x", clients=stubs.clients, sleep=stubs.sleep
+        )
+        env = _FakeEnv()
+        env.pkgs_prefix = PKGS_PREFIX
+        provider._env = env
+        provider._public_ip = "127.0.0.1"
+        await provider.execute(["pyautogui.typewrite('abc')"])
+
+    command = stubs.guest_posts[0]["command"]
+    decoded = base64.b64decode("".join(command[3:])).decode("utf-8")
+    assert decoded == PKGS_PREFIX.format(command="pyautogui.typewrite('abc')")

--- a/tests/unit/evaluation/adapters/osworld/test_guest_argv_exposure.py
+++ b/tests/unit/evaluation/adapters/osworld/test_guest_argv_exposure.py
@@ -30,6 +30,7 @@ import shutil
 import subprocess
 import sys
 import time
+import uuid
 from typing import Any
 
 import pytest
@@ -161,12 +162,29 @@ def test_the_typing_process_is_not_signalled_by_the_command_it_typed() -> None:
     decoy still dies. The agent's cleanup must keep working; only the false
     match on ourselves may disappear.
     """
+    # The pattern is made unique per run. `pkill -f` matches EVERY process on
+    # the host, and this repo is worked through many concurrent worktrees under
+    # `-n auto`: with the episode's literal constant, two overlapping runs of
+    # this file would have each one's pkill killing the other's decoy, and the
+    # assertion below would read the wrong process. The self-match property
+    # under test is unaffected by the pattern being unique -- what matters is
+    # that OUR OWN argv does not contain it.
+    unique_pattern = f"{FATAL_PATTERN} run-{uuid.uuid4().hex}"
+
+    # The decoy carries the pattern in its OWN argv rather than being renamed
+    # with `exec -a`, which is a bash builtin extension: on ubuntu-latest
+    # /bin/sh is dash, where it fails with "exec: -a: not found" and the decoy
+    # never starts. That is why this test had never once executed on Linux --
+    # the platform whose /proc/<pid>/cmdline semantics the fix is actually
+    # about. A python -c whose source embeds the pattern is visible to pgrep -f
+    # on both platforms with no shell dependency at all.
     decoy = subprocess.Popen(
-        ["/bin/sh", "-c", f'exec -a "{FATAL_PATTERN} decoy" sleep 30'],
+        [sys.executable, "-c", f"import time; time.sleep(30)  # {unique_pattern} decoy"],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
-    argv = python_source_argv("import time; time.sleep(10); typed = %r" % FATAL_TYPED_TEXT)
+    typed_text = FATAL_TYPED_TEXT.replace(FATAL_PATTERN, unique_pattern)
+    argv = python_source_argv("import time; time.sleep(10); typed = %r" % typed_text)
     typist = subprocess.Popen(
         [sys.executable, *argv[1:]], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
     )
@@ -177,7 +195,7 @@ def test_the_typing_process_is_not_signalled_by_the_command_it_typed() -> None:
         while time.monotonic() < deadline:
             if (
                 subprocess.run(
-                    ["pgrep", "-f", f"{FATAL_PATTERN} decoy"], capture_output=True
+                    ["pgrep", "-f", f"{unique_pattern} decoy"], capture_output=True
                 ).returncode
                 == 0
             ):
@@ -186,9 +204,12 @@ def test_the_typing_process_is_not_signalled_by_the_command_it_typed() -> None:
         else:
             pytest.fail("the decoy never became visible to the matcher")
 
-        subprocess.run(["pkill", "-f", FATAL_PATTERN], capture_output=True)
-        time.sleep(0.5)
+        subprocess.run(["pkill", "-f", unique_pattern], capture_output=True)
 
+        # Wait on the EVENT, not the clock. A fixed sleep here is a bet on
+        # machine load: under CI contention SIGTERM delivery and reaping can
+        # outlast any budget short enough to be worth having.
+        decoy.wait(timeout=10)
         assert decoy.poll() is not None, "the agent's own cleanup must still work"
         assert typist.poll() != -15, "our typing process was SIGTERMed by the text it typed"
         assert typist.poll() is None, "our typing process must still be running"

--- a/tests/unit/evaluation/adapters/osworld/test_guest_argv_exposure.py
+++ b/tests/unit/evaluation/adapters/osworld/test_guest_argv_exposure.py
@@ -107,6 +107,15 @@ def test_a_pkill_shaped_payload_no_longer_matches_our_own_live_process() -> None
     guest runs ``pyautogui.typewrite``; the host has no GUI stack, so the
     statement's runtime is stood in for by a sleep while the argv -- the thing
     under test -- is built exactly as production builds it.
+
+    The matcher runs from the TEST process, which is a sibling of the process
+    under test rather than its descendant. That is not incidental: ``pkill``
+    and ``pgrep`` deliberately never select their own ancestors, so a matcher
+    run as a child of the typing process cannot see it and would report a
+    false pass. The guest topology is the sibling one -- the agent types into
+    a terminal, and that terminal runs the command -- which is what
+    ``test_the_typing_process_is_not_signalled_by_the_command_it_typed``
+    exercises at the signal level.
     """
     source = PKGS_PREFIX.replace("import pyautogui; ", "").format(
         command="time.sleep(30); typed = %r" % FATAL_TYPED_TEXT
@@ -134,6 +143,60 @@ def test_a_pkill_shaped_payload_no_longer_matches_our_own_live_process() -> None
     finally:
         process.kill()
         process.wait(timeout=10)
+
+
+@pytest.mark.skipif(shutil.which("pkill") is None, reason="needs pkill")
+def test_the_typing_process_is_not_signalled_by_the_command_it_typed() -> None:
+    """The episode's actual failure, at the signal level: exit -15.
+
+    This reproduces the incident rather than a proxy for it. A decoy process
+    carrying the recording's command line stands in for the agent's own
+    ``ffmpeg``, a second process runs the statement whose text names that
+    pattern, and a real ``pkill -f`` then runs as a SIBLING of it -- the guest
+    topology, where the agent types into a terminal and the terminal runs the
+    command.
+
+    Two outcomes are asserted together, because fixing the first by breaking
+    the second would be no fix at all: our typing process survives, and the
+    decoy still dies. The agent's cleanup must keep working; only the false
+    match on ourselves may disappear.
+    """
+    decoy = subprocess.Popen(
+        ["/bin/sh", "-c", f'exec -a "{FATAL_PATTERN} decoy" sleep 30'],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    argv = python_source_argv("import time; time.sleep(10); typed = %r" % FATAL_TYPED_TEXT)
+    typist = subprocess.Popen(
+        [sys.executable, *argv[1:]], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+    )
+    try:
+        # Both must be visible to the matcher before it runs, or a survival
+        # result would only mean "nothing had started yet".
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            if (
+                subprocess.run(
+                    ["pgrep", "-f", f"{FATAL_PATTERN} decoy"], capture_output=True
+                ).returncode
+                == 0
+            ):
+                break
+            time.sleep(0.05)
+        else:
+            pytest.fail("the decoy never became visible to the matcher")
+
+        subprocess.run(["pkill", "-f", FATAL_PATTERN], capture_output=True)
+        time.sleep(0.5)
+
+        assert decoy.poll() is not None, "the agent's own cleanup must still work"
+        assert typist.poll() != -15, "our typing process was SIGTERMed by the text it typed"
+        assert typist.poll() is None, "our typing process must still be running"
+    finally:
+        for process in (decoy, typist):
+            if process.poll() is None:
+                process.kill()
+            process.wait(timeout=10)
 
 
 # ----------------------------------------------------------------------------

--- a/tests/unit/test_computer_input.py
+++ b/tests/unit/test_computer_input.py
@@ -7,6 +7,7 @@ cleanup without importing or installing GUI libraries on the host.
 
 from __future__ import annotations
 
+import base64
 import os
 import signal
 import subprocess
@@ -16,6 +17,7 @@ from pathlib import Path
 
 import pytest
 
+from local_operator import computer_input
 from local_operator.computer_input import paste_text_source, python_source_argv
 
 
@@ -152,9 +154,19 @@ def test_source_arguments_are_literals_not_caller_injection(
     assert json.loads((tmp_path / "keys").read_text()) == [key]
 
 
-def test_small_python_commands_keep_legacy_bytes() -> None:
+def test_even_a_small_command_is_encoded_rather_than_quoted_literally() -> None:
+    """No size fast path: a short statement is exactly the dangerous case.
+
+    This test previously asserted the opposite (``["python", "-c", source]``).
+    That literal shape is the argv exposure itself, and the payload that killed
+    ep-0ce67ac2d3a1 was a few dozen characters — well under any threshold a
+    "small commands stay legible" carve-out would have used.
+    """
     source = "pyautogui.typewrite('abc')"
-    assert python_source_argv(source) == ["python", "-c", source]
+    argv = python_source_argv(source)
+    assert source not in " ".join(argv)
+    assert argv[:3] == ["python", "-c", computer_input._SOURCE_BOOTSTRAP]
+    assert base64.b64decode("".join(argv[3:])).decode("utf-8") == source
 
 
 def test_large_argv_reconstruction_executes_once(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

The agent's typed text was handed to the guest as a literal `python -c <source>` argv, so that text appeared verbatim in the command line of **our own executing process**. Any pattern-matching process command the agent legitimately writes — `pkill -f`, `pgrep -f`, `killall`, `ps | grep` — could therefore match the very process that was typing it.

This is not hypothetical. Episode `ep-0ce67ac2d3a1` (OSWorld task_045) died with:

```
GuestExecutionError: guest action 1 failed (exit -15); input may be partial; batch not retried
```

The failing batch typed a perfectly reasonable cleanup command:

```
pkill -f "ffmpeg -y -f x11grab"; sleep 0.5; xdotool getactivewindow windowclose; ...
```

An earlier step had legitimately started `nohup ffmpeg -y -f x11grab ...` to record the screen, so the model was correctly cleaning up its *own* recording. But because the pattern `ffmpeg -y -f x11grab` was a literal substring of the argv of the process typing it, `pkill -f` matched that process and SIGTERMed it — the observed `-15`. The episode is unrecoverable at that point ("input may be partial; batch not retried"), so this silently destroyed episodes whenever an agent managed background processes by pattern, which is a routine desktop skill.

## Change class

C1 — standard, pre-authorized. Defect fix. No new surface, no API change.

## Approach

`python_source_argv` now base64-encodes the guest source, so argv carries only a fixed, **agent-independent** bootstrap plus opaque ASCII chunks.

The fix targets *our exposure*, not the agent's usage: there is no `pkill`/`pgrep`/`killall` detection anywhere in the diff. Blocking those would be both incomplete and paternalistic — the agent was doing the right thing.

Rejected alternatives, checked against the pinned guest server (`xlang-ai/osworld-server @ a3cc3f0`, cloned and read — **not** OSWorld-V2):

- **stdin** — impossible: `/execute` is `subprocess.run(command, shell=shell, ...)` with no `stdin=`/`input=`/`env=`.
- **write-a-file-then-exec** — needs a second round trip (`/setup/upload` + exec), creating exactly the new partial-commit boundary that the no-retry policy exists to avoid.
- **base64 in argv** — chosen. One arg vector, one exec, no new failure mode, and it reuses the encoding `paste_text_source` already uses. Being ASCII, it also subsumes the old `MAX_ARG_STRLEN` chunking, since the char bound *is* the byte bound.

The previous `<=64_000` fast path is deliberately dropped: a literal argv **is** the exposure, and the fatal payload here was ~200 chars. Any size threshold reinstates the bug for exactly the statements that matter.

## Evidence

Reproduced the episode's failure through a real HTTP `/execute` mirroring the pinned guest: **pre-fix `returncode -15`, post-fix `0`**, while a decoy `ffmpeg` process still dies in both runs — the agent's cleanup keeps working, only the self-match is gone.

```
tests/unit/evaluation/adapters/osworld/test_guest_argv_exposure.py   17 tests
tests/unit/evaluation/adapters/osworld/  (whole dir)                403 passed, 1 skipped
```

Mutation evidence: restoring the pre-fix function fails **13 of 17**. The 4 that pass in both states are preservation tests (redaction, no-retry, byte-limit, decode fidelity) — passing pre-fix is their correct behaviour.

**Non-obvious finding, documented in the tests:** the matcher must run as a *sibling*, not a child. `pkill`/`pgrep` never signal their own ancestors, so a self-run `pkill` returns rc 1 and reports a false pass. The first end-to-end harness had this wrong and showed a clean `0` pre-fix; it was caught because `-15` failed to reproduce. The guest topology is the sibling one — the agent types into a terminal, and the terminal runs the command.

Preserved deliberately, with tests: transport exceptions and guest stderr are still never surfaced (they may echo the command, credentials, or UI text); the controller's input patch still wraps every statement; the no-retry-on-unknown-outcome policy is unchanged; ordinary typing and clicking are unaffected.

**Gates (whole tree, as CI runs them, `build/` removed first):** flake8 clean · black 26.1.0 clean (1011 files) · isort 5.13.2 clean · pyright `0 errors`.

**Not verified against a live AWS guest.** The guest-side claim rests on reading the pinned `a3cc3f0` source plus a local mirror of its exec shape.

## Known pre-existing failures, not from this branch

This branch changes 4 files, all `computer_input`/OSWorld, and zero TUI files.

- `tests/unit/tui/test_stream_anchor.py::test_paging_the_subagent_body...` fails **~1-in-3 on clean `origin/main`** in isolation — a pre-existing load-sensitive flake.
- `test_tui_responsiveness` is a CPU-timing ceiling that appeared only under load.

## Version

No bump. `pyproject.toml` stays at the last released version (`0.51.1`) per the release policy.
