### PR TITLE
fix(tui): charge retained text by resident bytes, not len * 4

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2850,15 +2850,24 @@ class OperatorApp(App[None]):
         #: sidebar is open, and is fine when I close it", because closing pauses
         #: `_sidebar_timer`.
         #:
-        #: This converts an unbounded retry loop into ONE attempt per revision.
-        #: It is keyed by `presentation_revision` because that is the same
-        #: staleness stamp the cache-hit path uses: when the session changes,
-        #: the old refusal is no longer evidence about the new content, so it is
-        #: retried exactly once more. This is the half that makes the fix
-        #: durable rather than merely re-tuned — some session will always exceed
-        #: any finite budget (this operator holds a 218 MB journal), and without
-        #: it the next such session reproduces the identical lag.
-        self._sidebar_unretainable: dict[str, int] = {}
+        #: This converts an unbounded retry loop into ONE attempt per CONTENT
+        #: change. The value is `_sidebar_refusal_stamp(source)` — the pair the
+        #: refusal is actually evidence about — and NOT `presentation_revision`,
+        #: which an earlier revision of this fix used and which reopened the
+        #: whole loop on the population that provoked the report: `_on_message`
+        #: bumps `presentation_revision` on ANY event on a hidden session, so a
+        #: refused session that was also streaming a turn got a fresh stamp on
+        #: every 2 s poll and was re-prepared every single time (measured: 10
+        #: full prepares over 10 polls while busy, against 1 while idle).
+        #: `_sidebar_presentation_current` had already rejected that stamp as
+        #: too strict for exactly this reason; the admission cache had
+        #: inherited the strictness rather than the conclusion.
+        #:
+        #: This is the half that makes the fix durable rather than merely
+        #: re-tuned — some session will always exceed any finite budget (this
+        #: operator holds a 218 MB journal), and without it the next such
+        #: session reproduces the identical lag.
+        self._sidebar_unretainable: dict[str, tuple[int, int]] = {}
         #: The source whose draft was snapshotted at ``pending(id)`` and whose
         #: editor buffer was handed to the transition. ``None`` outside a
         #: switch. Commit consumes it (buffer appended to the target's draft);
@@ -4135,6 +4144,28 @@ class OperatorApp(App[None]):
             self._interactions.pop(id(session), None)
         await session.dispose()
 
