### PR TITLE
fix(evaluation): offer the decision envelope on the model's own tool channel

### DIFF
--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -916,11 +916,12 @@ class EpisodeRunner:
                 ),
                 input_tokens=decision.usage.input_tokens,
                 message_count=message_count,
-                # ``decision`` here is not always a ``ModelDecision``: a
-                # rejected reply or an aborted stream arrives as an error
-                # carrier that never saw a request object, so it cannot know
-                # what was offered. Those attempts record 0 rather than
-                # guessing, exactly as they did before the channel existed.
+                # ``decision`` here is not always a ``ModelDecision``. A
+                # rejected reply carries the count honestly, because the
+                # request was built and sent before the reply was judged. An
+                # ABORTED stream is the case this default exists for: it fails
+                # before there is a request object to read, so it cannot know
+                # what was offered and records 0 rather than guessing.
                 tool_count=getattr(decision, "offered_tool_count", 0),
                 prompt_cache_key=decision.prompt_cache_key,
                 context_tokens=decision.context_tokens,

--- a/local_operator/evaluation/runner/episode.py
+++ b/local_operator/evaluation/runner/episode.py
@@ -916,7 +916,12 @@ class EpisodeRunner:
                 ),
                 input_tokens=decision.usage.input_tokens,
                 message_count=message_count,
-                tool_count=0,
+                # ``decision`` here is not always a ``ModelDecision``: a
+                # rejected reply or an aborted stream arrives as an error
+                # carrier that never saw a request object, so it cannot know
+                # what was offered. Those attempts record 0 rather than
+                # guessing, exactly as they did before the channel existed.
+                tool_count=getattr(decision, "offered_tool_count", 0),
                 prompt_cache_key=decision.prompt_cache_key,
                 context_tokens=decision.context_tokens,
             ),

--- a/local_operator/evaluation/runner/model.py
+++ b/local_operator/evaluation/runner/model.py
@@ -83,6 +83,10 @@ class ModelDecision(ProtocolModel):
     stop_reason: StrictIdentifier = "stop"
     provider_request_id: StrictIdentifier = "unknown"
     tool_call_count: SafeCount = 0
+    #: Tools the request PUT ON THE WIRE. Distinct from ``tool_call_count``,
+    #: which counts how the model answered: a bundle showing a call against a
+    #: request that offered nothing is a state the wire cannot produce.
+    offered_tool_count: SafeCount = 0
     prompt_cache_key: StrictIdentifier | None = None
     context_tokens: SafeCount | None = None
     compaction: CompactionRecord | None = None
@@ -144,6 +148,7 @@ class DecisionRejected(Exception):
         stop_reason: str = "stop",
         provider_request_id: str = "unknown",
         tool_call_count: int = 0,
+        offered_tool_count: int = 0,
         prompt_cache_key: str | None = None,
         context_tokens: int | None = None,
         compaction: CompactionRecord | None = None,
@@ -167,6 +172,7 @@ class DecisionRejected(Exception):
         self.stop_reason = stop_reason
         self.provider_request_id = provider_request_id
         self.tool_call_count = tool_call_count
+        self.offered_tool_count = offered_tool_count
         self.prompt_cache_key = prompt_cache_key
         self.context_tokens = context_tokens
         self.compaction = compaction

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -47,12 +47,19 @@ from local_operator.evaluation.runner.model import (
 )
 from local_operator.evaluation.runner.public_reply import (
     MAX_PUBLIC_OBSERVATIONS_CHARS,
+    PUBLIC_REPLY_TOOL_DESCRIPTION,
     REJECTED_PUBLIC_REPLY,
     REPLY_VERSION,
     decode_public_reply,
     is_public_reply,
     looks_like_public_reply,
     public_reply_contract,
+    public_reply_schema,
+)
+from local_operator.harness.reply_channel import (
+    REPLY_CHANNEL_TOOL_NAME,
+    envelope_from_tool_call,
+    reply_channel_tools,
 )
 from local_operator.logger import get_logger
 
@@ -983,7 +990,28 @@ class ProviderModelClient:
                 )
             ],
             messages=list(messages),
-            tool_choice="none",
+            # The decision envelope, offered as the model's OWN tool channel
+            # when the spec supports one. A model trained hard on tool calling
+            # otherwise answers on that channel anyway — as native call syntax
+            # inside the text — and the strict decoder rejects a reply whose
+            # intent was right and whose channel was wrong, at the price of a
+            # full round trip. Both channels carry the same envelope and are
+            # validated by the same decoder; see harness/reply_channel.py.
+            #
+            # Built from frozen schema metadata and the static description, so
+            # the tools array (the FRONT of the provider cache prefix) is
+            # byte-identical on every step of the episode.
+            tools=reply_channel_tools(
+                self._model_spec,
+                public_reply_schema(),
+                description=PUBLIC_REPLY_TOOL_DESCRIPTION,
+            ),
+            # Still "none" in intent for every OTHER tool: the episode drives
+            # the environment through the action protocol, never through
+            # harness tools. ``auto`` here because the one tool on offer IS the
+            # reply, and "none" would forbid the channel we just offered — the
+            # exact contradiction that produced the rejections.
+            tool_choice="auto" if self._model_spec.supports_tools else "none",
             prompt_cache_key=self._prompt_cache_key,
         )
         (
@@ -994,7 +1022,14 @@ class ProviderModelClient:
             provider_request_id,
             context_tokens,
             stream_error,
+            channel_reply,
+            tool_call_count,
         ) = await self._stream(request)
+        if channel_reply is not None:
+            # The model answered on the offered channel. Its arguments ARE the
+            # envelope, so the raw JSON goes to the same decoder the prose path
+            # uses: no second parser, no salvage, identical rejections.
+            text = channel_reply
         self._last_request_ms = _now_ms()
         if context_tokens is not None:
             # A figure reported FOR the request just sent is measured against
@@ -1048,6 +1083,11 @@ class ProviderModelClient:
                 context_tokens=_estimate_context(messages),
                 compaction=compaction,
                 action_surface=action_surface,
+                # Was hardcoded to 0 while the runner sent no tools and read no
+                # call. Now that the reply channel exists, the bundle records
+                # how the model actually answered — which is the measurement
+                # that says whether offering the channel is paying off.
+                tool_call_count=tool_call_count,
             )
         except DecisionParseError as error:
             # The call happened and was billed; only the reply is unusable.
@@ -1151,7 +1191,10 @@ class ProviderModelClient:
             # whether an unsummarizable context is a provider failure or a
             # harness one (``ContextUnrecoverableError``), which is a different
             # question from this change's.
-            text, usage, cost, _stop, _rid, _ctx, _err = await self._stream(
+            # The summary request offers no tools (``_summary_request`` sends
+            # ``tool_choice="none"`` with an empty list), so the channel fields
+            # are inert here — a summary is prose by definition.
+            text, usage, cost, _stop, _rid, _ctx, _err, _channel, _calls = await self._stream(
                 self._summary_request(prompt)
             )
             summary_usage = usage
@@ -1350,7 +1393,7 @@ class ProviderModelClient:
 
     async def _stream(
         self, request: Any
-    ) -> tuple[str, ModelUsage, int, str, str, int | None, str | None]:
+    ) -> tuple[str, ModelUsage, int, str, str, int | None, str | None, str | None, int]:
         text = ""
         usage = ModelUsage()
         cost_micros = 0
@@ -1360,9 +1403,20 @@ class ProviderModelClient:
         provider_request_id = "unknown"
         context_tokens: int | None = None
         stream_error: str | None = None
+        # Reply-channel calls, accumulated per stream index because a provider
+        # delivers a call's name and its arguments across many deltas. Assembly
+        # is the harness loop's, so the two agree on what a provider's fragments
+        # add up to (``LoopRunner._assemble_tool_call``).
+        channel_calls: dict[int, dict[str, Any]] = {}
         async for event in self._stream_fn(request, None):
             if event.type == "text_delta":
                 text += event.delta
+            elif event.type == "tool_call_delta":
+                state = channel_calls.setdefault(event.index, {"name": "", "arg_parts": []})
+                if event.name:
+                    state["name"] += event.name
+                if event.argument_delta:
+                    state["arg_parts"].append(event.argument_delta)
             elif event.type == "usage":
                 usage, cost_micros = _usage_from(event.usage)
                 context_tokens = _context_tokens_from(event.usage)
@@ -1385,6 +1439,19 @@ class ProviderModelClient:
                 # normalized stop. Dropping this field is what left a refused
                 # episode's evidence blaming the model's JSON.
                 stream_error = event.error
