### PR TITLE
fix(mcp): tombstone dead OAuth grants instead of re-spending them

### DIFF
--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -563,6 +563,17 @@ class McpTokenStorage:
         connect that is already failing over a dead grant, so it degrades to
         today's behaviour (the storm) rather than raising. See
         :data:`GRANT_DEAD_AT_KEY` for why this carries no expiry.
+
+        Known window, recorded because a FALSE tombstone is the worst failure
+        this marker can introduce: the read-modify-write is not inside
+        :func:`_oauth_refresh_lock`, so a sibling process that persists a
+        rotated token between our read and our write has that write overwritten
+        by our stale snapshot plus the marker, and a live grant then reads as
+        dead until an interactive login. The ordering makes it unlikely — we
+        only reach here after the server rejected the grant, under the lock on
+        the coordinator path — and it is a pre-existing property of the same
+        read-modify-write in :meth:`set_tokens`, so it is left as-is rather than
+        fixed here alone; closing it means giving both writers the lock.
         """
         try:
             creds = self._read() or {}
@@ -2148,9 +2159,14 @@ async def ensure_mcp_oauth_fresh(
         # proceeds to the point where it raises McpAuthRequiredError, which the
         # manager renders as the actionable "run /mcp reauth" toast.
         #
-        # Logged at INFO, once per server per process (this runs once per
-        # server on the startup path): silence would read as "fixed" when it
-        # means "suppressed", and the operator still owes an interactive login.
+        # Logged at INFO once per CONNECT, not once per process: this is reached
+        # from _connect_server, which also serves auto-reconnect and /mcp login,
+        # so a server that reconnects logs it again. That is bounded rather than
+        # a storm — _reconnect's McpAuthRequiredError arm abandons auto-reconnect
+        # instead of retrying — and INFO is deliberate: silence would read as
+        # "fixed" when it means "suppressed", and the operator still owes an
+        # interactive login. Plain logger.info also means it reaches CLI and
+        # headless hosts, not only the TUI's toast surface.
         logger.info(
             "MCP OAuth grant for %s is known-dead (invalid_grant); skipping refresh "
             "-- run /mcp reauth to restore it",
@@ -2378,12 +2394,35 @@ def _make_refresh_coordinating_provider(
             if self._refresh_coord_storage.grant_is_dead():
                 # Same suppression as ensure_mcp_oauth_fresh, before the lock.
                 # Debug rather than info: the startup path already logged the
-                # actionable reauth line for this server this process, and this
-                # site can run per request.
+                # actionable reauth line for this connect, and this site can run
+                # per request.
                 logger.debug(
                     "MCP in-flight refresh skipped for %s: grant is known-dead",
                     self._refresh_coord_server_url,
                 )
+                # STRIPPING HERE IS LOAD-BEARING, not a tidy-up: returning from
+                # this coroutine falls through to the SDK's own UNLOCKED
+                # _refresh_token, which reads ctx.current_tokens directly and
+                # would POST the very token the authorization server already
+                # rejected — the family-revoking request this whole subsystem
+                # exists to prevent. Suppressing OUR refresh without dropping
+                # the token therefore removes the harmless POSTs and keeps the
+                # harmful one, which is strictly worse than not suppressing at
+                # all, because it also looks fixed.
+                #
+                # This branch is the STEADY STATE: boot 1 writes the tombstone
+                # and takes the "dead" arm below (which strips for the same
+                # reason); every boot after it arrives here instead. Measured at
+                # the wire before this strip existed: 1 SDK POST on every one of
+                # 5 already-tombstoned boots.
+                #
+                # Dropping the in-memory refresh token makes can_refresh_token()
+                # read False, so the SDK skips its refresh branch and goes to
+                # the authorization branch, which our non-interactive redirect
+                # handler turns into an actionable McpAuthRequiredError.
+                with contextlib.suppress(Exception):
+                    if ctx.current_tokens is not None:
+                        ctx.current_tokens.refresh_token = None
                 return
             try:
                 async with _oauth_refresh_lock(self._refresh_coord_server_url) as locked:

--- a/local_operator/mcp/auth.py
+++ b/local_operator/mcp/auth.py
@@ -50,7 +50,7 @@ import time
 import weakref
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 from urllib.parse import parse_qs, urlparse
 
 from pydantic import AnyUrl
@@ -93,6 +93,41 @@ DEFAULT_CALLBACK_PATH = "/callback"
 #: token was issued. Not part of the SDK's ``OAuthToken`` — see
 #: :meth:`McpTokenStorage.stored_token_expiry` for why we have to record it.
 TOKENS_OBTAINED_AT_KEY = "tokens_obtained_at"
+
+#: Payload key marking THIS row's refresh token as one the authorization server
+#: has already rejected with ``invalid_grant``. Set only by the parsed-body
+#: branch in :func:`_refresh_oauth_token_locked`; absence means "no such
+#: observation", never "known good".
+#:
+#: Why this exists: nothing used to record the rejection, so every process boot
+#: re-spent the same dead token (measured: 39 POSTs for one server, 87 for
+#: another, across 26 boots). For a provider running refresh-token REUSE
+#: DETECTION (Notion) that is not merely waste — re-presenting an already-rotated
+#: token revokes the ENTIRE token family, so a burst of session spawns turns one
+#: stale row into a fleet-wide logout.
+#:
+#: Why NO ttl: a dead grant is a CORRECTNESS fact that stays true until an
+#: interactive login replaces the grant, not a cost backoff. This is also why it
+#: is not stored in ``auth_credential_blocks``: ``block_credential`` clamps every
+#: block to ``MAX_CREDENTIAL_BLOCK_MS`` (1h), a ceiling that is load-bearing for
+#: provider quota backoff, so reusing that table would resume the storm — and the
+#: family revocation — every hour. That table is also keyed by integer
+#: ``credential_id`` plus a ``provider:type`` composite, where an MCP grant's
+#: identity is its ``server_url``. Wrong lifetime, wrong key.
+#:
+#: Living in the row payload makes it atomic with the grant it describes:
+#: :meth:`McpTokenStorage.clear` deletes it with the row, and
+#: :meth:`McpTokenStorage.set_tokens` clears it on any successful token write, so
+#: there is no way to leave a tombstone pointing at a token that no longer
+#: exists. It needs no migration — the payload already round-trips unknown keys.
+GRANT_DEAD_AT_KEY = "grant_dead_at"
+
+#: Outcome of one locked refresh attempt. Three-valued rather than ``bool``
+#: because the coordinator must tell a DEAD grant (never present this token
+#: again) from a merely FAILED one (transient; today's behaviour is correct).
+#: CAUTION: ``"failed"`` is a truthy string — every call site must compare
+#: against a member explicitly, never test truthiness.
+RefreshOutcome = Literal["refreshed", "failed", "dead"]
 
 #: Refresh this far BEFORE the stored access token's deadline. A connect that
 #: starts with a token dying in ten seconds would otherwise open with a 401 and
@@ -499,7 +534,44 @@ class McpTokenStorage:
         creds = self._read() or {}
         creds["tokens"] = tokens.model_dump(mode="json")
         creds[TOKENS_OBTAINED_AT_KEY] = time.time()
+        # Clearing the dead-grant tombstone belongs HERE rather than in the
+        # ``/mcp login`` / ``/mcp reauth`` commands: this is the one funnel every
+        # path that obtains a working token already goes through (a completed
+        # browser grant, and a refresh that unexpectedly succeeds), so a login
+        # path added later cannot forget to un-stick a suppressed server.
+        creds.pop(GRANT_DEAD_AT_KEY, None)
         self._write(creds)
+
+    def grant_is_dead(self) -> bool:
+        """Whether this row's refresh token is a known-dead grant.
+
+        ``True`` only when :meth:`mark_grant_dead` recorded an ``invalid_grant``
+        rejection that no later :meth:`set_tokens` has cleared. Tolerates a
+        missing store, row, or key by returning ``False``, like every other read
+        here: an unreadable store must never suppress a refresh that might work.
+        """
+        creds = self._read()
+        if creds is None:
+            return False
+        marker = creds.get(GRANT_DEAD_AT_KEY)
+        return isinstance(marker, (int, float)) and not isinstance(marker, bool) and marker > 0
+
+    def mark_grant_dead(self) -> None:
+        """Record that this row's refresh token was rejected as ``invalid_grant``.
+
+        Best-effort read-modify-write: a store failure here must not break the
+        connect that is already failing over a dead grant, so it degrades to
+        today's behaviour (the storm) rather than raising. See
+        :data:`GRANT_DEAD_AT_KEY` for why this carries no expiry.
+        """
+        try:
+            creds = self._read() or {}
+            creds[GRANT_DEAD_AT_KEY] = time.time()
+            self._write(creds)
+        except Exception:  # noqa: BLE001 — marking is an optimisation, never a gate
+            logger.debug(
+                "MCP dead-grant marker write failed for %s", self.credential_id, exc_info=True
+            )
 
     def stored_token_expiry(self) -> float | None:
         """Epoch seconds at which the stored access token expires, if knowable.