+    @staticmethod
+    def _sidebar_refusal_stamp(source: SessionInteraction) -> tuple[int, int]:
+        """What a `retainable()` refusal is evidence about: content, not events.
+
+        `(display_history_revision, history_message_count)`. Deliberately NOT
+        `presentation_revision`: that counts EVENTS (`_on_message`), so a
+        session streaming a turn bumps it dozens of times per poll while its
+        retained cost is unchanged, and a refusal keyed on it expires
+        immediately for precisely the busy sessions that make the re-
+        preparation loop expensive.
+
+        Both terms move only on durable content. `display_history_revision` is
+        bumped by compaction, prune and recovery (`remote.py:1385,1506`) — the
+        rewrites that can make an over-budget window SMALLER.
+        `history_message_count` is the durable row count.
+        """
+        session = source.session
+        return (
+            int(getattr(session, "display_history_revision", 0) or 0),
+            int(getattr(session, "history_message_count", 0) or 0),
+        )
+
     def _admit_sidebar_presentation(
         self,
         session_id: str,
@@ -4145,11 +4176,9 @@ class OperatorApp(App[None]):
 
         The single place either retain site consults the predicate, so the
         refusal record cannot drift from the decision that produced it. A
-        refusal is recorded against the source's `presentation_revision`, which
-        is the same staleness stamp `_sidebar_presentation_current` uses: it is
-        bumped by any event on the session, so a session that has changed since
-        it was refused gets exactly one fresh attempt rather than being
-        blacklisted for the life of the app.
+        refusal is recorded against `_sidebar_refusal_stamp`, so a session
+        whose CONTENT has changed since it was refused gets exactly one fresh
+        attempt rather than being blacklisted for the life of the app.
 
         Admission clears the record, because a session that fits now must not
         keep a stale refusal that would suppress its next prewarm.
@@ -4157,7 +4186,7 @@ class OperatorApp(App[None]):
         if presentation.retainable():
             self._sidebar_unretainable.pop(session_id, None)
             return True
-        self._sidebar_unretainable[session_id] = source.presentation_revision
+        self._sidebar_unretainable[session_id] = self._sidebar_refusal_stamp(source)
         return False
 
     def _sidebar_prewarm_refused(self, session_id: str) -> bool:
@@ -4166,14 +4195,39 @@ class OperatorApp(App[None]):
         Only for SPECULATIVE preparation. An explicit click must still prepare
         a too-large session — the user asked for it, they see a transition, and
         that path runs once instead of on every poll.
+
+        A refusal expires only on a change that could plausibly REVERSE it.
+        Every refusal cause is monotone in content — the text budget, the
+        128-block cap, the node cap, and a block whose `retained_payloads()`
+        declines — so APPENDING rows can never turn a refusal into an
+        admission, and retrying on growth is pure waste on the busiest
+        sessions. Only a rewrite (`display_history_revision`, i.e. compaction /
+        prune / recovery) or a drop in the durable row count can, so those are
+        the only two events that reopen the attempt.
+
+        The deliberate cost: a display window that slides a large message out
+        of range without a rewrite stays suppressed until one of those happens
+        or the sidebar closes (`_set_sidebar_open(False)` clears the map, so
+        every sidebar open is a fresh attempt and this is never permanent).
+        That is the safe direction — a missed cache entry costs one cold
+        switch, whereas an over-eager retry is the 2 s re-preparation loop this
+        whole change exists to close.
+
+        A source that has been released has no readable stamp; the refusal is
+        then trusted until the sidebar closes. Bounded and benign: it
+        suppresses only speculation, and an explicit click still prepares.
         """
         refused_at = self._sidebar_unretainable.get(session_id)
         if refused_at is None:
             return False
         source = self._sidebar_sources.get(session_id)
-        if source is not None and source.presentation_revision != refused_at:
-            # The conversation moved on; the old refusal says nothing about
-            # what it would cost to retain now. Retry once.
+        if source is None:
+            return True
+        replay_revision, history_size = self._sidebar_refusal_stamp(source)
+        refused_replay_revision, refused_history_size = refused_at
+        if replay_revision != refused_replay_revision or history_size < refused_history_size:
+            # Rewritten or shrunk: the old refusal says nothing about what it
+            # would cost to retain now. Retry once.
             del self._sidebar_unretainable[session_id]
             return False
         return True
@@ -4642,12 +4696,12 @@ class OperatorApp(App[None]):
                 if self._sidebar_prefetch is not None:
                     self._sidebar_prefetch.cancel()
                 retained, self._sidebar_presentations = self._sidebar_presentations, {}
-                # Refusals are stamped with a source's `presentation_revision`,
+                # Refusals are stamped from a source (`_sidebar_refusal_stamp`),
                 # and every source is disposed below — so those stamps become
-                # unreadable and a session that grew or shrank while the
-                # sidebar was shut would never be reconsidered. Dropping them
-                # costs at most one retry per session per sidebar open, which
-                # is bounded; keeping them risks a permanent blacklist.
+                # unreadable and a session that was compacted or pruned while
+                # the sidebar was shut would never be reconsidered. Dropping
+                # them costs at most one retry per session per sidebar open,
+                # which is bounded; keeping them risks a permanent blacklist.
                 self._sidebar_unretainable.clear()
                 for session_id, presentation in retained.items():
                     source = self._sidebar_sources.get(session_id)

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2835,6 +2835,30 @@ class OperatorApp(App[None]):
         self._sidebar_frame_pending = False
         self._sidebar_focus_restore: ReferenceType[Widget] | None = None
         self._sidebar_presentations: dict[str, SessionPresentation] = {}
+        #: Sessions whose prepared presentation `retainable()` refused, so
+        #: prewarm stops re-preparing them.
+        #:
+        #: A refused presentation is never inserted into
+        #: `_sidebar_presentations`, so without this set it never stops matching
+        #: the prewarm candidate filter below: every 2 s poll re-selected it and
+        #: paid a full `_prepare_sidebar_session` — connect, display window,
+        #: replay, MOUNT into the DOM, a layout wait, then teardown — on the
+        #: event loop, for a result guaranteed to be discarded. Three of the
+        #: reporting operator's ten live sessions were stuck in that loop, which
+        #: saturated both `PREWARM_PER_REFRESH` slots and starved legitimate
+        #: prewarming of the other seven. It read as "the UI lags while the
+        #: sidebar is open, and is fine when I close it", because closing pauses
+        #: `_sidebar_timer`.
+        #:
+        #: This converts an unbounded retry loop into ONE attempt per revision.
+        #: It is keyed by `presentation_revision` because that is the same
+        #: staleness stamp the cache-hit path uses: when the session changes,
+        #: the old refusal is no longer evidence about the new content, so it is
+        #: retried exactly once more. This is the half that makes the fix
+        #: durable rather than merely re-tuned — some session will always exceed
+        #: any finite budget (this operator holds a 218 MB journal), and without
+        #: it the next such session reproduces the identical lag.
+        self._sidebar_unretainable: dict[str, int] = {}
         #: The source whose draft was snapshotted at ``pending(id)`` and whose
         #: editor buffer was handed to the transition. ``None`` outside a
         #: switch. Commit consumes it (buffer appended to the target's draft);
@@ -4111,6 +4135,49 @@ class OperatorApp(App[None]):
             self._interactions.pop(id(session), None)
         await session.dispose()
 
+    def _admit_sidebar_presentation(
+        self,
+        session_id: str,
+        source: SessionInteraction,
+        presentation: SessionPresentation,
+    ) -> bool:
+        """Ask `retainable()` once, and REMEMBER a refusal.
+
+        The single place either retain site consults the predicate, so the
+        refusal record cannot drift from the decision that produced it. A
+        refusal is recorded against the source's `presentation_revision`, which
+        is the same staleness stamp `_sidebar_presentation_current` uses: it is
+        bumped by any event on the session, so a session that has changed since
+        it was refused gets exactly one fresh attempt rather than being
+        blacklisted for the life of the app.
+
+        Admission clears the record, because a session that fits now must not
+        keep a stale refusal that would suppress its next prewarm.
+        """
+        if presentation.retainable():
+            self._sidebar_unretainable.pop(session_id, None)
+            return True
+        self._sidebar_unretainable[session_id] = source.presentation_revision
+        return False
+
+    def _sidebar_prewarm_refused(self, session_id: str) -> bool:
+        """Whether prewarm should skip `session_id` because it was refused.
+
+        Only for SPECULATIVE preparation. An explicit click must still prepare
+        a too-large session — the user asked for it, they see a transition, and
+        that path runs once instead of on every poll.
+        """
+        refused_at = self._sidebar_unretainable.get(session_id)
+        if refused_at is None:
+            return False
+        source = self._sidebar_sources.get(session_id)
+        if source is not None and source.presentation_revision != refused_at:
+            # The conversation moved on; the old refusal says nothing about
+            # what it would cost to retain now. Retry once.
+            del self._sidebar_unretainable[session_id]
+            return False
+        return True
+
     async def _release_sidebar_preparation(
         self, prepared: tuple[SessionInteraction, SessionPresentation]
     ) -> None:
@@ -4232,7 +4299,9 @@ class OperatorApp(App[None]):
         if previous is not None:
             self._sidebar_sources[previous.session_id] = outgoing
             outgoing_presentation = self._capture_sidebar_presentation()
-            if outgoing_presentation.retainable():
+            if self._admit_sidebar_presentation(
+                previous.session_id, outgoing, outgoing_presentation
+            ):
                 self._sidebar_presentations[previous.session_id] = outgoing_presentation
                 outgoing_presentation = None
         self._park_sidebar_aside(outgoing)
@@ -4573,6 +4642,13 @@ class OperatorApp(App[None]):
                 if self._sidebar_prefetch is not None:
                     self._sidebar_prefetch.cancel()
                 retained, self._sidebar_presentations = self._sidebar_presentations, {}
+                # Refusals are stamped with a source's `presentation_revision`,
+                # and every source is disposed below — so those stamps become
+                # unreadable and a session that grew or shrank while the
+                # sidebar was shut would never be reconsidered. Dropping them
+                # costs at most one retry per session per sidebar open, which
+                # is bounded; keeping them risks a permanent blacklist.
+                self._sidebar_unretainable.clear()
                 for session_id, presentation in retained.items():
                     source = self._sidebar_sources.get(session_id)
                     if source is not None:
@@ -4693,6 +4769,11 @@ class OperatorApp(App[None]):
             if entry.id != current
             and entry.row.live_state
             and entry.id not in self._sidebar_presentations
+            # Never speculatively re-prepare what `retainable()` already
+            # refused at this revision: the result would be discarded again
+            # and the poll would re-select it forever. An explicit click still
+            # prepares it — the user asked, and that path does not loop.
+            and not self._sidebar_prewarm_refused(entry.id)
         ][:PREWARM_PER_REFRESH]
         if not candidates:
             return
@@ -4713,7 +4794,7 @@ class OperatorApp(App[None]):
                         and not self._sidebar_navigation.requested_id
                         and candidate.id not in self._sidebar_presentations
                         and candidate.id != str(getattr(self._session, "session_id", ""))
-                        and prepared[1].retainable()
+                        and self._admit_sidebar_presentation(candidate.id, prepared[0], prepared[1])
                     ):
                         self._sidebar_presentations[candidate.id] = prepared[1]
                         prepared = None

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -229,18 +229,34 @@ class SessionPresentation:
         is RESIDENT BYTES of retained text, not characters and not the JSON
         wire frame the window layer prices itself in. It exists so ONE parked
         view cannot pin an unbounded slice of a 200 MB journal in RAM;
-        ``RETAINED_PRESENTATIONS`` parked views each get this budget, so the
-        real ceiling is N x this number.
+        ``RETAINED_PRESENTATIONS`` parked views each get this budget, so
+        N x this number bounds the retained TEXT.
+
+        It does **not** bound a retained presentation's total resident cost.
+        The mounted ``TranscriptView`` and its widget tree are parked (offset
+        ``100vw``), not freed, and that tree is not what this method measures —
+        so N x the budget is a bound on one term, not a memory ceiling for the
+        cache. Stated plainly because the previous wording ("the real ceiling
+        is N x this number") reads as the latter, and the next person tuning
+        this needs to know which quantity they are holding. The text term is
+        still the one worth bounding here: it is the term that scales with
+        conversation length, which is what makes a long transcript expensive.
 
         **Why ``sys.getsizeof`` and not ``len(value) * k``.** CPython stores
         ``str`` in PEP 393 compact form: 1, 2 or 4 bytes per character
         depending on the widest code point, plus a header. So no constant
         multiplier is right for all content — measured here, the same 4096
         characters cost 4137 bytes as ASCII, 8250 as BMP and 16444 as astral.
-        ``getsizeof`` is the honest measure, it is the only one that cannot be
-        wrong in either direction, and it costs ~75 ns against ~29 ns for
-        ``len`` on a 500 KB string — irrelevant beside the mount + layout this
-        predicate decides whether to repeat.
+        ``getsizeof`` is the honest measure of one string object, and it costs
+        ~75 ns against ~29 ns for ``len`` on a 500 KB string — irrelevant
+        beside the mount + layout this predicate decides whether to repeat.
+
+        It is honest **per object**, which is why the charge sits below the
+        ``id(value) in seen`` check: charged above it, one string aliased by N
+        blocks was charged N times for a single allocation (measured: one
+        300 KB string under 5 keys charged 1.43 MiB and was refused at a true
+        cost of 0.29 MiB). Over-charging is how both previous mis-tunings
+        failed, so the identity check is load-bearing, not tidiness.
 
         **This bound has now been mis-tuned twice, in the same direction.**
         The node cap (see the comment below) silently refused every real owner
@@ -285,6 +301,20 @@ class SessionPresentation:
             self.held_steer_blocks,
         ]
         seen: set[int] = set()
+        # `seen` stores ADDRESSES, and an address only identifies an object
+        # among those that are simultaneously ALIVE. Every node the walk drops
+        # can therefore have its address handed to a later, unrelated node,
+        # which `seen` then skips as already-visited — silently un-charging it.
+        # This is not hypothetical: `retained_payloads()` builds a FRESH tuple
+        # per block, so on a 64-block presentation holding 64 KiB of distinct
+        # text each, 62 of 64 tuples reused a freed address and the walk
+        # charged 0.13 MiB against 4.00 MiB actual — and admitted it.
+        #
+        # So everything that gets an id in `seen` is kept alive here until the
+        # walk returns. Bounded by construction: the node cap caps the pointer
+        # count, and the string budget caps the transient TEXT held, because
+        # the walk returns False as soon as `remaining` goes negative.
+        alive: list[Any] = []
         remaining = RETAIN_TEXT_BYTES
         nodes = 0
         while stack:
@@ -300,19 +330,27 @@ class SessionPresentation:
             # trips long before on any real content.
             if nodes > 65536:
                 return False
+            if value is None or isinstance(value, (bool, int, float)):
+                continue
+            if id(value) in seen:
+                continue
+            seen.add(id(value))
+            alive.append(value)
             if isinstance(value, str):
                 # Resident cost, not character count: see the docstring. A
                 # `len(value) * 4` estimate here over-charged ASCII content 4x
                 # and disabled the cache entirely.
+                #
+                # Charged BELOW the identity check, so one string object held
+                # by N blocks costs one copy of RAM and is charged once. Above
+                # it, a transcript with repeated identical tool output was
+                # charged N x for a single allocation — an over-estimate, and
+                # over-estimating is the direction that produced both previous
+                # mis-tunings.
                 remaining -= sys.getsizeof(value)
             elif isinstance(value, bytes):
                 remaining -= len(value)
-            elif value is None or isinstance(value, (bool, int, float)):
-                pass
-            elif id(value) in seen:
-                continue
             else:
-                seen.add(id(value))
                 if isinstance(value, TranscriptBlock):
                     payload = value.retained_payloads()
                     if payload is None:

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -7,6 +7,7 @@ acknowledgement, or reference to the currently selected app session.
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, Protocol
@@ -24,6 +25,15 @@ from local_operator.tui.widgets.transcript import (
     TranscriptBlock,
     TranscriptView,
 )
+
+#: Resident bytes of retained text one parked presentation may hold, measured
+#: with ``sys.getsizeof`` rather than estimated from a character count. It must
+#: stay >= ``DISPLAY_HISTORY_BYTES`` (512 KiB): the window layer is permitted to
+#: produce a payload that large, so a smaller retain budget structurally refuses
+#: presentations the layer above legitimately built. See
+#: :meth:`SessionPresentation.retainable` for what this protects against and how
+#: to measure a real presentation against it before changing it.
+RETAIN_TEXT_BYTES = 1024 * 1024
 
 
 class HistoryPageNotice(NoticeBlock, can_focus=True):
@@ -214,6 +224,48 @@ class SessionPresentation:
 
         One cached view can otherwise retain arbitrarily much history. Unknown
         renderers (including decoded images) are rebuilt instead of guessing.
+
+        **What the budget is protecting against, and in what units.** The bound
+        is RESIDENT BYTES of retained text, not characters and not the JSON
+        wire frame the window layer prices itself in. It exists so ONE parked
+        view cannot pin an unbounded slice of a 200 MB journal in RAM;
+        ``RETAINED_PRESENTATIONS`` parked views each get this budget, so the
+        real ceiling is N x this number.
+
+        **Why ``sys.getsizeof`` and not ``len(value) * k``.** CPython stores
+        ``str`` in PEP 393 compact form: 1, 2 or 4 bytes per character
+        depending on the widest code point, plus a header. So no constant
+        multiplier is right for all content — measured here, the same 4096
+        characters cost 4137 bytes as ASCII, 8250 as BMP and 16444 as astral.
+        ``getsizeof`` is the honest measure, it is the only one that cannot be
+        wrong in either direction, and it costs ~75 ns against ~29 ns for
+        ``len`` on a 500 KB string — irrelevant beside the mount + layout this
+        predicate decides whether to repeat.
+
+        **This bound has now been mis-tuned twice, in the same direction.**
+        The node cap (see the comment below) silently refused every real owner
+        once. Then the string term charged ``len(value) * 4`` — a worst-case
+        UTF-32 assumption — against a 1 MiB budget, so the effective budget was
+        256 KiB while ``DISPLAY_HISTORY_BYTES`` permits the window layer to
+        hand this predicate a 512 KiB payload. The two limits contradicted each
+        other and the cache silently never cached: a refused presentation is
+        never inserted into ``_sidebar_presentations``, so it never stops
+        matching the prewarm candidate filter and is fully re-prepared (mount +
+        layout + unmount, on the event loop) on every 2 s sidebar poll. Three
+        of the operator's ten live sessions were stuck in that loop, which is
+        the reported "lag with the sidebar open, fine when I close it".
+
+        **How to verify this rather than re-derive it.** Do not reason about
+        the multiplier; measure a real presentation. Walk the same roots this
+        method walks, sum ``sys.getsizeof`` over the strings, and compare
+        against ``RETAIN_TEXT_BYTES``. On the operator's eight largest real
+        transcripts the retained text measures 3-660 KiB (the roots are the
+        blocks plus the unmounted ``_resume_pending_head``/``_resume_results``
+        paging buffers, which dominate at 127-357 KiB), so 1 MiB admits every
+        one of them with the largest at 64% of budget. If you are considering
+        tightening this, get that measurement first: the failure mode of a too-
+        tight bound here is not a rejected cache entry, it is a permanent
+        re-preparation loop that looks like general UI slowness.
         """
         if len(self.replay.view.blocks()) > 128:
             return False
@@ -233,7 +285,7 @@ class SessionPresentation:
             self.held_steer_blocks,
         ]
         seen: set[int] = set()