+        from local_operator.harness.types import ToolCall
+
+        calls = [
+            ToolCall(
+                name=state["name"],
+                raw_arguments="".join(state["arg_parts"]).strip() or None,
+            )
+            for _, state in sorted(channel_calls.items())
+        ]
+        # ``None`` when the model did not use the channel (read the prose
+        # instead); the empty string when it did and sent nothing usable, which
+        # is a rejection the decoder must still report.
+        channel_reply = envelope_from_tool_call(calls, name=REPLY_CHANNEL_TOOL_NAME)
         return (
             text,
             usage,
@@ -1393,6 +1460,12 @@ class ProviderModelClient:
             provider_request_id,
             context_tokens,
             stream_error,
+            channel_reply,
+            # Every call the stream carried, including any the model made to a
+            # name we never offered. Recorded in the evidence bundle rather
+            # than acted on: a model reaching for a tool that does not exist is
+            # a signal about the prompt, not something to salvage.
+            len(calls),
         )
 
 

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -525,6 +525,7 @@ def parse_decision(
     stop_reason: str = "stop",
     provider_request_id: str = "unknown",
     tool_call_count: int = 0,
+    offered_tool_count: int = 0,
     prompt_cache_key: str | None = None,
     context_tokens: int | None = None,
     compaction: CompactionRecord | None = None,
@@ -606,6 +607,7 @@ def parse_decision(
         stop_reason=stop_reason,
         provider_request_id=provider_request_id,
         tool_call_count=tool_call_count,
+        offered_tool_count=offered_tool_count,
         prompt_cache_key=prompt_cache_key,
         context_tokens=context_tokens,
         compaction=compaction,
@@ -1001,9 +1003,16 @@ class ProviderModelClient:
             # Built from frozen schema metadata and the static description, so
             # the tools array (the FRONT of the provider cache prefix) is
             # byte-identical on every step of the episode.
+            # Built from the NEGOTIATED surface, not the full ActionBatch. The
+            # prose prompt is surface-aware, so offering the unfiltered schema
+            # would advertise actions (``paste_text``, or ``ask_user`` on an
+            # adapter without it) that the surface then rejects -- inviting the
+            # model into exactly the rejection this change exists to prevent.
+            # The surface is fixed for the episode, so this stays byte-identical
+            # across steps and the cache prefix is unaffected.
             tools=reply_channel_tools(
                 self._model_spec,
-                public_reply_schema(),
+                public_reply_schema(action_surface),
                 description=PUBLIC_REPLY_TOOL_DESCRIPTION,
             ),
             # Still "none" in intent for every OTHER tool: the episode drives
@@ -1025,10 +1034,20 @@ class ProviderModelClient:
             channel_reply,
             tool_call_count,
         ) = await self._stream(request)
-        if channel_reply is not None:
+        if channel_reply:
             # The model answered on the offered channel. Its arguments ARE the
             # envelope, so the raw JSON goes to the same decoder the prose path
             # uses: no second parser, no salvage, identical rejections.
+            #
+            # Truthiness, not ``is not None``, and the distinction is a real
+            # regression rather than style. A model that answers in prose AND
+            # emits a name-only channel call -- no arguments, or an argument
+            # stream cut short by a length stop -- yields an EMPTY channel
+            # reply. Preferring it unconditionally would overwrite a complete,
+            # valid prose envelope with "", producing the exact
+            # "not valid JSON: Expecting value" rejection this change exists to
+            # remove, on a turn that previously succeeded. An empty channel
+            # reply carries no decision, so the prose text still stands.
             text = channel_reply
         self._last_request_ms = _now_ms()
         if context_tokens is not None:
@@ -1088,6 +1107,11 @@ class ProviderModelClient:
                 # how the model actually answered — which is the measurement
                 # that says whether offering the channel is paying off.
                 tool_call_count=tool_call_count,
+                # How many tools the REQUEST offered, so the request payload can
+                # say so rather than asserting a constant zero. Since the reply
+                # channel may now put one tool on the wire, a hardcoded 0 would
+                # describe a request the wire never carried.
+                offered_tool_count=len(request.tools or ()),
             )
         except DecisionParseError as error:
             # The call happened and was billed; only the reply is unusable.

--- a/local_operator/evaluation/runner/provider_client.py
+++ b/local_operator/evaluation/runner/provider_client.py
@@ -1145,6 +1145,12 @@ class ProviderModelClient:
                 cost_micros=cost_micros,
                 stop_reason=stop_reason,
                 provider_request_id=provider_request_id,
+                # The rejection path is where this number matters MOST: a reply
+                # rejected while the channel was on offer is the measurement
+                # that says whether offering it is paying off. Leaving it 0
+                # here would have made every rejected attempt look like a
+                # request that offered no tools, which the wire never sent.
+                offered_tool_count=len(request.tools or ()),
                 prompt_cache_key=self._prompt_cache_key,
                 context_tokens=_estimate_context(messages),
                 compaction=compaction,

--- a/local_operator/evaluation/runner/public_reply.py
+++ b/local_operator/evaluation/runner/public_reply.py
@@ -20,6 +20,15 @@ MAX_PUBLIC_OBSERVATIONS_CHARS = 2_000
 _ENVELOPE_KEYS = {"reply_version", "action_batch", "public_observations"}
 REJECTED_PUBLIC_REPLY = "(model reply rejected; no public observations accepted)"
 
+#: What the reply-channel function tells the model it is for. Kept beside the
+#: envelope it describes so the two cannot drift, and deliberately short: it
+#: rides in the request's cache prefix on every call of every episode.
+PUBLIC_REPLY_TOOL_DESCRIPTION = (
+    "Submit your decision for the current observation. This means exactly the "
+    "same thing as replying with the JSON envelope described in your "
+    "instructions -- use whichever is natural, and never both."
+)
+
 
 def is_public_reply(value: Any) -> bool:
     # Reserve every envelope key: a misspelled/missing version must not silently
@@ -131,15 +140,22 @@ def redact_public_reply(payload: str, redactions: RedactionSet) -> str:
     return canonical_bytes(value).decode("utf-8")
 
 
-def public_reply_contract() -> dict[str, Any]:
-    """Publish a reproducible reply identity separately from the tool surface.
+def public_reply_schema() -> dict[str, Any]:
+    """The envelope's JSON Schema, shared by the contract and the reply channel.
 
-    The action array schema is borrowed, not copied: its vocabulary and bounds
-    remain owned by ActionBatch. Negotiated execution restrictions are declared
-    by the existing action_surface metadata/tool digest and still gate parsing.
+    One definition with two readers. It is published in the evidence bundle's
+    reply contract (below) AND handed to the harness's structured reply channel
+    as that function's parameters, so the tool the model may call and the prose
+    envelope it may write are provably the same shape rather than two hand-kept
+    copies that drift apart.
+
+    Derived from :class:`ActionBatch` on every call rather than cached: it is
+    built from frozen model metadata, so it is deterministic — which is what
+    lets it ride in the prompt-cache prefix unchanged across an episode's
+    turns — and recomputing keeps a new action kind from drifting out.
     """
     batch_schema = ActionBatch.model_json_schema()
-    schema = {
+    return {
         "$defs": batch_schema["$defs"],
         "type": "object",
         "additionalProperties": False,
@@ -155,6 +171,16 @@ def public_reply_contract() -> dict[str, Any]:
             "public_observations": {"type": "string", "maxLength": MAX_PUBLIC_OBSERVATIONS_CHARS},
         },
     }
+
+
+def public_reply_contract() -> dict[str, Any]:
+    """Publish a reproducible reply identity separately from the tool surface.
+
+    The action array schema is borrowed, not copied: its vocabulary and bounds
+    remain owned by ActionBatch. Negotiated execution restrictions are declared
+    by the existing action_surface metadata/tool digest and still gate parsing.
+    """
+    schema = public_reply_schema()
     contract = {
         "schema": schema,
         "legacy_plain_action_batch": True,

--- a/local_operator/evaluation/runner/public_reply.py
+++ b/local_operator/evaluation/runner/public_reply.py
@@ -218,6 +218,21 @@ def _inlined_action_schema(model: Any) -> dict[str, Any]:
     schema = model.model_json_schema()
     defs = schema.pop("$defs", {})
 
+    # ``kind`` carries the discriminator, and pydantic does not mark it
+    # ``required`` because each model defaults it. That is safe under a
+    # discriminated union, where the tag selects the member before its fields
+    # are checked; it is NOT safe under the bare ``anyOf`` this flattening
+    # produces, because a batch omitting ``kind`` then satisfies whichever
+    # member happens to match on its other fields. The old schema denied such
+    # a batch and pydantic still rejects it, so leaving it out would admit at
+    # the schema what the validator refuses -- inviting the model into exactly
+    # the rejection this contract exists to prevent. Requiring the tag keeps
+    # the flattened set identical to the discriminated one.
+    required = schema.get("required")
+    if "kind" in schema.get("properties", {}) and isinstance(required, list):
+        if "kind" not in required:
+            schema["required"] = sorted([*required, "kind"])
+
     def resolve(node: Any) -> Any:
         if isinstance(node, dict):
             ref = node.get("$ref")

--- a/local_operator/evaluation/runner/public_reply.py
+++ b/local_operator/evaluation/runner/public_reply.py
@@ -8,11 +8,12 @@ text path as interactive sessions; private reasoning is never an input here.
 from __future__ import annotations
 
 import json
-from typing import Any, Mapping
+from typing import Any, Mapping, get_args
 from urllib.parse import unquote
 
+from local_operator.evaluation.action_surface import ActionSurface
 from local_operator.evaluation.evidence.models import canonical_bytes, canonical_digest
-from local_operator.evaluation.protocol import ActionBatch
+from local_operator.evaluation.protocol import ComputerAction
 from local_operator.evaluation.receipts import RedactionSet
 
 REPLY_VERSION = "1.0"
@@ -140,7 +141,13 @@ def redact_public_reply(payload: str, redactions: RedactionSet) -> str:
     return canonical_bytes(value).decode("utf-8")
 
 
-def public_reply_schema() -> dict[str, Any]:
+#: Every action kind the protocol defines, used when no surface is supplied.
+#: The published contract describes the protocol, not one adapter's negotiated
+#: subset, so it advertises them all.
+_ALL_ACTION_MODELS = get_args(get_args(ComputerAction)[0])
+
+
+def public_reply_schema(action_surface: ActionSurface | None = None) -> dict[str, Any]:
     """The envelope's JSON Schema, shared by the contract and the reply channel.
 
     One definition with two readers. It is published in the evidence bundle's
