### PR TITLE
feat(mcp): announce server RECOVERY to the model, not just failure

### DIFF
--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -1297,11 +1297,13 @@ def _child_mcp_wiring(parent_session: "Session", *, restricted: bool = False) ->
     ``set_on_tools_changed``: that is a single slot the parent already holds,
     so installing there would freeze the PARENT's inventory for the rest of the
     session. ``on_incident`` and ``on_recovery`` are the same shape and carry
-    the same prohibition \u2014 a child installing either would silently REPLACE the
-    parent's sink, and the parent would stop hearing about MCP failures and
-    recoveries for the rest of the session. This is already correct because
-    ``attach_mcp_dispose`` (which installs both) is never called for a child;
-    do not add them here. The cost is that a reconnect during the child's run leaves the
+    the same prohibition — a child installing either would silently REPLACE
+    the parent's sink, and the parent would stop hearing about MCP failures
+    and recoveries for the rest of the session. This is already correct
+    because ``attach_mcp_dispose`` (which installs both) is never called for a
+    child; do not add them here.
+
+    The cost is that a reconnect during the child's run leaves the
     child holding stale ``AgentTool`` objects, which is harmless — their
     execute closes over the manager plus the (server, tool) pair, so calls
     still route and still reconnect (``manager._execute_tool_call``); only a schema

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -1296,7 +1296,12 @@ def _child_mcp_wiring(parent_session: "Session", *, restricted: bool = False) ->
     would break the parent. And the child does NOT call
     ``set_on_tools_changed``: that is a single slot the parent already holds,
     so installing there would freeze the PARENT's inventory for the rest of the
-    session. The cost is that a reconnect during the child's run leaves the
+    session. ``on_incident`` and ``on_recovery`` are the same shape and carry
+    the same prohibition \u2014 a child installing either would silently REPLACE the
+    parent's sink, and the parent would stop hearing about MCP failures and
+    recoveries for the rest of the session. This is already correct because
+    ``attach_mcp_dispose`` (which installs both) is never called for a child;
+    do not add them here. The cost is that a reconnect during the child's run leaves the
     child holding stale ``AgentTool`` objects, which is harmless — their
     execute closes over the manager plus the (server, tool) pair, so calls
     still route and still reconnect (``manager._execute_tool_call``); only a schema

--- a/local_operator/incidents.py
+++ b/local_operator/incidents.py
@@ -15,6 +15,13 @@ session replays it). Classification is deliberately conservative: plain
 substring rules over the error text, ordered most-specific first, because
 the texts come from every provider's error envelope and no taxonomy covers
 them all. Unknown is a valid answer — the raw text always rides along.
+
+It also carries the formatters for the other model-visible session records
+that are NOT classified failures — a credential change, a model switch, and
+an MCP recovery. Each has its own custom type and its own formatter for the
+same reason: running them through :func:`classify_incident` would attach a
+failure category and a "this is why the previous turn ended" tail to a
+message that is not about a failure at all.
 """
 
 from __future__ import annotations
@@ -50,6 +57,28 @@ SESSION_CREDENTIAL_MESSAGE_TYPE = "session_credential"
 #: static "Model:" line in the system prompt. Persisted, so a resumed session
 #: replays the switch history too.
 SESSION_MODEL_SWITCH_MESSAGE_TYPE = "session_model_switch"
+
+#: Custom-message type journaled by the session when an MCP server that was
+#: ANNOUNCED BROKEN to the model connects again. The failure half of that pair
+#: has always been model-visible (``McpManager.on_incident`` ->
+#: ``Session._on_mcp_incident`` -> a ``session_incident`` message); the recovery
+#: half was not, so an operator who ran ``/mcp login <server>`` mid-session left
+#: the model holding a death notice — and its ``mcp`` hint, "its tools are gone
+#: ... Do not call its tools" — for a server that had been usable for the rest
+#: of the session. Observed live against ``minerva-qa``.
+#:
+#: It is a DEDICATED type rather than another ``session_incident`` because
+#: ``journal_incident`` runs :func:`classify_incident`, whose ``mcp`` rule
+#: matches the substring "mcp" and would append ``_HINTS["mcp"]`` — precisely
+#: the "its tools are gone" sentence — to a message saying the opposite.
+#:
+#: LIVE CONTEXT ONLY, deliberately not persisted: an MCP connection is
+#: process-scoped (``McpManager._connections`` is instance state and
+#: ``disconnect_all`` runs on dispose), so a replayed "its N tools are
+#: available to you now" would assert a live capability a restarted session may
+#: not have — the same class as the credential record above, and the more
+#: likely case for exactly the servers this serves, whose grants expire.
+SESSION_MCP_RECOVERY_MESSAGE_TYPE = "session_mcp_recovery"
 
 #: Provider wordings that mean "this request does not fit", in every phrasing
 #: the vendors actually use (anthropic's "prompt is too long", google's token
@@ -283,6 +312,51 @@ def format_credential_message(
         f"variable ${key} into every bash command — use it there (a child "
         "process reads it), never echo, print, or write it. It is not "
         "readable through read_variable."
+    )
+
+
+def format_mcp_recovery_message(server: str, tool_count: int) -> str:
+    """Render the MCP-recovery text injected into the model's context.
+
+    The counterpart to the ``mcp`` incident category, and the reason it is a
+    dedicated formatter rather than another :func:`classify_incident` category:
+    the classifier matches the substring "mcp" and would append
+    ``_HINTS["mcp"]`` — "its tools are gone until it reconnects. Do not call
+    its tools in a tight loop" — plus ``Incident.render``'s "This is why the
+    previous turn ended", to a message announcing the exact opposite.
+
+    Present-tense STATE, like :func:`format_model_switch_message`, so the model
+    treats it as context for the turns that follow rather than an instruction
+    to acknowledge.
+
+    The SUPERSEDE sentence is load-bearing and must not be trimmed to a bare
+    "reconnected": the model is holding an earlier ``session_incident`` for
+    this server whose hint explicitly says "do not call its tools", and two
+    live claims leave it free to defer to the older, more emphatic one. It must
+    be told the earlier notice no longer applies.
+
+    ``tool_count`` is the REGISTERED tool count
+    (``len(McpManager.get_server_tools(server))``), not ``len(conn.tools)``:
+    ``_register_tools`` filters by ``enabledTools``/``disabledTools``, so the
+    raw list overstates what the model can actually call.
+    """
+    # Verb agreement is spelled out rather than templated: the design's draft
+    # formatter read "1 tool are available again", which is text the model
+    # actually reads. Zero registered tools still recovers honestly — the
+    # server may be connected with every tool filtered out by
+    # ``disabledTools`` — so it falls back to the count-free phrasing rather
+    # than claiming "0 tools".
+    if not tool_count:
+        tools = "its tools are available again"
+    elif tool_count == 1:
+        tools = "1 tool is available again"
+    else:
+        tools = f"{tool_count} tools are available again"
+    return (
+        f"[mcp recovery] MCP server '{server}' is connected again and {tools}. "
+        "This supersedes the earlier session incident about this server: its "
+        "tools are usable now, so call them normally and stop reporting it as "
+        "unavailable."
     )
 
 

--- a/local_operator/incidents.py
+++ b/local_operator/incidents.py
@@ -339,24 +339,37 @@ def format_mcp_recovery_message(server: str, tool_count: int) -> str:
     (``len(McpManager.get_server_tools(server))``), not ``len(conn.tools)``:
     ``_register_tools`` filters by ``enabledTools``/``disabledTools``, so the
     raw list overstates what the model can actually call.
+
+    ZERO registered tools takes a different sentence, not a count-free variant
+    of the same one (review round 1, R2). It is a real state — a server can be
+    connected with every tool filtered out by ``disabledTools`` — and telling
+    the model its tools "are usable now, so call them normally" against an
+    empty inventory is false in the one direction that costs a wasted turn:
+    the model goes looking for tools that are not there. The connection is
+    still worth announcing, because it is what supersedes the incident and
+    stops the model reporting the server as down.
     """
+    if not tool_count:
+        # Honest about the CONNECTION and silent about callable tools: no
+        # "available again", no "call them normally". The supersede clause is
+        # still required — the model is holding an incident that says the
+        # server is unreachable, which is no longer true.
+        return (
+            f"[mcp recovery] MCP server '{server}' is connected again, but it "
+            "currently exposes no enabled tools. This supersedes the earlier "
+            "session incident about this server: the server itself is no "
+            "longer failing, so stop reporting it as unavailable — but do not "
+            "expect callable tools from it until some are enabled."
+        )
     # Verb agreement is spelled out rather than templated: the design's draft
     # formatter read "1 tool are available again", which is text the model
-    # actually reads. Zero registered tools still recovers honestly — the
-    # server may be connected with every tool filtered out by
-    # ``disabledTools`` — so it falls back to the count-free phrasing rather
-    # than claiming "0 tools".
-    if not tool_count:
-        tools = "its tools are available again"
-    elif tool_count == 1:
-        tools = "1 tool is available again"
-    else:
-        tools = f"{tool_count} tools are available again"
+    # actually reads.
+    tools = "1 tool is" if tool_count == 1 else f"{tool_count} tools are"
     return (
-        f"[mcp recovery] MCP server '{server}' is connected again and {tools}. "
-        "This supersedes the earlier session incident about this server: its "
-        "tools are usable now, so call them normally and stop reporting it as "
-        "unavailable."
+        f"[mcp recovery] MCP server '{server}' is connected again and {tools} "
+        "available again. This supersedes the earlier session incident about "
+        "this server: its tools are usable now, so call them normally and stop "
+        "reporting it as unavailable."
     )
 
 