-        remaining = 1024 * 1024
+        remaining = RETAIN_TEXT_BYTES
         nodes = 0
         while stack:
             value = stack.pop()
@@ -249,7 +301,10 @@ class SessionPresentation:
             if nodes > 65536:
                 return False
             if isinstance(value, str):
-                remaining -= len(value) * 4
+                # Resident cost, not character count: see the docstring. A
+                # `len(value) * 4` estimate here over-charged ASCII content 4x
+                # and disabled the cache entirely.
+                remaining -= sys.getsizeof(value)
             elif isinstance(value, bytes):
                 remaining -= len(value)
             elif value is None or isinstance(value, (bool, int, float)):

--- a/tests/unit/tui/test_sidebar_retain_budget.py
+++ b/tests/unit/tui/test_sidebar_retain_budget.py
@@ -1,0 +1,249 @@
+"""The presentation cache must actually cache, and a refusal must not loop.
+
+Two failures, one visible symptom. The operator reported "lag around the UI in
+general with the sidebar open, when I close the sidebar it's fine", plus session
+switches that stayed slow for long conversations. Both came from
+``SessionPresentation.retainable()`` refusing presentations it should admit:
+
+* the string term charged ``len(value) * 4`` (a worst-case UTF-32 estimate)
+  against a 1 MiB budget, so the effective budget was 256 KiB while
+  ``DISPLAY_HISTORY_BYTES`` lets the window layer hand it 512 KiB. Measured on
+  the operator's real transcripts, 4 of 8 were refused and 2 of those were
+  refused *purely* on the over-charge;
+* a refused presentation is never inserted into ``_sidebar_presentations``, so
+  it never stops matching the prewarm candidate filter. Every 2 s poll
+  re-selected it and paid a full prepare — connect, window, replay, MOUNT,
+  layout wait, teardown — on the event loop, for a result guaranteed to be
+  discarded.
+
+The assertions here are STRUCTURAL — retained/refused booleans and prepare call
+counts — not wall-clock bounds, per AGENTS.md §"Timing, flakes": the defect is
+"how many times did this run", which cannot flake, and this repo has abandoned
+numeric timing bounds as unportable.
+
+Each test asserts its PRECONDITION before its claim. A previous PR in this
+series shipped three vacuous tests, one of which passed *with* the defect
+present, so "the fixture is genuinely near the boundary" is checked rather than
+assumed.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from local_operator.tui.session_presentation import (
+    RETAIN_TEXT_BYTES,
+    PreparedReplay,
+    SessionPresentation,
+)
+from local_operator.tui.widgets.transcript import NoticeBlock
+
+
+@pytest.fixture(autouse=True)
+def isolated_retain(tmp_path, monkeypatch):
+    # Headless tests must never touch the operator's real config, cache, or
+    # multiplexer workspace. HOME as well as the config dir: the config var
+    # alone does not redirect the catalogue cache.
+    for key in tuple(os.environ):
+        if key.startswith("CMUX_"):
+            monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_NOTIFICATIONS", "1")
+
+
+def _presentation(text: str) -> SessionPresentation:
+    """A presentation holding exactly ``text`` in one retainable block.
+
+    ``NoticeBlock`` is used because it retains through the base
+    ``retained_payloads`` -> ``text()`` path and stores the string verbatim, so
+    the walk reaches exactly the bytes under test and nothing else is being
+    measured. (``AssistantBlock`` would re-render megabytes of Markdown per
+    fixture to hold the same string.)
+    """
+    replay = PreparedReplay()
+    block = NoticeBlock("payload", "note")
+    # The payload is installed AFTER construction on purpose. `retainable()`
+    # walks `retained_payloads()` -> `text()` -> `_text`, which is exactly what
+    # a real block exposes; constructing with the full string instead would
+    # make every fixture render a megabyte of Rich content the predicate never
+    # looks at, for no additional coverage.
+    block._text = text
+    replay.blocks.append(block)
+    replay.view._blocks.append(block)
+    return SessionPresentation(replay)
+
+
+def test_a_window_sized_payload_is_retainable():
+    """The retain budget must admit what the window layer is allowed to build.
+
+    ``DISPLAY_HISTORY_BYTES`` is 512 KiB and this budget is 1 MiB, so a
+    half-megabyte of ASCII prose — the largest window the layer above can
+    legitimately hand over — has to fit with room to spare. Under the
+    ``len * 4`` over-charge it did not: 512 KiB was charged as 2 MiB against a
+    1 MiB budget and refused.
+    """
+    from local_operator.session.history_window import DISPLAY_HISTORY_BYTES
+
+    text = "x" * DISPLAY_HISTORY_BYTES
+    presentation = _presentation(text)
+
+    # PRECONDITION: this fixture is genuinely the size being claimed, and the
+    # budget really is the one the window layer must fit inside. Without these
+    # the assertion below would pass on an empty presentation.
+    assert len(text) == 512 * 1024
+    assert RETAIN_TEXT_BYTES >= DISPLAY_HISTORY_BYTES
+    # PRECONDITION: the string is ASCII, so its resident cost is ~1 byte per
+    # character and the old estimate over-charged it by exactly 4x. If this
+    # ever fails the test is measuring a different thing than it claims.
+    assert sys.getsizeof(text) < len(text) * 1.01
+
+    assert presentation.retainable(), "a legal display window must be cacheable"
+
+
+def test_the_budget_still_refuses_a_payload_above_it():
+    """Removing the protection is not the fix; the bound must still bite.
+
+    One cached view must not be able to pin an arbitrary slice of a 200 MB
+    journal, and this host has hit macOS "out of application memory". A
+    presentation whose resident text exceeds the budget is still refused.
+    """
+    text = "x" * (RETAIN_TEXT_BYTES + 64 * 1024)
+    presentation = _presentation(text)
+
+    # PRECONDITION: over the budget by resident bytes, which is the unit the
+    # predicate now charges in — not by a character count that happens to agree.
+    assert sys.getsizeof(text) > RETAIN_TEXT_BYTES
+
+    assert not presentation.retainable(), "the memory bound must still refuse"
+
+
+def test_the_cost_estimate_is_resident_bytes_not_a_character_multiplier():
+    """Charge what the string actually costs, whatever its widest code point.
+
+    CPython stores ``str`` in PEP 393 compact form (1, 2 or 4 bytes per
+    character), so no constant multiplier is correct for all content. The guard
+    that matters in both directions: ASCII at 60% of budget must be admitted,
+    and the SAME character count in astral plane — which really does cost ~4x —
+    must be refused.
+    """
+    count = int(RETAIN_TEXT_BYTES * 0.6)
+    ascii_text = "x" * count
+    astral_text = "\U0001f642" * count
+
+    # PRECONDITION: identical character counts, different resident costs. This
+    # is the whole point — a `len()`-based charge cannot tell these apart, and
+    # a `len * 4` charge cannot tell them apart either.
+    assert len(ascii_text) == len(astral_text) == count
+    assert sys.getsizeof(ascii_text) < RETAIN_TEXT_BYTES
+    assert sys.getsizeof(astral_text) > RETAIN_TEXT_BYTES
+
+    assert _presentation(ascii_text).retainable(), "ASCII under budget must be admitted"
+    assert not _presentation(astral_text).retainable(), "4-byte chars must be charged 4 bytes"
+
+
+class _Source(SimpleNamespace):
+    """The two attributes the admission path reads off a ``SessionInteraction``."""
+
+    def __init__(self, session_id: str, revision: int = 0) -> None:
+        super().__init__(session_id=session_id, presentation_revision=revision)
+
+
+def _admission_host():
+    """An object carrying only the admission state, bound to the real methods.
+
+    The helpers under test read `_sidebar_unretainable` and `_sidebar_sources`
+    and nothing else, so binding them to a bare namespace exercises the
+    production code without booting a full app — and keeps the assertion about
+    admission rather than about Textual.
+    """
+    from local_operator.tui.app import OperatorApp
+
+    host = SimpleNamespace(_sidebar_unretainable={}, _sidebar_sources={})
+    host._admit_sidebar_presentation = OperatorApp._admit_sidebar_presentation.__get__(host)
+    host._sidebar_prewarm_refused = OperatorApp._sidebar_prewarm_refused.__get__(host)
+    return host
+
+
+def test_prewarm_stops_re_preparing_a_refused_session():
+    """A refusal must be remembered, or prewarm loops on it forever.
+
+    This is the load-bearing half. Some session will exceed any finite budget
+    (the reporting operator holds a 218 MB journal), so a correct budget alone
+    does not stop the loop — the next oversized conversation reproduces it.
+
+    The assertion is a COUNT of admission attempts across simulated polls, not
+    a duration.
+    """
+    host = _admission_host()
+    source = _Source("huge-session")
+    host._sidebar_sources["huge-session"] = source
+    oversized = _presentation("x" * (RETAIN_TEXT_BYTES + 64 * 1024))
+
+    # PRECONDITION: this presentation really is refused, so the loop under test
+    # is the one being described.
+    assert not oversized.retainable()
+
+    attempts = 0
+    for _ in range(10):  # ten 2-second sidebar polls
+        if host._sidebar_prewarm_refused("huge-session"):
+            continue
+        attempts += 1
+        host._admit_sidebar_presentation("huge-session", source, oversized)
+
+    assert attempts == 1, f"prewarm re-prepared a refused session {attempts} times over 10 polls"
+
+
+def test_a_changed_session_is_reconsidered_exactly_once_more():
+    """A refusal is evidence about content, and content changes.
+
+    Keyed on ``presentation_revision`` — the same staleness stamp the cache-hit
+    path uses — so a session that has moved on since it was refused gets one
+    fresh attempt instead of a permanent blacklist. The over-fix guard is that
+    it is ONE attempt, not a re-opened loop.
+    """
+    host = _admission_host()
+    source = _Source("grown-session", revision=1)
+    host._sidebar_sources["grown-session"] = source
+    oversized = _presentation("x" * (RETAIN_TEXT_BYTES + 64 * 1024))
+
+    assert not host._admit_sidebar_presentation("grown-session", source, oversized)
+    # PRECONDITION: it is currently suppressed, so the next assertion is about
+    # the revision bump and not about a set that was never populated.
+    assert host._sidebar_prewarm_refused("grown-session")
+
+    source.presentation_revision = 2
+    assert not host._sidebar_prewarm_refused(
+        "grown-session"
+    ), "a changed session must be reconsidered"
+
+    # And re-refusing at the new revision suppresses it again — one retry per
+    # change, not an unbounded retry loop.
+    host._admit_sidebar_presentation("grown-session", source, oversized)
+    assert host._sidebar_prewarm_refused("grown-session")
+
+
+def test_admission_clears_a_stale_refusal():
+    """A session that fits now must not carry a refusal that suppresses it.
+
+    Otherwise a conversation that shrank below the budget (compaction, a
+    cleared transcript) would be admitted to the cache while still being
+    skipped by prewarm — a split state that is hard to see and easy to keep.
+    """
+    host = _admission_host()
+    source = _Source("shrinking-session")
+    host._sidebar_sources["shrinking-session"] = source
+
+    assert not host._admit_sidebar_presentation(
+        "shrinking-session", source, _presentation("x" * (RETAIN_TEXT_BYTES + 64 * 1024))
+    )
+    # PRECONDITION: the refusal was actually recorded.
+    assert "shrinking-session" in host._sidebar_unretainable
+
+    assert host._admit_sidebar_presentation("shrinking-session", source, _presentation("small"))
+    assert "shrinking-session" not in host._sidebar_unretainable
+    assert not host._sidebar_prewarm_refused("shrinking-session")

--- a/tests/unit/tui/test_sidebar_retain_budget.py
+++ b/tests/unit/tui/test_sidebar_retain_budget.py
@@ -78,6 +78,22 @@ def _presentation(text: str) -> SessionPresentation:
     return SessionPresentation(replay)
 
 
+def _presentation_of(texts: list[str]) -> SessionPresentation:
+    """The same fixture over MANY blocks, one payload each.
+
+    Separate from :func:`_presentation` because block COUNT is the variable in
+    the address-reuse case: one payload tuple is built and freed per block, so
+    the hazard only appears once several of them are allocated in sequence.
+    """
+    replay = PreparedReplay()
+    for text in texts:
+        block = NoticeBlock("payload", "note")
+        block._text = text
+        replay.blocks.append(block)
+        replay.view._blocks.append(block)
+    return SessionPresentation(replay)
+
+
 def test_a_window_sized_payload_is_retainable():
     """The retain budget must admit what the window layer is allowed to build.
 
