### PR TITLE
chore(release): bump version to 0.51.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.6"
+version = "0.51.7"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Combined release for the window after v0.51.6. Owner session pid 61788.

Window (all merged; each announced at merge time per #740):
- [x] #722 `2e8a6ccd5` — Release: patch — a resumed conversation opens with scrollable history you can actually page back through, and loading older messages no longer jostles the rows you are reading.
- [x] #745 `4aeccec10` — Release: patch — exec mode’s config-root resolution is now guarded by tests that fail when it regresses, and the detached-exec log directory honours `LOCAL_OPERATOR_CONFIG_DIR` instead of a hardcoded home root.
- [x] #728 `f25af46ea` — Release: patch — a slow guest command expires on the guest and returns a definite answer, instead of expiring on our socket while the command keeps running.

**Bump: PATCH → 0.51.7.** All three are defect fixes to existing surfaces. No new command, no new surface, no API change; none clears the step-function bar. #722 restores reachability of a capability that already existed; #745 is test coverage plus one bounded fix in the same defect class; #728 is a fix inside the OSWorld evaluation harness, which no TUI/CLI/mobile user reaches.

Window derived with a plain `git log v0.51.6..origin/main` (never `--merges` — all three are squash-merged and `--merges` returns empty), and re-derived immediately before tagging, which is how #728 was picked up.

Scope: `pyproject.toml` only, one line. C0.