### PR TITLE
test(exec): guard the config-root resolution that #737 fixed unguarded

### DIFF
--- a/local_operator/exec_mode.py
+++ b/local_operator/exec_mode.py
@@ -7,10 +7,11 @@ exits 0 on success, non-zero on error. Two execution shapes:
   the print renderer, return 0/1;
 - ``--background``: spawn ``python -m local_operator.exec_worker`` detached
   (``start_new_session=True``) with stdout/stderr redirected to a timestamped
-  log under ``~/.local-operator/logs/``, record the job in the lightweight
-  JSONL ledger, print the job id + log path, and return 0 immediately. The
-  worker is what actually runs the task; it appends a terminal record
-  (``finished_at`` + ``exit_code``) to the same ledger on exit.
+  log under :func:`logs_dir` (``~/.local-operator/logs/`` by default, and the
+  override's ``logs/`` when ``LOCAL_OPERATOR_CONFIG_DIR`` is set), record the
+  job in the lightweight JSONL ledger, print the job id + log path, and return
+  0 immediately. The worker is what actually runs the task; it appends a
+  terminal record (``finished_at`` + ``exit_code``) to the same ledger on exit.
 
 No engine imports at module level — the session factory and renderer are
 imported inside the foreground path so ``import local_operator.exec_mode``
@@ -30,8 +31,38 @@ from pathlib import Path
 from typing import Any, Callable
 from uuid import uuid4
 
-#: Root for detached-exec logs and the jobs ledger (the legacy config dir).
-LOGS_DIR = Path.home() / ".local-operator" / "logs"
+
+def logs_dir() -> Path:
+    """Root for detached-exec logs and the jobs ledger: ``config_dir()/logs``.
+
+    Shares :data:`local_operator.paths.LOG_DIRNAME` with the app's rotating
+    log rather than spelling ``"logs"`` a second time. Under an override the
+    two therefore land in one directory, which is fine and deliberate: the
+    filenames are disjoint (``local-operator.log`` vs ``exec-*.log`` /
+    ``exec-jobs.jsonl``) and both roots are created 0700.
+
+    A FUNCTION, not the module constant this used to be, for the reason
+    :func:`local_operator.paths.config_dir` states in its own docstring: a
+    constant freezes whatever the first importer saw, and the override is read
+    from the environment on every call. The old constant was
+    ``Path.home() / ".local-operator" / "logs"``, written in the original CLI
+    rewrite BEFORE ``paths.py`` and ``LOCAL_OPERATOR_CONFIG_DIR`` existed at all
+    — which is what its "the legacy config dir" comment recorded. Three sibling
+    copies of that same expression in this file (the foreground factory, the
+    background worker's factory, and the preflight resolver) have since been
+    fixed to resolve through ``config_dir()``; this was the last one, and it
+    split the jobs ledger away from the root the rest of exec mode honours: with
+    the override set, ``exec --background`` wrote its config and agents under the
+    override while its log and ledger landed in the operator's real home.
+
+    Resolution is UNCHANGED when no override is set — ``config_dir()`` is itself
+    ``~/.local-operator`` — so an existing install's logs and ledger stay exactly
+    where they are. Only an overridden run moves, which is the whole point.
+    """
+    from local_operator.paths import LOG_DIRNAME, config_dir
+
+    return config_dir() / LOG_DIRNAME
+
 
 #: Ledger of spawned background jobs (lightweight; the harness AsyncJobManager
 #: is in-process and cannot track a detached OS process across CLI runs).
@@ -125,15 +156,22 @@ def build_worker_argv(command: str, exec_args: ExecArgs) -> list[str]:
     return argv
 
 
-def _ensure_logs_dir() -> None:
-    """Create ``LOGS_DIR`` owner-only (CL-10): the directory holds job logs
+def _ensure_logs_dir() -> Path:
+    """Create :func:`logs_dir` owner-only (CL-10): the directory holds job logs
     and the ledger, neither of which other users should read or tamper with.
+
+    Returns the resolved directory so a caller that needs the path uses the
+    SAME resolution this created, rather than calling the resolver a second
+    time — the override could differ between the two calls, and a log written
+    to a directory that was never created is the failure this prevents.
     """
-    LOGS_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+    directory = logs_dir()
+    directory.mkdir(mode=0o700, parents=True, exist_ok=True)
     try:
-        os.chmod(LOGS_DIR, 0o700)  # umask may have clipped the mode on mkdir
+        os.chmod(directory, 0o700)  # umask may have clipped the mode on mkdir
     except OSError:
         pass
+    return directory
 
 
 def _open_log_file(log_path: Path) -> Any:
@@ -150,8 +188,7 @@ def _append_job_record(log_path: Path, prompt: str, pid: int, job_id: str | None
     ``finished_at``/``exit_code`` start unset; the worker appends a terminal
     record carrying both when the run exits (CL-09).
     """
-    _ensure_logs_dir()
-    jobs_path = LOGS_DIR / JOBS_FILE
+    jobs_path = _ensure_logs_dir() / JOBS_FILE
 
     job_id = job_id or uuid4().hex[:12]
     record = {
@@ -180,7 +217,9 @@ def read_job_records() -> list[dict[str, Any]]:
     """Parse the JSONL ledger; tolerate a partial final line and any stray
     corruption by skipping it (the ledger must never break a reader)."""
     records: list[dict[str, Any]] = []
-    jobs_path = LOGS_DIR / JOBS_FILE
+    # Resolved, not created: a read must not be the thing that materialises the
+    # logs directory on a root that has none.
+    jobs_path = logs_dir() / JOBS_FILE
     if not jobs_path.exists():
         return records
     try:
@@ -204,8 +243,7 @@ def update_job_exit(job_id: str, exit_code: int) -> None:
     """Append the terminal record for ``job_id`` (CL-09): ``finished_at`` +
     ``exit_code``. Append-only keeps this race-free; consumers take the
     latest record per id, so the terminal record supersedes the spawn one."""
-    _ensure_logs_dir()
-    jobs_path = LOGS_DIR / JOBS_FILE
+    jobs_path = _ensure_logs_dir() / JOBS_FILE
     update = {
         "id": job_id,
         "finished_at": datetime.now().astimezone().isoformat(),
@@ -277,9 +315,9 @@ def _spawn_background(command: str, exec_args: ExecArgs) -> int:
         print(f"\n\033[1;31mError: preflight failed: {exc}\033[0m", file=sys.stderr)
         return 1
 
-    _ensure_logs_dir()
+    logs_root = _ensure_logs_dir()
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    log_path = LOGS_DIR / f"exec-{timestamp}-{slugify(command)}.log"
+    log_path = logs_root / f"exec-{timestamp}-{slugify(command)}.log"
 
     job_id = uuid4().hex[:12]
     argv = build_worker_argv(command, exec_args)

--- a/tests/unit/test_exec_mode.py
+++ b/tests/unit/test_exec_mode.py
@@ -42,6 +42,7 @@ from local_operator.harness.types import (
     ToolResult,
 )
 from local_operator.headless_print import PrintRenderer, printable_event, run_print_mode
+from local_operator.paths import CONFIG_DIR_ENV
 from local_operator.session.naming import ConversationName
 from local_operator.session.protocol import CompactionOutcome
 
@@ -719,9 +720,24 @@ async def test_run_print_mode_runs_before_dispose_when_the_prompt_raises() -> No
 # --- exec_mode background --------------------------------------------------------
 
 
+def _redirect_logs_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Point exec's logs/ledger root at ``tmp_path`` and return it.
+
+    Sets ``LOCAL_OPERATOR_CONFIG_DIR``, which is the ONLY seam now that
+    ``exec_mode.logs_dir()`` resolves through ``paths.config_dir()`` on every
+    call rather than freezing a module constant at import. That is deliberately
+    stricter than the ``monkeypatch.setattr(exec_mode, "LOGS_DIR", ...)`` these
+    tests used before: patching the constant redirected the ledger while every
+    OTHER root exec touches stayed on the real home, so a test could still reach
+    outside its sandbox through a path it was not thinking about.
+    """
+    root = tmp_path / "config"
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(root))
+    return root / "logs"
+
+
 def test_run_exec_background_spawn(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys) -> None:
-    logs_dir = tmp_path / "logs"
-    monkeypatch.setattr(exec_mode, "LOGS_DIR", logs_dir)
+    logs_dir = _redirect_logs_dir(monkeypatch, tmp_path)
     monkeypatch.setattr(exec_mode, "resolve_hosting_model_dry", lambda args: ("test", "m"))
 
     popen_mock = MagicMock()
@@ -808,9 +824,8 @@ def test_spawn_background_unconfigured_hosting_returns_one(
 
 def test_ledger_reader_tolerates_partial_line(tmp_path: Path, monkeypatch) -> None:
     """CL-11: a truncated trailing line (crash mid-write) never breaks reads."""
-    logs_dir = tmp_path / "logs"
-    logs_dir.mkdir()
-    monkeypatch.setattr(exec_mode, "LOGS_DIR", logs_dir)
+    logs_dir = _redirect_logs_dir(monkeypatch, tmp_path)
+    logs_dir.mkdir(parents=True)
     good = json.dumps({"id": "abc", "prompt": "ok"})
     (logs_dir / exec_mode.JOBS_FILE).write_text(
         good + "\n" + '{"id": "de", "prom', encoding="utf-8"
@@ -821,9 +836,8 @@ def test_ledger_reader_tolerates_partial_line(tmp_path: Path, monkeypatch) -> No
 
 
 def test_logs_dir_and_log_file_permissions(monkeypatch, tmp_path: Path) -> None:
-    """CL-10: LOGS_DIR is 0700 and job logs are created 0600."""
-    logs_dir = tmp_path / "logs"
-    monkeypatch.setattr(exec_mode, "LOGS_DIR", logs_dir)
+    """CL-10: the logs dir is 0700 and job logs are created 0600."""
+    logs_dir = _redirect_logs_dir(monkeypatch, tmp_path)
     monkeypatch.setattr(exec_mode, "resolve_hosting_model_dry", lambda args: ("test", "m"))
     popen_mock = MagicMock()
     popen_mock.return_value.pid = 1
@@ -841,8 +855,7 @@ def test_background_preflight_blocks_spawn(
 ) -> None:
     """CL-09: a failed hosting/model resolution returns non-zero WITHOUT
     spawning the worker or writing a log."""
-    logs_dir = tmp_path / "logs"
-    monkeypatch.setattr(exec_mode, "LOGS_DIR", logs_dir)
+    logs_dir = _redirect_logs_dir(monkeypatch, tmp_path)
 
     def broken(args):
         raise ValueError("Model name is not configured.")
@@ -863,9 +876,8 @@ def test_background_preflight_blocks_spawn(
 
 def test_worker_records_exit_in_ledger(monkeypatch, tmp_path: Path, capsys) -> None:
     """CL-09: main() with --job-id appends finished_at + exit_code."""
-    logs_dir = tmp_path / "logs"
-    logs_dir.mkdir()
-    monkeypatch.setattr(exec_mode, "LOGS_DIR", logs_dir)
+    logs_dir = _redirect_logs_dir(monkeypatch, tmp_path)
+    logs_dir.mkdir(parents=True)
     monkeypatch.setattr(sys, "argv", ["exec_worker", "--prompt", "x", "--job-id", "job1"])
     monkeypatch.setattr(exec_worker, "run", lambda _p, session_factory=None: 0)
 
@@ -1007,3 +1019,241 @@ def test_exec_worker_sigterm_yields_130(tmp_path: Path) -> None:
     assert proc.returncode == 130, f"stdout={stdout!r} stderr={stderr!r}"
     assert "EXIT 130" in stdout
     assert "Traceback" not in stderr
+
+
+# --- exec config-root resolution (#737 regression guards) -------------------------
+#
+# Both sites below hardcoded ``Path.home() / ".local-operator"`` and were fixed in
+# #737 to resolve through ``paths.config_dir()``. That fix shipped UNGUARDED: the
+# whole exec suite passed with either site reverted, because the only test that
+# reached ``_default_session_factory`` stubbed the managers with
+# ``lambda *a: object()`` and threw the directory away. These tests assert on the
+# ROOT THAT WAS ACTUALLY RESOLVED, so a revert to the hardcoded root fails them.
+#
+# ``LOCAL_OPERATOR_CONFIG_DIR`` is set with ``monkeypatch.setenv`` (the convention
+# everywhere else in the suite), which unsets it at teardown; the autouse
+# ``isolate_environment`` fixture in ``tests/conftest.py`` scrubs it and redirects
+# ``HOME`` to a scratch dir, so the "home root" a mutant would resolve is that
+# scratch dir and never the operator's real ``~/.local-operator``.
+
+
+def test_worker_session_factory_resolves_the_config_dir_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``exec --background``'s worker builds its managers under the override.
+
+    The BACKGROUND worker inherits the spawner's environment, so a hardcoded root
+    here made ``exec --background`` ignore ``LOCAL_OPERATOR_CONFIG_DIR`` while the
+    foreground run honoured it — one entry point resolving two different roots
+    depending on a flag. It also feeds the analytics session-name backfill through
+    ``create_session``'s store-maintenance pass, which writes to whatever root it
+    is handed, so a wrong root here strands names in a ledger nothing reads.
+
+    Asserted on the DIRECTORY EACH MANAGER RECEIVED, not on the fact that a call
+    happened: the pre-existing ``test_build_worker_argv_train_threaded_to_worker``
+    stubs the same three managers with ``lambda *a: object()`` and discards the
+    argument, which is exactly why the revert of this site passed 36/36.
+    """
+    override = tmp_path / "override-config"
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(override))
+    home_root = Path.home() / ".local-operator"
+
+    seen: dict[str, Path] = {}
+
+    def capture(name: str) -> Callable[..., object]:
+        def factory(directory: Path, *_rest: object, **_kwargs: object) -> object:
+            seen[name] = Path(directory)
+            return object()
+
+        return factory
+
+    monkeypatch.setattr("local_operator.config.ConfigManager", capture("config"))
+    monkeypatch.setattr("local_operator.credentials.CredentialManager", capture("credentials"))
+    monkeypatch.setattr("local_operator.agents.AgentRegistry", capture("agents"))
+    monkeypatch.setattr(
+        "local_operator.session_factory.create_session", lambda *a, **k: None  # noqa: ARG005
+    )
+
+    parsed = exec_worker.build_parser().parse_args(["--prompt", "x"])
+    exec_worker._default_session_factory(parsed)
+
+    assert seen == {
+        "config": override,
+        "credentials": override,
+        "agents": override,
+    }, (
+        f"the worker built its managers under {sorted(set(map(str, seen.values())))} "
+        f"instead of the override {override}; the home root is {home_root}"
+    )
+
+
+def test_worker_session_factory_writes_nothing_outside_the_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The same site, asserted on the SIDE EFFECTS of the real managers.
+
+    The stub test above pins the argument; this one pins where the bytes land,
+    with the genuine ``ConfigManager``/``CredentialManager``/``AgentRegistry``
+    constructed. That distinction is the whole lesson of #737's analytics half:
+    a redirected read path is not automatically a redirected WRITE path, and only
+    looking at the filesystem afterwards tells them apart. Constructing these
+    managers creates ``agents/`` and ``credentials.env``, so a hardcoded root
+    leaves that litter under ``HOME`` (the scratch ``HOME`` here — never the
+    operator's real one, which is what makes this safe to assert on).
+    """
+    override = tmp_path / "override-config"
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(override))
+    home_root = Path.home() / ".local-operator"
+    assert not home_root.exists(), "the scratch HOME must start clean for this assertion"
+
+    monkeypatch.setattr(
+        "local_operator.session_factory.create_session", lambda *a, **k: None  # noqa: ARG005
+    )
+
+    parsed = exec_worker.build_parser().parse_args(["--prompt", "x"])
+    exec_worker._default_session_factory(parsed)
+
+    # Asserted FIRST because it is the actual harm: an isolated exec run laying
+    # down credentials and an agent registry in the operator's real home.
+    assert not home_root.exists(), (
+        f"the worker created {sorted(p.name for p in home_root.rglob('*'))} under the "
+        f"home root {home_root} while LOCAL_OPERATOR_CONFIG_DIR pointed at {override}"
+    )
+    assert override.is_dir(), f"nothing was created under the override {override}"
+
+
+def test_preflight_resolves_agents_and_config_from_the_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``resolve_hosting_model_dry`` reads the override's agents and config.
+
+    Preflight exists to resolve hosting/model through the EXACT path the worker
+    will use, so reading a different root than the worker defeats its purpose:
+    with the override set, the hardcoded root validated against the developer's
+    real agents and config and then spawned a worker that used the override's.
+
+    Both roots are populated with DIFFERENT, individually valid answers, so the
+    returned pair names which root was read — a test that only seeded the
+    override would pass on a mutant by failing to find anything at either root
+    for the wrong reason. The agent is seeded only in the override, so
+    ``--agent-id`` resolving at all is itself evidence of the root used.
+    """
+    from local_operator.agents import AgentEditFields, AgentRegistry
+    from local_operator.config import ConfigManager
+
+    home_root = Path.home() / ".local-operator"
+    ConfigManager(home_root).update_config({"hosting": "openai", "model_name": "home-model"})
+
+    override = tmp_path / "override-config"
+    ConfigManager(override).update_config({"hosting": "anthropic", "model_name": "override-model"})
+    agent = AgentRegistry(override).create_agent(
+        AgentEditFields(
+            name="guarded",
+            security_prompt=None,
+            hosting="anthropic",
+            model="agent-model",
+            description=None,
+            last_message=None,
+            temperature=None,
+            tags=[],
+            categories=[],
+            top_p=None,
+            top_k=None,
+            max_tokens=None,
+            stop=None,
+            frequency_penalty=None,
+            presence_penalty=None,
+            seed=None,
+            current_working_directory=None,
+        )
+    )
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(override))
+
+    # No selector: the answer comes from the config file, so it names the root.
+    assert exec_mode.resolve_hosting_model_dry(ExecArgs()) == (
+        "anthropic",
+        "override-model",
+    ), "preflight read the config file at the home root instead of the override"
+
+    # And the registry lookup: this id exists ONLY under the override, so a
+    # preflight reading the home root raises "No agent found with ID".
+    assert exec_mode.resolve_hosting_model_dry(ExecArgs(agent_id=agent.id)) == (
+        "anthropic",
+        "agent-model",
+    ), "preflight read the agent registry at the home root instead of the override"
+
+
+def test_background_logs_and_ledger_follow_the_config_dir_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The jobs ledger and the job log live under the override, not the home root.
+
+    ``exec_mode.logs_dir()`` was a module constant hardcoding the home root — the
+    fourth copy of the expression #737 fixed at the other three sites in this file.
+    It split the jobs ledger away from the root the rest of exec mode honours: an
+    isolated ``exec --background`` built its config and agents under the override
+    and then wrote its log and its ledger into the operator's real home, which is
+    both the isolation defect #737 exists to prevent and litter nothing cleans up.
+
+    Asserted on the FILES THAT APPEAR, not on the resolver's return value: a
+    resolver can be correct while a caller keeps a stale copy of the old root, and
+    only looking at the filesystem afterwards tells those apart. The whole spawn
+    runs for real (``Popen`` alone is faked), so this covers the log path, the
+    0700 directory and the ledger write in one pass.
+    """
+    override = tmp_path / "override-config"
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(override))
+    home_logs = Path.home() / ".local-operator" / "logs"
+    monkeypatch.setattr(exec_mode, "resolve_hosting_model_dry", lambda args: ("test", "m"))
+
+    popen_mock = MagicMock()
+    popen_mock.return_value.pid = 5150
+    monkeypatch.setattr("local_operator.exec_mode.subprocess.Popen", popen_mock)
+
+    assert exec_mode.run_exec("isolated background task", ExecArgs(background=True)) == 0
+
+    # Asserted FIRST because it is the actual harm: a sandboxed run leaving its
+    # log and its job ledger in the operator's real home.
+    assert not home_logs.exists(), (
+        f"the spawn wrote {sorted(p.name for p in home_logs.rglob('*'))} into the home "
+        f"root {home_logs} while LOCAL_OPERATOR_CONFIG_DIR pointed at {override}"
+    )
+
+    logs_root = override / "logs"
+    assert [
+        p.name for p in logs_root.glob("exec-*.log")
+    ], f"no job log under the override's logs root {logs_root}"
+    assert (
+        logs_root / exec_mode.JOBS_FILE
+    ).exists(), f"the jobs ledger did not land under the override's logs root {logs_root}"
+    # The ledger is READ back through the same resolver, so a reader left on the
+    # old root would find nothing even though the write succeeded.
+    assert [r["pid"] for r in exec_mode.read_job_records()] == [5150]
+
+
+def test_worker_exit_record_follows_the_config_dir_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``update_job_exit`` writes the terminal record under the override too.
+
+    A separate entry point from the spawn: the detached worker calls this in its
+    own process at exit, inheriting the spawner's environment. With the root
+    hardcoded, the spawn record and the terminal record could land in two
+    different ledgers — the job would look permanently unfinished to any reader.
+    """
+    override = tmp_path / "override-config"
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(override))
+    home_logs = Path.home() / ".local-operator" / "logs"
+
+    monkeypatch.setattr(sys, "argv", ["exec_worker", "--prompt", "x", "--job-id", "jobx"])
+    monkeypatch.setattr(exec_worker, "run", lambda _p, session_factory=None: 0)
+
+    assert exec_worker.main() == 0
+
+    assert not home_logs.exists(), (
+        f"the worker wrote its terminal record into the home root {home_logs} "
+        f"while LOCAL_OPERATOR_CONFIG_DIR pointed at {override}"
+    )
+    assert (override / "logs" / exec_mode.JOBS_FILE).exists()
+    records = exec_mode.read_job_records()
+    assert any(r["id"] == "jobx" and r["exit_code"] == 0 for r in records)

--- a/tests/unit/test_json_stdout_purity.py
+++ b/tests/unit/test_json_stdout_purity.py
@@ -104,16 +104,17 @@ def test_background_job_notices_go_to_stderr(tmp_path, monkeypatch) -> None:
     """--json and --background are independent flags, so the two 'Started
     background job' lines must not precede the event stream on stdout."""
     from local_operator import exec_mode
+    from local_operator.paths import CONFIG_DIR_ENV
 
     monkeypatch.setattr(exec_mode, "resolve_hosting_model_dry", lambda _a: None)
-    monkeypatch.setattr(exec_mode, "_ensure_logs_dir", lambda: tmp_path)
     monkeypatch.setattr(exec_mode, "_append_job_record", lambda *a, **k: None)
-    # LOGS_DIR is resolved at IMPORT time from Path.home(), so patching only
-    # _ensure_logs_dir left the log path pointing at the real $HOME — the test
-    # passed on a machine that happened to have that directory and failed on a
-    # clean one. Both have to be redirected.
-    monkeypatch.setattr(exec_mode, "LOGS_DIR", tmp_path)
-    monkeypatch.setattr(exec_mode, "JOBS_LEDGER", tmp_path / "jobs.jsonl", raising=False)
+    # ONE seam redirects the whole logs root, because ``exec_mode.logs_dir()``
+    # resolves through ``paths.config_dir()`` on every call. This previously
+    # needed two patches (``_ensure_logs_dir`` AND the import-time ``LOGS_DIR``
+    # constant): stubbing only the first left the log path on the real $HOME, so
+    # the test passed on a machine that happened to have that directory and
+    # failed on a clean one. A resolver has no second copy to forget.
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(tmp_path))
 
     class FakeProc:
         pid = 4242