@@ -112,6 +128,19 @@ def test_the_budget_still_refuses_a_payload_above_it():
     journal, and this host has hit macOS "out of application memory". A
     presentation whose resident text exceeds the budget is still refused.
     """
+    # The bound must be ABSOLUTE, not merely self-consistent. Every fixture
+    # below is derived from `RETAIN_TEXT_BYTES`, so they all scale with it and
+    # stay green if the constant is raised 100x — which is exactly the
+    # mis-tuning this file exists to catch, and it has already happened twice
+    # in the same direction. `RETAINED_PRESENTATIONS` (4) parked views each get
+    # this budget, so the retained-text ceiling is 4x it; on a host that has
+    # hit macOS "out of application memory", 4 MiB of retained text is the most
+    # that can be justified without a fresh RSS measurement.
+    assert RETAIN_TEXT_BYTES <= 4 * 1024 * 1024, (
+        "the retain budget grew without a measurement: N x this bounds retained "
+        "text, and this host has hit 'out of application memory'"
+    )
+
     text = "x" * (RETAIN_TEXT_BYTES + 64 * 1024)
     presentation = _presentation(text)
 
@@ -120,6 +149,67 @@ def test_the_budget_still_refuses_a_payload_above_it():
     assert sys.getsizeof(text) > RETAIN_TEXT_BYTES
 
     assert not presentation.retainable(), "the memory bound must still refuse"
+
+
+def test_a_shared_string_is_charged_once_because_it_is_one_copy_of_ram():
+    """The charge is per OBJECT, so aliasing must not multiply it.
+
+    ``getsizeof`` is honest about one string; charging it above the identity
+    check made it dishonest about N references to that string, so a transcript
+    with repeated identical tool output was refused at N x its true cost. That
+    is the OVER-charging direction — the one that produced both previous
+    mis-tunings and the re-preparation loop.
+
+    A ``Mapping`` root is used rather than N blocks on purpose: each block
+    builds a fresh payload tuple, and freeing those is the separate address-
+    reuse hazard the walk's keepalive covers. One live container isolates
+    aliasing as the single variable.
+    """
+    shared = "y" * 300_000
+    presentation = SessionPresentation(PreparedReplay())
+    presentation.tool_cards = {f"call-{index}": shared for index in range(5)}
+
+    # PRECONDITIONS: genuinely ONE object, whose single copy fits and whose
+    # five-fold charge does not. Without these the assertion could pass on a
+    # fixture that was simply small.
+    assert len({id(value) for value in presentation.tool_cards.values()}) == 1
+    assert sys.getsizeof(shared) < RETAIN_TEXT_BYTES
+    assert 5 * sys.getsizeof(shared) > RETAIN_TEXT_BYTES
+
+    assert presentation.retainable(), "one string aliased N times is one copy of RAM"
+
+
+def test_distinct_blocks_are_all_charged_despite_recycled_payload_addresses():
+    """``seen`` holds addresses, which only identify objects that are ALIVE.
+
+    ``retained_payloads()`` returns a FRESH tuple per call. The walk pops it,
+    charges it and drops it — so CPython frees it and hands the same address to
+    the next block's tuple, which ``seen`` then skips as already-visited,
+    silently un-charging that block's text. Measured before the keepalive: 62
+    of 64 payload tuples were skipped and 0.13 MiB was charged against 4.00 MiB
+    actually held, and the presentation was admitted.
+
+    This is the UNDER-charging direction. It is the one that breaks the PR's
+    headline claim that memory is bounded, so it is asserted separately from
+    the aliasing case above rather than being folded into it.
+    """
+    texts = [chr(97 + index % 26) * 65536 for index in range(64)]
+    presentation = _presentation_of(texts)
+
+    # PRECONDITION: the strings really are distinct objects, so a correct walk
+    # has to charge all 64. Proven, not assumed — equal-valued literals would
+    # be interned and legitimately charged once.
+    assert len({id(text) for text in texts}) == 64
+    # PRECONDITION: genuinely over budget when every block is charged, and
+    # genuinely under it if only a couple are. The gap between these is what
+    # the defect lived in.
+    assert sum(sys.getsizeof(text) for text in texts) > RETAIN_TEXT_BYTES
+    assert 2 * sys.getsizeof(texts[0]) < RETAIN_TEXT_BYTES
+
+    assert not presentation.retainable(), (
+        "64 distinct blocks holding 4 MiB were admitted against a 1 MiB budget: "
+        "freed payload tuples recycled their addresses into `seen`"
+    )
 
 
 def test_the_cost_estimate_is_resident_bytes_not_a_character_multiplier():
@@ -147,10 +237,49 @@ def test_the_cost_estimate_is_resident_bytes_not_a_character_multiplier():
 
 
 class _Source(SimpleNamespace):
-    """The two attributes the admission path reads off a ``SessionInteraction``."""
+    """What the admission path reads off a ``SessionInteraction``.
 
