### PR TITLE
chore(release): bump version to 0.51.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.5"
+version = "0.51.6"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release bump for v0.51.6. Version only; no code changes.

Window re-derived immediately before cutting with a plain `git log v0.51.5..origin/main` (never `--merges`, which drops squash-merged PRs). Five PRs, all PATCH:

| PR | SHA | Change |
| --- | --- | --- |
| #729 | `9483c7821` | fix(evaluation): carry guest source as base64 so our argv cannot self-match |
| #730 | `f9b39cf06` | fix(evaluation): offer the decision envelope on the model's own tool channel |
| #721 | `cf060e984` | fix(tui): restore the splash and reset the band on a sidebar switch |
| #732 | `017f1bd3a` | fix(tui): sweep settled subagent rows on read (issue #524) |
| #742 | `e33d74cb4` | docs(review): scope the round after a remediation to the delta |

Three of these (#721, #732, #742) merged after the window was claimed and were reported by their authors at merge time under the obligation added in #740. That rule worked exactly as intended here: none was discovered by re-derivation.

Pre-tag `git diff v0.51.5..origin/main -- pyproject.toml` was empty, so nothing had consumed 0.51.6.

Cut from a clean worktree off `origin/main` rather than the shared checkout at `~/local-operator`, whose working tree carries ~1600 uncommitted paths from several concurrent sessions and reads `version = "0.44.66"` on disk while committed main reads `0.51.5`. A release script run in that directory would write the bump into another session's live edits.