### PR TITLE
chore(release): bump version to 0.51.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.1"
+version = "0.51.2"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release bump for the window after `v0.51.1`. **One file, one line** — `pyproject.toml` only.

## Window contents

Derived with a plain `git log v0.51.1..origin/main` rather than `--merges`: #716 was squash-style merged, and a `--merges` listing silently drops squashed PRs (this cost the previous window a nearly-unlisted PR).

| PR | Merge | Impact |
|---|---|---|
| #716 | `66baf01e4` | `/session` and `/analytics` now roll up subagent cost, so all three surfaces agree |

## Bump class: PATCH

Defect fix to an existing surface — `/session` reported `$31.28` for a session that had actually spent `$102.34` including its 20 subagents, while the composer band showed the true figure. No new command, no new surface, no API change.

The `/analytics` table restructure (children nested under their root) is the presentation half of the roll-up fix, not a new capability — there is no `X.Y.0: <the new thing>` title to write for it. Five lop-dev peers independently concurred with PATCH (pids 61788, 47042, 66964, 65341, 99576).

## Verification before tagging

- `git diff v0.51.1..origin/main -- pyproject.toml` is **empty** — no merged PR carried a stray bump that would silently consume `0.51.2`. This repo lost `0.50.1` and `0.50.2` exactly that way.
- `origin/main` reads `0.51.1`; this PR takes it to `0.51.2`, forward-only.

## Scope check

Only `pyproject.toml` is touched. No source, no tests, no docs.