@@ -1888,10 +1960,16 @@ async def _refresh_oauth_token_locked(
     server_url: str,
     storage: McpTokenStorage,
     endpoints: DiscoveredOAuthEndpoints,
-) -> bool:
+) -> RefreshOutcome:
     """Spend the stored refresh token against the DISCOVERED token endpoint.
 
-    Returns ``True`` when a fresh access token was persisted. The caller holds
+    Returns ``"refreshed"`` when a fresh access token was persisted, ``"dead"``
+    when the authorization server rejected the grant with ``invalid_grant`` (a
+    tombstone is written and the token must never be presented again), and
+    ``"failed"`` for every other outcome, including "nothing to refresh".
+    Callers MUST compare against a member: ``"failed"`` is truthy.
+
+    The caller holds
     the cross-process refresh lock, so exactly one process performs this
     exchange even when several sessions start together. Mirrors the SDK's
     refresh request exactly (grant type, client auth methods, RFC 6749 §6
@@ -1907,7 +1985,9 @@ async def _refresh_oauth_token_locked(
     tokens = await storage.get_tokens()
     client_info = await storage.get_client_info()
     if tokens is None or not tokens.refresh_token or client_info is None:
-        return False
+        # Nothing to spend — a missing token is not evidence that the grant is
+        # dead, so this must never tombstone.
+        return "failed"
 
     token_endpoint = str(endpoints.oauth_metadata.token_endpoint)
     data: dict[str, str] = {
@@ -1966,7 +2046,7 @@ async def _refresh_oauth_token_locked(
         # does not cover); a refresh that overran its budget is simply a failed
         # refresh, handled exactly like a transport error.
         logger.debug("MCP token refresh request failed for %s", server_url, exc_info=True)
-        return False
+        return "failed"
     if response.status_code != 200:
         # A revoked-grant rejection is qualitatively different from a transient
         # one and must be logged as such: for a rotating provider that runs
@@ -1984,18 +2064,24 @@ async def _refresh_oauth_token_locked(
                 "MCP OAuth grant revoked for %s (invalid_grant); run /mcp login to restore it",
                 server_url,
             )
-            return False
+            # Tombstone from HERE and nowhere else: this is the only site that
+            # has proof (a PARSED ``invalid_grant`` body, never a bare HTTP 400)
+            # that the grant itself is gone rather than the server having a bad
+            # minute. Misclassifying a transient 400 would permanently suppress
+            # refresh on a live grant until the user ran an interactive login.
+            storage.mark_grant_dead()
+            return "dead"
         # Informational, not debug: a rejected refresh is the thing that turns
         # into a login prompt, so its cause belongs in the readable log.
         logger.info("MCP token refresh rejected for %s: HTTP %s", server_url, response.status_code)
-        return False
+        return "failed"
     try:
         new_tokens = OAuthToken.model_validate_json(response.content)
     except Exception:  # noqa: BLE001 — an unparseable token is a failed refresh
         logger.debug(
             "MCP token refresh returned an invalid token for %s", server_url, exc_info=True
         )
-        return False
+        return "failed"
 
     # RFC 6749 §6: a refresh response may omit ``scope`` (unchanged) and
     # ``refresh_token`` (not rotated). Carry both forward so the persisted row
@@ -2005,7 +2091,7 @@ async def _refresh_oauth_token_locked(
     if new_tokens.refresh_token is None:
         new_tokens.refresh_token = tokens.refresh_token
     await storage.set_tokens(new_tokens)
-    return True
+    return "refreshed"
 
 
 async def ensure_mcp_oauth_fresh(
@@ -2036,6 +2122,9 @@ async def ensure_mcp_oauth_fresh(
     already-running sessions can still race a rotation there; that path fails
     into the non-interactive handler (an actionable error, not a popup) and
     the next startup heals it here.
+
+    A grant previously rejected with ``invalid_grant`` short-circuits before the
+    lock is taken: see :data:`GRANT_DEAD_AT_KEY`.
     """
     del cfg  # reserved — see docstring
     storage = McpTokenStorage(server_url, store)
@@ -2049,6 +2138,24 @@ async def ensure_mcp_oauth_fresh(
         )
 
     if _still_good(storage.stored_token_expiry(), await storage.get_tokens()):
