### PR TITLE
fix(tests): remove the import-warmup race from TUI settle budgets

### DIFF
--- a/tests/unit/tui/conftest.py
+++ b/tests/unit/tui/conftest.py
@@ -61,9 +61,12 @@ def _prepay_session_import_warmup() -> None:
     ``_construct_session`` → ``_warm_session_imports`` →
     ``asyncio.to_thread(warm_session_imports)`` before the factory is awaited.
     That warm-up imports ``mcp``, ``httpx``, ``httpcore``, ``truststore`` and
-    several ``local_operator`` modules — measured at 712 ms in a fresh test
-    process on this machine, matching the ~700 ms the app's own docstring
-    quotes.
+    several ``local_operator`` modules — hundreds of milliseconds in a fresh
+    test process, the same order as the ~700 ms the app's own docstring quotes.
+    The absolute figure is not stable enough to pin (samples on this machine
+    ranged from ~600 ms to ~1.6 s depending on load), and nothing here branches
+    on it. What matters, and what reproduces, is the RATIO in the next
+    paragraph.
 
     The tests that wait on the far side of a transition budget a fixed COUNT of
     event-loop turns (``_settle``'s ``tries``, ``MAX_PUMP_TURNS``), which is the
@@ -79,8 +82,10 @@ def _prepay_session_import_warmup() -> None:
 
     WHY PRE-PAYING RATHER THAN DISABLING. ``warm_session_imports`` is
     ``importlib.import_module`` over a fixed tuple, so it is idempotent against
-    ``sys.modules``: the first call in a process costs ~669 ms and every later
-    call costs ~0.01 ms (measured). The entire race is therefore the FIRST
+    ``sys.modules``: the first call in a process costs hundreds of milliseconds
+    and every later call costs ~0.01 ms — a ratio of four to five orders of
+    magnitude, which reproduced across machines and load levels even where the
+    absolute first-call figure did not. The entire race is therefore the FIRST
     construction in each process, and which test that is depends on collection
     order and on xdist sharding — a lottery, not a property of the two tests
     that happen to lose it today. Paying it here, in session setup, collapses
@@ -101,8 +106,9 @@ def _prepay_session_import_warmup() -> None:
     call ordering rather than this cache.
     """
     # Imported here, not at module scope: this conftest loads for every TUI
-    # test, and `session_factory` pulls ~154 ms of its own imports that only
-    # this fixture needs.
+    # test, and `session_factory` pulls a non-trivial import cost of its own
+    # (order of a hundred milliseconds, load-dependent) that only this fixture
+    # needs.
     from local_operator.session_factory import warm_session_imports
 
     # Never raises by contract — an optional extra that is not installed is the

--- a/tests/unit/tui/conftest.py
+++ b/tests/unit/tui/conftest.py
@@ -52,6 +52,64 @@ _STDLIB_MKDTEMP = tempfile.mkdtemp
 TCSS_PATH = str(Path(theme_mod.__file__).parent / "local_operator.tcss")
 
 
+@pytest.fixture(autouse=True, scope="session")
+def _prepay_session_import_warmup() -> None:
+    """Import the factory's heavy dependencies ONCE, before any test is timed.
+
+    WHY THIS EXISTS. ``OperatorApp`` defaults to ``warm_session_imports=True``,
+    so every boot and every ``/new``/``/reload``/``/resume`` transition runs
+    ``_construct_session`` → ``_warm_session_imports`` →
+    ``asyncio.to_thread(warm_session_imports)`` before the factory is awaited.
+    That warm-up imports ``mcp``, ``httpx``, ``httpcore``, ``truststore`` and
+    several ``local_operator`` modules — measured at 712 ms in a fresh test
+    process on this machine, matching the ~700 ms the app's own docstring
+    quotes.
+
+    The tests that wait on the far side of a transition budget a fixed COUNT of
+    event-loop turns (``_settle``'s ``tries``, ``MAX_PUMP_TURNS``), which is the
+    right shape per AGENTS.md — a turn count survives contention that a
+    wall-clock budget does not. But NOTHING relates that count to an import
+    running in a worker thread: ``pilot.pause()`` yields to the message pump, it
+    does not sleep, so ~60 turns can drain while the thread is still importing.
+    Under CPU contention the import inflates and the turn budget does not, and
+    the predicate is polled to exhaustion before the factory has been reached.
+    Measured on clean ``origin/main`` under 8 busy-loop processes:
+    ``test_new_starts_a_fresh_conversation`` and
+    ``test_new_replaces_the_visible_ledger`` failed 6/10.
+
+    WHY PRE-PAYING RATHER THAN DISABLING. ``warm_session_imports`` is
+    ``importlib.import_module`` over a fixed tuple, so it is idempotent against
+    ``sys.modules``: the first call in a process costs ~669 ms and every later
+    call costs ~0.01 ms (measured). The entire race is therefore the FIRST
+    construction in each process, and which test that is depends on collection
+    order and on xdist sharding — a lottery, not a property of the two tests
+    that happen to lose it today. Paying it here, in session setup, collapses
+    every in-test warm-up to a no-op hop while leaving the production path
+    exactly as it ships: the app still calls the warm-up, still hops to a
+    thread, still orders warm-then-factory. Passing ``warm_session_imports=False``
+    at the ~1400 construction sites in this suite would instead delete that
+    ordering from the code under test, and a fixture the test modules had to
+    request would change what pytest resolves — which is the perturbation
+    ``_reclaim_bare_mkdtemp`` above documents as having twice destabilised
+    timing-sensitive pilot tests.
+
+    Tests that assert ON the warm-up install their own fake and are unaffected:
+    ``test_boot_warms_session_imports_before_awaiting_the_factory`` patches
+    ``local_operator.session_factory.warm_session_imports`` and
+    ``tests/unit/test_startup_imports.py`` patches
+    ``OperatorApp._warm_session_imports``, so both still observe their own
+    call ordering rather than this cache.
+    """
+    # Imported here, not at module scope: this conftest loads for every TUI
+    # test, and `session_factory` pulls ~154 ms of its own imports that only
+    # this fixture needs.
+    from local_operator.session_factory import warm_session_imports
+
+    # Never raises by contract — an optional extra that is not installed is the
+    # factory's problem to report, not a collection error for the whole suite.
+    warm_session_imports()
+
+
 @pytest.fixture(autouse=True)
 def _reclaim_bare_mkdtemp() -> Iterator[None]:
     """Remove the ``tempfile.mkdtemp()`` dirs this suite abandons, per test.


### PR DESCRIPTION
## Summary

Two TUI tests have been failing intermittently on CI and passing everywhere else. The cause is a race that has nothing to do with what they assert, and it is not confined to those two — they are simply the ones losing a lottery that ~1400 construction sites are entered in.

`OperatorApp` defaults to `warm_session_imports=True`, so every boot and every `/new` / `/reload` / `/resume` runs `_construct_session` → `_warm_session_imports` → `asyncio.to_thread(warm_session_imports)` **before** awaiting the factory. That warm-up imports `mcp`, `httpx`, `httpcore`, `truststore` and several `local_operator` modules — the app's own docstring quotes ~700 ms, and I measured 712 ms in a fresh test process.

The tests waiting on the far side budget a fixed **count of event-loop turns** (`_settle`'s `tries`). That is the right shape — AGENTS.md is explicit that a turn count survives contention a wall-clock budget does not — but nothing relates that count to an import running in a worker thread. `pilot.pause()` yields to the message pump; it does not sleep. Under contention the import inflates and the turn budget does not, so the predicate is polled to exhaustion before the factory is ever reached and `boots == []`.

## This is pre-existing, and the proof is on clean main

| condition | result |
| --- | --- |
| isolated, at rest | 0/5 bare · 0/10 under `--cov` |
| **clean `origin/main`, no diff at all, under 8 busy-loop processes** | **6/10 failed** |
| same load, `warm_session_imports` monkeypatched to a no-op | **0/8 failed** |
| **this branch, same load, both affected tests, 12 reps** | **0/12 failed** |

Row 2 establishes the defect owes nothing to any feature branch. Row 3 establishes the mechanism by falsification rather than by argument. CI amplifies it: `tests/unit/conftest.py:413-414` skips the CPU-share cap when `CI` is set, so a 4-vCPU runner runs 4 xdist workers against this race.

## Change class

C1 — standard, pre-authorized. Test-infrastructure fix. No shipped code changes.

## The fix, and why this shape

`warm_session_imports` is `importlib.import_module` over a fixed tuple, so it is idempotent against `sys.modules`: **first call 669–712 ms, second 0.010 ms, third 0.003 ms** (measured). The race is therefore only ever the *first construction in a process*, and which test that is depends on collection order and xdist sharding. Fixing the two tests that lose it today would leave the other ~1417 sites in the draw.

So the warm-up is paid once in session setup, and every in-test warm-up collapses to a no-op thread hop. **The shipped path is untouched**: the app still calls the warm-up, still hops to a thread, still orders warm-then-factory.

Rejected alternatives:

- **`warm_session_imports=False` at each site** — ~1400 edits that *delete* the warm-then-factory ordering from the code under test at every one of them.
- **A requested (non-autouse) fixture** — test modules would have to depend on it, changing what pytest resolves. `_reclaim_bare_mkdtemp`'s own docstring records that exact perturbation destabilising timing-sensitive pilot tests **twice**, both reverted.
- **Making `_settle` bound a duration** — rejected, and the premise was wrong. This was my suggestion to the implementer and AGENTS.md:546-551 prescribes the opposite, citing seven prior issues: bound by loop turns, not seconds. A duration would reintroduce the calibrated-bet anti-pattern the repo has repeatedly paid to remove, and all 24 `_settle` callers would inherit it. The turn count was never the defect; the ~700 ms of unrelated import inside the budget was.

## Coverage preserved

The tests that assert **on** the warm-up install their own fakes, so they observe their own ordering rather than this cache: `test_boot_warms_session_imports_before_awaiting_the_factory` patches the module attribute, and `tests/unit/test_startup_imports.py` patches `OperatorApp._warm_session_imports`. Verified together with `test_session_factory.py`: 133 passed. No test loses meaningful coverage.

## Verification

- Full `tests/unit/tui/`: **5709 passed, 12 skipped, 0 failed** — including `test_steering_approval.py` and the `test_stream_anchor.py` pager, both on the known pre-existing list and both passing here.
- Gates whole-tree, as CI runs them, stale `build/` removed first: flake8 clean · black 26.1.0 (1020 files) clean · isort 5.13.2 clean · pyright `0 errors, 0 warnings`.
- `git diff origin/main...HEAD -- pyproject.toml` empty. No version bump.

## Scope and limits

**Not verified against real CI sharding** (4 xdist workers on a 4-vCPU runner with `CI` set). The mechanism predicts it holds — the prepay is per-process and each xdist worker runs its own session-scoped fixture — but that is inference from a local measurement, not an observation. The honest test is this PR's own CI run.

**Adjacent, deliberately not fixed here:** the same defaulted warm-up affects `OperatorApp` construction under `tests/unit/mobile/`, `tests/unit/session/`, `tests/unit/providers/` and `tests/e2e/`, which have no equivalent prepay. None is currently reported flaky, and widening the fix would have widened the slice past what the evidence supports. `test_startup_attachment.py:131` passes `warm_session_imports=False` explicitly, now redundant but harmless.
