### PR TITLE
fix(runtime): spawned children must import the install, not the cwd checkout

### DIFF
--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -42,7 +42,6 @@ import subprocess
 import sys
 import time
 import traceback
-from importlib.metadata import version
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -129,10 +128,27 @@ def build_cli_parser() -> argparse.ArgumentParser:
         " ~/.local-operator/sessions. Pass --resume with no id to reopen the most recent"
         " session.",
     )
+    # ``installed_version()``, not ``version("local-operator")``: install
+    # metadata is written once and never moves when the checkout's
+    # ``pyproject.toml`` does, so the bare metadata call reports the version an
+    # editable install was CREATED at rather than the one it is running — and a
+    # leftover ``*.egg-info`` shadows the real dist-info downward on top of
+    # that. Both were live here: the reported symptom this change ships with
+    # was a wrong version number, and `--version` is the surface a user checks
+    # first, so it must not be the one place that still answers from the stale
+    # channel. See :func:`local_operator.update.installed_version`.
+    #
+    # Imported inside the function because ``local_operator.update`` pulls
+    # ``ssl``/``urllib.request`` (measured ~28 ms cumulative against an ~84 ms
+    # `import local_operator.cli` baseline). This parser is built once per
+    # invocation, so the cost lands only on runs that build it, and the
+    # startup-path guards in tests/unit/test_import_graph.py stay satisfied.
+    from local_operator.update import installed_version
+
     parser.add_argument(
         "--version",
         action="version",
-        version=f"v{version('local-operator')}",
+        version=f"v{installed_version()}",
         help="Show program's version number and exit",
     )
     parser.add_argument(

--- a/local_operator/exec_mode.py
+++ b/local_operator/exec_mode.py
@@ -31,6 +31,8 @@ from pathlib import Path
 from typing import Any, Callable
 from uuid import uuid4
 
+from local_operator.interpreter import python_argv
+
 
 def logs_dir() -> Path:
     """Root for detached-exec logs and the jobs ledger: ``config_dir()/logs``.
@@ -125,7 +127,13 @@ def slugify(command: str, max_length: int = 40) -> str:
 def build_worker_argv(command: str, exec_args: ExecArgs) -> list[str]:
     """Serialize the exec request into ``python -m local_operator.exec_worker``
     argv. Only set flags are passed so defaults stay in one place (worker)."""
-    argv = [sys.executable, "-m", "local_operator.exec_worker", "--prompt", command]
+    # ``python_argv``: `exec --background` is launched from wherever the user
+    # happens to be standing, and the worker imports the whole harness
+    # (session_factory, agents, config) — so a run started inside a checkout of
+    # this project would execute that checkout rather than the installed build,
+    # silently answering with different code than `lop --version` reports.
+    # Same defect as the runtime spawn; see :mod:`local_operator.interpreter`.
+    argv = python_argv("-m", "local_operator.exec_worker", "--prompt", command)
     if exec_args.json_mode:
         argv.append("--json")
     if exec_args.yolo:

--- a/local_operator/interpreter.py
+++ b/local_operator/interpreter.py
@@ -2,8 +2,9 @@
 
 WHY THIS EXISTS
 ---------------
-Every ``[sys.executable, "-m", "local_operator...."]`` spawn in this codebase
-shared one latent defect: ``-m`` puts the child's WORKING DIRECTORY on
+Every spawn in this codebase that RE-ENTERS THIS PACKAGE
+(``[sys.executable, "-m", "local_operator...."]``, and the ``-c`` snippets that
+import it) shared one latent defect: ``-m`` puts the child's WORKING DIRECTORY on
 ``sys.path[0]``, *ahead of* site-packages. None of those spawns pass ``cwd=``,
 so the child inherits the parent's directory — and when that directory is a
 checkout of this project (the normal case for anyone developing it, and the

--- a/local_operator/interpreter.py
+++ b/local_operator/interpreter.py
@@ -1,0 +1,91 @@
+"""How this project re-enters a Python interpreter to run its own modules.
+
+WHY THIS EXISTS
+---------------
+Every ``[sys.executable, "-m", "local_operator...."]`` spawn in this codebase
+shared one latent defect: ``-m`` puts the child's WORKING DIRECTORY on
+``sys.path[0]``, *ahead of* site-packages. None of those spawns pass ``cwd=``,
+so the child inherits the parent's directory — and when that directory is a
+checkout of this project (the normal case for anyone developing it, and the
+exact case for an agent session whose cwd is a worktree), the child imports the
+CHECKOUT rather than the installed distribution it was supposed to run.
+
+Measured on a real uv-tool install, same interpreter, only cwd differing::
+
+    cd <a worktree whose pyproject says 0.51.0>
+      imports: <worktree>/local_operator/__init__.py       stamp 0.51.0@ad6db35
+    same command, isolation flag added:
+      imports: <uv tool>/…/site-packages/local_operator/…  stamp 0.51.5@ad6db35
+
+The parent TUI is immune by accident rather than by design: it launches through
+the console script ``~/.local/bin/lop``, whose ``sys.path[0]`` is ``bin/``.
+Only the children were exposed — which is how live runtime daemons ended up
+pinned to a superseded build, serving a session whose viewer was current and
+missing a fix the user could see was absent.
+
+WHY ``-P`` AND NOT ``PYTHONSAFEPATH=1``
+---------------------------------------
+The two are equivalent *for the process being started*, and the environment
+variable looks tidier because these call sites already build an ``env`` dict.
+It is nonetheless the wrong tool, for a reason that stays invisible until
+something downstream breaks: **the variable is inherited by the entire process
+subtree; the flag is not.** Measured, not assumed::
+
+    env PYTHONSAFEPATH=1 python child.py  ->  grandchild: SAFEPATH=1, path0 stripped
+    python -P child.py                    ->  grandchild: SAFEPATH=None, path0 ''
+
+That difference decides correctness here. A spawned runtime goes on to run the
+agent's ``bash`` tool, which copies ``os.environ`` into every command it
+executes. With the variable set, every ``python`` the user's agent runs — in
+the user's own project, against the user's own code — silently loses
+``sys.path[0]`` and stops importing modules sitting beside the script::
+
+    cd <a user project>; python runner.py  ->  ModuleNotFoundError: No module named 'usermod'
+
+Ordinary Python semantics would break in the user's workspace, caused by an
+isolation flag that was only ever meant to protect OUR import. The flag form
+corrects our child and changes nothing for anything that child launches, so the
+blast radius is exactly the one process we intended to fix.
+
+WHY NOT ``cwd=``
+----------------
+Pointing the child at a neutral directory would also stop the bad import, and
+is worse: the session's working directory is a user-facing contract. It is what
+the agent operates on, what its tools resolve relative paths against, and what
+the status bar shows. Changing it would trade a silent version skew for a
+silent behaviour change. ``-P`` removes only the implicit ``sys.path[0]``
+injection — precisely the defect, and nothing else.
+
+WHERE THE CWD IS STILL WANTED
+-----------------------------
+One child legitimately needs it. The ``eval`` worker executes USER code, and a
+cell doing ``import my_module`` beside the session's cwd must keep working. That
+worker re-inserts its own cwd *after* the harness modules have already resolved
+— see :mod:`local_operator.tools.eval_worker`. The ordering is the entire point:
+our modules bind to the install, user code still reaches the workspace.
+"""
+
+from __future__ import annotations
+
+import sys
+
+#: Interpreter flag suppressing the implicit ``sys.path[0]`` entry (the cwd for
+#: ``-m``/``-c``, the script's own directory for a path argument). CPython 3.11+;
+#: this project requires >=3.12, so it is always available and needs no guard.
+SAFE_PATH_FLAG = "-P"
+
+
+def python_argv(*args: str) -> list[str]:
+    """``[sys.executable, "-P", *args]`` — how this project re-enters Python.
+
+    Use for every self-spawn (``-m local_operator...``, ``-c`` snippets) so a
+    child cannot import a checkout that merely happens to be the cwd. Callers
+    pass their own ``-u``/``-m``/arguments as usual; this only guarantees the
+    isolation flag is present and FIRST, since interpreter options are
+    recognised only before ``-m``/``-c``.
+
+    ``sys.executable`` is read at call time and never cached: a runtime is
+    started by whichever interpreter is current, so an upgrade that replaces
+    the install under a long-lived parent is picked up by its next child.
+    """
+    return [sys.executable, SAFE_PATH_FLAG, *args]

--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -57,6 +57,7 @@ from pydantic import AnyUrl
 
 from local_operator.ansi import strip_control_sequences
 from local_operator.callback_page import callback_response
+from local_operator.interpreter import python_argv
 
 if TYPE_CHECKING:
     # The SDK is an optional extra: these names are needed for annotations
@@ -317,9 +318,13 @@ async def open_browser_quietly(url: str) -> bool:
 
     try:
         process = await asyncio.create_subprocess_exec(
-            sys.executable,
-            "-c",
-            _BROWSER_OPEN_SNIPPET,
+            # ``python_argv``: ``-c`` puts the cwd on ``sys.path`` too, so a
+            # file named ``webbrowser.py`` sitting in the session's directory
+            # shadows the stdlib module this snippet depends on (verified: the
+            # child raises out of the stray file instead of opening a browser).
+            # A user's OAuth login is not the place to execute whatever happens
+            # to share a name with a stdlib module.
+            *python_argv("-c", _BROWSER_OPEN_SNIPPET),
             url,
             stdin=asyncio.subprocess.DEVNULL,
             stdout=asyncio.subprocess.PIPE,

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -1692,8 +1692,7 @@ class MobileDaemon:
             # An observer daemon cannot adopt what it spawns (it never dials),
             # so a spawned child would be orphaned from its own control plane.
             raise RuntimeError("observer daemon cannot start sessions")
-        import sys
-
+        from local_operator.interpreter import python_argv
         from local_operator.mobile.attach_client import find_owner_record
         from local_operator.paths import config_dir
 
@@ -1726,9 +1725,13 @@ class MobileDaemon:
         # enclosing process. The child's existing adopt path mints this exact ID.
         env.pop("LOP_RUNTIME_DEFER_MATERIALISE", None)
         process = await asyncio.create_subprocess_exec(
-            sys.executable,
-            "-m",
-            "local_operator.session.runtime.process",
+            # ``python_argv``: this spawn passes no ``cwd=`` either, so without
+            # the isolation flag a daemon started from a checkout of this
+            # project would run that checkout instead of the install — the same
+            # defect as the viewer's spawn in ``session/runtime/launch.py``, and
+            # harder to notice here because nobody is watching a phone daemon's
+            # version. See :mod:`local_operator.interpreter`.
+            *python_argv("-m", "local_operator.session.runtime.process"),
             env=env,
             # Detached stdio: the child speaks through its record and socket;
             # a pipe back to the daemon would die with the daemon and take

--- a/local_operator/session/runtime/launch.py
+++ b/local_operator/session/runtime/launch.py
@@ -60,13 +60,14 @@ import asyncio
 import logging
 import os
 import subprocess
-import sys
 import tempfile
 import time
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Union
+
+from local_operator.interpreter import SAFE_PATH_FLAG
 
 logger = logging.getLogger(__name__)
 
@@ -298,7 +299,19 @@ def _spawn_runtime(
         argv0 = procname.branded_argv0(procname.LABEL_SESSION_ANON, id=str(session_id)[:8])
     try:
         process = subprocess.Popen(  # noqa: S603 — fixed argv, no shell
-            [argv0, "-m", "local_operator.session.runtime.process"],
+            # TWO INDEPENDENT PROPERTIES ON ONE SPAWN, both required.
+            # ``python_argv``'s flag supplies import isolation: this spawn passes
+            # no ``cwd=``, so the child inherits the viewer's directory, and
+            # ``-m`` would put that directory on ``sys.path`` ahead of
+            # site-packages. A session whose cwd is a checkout of this project
+            # then runs the CHECKOUT rather than the install — which is how live
+            # runtimes ended up pinned to a superseded build. See
+            # :mod:`local_operator.interpreter`.
+            # ``argv0``/``executable`` supply the process NAME (see
+            # :mod:`local_operator.procname`). They are orthogonal: the label
+            # replaces argv[0] only, and the flag must stay at index 1, because
+            # interpreter options are recognised only before ``-m``.
+            [argv0, SAFE_PATH_FLAG, "-m", "local_operator.session.runtime.process"],
             executable=executable,
             env=env,
             stdin=subprocess.DEVNULL,

--- a/local_operator/session/runtime/launch.py
+++ b/local_operator/session/runtime/launch.py
@@ -60,6 +60,7 @@ import asyncio
 import logging
 import os
 import subprocess
+import sys
 import tempfile
 import time
 import uuid
@@ -300,7 +301,7 @@ def _spawn_runtime(
     try:
         process = subprocess.Popen(  # noqa: S603 — fixed argv, no shell
             # TWO INDEPENDENT PROPERTIES ON ONE SPAWN, both required.
-            # ``python_argv``'s flag supplies import isolation: this spawn passes
+            # ``SAFE_PATH_FLAG`` supplies import isolation: this spawn passes
             # no ``cwd=``, so the child inherits the viewer's directory, and
             # ``-m`` would put that directory on ``sys.path`` ahead of
             # site-packages. A session whose cwd is a checkout of this project

--- a/local_operator/tools/eval.py
+++ b/local_operator/tools/eval.py
@@ -52,6 +52,7 @@ from local_operator.harness.types import (
     ToolContext,
     ToolResult,
 )
+from local_operator.interpreter import SAFE_PATH_FLAG
 from local_operator.tools.builtin import (
     TOOL_OUTPUT_LIMIT_CHARS,
     TRACEBACK_TAIL_CHARS,
@@ -505,7 +506,19 @@ async def _spawn(cwd: str, session_key: str = "") -> _Kernel:
         spawn_options["executable"] = str(link)
         argv0 = procname.branded_argv0(procname.LABEL_EVAL, id=_label_id(session_key))
     process = await asyncio.create_subprocess_exec(
+        # ``SAFE_PATH_FLAG`` even though this worker is the one child that WANTS
+        # the cwd importable: this spawn passes ``cwd=`` explicitly, so without
+        # the flag a session whose directory is a checkout of this project would
+        # load the harness protocol module from that checkout and could speak a
+        # different protocol version than the parent. The worker restores its
+        # own cwd for USER code after its own imports have resolved — see
+        # ``eval_worker._enable_cwd_imports``, which is what keeps
+        # ``import my_module`` working in a cell.
+        # ``argv0`` above is the process LABEL and replaces only argv[0]; the
+        # flag must follow it, since interpreter options are recognised only
+        # before ``-m``. Both properties are required on this one spawn.
         argv0,
+        SAFE_PATH_FLAG,
         "-u",
         "-m",
         "local_operator.tools.eval_worker",

--- a/local_operator/tools/eval_worker.py
+++ b/local_operator/tools/eval_worker.py
@@ -53,6 +53,7 @@ import ast
 import contextlib
 import io
 import json
+import os
 import reprlib
 import shlex
 import subprocess
@@ -573,10 +574,34 @@ def _handle(namespace: dict[str, Any], request: dict[str, Any]) -> dict[str, Any
     }
 
 
+def _enable_cwd_imports() -> None:
+    """Put the worker's cwd back on ``sys.path`` for USER code.
+
+    The parent launches this worker with ``-P`` (see
+    :mod:`local_operator.interpreter`) so that the harness modules imported
+    during startup resolve to the INSTALLED distribution rather than to a
+    checkout of this project that merely happens to be the session's working
+    directory. That flag also suppresses the implicit cwd entry that ordinary
+    Python gives a script, which user code legitimately relies on: a cell doing
+    ``import my_module`` beside the session's cwd must keep working, and
+    without this it fails with ``ModuleNotFoundError``.
+
+    Called AFTER this module's own imports have already bound — the ordering is
+    the whole point, and reversing it would reintroduce the defect ``-P`` is
+    here to fix. Appended, never inserted at position 0: user code gets its
+    workspace, but a stray module in the cwd still cannot shadow a stdlib or
+    harness import that the protocol itself depends on.
+    """
+    cwd = os.getcwd()
+    if cwd and cwd not in sys.path:
+        sys.path.append(cwd)
+
+
 def main() -> None:
     """Read requests, run them, answer — until stdin closes or the tool kills
     the process. Either ending is normal from this side: the tool owns the
     lifecycle (idle reaping, LRU eviction, timeout kill)."""
+    _enable_cwd_imports()
     namespace: dict[str, Any] = {
         "__name__": "__eval__",
         "__doc__": NAMESPACE_DOC,

--- a/local_operator/update.py
+++ b/local_operator/update.py
@@ -39,6 +39,8 @@ from enum import Enum
 from importlib.metadata import PackageNotFoundError, distribution, version
 from pathlib import Path
 from typing import Any, Callable, Literal
+from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 #: Same cache root the model catalogue uses, so there is one place to clear.
 _CACHE_DIR = Path("~/.local-operator/cache")
@@ -145,82 +147,114 @@ def installed_version() -> str:
     0.46.23 it had been installed at -- and the app showed that stale number to
     users in Settings > Updates (QA Q3 / UX U13).
 
-    PRECEDENCE: the HIGHER of the checkout's ``pyproject.toml`` and the install
-    metadata, when both are readable and parseable.
+    PRECEDENCE: the checkout's ``pyproject.toml`` when that checkout IS this
+    install (an editable install, verified through ``direct_url.json`` by
+    :func:`_editable_source_version`), otherwise the install metadata.
 
-    Not "the checkout always wins". Both sources are stale in opposite
-    directions and neither is authoritative on its own:
+    Not a maximum. This used to take the HIGHER of the two, on the argument that
+    both are stale in opposite directions -- metadata never moves with the tree,
+    while a stray ``pyproject.toml`` declaring an older version produced a
+    spurious "update available" (review round 2, MINOR-2) -- and that a maximum
+    therefore failed in the SAFE direction.
 
-    * metadata is written once at install time and never moves with the tree,
-      so a checkout at 0.49.0 reported the 0.46.23 it was installed at (QA Q3 /
-      UX U13) -- the bug this function exists to fix;
-    * a ``pyproject.toml`` is merely a file that happens to sit next to the
-      package, and one naming this project but declaring an older version (a
-      fixture, a scratch tree, a hand-edited ``version = "0.1.0"``) overrode
-      correct metadata and produced a spurious "update available" (review round
-      2, MINOR-2).
+    That argument only covers a stray NEWER file. A stray OLDER one drags the
+    number DOWN, and there is no direction of ``max`` that protects against
+    both, because the real defect was never the comparison: it was trusting a
+    file whose relationship to the running code had not been established. On a
+    real install a spawned child read a 0.51.0 checkout while running 0.51.5,
+    and the maximum could not help -- the wrong input simply won or lost on
+    magnitude.
 
-    Taking the maximum resolves both: the forward-moving tree wins over stale
-    metadata, and stale-looking file loses to metadata that knows better. It
-    also fails in the SAFE direction. The residual case is a deliberate checkout
-    of an OLDER tag alongside newer install metadata: this reports the newer
-    number and the user sees no update banner while running older code. That is
-    a missed banner rather than a false one, and this module already takes that
-    side of the trade -- see :func:`parse_version`, where an unparseable version
-    is treated as "not behind" because "a banner we cannot defend is worse than
-    none".
+    Once the source side is required to prove identity, the two are no longer
+    rival guesses about one unknown: a matched checkout is the live version of
+    the code that is executing and its metadata is a snapshot of an earlier
+    state, so the checkout is authoritative outright and the ordering is
+    irrelevant. When nothing proves identity there is only one input left.
 
-    A packaged (non-editable) install has no adjacent project file, so it never
-    takes this path and reports its metadata exactly as before; there is no
-    configuration in which a released build starts reading a stray file. Both an
-    editable install and a bare ``PYTHONPATH`` checkout are covered, which
-    matters because a leftover ``*.egg-info`` in the tree shadows the installed
-    distribution entirely and made "is this editable?" the wrong question.
+    A packaged (non-editable) install has no editable ``direct_url.json``, so it
+    reports its metadata exactly as before -- including when a checkout of this
+    project is sitting in the working directory, which is the case that broke.
     """
     source = _editable_source_version()
     try:
         metadata = version("local-operator")
     except PackageNotFoundError:
         metadata = ""
-    if not source:
-        return metadata
-    if not metadata:
-        return source
-    # Compare on parsed tuples; an unparseable side cannot be ordered, so the
-    # other one is the only defensible answer.
-    source_parts, metadata_parts = parse_version(source), parse_version(metadata)
-    if source_parts is None:
-        return metadata
-    if metadata_parts is None:
-        return source
-    return source if source_parts >= metadata_parts else metadata
+    # ``source`` is non-empty only when the imported tree was proven to be this
+    # install's editable source, so it describes the running code and wins
+    # outright. No comparison: an older matched checkout is a real downgrade of
+    # the code in memory, not a stale reading to be corrected upward.
+    return source or metadata
+
+
+def _editable_install_root() -> Path | None:
+    """The source tree an EDITABLE install of this project points at, if any.
+
+    PEP 610 records the origin of an editable install in ``direct_url.json`` as
+    a ``file://`` URL with ``dir_info.editable`` true. That URL is the one piece
+    of evidence that says which checkout the installed distribution actually
+    resolves to, as opposed to which checkout merely happens to be lying around.
+
+    ``None`` whenever this is not an editable install, the marker is missing, or
+    the URL is not a readable local path — every one of which means "no checkout
+    is authoritative here", which is the safe answer for the only caller.
+    """
+    data = _direct_url_payload()
+    if data is None:
+        return None
+    dir_info = data.get("dir_info")
+    editable = data.get("editable") is True or (
+        isinstance(dir_info, dict) and dir_info.get("editable") is True
+    )
+    if not editable:
+        return None
+    url = data.get("url")
+    if not isinstance(url, str) or not url.startswith("file:"):
+        return None
+    try:
+        return Path(url2pathname(urlparse(url).path)).resolve()
+    except (OSError, ValueError):
+        return None
 
 
 def _editable_source_version() -> str:
-    """The version in the checkout's ``pyproject.toml``, when code runs FROM it.
+    """The checkout's ``pyproject.toml`` version — only when it IS the install.
 
-    Two stale-metadata layouts produce the same wrong answer, and both are
-    normal for a working tree:
+    An editable install's ``dist-info`` is written once and never moves with the
+    tree, so a checkout at 0.49.0 reported the 0.46.23 it was installed at and
+    the app showed that stale number in Settings > Updates (QA Q3 / UX U13).
+    Reading the adjacent ``pyproject.toml`` fixes that — but only if the file
+    describes the code that is actually running.
 
-    * an editable install, whose ``dist-info`` is written once at install time;
-    * a leftover ``*.egg-info`` in the checkout, which shadows the installed
-      distribution entirely and is a gitignored build artifact nothing
-      refreshes.
+    IDENTITY, NOT ADJACENCY. This previously trusted any ``pyproject.toml``
+    sitting beside the imported package, on the reasoning that a released build
+    has no adjacent project file and so could never read a stray one. That
+    reasoning was false, and the failure was measured on a real install: a
+    spawned child whose working directory was a checkout of this project
+    imported THAT checkout (``-m`` puts the cwd on ``sys.path`` ahead of
+    site-packages — the defect :mod:`local_operator.interpreter` now prevents),
+    so ``Path(__file__)`` pointed into a tree the install had nothing to do
+    with. A 0.51.5 install reported 0.51.0, and its stale ``*.egg-info``
+    shadowed the real dist-info down to 0.49.3 as well.
 
-    Rather than distinguish them, this asks the question that actually matters:
-    is the imported package sitting next to a ``pyproject.toml``? If so the
-    running code IS that checkout, and the checkout's version is the truth
-    while any metadata is a copy of some earlier state.
+    So the checkout wins only when ``direct_url.json`` names it as the editable
+    source of the installed distribution. A stray tree — a scratch clone, a
+    worktree that merely happens to be the cwd, a fixture — is now ignored, and
+    the caller falls back to metadata that at least describes a real install.
 
-    Deliberately cheap and total: any doubt (no adjacent project file, an
-    unreadable or unexpected one) returns ``""`` so the caller falls back to
-    metadata rather than inventing a number.
+    Still cheap and total: any doubt (no editable install, a mismatched root, an
+    unreadable or unexpected file) returns ``""``, and nothing here may raise.
     """
     try:
         import tomllib
 
         # local_operator/update.py -> local_operator/ -> the checkout root.
-        pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+        root = Path(__file__).resolve().parent.parent
+        # The imported tree must BE the tree this install was made editable
+        # from; adjacency alone proves nothing about which code is running.
+        if root != _editable_install_root():
+            return ""
+        pyproject = root / "pyproject.toml"
         if not pyproject.is_file():
             return ""
         with pyproject.open("rb") as handle:

--- a/local_operator/update.py
+++ b/local_operator/update.py
@@ -36,11 +36,18 @@ import tempfile
 import time
 from dataclasses import dataclass
 from enum import Enum
-from importlib.metadata import PackageNotFoundError, distribution, version
+from importlib.metadata import (
+    PackageNotFoundError,
+    distribution,
+    distributions,
+    version,
+)
 from pathlib import Path
 from typing import Any, Callable, Literal
 from urllib.parse import urlparse
 from urllib.request import url2pathname
+
+from local_operator.interpreter import python_argv
 
 #: Same cache root the model catalogue uses, so there is one place to clear.
 _CACHE_DIR = Path("~/.local-operator/cache")
@@ -413,18 +420,43 @@ def check_latest(
 
 
 def _direct_url_payload() -> dict[str, Any] | None:
-    try:
-        dist = distribution("local-operator")
-    except PackageNotFoundError:
-        return None
-    text = dist.read_text("direct_url.json")
-    if not text:
-        return None
-    try:
-        data = json.loads(text)
-    except ValueError:
-        return None
-    return data if isinstance(data, dict) else None
+    """PEP 610 ``direct_url.json`` from the distribution that actually has one.
+
+    NOT ``distribution("local-operator")``. That returns the FIRST name match in
+    ``sys.path`` order, and a leftover ``local_operator.egg-info/`` in a checkout
+    -- a gitignored build artifact any ``pip install -e``/``setup.py`` run leaves
+    behind, present in real checkouts -- sits earlier than site-packages whenever
+    the cwd is on the path. Egg-info metadata predates PEP 610 and carries no
+    ``direct_url.json``, so the shadow made a genuine editable install look like
+    no install at all: ``_editable_install_root()`` returned ``None``, the
+    identity check in :func:`_editable_source_version` failed against its own
+    tree, and ``installed_version()`` fell through to the stale ``PKG-INFO``
+    number the egg-info advertised. Measured on a real ``uv pip install -e`` with
+    ``pyproject.toml`` at 0.51.7 and a leftover ``PKG-INFO`` at 0.46.23, that
+    reported 0.46.23 -- the very Settings > Updates staleness (QA Q3 / UX U13)
+    this module exists to prevent, reintroduced by the shadow rather than by any
+    version comparison.
+
+    So scan every installed distribution of this name and take the first that
+    publishes the marker. The marker is the evidence; a distribution without one
+    cannot answer the question and must not be allowed to answer it negatively.
+
+    Deliberately NOT "accept an egg-info found inside the candidate root": that
+    reasoning is adjacency again -- a STRAY checkout's egg-info also lives inside
+    that stray checkout, so it would vouch for exactly the unrelated tree this
+    function's caller was rewritten to reject.
+    """
+    for dist in distributions(name="local-operator"):
+        text = dist.read_text("direct_url.json")
+        if not text:
+            continue
+        try:
+            data = json.loads(text)
+        except ValueError:
+            continue
+        if isinstance(data, dict):
+            return data
+    return None
 
 
 def _is_editable_direct_url() -> bool:
@@ -792,9 +824,19 @@ def _mobile_restart_argv() -> list[str] | None:
     the one just upgraded, and restarting that would serve the wrong
     build while reporting success. If this interpreter is gone after the
     upgrade, the refresh fails honestly and the copy names the recovery.
+
+    ``python_argv`` (not a bare ``-m``), because the sentence above is only
+    true with it. :func:`refresh_mobile_after_upgrade` runs this argv with no
+    ``cwd=``, so the child inherits the directory the update was started from —
+    ``update.py``'s own ``lop update`` and the in-TUI ``/update`` worker both
+    run with a user or session cwd. When that directory is a checkout of this
+    project, ``-m`` puts it on ``sys.path`` ahead of site-packages and the
+    bounce restarts the daemon through the CHECKOUT: pre-upgrade code, running
+    under the post-upgrade interpreter, reporting success. See
+    :mod:`local_operator.interpreter`.
     """
     if sys.executable and Path(sys.executable).exists():
-        return [sys.executable, "-m", "local_operator.cli", "mobile", "restart"]
+        return python_argv("-m", "local_operator.cli", "mobile", "restart")
     return None
 
 

--- a/tests/unit/mobile/test_phone_startup.py
+++ b/tests/unit/mobile/test_phone_startup.py
@@ -70,7 +70,15 @@ def fixture_children(monkeypatch):
     children = []
 
     async def spawn(*args, **kwargs):
-        assert args == (sys.executable, "-m", "local_operator.session.runtime.process")
+        # ``-P`` is part of the contract, not decoration: without it the child
+        # imports whatever checkout happens to be the cwd instead of the
+        # installed distribution (see local_operator.interpreter).
+        assert args == (
+            sys.executable,
+            "-P",
+            "-m",
+            "local_operator.session.runtime.process",
+        )
         assert kwargs["start_new_session"] is True
         assert "LOP_RUNTIME_DEFER_MATERIALISE" not in kwargs["env"]
         child = await actual_spawn(sys.executable, "-c", CHILD, **kwargs)

--- a/tests/unit/session/runtime/test_launch_arbitration.py
+++ b/tests/unit/session/runtime/test_launch_arbitration.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import sys
 import time
 from pathlib import Path
 from typing import Any
@@ -45,6 +46,10 @@ from local_operator.session.runtime.types import SessionRecord
 from local_operator.session_lease import SessionLeaseHeldError, acquire_session_lease
 
 SESSION_ID = "sessionaaa01"
+
+#: Distinguishes "no ``cwd=`` was passed" from "``cwd=None`` was passed"; the
+#: spawn contract under test is the ABSENCE of the kwarg, not a null value.
+_MISSING = object()
 
 
 class FakeRuntimeFleet:
@@ -485,6 +490,78 @@ async def test_a_child_that_dies_reports_its_own_reason_not_a_generic_failure(
     assert "Settings > Providers" in raised.value.actionable
     assert "Traceback" not in raised.value.actionable
     assert "x.py" not in raised.value.actionable
+
+
+def test_spawn_runtime_argv_isolates_the_import_and_names_the_process(
+    tmp_path, monkeypatch
+) -> None:
+    """The REAL argv `_spawn_runtime` builds -- the line that fixes the bug.
+
+    WHY THIS EXISTS AND WHY IT ASSERTS ON THE PRODUCTION CALL. Every other
+    reference to `_spawn_runtime` in this module monkeypatches it away, because
+    arbitration is what those tests are about. The consequence was that the one
+    line this PR exists for -- the isolation flag on the `/new` spawn -- was
+    pinned by NOTHING: reverting it to the base argv left the whole suite green
+    (measured: 368 passed), while the PR's five other spawn sites were each
+    explicitly pinned. A guard that cannot go red is a decoration, which is this
+    change's own thesis, so its headline fix must not be the exception (QA Q2).
+
+    So `subprocess.Popen` is faked and `_spawn_runtime` itself is REAL. A test
+    that stubs `_spawn_runtime` cannot observe this argv at all, which is
+    exactly how the hole was created.
+
+    Both properties are asserted together because they are built at one call and
+    a clean merge can drop either half independently: the flag must sit at index
+    1 (interpreter options are only recognised BEFORE `-m`), and argv[0] carries
+    the process label whenever a branded image exists.
+    """
+    from local_operator.interpreter import SAFE_PATH_FLAG
+    from local_operator.session.runtime import launch as launch_module
+
+    recorded: dict[str, Any] = {}
+
+    class _Popen:
+        returncode = None
+
+        def poll(self):
+            return None
+
+        def kill(self):
+            return None
+
+    def fake_popen(argv, **kwargs: Any):
+        recorded["argv"] = list(argv)
+        recorded["executable"] = kwargs.get("executable")
+        # No `cwd=` is the whole reason the flag is required: the child would
+        # otherwise inherit the viewer's directory and import a checkout there.
+        recorded["cwd"] = kwargs.get("cwd", _MISSING)
+        return _Popen()
+
+    monkeypatch.setattr(launch_module.subprocess, "Popen", fake_popen)
+    process = launch_module._spawn_runtime("sess-argv01", str(tmp_path), defer_materialise=True)
+    capture = getattr(process, "lop_capture_path", None)
+    if capture is not None:
+        capture.unlink(missing_ok=True)
+
+    argv = recorded["argv"]
+    assert argv[1] == SAFE_PATH_FLAG, (
+        "the /new spawn lost its import-isolation flag: a session whose cwd is a "
+        f"checkout of this project will run THAT checkout, not the install. argv={argv}"
+    )
+    assert argv.index(SAFE_PATH_FLAG) < argv.index(
+        "-m"
+    ), f"the flag must precede -m or the interpreter ignores it; argv={argv}"
+    assert argv[2:] == ["-m", "local_operator.session.runtime.process"], argv
+    # Still no `cwd=`: if one is ever added the flag stops being the thing that
+    # protects the import, and this assertion should be revisited deliberately.
+    assert recorded["cwd"] is _MISSING, f"spawn grew a cwd= kwarg: {recorded['cwd']!r}"
+
+    # argv[0] is the process LABEL when a branded image exists (`executable=`
+    # then carries the real image), and the bare interpreter when it does not.
+    if recorded["executable"]:
+        assert argv[0].startswith("Local Operator [session] id="), argv[0]
+    else:
+        assert argv[0] == sys.executable, argv[0]
 
 
 def test_spawn_capture_is_private_and_anonymous(tmp_path, monkeypatch) -> None:

--- a/tests/unit/test_cli_new.py
+++ b/tests/unit/test_cli_new.py
@@ -1558,9 +1558,12 @@ def test_a_background_job_carries_the_session_it_was_told_to_resume() -> None:
     assert argv[argv.index("--resume") + 1] == "sess-abc123"
 
     # And the worker on the other side accepts what was serialized — parsed from
-    # the real argv minus the `python -m <module>` prefix, so the test breaks if
-    # the serialization and the worker's parser ever disagree.
-    assert build_parser().parse_args(argv[3:]).resume == "sess-abc123"
+    # the real argv minus the `python [flags] -m <module>` prefix, so the test
+    # breaks if the serialization and the worker's parser ever disagree.
+    # The prefix length is DERIVED rather than hardcoded: interpreter flags sit
+    # between the executable and `-m` (see local_operator.interpreter), so a
+    # fixed slice silently turns into a parser error when one is added.
+    assert build_parser().parse_args(argv[argv.index("-m") + 2 :]).resume == "sess-abc123"
 
     # Nothing is emitted when nothing was asked for.
     assert "--resume" not in build_worker_argv("hi", ExecArgs())

--- a/tests/unit/test_exec_mode.py
+++ b/tests/unit/test_exec_mode.py
@@ -42,6 +42,7 @@ from local_operator.harness.types import (
     ToolExecutionStartEvent,
     ToolResult,
 )
+from local_operator.interpreter import SAFE_PATH_FLAG
 from local_operator.headless_print import PrintRenderer, printable_event, run_print_mode
 from local_operator.paths import CONFIG_DIR_ENV
 from local_operator.session.naming import ConversationName
@@ -275,10 +276,13 @@ def test_build_worker_argv_roundtrip() -> None:
         model="gpt-4o",
     )
     argv = build_worker_argv("do it", args)
-    assert argv[:3] == [sys.executable, "-m", "local_operator.exec_worker"]
-    assert argv[3:5] == ["--prompt", "do it"]
+    # ``-P`` before ``-m``: interpreter options are only recognised there, and
+    # without it a background exec started inside a checkout of this project
+    # runs that checkout (see local_operator.interpreter).
+    assert argv[:4] == [sys.executable, "-P", "-m", "local_operator.exec_worker"]
+    assert argv[4:6] == ["--prompt", "do it"]
     # Every set flag serializes; parse it back through the worker parser.
-    parsed = exec_worker.build_parser().parse_args(argv[3:])
+    parsed = exec_worker.build_parser().parse_args(argv[argv.index("-m") + 2 :])
     assert parsed.prompt == "do it"
     assert parsed.json_mode is True
     assert parsed.yolo is True
@@ -292,7 +296,7 @@ def test_build_worker_argv_roundtrip() -> None:
 def test_build_worker_argv_train_threaded_to_worker(monkeypatch: pytest.MonkeyPatch) -> None:
     """CL-05: ExecArgs.train reaches the session-factory namespace via argv."""
     argv = build_worker_argv("t", ExecArgs(train=True))
-    parsed = exec_worker.build_parser().parse_args(argv[3:])
+    parsed = exec_worker.build_parser().parse_args(argv[argv.index("-m") + 2 :])
     assert parsed.train is True
     # And the worker's factory passes it into the session args namespace.
     seen: dict[str, Any] = {}
@@ -311,7 +315,7 @@ def test_build_worker_argv_train_threaded_to_worker(monkeypatch: pytest.MonkeyPa
 
 def test_build_worker_argv_omits_unset_flags() -> None:
     argv = build_worker_argv("bare", ExecArgs())
-    parsed = exec_worker.build_parser().parse_args(argv[3:])
+    parsed = exec_worker.build_parser().parse_args(argv[argv.index("-m") + 2 :])
     assert parsed.prompt == "bare"
     assert parsed.json_mode is False
     assert parsed.agent is None
@@ -330,7 +334,7 @@ def test_build_worker_argv_threads_control_to_the_worker() -> None:
     """
     argv = build_worker_argv("do it", ExecArgs(control=True))
     assert "--control" in argv
-    parsed = exec_worker.build_parser().parse_args(argv[3:])
+    parsed = exec_worker.build_parser().parse_args(argv[argv.index("-m") + 2 :])
     assert parsed.control is True
 
 
@@ -756,16 +760,20 @@ def test_run_exec_background_spawn(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
     argv = popen_mock.call_args[0][0]
     kwargs = popen_mock.call_args[1]
 
-    # argv[0] is the process LABEL when a branded interpreter image exists
-    # (`executable=` then carries the real image), and the bare interpreter
-    # when it does not. Both are correct; what must never drift is the module
-    # and the request that follow it. See `local_operator.procname`.
+    # BOTH properties on the one spawn, asserted together because they are the
+    # two halves that a merge can silently drop one of: argv[0] is the process
+    # LABEL when a branded interpreter image exists (`executable=` then carries
+    # the real image) and the bare interpreter when it does not, while
+    # `SAFE_PATH_FLAG` at index 1 keeps a background exec on the installed build
+    # rather than a checkout that happens to be the user's cwd. See
+    # `local_operator.procname` and `local_operator.interpreter`.
     if kwargs.get("executable"):
         assert os.path.basename(kwargs["executable"]) == "Local Operator"
         assert argv[0].startswith("Local Operator [exec] job=")
     else:
         assert argv[0] == sys.executable
     assert argv[1:5] == [
+        SAFE_PATH_FLAG,
         "-m",
         "local_operator.exec_worker",
         "--prompt",

--- a/tests/unit/test_exec_mode.py
+++ b/tests/unit/test_exec_mode.py
@@ -42,8 +42,8 @@ from local_operator.harness.types import (
     ToolExecutionStartEvent,
     ToolResult,
 )
-from local_operator.interpreter import SAFE_PATH_FLAG
 from local_operator.headless_print import PrintRenderer, printable_event, run_print_mode
+from local_operator.interpreter import SAFE_PATH_FLAG
 from local_operator.paths import CONFIG_DIR_ENV
 from local_operator.session.naming import ConversationName
 from local_operator.session.protocol import CompactionOutcome
@@ -772,8 +772,12 @@ def test_run_exec_background_spawn(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
         assert argv[0].startswith("Local Operator [exec] job=")
     else:
         assert argv[0] == sys.executable
-    assert argv[1:5] == [
-        SAFE_PATH_FLAG,
+    # Offset DERIVED, not hardcoded: a fixed slice is what broke when this PR
+    # inserted the isolation flag ahead of `-m`, and it failed as an opaque
+    # index error rather than naming the cause. Deriving it means another
+    # interpreter flag later cannot silently reintroduce that.
+    assert argv[1] == SAFE_PATH_FLAG
+    assert argv[argv.index("-m") :][:4] == [
         "-m",
         "local_operator.exec_worker",
         "--prompt",

--- a/tests/unit/test_interpreter_isolation.py
+++ b/tests/unit/test_interpreter_isolation.py
@@ -1,0 +1,179 @@
+"""A spawned child must import the INSTALL, never a checkout that is merely the cwd.
+
+WHY THESE ASSERT ON THE IMPORTED TREE, NOT ON THE ARGV
+------------------------------------------------------
+``-P`` in an argv list is the mechanism; the behaviour is which
+``local_operator/__init__.py`` the child actually binds. A test that only
+checks the flag is present passes just as happily if CPython changes what the
+flag does, or if a later edit reorders it after ``-m`` where the interpreter
+stops recognising it. So each test here spawns a REAL child from a directory
+containing a decoy package and asserts on the path the child reports importing.
+
+The decoy is a fake ``local_operator`` package rather than a real checkout:
+building one would cost a clone per test, and the property under test is only
+"does the cwd shadow site-packages", which any importable directory of that
+name demonstrates exactly as well.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from local_operator.interpreter import SAFE_PATH_FLAG, python_argv
+
+#: Reports which tree the name resolved to, and nothing else, so a failure
+#: message names the offending path rather than merely saying "False".
+_PROBE = "import local_operator; print(local_operator.__file__)"
+
+
+def _decoy_tree(root: Path) -> Path:
+    """A directory holding a package that would shadow the real one.
+
+    Marked with a sentinel attribute so a child importing it is unmistakable —
+    a wrong path could otherwise be misread as a venv layout difference.
+    """
+    package = root / "local_operator"
+    package.mkdir(parents=True, exist_ok=True)
+    (package / "__init__.py").write_text("DECOY = True\n", encoding="utf-8")
+    return root
+
+
+def _isolated_env() -> dict[str, str]:
+    """Environment for a child that must not touch the developer's real state.
+
+    Every ``CMUX_*`` variable is dropped: an inherited workspace id has
+    previously let a headless test rename a real cmux workspace.
+    """
+    env = {key: value for key, value in os.environ.items() if not key.startswith("CMUX_")}
+    # Must not leak in and mask the very difference these tests measure.
+    env.pop("PYTHONSAFEPATH", None)
+    return env
+
+
+def _run(argv: list[str], cwd: Path) -> str:
+    result = subprocess.run(
+        argv, cwd=str(cwd), env=_isolated_env(), capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, f"child failed: {result.stderr}"
+    return result.stdout.strip()
+
+
+def test_bare_dash_m_imports_the_cwd_and_is_the_defect(tmp_path: Path) -> None:
+    """The defect itself, pinned so the fix below is measured against something.
+
+    This is what every spawn site did before: no ``cwd=``, so the child inherits
+    the parent's directory, and ``-m``/``-c`` put that directory on
+    ``sys.path[0]`` AHEAD of site-packages. On a real install this made a
+    runtime import a 0.51.0 worktree while the install was 0.51.5.
+    """
+    root = _decoy_tree(tmp_path)
+    imported = _run([sys.executable, "-c", _PROBE], root)
+    assert imported == str(root / "local_operator" / "__init__.py"), (
+        "expected the unprotected child to import the cwd decoy; if this fails the "
+        "premise of this module changed and the fix below proves nothing"
+    )
+
+
+def test_python_argv_child_ignores_a_package_in_the_cwd(tmp_path: Path) -> None:
+    """The fix: same interpreter, same cwd, resolves the installed package."""
+    root = _decoy_tree(tmp_path)
+    imported = _run(python_argv("-c", _PROBE), root)
+    assert imported != str(root / "local_operator" / "__init__.py")
+    # Positive assertion too: "not the decoy" would also be satisfied by an
+    # unrelated failure mode, so name the tree it MUST have resolved to.
+    import local_operator
+
+    assert Path(imported) == Path(local_operator.__file__)
+
+
+def test_isolation_flag_precedes_the_module_selector() -> None:
+    """``-P`` after ``-m`` is consumed by the module, not by the interpreter.
+
+    Ordering is silent when wrong — the child still starts, still runs, and
+    still imports the checkout — so it is asserted rather than left to review.
+    """
+    argv = python_argv("-m", "local_operator.cli")
+    assert argv[0] == sys.executable
+    assert argv[1] == SAFE_PATH_FLAG
+    assert argv.index(SAFE_PATH_FLAG) < argv.index("-m")
+
+
+def test_isolation_does_not_leak_into_grandchildren(tmp_path: Path) -> None:
+    """Why the FLAG and not ``PYTHONSAFEPATH=1`` in the child's env.
+
+    The variable is inherited by the whole process subtree; the flag is not. A
+    runtime spawned by these call sites goes on to run the agent's ``bash``
+    tool, which copies ``os.environ`` into every command it executes — so the
+    variable form would strip ``sys.path[0]`` from every ``python`` the USER
+    runs in their own project, breaking ``import my_module`` beside a script.
+    That is a total break of ordinary Python semantics in the user's workspace,
+    caused by an isolation flag meant only to protect our own import.
+    """
+    root = _decoy_tree(tmp_path)
+    grandchild = (
+        "import subprocess, sys; "
+        f"print(subprocess.run([sys.executable, '-c', {_PROBE!r}], "
+        "capture_output=True, text=True).stdout.strip())"
+    )
+    # The flag protects the child but leaves the grandchild with normal rules,
+    # so the grandchild still sees the cwd package.
+    assert _run(python_argv("-c", grandchild), root) == str(root / "local_operator" / "__init__.py")
+
+    # The variable form, by contrast, reaches the grandchild too.
+    env = _isolated_env()
+    env["PYTHONSAFEPATH"] = "1"
+    leaked = subprocess.run(
+        [sys.executable, "-c", grandchild],
+        cwd=str(root),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert leaked.returncode == 0, leaked.stderr
+    assert leaked.stdout.strip() != str(root / "local_operator" / "__init__.py")
+
+
+def test_eval_worker_restores_cwd_imports_for_user_code(tmp_path: Path) -> None:
+    """``-P`` must not cost the eval tool its workspace imports.
+
+    The worker runs USER code, so a cell doing ``import my_module`` next to the
+    session's cwd has to keep working. ``_enable_cwd_imports`` puts the cwd back
+    AFTER the worker's own imports have resolved — this asserts both halves of
+    that ordering at once: the harness module came from the install, and the
+    user module still resolved from the cwd.
+    """
+    root = _decoy_tree(tmp_path)
+    (root / "usermod.py").write_text("VALUE = 'from the workspace'\n", encoding="utf-8")
+    probe = (
+        "from local_operator.tools.eval_worker import _enable_cwd_imports; "
+        "import local_operator; "
+        "_enable_cwd_imports(); "
+        "import usermod; "
+        "print(local_operator.__file__); print(usermod.VALUE)"
+    )
+    out = _run(python_argv("-c", probe), root).splitlines()
+    import local_operator
+
+    assert Path(out[0]) == Path(local_operator.__file__), "harness must bind to the install"
+    assert out[1] == "from the workspace", "user code must still import from the cwd"
+
+
+def test_cwd_restore_appends_so_it_cannot_shadow_harness_imports(tmp_path: Path) -> None:
+    """The restore appends rather than inserting at position 0.
+
+    A stray module in a user's directory must not be able to take over a name
+    the protocol itself imports; giving user code its workspace is not a licence
+    to let it shadow the worker's own dependencies.
+    """
+    root = _decoy_tree(tmp_path)
+    probe = (
+        "from local_operator.tools.eval_worker import _enable_cwd_imports; "
+        "_enable_cwd_imports(); "
+        "import local_operator; print(local_operator.__file__)"
+    )
+    imported = _run(python_argv("-c", probe), root)
+    assert imported != str(root / "local_operator" / "__init__.py")

--- a/tests/unit/test_procname.py
+++ b/tests/unit/test_procname.py
@@ -31,6 +31,7 @@ from pathlib import Path
 import pytest
 
 from local_operator import procname
+from local_operator.interpreter import SAFE_PATH_FLAG
 
 pytestmark = pytest.mark.skipif(
     sys.platform != "darwin",
@@ -713,3 +714,58 @@ def test_branded_image_actually_renames_the_process(branded):
     )
     assert result.returncode == 0, f"branded image failed to launch: {result.stderr}"
     assert result.stdout.strip() == procname.BRAND
+
+
+def test_branded_image_and_import_isolation_hold_on_the_same_spawn(branded, tmp_path):
+    """BOTH properties on ONE process — the pair a clean merge can silently halve.
+
+    Branding and import isolation were developed in parallel and land on the
+    SAME spawn calls with disjoint arguments: branding replaces ``argv[0]`` and
+    passes ``executable=``, isolation inserts ``SAFE_PATH_FLAG`` before ``-m``.
+    Git merges that without a conflict, and neither side's own tests can observe
+    the other being dropped — a child that keeps isolation but loses
+    ``executable=`` imports the right code while going back to an anonymous
+    ``python3.x`` row, and the reverse keeps the name while keeping the
+    version-skew bug that left live runtimes reporting a superseded build.
+
+    So this asserts the CONJUNCTION from a real spawn, with a decoy checkout as
+    the working directory (the exact condition that produced the skew):
+
+    * the kernel reports ``proc_name == BRAND`` — Activity Monitor's axis, and
+    * the child imports ``local_operator`` from the install, not from the cwd.
+    """
+    decoy = tmp_path / "decoy-checkout"
+    (decoy / "local_operator").mkdir(parents=True)
+    (decoy / "local_operator" / "__init__.py").write_text("", encoding="utf-8")
+    decoy_module = (decoy / "local_operator" / "__init__.py").resolve()
+
+    probe = (
+        "import ctypes,os,local_operator;"
+        "l=ctypes.CDLL('/usr/lib/libSystem.dylib');"
+        "b=ctypes.create_string_buffer(64);"
+        "l.proc_name(ctypes.c_int(os.getpid()),b,ctypes.c_uint(64));"
+        "print(b.value.decode());"
+        "print(local_operator.__file__)"
+    )
+    # The branded link is planted into a throwaway prefix that has no
+    # site-packages, so the "install" this child must prefer is supplied on
+    # PYTHONPATH. That is deliberate and does not weaken the test: `-P` strips
+    # the implicit sys.path[0] (the cwd) and leaves PYTHONPATH alone, so the
+    # decoy and the install compete exactly as they do in production.
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2])
+    result = subprocess.run(
+        # Exactly the argv shape the spawn sites build: branded argv[0], then
+        # the isolation flag, then the request.
+        [procname.branded_argv0(procname.LABEL_WAKES), SAFE_PATH_FLAG, "-c", probe],
+        executable=str(branded),
+        cwd=str(decoy),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"spawn failed: {result.stderr}"
+    name, module = result.stdout.strip().splitlines()[:2]
+    assert name == procname.BRAND
+    assert Path(module).resolve() != decoy_module

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -1071,3 +1071,53 @@ def test_installed_version_rereads_disk_within_one_process(tmp_path: Path) -> No
         )
     finally:
         _sys.path.remove(str(site))
+
+
+def test_cli_version_flag_reports_the_running_build(tmp_path: Path) -> None:
+    """`--version` must answer from `installed_version()`, not raw metadata.
+
+    THE SURFACE THE USER CHECKS FIRST. Install metadata is written once and
+    never moves when the checkout's `pyproject.toml` does, so
+    `importlib.metadata.version("local-operator")` reports the version an
+    editable install was CREATED at rather than the one it is running — and a
+    leftover `*.egg-info` shadows the real dist-info downward on top of that.
+    `installed_version()` corrects both; `--version` used to bypass it, so the
+    one surface a user reads to answer "which build am I on?" was also the one
+    still answering from the stale channel. That was the reported symptom this
+    change ships with, so shipping it uncorrected invites a duplicate report of
+    the bug it fixes.
+
+    THE FIXTURE HAS TO CREATE THE DIVERGENCE, or the test is vacuous: in a
+    clean checkout both channels agree, so asserting they match passes just as
+    well on the bypassing form (verified — the first version of this test did).
+    So the editable source is pinned to a version the metadata does not have,
+    which is the ordinary state of any editable checkout after a release bump.
+
+    Driven as a REAL SUBPROCESS through the parser builder, because the value
+    is baked in at construction time by an `argparse` `action="version"`: an
+    in-process call reads whatever the already-imported `cli` module captured,
+    which is exactly what a stale `.pyc` would hide.
+    """
+    repo = Path(__file__).resolve().parents[2]
+    marker = "9.9.9"
+    # Force the two channels apart: `_editable_source_version` is the input
+    # `installed_version()` prefers, and no real metadata can report 9.9.9.
+    probe = (
+        "import local_operator.update as u;"
+        f"u._editable_source_version=lambda: {marker!r};"
+        "import local_operator.cli as c;"
+        "p=c.build_cli_parser();"
+        "a=[x for x in p._actions if '--version' in getattr(x,'option_strings',[])][0];"
+        "print(a.version)"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, cwd=str(repo)
+    )
+    assert out.returncode == 0, f"probe failed:\n{out.stderr[-2000:]}"
+    printed = out.stdout.strip().splitlines()[-1]
+    assert printed == f"v{marker}", (
+        "`--version` did not read through installed_version(): "
+        f"got {printed!r}, expected 'v{marker}'. A raw "
+        "importlib.metadata.version() call reports the installed metadata and "
+        "cannot see the running checkout's version."
+    )

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -14,6 +14,7 @@ import httpx
 import pytest
 
 from local_operator import update as update_mod
+from local_operator.interpreter import SAFE_PATH_FLAG
 from local_operator.update import (
     TTL_S,
     InstallKind,
@@ -534,8 +535,12 @@ def test_refresh_restarts_via_new_distribution() -> None:
         result = refresh_mobile_after_upgrade()
     assert result == MobileRefresh(kind="restarted")
     run.assert_called_once()
+    # `SAFE_PATH_FLAG`, and BEFORE `-m`: this runs with no `cwd=`, so a bare
+    # `-m` would restart the daemon through a checkout that merely happened to
+    # be the update's working directory -- pre-upgrade code reporting success.
     assert run.call_args.args[0] == [
         sys.executable,
+        SAFE_PATH_FLAG,
         "-m",
         "local_operator.cli",
         "mobile",
@@ -634,8 +639,12 @@ def test_update_command_restarted_prints_phone_line(capsys: pytest.CaptureFixtur
     ):
         assert update_command(check=False) == 0
     captured = capsys.readouterr()
+    # See `test_refresh_restarts_via_new_distribution`: the isolation flag has
+    # to survive the `lop update` path too, which is one of the two callers
+    # that runs with a user cwd.
     assert run.call_args.args[0] == [
         sys.executable,
+        SAFE_PATH_FLAG,
         "-m",
         "local_operator.cli",
         "mobile",
@@ -856,6 +865,102 @@ def test_editable_source_version_never_raises() -> None:
     """ "Cheap and total": a version readout must degrade to `""`, never throw."""
     with patch.object(update_mod, "_editable_install_root", side_effect=OSError("boom")):
         assert update_mod._editable_source_version() == ""
+
+
+def _metadata_dir(root: Path, name: str, version: str, direct_url: str | None = None) -> Path:
+    """Write a real on-disk metadata directory `importlib.metadata` can discover."""
+    path = root / name
+    path.mkdir(parents=True)
+    key = "METADATA" if name.endswith(".dist-info") else "PKG-INFO"
+    (path / key).write_text(
+        f"Metadata-Version: 2.1\nName: local-operator\nVersion: {version}\n", encoding="utf-8"
+    )
+    if direct_url is not None:
+        (path / "direct_url.json").write_text(direct_url, encoding="utf-8")
+    return path
+
+
+def test_direct_url_payload_ignores_a_shadowing_egg_info(tmp_path: Path) -> None:
+    """A stale `*.egg-info` must not make a real editable install look absent.
+
+    THE REGRESSION THIS PINS. `local_operator.egg-info/` is a gitignored build
+    artifact that any `pip install -e` / `setup.py` run leaves in the checkout,
+    so it is present in real trees. Whenever the cwd is on `sys.path` it sorts
+    AHEAD of site-packages, and `distribution("local-operator")` -- which
+    returns the first name match in path order -- resolves to it. Egg-info
+    metadata predates PEP 610 and carries no `direct_url.json`, so reading the
+    marker through that single lookup answered "not an editable install" for an
+    install that plainly was one: `_editable_install_root()` returned `None`,
+    the identity check failed against its own tree, and `installed_version()`
+    fell through to the stale `PKG-INFO` number.
+
+    Measured on a genuine `uv pip install -e` with `pyproject.toml` at 0.51.7
+    and a leftover `PKG-INFO` at 0.46.23, that reported **0.46.23** -- the
+    Settings > Updates staleness (QA Q3 / UX U13) reintroduced by the shadow.
+
+    Real metadata directories on disk, not a patched payload: the ordering IS
+    the defect, so a fixture that hands over one distribution cannot observe it.
+    """
+    site = tmp_path / "site"
+    # Written egg-info first so it is the earlier entry in discovery order,
+    # which is the shape that shadowed the dist-info on a real checkout.
+    _metadata_dir(site, "local_operator.egg-info", "0.46.23")
+    _metadata_dir(
+        site,
+        "local_operator-0.51.7.dist-info",
+        "0.51.7",
+        direct_url='{"url": "file:///real/checkout", "dir_info": {"editable": true}}',
+    )
+
+    def _scan(*, name: str) -> list[object]:
+        from importlib.metadata import distributions
+
+        return list(distributions(name=name, path=[str(site)]))
+
+    with patch.object(update_mod, "distributions", _scan):
+        # The egg-info is found FIRST and has no marker; the dist-info's must
+        # still be the answer, or a real editable install reads as no install.
+        assert update_mod._direct_url_payload() == {
+            "url": "file:///real/checkout",
+            "dir_info": {"editable": True},
+        }
+        assert update_mod._editable_install_root() == Path("/real/checkout").resolve()
+
+
+def test_installed_version_survives_a_shadowing_egg_info(tmp_path: Path) -> None:
+    """End to end: the checkout's version wins over the shadowed stale number.
+
+    `_direct_url_payload` is the unit; this is the number the user actually
+    sees. `version("local-operator")` still resolves to the egg-info's stale
+    0.46.23 (that shadowing is `importlib.metadata`'s behaviour and not ours to
+    change), so this asserts the correction survives all the way out.
+    """
+    site = tmp_path / "site"
+    checkout = tmp_path / "checkout"
+    (checkout / "local_operator").mkdir(parents=True)
+    (checkout / "pyproject.toml").write_text(
+        '[project]\nname = "local-operator"\nversion = "0.51.7"\n', encoding="utf-8"
+    )
+    _metadata_dir(site, "local_operator.egg-info", "0.46.23")
+    _metadata_dir(
+        site,
+        "local_operator-0.51.7.dist-info",
+        "0.51.7",
+        direct_url=json.dumps({"url": checkout.resolve().as_uri(), "dir_info": {"editable": True}}),
+    )
+
+    def _scan(*, name: str) -> list[object]:
+        from importlib.metadata import distributions
+
+        return list(distributions(name=name, path=[str(site)]))
+
+    with (
+        patch.object(update_mod, "distributions", _scan),
+        patch.object(update_mod, "__file__", str(checkout / "local_operator" / "update.py")),
+        # The shadow the egg-info casts over the metadata channel, reproduced.
+        patch.object(update_mod, "version", return_value="0.46.23"),
+    ):
+        assert update_mod.installed_version() == "0.51.7"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -715,18 +715,21 @@ def test_perform_upgrade_does_not_refresh() -> None:
     run.assert_not_called()
 
 
-def test_installed_version_prefers_whichever_source_is_newer() -> None:
-    """Neither the checkout file nor the install metadata is authoritative alone.
+def test_installed_version_trusts_a_verified_checkout_in_either_direction() -> None:
+    """A checkout that IS this install wins outright -- it is the running code.
 
-    Both are stale in opposite directions, so `installed_version` takes the
-    higher of the two:
+    This used to take the MAXIMUM of the two, which only ever protected against
+    a stray NEWER file. A stray OLDER one dragged the number DOWN, and no
+    direction of `max` covers both, because the defect was never the comparison
+    -- it was trusting a file whose relationship to the running code was
+    unestablished. `_editable_source_version` now proves identity, so ordering
+    is irrelevant and the source side is authoritative both ways:
 
-    * metadata never moves with the tree, which reported 0.46.23 for a checkout
-      at 0.49.0 -- the bug the checkout lookup was added for (QA Q3 / UX U13);
-    * a `pyproject.toml` naming this project but declaring an older version (a
-      fixture, a scratch tree, a hand-edited `version = "0.1.0"`) overrode
-      correct metadata and produced a spurious "update available" (review round
-      2, MINOR-2).
+    * forwards, the original bug: metadata never moves with the tree, so a
+      checkout at 0.49.0 reported the 0.46.23 it was installed at (QA Q3/UX U13);
+    * backwards, which `max` got wrong: an editable checkout deliberately moved
+      to an OLDER revision really is running older code, and reporting the newer
+      metadata would hide that.
     """
     with (
         patch.object(update_mod, "_editable_source_version", return_value="0.49.0"),
@@ -735,28 +738,19 @@ def test_installed_version_prefers_whichever_source_is_newer() -> None:
         assert update_mod.installed_version() == "0.49.0"
 
     with (
-        patch.object(update_mod, "_editable_source_version", return_value="0.1.0"),
-        patch.object(update_mod, "version", return_value="0.49.2"),
+        patch.object(update_mod, "_editable_source_version", return_value="0.46.23"),
+        patch.object(update_mod, "version", return_value="0.49.0"),
     ):
-        assert update_mod.installed_version() == "0.49.2"
+        assert update_mod.installed_version() == "0.46.23"
 
 
-def test_installed_version_falls_back_when_a_side_is_missing_or_unparseable() -> None:
-    """An unorderable side cannot win; the other one is the only defensible answer."""
-    with (
-        patch.object(update_mod, "_editable_source_version", return_value="0.28.0rc1"),
-        patch.object(update_mod, "version", return_value="0.49.2"),
-    ):
-        assert update_mod.installed_version() == "0.49.2"
+def test_installed_version_falls_back_to_metadata_without_a_verified_checkout() -> None:
+    """Nothing proven about the tree leaves metadata as the only real input.
 
-    with (
-        patch.object(update_mod, "_editable_source_version", return_value="0.49.2"),
-        patch.object(update_mod, "version", return_value="not-a-version"),
-    ):
-        assert update_mod.installed_version() == "0.49.2"
-
-    # No adjacent project file: a packaged install reports its metadata exactly
-    # as it always did.
+    This is the packaged-install case, and now also the case that broke: a
+    stray checkout in the working directory yields `""` from the source side
+    rather than overriding a correct install version.
+    """
     with (
         patch.object(update_mod, "_editable_source_version", return_value=""),
         patch.object(update_mod, "version", return_value="0.49.2"),
@@ -768,6 +762,100 @@ def test_installed_version_falls_back_when_a_side_is_missing_or_unparseable() ->
         patch.object(update_mod, "version", side_effect=update_mod.PackageNotFoundError),
     ):
         assert update_mod.installed_version() == "0.49.2"
+
+    # Neither side readable: empty, never an invented number.
+    with (
+        patch.object(update_mod, "_editable_source_version", return_value=""),
+        patch.object(update_mod, "version", side_effect=update_mod.PackageNotFoundError),
+    ):
+        assert update_mod.installed_version() == ""
+
+
+def test_editable_source_version_ignores_a_checkout_that_is_not_the_install(
+    tmp_path: Path,
+) -> None:
+    """The measured defect: adjacency is not identity.
+
+    The old implementation trusted any `pyproject.toml` beside the imported
+    package, arguing that a released build has no adjacent project file and so
+    could never read a stray one. That was false on a real install: a spawned
+    child whose cwd was a checkout of this project imported THAT checkout, so
+    `Path(__file__)` pointed into a tree the install had nothing to do with,
+    and a 0.51.5 install reported 0.51.0.
+
+    Here the module resolves inside `tmp_path` while the install's editable
+    origin is a different directory -- exactly that shape.
+    """
+    stray = tmp_path / "stray-checkout"
+    (stray / "local_operator").mkdir(parents=True)
+    (stray / "pyproject.toml").write_text(
+        '[project]\nname = "local-operator"\nversion = "0.9.9"\n', encoding="utf-8"
+    )
+    module = stray / "local_operator" / "update.py"
+    module.write_text("", encoding="utf-8")
+
+    with (
+        patch.object(update_mod, "__file__", str(module)),
+        patch.object(
+            update_mod, "_editable_install_root", return_value=tmp_path / "the-real-install"
+        ),
+    ):
+        assert update_mod._editable_source_version() == ""
+
+    # ... and the same tree IS trusted once it is the install's editable source.
+    with (
+        patch.object(update_mod, "__file__", str(module)),
+        patch.object(update_mod, "_editable_install_root", return_value=stray.resolve()),
+    ):
+        assert update_mod._editable_source_version() == "0.9.9"
+
+
+def test_editable_source_version_ignores_a_non_editable_install(tmp_path: Path) -> None:
+    """A packaged wheel has no editable `direct_url.json`, so no tree is trusted.
+
+    Covers the released-build case directly: `_editable_install_root` returns
+    `None`, and a `pyproject.toml` sitting next to the imported package -- which
+    is what a stray checkout looks like -- must not be read.
+    """
+    stray = tmp_path / "checkout"
+    (stray / "local_operator").mkdir(parents=True)
+    (stray / "pyproject.toml").write_text(
+        '[project]\nname = "local-operator"\nversion = "0.9.9"\n', encoding="utf-8"
+    )
+    with (
+        patch.object(update_mod, "__file__", str(stray / "local_operator" / "update.py")),
+        patch.object(update_mod, "_editable_install_root", return_value=None),
+    ):
+        assert update_mod._editable_source_version() == ""
+
+
+def test_editable_install_root_reads_pep610_direct_url() -> None:
+    """`dir_info.editable` plus a `file://` URL is the only accepted evidence."""
+    with patch.object(
+        update_mod,
+        "_direct_url_payload",
+        return_value={"url": "file:///tmp/checkout", "dir_info": {"editable": True}},
+    ):
+        assert update_mod._editable_install_root() == Path("/tmp/checkout").resolve()
+
+    # A non-editable install (a wheel built from a temp dir, as `lop-update`
+    # produces) names a path that is NOT the running tree; it must not qualify.
+    with patch.object(
+        update_mod,
+        "_direct_url_payload",
+        return_value={"url": "file:///tmp/build-dir", "dir_info": {}},
+    ):
+        assert update_mod._editable_install_root() is None
+
+    for payload in ({"dir_info": {"editable": True}}, {"url": "https://pypi.org/x"}, None):
+        with patch.object(update_mod, "_direct_url_payload", return_value=payload):
+            assert update_mod._editable_install_root() is None
+
+
+def test_editable_source_version_never_raises() -> None:
+    """ "Cheap and total": a version readout must degrade to `""`, never throw."""
+    with patch.object(update_mod, "_editable_install_root", side_effect=OSError("boom")):
+        assert update_mod._editable_source_version() == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

> **Round 1 remediation (head `8f2ce1190`).** Two findings from `### Agent review — round 1` are fixed: a shadowing `*.egg-info` that made a real editable install read as no install (BLOCKER-1), and this last spawn site (MAJOR-1). The branch is **rebased onto `48285f0db` (#752, process branding)**, which touches the same spawn calls with disjoint arguments; both properties are now asserted together on one real spawn. See the remediation comment for evidence and mutation proofs.


`/new` could attach a runtime built from a **superseded version of the code**, with no way for the user to tell and no action they could take to fix it.

`session/runtime/launch.py:287` spawned the runtime as `[sys.executable, "-m", "local_operator.session.runtime.process"]` with **no `cwd=`**, so the child inherited the TUI's working directory. Python's `-m` puts the cwd at `sys.path[0]` **ahead of site-packages** — so when the session's directory is a checkout of this project (the normal case for anyone developing it), the child imported the **checkout** instead of the install.

The parent TUI is immune by accident rather than design: it launches through the console script `~/.local/bin/lop`, whose `sys.path[0]` is `bin/`. Only the children were exposed.

This was live, not theoretical. Three runtime daemons on this host were recorded at ref `8738b949`, an ancestor of the installed `ad6db35d` and tagged **v0.51.0** — a genuinely superseded build, still running. The checkout they imported did not contain PR #721's `_ensure_welcome_view`, which is exactly why `/new` still showed no splash after that fix shipped.

## Reproduction, on the real installed tool

Same interpreter (`~/.local/share/uv/tools/local-operator/bin/python`), same command, **only the cwd differs**:

```
$ cd ~/workspace/repos/lo-session-sidebar     # a worktree whose pyproject says 0.51.0
  imports from: .../lo-session-sidebar/local_operator/__init__.py
  installed_version(): 0.51.0                 <-- WRONG: the checkout's code

$ same command, isolation flag added
  imports from: ~/.local/share/uv/tools/local-operator/.../local_operator/__init__.py
  installed_version(): 0.51.5                 <-- CORRECT: the install
```

The stray checkout's leftover `*.egg-info` also shadowed the real dist-info, so `importlib.metadata` independently reported `0.49.3` — a third wrong number from the same root cause.

## End-to-end proof: the actual `/new` spawn path

Not a hand-built argv — this drives `session.runtime.launch._spawn_runtime`, the function `/new` calls, and reads back what the child bound:

```
BEFORE (origin/main shape, run by the INSTALLED 0.51.7 tool, cwd = a 0.51.0 checkout)
  called      : session.runtime.launch._spawn_runtime  (the /new path)
  argv built  : python -m local_operator.session.runtime.process
  cwd= kwarg  : <inherited — this is the point>
  child bound : .../lo-session-sidebar/local_operator/__init__.py   label 0.51.0@4311eb6

AFTER (this branch)
  argv built  : python -P -m local_operator.session.runtime.process
  child bound : .../lop-runtime-import/local_operator/__init__.py   label 0.51.7
```

The recorded `BuildStamp` — the exact value a viewer compares against — moves from the stray checkout's `0.51.0` to the install's `0.51.7`. That is the acceptance criterion: **`/new` attaches a runtime built from the currently installed version, with no user action.**

The `eval` worker, driven live through the real `_spawn`, shows the same correction:

```
BEFORE  worker harness : .../lo-session-sidebar/local_operator/__init__.py   0.51.0@4311eb6
AFTER   worker harness : .../lop-runtime-import/local_operator/__init__.py   0.51.7
```

## Why `-P` and not `PYTHONSAFEPATH=1`

The two are equivalent *for the process being started*, and the env var is tidier since these call sites already build an `env` dict. **It is the wrong tool, and this is the one decision in the PR worth reading.** The variable is inherited by the entire process subtree; the flag is not. Measured:

```
env PYTHONSAFEPATH=1 python child.py  ->  grandchild: SAFEPATH=1, path0 stripped
python -P child.py                    ->  grandchild: SAFEPATH=None, path0 ''
```

A spawned runtime goes on to run the agent's `bash` tool, which copies `os.environ` into every command it executes. With the variable set, **every `python` the user's agent runs in the user's own project loses `sys.path[0]`**:

```
cd <a user project>; python runner.py  ->  ModuleNotFoundError: No module named 'usermod'
```

That is a total break of ordinary Python semantics in the user's workspace, caused by an isolation flag meant only to protect *our* import. The flag form fixes our child and changes nothing for anything it launches.

Not `cwd=` either: the session's working directory is a user-facing contract — what the agent operates on, what tools resolve relative paths against, what the status bar shows. `-P` removes only the implicit `sys.path[0]` injection, which is precisely the defect.

## The six sites, each assessed rather than assumed

| site | exposure | action |
|---|---|---|
| `session/runtime/launch.py:287` | the reported defect; runs from the session's cwd | fixed |
| `mobile/daemon.py:1729` | same spawn, same inheritance; harder to notice — nobody watches a phone daemon's version | fixed |
| `exec_mode.py:97` | `exec --background` runs from wherever the user stands; the worker imports the whole harness | fixed |
| `tools/eval.py:477` | passes `cwd=` **explicitly** at the checkout, so the worker could load the protocol module from a checkout and speak a different version than its parent | fixed + cwd restored for user code |
| `mcp/auth.py:285` | `-c` also puts cwd on the path: a `webbrowser.py` in the session directory hijacks the OAuth browser open (verified — the child raises out of the stray file) | fixed |
| `update.py:797` — `_mobile_restart_argv` | the post-upgrade mobile bounce, run with no `cwd=` from wherever the update was started; its docstring promised the opposite | **fixed in review round 1 remediation** (was left on a bare `-m`; review MAJOR-1) |

**The `eval` worker is the one child that legitimately wants its cwd importable**, since it runs user code and a cell doing `import my_module` must keep working. `_enable_cwd_imports()` restores it **after** the worker's own imports have resolved — the ordering is the whole point. It **appends** rather than inserting at position 0, so user code gets its workspace but a stray module cannot shadow a harness import the protocol depends on. Verified live: harness binds the install, `import mymod` still returns `"hello from the user's workspace"`.

## The version probe that made the skew invisible

`_editable_source_version()` resolved `Path(__file__).parent.parent / "pyproject.toml"` and trusted whatever it found, on this reasoning in its own docstring:

> there is no configuration in which a released build starts reading a stray file

**That assertion was false**, and the measurement above is the counterexample: a released build whose child imported a checkout read that checkout's `pyproject.toml`. The intent behind it is legitimate (QA Q3 / UX U13: an editable install's dist-info is written once and goes stale), so it is kept — but it now requires the imported tree to **be** the install's editable source, per PEP 610 `direct_url.json`. Adjacency is not identity.

Consequently `installed_version()` drops `max(source, metadata)`. The docstring claimed the maximum "fails in the SAFE direction"; it only ever guarded a stray **newer** file, while a stray **older** one drags the number **down** — which is what happened here. Once the source side proves identity the two are no longer rival guesses about one unknown, so the verified checkout is authoritative outright and ordering is irrelevant. Both docstrings are rewritten; the false claim is called out so the next reader does not rebuild the old argument.

## `BuildStamp` deliberately NOT hardened

An equal-git-ref short-circuit was proposed to suppress the skew notice. It is **rejected and documented as rejected**, because it would have been actively harmful: the stale runtimes had a **different** ref (`8738b94` vs `ad6db35`), so the shortcut would not have suppressed this notice, and adopting it would mask exactly this class of real skew. `BuildStamp` equality is working correctly and is the only thing that surfaced the bug.

## Mutation evidence — every guard proven able to fail

Per AGENTS.md, each defect was reintroduced and watched go red.

**Removing `-P` from `python_argv`** (the pre-fix behaviour) — 4 failed, and the messages name the offending tree rather than merely reporting `False`:

```
FAILED test_isolation_flag_precedes_the_module_selector - AssertionError: assert '-m' == '-P'
FAILED test_eval_worker_restores_cwd_imports_for_user_code - AssertionError: harness must bind to the install
  assert PosixPath('.../pytest-25812/.../local_operator/__init__.py')
      == PosixPath('/private/tmp/lop-runtime-import/local_operator/__init__.py')
FAILED test_cwd_restore_appends_so_it_cannot_shadow_harness_imports
FAILED test_bare_dash_m_imports_the_cwd_and_is_the_defect
```

**Removing the identity check** from `_editable_source_version`:

```
FAILED test_editable_source_version_ignores_a_checkout_that_is_not_the_install - assert '0.9.9' == ''
FAILED test_editable_source_version_ignores_a_non_editable_install           - assert '0.9.9' == ''
FAILED test_editable_source_version_never_raises                             - assert '0.51.6' == ''
```

**Restoring `max(source, metadata)`**:

```
FAILED test_installed_version_trusts_a_verified_checkout_in_either_direction - assert '0.49.0' == '0.46.23'
```

Restored in each case: green. The tests assert on **the child's resolved module path**, not on the env var being present in a dict — the flag is the mechanism, the imported tree is the behaviour. `test_bare_dash_m_imports_the_cwd_and_is_the_defect` pins the defect itself, so the fix is measured against something rather than asserted into a vacuum.

## Gates — whole tree, exactly as CI

| gate | result |
|---|---|
| `flake8 .` | `rc=0` |
| `black --check .` (26.1.0) | `1032 files would be left unchanged`, `rc=0` |
| `isort --check .` (5.13.2) | `rc=0` |
| `pyright --pythonpath .venv/bin/python .` | `0 errors, 0 warnings, 0 informations`, `rc=0` |
| `pytest tests/e2e -m e2e -n0` | `47 passed`, `rc=0` |
| `pytest tests/unit` | `15605 passed, 18 skipped` in 30m07s, `rc=0` |

All headless runs used a fresh `HOME` **and** `LOCAL_OPERATOR_CONFIG_DIR` with every `CMUX_*` variable unset; the operator's live sessions and install were never modified (the install was read only).

An earlier local run of the suite showed 84 errors of `OSError: could not create numbered dir`. That was **host disk exhaustion, not this diff**: the shared volume stood at 99% (`460Gi total, 5.7Gi avail`) with 59 stale `pytest-of-damian` scratch directories left by concurrent sessions. Once the disk was reclaimed (`26Gi avail`) and the suite re-run under a private `TMPDIR`, the errors were gone and the run was clean. The table above is that clean run; the earlier counts are discarded, because a suite dying partway leaves half-written artifacts that read as genuine failures.

Existing argv-shape assertions across `test_exec_mode.py`, `test_phone_startup.py` and `test_cli_new.py` were updated for the new flag — they assert the spawn contract, and the contract changed on purpose.

**One of them was caught by CI rather than by me**, and it is worth naming: `test_cli_new.py` sliced `argv[3:]` to strip the `python -m <module>` prefix before handing the rest to the worker's parser, and a hardcoded slice turns into a bare `SystemExit: 2` when a flag is inserted ahead of `-m`. Rather than bump the constant, every such slice now **derives** the offset (`argv.index("-m") + 2`), so adding another interpreter flag later cannot silently reintroduce this. The failure mode was an argparse exit with no message naming the cause, which is exactly the kind of thing worth removing rather than re-tuning.

## Not addressed

- **`launch.py:486-497` — the reuse path.** `find_owner_record` returns any live record for a session id with **no build check**, so `/resume` can still attach to a stale owner. Real and separate: it affects `/resume`, not `/new`, and fixing it means deciding what to do with a live-but-stale runtime (retire it? warn?), which is a design question this PR should not settle silently.
- **Off-centre notice rendering on the splash** — a designer owns it.

## Release

`Release: patch — /new and background runtimes now run the installed build instead of whatever checkout happened to be the working directory.`

No version bump: `git diff origin/main -- pyproject.toml` is empty; it stays at `0.51.8` (the branch is rebased onto `48285f0db`, which carries v0.51.8). `version-bump-guard` passes.