+        return endpoints
+
+    if storage.grant_is_dead():
+        # Suppress BEFORE the lock: a grant the server already rejected must
+        # cost neither a lock acquire nor a token POST. Re-spending it is what
+        # revokes the whole token family on a reuse-detecting provider (see
+        # GRANT_DEAD_AT_KEY). Endpoints are still returned so the connect
+        # proceeds to the point where it raises McpAuthRequiredError, which the
+        # manager renders as the actionable "run /mcp reauth" toast.
+        #
+        # Logged at INFO, once per server per process (this runs once per
+        # server on the startup path): silence would read as "fixed" when it
+        # means "suppressed", and the operator still owes an interactive login.
+        logger.info(
+            "MCP OAuth grant for %s is known-dead (invalid_grant); skipping refresh "
+            "-- run /mcp reauth to restore it",
+            server_url,
+        )
         return endpoints
 
     tokens = await storage.get_tokens()
@@ -2268,6 +2375,16 @@ def _make_refresh_coordinating_provider(
             # intercept precisely when it would refresh, and never otherwise.
             if ctx.is_token_valid() or not ctx.can_refresh_token():
                 return
+            if self._refresh_coord_storage.grant_is_dead():
+                # Same suppression as ensure_mcp_oauth_fresh, before the lock.
+                # Debug rather than info: the startup path already logged the
+                # actionable reauth line for this server this process, and this
+                # site can run per request.
+                logger.debug(
+                    "MCP in-flight refresh skipped for %s: grant is known-dead",
+                    self._refresh_coord_server_url,
+                )
+                return
             try:
                 async with _oauth_refresh_lock(self._refresh_coord_server_url) as locked:
                     # Re-read under the lock: a sibling process may have rotated
@@ -2307,13 +2424,31 @@ def _make_refresh_coordinating_provider(
                         # locked, re-reading refresh targets the same URL the
                         # unlocked path would have.
                         endpoints = _fallback_endpoints_for(self._refresh_coord_server_url)
-                    refreshed = await _refresh_oauth_token_locked(
+                    outcome = await _refresh_oauth_token_locked(
                         self._refresh_coord_server_url,
                         self._refresh_coord_storage,
                         endpoints,
                     )
-                    if refreshed:
+                    # Compare explicitly: ``"failed"`` is a truthy string, so a
+                    # ``if outcome:`` here would invert this branch silently and
+                    # pyright would not catch it.
+                    if outcome == "refreshed":
                         await self._resync_from_store(ctx)
+                    elif outcome == "dead":
+                        # The third POST of the per-boot triple, and the one that
+                        # actually revokes the token family. Returning here still
+                        # falls through to the SDK's own UNLOCKED _refresh_token,
+                        # which would spend the token the authorization server
+                        # just rejected. Dropping the in-memory refresh token
+                        # makes the SDK's can_refresh_token() read False, so it
+                        # skips its refresh branch entirely and goes to the
+                        # authorization branch — which our non-interactive
+                        # redirect handler already turns into an actionable
+                        # McpAuthRequiredError. Same user-visible outcome, one
+                        # fewer family-revoking POST.
+                        with contextlib.suppress(Exception):
+                            if ctx.current_tokens is not None:
+                                ctx.current_tokens.refresh_token = None
             except Exception:  # noqa: BLE001 — coordination is best-effort
                 # A failed re-read/refresh must never break the request. But we
                 # must NOT let the SDK's unlocked refresh then spend a stale

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -1454,9 +1454,9 @@ class TestProactiveRefresh:
 
         refreshed = {"called": False}
 
-        async def fake_refresh(*args: Any, **kwargs: Any) -> bool:
+        async def fake_refresh(*args: Any, **kwargs: Any) -> auth_mod.RefreshOutcome:
             refreshed["called"] = True
-            return True
+            return "refreshed"
 
         monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", fake_refresh)
         monkeypatch.setattr(auth_mod, "discover_oauth_endpoints", self._fake_discovery())
@@ -1482,9 +1482,9 @@ class TestProactiveRefresh:
 
         refreshed = {"called": False}
 
-        async def fake_refresh(*args: Any, **kwargs: Any) -> bool:
+        async def fake_refresh(*args: Any, **kwargs: Any) -> auth_mod.RefreshOutcome:
             refreshed["called"] = True
-            return True
+            return "refreshed"
 
         monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", fake_refresh)
         monkeypatch.setattr(auth_mod, "discover_oauth_endpoints", self._fake_discovery())
@@ -1510,9 +1510,9 @@ class TestProactiveRefresh:
 
         refreshed = {"called": False}
 
-        async def fake_refresh(*args: Any, **kwargs: Any) -> bool:
+        async def fake_refresh(*args: Any, **kwargs: Any) -> auth_mod.RefreshOutcome:
             refreshed["called"] = True
-            return True
+            return "refreshed"
 
         async def no_discovery(url: str) -> Any:
             return None
@@ -1672,9 +1672,9 @@ class TestInflightRefreshCoordination:
 
         refresh_calls = {"n": 0}
 
-        async def fake_refresh(*args: Any, **kwargs: Any) -> bool:
+        async def fake_refresh(*args: Any, **kwargs: Any) -> auth_mod.RefreshOutcome:
             refresh_calls["n"] += 1
-            return True
+            return "refreshed"
 
         monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", fake_refresh)
 
@@ -1722,13 +1722,13 @@ class TestInflightRefreshCoordination:
 
         refresh_calls = {"n": 0}
 
-        async def fake_refresh(server_url, storage_arg, endpoints) -> bool:
+        async def fake_refresh(server_url, storage_arg, endpoints) -> auth_mod.RefreshOutcome:
             refresh_calls["n"] += 1
             # Mirror the real refresh: persist a fresh token under the lock.
             await storage_arg.set_tokens(
                 OAuthToken(access_token="refreshed", refresh_token="r2", expires_in=3600)
             )
-            return True
+            return "refreshed"
 
         monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", fake_refresh)
 
@@ -1873,10 +1873,12 @@ class TestInflightRefreshCoordination:
 
         refresh_calls: dict[str, Any] = {"n": 0, "endpoint": None}
 
-        async def fake_refresh(server_url: str, storage_arg: Any, endpoints: Any) -> bool:
+        async def fake_refresh(
+            server_url: str, storage_arg: Any, endpoints: Any
+        ) -> auth_mod.RefreshOutcome:
             refresh_calls["n"] += 1
             refresh_calls["endpoint"] = str(endpoints.oauth_metadata.token_endpoint)
-            return True
+            return "refreshed"
 
         monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", fake_refresh)
 
@@ -2154,11 +2156,13 @@ class TestInflightRefreshCoordination:
         # token would actually be spent on the wire.
         spent: dict[str, Any] = {}
 
-        async def spy_refresh(server_url: str, storage_arg: Any, endpoints: Any) -> bool:
+        async def spy_refresh(
+            server_url: str, storage_arg: Any, endpoints: Any
+        ) -> auth_mod.RefreshOutcome:
             tokens = await storage_arg.get_tokens()
             spent["refresh_token"] = tokens.refresh_token if tokens else None
             spent["endpoint"] = str(endpoints.oauth_metadata.token_endpoint)
-            return True
+            return "refreshed"
 
         monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", spy_refresh)
 
@@ -2260,9 +2264,9 @@ class TestRefreshOAuthTokenLocked:
     async def test_invalid_grant_is_a_dead_grant_not_retried(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """A revoked/reused refresh token (HTTP 400 invalid_grant) returns False
-        with ONE actionable log line and no retry — the manager turns the
-        resulting McpAuthRequiredError into a suspended reconnect."""
+        """A revoked/reused refresh token (HTTP 400 invalid_grant) returns
+        ``"dead"`` with ONE actionable log line and no retry — the manager turns
+        the resulting McpAuthRequiredError into a suspended reconnect."""
         import logging
 
         import httpx
@@ -2291,9 +2295,11 @@ class TestRefreshOAuthTokenLocked:
         monkeypatch.setattr(httpx, "AsyncClient", patched_client)
 
         with caplog.at_level(logging.INFO, logger="local_operator.mcp.auth"):
-            ok = await auth_mod._refresh_oauth_token_locked(self.URL, storage, self._endpoints())
+            outcome = await auth_mod._refresh_oauth_token_locked(
+                self.URL, storage, self._endpoints()
+            )
 
-        assert ok is False
+        assert outcome == "dead"
         # Exactly one POST — no auto-retry of a dead grant.
         assert calls["n"] == 1
         revoked_logs = [r for r in caplog.records if "revoked" in r.getMessage().lower()]
@@ -2330,8 +2336,8 @@ class TestRefreshOAuthTokenLocked:
 
         monkeypatch.setattr(httpx, "AsyncClient", patched_client)
 
-        ok = await auth_mod._refresh_oauth_token_locked(self.URL, storage, self._endpoints())
-        assert ok is True
+        outcome = await auth_mod._refresh_oauth_token_locked(self.URL, storage, self._endpoints())
+        assert outcome == "refreshed"
         assert seen["ua"]  # non-empty
         assert seen["ua"].startswith("local-operator")
 
@@ -2620,9 +2626,9 @@ class TestRefreshLockDegradePaths:
 
         refreshed = {"n": 0}
 
-        async def fake_refresh(*args: Any, **kwargs: Any) -> bool:
+        async def fake_refresh(*args: Any, **kwargs: Any) -> auth_mod.RefreshOutcome:
             refreshed["n"] += 1
-            return True
+            return "refreshed"
 
         monkeypatch.setattr(auth_mod, "discover_oauth_endpoints", fake_discover)
         monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", fake_refresh)
@@ -2660,9 +2666,9 @@ class TestRefreshLockDegradePaths:
 
         refreshed = {"n": 0}
 
-        async def fake_refresh(*args: Any, **kwargs: Any) -> bool:
+        async def fake_refresh(*args: Any, **kwargs: Any) -> auth_mod.RefreshOutcome:
             refreshed["n"] += 1
-            return True
+            return "refreshed"
 
         @contextlib.asynccontextmanager
         async def locked_stub(server_url: str):
@@ -2712,9 +2718,9 @@ class TestRefreshLockDegradePaths:
 
         refreshed = {"n": 0}
 
-        async def fake_refresh(*args: Any, **kwargs: Any) -> bool:
+        async def fake_refresh(*args: Any, **kwargs: Any) -> auth_mod.RefreshOutcome:
             refreshed["n"] += 1
-            return True
+            return "refreshed"
 
         monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", fake_refresh)
         monkeypatch.setattr(auth_mod, "_oauth_refresh_lock", self._unlocked_lock_stub())
@@ -2996,3 +3002,455 @@ class TestProbeOauthCapability:
         monkeypatch.setattr(auth_mod, "discover_oauth_endpoints", boom)
         cfg = MCPHttpServerConfig(url=self.URL)
         assert await auth_mod.probe_oauth_capability(cfg, FakeAuthStore()) is False
+
+
+class TestDeadGrantTombstone:
+    """A grant the authorization server rejected with ``invalid_grant`` must be
+    recorded and never re-presented.
+
+    The bug these guard: nothing used to record the rejection, so every process
+    boot re-spent the same dead refresh token (measured on this machine's log:
+    39 POSTs for one server and 87 for another across 26 boots). For a provider
+    running refresh-token REUSE DETECTION that is a fleet-wide logout, not
+    merely noise — re-presenting an already-rotated token revokes the entire
+    token family. The rejection arrived as a TRIPLE per boot, the third POST
+    coming from the SDK's own unlocked ``_refresh_token``, so suppression at the
+    proactive site alone would leave the family-revoking POST fully intact.
+
+    All assertions are structural — calls made, marker present/absent, in-memory
+    field cleared. Nothing here measures elapsed time.
+    """
+
+    URL = "https://mcp.example.com/v1/mcp"
+
+    def _cfg(self) -> MCPHttpServerConfig:
+        return MCPHttpServerConfig(url=self.URL, auth=MCPAuthConfig(type="oauth"))
+
+    def _endpoints(self):
+        from mcp.shared.auth import OAuthMetadata
+
+        from local_operator.mcp.auth import DiscoveredOAuthEndpoints
+
+        return DiscoveredOAuthEndpoints(
+            oauth_metadata=OAuthMetadata.model_validate(
+                {
+                    "issuer": self.URL,
+                    "authorization_endpoint": "https://a/authorize",
+                    "token_endpoint": "https://a/token",
+                }
+            )
+        )
+
+    @staticmethod
+    def _fake_discovery():
+        from mcp.shared.auth import OAuthMetadata
+
+        from local_operator.mcp.auth import DiscoveredOAuthEndpoints
+
+        async def discovery(url: str) -> DiscoveredOAuthEndpoints:
+            return DiscoveredOAuthEndpoints(
+                oauth_metadata=OAuthMetadata.model_validate(
+                    {
+                        "issuer": "https://mcp.example.com/v1/mcp",
+                        "authorization_endpoint": "https://a/authorize",
+                        "token_endpoint": "https://a/token",
+                    }
+                )
+            )
+
+        return discovery
+
+    async def _seed_expired(self, store: FakeAuthStore) -> McpTokenStorage:
+        """A row whose access token is already past its deadline, so every
+        refresh site engages."""
+        import time
+
+        from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+        storage = McpTokenStorage(self.URL, store)
+        await storage.set_tokens(
+            OAuthToken(access_token="a-old", refresh_token="r-old", expires_in=60)
+        )
+        await storage.set_client_info(OAuthClientInformationFull(client_id="cid"))
+        store.rows[0].data["tokens_obtained_at"] = time.time() - 600
+        return storage
+
+    def _mock_token_endpoint(self, monkeypatch: pytest.MonkeyPatch, response_factory):
+        """Route every httpx POST this module makes to an in-process handler and
+        count the requests. Counting at the TRANSPORT is what makes "zero POSTs"
+        a fact about the wire rather than about our logging."""
+        import httpx
+
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return response_factory(request)
+
+        transport = httpx.MockTransport(handler)
+        real_client = httpx.AsyncClient
+
+        def patched_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+            kwargs["transport"] = transport
+            return real_client(*args, **kwargs)
+
+        monkeypatch.setattr(httpx, "AsyncClient", patched_client)
+        return calls
+
+    @staticmethod
+    def _invalid_grant(request):
+        import httpx
+
+        return httpx.Response(
+            400,
+            json={"error": "invalid_grant", "error_description": "OAuth grant revoked"},
+            request=request,
+        )
+
+    # --- F1 / F2: only a parsed invalid_grant tombstones ------------------
+
+    @pytest.mark.asyncio
+    async def test_invalid_grant_writes_the_tombstone(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """F1: the parsed invalid_grant branch returns "dead" AND marks the row."""
+        from local_operator.mcp import auth as auth_mod
+
+        store = FakeAuthStore()
+        storage = await self._seed_expired(store)
+        assert storage.grant_is_dead() is False
+
+        self._mock_token_endpoint(monkeypatch, self._invalid_grant)
+
+        outcome = await auth_mod._refresh_oauth_token_locked(self.URL, storage, self._endpoints())
+
+        assert outcome == "dead"
+        assert storage.grant_is_dead() is True
+        assert store.rows[0].data[auth_mod.GRANT_DEAD_AT_KEY] > 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "factory_name",
+        ["server_error", "transport_error", "unparseable_body"],
+    )
+    async def test_transient_failures_never_tombstone(
+        self, monkeypatch: pytest.MonkeyPatch, factory_name: str
+    ) -> None:
+        """F2: a 500, a transport error and an unparseable 200 are all "failed"
+        with NO marker.
+
+        This is the regression guard for the design's stated risk 1: gating on a
+        bare HTTP 400 (or on any failure) would let one flaky provider minute
+        permanently suppress refresh on a live grant until the user noticed.
+        """
+        import httpx
+
+        from local_operator.mcp import auth as auth_mod
+
+        store = FakeAuthStore()
+        storage = await self._seed_expired(store)
+
+        def server_error(request):
+            return httpx.Response(500, text="upstream exploded", request=request)
+
+        def unparseable_body(request):
+            return httpx.Response(200, text="not a token at all", request=request)
+
+        def transport_error(request):
+            raise httpx.ConnectError("network down", request=request)
+
+        self._mock_token_endpoint(monkeypatch, locals()[factory_name])
+
+        outcome = await auth_mod._refresh_oauth_token_locked(self.URL, storage, self._endpoints())
+
+        assert outcome == "failed"
+        assert storage.grant_is_dead() is False
+        assert auth_mod.GRANT_DEAD_AT_KEY not in store.rows[0].data
+
+    @pytest.mark.asyncio
+    async def test_a_400_that_is_not_invalid_grant_never_tombstones(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """F2b: the gate is the PARSED body, not the status code."""
+        import httpx
+
+        from local_operator.mcp import auth as auth_mod
+
+        store = FakeAuthStore()
+        storage = await self._seed_expired(store)
+
+        self._mock_token_endpoint(
+            monkeypatch,
+            lambda request: httpx.Response(
+                400, json={"error": "temporarily_unavailable"}, request=request
+            ),
+        )
+
+        outcome = await auth_mod._refresh_oauth_token_locked(self.URL, storage, self._endpoints())
+
+        assert outcome == "failed"
+        assert storage.grant_is_dead() is False
+
+    @pytest.mark.asyncio
+    async def test_nothing_to_refresh_is_failed_not_dead(self) -> None:
+        """F2c: a row with no refresh token is "nothing to spend", not proof
+        that the grant was rejected."""
+        from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+        from local_operator.mcp import auth as auth_mod
+
+        store = FakeAuthStore()
+        storage = McpTokenStorage(self.URL, store)
+        await storage.set_tokens(OAuthToken(access_token="a", expires_in=60))
+        await storage.set_client_info(OAuthClientInformationFull(client_id="cid"))
+
+        outcome = await auth_mod._refresh_oauth_token_locked(self.URL, storage, self._endpoints())
+
+        assert outcome == "failed"
+        assert storage.grant_is_dead() is False
+
+    # --- F3: the proactive site spends nothing ----------------------------
+
+    @pytest.mark.asyncio
+    async def test_tombstoned_row_makes_zero_proactive_posts(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """F3 (headline): with the row tombstoned, ensure_mcp_oauth_fresh makes
+        ZERO token POSTs, and still logs the actionable reauth line."""
+        import logging
+
+        from local_operator.mcp import auth as auth_mod
+
+        auth_mod._DISCOVERED_ENDPOINTS_CACHE.clear()
+        store = FakeAuthStore()
+        storage = await self._seed_expired(store)
+        storage.mark_grant_dead()
+
+        calls = self._mock_token_endpoint(monkeypatch, self._invalid_grant)
+        monkeypatch.setattr(auth_mod, "discover_oauth_endpoints", self._fake_discovery())
+
+        with caplog.at_level(logging.INFO, logger="local_operator.mcp.auth"):
+            endpoints = await auth_mod.ensure_mcp_oauth_fresh(self.URL, self._cfg(), store=store)
+
+        assert calls["n"] == 0
+        # F6: endpoints still come back, so the connect proceeds to the
+        # actionable McpAuthRequiredError rather than failing early.
+        assert endpoints is not None
+        # Suppression must stay audible: silence would read as "fixed".
+        messages = [r.getMessage() for r in caplog.records if r.levelno >= logging.INFO]
+        skipped = [m for m in messages if "known-dead" in m]
+        assert len(skipped) == 1
+        assert "/mcp reauth" in skipped[0]
+
+    @pytest.mark.asyncio
+    async def test_untombstoned_row_still_refreshes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The suppression is conditional: an ordinary expired row still spends
+        its refresh token exactly once."""
+        from mcp.shared.auth import OAuthToken
+
+        from local_operator.mcp import auth as auth_mod
+
+        auth_mod._DISCOVERED_ENDPOINTS_CACHE.clear()
+        store = FakeAuthStore()
+        await self._seed_expired(store)
+
+        def ok(request):
+            import httpx
+
+            token = OAuthToken(access_token="a-new", refresh_token="r-new", expires_in=3600)
+            return httpx.Response(200, json=token.model_dump(mode="json"), request=request)
+
+        calls = self._mock_token_endpoint(monkeypatch, ok)
+        monkeypatch.setattr(auth_mod, "discover_oauth_endpoints", self._fake_discovery())
+
+        await auth_mod.ensure_mcp_oauth_fresh(self.URL, self._cfg(), store=store)
+
+        assert calls["n"] == 1
+
+    # --- F5 / F7: clearing --------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_set_tokens_clears_the_tombstone_and_refresh_resumes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """F5: tombstone -> set_tokens (what /mcp login and /mcp reauth do) ->
+        marker gone -> the proactive site refreshes normally again.
+
+        This is the escape hatch, and it is why the clear lives inside
+        set_tokens rather than in the login command.
+        """
+        import time
+
+        from mcp.shared.auth import OAuthToken
+
+        from local_operator.mcp import auth as auth_mod
+
+        auth_mod._DISCOVERED_ENDPOINTS_CACHE.clear()
+        store = FakeAuthStore()
+        storage = await self._seed_expired(store)
+        storage.mark_grant_dead()
+        assert storage.grant_is_dead() is True
+
+        # An interactive grant completes and persists working tokens...
+        await storage.set_tokens(
+            OAuthToken(access_token="a-fresh", refresh_token="r-fresh", expires_in=60)
+        )
+        assert storage.grant_is_dead() is False
+        assert auth_mod.GRANT_DEAD_AT_KEY not in store.rows[0].data
+
+        # ...and once that token ages out, refresh is live again.
+        store.rows[0].data["tokens_obtained_at"] = time.time() - 600
+
+        def ok(request):
+            import httpx
+
+            token = OAuthToken(access_token="a2", refresh_token="r2", expires_in=3600)
+            return httpx.Response(200, json=token.model_dump(mode="json"), request=request)
+
+        calls = self._mock_token_endpoint(monkeypatch, ok)
+        monkeypatch.setattr(auth_mod, "discover_oauth_endpoints", self._fake_discovery())
+
+        await auth_mod.ensure_mcp_oauth_fresh(self.URL, self._cfg(), store=store)
+
+        assert calls["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_clear_removes_the_row_with_its_tombstone(self) -> None:
+        """F7: logout deletes the row entirely — no orphan marker can outlive
+        the grant it describes."""
+        store = FakeAuthStore()
+        storage = await self._seed_expired(store)
+        storage.mark_grant_dead()
+
+        assert storage.clear() is True
+        assert store.rows == []
+        assert storage.grant_is_dead() is False
+
+    def test_a_missing_row_is_not_a_dead_grant(self) -> None:
+        """An unreadable/absent store must never suppress a refresh that might
+        work: absence means "no observation", not "known dead"."""
+        storage = McpTokenStorage(self.URL, FakeAuthStore())
+        assert storage.grant_is_dead() is False
+
+    # --- F4: the SDK's unlocked double-spend -------------------------------
+
+    async def _drive_auth_flow(self, provider) -> None:
+        """Pump async_auth_flow the way httpx does, feeding a 200 to whatever it
+        yields, so coordination runs without real network."""
+        import httpx
+
+        gen = provider.async_auth_flow(httpx.Request("POST", self.URL))
+        try:
+            request = await gen.__anext__()
+            while True:
+                response = httpx.Response(200, request=request)
+                try:
+                    request = await gen.asend(response)
+                except StopAsyncIteration:
+                    return
+        finally:
+            await gen.aclose()
+
+    @pytest.mark.asyncio
+    async def test_dead_outcome_strips_the_refresh_token_the_sdk_would_spend(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """F4: after a "dead" coordinated refresh, the in-memory refresh token is
+        gone, so the SDK's can_refresh_token() is False.
+
+        This is the structural invariant that closes the family revocation. The
+        SDK's own ``_refresh_token`` runs UNLOCKED after we return; with a
+        refresh token still in the context it would POST the corpse a third time
+        — the exact request that revokes every session's token on a
+        reuse-detecting provider. Asserting the field is None asserts the SDK
+        *cannot* make that request, rather than merely that it did not this run.
+        """
+        from local_operator.mcp import auth as auth_mod
+        from local_operator.mcp.auth import build_oauth_provider
+
+        store = FakeAuthStore()
+        await self._seed_expired(store)
+
+        provider = build_oauth_provider(self.URL, self._cfg(), store=store, endpoints=None)
+        async with provider.context.lock:
+            await provider._initialize()
+        assert provider.context.current_tokens is not None
+        assert provider.context.current_tokens.refresh_token == "r-old"
+        assert provider.context.can_refresh_token() is True
+
+        async def dead_refresh(*args: Any, **kwargs: Any) -> auth_mod.RefreshOutcome:
+            return "dead"
+
+        monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", dead_refresh)
+
+        await self._drive_auth_flow(provider)
+
+        assert provider.context.current_tokens is not None
+        assert provider.context.current_tokens.refresh_token is None
+        # The predicate the SDK gates its refresh branch on now reads False, so
+        # it goes to the authorization branch -> McpAuthRequiredError.
+        assert provider.context.can_refresh_token() is False
+
+    @pytest.mark.asyncio
+    async def test_failed_outcome_leaves_the_refresh_token_alone(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The inversion guard for the truthy-"failed" hazard.
+
+        ``"failed"`` is a truthy string, so a ``if outcome:`` at this call site
+        would treat a transient failure as a success and a dead grant as one
+        too. A transient failure must change nothing: today's behaviour (the SDK
+        retries unlocked) is correct for it.
+        """
+        from local_operator.mcp import auth as auth_mod
+        from local_operator.mcp.auth import build_oauth_provider
+
+        store = FakeAuthStore()
+        await self._seed_expired(store)
+
+        provider = build_oauth_provider(self.URL, self._cfg(), store=store, endpoints=None)
+        async with provider.context.lock:
+            await provider._initialize()
+
+        async def failed_refresh(*args: Any, **kwargs: Any) -> auth_mod.RefreshOutcome:
+            return "failed"
+
+        monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", failed_refresh)
+
+        # Scoped to the coordinator deliberately: driving the whole flow would
+        # then run the SDK's own unlocked refresh, which nulls current_tokens
+        # itself when it fails: that would assert the SDK's behaviour, not ours.
+        await provider._coordinate_inflight_refresh()
+
+        assert provider.context.current_tokens is not None
+        assert provider.context.current_tokens.refresh_token == "r-old"
+
+    @pytest.mark.asyncio
+    async def test_tombstoned_row_makes_zero_coordinator_posts(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """F4b: the coordinator short-circuits before taking the lock, so an
+        already-tombstoned grant costs no POST on the in-flight path either."""
+        from local_operator.mcp import auth as auth_mod
+        from local_operator.mcp.auth import build_oauth_provider
+
+        store = FakeAuthStore()
+        storage = await self._seed_expired(store)
+
+        provider = build_oauth_provider(self.URL, self._cfg(), store=store, endpoints=None)
+        async with provider.context.lock:
+            await provider._initialize()
+
+        storage.mark_grant_dead()
+
+        refresh_calls = {"n": 0}
+
+        async def counting_refresh(*args: Any, **kwargs: Any) -> auth_mod.RefreshOutcome:
+            refresh_calls["n"] += 1
+            return "dead"
+
+        monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", counting_refresh)
+
+        await self._drive_auth_flow(provider)
+
+        assert refresh_calls["n"] == 0

--- a/tests/unit/mcp/test_auth.py
+++ b/tests/unit/mcp/test_auth.py
@@ -3337,17 +3337,30 @@ class TestDeadGrantTombstone:
     async def _drive_auth_flow(self, provider) -> None:
         """Pump async_auth_flow the way httpx does, feeding a 200 to whatever it
         yields, so coordination runs without real network."""
+        await self._collect_flow_requests(provider)
+
+    async def _collect_flow_requests(self, provider) -> list[Any]:
+        """Pump the flow and RETURN every request it yielded.
+
+        The requests are the only place a caller can see what the authorization
+        server would receive: the SDK's own unlocked ``_refresh_token`` POSTs
+        through its vendored httpx, so a test that spies on our helpers is blind
+        to it. Returning them lets a test assert on the wire rather than on our
+        own call graph.
+        """
         import httpx
 
+        yielded: list[Any] = []
         gen = provider.async_auth_flow(httpx.Request("POST", self.URL))
         try:
             request = await gen.__anext__()
             while True:
+                yielded.append(request)
                 response = httpx.Response(200, request=request)
                 try:
                     request = await gen.asend(response)
                 except StopAsyncIteration:
-                    return
+                    return yielded
         finally:
             await gen.aclose()
 
@@ -3426,11 +3439,22 @@ class TestDeadGrantTombstone:
         assert provider.context.current_tokens.refresh_token == "r-old"
 
     @pytest.mark.asyncio
-    async def test_tombstoned_row_makes_zero_coordinator_posts(
+    async def test_already_tombstoned_boot_yields_no_token_post(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """F4b: the coordinator short-circuits before taking the lock, so an
-        already-tombstoned grant costs no POST on the in-flight path either."""
+        """F4b: a boot whose row is ALREADY tombstoned must yield zero token
+        POSTs — asserted at the wire, not on our helper.
+
+        This is the STEADY STATE the tombstone exists to serve: boot 1 writes
+        the marker and takes the ``"dead"`` branch, every boot after it takes
+        the pre-lock short-circuit instead. The earlier version of this test
+        counted calls to our monkeypatched ``_refresh_oauth_token_locked``,
+        which stays at zero while the SDK POSTs the dead token from its own
+        unlocked ``_refresh_token`` — so it could not observe the very leak it
+        claimed to cover, and 383 green tests coexisted with a POST on every
+        boot. Assert on the REQUESTS THE FLOW YIELDS instead: that is the thing
+        the authorization server actually sees.
+        """
         from local_operator.mcp import auth as auth_mod
         from local_operator.mcp.auth import build_oauth_provider
 
@@ -3441,6 +3465,8 @@ class TestDeadGrantTombstone:
         async with provider.context.lock:
             await provider._initialize()
 
+        # Tombstone AFTER _initialize: the provider is holding the dead refresh
+        # token in memory exactly as it does on a real boot 2+.
         storage.mark_grant_dead()
 
         refresh_calls = {"n": 0}
@@ -3451,6 +3477,16 @@ class TestDeadGrantTombstone:
 
         monkeypatch.setattr(auth_mod, "_refresh_oauth_token_locked", counting_refresh)
 
-        await self._drive_auth_flow(provider)
+        yielded = await self._collect_flow_requests(provider)
 
+        token_posts = [r for r in yielded if str(r.url).endswith("/token")]
+        assert token_posts == [], f"the SDK POSTed a tombstoned grant: {token_posts}"
+        # Our locked exchange must not run either — the short-circuit is before
+        # the lock, so a dead grant costs neither an acquire nor a POST.
         assert refresh_calls["n"] == 0
+        # The structural invariant behind the wire assertion: with no in-memory
+        # refresh token the SDK's refresh branch is unreachable, so this cannot
+        # regress into "did not POST this run" by accident.
+        assert provider.context.current_tokens is not None
+        assert provider.context.current_tokens.refresh_token is None
+        assert provider.context.can_refresh_token() is False


### PR DESCRIPTION
A refresh token the authorization server has already rejected with `invalid_grant` stayed in the `mcp-oauth` credential row forever. Nothing recorded that it was dead, so every process boot re-spent it — **39** token POSTs for Notion and **87** for minerva-qa across 26 boots on this machine's `mobile.log`.

For a provider running refresh-token **reuse detection** (Notion) that is not merely waste: re-presenting an already-rotated refresh token revokes the **entire token family**, logging out every session. That is the reported "Notion and minerva-qa MCPs ended up expired after clicking rapidly across sessions" — cheap session spawn turns a per-boot bug into a per-click one.

`Release: patch — a revoked MCP OAuth grant is now recorded and never re-presented, so a stale token no longer logs every session out of a reuse-detecting provider.`

## Why the fix had to cover three sites, not one

The 400s arrive as a **triple per boot**, and the third is the family-revoking one. Splitting Notion's 39 by httpx client instance:

```
28  INFO:httpx:HTTP Request: POST https://mcp.notion.com/token     # ours (proactive + coordinator)
13  INFO:httpx2:HTTP Request: POST https://mcp.notion.com/token    # the SDK's own client
44  WARNING:mcp.client.auth.oauth2:Token refresh failed: 400
```

A representative boot (log lines 3096–3110): `ensure_mcp_oauth_fresh` POSTs → `_coordinate_inflight_refresh` POSTs → and because that coordinated refresh **failed**, the code falls through to the SDK's own **unlocked** `_refresh_token`, which POSTs a third time and then 401s. A tombstone guarding only the proactive site would have removed most of the noise and left the actual fleet-wide-logout mechanism fully intact.

## What changed

Two files. No new table, no migration.

- **`GRANT_DEAD_AT_KEY = "grant_dead_at"`** in the existing `mcp-oauth` row payload. Written **only** by `_refresh_oauth_token_locked`'s parsed-body `invalid_grant` branch — never on a bare 400, or one transient provider hiccup would permanently suppress refresh on a live grant.
- **No TTL.** A dead grant is a *correctness* fact that holds until an interactive login replaces it, not a cost backoff. This is why `auth_credential_blocks` is the wrong home: `block_credential` clamps every block to `MAX_CREDENTIAL_BLOCK_MS` (1h), a ceiling that is load-bearing for provider quota backoff, so reusing it would give a storm — and a family revocation — that resumes **hourly**. It is also keyed by integer `credential_id` + `provider:type`, where MCP identity is `server_url`.
- **Cleared by `set_tokens`** (the one funnel every path that obtains a working token already goes through) and removed with the row by `clear()`, so `/mcp login` and `/mcp reauth` restore normally and a login path added later cannot forget to un-stick a server.
- **`_refresh_oauth_token_locked` returns `Literal["refreshed","failed","dead"]`** instead of `bool`, so the coordinator can distinguish dead from flaky and drop `ctx.current_tokens.refresh_token` in memory. `can_refresh_token()` then reads False, the SDK skips its refresh branch and goes to the authorization branch, which our non-interactive handler already converts into `McpAuthRequiredError` → the existing `run /mcp reauth <name>` toast. Same user-visible outcome, one fewer family-revoking POST.

`"failed"` is a **truthy string**, and pyright does not catch a `Literal` used in a boolean context, so both call sites were checked by hand and the surviving one compares against a member explicitly. A regression test pins it.

## Testing evidence

### Reproduction: POSTs counted at the stub, not in the log

> **Corrected in remediation round 1.** The table originally here measured only boots that START WITHOUT a tombstone, which is the one case that already behaved — boot 1 takes the `"dead"` branch, which strips the in-memory refresh token. It therefore never exercised the steady state (boot 2+, tombstone already on disk), where a leak was present. Reviewer and QA both caught this independently. Both harnesses below now attribute each POST to a client by User-Agent: our client pins `local-operator/<version>`, the SDK's vendored httpx sends its own.

The log is what this PR changes, so it cannot be the evidence. A stub token endpoint always returning `400 {"error":"invalid_grant"}` counts requests at the wire; each "boot" is a real subprocess with its own interpreter reading the same on-disk `auth.db`, under an **isolated `HOME`** (a fresh config dir alone is not enough — the cache root derives from the home directory independently).

**Steady state — row ALREADY tombstoned at boot 1, the case that matters:**

| boot | before remediation (`a2e8029`) | after (`77b943e`) |
|---|---|---|
| 1 | 1 (ours=0 **sdk=1**) | 0 |
| 2 | 1 (ours=0 **sdk=1**) | 0 |
| 3 | 1 (ours=0 **sdk=1**) | 0 |
| 4 | 1 (ours=0 **sdk=1**) | 0 |
| 5 | 1 (ours=0 **sdk=1**) | 0 |
| **total** | **5 — all of them the SDK's unlocked, family-revoking POST** | **0** |

**Cold start — no tombstone yet, 5 boots (after remediation):**

```
boot 1: token POSTs = 1 (ours=1 sdk=0)   <- writes the tombstone
boot 2: token POSTs = 0 (ours=0 sdk=0)
boot 3: token POSTs = 0 (ours=0 sdk=0)
boot 4: token POSTs = 0 (ours=0 sdk=0)
boot 5: token POSTs = 0 (ours=0 sdk=0)

TOTAL across 5 boots: 1 (ours=1 sdk=0)
```

**1 POST, ever, per grant** — spent by our own locked exchange, which is the request that proves the grant dead. Zero from the SDK's unlocked path in either scenario.

### Suppression stays audible

Silence would read as "fixed" when it means "suppressed" and the operator still owes a login:

```
INFO:local_operator.mcp.auth:MCP OAuth grant revoked for http://127.0.0.1:59670/mcp (invalid_grant); run /mcp login to restore it
boot 1: cumulative token POSTs at stub = 1
INFO:local_operator.mcp.auth:MCP OAuth grant for http://127.0.0.1:59670/mcp is known-dead (invalid_grant); skipping refresh -- run /mcp reauth to restore it
boot 2: cumulative token POSTs at stub = 1
INFO:local_operator.mcp.auth:MCP OAuth grant for http://127.0.0.1:59670/mcp is known-dead (invalid_grant); skipping refresh -- run /mcp reauth to restore it
boot 3: cumulative token POSTs at stub = 1
```

### Escape hatch: `/mcp reauth` restores refresh

```
tombstoned before reauth: True
tombstoned after  reauth: False
tombstoned after retry  : True
token POSTs during reauth+retry: 1  (1 == refresh resumed)
```

A completed grant clears the marker, the next expiry refreshes normally (1 POST), and since the stub still rejects, it re-tombstones — the loop closes correctly rather than becoming permanent.

### Every new guard proven able to go red

Per AGENTS.md ("Prove the test can still fail"), each guard was mutated on a scratch copy and the tests re-run:

| mutation | result |
|---|---|
| M1 drop `mark_grant_dead()` on `invalid_grant` | 1 failed |
| M2 tombstone on **any** 400 (drop the parsed-body gate) | 1 failed |
| M3 remove the `ensure_mcp_oauth_fresh` suppression | 3 failed |
| M4 remove the coordinator's `dead` branch (SDK double-spend returns) | 1 failed |
| M5 `set_tokens` stops clearing the tombstone | 1 failed |
| M6 coordinator loses its pre-lock short-circuit | 1 failed |
| M7 truthiness inversion (`if outcome:`) | 1 failed |
| **M8 remove the strip from the pre-lock early return** (reintroduces F1/Q1) | **1 failed** |

Tree restored and re-verified clean after each.

### Tests

14 tests in `TestDeadGrantTombstone`, all **structural** — calls made, marker present/absent, in-memory field cleared. No wall-clock assertions, per AGENTS.md's timing rules. Covers F1–F7 from the design: tombstone written on `invalid_grant`; **not** written for 500 / transport error / unparseable body / a non-`invalid_grant` 400 / "nothing to refresh"; zero proactive POSTs when tombstoned; zero coordinator POSTs; `refresh_token` stripped on `dead` and **left alone** on `failed`; `set_tokens` round trip; `clear()` leaves no orphan; endpoints still returned so the connect reaches the actionable error.

### Gates — whole tree, exactly as CI

```
python -m flake8 .                                  clean
uvx --from black==26.1.0 black --check .            1030 files unchanged
uvx isort==5.13.2 --check .                         clean
python -m pyright --pythonpath .venv/bin/python .   0 errors, 0 warnings
pytest tests/unit                                   1 failed, 15551 passed, 18 skipped (40:30)
```

**Disclosed:** the one failure is `tests/unit/tui/test_copy_command.py::test_the_receipt_is_the_shared_toast_in_the_shared_format` (`assert '' == 'copied 8 lines'`) — a pre-existing flake, not a regression. It touches nothing in this diff (clipboard, not MCP), and the run happened at **load average 219** with ~80 sibling worktrees active. Verified:

- passes serially on clean `origin/main` (35 passed)
- passes serially on this branch (35 passed)
- passes 3/3 under xdist on this branch (35 passed each)
- `tests/unit/mcp` — the surface this diff touches — 383 passed

The clipboard is a machine-global resource, which is the contention this shape of failure comes from.

## Scope

`local_operator/mcp/auth.py` and `tests/unit/mcp/test_auth.py`. `pyproject.toml` untouched at `0.51.6`.

Deliberately **not** in scope, each settled on measurement: the unlocked degrade path (`grep -c 'refresh lock not acquired'` = **0** across 26 boots — never reached, and touching it re-opens #401's TUI-freeze surface); `_still_good`'s `expiry is None` arm (load-bearing for four no-refresh non-expiring rows); cross-process endpoint-discovery caching (unauthenticated, behind the startup gate, and an on-disk cache adds a silent staleness failure to fix a cost nobody reported).

No user-visible surface changes — the `run /mcp reauth <name> — authorization expired` toast already ships today — so no design round is required.

