### PR TITLE
chore(release): bump version to 0.51.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.3"
+version = "0.51.4"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release bump for the window after `v0.51.3`. **One file, one line** — `pyproject.toml` only.

## Window contents

Derived with a plain `git log v0.51.3..origin/main` per #734 — never `--merges`, which silently drops squash-merged PRs.

| PR | Merge | Impact |
|---|---|---|
| #723 | `c8749aec7` | `/new` attach latency: poll densely while a spawned runtime is constructing |
| #736 | `be64882ca` | Docs: shard-attribution correction |
| #737 | `4af069a9c` | The analytics session-name backfill writes to the config dir it was given, not the global one |

## Bump class: PATCH

All three are fixes to existing surfaces. #737 is a defect fix, #723 makes an existing operation faster rather than adding a capability, #736 is docs-only. No new command, no new surface, no API change.

## Verification before tagging

- `git diff v0.51.3..origin/main -- pyproject.toml` is **empty** — nothing silently consumed `0.51.4`.
- `origin/main` reads `0.51.3`; this takes it to `0.51.4`, forward-only.

## Scope check

Only `pyproject.toml`. No source, no tests, no docs.