### PR DESCRIPTION
## Summary

PR #737 (merged, in v0.51.4) fixed a config-dir isolation defect: `exec_worker.py` and `exec_mode.py` hardcoded the home root instead of resolving through `paths.config_dir()`, so under a `LOCAL_OPERATOR_CONFIG_DIR` override, exec mode read from the wrong root.

**That fix shipped with no guard.** Reverting `exec_worker` to the hardcoded root left the entire exec suite passing 36/36, because the one test reaching that function stubs the managers with `lambda *a: object()` and discards the directory. It cannot observe what the fix changed. Four agents independently flagged it; the framing that stuck is that a test which cannot fail is worse than no test, because it is believed.

This adds coverage that actually fails when either site regresses, and fixes a third instance of the same defect class found while writing it.

## Change class

C1 — standard, pre-authorized. Test coverage plus one bounded production fix in the same defect class.

## Mutation evidence

Every guard here was proven by reverting its subject and watching it go red. Per AGENTS.md, a test that is the evidence for a claim is made to fail on purpose before being relied on.

**`exec_worker._default_session_factory`** — reverted `base_dir = config_dir()` to `Path.home() / ".local-operator"`:

```
FAILED test_worker_session_factory_resolves_the_config_dir_override
  AssertionError: the worker built its managers under
  ['.../home0/.local-operator'] instead of the override
  .../override-config; the home root is .../home0/.local-operator

FAILED test_worker_session_factory_writes_nothing_outside_the_override
  AssertionError: the worker created ['agents', 'credentials.env']
  under the home root .../home6/.local-operator while
  LOCAL_OPERATOR_CONFIG_DIR pointed at .../override-config
```

