### PR TITLE
docs(release): derive a window without --merges, and check for a consumed bump

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -635,9 +635,8 @@ Warnings that still hold, each of which has already cost a release:
   `Merge pull request #999 from feat` and never the substantive commit on the
   second parent, so when a merge subject is uninformative the plain log carries
   the real description and the first-parent walk does not. A release note that
-  omits a
-  merged PR is a defect in the release, not a cosmetic miss — it is the only
-  record of what changed under a user who is about to update.
+  omits a merged PR is a defect in the release, not a cosmetic miss — it is
+  the only record of what changed under a user who is about to update.
 - **Check `git diff <last-tag>..origin/main -- pyproject.toml` is empty before
   tagging.** A non-empty diff means a merged PR carried its own version bump
   and has silently consumed the number you are about to use. That is exactly

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -629,10 +629,13 @@ Warnings that still hold, each of which has already cost a release:
 
   The one only the second form lists is #720 (`78c20295e`), squash-merged; it
   nearly shipped unlisted in v0.51.1 and was caught only because its author was
-  watching. `--first-parent` happens to work here because both button shapes
-  land on that chain, but do not adopt it as a general "show me every PR"
-  idiom: it is another shape-based filter, and the next thing that does not fit
-  the shape will be dropped just as quietly. A release note that omits a
+  watching. `--first-parent` happens to work for *counting* the window because
+  both button shapes land on that chain, but do not adopt it as a general
+  "show me every PR" idiom: for a PR landed with the merge button it shows only
+  `Merge pull request #999 from feat` and never the substantive commit on the
+  second parent, so when a merge subject is uninformative the plain log carries
+  the real description and the first-parent walk does not. A release note that
+  omits a
   merged PR is a defect in the release, not a cosmetic miss — it is the only
   record of what changed under a user who is about to update.
 - **Check `git diff <last-tag>..origin/main -- pyproject.toml` is empty before
@@ -646,21 +649,34 @@ Warnings that still hold, each of which has already cost a release:
 - **A shard failure on your branch alone is not evidence your diff caused it.**
   CI shards the unit suite by `sorted(glob('tests/unit/**/test_*.py'))` and
   `i % 5` (`.github/workflows/ci.yml`), so **adding a single test file
-  re-shards every file after it in sort order**. Verified: adding one file
-  early in the ordering moves `tests/unit/tui/test_app_pilot.py` from index 252
-  to 253, i.e. shard 2 to shard 3. A test in the file that moved then fails on
-  your branch and nowhere else, reading exactly like "your diff broke the TUI"
-  when the diff touches no TUI file at all. It is load-sensitive and mostly
-  appears under coverage. Before concluding you caused a suspect shard failure,
-  reproduce it on clean `origin/main` **with** `--cov=local_operator` (several
-  of these pass 3/3 bare and fail intermittently under coverage) and check
-  whether your branch changed that file's shard index. Diagnosing this as a
-  real regression has already cost a review round.
-- **A red `cli-sanity`/`server-sanity` across several PRs at once is the
-  provider, not your diff.** Those jobs call a live model, so a third-party
+  re-shards every file after it in sort order**. Derive it against the ref CI
+  actually runs, not a stale local checkout:
+
+  ```sh
+  git ls-tree -r --name-only origin/main \
+    | grep -E '^tests/unit/.*test_.*\.py$' | sort | nl \
+    | grep tests/unit/tui/test_app_pilot.py     # 331st of 451 -> index 330
+  ```
+
+  At index 330 that file is in shard 0; add one test file earlier in the
+  ordering and it becomes 331, shard 1. This is not hypothetical — PR #730 did
+  exactly that (451 → 452 files) and its CI failure was `test_app_pilot.py`
+  failing in shard 1, on a branch that touched no TUI file. A test in the file
+  that moved fails on your branch and nowhere else, reading exactly like "your
+  diff broke the TUI". Before concluding you caused a suspect shard failure,
+  check whether your branch changed that file's shard index, and reproduce on
+  clean `origin/main` under the same conditions CI uses (the shard job runs
+  `pytest --cov`, and some of these failures do not reproduce bare).
+  Diagnosing this as a real regression has already cost a review round.
+- **Several PRs going red at once is a shared cause, not several bugs.**
+  `cli-sanity` and `server-sanity` call a live model (both are marked
+  "Live-LLM job" and take `OPENROUTER_API_KEY`), so a third-party outage or
   429 reddens every open PR simultaneously — including heads that touch
