### PR TITLE
docs(review): scope the round after a remediation to the delta

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -834,6 +834,38 @@ Never tag an owner in a *comment* to ask for review unless their review is
 genuinely required — the auto-request is not a comment tag, and a comment tag
 is what says the PR is waiting on that person.
 
+### Scope round N+1 to the remediation delta
+
+**A remediation is the most likely place in a PR for a new defect**, so the
+round that follows one is scoped to `<previous-head>..<new-head>` — not to the
+whole diff again. This is not merely a saving of effort. The whole-diff re-read
+is exactly what lets a small new defect hide behind a large surface that was
+already approved: attention spreads over hundreds of familiar lines, and the
+twenty that changed get the same share as the rest.
+
+The evidence is unusually strong. In one day, eight sessions independently
+reported the same shape on different PRs: three of four rounds where the
+remediation introduced the next defect; a fix for a mislabelled banner that
+reproduced the same mislabelling at larger scale in the digest; a fix whose two
+halves then drifted into a title and a subtitle describing different scopes; a
+remediation that reinstated the exact failure mode its own PR existed to fix; a
+round-2 fill-loop fix that left a resumed conversation ~120 messages behind.
+None was caught by re-reading the whole diff; every one was caught by a round
+that looked only at what had just changed.
+
+The reason a delta-scoped round works is worth stating, because it generalises
+past review: **a number — or a behaviour — that is right about an *adjacent*
+quantity is more dangerous than one that is obviously wrong, because nothing
+about it announces the mismatch.** A remediation is where adjacency is created,
+and the delta is the only view in which the new adjacency is visible at all.
+
+Two practical corollaries. Do not re-open dimensions the delta cannot have
+touched — a backend-only remediation keeps a design round valid, and re-running
+it spends a reviewer on unchanged pixels. And when a rebase moves the base,
+prove the content is unchanged (`git range-diff` plus byte-identical `+`/`-`
+line sets) and then run **one** convergence round over `<old-head>..<new-head>`,
+checking semantic conflicts only in files the upstream also touched.
+
 ## Security advisories
 
 Any agent handling a reported vulnerability or a GHSA for this repository

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -877,11 +877,11 @@ upstream also touched.
 
 **Finally, a terminal approval is a property of a SHA, not of a PR.** Commits
 landing after a clean round — including ones driven by a *different* stream,
-such as a design fix after a terminal code round — make it stale, and
-"everything else is green" is exactly when that lapses. The narrow exception
-is the one the freshness rules already name: changes that are exclusively
-non-conflicting fixes from parallel approved streams.
-
+such as a design fix after a terminal code round — make it stale, and the
+merge gate needs a fresh round on the current head. "Everything else is green"
+is exactly when that lapses. The one narrow exception: changes since the
+review that are exclusively non-conflicting fixes from parallel approved
+streams — a docs or nit commit from another round — leave it fresh.
 
 ## Security advisories
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -860,8 +860,9 @@ about it announces the mismatch.** A remediation is where adjacency is created,
 and the delta is the only view in which the new adjacency is visible at all.
 
 Two practical corollaries. Do not re-open dimensions the delta cannot have
-touched — a backend-only remediation keeps a design round valid, and re-running
-it spends a reviewer on unchanged pixels. And when a rebase moves the base,
+touched — a backend-only remediation keeps a design round valid, and
+re-running it spends a reviewer on unchanged pixels. And when a rebase moves
+the base,
 prove the content is unchanged (`git range-diff` plus byte-identical `+`/`-`
 line sets) and then run **one** convergence round over `<old-head>..<new-head>`,
 checking semantic conflicts only in files the upstream also touched.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -837,35 +837,20 @@ is what says the PR is waiting on that person.
 ### Scope round N+1 to the remediation delta
 
 **A remediation is the most likely place in a PR for a new defect**, so the
