### PR TITLE
docs(ci): the locale flag is a property of your command, not of CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -698,13 +698,16 @@ Warnings that still hold, each of which has already cost a release:
     | grep <the-test-file-that-failed>   # line N -> index N-1, shard (N-1) % 5
   ```
 
-  `LC_ALL=C` is load-bearing, not decoration: CI sorts in Python's byte order,
-  while shell `sort` honours `LC_COLLATE`. On an `en_*.UTF-8` locale the two
-  orderings diverge, and since no displacement happens to be a multiple of 5,
-  **every divergent file lands in a different shard** — 51 of 452 when
-  measured, versus 0 under `LC_ALL=C`. Getting this wrong says a file moved
-  shards when it did not, which is the same misattribution this warning exists
-  to prevent.
+  `LC_ALL=C` is load-bearing, and it is a property of **your** command, not of
+  CI. CI is locale-independent: `sorted()` compares Python strings by code
+  point. Shell `sort` does not — it honours `LC_COLLATE`, so on an
+  `en_*.UTF-8` locale it produces a different order from the one CI computed.
+  Since no displacement happens to be a multiple of 5, **every divergent file
+  then lands in a different shard** — 51 of 452 when measured, versus 0 under
+  `LC_ALL=C`. So the flag does not make CI deterministic; it makes your
+  reproduction agree with a partitioner that was already deterministic.
+  Without it you are told a file moved shards when it did not, which is the
+  same misattribution this warning exists to prevent.
 
   Run it once against `origin/main` and once against your branch. If the shard
   differs, the failing test ran in a different group than it does on `main`, so

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -703,8 +703,9 @@ Warnings that still hold, each of which has already cost a release:
   point. Shell `sort` does not — it honours `LC_COLLATE`, so on an
   `en_*.UTF-8` locale it produces a different order from the one CI computed.
   Since no displacement happens to be a multiple of 5, **every divergent file
-  then lands in a different shard** — 51 of 452 when measured, versus 0 under
-  `LC_ALL=C`. So the flag does not make CI deterministic; it makes your
+  then lands in a different shard** — measured at the time of writing, an
+  `en_*.UTF-8` shell sort misplaced 51 files where `LC_ALL=C` misplaced none.
+  So the flag does not make CI deterministic; it makes your
   reproduction agree with a partitioner that was already deterministic.
   Without it you are told a file moved shards when it did not, which is the
   same misattribution this warning exists to prevent.


### PR DESCRIPTION
One-paragraph precision fix to the shard-misattribution warning added in #736. Docs only, no code, no version bump.

## Why

A reviewer on #732 flagged that the paragraph reads as though CI's partitioner were locale-sensitive. It is not:

```
$ grep -n "sorted(glob" .github/workflows/ci.yml
366:  files = sorted(glob.glob('tests/unit/**/test_*.py', recursive=True))

$ grep -n "LC_ALL\|LC_COLLATE\|LANG" .github/workflows/ci.yml
(no matches)
```

`sorted()` compares Python strings by code point, and the workflow sets no locale variables. CI's ordering is deterministic and always has been.

The old wording — "CI sorts in Python's byte order, while shell `sort` honours `LC_COLLATE`" — is defensible read carefully, but it sits under a bolded `LC_ALL=C` instruction and invites the conclusion that the flag is what makes CI's ordering stable. Someone debugging a shard failure on that belief would go looking for locale drift in CI, which is exactly the misattribution the warning exists to prevent.

## What changed

The guidance is identical — still derive the index with `LC_ALL=C sort`. Only the *reason* changed, to say what is true:

> `LC_ALL=C` is load-bearing, and it is a property of **your** command, not of CI. CI is locale-independent: `sorted()` compares Python strings by code point. Shell `sort` does not […] So the flag does not make CI deterministic; it makes your reproduction agree with a partitioner that was already deterministic.

The 51-of-452 measurement is unchanged and still reproduces.

## Scope

`AGENTS.md` only, one paragraph. `pyproject.toml` untouched at 0.51.5.

Credit: caught by the round-3 reviewer on #732 while checking a disclosed test failure against this very guidance — the warning was used as intended and found imprecise in the process.