-  neither surface. The tell is shared fate: check whether sibling PRs went red
-  in the same window, and rerun the job before debugging your change.
+  neither surface. Re-sharding (above) produces the same fleet-wide pattern
+  from an entirely different cause. Either way the tell is the same: before
+  debugging your diff, check whether sibling PRs went red in the same window,
+  and confirm *which* job failed. A shard failure and a sanity failure look
+  equally alarming on the checks list and have nothing to do with each other.
 - **Never pre-create a bare tag** (`git tag vX.Y.Z && git push --tags`) and
   then make a release from it. The publish workflow triggers on the *release*
   being published, so a bare tag publishes nothing, and `gh release create`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -612,18 +612,29 @@ under a checked-out `main` moves the branch without touching the index, so
 
 Warnings that still hold, each of which has already cost a release:
 
-- **Never derive the window with `git log --merges`.** A squash-merged PR has
-  no merge commit, so `--merges` silently omits it and the release notes ship
-  without it. Use a plain `git log <last-tag>..origin/main`, or walk
-  `--first-parent` from the head back to the tag — a squash lands as a
-  single-parent commit *on that chain*, which is exactly why the plain forms
-  see it and `--merges` does not. Verify it against a real window rather than
-  taking it on faith — for v0.51.0..v0.51.1, `--merges` lists three PRs while
-  `--first-parent` lists four, and the missing one is #720 (`78c20295e`),
-  squash-merged. It nearly shipped unlisted, and was caught only because its
-  author happened to be watching. A release note that omits a merged PR is a
-  defect in the release, not a cosmetic miss: it is the only record of what
-  changed under a user who is about to update.
+- **Derive the window from the commits, not from the commit shape.** Use a
+  plain `git log <last-tag>..origin/main` and read the PR references out of it.
+  **Never `git log --merges`**: GitHub's *merge* button produces a merge commit
+  that `--merges` sees, while its *squash* button produces a single-parent
+  commit that `--merges` silently drops. So the trap fires **per PR, according
+  to which button someone happened to press** — which means a window is not
+  reliably empty when it is wrong, it is **partially listed**, and a partially
+  correct window looks right and survives review. Check it rather than trusting
+  this paragraph:
+
+  ```sh
+  git log --oneline --merges       v0.51.0..v0.51.1   # 3 PRs
+  git log --oneline --first-parent v0.51.0..v0.51.1   # 4 PRs
+  ```
+
+  The one only the second form lists is #720 (`78c20295e`), squash-merged; it
+  nearly shipped unlisted in v0.51.1 and was caught only because its author was
+  watching. `--first-parent` happens to work here because both button shapes
+  land on that chain, but do not adopt it as a general "show me every PR"
+  idiom: it is another shape-based filter, and the next thing that does not fit
+  the shape will be dropped just as quietly. A release note that omits a
+  merged PR is a defect in the release, not a cosmetic miss — it is the only
+  record of what changed under a user who is about to update.
 - **Check `git diff <last-tag>..origin/main -- pyproject.toml` is empty before
   tagging.** A non-empty diff means a merged PR carried its own version bump
   and has silently consumed the number you are about to use. That is exactly

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -632,6 +632,24 @@ Warnings that still hold, each of which has already cost a release:
   `version-bump-guard` CI job now catches this on the PR, but it does **not**
   block an `--admin` merge, because `main`'s ruleset configures no required
   status checks and admins hold a bypass. The pre-tag check is the backstop.
+- **A shard failure on your branch alone is not evidence your diff caused it.**
+  CI shards the unit suite by `sorted(glob('tests/unit/**/test_*.py'))` and
+  `i % 5` (`.github/workflows/ci.yml`), so **adding a single test file
+  re-shards every file after it in sort order**. Verified: adding one file
+  early in the ordering moves `tests/unit/tui/test_app_pilot.py` from index 252
+  to 253, i.e. shard 2 to shard 3. A test in the file that moved then fails on
+  your branch and nowhere else, reading exactly like "your diff broke the TUI"
+  when the diff touches no TUI file at all. It is load-sensitive and mostly
+  appears under coverage. Before concluding you caused a suspect shard failure,
+  reproduce it on clean `origin/main` **with** `--cov=local_operator` (several
+  of these pass 3/3 bare and fail intermittently under coverage) and check
+  whether your branch changed that file's shard index. Diagnosing this as a
+  real regression has already cost a review round.
+- **A red `cli-sanity`/`server-sanity` across several PRs at once is the
+  provider, not your diff.** Those jobs call a live model, so a third-party
+  429 reddens every open PR simultaneously — including heads that touch
+  neither surface. The tell is shared fate: check whether sibling PRs went red
+  in the same window, and rerun the job before debugging your change.
 - **Never pre-create a bare tag** (`git tag vX.Y.Z && git push --tags`) and
   then make a release from it. The publish workflow triggers on the *release*
   being published, so a bare tag publishes nothing, and `gh release create`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -612,6 +612,26 @@ under a checked-out `main` moves the branch without touching the index, so
 
 Warnings that still hold, each of which has already cost a release:
 