-round that follows one is scoped to `<previous-head>..<new-head>` — not to the
-whole diff again. This is not merely a saving of effort. The whole-diff re-read
-is exactly what lets a small new defect hide behind a large surface that was
-already approved: attention spreads over hundreds of familiar lines, and the
-twenty that changed get the same share as the rest.
+round that follows one is scoped to `<previous-head>..<new-head>` rather than
+re-reading the whole diff. Read that as a *detection* measure, not an
+efficiency one: a whole-diff re-read spreads attention over hundreds of
+already-approved lines, so the twenty that changed get the same share as the
+rest. A remediation also arrives with social proof — a reviewer asked for it,
+it is small, it is framed as closing something rather than opening anything —
+and each of those lowers scrutiny at exactly the moment it should not.
 
-**Read that as a detection measure, not an efficiency measure.** This is the
-part people drop, and dropping it turns the rule into a shortcut it was never
-meant to be. A remediation also arrives with social proof attached — a
-reviewer asked for it, it is small, and it is framed as *closing* something
-rather than opening anything — and each of those makes it less scrutinised at
-exactly the moment it deserves the same scrutiny as the original.
-
-The evidence is unusually strong. In one day, eight sessions independently
-reported **eleven** instances of the same shape on different PRs: three of four
-rounds where the remediation introduced the next defect; a mislabelled-banner
-fix that
-reproduced the same mislabelling at larger scale in the digest; a fix whose two
-halves then drifted into a title and a subtitle describing different scopes; a
-remediation that reinstated the exact failure mode its own PR existed to fix; a
-round-2 fill-loop fix that left a resumed conversation ~120 messages behind.
-None was caught by re-reading the whole diff; every one was caught by a round
-that looked only at what had just changed.
-
-The reason a delta-scoped round works is worth stating, because it generalises
-past review: **a number — or a behaviour — that is right about an *adjacent*
-quantity is more dangerous than one that is obviously wrong, because nothing
-about it announces the mismatch.** A remediation is where adjacency is created,
-and the delta is the only view in which the new adjacency is visible at all.
+This is not a hunch. Over one day, eight sessions reported this shape on
+unrelated PRs — a fix reproducing its own defect at larger scale in a second
+surface, a fix whose two halves drifted into describing different scopes, a
+round-2 fix leaving a resumed conversation ~120 messages behind. The reports
+are on the PR threads; what matters here is that the shape recurs often enough
+to plan for.
 
 Scoping to the delta is necessary but not sufficient. Three things make the
 round conclusive rather than merely narrow:
@@ -873,18 +858,14 @@ round conclusive rather than merely narrow:
 - **Run the same probe against the previous head.** "Is this new?" is only
   answerable by comparison — otherwise a reviewer finds a defect in the delta
   and cannot tell whether the remediation introduced it or whether they missed
-  it twice. The delta says *where* to look; the prior head says *whether it is
-  yours*.
-- **Check that the guard the remediation added can observe the defect it is
-  named for.** One round-1 fix closed a bottom-end contradiction (43,704 → 0)
-  while opening its mirror at the top (23,962 → 56,955), and the regression
-  test asserted only `at_bottom == nothing_below` — structurally incapable of
-  seeing what its own fix had introduced. The fix was right and the guard was
-  blind; those are different failures and need separate checks.
+  it twice.
+- **Check the guard the remediation added can observe the defect it names.**
+  A fix can be right while its regression test is structurally incapable of
+  seeing what that same fix broke elsewhere — a real case closed one end of a
+  contradiction, opened its mirror at the other, and asserted only on the end
+  it had fixed.
 - **Assert on what is painted, not only on the contract.** A round can verify
-  a contract is honoured and still miss that the resulting frame is wrong —
-  "a splash mounted while the user saw nothing is invisible to any assertion
-  on `_welcome_visible`."
+  a contract is honoured and still miss that the resulting frame is wrong.
 
 Two further corollaries. Do not re-open dimensions the delta cannot have
 touched — a backend-only remediation keeps a design round valid, and