-    def __init__(self, session_id: str, revision: int = 0) -> None:
-        super().__init__(session_id=session_id, presentation_revision=revision)
+    ``presentation_revision`` counts EVENTS and ``session`` carries the two
+    CONTENT stamps. Both are present because the distinction is the point: an
+    earlier revision of this fix keyed refusals on `presentation_revision`, and
+    a fixture that never moved it hid the resulting loop entirely.
+    """
+
+    def __init__(
+        self,
+        session_id: str,
+        revision: int = 0,
+        *,
+        replay_revision: int = 0,
+        history_size: int = 100,
+    ) -> None:
+        super().__init__(
+            session_id=session_id,
+            presentation_revision=revision,
+            session=SimpleNamespace(
+                display_history_revision=replay_revision,
+                history_message_count=history_size,
+            ),
+        )
+
+    def stream_events(self, count: int = 37) -> None:
+        """What a background turn does: bump the EVENT counter, nothing else.
+
+        `_on_message` bumps `presentation_revision` on any ``SessionEvent`` on
+        a hidden session, so a streaming turn moves it dozens of times per poll
+        while the retained cost is unchanged.
+        """
+        self.presentation_revision += count
+
+    def append_row(self) -> None:
+        """A durable row lands: the conversation GREW, so a refusal still holds."""
+        self.presentation_revision += 1
+        self.session.history_message_count += 1
+
+    def rewrite_history(self) -> None:
+        """Compaction/prune/recovery: the only change that can REVERSE a refusal."""
+        self.presentation_revision += 1
+        self.session.display_history_revision += 1
 
 
 def _admission_host():
@@ -166,6 +295,9 @@ def _admission_host():
     host = SimpleNamespace(_sidebar_unretainable={}, _sidebar_sources={})
     host._admit_sidebar_presentation = OperatorApp._admit_sidebar_presentation.__get__(host)
     host._sidebar_prewarm_refused = OperatorApp._sidebar_prewarm_refused.__get__(host)
+    # A staticmethod, like `_sidebar_source_stamp`: taken UNBOUND so the host
+    # calls it exactly as the production methods above do.
+    host._sidebar_refusal_stamp = OperatorApp._sidebar_refusal_stamp
     return host
 
 
@@ -178,53 +310,98 @@ def test_prewarm_stops_re_preparing_a_refused_session():
 
     The assertion is a COUNT of admission attempts across simulated polls, not
     a duration.
-    """
-    host = _admission_host()
-    source = _Source("huge-session")
-    host._sidebar_sources["huge-session"] = source
-    oversized = _presentation("x" * (RETAIN_TEXT_BYTES + 64 * 1024))
 
