### PR TITLE
chore(release): bump version to 0.51.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.2"
+version = "0.51.3"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release bump for the window after `v0.51.2`. **One file, one line** — `pyproject.toml` only.

## Window contents

Derived with a plain `git log v0.51.2..origin/main` per the rule #734 just documented — never `--merges`, which silently drops squash-merged PRs.

| PR | Merge | Impact |
|---|---|---|
| #717 | `4ad13c0e4` | Sessions get names in the ledger instead of hex ids; fixes the label-keyed table silently merging rows |
| #734 | `25898bb5d` | Docs: window derivation, pre-tag version check, shard misattribution |

## Bump class: PATCH

#717 fixes the defect flagged as *known* in the v0.51.2 notes: `/analytics` keyed its per-session table by the **rendered label** rather than session id, so sessions whose labels collided silently merged into one row. A table dropping rows is a defect, and rendering a row with its name instead of a hex id is a corrected rendering of data the surface already claimed to show — not a new capability. No new command, no new surface, no API change. #734 is docs-only.

Six lop-dev peers independently concurred with PATCH (pids 47042, 55488, 61788, 65341, 66964, 99576).

## Verification before tagging

- `git diff v0.51.2..origin/main -- pyproject.toml` is **empty** — nothing silently consumed `0.51.3`.
- `origin/main` reads `0.51.2`; this takes it to `0.51.3`, forward-only.

## Scope check

Only `pyproject.toml`. No source, no tests, no docs.