+- **Never derive the window with `git log --merges`.** A squash-merged PR has
+  no merge commit, so `--merges` silently omits it and the release notes ship
+  without it. Use a plain `git log <last-tag>..origin/main`, or walk
+  `--first-parent` from the head back to the tag — a squash lands as a
+  single-parent commit *on that chain*, which is exactly why the plain forms
+  see it and `--merges` does not. Verify it against a real window rather than
+  taking it on faith — for v0.51.0..v0.51.1, `--merges` lists three PRs while
+  `--first-parent` lists four, and the missing one is #720 (`78c20295e`),
+  squash-merged. It nearly shipped unlisted, and was caught only because its
+  author happened to be watching. A release note that omits a merged PR is a
+  defect in the release, not a cosmetic miss: it is the only record of what
+  changed under a user who is about to update.
+- **Check `git diff <last-tag>..origin/main -- pyproject.toml` is empty before
+  tagging.** A non-empty diff means a merged PR carried its own version bump
+  and has silently consumed the number you are about to use. That is exactly
+  how 0.50.1 and 0.50.2 were burned — each consumed by a PR's own bump, neither
+  ever built, tagged or published, and the next owner had to skip both. The
+  `version-bump-guard` CI job now catches this on the PR, but it does **not**
+  block an `--admin` merge, because `main`'s ruleset configures no required
+  status checks and admins hold a bypass. The pre-tag check is the backstop.
 - **Never pre-create a bare tag** (`git tag vX.Y.Z && git push --tags`) and
   then make a release from it. The publish workflow triggers on the *release*
   being published, so a bare tag publishes nothing, and `gh release create`


### PR DESCRIPTION
Two release-process traps that have each already cost a window, written into the release section of `AGENTS.md` where the owner will actually read them. Docs only — no code, no version bump.

## Why

Both were hit in the last two release windows and both were caught by luck rather than by process.

### 1. `git log --merges` silently drops squash-merged PRs

A squash-merged PR has no merge commit, so a window derived with `--merges` omits it entirely and the release notes ship without it.

Verified against a real window rather than asserted:

```
$ git log --oneline --merges v0.51.0..v0.51.1        # 3 PRs
d017115dd Merge pull request #725 ... chore/release-0.51.1
3081d0986 Merge pull request #718 ... fix/stop-button-runaway
49c476b78 Merge pull request #711 ... fix/viewer-transient-disconnect

$ git log --oneline --first-parent v0.51.0..v0.51.1  # 4 PRs
d017115dd Merge pull request #725 ... chore/release-0.51.1
78c20295e fix(tui): sidebar activity indicator ... (#720)   <-- squashed, missing above
3081d0986 Merge pull request #718 ... fix/stop-button-runaway
49c476b78 Merge pull request #711 ... fix/viewer-transient-disconnect
```

I hit this cutting v0.51.1: my first window listing used `--merges` and missed #720. It would have shipped inside the release **unlisted**, and was caught only because its author messaged me after merging. A release note that omits a merged PR is a defect in the release — it is the only record of what changed under a user who is about to update.

A `--first-parent` walk sees a squash because a squash lands as a single-parent commit *on that chain*. That is the reason the plain forms work and `--merges` does not, so the doc states the reason rather than just the rule.

### 2. A merged PR's own version bump silently consumes the next number

`git diff <last-tag>..origin/main -- pyproject.toml` must be empty before tagging. A non-empty diff means a merged PR carried its own bump and has eaten the number about to be used — which is how **0.50.1 and 0.50.2 were burned**, neither ever built, tagged or published, leaving the next owner to skip both.

`version-bump-guard` now catches this on the PR, but it does **not** block an `--admin` merge: `main`'s ruleset configures no required status checks and admins hold a bypass. So the pre-tag check is the backstop, not a redundant one — and the doc says so, since a reader who assumes CI has it covered will skip it.

## Evidence

The commands in the added text were run against real windows before being documented (output above). Nothing here changes code.

## Scope

`AGENTS.md` only, +20 lines, in the existing "Warnings that still hold, each of which has already cost a release" list. `pyproject.toml` untouched at 0.51.1.