@@ -149,14 +156,22 @@ def public_reply_schema() -> dict[str, Any]:
     envelope it may write are provably the same shape rather than two hand-kept
     copies that drift apart.
 
-    Derived from :class:`ActionBatch` on every call rather than cached: it is
-    built from frozen model metadata, so it is deterministic — which is what
-    lets it ride in the prompt-cache prefix unchanged across an episode's
-    turns — and recomputing keeps a new action kind from drifting out.
+    ``action_surface`` filters the admitted action kinds to the ones the
+    NEGOTIATED surface actually accepts. Passing it is what keeps the offered
+    schema honest: the prose prompt is surface-aware, so an unfiltered schema
+    would advertise ``paste_text`` — or ``ask_user`` on an adapter without it —
+    and the model following the schema would then be rejected by
+    ``validate_batch``. Omitting it keeps the full batch, which is what the
+    published contract wants.
+
+    Derived from the models on every call rather than cached: they are frozen
+    metadata, so the result is deterministic — which is what lets it ride in the
+    prompt-cache prefix unchanged across an episode's turns, the surface being
+    fixed for the episode — and recomputing keeps a new action kind from
+    drifting out.
     """
-    batch_schema = ActionBatch.model_json_schema()
+    models = action_surface.models if action_surface is not None else _ALL_ACTION_MODELS
     return {
-        "$defs": batch_schema["$defs"],
         "type": "object",
         "additionalProperties": False,
         "required": sorted(_ENVELOPE_KEYS),
@@ -166,11 +181,56 @@ def public_reply_schema() -> dict[str, Any]:
                 "type": "object",
                 "additionalProperties": False,
                 "required": ["actions"],
-                "properties": {"actions": batch_schema["properties"]["actions"]},
+                "properties": {
+                    "actions": {
+                        "type": "array",
+                        # ``anyOf`` over INLINED member schemas, not a ``$ref``
+                        # into ``$defs`` with a ``oneOf``/``discriminator``.
+                        #
+                        # This schema is handed to a provider as a function's
+                        # parameters, and Gemini's ``FunctionDeclaration``
+                        # accepts only a narrow OpenAPI 3.0 subset: ``$ref``,
+                        # ``$defs``, ``oneOf`` and ``discriminator`` are all
+                        # rejected with 400 INVALID_ARGUMENT, which would fail
+                        # EVERY request of a Gemini-routed episode rather than
+                        # degrading. ``tools/builtin.py`` carries the same
+                        # warning for the same reason. The discriminated union
+                        # is therefore flattened here: ``anyOf`` over concrete
+                        # member schemas is the same admitted set, expressed in
+                        # a shape every provider accepts.
+                        "items": {"anyOf": [_inlined_action_schema(m) for m in models]},
+                    }
+                },
             },
             "public_observations": {"type": "string", "maxLength": MAX_PUBLIC_OBSERVATIONS_CHARS},
         },
     }
+
+
+def _inlined_action_schema(model: Any) -> dict[str, Any]:
+    """One action model's schema with its ``$defs`` resolved into place.
+
+    Pydantic emits ``$ref``/``$defs`` for nested models. A provider that rejects
+    those constructs cannot read the result, so the references are substituted
+    for the definitions they name and the ``$defs`` block is dropped.
+    """
+
+    schema = model.model_json_schema()
+    defs = schema.pop("$defs", {})
+
+    def resolve(node: Any) -> Any:
+        if isinstance(node, dict):
+            ref = node.get("$ref")
+            if isinstance(ref, str) and ref.startswith("#/$defs/"):
+                target = defs.get(ref.rsplit("/", 1)[-1], {})
+                merged = {k: v for k, v in node.items() if k != "$ref"}
+                return {**resolve(target), **merged}
+            return {key: resolve(value) for key, value in node.items()}
+        if isinstance(node, list):
+            return [resolve(item) for item in node]
+        return node
+
+    return resolve(schema)
 
 
 def public_reply_contract() -> dict[str, Any]:

--- a/local_operator/harness/reply_channel.py
+++ b/local_operator/harness/reply_channel.py
@@ -53,6 +53,26 @@ prose path the other cohorts use successfully at a ~10% rejection rate, and a
 forced call is a worse failure when a model has genuinely nothing to say. The
 channel is OFFERED (``auto``); the prompt still describes the prose envelope,
 and both are accepted.
+
+**Which callers should adopt this, and which must not.** The test is whether
+the request already sends a tool array, because this one is APPENDED to it:
+
+* **Adopt it** when the request currently sends ``tools=[]`` and asks for a
+  strict structured reply in prose. The benchmark runner's decision envelope
+  (``evaluation/runner/provider_client.py``) is the first such caller: with an
+  empty array the wire carries no ``tools`` and no ``tool_choice`` key at all,
+  so the request neither offered the channel nor forbade it, and the tool this
+  module adds is the entire prefix delta.
+* **Do NOT adopt it** in ``Session.complete_aside`` or
+  ``Session.advise_compaction``. Those deliberately send the WORKING TURN's
+  live tool schema so their request rides the turn's already-cached prefix;
+  the tools block is the front of that prefix, so appending one more function
+  would diverge it at position 0 and force a full re-process at cache-WRITE
+  price. That was measured (``scripts/measure_advisor_cache.py``: 0% hit,
+  ``cache_write=14590`` against ``cache_write=568``), and it is the economics
+  the whole advisor feature rests on. Their rejection path is also cheap —
+  ``parse_hint`` returning ``None`` costs a fallback, not a re-prompt loop —
+  so they have neither the problem nor the headroom this trades against.
 """
 
 from __future__ import annotations