+    The BUSY case is the one that matters and the one an earlier revision of
+    this test missed. Its source never emitted an event, so it only ever
+    exercised an idle session — while the refusal was keyed on
+    `presentation_revision`, which every streamed event bumps. A refused
+    session that was also streaming therefore re-prepared on all ten polls with
+    this test green: 8-12 concurrent sessions with turns running is the
+    reporting operator's normal state, so the vacuous half was precisely the
+    population the change exists for.
+    """
+    oversized = _presentation("x" * (RETAIN_TEXT_BYTES + 64 * 1024))
     # PRECONDITION: this presentation really is refused, so the loop under test
     # is the one being described.
     assert not oversized.retainable()
 
-    attempts = 0
-    for _ in range(10):  # ten 2-second sidebar polls
-        if host._sidebar_prewarm_refused("huge-session"):
-            continue
-        attempts += 1
-        host._admit_sidebar_presentation("huge-session", source, oversized)
+    def polls(session_id: str, between_polls) -> int:
+        host = _admission_host()
+        source = _Source(session_id)
+        host._sidebar_sources[session_id] = source
+        attempts = 0
+        for _ in range(10):  # ten 2-second sidebar polls
+            between_polls(source)
+            if host._sidebar_prewarm_refused(session_id):
+                continue
+            attempts += 1
+            host._admit_sidebar_presentation(session_id, source, oversized)
+        return attempts
 
-    assert attempts == 1, f"prewarm re-prepared a refused session {attempts} times over 10 polls"
+    idle = polls("idle-session", lambda _source: None)
+    busy = polls("busy-session", lambda source: source.stream_events())
+    growing = polls("growing-session", lambda source: source.append_row())
+
+    assert idle == 1, f"prewarm re-prepared an idle refused session {idle} times over 10 polls"
+    assert busy == 1, (
+        f"prewarm re-prepared a BUSY refused session {busy} times over 10 polls: "
+        "the refusal expires on streamed events rather than on content change"
+    )
+    # Growth cannot reverse a refusal — every refusal cause is monotone in
+    # content — so appending rows must not reopen the attempt either.
+    assert (
+        growing == 1
+    ), f"prewarm re-prepared a GROWING refused session {growing} times over 10 polls"
 
 
-def test_a_changed_session_is_reconsidered_exactly_once_more():
-    """A refusal is evidence about content, and content changes.
+def test_a_rewritten_session_is_reconsidered_exactly_once_more():
+    """A refusal is evidence about content, and content can be REWRITTEN.
 
-    Keyed on ``presentation_revision`` — the same staleness stamp the cache-hit
-    path uses — so a session that has moved on since it was refused gets one
-    fresh attempt instead of a permanent blacklist. The over-fix guard is that
-    it is ONE attempt, not a re-opened loop.
+    Compaction, prune and recovery bump ``display_history_revision`` and are
+    the changes that can make an over-budget window smaller — so they are what
+    reopens the attempt. The over-fix guard is that it is ONE attempt, not a
+    re-opened loop.
     """
     host = _admission_host()
-    source = _Source("grown-session", revision=1)
-    host._sidebar_sources["grown-session"] = source
+    source = _Source("compacted-session", replay_revision=1)
+    host._sidebar_sources["compacted-session"] = source
     oversized = _presentation("x" * (RETAIN_TEXT_BYTES + 64 * 1024))
 
-    assert not host._admit_sidebar_presentation("grown-session", source, oversized)
+    assert not host._admit_sidebar_presentation("compacted-session", source, oversized)
     # PRECONDITION: it is currently suppressed, so the next assertion is about
-    # the revision bump and not about a set that was never populated.
-    assert host._sidebar_prewarm_refused("grown-session")
+    # the rewrite and not about a set that was never populated.
+    assert host._sidebar_prewarm_refused("compacted-session")
 
-    source.presentation_revision = 2
+    source.rewrite_history()
     assert not host._sidebar_prewarm_refused(
-        "grown-session"
-    ), "a changed session must be reconsidered"
+        "compacted-session"
+    ), "a rewritten session must be reconsidered"
 
-    # And re-refusing at the new revision suppresses it again — one retry per
-    # change, not an unbounded retry loop.
-    host._admit_sidebar_presentation("grown-session", source, oversized)
-    assert host._sidebar_prewarm_refused("grown-session")
+    # And re-refusing at the new stamp suppresses it again — one retry per
+    # rewrite, not an unbounded retry loop.
+    host._admit_sidebar_presentation("compacted-session", source, oversized)
+    assert host._sidebar_prewarm_refused("compacted-session")
+
+
+def test_a_shrunken_session_is_reconsidered():
+    """Fewer durable rows can genuinely fit where more did not.
+
+    The counterpart to the growth case: `history_message_count` falling is a
+    content change that can reverse a refusal, so it must reopen the attempt
+    even though `display_history_revision` is unchanged.
+    """
+    host = _admission_host()
+    source = _Source("shrunken-session", history_size=100)
+    host._sidebar_sources["shrunken-session"] = source
+    oversized = _presentation("x" * (RETAIN_TEXT_BYTES + 64 * 1024))
+
+    assert not host._admit_sidebar_presentation("shrunken-session", source, oversized)
+    assert host._sidebar_prewarm_refused("shrunken-session")
+
+    source.session.history_message_count = 40
+    assert not host._sidebar_prewarm_refused(
+        "shrunken-session"
+    ), "a session that lost rows must be reconsidered"
 
 
 def test_admission_clears_a_stale_refusal():
