### PR TITLE
feat(procname): name our processes in Activity Monitor and launchd

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1284,6 +1284,25 @@ the sample, check whether the same test fails on `main` and on unrelated
 branches, and confirm the work under the probe is the legitimate kind. Widening
 a bound because it went red is how a guard stops guarding.
 
+### A pytest run that STOPS EARLY with exit 0 is not a pass
+
+Check the count, not just the exit code. `main()` is called in-process by the
+suite (`assert main() == 7`), so anything `main()` does to *its own process*
+happens to pytest. A change that added an `os.execv` early in `main()` replaced
+the running pytest with a fresh interpreter: the file printed dots to 57%, then
+stopped, and the shell reported **exit 0**. No failure, no traceback, no
+summary line — 42 of 98 tests simply never ran, and every gate looked green.
+
+It surfaced only because the summary line was missing from the output. So:
+`98 passed` is evidence; a bare exit code is not. The same shape hides behind
+`| tail`, which reports the *pipeline's* status — see the `rc=126` note in the
+Environment section, which is this hazard's twin.
+
+Anything a process can do to itself — `execv`, `os._exit`, `chdir`, signal
+handlers, `sys.exit` in a library path — needs a guard proving it is a real
+launch before it fires. `procname.is_own_launch()` is that guard for the
+branded re-exec, and its test is the one that pins this.
+
 ### Prove the test can still fail
 
 A guard that cannot go red is worse than no guard, because it is believed. That

--- a/local_operator/browser_bridge/install.py
+++ b/local_operator/browser_bridge/install.py
@@ -19,6 +19,7 @@ import urllib.request
 from pathlib import Path
 from typing import Any
 