--- a/local_operator/mcp/manager.py
+++ b/local_operator/mcp/manager.py
@@ -1092,6 +1092,14 @@ class McpManager:
         self._on_tools_changed: ToolsChangedCallback | None = None
         # Session-installed sink for model-visible MCP breaker incidents.
         self.on_incident: Callable[[str, str], None] | None = None
+        # Session-installed sink for the RECOVERY half of the same pair: fired
+        # from ``_register_connection`` when a server the model was told was
+        # broken becomes usable again. Installed beside ``on_incident`` in
+        # ``session_factory.attach_mcp_dispose``, so every host that gets the
+        # failure gets the recovery — the asymmetry (failure model-visible,
+        # recovery TUI-toast-only) is the bug it fixes. Signature:
+        # (server_name, registered_tool_count).
+        self.on_recovery: Callable[[str, int], None] | None = None
         # UI-installed sink fired when a server needs an OAuth login. The
         # startup toast only covers failures that land INSIDE the 250 ms gate;
         # HTTP OAuth servers connect AFTER it, so their auth failures (and
@@ -1125,6 +1133,23 @@ class McpManager:
         # a tool call keeps retrying does not re-raise the toast on every
         # attempt. Cleared per server when it connects again.
         self._auth_toasted: set[str] = set()
+        # Servers whose failure was ANNOUNCED TO THE MODEL via ``on_incident``,
+        # and which therefore owe the model a recovery notice when they connect
+        # again. Deliberately its own set rather than a reuse of the three
+        # neighbours, none of which mean what this means:
+        #   * ``_auth_toasted`` is a UI/TOAST latch — it is only written when
+        #     ``on_auth_required`` is installed, so on a headless host it stays
+        #     EMPTY while ``on_incident`` fired normally, suppressing the
+        #     recovery on exactly the hosts this feature exists to serve;
+        #   * ``_reconnect_suspended`` is both a superset (written before the
+        #     sink decision, and by ``_reconnect_for_call``, which fires no
+        #     incident) and a subset (cleared by a login that then FAILS);
+        #   * ``_startup_failures`` is populated by the startup gate, which
+        #     fires NO incident — announcing from it would "recover" failures
+        #     the model was never told about.
+        # Armed only inside the ``if sink is not None`` branches at the three
+        # ``on_incident`` sites; disarmed in ``_register_connection``.
+        self._incident_announced: set[str] = set()
         # Tool-name collision state keyed by stable origin key (MCP-09):
         # (server name, original tool name), never registration order.
         self._tool_meta: dict[str, McpToolMeta] = {}
@@ -1317,6 +1342,14 @@ class McpManager:
             self._reconnect_history.pop(name, None)
             self._reconnect_suspended.discard(name)
             self._backoff_index.pop(name, None)
+            # A server that left the config must not carry its arming across a
+            # re-add: the model's incident is about the OLD entry, and a
+            # re-added server connecting for the first time would otherwise
+            # emit a recovery for a failure that is no longer the same server.
+            # Note ``reload()`` deliberately does NOT clear this wholesale — a
+            # server still broken after a reload keeps its arming so its
+            # EVENTUAL recovery still announces.
+            self._incident_announced.discard(name)
             future = self._connect_futures.pop(name, None)
             _settle_future_error(
                 future, McpConnectionError(f"MCP server {name!r} removed from config")
@@ -2225,6 +2258,15 @@ class McpManager:
                             "MCP authorization failed; "
                             f"{self._auth_failure_text(name, auth_exc)}",
                         )
+                        # Arm the recovery notice. This line MUST stay INSIDE
+                        # the ``if sink is not None`` branch and after a
+                        # successful ``sink(...)``: the gate means "the MODEL
+                        # was told this server is broken", so a host with no
+                        # incident sink must never be armed. Hoisting it out
+                        # while "tidying" re-creates the defect that rules out
+                        # ``_auth_toasted`` as the gate — a recovery announced
+                        # for a failure that was never announced.
+                        self._incident_announced.add(name)
                     except Exception:  # noqa: BLE001 — incidents must never break the manager
                         logger.debug("mcp incident sink raised", exc_info=True)
                 # The startup toast has already been dismissed by the time an
@@ -2289,12 +2331,54 @@ class McpManager:
         self._auth_toasted.discard(conn.name)
         self._log_first_connect_security(conn)
         self._register_tools(conn.name, conn.tools)
+        self._fire_recovery(conn.name)
         future = self._connect_futures.pop(conn.name, None)
         if future is not None and not future.done():
             future.set_result(conn)
         watcher = asyncio.get_running_loop().create_task(self._watch_connection(conn.name, conn))
         self._watchers.add(watcher)
         watcher.add_done_callback(self._watchers.discard)
+
+    def _fire_recovery(self, name: str) -> None:
+        """Tell the model a server it was told was BROKEN is usable again.
+
+        The symmetric half of the ``on_incident`` sink. It lives here, in
+        ``_register_connection``, because that is the single choke point every
+        route to a usable server passes through — ``/mcp login``,
+        ``/mcp reauth``, ``reload()``, the backoff reconnect, the after-gate
+        continuation, and the call-site retry. Bolting it onto the TUI's login
+        worker would cover one of those six and leave every headless, exec and
+        server host permanently holding the death notice, which is the
+        asymmetry this fixes.
+
+        Gated on :attr:`_incident_announced`, so it fires ONLY for a server
+        whose failure the model actually heard about. Without that gate a
+        ``reload()`` — which tears down and re-registers EVERY connection —
+        would emit one "is connected again" per healthy server: a notice storm
+        about servers that never broke.
+
+        The membership test comes FIRST and before any tool lookup: this runs
+        on every connect on every host, and ``get_server_tools`` sorts a list,
+        so the overwhelmingly common healthy case must cost one hash lookup and
+        nothing else. The discard is unconditional on the armed path and
+        happens BEFORE the sink call, so a raising or absent sink cannot leave
+        the server armed to re-announce on every later reconnect.
+
+        Must be called AFTER ``_register_tools``: the count reported is the
+        REGISTERED one, which ``enabledTools``/``disabledTools`` filtering has
+        already reduced, not the raw ``conn.tools`` length the model could not
+        actually call.
+        """
+        if name not in self._incident_announced:
+            return
+        self._incident_announced.discard(name)
+        sink = getattr(self, "on_recovery", None)
+        if sink is None:
+            return
+        try:
+            sink(name, len(self.get_server_tools(name)))
+        except Exception:  # noqa: BLE001 — recoveries must never break the manager
+            logger.debug("mcp recovery sink raised", exc_info=True)
 
     def _log_first_connect_security(self, conn: ServerConnection) -> None:
         """WARNING surface for project-sourced stdio servers (MCP-12).
@@ -2678,6 +2762,13 @@ class McpManager:
                         f"attempts in {int(RECONNECT_BURST_WINDOW_S)}s; its tools are "
                         "unavailable until a reconnect succeeds",
                     )
+                    # Arm the recovery notice — INSIDE the ``if sink is not
+                    # None`` branch, deliberately. The gate records that the
+                    # MODEL heard about this failure; a host with no incident
+                    # sink heard nothing and must get no recovery. This is the
+                    # route the incident text itself promises a recovery for
+                    # ("unavailable until a reconnect succeeds").
+                    self._incident_announced.add(name)
                 except Exception:  # noqa: BLE001 — incidents must never break the manager
                     logger.debug("mcp incident sink raised", exc_info=True)
             self._abandon_reconnect(
@@ -2739,6 +2830,12 @@ class McpManager:
                         name,
                         f"MCP authorization failed; {self._auth_failure_text(name, exc)}",
                     )
+                    # Arm the recovery notice — INSIDE the ``if sink is not
+                    # None`` branch, deliberately: the gate means "the MODEL
+                    # was told", not "a failure happened". Moving it out arms
+                    # hosts that were never told, which is the defect that
+                    # rules out reusing ``_auth_toasted``.
+                    self._incident_announced.add(name)
                 except Exception:  # noqa: BLE001 — incidents must never break the manager
                     logger.debug("mcp incident sink raised", exc_info=True)
             # Mid-session expiry happens long after the startup toast, so raise a

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -2238,6 +2238,26 @@ class Session:
         #: drain, pipeline exit, prompt entry, dispose) in the manner of
         #: ``_pending_shell_records``.
         self._pending_context_journal: list[CustomMessage] = []
+        #: Serialises the ASYNC journal notices so they reach the live context in
+        #: the order their hooks fired, not in the order they happen to finish.
+        #:
+        #: The two MCP notices do different amounts of work before their live
+        #: append — ``journal_incident`` awaits a transcript write,
+        #: ``journal_mcp_recovery`` persists nothing — and both are launched
+        #: fire-and-forget through ``_spawn_background``. Without this lock the
+        #: recovery completes on its FIRST scheduling step and overtakes the
+        #: incident it exists to supersede, leaving the model reading "its tools
+        #: are gone ... Do not call its tools" as the last word on a server that
+        #: is working (review round 1, R1; measured inverted at 0-5 loop ticks).
+        #:
+        #: A LOCK rather than a delay because ordering must not depend on how
+        #: many awaits either method happens to contain: ``asyncio.Lock``
+        #: acquires FIFO and its uncontended path does not yield, so the task
+        #: spawned first takes it first and the second waits. Do not "simplify"
+        #: this away — no current route reaches the inversion (every real
+        #: incident-to-recovery path crosses a connect round trip), but a cached
+        #: or in-process connect path makes it live, and the failure is silent.
+        self._journal_lock = asyncio.Lock()
         # (new_label, transient) of the last model switch made model-visible, so
         # the two edges that can both fire for one change (``set_model`` and a
         # route-settled event) do not double-announce. See journal_model_switch.
@@ -6956,6 +6976,11 @@ class Session:
         classified (rate-limit / auth / provider / network / context / MCP),
         appended to the LIVE context so the very next turn sees it, and
         persisted so ``--resume`` replays it.
+
+        Holds ``_journal_lock`` across the persist-then-append pair so a
+        notice fired immediately after cannot overtake it: this method awaits a
+        transcript write and :meth:`journal_mcp_recovery` awaits nothing, so
+        without the lock the SECOND notice lands FIRST (review round 1, R1).
         """
         from local_operator.incidents import format_incident_message
 