@@ -247,3 +424,97 @@ def test_admission_clears_a_stale_refusal():
     assert host._admit_sidebar_presentation("shrinking-session", source, _presentation("small"))
     assert "shrinking-session" not in host._sidebar_unretainable
     assert not host._sidebar_prewarm_refused("shrinking-session")
+
+
+@pytest.mark.asyncio
+async def test_prewarm_filter_stops_selecting_a_refused_session():
+    """The FILTER must skip a refused session, not merely the helper it calls.
+
+    The tests above drive `_sidebar_prewarm_refused` through a hand-written
+    poll loop, which proves the helper answers correctly but says nothing about
+    the one line that actually breaks the 2 s re-preparation loop — the
+    `and not self._sidebar_prewarm_refused(entry.id)` clause in
+    `_prewarm_sidebar`'s candidate comprehension. Deleting that clause left the
+    rest of this file entirely green while restoring `main`'s exact behaviour:
+    every poll re-selecting the same refused sessions and paying a full prepare
+    for a result guaranteed to be discarded.
+
+    So this drives the REAL `_prewarm_sidebar` over ten polls and counts
+    prepares. Only the prepare seam itself is stubbed — leasing reaches for an
+    owner record on disk and mounting needs a laid-out frame; the candidate
+    filter, the admission call and the refusal cache are all production code,
+    which is where the defect lived.
+    """
+    from local_operator.resume import SessionRow
+    from local_operator.tui.app import OperatorApp
+    from local_operator.tui.session_catalog import CatalogEntry
+    from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+    oversized = "x" * (RETAIN_TEXT_BYTES + 64 * 1024)
+    # PRECONDITION: the fixture is genuinely refused and the small one is
+    # genuinely admitted, so a count of 1 below means "stopped" rather than
+    # "never started", and the admissible session proves the filter has not
+    # simply been switched off for everyone.
+    assert not _presentation(oversized).retainable()
+    assert _presentation("small").retainable()
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._session_sidebar.display = True
+        # The timer would poll on its own schedule; this test supplies the
+        # polls explicitly so the count is the test's, not the clock's.
+        if app._sidebar_timer is not None:
+            app._sidebar_timer.pause()
+
+        prepares: list[str] = []
+
+        async def prepare(session_id: str, *, speculative: bool = False):
+            prepares.append(session_id)
+            source = _Source(session_id)
+            # `_Source` carries exactly the attributes the admission path reads
+            # (`presentation_revision`, and `session`'s two content stamps); a
+            # real `SessionInteraction` would need an owner record on disk.
+            app._sidebar_sources[session_id] = source  # type: ignore[assignment]
+            text = "small" if session_id == "small-session" else oversized
+            return source, _presentation(text)
+
+        app._prepare_sidebar_session = prepare  # type: ignore[method-assign]
+
+        async def release(prepared) -> None:
+            return None
+
+        app._release_sidebar_preparation = release  # type: ignore[method-assign]
+
+        entries = [
+            CatalogEntry(SessionRow("huge-session", 100, "Huge", live_state="busy")),
+            CatalogEntry(SessionRow("small-session", 50, "Small", live_state="busy")),
+        ]
+
+        for _ in range(10):  # ten 2-second sidebar polls
+            # A background turn streams between polls: this is what bumped
+            # `presentation_revision` and expired the refusal on the operator's
+            # actual population. Only the synthetic sources are bumped — the
+            # app's own current session is a real `SessionInteraction` in this
+            # dict and is not what this test drives.
+            for source in app._sidebar_sources.values():
+                if isinstance(source, _Source):
+                    source.stream_events()
+            app._prewarm_sidebar(entries)
+            worker = app._sidebar_prefetch
+            if worker is not None:
+                await worker.wait()
+            await pilot.pause()
+
+        huge = prepares.count("huge-session")
+        small = prepares.count("small-session")
+
+    assert huge == 1, (
+        f"_prewarm_sidebar re-prepared a refused session {huge} times over 10 polls: "
+        "the candidate filter does not consult the refusal cache"
+    )
+    # The admissible session is prepared once and then cached, which is what
+    # distinguishes "the filter works" from "prewarm stopped running".
+    assert small == 1, f"an admissible session was prepared {small} times instead of once"
+    assert "small-session" in app._sidebar_presentations
+    assert "huge-session" not in app._sidebar_presentations


### PR DESCRIPTION
## Summary

`SessionPresentation.retainable()` charged `len(value) * 4` — a worst-case UTF-32 estimate — against a `1024 * 1024` budget. The effective budget was therefore **256 KiB**, while `DISPLAY_HISTORY_BYTES` (512 KiB) permits the window layer to hand this predicate a payload twice that size. The two limits contradicted each other, so the presentation cache **silently never cached** the long conversations it exists for.

That is not merely a missed cache — it is a loop. A refused presentation is never inserted into `_sidebar_presentations`, so it never stops matching the `_prewarm_sidebar` candidate filter. Every 2 s poll re-selected it and paid a full `_prepare_sidebar_session` — connect, display window, replay, **mount into the DOM**, a `call_after_refresh` layout wait, then teardown — **on the event loop**, for a result guaranteed to be discarded. With `PREWARM_PER_REFRESH = 2`, the stuck sessions also **starved legitimate prewarming of every other session**, so switches stayed cold as well.

It stops the moment the sidebar closes, because `_sidebar_timer` pauses. That is exactly the reported symptom: *"there's a bit of lag around the UI in general with the sidebar open, when I close the sidebar it's fine."*

