### PR TITLE
fix(analytics): scope the session-name backfill's writes to its config_dir

### DIFF
--- a/local_operator/analytics/backfill.py
+++ b/local_operator/analytics/backfill.py
@@ -64,6 +64,7 @@ from __future__ import annotations
 import logging
 import re
 from pathlib import Path
+from typing import Callable
 
 from local_operator.analytics.model import condense_label
 from local_operator.analytics.store import SESSION_NAME_RANK_BACKFILL, AnalyticsStore
@@ -131,11 +132,59 @@ def backfill_analytics_session_names(
     # store-maintenance pass — passes the real config dir, where the two roots
     # happen to agree. It fires only when ``config_dir`` is NOT the default,
     # which is exactly what every isolated test, QA run and agent sandbox does,
-    # defeating the isolation those runs exist to guarantee. Deriving the path
-    # here keeps the production resolution byte-identical (``default_db_path``
-    # is itself ``config_dir() / "analytics.db"``) while making an isolated
-    # call actually isolated. Do not "simplify" this back to ``AnalyticsStore()``.
-    store = store if store is not None else AnalyticsStore(config_dir / "analytics.db")
+    # defeating the isolation those runs exist to guarantee.
+    #
+    # THE GUARANTEE THIS BUYS IS THE NARROW ONE: whatever root the caller hands
+    # us is the root we write to. It is NOT "production still lands on
+    # ``default_db_path()``" — that is a property of the CALLER passing
+    # ``paths.config_dir()``, not of this function, and it was briefly false:
+    # two registry construction sites hardcoded ``Path.home() / ".local-operator"``
+    # instead of the resolver, so with ``LOCAL_OPERATOR_CONFIG_DIR`` set an exec
+    # run arrived here with the home root while ``default_db_path()`` resolved
+    # to the override. Those two are fixed in this same commit
+    # (``exec_worker._default_session_factory``,
+    # ``exec_mode.resolve_hosting_model_dry``), but state the narrow invariant
+    # anyway: it is the one that stays true whatever a future caller passes.
+    #
+    # Do not "simplify" this back to ``AnalyticsStore()``.
+    db_path = config_dir / "analytics.db"
+    if store is None and not db_path.exists():
+        # No ledger, nothing to name. Returning before constructing the store
+        # keeps the sweep free of side effects on a root that has none: opening
+        # one CREATES ``analytics.db`` plus its -wal/-shm siblings, and this
+        # pass runs against whatever config dir a caller hands it. A read-only
+        # maintenance sweep must not be the thing that materialises a ledger.
+        return 0
+    owned = store is None
+    store = store if store is not None else AnalyticsStore(db_path)
+    try:
+        return _name_pending_sessions(store, config_dir, limit=limit, session_name=session_name)
+    finally:
+        # Only a store this call opened. A caller-supplied store outlives the
+        # call by construction (tests reuse theirs to assert on the result), and
+        # SQLite forbids closing a connection from another thread — so closing
+        # someone else's handle is a bug, not hygiene.
+        if owned:
+            store.close()
+
+
+def _name_pending_sessions(
+    store: AnalyticsStore,
+    config_dir: Path,
+    *,
+    limit: int,
+    session_name: Callable[[Path], str],
+) -> int:
+    """The sweep itself, against an already-resolved store.
+
+    Split from the public entry point so that one can own the store's lifetime
+    in a single ``finally``: the body below returns early from four places, and
+    wrapping all of it inline would bury the pass inside a ``try`` whose reader
+    has to check every branch to see what the cleanup covers.
+
+    ``session_name`` is threaded in rather than imported here for the reason
+    given at the call site — the ``resume`` import must stay inside the call.
+    """
     try:
         pending = store.sessions_missing_names()
     except Exception:  # noqa: BLE001 — an unreadable ledger is a no-op sweep

--- a/local_operator/analytics/backfill.py
+++ b/local_operator/analytics/backfill.py
@@ -119,7 +119,23 @@ def backfill_analytics_session_names(
     # (analytics may read resume; resume must never import analytics).
     from local_operator.resume import session_name
 
-    store = store if store is not None else AnalyticsStore()
+    # READS AND WRITES MUST SHARE ONE ROOT. The worklist, the session tree and
+    # the recovered names all come from ``config_dir``; a default-path store
+    # would take its ledger from ``default_db_path()`` instead, so a call with
+    # an isolated ``config_dir`` read transcripts out of the sandbox and wrote
+    # the resulting names into the operator's REAL ``~/.local-operator/
+    # analytics.db`` (observed: 612 rows written into a live ledger by a single
+    # test-shaped call with ``config_dir=/tmp/bfhome2``).
+    #
+    # The bug hid because the one production caller — ``session_factory``'s
+    # store-maintenance pass — passes the real config dir, where the two roots
+    # happen to agree. It fires only when ``config_dir`` is NOT the default,
+    # which is exactly what every isolated test, QA run and agent sandbox does,
+    # defeating the isolation those runs exist to guarantee. Deriving the path
+    # here keeps the production resolution byte-identical (``default_db_path``
+    # is itself ``config_dir() / "analytics.db"``) while making an isolated
+    # call actually isolated. Do not "simplify" this back to ``AnalyticsStore()``.
+    store = store if store is not None else AnalyticsStore(config_dir / "analytics.db")
     try:
         pending = store.sessions_missing_names()
     except Exception:  # noqa: BLE001 — an unreadable ledger is a no-op sweep

--- a/local_operator/exec_mode.py
+++ b/local_operator/exec_mode.py
@@ -231,11 +231,18 @@ def resolve_hosting_model_dry(exec_args: ExecArgs) -> tuple[str, str]:
     """
     from local_operator.agents import AgentRegistry
     from local_operator.config import ConfigManager
+    from local_operator.paths import config_dir
     from local_operator.session_factory import resolve_agent, resolve_hosting_model
 
-    config_dir = Path.home() / ".local-operator"
-    config_manager = ConfigManager(config_dir)
-    agent_registry = AgentRegistry(config_dir)
+    # config_dir(), not ``Path.home() / ".local-operator"``: the same missed copy
+    # fixed in ``_make_default_session_factory`` below. Preflight's whole purpose
+    # is to resolve hosting/model through the EXACT path the worker will use, so
+    # reading a different config root than the worker does defeats it — with
+    # LOCAL_OPERATOR_CONFIG_DIR set this validated against the developer's real
+    # agents and config and then spawned a worker that used the override's.
+    base_dir = config_dir()
+    config_manager = ConfigManager(base_dir)
+    agent_registry = AgentRegistry(base_dir)
     selector_args = argparse.Namespace(
         hosting=exec_args.hosting,
         model=exec_args.model,

--- a/local_operator/exec_worker.py
+++ b/local_operator/exec_worker.py
@@ -20,7 +20,6 @@ import inspect
 import os
 import signal
 import sys
-from pathlib import Path
 from typing import TYPE_CHECKING, Awaitable, Callable
 
 if TYPE_CHECKING:
@@ -124,6 +123,7 @@ def _default_session_factory(parsed: argparse.Namespace) -> Awaitable[SessionPro
     """
     from local_operator.config import ConfigManager
     from local_operator.credentials import CredentialManager
+    from local_operator.paths import config_dir
     from local_operator.session_factory import create_session
 
     session_args = argparse.Namespace(
@@ -135,13 +135,22 @@ def _default_session_factory(parsed: argparse.Namespace) -> Awaitable[SessionPro
         train=bool(getattr(parsed, "train", False)),
         resume=parsed.resume,
     )
-    config_dir = Path.home() / ".local-operator"
-    config_manager = ConfigManager(config_dir)
-    credential_manager = CredentialManager(config_dir)
+    # config_dir(), not ``Path.home() / ".local-operator"``: a missed copy of the
+    # hardcoded root that ``exec_mode._make_default_session_factory`` already
+    # fixed for the foreground path (see the comment there). This is the
+    # BACKGROUND worker, which inherits the spawner's environment, so leaving it
+    # hardcoded made ``exec --background`` ignore LOCAL_OPERATOR_CONFIG_DIR while
+    # the foreground run honoured it — the same entry point resolving two
+    # different roots depending on a flag. It also reaches the analytics
+    # session-name backfill through ``create_session``'s store-maintenance pass,
+    # which writes to whatever root it is handed.
+    base_dir = config_dir()
+    config_manager = ConfigManager(base_dir)
+    credential_manager = CredentialManager(base_dir)
 
     from local_operator.agents import AgentRegistry  # lazy: heavy module
 
-    agent_registry = AgentRegistry(config_dir)
+    agent_registry = AgentRegistry(base_dir)
     return create_session(session_args, config_manager, credential_manager, agent_registry)
 
 

--- a/tests/unit/analytics/test_backfill.py
+++ b/tests/unit/analytics/test_backfill.py
@@ -23,7 +23,9 @@ from local_operator.analytics.store import (
     SESSION_NAME_RANK_BACKFILL,
     SESSION_NAME_RANK_TITLE,
     AnalyticsStore,
+    default_db_path,
 )
+from local_operator.paths import CONFIG_DIR_ENV
 
 
 def _snap(session_id: str, parent: str = "") -> CallSnapshot:
@@ -331,3 +333,71 @@ def test_a_parent_named_in_the_same_pass_is_visible_to_its_children(tmp_path):
     assert names["aachild00001"] == "qa-tester · Investigate the analytics hex ids"
     assert "zzparent0001" not in names["aachild00001"]
     store.close()
+
+
+def test_backfill_writes_into_the_config_dir_it_was_given_not_the_default_ledger(
+    tmp_path, monkeypatch
+):
+    """The sweep's reads and its writes must resolve to ONE root.
+
+    Regression for a footgun that silently wrote a sandbox's recovered names
+    into the operator's live ledger: the pass honoured ``config_dir`` for its
+    transcript reads but built its default store from ``default_db_path()``,
+    so an isolated call read transcripts out of ``/tmp/...`` and wrote the
+    names it derived from them into ``~/.local-operator/analytics.db`` — 612
+    real rows, observed on the operator's own ledger from one such call. Only
+    the production caller, which passes the real config dir where the two roots
+    agree, was ever correct.
+
+    The arrangement reproduces that exact shape: BOTH ledgers carry the same
+    unnamed session id, and only the isolated root has the transcript on disk.
+    Under the defect the default store supplies the worklist, the isolated
+    directory supplies the name, and the default ledger takes the write.
+    ``LOCAL_OPERATOR_CONFIG_DIR`` points at a second tmp root so the "default"
+    ledger here is a stand-in and never the developer's own.
+    """
+    default_root = tmp_path / "default-config"
+    (default_root / "sessions").mkdir(parents=True)
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(default_root))
+    default_store = AnalyticsStore(default_db_path())
+    default_store.record_batch([_snap("aaaisolated1")])
+    default_store.close()
+
+    isolated = tmp_path / "isolated-config"
+    isolated.mkdir()
+    isolated_store = AnalyticsStore(isolated / "analytics.db")
+    isolated_store.record_batch([_snap("aaaisolated1")])
+    isolated_store.close()
+    # The transcript exists ONLY in the sandbox, so any name that reaches the
+    # default ledger provably came from the isolated root.
+    _session(isolated, "aaaisolated1", "Work done inside the sandbox")
+
+    assert backfill_analytics_session_names(isolated) == 1
+
+    # Asserted FIRST because it is the actual harm: a name derived from the
+    # sandbox landing in the ledger the operator uses for real.
+    default_reopened = AnalyticsStore(default_db_path())
+    leaked = _names(default_reopened).get("aaaisolated1", "")
+    default_reopened.close()
+    assert not leaked, (
+        f"the sweep wrote {leaked!r} — a name derived from the isolated config "
+        "dir — into the DEFAULT ledger; reads and writes must share one root"
+    )
+
+    reopened = AnalyticsStore(isolated / "analytics.db")
+    assert _names(reopened)["aaaisolated1"] == "Work done inside the sandbox"
+    reopened.close()
+
+
+def test_the_production_config_dir_still_resolves_to_the_default_ledger(tmp_path, monkeypatch):
+    """Deriving the store from ``config_dir`` must not move the real ledger.
+
+    The production caller (``session_factory``'s store-maintenance pass) hands
+    this function the real config dir. The derived path must therefore be the
+    exact file ``default_db_path()`` names — otherwise the fix for the isolation
+    bug would silently strand months of the operator's own history.
+    """
+    real_config_dir = tmp_path / "config"
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(real_config_dir))
+
+    assert real_config_dir / "analytics.db" == default_db_path()

--- a/tests/unit/analytics/test_backfill.py
+++ b/tests/unit/analytics/test_backfill.py
@@ -393,11 +393,45 @@ def test_the_production_config_dir_still_resolves_to_the_default_ledger(tmp_path
     """Deriving the store from ``config_dir`` must not move the real ledger.
 
     The production caller (``session_factory``'s store-maintenance pass) hands
-    this function the real config dir. The derived path must therefore be the
-    exact file ``default_db_path()`` names — otherwise the fix for the isolation
-    bug would silently strand months of the operator's own history.
+    this function the config dir ``paths.config_dir()`` resolves to, so the
+    sweep's write must land in the exact file ``default_db_path()`` names —
+    otherwise the fix for the isolation bug would silently strand months of the
+    operator's own history in a ledger nothing reads.
+
+    ASSERTED ON THE ACTUAL WRITE, never on a rebuilt path expression. The first
+    version of this test compared ``real_config_dir / "analytics.db"`` to
+    ``default_db_path()`` and never called the function under test at all: it
+    pinned ``default_db_path``'s own definition, and review demonstrated it
+    still PASSED when the production line was mutated to ``analytics2.db`` —
+    the exact stranding scenario this docstring claims to guard. So the unnamed
+    row is seeded in the file ``default_db_path()`` names and read back from
+    that same file, with no ``store`` argument so the sweep must resolve one
+    itself. A wrong filename now fails on both assertions below.
     """
     real_config_dir = tmp_path / "config"
+    real_config_dir.mkdir()
     monkeypatch.setenv(CONFIG_DIR_ENV, str(real_config_dir))
 
-    assert real_config_dir / "analytics.db" == default_db_path()
+    # Seed the worklist through default_db_path() — the ledger production reads
+    # — so a sweep resolving anywhere else finds nothing to do (returns 0) and a
+    # sweep WRITING anywhere else leaves this row unnamed.
+    ledger = default_db_path()
+    seeded = AnalyticsStore(ledger)
+    seeded.record_batch([_snap("aaaproduction")])
+    seeded.close()
+    _session(real_config_dir, "aaaproduction", "The operator's own history")
+
+    assert backfill_analytics_session_names(real_config_dir) == 1
+
+    reopened = AnalyticsStore(ledger)
+    named = _names(reopened)
+    reopened.close()
+    assert named.get("aaaproduction") == "The operator's own history", (
+        f"the sweep did not name the row in {ledger}, the file default_db_path() "
+        "resolves to for this config dir — production history would be stranded "
+        "in whatever ledger it wrote instead"
+    )
+
+    # And no SECOND ledger appeared beside it: a wrong filename in the same
+    # directory would otherwise slip past a check on the named row alone.
+    assert sorted(p.name for p in real_config_dir.glob("analytics*.db")) == ["analytics.db"]


### PR DESCRIPTION
## Summary

`backfill_analytics_session_names(config_dir, ...)` honoured `config_dir` for its **reads** but ignored it for its **writes**:

```python
store = store if store is not None else AnalyticsStore()   # ← default path, ignores config_dir
...
sessions = config_dir / "sessions"                          # ← honours config_dir
```

The two resolve to different roots whenever `config_dir` is not the default. An isolated call therefore reads transcripts out of the sandbox and writes the names it derives from them into the operator's **real** `~/.local-operator/analytics.db`. This is not hypothetical: a single test-shaped call with `config_dir=/tmp/bfhome2` wrote **612 rows** into the live ledger. That is how the defect was found.

**Change class: C1 (low risk).** One-line behavioural change in a startup maintenance pass, plus a regression test. No schema change, no turn-path change, no provider call.

### Users are not affected — and it is still worth fixing

The only production caller is `session_factory.py:1493`, which passes the real `config_dir`. There `config_dir` and the default store agree, so the behaviour is and always was correct.

That agreement is exactly what hid the bug. It fires **only** when `config_dir` is not the default — which is precisely what every isolated test, QA run and agent sandbox does. `AGENTS.md` ("Isolating a run") and the team's QA rules both insist on an isolated config dir so a test can never touch real data; this function silently defeated that guarantee and wrote to the operator's live ledger from a test.

## What changed

**`local_operator/analytics/backfill.py`** — the default store is derived from the `config_dir` that was passed in, so reads and writes always share one root:

```python
store = store if store is not None else AnalyticsStore(config_dir / "analytics.db")
```

The comment records the concrete symptom (an isolated-config call writing into the operator's live ledger), why the production caller hid it, and that the production resolution is unchanged — so nobody "simplifies" it back.

**Production resolution is byte-identical.** `default_db_path()` is itself `config_dir() / "analytics.db"`, so with the real config dir the derived path is the same file it has always been. Verified explicitly, for both the default root and an overridden one:

```
override=None                     config_dir=/tmp/bf-guard-home/.local-operator
   derived=/tmp/bf-guard-home/.local-operator/analytics.db
   default_db_path()=/tmp/bf-guard-home/.local-operator/analytics.db
   IDENTICAL ✓
override='/tmp/some-other-root'   config_dir=/tmp/some-other-root
   derived=/tmp/some-other-root/analytics.db
   default_db_path()=/tmp/some-other-root/analytics.db
   IDENTICAL ✓
```

## Audit: the sibling maintenance passes are clean

This is a pattern, not a one-off, so every pass in `session_factory`'s list was audited — plus an AST sweep over the whole package for any function taking a `config_dir` parameter that also constructs a default-path store or reads a default root (`default_db_path`, `config_dir()`, `default_cache_dir`, `Path.home()`, bare `AnalyticsStore()`/`AuthStore()`).

| Pass | Verdict |
|---|---|
| `backfill_session_origins` (`resume.py`) | **Clean** — every path derives from `config_dir / "sessions"`; no default read |
| `backfill_session_titles` (`resume.py`) | **Clean** — same, sidecar written next to the transcript it read |
| `cleanup_from_config` (`session/cleanup.py`) | **Clean** — threads `config_dir` into `run_cleanup` and `write_last_cleanup`; no default read |
| `sweep_orphan_groups` (`tools/group_reaper.py`) | **Clean** — scans `config_dir / PROC_GROUPS_DIRNAME` only |
| `backfill_analytics_session_names` (`analytics/backfill.py`) | **DEFECTIVE — fixed here** |

The AST sweep returned exactly two hits across `local_operator/`: this defect, and `mobile/attach_client.py::continue_command`, which passes `str(Path.home())` as the agent's **working directory** for an engaged runtime while forwarding `config_dir=config_dir` correctly — a different parameter, not this bug. **Not addressed**, no defect.

The other bare `AnalyticsStore()` constructions (`tui/app.py` ×2, `analytics/recorder.py`) are correct: none of them takes a `config_dir`, so the process-wide default is the right root.

## Testing evidence

### The regression test fails against the current code

The test reproduces the real shape rather than a proxy: **both** ledgers hold the same unnamed session id, and **only** the isolated root has the transcript on disk — so any name reaching the default ledger provably came from the sandbox. `LOCAL_OPERATOR_CONFIG_DIR` points at a second `tmp_path` root, so the "default" ledger is a stand-in and never the developer's own.

**Before the fix** (fix stashed, same test):

```
E       AssertionError: the sweep wrote 'Work done inside the sandbox' — a name derived
        from the isolated config dir — into the DEFAULT ledger; reads and writes must
        share one root
E       assert not 'Work done inside the sandbox'
tests/unit/analytics/test_backfill.py:382: AssertionError
1 failed, 1 passed, 15 deselected in 0.96s
```

**After the fix:**

```
$ .venv/bin/python -m pytest tests/unit/analytics/test_backfill.py -n0 -q
.................                                                        [100%]
17 passed in 1.41s
```

A second test pins the production invariant directly: the derived path must equal `default_db_path()`, so the fix can never strand the operator's real history.

### The real production path, driven end to end

Not just unit tests — the actual `session_factory._run_store_maintenance` coroutine (the real production entry point) was driven in a fully isolated `HOME`, with a hard assertion that the resolved db path is not under `~/.local-operator` before anything could write:

```
$ env -i PATH=/usr/bin:/bin HOME=/tmp/bf-prod-probe .venv/bin/python /tmp/prod_path_probe.py
guard ok: resolved db = /private/tmp/bf-prod-probe/.local-operator/analytics.db
name in isolated ledger: 'Production probe session'
PRODUCTION PASS OK — named via real session_factory entry point
```

The pass still names sessions through the production caller, and stays entirely inside the isolated root.

### Data safety

Every run was executed under a redirected `HOME` per `AGENTS.md`, and the live ledger was checksummed throughout. No synthetic id and no probe-derived name reached it:

```sql
SELECT session_id, COUNT(*) FROM calls WHERE session_id IN
  ('prodprobe001','aaaisolated1','dddefault001','aaa','zzparent0001','aachild00001',...);
-- (no rows)

SELECT COUNT(*) FROM session_names WHERE name IN
  ('Work done inside the sandbox','Production probe session','Work that lives in the real home');
-- 0
```

The file's own bytes do change during a working day — this session and other live `lop` sessions record calls into it — but it was stable across a 60 s window with no tests running, and the queries above confirm the change is live traffic, not test leakage.

### Suites

| Suite | Result |
|---|---|
| `tests/unit/analytics` | **128 passed** |
| `tests/unit/test_session_factory.py` (the production caller) | **127 passed** |
| `tests/unit/session` (cleanup pass) | **1570 passed** |
| `tests/unit/tools/test_group_reaper.py` (reaper pass) | **31 passed** |
| `tests/unit/test_cli_sessions_cleanup.py` | **10 passed** |
| `tests/unit/test_paths.py` | **13 passed** |

Targeted subsets rather than the whole tree: the host is heavily contended. **No pre-existing failure from the known list reproduced in any suite I ran**, and none of those files is touched by this diff.

### Gate

```
flake8                          → clean
black --check (26.1.0, pinned)  → 2 files unchanged
isort --check-only (5.13.2)     → clean
pyright --pythonpath .venv/bin/python → 0 errors, 0 warnings, 0 informations
```

## Not included

**No version bump.** `pyproject.toml` stays at `0.51.3`; the release window has an owner.