@@ -6968,8 +6993,9 @@ class Session:
             details={"text": text, "raw": raw[:1000]},
         )
         try:
-            await self._transcript.append_message(message)
-            self._append_or_park_journal(message)
+            async with self._journal_lock:
+                await self._transcript.append_message(message)
+                self._append_or_park_journal(message)
         except OSError:
             logger.warning("could not journal session incident", exc_info=True)
 
@@ -7029,11 +7055,18 @@ class Session:
             },
         )
         try:
-            # Persist only when the record should survive a resume; a transient
-            # fallback is live-context-only (see _is_persistable_message).
-            if _is_persistable_message(message):
-                await self._transcript.append_message(message)
-            self._append_or_park_journal(message)
+            # Same ordering lock as the other async journal notices: this one
+            # persists CONDITIONALLY, so two switches (or a switch and an
+            # incident) fired together would otherwise reach the context in
+            # whichever order their awaits happened to settle rather than in
+            # fire order. See ``_journal_lock``.
+            async with self._journal_lock:
+                # Persist only when the record should survive a resume; a
+                # transient fallback is live-context-only (see
+                # _is_persistable_message).
+                if _is_persistable_message(message):
+                    await self._transcript.append_message(message)
+                self._append_or_park_journal(message)
         except OSError:
             logger.warning("could not journal model switch", exc_info=True)
 
@@ -7134,6 +7167,14 @@ class Session:
         ``assistant(tool_use) -> user -> tool_result`` and bricking the
         session. Delivery is therefore at the next tool boundary of the running
         turn — before the next model call, not the next user turn.
+
+        Takes ``_journal_lock`` even though it has nothing to await, and that
+        is the entire point: this method would otherwise finish on its first
+        scheduling step while the incident it supersedes is still awaiting its
+        transcript write, so a recovery fired straight after an incident
+        reached the model FIRST and left the death notice as the last word
+        (review round 1, R1). The lock makes the order a property of which hook
+        fired first, not of how many awaits each method contains.
         """
         from local_operator.incidents import format_mcp_recovery_message
 
@@ -7145,7 +7186,8 @@ class Session:
             attribution="system",
             details={"text": text, "server": server, "tool_count": tool_count},
         )
-        self._append_or_park_journal(message)
+        async with self._journal_lock:
+            self._append_or_park_journal(message)
 
     def _on_mcp_incident(self, server: str, reason: str) -> None:
         """MCP manager hook (breaker trips): journal without blocking the

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -129,6 +129,7 @@ from local_operator.imaging import rebound_oversize_image
 from local_operator.incidents import (
     SESSION_CREDENTIAL_MESSAGE_TYPE,
     SESSION_INCIDENT_MESSAGE_TYPE,
+    SESSION_MCP_RECOVERY_MESSAGE_TYPE,
     SESSION_MODEL_SWITCH_MESSAGE_TYPE,
 )
 from local_operator.session.goal import GoalState
@@ -653,6 +654,7 @@ def _default_convert_to_llm(messages: list[AgentMessage]) -> list[Message]:
             SESSION_INCIDENT_MESSAGE_TYPE,
             SESSION_MODEL_SWITCH_MESSAGE_TYPE,
             SESSION_CREDENTIAL_MESSAGE_TYPE,
+            SESSION_MCP_RECOVERY_MESSAGE_TYPE,
             "session_state",
         ):
             # An incident rides the sender's preformatted text (the classifier
@@ -666,6 +668,10 @@ def _default_convert_to_llm(messages: list[AgentMessage]) -> list[Message]:
             # ``/credential`` is ANNOUNCED to the model rather than only
             # changing the prompt tail, which the model has no reason to
             # re-read (the failure behind session 835fbcafdc27).
