### PR TITLE
fix(harness): sweep settled subagent rows on read so the last batch leaves the dock

### DIFF
--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -66,7 +66,7 @@ UNRESOLVED_TERMINAL_STATUSES = frozenset({"failed", "interrupted"})
 
 def retention_expired(
     job: Any,
-    retention_ms: int,
+    retention_ms: float,
     *,
     now: float | None = None,
     settled_at: float | None = None,
@@ -114,7 +114,7 @@ def retention_expired(
 
 def roster_expired(
     job: Any,
-    retention_ms: int,
+    retention_ms: float,
     *,
     paused: bool = False,
     now: float | None = None,

--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -36,6 +36,43 @@ logger = logging.getLogger(__name__)
 DEFAULT_MAX_RUNNING_JOBS = 15
 DEFAULT_RETENTION_MS = 5 * 60_000
 
+
+def retention_expired(job: Any, retention_ms: int, *, now: float | None = None) -> bool:
+    """Has this row outlived its retention window?
+
+    THE one definition of "past retention", used by
+    :meth:`AsyncJobManager._sweep_due` (which evicts) and by the readers that
+    merely present a row (the TUI dock's roster resolver). Both have to answer
+    identically: a panel that applied its own arithmetic would eventually
+    disagree with the ledger it claims to be a view over, and the disagreement
+    would show up as a row that either lingers past the sweep or vanishes
+    before it — the two failure modes this function exists to make impossible.
+
+    Three exemptions, and each is load-bearing:
+
+    * a row with no ``settled_at`` has not settled, so retention has not
+      started;
+    * a ``running`` row is never expired, whatever its stamps say — retention
+      reclaims finished work and must never remove live work;
+    * a ``restored`` row is exempt permanently. Rehydrated rows carry the
+      PREVIOUS session's settle stamp, which is almost always already past the
+      window, so treating them normally would evict every resumed child on the
+      first pass — the exact rows resume exists to keep visible.
+
+    Accepts any row-shaped object (``AsyncJob`` on an owner, a ``JobState`` DTO
+    on a follower) via ``getattr``, because both reach the dock.
+    """
+    if bool(getattr(job, "restored", False)):
+        return False
+    if str(getattr(job, "status", "") or "") == "running":
+        return False
+    settled_at = getattr(job, "settled_at", None)
+    if settled_at is None:
+        return False
+    reference = time.time() if now is None else now
+    return float(settled_at) < reference - retention_ms / 1000.0
+
+
 #: Cap on a job's retained live-output tail (``AsyncJob.output_tail``). Sized
 #: to hold a meaningful working window of a chatty job (a terraform plan, a
 #: training loop's recent epochs) while staying far below the per-call result
@@ -399,6 +436,49 @@ class AsyncJobManager:
         return job
 
     def list(self, *, owner_id: str | None = None) -> list[AsyncJob]:
+        """Every job row, oldest first, with retention applied AT READ TIME.
+
+        The sweep runs here — not only on a settle — because retention's
+        contract (see :meth:`_sweep_due`) is "observable for the full retention
+        period after it settles", not "until some other job happens to settle".
+        Every other ``_sweep_due`` call site is inside a job's own settle/cancel
+        path, so the LAST batch of a session had nothing left to drive its
+        eviction: settled subagent rows sat in the dock's ``Subagents`` panel
+        for the rest of the session and were reclaimed only by starting a new
+        one (issue #524, observed as a live roster showing "+45 more").
+
+        Swept on READ rather than on a timer, deliberately:
+
+        * **The roster is a pull surface.** Every consumer already re-reads it
+          (the TUI's 1 Hz poll, the panel repaint, the ``jobs`` tool, the
+          resume-sidecar writer), and a row that is never read cannot be
+          observed stale. Sweeping where the observation happens makes "a
+          caller never sees an out-of-retention row" a property of the type
+          rather than of a timer's cadence, and it holds identically for
+          server/exec hosts that run no TUI poll at all.
+        * **A timer would need a lifecycle this object does not have.** The
+          manager is constructed outside a running loop in plenty of call sites
+          (tests, restore paths), so a ``create_task`` in ``__init__`` is not
+          available; starting one lazily then means a start hook, a cancel in
+          ``dispose``, and a task that must not outlive the manager — new
+          failure modes (a leaked task, a sweep firing into a disposed
+          manager) bought for no additional guarantee, since a row can only
+          matter once something reads it.
+        * **Cost is nil.** ``_sweep_due`` is one O(n) pass over a roster this
+          method already sorts in O(n log n), on a dict whose size is bounded
+          by the fan-out.
+
+        What this deliberately does NOT change: the sweep evicts only rows that
+        are already past ``settled_at + retention`` and are not ``running``, so
+        a caller sees exactly what it saw before INSIDE the window, and no live
+        job is ever removed. It also does not notify — an eviction is retention
+        arriving, not a job mutation, and firing ``_on_roster_change`` from a
+        read would re-enter this method through the session's own roster writer
+        (``Session._persist_subagent_roster`` reads ``jobs.list()``). The next
+        real mutation persists the shrunken roster, which is the same ordering
+        the existing post-delivery sweep already had.
+        """
+        self._sweep_due()
         jobs = list(self._jobs.values())
         if owner_id is not None:
             jobs = [job for job in jobs if job.owner_id == owner_id]
@@ -413,6 +493,19 @@ class AsyncJobManager:
     @property
     def max_running(self) -> int:
         return self._max_running
+
+    @property
+    def retention_ms(self) -> int:
+        """The retention window this manager applies, in milliseconds.
+
+        Exposed because a READER outside the manager has to be able to apply
+        the SAME window without guessing at it: the TUI dock resolves its rows
+        through the comms graph (which deliberately holds a reference the sweep
+        cannot free — see ``_ChildRecord.job_ref``), so it filters with
+        :func:`retention_expired` against this value rather than re-deriving a
+        constant that a test or a host may have overridden.
+        """
+        return self._retention_ms
 
     def set_max_running(self, value: int) -> None:
         """Change the concurrency ceiling on a LIVE manager.
@@ -1205,20 +1298,21 @@ class AsyncJobManager:
         Retention runs from ``settled_at`` (settle time), never
         ``start_time``: a job that ran longer than the window must still be
         observable for the full retention period after it settles.
+
+        Driven from two kinds of call site, and it needs both. The settle/cancel
+        paths sweep so a long-lived session's ledger stays bounded as work flows
+        through it; :meth:`list` sweeps so the contract above holds for the LAST
+        batch too, which has no later settle behind it (issue #524). Idempotent
+        and total: a second call with nothing due does nothing.
         """
-        cutoff = time.time() - self._retention_ms / 1000.0
+        now = time.time()
         for job_id in [
             job_id
             for job_id, job in self._jobs.items()
-            # ``restored`` rows are exempt: they carry the PREVIOUS session's
-            # settle stamp, which is almost always already past the retention
-            # window, so an unguarded sweep would evict every rehydrated child
-            # on the first pass after resume — the exact rows this feature
-            # exists to keep visible. They leave only when the session ends.
-            if not job.restored
-            and job.status != "running"
-            and job.settled_at is not None
-            and job.settled_at < cutoff
+            # The predicate (including the ``restored``/``running`` exemptions
+            # and why they exist) lives in :func:`retention_expired`, shared
+            # with the readers that present a row without owning it.
+            if retention_expired(job, self._retention_ms, now=now)
         ]:
             del self._jobs[job_id]
             self._signals.pop(job_id, None)

--- a/local_operator/harness/jobs.py
+++ b/local_operator/harness/jobs.py
@@ -37,16 +37,48 @@ DEFAULT_MAX_RUNNING_JOBS = 15
 DEFAULT_RETENTION_MS = 5 * 60_000
 
 
-def retention_expired(job: Any, retention_ms: int, *, now: float | None = None) -> bool:
-    """Has this row outlived its retention window?
+#: Terminal statuses that leave the USER with something still to do. They are
+#: the reason :func:`roster_expired` exists as a separate question from
+#: :func:`retention_expired`: retention's clock measures how long ago a job
+#: stopped, which cannot express whether anyone still needs the row.
+#:
+#: * ``failed`` — a failure asks for action, and its child page (the
+#:   trajectory that says WHY) is reachable only from a roster row. The panel
+#:   already holds this law everywhere else: ``_EVICTION_RANK`` ranks failures
+#:   above quietly-settled rows so the collapsed preview never drops the row
+#:   asking for attention, and ``note_child_failed`` re-opens a panel the user
+#:   deliberately hid for a single failure. Expiring a failure on the
+#:   quiet-success timer inverted both (design round 1, D1).
+#: * ``interrupted`` — a run cut off mid-flight, which is resumable and
+#:   therefore unfinished. In practice these rows also carry ``restored`` (the
+#:   only producer is :meth:`AsyncJobManager.restore`) and are exempt twice
+#:   over; naming it here keeps the RULE complete rather than relying on that
+#:   coincidence holding.
+#:
+#: ``cancelled`` is deliberately NOT here, and the omission is load-bearing:
+#: cancelling is the user saying "I am not coming back for this". Comms leans
+#: on exactly that reading — ``SubagentComms.cancel`` on a PAUSED child clears
+#: ``record.paused`` to record abandonment — so a cancelled row that never
+#: expired would make that clearing meaningless. ``completed`` is the base
+#: case the window was designed around.
+UNRESOLVED_TERMINAL_STATUSES = frozenset({"failed", "interrupted"})
 
-    THE one definition of "past retention", used by
-    :meth:`AsyncJobManager._sweep_due` (which evicts) and by the readers that
-    merely present a row (the TUI dock's roster resolver). Both have to answer
-    identically: a panel that applied its own arithmetic would eventually
-    disagree with the ledger it claims to be a view over, and the disagreement
-    would show up as a row that either lingers past the sweep or vanishes
-    before it — the two failure modes this function exists to make impossible.
+
+def retention_expired(
+    job: Any,
+    retention_ms: int,
+    *,
+    now: float | None = None,
+    settled_at: float | None = None,
+) -> bool:
+    """Has this row outlived its retention window? — the LEDGER's question.
+
+    Strictly "has the clock run out", which is what bounds a long session's
+    memory: :meth:`AsyncJobManager._sweep_due` evicts on exactly this answer.
+    It deliberately does NOT ask whether anyone still wants to see the row —
+    that is :func:`roster_expired`, and keeping the two apart is what lets the
+    ledger release execution evidence on schedule while the dock goes on
+    showing a failure the user has not looked at yet.
 
     Three exemptions, and each is load-bearing:
 
@@ -59,18 +91,75 @@ def retention_expired(job: Any, retention_ms: int, *, now: float | None = None) 
       window, so treating them normally would evict every resumed child on the
       first pass — the exact rows resume exists to keep visible.
 
-    Accepts any row-shaped object (``AsyncJob`` on an owner, a ``JobState`` DTO
-    on a follower) via ``getattr``, because both reach the dock.
+    Accepts any row-shaped object via ``getattr`` rather than requiring an
+    ``AsyncJob``, because the dock resolves rows through the comms graph and a
+    reduced host may hand it something else entirely.
+
+    ``settled_at`` overrides the row's own stamp. The exemptions above still
+    decide first, so an override can never expire a row the rules protect; it
+    exists so a READER may age a row against an adjusted instant (the dock
+    buckets stamps so a batch leaves together) without reimplementing any of
+    this. The ledger never passes it, and sweeps on the true stamp.
     """
     if bool(getattr(job, "restored", False)):
         return False
     if str(getattr(job, "status", "") or "") == "running":
         return False
-    settled_at = getattr(job, "settled_at", None)
-    if settled_at is None:
+    stamp = getattr(job, "settled_at", None) if settled_at is None else settled_at
+    if stamp is None:
         return False
     reference = time.time() if now is None else now
-    return float(settled_at) < reference - retention_ms / 1000.0
+    return float(stamp) < reference - retention_ms / 1000.0
+
+
+def roster_expired(
+    job: Any,
+    retention_ms: int,
+    *,
+    paused: bool = False,
+    now: float | None = None,
+    settled_at: float | None = None,
+) -> bool:
+    """May a ROSTER READER stop showing this row? — the dock's question.
+
+    THE RULE, stated once so the next reader knows what the window means:
+    **retention is a timer on quiet resolutions, not on unfinished business.**
+    A row the user must still act on or come back to — a failure to review, a
+    child they paused precisely to return to — does not age out on the same
+    clock as a success nobody needs to look at again. Everything else expires
+    when :func:`retention_expired` says the clock has run out.
+
+    Two exemptions on top of the ledger's, and they are one mistake, not two:
+    before this, visibility was decided from ``status`` + ``settled_at`` alone,
+    and neither field can express intent.
+
+    * :data:`UNRESOLVED_TERMINAL_STATUSES` (see it for why ``cancelled`` is
+      excluded) — the row is the only entry to the child's page, so dropping
+      it drops the trajectory that explains the failure.
+    * ``paused`` — passed in rather than read off the row, because
+      ``AsyncJob`` has no such field and cannot get one honestly.
+      ``SubagentComms.pause`` is MECHANICALLY A CANCEL (its own docstring says
+      so): it stamps ``status == "cancelled"`` and records the intent on
+      ``_ChildRecord.paused``, which the comms record owns and mutates in
+      three places (pause sets it, cancel and resume clear it). Copying that
+      onto the job row would create a second, independently-mutable source of
+      truth for one fact — the drift this PR exists to remove — so the reader
+      consults the owner instead. The caller already holds the comms node, so
+      this costs nothing to supply.
+
+    The asymmetry with the ledger is deliberate and cheap: the manager may
+    still sweep an exempt row out of ``_jobs`` (bounded memory is its job),
+    and the dock keeps rendering it through ``_ChildRecord.job_ref``, the same
+    surviving reference the whole two-layer fix rests on. So an unbounded pile
+    of failures cannot grow the ledger, and what the panel DRAWS is bounded by
+    its own density controls (``_EVICTION_RANK``, ``+N more``, ``ctrl+g``),
+    which already rank failures first.
+    """
+    if paused:
+        return False
+    if str(getattr(job, "status", "") or "") in UNRESOLVED_TERMINAL_STATUSES:
+        return False
+    return retention_expired(job, retention_ms, now=now, settled_at=settled_at)
 
 
 #: Cap on a job's retained live-output tail (``AsyncJob.output_tail``). Sized

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -81,6 +81,12 @@ from local_operator.harness.intent import (
     tool_activity,
 )
 
+# The retention predicate the job ledger sweeps with. Imported here so the dock
+# roster applies the SAME rule to rows the comms graph resolves (which the
+# manager's own sweep cannot reach — see `_subagent_roster`), rather than
+# re-deriving a window that could drift from the ledger's.
+from local_operator.harness.jobs import retention_expired
+
 # Free at runtime: `session.protocol` below already imports `harness.types` at
 # module level, so this adds no work to the boot path the lazy-import
 # discipline protects. The aside builds the request-scoped turns it hands to
@@ -15375,12 +15381,55 @@ class OperatorApp(App[None]):
             job = next((row for row in getattr(frontend, "jobs", ()) if row.id == job_id), None)
         return job
 
+    @staticmethod
+    def _within_retention(jobs: list[Any], manager: Any) -> list[Any]:
+        """Drop rows the ledger's retention window has already released.
+
+        Split out of :meth:`_subagent_roster` so the rule is testable on its
+        own and so the resolver's happy path stays one expression. Total and
+        silent by design — this feeds a status surface, so an unreadable
+        manager or a row of an unexpected shape returns the input unchanged
+        rather than blanking the dock: showing a stale row is a much smaller
+        failure than showing none.
+
+        The window comes from the LIVE manager (``retention_ms``); a follower
+        has no local manager, and its rows arrive already filtered by the
+        owner's own snapshot, so with no manager this is the identity.
+        """
+        retention_ms = getattr(manager, "retention_ms", None)
+        if not isinstance(retention_ms, int):
+            return jobs
+        now = time.time()
+        try:
+            return [job for job in jobs if not retention_expired(job, retention_ms, now=now)]
+        except Exception:  # noqa: BLE001 — the dock must not fail on a filter
+            return jobs
+
     def _subagent_roster(self) -> tuple[list[Any], Any]:
         """Resolve one direct-child scope for open, retarget, tick and close.
 
         The execution ledger is local on an owner and flattened on a follower.
         The comms graph is the common ownership contract, never the current row
         selection or a best-effort label match.
+
+        RETENTION IS APPLIED HERE, and it has to be. This resolver does not
+        read ``jobs.list()`` on the comms path — it walks the comms graph and
+        asks ``comms.job()`` for each node, and that lookup falls back to
+        ``_ChildRecord.job_ref``, a live reference the manager's ``del`` cannot
+        free (kept on purpose: a swept child must keep its durable identity so
+        its transcript page still resolves — see
+        ``test_a_swept_child_keeps_its_durable_identity_on_the_roster``). So
+        the manager sweeping a settled row does NOT by itself take it off the
+        dock: the graph hands the same row straight back, which is why issue
+        #524's panel kept showing settled children after the ledger had let
+        them go. Identity outliving retention is correct; PRESENTING it as a
+        current roster row is not, so the presentation layer filters.
+
+        Filtered with the manager's own :func:`retention_expired` against the
+        manager's own window, never a local re-derivation, so the panel and the
+        ledger cannot drift. A running row and a ``restored`` row are exempt by
+        that predicate, so a live child and a resumed session's rehydrated
+        children are untouched.
         """
         session = self._session
         comms = getattr(session, "_subagent_comms", None)
@@ -15392,6 +15441,7 @@ class OperatorApp(App[None]):
             if comms is not None and callable(getattr(comms, "children", None)):
                 nodes = comms.children(view.job_id if view is not None else None)
                 jobs = [job for node in nodes if (job := job_for(node.job_id)) is not None]
+                jobs = self._within_retention(jobs, manager)
                 return jobs, job_for(view.job_id) if view is not None else None
             # Old/local hosts without lineage can still show their root ledger,
             # but a child must never inherit its parent's roster by default.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -81,11 +81,11 @@ from local_operator.harness.intent import (
     tool_activity,
 )
 
-# The retention predicate the job ledger sweeps with. Imported here so the dock
-# roster applies the SAME rule to rows the comms graph resolves (which the
-# manager's own sweep cannot reach — see `_subagent_roster`), rather than
-# re-deriving a window that could drift from the ledger's.
-from local_operator.harness.jobs import retention_expired
+# The roster-visibility predicate, a superset of the retention clock the job
+# ledger sweeps with. Imported here so the dock applies the SAME window to rows
+# the comms graph resolves (which the manager's own sweep cannot reach — see
+# `_subagent_roster`), rather than re-deriving one that could drift from it.
+from local_operator.harness.jobs import roster_expired
 
 # Free at runtime: `session.protocol` below already imports `harness.types` at
 # module level, so this adds no work to the boot path the lazy-import
@@ -714,6 +714,83 @@ def _gate_timeout_notice(details: dict[str, Any]) -> str:
 #: dozen rows is the cheaper of those two costs. The band is only repainted
 #: when the count actually CHANGES.
 JOB_POLL_INTERVAL_S = 1.0
+
+#: Bucket the dock's expiry clock to this many seconds. Rows whose settle
+#: stamps fall in the same bucket therefore cross the window on the SAME
+#: repaint, so a fan-out that finished together leaves together — one visible
+#: event, matching how the user thinks about a batch ("that batch is done").
+#:
+#: Without it the dock shrinks a row at a time: six children settling a second
+#: apart produced six separate dock repaints, ratcheting down over minutes on
+#: a staggered fan-out (design round 1, D2). The movement was always confined
+#: to the dock — the composer stays pinned and transcript content does not
+#: drift — which is why this is polish rather than a defect.
+#:
+#: Chosen at 15 s as the largest bucket that is still small against the
+#: 5-minute default window (5% of it) — big enough to coalesce a realistic
+#: batch, small enough that "five minutes" stays an honest description.
+#: Quantising DOWN is what makes this safe: it can only ever DELAY an expiry,
+#: never hasten one, so no row is dropped before its full window has elapsed.
+#: Applied at the READER only; the ledger sweeps on the exact clock.
+ROSTER_EXPIRY_BUCKET_S = 15.0
+
+#: The bucket is also capped at this fraction of the window itself, which is
+#: what keeps the coalescing PROPORTIONATE instead of merely small in absolute
+#: terms. A fixed 15 s is 5% of the shipped five minutes and unnoticeable, but
+#: it would be twelve times a 1.2 s window — measured on a short-window probe,
+#: where a settled row that should have gone at 1.2 s was still docked because
+#: the bucket alone outlasted its whole retention. Since quantising can only
+#: delay, an oversized bucket does not break correctness; it silently
+#: lengthens the window, which is exactly the kind of quiet disagreement
+#: between stated and actual behaviour this PR exists to remove.
+ROSTER_EXPIRY_BUCKET_FRACTION = 0.05
+
+
+def _expiry_bucket_s(retention_ms: float) -> float:
+    """The coalescing bucket for one window. See :data:`ROSTER_EXPIRY_BUCKET_S`."""
+    proportional = max(0.0, retention_ms) / 1000.0 * ROSTER_EXPIRY_BUCKET_FRACTION
+    return min(ROSTER_EXPIRY_BUCKET_S, proportional)
+
+
+def _bucketed_settle_stamp(settled_at: float, retention_ms: float) -> float:
+    """Round a settle stamp UP to its bucket boundary, so rows that settled
+    within one bucket share an expiry instant and therefore leave the dock on
+    the SAME pass.
+
+    The quantization is on the STAMP, not on the reader's clock, and that
+    distinction is the whole mechanism — I measured the clock version first and
+    it does not coalesce at all. Flooring ``now`` makes the comparison instant
+    jump in steps, but each row is still compared against its own stamp, so six
+    rows a second apart still cross a stepping boundary one at a time (measured:
+    3 separate shrink events over ten 1 Hz ticks, against 6 unquantized). Giving
+    the rows a shared boundary is what makes one batch one event.
+
+    Rounds UP, never down: a later effective stamp means a LATER expiry, so a
+    row is only ever granted up to one extra bucket of visibility and can never
+    be dropped before its full window has elapsed.
+    """
+    bucket = _expiry_bucket_s(retention_ms)
+    if bucket <= 0:
+        return settled_at
+    remainder = settled_at % bucket
+    return settled_at if remainder == 0 else settled_at + (bucket - remainder)
+
+
+def _bucketed_stamp_of(job: Any, retention_ms: float) -> float | None:
+    """A row's settle stamp, bucketed — ``None`` when it has not settled.
+
+    ``None`` passes straight through so :func:`roster_expired` applies its own
+    "no stamp means retention has not started" rule rather than this function
+    inventing an answer for a running row.
+    """
+    settled_at = getattr(job, "settled_at", None)
+    if settled_at is None:
+        return None
+    try:
+        return _bucketed_settle_stamp(float(settled_at), retention_ms)
+    except (TypeError, ValueError):
+        return None
+
 
 #: How often the background usage warmer checks whether the active provider's
 #: quota row is going stale. The warmer only REFRESHES when the shared cache row
@@ -15382,28 +15459,85 @@ class OperatorApp(App[None]):
         return job
 
     @staticmethod
-    def _within_retention(jobs: list[Any], manager: Any) -> list[Any]:
-        """Drop rows the ledger's retention window has already released.
+    def _within_retention(jobs: list[Any], manager: Any, paused_ids: set[str]) -> list[Any]:
+        """Drop rows the roster window has released — see :func:`roster_expired`.
 
         Split out of :meth:`_subagent_roster` so the rule is testable on its
         own and so the resolver's happy path stays one expression. Total and
         silent by design — this feeds a status surface, so an unreadable
         manager or a row of an unexpected shape returns the input unchanged
         rather than blanking the dock: showing a stale row is a much smaller
-        failure than showing none.
+        failure than showing none. A filter that raises is LOGGED rather than
+        merely swallowed: failing open restores #524 exactly, and a permanent
+        failure that says nothing is undiagnosable (review round 1, m2).
 
-        The window comes from the LIVE manager (``retention_ms``); a follower
-        has no local manager, and its rows arrive already filtered by the
-        owner's own snapshot, so with no manager this is the identity.
+        ``paused_ids`` carries the intent the job row cannot: a paused child is
+        mechanically a cancelled one, so the flag lives on the comms record and
+        the resolver reads it there (see :func:`roster_expired`).
+
+        The window comes from the LIVE manager. ``retention_ms`` is accepted as
+        any real number but NOT as a ``bool`` — ``isinstance(True, int)`` is
+        true, and a stray ``True`` would silently impose a 1 ms window, while
+        the earlier ``int``-only guard silently disabled the filter for the
+        ``1000.0`` a float-passing embedder supplies (review round 1, m1).
+
+        A FOLLOWER has no local manager, so this is the identity there. That is
+        deliberate and NOT because its rows arrive pre-filtered — an earlier
+        version of this comment claimed that and it was false (review round 1,
+        M2): ``frontend_state._jobs`` overwrites the swept list wholesale with
+        ``comms.job_rows()``, the identical bypass this resolver closes on the
+        owner, so a viewer does still see rows the owner has shed. It is left
+        that way ON PURPOSE — the publish is the viewer's ONLY handle on a
+        swept child, and QA measured that filtering it drops the viewer to zero
+        rows and takes ``node()``/``get()`` to 0/3, breaking the transcript
+        page. Fixing it properly needs an identity-vs-membership split (a
+        presentation flag on ``JobState``, or filtering at the follower's own
+        resolver where the owner's window is not known), which is a distinct
+        change. Tracked as deferred on PR #732; see its consumer table.
         """
         retention_ms = getattr(manager, "retention_ms", None)
-        if not isinstance(retention_ms, int):
+        if isinstance(retention_ms, bool) or not isinstance(retention_ms, (int, float)):
             return jobs
         now = time.time()
+        window = float(retention_ms)
         try:
-            return [job for job in jobs if not retention_expired(job, retention_ms, now=now)]
+            return [
+                job
+                for job in jobs
+                if not roster_expired(
+                    job,
+                    int(retention_ms),
+                    paused=str(getattr(job, "id", "") or "") in paused_ids,
+                    now=now,
+                    settled_at=_bucketed_stamp_of(job, window),
+                )
+            ]
         except Exception:  # noqa: BLE001 — the dock must not fail on a filter
+            logger.warning("subagent roster retention filter failed", exc_info=True)
             return jobs
+
+    @staticmethod
+    def _paused_child_ids(comms: Any) -> set[str]:
+        """Job ids the parent PAUSED, read from the graph that owns the fact.
+
+        A pause is recorded on ``_ChildRecord.paused`` and surfaces as
+        ``node.status == "paused"`` (``SubagentComms._node``, where it outranks
+        every other status for the same reason it matters here). Reading the
+        node keeps this a pure consumer of the comms projection rather than a
+        second interpretation of the record.
+
+        Never raises: a status surface must not be taken down by a graph that
+        cannot answer, and an empty set simply means "no intent known", which
+        degrades to the plain retention rule.
+        """
+        try:
+            nodes = comms.nodes() if callable(getattr(comms, "nodes", None)) else ()
+            return {
+                str(node.job_id) for node in nodes if str(getattr(node, "status", "")) == "paused"
+            }
+        except Exception:  # noqa: BLE001 — the dock must not fail on a lookup
+            logger.warning("reading paused subagents failed", exc_info=True)
+            return set()
 
     def _subagent_roster(self) -> tuple[list[Any], Any]:
         """Resolve one direct-child scope for open, retarget, tick and close.
@@ -15412,7 +15546,7 @@ class OperatorApp(App[None]):
         The comms graph is the common ownership contract, never the current row
         selection or a best-effort label match.
 
-        RETENTION IS APPLIED HERE, and it has to be. This resolver does not
+        THE ROSTER WINDOW IS APPLIED HERE, and it has to be. This resolver does not
         read ``jobs.list()`` on the comms path — it walks the comms graph and
         asks ``comms.job()`` for each node, and that lookup falls back to
         ``_ChildRecord.job_ref``, a live reference the manager's ``del`` cannot
@@ -15425,11 +15559,14 @@ class OperatorApp(App[None]):
         them go. Identity outliving retention is correct; PRESENTING it as a
         current roster row is not, so the presentation layer filters.
 
-        Filtered with the manager's own :func:`retention_expired` against the
-        manager's own window, never a local re-derivation, so the panel and the
-        ledger cannot drift. A running row and a ``restored`` row are exempt by
-        that predicate, so a live child and a resumed session's rehydrated
-        children are untouched.
+        Filtered with :func:`roster_expired` against the manager's OWN window,
+        never a local re-derivation, so the panel and the ledger cannot drift
+        about when the clock runs out. Where they differ is deliberate and
+        stated in that function: the ledger evicts on time alone, while the
+        roster additionally keeps rows the user has unfinished business with
+        (a failure to review, a child they paused to come back to). Running
+        and ``restored`` rows are exempt in both, so a live child and a
+        resumed session's rehydrated children are untouched.
         """
         session = self._session
         comms = getattr(session, "_subagent_comms", None)
@@ -15441,7 +15578,7 @@ class OperatorApp(App[None]):
             if comms is not None and callable(getattr(comms, "children", None)):
                 nodes = comms.children(view.job_id if view is not None else None)
                 jobs = [job for node in nodes if (job := job_for(node.job_id)) is not None]
-                jobs = self._within_retention(jobs, manager)
+                jobs = self._within_retention(jobs, manager, self._paused_child_ids(comms))
                 return jobs, job_for(view.job_id) if view is not None else None
             # Old/local hosts without lineage can still show their root ledger,
             # but a child must never inherit its parent's roster by default.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -267,6 +267,7 @@ from local_operator.tui.widgets.subagent_panel import (
     SubagentPanel,
     SubagentRow,
     job_elapsed,
+    paused_child_ids,
 )
 from local_operator.tui.widgets.subagent_view import SubagentView, SubagentViewDismissed
 from local_operator.tui.widgets.toast import (
@@ -720,17 +721,17 @@ JOB_POLL_INTERVAL_S = 1.0
 #: repaint, so a fan-out that finished together leaves together — one visible
 #: event, matching how the user thinks about a batch ("that batch is done").
 #:
-#: Without it the dock shrinks a row at a time: six children settling a second
-#: apart produced six separate dock repaints, ratcheting down over minutes on
-#: a staggered fan-out (design round 1, D2). The movement was always confined
-#: to the dock — the composer stays pinned and transcript content does not
-#: drift — which is why this is polish rather than a defect.
+#: Without it the dock shrinks ONE ROW PER EXPIRY, so a fan-out ratchets down
+#: over as many repaints as it had children (design round 1, D2). The movement
+#: was always confined to the dock — the composer stays pinned and transcript
+#: content does not drift — which is why this is polish rather than a defect.
 #:
 #: Chosen at 15 s as the largest bucket that is still small against the
 #: 5-minute default window (5% of it) — big enough to coalesce a realistic
 #: batch, small enough that "five minutes" stays an honest description.
-#: Quantising DOWN is what makes this safe: it can only ever DELAY an expiry,
-#: never hasten one, so no row is dropped before its full window has elapsed.
+#: Rounding UP is what makes this safe: it can only ever DELAY an expiry,
+#: never hasten one, so no row is dropped before its full window has elapsed
+#: (see :func:`_bucketed_settle_stamp`, which is where the rounding happens).
 #: Applied at the READER only; the ledger sweeps on the exact clock.
 ROSTER_EXPIRY_BUCKET_S = 15.0
 
@@ -743,6 +744,14 @@ ROSTER_EXPIRY_BUCKET_S = 15.0
 #: delay, an oversized bucket does not break correctness; it silently
 #: lengthens the window, which is exactly the kind of quiet disagreement
 #: between stated and actual behaviour this PR exists to remove.
+#:
+#: A SECOND property falls out of this ratio and is worth naming, because
+#: :func:`_bucketed_settle_stamp` depends on it: a constant ratio means
+#: ``W / b == 20`` exactly whenever the fraction binds, so ``W mod b == 0`` on
+#: every window this rule produces. That is the condition under which
+#: bucketing a row's stamp and flooring the reader's clock agree — see that
+#: function for why the choice between them is about robustness rather than
+#: about one of them working and the other not.
 ROSTER_EXPIRY_BUCKET_FRACTION = 0.05
 
 
@@ -757,13 +766,49 @@ def _bucketed_settle_stamp(settled_at: float, retention_ms: float) -> float:
     within one bucket share an expiry instant and therefore leave the dock on
     the SAME pass.
 
-    The quantization is on the STAMP, not on the reader's clock, and that
-    distinction is the whole mechanism — I measured the clock version first and
-    it does not coalesce at all. Flooring ``now`` makes the comparison instant
-    jump in steps, but each row is still compared against its own stamp, so six
-    rows a second apart still cross a stepping boundary one at a time (measured:
-    3 separate shrink events over ten 1 Hz ticks, against 6 unquantized). Giving
-    the rows a shared boundary is what makes one batch one event.
+    QUANTISING THE READER'S CLOCK INSTEAD WOULD ALSO WORK on every window this
+    code ships. The reason to prefer this is robustness, not effectiveness, and
+    the distinction is recorded here rather than quietly dropped because this
+    comment is the record of why a reviewer's proposal was not taken.
+
+    An earlier version asserted the clock variant "does not coalesce at all",
+    citing a point measurement. That was WRONG: the figure came from a probe
+    that advanced each row's ``settled_at`` while holding ``now`` fixed — the
+    inverse of the real system, where the stamps are fixed and the clock
+    advances — and flooring a frozen clock is a constant, so that rig could not
+    show coalescing for the variant it was judging. Three independent reviewers
+    failed to reproduce it.
+
+    The honest argument is arithmetic, and unlike any measurement it holds at
+    every phase:
+
+    * flooring the clock expires a row at the first multiple of ``b`` after
+      ``settled_at + W``;
+    * bucketing the stamp expires it at ``ceil(settled_at / b) * b + W``.
+
+    Those coincide for rows sharing a bucket exactly when ``W mod b == 0``.
+    :data:`ROSTER_EXPIRY_BUCKET_FRACTION` makes that true by construction on
+    every window it produces (``W / b == 20``), which is why the clock variant
+    is *accidentally* correct here rather than wrong. Pick a window where the
+    ratio does not divide — ``W = 323.5 s``, ``W / b = 21.57`` — and the two
+    diverge. Bucketing the stamp is correct for ANY window, so it does not
+    depend on a constant elsewhere in this file continuing to hold.
+
+    NO POINT FIGURE FOR THE COALESCING IS QUOTED ANYWHERE HERE, deliberately.
+    How many repaints a batch costs depends on where its stamps fall against
+    the bucket grid: the same six rows shed in one pass at most alignments and
+    two when they straddle a boundary. Four separate agents measured this
+    mechanism and produced four different numbers, each correct for its own
+    alignment and each wrong as a general claim — which is exactly how the
+    false assertion above got written. What is true at every phase is the
+    ordering: bucketed is never worse than unbucketed, and unbucketed costs one
+    repaint per row. ``test_a_batch_that_settled_together_leaves_in_one_shrink_event``
+    asserts that as a phase sweep with an unbucketed control, rather than
+    pinning a single lucky alignment.
+
+    It also keeps the reader's clock honest: a row is still aged against the
+    real ``now``, so its age stays directly comparable to the ledger's, and
+    only the stamp is adjusted.
 
     Rounds UP, never down: a later effective stamp means a LATER expiry, so a
     row is only ever granted up to one extra bucket of visibility and can never
@@ -15459,7 +15504,7 @@ class OperatorApp(App[None]):
         return job
 
     @staticmethod
-    def _within_retention(jobs: list[Any], manager: Any, paused_ids: set[str]) -> list[Any]:
+    def _within_roster_window(jobs: list[Any], manager: Any, paused_ids: set[str]) -> list[Any]:
         """Drop rows the roster window has released — see :func:`roster_expired`.
 
         Split out of :meth:`_subagent_roster` so the rule is testable on its
@@ -15499,6 +15544,11 @@ class OperatorApp(App[None]):
         if isinstance(retention_ms, bool) or not isinstance(retention_ms, (int, float)):
             return jobs
         now = time.time()
+        # ONE representation of the window for both the predicate and the
+        # bucket. They previously took ``int`` and ``float`` of the same value:
+        # harmless at every realistic window, but two spellings of one quantity
+        # is how a sub-millisecond window ends up truncating to 0 in one of
+        # them and not the other (review round 2, F4).
         window = float(retention_ms)
         try:
             return [
@@ -15506,38 +15556,15 @@ class OperatorApp(App[None]):
                 for job in jobs
                 if not roster_expired(
                     job,
-                    int(retention_ms),
+                    window,
                     paused=str(getattr(job, "id", "") or "") in paused_ids,
                     now=now,
                     settled_at=_bucketed_stamp_of(job, window),
                 )
             ]
         except Exception:  # noqa: BLE001 — the dock must not fail on a filter
-            logger.warning("subagent roster retention filter failed", exc_info=True)
+            logger.warning("subagent roster window filter failed", exc_info=True)
             return jobs
-
-    @staticmethod
-    def _paused_child_ids(comms: Any) -> set[str]:
-        """Job ids the parent PAUSED, read from the graph that owns the fact.
-
-        A pause is recorded on ``_ChildRecord.paused`` and surfaces as
-        ``node.status == "paused"`` (``SubagentComms._node``, where it outranks
-        every other status for the same reason it matters here). Reading the
-        node keeps this a pure consumer of the comms projection rather than a
-        second interpretation of the record.
-
-        Never raises: a status surface must not be taken down by a graph that
-        cannot answer, and an empty set simply means "no intent known", which
-        degrades to the plain retention rule.
-        """
-        try:
-            nodes = comms.nodes() if callable(getattr(comms, "nodes", None)) else ()
-            return {
-                str(node.job_id) for node in nodes if str(getattr(node, "status", "")) == "paused"
-            }
-        except Exception:  # noqa: BLE001 — the dock must not fail on a lookup
-            logger.warning("reading paused subagents failed", exc_info=True)
-            return set()
 
     def _subagent_roster(self) -> tuple[list[Any], Any]:
         """Resolve one direct-child scope for open, retarget, tick and close.
@@ -15578,7 +15605,7 @@ class OperatorApp(App[None]):
             if comms is not None and callable(getattr(comms, "children", None)):
                 nodes = comms.children(view.job_id if view is not None else None)
                 jobs = [job for node in nodes if (job := job_for(node.job_id)) is not None]
-                jobs = self._within_retention(jobs, manager, self._paused_child_ids(comms))
+                jobs = self._within_roster_window(jobs, manager, paused_child_ids(comms))
                 return jobs, job_for(view.job_id) if view is not None else None
             # Old/local hosts without lineage can still show their root ledger,
             # but a child must never inherit its parent's roster by default.
@@ -16405,6 +16432,10 @@ class OperatorApp(App[None]):
             # opened from has been evicted from the ledger, and claiming the
             # child is still working would be the one wrong answer.
             status=str(getattr(job, "status", "") or "gone") if job is not None else "gone",
+            # A pause reads as ``cancelled`` on the job row; only the graph
+            # knows it was deliberate, and the page must not contradict the
+            # dock row it was opened from (design round 2, D5).
+            paused=str(getattr(node, "status", "")) == "paused",
             queued=bool(getattr(job, "queued", False)),
             elapsed=job_elapsed(job) if job is not None else "0s",
             # The settled outcome, for the one fact the page's own fields

--- a/local_operator/tui/widgets/subagent_panel.py
+++ b/local_operator/tui/widgets/subagent_panel.py
@@ -21,6 +21,7 @@ ledger.
 
 from __future__ import annotations
 
+import logging
 import time
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -44,6 +45,8 @@ from local_operator.tui.widgets.tool_card import (
     format_duration,
     truncate_cells,
 )
+
+logger = logging.getLogger(__name__)
 
 #: Spinner cadence shared with the status band: 12.5 fps is the app's one
 #: notion of "this is moving", and two different speeds on one screen would
@@ -75,6 +78,23 @@ GLYPH_QUEUED = "⏳"
 #: media-control marks (``⏸``/``⏯``, siblings of the wide ``⏳`` queued glyph) it
 #: cannot balloon to a two-cell colour emoji and shear the time column.
 GLYPH_INTERRUPTED = "↺"
+
+#: A child the parent stopped ON PURPOSE, meaning to come back to it.
+#:
+#: It needs its own mark because ``SubagentComms.pause`` is MECHANICALLY A
+#: CANCEL — the row it leaves behind carries ``status == "cancelled"`` — so
+#: without this a pause and an abandonment painted the identical ``⊘ cancelled``
+#: row. That was survivable while both expired on the same timer; once the dock
+#: began keeping paused rows forever and expiring cancelled ones after five
+#: minutes, two pixel-identical rows had opposite lifetimes, and the frame
+#: contradicted the intent the user had recorded (design round 2, D5).
+#:
+#: ``⏸`` (U+23F8) over the ``‖``/``∥`` alternatives: it is the one mark whose
+#: meaning is "paused" rather than "two lines", and it is ``east_asian_width=N``
+#: — checked, because the neighbouring media-control marks are exactly the trap
+#: :data:`GLYPH_INTERRUPTED` documents. Unlike its sibling ``⏳`` (W, two cells)
+#: it locks to ONE cell, so it cannot shear the time column.
+GLYPH_PAUSED = "⏸"
 
 #: Rows the panel spends on chrome rather than on jobs: the ``Subagents``
 #: caption. Named because :meth:`SubagentPanel.predicted_rows` adds it to the
@@ -200,7 +220,21 @@ DEFAULT_DOCK_DENSITY = Density.FULL
 #: ``hidden`` at all. The ``Subagents`` word goes before the numbers: on a
 #: 50-column terminal the reader can tell a row of ✗/⣾ counts from the todo
 #: list without the label, and cannot tell ``1 failed`` from nothing.
-_SUMMARY_SHED_ORDER = ("cancelled", "interrupted", "queued", "done", "label", "running", "failed")
+#: ``paused`` sheds just before ``running`` and after every quietly-settled
+#: count: it is a state the user deliberately created and will come back to
+#: (its row now outlives the window), so it outranks the outcomes that merely
+#: happened — but a child working RIGHT NOW still outranks one deliberately
+#: stopped, and a failure still outranks both.
+_SUMMARY_SHED_ORDER = (
+    "cancelled",
+    "interrupted",
+    "queued",
+    "done",
+    "label",
+    "paused",
+    "running",
+    "failed",
+)
 
 #: Eviction rank for the collapsed preview, lowest kept first. Running and
 #: queued children are the ones the user is waiting on; a failure is the one
@@ -213,11 +247,18 @@ _SUMMARY_SHED_ORDER = ("cancelled", "interrupted", "queued", "done", "label", "r
 #: together, so adding a queued rank later — the obvious edit, since the
 #: design names queued explicitly — would have silently changed behaviour for
 #: a state this table appears to describe (round 1, F4).
+#: ``paused`` ranks beside ``interrupted``, and it has to be here rather than
+#: falling to the default: those rows now OUTLIVE the retention window, so a
+#: preview that evicted one in favour of a quiet success would drop the row the
+#: user is coming back to while keeping one that is about to expire on its own
+#: (design round 2, D5). Below ``failed``, which still outranks everything
+#: settled.
 _EVICTION_RANK: dict[str, int] = {
     "running": 0,
     "queued": 0,
     "failed": 1,
     "interrupted": 2,
+    "paused": 2,
 }
 
 #: Seam between the numbers on a row. The same ` · ` the full-page view's
@@ -302,7 +343,7 @@ _DEFAULT_ROW_WIDTH = 120
 
 
 def status_glyph(
-    status: str, *, queued: bool = False, spinner_glyph: str = ""
+    status: str, *, queued: bool = False, spinner_glyph: str = "", paused: bool = False
 ) -> tuple[str, str, str]:
     """``(glyph, word, semantic colour token)`` for one task job's state.
 
@@ -310,6 +351,13 @@ def status_glyph(
     full-page view render the SAME job side by side — a user who leaves the
     page and reads the row must not meet a second vocabulary for the state
     they were just looking at.
+
+    ``paused`` is passed IN rather than read off the status, for the same
+    reason the roster filter takes it that way: a paused child's job row says
+    ``cancelled`` (pause is implemented as a cancel) and the intent lives on
+    ``_ChildRecord.paused``, which the comms graph owns. It outranks every
+    other state here exactly as it does in ``SubagentComms._describe``, so one
+    child cannot read as two things on two surfaces.
 
     The WORD comes back with the glyph rather than being read off the job,
     and that is not tidiness: a queued job's ``status`` is still ``running``,
@@ -320,6 +368,12 @@ def status_glyph(
     A running job's glyph is the caller's spinner frame: motion says "alive"
     and the ink stays neutral, so the accent green is not spent a sixth time.
     """
+    if paused and status != "running":
+        # Gated on "not running" so a pause still LANDING (the flag is set
+        # before the cancel it awaits) does not paint a stopped child while it
+        # is demonstrably still going — the same window ``_describe`` guards
+        # with its ``pausing`` state.
+        return GLYPH_PAUSED, "paused", "muted"
     if queued:
         return GLYPH_QUEUED, "queued", "dim"
     if status == "running":
@@ -488,6 +542,12 @@ class RowFacts:
     label: str
     status: str
     queued: bool
+    #: The parent stopped this child MEANING to come back to it. Carried as its
+    #: own fact rather than derived from ``status``, because a pause is
+    #: implemented as a cancel and the row cannot tell the two apart — see
+    #: :data:`GLYPH_PAUSED`. Sourced from the comms graph by the app and handed
+    #: down, so the panel stays a pure renderer of facts it is given.
+    paused: bool
     running: bool
     elapsed: str
     activity: str
@@ -508,7 +568,7 @@ class RowFacts:
     agent_role: str = ""
 
 
-def row_facts(job: Any, *, fallback_id: str, current: bool) -> RowFacts:
+def row_facts(job: Any, *, fallback_id: str, current: bool, paused: bool = False) -> RowFacts:
     """Read one job into the strings a row paints. Never raises.
 
     Guarded whole, and not merely with ``getattr`` defaults: a default only
@@ -519,19 +579,20 @@ def row_facts(job: Any, *, fallback_id: str, current: bool) -> RowFacts:
     message-handler exception, i.e. the whole app, for a status row.
     """
     try:
-        return _read_row(job, fallback_id=fallback_id, current=current)
+        return _read_row(job, fallback_id=fallback_id, current=current, paused=paused)
     except Exception:
         return RowFacts(
             label=fallback_id,
             status="running",
             queued=False,
+            paused=False,
             running=False,
             elapsed="0s",
             activity="",
         )
 
 
-def _read_row(job: Any, *, fallback_id: str, current: bool) -> RowFacts:
+def _read_row(job: Any, *, fallback_id: str, current: bool, paused: bool = False) -> RowFacts:
     """:func:`row_facts` without the net. Everything here may raise."""
     status = str(getattr(job, "status", "running"))
     queued = bool(getattr(job, "queued", False))
@@ -566,7 +627,14 @@ def _read_row(job: Any, *, fallback_id: str, current: bool) -> RowFacts:
         activity = " ".join(
             strip_control_sequences(str(getattr(job, "result_text", "") or "")).split()
         )
-        if not activity and status == "cancelled":
+        if not activity and paused:
+            # A paused child records no ``result_text`` — it was cancelled
+            # mid-run — so without this its row rests on the 1-cell ``⏸``
+            # alone, exactly the gap the cancelled and interrupted branches
+            # below already fill. Ahead of them because ``paused`` outranks the
+            # ``cancelled`` its job row actually carries.
+            activity = status_glyph(status, paused=True)[1]
+        elif not activity and status == "cancelled":
             # ``cancelled`` was the only state that painted no word: a job
             # cancelled mid-run records no ``result_text``, so the row's whole
             # state rested on a 1-cell ``⊘`` while the page it opens prints
@@ -601,6 +669,7 @@ def _read_row(job: Any, *, fallback_id: str, current: bool) -> RowFacts:
         label=strip_control_sequences(str(getattr(job, "label", "") or fallback_id)),
         status=status,
         queued=queued,
+        paused=paused,
         running=running,
         elapsed=job_elapsed(job),
         activity=activity,
@@ -789,7 +858,7 @@ def _glyph_cells(facts: RowFacts) -> int:
     the row draws is what lets ``compose_row``'s own truncate eat the last
     cell of a dollar figure.
     """
-    glyph, _word, _token = status_glyph(facts.status, queued=facts.queued)
+    glyph, _word, _token = status_glyph(facts.status, queued=facts.queued, paused=facts.paused)
     return max(_GLYPH_COL, cell_len(glyph))
 
 
@@ -1020,7 +1089,7 @@ def compose_row(
     role_width = _role_width(rung, role, role_column)
     role_pad = " " * max(0, role_width - cell_len(role))
     glyph, _word, token = status_glyph(
-        facts.status, queued=facts.queued, spinner_glyph=spinner_glyph
+        facts.status, queued=facts.queued, spinner_glyph=spinner_glyph, paused=facts.paused
     )
 
     row = Text(no_wrap=True, overflow="ellipsis")
@@ -1106,13 +1175,49 @@ class SummaryCounts(NamedTuple):
     failed: int = 0
     cancelled: int = 0
     interrupted: int = 0
+    #: Children the parent stopped meaning to return to. Its OWN bucket rather
+    #: than riding ``cancelled``: those two now have opposite lifetimes on the
+    #: dock (a pause persists, a cancel expires), so folding them together
+    #: would put the collapsed caption back in the position the expanded rows
+    #: just left — two states, one word (design round 2, D5).
+    paused: int = 0
 
     @property
     def total(self) -> int:
         return sum(self)
 
 
-def summary_counts(jobs: Sequence[Any]) -> SummaryCounts:
+def paused_child_ids(comms: Any) -> set[str]:
+    """Job ids the parent PAUSED, read from the graph that owns the fact.
+
+    THE one lookup, shared by the dock's roster filter (``OperatorApp``), the
+    panel's rows and the full-page view's title — because all three now render
+    or age a paused child differently from a cancelled one, and three copies of
+    "how do I tell?" is how they end up disagreeing. A pause is recorded on
+    ``_ChildRecord.paused`` and surfaces as ``node.status == "paused"``
+    (``SubagentComms._node``, where it outranks every other status for the same
+    reason it matters here), so this stays a pure consumer of that projection
+    rather than a second interpretation of the record.
+
+    Never raises: these are status surfaces, and a graph that cannot answer
+    must not take the app down. An empty set degrades to the previous
+    behaviour — a paused child painted as the cancel it mechanically is —
+    which is a wrong word, not a broken frame.
+    """
+    try:
+        nodes = comms.nodes() if callable(getattr(comms, "nodes", None)) else ()
+        return {str(node.job_id) for node in nodes if str(getattr(node, "status", "")) == "paused"}
+    except Exception:  # noqa: BLE001 — a status surface must not fail on a lookup
+        logger.warning("reading paused subagents failed", exc_info=True)
+        return set()
+
+
+def _paused_ids(session: Any) -> set[str]:
+    """:func:`paused_child_ids` for the comms graph hanging off a session."""
+    return paused_child_ids(getattr(session, "_subagent_comms", None))
+
+
+def summary_counts(jobs: Sequence[Any], *, paused_ids: set[str] | None = None) -> SummaryCounts:
     """Bucket task jobs by the state the row vocabulary already names.
 
     Reads through :func:`row_facts` rather than ``job.status`` directly so a
@@ -1121,9 +1226,13 @@ def summary_counts(jobs: Sequence[Any]) -> SummaryCounts:
     Restored rows arrive as ``interrupted``/``completed`` and bucket there.
     """
     counts = dict.fromkeys(SummaryCounts._fields, 0)
+    paused_ids = paused_ids or set()
     for job in jobs:
-        facts = row_facts(job, fallback_id="", current=False)
-        if facts.queued:
+        job_id = str(getattr(job, "id", "") or "")
+        facts = row_facts(job, fallback_id="", current=False, paused=job_id in paused_ids)
+        if facts.paused and facts.status != "running":
+            counts["paused"] += 1
+        elif facts.queued:
             counts["queued"] += 1
         elif facts.status == "running":
             counts["running"] += 1
@@ -1169,6 +1278,8 @@ def _summary_segments(
             segments.append(("failed", f"{GLYPH_FAILED}{counts.failed}", "danger"))
         else:
             segments.append(("failed", f"{counts.failed} failed", "danger"))
+    if counts.paused and "paused" not in dropped:
+        segments.append(("paused", f"{counts.paused} paused", "muted"))
     if counts.queued and "queued" not in dropped:
         segments.append(("queued", f"{counts.queued} queued", "dim"))
     if counts.cancelled and "cancelled" not in dropped:
@@ -1505,7 +1616,9 @@ class SubagentPanel(Container):
         #: than the expensive one (round 1, F3). One entry per job of
         #: ``(identity, status, queued)`` — see the method for why the flag is
         #: a term and not redundant with the status (round 2, Q2/F7).
-        self._summary_counts_key: tuple[tuple[int, str, bool], ...] | None = None
+        #: ``(id, status, queued, paused)`` per job — see ``_summary_counts``
+        #: for why each field is in the key and what a missing one costs.
+        self._summary_counts_key: tuple[tuple[int, str, bool, bool], ...] | None = None
         self._summary_counts_value: SummaryCounts = SummaryCounts()
         # Logical focus within the full roster. The expanded DOM displays only
         # one screenful around it; every job remains keyboard-reachable without
@@ -1516,6 +1629,12 @@ class SubagentPanel(Container):
         #: spinner tick repaints from it between refreshes rather than
         #: re-querying the manager eight times a second.
         self._jobs_by_id: dict[str, Any] = {}
+        #: Job ids the parent PAUSED, refreshed from the comms graph on every
+        #: sync. Held here rather than passed to each render call because a
+        #: pause is invisible on the job row itself (it reads ``cancelled``),
+        #: so every path that paints a row needs the same lookup — see
+        #: :data:`GLYPH_PAUSED`.
+        self._paused_ids: set[str] = set()
         self._selected_job_id = ""
         self._spinner_index = 0
         self._spinner_timer = None
@@ -1956,10 +2075,22 @@ class SubagentPanel(Container):
             # non-deterministically, since whether the row got a paint before
             # this sync depends on tick timing (it failed ~50% of runs in
             # isolation). It is the same staleness as F2, one function over.
-            facts = row_facts(self._jobs_by_id.get(job_id), fallback_id=job_id, current=False)
+            facts = row_facts(
+                self._jobs_by_id.get(job_id),
+                fallback_id=job_id,
+                current=False,
+                paused=job_id in self._paused_ids,
+            )
             # `queued` by its own name: the table ranks it explicitly, so
             # there is no longer a substitution here to keep in step.
-            status = "queued" if facts.queued else facts.status
+            # `paused` before `queued`, matching `summary_counts` and
+            # `status_glyph`: the job row underneath says `cancelled`, which
+            # ranks at the default, so reading the status alone would rank a
+            # deliberately-kept row below the successes about to expire.
+            if facts.paused and facts.status != "running":
+                status = "paused"
+            else:
+                status = "queued" if facts.queued else facts.status
             # Newest first within a rank: a negative index sorts later starts
             # ahead, which is the `[-budget:]` rule the slice had before.
             return (_EVICTION_RANK.get(status, 3), -index)
@@ -2034,6 +2165,7 @@ class SubagentPanel(Container):
             self._stats_for(selected_id, selected_job, True)
         if not task_jobs:
             self._jobs_by_id = {}
+            self._paused_ids = set()
             self._stats = {key: value for key, value in self._stats.items() if key == selected_id}
             self._sync_rows([])
             self.display = False
@@ -2050,6 +2182,7 @@ class SubagentPanel(Container):
         # and un-hiding on each tick would make `hidden` last one second.
         self.display = self._density is not Density.HIDDEN
         self._jobs_by_id = {str(getattr(job, "id", "") or ""): job for job in task_jobs}
+        self._paused_ids = _paused_ids(session)
         changed = self._sync_rows(task_jobs)
         self._apply_visibility()
         if changed:
@@ -2174,7 +2307,9 @@ class SubagentPanel(Container):
             job = self._jobs_by_id.get(job_id)
             if job is None:
                 continue
-            facts = row_facts(job, fallback_id=job_id, current=row.current)
+            facts = row_facts(
+                job, fallback_id=job_id, current=row.current, paused=job_id in self._paused_ids
+            )
             measured.append((job_id, row, facts, self._stats_for(job_id, job, reread_stats)))
         self._rung, self._column, self._clock, self._role_column = panel_layout(
             [(facts, stats) for _, _, facts, stats in measured], width
@@ -2384,15 +2519,27 @@ class SubagentPanel(Container):
         that stale tuple was the whole surface.
 
         Anything added to :func:`summary_counts`' bucketing belongs here too.
+
+        ``paused`` is the THIRD such field and it is the same trap as
+        ``queued``, one layer out: pausing a child changes the caption without
+        changing anything on the job row (the row already read ``cancelled``
+        the instant the pause landed), and the flag lives on the comms record.
+        Keyed on membership of ``_paused_ids`` so a pause or a resume moves the
+        key at the moment it moves the counts.
         """
         jobs = list(self._jobs_by_id.values())
         key = tuple(
-            (id(job), getattr(job, "status", ""), bool(getattr(job, "queued", False)))
+            (
+                id(job),
+                getattr(job, "status", ""),
+                bool(getattr(job, "queued", False)),
+                str(getattr(job, "id", "") or "") in self._paused_ids,
+            )
             for job in jobs
         )
         if self._summary_counts_key != key:
             self._summary_counts_key = key
-            self._summary_counts_value = summary_counts(jobs)
+            self._summary_counts_value = summary_counts(jobs, paused_ids=self._paused_ids)
         return self._summary_counts_value
 
     def _ledger_has_running(self) -> bool:
@@ -2532,7 +2679,12 @@ class SubagentPanel(Container):
                 job = self._jobs_by_id.get(job_id)
                 if job is not None and row.running:
                     row.paint(
-                        row_facts(job, fallback_id=job_id, current=row.current),
+                        row_facts(
+                            job,
+                            fallback_id=job_id,
+                            current=row.current,
+                            paused=job_id in self._paused_ids,
+                        ),
                         stats=self._stats_for(job_id, job, False),
                         spinner_glyph=glyph,
                         width=width,

--- a/local_operator/tui/widgets/subagent_view.py
+++ b/local_operator/tui/widgets/subagent_view.py
@@ -1679,6 +1679,10 @@ class SubagentView(Vertical):
         self._launch_prompts: dict[str, str] = {}
         self._status = "running"
         self._queued = False
+        #: See :meth:`show`. Initialised here as well so a title painted before
+        #: the first ``show`` (an early repaint on a freshly mounted page)
+        #: cannot raise on a missing attribute.
+        self._paused = False
         self._elapsed = "0s"
         #: The child's ROLE and effort TIER, recorded on the job at launch
         #: (``AsyncJob.agent_role``/``effort``). Shown in the title so the page
@@ -1819,6 +1823,7 @@ class SubagentView(Vertical):
         status: str,
         queued: bool,
         elapsed: str,
+        paused: bool = False,
         outcome: str = "",
         events: Sequence[Any],
         prompt: str = "",
@@ -1866,6 +1871,11 @@ class SubagentView(Vertical):
         self._label = strip_control_sequences(label or job_id)
         self._status = status
         self._queued = queued
+        # A pause is mechanically a cancel, so ``status`` reads ``cancelled``
+        # and only the comms graph knows the difference. Carried here so the
+        # page's title and the dock row it was opened from cannot name the
+        # same child two different things (design round 2, D5).
+        self._paused = paused
         self._elapsed = elapsed
         self._outcome = strip_control_sequences(outcome or "").strip()
         # Role and effort are launch-time facts and never change under a running
@@ -3143,8 +3153,14 @@ class SubagentView(Vertical):
             row.truncate(width, overflow="ellipsis")
             return row
 
-        glyph, word, token = status_glyph(self._status, queued=self._queued, spinner_glyph=spinner)
-        if self._status == "cancelled" and self._outcome == CANCELLED_BEFORE_START:
+        glyph, word, token = status_glyph(
+            self._status, queued=self._queued, spinner_glyph=spinner, paused=self._paused
+        )
+        if (
+            self._status == "cancelled"
+            and not self._paused
+            and self._outcome == CANCELLED_BEFORE_START
+        ):
             # `⊘ cancelled · 1m36s` beside rows reading `⣷ running · 7m53s`
             # presents a PARKED wait as a run: an operator concludes the child
             # burned a minute and a half of tokens before they killed it, when

--- a/tests/unit/harness/test_jobs.py
+++ b/tests/unit/harness/test_jobs.py
@@ -4,6 +4,7 @@ systems get wrong — owner-scoped delivery with dead-lettering."""
 from __future__ import annotations
 
 import asyncio
+import time
 
 import pytest
 
@@ -14,6 +15,8 @@ from local_operator.harness.jobs import (
     AsyncJob,
     AsyncJobManager,
     JobStatus,
+    retention_expired,
+    roster_expired,
 )
 from local_operator.harness.types import Usage
 
@@ -1086,3 +1089,92 @@ async def test_read_output_handles_a_cursor_from_another_job() -> None:
     assert (text, gap) == ("", False)
     assert seq == 5
     await manager.dispose()
+
+
+def test_the_ledger_clock_expires_every_terminal_status_alike():
+    """``retention_expired`` is strictly "has the clock run out". It is the
+    LEDGER's question, so it must not acquire opinions about intent: bounding
+    a long session's memory is its whole job, and a status it refused to
+    expire would be an unbounded leak in ``_jobs``."""
+    stale = time.time() - 86_400.0
+    statuses: tuple[JobStatus, ...] = ("completed", "failed", "cancelled", "interrupted")
+    for status in statuses:
+        row = AsyncJob(
+            id=status, type="task", status=status, start_time=1.0, settled_at=stale, label=status
+        )
+        assert retention_expired(row, 300_000) is True, status
+
+    running = AsyncJob(
+        id="r", type="task", status="running", start_time=1.0, settled_at=stale, label="r"
+    )
+    assert retention_expired(running, 300_000) is False
+    restored = AsyncJob(
+        id="x",
+        type="task",
+        status="completed",
+        start_time=1.0,
+        settled_at=stale,
+        restored=True,
+        label="x",
+    )
+    assert retention_expired(restored, 300_000) is False
+
+
+def test_the_roster_window_keeps_rows_the_user_has_unfinished_business_with():
+    """THE RULE: retention is a timer on quiet resolutions, not on unfinished
+    business. ``roster_expired`` is the reader's question and differs from the
+    ledger's on exactly the statuses a user must still act on or return to."""
+    stale = time.time() - 86_400.0
+
+    def row(status: JobStatus) -> AsyncJob:
+        return AsyncJob(
+            id=status, type="task", status=status, start_time=1.0, settled_at=stale, label=status
+        )
+
+    # Unfinished business: kept on screen however old.
+    assert roster_expired(row("failed"), 300_000) is False
+    assert roster_expired(row("interrupted"), 300_000) is False
+    assert roster_expired(row("cancelled"), 300_000, paused=True) is False
+
+    # Resolved: the window applies, and a plain cancel IS resolved — the user
+    # said they were not coming back for it (``SubagentComms.cancel`` clears a
+    # pause for exactly this reason).
+    assert roster_expired(row("completed"), 300_000) is True
+    assert roster_expired(row("cancelled"), 300_000) is True
+
+    # The ledger's own exemptions still hold through the reader.
+    assert roster_expired(row("running"), 300_000) is False
+
+    # A reader may age a row against an ADJUSTED stamp (the dock buckets them
+    # so a batch leaves together) without that override ever defeating an
+    # exemption: a failure stays whatever stamp it is handed.
+    ancient = 1.0
+    assert roster_expired(row("completed"), 300_000, settled_at=ancient) is True
+    assert roster_expired(row("failed"), 300_000, settled_at=ancient) is False
+    assert retention_expired(row("completed"), 300_000, settled_at=time.time()) is False
+    inside = AsyncJob(
+        id="fresh",
+        type="task",
+        status="completed",
+        start_time=1.0,
+        settled_at=time.time(),
+        label="fresh",
+    )
+    assert roster_expired(inside, 300_000) is False
+
+
+def test_an_exempt_row_is_still_swept_from_the_ledger():
+    """The asymmetry is deliberate and is what keeps the exemption cheap: the
+    manager still evicts a failure on time (bounded memory), while the dock
+    goes on drawing it through ``_ChildRecord.job_ref`` — the same surviving
+    reference the two-layer fix already rests on. So an unbounded pile of
+    failures cannot grow ``_jobs``."""
+    manager = AsyncJobManager(retention_ms=1)
+    stale = time.time() - 86_400.0
+    exempt: tuple[JobStatus, ...] = ("failed", "interrupted")
+    for status in exempt:
+        manager._jobs[status] = AsyncJob(
+            id=status, type="task", status=status, start_time=1.0, settled_at=stale, label=status
+        )
+
+    assert manager.list() == []  # the LEDGER releases them on schedule

--- a/tests/unit/harness/test_jobs.py
+++ b/tests/unit/harness/test_jobs.py
@@ -750,6 +750,81 @@ async def test_retention_sweep_drops_old_settled_jobs():
 
 
 @pytest.mark.asyncio
+async def test_the_last_batch_is_swept_with_no_later_job_settling():
+    """Issue #524. Every ``_sweep_due`` call site used to sit inside a job's
+    own settle path, so the LAST batch of a session was never swept: its rows
+    stayed in the dock's Subagents panel until a NEW job happened to settle,
+    which for the final batch is never. ``list()`` sweeps on read, so the
+    guarantee no longer depends on unrelated future work arriving.
+
+    The assertion that matters is the one made WITHOUT registering anything:
+    the old code passes every line of this test except that one."""
+    manager = AsyncJobManager(retention_ms=20)
+    for index in range(3):
+        manager.register("task", f"L{index}", quick_runner)
+    await wait_for(lambda: all(job.status == "completed" for job in manager.list()))
+    await asyncio.sleep(0.1)  # 5x the retention window
+
+    assert manager.list() == []  # no new job registered — this is the defect
+
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_read_never_sweeps_a_row_inside_its_retention_window():
+    """The other half of the contract: eviction must not become eager. A row
+    that settled a moment ago is still fully observable, which is what makes
+    the panel a stable surface rather than one that blinks rows away."""
+    manager = AsyncJobManager()  # the shipped 5-minute window
+    job_id = manager.register("task", "recent", quick_runner)
+    await manager.settled_event(job_id).wait()
+    await asyncio.sleep(0.05)
+
+    assert [job.id for job in manager.list()] == [job_id]
+    assert manager.get(job_id) is not None
+
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_a_read_never_sweeps_a_running_row():
+    """Retention reclaims FINISHED work. A running row has no ``settled_at``,
+    so no window has started for it — pinned with ``retention_ms=0``, where any
+    arithmetic slip would evict it on the first read."""
+    manager = AsyncJobManager(retention_ms=0)
+    gate = asyncio.Event()
+
+    async def blocked(job_id, signal, report_progress):
+        await gate.wait()
+        return "done"
+
+    job_id = manager.register("task", "long-runner", blocked)
+    await wait_for(lambda: require_job(manager, job_id).started_at is not None)
+
+    for _ in range(5):  # every read sweeps; none may take the live row
+        assert [job.id for job in manager.list()] == [job_id]
+
+    gate.set()
+    await manager.dispose()
+
+
+@pytest.mark.asyncio
+async def test_the_read_sweep_starts_no_background_task():
+    """Why ``list()`` rather than a timer: nothing to start, cancel, or leak.
+    A ``set_interval``/``create_task`` sweep would have to be torn down on
+    dispose, and this pins that no such task exists to forget."""
+    before = len(asyncio.all_tasks())
+    manager = AsyncJobManager(retention_ms=20)
+    for index in range(3):
+        manager.register("task", f"T{index}", quick_runner)
+    await wait_for(lambda: manager.list() == [])
+    await manager.dispose()
+    await asyncio.sleep(0)
+
+    assert len(asyncio.all_tasks()) == before
+
+
+@pytest.mark.asyncio
 async def test_list_scoped_by_owner():
     manager = AsyncJobManager()
     gate = asyncio.Event()

--- a/tests/unit/tui/test_band_panels.py
+++ b/tests/unit/tui/test_band_panels.py
@@ -32,10 +32,13 @@ from local_operator.tui.widgets.status_line import format_agents
 from local_operator.tui.widgets.subagent_panel import (
     MAX_SUBAGENT_ROWS,
     Density,
+    JobStats,
     SubagentPanel,
     SubagentRow,
     SummaryCounts,
+    compose_row,
     compose_summary,
+    row_facts,
 )
 from local_operator.tui.widgets.todo_panel import MAX_TODO_ROWS, TodoPanel
 
@@ -2149,32 +2152,67 @@ async def test_the_dock_keeps_a_paused_child_past_the_window() -> None:
 
 
 @pytest.mark.asyncio
-async def test_a_batch_that_settled_together_leaves_together() -> None:
-    """Design round 1, D2. Rows settling within one bucket cross the window on
-    the SAME repaint, so a fan-out that finished together reads as one event
-    rather than a dock that ratchets down a row at a time.
+async def test_a_batch_that_settled_together_leaves_in_one_shrink_event() -> None:
+    """Design round 1, D2 — and it MUST discriminate the mechanism.
 
-    Stamps are spread across a whole bucket to prove the coalescing, and the
-    window is long enough that none of them is expired yet at the start."""
-    session = FakeSession()
-    now = time.time()
-    # Settled one second apart, all inside a single 15 s bucket.
-    jobs = [_Job(f"b{index}", f"child {index}", status="completed") for index in range(6)]
-    for index, job in enumerate(jobs):
-        job.settled_at = now - index
-    session.jobs = _RetentionManager(jobs, retention_ms=600_000)
-    session._subagent_comms = _GraphComms(jobs)
+    The first version of this test aged all six rows past the window by an
+    identical amount and asserted the end state was empty, which is true with
+    or without bucketing; both reviewers independently mutation-tested it and
+    found it passes with the bucketing stubbed out (review round 2 F3, design
+    round 2). A test that cannot fail is worse than no test, so this one walks
+    the batch ACROSS the boundary a tick at a time and counts how many separate
+    repaints shrink the dock — the quantity D2 was actually about.
 
-    app = OperatorApp(_async_factory(session))
-    async with app.run_test(size=(100, 24)) as pilot:
-        await _boot_with_jobs(app, pilot)
-        assert len(app._subagent_roster()[0]) == 6
+    The unbucketed control in the same run is what makes the assertion bite: it
+    is computed from the same stamps through the same predicate, so if the
+    bucket ever stops coalescing, the two collapse to the same number and the
+    comparison fails.
+    """
+    from local_operator.harness.jobs import roster_expired
+    from local_operator.tui.app import _bucketed_settle_stamp
 
-        # Age the whole batch past the window by the same amount. Quantising
-        # means one pass takes all six, not six passes taking one each.
-        for job in jobs:
-            job.settled_at = (job.settled_at or 0.0) - 700_000.0
-        assert app._subagent_roster()[0] == []
+    window_ms = 300_000.0
+    base = 1_700_000_000.0
+
+    def visible(stamps: list[float], now: float, *, bucketed: bool) -> int:
+        return sum(
+            1
+            for stamp in stamps
+            if not roster_expired(
+                SimpleNamespace(status="completed", restored=False, settled_at=stamp),
+                window_ms,
+                now=now,
+                settled_at=_bucketed_settle_stamp(stamp, window_ms) if bucketed else stamp,
+            )
+        )
+
+    def shrink_events(stamps: list[float], *, bucketed: bool) -> int:
+        # One second per tick, exactly as the 1 Hz poll advances, over a range
+        # that brackets the whole crossing.
+        counts = [
+            visible(stamps, max(stamps) + window_ms / 1000.0 - 25 + tick, bucketed=bucketed)
+            for tick in range(60)
+        ]
+        return sum(1 for before, after in zip(counts, counts[1:]) if before != after)
+
+    # Swept across the batch's PHASE against the bucket grid rather than
+    # asserted at one convenient instant. A batch straddling a bucket boundary
+    # legitimately sheds in two events instead of one (both reviewers measured
+    # the same distribution, ~2/3 at one event and ~1/3 at two), so pinning a
+    # single phase would be pinning luck — while the property D2 is actually
+    # about holds at EVERY phase, which is what this asserts.
+    seen = set()
+    for phase in range(300):
+        offset = phase / 20.0  # 0-15 s in 50 ms steps: one whole bucket
+        # Settled one second apart, as a real fan-out does.
+        stamps = [base + offset - index for index in range(6)]
+        seen.add(shrink_events(stamps, bucketed=True))
+        assert shrink_events(stamps, bucketed=False) == 6, "control must always ratchet"
+
+    # Never worse than two repaints, always strictly better than the six the
+    # unbucketed control shows, at every alignment.
+    assert seen <= {1, 2}, seen
+    assert max(seen) < 6
 
 
 @pytest.mark.asyncio
@@ -2210,6 +2248,17 @@ async def test_the_expiry_clock_only_ever_rounds_a_row_a_longer_life() -> None:
     assert _expiry_bucket_s(300_000.0) == ROSTER_EXPIRY_BUCKET_S
     assert _expiry_bucket_s(1_200.0) < 1.2
     assert _expiry_bucket_s(0.0) == 0.0
+
+    # ``W mod b == 0`` — the invariant `_bucketed_settle_stamp`'s rationale now
+    # rests on, so it is pinned rather than asserted in prose. It is what makes
+    # flooring the reader's clock ACCIDENTALLY equivalent here; if a future
+    # bucket rule breaks it, that docstring's argument needs rewriting and this
+    # is the test that says so.
+    for window_s in (1.2, 5.0, 60.0, 300.0, 900.0):
+        bucket = _expiry_bucket_s(window_s * 1000.0)
+        assert bucket > 0
+        assert bucket < window_s
+        assert abs(window_s % bucket) < 1e-9, (window_s, bucket)
     # A zero-length bucket must not divide by zero; it simply does not coalesce.
     assert _bucketed_settle_stamp(base + 0.5, 0.0) == base + 0.5
 
@@ -2286,4 +2335,141 @@ async def test_a_raising_filter_shows_stale_rows_and_says_so(caplog) -> None:
             rows = app._subagent_roster()[0]
 
     assert [getattr(job, "id", "") for job in rows] == ["kept"]  # failed open
-    assert any("retention filter" in record.message for record in caplog.records)
+    assert any("roster window filter" in record.message for record in caplog.records)
+
+
+def test_a_paused_child_does_not_render_as_a_cancelled_one() -> None:
+    """Design round 2, D5. ``SubagentComms.pause`` is mechanically a cancel, so
+    both rows carry ``status == "cancelled"`` — and after the retention change
+    they have OPPOSITE lifetimes (a pause persists, a cancel expires in five
+    minutes). Two pixel-identical rows that behave differently is the frame
+    contradicting the intent the user recorded, so the pause gets its own word,
+    exactly as ``interrupted`` already has one for the same reason."""
+    from rich.cells import cell_len
+
+    from local_operator.tui.widgets.subagent_panel import (
+        GLYPH_CANCELLED,
+        GLYPH_PAUSED,
+        status_glyph,
+    )
+
+    paused = status_glyph("cancelled", paused=True)
+    cancelled = status_glyph("cancelled")
+
+    assert paused != cancelled
+    assert paused[0] == GLYPH_PAUSED and paused[1] == "paused"
+    assert cancelled[0] == GLYPH_CANCELLED and cancelled[1] == "cancelled"
+
+    # One cell, like every other glyph in the column: the media-control marks
+    # next to this one are two-cell emoji and would shear the time column.
+    assert cell_len(paused[0]) == 1 == cell_len(cancelled[0])
+
+    # A pause still LANDING must not paint the child as stopped while it is
+    # demonstrably running — the window `_describe` guards with "pausing".
+    assert status_glyph("running", paused=True, spinner_glyph="⣾")[1] == "running"
+
+
+def test_the_paused_word_matches_the_state_the_phone_already_shows() -> None:
+    """`mobile/projection.py` has mapped `paused`/`pausing` to a distinct
+    `parked` state all along, so before this the phone showed a state the TUI
+    did not. Pinned as a cross-surface agreement rather than a copy assertion:
+    what matters is that neither surface calls a pause a cancellation."""
+    from typing import get_args
+
+    from local_operator.mobile.types import SubagentStatus
+    from local_operator.tui.widgets.subagent_panel import status_glyph
+
+    assert "parked" in get_args(SubagentStatus)
+    assert status_glyph("cancelled", paused=True)[1] != status_glyph("cancelled")[1]
+
+
+@pytest.mark.asyncio
+async def test_the_dock_paints_a_paused_child_as_paused() -> None:
+    """The same distinction end to end through the real panel: the row the
+    filter keeps forever is also the row that says why it is being kept."""
+    from local_operator.tui.widgets.subagent_panel import GLYPH_PAUSED
+
+    session = FakeSession()
+    now = time.time()
+    held = _Job("held", "migrating the watchlist schema", status="cancelled")
+    held.settled_at = now
+    dropped = _Job("dropped", "abandoned the backfill probe", status="cancelled")
+    dropped.settled_at = now
+    jobs = [held, dropped]
+    session.jobs = _RetentionManager(jobs, retention_ms=300_000)
+    session._subagent_comms = _GraphComms(jobs, paused={"held"})
+
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        panel = await _boot_with_jobs(app, pilot)
+        for _ in range(4):
+            await pilot.pause()
+        # The text the rows painted, through the panel's own facts pipeline —
+        # `SubagentRow.paint` renders exactly this `compose_row` output, so a
+        # row's word here is the word on screen.
+        rendered = {
+            job_id: compose_row(
+                facts=row_facts(
+                    panel._jobs_by_id[job_id],
+                    fallback_id=job_id,
+                    current=False,
+                    paused=job_id in panel._paused_ids,
+                ),
+                stats=JobStats(),
+                spinner_glyph="⣾",
+                width=100,
+                rung=0,
+                column=40,
+                clock=6,
+                role_column=0,
+            ).plain
+            for job_id in panel._rows
+        }
+
+    assert GLYPH_PAUSED in rendered["held"], rendered["held"]
+    assert "paused" in rendered["held"]
+    # The ordinary cancel is untouched — this must distinguish the two, not
+    # rename both.
+    assert GLYPH_PAUSED not in rendered["dropped"], rendered["dropped"]
+    assert "cancelled" in rendered["dropped"]
+
+
+@pytest.mark.asyncio
+async def test_the_collapsed_caption_counts_a_pause_apart_from_a_cancel() -> None:
+    """The summary is the panel's ONLY representation at that density, so a
+    caption folding the two together would put the distinction straight back
+    where the expanded rows just took it out. Also pins the memo key: pausing
+    changes the counts without changing anything on the job row, the same trap
+    ``queued`` already documents."""
+    session = FakeSession()
+    now = time.time()
+    jobs = [
+        _Job("held", "migrating the watchlist schema", status="cancelled"),
+        _Job("dropped", "abandoned the backfill probe", status="cancelled"),
+    ]
+    for job in jobs:
+        job.settled_at = now
+    session.jobs = _RetentionManager(jobs, retention_ms=300_000)
+    comms = _GraphComms(jobs, paused={"held"})
+    session._subagent_comms = comms
+
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        panel = await _boot_with_jobs(app, pilot)
+        await pilot.press("ctrl+g")
+        await pilot.pause()
+        assert panel.density is Density.SUMMARY
+        caption = panel.summary_text()
+        assert "1 paused" in caption, caption
+        assert "1 cancelled" in caption, caption
+
+        # Resuming clears the flag on the RECORD; nothing on the job row moves.
+        # Without the memo key carrying it, the caption would keep saying
+        # "1 paused" indefinitely.
+        comms._paused = set()
+        app._refresh_band()
+        for _ in range(8):
+            await pilot.pause()
+        caption = panel.summary_text()
+        assert "paused" not in caption, caption
+        assert "2 cancelled" in caption, caption

--- a/tests/unit/tui/test_band_panels.py
+++ b/tests/unit/tui/test_band_panels.py
@@ -1953,8 +1953,10 @@ class _RetentionManager:
     one carries the attribute so the OWNER path is exercised.
     """
 
-    def __init__(self, jobs: list[Any], retention_ms: int) -> None:
+    def __init__(self, jobs: list[Any], retention_ms: float) -> None:
         self._jobs = jobs
+        # Typed as ``float`` deliberately: the filter accepts any real window
+        # and a test drives it with ``1000.0`` to pin that (review round 1, m1).
         self.retention_ms = retention_ms
 
     def list(self, *, owner_id: str | None = None) -> list[Any]:
@@ -1975,11 +1977,24 @@ class _GraphComms:
     manager alone did not clear the panel in issue #524.
     """
 
-    def __init__(self, jobs: list[Any]) -> None:
+    def __init__(self, jobs: list[Any], paused: set[str] | None = None) -> None:
         self._jobs = jobs
+        # Job ids the parent paused. Mirrors ``_ChildRecord.paused``, which
+        # surfaces as ``node.status == "paused"`` and outranks the row's own
+        # status — a pause is mechanically a CANCEL, so the job row cannot
+        # carry this fact and the reader must ask the graph for it.
+        self._paused = paused or set()
+
+    def _node(self, job: Any) -> Any:
+        job_id = str(job.id)
+        status = "paused" if job_id in self._paused else str(getattr(job, "status", ""))
+        return SimpleNamespace(job_id=job_id, status=status)
 
     def children(self, job_id: str | None) -> list[Any]:
-        return [SimpleNamespace(job_id=str(job.id)) for job in self._jobs]
+        return [self._node(job) for job in self._jobs]
+
+    def nodes(self) -> list[Any]:
+        return [self._node(job) for job in self._jobs]
 
     def job(self, job_id: str) -> Any:
         return next((job for job in self._jobs if str(getattr(job, "id", "")) == job_id), None)
@@ -2079,3 +2094,196 @@ async def test_a_roster_with_no_live_manager_is_left_alone() -> None:
         panel = await _boot_with_jobs(app, pilot)
         assert [str(job.id) for job in app._subagent_roster()[0]] == ["remote"]
         assert panel.display is True
+
+
+@pytest.mark.asyncio
+async def test_the_dock_keeps_a_failed_child_past_the_window() -> None:
+    """Design round 1, D1. A failure is the row the user most needs to come
+    back to, and the panel row is the ONLY entry to the child's page — so
+    expiring it on the quiet-success timer deleted the trajectory that explains
+    the failure. The panel already ranks failures above successes
+    (``_EVICTION_RANK``) and re-opens a hidden panel for one failure
+    (``note_child_failed``); this makes retention agree with both."""
+    session = FakeSession()
+    stale = time.time() - 86_400.0
+    failed = _Job("boom", "deploying to staging", status="failed")
+    failed.settled_at = stale
+    quiet = _Job("fine", "audited the tenant list", status="completed")
+    quiet.settled_at = stale
+    jobs = [failed, quiet]
+    session.jobs = _RetentionManager(jobs, retention_ms=1)
+    session._subagent_comms = _GraphComms(jobs)
+
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        panel = await _boot_with_jobs(app, pilot)
+        # The quiet success goes; the failure stays, and keeps the panel up.
+        assert [str(job.id) for job in app._subagent_roster()[0]] == ["boom"]
+        assert panel.display is True
+
+
+@pytest.mark.asyncio
+async def test_the_dock_keeps_a_paused_child_past_the_window() -> None:
+    """Review round 1, M1. ``SubagentComms.pause`` is mechanically a cancel, so
+    the row reads ``cancelled`` with a settle stamp and ``AsyncJob`` has no
+    ``paused`` field — the intent lives only on the comms record. Without
+    consulting it, a child paused precisely to come back to it left the dock
+    five minutes later: the very surface the user would come back through."""
+    session = FakeSession()
+    stale = time.time() - 86_400.0
+    paused = _Job("held", "migrating the tenant index", status="cancelled")
+    paused.settled_at = stale
+    # An ORDINARY cancel of the same age is the control: it must still expire,
+    # because cancelling says "I am not coming back for this".
+    dropped = _Job("dropped", "abandoned work", status="cancelled")
+    dropped.settled_at = stale
+    jobs = [paused, dropped]
+    session.jobs = _RetentionManager(jobs, retention_ms=1)
+    session._subagent_comms = _GraphComms(jobs, paused={"held"})
+
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        panel = await _boot_with_jobs(app, pilot)
+        assert [str(job.id) for job in app._subagent_roster()[0]] == ["held"]
+        assert panel.display is True
+
+
+@pytest.mark.asyncio
+async def test_a_batch_that_settled_together_leaves_together() -> None:
+    """Design round 1, D2. Rows settling within one bucket cross the window on
+    the SAME repaint, so a fan-out that finished together reads as one event
+    rather than a dock that ratchets down a row at a time.
+
+    Stamps are spread across a whole bucket to prove the coalescing, and the
+    window is long enough that none of them is expired yet at the start."""
+    session = FakeSession()
+    now = time.time()
+    # Settled one second apart, all inside a single 15 s bucket.
+    jobs = [_Job(f"b{index}", f"child {index}", status="completed") for index in range(6)]
+    for index, job in enumerate(jobs):
+        job.settled_at = now - index
+    session.jobs = _RetentionManager(jobs, retention_ms=600_000)
+    session._subagent_comms = _GraphComms(jobs)
+
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _boot_with_jobs(app, pilot)
+        assert len(app._subagent_roster()[0]) == 6
+
+        # Age the whole batch past the window by the same amount. Quantising
+        # means one pass takes all six, not six passes taking one each.
+        for job in jobs:
+            job.settled_at = (job.settled_at or 0.0) - 700_000.0
+        assert app._subagent_roster()[0] == []
+
+
+@pytest.mark.asyncio
+async def test_the_expiry_clock_only_ever_rounds_a_row_a_longer_life() -> None:
+    """The safety property behind the bucket: quantising the reader's ``now``
+    DOWN can only delay an expiry, never hasten one, so no row is dropped
+    before its full window has elapsed. Pinned across a whole bucket of offsets
+    rather than at one convenient instant."""
+    from local_operator.tui.app import (
+        ROSTER_EXPIRY_BUCKET_S,
+        _bucketed_settle_stamp,
+        _expiry_bucket_s,
+    )
+
+    window_ms = 300_000.0
+    # Rounding UP a settle stamp grants a LATER expiry, so a row can only ever
+    # gain visibility, never lose it — and never more than one bucket of it.
+    for offset in range(0, int(ROSTER_EXPIRY_BUCKET_S) + 1):
+        stamp = 1_700_000_000.0 + offset + 0.5
+        bucketed = _bucketed_settle_stamp(stamp, window_ms)
+        assert bucketed >= stamp
+        assert bucketed - stamp < ROSTER_EXPIRY_BUCKET_S
+
+    # Stamps within one bucket collapse to ONE expiry instant, which is what
+    # makes a batch leave together instead of a row at a time.
+    base = 1_700_000_000.0
+    together = {_bucketed_settle_stamp(base + n, window_ms) for n in range(6)}
+    assert len(together) == 1
+
+    # The bucket is capped as a FRACTION of the window, not just in absolute
+    # terms: a fixed 15 s would be twelve times a 1.2 s window and would
+    # silently lengthen it, which a short-window probe caught on real objects.
+    assert _expiry_bucket_s(300_000.0) == ROSTER_EXPIRY_BUCKET_S
+    assert _expiry_bucket_s(1_200.0) < 1.2
+    assert _expiry_bucket_s(0.0) == 0.0
+    # A zero-length bucket must not divide by zero; it simply does not coalesce.
+    assert _bucketed_settle_stamp(base + 0.5, 0.0) == base + 0.5
+
+
+@pytest.mark.asyncio
+async def test_a_float_or_bool_window_is_handled_rather_than_silently_ignored() -> None:
+    """Review round 1, m1. ``AsyncJobManager`` type-hints ``retention_ms: int``
+    but never coerces, so an embedder passing ``1000.0`` used to disable the
+    dock filter entirely and silently reinstate #524; and ``isinstance(True,
+    int)`` would have accepted a stray ``True`` as a 1 ms window."""
+    session = FakeSession()
+    stale = _Job("old", "long finished", status="completed")
+    stale.settled_at = time.time() - 86_400.0
+    live = _Job("live", "still working", status="running")
+    jobs = [stale, live]
+    session._subagent_comms = _GraphComms(jobs)
+
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        # A float window is honoured, not ignored.
+        session.jobs = _RetentionManager(jobs, retention_ms=1000.0)
+        await _boot_with_jobs(app, pilot)
+        assert [str(job.id) for job in app._subagent_roster()[0]] == ["live"]
+
+        # A bool is NOT a window: refused, so the filter is the identity
+        # rather than a surprise 1 ms window that drops everything settled.
+        session.jobs = _RetentionManager(jobs, retention_ms=True)
+        app._refresh_band()
+        await pilot.pause()
+        assert [str(job.id) for job in app._subagent_roster()[0]] == ["old", "live"]
+
+
+@pytest.mark.asyncio
+async def test_a_raising_filter_shows_stale_rows_and_says_so(caplog) -> None:
+    """Review round 1, m2. Failing OPEN is the right direction for a status
+    surface — a stale row beats a blank dock — but a permanent failure that
+    logs nothing is undiagnosable and silently restores #524."""
+
+    class _Exploding:
+        retention_ms = 1
+
+        def list(self, *, owner_id: str | None = None) -> list[Any]:
+            return []
+
+        def get(self, job_id: str, *, owner_id: str | None = None) -> Any:
+            return None
+
+    session = FakeSession()
+    row = _Job("kept", "unreadable row", status="completed")
+    row.settled_at = time.time() - 86_400.0
+
+    # A row the FILTER cannot judge: it resolves through comms normally, and
+    # only the stamp retention ages against is unreadable. Scoped that tightly
+    # so the test exercises the filter's own guard rather than the resolver's.
+    class _Hostile:
+        id = "kept"
+        type = "task"
+        status = "completed"
+        restored = False
+        label = "unreadable row"
+
+        @property
+        def settled_at(self) -> float:
+            raise RuntimeError("row shape cannot be read")
+
+    hostile = _Hostile()
+    session.jobs = _Exploding()
+    session._subagent_comms = _GraphComms([hostile])
+
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        with caplog.at_level("WARNING"):
+            await _boot_with_jobs(app, pilot)
+            rows = app._subagent_roster()[0]
+
+    assert [getattr(job, "id", "") for job in rows] == ["kept"]  # failed open
+    assert any("retention filter" in record.message for record in caplog.records)

--- a/tests/unit/tui/test_band_panels.py
+++ b/tests/unit/tui/test_band_panels.py
@@ -11,7 +11,9 @@ isolated widget calls that can pass while the wiring is dead.
 from __future__ import annotations
 
 import asyncio
+import time
 from collections.abc import Callable, Sequence
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -276,6 +278,12 @@ class _Job:
         self.result_text: str | None = None
         self.error_text: str | None = None
         self.settled_at: float | None = None
+        # Mirrors ``AsyncJob.restored``: rehydrated from a previous session's
+        # roster on resume. Declared (rather than set ad hoc by the one test
+        # that needs it) because retention EXEMPTS it — see
+        # ``jobs.retention_expired`` — so a fixture missing the attribute would
+        # be silently answering "not restored" through a ``getattr`` default.
+        self.restored: bool = False
         self.trajectory: list[dict[str, Any]] | None = None
         # Mirrors ``AsyncJob.agent_role``/``effort``: the child's role and
         # effort tier, recorded at launch. Defaulted to the real model's
@@ -1935,3 +1943,139 @@ async def test_the_gate_admitting_a_queued_child_updates_the_summary_caption() -
         caption = panel.summary_text()
         assert "3 running" in caption, caption
         assert "queued" not in caption, caption
+
+
+class _RetentionManager:
+    """The slice of ``AsyncJobManager`` the dock roster reads, with a window.
+
+    ``_fake_jobs`` deliberately exposes no ``retention_ms``, which is the
+    "no live manager" case (a follower) where the filter is the identity. This
+    one carries the attribute so the OWNER path is exercised.
+    """
+
+    def __init__(self, jobs: list[Any], retention_ms: int) -> None:
+        self._jobs = jobs
+        self.retention_ms = retention_ms
+
+    def list(self, *, owner_id: str | None = None) -> list[Any]:
+        return list(self._jobs)
+
+    def get(self, job_id: str, *, owner_id: str | None = None) -> Any:
+        return next((job for job in self._jobs if str(getattr(job, "id", "")) == job_id), None)
+
+
+class _GraphComms:
+    """A comms graph that keeps resolving a row after the ledger let it go.
+
+    This is not a simplification — it is what the real registry does. Every
+    ``_ChildRecord`` holds a ``job_ref``, so ``comms.job()`` answers for a
+    child whose execution row the retention sweep already deleted (pinned by
+    ``test_a_swept_child_keeps_its_durable_identity_on_the_roster``). The dock
+    resolves its rows through exactly this path, which is why sweeping the
+    manager alone did not clear the panel in issue #524.
+    """
+
+    def __init__(self, jobs: list[Any]) -> None:
+        self._jobs = jobs
+
+    def children(self, job_id: str | None) -> list[Any]:
+        return [SimpleNamespace(job_id=str(job.id)) for job in self._jobs]
+
+    def job(self, job_id: str) -> Any:
+        return next((job for job in self._jobs if str(getattr(job, "id", "")) == job_id), None)
+
+
+@pytest.mark.asyncio
+async def test_the_dock_sheds_a_settled_row_once_retention_passes() -> None:
+    """Issue #524, at the surface the operator actually sees.
+
+    The panel is a VIEW over the roster, and the roster it reads comes from the
+    comms graph rather than ``jobs.list()`` — so this asserts the user-visible
+    end of the fix: rows inside the window are shown, rows past it are gone,
+    and the panel hides itself when nothing is left. No new job is registered
+    between the two assertions; only time passes.
+    """
+    session = FakeSession()
+    now = time.time()
+    jobs = [_Job(f"sub-{index}", f"child {index}", status="completed") for index in range(3)]
+    for job in jobs:
+        job.settled_at = now  # just settled: inside any sane window
+    session.jobs = _RetentionManager(jobs, retention_ms=300_000)
+    session._subagent_comms = _GraphComms(jobs)
+
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        panel = await _boot_with_jobs(app, pilot)
+        assert panel.display is True
+        assert [str(job.id) for job in app._subagent_roster()[0]] == ["sub-0", "sub-1", "sub-2"]
+
+        # Retention elapses. NOTHING is registered, cancelled or settled — the
+        # rows are simply older than the window now.
+        for job in jobs:
+            job.settled_at = now - 600.0
+        app._refresh_band()
+        for _ in range(4):
+            await pilot.pause()
+
+        assert app._subagent_roster()[0] == []
+        assert panel.display is False
+
+
+@pytest.mark.asyncio
+async def test_the_dock_keeps_a_running_child_whatever_its_stamps_say() -> None:
+    """The filter must never reach a live child. A running row is exempt in
+    :func:`retention_expired` regardless of ``settled_at``, and this pins that
+    at the dock rather than only at the manager."""
+    session = FakeSession()
+    running = _Job("live", "still working", status="running")
+    running.settled_at = time.time() - 600.0  # nonsense stamp; status wins
+    settled = _Job("done", "finished long ago", status="completed")
+    settled.settled_at = time.time() - 600.0
+    jobs = [running, settled]
+    session.jobs = _RetentionManager(jobs, retention_ms=1)
+    session._subagent_comms = _GraphComms(jobs)
+
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        panel = await _boot_with_jobs(app, pilot)
+        assert [str(job.id) for job in app._subagent_roster()[0]] == ["live"]
+        assert panel.display is True
+
+
+@pytest.mark.asyncio
+async def test_the_dock_keeps_restored_rows_after_a_resume() -> None:
+    """A rehydrated child carries the PREVIOUS session's settle stamp, which is
+    always past the window. Filtering it would empty the dock of exactly the
+    rows resume exists to show."""
+    session = FakeSession()
+    restored = _Job("old", "from last session", status="completed")
+    restored.settled_at = time.time() - 86_400.0
+    restored.restored = True
+    jobs = [restored]
+    session.jobs = _RetentionManager(jobs, retention_ms=1)
+    session._subagent_comms = _GraphComms(jobs)
+
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        panel = await _boot_with_jobs(app, pilot)
+        assert [str(job.id) for job in app._subagent_roster()[0]] == ["old"]
+        assert panel.display is True
+
+
+@pytest.mark.asyncio
+async def test_a_roster_with_no_live_manager_is_left_alone() -> None:
+    """A follower has no local manager to read a window from; its rows arrive
+    already filtered by the owner. The filter is the identity there rather than
+    a second, uninformed opinion about what to hide."""
+    session = FakeSession()
+    settled = _Job("remote", "owner-side child", status="completed")
+    settled.settled_at = time.time() - 86_400.0
+    jobs = [settled]
+    session.jobs = _fake_jobs(*jobs)  # no ``retention_ms`` attribute
+    session._subagent_comms = _GraphComms(jobs)
+
+    app = OperatorApp(_async_factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        panel = await _boot_with_jobs(app, pilot)
+        assert [str(job.id) for job in app._subagent_roster()[0]] == ["remote"]
+        assert panel.display is True


### PR DESCRIPTION
## Summary

Fixes #524. `AsyncJobManager._sweep_due` had **three call sites, all inside a job's own settle/cancel path**. So retention did not mean "five minutes after a job settles" — it meant "until the next job settles", which for the **last batch of a session is never**. Settled subagent rows stayed in the dock's `Subagents` panel for the rest of the session; the reporter's live roster showed `+45 more` settled children.

Two layers had to change, and the second one is the interesting half.

## 1. The ledger: `list()` sweeps on read

`AsyncJobManager.list()` now runs the sweep before returning.

**Why read rather than a timer** — this was the real decision, and both options work:

- **The roster is a pull surface.** Every consumer already re-reads it: the TUI's 1 Hz poll, the panel repaint, the `jobs` tool, the resume-sidecar writer. A row that is never read cannot be observed stale. Sweeping *where the observation happens* makes "a caller never sees an out-of-retention row" a property of the type rather than of a timer's cadence — and it holds identically for **server/exec hosts that run no TUI poll at all**, which the issue explicitly asks for.
- **A timer needs a lifecycle this object does not have.** `AsyncJobManager` is constructed outside a running loop in plenty of call sites (tests, restore paths), so `create_task` in `__init__` is not available. Starting one lazily means a start hook, a cancel in `dispose`, and a task that must not outlive the manager — new failure modes (leaked task, sweep firing into a disposed manager) bought for **no additional guarantee**, since a row can only matter once something reads it.
- **Cost is nil**, and measured: `list()` over 100 retained rows is **19.0 µs/call** against a 1 Hz poll. It is one O(n) pass over a roster the method already sorts in O(n log n).

Nothing changes *inside* the window: the sweep only ever evicts rows already past `settled_at + retention`, and never a running row.

## 2. The dock: sweeping the ledger alone did NOT clear the panel

This is what the manager-side fix on its own does **not** do, and I found it by driving the real panel rather than trusting the issue's model of it:

```
t=+1.5s    manager.list(): []                                        <- ledger swept
t=+1.5s    panel roster  : [('L0','completed'), ('L1','completed'), ('L2','completed')]   <- still docked
```

`OperatorApp._subagent_roster()` **does not read `jobs.list()`** on the comms path. It walks `comms.children()` and asks `comms.job()` per node, and that lookup falls back to `_ChildRecord.job_ref` — a live reference the sweep's `del` cannot free. That reference is **deliberate and must stay**: `test_a_swept_child_keeps_its_durable_identity_on_the_roster` pins it, because a swept child still needs the `session_id`/`session_dir` its transcript page resolves through (otherwise a settled child renders "no saved transcript" over a fully intact transcript).

So: **identity outliving retention is correct; presenting it as a current roster row is not.** The presentation layer filters, using the ledger's own predicate and the ledger's own window — never a locally re-derived constant, so the panel and the ledger cannot drift.

`retention_expired(job, retention_ms)` is extracted as **the one definition of "past retention"**, shared by the sweep (which evicts) and the reader (which merely hides). Its exemptions are unchanged and both load-bearing: a **running** row is never expired whatever its stamps say, and a **`restored`** row is exempt permanently (rehydrated rows carry the previous session's settle stamp, so treating them normally would evict every resumed child on the first pass).

A follower has no local manager and its rows arrive already filtered by the owner, so with no `retention_ms` the filter is the **identity** rather than a second uninformed opinion about what to hide.

## Other consumers of the same retention

Asked for explicitly, and checked rather than assumed. Everything reading the ledger goes through `list()`/`get()` and is fixed by change 1:

| surface | path | status |
|---|---|---|
| `jobs op='list'` tool (`tools/builtin.py:8347`) | `jobs.list()` | fixed by 1 — verified A/B below |
| resume sidecar writer (`session.py:8434`) | `jobs.list()` | fixed by 1 |
| `running_subagents` / Esc ladder (`session.py:4318`) | `jobs.list()` | unaffected — filters `status == "running"`, which retention never touches |
| `frontend_state._jobs` (follower projection) | `jobs.list()`, then **overridden** by `comms.job_rows()` | same `job_ref` layer as the dock |
| dock `SubagentPanel` | `comms.children()` → `job_ref` | **needed change 2** |

`frontend_state._jobs` reads `comms.job_rows()` over the manager's rows, so a follower's projection has the same shape. **Not widened into this PR**: those rows carry durable identity a follower's *transcript page* resolves through, and dropping them there is a distinct behavioural call about what a viewer sees after a swept child — worth its own change, not a silent rider on a dock fix. Called out here rather than fixed quietly.

## Testing evidence

### The issue's exact repro, A/B — rows gone at t=1.05s with NO new job registered

Verbatim from the issue body, run against a clean `origin/main` worktree and this branch:

```
origin/main (d017115dd)                          this branch
t=0.05s   [L0 completed, L1, L2]                 t=0.05s   [L0 completed, L1, L2]
t=1.05s   [L0 completed, L1, L2]  <-- 5x past    t=1.05s   []            <-- swept, nothing registered
after new [L-new completed]                      after new []
```

### The rest of the required proofs

```
1. retention window honoured (5 min default, settled 1s ago)
   list() -> [('fresh', 'completed')]                                    PASS
2. a RUNNING job is never swept (retention_ms=0, 5 consecutive reads)
   get() -> running, list() -> ['long-runner']                           PASS
3. restored rows exempt; an ordinary same-age row IS evicted
   list() -> [('from-last-session', True)]                               PASS
4. no leaked task (read-driven sweep spawns none)
   tasks before=1 during=1 after_dispose=1                               PASS
5. the issue's exact repro
   t=1.05s [] with NO new job registered                                 PASS
6. cost: list() over 100 retained rows = 19.0 us/call (1 Hz poll)
```

Check 2 is pinned at `retention_ms=0`, where any arithmetic slip evicts the live row on the first read. Checks 3 and 4 **fail on clean main** and pass here. On the timer question (4): there is no timer, so there is no task to cancel and none to leak — `asyncio.all_tasks()` is unchanged across the manager's whole life and across `dispose()`.

### `jobs` tool surface, A/B

```
                origin/main                              this branch
inside window : [L0(completed), L1, L2]                  [L0(completed), L1, L2]
past window   : [L0(completed), L1, L2]   <-- stale      'no background jobs'
```

### The REAL TUI dock, driven end to end

A real `Session` with **three real subagents** behind the real `OperatorApp`, isolated config dir, every `CMUX_*` variable unset. Retention shortened to 1.5 s so the window is watchable; the mechanism is identical at the shipped five minutes. **No job is registered between the two captures — only time passes.**

```
                       origin/main (d017115dd)      this branch
BEFORE (inside window)
  panel.display          True                        True
  roster labels          ['L0','L1','L2']            ['L0','L1','L2']
AFTER (retention elapsed, NO new job registered)
  panel.display          True    <-- the defect      False
  roster labels          ['L0','L1','L2']            []
  manager.list()         ['L0','L1','L2']            []
```

On `origin/main` the two SVG frames are **byte-identical** (`md5` match) — the panel does not move at all, which is the bug rendered.

### Rendered frames (looked at, not just asserted)

Captured with `app.save_screenshot()` at 100×30, rasterized and **viewed**. The before-frame comes from a throwaway detached `origin/main` worktree, never a `git stash`. Text reconstructed from the two SVGs:

```
BASELINE (origin/main), after retention elapsed
   |Subagents                    ctrl+g
   |• L0  ✓ 0s    child did the work
   |• L1  ✓ 0s    child did the work
   |• L2  ✓ 0s    child did the work
   |
   |❯ Message Local Operator…
   |◆ test/m › ⌂ .          ▦ 2.6%/100k ‹ ◷ 0s

THIS BRANCH, after retention elapsed
   |
   |                                              (panel gone; dock reclaimed)
   |
   |❯ Message Local Operator…
   |◆ test/m › ⌂ .          ▦ 2.6%/100k ‹ ◷ 0s
```

The in-window frames are the **same on both** (panel present, three rows) — the fix is not "hide the panel", it is "stop showing rows the ledger has released". Two run-to-run differences I checked before claiming them as mine (an extra transcript line, the `◷ 0s` segment) reproduce **on baseline too** across repeated runs, so they are capture timing, not this change.

### Quality gates — whole tree, exactly as CI

```
.venv/bin/python -m flake8 .                                  0
uvx --from black==26.1.0 black --check .                      1013 files unchanged
uvx isort==5.13.2 --check .                                   clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .   0 errors, 0 warnings
.venv/bin/python -m pytest tests/unit -q                      15271 passed, 18 skipped (33:08)
```

Full suite is **green with zero failures** — including the four pre-existing flakes that fail on clean main under load, which passed on this run.

### Tests added

Four in `tests/unit/harness/test_jobs.py`, four in `tests/unit/tui/test_band_panels.py`. The four that pin the defect were confirmed to **FAIL on clean `origin/main`** and pass here (the other four guard against over-correction — the in-window row, the running child, the restored row, the follower with no manager, all of which must NOT be filtered).

`_Job` in the band-panel fixtures gained an explicit `restored` attribute: retention *exempts* it, so a fixture missing it was silently answering "not restored" through a `getattr` default.

## Notes

- **No version bump** — `pyproject.toml` stays at 0.51.1.
- #525 covers the UX half (a collapse/dismiss affordance while children run). This is the mechanical half only; the panel now self-clears, and #525 remains about giving the user control in the meantime.