Restored: 41 passed. The assertions name both the observed and the expected root, so a future failure says which directory was used rather than only that a set comparison failed.

Note the second test asserts on a **side effect on the filesystem** — which directories the worker actually created — not on whether a resolver was called. A test that asserts the call is satisfied by a stub; this one is not.

## The third instance: `exec_mode.LOGS_DIR`

Flagged as a follow-up on #737 and explicitly left ambiguous, because its comment called it "the legacy config dir" and that could have meant deliberate. It is not deliberate.

`LOGS_DIR = Path.home() / ".local-operator" / "logs"` was written in the original CLI rewrite **before `paths.py` and `LOCAL_OPERATOR_CONFIG_DIR` existed at all** — the comment recorded the era, not an intent to opt out. Under an override, the jobs ledger and the exec logs split from the honoured root while three sibling call sites resolve correctly.

It is now `logs_dir()`, **a function rather than a constant**, for the reason `paths.config_dir` gives in its own docstring: a constant freezes whatever the first importer saw, while the override is read from the environment on every call. It shares `paths.LOG_DIRNAME` rather than spelling `"logs"` a second time.

Under an override this puts exec's logs in the same directory as the app's rotating log. That is deliberate and documented in the docstring: filenames are disjoint (`local-operator.log` vs `exec-*.log` / `exec-jobs.jsonl`) and both roots are created 0700. Inventing a second directory name to avoid sharing would have been the larger change.

## Verification

- `tests/unit/test_exec_mode.py` 41 passed; `test_json_stdout_purity.py` updated for the constant-to-function change.
- Whole-tree gates as CI runs them: flake8, black 26.1.0, isort 5.13.2, pyright `0 errors`.
- `git diff origin/main...HEAD -- pyproject.toml` empty. No version bump.
- No test writes to the real `~/.local-operator`; the override tests assert that explicitly, which is the defect class #737 fixed.

## Scope

The follow-up as filed was test coverage. The `LOGS_DIR` fix is included because it is the same defect, in the same file, in the same call chain, and leaving it would have meant a third round on identical ground. Both are guarded.