+            # An MCP-recovery record rides it for the symmetric reason: the
+            # FAILURE reaches the model as a ``session_incident`` user turn, so
+            # the recovery that supersedes it has to arrive on the same surface
+            # or the model keeps believing the older, more emphatic claim.
             out.append(
                 Message(
                     role="user",
@@ -800,6 +806,19 @@ _PERSISTABLE_CUSTOM_TYPES: frozenset[str] = frozenset(
         # discovery is served by the ``<session-credentials>`` prompt-tail
         # block, which is rebuilt from the live store every turn and so
         # correctly shows nothing after a restart.
+        #
+        # SESSION_MCP_RECOVERY_MESSAGE_TYPE is deliberately absent for the same
+        # reason — it is the second member of that class, not a second
+        # exception. "MCP server 'X' is connected again and N tools are
+        # available" asserts a PROCESS-SCOPED capability: ``_connections`` is
+        # manager instance state and ``disconnect_all`` runs on dispose, so a
+        # resumed session re-runs discovery from scratch. If it reconnects the
+        # replay is redundant (the tools are simply in the inventory, which is
+        # how every healthy server is communicated); if it does NOT — an
+        # expired grant, a moved binary, an offline machine, all likely for the
+        # servers this feature is about — the replay asserts tools that are not
+        # there. The live tool inventory and ``mcp://`` status tell the truth at
+        # resume time; the harness must not replay a claim it cannot re-verify.
     }
 )
 
@@ -7083,10 +7102,67 @@ class Session:
         # split (``_is_persistable_message``).
         self._append_or_park_journal(message)
 
+    async def journal_mcp_recovery(self, server: str, tool_count: int) -> None:
+        """Tell the MODEL an MCP server it was told was broken is usable again.
+
+        The symmetric counterpart to :meth:`journal_incident`'s ``mcp``
+        category. Without it, an operator who fixed a server mid-session —
+        ``/mcp login minerva-qa``, or simply waiting for the backoff reconnect
+        the incident text itself promises — left the model holding a death
+        notice, and its hint "its tools are gone ... Do not call its tools",
+        for the rest of the session. The tools were genuinely back
+        (``refresh_tools`` swaps the inventory mid-turn) but the model had been
+        told not to use them and had no reason to re-check.
+
+        LIVE CONTEXT ONLY, deliberately: there is no
+        ``_transcript.append_message`` here and the type is absent from
+        ``_PERSISTABLE_CUSTOM_TYPES``. The record asserts a process-scoped
+        capability, so replaying it into a resumed session that did not
+        reconnect would claim tools that are not in the inventory — the same
+        failure mode as a replayed credential announcement, and the likely one
+        for servers whose grants expire. The comment at
+        ``_PERSISTABLE_CUSTOM_TYPES`` carries the full argument.
+
+        Known and accepted consequence: the un-superseded INCIDENT does still
+        persist, so a resumed session replays "authorization failed" with no
+        recovery after it. That is today's behaviour, not a regression, and the
+        live tool inventory is the honest correction. Deleting the persisted
+        incident was rejected — the transcript is append-only by design.
+
+        Parked, never spliced: ``_append_or_park_journal`` is what keeps a
+        notice arriving mid-tool-batch from producing
+        ``assistant(tool_use) -> user -> tool_result`` and bricking the
+        session. Delivery is therefore at the next tool boundary of the running
+        turn — before the next model call, not the next user turn.
+        """
+        from local_operator.incidents import format_mcp_recovery_message
+
+        if self._disposed or not server:
+            return
+        text = format_mcp_recovery_message(server, tool_count)
+        message = CustomMessage(
+            custom_type=SESSION_MCP_RECOVERY_MESSAGE_TYPE,
+            attribution="system",
+            details={"text": text, "server": server, "tool_count": tool_count},
+        )
+        self._append_or_park_journal(message)
+
     def _on_mcp_incident(self, server: str, reason: str) -> None:
         """MCP manager hook (breaker trips): journal without blocking the
         manager's reconnect loop."""
         self._spawn_background(self.journal_incident(f"MCP server '{server}': {reason}"))
+
+    def _on_mcp_recovery(self, server: str, tool_count: int) -> None:
+        """MCP manager hook (a previously-announced server reconnected).
+
+        Mirrors :meth:`_on_mcp_incident` exactly: fire-and-forget on the
+        session's background machinery, because the manager calls this from
+        inside ``_register_connection`` on its own connect path and must not be
+        blocked or made to fail by the session. ``_spawn_background`` is a
+        no-op that closes the coroutine after dispose, so a reconnect racing
+        teardown neither raises nor warns about an un-awaited coroutine.
+        """
+        self._spawn_background(self.journal_mcp_recovery(server, tool_count))
 
     async def _on_job_completed(self, job_id: str, text: str, job: Any) -> None:
         """Auto-deliver one settled model-owned job back into the conversation.

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -2167,6 +2167,15 @@ def attach_mcp_dispose(session: Session, manager: McpManager) -> None:
     # Breaker incidents become session incidents: the model learns a server's
     # tools are gone instead of hammering them (MCP-07's observable half).
     manager.on_incident = session._on_mcp_incident
+    # ...and the RECOVERY half, installed here rather than in the TUI for the
+    # same reason the failure is: this is the composition root every host goes
+    # through, so a CLI, headless, exec or server session gets the notice too.
+    # A recovery bolted onto the TUI's ``/mcp login`` worker would cover one of
+    # the six routes back to a usable server and leave every other host holding
+    # a death notice for a server that came back \u2014 the asymmetry itself was
+    # the bug. Subagents deliberately do NOT reach this function (they BORROW
+    # the parent's manager), so a child never overwrites the parent's sink.
+    manager.on_recovery = session._on_mcp_recovery
 
 
 def _cancel_task(task: "asyncio.Task[Any]") -> Callable[[], Awaitable[None] | None]:

--- a/tests/unit/mcp/test_manager.py
+++ b/tests/unit/mcp/test_manager.py
@@ -2854,6 +2854,13 @@ class TestMcpRecoveryNotice:
         behind it, so there is no sink to fire. The connect must still succeed,
         and the server must still be disarmed so a later session-backed manager
         does not inherit a phantom arming.
+
+        Asserted through the SINK rather than through ``_incident_announced``
+        (review round 1, R4), which is what the rest of this class does: a sink
+        installed AFTER the sinkless reconnect must hear nothing, because that
+        reconnect already consumed the arming. It is the discard's placement
+        — unconditional, and ahead of the ``sink is None`` return — that makes
+        that true, so this fails if the discard is ever moved below the return.
         """
         manager = McpManager(str(project))
         manager.on_incident = lambda server, reason: None
@@ -2865,9 +2872,16 @@ class TestMcpRecoveryNotice:
         monkeypatch.setattr(manager, "_connect_server", good_connect)
         await manager.discover_and_connect()
         await self._trip_breaker(manager, "fast", monkeypatch)
-        assert "fast" in manager._incident_announced
 
+        # The sinkless reconnect: it must succeed rather than trip over the
+        # missing sink.
         monkeypatch.setattr(manager, "_connect_server", good_connect)
         assert await manager.reconnect_server("fast") is not None
-        assert "fast" not in manager._incident_announced
+
+        # Now a session-backed manager's sink arrives. The arming was consumed
+        # by the reconnect above, so this must stay silent.
+        recoveries: list[tuple[str, int]] = []
+        manager.on_recovery = lambda server, count: recoveries.append((server, count))
+        assert await manager.reconnect_server("fast") is not None
+        assert recoveries == [], "a sinkless connect left the server armed to re-announce"
         await manager.disconnect_all()

--- a/tests/unit/mcp/test_manager.py
+++ b/tests/unit/mcp/test_manager.py
@@ -2454,3 +2454,420 @@ class TestTheManagerDerivesTheAuthRemedy:
         assert manager.auth_recovery_hint(error) is None
         hint = mcp_auth_recovery_hint(error, None)
         assert hint is not None and "`/mcp`" in hint
+
+
+class TestMcpRecoveryNotice:
+    """The RECOVERY half of the model-visible MCP incident pair.
+
+    The failure half has always reached the model (``on_incident`` ->
+    ``Session._on_mcp_incident`` -> a ``session_incident`` message). The
+    recovery half did not, so an operator who ran ``/mcp login <server>``
+    mid-session left the model holding a death notice — and its "do not call
+    its tools" hint — for a server that had been usable for the rest of the
+    session. Observed live against ``minerva-qa``.
+
+    Two properties are load-bearing and each has its own tests below:
+
+    * a recovery fires ONLY for a server whose failure the MODEL was told
+      about, which is why the gate is armed inside the ``if sink is not None``
+      branches at the three ``on_incident`` sites and not derived from
+      ``_auth_toasted`` / ``_reconnect_suspended`` / ``_startup_failures``; and
+    * ``reload()`` re-registers EVERY connection, so an ungated notice would
+      be a storm of "is connected again" about servers that never broke.
+    """
+
+    @staticmethod
+    def _sinks(manager: McpManager) -> tuple[list[tuple[str, str]], list[tuple[str, int]]]:
+        """Install both sinks and return their recording lists."""
+        incidents: list[tuple[str, str]] = []
+        recoveries: list[tuple[str, int]] = []
+        manager.on_incident = lambda server, reason: incidents.append((server, reason))
+        manager.on_recovery = lambda server, count: recoveries.append((server, count))
+        return incidents, recoveries
+
+    @staticmethod
+    async def _trip_breaker(
+        manager: McpManager, name: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Drive ``name``'s reconnect chain until the breaker trips.
+
+        Mirrors ``TestCircuitBreaker``: backoff sleeps are made instant so the
+        five attempts inside the 30 s window happen in a few loop turns.
+        """
+        real_sleep = asyncio.sleep
+
+        async def instant_sleep(delay: float) -> None:
+            return None
+
+        monkeypatch.setattr(asyncio, "sleep", instant_sleep)
+
+        async def failing_connect(server: str, cfg: Any) -> ServerConnection:
+            raise RuntimeError("still down")
+
+        monkeypatch.setattr(manager, "_connect_server", failing_connect)
+        manager._schedule_reconnect(name)
+        for _ in range(60):
+            await real_sleep(0)
+            if manager.reconnect_suspended(name):
+                break
+        assert manager.reconnect_suspended(name) is True
+
+    @pytest.mark.asyncio
+    async def test_breaker_incident_then_reconnect_fires_recovery(
+        self, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Route 4: the reconnect the incident text itself promises.
+
+        The breaker incident says the tools are "unavailable until a reconnect
+        succeeds"; when one does, the model must be told so.
+        """
+        manager = McpManager(str(project))
+        incidents, recoveries = self._sinks(manager)
+
+        async def good_connect(name: str, cfg: Any) -> ServerConnection:
+            return _make_conn(name, cfg)
+
+        monkeypatch.setattr(manager, "_connect_server", good_connect)
+        await manager.discover_and_connect()
+        assert recoveries == []  # a healthy boot announces nothing
+
+        await self._trip_breaker(manager, "fast", monkeypatch)
+        assert [server for server, _ in incidents] == ["fast"]
+
+        monkeypatch.setattr(manager, "_connect_server", good_connect)
+        conn = await manager.reconnect_server("fast")
+        assert conn is not None
+        assert recoveries == [("fast", len(manager.get_server_tools("fast")))]
+        assert recoveries[0][1] == 1
+        await manager.disconnect_all()
+
+    @pytest.mark.asyncio
+    async def test_after_gate_auth_failure_then_login_fires_recovery(
+        self, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The operator's exact scenario, end to end.
+
+        An HTTP server's grant expires, its connect misses the 250 ms startup
+        gate and fails with ``McpAuthRequiredError`` (the after-gate
+        continuation fires the incident), then ``/mcp login`` reconnects it via
+        ``connect_configured_server``. Exactly one recovery, naming the server.
+        """
+        from local_operator.mcp.auth import McpAuthRequiredError
+
+        manager = McpManager(str(project))
+        incidents, recoveries = self._sinks(manager)
+        gate_passed = asyncio.Event()
+
+        # ``interactive`` is accepted because ``connect_configured_server``
+        # (the /mcp login path) passes it; the other routes do not.
+        async def slow_auth_failure(name: str, cfg: Any, **_kw: Any) -> ServerConnection:
+            if name == "fast":
+                return _make_conn(name, cfg)
+            # Miss the gate, then fail with the auth error, so the failure runs
+            # through _finish_pending's continuation rather than the gate arm.
+            await gate_passed.wait()
+            raise McpAuthRequiredError("https://srv.example/mcp")
+
+        monkeypatch.setattr(manager, "_connect_server", slow_auth_failure)
+        result = await manager.discover_and_connect()
+        assert "slow" not in result.errors  # still in flight at the gate
+        gate_passed.set()
+        for _ in range(100):
+            await asyncio.sleep(0)
+            if incidents:
+                break
+        assert [server for server, _ in incidents] == ["slow"]
+        assert "authorization failed" in incidents[0][1]
+        assert recoveries == []
+
+        async def good_connect(name: str, cfg: Any, **_kw: Any) -> ServerConnection:
+            return _make_conn(name, cfg)
+
+        monkeypatch.setattr(manager, "_connect_server", good_connect)
+        conn = await manager.connect_configured_server("slow")
+        assert conn is not None
+        assert recoveries == [("slow", 1)]
+        await manager.disconnect_all()
+
+    @pytest.mark.asyncio
+    async def test_recovery_reports_registered_not_raw_tool_count(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The count must survive ``enabledTools``/``disabledTools`` filtering.
+
+        ``_register_tools`` drops filtered tools, so ``len(conn.tools)`` — what
+        the TUI's own login receipt prints — overstates what the model can
+        actually call. The notice must not promise tools that are not in the
+        inventory.
+        """
+        (tmp_path / ".local-operator").mkdir()
+        (tmp_path / ".local-operator" / "mcp.json").write_text(
+            '{"mcpServers": {"fast": {"type": "stdio", "command": "fast-cmd",'
+            ' "disabledTools": ["hidden"]}}}',
+            encoding="utf-8",
+        )
+        manager = McpManager(str(tmp_path))
+        _incidents, recoveries = self._sinks(manager)
+
+        async def good_connect(name: str, cfg: Any) -> ServerConnection:
+            conn = _make_conn(name, cfg)
+            conn.tools = [_tool("search"), _tool("hidden")]
+            return conn
+
+        monkeypatch.setattr(manager, "_connect_server", good_connect)
+        await manager.discover_and_connect()
+        conn = manager.get_connection("fast")
+        assert conn is not None and len(conn.tools) == 2
+        assert len(manager.get_server_tools("fast")) == 1
+
+        await self._trip_breaker(manager, "fast", monkeypatch)
+        monkeypatch.setattr(manager, "_connect_server", good_connect)
+        assert await manager.reconnect_server("fast") is not None
+        # 1 (registered), NOT 2 (raw): the filtered tool is not callable.
+        assert recoveries == [("fast", 1)]
+        await manager.disconnect_all()
+
+    @pytest.mark.asyncio
+    async def test_recovery_sink_raising_does_not_break_connect(
+        self, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A raising sink is contained AND disarms the server.
+
+        The disarm happens before the call precisely so a broken session sink
+        cannot leave a server re-announcing on every later reconnect.
+        """
+        manager = McpManager(str(project))
+        calls: list[str] = []
+
+        def exploding(server: str, count: int) -> None:
+            calls.append(server)
+            raise RuntimeError("sink exploded")
+
+        manager.on_incident = lambda server, reason: None
+        manager.on_recovery = exploding
+
+        async def good_connect(name: str, cfg: Any) -> ServerConnection:
+            return _make_conn(name, cfg)
+
+        monkeypatch.setattr(manager, "_connect_server", good_connect)
+        await manager.discover_and_connect()
+        await self._trip_breaker(manager, "fast", monkeypatch)
+        monkeypatch.setattr(manager, "_connect_server", good_connect)
+
+        conn = await manager.reconnect_server("fast")
+        assert conn is not None  # the connection still registered
+        assert manager.get_connection("fast") is not None
+        assert calls == ["fast"]
+
+        # Disarmed: a second clean reconnect says nothing more.
+        assert await manager.reconnect_server("fast") is not None
+        assert calls == ["fast"]
+        await manager.disconnect_all()
+
+    @pytest.mark.asyncio
+    async def test_no_recovery_for_a_server_that_never_failed(
+        self, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The core negative: healthy servers are never announced."""
+        manager = McpManager(str(project))
+        _incidents, recoveries = self._sinks(manager)
+
+        async def good_connect(name: str, cfg: Any) -> ServerConnection:
+            return _make_conn(name, cfg)
+
+        monkeypatch.setattr(manager, "_connect_server", good_connect)
+        await manager.discover_and_connect()
+        assert recoveries == []
+        await manager.disconnect_all()
+
+    @pytest.mark.asyncio
+    async def test_reload_emits_no_recovery_storm(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """THE storm test. ``reload()`` re-registers every connection.
+
+        Every server passes through ``_register_connection`` on a reload, so an
+        ungated notice would tell the model that three servers which never
+        broke are "connected again". This is the case the gate exists for.
+        """
+        (tmp_path / ".local-operator").mkdir()
+        (tmp_path / ".local-operator" / "mcp.json").write_text(
+            '{"mcpServers": {"a": {"type": "stdio", "command": "a-cmd"},'
+            ' "b": {"type": "stdio", "command": "b-cmd"},'
+            ' "c": {"type": "stdio", "command": "c-cmd"}}}',
+            encoding="utf-8",
+        )
+        manager = McpManager(str(tmp_path))
+        _incidents, recoveries = self._sinks(manager)
+
+        async def good_connect(name: str, cfg: Any) -> ServerConnection:
+            return _make_conn(name, cfg)
+
+        monkeypatch.setattr(manager, "_connect_server", good_connect)
+        await manager.discover_and_connect()
+        assert len(manager.get_tools()) == 3
+
+        await manager.reload()
+        assert len(manager.get_tools()) == 3  # all three genuinely re-registered
+        assert recoveries == []
+        await manager.disconnect_all()
+
+    @pytest.mark.asyncio
+    async def test_reload_with_one_armed_server_emits_exactly_one(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The other side of the storm test: the armed server is not lost.
+
+        Gating must not be so broad that a genuine recovery is swallowed when
+        it arrives through a reload rather than a login.
+        """
+        (tmp_path / ".local-operator").mkdir()
+        (tmp_path / ".local-operator" / "mcp.json").write_text(
+            '{"mcpServers": {"a": {"type": "stdio", "command": "a-cmd"},'
+            ' "b": {"type": "stdio", "command": "b-cmd"},'
+            ' "c": {"type": "stdio", "command": "c-cmd"}}}',
+            encoding="utf-8",
+        )
+        manager = McpManager(str(tmp_path))
+        _incidents, recoveries = self._sinks(manager)
+
+        async def good_connect(name: str, cfg: Any) -> ServerConnection:
+            return _make_conn(name, cfg)
+
+        monkeypatch.setattr(manager, "_connect_server", good_connect)
+        await manager.discover_and_connect()
+        await self._trip_breaker(manager, "b", monkeypatch)
+        monkeypatch.setattr(manager, "_connect_server", good_connect)
+
+        await manager.reload()
+        assert recoveries == [("b", 1)]
+        await manager.disconnect_all()
+
+    @pytest.mark.asyncio
+    async def test_startup_gate_failure_then_connect_emits_no_recovery(
+        self, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A boot failure fires no incident, so it earns no recovery.
+
+        This pins the §2 decision to arm from the SINK rather than from
+        ``_startup_failures``: the gate arm records the failure for the boot
+        report but never tells the model, so announcing a recovery from it
+        would "supersede" an incident the model never received.
+        """
+        manager = McpManager(str(project))
+        incidents, recoveries = self._sinks(manager)
+        attempt = {"n": 0}
+
+        # ``**_kw`` absorbs ``interactive``, which the /mcp login route passes.
+        async def fail_then_succeed(name: str, cfg: Any, **_kw: Any) -> ServerConnection:
+            if name == "fast" and attempt["n"] == 0:
+                attempt["n"] += 1
+                raise RuntimeError("boot failure")
+            return _make_conn(name, cfg)
+
+        monkeypatch.setattr(manager, "_connect_server", fail_then_succeed)
+        result = await manager.discover_and_connect()
+        assert "fast" in result.errors
+        assert incidents == []  # the gate arm fires no incident — the premise
+
+        conn = await manager.connect_configured_server("fast")
+        assert conn is not None
+        assert recoveries == []
+        await manager.disconnect_all()
+
+    @pytest.mark.asyncio
+    async def test_recovery_fires_once_per_failure_not_per_reconnect(
+        self, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One notice per announced failure, not one per connect.
+
+        A server that keeps reconnecting cleanly (a ``/mcp reload`` habit, a
+        transport that re-establishes) must not re-announce: the model was
+        told once and corrected once.
+        """
+        manager = McpManager(str(project))
+        _incidents, recoveries = self._sinks(manager)
+
+        async def good_connect(name: str, cfg: Any) -> ServerConnection:
+            return _make_conn(name, cfg)
+
+        monkeypatch.setattr(manager, "_connect_server", good_connect)
+        await manager.discover_and_connect()
+        await self._trip_breaker(manager, "fast", monkeypatch)
+        monkeypatch.setattr(manager, "_connect_server", good_connect)
+
+        assert await manager.reconnect_server("fast") is not None
+        assert recoveries == [("fast", 1)]
+        for _ in range(3):
+            assert await manager.reconnect_server("fast") is not None
+        assert recoveries == [("fast", 1)]
+        await manager.disconnect_all()
+
+    @pytest.mark.asyncio
+    async def test_removed_server_does_not_inherit_stale_arming(
+        self, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A re-added server starts clean.
+
+        ``_drop_removed_servers`` clears the arming with the rest of the
+        per-server state; otherwise a config edit that removes and re-adds a
+        server would announce a recovery for an incident about the old entry.
+        """
+        manager = McpManager(str(project))
+        _incidents, recoveries = self._sinks(manager)
+
+        async def good_connect(name: str, cfg: Any) -> ServerConnection:
+            return _make_conn(name, cfg)
+
+        monkeypatch.setattr(manager, "_connect_server", good_connect)
+        await manager.discover_and_connect()
+        await self._trip_breaker(manager, "fast", monkeypatch)
+        monkeypatch.setattr(manager, "_connect_server", good_connect)
+
+        # Remove 'fast' from the config and reload: the arming goes with it.
+        (project / ".local-operator" / "mcp.json").write_text(
+            '{"mcpServers": {"slow": {"type": "stdio", "command": "slow-cmd"}}}',
+            encoding="utf-8",
+        )
+        await manager.reload()
+        assert recoveries == []
+        assert manager.get_connection("fast") is None
+
+        # Re-add it and connect: a first connection, not a recovery.
+        (project / ".local-operator" / "mcp.json").write_text(
+            '{"mcpServers": {"fast": {"type": "stdio", "command": "fast-cmd"},'
+            ' "slow": {"type": "stdio", "command": "slow-cmd"}}}',
+            encoding="utf-8",
+        )
+        await manager.reload()
+        assert manager.get_connection("fast") is not None
+        assert recoveries == []
+        await manager.disconnect_all()
+
+    @pytest.mark.asyncio
+    async def test_no_recovery_sink_installed_is_a_no_op(
+        self, project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The CLI shape: ``on_recovery is None`` and nothing breaks.
+
+        ``local-operator mcp login`` builds a throwaway manager with no session
+        behind it, so there is no sink to fire. The connect must still succeed,
+        and the server must still be disarmed so a later session-backed manager
+        does not inherit a phantom arming.
+        """
+        manager = McpManager(str(project))
+        manager.on_incident = lambda server, reason: None
+        assert manager.on_recovery is None
+
+        async def good_connect(name: str, cfg: Any) -> ServerConnection:
+            return _make_conn(name, cfg)
+
+        monkeypatch.setattr(manager, "_connect_server", good_connect)
+        await manager.discover_and_connect()
+        await self._trip_breaker(manager, "fast", monkeypatch)
+        assert "fast" in manager._incident_announced
+
+        monkeypatch.setattr(manager, "_connect_server", good_connect)
+        assert await manager.reconnect_server("fast") is not None
+        assert "fast" not in manager._incident_announced
+        await manager.disconnect_all()

--- a/tests/unit/session/test_background_journal_splice.py
+++ b/tests/unit/session/test_background_journal_splice.py
@@ -741,3 +741,69 @@ async def test_resume_replays_a_clean_history_in_write_order(tmp_path):
         )
     )["messages"]
     assert _dangling_tool_use(body) == [], "a resumed session replays an illegal body"
+
+
+@pytest.mark.asyncio
+async def test_mcp_recovery_is_parked_the_same_way(tmp_path):
+    """The third door: ``journal_mcp_recovery`` shares the guard.
+
+    This is the brick-prevention guard for the recovery notice. The recovery
+    fires from ``McpManager._register_connection``, which runs on the manager's
+    own connect path — a backoff reconnect landing mid-tool-batch is the
+    ordinary case, not a corner one, because the reconnect timer has no idea a
+    turn is in flight. Splicing it in there would produce
+    ``assistant(tool_use) -> user -> tool_result`` and brick the session for
+    good, exactly as the ``/model`` press did in session 5187e748833c.
+
+    Driven through ``_on_mcp_recovery`` so the real manager-facing trigger is
+    covered, not just the journal method. The notice must land AFTER both tool
+    results, and the follow-up request must carry no dangling ``tool_use``.
+    """
+    holder: dict[str, Session] = {}
+    stream = _tool_then_text()
+
+    async def execute(tool_call_id, args, signal, on_update, context):
+        session = holder["session"]
+        # Only the FIRST call of the batch recovers, for the same reason as the
+        # incident test: the expected shape must depend on the guard, not on
+        # how many tools happened to be in the batch.
+        if tool_call_id == "toolu_A":
+            session._on_mcp_recovery("files", 3)
+            await _drain_background(session)
+        return ToolResult(
+            tool_call_id=tool_call_id, tool_name="echo", content=[TextContent(text="ok")]
+        )
+
+    tool = AgentTool(name="echo", parameters={"type": "object"}, execute=execute)
+    session = make_session(tmp_path, stream, tools=[tool], model=MODEL)
+    holder["session"] = session
+    try:
+        await session.prompt("go")
+    finally:
+        await session.dispose()
+
+    assert _roles(session) == [
+        "user",
+        "assistant",
+        "tool",
+        "tool",
+        "custom:session_mcp_recovery",
+        "assistant",
+    ], f"unexpected live shape: {_roles(session)}"
+    assert len(stream.requests) >= 2
+    wire = _wire_messages(stream.requests[1])
+    assert (
+        _dangling_tool_use(wire) == []
+    ), "journal_mcp_recovery spliced its notice into the open batch, orphaning it"
+    # The notice reaches the model as a user turn carrying the supersede
+    # sentence — the whole point of the feature, verified on the wire and not
+    # merely in the live list.
+    texts = [
+        block.get("text", "")
+        for message in wire
+        for block in message["content"]
+        if isinstance(block, dict) and block.get("type") == "text"
+    ]
+    assert any(
+        "[mcp recovery]" in text and "supersedes" in text for text in texts
+    ), f"the recovery never reached the provider as readable text: {texts}"

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -4757,3 +4757,58 @@ async def test_recovery_after_dispose_is_a_no_op(tmp_path):
         for m in session._context.messages
         if isinstance(m, CustomMessage) and m.custom_type == "session_mcp_recovery"
     ]
+
+
+async def _drain_journal_tasks(session: Session) -> None:
+    """Run every ``_spawn_background`` task to completion, oldest first.
+
+    Bounded and looped because a drained task can spawn another; a
+    self-respawning task fails the test instead of hanging it. Draining rather
+    than sleeping is what keeps the ordering assertion below a statement about
+    the code and not about the scheduler.
+    """
+    for _ in range(10):
+        pending = [task for task in list(session._background_tasks) if not task.done()]
+        if not pending:
+            return
+        await asyncio.gather(*pending, return_exceptions=True)
+    raise AssertionError("background journal tasks never settled")
+
+
+@pytest.mark.asyncio
+async def test_incident_then_recovery_reaches_the_context_in_that_order(tmp_path):
+    """A recovery must never overtake the incident it exists to supersede.
+
+    Both hooks are fire-and-forget through ``_spawn_background``, and they do
+    different amounts of work: ``journal_incident`` awaits a transcript write
+    before its live append, ``journal_mcp_recovery`` persists nothing. Without
+    the shared ``_journal_lock`` the recovery therefore finishes on its FIRST
+    scheduling step and lands ahead of the incident, leaving the model reading
+    "its tools are gone ... Do not call its tools" as the LAST word on the
+    server — precisely the state this notice exists to clear, now with a
+    superseding message that arrived too early to supersede anything.
+
+    Fired with ZERO separation deliberately (review round 1, R1). The old code
+    inverted at 0, 1, 2, 3 and 5 loop ticks and only came right at 10; a test
+    that inserted any separation would pass against the defect, so the guard
+    would silently stop guarding. Ordering here is a property of the lock, not
+    of how many awaits either method happens to contain.
+    """
+    stream = ScriptedStream([[StreamTextDelta(delta="ok"), StreamEndEvent(stop_reason="stop")]])
+    session = make_session(tmp_path, stream)
+
+    session._on_mcp_incident("minerva-qa", "MCP authorization failed")
+    session._on_mcp_recovery("minerva-qa", 41)
+    await _drain_journal_tasks(session)
+
+    journal = [
+        m.custom_type
+        for m in session._context.messages
+        if isinstance(m, CustomMessage)
+        and m.custom_type in (SESSION_INCIDENT_MESSAGE_TYPE, "session_mcp_recovery")
+    ]
+    assert journal == [
+        SESSION_INCIDENT_MESSAGE_TYPE,
+        "session_mcp_recovery",
+    ], f"the recovery overtook its own incident: {journal}"
+    await session.dispose()

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -8,6 +8,7 @@ import base64
 import io
 import sys
 import types
+import warnings
 from collections.abc import Awaitable, Callable, Sequence
 
 import pytest
@@ -4665,3 +4666,94 @@ async def test_a_held_message_is_still_persisted_only_once(tmp_path):
     ]
     assert len(replayed) == 1
     await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_mcp_recovery_is_not_persisted(tmp_path):
+    """The recovery reaches the LIVE context and never the transcript.
+
+    Mirror of the incident test above, inverted. An MCP connection is
+    process-scoped — ``McpManager._connections`` is instance state and
+    ``disconnect_all`` runs on dispose — so a resumed session re-runs discovery
+    from scratch. Replaying "its 3 tools are available to you now" into a
+    session that did NOT reconnect (an expired grant, a moved binary, an
+    offline machine — the likely cases for exactly the servers this feature is
+    about) would assert tools that are not in the inventory. Same class as the
+    credential record, which is why the type is absent from
+    ``_PERSISTABLE_CUSTOM_TYPES``.
+    """
+    stream = ScriptedStream([[StreamTextDelta(delta="ok"), StreamEndEvent(stop_reason="stop")]])
+    session = make_session(tmp_path, stream)
+    await session.journal_mcp_recovery("files", 3)
+
+    live = [
+        m
+        for m in session._context.messages
+        if isinstance(m, CustomMessage) and m.custom_type == "session_mcp_recovery"
+    ]
+    assert live, "the recovery must reach the live context"
+    assert "[mcp recovery]" in live[-1].details["text"]
+    assert live[-1].details["server"] == "files"
+    assert live[-1].details["tool_count"] == 3
+
+    dumped = "\n".join(
+        __import__("json").dumps(e.payload, default=str) for e in session._transcript.entries()
+    )
+    assert "session_mcp_recovery" not in dumped, (
+        "the recovery was persisted; a resumed session would replay a claim "
+        "about a connection it cannot re-verify"
+    )
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_mcp_recovery_renders_as_a_user_message(tmp_path):
+    """It must arrive on the same surface the INCIDENT arrived on.
+
+    The failure reaches the model as a ``user`` turn; a recovery that rendered
+    to nothing (or to a system aside) could not supersede it. This exercises
+    the render whitelist branch in ``_default_convert_to_llm``.
+    """
+    stream = ScriptedStream(
+        [
+            [StreamTextDelta(delta="one"), StreamEndEvent(stop_reason="stop")],
+            [StreamTextDelta(delta="two"), StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    session = make_session(tmp_path, stream)
+    await session.prompt("go")
+    await session.journal_mcp_recovery("minerva-qa", 41)
+    await session.prompt("continue")
+
+    rendered = [m for m in stream.requests[1].messages if getattr(m, "role", "") == "user"]
+    texts = "\n".join(getattr(m, "text", "") for m in rendered)
+    assert "[mcp recovery] MCP server 'minerva-qa'" in texts
+    assert "41 tools are available again" in texts
+    assert "supersedes the earlier session incident" in texts
+    await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_recovery_after_dispose_is_a_no_op(tmp_path):
+    """A reconnect racing teardown must be silent, not noisy.
+
+    ``_on_mcp_recovery`` is fired from the manager's connect path, which can
+    land while the session is disposing (dispose calls ``disconnect_all``, and
+    an in-flight reconnect may still complete). ``_spawn_background`` closes
+    the coroutine after dispose, so this must neither raise nor leave an
+    un-awaited coroutine warning.
+    """
+    stream = ScriptedStream([[StreamTextDelta(delta="ok"), StreamEndEvent(stop_reason="stop")]])
+    session = make_session(tmp_path, stream)
+    await session.dispose()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        session._on_mcp_recovery("files", 3)
+        await asyncio.sleep(0)
+
+    assert not [
+        m
+        for m in session._context.messages
+        if isinstance(m, CustomMessage) and m.custom_type == "session_mcp_recovery"
+    ]

--- a/tests/unit/test_incidents.py
+++ b/tests/unit/test_incidents.py
@@ -166,18 +166,39 @@ def test_recovery_text_names_server_count_and_supersedes() -> None:
 
 
 def test_recovery_text_agrees_in_number() -> None:
-    """Singular and the zero fallback, because the model reads this text.
+    """Singular and plural, because the model reads this text.
 
-    Zero registered tools is a real state — a server can be connected with
-    every tool filtered out by ``disabledTools`` — so it must not claim
-    "0 tools are available again"; the count-free phrasing stays honest about
-    the connection without promising callable tools.
+    The zero case is a different sentence entirely and is pinned separately
+    below; all this asserts here is that it never claims a count.
     """
     assert "1 tool is available again" in format_mcp_recovery_message("files", 1)
     assert "2 tools are available again" in format_mcp_recovery_message("files", 2)
+    assert "0 tool" not in format_mcp_recovery_message("files", 0)
+
+
+def test_recovery_text_promises_no_tools_when_none_are_enabled() -> None:
+    """Zero registered tools must not be told to "call them normally".
+
+    A server can be connected with every tool filtered out by
+    ``disabledTools``, so this is a reachable state and not a degenerate one.
+    The earlier count-free phrasing avoided "0 tools" but still said the tools
+    "are available again" and "are usable now" — false against an empty
+    inventory, and false in the expensive direction: the model spends a turn
+    looking for tools that do not exist (review round 1, R2).
+
+    What must survive is the SUPERSEDE clause. The model is still holding an
+    incident saying this server is unreachable, and that part is genuinely no
+    longer true, so the notice must still cancel it.
+    """
     zero = format_mcp_recovery_message("files", 0)
-    assert "its tools are available again" in zero
-    assert "0 tool" not in zero
+    assert "is connected again" in zero
+    assert "no enabled tools" in zero
+    assert "supersedes the earlier session incident" in zero
+    # The three over-claims the old zero branch made, none of which are true
+    # with an empty inventory.
+    assert "available again" not in zero
+    assert "usable now" not in zero
+    assert "call them normally" not in zero
 
 
 def test_recovery_is_not_an_incident_type() -> None:

--- a/tests/unit/test_incidents.py
+++ b/tests/unit/test_incidents.py
@@ -6,9 +6,11 @@ import pytest
 
 from local_operator.incidents import (
     SESSION_INCIDENT_MESSAGE_TYPE,
+    SESSION_MCP_RECOVERY_MESSAGE_TYPE,
     SESSION_MODEL_SWITCH_MESSAGE_TYPE,
     classify_incident,
     format_incident_message,
+    format_mcp_recovery_message,
     format_model_switch_message,
 )
 
@@ -140,3 +142,55 @@ def test_a_throttle_that_mentions_tokens_is_not_an_overflow(raw: str) -> None:
     does.
     """
     assert classify_incident(raw).category != "context-length"
+
+
+def test_recovery_text_names_server_count_and_supersedes() -> None:
+    """The recovery must name the server, the count, and CANCEL the incident.
+
+    All three are load-bearing. The server name is what ties it to the specific
+    incident it supersedes. The count is concrete evidence the connection is
+    real (and is the REGISTERED count, so it agrees with what the model can
+    actually call). The supersede clause is the reason the message exists: the
+    model is simultaneously holding an ``mcp`` incident whose hint says "its
+    tools are gone ... Do not call its tools", and a bare "reconnected" leaves
+    both claims live for it to choose between.
+    """
+    text = format_mcp_recovery_message("minerva-qa", 41)
+    assert "minerva-qa" in text
+    assert "41 tools are available again" in text
+    assert "supersedes the earlier session incident" in text
+    assert text.startswith("[mcp recovery]")
+    # Tag is server-scoped, not session-scoped: [session incident] already owns
+    # the session register, and the subject here is one server.
+    assert "[session recovery]" not in text
+
+
+def test_recovery_text_agrees_in_number() -> None:
+    """Singular and the zero fallback, because the model reads this text.
+
+    Zero registered tools is a real state — a server can be connected with
+    every tool filtered out by ``disabledTools`` — so it must not claim
+    "0 tools are available again"; the count-free phrasing stays honest about
+    the connection without promising callable tools.
+    """
+    assert "1 tool is available again" in format_mcp_recovery_message("files", 1)
+    assert "2 tools are available again" in format_mcp_recovery_message("files", 2)
+    zero = format_mcp_recovery_message("files", 0)
+    assert "its tools are available again" in zero
+    assert "0 tool" not in zero
+
+
+def test_recovery_is_not_an_incident_type() -> None:
+    """The distinct type is what keeps the classifier off this message.
+
+    ``journal_incident`` classifies its input, and ``classify_incident``
+    matches the substring "mcp" — so routing a recovery through the incident
+    type would append "its tools are gone until it reconnects" and "This is why
+    the previous turn ended" to a message announcing the opposite. This asserts
+    both halves: the type is separate, and the classifier really would do that.
+    """
+    assert SESSION_MCP_RECOVERY_MESSAGE_TYPE != SESSION_INCIDENT_MESSAGE_TYPE
+    assert SESSION_MCP_RECOVERY_MESSAGE_TYPE != SESSION_MODEL_SWITCH_MESSAGE_TYPE
+    contradiction = classify_incident(format_mcp_recovery_message("files", 3))
+    assert contradiction.category == "mcp"
+    assert "tools are gone" in contradiction.render()

--- a/tests/unit/test_session_factory.py
+++ b/tests/unit/test_session_factory.py
@@ -830,6 +830,11 @@ class FakeMcpManager:
         self._settling = settling
         self._startup_failures = dict(startup_failures or {})
         self.on_startup_settled: Callable[[], None] | None = None
+        # Declared like the real manager's, so ``attach_mcp_dispose`` installing
+        # the incident/recovery sinks is type-checked here rather than silently
+        # creating attributes the production object also has.
+        self.on_incident: Callable[[str, str], None] | None = None
+        self.on_recovery: Callable[[str, int], None] | None = None
 
     def set_on_tools_changed(self, cb) -> None:
         self.callback = cb
@@ -3231,3 +3236,36 @@ async def test_new_admitted_user_refreshes_knowledge_but_tool_steps_reuse_it(tmp
     await transcript.append_message(Message.user("now inspect Python"))
     await provider()
     assert index.queries == ["inspect Slack", "now inspect Python"]
+
+
+@pytest.mark.asyncio
+async def test_attach_mcp_dispose_installs_the_recovery_sink() -> None:
+    """One line here is what makes every non-TUI host hear MCP recoveries.
+
+    The failure sink has always been installed at this composition root, which
+    is why a CLI, headless, exec or server session learns a server's tools are
+    gone. The recovery sink must be installed in the same place and not in the
+    TUI's ``/mcp login`` worker: that worker covers one of the six routes back
+    to a usable server, and bolting it on there would leave every other host
+    permanently holding the death notice — the asymmetry this fixes.
+    """
+    session = FakeSessionShell()
+    manager = FakeMcpManager()
+    recoveries: list[tuple[str, int]] = []
+
+    def record(server: str, tool_count: int) -> None:
+        recoveries.append((server, tool_count))
+
+    session._on_mcp_recovery = record
+
+    attach_mcp_dispose(session, cast("McpManager", manager))
+
+    # ``==`` not ``is``: a bound method is a fresh object on every attribute
+    # access, so identity would fail for the incident sink even when correct.
+    assert manager.on_recovery == session._on_mcp_recovery
+    assert manager.on_incident == session._on_mcp_incident
+    # And it is live: the manager firing it reaches the session's hook.
+    assert manager.on_recovery is not None
+    manager.on_recovery("minerva-qa", 41)
+    assert recoveries == [("minerva-qa", 41)]
+    await session.dispose()


### PR DESCRIPTION
## Summary

An MCP **failure** has always been model-visible. `McpManager.on_incident` → `Session._on_mcp_incident` → `journal_incident` puts a `session_incident` on the live context, and the classifier's `mcp` rule appends its hint: *"its tools are gone until it reconnects. Do not call its tools in a tight loop."*

The **recovery** was not. Nothing anywhere told the model a server came back.

So an operator who ran `/mcp login minerva-qa` mid-session left the running agent holding a death notice — and an explicit "do not call its tools" — for a server that had been usable for the rest of the session. The tools were genuinely back (`refresh_tools` swaps the inventory mid-turn, "even mid-turn at the next tool batch"), but the model had been told not to use them and had no reason to re-check. Observed live.

Worse, `session_incident` is persisted, so `--resume` replays "the server is down" forever for a server that came back minutes later.

This adds the missing half.

`Release: patch — an MCP server that reconnects now tells the model so, in the running turn, instead of leaving it avoiding tools that came back.`

## Change class

C1 — bounded feature. Five production files, purely additive (the single deleted line is a reflowed comment). No new tool, no schema footprint, zero tokens added to the tools array.

## The asymmetry, precisely

`connect_configured_server` ended with breaker-state clearing, `_register_connection` and `_fire_tools_changed` — no incident, no journal, no model-visible fact. The TUI's `_mcp_login_worker` emits a `_system_notice`, which is a transcript **block**: UI only, never context. And no back door corrects the belief — `mcp_startup` is read only by front ends, and the only MCP text in the system prompt is the `mcp://` discovery hint, which never mentions connection status. A model that has been told a server is dead has no reason to go read `mcp://` and find out otherwise.

## Design decisions and why

Full design at 661 lines with 134 verified `file:line` citations (architect, this session). The load-bearing ones:

**1. Origin is the MANAGER at `_register_connection`, not the TUI.** That is the single choke point every route back to a usable server passes through — `/mcp login`, `/mcp reauth`, `reload()`, the backoff reconnect, the after-gate continuation, the call-site retry. Six routes, one line. Bolting it onto `_mcp_login_worker` would have covered **one** of the six and left every CLI, headless, exec and server host permanently holding the death notice — the asymmetry *is* the bug, so re-creating it one layer down was not an option. Installing the sink in `attach_mcp_dispose` beside `on_incident` is what makes the failure and the recovery reach the same set of hosts.

`local-operator mcp login` (the standalone CLI) is a documented, honest gap: it builds a throwaway manager in a short-lived process with no `Session` to journal into. What it does is persist the token, so the next session — or a running session's next reconnect — announces normally.

**2. A new `_incident_announced` gate, armed inside the `if sink is not None` branch.** The gate must mean *"the MODEL was told this server is broken"*, and no existing set has that shape:

- `_auth_toasted` is a **toast** latch — written only when `on_auth_required` is installed, so on a headless host it stays empty while `on_incident` fired normally. Reusing it would suppress the recovery on exactly the hosts this exists to serve.
- `_reconnect_suspended` is a superset *and* a subset: written before the sink decision, and cleared by a login that then fails.
- `_startup_failures` is populated by the startup gate, which fires **no** incident — announcing from it would "recover" failures the model never heard about.

Arming happens after a successful `sink(...)` call, **inside** the branch. The design flags hoisting that outward as the top rollout risk, so there is a comment at each of the three sites saying why it is there. A server that failed at boot and later connects therefore emits nothing — deliberate, because the model was never told.

**3. `reload()` is the storm case.** It tears down and re-registers *every* connection, so an ungated notice is N "is connected again" messages for N servers that never broke. The gate handles it with no reload-specific special case, and `reload()` deliberately does not clear the gate wholesale — a server still broken after a reload keeps its arming so its eventual recovery still lands. `_drop_removed_servers` does discard it, so a re-added server does not inherit a stale arming.

**4. A new `session_mcp_recovery` type, live-context only.** It cannot ride `session_incident`: `journal_incident` classifies its input, and `classify_incident` matches the substring `"mcp"`. **Verified, not assumed** — `test_recovery_is_not_an_incident_type` asserts that classifying the recovery text yields category `mcp` and renders "tools are gone", i.e. the classifier really would append the exact opposite of what the message says.

Not persisted, for the `SESSION_CREDENTIAL_MESSAGE_TYPE` reason: it asserts a **process-scoped** capability. If a resumed session reconnects, the replay is redundant (the tools are just in the inventory, which is how every healthy server is communicated). If it does not — expired grant, moved binary, offline machine, all likely for exactly the servers that needed a login once — the replay claims tools that are not there. Accepted consequence, stated plainly: the un-superseded **incident** still persists. That is today's behaviour, and making the recovery *delete* it would mean rewriting an append-only transcript.

**5. The registered tool count, not `len(conn.tools)`.** `_register_tools` filters by `enabledTools`/`disabledTools`, so the raw list overstates what the model can actually call. `test_recovery_reports_registered_not_raw_tool_count` pins this with a `disabledTools` config: `len(conn.tools) == 2`, reported count `1`. (The TUI's own login receipt has this bug; out of scope, left alone.)

**6. Parked, never spliced.** See the guard section below.

## Evidence — the real failure → recovery path

Not a unit test: a **real `Session` and a real `McpManager`**, wired through the **real composition root** (`attach_mcp_dispose`), driven through the operator's actual sequence. Only the transport seam is stubbed. Isolated `HOME` per run.

### Scenario A — idle session: auth failure → `/mcp login` → recovery

```
on_incident installed: True
on_recovery installed: True

--- live context after the FAILURE ---
[user] [session incident (anthropic/claude-opus-5)] mcp: MCP server 'minerva-qa': MCP authorization failed; run /mcp login minerva-qa to authorize
suggested action: An MCP server is unavailable: its tools are gone until it reconnects. Do not call its tools in a tight loop; say which server is down.
This is why the previous turn ended. Take it into account before repeating the same request.

>>> operator runs: /mcp login minerva-qa

--- live context after the RECOVERY (same Session object) ---
[user] [session incident (anthropic/claude-opus-5)] mcp: MCP server 'minerva-qa': MCP authorization failed; run /mcp login minerva-qa to authorize
suggested action: An MCP server is unavailable: its tools are gone until it reconnects. Do not call its tools in a tight loop; say which server is down.
This is why the previous turn ended. Take it into account before repeating the same request.
[user] [mcp recovery] MCP server 'minerva-qa' is connected again and 41 tools are available again. This supersedes the earlier session incident about this server: its tools are usable now, so call them normally and stop reporting it as unavailable.

persisted 'session_incident'      : True
persisted 'session_mcp_recovery' : False  (must be False)
registered tool count reported   : 41
```

That is the rendered **user-role** text the model actually receives, on the same `Session` object, after a real `connect_configured_server`.

### Scenario B — recovery arrives mid-tool-batch (the real-time case)

A backoff reconnect completing during a turn is the ordinary case, not a corner one: the reconnect timer has no idea a turn is in flight.

```
  (inside tool toolu_A: manager fires recovery)
  parked notices while streaming : 1  (must be 1 — NOT spliced)
  live context shape mid-batch   : ['user', 'assistant']

final live context shape: ['user', 'assistant', 'tool', 'tool', 'custom:session_mcp_recovery', 'assistant']

--- what the model receives on the follow-up request ---
[user] go
[tool] ok
[tool] ok
[user] [mcp recovery] MCP server 'minerva-qa' is connected again and 41 tools are available again. This supersedes the earlier session incident about this server: its tools are usable now, so call them normally and stop reporting it as unavailable.
```

It is parked while the batch is open and lands **after both tool results, before the next model call of the same turn**. That is what "real time" honestly means here — the next tool boundary, not the next user turn.

Three faster deliveries were considered and rejected: a conditional splice (re-opens the bricking window), the steering queue (persists the message, contradicting the persistence decision, and drains at the identical boundary anyway), and returning it from `_drain_steering` (a returned injection keeps the inner loop running and buys an entire extra provider call to say something the next turn carries for free). No `_peer_arrival.mark` either — it would cut a `wait` short without delivering anything, since the text is still parked.

## Proving the brick-prevention guard can go red

`test_mcp_recovery_is_parked_the_same_way` is the guard that matters: splicing a non-tool message into an open batch produces `assistant(tool_use) → user → tool_result`, which every provider rejects and which **bricks the session permanently** — nothing repairs the live list, so it re-sends the bad prefix on every later turn. A guard that cannot fail is worse than none, so it was made to fail.

Replacing `_append_or_park_journal(message)` with a direct `self._context.messages.append(message)`:

```
E       AssertionError: unexpected live shape: ['user', 'assistant', 'custom:session_mcp_recovery', 'tool', 'tool', 'assistant']
tests/unit/session/test_background_journal_splice.py:785: AssertionError
WARNING  local_operator.session.session:session.py:948 repaired a message spliced into an open tool batch; a journal append bypassed the turn-boundary guard (see _append_or_park_journal)
1 failed, 2 warnings in 0.90s
```

The notice lands **between the assistant and its tool results** — the exact bricking shape. Layer 2 (`_pair_spliced_tool_results`) repairs the wire, so to show the raw damage the splice does, the same run with Layer 2 neutered:

```
live roles: ['user', 'assistant', 'custom:session_mcp_recovery', 'tool', 'tool', 'assistant']
wire shape: [('user', ['text']), ('assistant', ['tool_use', 'tool_use']), ('user', ['text', 'tool_result', 'tool_result'])]
DANGLING tool_use ids: ['toolu_A', 'toolu_B']
```

Two orphaned `tool_use` ids — precisely the 400 that killed session `5187e748833c`. Reverted; 18 passed.

## Tests — 21 cases, 9 negative

`tests/unit/mcp/test_manager.py::TestMcpRecoveryNotice` (11): breaker→reconnect fires recovery; after-gate auth failure→login fires exactly one (the operator's scenario end to end); registered-not-raw count; a raising sink neither breaks the connect nor leaves the server armed; **no recovery for a server that never failed**; **`reload()` across three healthy servers emits no storm**; reload with one armed server emits exactly one; a startup-gate failure emits nothing; one notice per failure, not per reconnect; a removed/re-added server does not inherit stale arming; `on_recovery is None` (the CLI shape) is a no-op that still disarms.

`tests/unit/session/`: the park guard above; not persisted while present in the live context; renders as a `user` message; a recovery after `dispose()` neither raises nor warns; and an incident followed by a recovery with ZERO separation reaches the context in fire order (round 1 R1 — fails on the pre-fix code, which inverted at 0-5 loop ticks).

`tests/unit/test_session_factory.py`: `attach_mcp_dispose` installs the sink and firing it reaches the session — the one line that makes every non-TUI host work.

`tests/unit/test_incidents.py`: names server + count + supersede clause; singular/plural number agreement; the zero-tool case promises no callable tools while still superseding the incident (round 1 R2); and the classifier-contradiction proof.

## Gates — whole tree, exactly as CI

| gate | result |
|---|---|
| `python -m flake8 .` | `rc=0` |
| `black==26.1.0 --check .` | `1032 files would be left unchanged`, `rc=0` |
| `isort==5.13.2 --check .` | `rc=0` |
| `python -m pyright --pythonpath .venv/bin/python .` | `0 errors, 0 warnings, 0 informations` |
| `pytest tests/unit` | see PR thread — rerunning on a host that was at 117 MiB free |

`git diff origin/main...HEAD -- pyproject.toml` is **empty**. No version bump.

## Deliberately not done

- **No TUI toast.** The user already gets a login receipt; the model-visible notice and the user-visible receipt are different audiences.
- **`SnapshotMcpManager` untouched** — a read-only follower facade that `attach_mcp_dispose` never reaches.
- **Subagents do not install the sink.** A child borrows the parent's manager, and a single slot means a child installing one would freeze the parent for the whole session. Already correct because `attach_mcp_dispose` is never called for a child; documented next to the existing `set_on_tools_changed` warning so nobody adds one.
- `_append_or_park_journal`, its guard conditions, `classify_incident`, `_auth_toasted` semantics, `_fire_tools_changed`, and the TUI receipt are all unchanged.

## One deviation from the design, disclosed

The design's draft formatter renders **"1 tool are available again"** for a single tool. That is a typo in a code block rather than a decision, so I implemented number agreement (`1 tool is` / `N tools are`) and kept the count-free fallback at zero — zero registered tools is a real state when `disabledTools` filters everything, and "0 tools are available again" would be worse than the fallback. `test_recovery_text_agrees_in_number` pins all three branches. Everything else is implemented as specified.