@@ -894,11 +875,13 @@ the base, prove the content is unchanged (`git range-diff` plus byte-identical
 `<old-head>..<new-head>`, checking semantic conflicts only in files the
 upstream also touched.
 
-**Finally, a terminal approval is a property of a SHA, not of a PR.** If a
-round went terminal and commits landed afterwards — including commits driven
-by a *different* stream, such as a design fix after a clean code round — the
-approval is stale and the merge gate needs a fresh round on the current head.
-"Everything else is green" is precisely when this lapses.
+**Finally, a terminal approval is a property of a SHA, not of a PR.** Commits
+landing after a clean round — including ones driven by a *different* stream,
+such as a design fix after a terminal code round — make it stale, and
+"everything else is green" is exactly when that lapses. The narrow exception
+is the one the freshness rules already name: changes that are exclusively
+non-conflicting fixes from parallel approved streams.
+
 
 ## Security advisories
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -843,9 +843,17 @@ is exactly what lets a small new defect hide behind a large surface that was
 already approved: attention spreads over hundreds of familiar lines, and the
 twenty that changed get the same share as the rest.
 
+**Read that as a detection measure, not an efficiency measure.** This is the
+part people drop, and dropping it turns the rule into a shortcut it was never
+meant to be. A remediation also arrives with social proof attached — a
+reviewer asked for it, it is small, and it is framed as *closing* something
+rather than opening anything — and each of those makes it less scrutinised at
+exactly the moment it deserves the same scrutiny as the original.
+
 The evidence is unusually strong. In one day, eight sessions independently
-reported the same shape on different PRs: three of four rounds where the
-remediation introduced the next defect; a fix for a mislabelled banner that
+reported **eleven** instances of the same shape on different PRs: three of four
+rounds where the remediation introduced the next defect; a mislabelled-banner
+fix that
 reproduced the same mislabelling at larger scale in the digest; a fix whose two
 halves then drifted into a title and a subtitle describing different scopes; a
 remediation that reinstated the exact failure mode its own PR existed to fix; a
@@ -859,13 +867,38 @@ quantity is more dangerous than one that is obviously wrong, because nothing
 about it announces the mismatch.** A remediation is where adjacency is created,
 and the delta is the only view in which the new adjacency is visible at all.
 
-Two practical corollaries. Do not re-open dimensions the delta cannot have
+Scoping to the delta is necessary but not sufficient. Three things make the
+round conclusive rather than merely narrow:
+
+- **Run the same probe against the previous head.** "Is this new?" is only
+  answerable by comparison — otherwise a reviewer finds a defect in the delta
+  and cannot tell whether the remediation introduced it or whether they missed
+  it twice. The delta says *where* to look; the prior head says *whether it is
+  yours*.
+- **Check that the guard the remediation added can observe the defect it is
+  named for.** One round-1 fix closed a bottom-end contradiction (43,704 → 0)
+  while opening its mirror at the top (23,962 → 56,955), and the regression
+  test asserted only `at_bottom == nothing_below` — structurally incapable of
+  seeing what its own fix had introduced. The fix was right and the guard was
+  blind; those are different failures and need separate checks.
+- **Assert on what is painted, not only on the contract.** A round can verify
+  a contract is honoured and still miss that the resulting frame is wrong —
+  "a splash mounted while the user saw nothing is invisible to any assertion
+  on `_welcome_visible`."
+
+Two further corollaries. Do not re-open dimensions the delta cannot have
 touched — a backend-only remediation keeps a design round valid, and
 re-running it spends a reviewer on unchanged pixels. And when a rebase moves
-the base,
-prove the content is unchanged (`git range-diff` plus byte-identical `+`/`-`
-line sets) and then run **one** convergence round over `<old-head>..<new-head>`,
-checking semantic conflicts only in files the upstream also touched.
+the base, prove the content is unchanged (`git range-diff` plus byte-identical
+`+`/`-` line sets) and then run **one** convergence round over
+`<old-head>..<new-head>`, checking semantic conflicts only in files the
+upstream also touched.
+
+**Finally, a terminal approval is a property of a SHA, not of a PR.** If a
+round went terminal and commits landed afterwards — including commits driven
+by a *different* stream, such as a design fix after a clean code round — the
+approval is stale and the merge gate needs a fresh round on the current head.
+"Everything else is green" is precisely when this lapses.
 
 ## Security advisories
 


### PR DESCRIPTION
Writes down a failure shape that eight sessions hit independently in a single day. Docs only, no code, no version bump.

## The rule

**A remediation is the most likely place in a PR for a new defect**, so the round after one is scoped to `<previous-head>..<new-head>` rather than re-reading the whole diff.

## Why it is not about effort

"Scope to the delta" *reads* like an efficiency measure and is a **detection** measure. A whole-diff re-read spreads attention over hundreds of already-approved lines, so the twenty that changed get the same share as the rest. A remediation also arrives with social proof — a reviewer asked for it, it is small, it is framed as closing something rather than opening anything — and each of those lowers scrutiny at exactly the moment it should not.

## Three additions that make the round conclusive

Scoping to the delta is necessary but not sufficient. Each of these caught something the bare rule does not:

- **Run the same probe against the previous head.** "Is this new?" is only answerable by comparison — otherwise a reviewer finds a defect in the delta and cannot tell whether the remediation introduced it or whether they missed it twice.
- **Check the guard the remediation added can observe the defect it names.** A fix can be right while its regression test is structurally incapable of seeing what that same fix broke elsewhere.
- **Assert on what is painted, not only on the contract.** A round can verify a contract is honoured and still miss that the resulting frame is wrong.

Plus its own line: **a terminal approval is a property of a SHA, not of a PR.** Commits landing after a clean round — including ones driven by a *different* stream, such as a design fix after a terminal code round — make it stale. It names the exception the freshness rules already carry, rather than contradicting them.

## On the evidence, after round 1

Round 1 found three MAJORs and every one was correct. The most useful was that I described **#732 backwards** — one of only two PRs I claimed first-hand knowledge of. The single "reinstate" hit in that thread is a round-1 remediation *closing* a hazard present in the original submission, not creating one. #732 does contain a remediation-introduced defect, but it is a class recurrence inside the PR rather than its headline bug returning.

The tally also did not reconcile (prose said eleven, the table summed to 13–14, "eight sessions" against seven credited pids), and the section cited a symbol and a test that **exist nowhere in this tree** — they come from #726, still open and possibly never merging.

So the per-PR anecdotes are gone. The detail lives on the PR threads where it stays checkable and cannot rot; the section now claims only that the shape recurs often enough to plan for, which is what the evidence actually supports. The hedge is no longer undone by an unqualified "none/every one" in the following sentence.

## Length

Cut from 660 words to 469 on the reviewer's advice — `AGENTS.md` is read by every agent on every task, so 4.5% of the file is a real cost. The "adjacent quantity" paragraph went first: most quotable, least actionable, and it changed no behaviour the bullets do not already prescribe. Every instruction survives.

## Placement

With the review-gate material rather than the testing section: the subject is *which commits a reviewer reads*, and its consumers are the freshness rules above it. Filed under testing, nobody scoping round 3 would find it.

## Credit

Pattern raised by pid 66964, who asked it be written once rather than duplicated. Detection-vs-efficiency framing and the social-proof mechanism: pid 65341. Previous-head comparison: pid 61788. Blind-guard check: pid 47042. Contract vs frame: pid 55488. SHA-not-PR: pid 3894 and pid 66964 independently.

## Scope

`AGENTS.md` only, one section. `pyproject.toml` untouched at 0.51.5.