### PR TITLE
docs(agents): name `git add -A` as a whole-tree operation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1084,17 +1084,23 @@ owns its own venv".
 Every command named above takes something away, so the rule reads as being
 about destruction — and an agent who had read it walked into this anyway,
 because adding sounds safe. It is not: in a checkout other agents are working
-in, `-A` and `-a` are whole-tree operations in exactly the sense above, and
-they sweep whatever every peer has in flight into **your** commit under **your**
-authorship. Nothing in the output says so; the fabricated authorship surfaces
-only later, out of `git log`. Stage explicit pathspecs —
-`git add <the files you actually edited>`. Measured on `feat/move-command`
+in, both are whole-tree operations in exactly the sense above, sweeping peers'
+in-flight work into **your** commit under **your** authorship. They differ only
+in reach — `-a` takes every *tracked* modification, `-A` takes those and
+untracked files as well — so `-A` is the wider hazard and neither is narrow.
+Nothing useful in the output says so (`add -A` prints nothing at all;
+`commit -a` prints a file count, never names or authorship), and the fabricated
+authorship surfaces only later, out of `git log`. Stage explicit pathspecs —
+`git add <the files you actually edited>`. The ban lifts where the destructive
+one does: in a throwaway worktree nobody else touches, `-A` is fine, because
+there is no other work for it to reach. Measured on `feat/move-command`
 (PR #727), where two sessions shared one worktree: `5b1de59e1` at 10:59:36
 swept a peer's in-progress `tests/unit/session/test_remote_move.py` into a
 `fix(tui):` commit, and `type-check` failed at `test_remote_move.py:368:37`
 (`CancelledError` not assignable to `Exception | None`) because the widening
 that makes that test type-check landed 3m24s later in the peer's own commit
-`06ee21d9e`. The PR's head was red for a defect its own change did not contain.
+`06ee21d9e`. The PR's head was red for a defect its own intended change did
+not contain.
 
 Two stills side by side catch what a single "looks fine" never does. The
 usage-card round found a **pre-existing** bug this way: the after-frame had a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1080,6 +1080,22 @@ the one the venv was installed from, and this checkout is deleted immediately.
 Never copy that line into a feature worktree — see "Every feature worktree
 owns its own venv".
 
+**The same hazard has an additive form: `git add -A` and `git commit -a`.**
+Every command named above takes something away, so the rule reads as being
+about destruction — and an agent who had read it walked into this anyway,
+because adding sounds safe. It is not: in a checkout other agents are working
+in, `-A` and `-a` are whole-tree operations in exactly the sense above, and
+they sweep whatever every peer has in flight into **your** commit under **your**
+authorship. Nothing in the output says so; the fabricated authorship surfaces
+only later, out of `git log`. Stage explicit pathspecs —
+`git add <the files you actually edited>`. Measured on `feat/move-command`
+(PR #727), where two sessions shared one worktree: `5b1de59e1` at 10:59:36
+swept a peer's in-progress `tests/unit/session/test_remote_move.py` into a
+`fix(tui):` commit, and `type-check` failed at `test_remote_move.py:368:37`
+(`CancelledError` not assignable to `Exception | None`) because the widening
+that makes that test type-check landed 3m24s later in the peer's own commit
+`06ee21d9e`. The PR's head was red for a defect its own change did not contain.
+
 Two stills side by side catch what a single "looks fine" never does. The
 usage-card round found a **pre-existing** bug this way: the after-frame had a
 scrollbar the before-frame did not, which turned out to be any tall overlay


### PR DESCRIPTION
Adds one paragraph to `AGENTS.md`, immediately after the existing whole-tree prohibition ("Never `git stash` to get a before-frame"), covering the additive form of the same hazard.

## Why

The existing rule names only destructive commands — `stash`, `checkout --`, `restore`, `reset --hard`, `clean`. All of them obviously take something away, so the rule reads as being about *losing* work. `git add -A` obviously **adds**, so it reads as safe — and an agent who had read that rule walked into it anyway. The damage is also quieter than the destructive commands: nothing in `git add`'s output says it staged four files belonging to someone else, and the fabricated authorship is discoverable only later, out of `git log`.

It is placed adjacent to the existing prohibition rather than in a new section so a reader meets both forms together; the existing rule is not restated.

## The incident it records (verified, not recalled)

Two sessions were working concurrently in one worktree on `feat/move-command` (PR #727).

| fact | verification |
|---|---|
| `5b1de59e1` (10:59:36) touched 8 files including `tests/unit/session/test_remote_move.py` | `git show --stat 5b1de59e1` |
| the swept content was not in the branch before it | `git show 7b44142e5:tests/unit/session/test_remote_move.py \| grep -c CancelledError` → `0`; same on `5b1de59e1` → `5` |
| CI went red on that head, on `type-check` only | check-runs for `5b1de59e1d846019652f7e4bce42801cea85b0b9`: `type-check failure`, all 5 `test` shards + `lint` `success` |
| the exact error | job log: `test_remote_move.py:368:37 - error: Argument of type "CancelledError" cannot be assigned to parameter "error" of type "Exception \| None"` |
| the fix arrived 3m24s later, in the peer's own commit | `06ee21d9e` (11:03:00), a 1-file commit widening `FakeClient.__init__` to `BaseException \| None` |

So a PR's head was broken by commit interleaving rather than by anything wrong with its own change. Those figures (10:59:36, `368:37`, 3m24s, `06ee21d9e`) are the ones written into the paragraph.

## Scope

Docs only — `AGENTS.md`, `+16 −0`, one hunk. `pyproject.toml` untouched (`git diff --name-only` → `AGENTS.md`), so `version-bump-guard` is unaffected.

## Testing evidence

No code changed, so there is no runtime path to exercise; the artifact is the rendered prose and the claims inside it.

- **Every factual claim in the paragraph was verified against git and the CI logs before it was written**, per the table above — the SHAs, the timestamps, the file, the error text and the 3m24s gap are observed, not recalled.
- **Not already present**: `git fetch origin main && git show origin/main:AGENTS.md | grep -n "add -A"` → no match (rc=1), and likewise for `commit -a`. This is the only copy; a second copy of a rule is how two sections drift.
- **Placement**: the new block starts at the line after `owns its own venv".`, which is the close of the existing prohibition's worktree remedy.
- **Formatting**: no line in the new block exceeds 80 columns, matching the file.
- **Practised what it preaches**: written in a throwaway worktree cut from `origin/main` (never the shared checkout, which currently holds ~1600 uncommitted paths from other sessions), staged with an explicit pathspec — `git add AGENTS.md`, never `-A` — and the worktree removed afterwards.

## Round 1 remediation

Three findings folded into one commit (`d0e923a1f`); see the remediation comment for the per-finding answer. MINOR-1 was a genuine factual error — `git commit -a` stages tracked modifications only, so a peer's *untracked* file survives it, which I reproduced before rewriting the clause. The paragraph now states each command's real reach and names the throwaway-worktree escape hatch, matching the shape of the sibling prohibition it sits beside.

**The review itself produced better evidence for this rule than the incident does.** The reviewer's first `grep` of `AGENTS.md` read the root checkout's working copy — which is `MM` right now, a peer's in-flight draft — and they caught it and redid the whole review against `origin/main` and a named `refs/lo-read/pr749` ref. So while reviewing a PR about shared-checkout contamination, they were momentarily contaminated by the shared checkout. That is the same failure family, live, during the review of the rule about it: the hazard is ambient in this repo, not a one-off that happened once on `feat/move-command`.

Release: patch — AGENTS.md records that `git add -A` / `git commit -a` sweep peers' in-flight work in a shared checkout, with the measured CI failure that cost.
