### PR TITLE
fix(tui): route a notification click to the running TUI, not a new window

### DIFF
--- a/docs/SESSION_SIDEBAR.md
+++ b/docs/SESSION_SIDEBAR.md
@@ -23,7 +23,9 @@ turn it leaves and so denies its queued approvals. Anything that switches on the
 user's behalf therefore goes through `_select_sidebar_session` — the one entry
 point both the keystroke and a notification click use — rather than issuing a
 `/resume` that merely resembles it. A click routed the second way answered a
-parked approval "no" in the session being left, with no receipt. Preparation never acknowledges completion attention. The current binding
+parked approval "no" in the session being left, with no receipt.
+
+Preparation never acknowledges completion attention. The current binding
 changes only after canonical attachment and prepared replay; navigation stays
 pending until a real displayed frame also has the correct scroll/gate surface.
 

--- a/docs/SESSION_SIDEBAR.md
+++ b/docs/SESSION_SIDEBAR.md
@@ -16,7 +16,14 @@ that ends above the input dock and closes after any valid selection.
 `SessionInteraction` owns each source's turns, loop, shell, compaction, draft,
 approval policy, gate input and accounting. A prepared/retained view owns widgets,
 not work. Switching does not answer a gate, cancel a turn, or redirect its eventual
-result. Preparation never acknowledges completion attention. The current binding
+result.
+
+That guarantee belongs to this navigation, **not** to `/resume`, which ends the
+turn it leaves and so denies its queued approvals. Anything that switches on the
+user's behalf therefore goes through `_select_sidebar_session` — the one entry
+point both the keystroke and a notification click use — rather than issuing a
+`/resume` that merely resembles it. A click routed the second way answered a
+parked approval "no" in the session being left, with no receipt. Preparation never acknowledges completion attention. The current binding
 changes only after canonical attachment and prepared replay; navigation stays
 pending until a real displayed frame also has the correct scroll/gate surface.
 