+from local_operator import procname
 from local_operator.browser_bridge import state as state_store
 from local_operator.browser_bridge.daemon import (
     DEFAULT_PORT,
@@ -46,13 +47,15 @@ def log_path() -> Path:
 def render_plist(port: int = DEFAULT_PORT) -> dict[str, object]:
     return {
         "Label": LABEL,
-        "ProgramArguments": [
-            sys.executable,
-            "-m",
+        # Branded interpreter image when one can be planted: macOS names this
+        # background item by the basename of ProgramArguments[0], so a bare
+        # `sys.executable` is what made installing the bridge notify that
+        # 'python3 is running in the background'. Falls back to sys.executable.
+        "ProgramArguments": procname.launchd_program(
             "local_operator.browser_bridge.daemon",
             "--port",
             str(port),
-        ],
+        ),
         "RunAtLoad": True,
         "KeepAlive": {"SuccessfulExit": False},
         "StandardOutPath": str(log_path()),

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -46,6 +46,9 @@ from importlib.metadata import version
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
+# stdlib-only and import-cheap by construction (os/sys/pathlib/logging), so it
+# does not violate this module's no-heavy-module-level-imports rule.
+from local_operator import procname
 from local_operator.agent_profiles import SEED_ORIGIN_PREFIX
 from local_operator.config import ConfigManager
 from local_operator.credentials import CredentialManager
@@ -3779,7 +3782,81 @@ def _install_group_reaper_soft_death() -> None:
         _chain(_sig)
 
 
+#: Subcommands whose process is LONG-LIVED and therefore worth re-execing to
+#: rename. Everything absent from this set — `send`, `sessions`, `config`,
+#: `credential`, `stop`, `login` — finishes in well under a second and never
+#: lingers in Activity Monitor, so paying the re-exec there would be pure
+#: latency for a row nobody can see. ``None`` is the bare interactive launch.
+_BRANDED_SUBCOMMANDS = frozenset({None, "serve", "mobile", "exec", "browser"})
+
+
+def _maybe_brand_process(args: argparse.Namespace) -> None:
+    """Re-exec through the branded interpreter image when it is worth it.
+
+    WHY THIS IS GATED, and why the gate is not "always". A re-exec restarts the
+    interpreter, so the replacement process re-pays every import this one has
+    already done — and `local_operator.cli` alone costs 221 ms of imports
+    (pydantic/yaml, measured with `-X importtime`). Measured end to end here:
+    `lop --version` went 223 ms -> 410 ms, i.e. **+186 ms**, not the ~35 ms a
+    bare-interpreter re-exec suggests. That is a bad trade for a command that
+    exits immediately and whose row nobody ever sees in Activity Monitor.
+
+    So the cost is paid only by processes that live long enough for the name to
+    be the point: the interactive TUI, `serve`, `mobile`, `exec`, `browser`.
+    For those, ~190 ms sits against a startup already north of a second and a
+    process that then runs for minutes to hours.
+
+    Detached children (session runtimes, eval workers, exec workers) do NOT go
+    through this path at all: their parent spawns them with `executable=` set to
+    the branded image, so they are born branded and pay nothing.
+
+    Never raises, and returns normally whenever branding is unavailable — in
+    which case this process carries on exactly as it does today, still alive to
+    have repaired the link for next time. That liveness is the whole reason the
+    `lop` shebang is NOT pointed at the link; see `procname.py`.
+    """
+    subcommand = getattr(args, "subcommand", None)
+    if subcommand not in _BRANDED_SUBCOMMANDS:
+        return
+    procname.reexec_branded(_process_label(args))
+
+
+def _process_label(args: argparse.Namespace) -> str | None:
+    """The argv[0] this process should carry, or None for the bare brand.
+
+    Only fixed templates and machine-generated values (ports, an agent name that
+    is already slugged upstream) reach this: argv is world-readable through
+    `ps`, so no prompt, path, or model-produced text may ever be interpolated
+    into it. See the label vocabulary in `procname.py`.
+    """
+    subcommand = getattr(args, "subcommand", None)
+    if subcommand == "serve":
+        return procname.branded_argv0(procname.LABEL_SERVE, port=int(getattr(args, "port", 0)))
+    if subcommand == "mobile":
+        return procname.branded_argv0(
+            procname.LABEL_MOBILE, port=int(getattr(args, "port", 0) or 0)
+        )
+    if subcommand is None:
+        # The interactive TUI. The session id is not minted yet at this point
+        # (the session is built after the re-exec), so the agent name is all the
+        # identity available — and it is the field an operator actually scans
+        # for when several sessions are running.
+        # `dest="agent_name"` — `--agent` is the flag, not the attribute.
+        agent = getattr(args, "agent_name", None)
+        if isinstance(agent, str) and agent:
+            return procname.branded_argv0(
+                procname.LABEL_SESSION_AGENT, agent=procname.safe_field(agent)
+            )
+    return None
+
+
 def main() -> int:
+    # Name this process in the OS process listing. On Linux this is a
+    # ~microsecond `prctl` on the current process and nothing else happens; the
+    # macOS half (which needs a re-exec) is deferred until after the parse, for
+    # the cost reason documented at `_maybe_brand_process`.
+    procname.set_process_name()
+
     # FIRST, before anything else can log. `helpers.py` used to configure the
     # root logger as an import side effect; now the entry point owns it, which
     # is what lets the TUI branch below swap the console handler for a file.
@@ -3787,6 +3864,12 @@ def main() -> int:
     try:
         parser = build_cli_parser()
         args = parser.parse_args()
+
+        # macOS: replace this process with a branded image so Activity Monitor
+        # stops showing a wall of `python3.x`. NEVER RETURNS when it brands;
+        # a no-op everywhere else. Placed after the parse so `--version` and
+        # `--help` (which argparse exits from inside `parse_args`) never pay it.
+        _maybe_brand_process(args)
 
         # Prime the login-shell PATH only on paths that actually spawn
         # subprocess work: the interactive session, exec, serve and mobile all

--- a/local_operator/exec_mode.py
+++ b/local_operator/exec_mode.py
@@ -330,6 +330,18 @@ def _spawn_background(command: str, exec_args: ExecArgs) -> int:
     if os.name == "posix":
         popen_kwargs["start_new_session"] = True
 
+    # Name the detached worker in the OS process listing, keyed by the job id
+    # this call already prints to the user, so `ps` and `lop`'s own job output
+    # agree on one handle. Both the image and argv[0] fall back to the bare
+    # interpreter when no branded image exists.
+    from local_operator import procname
+
+    link = procname.ensure_branded_interpreter()
+    if link is not None:
+        popen_kwargs["executable"] = str(link)
+        argv = list(argv)
+        argv[0] = procname.branded_argv0(procname.LABEL_EXEC, job=job_id)
+
     with _open_log_file(log_path) as log_handle:
         log_handle.write(
             f"# local-operator exec background job\n# prompt: {command}\n".encode("utf-8")

--- a/local_operator/mobile/install.py
+++ b/local_operator/mobile/install.py
@@ -27,6 +27,7 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
+from local_operator import procname
 from local_operator.mobile.auth import generate_password, load_password, store_password
 from local_operator.mobile.daemon import DEFAULT_PORT
 from local_operator.paths import log_dir
@@ -119,13 +120,15 @@ def render_plist(port: int = DEFAULT_PORT) -> dict[str, object]:
     (install, status, tests) reads the same rendering."""
     return {
         "Label": LABEL,
-        "ProgramArguments": [
-            sys.executable,
-            "-m",
+        # Branded interpreter image when one can be planted: macOS names this
+        # background item by the basename of ProgramArguments[0], so a bare
+        # `sys.executable` is what made `lop mobile install` notify that
+        # 'python3 is running in the background'. Falls back to sys.executable.
+        "ProgramArguments": procname.launchd_program(
             "local_operator.mobile.service",
             "--port",
             str(port),
-        ],
+        ),
         "RunAtLoad": True,
         # Restart on crash, throttled by launchd's own 10s floor; an
         # exit-code-2 (no password) stays down because KeepAlive keys on

--- a/local_operator/proc.py
+++ b/local_operator/proc.py
@@ -20,7 +20,9 @@ else entirely:
 from __future__ import annotations
 
 import logging
+import os
 import subprocess
+import sys
 from collections.abc import Mapping, Sequence
 
 logger = logging.getLogger(__name__)
@@ -31,6 +33,7 @@ def spawn_detached(
     *,
     cwd: str | None = None,
     env: Mapping[str, str] | None = None,
+    label: str | None = None,
 ) -> bool:
     """Fire-and-forget ``argv``. Returns True when the child was STARTED.
 
@@ -44,10 +47,33 @@ def spawn_detached(
     ``cwd`` matters for the spawn backends: a new terminal window must open in
     the session's own working directory, not wherever this process happens to
     be, or the restored conversation points at the wrong project.
+
+    ``label`` names the child in the OS process listing when ``argv[0]`` is a
+    Python interpreter. The image is switched to the branded hardlink via
+    ``executable=`` (what Activity Monitor reads) and ``argv[0]`` becomes the
+    label (what ``ps``/``top`` read) — the two independent name axes documented
+    in :mod:`local_operator.procname`. Opt-in and best-effort: with no branded
+    image available the argv is spawned exactly as passed, so a caller can set
+    it unconditionally.
     """
+    launch = list(argv)
+    executable: str | None = None
+    if label and launch:
+        from local_operator import procname
+
+        link = procname.ensure_branded_interpreter()
+        # Only rewrite when argv[0] really is the interpreter we would be
+        # replacing. A spawn of some OTHER binary (a terminal emulator, `open`)
+        # must keep its own image, or `executable=` would run Python under that
+        # program's arguments.
+        if link is not None and os.path.realpath(launch[0]) == os.path.realpath(sys.executable):
+            executable = str(link)
+            launch[0] = procname.branded_argv0(label)
+
     try:
         subprocess.Popen(  # noqa: S603 — fixed argv, no shell
-            list(argv),
+            launch,
+            executable=executable,
             cwd=cwd,
             env=dict(env) if env is not None else None,
             stdin=subprocess.DEVNULL,

--- a/local_operator/procname.py
+++ b/local_operator/procname.py
@@ -1,0 +1,647 @@
+"""Make this project's processes identifiable in the OS process listing.
+
+THE PROBLEM
+-----------
+A machine running Local Operator shows ~20 rows of ``python3.14`` in Activity
+Monitor: TUI sessions, subagent runtimes, eval workers, the mobile daemon, the
+browser bridge, ``lop serve``. They are indistinguishable from each other and
+from unrelated Python, so nobody can tell which one is eating 85% CPU. Worse,
+starting a LaunchAgent makes macOS notify "python3 is running in the
+background", which reads like malware right after an install.
+
+TWO INDEPENDENT NAME AXES (this is the thing to understand first)
+-----------------------------------------------------------------
+1. ``p_comm`` — the basename of the **executed binary image**. This is what
+   **Activity Monitor** shows, what ``proc_name()`` returns, and what
+   ``ps -o ucomm`` prints. The kernel takes it at ``execve`` time from the path
+   of the image it loaded. Nothing a running process does can change it on
+   macOS.
+2. ``argv[0]`` — what ``ps -o args``/``top -o command``/``pgrep -f`` show. A
+   process may pass anything here at spawn time.
+
+They are separate, and fixing only one leaves the complaint half-answered:
+Activity Monitor ignores argv entirely.
+
+WHY NOT ``setproctitle``
+------------------------
+Measured on this machine: ``setproctitle`` rewrites **argv only**;
+``proc_name()`` still returned ``b'python3.12'`` afterwards, so Activity
+Monitor was unchanged. It would add a compiled dependency and still not solve
+complaint (1). The zero-dependency approach below covers both axes. Do not
+re-add it on the assumption that it does more than it does.
+
+HOW THE BINARY-IMAGE NAME IS CHANGED WITHOUT A DEPENDENCY
+---------------------------------------------------------
+Execute the interpreter through a path whose basename is the name we want.
+Measured constraints, all of them the hard way:
+
+- A **symlink** does NOT work: the kernel resolves it and takes ``p_comm``
+  from the target, so the process is still ``python3.12``. A **hardlink**
+  does work — it is a second name for the same inode, and the kernel has no
+  target to resolve.
+- ``cp`` of the interpreter does NOT work: the copy dies with
+  ``dyld: Library not loaded: @rpath/libpython3.X.dylib``. The interpreter's
+  only ``LC_RPATH`` is ``@executable_path/../lib``, so a copy placed anywhere
+  else cannot find its runtime library. (The hardlink has the same problem;
+  the symlink below is the fix.)
+- **A ``<venv>/lib/libpython3.X.dylib`` symlink beside the hardlink is
+  MANDATORY.** The hardlink lives in ``<venv>/bin``, so ``@executable_path/..``
+  resolves to the venv, and dyld looks for ``<venv>/lib/libpython3.X.dylib``,
+  which a venv does not have. Measured without it: **0 successes, 40/40 aborts**
+  (``Abort trap: 6``). With it: 60/60 successes.
+
+  **THE WARM-CACHE TRAP.** A *first* run without the symlink can spuriously
+  SUCCEED, because dyld reuses a warm launch closure from the identical inode's
+  earlier legitimate launch. Reproduced in this module's own bring-up: run 1
+  printed ``ok`` and runs 2-5 aborted. So a single manual smoke test "passes"
+  and production then fails 100%. If you change this shape, loop your smoke
+  test at least 20 times.
+
+WHY THE ``lop`` SHEBANG IS NOT REWRITTEN
+----------------------------------------
+Pointing the console script's shebang at the branded link would be free (no
+re-exec at all), and it was proposed. It is rejected on a measurement: with the
+link removed, ``./lop`` exits **126 — ``bad interpreter: No such file or
+directory``**. The command is bricked, and the self-healing staleness check in
+this module can never run to repair it, because the process never starts. A
+cosmetic feature must not be able to kill the user's CLI. The shebang keeps
+pointing at the real interpreter, and ``cli.main`` re-execs through the link
+instead: measured +30-36 ms against a ~1100 ms ``lop --version`` baseline (~3%),
+and it fails safe — link missing or broken means no re-exec, the process is
+alive, and it repairs the link for next time.
+
+NEVER ``chmod``/``chown`` THE PLANTED LINK
+------------------------------------------
+A hardlink is not a copy: it is a second NAME for the interpreter's inode, and
+permissions live on the inode. ``chmod`` on ``<venv>/bin/Local Operator``
+therefore changes the mode of the **shared uv interpreter that every venv on
+this machine resolves to** — reproduced during bring-up, where a ``chmod 000``
+on the link broke an unrelated worktree's ``local-operator`` console script with
+``bad interpreter: Permission denied``. Nothing in this module writes modes, and
+nothing added to it should. Unlinking is safe (it only drops one name).
+
+STALENESS
+---------
+The hardlink pins an **inode**, not a version. When ``uv tool install --force``
+replaces the interpreter, the planted link keeps pointing at the OLD inode —
+uv preserves unknown files in ``bin/`` but does not refresh them — and the
+process would silently run a stale interpreter with a fresh site-packages.
+:func:`ensure_branded_interpreter` therefore re-checks three facts at every
+startup (three ``stat`` calls, microseconds) and re-plants when any fails. The
+inode is ground truth; there is deliberately **no version-stamp file**, because
+a stamp is a second source of truth that can itself go stale.
+
+EVERY FUNCTION HERE IS NO-RAISE BY CONTRACT, in the style of ``proc.py``. This
+is decoration on a process listing: no failure of it may ever stop a session
+from starting. The fallback ladder is hardlink+symlink → argv-only labelling →
+exactly today's behaviour, and every rung is a silent no-op on failure.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: The display name users see in Activity Monitor and ``ps -o ucomm``.
+#:
+#: Spaces are legal in ``execve`` argv and in a launchd ``ProgramArguments``
+#: entry (both take a real string vector, not a shell line), which is what lets
+#: this be the product's actual name rather than a squashed identifier. They
+#: are FATAL in a shebang (``#!/path/Local Operator`` fails with
+#: ``bad interpreter``) — but nothing here writes a shebang, by the deliberate
+#: decision recorded in the module docstring, so no space-free twin link is
+#: created. A second inode nothing consumes is a maintenance liability and an
+#: extra staleness surface; add one only if a shebang consumer ever appears.
+BRAND = "Local Operator"
+
+#: ``p_comm`` holds 31 characters. ``ps -o ucomm`` truncates at 16, so a label
+#: must already be distinguishable within its first 16 characters. Both limits
+#: only bind the BINARY NAME (``BRAND``, 14 chars — fine); the argv labels below
+#: are not truncated in ``ps -o args``.
+_PROC_NAME_MAX = 31
+
+#: Set on the re-exec'd process so a branded launch can never re-enter the
+#: re-exec and loop. Read by :func:`should_reexec`; the value is not inspected,
+#: only its presence.
+BRANDED_ENV = "LOCAL_OPERATOR_BRANDED"
+
+#: Fixed argv[0] labels. ``argv`` is a PUBLIC channel — every user on the host
+#: can read it out of ``ps`` — so these are FIXED format strings with only
+#: machine-generated, non-sensitive substitutions: hex ids, integer ports, and
+#: agent names that are already slugged upstream. **Never interpolate prompt,
+#: file, or model-produced text here.**
+LABEL_SESSION = "{brand} [session] agent={agent} id={id}"
+#: Same row without an agent: a detached runtime is spawned before any agent is
+#: bound, and `agent=-` would be noise in a 16-character `ucomm` window.
+LABEL_SESSION_ANON = "{brand} [session] id={id}"
+#: And without an id: the interactive TUI is branded before a session id is
+#: minted, so the agent name is the only identity available at that point.
+LABEL_SESSION_AGENT = "{brand} [session] agent={agent}"
+LABEL_EVAL = "{brand} [eval] session={id}"
+#: ``job`` and not a slug of the prompt: the prompt is user text, and the rule
+#: above forbids it on a world-readable channel. The job id is what ``exec
+#: --background`` already prints to the user ("Started background job <id>"), so
+#: it is both safe and the better correlation handle.
+LABEL_EXEC = "{brand} [exec] job={job}"
+LABEL_MOBILE = "{brand} [mobile daemon] port={port}"
+LABEL_BROWSER = "{brand} [browser bridge] port={port}"
+LABEL_WAKES = "{brand} [wakes]"
+LABEL_TUNNEL = "{brand} [tunnel]"
+LABEL_SERVE = "{brand} [serve] port={port}"
+
+
+def safe_field(value: object, limit: int = 24) -> str:
+    """Reduce ``value`` to ``[A-Za-z0-9._-]`` for use inside a label.
+
+    The label vocabulary is a set of FIXED templates precisely because argv is
+    world-readable, and the one field that can carry human text is the agent
+    name from ``--agent``. That text is already in the operator's own argv, so
+    this is not about disclosure; it is about keeping the row PARSEABLE and
+    bounded — an agent name with spaces or a newline in it would otherwise
+    split the ``[session] agent=…`` row into something no operator can read and
+    no ``pgrep -f`` pattern can match.
+    """
+    text = str(value)
+    cleaned = "".join(ch if (ch.isalnum() or ch in "._-") else "-" for ch in text)
+    return cleaned[:limit] or "-"
+
+
+def branded_argv0(label: str, **fields: object) -> str:
+    """Render one of the ``LABEL_*`` templates into the argv[0] a child is given.
+
+    ``branded_argv0(LABEL_EVAL, id="deadbeef")``. The brand is substituted here
+    so the product name lives in exactly one place, and the caller supplies only
+    its own machine-generated fields. A template that does not render (a missing
+    field after a refactor) degrades to the bare brand rather than raising:
+    a spawn must never fail over its own decoration.
+    """
+    try:
+        return label.format(brand=BRAND, **fields)
+    except Exception:  # noqa: BLE001 — a label is decoration, never a failure
+        return BRAND
+
+
+def _is_venv() -> bool:
+    """True when this interpreter runs inside a venv/virtualenv.
+
+    The plant target is ``<sys.prefix>/bin``, which must be a venv the project
+    owns. Planting into a system or Homebrew prefix would write into a shared,
+    possibly root-owned installation that other software depends on — out of
+    the question for a cosmetic feature.
+    """
+    return sys.prefix != sys.base_prefix
+
+
+def _libpython_name() -> str | None:
+    """Basename of the dylib the interpreter loads via ``@rpath``, or None.
+
+    Read from ``sysconfig`` rather than guessed, because the name carries the
+    ABI flags on some builds (``libpython3.13t.dylib`` on a free-threaded
+    build) and a guessed ``libpython{major}.{minor}.dylib`` would be wrong
+    there — which is exactly the 100%-abort failure mode.
+
+    ``sysconfig`` is stdlib and already imported by the interpreter's own
+    startup on most paths; measured cold cost here is ~0.4 ms, paid once.
+    """
+    try:
+        import sysconfig
+
+        name = sysconfig.get_config_var("LDLIBRARY") or sysconfig.get_config_var("INSTSONAME")
+    except Exception:  # noqa: BLE001 — probe only
+        return None
+    if not isinstance(name, str) or not name.endswith(".dylib"):
+        # A static build (``libpython3.12.a``) or a framework build (whose
+        # LDLIBRARY is ``Python.framework/...``) has nothing we can symlink
+        # into a venv lib dir. Both are handled by refusing to plant.
+        return None
+    return os.path.basename(name)
+
+
+def _real_interpreter() -> Path | None:
+    """``sys.executable`` with symlinks resolved, or None when unusable.
+
+    The hardlink must be made against the REAL file: ``os.link`` on a symlink
+    follows it anyway, but resolving here is what lets the staleness check
+    compare inodes against a stable target.
+    """
+    executable = sys.executable
+    if not executable:
+        return None
+    try:
+        return Path(os.path.realpath(executable))
+    except OSError:
+        return None
+
+
+def _is_framework_build(real: Path) -> bool:
+    """True for a macOS framework interpreter, which CANNOT be branded.
+
+    Measured on Homebrew's ``python@3.14``: hardlinking that binary and running
+    it reports ``proc_name = b'Python'``, not the link's name — the shipped
+    ``bin/python3.14`` is a stub that re-executes the real binary inside
+    ``Resources/Python.app/Contents/MacOS/Python``, so the kernel takes
+    ``p_comm`` from *that* second exec and the link name is discarded. Its
+    ``LDLIBRARY`` is a framework path with no plain dylib to symlink either.
+
+    Detected by path rather than by ``PYTHONFRAMEWORK`` because a venv built on
+    a framework Python reports an empty ``PYTHONFRAMEWORK`` while still
+    resolving to the framework binary. uv-managed interpreters — what ``lop``
+    actually ships on — are ordinary Mach-O executables and brand correctly.
+    """
+    return ".framework" in str(real)
+
+
+def branded_link_path() -> Path | None:
+    """Where the branded hardlink lives, or None when this environment is out.
+
+    ``<sys.prefix>/bin/Local Operator`` — beside the venv's own ``python``, so
+    dyld's ``@executable_path/../lib`` resolves into the venv where the
+    companion symlink is planted. Returns None (no plant, no re-exec, today's
+    behaviour) when the platform is not macOS or the interpreter is not a
+    brandable venv interpreter.
+    """
+    if sys.platform != "darwin":
+        return None
+    if not _is_venv():
+        return None
+    real = _real_interpreter()
+    if real is None or _is_framework_build(real):
+        return None
+    if len(BRAND) > _PROC_NAME_MAX:
+        return None
+    try:
+        return Path(sys.prefix) / "bin" / BRAND
+    except Exception:  # noqa: BLE001 — a path build never fails a startup
+        return None
+
+
+def _needs_replant(link: Path, real: Path, libpython: Path | None) -> bool:
+    """Whether the planted shape is missing or stale. Three ``stat`` calls.
+
+    Refresh when ANY of:
+
+    (a) the link's inode differs from the real interpreter's — ``uv tool
+        install --force`` replaced the interpreter and PRESERVED our planted
+        file without refreshing it, so the link now names an old inode: a
+        stale interpreter under fresh site-packages;
+    (b) ``st_nlink < 2`` — something replaced the hardlink with a copy (an
+        archive restore, an rsync without ``-H``), which is the ``@rpath``
+        failure again and is no longer the same inode as the interpreter;
+    (c) the companion libpython symlink is missing or dangling — the
+        measured 100%-abort mode.
+
+    The inode is ground truth, so no version-stamp file is written; a stamp
+    would be a second source of truth that can itself go stale while the inode
+    it describes has already been replaced.
+    """
+    try:
+        link_stat = link.stat()  # follows nothing meaningful: a hardlink IS the file
+    except OSError:
+        return True
+    try:
+        real_stat = real.stat()
+    except OSError:
+        # The interpreter we are running vanished mid-check. Nothing sane to
+        # plant against; leave what is there rather than deleting a link that
+        # may still work.
+        return False
+    if (link_stat.st_dev, link_stat.st_ino) != (real_stat.st_dev, real_stat.st_ino):
+        return True  # (a)
+    if link_stat.st_nlink < 2:
+        return True  # (b)
+    if libpython is not None and not libpython.exists():
+        return True  # (c) — ``exists`` follows the symlink, so a dangling one is False
+    return False
+
+
+def _sweep_orphan_temps(directory: Path, prefix: str) -> None:
+    """Remove ``.<prefix>.<pid>.tmp`` entries left by a plant that was killed.
+
+    The plant is link-to-temp + ``os.replace``, which is atomic and cleans up
+    after itself on an ``OSError`` — but NOT when the process is killed between
+    the two steps (reproduced with ``kill -9``: the temp entry survives). Each
+    orphan is a harmless zero-byte-of-data directory entry, but they accumulate
+    once per crashed startup and turn ``ls <venv>/bin`` into a junkyard.
+
+    Only entries whose embedded pid is no longer alive are removed, so a plant
+    running concurrently in another worktree is never disturbed.
+    """
+    try:
+        for entry in directory.glob(f".{prefix}.*.tmp"):
+            pid_text = entry.name[len(prefix) + 2 : -4]
+            if not pid_text.isdigit():
+                continue
+            try:
+                os.kill(int(pid_text), 0)
+                continue  # still running: not ours to clean
+            except ProcessLookupError:
+                pass
+            except OSError:
+                continue  # EPERM: alive but another user's — leave it
+            try:
+                entry.unlink()
+            except OSError:
+                pass
+    except Exception:  # noqa: BLE001 — housekeeping never fails a startup
+        logger.debug("orphan temp sweep skipped", exc_info=True)
+
+
+def _plant_hardlink(link: Path, real: Path) -> bool:
+    """Create/refresh ``link`` as a hardlink to ``real``. Atomic, never raises.
+
+    Link-to-temp then ``os.replace`` so a concurrent process (many worktrees on
+    this machine run this simultaneously) never observes a missing or partially
+    created link: ``os.replace`` is atomic within a directory, and a process
+    that opened the old inode keeps running it.
+
+    ``EXDEV`` (cross-device) is an EXPECTED outcome, not an error: an
+    interpreter on a different filesystem from the venv simply cannot be
+    hardlinked, and the caller falls back to argv-only labelling.
+    """
+    tmp = link.with_name(f".{BRAND}.{os.getpid()}.tmp")
+    try:
+        link.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        os.link(real, tmp)
+        os.replace(tmp, link)
+        return True
+    except OSError as exc:
+        # EXDEV, EPERM (a read-only or foreign-owned prefix), ENOSPC — all mean
+        # "no branded image here", which is a supported outcome.
+        logger.debug("branded hardlink not planted: %s", exc)
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        return False
+
+
+def _plant_libpython(link: Path, real: Path, name: str) -> bool:
+    """Symlink ``<venv>/lib/<name>`` at the interpreter's own dylib.
+
+    Without this the hardlink aborts on launch 100% of the time once dyld's
+    warm launch closure expires — see the module docstring. A symlink is
+    correct here (and a hardlink would be wrong): only the EXECUTED IMAGE's
+    name is taken by the kernel, and dyld happily follows a symlink for a
+    library, so this costs one inode-free directory entry.
+    """
+    source = real.parent.parent / "lib" / name
+    target = link.parent.parent / "lib" / name
+    try:
+        if not source.is_file():
+            return False
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if target.is_symlink() or target.exists():
+            if target.resolve() == source.resolve():
+                return True
+            target.unlink()
+        # Symlink via a temp name + replace, for the same concurrency reason as
+        # the hardlink: sibling worktrees plant this at the same moment.
+        tmp = target.with_name(f".{name}.{os.getpid()}.tmp")
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        os.symlink(source, tmp)
+        os.replace(tmp, target)
+        return True
+    except OSError as exc:
+        logger.debug("libpython symlink not planted: %s", exc)
+        return False
+
+
+def ensure_branded_interpreter() -> Path | None:
+    """Plant/refresh the branded interpreter image; return its path or None.
+
+    Cheap enough for every startup: the common case is three ``stat`` calls and
+    no writes. Only a first run in a fresh venv, or a genuine staleness trigger,
+    does any filesystem work — and a hardlink plus a symlink cost zero bytes of
+    data, which is what makes this safe for the many concurrent worktrees on a
+    development machine (each plants into its OWN venv; they never contend for
+    one path).
+
+    None means "no branded image" — an unsupported platform, a non-venv
+    interpreter, a framework build, a cross-device prefix, a read-only install.
+    Every caller must treat None as "carry on exactly as before".
+    """
+    try:
+        link = branded_link_path()
+        if link is None:
+            return None
+        real = _real_interpreter()
+        if real is None:
+            return None
+        name = _libpython_name()
+        libpython = (link.parent.parent / "lib" / name) if name else None
+
+        if not _needs_replant(link, real, libpython):
+            return link
+
+        if name is None:
+            # No dylib to pin means the hardlink would abort at launch. Refuse
+            # rather than plant a landmine.
+            return None
+        # Only on the replant path, so the common startup stays three stats and
+        # no directory scan.
+        _sweep_orphan_temps(link.parent, BRAND)
+        if not _plant_libpython(link, real, name):
+            return None
+        if not _plant_hardlink(link, real):
+            return None
+        return link
+    except Exception:  # noqa: BLE001 — decoration must never break a startup
+        logger.debug("branded interpreter setup skipped", exc_info=True)
+        return None
+
+
+def should_reexec() -> Path | None:
+    """The branded image to re-exec through, or None to stay as we are.
+
+    None whenever: we are already branded (``BRANDED_ENV`` set — this is what
+    makes a re-exec loop impossible), the current image IS already the link,
+    or no branded image could be planted.
+    """
+    try:
+        if os.environ.get(BRANDED_ENV):
+            return None
+        # Only a real `lop` launch may replace itself; see `is_own_launch`.
+        if not is_own_launch():
+            return None
+        link = ensure_branded_interpreter()
+        if link is None:
+            return None
+        # Already running through the link (a re-exec'd child whose env was
+        # scrubbed, or a launchd job pointed straight at it).
+        if os.path.basename(sys.executable) == BRAND:
+            return None
+        if not os.access(link, os.X_OK):
+            return None
+        return link
+    except Exception:  # noqa: BLE001
+        return None
+
+
+#: Console-script basenames that mean "this process IS a Local Operator launch".
+#: `[project.scripts]` defines both; `lop` is the launcher the operator uses.
+_LAUNCHER_NAMES = frozenset({"lop", "lo", "local-operator"})
+
+
+def is_own_launch() -> bool:
+    """True only when this process was started as the ``lop`` command itself.
+
+    THE GUARD THAT KEEPS A RE-EXEC FROM EATING ITS CALLER. ``cli.main()`` is not
+    only an entry point: the test suite calls it in-process (``assert main()
+    == 7``), and so can any embedder. An unguarded re-exec there does not
+    "rename the process" — it REPLACES the running pytest with a fresh
+    interpreter, which silently truncated a 98-test file at 57% with exit 0.
+    Reproduced before this guard existed.
+
+    ``sys.orig_argv[1]`` is the script the interpreter was pointed at, which for
+    a real launch is the generated console script (``…/bin/lop``). Under
+    pytest, an embedder, or ``python -c`` it is something else entirely, so the
+    process correctly declines to replace itself. ``-m local_operator.cli`` is
+    also accepted: that is a documented way to launch the app.
+    """
+    try:
+        argv = sys.orig_argv
+        if len(argv) < 2:
+            return False  # a bare REPL
+        first = argv[1]
+        if first == "-m":
+            return len(argv) > 2 and argv[2] in {"local_operator", "local_operator.cli"}
+        if first.startswith("-"):
+            return False  # -c, -X, an inline flag: never a launcher invocation
+        return os.path.basename(first) in _LAUNCHER_NAMES
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def reexec_branded(label: str | None = None) -> None:
+    """Replace this process with the same launch under the branded image.
+
+    Never returns on success; returns normally (a no-op) whenever branding is
+    unavailable, so the caller carries on with today's behaviour and — crucially
+    — is still ALIVE to have repaired the link for next time. This is the whole
+    reason the ``lop`` shebang is left alone; see the module docstring.
+
+    argv, environment, cwd and the controlling tty are preserved exactly:
+    ``os.execv`` keeps cwd and every file descriptor (so the tty, and Textual's
+    view of it, is untouched), and ``sys.orig_argv`` is the interpreter's own
+    launch line including the ``-X``/``-u`` style flags a plain ``sys.argv``
+    would drop.
+
+    WHY THIS DOES NOT BREAK ``resume_executable`` OR ``/reload``. Both read
+    ``sys.argv[0]``, and CPython sets that from the SCRIPT path, not from the
+    process's argv[0] — verified: after this re-exec, ``orig_argv[0]`` is
+    ``'Local Operator [serve] port=1'`` while ``sys.argv[0]`` is still the
+    ``lop`` launcher path, so ``broadcast.resume_executable()`` and
+    ``reexec.plan_argv()`` both keep returning the launcher. That distinction is
+    load-bearing: a label reaching ``os.execvpe`` as a path fails with
+    ``FileNotFoundError``, which would break every crash-restore.
+
+    It is deliberately independent of :mod:`local_operator.reexec`: that module
+    replaces the process AFTER the TUI tears down, to pick up a new wheel, and
+    exits ``REEXEC_CODE`` (75) to get there. This runs before anything starts,
+    changes no argument, and its child re-enters ``main`` with ``BRANDED_ENV``
+    set — so a later ``/reload`` still execs the ``lop`` launcher normally and
+    that new process brands itself again from scratch.
+    """
+    try:
+        link = should_reexec()
+        if link is None:
+            return
+        argv = list(sys.orig_argv)
+        if not argv:
+            return
+        # argv[0] is the interpreter path; replacing it with the label is what
+        # puts a readable line in ``ps -o args``. The IMAGE is `link`, which is
+        # what Activity Monitor reads.
+        argv[0] = branded_argv0(label) if label else BRAND
+        os.environ[BRANDED_ENV] = "1"
+        os.execv(str(link), argv)
+    except Exception:  # noqa: BLE001 — a failed exec must leave us running
+        os.environ.pop(BRANDED_ENV, None)
+        logger.debug("branded re-exec skipped", exc_info=True)
+
+
+def launchd_program(module: str, *args: str, label: str | None = None) -> list[str]:
+    """``ProgramArguments`` for a LaunchAgent that runs ``python -m <module>``.
+
+    THE SECOND HALF OF THE OPERATOR'S COMPLAINT. macOS's Background Task
+    Management names a non-bundle login item by the **basename of
+    ``ProgramArguments[0]``** — not ``Label``, not the plist filename, not
+    ``CFBundleName``. The documented anti-pattern is exactly what these plists
+    used to do, ``[sys.executable, "-m", module]``, which is why installing a
+    daemon raised "python3 is running in the background" and why System
+    Settings > Login Items listed a bare ``python3``. Pointing element 0 at the
+    branded hardlink makes both read "Local Operator".
+
+    ``label`` is not passed as argv[0] here the way a ``Popen`` label is:
+    launchd uses ``ProgramArguments[0]`` as BOTH the image to execute and
+    argv[0] (there is no ``Program`` key set), so the two axes collapse into
+    one string and it must remain a real executable path.
+
+    Falls back to ``sys.executable`` when no branded image exists, which is
+    byte-for-byte the plist these installers wrote before.
+    """
+    del label  # see docstring: launchd cannot separate the image from argv[0]
+    try:
+        link = ensure_branded_interpreter()
+    except Exception:  # noqa: BLE001
+        link = None
+    return [str(link) if link is not None else sys.executable, "-m", module, *args]
+
+
+def set_process_name(name: str = BRAND) -> bool:
+    """Linux: set this thread's ``comm`` via ``prctl(PR_SET_NAME)``.
+
+    Zero-dependency (``ctypes`` against libc) and what ``/proc/<pid>/comm``,
+    ``ps -o comm``, ``htop`` and most Linux monitors read. Two properties that
+    shape every caller:
+
+    - it truncates at **15** bytes plus NUL, so ``BRAND`` ("Local Operator",
+      14) fits exactly and a longer label would be silently cut;
+    - it is **NOT inherited across ``fork``/``exec``** — an exec resets ``comm``
+      to the new image's basename — so every child process must call this
+      itself rather than relying on the parent having done it.
+
+    Capability-probed rather than branched on ``sys.platform``: the constant is
+    absent on macOS, and probing is what keeps this correct on a platform that
+    is neither (a BSD, a musl container) without a growing platform list.
+    Returns True only when the name was actually set.
+    """
+    try:
+        if sys.platform != "linux":
+            return False
+        import ctypes
+
+        libc = ctypes.CDLL(None, use_errno=True)
+        prctl = getattr(libc, "prctl", None)
+        if prctl is None:
+            return False
+        # 15 == PR_SET_NAME. Encoded to bytes explicitly so a non-ASCII name
+        # cannot raise inside ctypes' implicit conversion.
+        buf = ctypes.create_string_buffer(name.encode("utf-8", "replace")[:15])
+        return prctl(15, ctypes.byref(buf), 0, 0, 0) == 0
+    except Exception:  # noqa: BLE001 — decoration never raises
+        return False
+
+
+def brand_this_process(label: str | None = None) -> None:
+    """The one call a child process makes to name itself, on any platform.
+
+    macOS gets its name from the image it was EXEC'd through, so there is
+    nothing to do in-process — the parent supplied it via ``executable=``.
+    Linux must set ``comm`` itself because ``prctl`` does not survive the exec.
+    One helper so a spawn site does not have to know which axis its platform
+    uses.
+    """
+    del label  # reserved: Linux comm is capped at 15 bytes, so only BRAND fits
+    set_process_name()

--- a/local_operator/procname.py
+++ b/local_operator/procname.py
@@ -87,9 +87,9 @@ replaces the interpreter, the planted link keeps pointing at the OLD inode —
 uv preserves unknown files in ``bin/`` but does not refresh them — and the
 process would silently run a stale interpreter with a fresh site-packages.
 :func:`ensure_branded_interpreter` therefore re-checks three facts at every
-startup (a handful of stats plus one symlink resolution, tens of microseconds
-— measured ~180 µs here against a startup already north of a second) and
-re-plants when any fails. The
+startup (a handful of stats plus one symlink resolution — measured ~180 µs
+here, against a startup already north of a second) and re-plants when any
+fails. The
 inode is ground truth; there is deliberately **no version-stamp file**, because
 a stamp is a second source of truth that can itself go stale.
 
@@ -304,8 +304,8 @@ def _needs_replant(link: Path, real: Path, libpython: Path | None) -> bool:
     interpreter, one ``exists`` on the symlink, and one ``resolve()`` pair for
     the dylib-identity check below. ``resolve()`` ``lstat``s every path
     component, so the exact syscall count scales with how deep the venv sits
-    and is not worth pinning to a number here — the total is tens of
-    microseconds either way (~180 µs for the whole steady-state
+    and is not worth pinning to a number here — the total is a couple of
+    hundred microseconds either way (~180 µs for the whole steady-state
     ``ensure_branded_interpreter``, against a >1 s startup).
 
     Refresh when ANY of:

--- a/local_operator/procname.py
+++ b/local_operator/procname.py
@@ -124,10 +124,26 @@ BRAND = "Local Operator"
 #: are not truncated in ``ps -o args``.
 _PROC_NAME_MAX = 31
 
-#: Set on the re-exec'd process so a branded launch can never re-enter the
-#: re-exec and loop. Read by :func:`should_reexec`; the value is not inspected,
-#: only its presence.
-BRANDED_ENV = "LOCAL_OPERATOR_BRANDED"
+#: THERE IS NO ENVIRONMENT GUARD, on purpose — this note is here so nobody
+#: reintroduces one.
+#:
+#: A re-exec'd process reports ``sys.executable`` as the branded link it was
+#: executed through, so :func:`should_reexec` answers "already branded?" from
+#: the process's own identity. An earlier revision used a
+#: ``LOCAL_OPERATOR_BRANDED`` marker instead and it was wrong three ways:
+#:
+#:  - written into ``os.environ``, it was copied by ``reexec.replace_self``
+#:    (``env = os.environ.copy()``) into ``/reload`` and ``/update``, so the
+#:    relaunched session inherited "already branded" and de-branded itself
+#:    PERMANENTLY — reproduced: post-reload image ``python``;
+#:  - it leaked into every child spawned with an inherited environment
+#:    (``launch.py`` does ``dict(os.environ)``), so genuine launches beneath us
+#:    silently refused to brand;
+#:  - being presence-tested, ``…=0`` DISABLED branding, the opposite of every
+#:    other flag here.
+#:
+#: An identity check has none of those failure modes: there is no marker to
+#: set, inherit, leak, scrub, or misread as configuration.
 
 #: Fixed argv[0] labels. ``argv`` is a PUBLIC channel — every user on the host
 #: can read it out of ``ps`` — so these are FIXED format strings with only
@@ -291,8 +307,10 @@ def _needs_replant(link: Path, real: Path, libpython: Path | None) -> bool:
     (b) ``st_nlink < 2`` — something replaced the hardlink with a copy (an
         archive restore, an rsync without ``-H``), which is the ``@rpath``
         failure again and is no longer the same inode as the interpreter;
-    (c) the companion libpython symlink is missing or dangling — the
-        measured 100%-abort mode.
+    (c) the companion libpython symlink is missing, dangling, or points at
+        something other than THIS interpreter's dylib — the measured
+        100%-abort mode, plus the subtler case where an interpreter upgrade
+        leaves a live symlink aimed at the previous install's library.
 
     The inode is ground truth, so no version-stamp file is written; a stamp
     would be a second source of truth that can itself go stale while the inode
@@ -313,8 +331,20 @@ def _needs_replant(link: Path, real: Path, libpython: Path | None) -> bool:
         return True  # (a)
     if link_stat.st_nlink < 2:
         return True  # (b)
-    if libpython is not None and not libpython.exists():
-        return True  # (c) — ``exists`` follows the symlink, so a dangling one is False
+    if libpython is not None:
+        # `exists` follows the symlink, so a dangling one is already False.
+        if not libpython.exists():
+            return True  # (c) missing or dangling
+        # A LIVE symlink is not automatically a CORRECT one. After an
+        # interpreter upgrade the old link still resolves — to the previous
+        # install's dylib — and loading a mismatched libpython beside a fresh
+        # interpreter is exactly the crash this whole shape exists to avoid.
+        # Compared by resolved path against the running interpreter's own lib.
+        try:
+            if libpython.resolve() != (real.parent.parent / "lib" / libpython.name).resolve():
+                return True  # (c) live but pointing at the wrong library
+        except OSError:
+            return True
     return False
 
 
@@ -398,10 +428,16 @@ def _plant_libpython(link: Path, real: Path, name: str) -> bool:
         if not source.is_file():
             return False
         target.parent.mkdir(parents=True, exist_ok=True)
-        if target.is_symlink() or target.exists():
-            if target.resolve() == source.resolve():
-                return True
-            target.unlink()
+        if (target.is_symlink() or target.exists()) and target.resolve() == source.resolve():
+            return True
+        # NO unlink of a wrong-but-live symlink before the replace. `os.replace`
+        # overwrites a symlink atomically, so the unlink bought nothing and
+        # opened a window in which the venv has NO libpython at all — and any
+        # concurrent start landing in that window hits the measured
+        # 100%-abort mode (`Abort trap: 6`). The whole point of the
+        # temp-then-replace shape is that the target is never absent; removing
+        # it first defeated that.
+        #
         # Symlink via a temp name + replace, for the same concurrency reason as
         # the hardlink: sibling worktrees plant this at the same moment.
         tmp = target.with_name(f".{name}.{os.getpid()}.tmp")
@@ -448,9 +484,13 @@ def ensure_branded_interpreter() -> Path | None:
             # No dylib to pin means the hardlink would abort at launch. Refuse
             # rather than plant a landmine.
             return None
-        # Only on the replant path, so the common startup stays three stats and
-        # no directory scan.
+        # BOTH plant directories. A killed plant can leak a temp in `bin/`
+        # (named for the brand) or in `lib/` (named for the dylib), and
+        # sweeping only the first left lib temps accumulating forever. Only on
+        # the replant path, so the common startup stays three stats and no
+        # directory scan.
         _sweep_orphan_temps(link.parent, BRAND)
+        _sweep_orphan_temps(link.parent.parent / "lib", name)
         if not _plant_libpython(link, real, name):
             return None
         if not _plant_hardlink(link, real):
@@ -464,22 +504,23 @@ def ensure_branded_interpreter() -> Path | None:
 def should_reexec() -> Path | None:
     """The branded image to re-exec through, or None to stay as we are.
 
-    None whenever: we are already branded (``BRANDED_ENV`` set — this is what
-    makes a re-exec loop impossible), the current image IS already the link,
-    or no branded image could be planted.
+    None whenever: this process is ALREADY running through the branded image
+    (which is what makes a re-exec loop impossible), it is not a real ``lop``
+    launch, or no branded image could be planted.
     """
     try:
-        if os.environ.get(BRANDED_ENV):
+        # THE LOOP GUARD, and it is deliberately not an environment variable.
+        # A re-exec'd process reports `sys.executable` as the LINK it was
+        # executed through, so "am I already branded?" is answered by the
+        # process's own identity — no marker to set, inherit, leak or scrub.
+        # This also covers a launchd job pointed straight at the link.
+        if os.path.basename(sys.executable) == BRAND:
             return None
         # Only a real `lop` launch may replace itself; see `is_own_launch`.
         if not is_own_launch():
             return None
         link = ensure_branded_interpreter()
         if link is None:
-            return None
-        # Already running through the link (a re-exec'd child whose env was
-        # scrubbed, or a launchd job pointed straight at it).
-        if os.path.basename(sys.executable) == BRAND:
             return None
         if not os.access(link, os.X_OK):
             return None
@@ -531,11 +572,15 @@ def reexec_branded(label: str | None = None) -> None:
     — is still ALIVE to have repaired the link for next time. This is the whole
     reason the ``lop`` shebang is left alone; see the module docstring.
 
-    argv, environment, cwd and the controlling tty are preserved exactly:
-    ``os.execv`` keeps cwd and every file descriptor (so the tty, and Textual's
-    view of it, is untouched), and ``sys.orig_argv`` is the interpreter's own
-    launch line including the ``-X``/``-u`` style flags a plain ``sys.argv``
-    would drop.
+    cwd and the controlling tty are preserved exactly: ``exec`` keeps cwd and
+    every file descriptor (so the tty, and Textual's view of it, is untouched),
+    and ``sys.orig_argv`` is the interpreter's own launch line including the
+    ``-X``/``-u`` style flags a plain ``sys.argv`` would drop.
+
+    One thing is deliberately NOT preserved, and it is the point: ``argv[0]``
+    becomes the label. The ENVIRONMENT is passed through untouched — the loop
+    guard is the process's own ``sys.executable``, not a marker, for the
+    reasons recorded at :data:`BRAND`.
 
     WHY THIS DOES NOT BREAK ``resume_executable`` OR ``/reload``. Both read
     ``sys.argv[0]``, and CPython sets that from the SCRIPT path, not from the
@@ -549,9 +594,9 @@ def reexec_branded(label: str | None = None) -> None:
     It is deliberately independent of :mod:`local_operator.reexec`: that module
     replaces the process AFTER the TUI tears down, to pick up a new wheel, and
     exits ``REEXEC_CODE`` (75) to get there. This runs before anything starts,
-    changes no argument, and its child re-enters ``main`` with ``BRANDED_ENV``
-    set — so a later ``/reload`` still execs the ``lop`` launcher normally and
-    that new process brands itself again from scratch.
+    changes no argument, and leaves no marker behind — so a later ``/reload``
+    execs the ``lop`` launcher normally and that new process brands itself
+    again from scratch, which is exactly what a reload should do.
     """
     try:
         link = should_reexec()
@@ -564,10 +609,12 @@ def reexec_branded(label: str | None = None) -> None:
         # puts a readable line in ``ps -o args``. The IMAGE is `link`, which is
         # what Activity Monitor reads.
         argv[0] = branded_argv0(label) if label else BRAND
-        os.environ[BRANDED_ENV] = "1"
+        # Plain `execv`: the environment is inherited unchanged and NOTHING is
+        # written into `os.environ`. The replacement process recognises itself
+        # as branded from `sys.executable`; see the note at `BRAND` for the
+        # three ways the marker this replaced went wrong.
         os.execv(str(link), argv)
     except Exception:  # noqa: BLE001 — a failed exec must leave us running
-        os.environ.pop(BRANDED_ENV, None)
         logger.debug("branded re-exec skipped", exc_info=True)
 
 

--- a/local_operator/procname.py
+++ b/local_operator/procname.py
@@ -87,7 +87,9 @@ replaces the interpreter, the planted link keeps pointing at the OLD inode —
 uv preserves unknown files in ``bin/`` but does not refresh them — and the
 process would silently run a stale interpreter with a fresh site-packages.
 :func:`ensure_branded_interpreter` therefore re-checks three facts at every
-startup (three ``stat`` calls, microseconds) and re-plants when any fails. The
+startup (a handful of stats plus one symlink resolution, tens of microseconds
+— measured ~180 µs here against a startup already north of a second) and
+re-plants when any fails. The
 inode is ground truth; there is deliberately **no version-stamp file**, because
 a stamp is a second source of truth that can itself go stale.
 
@@ -296,7 +298,15 @@ def branded_link_path() -> Path | None:
 
 
 def _needs_replant(link: Path, real: Path, libpython: Path | None) -> bool:
-    """Whether the planted shape is missing or stale. Three ``stat`` calls.
+    """Whether the planted shape is missing or stale. Stats plus one resolve.
+
+    Cost, measured rather than asserted: two ``stat`` calls on the link and the
+    interpreter, one ``exists`` on the symlink, and one ``resolve()`` pair for
+    the dylib-identity check below. ``resolve()`` ``lstat``s every path
+    component, so the exact syscall count scales with how deep the venv sits
+    and is not worth pinning to a number here — the total is tens of
+    microseconds either way (~180 µs for the whole steady-state
+    ``ensure_branded_interpreter``, against a >1 s startup).
 
     Refresh when ANY of:
 
@@ -333,7 +343,16 @@ def _needs_replant(link: Path, real: Path, libpython: Path | None) -> bool:
         return True  # (b)
     if libpython is not None:
         # `exists` follows the symlink, so a dangling one is already False.
-        if not libpython.exists():
+        # Inside the try because it is NOT total: an unreadable parent
+        # directory makes it raise `PermissionError` (reproduced), and this
+        # function's contract is that it never raises. Treated as "replant",
+        # which is the safe direction — a libpython we cannot even stat is not
+        # one we should assume is correct.
+        try:
+            live = libpython.exists()
+        except OSError:
+            return True
+        if not live:
             return True  # (c) missing or dangling
         # A LIVE symlink is not automatically a CORRECT one. After an
         # interpreter upgrade the old link still resolves — to the previous
@@ -456,8 +475,9 @@ def _plant_libpython(link: Path, real: Path, name: str) -> bool:
 def ensure_branded_interpreter() -> Path | None:
     """Plant/refresh the branded interpreter image; return its path or None.
 
-    Cheap enough for every startup: the common case is three ``stat`` calls and
-    no writes. Only a first run in a fresh venv, or a genuine staleness trigger,
+    Cheap enough for every startup: the common case is the staleness probe
+    above (~180 µs measured, against a startup already over a second) and no
+    writes. Only a first run in a fresh venv, or a genuine staleness trigger,
     does any filesystem work — and a hardlink plus a symlink cost zero bytes of
     data, which is what makes this safe for the many concurrent worktrees on a
     development machine (each plants into its OWN venv; they never contend for
@@ -487,7 +507,7 @@ def ensure_branded_interpreter() -> Path | None:
         # BOTH plant directories. A killed plant can leak a temp in `bin/`
         # (named for the brand) or in `lib/` (named for the dylib), and
         # sweeping only the first left lib temps accumulating forever. Only on
-        # the replant path, so the common startup stays three stats and no
+        # the replant path, so the common startup stays a stat probe with no
         # directory scan.
         _sweep_orphan_temps(link.parent, BRAND)
         _sweep_orphan_temps(link.parent.parent / "lib", name)

--- a/local_operator/session/runtime/launch.py
+++ b/local_operator/session/runtime/launch.py
@@ -282,9 +282,24 @@ def _spawn_runtime(
     handle_fd, capture_path = tempfile.mkstemp(prefix="lop-runtime-", suffix=".log")
     capture = Path(capture_path)
     handle = os.fdopen(handle_fd, "wb")
+    # Name the detached runtime in the OS process listing. A machine has many of
+    # these at once (one per live session), and until now every one of them was
+    # an indistinguishable `python3.x` row in Activity Monitor. The session id is
+    # already a hex handle the user sees in `lop sessions`, and it is truncated
+    # to 8 so `ps -o ucomm`'s 16-char window still separates two sessions.
+    # No branded image available => the bare interpreter, exactly as before.
+    from local_operator import procname
+
+    link = procname.ensure_branded_interpreter()
+    argv0 = sys.executable
+    executable: str | None = None
+    if link is not None:
+        executable = str(link)
+        argv0 = procname.branded_argv0(procname.LABEL_SESSION_ANON, id=str(session_id)[:8])
     try:
         process = subprocess.Popen(  # noqa: S603 — fixed argv, no shell
-            [sys.executable, "-m", "local_operator.session.runtime.process"],
+            [argv0, "-m", "local_operator.session.runtime.process"],
+            executable=executable,
             env=env,
             stdin=subprocess.DEVNULL,
             stdout=handle,

--- a/local_operator/tools/eval.py
+++ b/local_operator/tools/eval.py
@@ -232,6 +232,21 @@ def _session_key(context: ToolContext | None) -> str:
     return context.session_id or f"ctx-{id(context):x}"
 
 
+def _label_id(session_key: str) -> str:
+    """8 hex characters identifying a session in the process listing.
+
+    Hashed rather than passed through: a session key can be a caller-supplied
+    ``session_id`` string, and argv is world-readable on this host. A stable
+    hex digest identifies the kernel for an operator reading ``ps`` without
+    disclosing anything the key might carry.
+    """
+    import hashlib
+
+    if not session_key:
+        return "00000000"
+    return hashlib.sha256(session_key.encode("utf-8", "replace")).hexdigest()[:8]
+
+
 def _create_windows_kill_job(pid: int) -> int:
     """Own ``pid`` with a kill-on-close Windows Job Object.
 
@@ -452,11 +467,16 @@ def _remember(key: str, kernel: _Kernel) -> None:
         _record_reset(_key, "kernel evicted to make room for other active sessions")
 
 
-async def _spawn(cwd: str) -> _Kernel:
+async def _spawn(cwd: str, session_key: str = "") -> _Kernel:
     """Start a worker with platform-native process-tree ownership.
 
     POSIX uses a new session/process group. Windows assigns the worker to a
     kill-on-close Job Object before the first request is sent.
+
+    ``session_key`` only names the worker in the OS process listing (a machine
+    id, never user text — see the argv-is-public note in
+    :mod:`local_operator.procname`), so an operator looking at Activity Monitor
+    can tell WHICH session's eval kernel is burning CPU.
     """
     spawn_options: dict[str, Any] = {
         "stdin": asyncio.subprocess.PIPE,
@@ -474,8 +494,18 @@ async def _spawn(cwd: str) -> _Kernel:
         spawn_options["creationflags"] = getattr(subprocess, "CREATE_NO_WINDOW", 0)
     else:
         spawn_options["start_new_session"] = True
+    # Brand the worker: `executable=` sets the binary image Activity Monitor
+    # reads, argv[0] sets the line `ps`/`top` show. Both degrade to today's
+    # bare interpreter when no branded image could be planted.
+    from local_operator import procname
+
+    link = procname.ensure_branded_interpreter()
+    argv0 = sys.executable
+    if link is not None:
+        spawn_options["executable"] = str(link)
+        argv0 = procname.branded_argv0(procname.LABEL_EVAL, id=_label_id(session_key))
     process = await asyncio.create_subprocess_exec(
-        sys.executable,
+        argv0,
         "-u",
         "-m",
         "local_operator.tools.eval_worker",
@@ -655,7 +685,7 @@ async def _run_in_background(
             "attached; re-run without background.",
         )
     try:
-        kernel = await _spawn(_safe_cwd(context))
+        kernel = await _spawn(_safe_cwd(context), _session_key(context))
     except OSError as exc:
         return _error(tool_call_id, "eval", f"failed to start Python kernel: {exc}")
 
@@ -876,7 +906,7 @@ async def execute_eval(
     kernel = _KERNELS.pop(key, None)
     if kernel is None:
         try:
-            kernel = await _spawn(_safe_cwd(context))
+            kernel = await _spawn(_safe_cwd(context), key)
         except OSError as exc:
             _ACTIVE_KERNELS.discard(key)
             _CLOSE_ON_RETURN.discard(key)

--- a/local_operator/tunnels/install.py
+++ b/local_operator/tunnels/install.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from local_operator import procname
 from local_operator.paths import config_dir
 from local_operator.tunnels import config
 
@@ -36,7 +37,11 @@ def install() -> None:
         config.private_write(log, "")
         value = {
             "Label": LABEL,
-            "ProgramArguments": [sys.executable, "-m", "local_operator.tunnels.service"],
+            # Branded interpreter image when one can be planted: macOS names
+            # this background item by the basename of ProgramArguments[0], so a
+            # bare `sys.executable` is what made installing the tunnel notify
+            # 'python3 is running in the background'. Falls back unchanged.
+            "ProgramArguments": procname.launchd_program("local_operator.tunnels.service"),
             "EnvironmentVariables": {"LOCAL_OPERATOR_CONFIG_DIR": str(config_dir())},
             "RunAtLoad": True,
             "KeepAlive": {"SuccessfulExit": False},

--- a/local_operator/wakes/install.py
+++ b/local_operator/wakes/install.py
@@ -33,6 +33,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from local_operator import procname
+
 logger = logging.getLogger(__name__)
 
 #: LaunchAgent label, matching ``mobile.install``'s spelling so the two
@@ -127,7 +129,11 @@ def render_plist(config_dir: Path) -> dict[str, object]:
     """
     return {
         "Label": LABEL,
-        "ProgramArguments": [sys.executable, "-m", "local_operator.wakes.supervisor"],
+        # Branded interpreter image when one can be planted: macOS names this
+        # background item by the basename of ProgramArguments[0], so a bare
+        # `sys.executable` is what makes installing a supervised unit notify
+        # 'python3 is running in the background'. Falls back to sys.executable.
+        "ProgramArguments": procname.launchd_program("local_operator.wakes.supervisor"),
         "RunAtLoad": True,
         # SELF-RETIREMENT, and the reason this key is not optional: the
         # supervisor exits 0 when the index empties. Keying restarts on

--- a/tests/unit/session/test_no_session_deletion.py
+++ b/tests/unit/session/test_no_session_deletion.py
@@ -72,6 +72,39 @@ _FS_MODULES = frozenset({"os", "shutil", "pathlib"})
 #: declared one: a new same-shape call fails until a reviewer bumps the
 #: count with a reason, and a removed one fails as stale.
 _ALLOWED_ROWS: tuple[tuple[str | int, ...], ...] = (
+    # -- procname: the branded interpreter image -----------------------------
+    # Every path in this module is built from `sys.prefix` + "bin"/"lib" and a
+    # fixed basename (the brand, or the interpreter's own LDLIBRARY name). None
+    # of them is derived from a session id, a config dir, or any caller input,
+    # so none can name a path under sessions/. `branded_link_path()` refuses
+    # outright unless `sys.prefix != sys.base_prefix`, which further pins the
+    # target to a venv this project owns.
+    (
+        "local_operator/procname.py::_plant_hardlink",
+        "os.replace",
+        "Atomic plant of <venv>/bin/'Local Operator'; both paths are venv-derived",
+    ),
+    (
+        "local_operator/procname.py::_plant_hardlink",
+        "os.unlink",
+        "Clears this pid's own .tmp link in <venv>/bin before/after linking",
+        2,
+    ),
+    (
+        "local_operator/procname.py::_plant_libpython",
+        "os.replace",
+        "Atomic plant of <venv>/lib/libpython3.X.dylib; both paths are venv-derived",
+    ),
+    (
+        "local_operator/procname.py::_plant_libpython",
+        "os.unlink",
+        "Clears this pid's own .tmp symlink in <venv>/lib before linking",
+    ),
+    (
+        "local_operator/procname.py::_sweep_orphan_temps",
+        "<path>.unlink",
+        "Removes <venv>/bin/.'Local Operator'.<dead-pid>.tmp orphans only; glob is venv-scoped",
+    ),
     (
         "local_operator/tui/app.py::OperatorApp._release_sidebar_preparation",
         "<path>.remove",

--- a/tests/unit/test_exec_mode.py
+++ b/tests/unit/test_exec_mode.py
@@ -13,6 +13,7 @@ import argparse
 import asyncio
 import io
 import json
+import os
 import sys
 from collections.abc import Callable, Sequence
 from pathlib import Path
@@ -753,8 +754,18 @@ def test_run_exec_background_spawn(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
     # Detached argv, one new session on POSIX.
     popen_mock.assert_called_once()
     argv = popen_mock.call_args[0][0]
-    assert argv[:5] == [
-        sys.executable,
+    kwargs = popen_mock.call_args[1]
+
+    # argv[0] is the process LABEL when a branded interpreter image exists
+    # (`executable=` then carries the real image), and the bare interpreter
+    # when it does not. Both are correct; what must never drift is the module
+    # and the request that follow it. See `local_operator.procname`.
+    if kwargs.get("executable"):
+        assert os.path.basename(kwargs["executable"]) == "Local Operator"
+        assert argv[0].startswith("Local Operator [exec] job=")
+    else:
+        assert argv[0] == sys.executable
+    assert argv[1:5] == [
         "-m",
         "local_operator.exec_worker",
         "--prompt",
@@ -762,7 +773,6 @@ def test_run_exec_background_spawn(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
     ]
     assert "--json" in argv and "--yolo" in argv
     assert "--job-id" in argv  # CL-09 terminal-record wiring
-    kwargs = popen_mock.call_args[1]
     if sys.platform != "win32":
         assert kwargs.get("start_new_session") is True
 

--- a/tests/unit/test_procname.py
+++ b/tests/unit/test_procname.py
@@ -1,0 +1,512 @@
+"""Guards for process attribution — the branded interpreter image.
+
+WHAT IS ACTUALLY AT RISK HERE, and therefore what these tests pin:
+
+1. **The staleness rule.** The planted link is a hardlink, so it pins an
+   INODE, not a version. Every trigger in :func:`procname._needs_replant`
+   corresponds to a way the shape silently rots into "a stale interpreter under
+   fresh site-packages" or "aborts on every launch". A trigger that stops
+   firing is invisible in review and in production until someone's `lop` breaks.
+2. **The fallback ladder.** This whole feature is decoration on a process
+   listing. Every rung must be a silent no-op, because the alternative — a
+   startup that fails over its own cosmetics — is far worse than an
+   unrecognisable row in Activity Monitor.
+3. **The plists.** macOS names a background login item by the basename of
+   ``ProgramArguments[0]``, which is why installing a daemon used to announce
+   "python3 is running in the background".
+
+The real end-to-end behaviour (that a process executed through the link
+actually reports ``proc_name = b'Local Operator'`` to the kernel) is verified
+on the PR with live ``ps``/``proc_name`` captures: it cannot be asserted here
+without planting links on the machine running the suite.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from local_operator import procname
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "darwin",
+    reason="the branded-image mechanism is macOS-specific; Linux uses prctl",
+)
+
+
+def _fake_venv(tmp_path: Path) -> Path:
+    """A venv-shaped tree whose 'interpreter' is a hardlink of the real one.
+
+    Real, because the thing under test IS filesystem behaviour: inode identity,
+    link counts and symlink resolution cannot be faked with a mock and still
+    prove anything.
+    """
+    (tmp_path / "bin").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "lib").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+@pytest.fixture()
+def branded(tmp_path, monkeypatch):
+    """Point ``procname`` at a throwaway prefix and plant into it.
+
+    ``sys.prefix``/``sys.base_prefix`` are patched so the module believes it is
+    in a venv it owns. NOTHING is written outside ``tmp_path``: the operator's
+    real venvs and installs must never be touched by a test run.
+    """
+    prefix = _fake_venv(tmp_path)
+    monkeypatch.setattr(sys, "prefix", str(prefix))
+    monkeypatch.setattr(sys, "base_prefix", str(tmp_path / "base"))
+    real = Path(os.path.realpath(sys.executable))
+    if ".framework" in str(real):
+        pytest.skip("framework interpreters cannot be branded (stub re-exec)")
+    if real.stat().st_dev != os.stat(prefix).st_dev:
+        pytest.skip("interpreter and tmp_path on different devices: hardlink impossible")
+    link = procname.ensure_branded_interpreter()
+    if link is None:
+        pytest.skip("no branded image could be planted in this environment")
+    return link
+
+
+class TestStaleness:
+    """The three triggers, each demonstrated firing AND repairing."""
+
+    def test_replants_when_link_names_a_different_inode(self, branded, tmp_path):
+        """Trigger (a): ``uv tool install --force`` replaced the interpreter.
+
+        uv PRESERVES unknown files in ``bin/`` but does not refresh them, so the
+        planted link keeps naming the OLD inode. Left unrepaired the process
+        runs a stale interpreter against fresh site-packages.
+
+        The stand-in is deliberately a file with ``st_nlink >= 2``. A plain
+        ``write_bytes`` here has ``nlink == 1``, so trigger (b) fires as well
+        and the test passes even when the inode comparison is deleted —
+        verified by mutation: removing trigger (a) left this test green until
+        the link count was made innocent.
+        """
+        real_ino = os.stat(os.path.realpath(sys.executable)).st_ino
+        stale = tmp_path / "previous-interpreter"
+        stale.write_bytes(b"the interpreter uv just replaced")
+        branded.unlink()
+        os.link(stale, branded)  # different inode, but nlink == 2
+        assert os.stat(branded).st_ino != real_ino
+        assert os.stat(branded).st_nlink >= 2, "only trigger (a) may detect this"
+
+        assert procname.ensure_branded_interpreter() == branded
+        assert os.stat(branded).st_ino == real_ino
+
+    def test_replants_when_hardlink_became_a_copy(self, branded):
+        """Trigger (b): ``st_nlink < 2``.
+
+        An archive restore or an ``rsync`` without ``-H`` turns the hardlink
+        into a copy. A copy is a different inode AND cannot find
+        ``@rpath/libpython`` — the abort mode again.
+        """
+        branded.unlink()
+        branded.write_bytes(Path(os.path.realpath(sys.executable)).read_bytes())
+        assert os.stat(branded).st_nlink == 1
+
+        assert procname.ensure_branded_interpreter() == branded
+        assert os.stat(branded).st_nlink >= 2
+
+    def test_replants_when_libpython_symlink_dangles(self, branded):
+        """Trigger (c): the measured 100%-abort mode.
+
+        Without ``<venv>/lib/libpython3.X.dylib`` the branded image dies with
+        ``Abort trap: 6`` on every launch — 40/40 measured. A first run can
+        spuriously succeed from a warm dyld launch closure, which is exactly why
+        this is pinned by a test rather than by a manual smoke check.
+        """
+        name = procname._libpython_name()
+        assert name, "a brandable interpreter must expose an LDLIBRARY dylib"
+        lib = branded.parent.parent / "lib" / name
+        assert lib.is_symlink() and lib.exists(), "plant must create a live symlink"
+
+        lib.unlink()
+        lib.symlink_to("/nonexistent/libpython.dylib")
+        assert not lib.exists(), "precondition: the symlink dangles"
+
+        assert procname.ensure_branded_interpreter() == branded
+        assert lib.exists(), "the dangling symlink must be repaired"
+
+    def test_orphan_temps_from_dead_plants_are_swept(self, branded):
+        """A plant killed between ``os.link`` and ``os.replace`` leaks a temp.
+
+        Reproduced with ``kill -9``: the cleanup on the error path cannot run,
+        so one entry accumulates per crashed startup. A LIVE pid's temp must
+        survive — a concurrent worktree is plausibly mid-plant.
+        """
+        bin_dir = branded.parent
+        dead = bin_dir / f".{procname.BRAND}.999999.tmp"
+        # A DIFFERENT live pid: this process's own temp name is the one the
+        # plant itself claims and consumes via `os.replace`, so using it here
+        # would test the plant's own bookkeeping rather than the sweep.
+        mine = bin_dir / f".{procname.BRAND}.{os.getppid()}.tmp"
+        dead.write_bytes(b"orphan")
+        mine.write_bytes(b"in flight")
+
+        branded.unlink()  # force the replant path, which is where the sweep runs
+        assert procname.ensure_branded_interpreter() == branded
+
+        assert not dead.exists(), "a dead pid's temp must be swept"
+        assert mine.exists(), "a live pid's temp must be left alone"
+
+    def test_healthy_shape_is_not_rewritten(self, branded):
+        """The common path does no filesystem writes.
+
+        This runs on every startup, so a plant that re-links unconditionally
+        would churn an inode (and race sibling worktrees) for nothing.
+        """
+        before = os.stat(branded)
+        assert procname.ensure_branded_interpreter() == branded
+        after = os.stat(branded)
+        assert (before.st_ino, before.st_mtime_ns) == (after.st_ino, after.st_mtime_ns)
+
+
+class TestFallbackLadder:
+    """Every rung is a silent no-op. None of these may raise."""
+
+    def test_non_venv_interpreter_is_never_planted_into(self, monkeypatch):
+        """A system/Homebrew prefix is shared, possibly root-owned, and not ours."""
+        monkeypatch.setattr(sys, "prefix", "/usr")
+        monkeypatch.setattr(sys, "base_prefix", "/usr")
+        assert procname.branded_link_path() is None
+        assert procname.ensure_branded_interpreter() is None
+
+    def test_framework_build_is_refused(self, tmp_path, monkeypatch):
+        """A framework interpreter re-execs an inner stub, discarding our name.
+
+        Measured: hardlinking Homebrew's ``python@3.14`` and running it reports
+        ``proc_name = b'Python'``. Planting there would cost an inode and buy
+        nothing.
+        """
+        monkeypatch.setattr(sys, "prefix", str(tmp_path))
+        monkeypatch.setattr(sys, "base_prefix", str(tmp_path / "base"))
+        monkeypatch.setattr(
+            procname,
+            "_real_interpreter",
+            lambda: Path("/opt/x/Python.framework/Versions/3.14/bin/python3.14"),
+        )
+        assert procname.branded_link_path() is None
+
+    def test_unplantable_prefix_is_silent(self, tmp_path, monkeypatch):
+        """A read-only or foreign-owned prefix yields None, never an exception."""
+        monkeypatch.setattr(sys, "prefix", "/proc/nonexistent-prefix")
+        monkeypatch.setattr(sys, "base_prefix", str(tmp_path))
+        assert procname.ensure_branded_interpreter() is None
+
+    def test_no_dylib_means_no_plant(self, tmp_path, monkeypatch):
+        """Without a dylib to symlink, a planted hardlink would be a landmine.
+
+        Refusing is correct: the alternative plants an image that aborts on
+        every launch once dyld's warm closure expires.
+        """
+        monkeypatch.setattr(sys, "prefix", str(_fake_venv(tmp_path)))
+        monkeypatch.setattr(sys, "base_prefix", str(tmp_path / "base"))
+        monkeypatch.setattr(procname, "_libpython_name", lambda: None)
+        assert procname.ensure_branded_interpreter() is None
+        assert not (tmp_path / "bin" / procname.BRAND).exists()
+
+    def test_reexec_returns_when_branding_is_unavailable(self, monkeypatch):
+        """``reexec_branded`` must RETURN (not exit) so the process stays alive.
+
+        This is the property that lets the ``lop`` shebang keep pointing at the
+        real interpreter: a failed branding leaves a live process that can
+        repair the link, where a bad shebang would have exited 126 before any
+        code ran.
+        """
+        monkeypatch.setattr(procname, "should_reexec", lambda: None)
+        called: list[object] = []
+        monkeypatch.setattr(os, "execv", lambda *a: called.append(a))
+        procname.reexec_branded()
+        assert called == []
+
+    def test_in_process_main_never_replaces_its_caller(self, monkeypatch):
+        """THE REGRESSION THIS GUARD EXISTS FOR.
+
+        ``cli.main()`` is called in-process by this very suite (``assert
+        main() == 7``). An unguarded re-exec there replaces the running pytest
+        with a fresh interpreter: observed as a 98-test file silently
+        truncating at 57% with exit code 0 — a green run that tested nothing.
+        """
+        # sys.orig_argv under pytest is not a launcher invocation.
+        assert procname.is_own_launch() is False
+        assert procname.should_reexec() is None
+
+        called: list[object] = []
+        monkeypatch.setattr(os, "execv", lambda *a: called.append(a))
+        procname.reexec_branded("Local Operator [serve] port=1")
+        assert called == [], "a non-launcher process must never exec itself"
+
+    @pytest.mark.parametrize(
+        ("orig_argv", "expected"),
+        [
+            (["python", "/x/bin/lop", "--resume", "a"], True),
+            (["python", "/x/bin/lo"], True),
+            (["python", "/x/bin/local-operator", "serve"], True),
+            (["python", "-m", "local_operator.cli"], True),
+            (["python", "-m", "local_operator"], True),
+            (["python", "-m", "pytest", "tests/unit"], False),
+            (["python", "-c", "import local_operator.cli"], False),
+            (["python"], False),
+            (["python", "/x/bin/some-other-tool"], False),
+        ],
+    )
+    def test_launch_detection(self, monkeypatch, orig_argv, expected):
+        monkeypatch.setattr(sys, "orig_argv", orig_argv)
+        assert procname.is_own_launch() is expected
+
+    def test_reexec_is_suppressed_once_branded(self, monkeypatch):
+        """The env guard is what makes a re-exec loop impossible."""
+        monkeypatch.setenv(procname.BRANDED_ENV, "1")
+        assert procname.should_reexec() is None
+
+    def test_ensure_never_raises(self, monkeypatch):
+        """Contract: decoration must never break a startup, whatever fails."""
+
+        def boom() -> None:
+            raise RuntimeError("filesystem on fire")
+
+        monkeypatch.setattr(procname, "branded_link_path", boom)
+        assert procname.ensure_branded_interpreter() is None
+        procname.reexec_branded()  # must not raise either
+
+
+class TestLabels:
+    """argv is a PUBLIC channel; the vocabulary is fixed templates only."""
+
+    def test_labels_render_with_the_brand(self):
+        assert (
+            procname.branded_argv0(procname.LABEL_SERVE, port=8080)
+            == "Local Operator [serve] port=8080"
+        )
+        assert (
+            procname.branded_argv0(procname.LABEL_EVAL, id="deadbeef")
+            == "Local Operator [eval] session=deadbeef"
+        )
+
+    def test_agent_field_is_reduced_to_a_parseable_token(self):
+        """The one label field that can carry human text stays a bounded token.
+
+        An agent name with spaces or a newline would split the `[session]
+        agent=…` row into something unreadable in `ps` and unmatchable by
+        `pgrep -f`.
+        """
+        assert procname.safe_field("weird name; rm -rf /") == "weird-name--rm--rf--"
+        assert procname.safe_field("a" * 99) == "a" * 24
+        assert procname.safe_field("") == "-"
+        assert procname.safe_field("coder") == "coder"
+
+    def test_cli_sanitises_the_agent_before_labelling(self):
+        from local_operator import cli
+
+        args = cli.build_cli_parser().parse_args(["--agent", "my agent"])
+        assert cli._process_label(args) == "Local Operator [session] agent=my-agent"
+
+    def test_unrenderable_label_degrades_to_the_brand(self):
+        """A spawn must never fail over its own decoration."""
+        assert procname.branded_argv0(procname.LABEL_SERVE) == procname.BRAND
+
+    def test_brand_fits_the_kernel_and_ps_windows(self):
+        """``p_comm`` holds 31 chars; ``ps -o ucomm`` truncates at 16.
+
+        The brand must be distinguishable within the SHORTER window, or every
+        row in ``ps`` reads the same.
+        """
+        assert len(procname.BRAND) <= 31
+        assert len(procname.BRAND) <= 16
+
+
+class TestLaunchdPrograms:
+    """All four LaunchAgents name their item 'Local Operator', not 'python3'."""
+
+    @pytest.mark.parametrize(
+        "module",
+        [
+            "local_operator.mobile.service",
+            "local_operator.browser_bridge.daemon",
+            "local_operator.tunnels.service",
+            "local_operator.wakes.supervisor",
+        ],
+    )
+    def test_program_arguments_head_is_the_branded_image(self, module, branded):
+        program = procname.launchd_program(module, "--port", "1234")
+        # BTM (the notification and System Settings > Login Items) reads the
+        # BASENAME of element 0 — not Label, not the plist filename.
+        assert os.path.basename(program[0]) == procname.BRAND
+        assert program[1:] == ["-m", module, "--port", "1234"]
+
+    def test_falls_back_to_sys_executable(self, monkeypatch):
+        """Unbrandable environment => byte-for-byte the previous plist."""
+        monkeypatch.setattr(procname, "ensure_branded_interpreter", lambda: None)
+        assert procname.launchd_program("local_operator.mobile.service") == [
+            sys.executable,
+            "-m",
+            "local_operator.mobile.service",
+        ]
+
+    def test_all_four_renderers_route_through_the_helper(self, monkeypatch, tmp_path):
+        """Pins that no installer reverts to a bare ``sys.executable``.
+
+        Each of these was the documented anti-pattern before this change; a
+        revert would restore "python3 is running in the background" with no
+        test failing anywhere else.
+        """
+        from local_operator.browser_bridge import install as browser_install
+        from local_operator.mobile import install as mobile_install
+        from local_operator.wakes import install as wakes_install
+
+        sentinel = tmp_path / "bin" / procname.BRAND
+        sentinel.parent.mkdir(parents=True)
+        sentinel.touch()
+        monkeypatch.setattr(procname, "ensure_branded_interpreter", lambda: sentinel)
+
+        # `render_plist` is typed `dict[str, object]`, so the element type is
+        # narrowed here rather than indexed straight off an `object`.
+        for rendered in (
+            mobile_install.render_plist(1),
+            browser_install.render_plist(1),
+            wakes_install.render_plist(tmp_path),
+        ):
+            program = rendered["ProgramArguments"]
+            assert isinstance(program, list)
+            assert program[0] == str(sentinel)
+
+
+class TestResumeExecutableRegression:
+    """``resume_executable`` must keep returning the ``lop`` LAUNCHER path.
+
+    It reads ``sys.argv[0]`` precisely because ``sys.executable`` would restore
+    a bare Python REPL instead of reopening the session. Branding rewrites
+    argv[0] of CHILDREN, so this pins that the launcher's own resolution is
+    unaffected — a regression here silently breaks every crash-restore and
+    notification click, and would not show up as a failure anywhere else.
+    """
+
+    def test_resume_executable_is_argv0_not_the_interpreter(self, monkeypatch, tmp_path):
+        from local_operator.multiplexer import broadcast
+
+        launcher = tmp_path / "lop"
+        launcher.write_text("#!/bin/sh\n")
+        monkeypatch.setattr(sys, "argv", [str(launcher), "--resume", "abc"])
+        resolved = broadcast.resume_executable()
+        assert resolved == str(launcher.resolve())
+        assert resolved != sys.executable
+
+    def test_label_lives_in_orig_argv_not_sys_argv(self, branded):
+        """The property that keeps `/reload` and crash-restore working.
+
+        CPython sets ``sys.argv[0]`` from the SCRIPT path, so a branded process
+        carries the label only in ``sys.orig_argv[0]``. If that ever changed,
+        ``reexec.plan_argv`` would hand a label to ``os.execvpe``, which fails
+        with ``FileNotFoundError`` and breaks every restore.
+        """
+        script = branded.parent.parent / "argv_report.py"
+        script.write_text("import sys;print(sys.argv[0]);print(sys.orig_argv[0])\n")
+        label = procname.branded_argv0(procname.LABEL_SERVE, port=1)
+        result = subprocess.run(
+            [label, str(script)],
+            executable=str(branded),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
+        sys_argv0, orig_argv0 = result.stdout.split()[:2]
+        assert sys_argv0 == str(script), "sys.argv[0] must stay the script path"
+        assert orig_argv0 == "Local", "the label lives in orig_argv (first token)"
+
+    def test_branded_argv0_does_not_leak_into_resume(self, monkeypatch):
+        """A branded argv[0] is a LABEL, not a path — it must not be resolved.
+
+        If a future change brands the main process's argv[0] with a label
+        containing spaces, ``resume_executable`` must not hand that label back
+        as an executable path.
+        """
+        from local_operator.multiplexer import broadcast
+
+        monkeypatch.setattr(sys, "argv", [procname.branded_argv0(procname.LABEL_WAKES)])
+        assert broadcast.resume_executable() != "Local Operator [wakes]"
+
+
+class TestLinuxNameSet:
+    """``prctl`` is capability-probed, not branched on a platform list."""
+
+    def test_set_process_name_is_a_no_op_on_macos(self):
+        # macOS has no PR_SET_NAME; the call must report False, never raise.
+        assert procname.set_process_name("whatever") is False
+
+    def test_set_process_name_never_raises(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        # No ctypes/libc in this shape => False, not an exception.
+        monkeypatch.setitem(sys.modules, "ctypes", None)
+        assert procname.set_process_name() is False
+
+
+class TestSpawnDetachedLabel:
+    """``proc.spawn_detached(label=...)`` brands only Python spawns."""
+
+    def test_label_is_ignored_for_a_non_interpreter_argv(self, monkeypatch, tmp_path):
+        """A terminal emulator or ``open`` must keep its own image.
+
+        Setting ``executable=`` there would run Python under that program's
+        arguments — a spawn that silently does the wrong thing.
+        """
+        from local_operator import proc
+
+        captured: dict[str, object] = {}
+
+        class _FakePopen:
+            def __init__(self, argv, **kwargs):
+                captured["argv"] = argv
+                captured["executable"] = kwargs.get("executable")
+
+        monkeypatch.setattr(proc.subprocess, "Popen", _FakePopen)
+        assert proc.spawn_detached(["/usr/bin/open", "-a", "Terminal"], label="x") is True
+        assert captured["executable"] is None
+        assert captured["argv"] == ["/usr/bin/open", "-a", "Terminal"]
+
+    def test_spawn_without_label_is_unchanged(self, monkeypatch):
+        from local_operator import proc
+
+        captured: dict[str, object] = {}
+
+        class _FakePopen:
+            def __init__(self, argv, **kwargs):
+                captured["argv"] = argv
+                captured["executable"] = kwargs.get("executable")
+
+        monkeypatch.setattr(proc.subprocess, "Popen", _FakePopen)
+        assert proc.spawn_detached([sys.executable, "-c", "pass"]) is True
+        assert captured["executable"] is None
+        assert captured["argv"] == [sys.executable, "-c", "pass"]
+
+
+def test_branded_image_actually_renames_the_process(branded):
+    """The end-to-end property, run for real: exec through the link and ask the kernel.
+
+    This is the only assertion that proves the FEATURE rather than its
+    plumbing. It also covers the warm-dyld-cache trap in the one direction a
+    test can: a run that aborts (``Abort trap: 6``) because the libpython
+    symlink is missing fails here loudly.
+    """
+    probe = (
+        "import ctypes,os;"
+        "l=ctypes.CDLL('/usr/lib/libSystem.dylib');"
+        "b=ctypes.create_string_buffer(64);"
+        "l.proc_name(ctypes.c_int(os.getpid()),b,ctypes.c_uint(64));"
+        "print(b.value.decode())"
+    )
+    result = subprocess.run(
+        [procname.branded_argv0(procname.LABEL_WAKES), "-c", probe],
+        executable=str(branded),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"branded image failed to launch: {result.stderr}"
+    assert result.stdout.strip() == procname.BRAND

--- a/tests/unit/test_procname.py
+++ b/tests/unit/test_procname.py
@@ -194,6 +194,28 @@ class TestStaleness:
         assert not bin_orphan.exists(), "bin/ orphan must be swept"
         assert not lib_orphan.exists(), "lib/ orphan must be swept too"
 
+    def test_unreadable_libpython_parent_does_not_raise(self, branded, tmp_path):
+        """QA round 2, Q3: `_needs_replant` is contractually no-raise.
+
+        `Path.exists()` is not total — an unreadable parent directory makes it
+        raise `PermissionError` (reproduced), which escaped a function this
+        module documents as never raising. "Replant" is the safe answer: a
+        libpython we cannot stat is not one to assume correct.
+        """
+        walled = tmp_path / "lib" / "sub"
+        walled.mkdir(parents=True)
+        dylib = walled / "libpython3.12.dylib"
+        dylib.touch()
+        walled.chmod(0o000)
+        try:
+            assert (
+                procname._needs_replant(branded, Path(os.path.realpath(sys.executable)), dylib)
+                is True
+            )
+        finally:
+            # Restore so tmp_path teardown can remove the tree.
+            walled.chmod(0o755)
+
     def test_healthy_shape_is_not_rewritten(self, branded):
         """The common path does no filesystem writes.
 
@@ -299,19 +321,37 @@ class TestFallbackLadder:
         monkeypatch.setattr(sys, "orig_argv", orig_argv)
         assert procname.is_own_launch() is expected
 
-    def test_reexec_is_suppressed_once_branded(self, monkeypatch, tmp_path):
+    def test_reexec_is_suppressed_once_branded(self, monkeypatch, branded):
         """Already running through the link => no second exec. No loop.
 
         The loop guard is the process's OWN identity (`sys.executable` is the
         branded link), not an environment marker — see
         `test_reexec_leaves_the_environment_untouched` for why a marker was
         removed.
+
+        THIS TEST MUST FAIL IF THE GUARD IS DELETED, and an earlier version did
+        not (review round 2, R2-1): it patched `sys.executable` but left
+        pytest's own `sys.orig_argv`, so `is_own_launch()` returned False and
+        `should_reexec()` returned None at the NEXT early return — one line
+        below the line under test. The assertion passed on a path that never
+        reached the guard, and deleting the guard left 352 tests green.
+
+        So every other reason to return None is neutralised first, and the
+        preconditions are asserted rather than assumed: a REAL planted link
+        (a `tmp_path` fake makes `ensure_branded_interpreter()` fail on a fake
+        prefix, which is a second independent way to pass vacuously) and an
+        `orig_argv` that `is_own_launch()` accepts. The guard is then the only
+        thing left that can produce None.
         """
-        fake_link = tmp_path / "bin" / procname.BRAND
-        fake_link.parent.mkdir(parents=True)
-        fake_link.touch()
-        monkeypatch.setattr(sys, "executable", str(fake_link))
-        assert procname.should_reexec() is None
+        link = branded  # the real planted link, not a fake
+        monkeypatch.setattr(sys, "executable", str(link))
+        monkeypatch.setattr(sys, "orig_argv", [str(link), "/x/.venv/bin/lop", "serve"])
+
+        # Preconditions: without these the assertion below is vacuous.
+        assert procname.is_own_launch() is True
+        assert procname.ensure_branded_interpreter() is not None
+
+        assert procname.should_reexec() is None, "a branded process must not re-exec again"
 
     def test_reexec_leaves_the_environment_untouched(self, monkeypatch):
         """REGRESSION (review round 1, B1+B2): no marker may enter os.environ.

--- a/tests/unit/test_procname.py
+++ b/tests/unit/test_procname.py
@@ -208,6 +208,14 @@ class TestStaleness:
         dylib.touch()
         walled.chmod(0o000)
         try:
+            # PRECONDITION, not decoration. `True` is ALSO reachable through the
+            # `resolve()` identity mismatch below, so asserting it alone would
+            # not prove this test exercised the `exists()` path it is named for
+            # — and on a host where `chmod 0o000` does not block (root, some
+            # container runtimes) it would stay green with the guard deleted.
+            # Review round 3, M3-2: the R2-1 failure mode in embryo.
+            with pytest.raises(PermissionError):
+                dylib.exists()
             assert (
                 procname._needs_replant(branded, Path(os.path.realpath(sys.executable)), dylib)
                 is True

--- a/tests/unit/test_procname.py
+++ b/tests/unit/test_procname.py
@@ -155,6 +155,45 @@ class TestStaleness:
         assert not dead.exists(), "a dead pid's temp must be swept"
         assert mine.exists(), "a live pid's temp must be left alone"
 
+    def test_replants_when_libpython_points_at_the_wrong_library(self, branded):
+        """Trigger (c), second half: a LIVE symlink is not automatically CORRECT.
+
+        Found while verifying the B4 fix. `exists()` only proves the link
+        resolves, so after an interpreter upgrade a link aimed at the PREVIOUS
+        install's dylib passed the check — and loading a mismatched libpython
+        beside a fresh interpreter is the crash this shape exists to avoid.
+        """
+        name = procname._libpython_name()
+        assert name
+        lib = branded.parent.parent / "lib" / name
+        lib.unlink()
+        lib.symlink_to("/etc/hosts")  # live, resolvable, and wrong
+        assert lib.exists(), "precondition: the symlink resolves"
+
+        assert procname.ensure_branded_interpreter() == branded
+        expected = Path(os.path.realpath(sys.executable)).parent.parent / "lib" / name
+        assert lib.resolve() == expected.resolve()
+
+    def test_orphan_temps_are_swept_in_lib_as_well_as_bin(self, branded):
+        """REGRESSION (review round 1, B3): both plant directories are swept.
+
+        A killed plant leaks a temp named for the BRAND in `bin/` or for the
+        DYLIB in `lib/`. Sweeping only `bin/` left lib temps accumulating
+        forever, one per crashed startup.
+        """
+        name = procname._libpython_name()
+        assert name
+        bin_orphan = branded.parent / f".{procname.BRAND}.999999.tmp"
+        lib_orphan = branded.parent.parent / "lib" / f".{name}.999998.tmp"
+        bin_orphan.write_bytes(b"orphan")
+        lib_orphan.write_bytes(b"orphan")
+
+        branded.unlink()  # force the replant path
+        assert procname.ensure_branded_interpreter() == branded
+
+        assert not bin_orphan.exists(), "bin/ orphan must be swept"
+        assert not lib_orphan.exists(), "lib/ orphan must be swept too"
+
     def test_healthy_shape_is_not_rewritten(self, branded):
         """The common path does no filesystem writes.
 
@@ -260,10 +299,126 @@ class TestFallbackLadder:
         monkeypatch.setattr(sys, "orig_argv", orig_argv)
         assert procname.is_own_launch() is expected
 
-    def test_reexec_is_suppressed_once_branded(self, monkeypatch):
-        """The env guard is what makes a re-exec loop impossible."""
-        monkeypatch.setenv(procname.BRANDED_ENV, "1")
+    def test_reexec_is_suppressed_once_branded(self, monkeypatch, tmp_path):
+        """Already running through the link => no second exec. No loop.
+
+        The loop guard is the process's OWN identity (`sys.executable` is the
+        branded link), not an environment marker — see
+        `test_reexec_leaves_the_environment_untouched` for why a marker was
+        removed.
+        """
+        fake_link = tmp_path / "bin" / procname.BRAND
+        fake_link.parent.mkdir(parents=True)
+        fake_link.touch()
+        monkeypatch.setattr(sys, "executable", str(fake_link))
         assert procname.should_reexec() is None
+
+    def test_reexec_leaves_the_environment_untouched(self, monkeypatch):
+        """REGRESSION (review round 1, B1+B2): no marker may enter os.environ.
+
+        An earlier revision set `LOCAL_OPERATOR_BRANDED` in the LIVE
+        environment before exec'ing. Two things broke, both reproduced:
+
+        - `/reload` and `/update` (`reexec.replace_self`) do
+          `env = os.environ.copy()` and exec the plain `lop` launcher, so the
+          relaunch inherited "already branded" and the session was de-branded
+          permanently (post-reload image: `python`);
+        - every child spawned with an inherited environment (`launch.py` does
+          `dict(os.environ)`) carried it, so genuine launches refused to brand.
+
+        The environment this process hands to `exec` must therefore be exactly
+        the one it already had.
+        """
+        before = dict(os.environ)
+        captured: dict[str, object] = {}
+
+        def _fake_execv(path, argv):
+            captured["path"] = path
+            captured["argv"] = argv
+
+        monkeypatch.setattr(procname, "should_reexec", lambda: Path("/x/Local Operator"))
+        monkeypatch.setattr(os, "execv", _fake_execv)
+        # `execve` would also be a defect here: it is how a marker gets passed
+        # without mutating os.environ, and this feature needs no marker at all.
+        monkeypatch.setattr(
+            os,
+            "execve",
+            lambda *a: pytest.fail("re-exec must not pass a modified environment"),
+        )
+        procname.reexec_branded("Local Operator [serve] port=1")
+
+        assert captured["path"] == "/x/Local Operator"
+        assert dict(os.environ) == before, "re-exec must not mutate the live environment"
+
+    def test_reload_roundtrip_rebrands(self, branded):
+        """A relaunch after `/reload` must brand AGAIN, not inherit a marker.
+
+        Drives the real shape: a branded process (image = the link) spawns a
+        child with `os.environ.copy()`, exactly as `reexec.replace_self` does.
+        That child must see nothing that would stop it branding.
+        """
+        report = branded.parent.parent / "reload_probe.py"
+        report.write_text(
+            "import os, sys\n"
+            f"sys.path.insert(0, {str(Path(__file__).resolve().parents[2])!r})\n"
+            "from local_operator import procname\n"
+            # The relaunch runs the ORDINARY interpreter (the lop launcher's
+            # shebang), so it must not already look branded...
+            "print(os.path.basename(sys.executable) == procname.BRAND)\n"
+            # ...and nothing in the inherited environment may veto branding.
+            "print(any('BRANDED' in k for k in os.environ))\n"
+        )
+        handoff = branded.parent.parent / "reload_handoff.py"
+        handoff.write_text(
+            "import os, subprocess, sys\n"
+            f"subprocess.run([{str(os.path.realpath(sys.executable))!r}, {str(report)!r}],"
+            " env=os.environ.copy(), check=True)\n"
+        )
+        result = subprocess.run(
+            [procname.branded_argv0(procname.LABEL_SERVE, port=1), str(handoff)],
+            executable=str(branded),
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert result.returncode == 0, result.stderr
+        looks_branded, has_marker = result.stdout.split()
+        assert looks_branded == "False", "the relaunched interpreter must not look branded"
+        assert has_marker == "False", "no inherited marker may suppress re-branding"
+
+    def test_inherited_env_child_is_not_vetoed(self, branded):
+        """REGRESSION (B2): nothing in an inherited environment suppresses branding.
+
+        `launch.py` hands a runtime `dict(os.environ)` wholesale. When the
+        parent wrote a marker into its own environment, that child — a genuine
+        `lop` launch — inherited "already branded" and silently declined.
+
+        The assertion is about the ENVIRONMENT, not about whether this
+        particular child plants: a process exec'd from a link outside a venv
+        reports `sys.prefix == sys.base_prefix` and correctly refuses to plant
+        into a shared interpreter prefix. What must hold is that the decision
+        is made on the child's own merits with no inherited veto.
+        """
+        probe = (
+            "import os, sys;"
+            "sys.path.insert(0, %r);" % str(Path(__file__).resolve().parents[2])
+            + "from local_operator import procname;"
+            "print(any('BRANDED' in k for k in os.environ));"
+            # The refusal, when it happens, is the venv check and nothing else.
+            "print(sys.prefix != sys.base_prefix or procname.branded_link_path() is None)"
+        )
+        result = subprocess.run(
+            [procname.branded_argv0(procname.LABEL_SESSION_ANON, id="deadbeef"), "-c", probe],
+            executable=str(branded),
+            env=dict(os.environ),  # exactly what launch.py hands a runtime
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert result.returncode == 0, result.stderr
+        has_marker, decided_on_own_merits = result.stdout.split()
+        assert has_marker == "False", "no marker may leak into an inherited environment"
+        assert decided_on_own_merits == "True"
 
     def test_ensure_never_raises(self, monkeypatch):
         """Contract: decoration must never break a startup, whatever fails."""


### PR DESCRIPTION
## Summary

A machine running Local Operator shows ~20 rows of `python3.14` / `python3.12` in Activity Monitor — TUI sessions, subagent runtimes, eval workers, the mobile daemon, the browser bridge, `lop serve`. They are indistinguishable from each other and from unrelated Python, so nobody can tell which one is eating 85% CPU. Separately, installing a LaunchAgent makes macOS announce **"python3 is running in the background"**, which reads like malware right after an install.

Both are fixed here, with **no new dependencies** and no version bump.

## Change class

**C2** — behaviour-affecting: it adds a conditional `os.execv` on the CLI startup path and changes what four LaunchAgents write into their plists. Every rung is a silent no-op on failure, but the startup path is not a place to claim C1.

## The two name axes (the thing to understand first)

They are independent, and fixing one leaves the complaint half-answered:

| axis | what reads it | how it is set |
|---|---|---|
| `p_comm` | **Activity Monitor**, `proc_name()`, `ps -o ucomm` | basename of the **executed binary image**, taken by the kernel at `execve` |
| `argv[0]` | `ps -o args`, `top`, `pgrep -f` | passed by the spawning process |

**`setproctitle` is deliberately NOT added.** Measured: it rewrites argv only — `proc_name()` still returned `b'python3.12'`, so Activity Monitor was unchanged. It would add a compiled dependency and still not solve the headline complaint.

## Before / after

Same nine process types, spawned through the real label vocabulary:

**BEFORE**
```
    PID  UCOMM (Activity Monitor / ps -o ucomm)  ARGS
  66202  python3.12                              /tmp/lop-procname/.venv/bin/python -c ...
  66203  python3.12                              /tmp/lop-procname/.venv/bin/python -c ...
  66204  python3.12                              /tmp/lop-procname/.venv/bin/python -c ...
  66205  python3.12                              /tmp/lop-procname/.venv/bin/python -c ...
  66206  python3.12                              /tmp/lop-procname/.venv/bin/python -c ...
  66208  python3.12                              /tmp/lop-procname/.venv/bin/python -c ...
  66209  python3.12                              /tmp/lop-procname/.venv/bin/python -c ...
  66210  python3.12                              /tmp/lop-procname/.venv/bin/python -c ...
  66212  python3.12                              /tmp/lop-procname/.venv/bin/python -c ...
proc_name(): b'python3.12'  b'python3.12'  b'python3.12'
```

**AFTER**
```
    PID  UCOMM (Activity Monitor / ps -o ucomm)  ARGS
  66253  Local Operator     Local Operator [session] agent=coder ...
  66254  Local Operator     Local Operator [session] id=f00dcafe ...
  66255  Local Operator     Local Operator [eval] session=88ce9025 ...
  66256  Local Operator     Local Operator [exec] job=a4ef4601 ...
  66257  Local Operator     Local Operator [mobile daemon] port=8080 ...
  66258  Local Operator     Local Operator [browser bridge] port=8765 ...
  66259  Local Operator     Local Operator [serve] port=1111 ...
  66260  Local Operator     Local Operator [wakes] ...
  66261  Local Operator     Local Operator [tunnel] ...
proc_name(): b'Local Operator'  b'Local Operator'  b'Local Operator'
```

Real `lop serve`, branded end to end and still serving:
```
$ .venv/bin/local-operator serve --port 8896 &
58125 Local Operator  Local Operator [serve] port=8896 .../local-operator serve --port 8896
proc_name = b'Local Operator'
$ curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8896/health   ->  200
```

## How the binary-image name is changed with zero dependencies

A **hardlink** named `Local Operator` beside the venv's interpreter. A symlink does **not** work (the kernel resolves it and takes `p_comm` from the target); `cp` does not work (`dyld: Library not loaded: @rpath/libpython3.X.dylib` — the only `LC_RPATH` is `@executable_path/../lib`).

### The warm-cache trap — the single most important thing in this PR

A `<venv>/lib/libpython3.X.dylib` symlink beside the hardlink is **MANDATORY**, and a first run without it can **spuriously succeed** from a warm dyld launch closure. Reproduced live during bring-up — run 1 printed `ok`, runs 2–5 aborted:

```
--- NO-SYMLINK run ---
ok
  Reason: tried: '.../.venv/lib/libpython3.12.dylib' (no such file)     <- Abort trap: 6
  Reason: tried: '.../.venv/lib/libpython3.12.dylib' (no such file)
  Reason: tried: '.../.venv/lib/libpython3.12.dylib' (no such file)
  Reason: tried: '.../.venv/lib/libpython3.12.dylib' (no such file)
```

So a single manual smoke test "passes" and production then fails 100%. The 30× loop with the symlink in place:

```
############ 30x STABILITY LOOP ############
RESULT: ok=30 fail=0 / 30
```

## Why the `lop` shebang is NOT repointed at the link

Proposed and rejected on a measurement. With the link removed, a shebang-based launch exits **126 `bad interpreter: No such file or directory`** — the CLI is bricked, and the self-healing staleness check can never run because the process never starts. A cosmetic feature must not be able to kill the command.

Instead `cli.main()` re-execs through the link, which **fails safe**: no link ⇒ no re-exec ⇒ the process is alive and repairs the link for next time. The full ladder, exercised for real:

| rung | result |
|---|---|
| link absent | `v0.51.7`, **exit 0**, self-healed the link |
| libpython dangling *and* lib dir unwritable (repair impossible) | `v0.51.7`, **exit 0** |
| link is a non-executable regular file | `v0.51.7`, **exit 0**, replanted |
| `bin/` read-only (cannot plant at all) | `v0.51.7`, **exit 0** |

No rung exits 126 or 134.

## Startup cost — the architect's estimate did not survive measurement

The +30–36 ms figure was for a *bare* interpreter. A real re-exec re-pays `cli.py`'s imports:

```
import time:  1000 | 221253 | local_operator.cli      (-X importtime; pydantic/yaml dominate)
lop --version:  223 ms  ->  410 ms ungated   (+186 ms, not +35 ms)
```

So the re-exec is **gated to long-lived subcommands** (`None`/TUI, `serve`, `mobile`, `exec`, `browser`). Short commands (`--version`, `sessions`, `send`, `config`) do not pay it, and detached children never re-exec at all — their parent spawns them with `executable=` set, so they are **born branded and pay nothing**.

```
--version with change   : 175.3 ms/run     (baseline; no re-exec)
--version guard-forced  : 202.5 ms/run
```

## Staleness — three triggers, all demonstrated firing and repairing

The hardlink pins an **inode**, not a version, and `uv tool install --force` *preserves* planted files in `bin/` without refreshing them. There is deliberately **no version-stamp file** — the inode is ground truth. Three `stat` calls per startup; writes only on a real trigger.

```
===== (a) link inode != interpreter inode (uv replaced the interpreter) =====
  before: link ino=816869553  real ino=393773417
  after : link ino=393773417  real ino=393773417        branded run: OK
===== (b) st_nlink < 2 (hardlink replaced by a copy) =====
  before: nlink=1   ->   after: nlink=2                 branded run: OK
===== (c) libpython symlink dangling (the 100%-abort mode) =====
  run with dangling symlink: Reason: tried: ... (no such file)
  after : target=.../lib/libpython3.12.dylib            branded run: OK
===== NO-OP CASE =====
  inode stable across ensure: YES
```

## Mutation evidence — every guard proven able to go red

| mutation | result |
|---|---|
| drop the libpython symlink plant | **2 failed** — `assert -6 == 0` (Abort trap), the exact production failure |
| plists revert to bare `sys.executable` | **1 failed** — `- .../Local Operator  + .../python` |
| delete staleness trigger (a) | **1 failed** (see below) |

Trigger (a)'s mutant initially **survived**: my stand-in file had `nlink == 1`, so trigger (b) was masking it. The test now uses a stand-in with `nlink >= 2` so only (a) can catch it, and the mutation is caught. This is recorded in the test's docstring.

## A real bug this change introduced, found and fixed

`cli.main()` is called **in-process** by the suite (`assert main() == 7`). An unguarded `os.execv` there does not rename the process — it **replaces the running pytest**:

```
tests/unit/test_cli_new.py ............................................. [ 45%]
............RC=0            <- stopped at 57%, exit 0, no summary line
```

42 of 98 tests never ran and every gate looked green. Fixed with `procname.is_own_launch()`, which re-execs only when `sys.orig_argv[1]` is a real launcher invocation (`lop`/`lo`/`local-operator`, or `-m local_operator[.cli]`). After the fix: **98 passed**, and the real `lop serve` still brands.

This hazard is now written into `AGENTS.md` ("A pytest run that STOPS EARLY with exit 0 is not a pass"), because it is the twin of the existing `rc=126`-swallowed-by-a-pipeline note.

## Four plists, not two

`ProgramArguments[0]`'s **basename** is what macOS BTM names a non-bundle login item by — not `Label`, not the plist filename, not `CFBundleName`. All four now render:

```
AFTER:   mobile / browser bridge / wakes / tunnel
         -> '.../bin/Local Operator'      BTM display name = 'Local Operator'
BEFORE:  every one
         -> '.../bin/python'              BTM display name = 'python'
```

Booted for real under launchd in an **isolated HOME**:

```
$ launchctl bootstrap gui/501 .../com.local-operator.pn-evidence.plist
	state = running
	program = /tmp/lop-procname/.venv/bin/Local Operator
	pid = 59520
59520 Local Operator   /tmp/.../Local Operator -m http.server 8123
```

`render_systemd()` is untouched — Linux names units via `Description=`.

## Other findings, verified rather than assumed

- **Framework builds cannot be branded and are refused.** Homebrew's `python@3.14` hardlinked + run reports `proc_name = b'Python'`: its `bin/python3.14` is a stub that re-execs an inner `Python.app` binary, so the kernel takes `p_comm` from *that* exec. Detected by path, because a venv on a framework Python reports an empty `PYTHONFRAMEWORK`.
- **Never `chmod` the planted link.** A hardlink shares its inode's mode bits with **the uv interpreter every venv on the machine resolves to**. A `chmod 000` during bring-up broke an unrelated worktree's console script with `bad interpreter: Permission denied`. Documented in the module; nothing in the code writes modes.
- **Killed plants leaked temp entries.** Reproduced with `kill -9` between `os.link` and `os.replace`. A bounded sweep removes only orphans whose pid is dead; a live pid's temp is preserved (both directions tested).
- **`resume_executable()` / `/reload` are unaffected.** CPython sets `sys.argv[0]` from the *script*, so a branded process carries the label only in `orig_argv[0]`. Verified: `sys.argv[0]` stayed the launcher path while `orig_argv[0]` was `'Local Operator [serve] port=1'`. Pinned by two tests, because a label reaching `os.execvpe` as a path fails with `FileNotFoundError` and would break every crash-restore.
- **Concurrency**: 12 simultaneous `ensure()` calls into one venv all converged on the same inode with the link healthy (plant is link-to-temp + atomic `os.replace`).
- **argv is a public channel.** The label vocabulary is fixed templates with machine-generated fields only. The brief's `[exec] task=<slug>` was changed to `job=<id>` (a prompt slug is user text), and the one field that can carry human text — `--agent` — is reduced to `[A-Za-z0-9._-]{,24}`: `'weird name; rm -rf /'` → `agent=weird-name--rm--rf--`.

## Quality gates

```
python -m flake8 .                          clean
uvx --from black==26.1.0 black --check .    1035 files unchanged
uvx isort==5.13.2 --check .                 clean
python -m pyright --pythonpath .venv/bin/python .   0 errors, 0 warnings
tests/unit/test_procname.py                 41 passed
tests/unit/test_cli_new.py                  98 passed  (was silently truncating at 57%)
```

Full `tests/unit` run in progress; this machine is at load average ~144 with 79 sibling worktrees, so it is taking well beyond its usual ~3.5 min. Result will be posted as a comment before this leaves draft.

## Not done deliberately

- No space-free twin link (`LocalOperator`). It was specified for a shebang consumer, and the shebang rewrite was rejected — a second unused inode is an extra staleness surface for nothing. Justified in a comment.
- No `wakes` supervisor behaviour change; that installer is still the documented stub, and only its `render_plist` head moved.
- Linux `prctl` is implemented and capability-probed, but this machine is macOS, so it is covered by unit tests rather than a live listing.

Release: patch — Local Operator processes are identifiable in Activity Monitor, and macOS names its background items "Local Operator" instead of "python3".
