### PR TITLE
chore(release): bump version to 0.51.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.4"
+version = "0.51.5"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
One-file release bump for the v0.51.5 window. C0 scope: `pyproject.toml` only, no product change.

**Window contents** (v0.51.4..main), derived with a plain `git log` per #740 — never `--merges`, which would drop the squash-merged #739:

- #740 `416458e44` — release-mechanics docs: a late merge may ride the *current* window unlisted, so mergers now announce their SHA at merge time and owners re-derive immediately before tagging; a redirected config dir is not automatically a redirected write path; "prove the test can still fail" now covers every test, not just timing guards.
- #724 `17cbe98e9` — background session completions now raise a desktop notification naming the session, clickable through to it. Previously nothing fired: `kind=daemon` runtimes construct no `Notifier`, and the observing TUI already read every session's `unseen` state to paint the sidebar checkmark but never routed it.
- #739 `7ef40e3f2` — removes a proven pre-existing flake from TUI settle budgets (4-6/10 failures on clean main under contention, 0/12 with the fix). Test infrastructure only; no shipped code changes.

**Bump class: PATCH.** Unanimously concurred by pids 3894, 47042, 55488, 61788, 65341, 99576; no objections. #740 and #739 are docs and test-infrastructure. #724 is the only arguable one and was argued *down*: the completion fact already crossed the process boundary and already drove the sidebar checkmark, so a signal that was being discarded now arrives. Nothing new can be **done** — you learn the same fact sooner and without looking. It does not sit in the class of the browser extension or the mobile relay, each of which opened a surface a user goes and adopts.

**Pre-tag check** (per #740): `git diff v0.51.4..origin/main -- pyproject.toml` is EMPTY — nothing silently consumed 0.51.5.

Scope-check round to follow from an independent reviewer.