--- a/local_operator/session/runtime/viewer_client.py
+++ b/local_operator/session/runtime/viewer_client.py
@@ -23,7 +23,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from local_operator.session.runtime.viewers import ViewerRecord
+from local_operator.session.runtime.viewers import (
+    FOCUS_WINDOW_CAPABILITY,
+    KNOWN_VIEWER_PROTOCOLS,
+    VIEWER_ACK_GRACE_S,
+    VIEWER_RESUME_TIMEOUT_S,
+    ViewerRecord,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -34,11 +40,19 @@ _DIAL_TIMEOUT_S = 1.0
 #: How long one op may take to be acknowledged. ``resume_session`` crosses to
 #: the application's loop and runs a real ``/resume``, which on a cold, long
 #: transcript is genuinely slow — the architect measured ``Transcript.__init__``
-#: at 3.9 s on this host's largest session. The ack is what tells us not to
-#: spawn a second window, so waiting a little longer here is strictly better
-#: than giving up and producing the exact duplicate window this feature exists
-#: to remove.
-_ACK_TIMEOUT_S = 8.0
+#: at 3.9 s on this host's largest session.
+#:
+#: DERIVED, NOT CHOSEN. It is the server's own bound on that work
+#: (``VIEWER_RESUME_TIMEOUT_S``, applied in ``viewer_resume_session``) plus
+#: enough slack for the round trip, so this side can never give up first. The
+#: ack is what tells us not to spawn a second window; a client that timed out
+#: while the server carried the switch to completion delivered BOTH — the
+#: session switched in the running window AND a duplicate terminal opened,
+#: which is the exact defect this feature exists to remove, reproduced at a
+#: measured 8.5 s ``/resume``. Waiting a little longer here is strictly better.
+#: Both terms live in ``viewers`` so neither side can be edited into an
+#: inversion on its own.
+_ACK_TIMEOUT_S = VIEWER_RESUME_TIMEOUT_S + VIEWER_ACK_GRACE_S
 
 #: ``focus_window`` is a bounded subprocess on the far side and nothing else.
 #: It gets a short leash because a failure to raise a window is cosmetic —
@@ -149,7 +163,12 @@ async def deliver_click(
             outcome.switched = True
             outcome.detail = "already displayed"
 
-        if want_focus:
+        if want_focus and FOCUS_WINDOW_CAPABILITY in record.capabilities:
+            # The capability is READ here, not merely published. A viewer that
+            # cannot raise its window (ssh, Linux, an unknown emulator) answers
+            # the unknown-op error, and waiting out a round trip for a refusal
+            # we were told about in the record is latency spent on the click
+            # path for nothing. The switch has already landed either way.
             req = 2
             writer.write(json.dumps({"op": "focus_window", "req": req}).encode() + b"\n")
             await writer.drain()
@@ -184,7 +203,17 @@ def needs_switch(record: ViewerRecord, session_id: str) -> bool:
 def choose_viewer(records: list[ViewerRecord], session_id: str) -> ViewerRecord | None:
     """Pick the viewer that should take this click, deterministically.
 
-    Precedence, and each rung is a reason rather than a preference:
+    Only viewers speaking a protocol this build knows are considered at all.
+    That filter is applied FIRST, before either rung below, because dialing a
+    socket whose frames we cannot predict is worse than not dialing it: the
+    click would spend its ack timeout on a conversation neither side
+    understands, when falling through to the spawn works against any build.
+    ``viewers.KNOWN_VIEWER_PROTOCOLS`` documented this refusal long before
+    anything performed it — the check is here now, because a contract that
+    exists only in prose is what shipped this module's original bug.
+
+    Precedence among the remainder, and each rung is a reason rather than a
+    preference:
 
     1. **A viewer already displaying the target.** Switching it is a no-op, so
        this is the cheapest and least disruptive outcome available.
@@ -205,11 +234,12 @@ def choose_viewer(records: list[ViewerRecord], session_id: str) -> ViewerRecord 
     fall back to spawning a terminal — the behaviour that exists today and must
     keep working.
     """
-    for record in records:
+    speakable = [rec for rec in records if rec.protocol in KNOWN_VIEWER_PROTOCOLS]
+    for record in speakable:
         if record.current_session == session_id:
             return record
     switchable = sorted(
-        (rec for rec in records if rec.can_switch),
+        (rec for rec in speakable if rec.can_switch),
         key=lambda rec: (-rec.focused_at, rec.pid),
     )
     return switchable[0] if switchable else None

--- a/local_operator/session/runtime/viewer_client.py
+++ b/local_operator/session/runtime/viewer_client.py
@@ -1,0 +1,241 @@
+"""Dial a viewer and ask it to display a session, bounded at every step.
+
+The client half of :mod:`local_operator.session.runtime.viewer_server`. Its one
+production caller is the notification click handler
+(:mod:`local_operator.tui.resume_click`), which runs detached with no event
+loop and no user waiting on a prompt — so every failure here is an ordinary
+answer that falls through to the next rung, never an exception the user sees.
+
+BOUNDED IS THE WHOLE CONTRACT. A click that hangs is worse than a click that
+does nothing: the user gets no window and no explanation, and on macOS the
+30 s activation window closes while they wait. Every await below carries a
+timeout, and the totals are chosen so the *fallback* spawn still happens
+comfortably inside that window even when a viewer is wedged and every dial
+times out.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from local_operator.session.runtime.viewers import ViewerRecord
+
+logger = logging.getLogger(__name__)
+
+#: Connect + authenticate. Loopback, so a healthy viewer answers in
+#: microseconds; this bound exists for the wedged one.
+_DIAL_TIMEOUT_S = 1.0
+
+#: How long one op may take to be acknowledged. ``resume_session`` crosses to
+#: the application's loop and runs a real ``/resume``, which on a cold, long
+#: transcript is genuinely slow — the architect measured ``Transcript.__init__``
+#: at 3.9 s on this host's largest session. The ack is what tells us not to
+#: spawn a second window, so waiting a little longer here is strictly better
+#: than giving up and producing the exact duplicate window this feature exists
+#: to remove.
+_ACK_TIMEOUT_S = 8.0
+
+#: ``focus_window`` is a bounded subprocess on the far side and nothing else.
+#: It gets a short leash because a failure to raise a window is cosmetic —
+#: the session has already been switched by then.
+_FOCUS_TIMEOUT_S = 3.0
+
+#: Bound on one frame. The viewer's replies are tiny; this stops a wedged or
+#: hostile writer from growing this process's memory.
+_MAX_FRAME_BYTES = 64 * 1024
+
+
+@dataclass
+class ViewerOutcome:
+    """What the click managed to achieve. ``switched`` is the one that decides
+    whether the caller may skip the spawn — focus is chrome on top of it."""
+
+    switched: bool = False
+    focused: bool = False
+    detail: str = ""
+
+
+async def _read_reply(
+    reader: asyncio.StreamReader, req: int, timeout_s: float
+) -> dict[str, Any] | None:
+    """Read frames until the one answering ``req``, or give up.
+
+    Frames are read and split HERE rather than with ``readline`` because
+    ``StreamReader.readline`` raises ``LimitOverrunError`` *without consuming
+    the buffer*, so one oversized line wedges every later read — the defect
+    ``session/runtime/control.py`` documents for ``lop send``. This endpoint
+    emits nothing large today, but the failure is silent and permanent if it
+    ever does, and the fix is four lines.
+    """
+    buf = bytearray()
+
+    async def _read() -> dict[str, Any] | None:
+        while True:
+            nl = buf.find(b"\n")
+            if nl == -1:
+                if len(buf) > _MAX_FRAME_BYTES:
+                    return None
+                chunk = await reader.read(4096)
+                if not chunk:
+                    return None
+                buf.extend(chunk)
+                continue
+            line = bytes(buf[: nl + 1])
+            del buf[: nl + 1]
+            try:
+                frame = json.loads(line.decode("utf-8", "replace"))
+            except ValueError:
+                continue
+            if isinstance(frame, dict) and frame.get("req") == req:
+                return frame
+
+    try:
+        return await asyncio.wait_for(_read(), timeout=timeout_s)
+    except (TimeoutError, OSError, ConnectionError):
+        return None
+
+
+async def deliver_click(
+    record: ViewerRecord, session_id: str, *, want_focus: bool = True
+) -> ViewerOutcome:
+    """Switch ``record``'s viewer to ``session_id`` and bring it forward.
+
+    ORDER MATTERS: switch first, then focus. Raising the window before the
+    switch shows the user the *previous* session for as long as the switch
+    takes, which on a cold long conversation is seconds of looking at the wrong
+    thing. Switching first means whatever comes forward is already correct.
+
+    A viewer already displaying the target is switched anyway? No — the caller
+    passes that case through ``needs_switch`` below, because re-running
+    ``/resume`` on the session already on screen would rebuild the view and
+    throw away the user's scroll position for no gain.
+    """
+    outcome = ViewerOutcome()
+    try:
+        reader, writer = await asyncio.wait_for(
+            asyncio.open_connection("127.0.0.1", record.control_port),
+            timeout=_DIAL_TIMEOUT_S,
+        )
+    except (OSError, TimeoutError):
+        # Refused or unreachable: the process is gone or wedged. Not an error —
+        # it is the cheapest possible "route elsewhere".
+        outcome.detail = "viewer unreachable"
+        return outcome
+    try:
+        writer.write(json.dumps({"key": record.control_key}).encode() + b"\n")
+        await writer.drain()
+
+        req = 1
+        if needs_switch(record, session_id):
+            writer.write(
+                json.dumps({"op": "resume_session", "req": req, "session_id": session_id}).encode()
+                + b"\n"
+            )
+            await writer.drain()
+            reply = await _read_reply(reader, req, _ACK_TIMEOUT_S)
+            if reply is None or reply.get("op") != "ack":
+                outcome.detail = (reply or {}).get("detail", "no answer to resume_session")
+                return outcome
+            outcome.switched = True
+            outcome.detail = str(reply.get("detail", ""))
+        else:
+            # Already on screen. Nothing to switch, and saying so is what lets
+            # the caller skip the spawn: the session IS displayed.
+            outcome.switched = True
+            outcome.detail = "already displayed"
+
+        if want_focus:
+            req = 2
+            writer.write(json.dumps({"op": "focus_window", "req": req}).encode() + b"\n")
+            await writer.drain()
+            reply = await _read_reply(reader, req, _FOCUS_TIMEOUT_S)
+            # A viewer that cannot focus answers with an error frame, and that
+            # is a fine outcome: the session is switched and the user finds the
+            # window themselves. Never let it undo `switched`.
+            outcome.focused = bool(reply is not None and reply.get("op") == "ack")
+        return outcome
+    except (OSError, ConnectionError) as exc:
+        outcome.detail = f"viewer connection lost: {exc}"
+        return outcome
+    finally:
+        try:
+            writer.close()
+            await writer.wait_closed()
+        except (OSError, ConnectionError):
+            pass
+
+
+def needs_switch(record: ViewerRecord, session_id: str) -> bool:
+    """Whether this viewer must be told to change what it displays.
+
+    False when it is already showing the target — the click then costs only an
+    OS activation, which is both the cheapest outcome and the least surprising:
+    re-resuming a session already on screen would rebuild its view and discard
+    the user's scroll position.
+    """
+    return record.current_session != session_id
+
+
+def choose_viewer(records: list[ViewerRecord], session_id: str) -> ViewerRecord | None:
+    """Pick the viewer that should take this click, deterministically.
+
+    Precedence, and each rung is a reason rather than a preference:
+
+    1. **A viewer already displaying the target.** Switching it is a no-op, so
+       this is the cheapest and least disruptive outcome available.
+    2. **The most recently focused viewer that can switch.** The window the
+       user was last in is the best available proxy for where they expect to
+       land. Ties (two viewers never focused) break on the lowest pid, so
+       repeated clicks are stable rather than alternating.
+
+    THE ORDERING IS APPLIED HERE, not inherited from the caller. ``scan_viewers``
+    happens to return records in this order already, and an earlier draft of
+    this function relied on that — which made it silently wrong for any caller
+    holding records from anywhere else, and the docstring promised a precedence
+    the code did not implement. A function whose contract is "pick
+    deterministically" has to do its own sorting; borrowing the guarantee from a
+    collaborator is how it gets lost.
+
+    Returns ``None`` when nothing can take it, which is the caller's signal to
+    fall back to spawning a terminal — the behaviour that exists today and must
+    keep working.
+    """
+    for record in records:
+        if record.current_session == session_id:
+            return record
+    switchable = sorted(
+        (rec for rec in records if rec.can_switch),
+        key=lambda rec: (-rec.focused_at, rec.pid),
+    )
+    return switchable[0] if switchable else None
+
+
+def route_click(session_id: str, root: Path | None = None) -> ViewerOutcome:
+    """Resolve and deliver, synchronously, for the detached click process.
+
+    Runs its own event loop because the click handler has none — it is a
+    short-lived process macOS handed an activation. Returns an outcome whose
+    ``switched`` flag is the caller's whole decision: True means a live window
+    is now showing the session and nothing should be spawned.
+    """
+    from local_operator.session.runtime.viewers import scan_viewers
+
+    try:
+        records = scan_viewers(root)
+    except OSError:
+        # No viewer directory, or an unreadable one. An ordinary answer on a
+        # machine where no TUI has ever run.
+        return ViewerOutcome(detail="no viewer records")
+    target = choose_viewer(records, session_id)
+    if target is None:
+        return ViewerOutcome(detail="no viewer available")
+    try:
+        return asyncio.run(deliver_click(target, session_id))
+    except Exception:  # noqa: BLE001 — a routing failure must fall back, never raise
+        logger.debug("viewer click routing failed", exc_info=True)
+        return ViewerOutcome(detail="viewer routing failed")

--- a/local_operator/session/runtime/viewer_server.py
+++ b/local_operator/session/runtime/viewer_server.py
@@ -52,10 +52,12 @@ import logging
 import os
 import secrets
 import threading
+import time
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Protocol, cast
 
 from local_operator.session.runtime.viewers import (
+    FOCUS_WINDOW_CAPABILITY,
     VIEWER_HEARTBEAT_INTERVAL_S,
     ViewerRecord,
     publish_viewer,
@@ -73,11 +75,11 @@ _AUTH_TIMEOUT_S = 5.0
 #: magnitude against any real frame.
 _MAX_LINE_BYTES = 64 * 1024
 
-#: Advertised when the host can activate its own window. ``hasattr``-gated by
-#: the publisher exactly as ``SessionRecord.capabilities`` is: advertising a
-#: capability the host cannot honour is worse than omitting it, because the
-#: client then skips a fallback that would have worked.
-FOCUS_WINDOW_CAPABILITY = "focus-window-v1"
+#: Re-exported for the callers (and tests) that reach for it here, beside the
+#: endpoint that advertises it. It is DEFINED in ``viewers`` because the client
+#: reads it too, and a capability string spelled in two modules is a capability
+#: that will eventually be spelled two ways.
+__all__ = ["FOCUS_WINDOW_CAPABILITY", "ViewerHost", "ViewerServer"]
 
 
 class ViewerHost(Protocol):
@@ -143,6 +145,15 @@ class ViewerServer:
         session rather than a list of displayable ones — see ``ViewerRecord``,
         where the reasoning is that an enumerated list is a cache of something
         that changes without this process knowing.
+
+        **THIS RUNS ON TEXTUAL'S LOOP AND TOUCHES DISK.** ``_republish`` is
+        ``mkstemp`` + ``write`` + ``chmod`` + ``os.replace``, measured at
+        **0.808 ms per call** on this host. That is affordable only because of
+        the cadence: the early return below makes a repeat swap free, and the
+        other two callers are a focus gain and a 15 s heartbeat. A third caller
+        on a poll or a per-frame hook would put a synchronous disk write on the
+        event loop at UI cadence — the shape the sidebar-lag investigation
+        traced its stalls back to — and must hop to a thread instead.
         """
         if self._record.current_session == session_id:
             return
@@ -160,8 +171,6 @@ class ViewerServer:
         """
         if not focused:
             return
-        import time
-
         self._record.focused_at = time.time()
         self._republish()
 
@@ -289,7 +298,21 @@ class ViewerServer:
             return
         try:
             while not self._closed.is_set():
-                line = await reader.readline()
+                try:
+                    line = await reader.readline()
+                except ValueError:
+                    # An over-limit line: `start_server(..., limit=...)` makes
+                    # `readline` raise `LimitOverrunError` (a `ValueError`)
+                    # WITHOUT consuming the buffer, so the same read would raise
+                    # forever. Uncaught it escaped `client_connected_cb`, skipped
+                    # the reply and logged an asyncio traceback while the client
+                    # waited out its ack timeout. `viewer_client._read_reply`
+                    # hand-rolls its framing to dodge this exact defect on its
+                    # side; closing the conversation is the server's equivalent —
+                    # the peer is authenticated, so this is a bug in a peer
+                    # rather than an attack, and it falls back correctly.
+                    logger.debug("viewer control: oversized frame, closing the conversation")
+                    return
                 if not line:
                     return
                 try:

--- a/local_operator/session/runtime/viewer_server.py
+++ b/local_operator/session/runtime/viewer_server.py
@@ -1,0 +1,349 @@
+"""The viewer control endpoint: a socket that outlives every session swap.
+
+WHAT THIS IS FOR. A notification click needs to tell an already-running TUI
+"display session X and come to the front". The ops for that mostly exist
+already — ``resume_session`` is a session-runtime op with a working handler
+(``mobile/tui_handle.py``) — but in the state the operator actually runs in,
+**there is no socket to send them to.**
+
+Why not: ``RuntimeServer`` binds its listener and publishes its record in the
+same step (``server.py::_serve``), and ``OperatorApp._mobile_adopted`` closes
+the whole registrant the moment the app follows a ``RemoteSession``. Following a
+remote session is the *normal* sidebar state, so a sidebar user's TUI is
+listening on nothing. Keeping the RuntimeServer alive instead is not available:
+its own comment records that a second registrant for one transcript corrupts
+daemon routing, and this host runs a live phone daemon.
+
+So this is a **transport**, not a protocol change. ``PROTOCOL_VERSION`` does not
+move and no session frame changes shape; what is new is an endpoint scoped to
+the *process* rather than to a *transcript*, which is a different object with a
+different lifetime. That distinction is the whole design: a session endpoint
+dies at every ``/resume``, and the thing a click must reach is precisely the
+thing that survives one.
+
+DELIBERATELY TWO OPS, AND NOT MORE. ``resume_session`` and ``focus_window``,
+full stop. It is tempting to mirror RuntimeServer's surface "for symmetry" —
+do not. The authorization story here is exactly one 0600 key under a 0700
+directory, and that is sufficient *because* the surface is two ops that a user
+could perform with two keystrokes at the same keyboard. Every op added is one
+a later reader will assume was held to the same standard, so the narrowness is
+load-bearing rather than an oversight to be tidied up.
+
+LIFECYCLE IS THE RISK HERE, so it is stated plainly. This object owns a
+listening socket across state changes that previously tore everything down.
+Three properties are maintained and tested:
+
+* ``start()`` is idempotent — a swap must never bind a second listener. The
+  cautionary tale is the source leak at ``tui/app.py`` (25 open/close cycles
+  leaked 50 sources); a leaked *listener* is worse than a leaked source because
+  it also leaks a record advertising a port.
+* ``close()`` is idempotent, safe from any thread, and unpublishes the record.
+* A record whose process died is reaped by the reader (``scan_viewers`` checks
+  pid liveness), so a ``kill -9`` costs one stale file and never a misroute.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import hmac
+import json
+import logging
+import os
+import secrets
+import threading
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Protocol, cast
+
+from local_operator.session.runtime.viewers import (
+    VIEWER_HEARTBEAT_INTERVAL_S,
+    ViewerRecord,
+    publish_viewer,
+    unpublish_viewer,
+)
+
+logger = logging.getLogger(__name__)
+
+#: How long a dial may take to present its key. Matches RuntimeServer's own
+#: auth deadline: the client is on loopback and has nothing to compute.
+_AUTH_TIMEOUT_S = 5.0
+
+#: A viewer frame is a handful of fields. The cap exists so a wedged or hostile
+#: writer cannot grow this process's memory; it is generous by two orders of
+#: magnitude against any real frame.
+_MAX_LINE_BYTES = 64 * 1024
+
+#: Advertised when the host can activate its own window. ``hasattr``-gated by
+#: the publisher exactly as ``SessionRecord.capabilities`` is: advertising a
+#: capability the host cannot honour is worse than omitting it, because the
+#: client then skips a fallback that would have worked.
+FOCUS_WINDOW_CAPABILITY = "focus-window-v1"
+
+
+class ViewerHost(Protocol):
+    """What the viewer endpoint needs from the application hosting it.
+
+    Both methods are called ON the viewer's own loop (its own thread) and are
+    expected to make whatever hop the host needs — for the TUI, Textual's
+    ``call_from_thread``. Each returns a short human-readable receipt that
+    becomes the ``ack`` detail, matching ``SessionHandle``'s convention so the
+    two endpoints read the same way.
+    """
+
+    async def viewer_resume_session(self, session_id: str) -> str:
+        """Display ``session_id`` in this viewer. Same act as the user pressing
+        the sidebar row."""
+        ...
+
+    async def viewer_focus_window(self) -> str:
+        """Bring this viewer's window to the front, best effort."""
+        ...
+
+
+class ViewerServer:
+    """One per process. Construct, :meth:`start`, :meth:`close`.
+
+    Threaded like ``RuntimeServer``: its own loop on its own thread, so a
+    blocked application loop cannot stop a click from being answered, and a
+    slow click cannot stall the application.
+    """
+
+    def __init__(self, host: ViewerHost, *, surface: str = "tui", root: Path | None = None) -> None:
+        self._host = host
+        self._root = root
+        self._record = ViewerRecord(
+            pid=os.getpid(),
+            surface=surface,
+            control_port=0,  # stamped when the listener binds
+            control_key=secrets.token_hex(32),
+            # Gated on the host actually implementing it, never assumed. A
+            # headless or non-macOS host that cannot raise a window must not
+            # advertise that it can.
+            capabilities=(
+                [FOCUS_WINDOW_CAPABILITY] if hasattr(host, "viewer_focus_window") else []
+            ),
+        )
+        self._server: asyncio.AbstractServer | None = None
+        self._thread: threading.Thread | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._heartbeat_task: asyncio.Task[None] | None = None
+        self._closed = threading.Event()
+        #: Set once the listener is bound and the record published, so a caller
+        #: that needs the record to exist (a test, or a diagnostic) can wait
+        #: for it rather than sleeping.
+        self.ready = threading.Event()
+
+    # -- state the application pushes in -------------------------------------
+
+    def note_session(self, session_id: str) -> None:
+        """Record which session is on screen now. Called on every swap.
+
+        Cheap by construction: one field and one staged write, with no
+        enumeration of anything. The record deliberately holds only the CURRENT
+        session rather than a list of displayable ones — see ``ViewerRecord``,
+        where the reasoning is that an enumerated list is a cache of something
+        that changes without this process knowing.
+        """
+        if self._record.current_session == session_id:
+            return
+        self._record.current_session = session_id
+        self._republish()
+
+    def note_focused(self, focused: bool) -> None:
+        """Record that this window just gained OS focus.
+
+        Only the gaining edge is stamped: ``focused_at`` answers "when was the
+        user last HERE", which is the tiebreak when several viewers could take
+        a session. A blur carries no routing information, so it writes nothing
+        — and not writing is what keeps an alt-tab from producing a disk write
+        per keystroke.
+        """
+        if not focused:
+            return
+        import time
+
+        self._record.focused_at = time.time()
+        self._republish()
+
+    def _republish(self) -> None:
+        if self._closed.is_set() or not self.ready.is_set():
+            return
+        try:
+            publish_viewer(self._record, self._root)
+        except OSError:
+            # A full or read-only disk must not take down the TUI over a
+            # discovery record. The next heartbeat retries.
+            logger.debug("viewer record refresh failed", exc_info=True)
+
+    # -- lifecycle ------------------------------------------------------------
+
+    def start(self) -> None:
+        """Bind, publish, and begin heartbeating on a dedicated thread.
+
+        IDEMPOTENT, and that is load-bearing rather than defensive: this is
+        started from the app's session-adoption path, which runs again on every
+        ``/resume``. A second bind there would leak a listener and a record per
+        swap — the leak class documented in ``tui/app.py``, made worse by also
+        advertising the leaked port.
+        """
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(target=self._run, name="lop-viewer-endpoint", daemon=True)
+        self._thread.start()
+
+    def _run(self) -> None:
+        loop = asyncio.new_event_loop()
+        self._loop = loop
+        try:
+            loop.run_until_complete(self._serve())
+        except Exception:  # noqa: BLE001 — a dead endpoint must not kill the TUI
+            logger.warning("viewer endpoint loop died", exc_info=True)
+        finally:
+            with contextlib.suppress(Exception):
+                loop.close()
+            self.ready.set()  # unblock anyone waiting on a start that failed
+
+    async def _serve(self) -> None:
+        # Port 0: the OS picks and the record carries the number. Loopback
+        # only — the key authorizes, but binding to localhost means an
+        # off-host attacker never reaches the auth check at all.
+        self._server = await asyncio.start_server(
+            self._on_connection, host="127.0.0.1", port=0, limit=_MAX_LINE_BYTES
+        )
+        self._record.control_port = self._server.sockets[0].getsockname()[1]
+        try:
+            publish_viewer(self._record, self._root)
+        except OSError:
+            # Nothing can route to us, but the TUI is otherwise fine. Serve
+            # anyway: the heartbeat retries the publish, and a transient ENOSPC
+            # should not permanently cost the user click-through.
+            logger.debug("viewer record publish failed", exc_info=True)
+        self.ready.set()
+        self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+        try:
+            while not self._closed.is_set():
+                await asyncio.sleep(0.2)
+        finally:
+            await self._shutdown()
+
+    async def _heartbeat_loop(self) -> None:
+        while not self._closed.is_set():
+            await asyncio.sleep(VIEWER_HEARTBEAT_INTERVAL_S)
+            if self._closed.is_set():
+                return
+            self._republish()
+
+    async def _shutdown(self) -> None:
+        if self._heartbeat_task is not None:
+            self._heartbeat_task.cancel()
+            await asyncio.gather(self._heartbeat_task, return_exceptions=True)
+            self._heartbeat_task = None
+        if self._server is not None:
+            self._server.close()
+            with contextlib.suppress(Exception):
+                await self._server.wait_closed()
+            self._server = None
+        unpublish_viewer(self._record.pid, self._root)
+
+    def close(self) -> None:
+        """Stop serving and remove the record. Idempotent, safe from any thread.
+
+        The record is removed HERE as well as in ``_shutdown`` because a loop
+        that never started (a failed bind) has no ``_shutdown`` to run, and a
+        record left behind advertises a port nothing is listening on — which
+        costs a later click its bounded dial timeout before it falls back.
+        """
+        if self._closed.is_set():
+            return
+        self._closed.set()
+        thread = self._thread
+        if thread is not None and thread.is_alive():
+            # The serve loop polls `_closed` every 200 ms and runs `_shutdown`
+            # itself. Join briefly so a clean exit really has released the
+            # port; a slow teardown must not hold up the app's own exit, and
+            # the daemon thread cannot outlive the process regardless.
+            thread.join(timeout=2.0)
+        unpublish_viewer(self._record.pid, self._root)
+
+    # -- the wire -------------------------------------------------------------
+
+    async def _on_connection(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        """One control conversation: authenticate, then serve ops until EOF.
+
+        Auth is the first frame and anything wrong closes WITHOUT a reply, for
+        the reason RuntimeServer states: a port that answers bad keys with
+        errors is an oracle, however small.
+        """
+        try:
+            line = await asyncio.wait_for(reader.readline(), timeout=_AUTH_TIMEOUT_S)
+            frame = json.loads(line.decode("utf-8", "replace"))
+        except (TimeoutError, ValueError, UnicodeDecodeError, OSError):
+            writer.close()
+            return
+        key = frame.get("key", "") if isinstance(frame, dict) else ""
+        if not isinstance(key, str) or not hmac.compare_digest(key, self._record.control_key):
+            logger.warning("viewer control: rejected a bad key")
+            writer.close()
+            return
+        try:
+            while not self._closed.is_set():
+                line = await reader.readline()
+                if not line:
+                    return
+                try:
+                    request = json.loads(line.decode("utf-8", "replace"))
+                except ValueError:
+                    continue  # noise on an authenticated loopback socket
+                if not isinstance(request, dict):
+                    continue
+                await self._dispatch(request, writer)
+        except (OSError, ConnectionError):
+            return
+        finally:
+            with contextlib.suppress(Exception):
+                writer.close()
+
+    async def _dispatch(self, frame: dict[str, Any], writer: asyncio.StreamWriter) -> None:
+        op = str(frame.get("op") or "")
+        req = frame.get("req")
+        try:
+            detail = await self._apply(op, frame)
+            reply: dict[str, Any] = {"op": "ack", "req": req, "detail": detail}
+        except Exception as exc:  # noqa: BLE001 — the error IS the answer
+            # An UNKNOWN op lands here too, and that is the interoperability
+            # story: a newer client asking an older viewer for something it
+            # does not have reads the error and degrades, exactly as an old
+            # daemon does with an unknown session op.
+            reply = {"op": "error", "req": req, "detail": str(exc)}
+        try:
+            writer.write(json.dumps(reply).encode() + b"\n")
+            await writer.drain()
+        except (OSError, ConnectionError):
+            return
+
+    async def _apply(self, op: str, frame: dict[str, Any]) -> str:
+        if op == "resume_session":
+            session_id = str(frame.get("session_id", ""))
+            if not session_id:
+                raise ValueError("resume_session needs a session_id")
+            handler: Callable[[str], Awaitable[str]] = self._host.viewer_resume_session
+            return await handler(session_id)
+        if op == "focus_window":
+            # getattr-probed rather than called directly: the capability is
+            # optional, and a host that never implemented it must answer the
+            # unknown-op error rather than raise AttributeError. Same shape the
+            # session runtime uses for its own optional ops.
+            focus = getattr(self._host, "viewer_focus_window", None)
+            if not callable(focus):
+                raise ValueError("this viewer cannot activate its window")
+            focus_call = cast(Callable[[], Awaitable[str]], focus)
+            return await focus_call()
+        raise ValueError(f"unknown viewer op: {op or '(none)'}")
+
+    # -- introspection for tests and diagnostics ------------------------------
+
+    @property
+    def record(self) -> ViewerRecord:
+        return self._record

--- a/local_operator/session/runtime/viewer_server.py
+++ b/local_operator/session/runtime/viewer_server.py
@@ -75,10 +75,11 @@ _AUTH_TIMEOUT_S = 5.0
 #: magnitude against any real frame.
 _MAX_LINE_BYTES = 64 * 1024
 
-#: Re-exported for the callers (and tests) that reach for it here, beside the
-#: endpoint that advertises it. It is DEFINED in ``viewers`` because the client
-#: reads it too, and a capability string spelled in two modules is a capability
-#: that will eventually be spelled two ways.
+#: ``FOCUS_WINDOW_CAPABILITY`` is listed here so it stays importable from this
+#: module for the callers (and tests) that reach for it beside the endpoint
+#: advertising it. It is DEFINED in ``viewers`` because the client reads it
+#: too, and a capability string spelled in two modules is a capability that
+#: will eventually be spelled two ways.
 __all__ = ["FOCUS_WINDOW_CAPABILITY", "ViewerHost", "ViewerServer"]
 
 

--- a/local_operator/session/runtime/viewers.py
+++ b/local_operator/session/runtime/viewers.py
@@ -1,0 +1,236 @@
+"""Viewer discovery: which PROCESS is displaying which session, right now.
+
+A session record (:mod:`local_operator.session.runtime.registry`) answers "where
+does this transcript live". This module answers a different question that
+nothing could answer before: **"which running window can put session X on
+screen"**. They are not the same question, and conflating them is what this
+module exists to avoid.
+
+WHY IT IS NEEDED. A desktop notification's click used to spawn a brand-new
+terminal, because :mod:`local_operator.tui.resume_click` was written when a
+notification was only ever posted with nothing watching. PR #724 broke that
+premise: a live TUI now posts a toast for a *background* session it can display
+through its own sidebar. The click had no way to find that TUI — so it opened a
+second window running a second process for a session already one keystroke
+away. The operator hit this and reported it; an orphaned Ghostty from exactly
+that path was still resident when this was written.
+
+WHY IT IS A SEPARATE DIRECTORY, AND NOT A ``kind="viewer"`` SESSION RECORD.
+This was the design's first proposal and it is unshippable, for three reasons
+worth recording so nobody re-proposes it:
+
+1. **The path collides.** ``registry.record_path`` is ``run/mobile/<pid>.json``,
+   keyed by pid. A TUI that owns a local session already writes that exact file.
+   A viewer record from the same process IS that file; one silently overwrites
+   the other.
+2. **Old binaries cannot be taught to ignore it.** ``SessionRecord.from_json``
+   drops unknown *keys*; it does not validate ``kind``'s *value*. So a process
+   running a previous build parses ``kind="viewer"`` as an ordinary session
+   record. It would then be a target for ``lop stop --all``'s SIGTERM ladder
+   (``session/runtime/control.py::_stop_targets``), a routable peer for ``lop
+   send`` (``mobile/peer_send.resolve_peer_target``), and a session row on the
+   phone. A change that makes an OLDER peer misbehave is not additive, and this
+   host routinely runs a dozen mixed-version sessions at once.
+3. **There is no single scan site to filter.** ``registry.scan`` has around a
+   dozen non-test callers; a rule enforced in twelve places is a rule that will
+   be broken in the thirteenth.
+
+A separate directory has none of those properties: an old binary globs
+``run/mobile/*.json`` and never sees these files at all. The precedent is
+already in the tree — ``browser_bridge/state.py`` keeps its own discovery file
+under ``run/browser`` for the same isolation reason.
+
+Stdlib-only and import-light by the same contract as ``registry``: the viewer
+publishes on the TUI startup path, and ``tests/unit/test_import_graph.py`` pins
+what that path may pull in.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from local_operator.paths import config_dir
+from local_operator.session.runtime.registry import pid_alive
+
+#: Deliberately NOT ``run/mobile``. See the module docstring: sharing that
+#: directory would put viewer records in front of every older binary's
+#: ``registry.scan``, which treats whatever it finds as a stoppable, routable
+#: session. Treat this literal as a wire constant, exactly as ``RUN_DIRNAME``
+#: is treated — two builds coexist in running processes and there is no
+#: migration that avoids it.
+VIEWER_RUN_DIRNAME = "run/viewers"
+
+#: Version of the *viewer* control surface, independent of the session
+#: runtime's ``PROTOCOL_VERSION`` (which stays at 5; this adds no session
+#: frame). A viewer client refuses a record whose ``protocol`` it does not
+#: know rather than dialing a socket whose frames it cannot predict.
+VIEWER_PROTOCOL = 1
+
+#: Same cadence and grace as the session runtime's, so "is this alive" reads
+#: the same way in both places and an operator debugging one has learned the
+#: other. Divergence here would be a second thing to remember for no gain.
+VIEWER_HEARTBEAT_INTERVAL_S = 15.0
+VIEWER_HEARTBEAT_TIMEOUT_S = 45.0
+
+
+@dataclass
+class ViewerRecord:
+    """One record per PROCESS that can put a session on screen.
+
+    Keyed by pid like a session record, and for the same reason: a process
+    hosts one viewer, so the pid is the natural uniqueness token and a
+    ``kill -9`` leaves exactly one stale file to reap.
+
+    ``control_key`` carries the whole authorization story, again as the session
+    record does: the file is 0600 under a 0700 directory, so anything that can
+    read the key is already the owning account.
+
+    **``current_session`` is the only session id here, deliberately.** The
+    design this implements had the record enumerate every session the viewer
+    could display. A sidebar TUI can display anything in the catalogue, so that
+    list would be large and would be rewritten on every 2 s catalogue poll —
+    write amplification of precisely the kind that makes the sidebar laggy in
+    the first place. ``can_switch`` says "this viewer can be told to display
+    something else", which is the fact routing actually needs; the id it happens
+    to be showing is the separate fact that lets a click skip a redundant
+    switch.
+    """
+
+    pid: int
+    #: What kind of surface this is. Only ``"tui"`` exists today; the field is
+    #: here because the Electron desktop app is a viewer with a strictly better
+    #: focus ceiling and will want to publish one of these unchanged.
+    surface: str
+    control_port: int
+    control_key: str
+    #: The session on screen RIGHT NOW, or ``""`` while the app is still
+    #: booting and has bound nothing. A click for this id needs no switch —
+    #: only focus — which is both the cheapest outcome and the one that does
+    #: not disturb the user's scroll position.
+    current_session: str = ""
+    #: Whether this viewer honours ``resume_session``. False for a surface that
+    #: can only be focused, so resolution can prefer one that can actually take
+    #: the session rather than dialing and being refused.
+    can_switch: bool = True
+    #: When this viewer last held OS focus (``time.time()``). The best
+    #: available proxy for "the window the user expects to land in" when
+    #: several viewers could take the same session. 0.0 means never focused.
+    focused_at: float = 0.0
+    protocol: int = VIEWER_PROTOCOL
+    started_at: float = field(default_factory=time.time)
+    heartbeat_at: float = field(default_factory=time.time)
+    #: Advertised capability strings, ``hasattr``-gated by the publisher
+    #: exactly as ``SessionRecord.capabilities`` is. A viewer that cannot
+    #: activate its window must not advertise that it can, because the client
+    #: then skips a fallback that would have worked.
+    capabilities: list[str] = field(default_factory=list)
+
+    def to_json(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @staticmethod
+    def from_json(data: dict[str, Any]) -> "ViewerRecord":
+        # Tolerate unknown keys for the same forward-compatibility reason
+        # SessionRecord does: a newer viewer's record must be readable by an
+        # older client, which is what lets the two coexist mid-upgrade.
+        known = set(ViewerRecord.__dataclass_fields__)
+        return ViewerRecord(**{k: v for k, v in data.items() if k in known})
+
+
+def viewer_run_dir(root: Path | None = None) -> Path:
+    """The viewer record directory, created 0700 on first use.
+
+    Creating is the WRITER's business, but readers reach it too and a missing
+    directory is an ordinary answer (no viewer has ever run here), so this
+    stays mkdir-on-read like ``registry.run_dir`` rather than raising.
+    """
+    path = (root or config_dir()) / VIEWER_RUN_DIRNAME
+    path.mkdir(parents=True, exist_ok=True)
+    os.chmod(path, 0o700)
+    return path
+
+
+def viewer_record_path(pid: int, root: Path | None = None) -> Path:
+    """Where one viewer's record lives."""
+    return viewer_run_dir(root) / f"{pid}.json"
+
+
+def publish_viewer(record: ViewerRecord, root: Path | None = None) -> Path:
+    """Write (or refresh) a viewer record, staged so a scanner reads either the
+    old file or the new one and never a half-written one."""
+    directory = viewer_run_dir(root)
+    record.heartbeat_at = time.time()
+    fd, tmp = tempfile.mkstemp(dir=directory, prefix=f".{record.pid}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as handle:
+            json.dump(record.to_json(), handle)
+        os.chmod(tmp, 0o600)
+        target = directory / f"{record.pid}.json"
+        os.replace(tmp, target)
+        return target
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def unpublish_viewer(pid: int, root: Path | None = None) -> None:
+    """Remove a viewer's record on clean exit. Best-effort by contract: an exit
+    path must never raise over a missing file."""
+    try:
+        viewer_record_path(pid, root).unlink()
+    except OSError:
+        pass
+
+
+def scan_viewers(root: Path | None = None) -> list[ViewerRecord]:
+    """Every LIVE viewer, freshest focus first, reaping what is dead.
+
+    Only live records are returned — unlike ``registry.scan``, which reports
+    ``wedged`` because a user needs to *see* a wedged session in ``lop
+    sessions``. Nothing here is user-facing: a wedged viewer is one that cannot
+    answer a dial, and reporting it would only make the click try a socket that
+    will time out before falling back to the spawn it should have gone to
+    directly. So a stale heartbeat is filtered out rather than surfaced.
+
+    Ordering is the routing preference, applied once here so every caller
+    resolves identically: most recently focused first (the window the user was
+    last in is where they expect to land), then lowest pid as a deterministic
+    tiebreak so two never-focused viewers do not alternate between scans.
+    """
+    directory = viewer_run_dir(root)
+    now = time.time()
+    out: list[ViewerRecord] = []
+    for path in sorted(directory.glob("*.json")):
+        try:
+            record = ViewerRecord.from_json(json.loads(path.read_text()))
+        except (OSError, ValueError, TypeError):
+            # The only writer is the staged write above, so an unparseable file
+            # means an interrupted crash rather than a format worth preserving.
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            continue
+        if not pid_alive(record.pid):
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            continue
+        if now - record.heartbeat_at > VIEWER_HEARTBEAT_TIMEOUT_S:
+            # Alive but quiet: the process is wedged or stopped. Leave the file
+            # (its owner may recover and resume beating) but do not offer it as
+            # a routing target.
+            continue
+        out.append(record)
+    out.sort(key=lambda rec: (-rec.focused_at, rec.pid))
+    return out

--- a/local_operator/session/runtime/viewers.py
+++ b/local_operator/session/runtime/viewers.py
@@ -128,11 +128,15 @@ VIEWER_ACK_GRACE_S = 5.0
 #: session switched. Measured on the derived bounds: clean at 9.8 s, both
 #: outcomes at 10.2 s and every value above it.
 #:
-#: So the timeout now cancels the navigation and reads what is on screen once
-#: it has stopped, and this is the budget for that. It is spent INSIDE the
-#: client's grace — the server has to answer before the client stops
-#: listening — which is why it is a fraction of the grace rather than a third
-#: literal: the ordering ``RESUME + ABANDON < RESUME + GRACE`` is arithmetic
+#: So the timeout now stops the navigation and reads what is on screen once it
+#: has stopped, and this is the budget for that. The budget covers the hop for a
+#: navigation that EXISTS; one that has not been created yet is refused instead,
+#: by a flag the endpoint publishes before hopping and ``apply`` reads on
+#: Textual's thread — no budget can cover that case, because there is nothing
+#: yet to spend it on. It is spent INSIDE the client's grace — the server has to
+#: answer before the client stops listening — which is why it is a fraction of
+#: the grace rather than a third literal: the ordering
+#: ``RESUME + ABANDON < RESUME + GRACE`` is arithmetic
 #: that cannot be edited into an inversion on one side, and the remaining half
 #: stays with the socket round trip the grace was sized for.
 VIEWER_ABANDON_SETTLE_S = VIEWER_ACK_GRACE_S / 2

--- a/local_operator/session/runtime/viewers.py
+++ b/local_operator/session/runtime/viewers.py
@@ -118,6 +118,25 @@ VIEWER_RESUME_TIMEOUT_S = 10.0
 #: this is slack, not patience.
 VIEWER_ACK_GRACE_S = 5.0
 
+#: How long the server may spend STOPPING a switch that overran the bound
+#: above, before it answers the click.
+#:
+#: The bound alone never made "never both" true, it only moved the delay at
+#: which both happened: ``wait_for`` cancels the waiter, not the navigation, so
+#: a switch slower than ``VIEWER_RESUME_TIMEOUT_S`` still committed after the
+#: endpoint had already answered failure — the caller spawned a window AND the
+#: session switched. Measured on the derived bounds: clean at 9.8 s, both
+#: outcomes at 10.2 s and every value above it.
+#:
+#: So the timeout now cancels the navigation and reads what is on screen once
+#: it has stopped, and this is the budget for that. It is spent INSIDE the
+#: client's grace — the server has to answer before the client stops
+#: listening — which is why it is a fraction of the grace rather than a third
+#: literal: the ordering ``RESUME + ABANDON < RESUME + GRACE`` is arithmetic
+#: that cannot be edited into an inversion on one side, and the remaining half
+#: stays with the socket round trip the grace was sized for.
+VIEWER_ABANDON_SETTLE_S = VIEWER_ACK_GRACE_S / 2
+
 #: Same cadence and grace as the session runtime's, so "is this alive" reads
 #: the same way in both places and an operator debugging one has learned the
 #: other. Divergence here would be a second thing to remember for no gain.

--- a/local_operator/session/runtime/viewers.py
+++ b/local_operator/session/runtime/viewers.py
@@ -69,8 +69,54 @@ VIEWER_RUN_DIRNAME = "run/viewers"
 #: Version of the *viewer* control surface, independent of the session
 #: runtime's ``PROTOCOL_VERSION`` (which stays at 5; this adds no session
 #: frame). A viewer client refuses a record whose ``protocol`` it does not
-#: know rather than dialing a socket whose frames it cannot predict.
+#: know rather than dialing a socket whose frames it cannot predict — see
+#: ``KNOWN_VIEWER_PROTOCOLS``, which is where that refusal is implemented.
 VIEWER_PROTOCOL = 1
+
+#: Every viewer protocol this build can hold a conversation in. ``choose_viewer``
+#: skips a record outside this set, so a FUTURE viewer publishing ``protocol=2``
+#: is routed past rather than dialed with frames it may not understand — the
+#: click then falls through to the spawn, which works against any build.
+#:
+#: This exists as a set rather than a ``<=`` comparison because the useful
+#: question is "can I speak this", not "is it older than me": a build that drops
+#: support for a retired version answers correctly by removing it from here, and
+#: nothing else has to change. The comment above used to describe this check
+#: while no code performed it; a stale docstring on this exact path is what
+#: shipped the bug this module was written to fix, so the prose is now backed by
+#: an implementation rather than the other way round.
+KNOWN_VIEWER_PROTOCOLS = frozenset({VIEWER_PROTOCOL})
+
+#: Advertised by a viewer whose host can activate its own window, and CONSULTED
+#: by the client before it spends a round trip asking. Lives here, beside the
+#: record that carries it, so neither half has to import the other's module to
+#: agree on the spelling.
+FOCUS_WINDOW_CAPABILITY = "focus-window-v1"
+
+#: THE OUTER BOUND ON ONE ``resume_session``, owned here because BOTH halves
+#: must agree on it and they live in different processes.
+#:
+#: The viewer server bounds its whole hop-into-the-app-and-wait-for-the-switch
+#: with this (``tui/app.py::OperatorApp.viewer_resume_session``); the client
+#: derives its own ack deadline from it below. The ordering is the invariant:
+#: **the client must never give up on a switch the server is still going to
+#: land.** When it did, the click produced BOTH outcomes — the running TUI
+#: switched sessions *and* a second terminal window opened for the same
+#: session, which is precisely the bug this feature exists to remove. That was
+#: not hypothetical: with an 8.0 s client bound against a 10.0 s server bound,
+#: a ``/resume`` measured at 8.5 s reproduced the duplicate window every time.
+#:
+#: Expressing the relationship as arithmetic rather than as two hand-maintained
+#: literals two files apart is deliberate. A comment asking a future editor to
+#: check the other side is a rule that gets broken; a derived constant cannot be
+#: inverted without deleting the derivation.
+VIEWER_RESUME_TIMEOUT_S = 10.0
+
+#: How much longer than the server's bound the client waits before concluding
+#: that no ack is coming. It only has to cover the socket round trip and
+#: scheduling on a loaded host — the server has already given up by then, so
+#: this is slack, not patience.
+VIEWER_ACK_GRACE_S = 5.0
 
 #: Same cadence and grace as the session runtime's, so "is this alive" reads
 #: the same way in both places and an operator debugging one has learned the
@@ -117,6 +163,13 @@ class ViewerRecord:
     #: Whether this viewer honours ``resume_session``. False for a surface that
     #: can only be focused, so resolution can prefer one that can actually take
     #: the session rather than dialing and being refused.
+    #:
+    #: **No producer in this repository writes ``False`` today** — every viewer
+    #: is a TUI and every TUI can switch. It is published anyway because the
+    #: Electron desktop app is expected to be a focus-only viewer at first, and
+    #: a routing field that appears later cannot be read by builds already
+    #: running. ``choose_viewer`` honours it now so the older client does the
+    #: right thing on the day something publishes ``False``.
     can_switch: bool = True
     #: When this viewer last held OS focus (``time.time()``). The best
     #: available proxy for "the window the user expects to land in" when
@@ -125,10 +178,15 @@ class ViewerRecord:
     protocol: int = VIEWER_PROTOCOL
     started_at: float = field(default_factory=time.time)
     heartbeat_at: float = field(default_factory=time.time)
-    #: Advertised capability strings, ``hasattr``-gated by the publisher
-    #: exactly as ``SessionRecord.capabilities`` is. A viewer that cannot
-    #: activate its window must not advertise that it can, because the client
-    #: then skips a fallback that would have worked.
+    #: Advertised capability strings, ``hasattr``-gated by the publisher exactly
+    #: as ``SessionRecord.capabilities`` is, and READ by the client before it
+    #: asks for an optional op (``deliver_click`` skips ``focus_window`` when
+    #: ``FOCUS_WINDOW_CAPABILITY`` is absent).
+    #:
+    #: A viewer that cannot activate its window must therefore not advertise
+    #: that it can: the client would spend a round trip and its focus timeout on
+    #: a request that can only be refused. The reverse under-advertisement is
+    #: harmless — focus is chrome, and the switch has already happened.
     capabilities: list[str] = field(default_factory=list)
 
     def to_json(self) -> dict[str, Any]:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -27,6 +27,7 @@ import inspect
 import logging
 import os
 import sys
+import threading
 import time
 import uuid
 from collections.abc import Mapping, Sequence
@@ -4652,8 +4653,27 @@ class OperatorApp(App[None]):
                 self._set_sidebar_open(False)
             self._editor().focus()
             return
+        self._select_sidebar_session(message.session_id)
+
+    def _select_sidebar_session(self, session_id: str) -> asyncio.Task[None]:
+        """Start a sidebar navigation to ``session_id`` — the ONE way to switch.
+
+        Extracted so the notification-click path (:meth:`viewer_resume_session`)
+        starts a switch by literally the same code as the user's keystroke,
+        rather than by a second route that merely resembles it. That distinction
+        is not cosmetic: ``/resume`` looks equivalent and is not — it calls
+        ``_deny_queued_approvals``, so switching that way silently answers "no"
+        to an approval the user had parked in the session being left, which
+        ``docs/SESSION_SIDEBAR.md`` explicitly forbids of a switch. Sidebar
+        navigation instead *suspends* those gates (``_suspend_sidebar_gates``
+        snapshots the card and ``_restore_gate_draft`` puts it back on return).
+
+        Cancelling the outgoing session's worker group first is part of that
+        contract and not an optimisation: those workers still hold the
+        presentation the navigation is about to replace.
+        """
         self._sidebar_prior_workers.update(self.workers.cancel_group(self, "session"))
-        self._sidebar_navigation.select(message.session_id)
+        return self._sidebar_navigation.select(session_id)
 
     def _apply_sidebar_settings(self) -> None:
         settings = SidebarSettings.from_values(self._config_values())
@@ -15475,36 +15495,99 @@ class OperatorApp(App[None]):
     async def viewer_resume_session(self, session_id: str) -> str:
         """Display ``session_id`` here — the click's whole purpose.
 
-        Routed through the app's own ``/resume`` on Textual's thread, which is
-        the SAME path the user's sidebar keystroke takes. That is deliberate:
-        it inherits the sidebar's invariants wholesale (a switch never answers
-        a gate, never cancels a turn, never redirects its result) rather than
-        creating a second way to change which session is on screen.
+        THE SIDEBAR'S NAVIGATION, LITERALLY. This calls
+        :meth:`_select_sidebar_session`, the same function the user's sidebar
+        keystroke reaches, so the click inherits the sidebar's invariants by
+        construction rather than by resemblance. It used to run ``/resume``
+        instead, which *looks* equivalent and is not: ``/resume`` reloads
+        through ``_deny_queued_approvals``, so a click about session B silently
+        answered "no" to an approval the user had parked in session A and
+        rendered no receipt for it — measured, and forbidden in as many words by
+        ``docs/SESSION_SIDEBAR.md`` ("Switching does not answer a gate, cancel a
+        turn, or redirect its eventual result"). This docstring asserted that
+        inheritance while the code did not have it; a docstring outrunning its
+        code on this exact path is the defect this whole module was written to
+        fix, so it is now the same code rather than a matching promise.
 
-        Called on the viewer endpoint's own loop, so the hop to Textual is made
-        here and bounded — an app inside a modal's nested pump would otherwise
-        wedge this dispatch indefinitely, and the click's caller is waiting on
-        the ack to decide whether to spawn a window.
+        THE ACK MEANS DISPLAYED, NOT DISPATCHED. The click's caller skips its
+        spawn fallback on this ack, so returning success for a session that
+        failed to open cost the user both outcomes: no new window AND the loss
+        of the conversation they were reading. Resolution therefore waits for
+        the navigation task and then checks what is actually on screen. The
+        sidebar path helps twice here — it prepares off-screen and commits only
+        once the target is ready, so a failure leaves the outgoing conversation
+        exactly where it was, and this raises so ``switched`` stays False and
+        the spawn runs.
+
+        BOUNDED END TO END, and the bound is real this time. ``call_from_thread``
+        blocks its caller with no timeout of its own (textual 8.2.8 ends in a
+        bare ``future.result()``), so the previous ``wait_for`` sat *after* the
+        hazard it named and an app wedged in a nested pump ran past it
+        indefinitely — measured at 30 s against a 12 s outer bound. The blocking
+        call is now inside the ``wait_for`` via a worker thread. A timeout
+        strands that worker until Textual services the callback, which is
+        unavoidable (an enqueued ``call_from_thread`` cannot be recalled) and
+        acceptable: it is a pooled thread rather than this endpoint's loop, so
+        the endpoint keeps answering and the click falls back on time.
+
+        ``VIEWER_RESUME_TIMEOUT_S`` is shared with the client's ack deadline,
+        which is derived from it — see ``session/runtime/viewers``. The client
+        MUST outlast this bound; when it did not, a slow switch delivered the
+        switch *and* a duplicate window, which is the exact bug this feature
+        removes.
         """
         # The same set-once helper the mobile handle's app hop uses, imported
         # rather than re-declared: two spellings of "resolve this future unless
         # a cancellation already did" is exactly the duplication that lets one
         # of them drift into swallowing an error.
         from local_operator.mobile.tui_handle import _set_unless_done
+        from local_operator.session.runtime.viewers import VIEWER_RESUME_TIMEOUT_S
+
+        if threading.get_ident() == getattr(self, "_thread_id", None):
+            # Preserved from before the worker-thread hop below, which would
+            # otherwise make this reachable and self-deadlocking. The endpoint
+            # always calls from its own thread; anything calling from Textual's
+            # is a wiring mistake and should hear so rather than hang.
+            raise RuntimeError("viewer_resume_session must not run on the app's own thread")
 
         loop = asyncio.get_running_loop()
-        future: asyncio.Future[None] = loop.create_future()
+        future: asyncio.Future[str] = loop.create_future()
 
         def apply() -> None:
+            """On Textual's thread: start the switch and report where it landed."""
             try:
-                self._run_slash_command(f"/resume {session_id}")
-                loop.call_soon_threadsafe(_set_unless_done, future, None, None)
+                task = self._select_sidebar_session(session_id)
             except Exception as exc:  # noqa: BLE001 — the error IS the answer
                 loop.call_soon_threadsafe(_set_unless_done, future, None, exc)
+                return
 
-        self.call_from_thread(apply)
-        await asyncio.wait_for(future, timeout=10.0)
-        return f"displayed {session_id}"
+            def settled(_task: "asyncio.Task[None]") -> None:
+                # Still on Textual's thread, so reading the binding is safe.
+                # `SessionNavigation` reports failure through its `failed`
+                # callback and completes normally, so the task's own outcome
+                # cannot be trusted as the answer — what is on screen can.
+                current = getattr(self._session, "session_id", "") if self._session else ""
+                if current == session_id:
+                    loop.call_soon_threadsafe(
+                        _set_unless_done, future, f"displayed {session_id}", None
+                    )
+                else:
+                    error = _task.exception() if not _task.cancelled() else None
+                    loop.call_soon_threadsafe(
+                        _set_unless_done,
+                        future,
+                        None,
+                        error or RuntimeError(f"could not display {session_id}"),
+                    )
+
+            task.add_done_callback(settled)
+
+        async def hop_and_wait() -> str:
+            # `to_thread` is what puts the blocking enqueue INSIDE the bound.
+            await asyncio.to_thread(self.call_from_thread, apply)
+            return await future
+
+        return await asyncio.wait_for(hop_and_wait(), timeout=VIEWER_RESUME_TIMEOUT_S)
 
     async def viewer_focus_window(self) -> str:
         """Bring this window forward. Best-effort, bounded, off the event loop.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -15530,18 +15530,45 @@ class OperatorApp(App[None]):
         acceptable: it is a pooled thread rather than this endpoint's loop, so
         the endpoint keeps answering and the click falls back on time.
 
+        NEVER BOTH — A SWITCH OR A SPAWN, AT ANY DELAY. That is the property
+        this endpoint owes its caller, and the bound alone never delivered it:
+        ``wait_for`` cancels the waiter, not the navigation, so a switch slower
+        than the bound still committed *after* this had answered failure, and
+        the caller spawned a window for a session that then switched underneath
+        it. Raising the bound only moved the delay at which that happened —
+        measured clean at 9.8 s and doubled at 10.2 s.
+
+        So an overrun is now stopped rather than merely stopped waiting for.
+        The timeout hops back and calls ``SessionNavigation.abandon``, whose
+        generation bump fences the navigation out of committing, and then reads
+        what is on screen: a switch that beat the fence is reported as the
+        success it is, and one that did not can no longer land. Two outcomes,
+        never both — by construction rather than by the bound being large
+        enough. ``abandon`` is scoped to the task this call started, so a switch
+        the USER began while this one overran is not cancelled with it.
+
+        A cancelled navigation cannot half-swap the app: ``SessionNavigation``
+        commits with no await between its final generation check and
+        ``_commit_sidebar_session``, so the fence lands strictly before or
+        strictly after the swap, and preparation is discarded through the same
+        ``release``/``pending("")`` path a user's own cancel uses — leaving the
+        outgoing conversation, its draft and its suspended gates as they were.
+
         ``VIEWER_RESUME_TIMEOUT_S`` is shared with the client's ack deadline,
         which is derived from it — see ``session/runtime/viewers``. The client
-        MUST outlast this bound; when it did not, a slow switch delivered the
-        switch *and* a duplicate window, which is the exact bug this feature
-        removes.
+        MUST outlast this bound plus the abandon budget spent above; when it did
+        not, a slow switch delivered the switch *and* a duplicate window, which
+        is the exact bug this feature removes.
         """
         # The same set-once helper the mobile handle's app hop uses, imported
         # rather than re-declared: two spellings of "resolve this future unless
         # a cancellation already did" is exactly the duplication that lets one
         # of them drift into swallowing an error.
         from local_operator.mobile.tui_handle import _set_unless_done
-        from local_operator.session.runtime.viewers import VIEWER_RESUME_TIMEOUT_S
+        from local_operator.session.runtime.viewers import (
+            VIEWER_ABANDON_SETTLE_S,
+            VIEWER_RESUME_TIMEOUT_S,
+        )
 
         if threading.get_ident() == getattr(self, "_thread_id", None):
             # Preserved from before the worker-thread hop below, which would
@@ -15553,6 +15580,10 @@ class OperatorApp(App[None]):
         loop = asyncio.get_running_loop()
         future: asyncio.Future[str] = loop.create_future()
 
+        # Written on Textual's thread by `apply`, read on Textual's thread by
+        # `abandon`; the hop between them is what makes that safe.
+        started: list["asyncio.Task[None]"] = []
+
         def apply() -> None:
             """On Textual's thread: start the switch and report where it landed."""
             try:
@@ -15560,6 +15591,7 @@ class OperatorApp(App[None]):
             except Exception as exc:  # noqa: BLE001 — the error IS the answer
                 loop.call_soon_threadsafe(_set_unless_done, future, None, exc)
                 return
+            started.append(task)
 
             def settled(_task: "asyncio.Task[None]") -> None:
                 # Still on Textual's thread, so reading the binding is safe.
@@ -15587,7 +15619,41 @@ class OperatorApp(App[None]):
             await asyncio.to_thread(self.call_from_thread, apply)
             return await future
 
-        return await asyncio.wait_for(hop_and_wait(), timeout=VIEWER_RESUME_TIMEOUT_S)
+        def abandon() -> str:
+            """On Textual's thread: stop the overrun switch, then report truthfully.
+
+            Reading the binding here rather than assuming failure is the whole
+            point. The navigation may have committed in the moment between the
+            bound expiring and this callback running, and answering "failed"
+            for a switch that is on screen is exactly the lie that spawns the
+            duplicate window.
+            """
+            task = started[0]
+            self._sidebar_navigation.abandon(task)
+            current = getattr(self._session, "session_id", "") if self._session else ""
+            return f"displayed {session_id}" if current == session_id else ""
+
+        try:
+            return await asyncio.wait_for(hop_and_wait(), timeout=VIEWER_RESUME_TIMEOUT_S)
+        except (asyncio.TimeoutError, TimeoutError):
+            if not started:
+                # The bound expired inside the hop itself — a wedged app that
+                # never serviced the enqueue, so no navigation exists to stop
+                # and nothing can commit behind us.
+                raise
+            # Bounded again, and inside the client's remaining grace: this hop
+            # is enqueued behind whatever made the switch slow, so an app wedged
+            # badly enough to swallow it must not convert a duplicate window
+            # into an endpoint that never answers at all.
+            landed = await asyncio.wait_for(
+                asyncio.to_thread(self.call_from_thread, abandon),
+                timeout=VIEWER_ABANDON_SETTLE_S,
+            )
+            if landed:
+                # It committed before the fence. The switch the user asked for
+                # happened, late; saying so is what stops the second window.
+                return landed
+            raise
 
     async def viewer_focus_window(self) -> str:
         """Bring this window forward. Best-effort, bounded, off the event loop.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2751,6 +2751,12 @@ class OperatorApp(App[None]):
         #: first session is adopted; torn down in ``on_unmount``.
         self._mobile_registrant: Any = None
         self._mobile_handle: Any = None
+        #: The PROCESS-scoped viewer endpoint, distinct from the session-scoped
+        #: mobile registrant above and with a deliberately different lifetime:
+        #: it survives every `/resume`, because the thing a notification click
+        #: must reach is precisely the thing that outlives a session swap. See
+        #: `_viewer_adopted`.
+        self._viewer_server: Any = None
         # Separate from user inactivity: this watches the OS-backed terminal
         # reader. A mounted but untouched TUI remains alive indefinitely.
         from local_operator.session.runtime.process import _grace_seconds
@@ -15266,6 +15272,16 @@ class OperatorApp(App[None]):
         if self._notifier is not None:
             self._notifier.set_focused(True)
         self._set_animation_focused(True)
+        # Stamp when the user was last HERE. When several windows could take a
+        # notification click, this is the tiebreak that sends it to the one they
+        # were most recently working in. Only the gaining edge is recorded — a
+        # blur carries no routing information, so an alt-tab costs no write.
+        server = self._viewer_server
+        if server is not None:
+            try:
+                server.note_focused(True)
+            except Exception:  # noqa: BLE001 — focus bookkeeping is never worth an event
+                logger.debug("viewer focus stamp failed", exc_info=True)
 
     def on_app_blur(self, event: AppBlur) -> None:
         """The terminal lost OS focus \u2014 notify, and slow every animation."""
@@ -15404,6 +15420,116 @@ class OperatorApp(App[None]):
         if self._notify(kind):
             self._waiting_kind = kind
 
+    def _viewer_adopted(self, session: Any) -> None:
+        """Publish (once) and keep current the record that makes this window
+        reachable by a notification click.
+
+        WHY THIS IS NOT PART OF ``_mobile_adopted``. That method manages a
+        SESSION-scoped registrant and tears it down whenever the app follows a
+        ``RemoteSession`` — which is the normal sidebar state — because a second
+        registrant for one transcript corrupts daemon routing. Correct, and it
+        leaves a sidebar user's TUI listening on nothing, which is why a
+        notification click had no live process to route to and spawned a whole
+        new window instead.
+
+        This endpoint describes the PROCESS: which window can put a session on
+        screen. It is published once and then merely re-stamped with whichever
+        session is current, local or remote alike, so it is available in exactly
+        the state the session registrant is not. Its record lives in a separate
+        run directory, so no older binary's ``registry.scan`` can mistake it for
+        a stoppable, routable session — see ``session/runtime/viewers``.
+
+        Best-effort by contract, like the mobile bridge: click-through is chrome
+        and must never be a startup gate for the terminal.
+        """
+        session_id = str(getattr(session, "session_id", "") or "")
+        if self._viewer_server is None:
+            try:
+                from local_operator.session.runtime.viewer_server import ViewerServer
+
+                self._viewer_server = ViewerServer(self)
+                self._viewer_server.start()
+            except Exception:  # noqa: BLE001 — a viewer record is never worth the TUI
+                logger.debug("viewer endpoint failed to start", exc_info=True)
+                self._viewer_server = None
+                return
+        try:
+            self._viewer_server.note_session(session_id)
+        except Exception:  # noqa: BLE001
+            logger.debug("viewer record refresh failed", exc_info=True)
+
+    def _viewer_teardown(self) -> None:
+        """Stop serving and remove the record. Idempotent, and called on the
+        one clean-exit path so a closed window stops advertising a port."""
+        server = self._viewer_server
+        if server is None:
+            return
+        self._viewer_server = None
+        try:
+            server.close()
+        except Exception:  # noqa: BLE001 — an exit path must not raise
+            logger.debug("viewer endpoint close failed", exc_info=True)
+
+    # -- ViewerHost: what a notification click may ask of this window ---------
+
+    async def viewer_resume_session(self, session_id: str) -> str:
+        """Display ``session_id`` here — the click's whole purpose.
+
+        Routed through the app's own ``/resume`` on Textual's thread, which is
+        the SAME path the user's sidebar keystroke takes. That is deliberate:
+        it inherits the sidebar's invariants wholesale (a switch never answers
+        a gate, never cancels a turn, never redirects its result) rather than
+        creating a second way to change which session is on screen.
+
+        Called on the viewer endpoint's own loop, so the hop to Textual is made
+        here and bounded — an app inside a modal's nested pump would otherwise
+        wedge this dispatch indefinitely, and the click's caller is waiting on
+        the ack to decide whether to spawn a window.
+        """
+        # The same set-once helper the mobile handle's app hop uses, imported
+        # rather than re-declared: two spellings of "resolve this future unless
+        # a cancellation already did" is exactly the duplication that lets one
+        # of them drift into swallowing an error.
+        from local_operator.mobile.tui_handle import _set_unless_done
+
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[None] = loop.create_future()
+
+        def apply() -> None:
+            try:
+                self._run_slash_command(f"/resume {session_id}")
+                loop.call_soon_threadsafe(_set_unless_done, future, None, None)
+            except Exception as exc:  # noqa: BLE001 — the error IS the answer
+                loop.call_soon_threadsafe(_set_unless_done, future, None, exc)
+
+        self.call_from_thread(apply)
+        await asyncio.wait_for(future, timeout=10.0)
+        return f"displayed {session_id}"
+
+    async def viewer_focus_window(self) -> str:
+        """Bring this window forward. Best-effort, bounded, off the event loop.
+
+        THE SUBPROCESS RUNS IN A THREAD, and that is not incidental. This is an
+        OS call on a path whose whole contract is that a notification is chrome:
+        a blocking `subprocess.run` on Textual's loop would freeze the UI for as
+        long as the window server took to answer, which is the frozen-event-loop
+        class ``tests/e2e/watchdog.py`` exists to catch and which a Python-level
+        probe cannot see. It runs on the viewer endpoint's thread instead, and
+        the helper bounds it with a timeout regardless.
+
+        Solicited focus only: this is reachable exclusively from a click the
+        user made. Nothing else in the codebase may call it.
+        """
+        from local_operator.tui.window_focus import activate_window
+
+        activated = await asyncio.to_thread(activate_window)
+        if not activated:
+            # An honest "no" rather than a lie: the session is switched and the
+            # user finds the window themselves. The client treats this as a
+            # non-failure precisely because the switch already succeeded.
+            raise ValueError("no window activation available here")
+        return "activated"
+
     def _mobile_adopted(self, session: Any) -> None:
         """Bring the mobile bridge up (once) or re-point it at a new session.
 
@@ -15422,6 +15548,10 @@ class OperatorApp(App[None]):
         # transcript and corrupt daemon routing. If this process previously
         # owned a local session, tear its record down while following remotely;
         # takeover calls this again with a real Session and starts a fresh owner.
+        # The viewer endpoint is published for EVERY session, remote included —
+        # that is the whole point of it being process-scoped, and it is what the
+        # teardown below would otherwise take away in the normal sidebar state.
+        self._viewer_adopted(session)
         if bool(getattr(session, "is_remote", False)):
             self._mobile_teardown()
             return
@@ -15563,6 +15693,12 @@ class OperatorApp(App[None]):
         # the common case so the phone list drops the session immediately
         # rather than at the next scan.
         self._mobile_teardown()
+        # And the viewer record, for the same reason and with an extra one of
+        # its own: it advertises a LISTENING PORT, so a record left behind
+        # costs the next notification click its full dial timeout before it
+        # falls back to a spawn. A killed process leaves the file, which the
+        # reader reaps on the pid-liveness check.
+        self._viewer_teardown()
         # Alongside the mobile record and for the same reason: this is a clean
         # exit, so the pane must stop advertising a session the user has just
         # closed. A crash never reaches this line, which is what leaves the

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -15530,22 +15530,62 @@ class OperatorApp(App[None]):
         acceptable: it is a pooled thread rather than this endpoint's loop, so
         the endpoint keeps answering and the click falls back on time.
 
-        NEVER BOTH — A SWITCH OR A SPAWN, AT ANY DELAY. That is the property
-        this endpoint owes its caller, and the bound alone never delivered it:
+        ONE CLICK YIELDS A SWITCH OR A SPAWN, NEVER BOTH, AT ANY DELAY. That is
+        the property this endpoint owes its caller, and it is stated with its
+        scope — one click — because that is the scope the code delivers; the
+        residue for a PAIR of clicks is written out at the end of this
+        docstring rather than papered over. This file exists because a
+        docstring asserted an invariant its code did not have, so an
+        unconditional claim here would be the same defect in a new place.
+
+        The bound alone never delivered even the single-click property:
         ``wait_for`` cancels the waiter, not the navigation, so a switch slower
         than the bound still committed *after* this had answered failure, and
         the caller spawned a window for a session that then switched underneath
         it. Raising the bound only moved the delay at which that happened —
         measured clean at 9.8 s and doubled at 10.2 s.
 
-        So an overrun is now stopped rather than merely stopped waiting for.
-        The timeout hops back and calls ``SessionNavigation.abandon``, whose
-        generation bump fences the navigation out of committing, and then reads
-        what is on screen: a switch that beat the fence is reported as the
-        success it is, and one that did not can no longer land. Two outcomes,
-        never both — by construction rather than by the bound being large
-        enough. ``abandon`` is scoped to the task this call started, so a switch
-        the USER began while this one overran is not cancelled with it.
+        So an overrun is now stopped rather than merely stopped waiting for,
+        and the give-up binds TWO orderings because the app can be slow in two
+        different places:
+
+        * **A navigation that already exists** is fenced. The timeout hops back
+          and calls ``SessionNavigation.abandon``, whose generation bump fences
+          it out of committing, and then reads what is on screen: a switch that
+          beat the fence is reported as the success it is, and one that did not
+          can no longer land.
+        * **A navigation that does not exist yet** is refused. The bound can
+          expire while the enqueue is still queued, so an app that services the
+          hop LATE would otherwise start a switch behind an endpoint that had
+          already answered failure — the same double action reached through the
+          sibling branch, and reproducible with nothing patched at all, merely a
+          loop busy past the bound. The endpoint therefore publishes that it has
+          given up BEFORE it hops, and ``apply`` reads that on Textual's thread
+          before it can create anything. A check would race the creation it is
+          trying to catch, because the two run on different threads; a refusal
+          is ordered by the thread that would do the work.
+
+        Both are needed: which one carries a given run depends on whether
+        Textual services ``apply`` before or after the abandon callback, and
+        each has a test that goes red when only that mechanism is removed.
+
+        ``abandon`` is scoped to the task this call started, so a switch the
+        USER began while this one overran is not cancelled with it.
+
+        A CLICK SUPERSEDED BY ANOTHER CLICK FOR THE SAME SESSION follows its
+        successor instead of reporting failure. ``select`` retires the current
+        navigation, so two clicks on one session inside the preparation window
+        used to give the first a truthful "not displayed" — its successor had
+        not committed yet — and that click spawned a window the successor then
+        switched underneath. Neither click overran anything, so this is not the
+        fence's path; the resolution above is where it is fixed.
+
+        WHAT REMAINS, stated rather than implied: two clicks on DIFFERENT
+        sessions in that window still produce a spawn and a switch. That is one
+        outcome each for two distinct requests rather than two for one, and it
+        is arguably correct — the superseded click really is about a session
+        that is not on screen. It is called out here because the guarantee
+        above is per click, and a reader is owed the boundary of it.
 
         A cancelled navigation cannot half-swap the app: ``SessionNavigation``
         commits with no await between its final generation check and
@@ -15581,17 +15621,40 @@ class OperatorApp(App[None]):
         future: asyncio.Future[str] = loop.create_future()
 
         # Written on Textual's thread by `apply`, read on Textual's thread by
-        # `abandon`; the hop between them is what makes that safe.
-        started: list["asyncio.Task[None]"] = []
+        # `abandon`; the hop between them is what makes that safe. ONE slot, and
+        # spelled as one: it holds the single navigation this call started, and
+        # a list made "no navigation yet" and "navigation, then abandoned" look
+        # like the same emptiness at a glance.
+        started: "asyncio.Task[None] | None" = None
+
+        #: Set by the endpoint thread the instant it gives up, read on Textual's
+        #: thread by `apply` before it starts anything. A REFUSAL, not a check:
+        #: the endpoint cannot poll for a navigation that has not been created
+        #: yet, so the only race-free way to stop one is to leave a decision
+        #: where the thread that would create it must read it first.
+        abandoned = False
 
         def apply() -> None:
             """On Textual's thread: start the switch and report where it landed."""
+            nonlocal started
+            if abandoned:
+                # The caller already answered failure and its spawn is running.
+                # Starting the switch now would deliver BOTH outcomes, which is
+                # the whole defect; refusing is what makes the endpoint's answer
+                # true after the fact rather than merely true when it was given.
+                loop.call_soon_threadsafe(
+                    _set_unless_done,
+                    future,
+                    None,
+                    TimeoutError(f"gave up on {session_id} before this hop was serviced"),
+                )
+                return
             try:
                 task = self._select_sidebar_session(session_id)
             except Exception as exc:  # noqa: BLE001 — the error IS the answer
                 loop.call_soon_threadsafe(_set_unless_done, future, None, exc)
                 return
-            started.append(task)
+            started = task
 
             def settled(_task: "asyncio.Task[None]") -> None:
                 # Still on Textual's thread, so reading the binding is safe.
@@ -15603,14 +15666,34 @@ class OperatorApp(App[None]):
                     loop.call_soon_threadsafe(
                         _set_unless_done, future, f"displayed {session_id}", None
                     )
-                else:
-                    error = _task.exception() if not _task.cancelled() else None
-                    loop.call_soon_threadsafe(
-                        _set_unless_done,
-                        future,
-                        None,
-                        error or RuntimeError(f"could not display {session_id}"),
-                    )
+                    return
+                # SUPERSEDED BY A SWITCH TO THE SAME PLACE IS NOT A FAILURE.
+                # `SessionNavigation.select` cancels the current navigation, so
+                # a second click on the same session inside the preparation
+                # window retires this one — and answering "could not display"
+                # for it made that click spawn a window while its successor
+                # switched the app to the very session it spawned for (Q4). The
+                # question is only ever "is the user going to end up here", so
+                # follow the navigation that replaced this one rather than
+                # reporting on a task that was retired for heading the right
+                # way. Bounded by the endpoint's own `wait_for`, and only ever
+                # re-armed onto a DIFFERENT task, so it cannot spin.
+                successor = self._sidebar_navigation._task
+                if (
+                    successor is not None
+                    and successor is not _task
+                    and not successor.done()
+                    and self._sidebar_navigation.requested_id == session_id
+                ):
+                    successor.add_done_callback(settled)
+                    return
+                error = _task.exception() if not _task.cancelled() else None
+                loop.call_soon_threadsafe(
+                    _set_unless_done,
+                    future,
+                    None,
+                    error or RuntimeError(f"could not display {session_id}"),
+                )
 
             task.add_done_callback(settled)
 
@@ -15628,23 +15711,35 @@ class OperatorApp(App[None]):
             for a switch that is on screen is exactly the lie that spawns the
             duplicate window.
             """
-            task = started[0]
-            self._sidebar_navigation.abandon(task)
+            task = started
+            if task is not None:
+                self._sidebar_navigation.abandon(task)
             current = getattr(self._session, "session_id", "") if self._session else ""
             return f"displayed {session_id}" if current == session_id else ""
 
         try:
             return await asyncio.wait_for(hop_and_wait(), timeout=VIEWER_RESUME_TIMEOUT_S)
         except (asyncio.TimeoutError, TimeoutError):
-            if not started:
-                # The bound expired inside the hop itself — a wedged app that
-                # never serviced the enqueue, so no navigation exists to stop
-                # and nothing can commit behind us.
-                raise
+            # REFUSE BEFORE HOPPING, and the order is the correctness argument.
+            # The bound can expire while the enqueue is still queued, so there
+            # may be no navigation to abandon *yet* — an app that services the
+            # hop late runs `apply` after this branch, starting a switch behind
+            # an endpoint that has already answered failure. Reading `started`
+            # here and raising when it is empty was that hole: a check races the
+            # creation it is trying to catch, because the two run on different
+            # threads. Setting the refusal first closes it without a race — it
+            # is published before this thread does anything else, and `apply`
+            # reads it on Textual's thread before it can create anything, so
+            # every ordering ends in one outcome. The hop below then handles the
+            # other case, a navigation that already exists.
+            abandoned = True
             # Bounded again, and inside the client's remaining grace: this hop
             # is enqueued behind whatever made the switch slow, so an app wedged
             # badly enough to swallow it must not convert a duplicate window
-            # into an endpoint that never answers at all.
+            # into an endpoint that never answers at all. It runs even when no
+            # navigation was recorded — Textual serialises it against `apply`,
+            # so arriving first means the refusal above is what `apply` sees,
+            # and arriving second means there is a real task to fence.
             landed = await asyncio.wait_for(
                 asyncio.to_thread(self.call_from_thread, abandon),
                 timeout=VIEWER_ABANDON_SETTLE_S,

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -15530,13 +15530,19 @@ class OperatorApp(App[None]):
         acceptable: it is a pooled thread rather than this endpoint's loop, so
         the endpoint keeps answering and the click falls back on time.
 
-        ONE CLICK YIELDS A SWITCH OR A SPAWN, NEVER BOTH, AT ANY DELAY. That is
-        the property this endpoint owes its caller, and it is stated with its
-        scope — one click — because that is the scope the code delivers; the
-        residue for a PAIR of clicks is written out at the end of this
-        docstring rather than papered over. This file exists because a
-        docstring asserted an invariant its code did not have, so an
-        unconditional claim here would be the same defect in a new place.
+        ONE CLICK YIELDS A SWITCH OR A SPAWN, NEVER BOTH — unconditionally
+        while no switch has started, and for a switch already under way as long
+        as the app services the give-up hop within ``VIEWER_ABANDON_SETTLE_S``.
+        That is the property this endpoint owes its caller, and the condition is
+        in the claim rather than in a footnote because the two mechanisms below
+        genuinely differ in what they need: the refusal asks nothing of the app,
+        while the fence has to actually run to fence anything. Both residues —
+        a PAIR of clicks, and a wedge outlasting the settle budget — are written
+        out at the end of this docstring rather than papered over. This file
+        exists because a docstring asserted an invariant its code did not have,
+        and this clause has now been caught claiming more than the code delivers
+        three times, so a headline that a later paragraph has to walk back would
+        be the same defect in a new place.
 
         The bound alone never delivered even the single-click property:
         ``wait_for`` cancels the waiter, not the navigation, so a switch slower
@@ -15580,12 +15586,24 @@ class OperatorApp(App[None]):
         switched underneath. Neither click overran anything, so this is not the
         fence's path; the resolution above is where it is fixed.
 
-        WHAT REMAINS, stated rather than implied: two clicks on DIFFERENT
+        WHAT REMAINS, stated rather than implied. First, two clicks on DIFFERENT
         sessions in that window still produce a spawn and a switch. That is one
         outcome each for two distinct requests rather than two for one, and it
         is arguably correct — the superseded click really is about a session
         that is not on screen. It is called out here because the guarantee
         above is per click, and a reader is owed the boundary of it.
+
+        Second, and this is why the guarantee above is conditional: a wedge that
+        outlasts ``VIEWER_RESUME_TIMEOUT_S`` and then ``VIEWER_ABANDON_SETTLE_S``
+        on top of it can still deliver both, in the one ordering where ``apply``
+        was serviced early enough that a navigation EXISTS. The settle hop below
+        expires too, so ``abandon`` never runs, nothing fences the live
+        navigation, and the bare ``raise`` answers failure while the switch
+        commits behind it. That residue predates this change — it is the
+        ``except`` arm's ``raise``, which reproduces identically before it — and
+        removing it needs a fence that does not depend on the app answering at
+        all, which is a larger change than this one. It is recorded because the
+        headline would otherwise deny it.
 
         A cancelled navigation cannot half-swap the app: ``SessionNavigation``
         commits with no await between its final generation check and
@@ -15642,12 +15660,16 @@ class OperatorApp(App[None]):
                 # Starting the switch now would deliver BOTH outcomes, which is
                 # the whole defect; refusing is what makes the endpoint's answer
                 # true after the fact rather than merely true when it was given.
-                loop.call_soon_threadsafe(
-                    _set_unless_done,
-                    future,
-                    None,
-                    TimeoutError(f"gave up on {session_id} before this hop was serviced"),
-                )
+                #
+                # CANCELLED RATHER THAN FAILED, because nobody is left to read a
+                # failure. `abandoned` is only ever set after `wait_for` has
+                # already cancelled `hop_and_wait`, so the `await future` that
+                # would have retrieved an exception here no longer exists —
+                # resolving it with one instead made asyncio report "Future
+                # exception was never retrieved" on stderr at collection time.
+                # A cancellation carries the same "this hop produced nothing"
+                # and is not owed a reader.
+                loop.call_soon_threadsafe(future.cancel)
                 return
             try:
                 task = self._select_sidebar_session(session_id)

--- a/local_operator/tui/resume_click.py
+++ b/local_operator/tui/resume_click.py
@@ -123,10 +123,16 @@ def _route_to_viewer(session_id: str) -> bool:
     """Ask an already-running viewer to display the session. True if one did.
 
     Every failure mode — no viewer, a wedged one, a refused socket, a viewer
-    that died between the scan and the dial — returns False and falls through
-    to the spawn, which is the path that works when nothing is running. The
-    dial is bounded end to end (``viewer_client``), so a wedged viewer costs a
-    second or two rather than the click.
+    that died between the scan and the dial, **and a viewer that took the
+    request but could not display the session** — returns False and falls
+    through to the spawn, which is the path that works when nothing is running.
+    That last one is why the viewer's ack resolves against the boot OUTCOME
+    rather than the dispatch: a "yes" for a session that failed to open would
+    suppress this fallback AND cost the user the conversation they were reading,
+    leaving them on an error splash with no window and no way back.
+
+    The dial is bounded end to end (``viewer_client``), so a wedged viewer costs
+    a second or two rather than the click.
 
     The import is local and stays that way: this module is reached from a
     detached click process where startup cost is the user's latency, and

--- a/local_operator/tui/resume_click.py
+++ b/local_operator/tui/resume_click.py
@@ -1,15 +1,55 @@
-"""Open a session in the user's terminal — the notification's click action.
+"""Take the user to a session — the notification's click action.
 
 ``python -m local_operator.tui.resume_click <session-id>``
 
-A desktop notification is only sent when NOTHING is watching the session, so
-by definition there is no emulator around the sending process to inherit. The
-click therefore has to OPEN a terminal, which is exactly what the fork
-machinery already does: :func:`local_operator.spawn.registry.active_backend`
-picks Ghostty / kitty / WezTerm / Apple Terminal, and
+**THE PREMISE THIS MODULE WAS BUILT ON EXPIRED, AND THE STALE VERSION OF THIS
+DOCSTRING IS HOW A BUG SHIPPED.** It used to open with: "a desktop notification
+is only sent when NOTHING is watching the session, so by definition there is no
+emulator around the sending process to inherit. The click therefore has to OPEN
+a terminal." That was true when written — ``detached_notify`` had one caller,
+``session/runtime/owned.py::_announce_pending``, which fires only after
+``_watching_surfaces()`` comes back empty.
+
+Background-completion notifications (#724) added a second caller: the observer
+leg in ``tui/app.py::_deliver_background_completion`` posts a toast **from a
+live, running TUI** for a background session that TUI can already display
+through its own sidebar. The handler then did exactly what the docstring said
+and spawned a terminal — so clicking a notification opened a second window
+running a second process for a session that was one keystroke away. The
+operator reported it, and an orphaned Ghostty from this exact path
+(``ghostty --initial-command=... lop --resume <id>``) was still resident when
+this was rewritten.
+
+So the premise is no longer assumed; it is **checked**. The ladder:
+
+1. **A live viewer can display it** — tell that process to switch and to bring
+   its window forward. No new process, no second copy of the session.
+2. **Nothing suitable is running** — the original premise genuinely holds, and
+   the spawn below is exactly what it always was. That path is why this module
+   exists and it is deliberately unchanged.
+
+The spawn still uses the fork machinery wholesale:
+:func:`local_operator.spawn.registry.active_backend` picks Ghostty / kitty /
+WezTerm / Apple Terminal, and
 :func:`local_operator.multiplexer.broadcast.resume_argv` builds the
 restore-and-idle command line behind its safety boundary (no prompt, no
 ``--exec``, nothing that continues an interrupted turn unattended).
+
+**Switching a viewer is a DIFFERENT ACT from spawning a resume, and both stay
+honest.** The spawn path restores a transcript into a new process behind
+``resume_argv``'s boundary. The viewer path starts no process at all — it asks
+a window the user already has to display something it could already display, by
+the same route as pressing the sidebar row. It is strictly the safer of the
+two, and it never touches the attention store: a click must not mark anything
+read.
+
+**SOLICITED FOCUS LIVES HERE AND ONLY HERE.** A background agent must never
+take the user's focus. A user clicking a notification is the paradigm case of
+asking for it. That distinction is encoded structurally rather than with a
+runtime flag: this module is reached only from the notifier's click action, so
+the activation call is reachable only from a human gesture, and a grep proves
+it. Do not call the focus helper from a poller, a refresh, or a notification
+poster.
 
 Kept as a module rather than inlined in the notifier's shell command for two
 reasons. The click command is embedded in an ``NSTask`` shell string, so the
@@ -18,9 +58,10 @@ with a space. And a backend choice made at CLICK time is better than one made
 when the notification was posted — the user may have opened a terminal in
 between, which is the common case for "I came back to my desk".
 
-Best-effort, like everything on this path: an unpickable backend falls back to
-launching the resume argv directly, and every failure is silent. The user's
-recourse is the same either way — `lop --resume <id>` in their own terminal.
+Best-effort, like everything on this path: an unreachable viewer falls through
+to the spawn, an unpickable backend falls back to launching the resume argv
+directly, and every failure is silent. The user's recourse is the same either
+way — `lop --resume <id>` in their own terminal.
 """
 
 from __future__ import annotations
@@ -66,7 +107,52 @@ def _session_cwd(session_id: str) -> str:
 
 
 def open_session(session_id: str) -> bool:
-    """Open ``session_id`` in a terminal. True if something was launched."""
+    """Take the user to ``session_id``. True if anything was achieved.
+
+    Tries the in-place route first (a running viewer switches and comes
+    forward), and falls back to spawning a terminal when nothing suitable is
+    running. The fallback is the behaviour that shipped before viewers existed
+    and is deliberately byte-identical to it.
+    """
+    if _route_to_viewer(session_id):
+        return True
+    return _spawn_terminal(session_id)
+
+
+def _route_to_viewer(session_id: str) -> bool:
+    """Ask an already-running viewer to display the session. True if one did.
+
+    Every failure mode — no viewer, a wedged one, a refused socket, a viewer
+    that died between the scan and the dial — returns False and falls through
+    to the spawn, which is the path that works when nothing is running. The
+    dial is bounded end to end (``viewer_client``), so a wedged viewer costs a
+    second or two rather than the click.
+
+    The import is local and stays that way: this module is reached from a
+    detached click process where startup cost is the user's latency, and
+    nothing above needs the viewer stack.
+    """
+    try:
+        from local_operator.session.runtime.viewer_client import route_click
+
+        outcome = route_click(session_id)
+    except Exception:  # noqa: BLE001 — routing must never eat the click
+        logger.debug("viewer routing failed; falling back to a spawn", exc_info=True)
+        return False
+    if outcome.switched:
+        logger.debug("click routed to a live viewer: %s", outcome.detail)
+        return True
+    return False
+
+
+def _spawn_terminal(session_id: str) -> bool:
+    """Open ``session_id`` in a NEW terminal. True if something was launched.
+
+    THE ORIGINAL PATH, unchanged. Reached only when no viewer can take the
+    click, which is the condition the module's first docstring assumed always
+    held. It is the only route on a machine with no TUI running, so its argv
+    and its fallbacks are preserved exactly.
+    """
     import shutil
 
     from local_operator.multiplexer.broadcast import resume_argv, resume_executable

--- a/local_operator/tui/session_navigation.py
+++ b/local_operator/tui/session_navigation.py
@@ -141,6 +141,32 @@ class SessionNavigation(Generic[Prepared]):
         self.intent_id = ""
         self._pending("")
 
+    def abandon(self, task: "asyncio.Task[None]") -> bool:
+        """Stop ONE navigation the caller started, if it is still in flight.
+
+        :meth:`cancel` stops whatever is current, which is right for a user who
+        just changed their mind and wrong for a caller giving up on its own
+        request: a notification click that overruns its bound must not cancel a
+        switch the user began in the meantime. Returns whether this call is the
+        one that stopped ``task``, so a caller can tell "I stopped it" from "it
+        was already finished or already superseded" — both of which mean the
+        caller must read the outcome rather than assume one.
+
+        THE GENERATION BUMP IS THE FENCE, and it is why this is not merely a
+        polite ``task.cancel()``. Cancellation is delivered when the task next
+        yields, which is unbounded; the bump is immediate and
+        :meth:`_prepare_and_commit` re-reads it directly before ``_commit``
+        with no await in between. So a navigation that outruns a caller's bound
+        either commits before the bump — the caller reads a completed switch —
+        or is fenced out of committing at all. It cannot commit *after* the
+        caller has been told it failed, which is the state that gave a click
+        both a session switch and a duplicate window.
+        """
+        if self._task is not task or task.done():
+            return False
+        self.cancel()
+        return True
+
     async def close(self) -> None:
         self._closed = True
         self.generation += 1

--- a/local_operator/tui/window_focus.py
+++ b/local_operator/tui/window_focus.py
@@ -1,0 +1,135 @@
+"""Bring this process's terminal window forward, at the measured ceiling.
+
+Called by a viewer answering a notification click — the user performed a
+deliberate gesture whose entire meaning is "take me there", which is the one
+circumstance in which taking focus is solicited rather than rude. Nothing else
+in this codebase may call it; see ``tui/resume_click.py`` for why that rule is
+structural rather than a flag.
+
+## What is reachable, and what is a trap
+
+Measured on this host (macOS 25.6.0, Ghostty 1.3.1) before any of this was
+written:
+
+| probe | result | time |
+|---|---|---|
+| ``open -a Ghostty`` | rc=0 | **0.11 s** |
+| ``osascript ... to activate`` | rc=0 | 0.53 s |
+| ``osascript ... get frontmost`` | ``false`` | 0.07 s |
+| ``osascript ... count windows`` | **``0`` — while 2 windows existed** | 0.20 s |
+| ``osascript ... get properties of front window`` | **error** | 0.18 s |
+
+**NEVER TRAVERSE THE EMULATOR'S APPLESCRIPT OBJECT MODEL.** Not with a guard,
+not with a timeout. Two independent measurements of Ghostty 1.3.1 disagree
+about *how* it fails — one observed ``count windows`` hanging until killed at
+30 s, the other a fast, confidently wrong ``0`` while System Events reported
+two real windows — and the disagreement does not matter, because both are
+disqualifying. A wrong answer is worse than a hang: a timeout at least fails
+loudly, whereas ``0`` leads code to conclude there is no window and skip the
+activation that would have worked.
+
+So window *selection* is not available from the OS side and is not attempted
+here. What is available is application-level activation, which goes through
+AppKit, touches no Apple Event object graph, and is five times faster.
+
+## The honest ceiling
+
+With one terminal window this is exact: the viewer switched to the right
+session and its application comes forward. With **two** terminal windows the
+session switch is still exact — it was addressed to a specific process — but
+``open -a`` fronts the *application*, and macOS raises whichever window was
+frontmost most recently, which may not be the one that switched. The user then
+sees the right session one Cmd-\\` away.
+
+That is a real limitation, and it is still strictly better than the behaviour
+it replaces: a brand-new window running a second process for a session already
+on screen. Window-exact focus is reachable through the accessibility API
+(``AXRaise`` works on these windows and the TUI already writes a session-named
+title), but it requires a permission grant with a system prompt, so it is
+deliberately left for a later, opt-in change rather than imposed on everyone
+for a chrome feature.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+import sys
+
+from local_operator import terminals
+
+logger = logging.getLogger(__name__)
+
+#: Every OS call is bounded. `timeout(1)` is not on this host's PATH, so the
+#: bound is Python's — ``subprocess.run(..., timeout=)``. Generous against the
+#: 0.11 s measurement and still far below the point a user would call the
+#: click broken.
+_ACTIVATION_TIMEOUT_S = 5.0
+
+
+def _bundle_for(env: terminals.EnvMap | None = None) -> str | None:
+    """The macOS application bundle to activate, from environment markers only.
+
+    Markers rather than a query, for the reason ``terminals`` states: a
+    capability query needs stdin, and stdin belongs to Textual's input loop
+    while the app is running.
+
+    Returns ``None`` for a terminal with no bundle to raise (ssh, an unknown
+    emulator), which is an ordinary answer — the switch has already happened
+    and the user finds their own window.
+    """
+    if terminals.is_ssh(env):
+        # A window on the far end of an ssh hop is not ours to raise, and the
+        # markers are inherited across the hop, so this test must come first.
+        return None
+    if terminals.is_ghostty(env):
+        return "Ghostty"
+    if terminals.is_iterm(env):
+        return "iTerm"
+    if terminals.is_apple_terminal(env):
+        return "Terminal"
+    if terminals.is_wezterm(env):
+        return "WezTerm"
+    if terminals.is_kitty(env):
+        return "kitty"
+    return None
+
+
+def activate_window(env: terminals.EnvMap | None = None) -> bool:
+    """Bring this process's terminal application forward. True if a call ran.
+
+    Best-effort by contract and non-raising: this is chrome on a notification
+    click, and a window that fails to raise must never propagate an error into
+    the caller — still less into the event loop of the TUI hosting it. Callers
+    run it off the loop; see ``tui/app.py``'s viewer host.
+    """
+    if sys.platform != "darwin":
+        # Linux/BSD window activation is a window-manager question with no
+        # portable answer (wmctrl, xdotool, a Wayland compositor protocol, or
+        # nothing at all). Reporting False here means the session switch still
+        # happened and the user alt-tabs, which is honest; guessing at a WM
+        # would be a second untested surface for no measured benefit.
+        return False
+    bundle = _bundle_for(env)
+    if bundle is None:
+        return False
+    opener = shutil.which("open")
+    if opener is None:
+        # `open` is in the base system; its absence means a far more broken
+        # machine than a notification click can help with.
+        return False
+    try:
+        # `open -a <bundle>` WITHOUT `-n`. The `-n` in `spawn/ghostty.py` is
+        # what makes that path open a NEW instance — precisely the behaviour
+        # this module exists to avoid. Bare `-a` activates the running one.
+        result = subprocess.run(  # noqa: S603 — fixed argv, no shell
+            [opener, "-a", bundle],
+            capture_output=True,
+            timeout=_ACTIVATION_TIMEOUT_S,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        logger.debug("window activation did not complete", exc_info=True)
+        return False
+    return result.returncode == 0

--- a/tests/unit/session/test_no_session_deletion.py
+++ b/tests/unit/session/test_no_session_deletion.py
@@ -312,6 +312,19 @@ _ALLOWED_ROWS: tuple[tuple[str | int, ...], ...] = (
         "os.unlink",
         "temp FILE -> runtime/<pid>.json",
     ),
+    # The viewer registry is the same staged-write shape as the session
+    # registry above, one directory over (run/viewers rather than run/mobile)
+    # and reaching sessions/ no more than that one does.
+    (
+        "local_operator/session/runtime/viewers.py::publish_viewer",
+        "os.replace",
+        "temp FILE -> run/viewers/<pid>.json",
+    ),
+    (
+        "local_operator/session/runtime/viewers.py::publish_viewer",
+        "os.unlink",
+        "temp FILE -> run/viewers/<pid>.json",
+    ),
     (
         "local_operator/session/runtime/inbox.py::_replace_remainder",
         "os.replace",
@@ -488,6 +501,17 @@ _ALLOWED_ROWS: tuple[tuple[str | int, ...], ...] = (
         "local_operator/session/runtime/registry.py::unpublish",
         "<path>.unlink",
         "own runtime/<pid>.json FILE",
+    ),
+    (
+        "local_operator/session/runtime/viewers.py::scan_viewers",
+        "<path>.unlink",
+        "stale or unparseable run/viewers/<pid>.json FILE",
+        2,
+    ),
+    (
+        "local_operator/session/runtime/viewers.py::unpublish_viewer",
+        "<path>.unlink",
+        "own run/viewers/<pid>.json FILE",
     ),
     (
         "local_operator/session/search_index.py::_save",
@@ -872,6 +896,7 @@ _NEAR_DISPLACERS: frozenset[str] = frozenset(
         "local_operator/session/remote.py::RemoteSession._apply_frontend_facades",  # facade
         "local_operator/session/runtime/inbox.py::_replace_remainder",  # tmp -> inbox FILE
         "local_operator/session/runtime/registry.py::publish",  # tmp -> registry FILE
+        "local_operator/session/runtime/viewers.py::publish_viewer",  # tmp -> viewer FILE
         "local_operator/session/search_index.py::_save",  # tmp -> index FILE
         "local_operator/session/session.py::_write_roster_sidecar",  # tmp -> roster FILE
         "local_operator/session/transcript.py::Transcript._replace_file",  # tmp -> transcript

--- a/tests/unit/session/test_viewer_routing.py
+++ b/tests/unit/session/test_viewer_routing.py
@@ -1,0 +1,390 @@
+"""Viewer discovery and notification click routing.
+
+The behaviour under test is "a notification click lands in the window the user
+already has, instead of opening a new one". Its failure mode in the wild was a
+silent one — an orphaned terminal per click — so the assertions here are about
+observable acts (was a process spawned, was a switch issued) rather than about
+internal state.
+
+Every test that touches disk passes an explicit ``root``: the operator runs a
+dozen live sessions on this machine and a test that wrote into their real
+``run/`` would publish a record advertising a port pytest is about to close.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import threading
+import time
+from typing import Any
+
+import pytest
+
+from local_operator.session.runtime.viewer_client import (
+    choose_viewer,
+    deliver_click,
+    needs_switch,
+    route_click,
+)
+from local_operator.session.runtime.viewer_server import (
+    FOCUS_WINDOW_CAPABILITY,
+    ViewerServer,
+)
+from local_operator.session.runtime.viewers import (
+    VIEWER_HEARTBEAT_TIMEOUT_S,
+    ViewerRecord,
+    publish_viewer,
+    scan_viewers,
+    viewer_record_path,
+    viewer_run_dir,
+)
+
+
+class _Host:
+    """A viewer host that records what a click asked of it."""
+
+    def __init__(self) -> None:
+        self.resumed: list[str] = []
+        self.focus_threads: list[int] = []
+
+    async def viewer_resume_session(self, session_id: str) -> str:
+        self.resumed.append(session_id)
+        return f"displayed {session_id}"
+
+    async def viewer_focus_window(self) -> str:
+        self.focus_threads.append(threading.get_ident())
+        return "activated"
+
+
+class _NoFocusHost:
+    """A viewer that cannot raise a window — ssh, Linux, an unknown emulator.
+
+    The absence of the attribute is the point: the capability gate and the
+    dispatcher both use ``hasattr``/``getattr``, so a host that merely set the
+    attribute to ``None`` would still advertise and still be dispatched to.
+    """
+
+    def __init__(self) -> None:
+        self.resumed: list[str] = []
+
+    async def viewer_resume_session(self, session_id: str) -> str:
+        self.resumed.append(session_id)
+        return f"displayed {session_id}"
+
+
+@pytest.fixture
+def viewer_root(tmp_path):
+    """An isolated config root. Never the operator's real one."""
+    return tmp_path
+
+
+def _started(host, root):
+    server = ViewerServer(host, root=root)
+    server.start()
+    assert server.ready.wait(timeout=5.0), "viewer endpoint never bound"
+    return server
+
+
+def _endpoint_threads() -> int:
+    """How many viewer endpoint threads this process is running.
+
+    The listener is what leaks when ``start()`` stops being idempotent, and a
+    pid-keyed record cannot show that — the second endpoint simply overwrites
+    the first one's file. The thread is the observable.
+    """
+    return sum(1 for t in threading.enumerate() if t.name == "lop-viewer-endpoint")
+
+
+def test_viewer_record_is_invisible_to_the_session_registry(viewer_root):
+    """THE compatibility guarantee, and the reason viewer records live in their
+    own directory.
+
+    ``SessionRecord.from_json`` drops unknown KEYS but never validates ``kind``'s
+    VALUE, so a ``kind="viewer"`` record placed in ``run/mobile`` parses as an
+    ordinary session on every older build — becoming a ``lop stop --all`` target
+    and a ``lop send`` destination. Older builds cannot be taught otherwise, and
+    a dozen of them run on this machine at once, so isolation is the only
+    mechanism available.
+    """
+    from local_operator.session.runtime import registry
+
+    publish_viewer(
+        ViewerRecord(pid=os.getpid(), surface="tui", control_port=1, control_key="k" * 64),
+        viewer_root,
+    )
+    assert scan_viewers(viewer_root), "precondition: the viewer record must exist"
+    # PRECONDITION: the two directories must genuinely be different ones. Without
+    # this the assertion below is satisfied by an empty `run/mobile` that the
+    # viewer never wrote to for some unrelated reason, and the test would keep
+    # passing if the directories were merged AND the session scan happened to
+    # reap the record it could not parse.
+    assert (viewer_root / "run/viewers").is_dir()
+    assert not (viewer_root / "run/mobile").exists() or not list(
+        (viewer_root / "run/mobile").glob("*.json")
+    ), "a viewer record must never be written where the session registry scans"
+    # The session registry — what every older binary scans — must see nothing.
+    assert registry.scan(viewer_root) == []
+
+
+def test_dead_viewer_records_are_reaped_and_never_routed_to(viewer_root):
+    """A ``kill -9``'d viewer leaves a file; it must not cost a click a dial."""
+    dead = ViewerRecord(pid=2**22, surface="tui", control_port=1, control_key="k" * 64)
+    publish_viewer(dead, viewer_root)
+    path = viewer_record_path(dead.pid, viewer_root)
+    assert path.exists(), "precondition: the stale record must be on disk"
+
+    assert scan_viewers(viewer_root) == []
+    assert not path.exists(), "the stale record should have been reaped"
+
+
+def test_quiet_viewer_is_not_offered_as_a_target(viewer_root):
+    """A wedged viewer (alive, not heartbeating) cannot answer a dial.
+
+    It is filtered rather than surfaced: offering it would spend the click's
+    dial timeout before the fallback it should have gone to directly.
+    """
+    record = ViewerRecord(pid=os.getpid(), surface="tui", control_port=1, control_key="k" * 64)
+    publish_viewer(record, viewer_root)
+    stale = json.loads(viewer_record_path(os.getpid(), viewer_root).read_text())
+    stale["heartbeat_at"] = time.time() - (VIEWER_HEARTBEAT_TIMEOUT_S + 10)
+    viewer_record_path(os.getpid(), viewer_root).write_text(json.dumps(stale))
+
+    assert scan_viewers(viewer_root) == []
+
+
+def test_click_switches_a_running_viewer_and_does_not_spawn(viewer_root):
+    """C1 — the operator's reported bug, inverted into the expected behaviour."""
+    host = _Host()
+    server = _started(host, viewer_root)
+    try:
+        server.note_session("on-screen")
+        records = scan_viewers(viewer_root)
+        assert len(records) == 1, "precondition: exactly one viewer must be live"
+
+        outcome = asyncio.run(deliver_click(records[0], "wanted"))
+
+        assert outcome.switched is True
+        assert host.resumed == ["wanted"]
+    finally:
+        server.close()
+
+
+def test_click_for_the_displayed_session_does_not_re_resume(viewer_root):
+    """C2 — focus, but no switch.
+
+    Re-running ``/resume`` on the session already on screen would rebuild the
+    view and throw away the user's scroll position for no gain.
+    """
+    host = _Host()
+    server = _started(host, viewer_root)
+    try:
+        server.note_session("already-here")
+        records = scan_viewers(viewer_root)
+        assert needs_switch(records[0], "already-here") is False
+
+        outcome = asyncio.run(deliver_click(records[0], "already-here"))
+
+        assert outcome.switched is True, "the session IS displayed, so do not spawn"
+        assert host.resumed == [], "no /resume may be issued for the visible session"
+    finally:
+        server.close()
+
+
+def test_switch_succeeds_even_when_the_window_cannot_be_focused(viewer_root):
+    """C3 — focus is chrome; the switch is the outcome that matters."""
+    host = _NoFocusHost()
+    server = _started(host, viewer_root)
+    try:
+        assert (
+            FOCUS_WINDOW_CAPABILITY not in server.record.capabilities
+        ), "precondition: a host without the method must not advertise the capability"
+        server.note_session("other")
+        records = scan_viewers(viewer_root)
+
+        outcome = asyncio.run(deliver_click(records[0], "wanted"))
+
+        assert outcome.switched is True
+        assert outcome.focused is False
+        assert host.resumed == ["wanted"]
+    finally:
+        server.close()
+
+
+def test_unreachable_viewer_falls_through_without_switching(viewer_root):
+    """C5 — a record pointing at a dead port must not swallow the click.
+
+    Asserts the OUTCOME (routing declined, so the caller spawns) rather than a
+    wall-clock bound: this repo has abandoned numeric timing bounds as
+    unportable, and "did it decline" is the fact the caller acts on.
+    """
+    publish_viewer(
+        # A live pid (ours) with a port nothing listens on: the wedged-viewer
+        # shape, which pid liveness alone cannot detect.
+        ViewerRecord(pid=os.getpid(), surface="tui", control_port=1, control_key="k" * 64),
+        viewer_root,
+    )
+    assert scan_viewers(viewer_root), "precondition: the record must look live"
+
+    outcome = route_click("wanted", viewer_root)
+
+    assert outcome.switched is False
+
+
+def test_no_viewer_running_declines_so_the_spawn_path_runs(viewer_root):
+    """C4 — the original premise, now checked instead of assumed."""
+    viewer_run_dir(viewer_root)
+    outcome = route_click("wanted", viewer_root)
+    assert outcome.switched is False
+
+
+def test_viewer_precedence_is_deterministic():
+    """C6 — several viewers could take it.
+
+    The already-displaying viewer wins (switching it is a no-op), then the most
+    recently focused, then the lowest pid. Ordering is asserted against an
+    INPUT LIST IN THE WRONG ORDER, because the function must sort rather than
+    inherit its collaborator's ordering.
+    """
+    old_focus = ViewerRecord(
+        pid=1, surface="tui", control_port=1, control_key="a", current_session="x", focused_at=100.0
+    )
+    showing = ViewerRecord(
+        pid=2, surface="tui", control_port=2, control_key="b", current_session="wanted"
+    )
+    recent = ViewerRecord(
+        pid=3, surface="tui", control_port=3, control_key="c", current_session="y", focused_at=500.0
+    )
+
+    assert choose_viewer([old_focus, showing, recent], "wanted") is showing
+    assert choose_viewer([old_focus, recent], "nobody-has-it") is recent
+    assert choose_viewer([], "wanted") is None
+
+
+def test_a_viewer_that_cannot_switch_is_not_chosen():
+    """``can_switch`` is a capability statement, and routing must honour it."""
+    fixed = ViewerRecord(
+        pid=1, surface="tui", control_port=1, control_key="a", can_switch=False, focused_at=900.0
+    )
+    assert choose_viewer([fixed], "wanted") is None
+
+
+def test_focus_runs_off_the_event_loop(viewer_root):
+    """STRUCTURAL: the OS call must not execute on the caller's loop.
+
+    A thread-identity assertion rather than a timing bound, per this repo's
+    standing preference: it is a fact about WHERE the code ran and fails
+    deterministically the moment someone drops the ``to_thread`` hop, whereas a
+    wall-clock bound on a window-server call is unportable by construction.
+    """
+    host = _Host()
+    server = _started(host, viewer_root)
+    try:
+        server.note_session("other")
+        records = scan_viewers(viewer_root)
+        caller_thread = threading.get_ident()
+
+        asyncio.run(deliver_click(records[0], "wanted"))
+
+        assert host.focus_threads, "precondition: focus must actually have been invoked"
+        assert caller_thread not in host.focus_threads
+    finally:
+        server.close()
+
+
+def test_starting_twice_binds_one_listener(viewer_root):
+    """The endpoint outlives session swaps, so ``start()`` is re-entered.
+
+    A second bind would leak a listener AND a record advertising its port —
+    strictly worse than the source-leak class this codebase already documents.
+    """
+    host = _Host()
+    server = _started(host, viewer_root)
+    try:
+        port = server.record.control_port
+        threads_before = _endpoint_threads()
+        assert threads_before == 1, "precondition: exactly one endpoint thread should exist"
+
+        server.start()
+        server.start()
+
+        # THREAD COUNT, not the record or the port. The record is keyed by pid,
+        # so a second endpoint in the same process OVERWRITES the first one's
+        # file and leaves the port field looking correct — a leaked listener is
+        # invisible on disk. The thread is the thing that actually leaks, so it
+        # is the thing to count.
+        assert _endpoint_threads() == 1
+        assert server.record.control_port == port
+    finally:
+        server.close()
+
+
+def test_close_removes_the_record(viewer_root):
+    """A closed window must stop advertising a port nothing is listening on."""
+    server = _started(_Host(), viewer_root)
+    path = viewer_record_path(os.getpid(), viewer_root)
+    assert path.exists(), "precondition: the record must have been published"
+
+    server.close()
+    server.close()  # idempotent
+
+    # Poll rather than assert once: the serve loop notices `_closed` on its own
+    # 200 ms tick and unpublishes from there, so a bare assertion races the
+    # teardown it is checking and would pass on the synchronous unlink alone.
+    deadline = time.time() + 5.0
+    while path.exists() and time.time() < deadline:
+        time.sleep(0.05)
+    assert not path.exists()
+
+
+def test_unknown_op_is_answered_not_dropped(viewer_root):
+    """Mid-upgrade skew: a newer client asking an older viewer for something it
+    does not have must read an error and degrade, never hang."""
+    server = _started(_Host(), viewer_root)
+    try:
+        record = scan_viewers(viewer_root)[0]
+
+        async def probe() -> dict[str, Any]:
+            reader, writer = await asyncio.open_connection("127.0.0.1", record.control_port)
+            writer.write(json.dumps({"key": record.control_key}).encode() + b"\n")
+            writer.write(json.dumps({"op": "not_a_real_op", "req": 7}).encode() + b"\n")
+            await writer.drain()
+            line = await asyncio.wait_for(reader.readline(), timeout=5.0)
+            writer.close()
+            return json.loads(line)
+
+        reply = asyncio.run(probe())
+        assert reply["req"] == 7
+        assert reply["op"] == "error"
+    finally:
+        server.close()
+
+
+def test_a_bad_key_is_refused_without_a_reply(viewer_root):
+    """An endpoint that answers wrong keys with errors is an oracle."""
+    server = _started(_Host(), viewer_root)
+    try:
+        record = scan_viewers(viewer_root)[0]
+
+        async def probe() -> bytes:
+            reader, writer = await asyncio.open_connection("127.0.0.1", record.control_port)
+            writer.write(json.dumps({"key": "wrong"}).encode() + b"\n")
+            writer.write(json.dumps({"op": "focus_window", "req": 1}).encode() + b"\n")
+            try:
+                await writer.drain()
+                data = await asyncio.wait_for(reader.read(1024), timeout=5.0)
+            except (ConnectionResetError, BrokenPipeError):
+                # A close against unread bytes sends RST rather than FIN, so the
+                # peer may observe a reset instead of a clean EOF. Both mean the
+                # same thing here and which one occurs is a kernel timing
+                # detail, so accepting only EOF made this test flaky rather than
+                # strict.
+                return b""
+            finally:
+                writer.close()
+            return data
+
+        assert asyncio.run(probe()) == b"", "an authenticated reply must never follow a bad key"
+    finally:
+        server.close()

--- a/tests/unit/session/test_viewer_routing.py
+++ b/tests/unit/session/test_viewer_routing.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import threading
 import time
@@ -43,18 +44,39 @@ from local_operator.session.runtime.viewers import (
 
 
 class _Host:
-    """A viewer host that records what a click asked of it."""
+    """A viewer host that records what a click asked of it.
+
+    ``viewer_focus_window`` mirrors the production host's shape — it hops the
+    blocking OS call onto a worker thread — because the property under test is
+    "the OS call does not run on the loop that is serving this conversation".
+    A double that recorded only its own thread could not express that: see
+    ``test_focus_runs_off_the_serving_loop`` for why that shape was vacuous.
+    """
 
     def __init__(self) -> None:
         self.resumed: list[str] = []
+        #: The thread the host coroutine itself was scheduled on — i.e. the
+        #: viewer endpoint's loop thread.
+        self.handler_threads: list[int] = []
+        #: The thread the (blocking) OS call actually executed on.
         self.focus_threads: list[int] = []
+        #: Set True to drop the ``to_thread`` hop, reproducing the defect.
+        self.focus_on_the_loop = False
 
     async def viewer_resume_session(self, session_id: str) -> str:
         self.resumed.append(session_id)
         return f"displayed {session_id}"
 
     async def viewer_focus_window(self) -> str:
-        self.focus_threads.append(threading.get_ident())
+        self.handler_threads.append(threading.get_ident())
+
+        def activate() -> int:
+            return threading.get_ident()
+
+        if self.focus_on_the_loop:
+            self.focus_threads.append(activate())
+        else:
+            self.focus_threads.append(await asyncio.to_thread(activate))
         return "activated"
 
 
@@ -270,25 +292,204 @@ def test_a_viewer_that_cannot_switch_is_not_chosen():
     assert choose_viewer([fixed], "wanted") is None
 
 
-def test_focus_runs_off_the_event_loop(viewer_root):
-    """STRUCTURAL: the OS call must not execute on the caller's loop.
+def test_focus_runs_off_the_serving_loop(viewer_root):
+    """STRUCTURAL: the OS call must not execute on the loop serving the click.
 
     A thread-identity assertion rather than a timing bound, per this repo's
-    standing preference: it is a fact about WHERE the code ran and fails
-    deterministically the moment someone drops the ``to_thread`` hop, whereas a
+    standing preference: it is a fact about WHERE the code ran, whereas a
     wall-clock bound on a window-server call is unportable by construction.
+
+    **THE COMPARISON IS AGAINST THE HANDLER'S OWN THREAD, and the earlier
+    version's choice of the CALLER's thread is why it was vacuous.**
+    ``ViewerServer`` always serves on its dedicated ``lop-viewer-endpoint``
+    thread, so the handler can never run on the caller's thread whatever the
+    production code does — the assertion was satisfied by the threading model
+    alone and passed with the ``to_thread`` hop deleted (found independently by
+    the reviewer and by QA, both by mutation). The property that actually
+    matters is that a blocking OS call does not occupy the loop that has to keep
+    answering this conversation, and only handler-vs-OS-call expresses it.
+
+    ``_Host.focus_on_the_loop`` is the defect switch, exercised below, so this
+    guard's ability to go red is asserted rather than assumed.
     """
     host = _Host()
     server = _started(host, viewer_root)
     try:
         server.note_session("other")
         records = scan_viewers(viewer_root)
-        caller_thread = threading.get_ident()
 
         asyncio.run(deliver_click(records[0], "wanted"))
 
         assert host.focus_threads, "precondition: focus must actually have been invoked"
-        assert caller_thread not in host.focus_threads
+        assert host.handler_threads, "precondition: the host coroutine must have run"
+        # PRECONDITION for the assertion below to mean anything: the handler
+        # must not have run on this test's thread, or "different from the
+        # handler" would be trivially true of anything the endpoint did.
+        assert threading.get_ident() not in host.handler_threads
+        assert host.focus_threads[0] != host.handler_threads[0], (
+            "the OS call ran on the loop serving the click; a slow window "
+            "server would stall this endpoint"
+        )
+    finally:
+        server.close()
+
+
+def test_the_focus_thread_guard_goes_red_when_the_hop_is_dropped(viewer_root):
+    """The mutation the guard above is meant to catch, asserted as a behaviour.
+
+    Guard vacuity is not detectable from a passing test, so the defect is
+    reproduced here in the double rather than left to a manual mutation that
+    nobody re-runs: with the hop dropped, the OS call lands on the very loop
+    thread the handler is running on. If this test ever stops observing that
+    equality, the guard above has stopped being able to fail.
+    """
+    host = _Host()
+    host.focus_on_the_loop = True
+    server = _started(host, viewer_root)
+    try:
+        server.note_session("other")
+        records = scan_viewers(viewer_root)
+
+        asyncio.run(deliver_click(records[0], "wanted"))
+
+        assert host.focus_threads and host.handler_threads, "precondition: focus must have run"
+        assert host.focus_threads[0] == host.handler_threads[0]
+    finally:
+        server.close()
+
+
+def test_the_client_ack_bound_outlasts_the_server_resume_bound():
+    """Q1: the two bounds must never invert, and are derived so they cannot.
+
+    An 8.0 s client ack against a 10.0 s server bound gave the user BOTH
+    outcomes for a ``/resume`` measured at 8.5 s — the running TUI switched AND
+    a duplicate terminal opened, which is the precise defect this feature
+    removes. The client now derives its deadline from the server's, so an edit
+    to one carries to the other; this asserts the resulting ordering, and the
+    grace term's sign, rather than two hand-checked literals.
+    """
+    from local_operator.session.runtime import viewer_client
+    from local_operator.session.runtime.viewers import (
+        VIEWER_ACK_GRACE_S,
+        VIEWER_RESUME_TIMEOUT_S,
+    )
+
+    assert VIEWER_ACK_GRACE_S > 0, "a non-positive grace makes the two bounds equal or inverted"
+    assert viewer_client._ACK_TIMEOUT_S > VIEWER_RESUME_TIMEOUT_S, (
+        "the client must never give up on a switch the server is still going "
+        "to land: that delivers a switch AND a duplicate window"
+    )
+
+
+def test_a_viewer_speaking_an_unknown_protocol_is_not_dialed():
+    """MINOR-3: the refusal ``viewers`` documents is now performed.
+
+    Dialing a socket whose frames we cannot predict is worse than not dialing
+    it — the click spends its ack timeout on a conversation neither side
+    understands, when the spawn fallback works against any build.
+    """
+    from local_operator.session.runtime.viewers import VIEWER_PROTOCOL
+
+    future = ViewerRecord(
+        pid=1,
+        surface="tui",
+        control_port=1,
+        control_key="a",
+        protocol=VIEWER_PROTOCOL + 1,
+        focused_at=900.0,
+    )
+    known = ViewerRecord(pid=2, surface="tui", control_port=2, control_key="b", focused_at=100.0)
+
+    assert choose_viewer([future], "wanted") is None
+    # Even when it is the freshest and already displaying the target, which is
+    # rung 1 of the precedence — the protocol filter must precede both rungs.
+    future.current_session = "wanted"
+    assert choose_viewer([future, known], "wanted") is known
+
+
+def test_focus_is_not_requested_from_a_viewer_that_cannot_do_it(viewer_root):
+    """MINOR-4: the advertised capability is READ, not merely published.
+
+    A viewer without the method answers the unknown-op error; spending a round
+    trip and the focus timeout to be told what the record already said is
+    latency on the click path for nothing.
+    """
+    host = _NoFocusHost()
+    server = _started(host, viewer_root)
+    # Spy on the SERVER's dispatcher rather than adding a counter to production
+    # code: the observable question is "did a focus_window frame arrive", and
+    # the wire is where that is answerable.
+    seen_ops: list[str] = []
+    original = server._dispatch
+
+    async def spy(frame, writer):
+        seen_ops.append(str(frame.get("op") or ""))
+        return await original(frame, writer)
+
+    server._dispatch = spy  # type: ignore[method-assign]
+    try:
+        server.note_session("other")
+        records = scan_viewers(viewer_root)
+        assert FOCUS_WINDOW_CAPABILITY not in records[0].capabilities, "precondition"
+
+        outcome = asyncio.run(deliver_click(records[0], "wanted"))
+
+        assert outcome.switched is True
+        assert outcome.focused is False
+        assert "resume_session" in seen_ops, "precondition: the spy must see the switch"
+        assert "focus_window" not in seen_ops, "no focus_window frame should have been sent"
+    finally:
+        server.close()
+
+
+def test_an_oversized_frame_does_not_wedge_an_authenticated_conversation(viewer_root, caplog):
+    """MINOR-6: ``readline`` raises on an over-limit line WITHOUT consuming it.
+
+    The client half hand-rolls its framing to dodge this exact defect; the
+    server half did not, so an over-limit line raised ``LimitOverrunError``
+    (a ``ValueError``) out of ``client_connected_cb``.
+
+    **THE ASSERTION IS ON THE ESCAPING EXCEPTION, NOT ON THE CLOSED SOCKET, and
+    that is the whole point of this test's shape.** Its first version checked
+    that the conversation ended — which it does either way, since an uncaught
+    exception tears the connection down just as a deliberate return does. That
+    version passed with the defect reintroduced (mutation-proven), i.e. it was
+    vacuous. What actually distinguishes handled from unhandled here is asyncio
+    logging the traceback, so that is what is asserted.
+    """
+    caplog.set_level(logging.ERROR, logger="asyncio")
+    server = _started(_Host(), viewer_root)
+    try:
+        record = scan_viewers(viewer_root)[0]
+
+        async def probe() -> bytes:
+            reader, writer = await asyncio.open_connection("127.0.0.1", record.control_port)
+            writer.write(json.dumps({"key": record.control_key}).encode() + b"\n")
+            await writer.drain()
+            # One line, comfortably over the endpoint's 64 KiB frame limit.
+            writer.write(b"x" * (128 * 1024) + b"\n")
+            try:
+                await writer.drain()
+                return await asyncio.wait_for(reader.read(1024), timeout=5.0)
+            except (ConnectionResetError, BrokenPipeError):
+                # A close against unread bytes may surface as RST rather than
+                # FIN; both mean the conversation ended, as elsewhere here.
+                return b""
+            finally:
+                writer.close()
+
+        assert asyncio.run(probe()) == b"", "the conversation should end, not hang or reply"
+        # The endpoint's loop logs from its own thread; give it a moment to.
+        deadline = time.time() + 2.0
+        while time.time() < deadline and not caplog.records:
+            time.sleep(0.05)
+        escaped = [
+            record
+            for record in caplog.records
+            if "client_connected_cb" in record.getMessage()
+            or "LimitOverrunError" in (record.exc_text or "")
+        ]
+        assert not escaped, f"the over-limit line escaped the handler: {escaped}"
     finally:
         server.close()
 

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -1847,3 +1847,195 @@ async def test_the_real_hosts_focus_call_runs_off_the_serving_loop():
             "server would stall the endpoint and the click would fall back to "
             "spawning the very window this feature removes"
         )
+
+
+async def _pump_until(pilot, predicate, *, what: str, turns: int = 2000) -> None:
+    """Pump Textual until ``predicate`` holds, then return immediately.
+
+    Bounded by TURNS rather than by a wall-clock budget: per-test durations here
+    vary by orders of magnitude under xdist contention, and a fixed drain both
+    flakes and taxes every run with time the work did not need. The deadline is
+    a backstop against a wedge, never the assertion — see AGENTS.md, "Wait on
+    the event, never on the clock".
+    """
+    for _ in range(turns):
+        if predicate():
+            return
+        await pilot.pause()
+        await asyncio.sleep(0.005)
+    raise AssertionError(f"timed out waiting for {what}")
+
+
+@pytest.mark.asyncio
+async def test_a_switch_that_overruns_the_bound_cannot_also_commit():
+    """Q3: never both — a click causes a switch or a spawn, never one of each.
+
+    The derived bounds fixed the CLIENT giving up first; they did not stop the
+    APP from committing behind the endpoint's back. ``wait_for`` cancels the
+    waiter, not the navigation, so a switch slower than
+    ``VIEWER_RESUME_TIMEOUT_S`` still landed on screen after the endpoint had
+    answered failure — ``deliver_click`` reported ``switched=False``,
+    ``resume_click.open_session`` spawned a window, and the session switched
+    underneath it. QA measured the threshold move rather than close: clean at
+    9.8 s, both outcomes at 10.2 s and every value above.
+
+    THE ASSERTION IS THE CONJUNCTION, not the timeout. A test that only checked
+    "the endpoint raised" passes with the defect fully present — that is the
+    whole shape of this bug. So this checks what the CALLER would do with the
+    answer against what is actually on screen: a raise means the caller spawns,
+    so the binding must not have moved; a success means it does not spawn, so
+    the binding must have. Either is correct; only the pair is the defect.
+
+    The navigation is slowed inside ``prepare`` — where a cold transcript's real
+    seconds go — so the commit is genuinely still ahead of it when the bound
+    expires, rather than being suppressed before it starts.
+    """
+    from local_operator.session.runtime import viewers
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        committed: list[str] = []
+
+        async def slow_prepare(session_id: str, *args, **kwargs):
+            # Comfortably longer than the patched bound, so the endpoint gives
+            # up while the switch is genuinely still in flight. Both are scaled
+            # down together: what is under test is the ORDER of the bound, the
+            # fence and the commit, which is scale-free.
+            await asyncio.sleep(1.0)
+            return session_id
+
+        def commit(session_id: str, prepared, generation: int):
+            # What a real commit does that matters here: move the binding.
+            committed.append(session_id)
+            app._adopted_session_id = session_id
+            return None
+
+        navigation = app._sidebar_navigation
+        with (
+            patch.object(navigation, "_prepare", slow_prepare),
+            patch.object(navigation, "_commit", commit),
+            patch.object(navigation, "_release", lambda prepared: asyncio.sleep(0)),
+            patch.object(viewers, "VIEWER_RESUME_TIMEOUT_S", 0.3),
+            patch.object(viewers, "VIEWER_ABANDON_SETTLE_S", 2.5),
+            patch.object(
+                type(app._session),
+                "session_id",
+                property(lambda _s: committed[-1] if committed else "origin"),
+            ),
+        ):
+            future = _call_from_viewer_thread(app, "target-session")
+            await _pump_until(pilot, future.done, what="the endpoint to answer")
+            try:
+                detail = future.result(timeout=5)
+                switched = True
+            except Exception:
+                detail = ""
+                switched = False
+
+            # The defect commits AFTER the endpoint has answered, so answering
+            # is not the end of it: settle the navigation itself before reading
+            # what landed, or a late commit is simply missed.
+            task = navigation._task
+            await _pump_until(
+                pilot,
+                lambda: task is None or task.done(),
+                what="the navigation to settle",
+            )
+
+        landed = "target-session" in committed
+        spawn_would_run = not switched
+        assert not (landed and spawn_would_run), (
+            "DOUBLE ACTION: the switch committed at "
+            f"{committed!r} while the endpoint answered failure, so the click "
+            "delivers a session switch AND a duplicate window — the exact "
+            "outcome this feature exists to prevent"
+        )
+        assert switched == landed, (
+            f"the ack must describe what happened: switched={switched} "
+            f"detail={detail!r} committed={committed!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_abandoning_an_overrun_click_leaves_the_outgoing_session_whole():
+    """Q3, the other half: the cure must not be worse than the disease.
+
+    Cancelling mid-switch was the stated reason for NOT adding cancellation in
+    round 2 — a half-swapped app is worse than a duplicate window. This asserts
+    the outcome rather than the reasoning.
+
+    THE PREPARATION HERE REFUSES TO BE CANCELLED, deliberately. That models the
+    case the endpoint's own docstring concedes — enqueued work that cannot be
+    recalled — and it is what makes this a test of the FENCE rather than of
+    ``task.cancel()``. If the guarantee rested on cancellation being delivered
+    in time it would be a race; it rests instead on the generation bump, which
+    is synchronous, and on ``SessionNavigation`` running no await between its
+    final generation check and ``_commit``. So the un-cancellable navigation
+    below runs to completion and STILL cannot commit, and its preparation is
+    released through the same path a user's own cancel uses.
+    """
+    from local_operator.session.runtime import viewers
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._editor().load_text("half-typed thought")
+        await pilot.pause()
+        released: list[str] = []
+        committed: list[str] = []
+        prepared_fully: list[str] = []
+
+        async def stubborn_prepare(session_id: str, *args, **kwargs):
+            # Work that outlives its cancellation, as a blocking enqueue does.
+            inner = asyncio.ensure_future(asyncio.sleep(1.0))
+            while not inner.done():
+                try:
+                    await asyncio.shield(inner)
+                except asyncio.CancelledError:
+                    pass
+            prepared_fully.append(session_id)
+            return session_id
+
+        async def release(prepared) -> None:
+            released.append(prepared)
+
+        navigation = app._sidebar_navigation
+        with (
+            patch.object(navigation, "_prepare", stubborn_prepare),
+            patch.object(navigation, "_commit", lambda *a: committed.append(a[0])),
+            patch.object(navigation, "_release", release),
+            patch.object(viewers, "VIEWER_RESUME_TIMEOUT_S", 0.3),
+            patch.object(viewers, "VIEWER_ABANDON_SETTLE_S", 2.5),
+        ):
+            future = _call_from_viewer_thread(app, "target-session")
+            await _pump_until(pilot, future.done, what="the endpoint to answer")
+            with pytest.raises(Exception):
+                future.result(timeout=5)
+            # The un-cancellable preparation must be allowed to FINISH: the
+            # property is that it cannot commit even then.
+            task = navigation._task
+            await _pump_until(
+                pilot,
+                lambda: bool(prepared_fully) and (task is None or task.done()),
+                what="the stubborn preparation to run to completion",
+            )
+
+        assert prepared_fully == ["target-session"], (
+            "precondition: the preparation must have survived cancellation and "
+            "run to completion, or this proves nothing about the fence"
+        )
+        assert committed == [], (
+            "the fence must stop a completed preparation from committing after "
+            "the endpoint answered failure"
+        )
+        assert released == [
+            "target-session"
+        ], f"the fenced preparation must be released, not leaked: {released!r}"
+        # The outgoing conversation is untouched: still bound, still typed in.
+        assert app._session is not None
+        assert (
+            app._editor().text == "half-typed thought"
+        ), "the draft the user was holding must survive an abandoned click"
+        assert navigation.requested_id == "", "the navigation boundary must be released"
+        assert not [t for t in navigation._tasks if not t.done()], "no navigation task may leak"

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -1929,7 +1929,13 @@ async def test_a_switch_that_overruns_the_bound_cannot_also_commit():
             try:
                 detail = future.result(timeout=5)
                 switched = True
-            except Exception:
+            except (TimeoutError, RuntimeError):
+                # NARROW ON PURPOSE. The endpoint answers failure with exactly
+                # these two -- the bound expiring, or "could not display" -- so
+                # catching `Exception` here would file a genuine defect in the
+                # click path (an AttributeError in `apply`, say) as a perfectly
+                # ordinary spawn, and the assertion below would pass while the
+                # thing it guards was broken.
                 detail = ""
                 switched = False
 
@@ -2106,7 +2112,13 @@ async def test_a_click_the_app_services_late_cannot_start_a_switch_at_all():
             try:
                 detail = future.result(timeout=5)
                 switched = True
-            except Exception:
+            except (TimeoutError, RuntimeError):
+                # NARROW ON PURPOSE. The endpoint answers failure with exactly
+                # these two -- the bound expiring, or "could not display" -- so
+                # catching `Exception` here would file a genuine defect in the
+                # click path (an AttributeError in `apply`, say) as a perfectly
+                # ordinary spawn, and the assertion below would pass while the
+                # thing it guards was broken.
                 detail = ""
                 switched = False
 
@@ -2282,7 +2294,13 @@ async def test_a_hop_the_pool_starts_late_is_refused_rather_than_fenced():
             try:
                 detail = future.result(timeout=5)
                 switched = True
-            except Exception:
+            except (TimeoutError, RuntimeError):
+                # NARROW ON PURPOSE. The endpoint answers failure with exactly
+                # these two -- the bound expiring, or "could not display" -- so
+                # catching `Exception` here would file a genuine defect in the
+                # click path (an AttributeError in `apply`, say) as a perfectly
+                # ordinary spawn, and the assertion below would pass while the
+                # thing it guards was broken.
                 detail = ""
                 switched = False
 
@@ -2370,7 +2388,10 @@ async def test_a_click_superseded_by_a_click_for_the_same_session_does_not_spawn
                 try:
                     future.result(timeout=5)
                     outcomes.append("switch")
-                except Exception:
+                except (TimeoutError, RuntimeError):
+                    # Narrow for the same reason as the tests above: only these
+                    # two mean "the click spawns", and an unexpected error
+                    # recorded as a spawn would let this pass vacuously.
                     outcomes.append("spawn")
 
         # THE INVARIANT IS AGREEMENT, NOT A COUNT. Whether the second click

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import os
+import threading
 import time
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import replace
 from unittest.mock import patch
 
@@ -1600,3 +1602,248 @@ async def test_no_reachable_unseen_row_pairs_a_glyph_with_the_wrong_words():
                         checked += 1
     # 3 kinds x 5 states x 3 gates x 3 wake shapes.
     assert checked == 135, checked
+
+
+# --- notification-click routing (PR #750, round 1 remediation) ---------------
+#
+# These drive `OperatorApp.viewer_resume_session` — the method a notification
+# click reaches over the viewer endpoint — against the REAL app rather than a
+# double, because the findings they guard are both about the app-side path the
+# double cannot have: which switch route runs (D1) and what "displayed" means
+# when the target cannot open (D2).
+
+
+def _call_from_viewer_thread(app: OperatorApp, session_id: str) -> "Future[str]":
+    """Invoke the click's entry point the way the endpoint does: off the app's
+    thread, on its own PERSISTENT loop.
+
+    Calling it from Textual's thread is refused by contract
+    (``call_from_thread`` raises), so faking that would exercise a path that
+    does not exist.
+
+    THE LOOP IS NOT ``asyncio.run``, and that is load-bearing rather than
+    stylistic. ``asyncio.run`` calls ``shutdown_default_executor`` on the way
+    out, which JOINS any worker thread still blocked in ``to_thread`` — so a
+    timeout that fired correctly at 0.5 s did not return to the caller until the
+    stranded worker finished 30 s later, and the wedge test below read that as
+    an unbounded hop. Measured in isolation: ``wait_for`` fired at 0.50 s,
+    ``asyncio.run`` returned at 30.02 s. ``ViewerServer`` runs its loop with
+    ``run_until_complete`` on a long-lived thread and never tears it down per
+    call, so the harness matches production and the test measures the bound
+    rather than the teardown.
+    """
+    pool = ThreadPoolExecutor(max_workers=1)
+    loop = asyncio.new_event_loop()
+
+    def run() -> str:
+        try:
+            return loop.run_until_complete(app.viewer_resume_session(session_id))
+        finally:
+            # Deliberately NOT `shutdown_default_executor`; see above.
+            loop.close()
+
+    future = pool.submit(run)
+    pool.shutdown(wait=False)
+    return future
+
+
+@pytest.mark.asyncio
+async def test_a_notification_click_switches_by_the_sidebars_own_route():
+    """D1: the click must not answer a gate the user parked in the session it
+    leaves.
+
+    ``/resume`` reloads through ``_deny_queued_approvals``, so routing the click
+    that way silently answered "no" to a pending approval in the OUTGOING
+    session and rendered no receipt — a click about session B spending session
+    A's decision. ``docs/SESSION_SIDEBAR.md`` forbids it of a switch in as many
+    words, and ``viewer_resume_session``'s own docstring claimed to inherit that
+    invariant while taking the other path.
+
+    Asserted structurally, on WHICH route runs: the sidebar navigation is the
+    one that suspends gates (``_suspend_sidebar_gates``) rather than denying
+    them, so "the click starts a sidebar navigation and runs no /resume" is the
+    property, and it cannot drift the way a re-derived gate assertion could.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        selected: list[str] = []
+        commands: list[str] = []
+
+        def settle(session_id: str):
+            selected.append(session_id)
+            done: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+            done.set_result(None)
+            task = asyncio.ensure_future(asyncio.sleep(0))
+            # Pretend the navigation landed: the ack is resolved against what
+            # is on screen, so the identity has to move for a success.
+            app._adopted_session_id = session_id
+            return task
+
+        with (
+            patch.object(app, "_select_sidebar_session", side_effect=settle),
+            patch.object(app, "_run_slash_command", side_effect=commands.append),
+            patch.object(type(app._session), "session_id", property(lambda _s: "target-session")),
+        ):
+            future = _call_from_viewer_thread(app, "target-session")
+            for _ in range(200):
+                if future.done():
+                    break
+                await pilot.pause()
+                await asyncio.sleep(0.01)
+            detail = future.result(timeout=5)
+
+        assert detail == "displayed target-session"
+        assert selected == ["target-session"], "the click must use the sidebar's navigation"
+        assert commands == [], (
+            "no slash command may run: /resume denies the outgoing session's "
+            "parked approval, which a switch must never do"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_click_on_a_session_that_cannot_open_does_not_claim_success():
+    """D2: the ack means DISPLAYED, not dispatched.
+
+    ``open_session`` skips its spawn fallback on this ack, so reporting success
+    for a session that failed to open cost the user both outcomes — no new
+    window AND the conversation they were reading. ``SessionNavigation`` reports
+    failure through its ``failed`` callback and completes its task NORMALLY, so
+    the task's own outcome is not the answer; what is on screen is.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+
+        def settle(session_id: str):
+            # The navigation runs and finishes; the binding never moves, which
+            # is exactly what a failed boot looks like from here.
+            return asyncio.ensure_future(asyncio.sleep(0))
+
+        with (
+            patch.object(app, "_select_sidebar_session", side_effect=settle),
+            patch.object(
+                type(app._session), "session_id", property(lambda _s: "still-the-old-one")
+            ),
+        ):
+            future = _call_from_viewer_thread(app, "cannot-open")
+            for _ in range(200):
+                if future.done():
+                    break
+                await pilot.pause()
+                await asyncio.sleep(0.01)
+            with pytest.raises(Exception) as excinfo:
+                future.result(timeout=5)
+
+        assert "cannot-open" in str(excinfo.value), (
+            "a failed switch must raise so the ack is an error frame and the "
+            "click falls through to its spawn fallback"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_blocking_app_hop_does_not_outlast_the_click_bound():
+    """MAJOR-2: the hop into Textual is bounded, and now really is.
+
+    ``App.call_from_thread`` ends in a bare ``future.result()`` — it blocks its
+    caller with no timeout of its own — so a ``wait_for`` placed AFTER it never
+    applied to the hazard the docstring named, and an app wedged in a nested
+    pump ran 30 s against a 12 s outer bound. The blocking enqueue is inside the
+    bound now, via ``to_thread``.
+
+    **THE HAZARD IS SIMULATED IN ``call_from_thread`` ITSELF, not by wedging the
+    app's loop, and that is not a shortcut.** A first version of this test
+    blocked Textual's loop with ``call_later`` — but the pilot's own coroutine
+    runs ON that loop, so the test body could not advance until the block
+    expired either. It measured its own suspension (32 s per run) rather than
+    the bound, and would have reported success for the wrong reason. Patching
+    the blocking call reproduces exactly the property under test — an enqueue
+    that never returns — while leaving the loop able to run the assertions.
+    """
+    from local_operator.session.runtime.viewers import VIEWER_RESUME_TIMEOUT_S
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        entered = threading.Event()
+        released = threading.Event()
+
+        def never_returns(callback, *args, **kwargs):
+            # What a wedged app does to its caller: the callback is enqueued and
+            # nothing ever services it.
+            entered.set()
+            released.wait(timeout=30)
+
+        try:
+            with (
+                patch.object(type(app), "call_from_thread", never_returns),
+                patch("local_operator.session.runtime.viewers.VIEWER_RESUME_TIMEOUT_S", 0.5),
+            ):
+                started = time.monotonic()
+                future = _call_from_viewer_thread(app, "anything")
+                with pytest.raises(asyncio.TimeoutError):
+                    # Generous relative to the 0.5 s bound and far below the
+                    # 30 s block, so the two outcomes are unambiguous.
+                    await asyncio.to_thread(future.result, 10)
+                elapsed = time.monotonic() - started
+        finally:
+            released.set()
+
+        assert entered.is_set(), "precondition: the blocking hop must have been entered"
+        assert elapsed < 5.0, (
+            f"the bound did not apply to the blocking hop: gave up after "
+            f"{elapsed:.1f}s against a 0.5s bound (the real one is "
+            f"{VIEWER_RESUME_TIMEOUT_S}s)"
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_real_hosts_focus_call_runs_off_the_serving_loop():
+    """MAJOR-1/Q2: the property asserted against the METHOD THAT SHIPS.
+
+    ``tests/unit/session/test_viewer_routing.py`` guards this shape too, but
+    through a double — so it proves the contract is expressible, not that
+    ``OperatorApp.viewer_focus_window`` honours it. Deleting the ``to_thread``
+    hop in ``app.py`` leaves that test green (verified). This one is the guard
+    that goes red for it, which is what both review streams asked for: this is
+    the method whose blocking ``subprocess.run`` would freeze the TUI, and the
+    frozen-loop class is invisible to a Python-level probe once it happens.
+
+    ``activate_window`` is patched to report its thread rather than to touch the
+    window server: the question is WHERE it ran, and a real OS call would make
+    this test depend on a macOS window server that CI does not have.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        ran_on: list[int] = []
+
+        def fake_activate() -> bool:
+            ran_on.append(threading.get_ident())
+            return True
+
+        with patch("local_operator.tui.window_focus.activate_window", fake_activate):
+            handler_thread: list[int] = []
+
+            async def call() -> str:
+                handler_thread.append(threading.get_ident())
+                return await app.viewer_focus_window()
+
+            loop = asyncio.new_event_loop()
+            try:
+                detail = await asyncio.to_thread(loop.run_until_complete, call())
+            finally:
+                loop.close()
+
+        assert detail == "activated"
+        assert ran_on, "precondition: the activation must actually have been attempted"
+        assert handler_thread, "precondition: the host coroutine must have run"
+        # PRECONDITION: the coroutine ran on its own loop thread, not Textual's
+        # — otherwise "different from the handler" says nothing about the loop
+        # this endpoint has to keep serving.
+        assert handler_thread[0] != threading.get_ident()
+        assert ran_on[0] != handler_thread[0], (
+            "the OS call ran on the loop serving the click; a slow window "
+            "server would stall the endpoint and the click would fall back to "
+            "spawning the very window this feature removes"
+        )

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -2039,3 +2039,349 @@ async def test_abandoning_an_overrun_click_leaves_the_outgoing_session_whole():
         ), "the draft the user was holding must survive an abandoned click"
         assert navigation.requested_id == "", "the navigation boundary must be released"
         assert not [t for t in navigation._tasks if not t.done()], "no navigation task may leak"
+
+
+@pytest.mark.asyncio
+async def test_a_click_the_app_services_late_cannot_start_a_switch_at_all():
+    """MAJOR-3: the give-up must bind the app that is merely SLOW, not only the
+    one that is wedged.
+
+    The `not started` branch used to raise on the premise that an expired bound
+    with no recorded navigation meant none could exist — true for an app that
+    NEVER services the enqueue, false for one that services it LATE. The
+    endpoint's own docstring concedes the second case: a timeout strands the
+    worker until Textual gets to the callback, which cannot be recalled. When
+    that worker finally ran it started a real navigation behind an endpoint that
+    had already answered failure, so the caller had spawned its window and the
+    session then switched underneath it — a switch AND a duplicate window, the
+    exact pair this feature removes, reached through the sibling branch of the
+    one Q3 closed.
+
+    NOTHING ON THE CLICK PATH IS PATCHED HERE, and that is the point. Textual's
+    loop is simply blocked past the bound, which on a box running 8-17 sessions
+    at load 150+ is the ordinary state rather than an exotic one. A probe that
+    patched `call_from_thread` to be slow would prove only that the patch works.
+
+    The guarantee is a REFUSAL rather than a check: the endpoint publishes that
+    it has given up before it hops, and `apply` reads that on Textual's thread
+    before it can create anything. A check would race the creation it is trying
+    to catch, since the two run on different threads; a refusal is ordered by
+    the same thread that would do the work.
+    """
+    from local_operator.session.runtime import viewers
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        committed: list[str] = []
+
+        async def prepare(session_id: str, *args, **kwargs):
+            return session_id
+
+        def commit(session_id: str, prepared, generation: int):
+            committed.append(session_id)
+            app._adopted_session_id = session_id
+            return None
+
+        navigation = app._sidebar_navigation
+        with (
+            patch.object(navigation, "_prepare", prepare),
+            patch.object(navigation, "_commit", commit),
+            patch.object(navigation, "_release", lambda prepared: asyncio.sleep(0)),
+            patch.object(viewers, "VIEWER_RESUME_TIMEOUT_S", 0.3),
+            patch.object(viewers, "VIEWER_ABANDON_SETTLE_S", 2.5),
+            patch.object(
+                type(app._session),
+                "session_id",
+                property(lambda _s: committed[-1] if committed else "origin"),
+            ),
+        ):
+            future = _call_from_viewer_thread(app, "target-session")
+            # Block Textual's own thread past the bound with no pump at all, so
+            # the enqueue is not serviced until after the endpoint has given up.
+            # A sleep on this thread IS the condition under test.
+            time.sleep(0.9)
+
+            await _pump_until(pilot, future.done, what="the endpoint to answer")
+            try:
+                detail = future.result(timeout=5)
+                switched = True
+            except Exception:
+                detail = ""
+                switched = False
+
+            # The stranded hop is still pending. Servicing it is the whole
+            # hazard, so pump well past it rather than stopping at the answer.
+            for _ in range(400):
+                await pilot.pause()
+                await asyncio.sleep(0.005)
+                task = navigation._task
+                if committed and (task is None or task.done()):
+                    break
+
+        landed = "target-session" in committed
+        spawn_would_run = not switched
+        assert not (landed and spawn_would_run), (
+            "DOUBLE ACTION via a LATE-serviced hop: the switch committed at "
+            f"{committed!r} while the endpoint answered failure, so the click "
+            "delivers a session switch AND a duplicate window"
+        )
+        assert switched == landed, (
+            f"the ack must describe what happened: switched={switched} "
+            f"detail={detail!r} committed={committed!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_an_abandoned_click_cannot_cancel_the_switch_the_user_began():
+    """MINOR-7: `abandon` is scoped to ONE task, and the scoping is load-bearing.
+
+    `cancel()` stops whatever navigation is current, which is right for a user
+    changing their mind and catastrophic for a click giving up on itself: by the
+    time an overrunning click abandons, the current navigation may be the USER'S,
+    started meanwhile from the sidebar. Cancelling that loses a switch they asked
+    for and commits nothing — worse than the duplicate window being fixed.
+
+    THE INTERLEAVING IS CONSTRUCTED, NOT RACED. Wall-clock racing cannot reach
+    it reliably: measured, the click's abandon fires ~13 ms before the user's
+    select, so the ordering under test simply does not occur on its own. Driving
+    the user's select from inside the click's own preparation makes the hazardous
+    order the only one this test can produce, which is what lets it hold the
+    guard down. Mutating the scoping check out (`if self._task is not task or
+    task.done(): return False` → `pass`) turns this red; it left the rest of the
+    suite green, which is why the guard needed a test of its own.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        committed: list[str] = []
+        navigation = app._sidebar_navigation
+        started_user: list["asyncio.Task[None]"] = []
+        user_may_finish = asyncio.Event()
+
+        async def prepare(session_id: str, *args, **kwargs):
+            if session_id == "click-session":
+                # The user reaches the sidebar while the click is still
+                # preparing, so THEIR navigation is the current one when the
+                # click below gives up. This is the ordering the guard exists
+                # for, made deterministic rather than waited for.
+                if not started_user:
+                    started_user.append(navigation.select("user-session"))
+                await asyncio.sleep(1.0)
+                return session_id
+            # The user's own preparation is held OPEN across the abandon, so
+            # their navigation is genuinely in flight when the click gives up.
+            # Letting it commit first would make an unscoped abandon look
+            # harmless: the damage is to a switch still being prepared.
+            await user_may_finish.wait()
+            return session_id
+
+        def commit(session_id: str, prepared, generation: int):
+            committed.append(session_id)
+            return None
+
+        with (
+            patch.object(navigation, "_prepare", prepare),
+            patch.object(navigation, "_commit", commit),
+            patch.object(navigation, "_release", lambda prepared: asyncio.sleep(0)),
+        ):
+            click_task = navigation.select("click-session")
+            await _pump_until(pilot, lambda: bool(started_user), what="the user's own switch")
+
+            user_task = started_user[0]
+            # Exactly what the endpoint's timeout does, on Textual's thread,
+            # while the user's switch is still preparing.
+            stopped = navigation.abandon(click_task)
+            user_may_finish.set()
+            await _pump_until(pilot, lambda: user_task.done(), what="the user's switch to settle")
+
+        # The CONSEQUENCE first: an unscoped abandon does not merely return the
+        # wrong value, it cancels the user's switch and commits nothing, which
+        # is a worse outcome than the duplicate window this feature removes.
+        assert committed == ["user-session"], (
+            "the switch the USER began must still commit after an overrunning "
+            f"click gave up: committed={committed!r}"
+        )
+        assert user_task.cancelled() is False, (
+            "the user's switch must not be cancelled by a click abandoning "
+            "its own overrun request"
+        )
+        assert stopped is False, (
+            "abandon must refuse a task that is no longer the current "
+            "navigation: the click's own switch was superseded by the user's"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_hop_the_pool_starts_late_is_refused_rather_than_fenced():
+    """MAJOR-3, the ordering the abandon hop alone cannot cover.
+
+    The endpoint has two mechanisms and they carry DIFFERENT orderings, which is
+    why both exist. Normally `apply` is enqueued first and Textual services it
+    first, so by the time the timeout hops back there is a real navigation and
+    the fence stops it — that is
+    ``test_a_click_the_app_services_late_cannot_start_a_switch_at_all``.
+
+    This is the other order. When the endpoint's first ``to_thread`` cannot even
+    start — a saturated pool on a box already running 8-17 sessions — the
+    abandon callback is serviced BEFORE `apply` is. The fence then has nothing
+    to fence: `started` is empty because no navigation exists yet, and one is
+    created afterwards, behind an endpoint that has already answered failure.
+
+    Only the refusal covers this, and it is why the give-up is published as a
+    decision rather than performed as a check. Proven by mutation: removing the
+    refusal while KEEPING the symmetric hop leaves this red
+    (``committed=['target-session']`` against ``switched=False``) while the
+    sibling test above stays green, so neither mechanism is a decoration.
+
+    Only the enqueue is delayed; nothing on the click path is patched.
+    """
+    from local_operator.session.runtime import viewers
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        committed: list[str] = []
+
+        async def prepare(session_id: str, *args, **kwargs):
+            return session_id
+
+        def commit(session_id: str, prepared, generation: int):
+            committed.append(session_id)
+            app._adopted_session_id = session_id
+            return None
+
+        navigation = app._sidebar_navigation
+        real_call_from_thread = app.call_from_thread
+        serviced: list[str] = []
+
+        def late_pool(fn, *args, **kwargs):
+            serviced.append(getattr(fn, "__name__", "?"))
+            if getattr(fn, "__name__", "") == "apply":
+                # The pool cannot start this worker until after the bound has
+                # expired and the abandon hop has run. The delay is on the
+                # ENQUEUE, not on the navigation.
+                time.sleep(0.8)
+            return real_call_from_thread(fn, *args, **kwargs)
+
+        with (
+            patch.object(navigation, "_prepare", prepare),
+            patch.object(navigation, "_commit", commit),
+            patch.object(navigation, "_release", lambda prepared: asyncio.sleep(0)),
+            patch.object(viewers, "VIEWER_RESUME_TIMEOUT_S", 0.3),
+            patch.object(viewers, "VIEWER_ABANDON_SETTLE_S", 2.5),
+            patch.object(app, "call_from_thread", late_pool),
+            patch.object(
+                type(app._session),
+                "session_id",
+                property(lambda _s: committed[-1] if committed else "origin"),
+            ),
+        ):
+            future = _call_from_viewer_thread(app, "target-session")
+            await _pump_until(pilot, future.done, what="the endpoint to answer")
+            try:
+                detail = future.result(timeout=5)
+                switched = True
+            except Exception:
+                detail = ""
+                switched = False
+
+            for _ in range(600):
+                await pilot.pause()
+                await asyncio.sleep(0.005)
+                task = navigation._task
+                if committed and (task is None or task.done()):
+                    break
+
+        landed = "target-session" in committed
+        assert not (landed and not switched), (
+            "DOUBLE ACTION via a hop the pool started late: the switch "
+            f"committed at {committed!r} while the endpoint answered failure"
+        )
+        assert switched == landed, (
+            f"the ack must describe what happened: switched={switched} "
+            f"detail={detail!r} committed={committed!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_click_superseded_by_a_click_for_the_same_session_does_not_spawn():
+    """Q4: two clicks on the SAME session must not yield a switch and a spawn.
+
+    ``SessionNavigation.select`` bumps the generation and cancels the current
+    navigation — correct for a user changing their mind, and it means a second
+    click inside the preparation window retires the first. The first click was
+    then truthfully told "not displayed" (its successor had not committed yet)
+    and fell through to its spawn, so the app switched to the session a window
+    had just been opened for. The fence never ran here: neither click exceeded
+    its bound, so this is a different path from the overrun cases above.
+
+    The question a click actually asks is "is the user going to end up here",
+    so a navigation retired for heading to the SAME place is followed rather
+    than reported on. A different target is untouched — that click really is
+    about a session that is not being displayed, and it should still spawn.
+    """
+    from local_operator.session.runtime import viewers
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        committed: list[str] = []
+
+        async def prepare(session_id: str, *args, **kwargs):
+            # Long enough that the second click lands while the first is still
+            # preparing, which is the window this defect lives in.
+            await asyncio.sleep(0.5)
+            return session_id
+
+        def commit(session_id: str, prepared, generation: int):
+            committed.append(session_id)
+            app._adopted_session_id = session_id
+            return None
+
+        navigation = app._sidebar_navigation
+        with (
+            patch.object(navigation, "_prepare", prepare),
+            patch.object(navigation, "_commit", commit),
+            patch.object(navigation, "_release", lambda prepared: asyncio.sleep(0)),
+            patch.object(viewers, "VIEWER_RESUME_TIMEOUT_S", 5.0),
+            patch.object(viewers, "VIEWER_ABANDON_SETTLE_S", 2.5),
+            patch.object(
+                type(app._session),
+                "session_id",
+                property(lambda _s: committed[-1] if committed else "origin"),
+            ),
+        ):
+            first = _call_from_viewer_thread(app, "target-session")
+            # A few turns, not a sleep: the second click must arrive while the
+            # first is preparing, and the preparation is what bounds that.
+            for _ in range(3):
+                await pilot.pause()
+                await asyncio.sleep(0.005)
+            second = _call_from_viewer_thread(app, "target-session")
+
+            await _pump_until(
+                pilot,
+                lambda: first.done() and second.done(),
+                what="both clicks to answer",
+            )
+            outcomes = []
+            for future in (first, second):
+                try:
+                    future.result(timeout=5)
+                    outcomes.append("switch")
+                except Exception:
+                    outcomes.append("spawn")
+
+        # THE INVARIANT IS AGREEMENT, NOT A COUNT. Whether the second click
+        # lands inside the first's preparation or after it has committed is a
+        # scheduling outcome this test cannot pin under contention — and both
+        # are correct. What must never happen is a click reporting failure, and
+        # so spawning a window, for a session that is on screen.
+        assert "spawn" not in outcomes, (
+            "a click superseded by another click for the SAME session must not "
+            f"spawn a window the successor then switches underneath: {outcomes}"
+        )
+        assert committed and set(committed) == {"target-session"}, (
+            "every switch that landed must be the session the clicks asked " f"for: {committed!r}"
+        )


### PR DESCRIPTION
## Summary

Clicking a background-completion notification opened a **new Ghostty window** instead of taking the user to the session in the terminal they already had open. This routes the click to the running TUI, which switches to that session and brings its window forward. When nothing suitable is running, the old spawn behaviour is unchanged.

The handler was not buggy — it was faithfully executing a premise that had expired. `resume_click.py` opened with:

> "A desktop notification is only sent when NOTHING is watching the session, so by definition there is no emulator around the sending process to inherit. The click therefore has to OPEN a terminal"

True when written: `detached_notify` had one `session_id`-carrying caller, `owned.py::_announce_pending`, reached only after `_watching_surfaces()` came back empty. #724 (v0.51.5) added a second one — the observer leg in `tui/app.py::_deliver_background_completion` — which posts a toast **from a live, running TUI** for a background session that TUI can already display through its sidebar. The premise became false in exactly the case the feature was built for.

The premise is no longer assumed; it is **checked**, and the spawn is demoted to the fallback it was always documented to be.

## Change class

C2 — new surface (a discovery record and a loopback endpoint) on an existing feature's path. No API change, no `PROTOCOL_VERSION` change.

## Two halves, because either alone is inert

**(a) A viewer record.** There was no path from a session id to the process displaying it. `_mobile_adopted` tears the session registrant down whenever the app follows a `RemoteSession` — the normal sidebar state — so a sidebar user published nothing. On this machine before the change: 12 records in `run/mobile/`, all `kind="daemon"`, zero `kind="tui"`.

**(b) A viewer endpoint.** The ops existed; the socket did not. `RuntimeServer` binds its listener and publishes its record in the same step, so the same teardown that removes the record also closes the socket. A process-scoped endpoint now outlives session swaps and serves exactly two ops.

## Deviations from the design doc, and why

Two of the design's load-bearing claims did not survive contact with the committed ref. Both were checked before building.

**1. Viewer records must not live in `run/mobile/`.** The design proposed `kind="viewer"` records there, filtered "at the one scan site". There are ~12 scan sites; the path is `run/mobile/<pid>.json`, so a TUI that also owns a local session writes the *same file* twice; and — the decisive one — **older builds cannot be taught to ignore them.** `SessionRecord.from_json` drops unknown *keys* but never validates `kind`'s *value*, so an older process parses `kind="viewer"` as an ordinary session record. Measured against `origin/main` with a live pid:

```
registry.scan()            -> 1 record, kind=['viewer'], state=['live']
lop stop --all would walk its SIGTERM ladder against 1 target: pid [26528]
lop send routes a message to the viewer process: True
```

That is an older `lop stop --all` sending SIGTERM to the window the operator is working in. A change that makes an *older* peer misbehave is not additive, and a dozen older sessions run on this host concurrently. Records go in `run/viewers/` instead — the same isolation `browser_bridge` already uses for `run/browser`. Same probe against this branch:

```
registry.scan()            -> 0 record(s)
lop stop --all targets     -> 0
lop send resolves a viewer -> None ("no live session matches")
```

**2. "Zero protocol change" was half right.** `resume_session` does exist (`server.py:1918`) with a working handler that runs `/resume` on the app's loop, and the attach guard genuinely does not apply to a daemon-class dial — all confirmed. But in the operator's normal sidebar state **there is no listener bound to send it to**. Keeping the `RuntimeServer` alive while remote is not available: its own comment records that a second registrant per transcript corrupts daemon routing. So this adds a *transport* for existing ops. `PROTOCOL_VERSION` stays at 5 and no session frame changes shape.

**3. Dropped the record's enumerated `sessions` list.** A sidebar TUI can display anything in the catalogue, so the list is a cache of something that changes without the writer knowing — wrong the moment a session ends, and rewritten on every 2 s catalogue poll. The record carries `current_session` + `can_switch`, which is a capability statement rather than an inventory snapshot.

## OS focus — built to the measured ceiling

`open -a <bundle>` (0.11 s measured), run off the event loop via `asyncio.to_thread` and bounded by `subprocess.run(timeout=)`. A frozen event loop is the class `tests/e2e/watchdog.py` exists to catch precisely because a Python probe cannot see it.

**The emulator's AppleScript object model is never traversed**, not even with a guard. Ghostty 1.3.1 returns a confidently wrong `0` window count while two windows exist, and has separately been observed hanging until killed. A wrong answer is worse than a hang — a timeout at least fails loudly.

**Honest about the multi-window ceiling.** On the operator's current topology (one Ghostty window, one TUI) this is exact. With two TUI windows the *right* TUI switches to the *right* session — that part is addressed by pid — but `open -a` fronts the **application**, and macOS raises whichever window was most recently frontmost. The user may land behind the wrong window and need one Cmd-\`. Still strictly better than today's orphaned second process. Window-exact focus via the accessibility API needs a permission prompt and is deliberately out of scope.

## Evidence

**The bug, then the fix — against a real `OperatorApp`** (Textual `run_test` pilot, real stylesheet, `spawn_detached` stubbed to record rather than open windows on the operator's desktop):

```
######## before (viewer endpoint disabled = main's behaviour) ########
  viewer records visible to a click: 0
  NEW TERMINAL WINDOWS SPAWNED: 1
    spawn argv: ['open', '-na', 'Ghostty.app', '--args'] ...
  app slash commands run: []
  VERDICT: BUG REPRODUCED: a new terminal window was spawned

######## after ########
  [after] viewer endpoint bound on port 64809
  [after] record.current_session='sess'
  viewer records visible to a click: 1
  NEW TERMINAL WINDOWS SPAWNED: 0
  app slash commands run: ['/resume bbbbbbbbbbbb']
  VERDICT: FIXED: the running TUI switched; no new window
```

**C4 — the spawn fallback is byte-identical to `origin/main`.** The whole downside risk of this change is breaking the path that already works, so it is diffed rather than asserted. Same probe run against a throwaway worktree at the committed ref and against this branch, normalised for repo path and isolated HOME:

```
argv: ["open", "-na", "Ghostty.app", "--args",
       "--working-directory=ISO",
       "--initial-command=... --resume 9f8e5b652ac7"]
diff -> IDENTICAL
```

**Old-binary / new-binary coexistence** (the operator has ~12 live sessions on the previous build) — the two probes quoted under Deviation 1 above.

**Matrix**, driven against a real endpoint over a real socket in an isolated `HOME`:

| Case | Result |
|---|---|
| C1 viewer running, target not displayed | switch issued, no spawn — PASS |
| C2 target already displayed | focus only; **no `/resume`**, scroll undisturbed — PASS |
| C3 viewer cannot focus (ssh/Linux) | switch succeeds, focus declines — PASS |
| C4 no viewer running | routing declines, spawn path runs — PASS |
| C5 wedged viewer (live pid, dead port) | bounded fail → falls through — PASS |
| C6 several viewers | deterministic: displaying → focused → pid — PASS |
| stale record, dead pid | reaped, never routed to — PASS |

C7 (cmux) and C8 (Electron) are **BLOCKED** on this host — cmux is not running and the desktop app is cross-repo. Recorded as blocked rather than stubbed.

**Every guard was proven able to fail.** Each defect reintroduced, test watched go red, reverted:

| Defect reintroduced | Result |
|---|---|
| `choose_viewer` borrows caller ordering | C6 precedence — **red** |
| always re-switch (drop the already-displayed check) | C2 — **red** |
| focus call moved onto the event loop | thread-identity assertion — **red** |
| `subprocess.run` timeout removed | boundedness assertion — **red** |
| `start()` made non-idempotent | endpoint-thread count — **red** |
| `close()` leaves the record | record removal — **red** |
| records moved back to `run/mobile` | registry-isolation — **red** |
| auth check bypassed | bad-key refusal — **red** |

Two of these were caught being **vacuous first**: the no-focus case had never wired its host to a server, and the idempotence test asserted on a pid-keyed record that a second endpoint simply overwrites — invisible. Both rewritten to assert the observable (advertised capabilities; live endpoint-thread count).

`choose_viewer`'s ordering bug was found by this process, not by review: it borrowed `scan_viewers`'s ordering while its docstring promised its own, so it was wrong for any other caller.

## Gates

Whole tree, exactly as CI runs them: **flake8 clean · black 26.1.0 clean · isort 5.13.2 clean · pyright `0 errors, 0 warnings`.**

```
tests/unit/session/test_viewer_routing.py     15 passed   (5x consecutive, stable)
tests/unit/session/                        1609 passed
tests/unit/test_import_graph.py             166 passed (with the above)
tests/unit/tui/test_app_pilot.py            323 passed
```

The full `-n auto` suite was deliberately **not** run locally: this host hit macOS "out of application memory" twice today with ~12 live sessions and peer worktrees building. Targeted surfaces plus neighbours locally; CI runs the matrix.

`tests/unit/session/test_no_session_deletion.py` correctly flagged the new module's staged writes and required an explicit allow-list entry with justification — registered alongside `registry.py`'s identical entries rather than suppressed.

## Hygiene

Isolated `HOME` **and** `LOCAL_OPERATOR_CONFIG_DIR` throughout, `CMUX_*` scrubbed, synthetic session ids, `spawn_detached` stubbed. Verified afterwards that the operator's real config is untouched: no `run/viewers/` exists there, all 11 `run/mobile` records are still `kind=daemon`, and no new `--initial-command=` process was spawned by any of this testing.

## Deferred

- **`local-operator://` URL scheme** — deferred; orthogonal. It addresses only the >30 s case after `kActivationWindow` expires, and would face the identical routing question. Becomes a small handler now that viewer records exist.
- **Accessibility window-exact focus** — deferred; needs a permission prompt, and out of scope per the brief.
- **`local-operator-ui` (Electron)** — cross-repo. It is a viewer with a better focus ceiling (`BrowserWindow.show()` is window-exact, no permission) and participates in this routing for free if it publishes a viewer record.

## Version

`pyproject.toml` untouched — a release owner bumps per window.