--- a/local_operator/harness/reply_channel.py
+++ b/local_operator/harness/reply_channel.py
@@ -1,0 +1,175 @@
+"""Offer a structured reply as the model's own tool channel, not only as prose.
+
+Some requests do not want the model to ACT — they want one structured answer
+back: the benchmark runner's action envelope, a compaction advisor's hint, any
+"reply with this exact JSON object" errand. The established way to ask is prose
+("reply with a single JSON object and nothing else") plus ``tool_choice="none"``.
+
+That works until it meets a model whose tool channel is the strongest thing in
+its post-training. Under pressure such a model answers on the channel it was
+trained to answer on, emitting its own native call syntax as TEXT, and a strict
+prose decoder throws the whole reply away — a full paid round trip returning
+``not valid JSON: Expecting value: line 1 column 1``, with the model's INTENT
+correct and only its CHANNEL wrong.
+
+Measured over three cohorts on the same frozen benchmark tasks and the same
+harness family, counting accepted batches against rejected replies:
+
+    cohort   accepted   rejected   rejection rate
+    luna          125         18            12.6%
+    opus          149         16             9.7%
+    kimi           46         36            43.9%
+
+33 of kimi's 36 rejections were exactly this: native tool syntax where the
+envelope belonged.
+
+The fix is to stop making the two channels rivals. When the model spec says
+tools are supported, the SAME envelope is also offered as one function whose
+parameters ARE the envelope schema, and a call to it is read as the reply.
+Nothing executes it — it is a reply channel, not a capability — so the caller
+keeps driving whatever it drove before and both channels converge on one
+validated structure.
+
+Three properties this module exists to hold, each of which is load-bearing:
+
+* **One validated structure.** :func:`envelope_from_tool_call` returns the
+  argument JSON as TEXT for the caller's existing decoder. There is no second
+  parser and no salvage path: a malformed reply on the tool channel fails in
+  the same decoder, with the same message, as a malformed reply in prose. The
+  channel changes where the bytes come from, never what counts as valid.
+* **Cache stability.** The offered tool rides in the request prefix (the tools
+  array sits at the FRONT of it — tools -> system -> messages on Anthropic, and
+  inside the cached body on the OpenAI-compatible and Gemini wires), so it is
+  built from static inputs and is byte-identical on every turn of a request
+  family. A schema that varied per turn would re-write the prefix on each call
+  and cost more than the rejections it saves.
+* **No model, provider, or task knowledge.** The only question asked is the
+  capability the spec already reports (``supports_tools``). Sniffing for a
+  vendor's marker syntax and salvaging it would be a per-model rule that ages
+  badly and silently widens what the harness accepts.
+
+Deliberately NOT ``tool_choice="required"``. Forcing the call would remove the
+prose path the other cohorts use successfully at a ~10% rejection rate, and a
+forced call is a worse failure when a model has genuinely nothing to say. The
+channel is OFFERED (``auto``); the prompt still describes the prose envelope,
+and both are accepted.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any, Iterable
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle guard, types only
+    from local_operator.harness.types import AgentTool, ToolCall
+
+#: The reply channel is a CHANNEL, never a capability: nothing dispatches it,
+#: so a name collision with a real tool would be a silent misroute rather than
+#: a loud one. It is namespaced and stable — the name is part of the request
+#: prefix, so renaming it per turn would break the prompt cache.
+REPLY_CHANNEL_TOOL_NAME = "lop_structured_reply"
+
+
+async def _never_executes(
+    _name: str,
+    _arguments: dict[str, Any],
+    _signal: Any,
+    _update: Any,
+    _context: Any,
+) -> Any:
+    """Fail loudly if this tool is ever dispatched.
+
+    The reply channel is consumed by the caller reading the stream, never by
+    the tool loop. Reaching this function means some caller put the channel in
+    a request whose tool calls are EXECUTED, which would run the model's reply
+    as if it were an action — so it raises instead of returning a benign
+    result that would hide the wiring mistake.
+    """
+    raise RuntimeError(
+        f"{REPLY_CHANNEL_TOOL_NAME} is a reply channel and must never be executed; "
+        "the caller is expected to read it from the stream"
+    )
+
+
+def build_reply_channel_tool(
+    schema: dict[str, Any],
+    *,
+    description: str,
+    name: str = REPLY_CHANNEL_TOOL_NAME,
+) -> "AgentTool":
+    """One function whose parameters ARE the caller's reply envelope.
+
+    ``schema`` is passed through unchanged rather than rebuilt here: the
+    envelope's shape stays owned by whoever defines the envelope, so this
+    module cannot drift from the decoder that validates it. Callers that
+    already publish a JSON Schema for their prose contract should hand that
+    exact object over, which is what makes the two channels the same contract.
+    """
+    from local_operator.harness.types import AgentTool
+
+    return AgentTool(
+        name=name,
+        label="Structured reply",
+        description=description,
+        parameters=schema,
+        # Read tier and non-interruptible are the honest values for something
+        # that performs no side effect; they matter only if a host renders the
+        # tool, since nothing ever runs it.
+        approval_tier="read",
+        concurrency="shared",
+        interruptible=False,
+        # Kept out of any surface that lists callable tools to a user: this is
+        # transport, not a capability someone can invoke.
+        hidden=True,
+        execute=_never_executes,
+    )
+
+
+def reply_channel_tools(
+    model_spec: Any,
+    schema: dict[str, Any],
+    *,
+    description: str,
+    name: str = REPLY_CHANNEL_TOOL_NAME,
+) -> list["AgentTool"]:
+    """The channel when the spec supports tools, and an empty list when not.
+
+    Gating on the spec's own capability flag is what keeps this general. A
+    model with no tool support must still get the request it always got — an
+    empty tools array, no ``tool_choice`` key on the wire at all — because
+    offering a function to a model that cannot take one is at best ignored and
+    at worst a provider-side rejection of the whole request.
+    """
+    if not getattr(model_spec, "supports_tools", False):
+        return []
+    return [build_reply_channel_tool(schema, description=description, name=name)]
+
+
+def envelope_from_tool_call(calls: Iterable["ToolCall"], *, name: str) -> str | None:
+    """The raw argument JSON of the first reply-channel call, or ``None``.
+
+    Returns TEXT, not a parsed object, so the caller feeds it to the very
+    decoder that validates a prose reply. That is the whole point: one
+    validated structure, one set of rejection messages, and no second notion
+    of what a well-formed envelope is.
+
+    ``raw_arguments`` is preferred over the parsed ``arguments`` because it is
+    what the provider actually sent. Round-tripping through ``json.dumps``
+    would quietly REPAIR a duplicate key or a trailing-comma artefact that the
+    strict decoder is supposed to reject, turning a channel meant to be
+    transparent into a lenient one. It falls back to re-serializing only when
+    the provider gave no raw string.
+
+    A call that is present but carries nothing usable returns the empty string
+    rather than ``None`` — a distinction the caller needs, because "the model
+    used the channel and sent garbage" is a rejection to report, while "the
+    model did not use the channel" means read the prose instead.
+    """
+    for call in calls:
+        if call.name != name:
+            continue
+        raw = call.raw_arguments
+        if raw is not None:
+            return raw
+        return json.dumps(call.arguments) if call.arguments else ""
+    return None

--- a/local_operator/harness/reply_channel.py
+++ b/local_operator/harness/reply_channel.py
@@ -193,17 +193,33 @@ def envelope_from_tool_call(calls: Iterable["ToolCall"], *, name: str) -> str | 
     # refuses -- "which one did the model mean?" -- and taking the first would
     # execute a decision the model may have superseded.
     #
-    # Rather than inventing a second rejection, hand the decoder BOTH envelopes
-    # concatenated. Its competing-batch rule keys on ``observation_id``, so two
-    # batches for one observation produce its own "send exactly one action
-    # batch" message, and two for DIFFERENT observations stay tolerated exactly
-    # as they are in prose. One notion of a well-formed reply, one set of
-    # rejections -- which is the property this channel exists to preserve.
+    # Rather than inventing a second rejection, hand the decoder every envelope
+    # the model sent, concatenated, and let its own rules judge them. The
+    # property being preserved is PARITY, not any particular message: the same
+    # concatenated text fails identically whether it arrives as prose or as
+    # calls, so the channel cannot accept a shape prose refuses.
+    #
+    # Which rule fires depends on the reply version. The v1 envelope decoder
+    # requires exactly one object with no trailing text, so it refuses two
+    # envelopes on framing before observation ids are ever compared -- two
+    # batches for DIFFERENT observations are refused there too, and that is
+    # the pre-existing v1 contract rather than anything this channel adds.
+    # The legacy actions-only decoder keeps its own competing-batch rule keyed
+    # on ``observation_id``. Either way the channel inherits the verdict.
+    #
+    # Only calls that actually CARRY an envelope are joined. Joining empty ones
+    # would produce a string of separators -- truthy, so the caller would
+    # prefer it over a perfectly good prose reply and destroy it, which is
+    # exactly the regression the empty-single-call path already guards against.
     if len(matched) > 1:
-        return "\n".join(_call_text(call) for call in matched)
+        carried = [text for text in map(_call_text, matched) if text.strip()]
+        if not carried:
+            return ""
+        if len(carried) == 1:
+            return carried[0]
+        return "\n".join(carried)
 
-    call = matched[0]
-    return _call_text(call)
+    return _call_text(matched[0])
 
 
 def _call_text(call: "ToolCall") -> str:

--- a/local_operator/harness/reply_channel.py
+++ b/local_operator/harness/reply_channel.py
@@ -185,11 +185,36 @@ def envelope_from_tool_call(calls: Iterable["ToolCall"], *, name: str) -> str | 
     used the channel and sent garbage" is a rejection to report, while "the
     model did not use the channel" means read the prose instead.
     """