This also answers the "can session switching be more like terminal multiplexing?" ask. **It already is** — `RETAINED_PRESENTATIONS = 4`, an LRU with recency reinsertion, parked off-screen at `100vw` (#694). This predicate was disabling it for precisely the conversations that are slow to switch. No second residency mechanism is added; that would be a memory-for-latency trade this host cannot afford and would double the surface for the leak class documented at `app.py:4580`.

## Change class

C1 — one predicate, one set, two call sites routed through a single admission helper.

## Reproduction, on a copy of real data

Copied the operator's 8 largest transcripts to `/tmp` (read-only; live sessions and `attention.db` untouched), built the **real** `display_window` → `PreparedReplay` pair for each, and priced them the way the shipped predicate does.

**Before** — 4 of 8 refused:

| session | msgs | resident text | % of 1 MiB | `retainable()` |
|---|---|---|---|---|
| `0c2b64b57859` | 119 | 228 KiB | 22% | True |
| `29435655756c` | 120 | 276 KiB | 27% | True |
| `4140ee201ce1` | 120 | 242 KiB | 24% | True |
| `835fbcafdc27` | 119 | 596 KiB | 58% | **False** |
| `94868d212048` | 119 | 362 KiB | 35% | True |
| `9f8e5b652ac7` | 119 | 267 KiB | 26% | **False** |
| `ab0090b7062f` | 108 | 552 KiB | 54% | **False** |
| `bda7b76d34e0` | 120 | 660 KiB | 64% | **False** |

**After** — 6 of 8 admitted. `835fbcafdc27` and `ab0090b7062f` flip to `True`; they were refused *purely* on the 4x over-charge at 58% and 54% of budget.

## A finding the design missed: there are TWO refusal causes

The design attributed all refusals to the budget. Measuring block-by-block shows that is only true for two of the four. `9f8e5b652ac7` and `bda7b76d34e0` are refused at 26% and 64% of budget — **well inside it** — because they contain a `WakeBlock`, which does not override `retained_payloads()` and has no `text()` method, so the base implementation returns `None` and the walk refuses the whole presentation:

```
9f8e5b652ac7 [('NoticeBlock', ok), ('WakeBlock', REFUSES), ('ToolCard', ok), ('AssistantBlock', ok)]
bda7b76d34e0 [('NoticeBlock', ok), ('WakeBlock', REFUSES), ('ToolCard', ok), ('AssistantBlock', ok)]
```

That is a real second defect and a plausible cause of a share of the operator's remaining lag — a session with any scheduled wake in its visible window can never be cached, whatever its size. **It is deliberately NOT fixed here**: giving `WakeBlock` a payload contract is a widget change with its own correctness question (the expansion text and the catch-up flag both have to survive a park), and this PR's scope is the cost estimate. Recorded for the manager rather than filed as an issue, per the no-follow-up-issues rule.

The refusal set below is what keeps that unfixed case from being expensive: those two sessions are now refused **once** instead of every 2 s.

## The second change: refusals are remembered

A corrected budget alone does not close the loop — some session will always exceed any finite bound (this operator holds a 218 MB journal). `_sidebar_unretainable` records a refusal against the source's `presentation_revision` and `_prewarm_sidebar` skips it. Keyed on the revision because that is the same staleness stamp `_sidebar_presentation_current` uses, so a session that has changed since it was refused gets exactly **one** fresh attempt rather than a permanent blacklist. An explicit click still prepares it — the user asked, and that path does not loop.

## Memory bound, honestly

"We fixed the cache" must not secretly mean "we now retain 40 MB".

```
budget per presentation: 1024 KiB
RETAINED_PRESENTATIONS : 4
THEORETICAL ceiling    : 4.0 MiB of retained text
ACTUAL worst-4 here    : 1.74 MiB  (835fbcafdc27, ab0090b7062f, 94868d212048, 29435655756c)
```

The largest real presentation sits at 64% of budget, so the bound still bites before anything pathological is admitted — and 4 MiB is far less than the allocation pressure the discarded re-preparation was generating every two seconds.

## Mutation evidence — every guard proven able to fail

Per AGENTS.md, each guard was verified by reintroducing the defect and watching it go red, then reverting. Six variants, in both directions:

| # | defect reintroduced | result |
|---|---|---|
| 1 | `remaining -= len(value) * 4` (the shipped bug) | **2 failed**, 4 passed |
| 2 | `remaining -= len(value)` (the likely future "tidy") | **1 failed** — `4-byte chars must be charged 4 bytes` |
| 3 | string charge removed entirely | **5 failed**, 1 passed |
| 4 | refusal not recorded | **3 failed** — `prewarm re-prepared a refused session 10 times over 10 polls` |
| 5 | permanent blacklist (never reconsider on a content change) | **1 failed** — `a rewritten session must be reconsidered` |
| 6 | admission does not clear a stale refusal | **1 failed** |

Restored: **6 passed**. Note #2 and #3 — the tests fail on *loosening* the bound as well as tightening it, so "just delete the cap" cannot pass either.

**Round 1 added four more, after review found the refusal key and two `seen` defects.** Full quoted output is in the [remediation comment](https://github.com/damianvtran/local-operator/pull/747#issuecomment-5574292386); the head is `2aa3e5a5` and the file is now **10 passed**:

| # | defect reintroduced | result |
|---|---|---|
| 7 | refusal keyed on `presentation_revision` (**R1**, the reviewed head's bug) | **3 failed** — `prewarm re-prepared a BUSY refused session 10 times over 10 polls` |
| 8 | `and not self._sidebar_prewarm_refused(entry.id)` deleted (**Q5**) | **1 failed** — `_prewarm_sidebar re-prepared a refused session 10 times over 10 polls`; this left the file green before |
| 9 | `str` charged above the identity check (**R2**) | **1 failed** — `one string aliased N times is one copy of RAM` |
| 10 | walk keepalive removed (**Q1**) | **1 failed** — `64 distinct blocks holding 4 MiB were admitted against a 1 MiB budget` |
| 11 | `RETAIN_TEXT_BYTES` raised 100x (**Q4**) | **1 failed** — `the retain budget grew without a measurement`; this left the file green before |

Every test also asserts its **precondition** before its claim (that the fixture really is 512 KiB, really is ASCII, really is over budget, really is currently suppressed). A previous PR in this series shipped three vacuous tests, one of which passed *with* the defect present; these do not have that shape.

Assertions are **structural** — admitted/refused booleans and a count of admission attempts across ten simulated polls — not wall-clock bounds, per AGENTS.md §"Timing, flakes".

## Gates

Run over the whole tree exactly as CI, via `python -m` / `uvx` (never the `.venv/bin` console scripts):

```
python -m flake8 .                               → clean
uvx --from black==26.1.0 black --check .         → 1031 files unchanged
uvx isort==5.13.2 --check .                      → clean
python -m pyright --pythonpath .venv/bin/python . → 0 errors, 0 warnings
```

Targeted suites (host is under memory pressure, so no `-n auto` run; CI has the matrix):

```
tests/unit/tui/test_sidebar_retain_budget.py  10 passed   (6 before round 1)
tests/unit/tui/test_sidebar_swap_reset.py      8 passed
tests/unit/tui/test_session_sidebar.py        48 passed
tests/unit/tui/test_sidebar_source_state.py   12 passed
```

All four gates re-run clean on `2aa3e5a5` (flake8, black 1031 unchanged, isort, pyright 0 errors / 0 warnings).

One run of the last two paired showed `test_requested_row_is_distinguishable_from_the_keyboard_cursor` failing on a spinner animation frame (`⣽`). It is unrelated to this diff and **not a regression**: it passes alone on this branch, and the same pairing was then re-run 3× on this branch at **60/60**. Reported rather than papered over.

## Visual surface

**None.** This is a cache-admission change. It alters *whether* a prepared presentation is kept, never how one is built or painted — the same `PreparedReplay` renders identically whether it was retained or rebuilt. The user-visible effect is the absence of repeated work.

> **Correction (review round 1).** An earlier version of this section claimed "the scroll anchor is restored on the cache-hit path exactly as it is on the rebuild path". **That was false, and I am striking it.** QA measured the two paths and they differ: on a cache HIT the anchor is restored (`y=11.0 tail=False`, one `restore_navigation_anchor()` call); on a REBUILD it is not (`y=20.0 tail=True`, zero calls), because a refused presentation has its source disposed and the anchor lives in `source.draft`. QA rendered both frames and confirmed it visually — the hit frame sits mid-conversation, the rebuild frame is pinned at the tail.
>
> **This behaviour is PRE-EXISTING and unchanged by this diff.** The identical probe against `origin/main` produces the identical result (`restores_on_return=[]`, `y=20.0 tail=True`). This PR in fact *reduces* how often a user meets it, by admitting 4 more of 12 real sessions to the cache. No code here touches a painting path.
>
> I am flagging it prominently because the reviewing manager relied on that sentence to skip the design round, and it should not have carried that weight. QA's judgement, which the manager accepted, is that it does not reopen the design round: the diff changes no painting path and strictly increases the fraction of switches that keep their position. **The design round remains skipped on that reasoning, not on my original incorrect claim.**

**No design round needed** — on the reasoning above.

## Not in scope

- `Transcript.__init__` at 3,883 ms on the 17,766-line transcript is the cold-path cost and is PR 3. Confirmed still dominant here (2.8–3.2 s in these runs) and left alone.
- `WakeBlock.retained_payloads()` returning `None`, above. **Deferred** — a widget contract change with its own park-survival question for the expansion text and catch-up flag. Review round 1 noted this deferral is only safe once R1 is fixed (those sessions can never be admitted at any size, so they depend entirely on the refusal cache to stay cheap); R1 **is** fixed in `2aa3e5a5`, so it is now safe.
- No version bump; `pyproject.toml` untouched. A release owner bumps per window.