-    for call in calls:
-        if call.name != name:
-            continue
-        raw = call.raw_arguments
-        if raw is not None:
-            return raw
-        return json.dumps(call.arguments) if call.arguments else ""
-    return None
+    matched = [call for call in calls if call.name == name]
+    if not matched:
+        return None
+
+    # Two calls naming the channel is the SAME ambiguity the prose decoder
+    # refuses -- "which one did the model mean?" -- and taking the first would
+    # execute a decision the model may have superseded.
+    #
+    # Rather than inventing a second rejection, hand the decoder BOTH envelopes
+    # concatenated. Its competing-batch rule keys on ``observation_id``, so two
+    # batches for one observation produce its own "send exactly one action
+    # batch" message, and two for DIFFERENT observations stay tolerated exactly
+    # as they are in prose. One notion of a well-formed reply, one set of
+    # rejections -- which is the property this channel exists to preserve.
+    if len(matched) > 1:
+        return "\n".join(_call_text(call) for call in matched)
+
+    call = matched[0]
+    return _call_text(call)
+
+
+def _call_text(call: "ToolCall") -> str:
+    """The envelope text one channel call carries, empty when it carries none.
+
+    ``raw_arguments`` is preferred over the parsed ``arguments`` because it is
+    what the provider actually sent; re-serializing would quietly REPAIR a
+    duplicate key or trailing-comma artefact the strict decoder must reject.
+    """
+
+    raw = call.raw_arguments
+    if raw is not None:
+        return raw
+    return json.dumps(call.arguments) if call.arguments else ""

--- a/tests/unit/evaluation/runner/test_provider_client.py
+++ b/tests/unit/evaluation/runner/test_provider_client.py
@@ -148,7 +148,10 @@ class ScriptedStream:
 
 
 def _client(stream: Any, tmp_path: Path | None = None, **overrides: Any) -> ProviderModelClient:
-    spec = ModelSpec(provider="provider", model_id="model")
+    # The spec is an override like any other: the reply-channel tests need a
+    # model whose ``supports_tools`` differs, and a second near-identical
+    # factory beside this one would be the drift it exists to prevent.
+    spec = overrides.pop("model_spec", None) or ModelSpec(provider="provider", model_id="model")
     root = tmp_path if tmp_path is not None else Path("/nonexistent-artifact-root")
     return ProviderModelClient(
         stream, route=ROUTE, model_spec=spec, artifact_root=root, **overrides

--- a/tests/unit/evaluation/runner/test_provider_client.py
+++ b/tests/unit/evaluation/runner/test_provider_client.py
@@ -40,11 +40,13 @@ from local_operator.evaluation.runner.provider_client import (
     build_system_prompt,
     parse_decision,
 )
+from local_operator.harness.reply_channel import REPLY_CHANNEL_TOOL_NAME
 from local_operator.harness.types import (
     ImageContent,
     ModelSpec,
     StreamEndEvent,
     StreamTextDelta,
+    StreamToolCallDelta,
     StreamUsageEvent,
     TextContent,
     Usage,
@@ -453,9 +455,13 @@ async def test_client_sends_the_system_prompt_as_a_cacheable_block() -> None:
     request = stream.requests[0]
     assert len(request.system_blocks) == 1
     assert request.messages[0].role == "user"
-    # The episode drives the environment through the protocol, not through
-    # harness tools, so the provider must not be offered any.
-    assert request.tool_choice == "none"
+    # The episode still drives the environment through the protocol, never
+    # through harness tools: the ONLY function offered is the reply channel,
+    # which nothing executes. ``auto`` rather than the old ``none`` because
+    # forbidding the channel we just offered is the contradiction that made a
+    # tool-trained model's reply unparseable — see harness/reply_channel.py.
+    assert request.tool_choice == "auto"
+    assert [tool.name for tool in request.tools] == [REPLY_CHANNEL_TOOL_NAME]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/evaluation/runner/test_provider_client.py
+++ b/tests/unit/evaluation/runner/test_provider_client.py
@@ -46,7 +46,6 @@ from local_operator.harness.types import (
     ModelSpec,
     StreamEndEvent,
     StreamTextDelta,
-    StreamToolCallDelta,
     StreamUsageEvent,
     TextContent,
     Usage,

--- a/tests/unit/evaluation/runner/test_reply_channel.py
+++ b/tests/unit/evaluation/runner/test_reply_channel.py
@@ -1,0 +1,335 @@
+"""The decision envelope offered as the model's own tool channel.
+
+A model whose tool channel is the strongest thing in its post-training answers
+on that channel under pressure, emitting native call syntax as TEXT that the
+strict prose decoder throws away — a full paid round trip for a reply whose
+intent was right and whose channel was wrong (43.9% of one measured cohort's
+replies against ~10% for two others).
+
+These tests hold the four properties that make the fix a fix rather than a
+loosening: the channel is offered on capability alone, both channels converge
+on ONE validated envelope, a malformed reply is still rejected identically on
+either channel, and the schema that rides in the prompt-cache prefix is stable
+across turns.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, AsyncIterator
+
+import pytest
+
+from local_operator.evaluation.protocol import ActionBatch
+from local_operator.evaluation.runner.model import DecisionRejected
+from local_operator.evaluation.runner.public_reply import (
+    public_reply_contract,
+    public_reply_schema,
+)
+from local_operator.harness.reply_channel import (
+    REPLY_CHANNEL_TOOL_NAME,
+    build_reply_channel_tool,
+    envelope_from_tool_call,
+    reply_channel_tools,
+)
+from local_operator.harness.types import (
+    ModelSpec,
+    StreamEndEvent,
+    StreamTextDelta,
+    StreamToolCallDelta,
+    ToolCall,
+)
+from tests.unit.evaluation.runner.test_provider_client import (
+    ROUTE,
+    _client,
+    _turns,
+    finish_payload,
+    observation,
+)
+from tests.unit.evaluation.runner.test_public_reply import envelope
+
+
+class ChannelStream:
+    """A provider that answers by CALLING the reply channel instead of writing prose.
+
+    Arguments arrive in fragments, as a real provider streams them: a client
+    that read only the first delta would pass a whole-string fake and then fail
+    against every live provider.
+    """
+
+    def __init__(
+        self,
+        arguments: str,
+        *,
+        name: str = REPLY_CHANNEL_TOOL_NAME,
+        text: str = "",
+        chunk: int = 5,
+        stop_reason: str = "toolUse",
+    ) -> None:
+        self.arguments = arguments
+        self.name = name
+        self.text = text
+        self.chunk = chunk
+        self.stop_reason = stop_reason
+        self.requests: list[Any] = []
+
+    def __call__(self, request: Any, signal: Any) -> AsyncIterator[Any]:
+        self.requests.append(request)
+        return self._events()
+
+    async def _events(self) -> AsyncIterator[Any]:
+        if self.text:
+            yield StreamTextDelta(delta=self.text)
+        yield StreamToolCallDelta(index=0, id="call-1", name=self.name)
+        for start in range(0, len(self.arguments), self.chunk):
+            yield StreamToolCallDelta(
+                index=0, argument_delta=self.arguments[start : start + self.chunk]
+            )
+        yield StreamEndEvent(stop_reason=self.stop_reason)
+
+
+def _spec(*, supports_tools: bool) -> ModelSpec:
+    return ModelSpec(provider="provider", model_id="model", supports_tools=supports_tools)
+
+
+# ---------------------------------------------------------------------------
+# The channel is offered on capability alone
+# ---------------------------------------------------------------------------
+
+
+def test_reply_channel_is_offered_only_when_the_spec_supports_tools() -> None:
+    """Capability is the ONLY question asked — never the model or provider name."""
+
+    schema = public_reply_schema()
+    offered = reply_channel_tools(_spec(supports_tools=True), schema, description="d")
+    withheld = reply_channel_tools(_spec(supports_tools=False), schema, description="d")
+
+    assert [tool.name for tool in offered] == [REPLY_CHANNEL_TOOL_NAME]
+    assert withheld == []
+
+
+@pytest.mark.asyncio
+async def test_a_tools_capable_model_is_offered_the_channel() -> None:
+    from tests.unit.evaluation.runner.test_provider_client import ScriptedStream
+
+    current = observation()
+    stream = ScriptedStream(finish_payload(current))
+
+    await _client(stream, model_spec=_spec(supports_tools=True)).decide(current, _turns(current))
+
+    request = stream.requests[0]
+    assert [tool.name for tool in request.tools] == [REPLY_CHANNEL_TOOL_NAME]
+    # Offered, never forced: the prose path still works for the cohorts that
+    # already use it successfully, and a forced call is a worse failure when a
+    # model has genuinely nothing to say.
+    assert request.tool_choice == "auto"
+
+
+@pytest.mark.asyncio
+async def test_a_model_without_tool_support_gets_the_request_it_always_got() -> None:
+    """No tools and no wire ``tool_choice`` key — offering a function to a model
+    that cannot take one is at best ignored and at worst a 400 on the whole
+    request."""
+
+    from tests.unit.evaluation.runner.test_provider_client import ScriptedStream
+
+    current = observation()
+    stream = ScriptedStream(finish_payload(current))
+
+    await _client(stream, model_spec=_spec(supports_tools=False)).decide(current, _turns(current))
+
+    request = stream.requests[0]
+    assert request.tools == []
+    assert request.tool_choice == "none"
+
+
+def test_the_channel_is_a_reply_not_a_capability() -> None:
+    """Nothing may execute it: a dispatched reply channel would run the model's
+    answer as if it were an action, so it fails loudly rather than benignly."""
+
+    tool = build_reply_channel_tool(public_reply_schema(), description="d")
+
+    assert tool.hidden is True
+    assert tool.approval_tier == "read"
+    with pytest.raises(RuntimeError, match="never be executed"):
+        import asyncio
+
+        asyncio.run(tool.execute(tool.name, {}, None, None, None))  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Both channels converge on one validated envelope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_both_channels_produce_the_identical_validated_envelope() -> None:
+    """The whole point of the fix: same bytes in, same decision out."""
+
+    from tests.unit.evaluation.runner.test_provider_client import ScriptedStream
+
+    current = observation()
+    body = envelope(finish_payload(current), "Visible status: ready")
+
+    prose = await _client(
+        ScriptedStream(body), model_spec=_spec(supports_tools=True)
+    ).decide(current, _turns(current))
+    channel = await _client(
+        ChannelStream(body), model_spec=_spec(supports_tools=True)
+    ).decide(current, _turns(current))
+
+    assert isinstance(channel.action_batch, ActionBatch)
+    assert channel.action_batch.to_canonical_json() == prose.action_batch.to_canonical_json()
+    assert channel.public_reply == prose.public_reply
+    channel.action_batch.validate_for(current)
+
+
+@pytest.mark.asyncio
+async def test_a_legacy_bare_batch_is_accepted_on_the_channel_too() -> None:
+    """The channel carries whatever the prose path carries, envelope or not."""
+
+    current = observation()
+
+    decision = await _client(
+        ChannelStream(finish_payload(current)), model_spec=_spec(supports_tools=True)
+    ).decide(current, _turns(current))
+
+    assert decision.public_reply is None
+    decision.action_batch.validate_for(current)
+
+
+def test_the_channel_hands_back_raw_bytes_rather_than_a_repaired_object() -> None:
+    """Re-serializing would quietly REPAIR duplicate keys the strict decoder
+    exists to reject, turning a transparent channel into a lenient one."""
+
+    duplicated = '{"reply_version": "1.0", "reply_version": "1.0"}'
+    call = ToolCall(name=REPLY_CHANNEL_TOOL_NAME, raw_arguments=duplicated)
+
+    assert envelope_from_tool_call([call], name=REPLY_CHANNEL_TOOL_NAME) == duplicated
+
+
+def test_an_unused_channel_is_distinguishable_from_an_empty_one() -> None:
+    """``None`` means read the prose; ``""`` means the model used the channel
+    and sent nothing usable, which is a rejection to report."""
+
+    unused = envelope_from_tool_call(
+        [ToolCall(name="something_else", raw_arguments="{}")], name=REPLY_CHANNEL_TOOL_NAME
+    )
+    empty = envelope_from_tool_call(
+        [ToolCall(name=REPLY_CHANNEL_TOOL_NAME, raw_arguments=None)],
+        name=REPLY_CHANNEL_TOOL_NAME,
+    )
+
+    assert unused is None
+    assert empty == ""
+
+
+# ---------------------------------------------------------------------------
+# Rejection is unchanged — no new salvage path, no loosened validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "body",
+    [
+        "not json at all",
+        '{"reply_version": "9.9", "action_batch": {"actions": []}, "public_observations": ""}',
+        '{"actions": []}',
+        "",
+    ],
+)
+async def test_a_malformed_reply_is_rejected_on_the_channel_exactly_as_in_prose(
+    body: str,
+) -> None:
+    from tests.unit.evaluation.runner.test_provider_client import ScriptedStream
+
+    current = observation()
+
+    with pytest.raises(DecisionRejected) as prose:
+        await _client(ScriptedStream(body), model_spec=_spec(supports_tools=True)).decide(
+            current, _turns(current)
+        )
+    with pytest.raises(DecisionRejected) as channel:
+        await _client(ChannelStream(body), model_spec=_spec(supports_tools=True)).decide(
+            current, _turns(current)
+        )
+
+    assert str(channel.value) == str(prose.value)
+
+
+@pytest.mark.asyncio
+async def test_native_tool_syntax_in_prose_is_still_rejected() -> None:
+    """The marker sequence that motivated this work is NOT salvaged. Offering
+    the real channel is the fix; sniffing for a vendor's syntax would be a
+    per-model rule that ages badly and silently widens what is accepted."""
+
+    from tests.unit.evaluation.runner.test_provider_client import ScriptedStream
+
+    current = observation()
+    body = '<|open|>tools<|sep|><|open|>call tool="terminal"{"cmd": "ls"}'
+
+    with pytest.raises(DecisionRejected):
+        await _client(ScriptedStream(body), model_spec=_spec(supports_tools=True)).decide(
+            current, _turns(current)
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_call_to_a_name_we_never_offered_is_not_read_as_a_reply() -> None:
+    """Only THE channel is a reply. Any other call is counted for the evidence
+    bundle and otherwise ignored, so the prose path still decides."""
+
+    current = observation()
+    stream = ChannelStream(finish_payload(current), name="terminal", text="")
+
+    with pytest.raises(DecisionRejected):
+        await _client(stream, model_spec=_spec(supports_tools=True)).decide(
+            current, _turns(current)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Prompt-cache stability
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_request_prefix_stays_cache_stable_across_turns() -> None:
+    """The tools array is the FRONT of the provider cache prefix. A schema that
+    varied per turn would re-write the whole prefix on every call and cost more
+    than the rejections it saves."""
+
+    from tests.unit.evaluation.runner.test_provider_client import ScriptedStream
+
+    first = observation(0)
+    second = observation(1)
+    stream = ScriptedStream(finish_payload(first))
+    client = _client(stream, model_spec=_spec(supports_tools=True))
+
+    await client.decide(first, _turns(first))
+    stream.text = finish_payload(second)
+    await client.decide(second, _turns(first, second))
+
+    tools = [request.tools for request in stream.requests]
+    assert len(tools) == 2
+    assert _serialized(tools[0]) == _serialized(tools[1])
+    # System block too: the channel must not have made the prompt turn-dependent.
+    assert stream.requests[0].system_blocks == stream.requests[1].system_blocks
+
+
+def _serialized(tools: list[Any]) -> str:
+    return json.dumps(
+        [{"name": t.name, "description": t.description, "parameters": t.parameters} for t in tools],
+        sort_keys=True,
+    )
+
+
+def test_the_channel_schema_is_the_published_contract_schema() -> None:
+    """One definition, two readers. If these ever diverge, the tool a model may
+    call and the envelope the decoder validates are different shapes."""
+
+    published = json.loads(public_reply_contract()["model_reply_contract"])["schema"]
+    tool = build_reply_channel_tool(public_reply_schema(), description="d")
+
+    assert tool.parameters == published

--- a/tests/unit/evaluation/runner/test_reply_channel.py
+++ b/tests/unit/evaluation/runner/test_reply_channel.py
@@ -40,7 +40,6 @@ from local_operator.harness.types import (
     ToolCall,
 )
 from tests.unit.evaluation.runner.test_provider_client import (
-    ROUTE,
     _client,
     _turns,
     finish_payload,
@@ -171,12 +170,12 @@ async def test_both_channels_produce_the_identical_validated_envelope() -> None:
     current = observation()
     body = envelope(finish_payload(current), "Visible status: ready")
 
-    prose = await _client(
-        ScriptedStream(body), model_spec=_spec(supports_tools=True)
-    ).decide(current, _turns(current))
-    channel = await _client(
-        ChannelStream(body), model_spec=_spec(supports_tools=True)
-    ).decide(current, _turns(current))
+    prose = await _client(ScriptedStream(body), model_spec=_spec(supports_tools=True)).decide(
+        current, _turns(current)
+    )
+    channel = await _client(ChannelStream(body), model_spec=_spec(supports_tools=True)).decide(
+        current, _turns(current)
+    )
 
     assert isinstance(channel.action_batch, ActionBatch)
     assert channel.action_batch.to_canonical_json() == prose.action_batch.to_canonical_json()

--- a/tests/unit/evaluation/runner/test_reply_channel.py
+++ b/tests/unit/evaluation/runner/test_reply_channel.py
@@ -332,3 +332,138 @@ def test_the_channel_schema_is_the_published_contract_schema() -> None:
     tool = build_reply_channel_tool(public_reply_schema(), description="d")
 
     assert tool.parameters == published
+
+
+# ---------------------------------------------------------------------------
+# Round 1 review: the channel must not accept what prose refuses, and the
+# schema it offers must be one every provider can actually read.
+# ---------------------------------------------------------------------------
+
+
+class TwoCallStream:
+    """A provider that names the reply channel TWICE for one observation."""
+
+    def __init__(self, first: str, second: str) -> None:
+        self.first = first
+        self.second = second
+        self.requests: list[Any] = []
+
+    def __call__(self, request: Any, signal: Any) -> AsyncIterator[Any]:
+        self.requests.append(request)
+        return self._events()
+
+    async def _events(self) -> AsyncIterator[Any]:
+        for index, arguments in enumerate((self.first, self.second)):
+            yield StreamToolCallDelta(index=index, id=f"call-{index}", name=REPLY_CHANNEL_TOOL_NAME)
+            yield StreamToolCallDelta(index=index, argument_delta=arguments)
+        yield StreamEndEvent(stop_reason="toolUse")
+
+
+class NamedButEmptyCallStream:
+    """Prose carries a COMPLETE envelope; the channel is named with no arguments.
+
+    A length stop mid-call produces the same shape, which is why this is a
+    regression risk rather than a curiosity: the model did answer, in prose.
+    """
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.requests: list[Any] = []
+
+    def __call__(self, request: Any, signal: Any) -> AsyncIterator[Any]:
+        self.requests.append(request)
+        return self._events()
+
+    async def _events(self) -> AsyncIterator[Any]:
+        yield StreamTextDelta(delta=self.text)
+        yield StreamToolCallDelta(index=0, id="call-1", name=REPLY_CHANNEL_TOOL_NAME)
+        yield StreamEndEvent(stop_reason="toolUse")
+
+
+@pytest.mark.asyncio
+async def test_two_channel_calls_are_refused_exactly_as_two_prose_batches_are() -> None:
+    """The channel may not accept an ambiguity the prose decoder rejects.
+
+    Taking the first call would execute a decision the model may have
+    superseded — the precise reason the prose path refuses a second batch for
+    the same observation. Both channels must reach the same verdict, or the
+    channel has become a lenient second contract.
+    """
+
+    current = observation()
+    body = envelope(finish_payload(current), "Visible status: ready")
+
+    client = _client(TwoCallStream(body, body), model_spec=_spec(supports_tools=True))
+    with pytest.raises(DecisionRejected) as raised:
+        await client.decide(current, _turns(current))
+
+    assert "second action batch for the same observation" in str(raised.value)
+
+
+@pytest.mark.asyncio
+async def test_an_empty_channel_call_leaves_a_valid_prose_reply_standing() -> None:
+    """Naming the channel without arguments must not destroy a good prose answer.
+
+    Preferring the channel unconditionally turned a turn the harness would have
+    accepted into "not valid JSON: Expecting value" — the very rejection the
+    channel exists to remove.
+    """
+
+    current = observation()
+    body = envelope(finish_payload(current), "Visible status: ready")
+    client = _client(NamedButEmptyCallStream(body), model_spec=_spec(supports_tools=True))
+
+    decision = await client.decide(current, _turns(current))
+
+    assert isinstance(decision.action_batch, ActionBatch)
+    decision.action_batch.validate_for(current)
+
+
+def test_the_offered_schema_avoids_constructs_providers_reject() -> None:
+    """The schema goes on the wire as a function declaration, so it must be portable.
+
+    Gemini's ``FunctionDeclaration.parameters`` accepts a narrow OpenAPI subset:
+    ``$ref``, ``$defs``, ``oneOf`` and ``discriminator`` are rejected with 400
+    INVALID_ARGUMENT, which would fail EVERY request of a Gemini-routed episode
+    rather than degrading. This was previously unreachable only because the
+    runner sent no tools at all.
+    """
+
+    serialized = json.dumps(public_reply_schema())
+
+    for construct in ("$ref", "$defs", "oneOf", "discriminator"):
+        assert construct not in serialized, f"{construct} reaches the provider verbatim"
+
+
+def test_the_offered_schema_advertises_only_what_the_surface_accepts() -> None:
+    """Offering an action the surface rejects invites the model into a rejection.
+
+    The prose prompt is surface-aware, so an unfiltered schema would present a
+    different contract than the prompt — and a model following the schema would
+    be refused by ``validate_batch``.
+    """
+
+    from dataclasses import replace
+
+    from local_operator.evaluation.runner.provider_client import LEGACY_ACTION_SURFACE
+
+    legacy = json.dumps(public_reply_schema(LEGACY_ACTION_SURFACE))
+    assert "paste_text" not in legacy
+
+    without_ask = replace(LEGACY_ACTION_SURFACE, ask_user=False)
+    assert "ask_user" not in json.dumps(public_reply_schema(without_ask))
+
+    # Unchanged for the published contract, which describes the protocol rather
+    # than one adapter's negotiated subset.
+    assert "paste_text" in json.dumps(public_reply_schema())
+
+
+def test_the_surface_scoped_schema_is_still_byte_stable_across_turns() -> None:
+    """The surface is fixed for an episode, so the cache prefix must not move."""
+
+    from local_operator.evaluation.runner.provider_client import LEGACY_ACTION_SURFACE
+
+    first = json.dumps(public_reply_schema(LEGACY_ACTION_SURFACE), sort_keys=True)
+    second = json.dumps(public_reply_schema(LEGACY_ACTION_SURFACE), sort_keys=True)
+
+    assert first == second

--- a/tests/unit/evaluation/runner/test_reply_channel.py
+++ b/tests/unit/evaluation/runner/test_reply_channel.py
@@ -561,3 +561,48 @@ def test_the_flattened_schema_admits_exactly_what_the_validator_admits() -> None
 
     for action in cases:
         assert admitted_by_schema(action) == admitted_by_validator(action), action
+
+    # The agreement above is about SHAPE: presence, type, and per-field range.
+    # It is deliberately not total, and saying so here matters because a green
+    # test otherwise reads as "the schema and the validator agree, full stop".
+    #
+    # A cross-field invariant cannot be expressed in the JSON Schema subset
+    # these providers accept, so the validator stays strictly stricter for
+    # those. ``ScrollAction`` requires some motion; the schema admits a scroll
+    # with both deltas zero and pydantic then rejects it. This is INHERENT, not
+    # a consequence of flattening: the pre-flattening discriminated schema
+    # admitted it too. What the flattening must not do is widen the set beyond
+    # that pre-existing boundary, which is what the loop above pins.
+    motionless_scroll = {
+        "kind": "scroll",
+        "observation_id": "o",
+        "frame_id": "f",
+        "x": 1,
+        "y": 2,
+        "delta_x": 0,
+        "delta_y": 0,
+    }
+    assert admitted_by_schema(motionless_scroll) is True
+    assert admitted_by_validator(motionless_scroll) is False
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_reply_still_records_the_tools_the_request_offered() -> None:
+    """The rejection path is where the offered count matters most.
+
+    A reply rejected WHILE the channel was on offer is the measurement that
+    says whether offering it is paying off. Recording 0 there would describe a
+    request the wire never sent, and would understate exactly the population
+    worth counting.
+    """
+
+    from local_operator.evaluation.runner.model import DecisionRejected
+    from tests.unit.evaluation.runner.test_provider_client import ScriptedStream
+
+    current = observation()
+    client = _client(ScriptedStream("not json at all"), model_spec=_spec(supports_tools=True))
+
+    with pytest.raises(DecisionRejected) as raised:
+        await client.decide(current, _turns(current))
+
+    assert raised.value.offered_tool_count == 1

--- a/tests/unit/evaluation/runner/test_reply_channel.py
+++ b/tests/unit/evaluation/runner/test_reply_channel.py
@@ -467,3 +467,97 @@ def test_the_surface_scoped_schema_is_still_byte_stable_across_turns() -> None:
     second = json.dumps(public_reply_schema(LEGACY_ACTION_SURFACE), sort_keys=True)
 
     assert first == second
+
+
+# ---------------------------------------------------------------------------
+# Round 2 review: the round 1 fixes reopened one defect and widened the schema.
+# ---------------------------------------------------------------------------
+
+
+class TwoEmptyCallStream:
+    """Prose carries a COMPLETE envelope; the channel is named twice, emptily.
+
+    The single-empty-call case was already guarded. Joining several empty calls
+    produced a string of separators, which is TRUTHY, so the guard was bypassed
+    and the good prose reply was destroyed anyway.
+    """
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.requests: list[Any] = []
+
+    def __call__(self, request: Any, signal: Any) -> AsyncIterator[Any]:
+        self.requests.append(request)
+        return self._events()
+
+    async def _events(self) -> AsyncIterator[Any]:
+        yield StreamTextDelta(delta=self.text)
+        for index in range(2):
+            yield StreamToolCallDelta(index=index, id=f"call-{index}", name=REPLY_CHANNEL_TOOL_NAME)
+        yield StreamEndEvent(stop_reason="toolUse")
+
+
+@pytest.mark.asyncio
+async def test_several_empty_channel_calls_still_leave_the_prose_reply_standing() -> None:
+    """Joining empty calls must not manufacture a truthy reply out of separators."""
+
+    current = observation()
+    body = envelope(finish_payload(current), "Visible status: ready")
+    client = _client(TwoEmptyCallStream(body), model_spec=_spec(supports_tools=True))
+
+    decision = await client.decide(current, _turns(current))
+
+    assert isinstance(decision.action_batch, ActionBatch)
+    decision.action_batch.validate_for(current)
+
+
+def test_the_flattened_schema_admits_exactly_what_the_validator_admits() -> None:
+    """Flattening a discriminated union must not widen the admitted set.
+
+    ``kind`` carries the discriminator and pydantic leaves it out of
+    ``required`` because each member defaults it. That is safe under a
+    discriminated union, where the tag selects the member before its fields are
+    checked, and unsafe under a bare ``anyOf``, where a tag-less action matches
+    whichever member its other fields happen to satisfy. Admitting at the
+    schema what the validator rejects invites the model into a rejection, which
+    is the failure class this contract exists to prevent.
+    """
+
+    import jsonschema
+
+    items = public_reply_schema()["properties"]["action_batch"]["properties"]["actions"]["items"]
+    base = {
+        "protocol_version": "1.0",
+        "task_id": "t",
+        "episode_id": "e",
+        "observation_id": "o",
+        "kind": "action_batch",
+    }
+
+    def admitted_by_schema(action: dict[str, Any]) -> bool:
+        try:
+            jsonschema.validate(action, items)
+            return True
+        except jsonschema.ValidationError:
+            return False
+
+    def admitted_by_validator(action: dict[str, Any]) -> bool:
+        try:
+            ActionBatch.model_validate({**base, "actions": [action]})
+            return True
+        except Exception:
+            return False
+
+    cases = [
+        # The exact widening round 2 found: no ``kind``, but a click's fields.
+        {"observation_id": "o", "frame_id": "f", "x": 1, "y": 2},
+        {"kind": "click", "observation_id": "o", "frame_id": "f", "x": 1, "y": 2},
+        {"kind": "wait", "observation_id": "o", "duration_ms": 10},
+        {"kind": "type", "observation_id": "o", "text": "hi"},
+        {"kind": "finish", "observation_id": "o", "status": "done", "reason": "r"},
+        {"kind": "nope", "observation_id": "o"},
+        {"kind": "wait", "observation_id": "o", "duration_ms": 999999},
+    ]
+
+    for action in cases:
+        assert admitted_by_schema(action) == admitted_by_validator(action), action


### PR DESCRIPTION
## Summary

A model with a strongly trained tool-calling channel was throwing away nearly half its replies. Measured across three cohorts on the same ten frozen benchmark tasks and the same harness, counting accepted action batches against rejected replies in the retained evidence bundles:

| cohort | accepted | rejected | rejection rate |
| --- | --- | --- | --- |
| luna | 125 | 18 | 12.6% |
| opus | 149 | 16 | 9.7% |
| kimi | 46 | 36 | **43.9%** |

33 of kimi's 36 rejections were the same thing: the model emitted its **own native tool-call syntax** instead of the JSON envelope the prompt asks for in prose. The intent was right and the channel was wrong. Each rejection costs a full paid round trip and returns `decision is not valid JSON: Expecting value: line 1 column 1 (char 0)`.

## The cause is not what it looked like

The initial hypothesis was that `tool_choice="none"` **forbade** the trained channel. It does not. Both call sites pass `tools=[]`, and every body builder gates the choice on the list:

```python
if request.tools:
    body["tools"] = _tools_to_openai(request.tools)
    body["tool_choice"] = ...
```

With an empty list, **neither `tools` nor `tool_choice` reaches the wire at all**. The request therefore neither offered the channel nor forbade it — the model was left to guess, and a tool-trained one guessed its own syntax. The fix is *offering* the channel, not relaxing a restriction.

## Change class

C1 — standard, pre-authorized. Defect fix in how a request is built. No API change.

## What changed

The decision envelope is offered as one function whose parameters **are** `public_reply_schema()`, gated on `spec.supports_tools`. A call is read back as raw argument bytes and fed to the **existing** decoder — no second parser, no salvage path, no loosened validation, and no model, provider, or task strings anywhere in the logic.

- `local_operator/harness/reply_channel.py` (new) — shared, benchmark-agnostic
- `evaluation/runner/provider_client.py`, `evaluation/runner/public_reply.py`

Rejected: **cheaper recovery from rejection** (treats the symptom; still one wasted paid trip each time); **leaving it alone** (disproved by the reproduction below); **`tool_choice="required"`** (would break the prose path two cohorts already use at ~10%); **sniffing for native-syntax markers and salvaging them** (ages badly, and special-cases a model).

## Harness-wide, not benchmark-local

The mechanism lives in `harness/`, usable by any caller — this is the point, since a win here should be a win for ordinary `lop` sessions too.

`complete_aside`/`advise_compaction` were deliberately **not** retrofitted: they send the working turn's *live* schema so as to ride its cached prefix, and appending a function would diverge that prefix at position 0. Measured cost of getting this wrong: `cache_write=14590` vs `568`. That boundary is documented in the module rather than left implicit, and those paths have a cheap rejection path anyway.

## Evidence

In-process, driving a fake `stream_fn` and asserting on the resulting `ChatRequest` and on the decoded envelope. Round 1 review correctly noted that this section originally claimed loopback HTTP/SSE and wire-body inspection, which the test file does not do — and that the gap is exactly why F3 (a schema Gemini rejects) went unnoticed. What these tests actually prove:

- capable spec → `tools: ['lop_structured_reply']`, `tool_choice: auto`; a reply on the channel parses and validates
- non-capable spec → no `tools`, no `tool_choice`; request byte-unchanged
- both channels → **identical canonical batch**
- the same reply on clean `origin/main` → `decision is not valid JSON: Expecting value: line 1 column 1 (char 0)` — the exact production error, reproduced and then fixed

```
tests/unit/evaluation/runner/test_reply_channel.py    16 passed
tests/unit/evaluation/runner/  (whole dir)           356 passed
```

Mutation evidence: 6 mutations, each killing its test — channel not offered; reply ignored (reproduces the production error verbatim); capability gate removed; raw bytes re-serialized; name check dropped; schema made turn-dependent.

**Gates (whole tree, as CI runs them, `build/` removed first):** flake8 clean · black 26.1.0 clean · isort 5.13.2 clean · pyright `0 errors`.

**The rejection-rate improvement itself is unmeasured.** That needs a live benchmark run against a paid provider, which this branch did not do. What is proven here is narrower and honest: a reply shape that was previously discarded is now accepted and validated identically to the prose path.

## Follow-up observations

Not fixed here, surfaced rather than ticketed:

- `parse_decision`'s `tool_call_count` was hardcoded `0`; wired through, since it is the metric that will say whether this pays off.
- `server/utils/operator.py:580` has the same `tools=[] + tool_choice="none"` no-op. Harmless there — that path wants prose — but it does not do what it reads like.

## Known pre-existing failures, not from this branch

Verified on clean `origin/main`: 4 in `tests/unit/harness/test_efficiency.py`, plus `test_eval_tool.py::test_eval_tool_bridge_uses_this_calls_dispatch` and `test_steering_approval.py::test_empty_assistant_message_mounts_no_block`.

## Version

No bump. `pyproject.toml` stays at the last released version (`0.51.1`) per the release policy.

