### PR TITLE
feat(tui): add /info, an install and runtime diagnostic screen

### DIFF
--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -1967,45 +1967,20 @@ def sessions_command(args: argparse.Namespace) -> int:
     if getattr(args, "sessions_command", None) == "cleanup":
         return sessions_cleanup_command(args)
 
-    from local_operator.mobile.resources import session_resource_usage
-    from local_operator.session.runtime import registry
+    # The row shape lives in ``info.collect`` and is shared with ``/info``,
+    # which needs the same "which sessions exist and what do they cost" answer
+    # plus an ``is_self`` mark and roll-up counters. It was EXTRACTED rather
+    # than copied because two of the details here are subtle enough that a
+    # second implementation would have drifted on them: the ``getattr``
+    # defaulting that keeps a record written by an OLDER runtime listing rather
+    # than raising mid-table, and ``state``'s meaning (``stale`` is a record the
+    # scan just deleted, not an idle session). The ``--json`` key order is part
+    # of the CLI's published contract, so ``session_rows`` pins it explicitly
+    # rather than deriving it from the dataclass — which would also have leaked
+    # ``is_self``, a field this command never had.
+    from local_operator.info.collect import session_rows
 
-    scanned = registry.scan(config_dir())
-    now = time.time()
-    live_pids = [rec.pid for rec, state in scanned if state == "live"]
-    usage = session_resource_usage(live_pids)
-
-    rows = []
-    for rec, state in scanned:
-        use = usage.get(rec.pid)
-        rows.append(
-            {
-                "state": state,
-                "pid": rec.pid,
-                "kind": rec.kind,
-                "conversation_name": rec.conversation_name,
-                "session_id": rec.session_id,
-                "model_label": rec.model_label,
-                "cwd": rec.cwd,
-                "rss_bytes": use.rss_bytes if use else None,
-                "footprint_bytes": use.footprint_bytes if use else None,
-                "uptime_s": max(0.0, now - rec.started_at),
-                "heartbeat_age_s": max(0.0, now - rec.heartbeat_at),
-                # Live state from the record. Defaulted through getattr so a
-                # record written by an OLDER runtime (which has no such fields)
-                # lists cleanly rather than raising mid-table.
-                "pending": getattr(rec, "pending", None),
-                "busy": bool(getattr(rec, "busy", False)),
-                "detached": bool(getattr(rec, "detached", False)),
-                # Which build each runtime is running, for diagnosing skew
-                # across a host that replaces its install several times a day.
-                # Same getattr defaulting as the live-state fields above, and
-                # deliberately JSON-only: the fixed-width table is already
-                # eight columns wide.
-                "version": getattr(rec, "version", "") or "",
-                "source_ref": getattr(rec, "source_ref", "") or "",
-            }
-        )
+    rows = session_rows(config_dir())
 
     if args.json:
         print(_json.dumps(rows, indent=2))

--- a/local_operator/info/__init__.py
+++ b/local_operator/info/__init__.py
@@ -1,0 +1,62 @@
+"""What this install is, what is running on this machine, and what to paste.
+
+Three modules, split the way ``local_operator/analytics/`` is split and for one
+extra reason on top of that precedent:
+
+* :mod:`~local_operator.info.model` — frozen dataclasses. Stdlib only, no I/O,
+  no ``rich``, no ``textual``. That is what a future ``lop info`` and every unit
+  test import, and ``tests/unit/info/test_model.py`` pins it.
+* :mod:`~local_operator.info.collect` — the probes, every heavyweight import
+  function-local, every field independently guarded.
+* :mod:`~local_operator.info.render` — the redacted plain-text export.
+
+The TUI renderer lives in ``tui/widgets/info_panel.py``, outside this package,
+so nothing here depends on Textual.
+
+Importing this package must stay cheap: ``collect`` reaches ``mobile.resources``,
+``browser_bridge``, ``credentials``, ``agents`` and ``teams``, none of which
+belong on the path every ``lop --version`` pays for.
+"""
+
+from local_operator.info.collect import (
+    LiveState,
+    build_subagent_tree,
+    collect_info,
+    collect_live,
+    collect_sessions,
+    collect_snapshot,
+    session_rows,
+)
+from local_operator.info.model import (
+    UNKNOWN,
+    AgentsInfo,
+    EnvInfo,
+    InfoSnapshot,
+    InstallInfo,
+    ProcessInfo,
+    SessionLine,
+    SessionsInfo,
+    SubagentLine,
+)
+from local_operator.info.render import build_export, relativise_home
+
+__all__ = [
+    "UNKNOWN",
+    "AgentsInfo",
+    "EnvInfo",
+    "InfoSnapshot",
+    "InstallInfo",
+    "LiveState",
+    "ProcessInfo",
+    "SessionLine",
+    "SessionsInfo",
+    "SubagentLine",
+    "build_export",
+    "build_subagent_tree",
+    "collect_info",
+    "collect_live",
+    "collect_sessions",
+    "collect_snapshot",
+    "relativise_home",
+    "session_rows",
+]

--- a/local_operator/info/collect.py
+++ b/local_operator/info/collect.py
@@ -476,6 +476,20 @@ def build_subagent_tree(
     return tuple(rows), deepest, below_cap
 
 
+def _require_root(root: Path) -> Path:
+    """``root``, or RAISE when it is the unreadable sentinel.
+
+    Some registries walk a missing directory and return an empty list instead of
+    raising, which turns "we could not resolve the config dir" into an
+    authoritative-looking ``0``. Forcing the failure here routes those probes
+    through :func:`_safe` like every other one, so the field renders as unknown
+    and is named in the degraded block (QA round 2, Q8).
+    """
+    if root == _UNREADABLE_ROOT:
+        raise OSError("config dir could not be resolved")
+    return root
+
+
 def collect_agents(live: "LiveState", errors: list[tuple[str, str]]) -> AgentsInfo:
     """Profile and team counts (filesystem walks) over the live tree.
 
@@ -496,9 +510,21 @@ def collect_agents(live: "LiveState", errors: list[tuple[str, str]]) -> AgentsIn
         # 12.1 ms and 2.3 ms respectively on this host: filesystem walks, hence
         # the worker thread rather than the paint path.
         profiles=_safe(
-            "agents.profiles", lambda: len(AgentRegistry(root).list_agents()), 0, errors
+            "agents.profiles",
+            lambda: len(AgentRegistry(_require_root(root)).list_agents()),
+            0,
+            errors,
         ),
-        teams=_safe("agents.teams", lambda: len(TeamRegistry(root).list_teams()), 0, errors),
+        # `_require_root` rather than a bare call: `TeamRegistry.list_teams()`
+        # does NOT raise on a directory that does not exist, it returns 0. So on
+        # an unresolvable home `teams` was a plausible zero with NO degraded
+        # entry naming it anywhere — the one field on the screen with no honest
+        # marker at all, where `profiles` and `credentials` at least raised and
+        # were caught (QA round 2, Q8). A count read out of a config root we
+        # could not resolve is not a measurement, whatever the walk returns.
+        teams=_safe(
+            "agents.teams", lambda: len(TeamRegistry(_require_root(root)).list_teams()), 0, errors
+        ),
         tree=live.tree,
         running=live.running,
         queued=live.queued,

--- a/local_operator/info/collect.py
+++ b/local_operator/info/collect.py
@@ -1,0 +1,773 @@
+"""The ``/info`` probes: fill :mod:`local_operator.info.model`'s shapes from the
+real system.
+
+**Every heavyweight import here is function-local**, following ``update.py``'s
+``import httpx`` inside ``_fetch_pypi_version`` and ``cli.py``'s deferred
+imports, for the reason ``session/runtime/types.py`` states outright: modules on
+the CLI startup path are paid for by every ``lop`` invocation including
+``--version``. This module reaches ``mobile.resources``, ``browser_bridge``,
+``credentials``, ``agents`` and ``teams``; none of that may become importable
+cost for anyone who is not looking at the screen.
+
+**Two collection phases, and the split is load-bearing.**
+
+:func:`collect_live` reads only in-memory state (the subagent graph, the job
+manager's capacity, the theme, the terminal size) and runs ON the event loop,
+before the screen yields. :func:`collect_snapshot` does every blocking probe and
+runs in a worker thread. The reason is the same rule
+``SessionDiagnostics.capture`` states at ``session_panel.py``: a ``/new`` or
+``/resume`` landing during the disk read must not put a NEW subagent tree under
+an OLD header. The blocking half is genuinely slow —
+``session_resource_usage`` measured **879.5 ms** for 12 pids on this host,
+because on macOS it shells ``top -l1`` for the whole system — which is 26
+dropped frames at 30 fps, so it cannot be anywhere near the paint path.
+
+**No probe here may reach the network.** ``update.check_latest()`` is banned on
+this path and :func:`collect_install` calls ``update.cached_latest()`` instead;
+``tests/unit/info/test_collect.py`` pins that with a raising fake rather than a
+timing bound. See ``cached_latest``'s own docstring for the measurement.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Callable, Iterable, Sequence, TypeVar
+
+from local_operator.info.model import (
+    AgentsInfo,
+    EnvInfo,
+    InfoSnapshot,
+    InstallInfo,
+    ProcessInfo,
+    SessionLine,
+    SessionsInfo,
+    SubagentLine,
+)
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+#: How deep the tree is walked before the remainder is folded into a summary
+#: row. Matches the renderer's cap: nesting past three is rare, and at that
+#: point the COUNT is the fact that matters rather than the indentation.
+MAX_TREE_DEPTH = 3
+
+#: Environment markers that identify the terminal multiplexer, most specific
+#: first. Names only — a marker's VALUE can carry a socket path or a workspace
+#: id, and this screen is pasted into issues.
+_MULTIPLEXER_MARKERS: tuple[tuple[str, str], ...] = (
+    ("CMUX_SOCKET_PATH", "cmux"),
+    ("CMUX_WORKSPACE_ID", "cmux"),
+    ("TMUX", "tmux"),
+    ("STY", "screen"),
+    ("ZELLIJ", "zellij"),
+    ("WEZTERM_PANE", "wezterm"),
+)
+
+
+def _safe(name: str, fn: Callable[[], T], default: T, errors: list[tuple[str, str]]) -> T:
+    """Run one probe; a failure becomes ``default`` plus a NAMED reason.
+
+    A whole-snapshot ``try/except`` is what this exists to prevent. ``/info`` is
+    opened when something is already wrong, so one unreadable probe must cost
+    exactly its own field — a single broken read must never erase the version
+    number, which is the field a bug report most needs.
+
+    The reason is KEPT rather than swallowed the way this codebase's other
+    best-effort paths swallow theirs, because a bare ``cache dir  —`` sends the
+    reporter back for a second round trip to find out whether the field does not
+    apply or the screen is broken.
+    """
+    try:
+        return fn()
+    except Exception as exc:  # noqa: BLE001 — a diagnostic screen never raises
+        logger.debug("info: %s probe failed", name, exc_info=True)
+        errors.append((name, f"{type(exc).__name__}: {exc}"[:120]))
+        return default
+
+
+def _resolved_import_path() -> str:
+    """Where ``import local_operator`` ACTUALLY came from, resolved.
+
+    ``__file__`` is the package's ``__init__.py``; its parent is the directory a
+    reader can compare against the install prefix, and it is the exact command
+    AGENTS.md prescribes for settling this by hand
+    (``python -c "import local_operator; print(local_operator.__file__)"``).
+    Symlinks are resolved so a linked venv cannot report the path it was reached
+    THROUGH rather than the tree it actually reads.
+    """
+    import local_operator
+
+    return str(Path(local_operator.__file__).resolve().parent)
+
+
+def _import_path_is_foreign(import_path: str, prefix: str) -> bool:
+    """Whether the running code sits outside the install it claims to be.
+
+    A containment test rather than equality: an install's package legitimately
+    lives several directories under its prefix
+    (``<prefix>/lib/python3.12/site-packages/local_operator``), so equality
+    would flag every healthy install and this warning would mean nothing.
+
+    An EDITABLE install is the one legitimate divergence — its package is the
+    checkout by design — but it is not special-cased here, because the case this
+    exists to catch is indistinguishable from it at this level and the renderer
+    has ``kind`` in hand to word the two differently.
+    """
+    if not import_path or not prefix:
+        return False
+    try:
+        return not Path(import_path).is_relative_to(Path(prefix).resolve())
+    except (OSError, ValueError):
+        # An unresolvable path is not evidence of a foreign import; claiming a
+        # warning state from a failed comparison would be a false alarm on the
+        # screen whose job is to be trusted.
+        return False
+
+
+def collect_install(errors: list[tuple[str, str]]) -> InstallInfo:
+    """Which build this is and where it came from. No network, ever."""
+    import platform
+
+    from local_operator import update
+
+    version = _safe("install.version", update.installed_version, "", errors)
+    kind = _safe("install.kind", lambda: update.install_kind().value, "", errors)
+    latest, latest_age = _safe(
+        # NOT ``check_latest``: that is the upgrade path and its TTL miss makes a
+        # live 5 s HTTP call and rewrites the cache. See ``update.cached_latest``.
+        "install.latest",
+        update.cached_latest,
+        (None, None),
+        errors,
+    )
+    import_path = _safe("install.import_path", _resolved_import_path, "", errors)
+    return InstallInfo(
+        version=version,
+        kind=kind,
+        prefix=sys.prefix,
+        executable=sys.executable,
+        import_path=import_path,
+        import_path_foreign=_import_path_is_foreign(import_path, sys.prefix),
+        is_git_snapshot=_safe("install.snapshot", update.is_git_snapshot, False, errors),
+        source_ref=_safe("install.source_ref", update.source_ref, "", errors),
+        build_age_s=_safe("install.build_age", update.build_marker_age_s, None, errors),
+        latest_known=latest,
+        latest_age_s=latest_age,
+        behind=update.is_behind(version, latest),
+        python_version=platform.python_version(),
+        python_implementation=platform.python_implementation(),
+        # 15 ms on its FIRST call and ~0 afterwards (it caches internally), so
+        # it is cheap insurance to keep it on the worker with everything else.
+        platform=_safe("install.platform", platform.platform, "", errors),
+        machine=_safe("install.machine", platform.machine, "", errors),
+    )
+
+
+def own_control_port(root: Path | None = None) -> int | None:
+    """This process's own control-socket port, read from its published record.
+
+    Read HERE rather than carried on :class:`SessionLine`, which is kept to
+    exactly the shape ``lop sessions`` publishes plus ``is_self``. The port
+    itself is safe to render — a port number is not a credential and it is the
+    useful half for debugging an attach — but the record it sits in also holds
+    ``control_key``, so the narrow read is the one that cannot grow a leak by
+    someone later adding "the whole record" to the session dataclass.
+    """
+    import json
+
+    from local_operator.session.runtime import registry
+
+    raw = json.loads(registry.record_path(os.getpid(), root).read_text(encoding="utf-8"))
+    port = raw.get("control_port")
+    return int(port) if isinstance(port, (int, float)) else None
+
+
+def collect_process(
+    live: "LiveState",
+    *,
+    self_line: SessionLine | None,
+    errors: list[tuple[str, str]],
+    root: Path | None = None,
+) -> ProcessInfo:
+    """This runtime, and the four directories it actually resolved.
+
+    ``config_dir`` and ``cache_dir`` are both reported because they are derived
+    INDEPENDENTLY — the cache root comes off ``$HOME`` whatever
+    ``LOCAL_OPERATOR_CONFIG_DIR`` says — and AGENTS.md records that divergence
+    as one that silently produces a plausible wrong answer. Seeing the two
+    side by side is the whole diagnostic.
+
+    ``uptime_s`` prefers this process's own published ``SessionRecord``, matched
+    on pid by the scan that :func:`collect_sessions` already ran, so ``/info``
+    and ``lop sessions`` cannot report two different uptimes for one session.
+    """
+    from local_operator import paths, update
+    from local_operator.session.runtime.types import PROTOCOL_VERSION
+
+    return ProcessInfo(
+        pid=os.getpid(),
+        session_id=live.session_id,
+        conversation_name=live.conversation_name,
+        cwd=_safe("process.cwd", os.getcwd, "", errors),
+        model_label=live.model_label,
+        effective_model=live.effective_model,
+        uptime_s=self_line.uptime_s if self_line is not None else live.uptime_s,
+        config_dir=_safe("process.config_dir", lambda: str(paths.config_dir()), "", errors),
+        config_dir_redirected=bool(os.environ.get(paths.CONFIG_DIR_ENV)),
+        agent_home=_safe("process.agent_home", lambda: str(paths.agent_home_dir()), "", errors),
+        agent_home_redirected=bool(os.environ.get(paths.AGENT_HOME_ENV)),
+        cache_dir=_safe("process.cache_dir", lambda: str(update.default_cache_dir()), "", errors),
+        log_dir=_safe("process.log_dir", lambda: str(paths.log_dir()), "", errors),
+        # Absent for a runtime that never published a record (exec mode, a
+        # test harness): that is a legitimate state, not a failure, so it is
+        # not recorded in ``degraded``.
+        control_port=(
+            _safe("process.control_port", lambda: own_control_port(root), None, errors)
+            if self_line is not None
+            else None
+        ),
+        protocol=PROTOCOL_VERSION,
+        kind=self_line.kind if self_line is not None else live.kind,
+    )
+
+
+def collect_sessions(
+    root: Path | None = None,
+    *,
+    scan: Callable[..., list[tuple[Any, str]]] | None = None,
+    usage: Callable[..., dict[int, Any]] | None = None,
+    self_pid: int | None = None,
+    now: float | None = None,
+) -> SessionsInfo:
+    """Every session on this machine, as ``lop sessions`` already describes them.
+
+    **This is the ONE implementation.** ``cli.sessions_command`` calls it for
+    both its table and its ``--json`` output; a second copy of "which sessions
+    exist and what do they cost" is precisely the drift this codebase writes
+    essays about avoiding. Two specific details make the duplication dangerous
+    rather than merely untidy:
+
+    * the ``getattr(rec, ..., default)`` spellings below exist because a record
+      written by an OLDER runtime lacks those fields entirely. That rule has to
+      hold in both readers, or ``/info`` raises mid-table on a host that is
+      mid-upgrade — the exact host ``/info`` is opened on.
+    * ``state`` is subtle: ``stale`` means ``registry.scan`` just DELETED the
+      record file, not that the session is idle. A second implementation would
+      have got the counters wrong.
+
+    ``scan`` / ``usage`` / ``now`` are injectable seams so the tests can pin the
+    degradation matrix without a real machine's sessions under them.
+    """
+    from local_operator.mobile.resources import session_resource_usage
+    from local_operator.session.runtime import registry
+
+    scan_fn = scan or registry.scan
+    usage_fn = usage or session_resource_usage
+    scanned = scan_fn(root)
+    stamp = time.time() if now is None else now
+    live_pids = [rec.pid for rec, state in scanned if state == "live"]
+    measured = usage_fn(live_pids)
+
+    lines: list[SessionLine] = []
+    for rec, state in scanned:
+        use = measured.get(rec.pid)
+        lines.append(
+            SessionLine(
+                state=state,
+                pid=rec.pid,
+                kind=rec.kind,
+                conversation_name=rec.conversation_name,
+                session_id=rec.session_id,
+                model_label=rec.model_label,
+                cwd=rec.cwd,
+                rss_bytes=use.rss_bytes if use else None,
+                footprint_bytes=use.footprint_bytes if use else None,
+                uptime_s=max(0.0, stamp - rec.started_at),
+                heartbeat_age_s=max(0.0, stamp - rec.heartbeat_at),
+                # Live state from the record. Defaulted through getattr so a
+                # record written by an OLDER runtime (which has no such fields)
+                # lists cleanly rather than raising mid-table.
+                pending=getattr(rec, "pending", None),
+                busy=bool(getattr(rec, "busy", False)),
+                detached=bool(getattr(rec, "detached", False)),
+                # Which build each runtime is running, for diagnosing skew
+                # across a host that replaces its install several times a day.
+                # Same getattr defaulting as the live-state fields above.
+                version=getattr(rec, "version", "") or "",
+                source_ref=getattr(rec, "source_ref", "") or "",
+                is_self=self_pid is not None and rec.pid == self_pid,
+            )
+        )
+
+    builds = {(line.version, line.source_ref) for line in lines if line.state == "live"}
+    builds.discard(("", ""))
+    return SessionsInfo(
+        lines=tuple(lines),
+        total=len(lines),
+        live=sum(1 for line in lines if line.state == "live"),
+        wedged=sum(1 for line in lines if line.state == "wedged"),
+        stale=sum(1 for line in lines if line.state == "stale"),
+        busy=sum(1 for line in lines if line.busy),
+        pending=sum(1 for line in lines if line.pending),
+        detached=sum(1 for line in lines if line.detached),
+        build_skew=len(builds) > 1,
+        # "Nothing measured at all" is a different fact from "this pid could
+        # not be measured", and only the first should suppress the column.
+        usage_available=not live_pids
+        or any(line.rss_bytes is not None or line.footprint_bytes is not None for line in lines),
+    )
+
+
+def session_rows(root: Path | None = None) -> list[dict[str, Any]]:
+    """``lop sessions --json``'s rows, in its established key order.
+
+    The CLI's ``--json`` contract is a published surface, so the key order and
+    the key names are pinned here (``tests/unit/info/test_sessions_extraction.py``
+    compares against the pre-extraction literal) rather than derived from
+    ``dataclasses.asdict``, which would leak ``is_self`` — a field the CLI never
+    had — into it.
+    """
+    info = collect_sessions(root)
+    return [
+        {
+            "state": line.state,
+            "pid": line.pid,
+            "kind": line.kind,
+            "conversation_name": line.conversation_name,
+            "session_id": line.session_id,
+            "model_label": line.model_label,
+            "cwd": line.cwd,
+            "rss_bytes": line.rss_bytes,
+            "footprint_bytes": line.footprint_bytes,
+            "uptime_s": line.uptime_s,
+            "heartbeat_age_s": line.heartbeat_age_s,
+            "pending": line.pending,
+            "busy": line.busy,
+            "detached": line.detached,
+            "version": line.version,
+            "source_ref": line.source_ref,
+        }
+        for line in info.lines
+    ]
+
+
+def build_subagent_tree(
+    nodes: Sequence[Any],
+    *,
+    max_depth: int = MAX_TREE_DEPTH,
+) -> tuple[tuple[SubagentLine, ...], int, int]:
+    """Flatten a comms roster into ``(rows, max_depth_seen, nodes_below_cap)``.
+
+    Built from ``comms.nodes()`` plus ``parent_job_id``, NOT by recursing job
+    managers, because nested launches land in the ROOT session's single records
+    map tagged with their true parent's job id — ``nodes()``' own docstring says
+    consumers need the complete roster since the root event stream "can only
+    ever describe direct children". So one flat read already contains every
+    depth.
+
+    The walk carries a ``seen`` set for the same reason ``comms.ancestors()``
+    does: a restored snapshot can carry a malformed edge, and a cycle here would
+    hang the screen rather than merely misdraw it. Orphans — a node whose parent
+    is not in the roster, which the settled-record eviction can produce — are
+    walked from the root rather than silently dropped, since a running subagent
+    missing from a "what is running" screen is the worst possible error.
+
+    Ordering is running first, then queued, then everything settled: that is the
+    question being asked, mirroring ``sort_needs_you_first``'s urgency-first
+    principle.
+    """
+    children: dict[str | None, list[Any]] = defaultdict(list)
+    known = {getattr(node, "job_id", "") for node in nodes}
+    for node in nodes:
+        parent = getattr(node, "parent_job_id", None)
+        # An orphan is re-parented to the root: its parent record was evicted,
+        # not its existence.
+        children[parent if parent in known else None].append(node)
+
+    def rank(node: Any) -> tuple[int, str]:
+        status = str(getattr(node, "status", "") or "")
+        order = 0 if status in ("running", "starting") else 1 if status == "queued" else 2
+        return order, str(getattr(node, "label", "") or "")
+
+    rows: list[SubagentLine] = []
+    seen: set[str] = set()
+    deepest = 0
+    below_cap = 0
+
+    def walk(parent: str | None, depth: int) -> None:
+        nonlocal deepest, below_cap
+        for node in sorted(children.get(parent, ()), key=rank):
+            job_id = str(getattr(node, "job_id", "") or "")
+            if job_id in seen:
+                continue
+            seen.add(job_id)
+            deepest = max(deepest, depth)
+            if depth >= max_depth:
+                below_cap += 1
+            else:
+                rows.append(
+                    SubagentLine(
+                        job_id=job_id,
+                        label=str(getattr(node, "label", "") or ""),
+                        status=str(getattr(node, "status", "") or ""),
+                        depth=depth,
+                        agent_role=str(getattr(node, "agent_role", "") or ""),
+                        effort=str(getattr(node, "effort", "") or ""),
+                        parent_job_id=getattr(node, "parent_job_id", None),
+                        session_id=getattr(node, "session_id", None),
+                        live=bool(getattr(node, "live", False)),
+                    )
+                )
+            walk(job_id, depth + 1)
+
+    walk(None, 0)
+    return tuple(rows), deepest, below_cap
+
+
+def collect_agents(live: "LiveState", errors: list[tuple[str, str]]) -> AgentsInfo:
+    """Profile and team counts (filesystem walks) over the live tree.
+
+    The TREE itself is not read here — it was captured on the event loop by
+    :func:`collect_live`, deliberately, so a ``/new`` during this ~900 ms
+    snapshot cannot swap the session under an already-painted header.
+    """
+    from local_operator.agents import AgentRegistry
+    from local_operator.paths import config_dir
+    from local_operator.teams import TeamRegistry
+
+    root = config_dir()
+    return AgentsInfo(
+        # 12.1 ms and 2.3 ms respectively on this host: filesystem walks, hence
+        # the worker thread rather than the paint path.
+        profiles=_safe(
+            "agents.profiles", lambda: len(AgentRegistry(root).list_agents()), 0, errors
+        ),
+        teams=_safe("agents.teams", lambda: len(TeamRegistry(root).list_teams()), 0, errors),
+        tree=live.tree,
+        running=live.running,
+        queued=live.queued,
+        settled=live.settled,
+        max_running=live.max_running,
+        at_capacity=live.at_capacity,
+        max_depth=live.max_depth,
+        deeper=live.deeper,
+        # Always False today: nothing about another session's subagents is
+        # observable without a new control-socket op and a PROTOCOL_VERSION
+        # bump. The field is the seam that lets the screen become truthful
+        # later without a copy edit.
+        cross_session_known=False,
+    )
+
+
+def collect_env(live: "LiveState", errors: list[tuple[str, str]]) -> EnvInfo:
+    """The bug-report extras. Names only — never a credential value."""
+    from local_operator.browser_bridge import state as bridge_state
+    from local_operator.credentials import CredentialManager
+    from local_operator.guides.discovery import discover_guides
+    from local_operator.paths import config_dir
+
+    root = config_dir()
+
+    def browser() -> tuple[str, str, bool]:
+        # The FILE classification (0.06 ms, cannot hang), not
+        # ``backend.bridge_browser_reachable``, which issues a bounded loopback
+        # request on the STALE branch and is async. A diagnostic reports what the
+        # file says and labels the uncertainty; resolving it is /browser's job.
+        kind, current = bridge_state.liveness(root)
+        label = {
+            bridge_state.Liveness.FRESH: "extension",
+            bridge_state.Liveness.STALE: "extension (stale)",
+        }.get(kind, "none")
+        return (
+            label,
+            getattr(current, "browser_name", "") or "",
+            bool(getattr(current, "paired", False)),
+        )
+
+    def mobile() -> tuple[bool, bool, int | None]:
+        # NOT ``install.status()``: it costs 37.2 ms because it also does
+        # ``_bundle_state()`` and its OWN ``registry.scan()`` — a second scan
+        # this snapshot already paid for — and shells ``launchctl`` on some
+        # paths. These two targeted calls are 0.83 ms combined.
+        from local_operator.mobile import install as mobile_install
+
+        installed = mobile_install.plist_path().exists()
+        port = mobile_install.DEFAULT_PORT
+        healthy = bool(installed and mobile_install.health(port))
+        return installed, healthy, port
+
+    backend, browser_name, paired = _safe("env.browser", browser, ("none", "", False), errors)
+    installed, healthy, port = _safe("env.mobile", mobile, (False, False, None), errors)
+    return EnvInfo(
+        mcp_configured=live.mcp_configured,
+        mcp_connected=live.mcp_connected,
+        mcp_failed=live.mcp_failed,
+        mcp_settling=live.mcp_settling,
+        mcp_failures=live.mcp_failures,
+        approval_mode=live.approval_mode,
+        theme=live.theme,
+        terminal_size=live.terminal_size,
+        term=os.environ.get("TERM", ""),
+        colorterm=os.environ.get("COLORTERM", ""),
+        multiplexer=_multiplexer(),
+        is_tty=_safe("env.tty", sys.stdout.isatty, False, errors),
+        browser_backend=backend,
+        browser_name=browser_name,
+        browser_paired=paired,
+        mobile_installed=installed,
+        mobile_healthy=healthy,
+        mobile_port=port,
+        # KEY NAMES ONLY. ``get_credentials`` returns SecretStr values and this
+        # screen is pasted into issues; a name answers the diagnostic question
+        # ("is it even set?") and a value answers nothing this screen asks.
+        credential_keys=_safe(
+            "env.credentials",
+            lambda: tuple(CredentialManager(root).list_credential_keys()),
+            (),
+            errors,
+        ),
+        guides=_safe("env.guides", lambda: len(discover_guides()), 0, errors),
+        skills=live.skills,
+        tools=live.tools,
+    )
+
+
+def _multiplexer() -> str:
+    """Which multiplexer this terminal is inside, by marker NAME only.
+
+    A marker's value carries a socket path or a workspace id; neither is
+    diagnostic and both are identifying, so only the name is consulted.
+    """
+    for variable, name in _MULTIPLEXER_MARKERS:
+        if os.environ.get(variable) is not None:
+            return name
+    return ""
+
+
+class LiveState:
+    """In-memory state captured ON the event loop, before the worker yields.
+
+    Every field here is a scalar or an immutable tuple read from a live object
+    in one synchronous pass — the same rule, and for the same reason, as
+    ``SessionDiagnostics.capture``: "never hold a mutable session across a disk
+    read". The subagent tree in particular MUST be captured here rather than in
+    the worker. It is an in-memory dict walk (free), and a ``/new`` or
+    ``/resume`` arriving during the ~900 ms session probe would otherwise put a
+    brand-new tree under a header describing the old session.
+    """
+
+    __slots__ = (
+        "session_id",
+        "conversation_name",
+        "model_label",
+        "effective_model",
+        "kind",
+        "uptime_s",
+        "tree",
+        "running",
+        "queued",
+        "settled",
+        "max_running",
+        "at_capacity",
+        "max_depth",
+        "deeper",
+        "mcp_configured",
+        "mcp_connected",
+        "mcp_failed",
+        "mcp_settling",
+        "mcp_failures",
+        "approval_mode",
+        "theme",
+        "terminal_size",
+        "skills",
+        "tools",
+    )
+
+    def __init__(self, **values: Any) -> None:
+        for name in self.__slots__:
+            setattr(self, name, values.get(name, _LIVE_DEFAULTS[name]))
+
+
+#: Defaults chosen so a ``LiveState()`` with nothing supplied renders a screen
+#: of ``—`` and crashes nothing — the same contract ``model.py`` states.
+_LIVE_DEFAULTS: dict[str, Any] = {
+    "session_id": "",
+    "conversation_name": "",
+    "model_label": "",
+    "effective_model": "",
+    "kind": "tui",
+    "uptime_s": None,
+    "tree": (),
+    "running": 0,
+    "queued": 0,
+    "settled": 0,
+    "max_running": None,
+    "at_capacity": False,
+    "max_depth": 0,
+    "deeper": 0,
+    "mcp_configured": 0,
+    "mcp_connected": 0,
+    "mcp_failed": 0,
+    "mcp_settling": False,
+    "mcp_failures": (),
+    "approval_mode": "",
+    "theme": "",
+    "terminal_size": None,
+    "skills": 0,
+    "tools": 0,
+}
+
+
+def collect_live(
+    session: Any,
+    *,
+    approve_all: bool = False,
+    theme: str = "",
+    size: tuple[int, int] | None = None,
+    skills: int = 0,
+    tools: int = 0,
+) -> LiveState:
+    """Snapshot the live objects synchronously. Safe on the paint path.
+
+    Everything read here is an in-memory attribute or dict walk. Nothing touches
+    the filesystem, a socket or a subprocess — that is what makes it legitimate
+    on the event loop, and what the caller relies on when it pushes the screen
+    before starting the worker.
+    """
+    errors: list[tuple[str, str]] = []
+    tree: tuple[SubagentLine, ...] = ()
+    deepest = 0
+    deeper = 0
+    running = queued = settled = 0
+    max_running: int | None = None
+    at_capacity = False
+
+    # ``_attr`` and not a bare ``getattr``: every one of these is a PROPERTY on
+    # the real Session, and a property on an unhealthy session can raise. A bare
+    # getattr would let that propagate out of a function whose entire contract
+    # is "safe on the paint path", turning a wedged session into a crash on the
+    # one screen that exists to describe it.
+    comms = _attr(session, "subagent_comms", None) if session is not None else None
+    if comms is not None:
+        nodes = _safe("live.subagents", comms.nodes, [], errors)
+        tree, deepest, deeper = build_subagent_tree(nodes)
+        for node in nodes:
+            status = str(getattr(node, "status", "") or "")
+            if status in ("running", "starting", "pausing"):
+                running += 1
+            elif status == "queued":
+                queued += 1
+            else:
+                settled += 1
+
+    jobs = _attr(session, "jobs", None) if session is not None else None
+    if jobs is not None:
+        max_running = _safe("live.max_running", lambda: int(jobs.max_running), None, errors)
+        at_capacity = _safe("live.at_capacity", lambda: bool(jobs.at_capacity()), False, errors)
+
+    startup = _attr(session, "mcp_startup", None) if session is not None else None
+    failures: dict[str, str] = dict(_attr(startup, "failures", {}) or {})
+    return LiveState(
+        session_id=_attr(session, "session_id", ""),
+        conversation_name=_attr(session, "conversation_name", ""),
+        model_label=_attr(session, "model_label", ""),
+        effective_model=_attr(session, "effective_model_label", ""),
+        uptime_s=None,
+        tree=tree,
+        running=running,
+        queued=queued,
+        settled=settled,
+        max_running=max_running,
+        at_capacity=at_capacity,
+        max_depth=deepest,
+        deeper=deeper,
+        mcp_configured=len(getattr(startup, "configured", ()) or ()),
+        mcp_connected=len(getattr(startup, "connected", ()) or ()),
+        mcp_failed=len(failures),
+        mcp_settling=bool(getattr(startup, "settling", False)),
+        # Server NAMES and the failure MESSAGE only, truncated: a message can
+        # quote a command line, and the ones that matter ("command not found:
+        # gh") are short.
+        mcp_failures=tuple((name, str(text)[:120]) for name, text in sorted(failures.items())),
+        approval_mode="auto" if approve_all else "ask",
+        theme=theme,
+        terminal_size=tuple(size) if size else None,  # type: ignore[arg-type]
+        skills=skills,
+        tools=tools,
+    )
+
+
+def _attr(obj: Any, name: str, default: T) -> T:
+    """Read one public attribute, tolerating a facade that lacks it or a property
+    that RAISES.
+
+    The raising case is the one that matters and the one a bare ``getattr``
+    misses: ``session_id``, ``model_label`` and ``subagent_comms`` are all
+    properties on the real ``Session``, so a session that is itself unhealthy —
+    exactly the session someone opens ``/info`` about — would otherwise take the
+    screen down with it.
+    """
+    try:
+        value = getattr(obj, name, default)
+    except Exception:  # noqa: BLE001 — an unhealthy session still gets a screen
+        return default
+    return default if value is None else value
+
+
+def collect_snapshot(live: LiveState, *, root: Path | None = None) -> InfoSnapshot:
+    """Every blocking probe, on a worker thread. Never call this on the loop.
+
+    Blocking is the point: ``session_resource_usage`` alone measured 879.5 ms
+    for 12 pids (it shells ``top -l1`` for the whole system on macOS, a trade
+    documented in ``mobile/resources.py``). Each block is guarded independently
+    so one wedged filesystem costs its own section and nothing else.
+    """
+    errors: list[tuple[str, str]] = []
+    self_pid = os.getpid()
+    sessions = _safe(
+        "sessions",
+        lambda: collect_sessions(root, self_pid=self_pid),
+        SessionsInfo(available=False),
+        errors,
+    )
+    self_line = next((line for line in sessions.lines if line.is_self), None)
+    return InfoSnapshot(
+        install=collect_install(errors),
+        process=collect_process(live, self_line=self_line, errors=errors, root=root),
+        sessions=sessions,
+        agents=collect_agents(live, errors),
+        env=collect_env(live, errors),
+        degraded=tuple(errors),
+        captured_at=time.time(),
+    )
+
+
+def collect_info(
+    session: Any = None,
+    *,
+    approve_all: bool = False,
+    theme: str = "",
+    size: tuple[int, int] | None = None,
+    root: Path | None = None,
+) -> InfoSnapshot:
+    """Both phases at once — for the CLI and for tests, never for the TUI.
+
+    The TUI must keep the two apart (``collect_live`` on the loop,
+    ``collect_snapshot`` in a worker) so the screen paints before the 900 ms
+    probe. A non-interactive caller has no frame to protect and can pay for both
+    in one go.
+    """
+    live = collect_live(session, approve_all=approve_all, theme=theme, size=size)
+    return collect_snapshot(live, root=root)
+
+
+def degraded_names(errors: Iterable[tuple[str, str]]) -> tuple[str, ...]:
+    """Just the field names that failed, for a compact footnote."""
+    return tuple(name for name, _ in errors)

--- a/local_operator/info/collect.py
+++ b/local_operator/info/collect.py
@@ -59,15 +59,29 @@ T = TypeVar("T")
 MAX_TREE_DEPTH = 3
 
 #: Environment markers that identify the terminal multiplexer, most specific
-#: first. Names only — a marker's VALUE can carry a socket path or a workspace
-#: id, and this screen is pasted into issues.
+#: first. PRESENCE only — a marker's VALUE can carry a socket path or a
+#: workspace id, both identifying, and this screen is pasted into issues.
+#:
+#: Spelled as module-level constants rather than as string literals inside the
+#: tuple because ``tests/unit/test_ambient_env_isolation.py`` resolves env reads
+#: through the AST: it follows a ``NAME = "VAR"`` constant but cannot see a name
+#: buried in a tuple-of-tuples literal. Written the other way, three of these
+#: reads were invisible to the audit that exists to catch exactly that, so the
+#: names went unaccounted while looking accounted for (QA round 1, Q4).
+_ENV_CMUX_SOCKET_PATH = "CMUX_SOCKET_PATH"
+_ENV_CMUX_WORKSPACE_ID = "CMUX_WORKSPACE_ID"
+_ENV_TMUX = "TMUX"
+_ENV_STY = "STY"
+_ENV_ZELLIJ = "ZELLIJ"
+_ENV_WEZTERM_PANE = "WEZTERM_PANE"
+
 _MULTIPLEXER_MARKERS: tuple[tuple[str, str], ...] = (
-    ("CMUX_SOCKET_PATH", "cmux"),
-    ("CMUX_WORKSPACE_ID", "cmux"),
-    ("TMUX", "tmux"),
-    ("STY", "screen"),
-    ("ZELLIJ", "zellij"),
-    ("WEZTERM_PANE", "wezterm"),
+    (_ENV_CMUX_SOCKET_PATH, "cmux"),
+    (_ENV_CMUX_WORKSPACE_ID, "cmux"),
+    (_ENV_TMUX, "tmux"),
+    (_ENV_STY, "screen"),
+    (_ENV_ZELLIJ, "zellij"),
+    (_ENV_WEZTERM_PANE, "wezterm"),
 )
 
 
@@ -163,8 +177,11 @@ def collect_install(errors: list[tuple[str, str]]) -> InstallInfo:
         behind=update.is_behind(version, latest),
         python_version=platform.python_version(),
         python_implementation=platform.python_implementation(),
-        # 15 ms on its FIRST call and ~0 afterwards (it caches internally), so
-        # it is cheap insurance to keep it on the worker with everything else.
+        # ~15 ms, measured. CPython memoizes ``platform.uname()`` but NOT
+        # ``platform.platform()``, which re-formats on every call, so this is
+        # paid each time rather than once (review round 1, N4 — the earlier
+        # comment here asserted a caching behaviour that does not exist). Cheap
+        # either way on the worker thread.
         platform=_safe("install.platform", platform.platform, "", errors),
         machine=_safe("install.machine", platform.machine, "", errors),
     )
@@ -428,6 +445,34 @@ def build_subagent_tree(
             walk(job_id, depth + 1)
 
     walk(None, 0)
+
+    # A CYCLE reaches nothing from the root: every node's parent is present, so
+    # nothing buckets under ``None`` and the walk above iterates an empty list.
+    # The ``seen`` set stops the hang but does not restore the nodes, so the
+    # header said "2 running" over an empty tree — one screen contradicting
+    # itself, and by this function's own docstring the worst error it can make
+    # (review round 1, M1). Anything still unreached is emitted at depth 0, the
+    # same treatment an orphan gets: a malformed edge costs indentation, never
+    # existence.
+    for node in sorted(nodes, key=rank):
+        job_id = str(getattr(node, "job_id", "") or "")
+        if job_id in seen:
+            continue
+        seen.add(job_id)
+        rows.append(
+            SubagentLine(
+                job_id=job_id,
+                label=str(getattr(node, "label", "") or ""),
+                status=str(getattr(node, "status", "") or ""),
+                depth=0,
+                agent_role=str(getattr(node, "agent_role", "") or ""),
+                effort=str(getattr(node, "effort", "") or ""),
+                parent_job_id=getattr(node, "parent_job_id", None),
+                session_id=getattr(node, "session_id", None),
+                live=bool(getattr(node, "live", False)),
+            )
+        )
+
     return tuple(rows), deepest, below_cap
 
 
@@ -442,7 +487,11 @@ def collect_agents(live: "LiveState", errors: list[tuple[str, str]]) -> AgentsIn
     from local_operator.paths import config_dir
     from local_operator.teams import TeamRegistry
 
-    root = config_dir()
+    # Guarded like any other probe: `config_dir()` is `Path.home() / ...` and
+    # `Path.home()` RAISES when the home directory cannot be resolved, so a bare
+    # call here escaped the block and crashed the app (review round 1, B1).
+    # `_UNREADABLE_ROOT` rather than `Path(".")` — see `collect_env`.
+    root = _safe("agents.config_dir", config_dir, _UNREADABLE_ROOT, errors)
     return AgentsInfo(
         # 12.1 ms and 2.3 ms respectively on this host: filesystem walks, hence
         # the worker thread rather than the paint path.
@@ -473,7 +522,14 @@ def collect_env(live: "LiveState", errors: list[tuple[str, str]]) -> EnvInfo:
     from local_operator.guides.discovery import discover_guides
     from local_operator.paths import config_dir
 
-    root = config_dir()
+    # Same guard as `collect_agents`, for the same reason (review round 1, B1).
+    # The fallback is `_UNREADABLE_ROOT`, NOT `Path(".")`: `CredentialManager`
+    # CREATES its store on construction, so a relative fallback made this
+    # read-only diagnostic write a `credentials.env` into whatever directory the
+    # user happened to be in — observed for real while testing the B1 guard.
+    # A diagnostic that mutates the machine it is describing is the same class
+    # of fault as `check_latest()` rewriting the cache, which §2.1 bans.
+    root = _safe("env.config_dir", config_dir, _UNREADABLE_ROOT, errors)
 
     def browser() -> tuple[str, str, bool]:
         # The FILE classification (0.06 ms, cannot hang), not
@@ -499,8 +555,13 @@ def collect_env(live: "LiveState", errors: list[tuple[str, str]]) -> EnvInfo:
         from local_operator.mobile import install as mobile_install
 
         installed = mobile_install.plist_path().exists()
-        port = mobile_install.DEFAULT_PORT
-        healthy = bool(installed and mobile_install.health(port))
+        # The port is only a MEASUREMENT when something is installed to listen
+        # on it. Publishing the module default regardless made an unconfigured
+        # host report a plausible number for a relay it does not run — the
+        # "absent is not a measured value" rule this screen inherits from
+        # ``/session`` (review round 1, N2).
+        port = mobile_install.DEFAULT_PORT if installed else None
+        healthy = bool(installed and port and mobile_install.health(port))
         return installed, healthy, port
 
     backend, browser_name, paired = _safe("env.browser", browser, ("none", "", False), errors)
@@ -535,19 +596,45 @@ def collect_env(live: "LiveState", errors: list[tuple[str, str]]) -> EnvInfo:
         ),
         guides=_safe("env.guides", lambda: len(discover_guides()), 0, errors),
         skills=live.skills,
-        tools=live.tools,
     )
 
 
+#: Stand-in config root for when `config_dir()` itself cannot be resolved.
+#: Deliberately a path that cannot exist and cannot be created, so a probe whose
+#: constructor would otherwise MATERIALISE a store (``CredentialManager`` writes
+#: a ``credentials.env``) fails into `_safe` and is reported as degraded,
+#: instead of silently writing into the process's current directory. `/info`
+#: reads; it must never leave anything behind on the host it is describing.
+_UNREADABLE_ROOT = Path("/nonexistent/local-operator-info-unreadable-config-root")
+
+
 def _multiplexer() -> str:
-    """Which multiplexer this terminal is inside, by marker NAME only.
+    """Which multiplexer this terminal is inside, by marker PRESENCE only.
 
     A marker's value carries a socket path or a workspace id; neither is
-    diagnostic and both are identifying, so only the name is consulted.
+    diagnostic and both are identifying, so only presence is consulted and the
+    value is never read, never stored and never rendered.
+
+    Each read is spelled out rather than looped over
+    :data:`_MULTIPLEXER_MARKERS`, because the ambient-environment audit resolves
+    reads through the AST and cannot follow a loop variable — written as a loop,
+    these reads were invisible to the guard that exists to account for exactly
+    them (QA round 1, Q4). The tuple remains the ORDER of preference (most
+    specific first) and this function is checked against it by
+    ``test_every_multiplexer_marker_is_probed``, so the two cannot drift.
     """
-    for variable, name in _MULTIPLEXER_MARKERS:
-        if os.environ.get(variable) is not None:
-            return name
+    if os.environ.get(_ENV_CMUX_SOCKET_PATH) is not None:
+        return "cmux"
+    if os.environ.get(_ENV_CMUX_WORKSPACE_ID) is not None:
+        return "cmux"
+    if os.environ.get(_ENV_TMUX) is not None:
+        return "tmux"
+    if os.environ.get(_ENV_STY) is not None:
+        return "screen"
+    if os.environ.get(_ENV_ZELLIJ) is not None:
+        return "zellij"
+    if os.environ.get(_ENV_WEZTERM_PANE) is not None:
+        return "wezterm"
     return ""
 
 
@@ -587,7 +674,6 @@ class LiveState:
         "theme",
         "terminal_size",
         "skills",
-        "tools",
     )
 
     def __init__(self, **values: Any) -> None:
@@ -621,7 +707,6 @@ _LIVE_DEFAULTS: dict[str, Any] = {
     "theme": "",
     "terminal_size": None,
     "skills": 0,
-    "tools": 0,
 }
 
 
@@ -632,7 +717,6 @@ def collect_live(
     theme: str = "",
     size: tuple[int, int] | None = None,
     skills: int = 0,
-    tools: int = 0,
 ) -> LiveState:
     """Snapshot the live objects synchronously. Safe on the paint path.
 
@@ -700,7 +784,6 @@ def collect_live(
         theme=theme,
         terminal_size=tuple(size) if size else None,  # type: ignore[arg-type]
         skills=skills,
-        tools=tools,
     )
 
 
@@ -738,12 +821,26 @@ def collect_snapshot(live: LiveState, *, root: Path | None = None) -> InfoSnapsh
         errors,
     )
     self_line = next((line for line in sessions.lines if line.is_self), None)
+    # EVERY block call is wrapped, not just the probes inside them. The
+    # individual `_safe`s within each collector guard only what is inside their
+    # lambdas; a block function's own prologue — its function-local imports and
+    # its `config_dir()` call — was bare, so an unresolvable home
+    # (`Path.home()` raises `RuntimeError`) or a broken submodule propagated out
+    # of here. That is worse than an empty screen: `run_worker` defaults to
+    # `exit_on_error=True`, so the exception took the whole APP down, on exactly
+    # the broken host `/info` exists to describe (review round 1, B1). The
+    # fallbacks are all-defaults instances, which `model.py` guarantees render.
     return InfoSnapshot(
-        install=collect_install(errors),
-        process=collect_process(live, self_line=self_line, errors=errors, root=root),
+        install=_safe("install", lambda: collect_install(errors), InstallInfo(), errors),
+        process=_safe(
+            "process",
+            lambda: collect_process(live, self_line=self_line, errors=errors, root=root),
+            ProcessInfo(),
+            errors,
+        ),
         sessions=sessions,
-        agents=collect_agents(live, errors),
-        env=collect_env(live, errors),
+        agents=_safe("agents", lambda: collect_agents(live, errors), AgentsInfo(), errors),
+        env=_safe("env", lambda: collect_env(live, errors), EnvInfo(), errors),
         degraded=tuple(errors),
         captured_at=time.time(),
     )

--- a/local_operator/info/model.py
+++ b/local_operator/info/model.py
@@ -68,6 +68,11 @@ class InstallInfo:
     #: WARNING state, not an unavailable one: everything was read successfully,
     #: and what it says is that this runtime is executing code from somewhere
     #: other than the install it reports.
+    #:
+    #: Do NOT read this field directly to decide whether to warn — call
+    #: :func:`is_shadowed_install`, which also excludes the benign editable
+    #: case. QA round 1 (Q1) found the screen and the export reaching opposite
+    #: conclusions from one snapshot because each spelled the condition itself.
     import_path_foreign: bool = False
     is_git_snapshot: bool = False
     source_ref: str = ""
@@ -270,11 +275,76 @@ class EnvInfo:
     browser_paired: bool = False
     mobile_installed: bool = False
     mobile_healthy: bool = False
+    #: ``None`` when the relay is not installed. A port is only a measurement
+    #: when something is listening on it; publishing the module's DEFAULT_PORT
+    #: regardless made an unconfigured host report a plausible number, which is
+    #: the "absent is not a measured value" rule this screen inherits from
+    #: ``/session`` (review round 1, N2).
     mobile_port: int | None = None
     credential_keys: tuple[str, ...] = ()
     guides: int = 0
     skills: int = 0
-    tools: int = 0
+
+
+def format_duration(seconds: float | None) -> str:
+    """``42s`` / ``4m`` / ``3h 12m`` / ``2d 4h``. ONE spelling for both surfaces.
+
+    Lives here, beside the dataclasses, because both the screen and the export
+    render the same fields and a quantity that reads two ways across two halves
+    of one screen is a defect — this PR's own B2/Q1 finding was exactly that,
+    two surfaces reaching opposite conclusions from one snapshot. The two copies
+    happened to agree on every sampled value when they were measured, which is
+    the argument FOR sharing rather than against it: they agree today and
+    nothing made them keep agreeing.
+
+    ``model.py`` is the right home because it is the module both already import
+    and it is stdlib-only by contract, so sharing costs no new coupling.
+
+    ``None`` is "not measured" and says so; it is never a zero duration.
+    """
+    if seconds is None:
+        return "unknown"
+    total = int(max(0.0, seconds))
+    if total < 60:
+        return f"{total}s"
+    if total < 3600:
+        return f"{total // 60}m"
+    if total < 86400:
+        return f"{total // 3600}h {(total % 3600) // 60}m"
+    return f"{total // 86400}d {(total % 86400) // 3600}h"
+
+
+def format_bytes(value: int | None) -> str:
+    """``181 MB`` / ``1.9 GB``, or :data:`UNKNOWN` when nothing was measured.
+
+    Shared for the same reason as :func:`format_duration`. ``None`` renders as
+    the unknown sentinel rather than ``0 MB``: a process whose memory could not
+    be read is not a process using no memory.
+    """
+    if value is None:
+        return UNKNOWN
+    if value >= 1 << 30:
+        return f"{value / (1 << 30):.1f} GB"
+    return f"{value / (1 << 20):.0f} MB"
+
+
+def is_shadowed_install(install: InstallInfo) -> bool:
+    """Whether the running code is a checkout SHADOWING the reported install.
+
+    **The single source of truth for that judgement**, called by the screen and
+    by the export. Both used to spell the condition themselves, and they drifted
+    exactly as you would expect: the screen excluded the editable case and the
+    export did not, so every contributor running an editable checkout — which is
+    every contributor to this repo — copied a bug report asserting their install
+    was shadowed, sending a maintainer after AGENTS.md's most-documented trap
+    while it was not occurring (QA round 1, Q1).
+
+    An editable install's package IS the checkout by design, so a divergence
+    there is expected rather than alarming. Every other kind diverging is the
+    ``runtime/launch.py`` trap: spawned with ``-m`` and no ``cwd=``, so the
+    launching session's directory precedes site-packages on ``sys.path``.
+    """
+    return install.import_path_foreign and install.kind != "editable"
 
 
 @dataclass(frozen=True)

--- a/local_operator/info/model.py
+++ b/local_operator/info/model.py
@@ -1,0 +1,296 @@
+"""The ``/info`` snapshot's dataclasses. Pure data: no I/O, no rich, no Textual.
+
+Split from :mod:`local_operator.info.collect` for the reason
+``local_operator/analytics/`` splits ``model.py`` from ``store.py``, and for one
+harder constraint on top of it. ``collect`` has to reach ``mobile.resources``,
+``browser_bridge.state``, ``credentials``, ``agents`` and ``teams`` — none of
+which belong anywhere near a ``lop --version`` — while this module is what a
+future ``lop info`` renderer and every unit test import. Keeping the two apart
+makes "the shapes are cheap and the probes are not" a property of the import
+graph rather than of anyone's discipline, and ``test_model.py`` asserts it.
+
+**Every field has a default, and an all-defaults instance must render.** That is
+not tidiness: ``/info`` is the screen a user opens when something is already
+broken, so the collector degrades field by field (see :func:`collect._safe`) and
+hands the renderer whatever it managed to read. A dataclass with a required
+field would turn one unreadable probe into an empty screen, which is the exact
+failure this design exists to prevent.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+#: Sentinel a renderer prints for a scalar nobody could read. Matches what
+#: ``lop sessions`` already prints for an unmeasurable pid
+#: (``mobile/resources.py``: "the caller prints ``—`` for unknowns"), so the two
+#: surfaces spell "we looked and could not tell" the same way.
+UNKNOWN = "—"
+
+
+@dataclass(frozen=True)
+class InstallInfo:
+    """Which build this is, where it came from, and whether it is current.
+
+    The editable-vs-uv-tool distinction is the single most common source of "I
+    fixed it and nothing changed" in this codebase (AGENTS.md devotes a whole
+    section to it), so ``kind`` and ``prefix`` are as load-bearing as
+    ``version``.
+    """
+
+    version: str = ""
+    #: ``update.InstallKind`` value, as a plain string — this module must not
+    #: import :mod:`local_operator.update` (see the module docstring).
+    kind: str = ""
+    prefix: str = ""
+    executable: str = ""
+    #: The package directory ``local_operator`` ACTUALLY resolved to, from
+    #: ``local_operator.__file__``. Reported alongside :attr:`prefix` rather
+    #: than assumed equal to it, because the two genuinely come apart and the
+    #: divergence is invisible from every other surface:
+    #:
+    #: ``session/runtime/launch.py:287`` spawns the runtime as
+    #: ``[sys.executable, "-m", ...]`` with NO ``cwd=``, so the launching
+    #: session's working directory lands on ``sys.path[0]`` ahead of
+    #: site-packages. A session whose cwd is a checkout of this repo therefore
+    #: runs THAT CHECKOUT's code while every other field — version, install
+    #: kind, prefix — describes the install it was launched from, and ``/reload``
+    #: does not fix it. AGENTS.md documents the same class of trap for
+    #: symlinked venvs: "an agent that tested the feature interactively this way
+    #: has tested nothing, and will report a working change as broken — or
+    #: worse, a broken change as working."
+    #:
+    #: This is the field that makes "which code am I actually running"
+    #: answerable without inference, which is the whole reason the screen
+    #: exists.
+    import_path: str = ""
+    #: True when :attr:`import_path` does not sit under :attr:`prefix`. A
+    #: WARNING state, not an unavailable one: everything was read successfully,
+    #: and what it says is that this runtime is executing code from somewhere
+    #: other than the install it reports.
+    import_path_foreign: bool = False
+    is_git_snapshot: bool = False
+    source_ref: str = ""
+    build_age_s: float | None = None
+    #: The last PyPI answer already on disk, from ``update.cached_latest`` — a
+    #: read that NEVER fetches. ``None`` means "never checked", which is a
+    #: different fact from "up to date" and must render differently.
+    latest_known: str | None = None
+    latest_age_s: float | None = None
+    behind: bool = False
+    python_version: str = ""
+    python_implementation: str = ""
+    platform: str = ""
+    machine: str = ""
+
+
+@dataclass(frozen=True)
+class ProcessInfo:
+    """The runtime the user is typing into, and the directories it resolved.
+
+    ``config_dir`` and ``cache_dir`` are carried side by side deliberately: the
+    cache root derives from ``$HOME`` independently of
+    ``LOCAL_OPERATOR_CONFIG_DIR``, which AGENTS.md documents as silently
+    producing a *plausible wrong answer* in an "isolated" run. Showing both is
+    how a reader sees the divergence instead of assuming it away.
+    """
+
+    pid: int = 0
+    session_id: str = ""
+    conversation_name: str = ""
+    cwd: str = ""
+    model_label: str = ""
+    effective_model: str = ""
+    uptime_s: float | None = None
+    config_dir: str = ""
+    config_dir_redirected: bool = False
+    agent_home: str = ""
+    agent_home_redirected: bool = False
+    cache_dir: str = ""
+    log_dir: str = ""
+    #: Control-socket PORT only. The record's ``control_key`` is never carried
+    #: anywhere in this module — see :class:`SessionLine`.
+    control_port: int | None = None
+    protocol: int | None = None
+    kind: str = ""
+
+
+@dataclass(frozen=True)
+class SessionLine:
+    """One session on this machine, as ``lop sessions`` already describes it.
+
+    **``control_key`` is deliberately absent, and its absence is a tested
+    invariant** (``tests/unit/info/test_redaction.py``). ``SessionRecord``
+    carries a 64-hex control key that is the entire authorization story of the
+    control socket, and ``/info``'s output is what lands in a GitHub issue.
+    Omitting the field from the dataclass — rather than omitting it from one
+    renderer — is what makes the guarantee survive a later renderer change:
+    there is no attribute for a future ``asdict``-style dump to reach.
+    """
+
+    pid: int = 0
+    kind: str = ""
+    #: ``live`` | ``wedged`` | ``stale``. ``stale`` means the scan just DELETED
+    #: the record file (``registry.scan``), not that the session is idle.
+    state: str = ""
+    session_id: str = ""
+    conversation_name: str = ""
+    model_label: str = ""
+    cwd: str = ""
+    uptime_s: float = 0.0
+    heartbeat_age_s: float = 0.0
+    rss_bytes: int | None = None
+    footprint_bytes: int | None = None
+    pending: str | None = None
+    busy: bool = False
+    detached: bool = False
+    version: str = ""
+    source_ref: str = ""
+    #: Whether this row is the session running ``/info``. The reason the row
+    #: builder was EXTRACTED rather than copied: ``lop sessions`` has no such
+    #: concept, and a second implementation would have drifted on the subtler
+    #: fields (the ``getattr`` defaulting for mid-upgrade records) long before
+    #: it drifted on this one.
+    is_self: bool = False
+
+
+@dataclass(frozen=True)
+class SessionsInfo:
+    """Every session on this machine, plus the roll-ups the header reads from."""
+
+    lines: tuple[SessionLine, ...] = ()
+    total: int = 0
+    live: int = 0
+    wedged: int = 0
+    stale: int = 0
+    busy: int = 0
+    pending: int = 0
+    detached: int = 0
+    #: More than one distinct non-empty ``(version, source_ref)`` among LIVE
+    #: sessions: a host mid-upgrade, running two builds at once. Worth naming,
+    #: because "I fixed it and the other window still does it" is that.
+    build_skew: bool = False
+    #: False when the memory probes returned nothing at all, so the screen can
+    #: say "not measured" instead of printing a column of ``—`` that reads as
+    #: every session using no memory.
+    usage_available: bool = True
+    #: False when the scan itself failed, which replaces the whole section
+    #: header rather than annotating it.
+    available: bool = True
+
+
+@dataclass(frozen=True)
+class SubagentLine:
+    """One node of this session's subagent lineage, flattened depth-first."""
+
+    job_id: str = ""
+    label: str = ""
+    #: ``running`` | ``queued`` | ``starting`` | ``pausing`` | ``paused`` |
+    #: ``completed`` | ``failed`` | ``cancelled`` | ``gone``.
+    status: str = ""
+    depth: int = 0
+    agent_role: str = ""
+    effort: str = ""
+    parent_job_id: str | None = None
+    session_id: str | None = None
+    live: bool = False
+
+
+@dataclass(frozen=True)
+class AgentsInfo:
+    """Agent profiles, teams, and the subagent tree of THIS session.
+
+    The tree is this session's only. ``SubagentComms`` is a live in-memory
+    object on one ``Session`` and ``SessionRecord`` carries no subagent field,
+    so nothing about another session's children is observable without a new
+    control-socket op and a ``PROTOCOL_VERSION`` bump. The screen says so rather
+    than implying a fleet-wide view; :attr:`cross_session_known` is the seam a
+    later change would flip, and is always ``False`` today.
+    """
+
+    profiles: int = 0
+    teams: int = 0
+    tree: tuple[SubagentLine, ...] = ()
+    running: int = 0
+    queued: int = 0
+    #: Settled AND STILL RETAINED. ``SubagentComms._evict_overflow`` drops
+    #: settled records past its cap, so this is not "settled ever" and the label
+    #: must not claim it is — a count that silently under-reports inside a bug
+    #: report is worse than one that states what it counts.
+    settled: int = 0
+    max_running: int | None = None
+    at_capacity: bool = False
+    max_depth: int = 0
+    #: Number of nodes below the render depth cap, folded into one summary row
+    #: rather than indented off the card.
+    deeper: int = 0
+    cross_session_known: bool = False
+
+
+@dataclass(frozen=True)
+class EnvInfo:
+    """The debugging extras a bug report is asked for on the second round trip.
+
+    Credential KEY NAMES only — never a value, a length, a prefix or a hash. A
+    "first four characters" habit is how key prefixes end up in issues, and the
+    diagnostic question ("is the key even set?") is fully answered by the name.
+
+    **No tool-call or request success/failure RATE belongs here, deliberately.**
+    ``/session`` owns call-outcome measurement (tool-call validity against
+    execution errors, each with a stated denominator), and a second
+    success-ish figure computed here would disagree with it in cases neither
+    screen explains — leaving a user with two numbers and no way to tell which
+    is right. The MCP counts below are a DIFFERENT quantity and stay: server
+    reachability is not call outcome. The surface split this preserves is
+    ``/analytics`` = historical spend across sessions, ``/session`` = this
+    session's ledger and health, ``/info`` = install provenance and what is
+    actually running.
+    """
+
+    mcp_configured: int = 0
+    mcp_connected: int = 0
+    mcp_failed: int = 0
+    #: True while servers deferred past the startup gate are still connecting.
+    #: Shown, because reporting "1 of 3 up" mid-handshake makes a user file a
+    #: bug about a server that came up a second later.
+    mcp_settling: bool = False
+    mcp_failures: tuple[tuple[str, str], ...] = ()
+    approval_mode: str = ""
+    theme: str = ""
+    terminal_size: tuple[int, int] | None = None
+    term: str = ""
+    colorterm: str = ""
+    multiplexer: str = ""
+    is_tty: bool = False
+    #: ``extension`` | ``extension (stale)`` | ``none``, from the FILE
+    #: classification (``browser_bridge.state.liveness``) — 0.06 ms and unable
+    #: to hang. Availability nuance is ``/browser``'s job, not a diagnostic's.
+    browser_backend: str = ""
+    browser_name: str = ""
+    browser_paired: bool = False
+    mobile_installed: bool = False
+    mobile_healthy: bool = False
+    mobile_port: int | None = None
+    credential_keys: tuple[str, ...] = ()
+    guides: int = 0
+    skills: int = 0
+    tools: int = 0
+
+
+@dataclass(frozen=True)
+class InfoSnapshot:
+    """Everything ``/info`` renders, with each block degrading independently.
+
+    :attr:`degraded` maps a block or field name to the one-line reason it could
+    not be read. A bug report has to be able to say WHY a field is ``—``:
+    without the reason, an unreadable value costs the reporter a second round
+    trip, which is the cost this screen exists to remove.
+    """
+
+    install: InstallInfo = field(default_factory=InstallInfo)
+    process: ProcessInfo = field(default_factory=ProcessInfo)
+    sessions: SessionsInfo = field(default_factory=SessionsInfo)
+    agents: AgentsInfo = field(default_factory=AgentsInfo)
+    env: EnvInfo = field(default_factory=EnvInfo)
+    degraded: tuple[tuple[str, str], ...] = ()
+    captured_at: float = 0.0

--- a/local_operator/info/render.py
+++ b/local_operator/info/render.py
@@ -71,6 +71,15 @@ def _home() -> str:
     callers then return their input unchanged. That is the honest outcome
     rather than a redaction failure: what would be stripped is *this user's
     home prefix*, and on this host that concept is exactly what is unavailable.
+
+    DELIBERATELY NOT CACHED, and the round-2 commit message describing it as
+    "memoised" was wrong about the code (review round 3, M1). Recomputing per
+    call is the safer behaviour and the one that was verified: a cache would
+    pin a TRANSIENT failure for the life of the process, so a home that became
+    resolvable again would still export unrelativised paths. Both relativisers
+    read this same function, so they cannot disagree within one document even
+    though each call is independent. The cost is a `Path.home()` per row, which
+    is an environment lookup on a screen the user opened by hand.
     """
     try:
         return str(Path.home())

--- a/local_operator/info/render.py
+++ b/local_operator/info/render.py
@@ -36,7 +36,14 @@ import os
 import time
 from pathlib import Path
 
-from local_operator.info.model import InfoSnapshot, SubagentLine
+from local_operator.info.model import (
+    UNKNOWN,
+    InfoSnapshot,
+    SubagentLine,
+    format_bytes,
+    format_duration,
+    is_shadowed_install,
+)
 
 #: Fields the export never prints, restated here as a NAME LIST purely so a
 #: reader of this module sees the rule without chasing three dataclasses. The
@@ -63,26 +70,48 @@ def relativise_home(path: str) -> str:
     return path
 
 
-def _duration(seconds: float | None) -> str:
-    """``4m`` / ``3h 12m`` / ``2d 4h`` — the export's one duration spelling."""
-    if seconds is None:
-        return "unknown"
-    total = int(max(0.0, seconds))
-    if total < 60:
-        return f"{total}s"
-    if total < 3600:
-        return f"{total // 60}m"
-    if total < 86400:
-        return f"{total // 3600}h {(total % 3600) // 60}m"
-    return f"{total // 86400}d {(total % 86400) // 3600}h"
+def _scrub(text: str) -> str:
+    """Home-relativise FREE TEXT before it reaches the export.
+
+    The explicit path fields were always relativised; two channels carrying
+    text this module does not compose were not. MCP failure messages are
+    ``str(exc)`` from a failed connect (typically ``command not found:
+    <absolute path>``) and a ``degraded`` reason is
+    ``f"{type(exc).__name__}: {exc}"``, where an ``OSError`` message contains
+    the filename it failed on. Both routinely carry ``$HOME`` — exactly the
+    disclosure this module's docstring says must never happen, in the artifact
+    built to be pasted publicly (review round 1, B2).
+
+    Applied per free-text channel AND again over the whole document by
+    :func:`build_export`, so a future field that forgets to call it is still
+    covered.
+    """
+    return relativise_home_everywhere(text)
 
 
-def _bytes(value: int | None) -> str:
-    if value is None:
-        return "—"
-    if value >= 1 << 30:
-        return f"{value / (1 << 30):.1f} GB"
-    return f"{value / (1 << 20):.0f} MB"
+def relativise_home_everywhere(text: str) -> str:
+    """Replace every occurrence of the home directory anywhere in ``text``.
+
+    Unlike :func:`relativise_home`, which anchors at the START of a path, this
+    rewrites a home path embedded mid-sentence — which is the shape a failure
+    message has.
+    """
+    if not text:
+        return text
+    home = str(Path.home())
+    return text.replace(home + os.sep, "~" + os.sep).replace(home, "~")
+
+
+def _value(text: str) -> str:
+    """A scalar for the export, with the SAME unknown spelling the screen uses.
+
+    The screen renders an unreadable value as ``UNKNOWN``; the export used to
+    interpolate the empty string, so one snapshot produced seven blank fields
+    and the two surfaces disagreed about what had been read. A blank in a
+    pasted report is indistinguishable from a rendering bug, which is the second
+    round trip this screen exists to remove (review round 1, M4).
+    """
+    return text or UNKNOWN
 
 
 def _latest_line(snapshot: InfoSnapshot) -> str:
@@ -93,6 +122,13 @@ def _latest_line(snapshot: InfoSnapshot) -> str:
     over, printing the latter from the former is an outright lie.
     """
     install = snapshot.install
+    if not install.version:
+        # The unknown is on the INSTALLED side here rather than the latest side,
+        # but the lie is the same one: ``is_behind("", latest)`` is False by
+        # design, so a failed version probe beside a cached NEWER release
+        # reported currency. Both halves fail together on a broken install,
+        # which is the state /info is opened in (review round 1, M3).
+        return "unknown (installed version unreadable)"
     if install.latest_known is None:
         return "unknown (never checked)"
     from local_operator.update import TTL_S
@@ -101,7 +137,7 @@ def _latest_line(snapshot: InfoSnapshot) -> str:
     if age is None:
         return install.latest_known
     stale = " (stale)" if age > TTL_S else ""
-    return f"{install.latest_known} · checked {_duration(age)} ago{stale}"
+    return f"{install.latest_known} · checked {format_duration(age)} ago{stale}"
 
 
 def _tree_lines(tree: tuple[SubagentLine, ...], deeper: int) -> list[str]:
@@ -141,48 +177,47 @@ def build_export(snapshot: InfoSnapshot) -> str:
         )
         if part
     )
-    stamp = (
-        time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(snapshot.captured_at))
-        if snapshot.captured_at
-        else "unknown"
-    )
-
-    lines: list[str] = [head, f"captured {stamp}", "", "## Install"]
+    lines: list[str] = ["## Install"]
     lines += [
-        f"  version           {install.version or '—'}",
+        f"  version           {_value(install.version)}",
         f"  latest known      {_latest_line(snapshot)}",
-        f"  install kind      {install.kind or '—'}",
-        f"  install path      {relativise_home(install.prefix)}",
-        f"  interpreter       {relativise_home(install.executable)}",
+        f"  install kind      {_value(install.kind)}",
+        f"  install path      {_value(relativise_home(install.prefix))}",
+        f"  interpreter       {_value(relativise_home(install.executable))}",
         # Included unconditionally, and marked when it diverges: a maintainer
         # reading a bug report needs to know the reporter's runtime was running
         # a checkout rather than the version the first line claims.
-        f"  running code      {relativise_home(install.import_path) or '—'}"
+        f"  running code      {_value(relativise_home(install.import_path))}"
         + (
             "  (NOT under the install path — a checkout is shadowing it)"
-            if install.import_path_foreign
-            else ""
+            if is_shadowed_install(install)
+            else "  (an editable checkout, as expected)" if install.import_path_foreign else ""
         ),
         f"  source            {'git snapshot' if install.is_git_snapshot else 'PyPI wheel'}"
         + (f" @ {install.source_ref[:12]}" if install.source_ref else ""),
-        f"  build age         {_duration(install.build_age_s)}",
-        f"  python            {install.python_version} ({install.python_implementation})",
-        f"  platform          {install.platform or '—'} · {install.machine or '—'}",
+        f"  build age         {format_duration(install.build_age_s)}",
+        "  python            "
+        + (
+            f"{install.python_version} ({install.python_implementation})"
+            if install.python_version and install.python_implementation
+            else _value(install.python_version or install.python_implementation)
+        ),
+        f"  platform          {_value(install.platform)} · {_value(install.machine)}",
         "",
         "## This session",
-        f"  session id        {process.session_id or '—'}",
-        f"  kind              {process.kind or '—'}",
+        f"  session id        {_value(process.session_id)}",
+        f"  kind              {_value(process.kind)}",
         f"  pid               {process.pid}",
-        f"  model             {process.model_label or '—'}",
-        f"  effective model   {process.effective_model or process.model_label or '—'}",
-        f"  uptime            {_duration(process.uptime_s)}",
-        f"  working dir       {relativise_home(process.cwd)}",
-        f"  config dir        {relativise_home(process.config_dir)}"
+        f"  model             {_value(process.model_label)}",
+        f"  effective model   {_value(process.effective_model or process.model_label)}",
+        f"  uptime            {format_duration(process.uptime_s)}",
+        f"  working dir       {_value(relativise_home(process.cwd))}",
+        f"  config dir        {_value(relativise_home(process.config_dir))}"
         + ("  (redirected)" if process.config_dir_redirected else ""),
-        f"  cache dir         {relativise_home(process.cache_dir)}",
-        f"  agent home        {relativise_home(process.agent_home)}"
+        f"  cache dir         {_value(relativise_home(process.cache_dir))}",
+        f"  agent home        {_value(relativise_home(process.agent_home))}"
         + ("  (redirected)" if process.agent_home_redirected else ""),
-        f"  log dir           {relativise_home(process.log_dir)}",
+        f"  log dir           {_value(relativise_home(process.log_dir))}",
         f"  control port      {process.control_port if process.control_port else '—'}",
         f"  protocol          {process.protocol if process.protocol else '—'}",
         "",
@@ -201,12 +236,12 @@ def build_export(snapshot: InfoSnapshot) -> str:
         for line in sessions.lines:
             mark = "*" if line.is_self else "-"
             name = line.conversation_name or line.session_id or str(line.pid)
-            memory = _bytes(line.footprint_bytes or line.rss_bytes)
+            memory = format_bytes(line.footprint_bytes or line.rss_bytes)
             extra = " · busy" if line.busy else ""
             extra += f" · needs {line.pending}" if line.pending else ""
             lines.append(
                 f"  {mark} [{line.state}] {name} · {line.kind} · pid {line.pid} · "
-                f"{_duration(line.uptime_s)} · {memory}{extra}"
+                f"{format_duration(line.uptime_s)} · {memory}{extra}"
             )
             lines.append(f"      {relativise_home(line.cwd)} · {line.model_label or '—'}")
 
@@ -258,10 +293,9 @@ def build_export(snapshot: InfoSnapshot) -> str:
     # servers that came up a second later.
     if env.mcp_failures and not env.mcp_settling:
         for name, message in env.mcp_failures:
-            lines.append(f"      {name}: {message}")
+            lines.append(f"      {name}: {_scrub(message)}")
     lines.append(f"  guides            {env.guides}")
     lines.append(f"  skills            {env.skills}")
-    lines.append(f"  tools             {env.tools}")
     # NAMES ONLY, and this is the line the redaction test reads.
     lines.append(
         f"  credentials       {len(env.credential_keys)} keys"
@@ -271,6 +305,37 @@ def build_export(snapshot: InfoSnapshot) -> str:
     if snapshot.degraded:
         lines += ["", "## Could not read"]
         for name, reason in snapshot.degraded:
-            lines.append(f"  {name}: {reason}")
+            lines.append(f"  {name}: {_scrub(reason)}")
 
-    return "\n".join(lines) + "\n"
+    body = "\n".join(lines)
+    # A FINAL whole-document pass, on top of the per-channel `_scrub` above.
+    # Belt and braces deliberately: the per-site calls document intent at the
+    # two channels known to carry free text, and this one covers any field a
+    # later change adds without remembering to scrub it. Both are cheap string
+    # replacements over a ~50-line document (review round 1, B2).
+    body = relativise_home_everywhere(body)
+
+    # FENCED, reversing this module's original "no fence" position. The
+    # reasoning against a fence is sound for prose and does not survive contact
+    # with this payload: 43 of ~55 lines are `  label<spaces>value`, and GFM
+    # collapses space runs and folds them into one `<p>...<br>` paragraph — the
+    # two-space indent even reads as a list continuation, so a session block
+    # came out as an actual `<ul><li>`. Verified against GitHub's own /markdown
+    # API rather than assumed (UX round 1, U1). A user cannot "want it without a
+    # fence" because without one the alignment that makes it readable is gone,
+    # and the failure is invisible to the person pasting it.
+    #
+    # The triage header stays OUTSIDE the fence so it remains greppable and
+    # readable in a notification email, and the `<details>` wrapper keeps a
+    # 55-line block from burying the reporter's own words.
+    stamp = (
+        time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(snapshot.captured_at))
+        if snapshot.captured_at
+        else "unknown"
+    )
+    return (
+        f"{head}\n\n"
+        f"<details><summary>/info report — captured {stamp}</summary>\n\n"
+        f"```text\n{body}\n```\n\n"
+        "</details>\n"
+    )

--- a/local_operator/info/render.py
+++ b/local_operator/info/render.py
@@ -52,6 +52,32 @@ from local_operator.info.model import (
 NEVER_EXPORTED = ("control_key", "session_key", "credential values")
 
 
+def _home() -> str:
+    """The home directory, or ``""`` when it cannot be resolved. NEVER raises.
+
+    ``Path.home()`` raises ``RuntimeError`` when the home cannot be resolved,
+    which is the same failure class ``collect.py`` is wrapped against — and the
+    export is reached from ``action_copy_report``, a SYNCHRONOUS key action on
+    the message pump. No worker sits under it, so ``exit_on_error=False``
+    cannot help: an escape here takes the application down.
+
+    That path only became reachable once the collect-side guards landed. Before
+    them the app died at probe time and the user never got a screen to press
+    ``ctrl+r`` on; after them the screen opens and re-probes cleanly, and the
+    copy gesture — the one gesture this feature is advertised for — was the
+    remaining way to kill the session (review round 2, F1).
+
+    An empty string means "there is no home to relativise against", and both
+    callers then return their input unchanged. That is the honest outcome
+    rather than a redaction failure: what would be stripped is *this user's
+    home prefix*, and on this host that concept is exactly what is unavailable.
+    """
+    try:
+        return str(Path.home())
+    except (RuntimeError, OSError):
+        return ""
+
+
 def relativise_home(path: str) -> str:
     """``/Users/x/repos/y`` → ``~/repos/y``. Everything below ``~`` is kept.
 
@@ -61,7 +87,9 @@ def relativise_home(path: str) -> str:
     """
     if not path:
         return path
-    home = str(Path.home())
+    home = _home()
+    if not home:
+        return path
     if path == home:
         return "~"
     prefix = home + os.sep
@@ -70,35 +98,33 @@ def relativise_home(path: str) -> str:
     return path
 
 
-def _scrub(text: str) -> str:
-    """Home-relativise FREE TEXT before it reaches the export.
+def relativise_home_everywhere(text: str) -> str:
+    """Replace every occurrence of the home directory anywhere in ``text``.
 
-    The explicit path fields were always relativised; two channels carrying
-    text this module does not compose were not. MCP failure messages are
-    ``str(exc)`` from a failed connect (typically ``command not found:
-    <absolute path>``) and a ``degraded`` reason is
+    Unlike :func:`relativise_home`, which anchors at the START of a path, this
+    rewrites a home path embedded mid-sentence — which is the shape a failure
+    message has. That is why FREE TEXT is routed through here: MCP failure
+    messages are ``str(exc)`` from a failed connect (typically ``command not
+    found: <absolute path>``) and a ``degraded`` reason is
     ``f"{type(exc).__name__}: {exc}"``, where an ``OSError`` message contains
     the filename it failed on. Both routinely carry ``$HOME`` — exactly the
     disclosure this module's docstring says must never happen, in the artifact
     built to be pasted publicly (review round 1, B2).
 
     Applied per free-text channel AND again over the whole document by
-    :func:`build_export`, so a future field that forgets to call it is still
-    covered.
-    """
-    return relativise_home_everywhere(text)
-
-
-def relativise_home_everywhere(text: str) -> str:
-    """Replace every occurrence of the home directory anywhere in ``text``.
-
-    Unlike :func:`relativise_home`, which anchors at the START of a path, this
-    rewrites a home path embedded mid-sentence — which is the shape a failure
-    message has.
+    :func:`build_export`. That backstop covers the HOME DIRECTORY only — it is
+    a literal replacement of one string. It does NOT cover the other
+    identifying shapes: an absolute socket path outside ``$HOME``
+    (``CMUX_SOCKET_PATH``) or a ``/var/folders/...`` temp path pass through it
+    untouched. A new free-text field therefore still needs its own scrub at
+    source; the document pass is a safety net for the one shape, not a general
+    redaction pass (review round 2, F2).
     """
     if not text:
         return text
-    home = str(Path.home())
+    home = _home()
+    if not home:
+        return text
     return text.replace(home + os.sep, "~" + os.sep).replace(home, "~")
 
 
@@ -293,7 +319,7 @@ def build_export(snapshot: InfoSnapshot) -> str:
     # servers that came up a second later.
     if env.mcp_failures and not env.mcp_settling:
         for name, message in env.mcp_failures:
-            lines.append(f"      {name}: {_scrub(message)}")
+            lines.append(f"      {name}: {relativise_home_everywhere(message)}")
     lines.append(f"  guides            {env.guides}")
     lines.append(f"  skills            {env.skills}")
     # NAMES ONLY, and this is the line the redaction test reads.
@@ -305,7 +331,7 @@ def build_export(snapshot: InfoSnapshot) -> str:
     if snapshot.degraded:
         lines += ["", "## Could not read"]
         for name, reason in snapshot.degraded:
-            lines.append(f"  {name}: {_scrub(reason)}")
+            lines.append(f"  {name}: {relativise_home_everywhere(reason)}")
 
     body = "\n".join(lines)
     # A FINAL whole-document pass, on top of the per-channel `_scrub` above.

--- a/local_operator/info/render.py
+++ b/local_operator/info/render.py
@@ -1,0 +1,276 @@
+"""The plain-text export of an :class:`InfoSnapshot`, for pasting into an issue.
+
+**One export mode, and it is redacted. There is no unredacted mode.** A user
+told "press ctrl+r, or ctrl+shift+r for the full one" will press the wrong one
+under stress, and the mode that leaks would be the one with the better name. The
+boundary is drawn where the risk actually changes instead: the SCREEN shows
+verbatim paths (local debugging, private, and every high-value bug in this
+codebase's history is a path bug — the editable-venv resolution trap,
+``LOCAL_OPERATOR_CONFIG_DIR`` not redirecting the cache, ``lop-update``
+installing from the wrong ref), while the EXPORT is home-relativised, because
+that is the artifact that leaves the machine.
+
+What can never appear here, at any width and through any future edit:
+
+* ``SessionRecord.control_key`` — 64 hex characters that ARE the control
+  socket's whole authorization story. It is not a field on
+  :class:`~local_operator.info.model.SessionLine` at all, which is what makes
+  the guarantee structural rather than a property of this file.
+* ``BridgeState.session_key`` — same reasoning; only ``paired``,
+  ``extension_connected``, ``browser_name`` and ``port`` are collected.
+* Credential VALUES. Names only, and not a prefix, a length or a hash: a
+  "first four characters" habit is how key prefixes end up in issues.
+* An absolute ``/Users/<name>`` or ``/home/<name>`` prefix. A macOS username in
+  an issue is low-sensitivity, but a ``cwd`` like
+  ``/Users/x/clients/acme-merger-diligence`` is real information, and the export
+  is the thing that gets pasted somewhere public.
+
+``tests/unit/info/test_redaction.py`` asserts each of those against a snapshot
+deliberately seeded with a known key, and is the highest-value file in this
+package.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+from local_operator.info.model import InfoSnapshot, SubagentLine
+
+#: Fields the export never prints, restated here as a NAME LIST purely so a
+#: reader of this module sees the rule without chasing three dataclasses. The
+#: enforcement is structural (the fields do not exist on the collected shapes);
+#: this is documentation, not a filter.
+NEVER_EXPORTED = ("control_key", "session_key", "credential values")
+
+
+def relativise_home(path: str) -> str:
+    """``/Users/x/repos/y`` → ``~/repos/y``. Everything below ``~`` is kept.
+
+    The username is the identifying part; the path BELOW the home directory is
+    the diagnostic part (``~/local-operator``, ``~/workspace/repos/lo-x`` all
+    say something a maintainer needs). So exactly one segment is removed.
+    """
+    if not path:
+        return path
+    home = str(Path.home())
+    if path == home:
+        return "~"
+    prefix = home + os.sep
+    if path.startswith(prefix):
+        return "~" + os.sep + path[len(prefix) :]
+    return path
+
+
+def _duration(seconds: float | None) -> str:
+    """``4m`` / ``3h 12m`` / ``2d 4h`` — the export's one duration spelling."""
+    if seconds is None:
+        return "unknown"
+    total = int(max(0.0, seconds))
+    if total < 60:
+        return f"{total}s"
+    if total < 3600:
+        return f"{total // 60}m"
+    if total < 86400:
+        return f"{total // 3600}h {(total % 3600) // 60}m"
+    return f"{total // 86400}d {(total % 86400) // 3600}h"
+
+
+def _bytes(value: int | None) -> str:
+    if value is None:
+        return "—"
+    if value >= 1 << 30:
+        return f"{value / (1 << 30):.1f} GB"
+    return f"{value / (1 << 20):.0f} MB"
+
+
+def _latest_line(snapshot: InfoSnapshot) -> str:
+    """The three PyPI states, never collapsed into two.
+
+    ``None`` is "we have never asked", which is a different fact from "you are
+    up to date" — and on the broken network that ``/info`` is usually opened
+    over, printing the latter from the former is an outright lie.
+    """
+    install = snapshot.install
+    if install.latest_known is None:
+        return "unknown (never checked)"
+    from local_operator.update import TTL_S
+
+    age = install.latest_age_s
+    if age is None:
+        return install.latest_known
+    stale = " (stale)" if age > TTL_S else ""
+    return f"{install.latest_known} · checked {_duration(age)} ago{stale}"
+
+
+def _tree_lines(tree: tuple[SubagentLine, ...], deeper: int) -> list[str]:
+    out: list[str] = []
+    for node in tree:
+        indent = "  " * node.depth
+        role = f" [{node.agent_role}]" if node.agent_role else ""
+        out.append(f"  {indent}- {node.label or node.job_id}{role}: {node.status}")
+    if deeper:
+        out.append(f"  + {deeper} deeper")
+    return out
+
+
+def build_export(snapshot: InfoSnapshot) -> str:
+    """The whole snapshot as plain text, home-relativised, ready to paste.
+
+    No markdown code fence is added. The user is pasting into a GitHub issue and
+    may want a fence, a details block or neither; one we add is one they have to
+    remove first.
+
+    The first line is a single-line triage header so a maintainer can classify
+    the report without reading the body.
+    """
+    install = snapshot.install
+    process = snapshot.process
+    sessions = snapshot.sessions
+    agents = snapshot.agents
+    env = snapshot.env
+
+    head = " · ".join(
+        part
+        for part in (
+            f"local-operator {install.version or 'unknown'}",
+            install.kind or "unknown install",
+            install.platform or "",
+            f"py{install.python_version}" if install.python_version else "",
+        )
+        if part
+    )
+    stamp = (
+        time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(snapshot.captured_at))
+        if snapshot.captured_at
+        else "unknown"
+    )
+
+    lines: list[str] = [head, f"captured {stamp}", "", "## Install"]
+    lines += [
+        f"  version           {install.version or '—'}",
+        f"  latest known      {_latest_line(snapshot)}",
+        f"  install kind      {install.kind or '—'}",
+        f"  install path      {relativise_home(install.prefix)}",
+        f"  interpreter       {relativise_home(install.executable)}",
+        # Included unconditionally, and marked when it diverges: a maintainer
+        # reading a bug report needs to know the reporter's runtime was running
+        # a checkout rather than the version the first line claims.
+        f"  running code      {relativise_home(install.import_path) or '—'}"
+        + (
+            "  (NOT under the install path — a checkout is shadowing it)"
+            if install.import_path_foreign
+            else ""
+        ),
+        f"  source            {'git snapshot' if install.is_git_snapshot else 'PyPI wheel'}"
+        + (f" @ {install.source_ref[:12]}" if install.source_ref else ""),
+        f"  build age         {_duration(install.build_age_s)}",
+        f"  python            {install.python_version} ({install.python_implementation})",
+        f"  platform          {install.platform or '—'} · {install.machine or '—'}",
+        "",
+        "## This session",
+        f"  session id        {process.session_id or '—'}",
+        f"  kind              {process.kind or '—'}",
+        f"  pid               {process.pid}",
+        f"  model             {process.model_label or '—'}",
+        f"  effective model   {process.effective_model or process.model_label or '—'}",
+        f"  uptime            {_duration(process.uptime_s)}",
+        f"  working dir       {relativise_home(process.cwd)}",
+        f"  config dir        {relativise_home(process.config_dir)}"
+        + ("  (redirected)" if process.config_dir_redirected else ""),
+        f"  cache dir         {relativise_home(process.cache_dir)}",
+        f"  agent home        {relativise_home(process.agent_home)}"
+        + ("  (redirected)" if process.agent_home_redirected else ""),
+        f"  log dir           {relativise_home(process.log_dir)}",
+        f"  control port      {process.control_port if process.control_port else '—'}",
+        f"  protocol          {process.protocol if process.protocol else '—'}",
+        "",
+        "## Sessions on this machine",
+    ]
+
+    if not sessions.available:
+        lines.append("  unavailable — the session registry could not be scanned")
+    elif not sessions.lines:
+        lines.append("  none")
+    else:
+        lines.append(
+            f"  {sessions.live} live · {sessions.wedged} wedged · {sessions.total} total"
+            + (" · BUILD SKEW" if sessions.build_skew else "")
+        )
+        for line in sessions.lines:
+            mark = "*" if line.is_self else "-"
+            name = line.conversation_name or line.session_id or str(line.pid)
+            memory = _bytes(line.footprint_bytes or line.rss_bytes)
+            extra = " · busy" if line.busy else ""
+            extra += f" · needs {line.pending}" if line.pending else ""
+            lines.append(
+                f"  {mark} [{line.state}] {name} · {line.kind} · pid {line.pid} · "
+                f"{_duration(line.uptime_s)} · {memory}{extra}"
+            )
+            lines.append(f"      {relativise_home(line.cwd)} · {line.model_label or '—'}")
+
+    lines += ["", "## Agents and subagents"]
+    lines.append(f"  profiles          {agents.profiles}")
+    lines.append(f"  teams             {agents.teams}")
+    lines.append(
+        f"  subagents         {agents.running} running · {agents.queued} queued · "
+        f"{agents.settled} settled (retained)"
+    )
+    if agents.max_running is not None:
+        lines.append(
+            f"  capacity          {agents.max_running} concurrent"
+            + ("  (AT CAPACITY)" if agents.at_capacity else "")
+        )
+    if agents.tree:
+        lines.append(f"  tree (this session only, depth {agents.max_depth}):")
+        lines += _tree_lines(agents.tree, agents.deeper)
+    else:
+        lines.append("  no subagents launched in this session")
+    # Stated, not implied: only this session's tree is observable, so a report
+    # that showed one tree could otherwise be read as a fleet-wide total.
+    lines.append("  (other sessions report busy/pending and memory only)")
+
+    lines += [
+        "",
+        "## Environment",
+        f"  terminal          {env.term or '—'}"
+        + (f" · {env.terminal_size[0]}x{env.terminal_size[1]}" if env.terminal_size else "")
+        + (f" · {env.colorterm}" if env.colorterm else ""),
+        f"  multiplexer       {env.multiplexer or 'none'}",
+        f"  tty               {'yes' if env.is_tty else 'no'}",
+        f"  theme             {env.theme or '—'}",
+        f"  approvals         {env.approval_mode or '—'}",
+        f"  browser           {env.browser_backend or 'none'}"
+        + (f" · {env.browser_name}" if env.browser_name else ""),
+        "  mobile            "
+        + (
+            ("installed" if env.mobile_installed else "not installed")
+            + (" · healthy" if env.mobile_healthy else "")
+            + (f" · port {env.mobile_port}" if env.mobile_installed and env.mobile_port else "")
+        ),
+        f"  mcp               {env.mcp_connected}/{env.mcp_configured} connected"
+        + (" · still connecting" if env.mcp_settling else "")
+        + (f" · {env.mcp_failed} failed" if env.mcp_failed and not env.mcp_settling else ""),
+    ]
+    # Failures are suppressed while SETTLING for the reason McpStartupOutcome
+    # states: naming a server as failed mid-handshake produces bug reports about
+    # servers that came up a second later.
+    if env.mcp_failures and not env.mcp_settling:
+        for name, message in env.mcp_failures:
+            lines.append(f"      {name}: {message}")
+    lines.append(f"  guides            {env.guides}")
+    lines.append(f"  skills            {env.skills}")
+    lines.append(f"  tools             {env.tools}")
+    # NAMES ONLY, and this is the line the redaction test reads.
+    lines.append(
+        f"  credentials       {len(env.credential_keys)} keys"
+        + (f": {', '.join(env.credential_keys)}" if env.credential_keys else "")
+    )
+
+    if snapshot.degraded:
+        lines += ["", "## Could not read"]
+        for name, reason in snapshot.degraded:
+            lines.append(f"  {name}: {reason}")
+
+    return "\n".join(lines) + "\n"

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -686,6 +686,14 @@ _FRONTEND_LOCAL_SLASHES = {
     # Like analytics, reads the shared local ledger for the mirrored current
     # session ID. No owner RPC or new transport payload is needed.
     "session",
+    # Everything /info reports is a fact about the process DRAWING the screen:
+    # its install prefix and resolved import path, its pid and control port, the
+    # session registry on this host, this frontend's terminal and theme. Routed
+    # to the owner it would describe the owner's machine while the header names
+    # this one — the wrong-machine answer on the one screen whose entire job is
+    # "which code am I actually running". Same argument as `/theme`, `/settings`
+    # and the `desktop_destination` this command deliberately omits.
+    "info",
     "skills",
     "login",
     "logout",

--- a/local_operator/slash_commands.py
+++ b/local_operator/slash_commands.py
@@ -296,6 +296,22 @@ SLASH_COMMANDS: list[SlashCommand] = [
         "Current-session usage, cost and request diagnostics",
         desktop_destination="session.diagnostics",
     ),
+    # Beside `/session` because it is the same family — a read-only diagnostic
+    # screen with no owner execution — but a WIDER scope: `/session` describes
+    # one conversation's spend, `/info` describes the INSTALL and every runtime
+    # on the machine. It is the screen a user is asked to paste into an issue,
+    # which is why it takes no argument at all: there is one answer, and making
+    # someone name it would be a gate in front of a command that has one.
+    #
+    # No `desktop_destination`: every field it renders is a fact about THIS
+    # process and THIS host (install prefix, pids, RSS, the in-memory subagent
+    # graph), so a desktop surface pointed at it would describe the machine the
+    # host runs on rather than the one the user is asking about. Like `/context`
+    # it needs no `native_action` branch or `OWNER_COMMANDS` entry.
+    SlashCommand(
+        "info",
+        "Install, version, sessions and subagents on this machine",
+    ),
     # The screen it opens IS the receipt (same rule as `/usage`). The argument
     # names WHICH analytics view; today only `usage` exists, so the list is an
     # OFFER — a bare `/analytics` opens the usage view rather than doing

--- a/local_operator/slash_commands.py
+++ b/local_operator/slash_commands.py
@@ -310,7 +310,15 @@ SLASH_COMMANDS: list[SlashCommand] = [
     # it needs no `native_action` branch or `OWNER_COMMANDS` entry.
     SlashCommand(
         "info",
-        "Install, version, sessions and subagents on this machine",
+        # "running sessions", not "sessions": `/analytics` describes past
+        # CONVERSATIONS and this describes live PROCESSES, and both descriptions
+        # sit in one picker where the shared word read as the same thing (UX
+        # round 1, U9). One word buys the distinction.
+        "Install, version, and running sessions on this machine",
+        # A user who has just been asked "what version are you on?" reaches for
+        # the word they were asked, not for the name of our screen. Alias rows
+        # share a line in the picker, so this costs no space (UX round 1, U8).
+        aliases=("version", "about"),
     ),
     # The screen it opens IS the receipt (same rule as `/usage`). The argument
     # names WHICH analytics view; today only `usage` exists, so the list is an

--- a/local_operator/slash_commands.py
+++ b/local_operator/slash_commands.py
@@ -315,10 +315,17 @@ SLASH_COMMANDS: list[SlashCommand] = [
         # sit in one picker where the shared word read as the same thing (UX
         # round 1, U9). One word buys the distinction.
         "Install, version, and running sessions on this machine",
-        # A user who has just been asked "what version are you on?" reaches for
-        # the word they were asked, not for the name of our screen. Alias rows
-        # share a line in the picker, so this costs no space (UX round 1, U8).
-        aliases=("version", "about"),
+        # NO ALIASES, deliberately — `version`/`about` were added for UX round 1
+        # U8 and reverted the same round. The claim that alias rows "cost no
+        # space" is false here: the picker measures ONE name column across every
+        # row, so `/info  /version  /about` at 23 cells became the widest entry
+        # (previous max `/settings  /config`, 18) and took those 5 cells from
+        # every other command's description. Measured consequence at 80 columns:
+        # `/help`'s description collapsed to `List all co…`, and the `/model`
+        # and `ctrl+v` rows in `/help` wrapped. Discoverability for one command
+        # is not worth truncating the descriptions of all of them, and `/help`
+        # already lists this one. See `test_descriptions_come_back_above_the_
+        # collapse_width`, which is the guard that caught it.
     ),
     # The screen it opens IS the receipt (same rule as `/usage`). The argument
     # names WHICH analytics view; today only `usage` exists, so the list is an

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -308,10 +308,12 @@ if TYPE_CHECKING:  # keeps the provider graph off the TUI's runtime import path
     from pathlib import Path
 
     from local_operator.herdr import HerdrReporter
+    from local_operator.info.collect import LiveState
     from local_operator.multiplexer import SessionBroadcast
     from local_operator.providers.controller import CatalogueEntry
     from local_operator.providers.oauth.callback_server import LoginCallbacks
     from local_operator.skills.discovery import Skill
+    from local_operator.tui.widgets.info_panel import InfoScreen
     from local_operator.tui.widgets.session_panel import (
         SessionDiagnostics,
         SessionScreen,
@@ -18946,6 +18948,8 @@ class OperatorApp(App[None]):
             self._cmd_analytics(arg, notice)
         elif command == "/session":
             self._cmd_session(arg, notice)
+        elif command == "/info":
+            self._cmd_info(arg, notice)
         elif command == "/context":
             block = self._context_block()
             if block is not None:
@@ -22977,6 +22981,97 @@ class OperatorApp(App[None]):
             screen.invalidate()
             return
         screen.set_report(report)
+
+    def _cmd_info(self, arg: str, notice: NoticeFn) -> None:
+        """``/info`` — this install, this machine's sessions, and the subagent tree.
+
+        Two-phase, and the split is the whole design. The LIVE state (the
+        subagent graph, job capacity, MCP startup, approval mode, theme,
+        terminal size) is captured HERE, synchronously, before anything yields:
+        it is all in-memory reads, and a ``/new`` or ``/resume`` arriving during
+        the disk probe must not put a brand-new subagent tree under a header
+        describing the old session — the rule ``SessionDiagnostics.capture``
+        states at ``session_panel.py``. Everything blocking then runs in a
+        worker, because the sessions block alone measured **879.5 ms** on this
+        host (``session_resource_usage`` shells ``top -l1`` for the whole system
+        on macOS), which is ~26 dropped frames at 30 fps.
+
+        The screen is pushed BEFORE the probe starts, like ``/session`` and
+        unlike ``/analytics``: it is useful from frame one (version, session id,
+        model and the tree are all in the live capture) and it owns a visible,
+        cancellable surface so a late result updates it rather than pushing over
+        whatever the user did next.
+        """
+        from local_operator.tui.widgets.info_panel import InfoScreen
+
+        if arg.strip():
+            # Nothing ran, so the boot composition must survive it — the same
+            # rejection rule ``_cmd_analytics`` and ``_cmd_session`` follow.
+            self._system_notice("/info takes no arguments; it reports this install", "warning")
+            return
+        live = self._capture_info_live()
+        screen = InfoScreen(live)
+        self.push_screen(screen)
+        self.run_worker(
+            self._open_info_worker(screen, live),
+            thread=False,
+            group="info",
+            exclusive=True,
+        )
+
+    def _capture_info_live(self) -> "LiveState":
+        """Snapshot in-memory state for ``/info``. Safe on the paint path.
+
+        App state (approval mode, theme, terminal size, the discovered-skill
+        count) is attached at the call site rather than read inside the
+        collector, exactly as ``spend_is_floor`` is for ``/session``: the
+        collector describes the SESSION, and these belong to the app around it.
+        """
+        from local_operator.info.collect import collect_live
+        from local_operator.tui import theme as theme_mod
+
+        try:
+            skills = len(self._discovered_skills())
+        except Exception:  # noqa: BLE001 — a diagnostic never fails on a count
+            skills = 0
+        return collect_live(
+            self._session,
+            approve_all=self._approve_all,
+            theme=theme_mod.current_theme(),
+            size=(self.size.width, self.size.height),
+            skills=skills,
+        )
+
+    async def _open_info_worker(self, screen: "InfoScreen", live: "LiveState") -> None:
+        """Run every blocking probe off the loop, then publish onto the screen."""
+        from local_operator.info.collect import collect_snapshot
+
+        snapshot = await asyncio.to_thread(collect_snapshot, live)
+        # ``_open_session_report_worker``'s guard verbatim: a result that
+        # arrives after the user dismissed the screen, or after another modal
+        # replaced it, must be dropped rather than painted somewhere new.
+        if screen.presentation_cancelled or screen not in self.screen_stack:
+            return
+        screen.set_snapshot(snapshot)
+
+    def refresh_info_screen(self, screen: "InfoScreen") -> None:
+        """Re-run the probes for an open ``/info`` (its ``r`` binding).
+
+        Manual only, never a timer: a ``top -l1`` fork per second is a real cost
+        on the machine being diagnosed, and this screen is a snapshot rather
+        than a monitor. The live half is re-captured too, so ``r`` after
+        launching a subagent shows it.
+        """
+        if screen.presentation_cancelled or screen not in self.screen_stack:
+            return
+        live = self._capture_info_live()
+        screen.live = live
+        self.run_worker(
+            self._open_info_worker(screen, live),
+            thread=False,
+            group="info",
+            exclusive=True,
+        )
 
     def _cmd_usage(self, arg: str, notice: NoticeFn) -> None:
         """``/usage [provider]`` — fetch live quota for a provider (or all)."""

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -23017,6 +23017,13 @@ class OperatorApp(App[None]):
             thread=False,
             group="info",
             exclusive=True,
+            # Textual defaults this to True, which turns any escape from the
+            # probe into an application exit. `collect_snapshot` is now
+            # failure-isolated block by block, so nothing SHOULD escape — this
+            # is the second half of that belt-and-braces: the screen a user
+            # opens BECAUSE their install is broken must never be the thing that
+            # takes their session down (review round 1, B1).
+            exit_on_error=False,
         )
 
     def _capture_info_live(self) -> "LiveState":
@@ -23071,6 +23078,13 @@ class OperatorApp(App[None]):
             thread=False,
             group="info",
             exclusive=True,
+            # Textual defaults this to True, which turns any escape from the
+            # probe into an application exit. `collect_snapshot` is now
+            # failure-isolated block by block, so nothing SHOULD escape — this
+            # is the second half of that belt-and-braces: the screen a user
+            # opens BECAUSE their install is broken must never be the thing that
+            # takes their session down (review round 1, B1).
+            exit_on_error=False,
         )
 
     def _cmd_usage(self, arg: str, notice: NoticeFn) -> None:

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -1860,12 +1860,13 @@ SessionPickerScreen .session-picker {
  * the body can be long (a per-session table grows without bound), so the card
  * pins a title and a hint and puts the report itself in a VerticalScroll
  * between them, rather than sizing to content the way the picker does. */
-AnalyticsScreen, SessionScreen {
+AnalyticsScreen, SessionScreen, InfoScreen {
     align: center middle;
     background: $lo-sunken;
 }
 
-AnalyticsScreen .analytics-panel, SessionScreen .analytics-panel {
+AnalyticsScreen .analytics-panel, SessionScreen .analytics-panel,
+InfoScreen .analytics-panel {
     /* Responsive: 90% of the terminal, capped generously so a large screen
      * actually gets a larger frame (the token+cost tables have more columns to
      * show) while a small one still fits. The old max-width of 100 left a wide
@@ -1881,7 +1882,7 @@ AnalyticsScreen .analytics-panel, SessionScreen .analytics-panel {
     padding: 1 2;
 }
 
-#analytics-title, #session-report-title {
+#analytics-title, #session-report-title, #info-title {
     /* Title line + a `─` rule under it (two lines), then a blank padding row
      * before the scrolling body. */
     width: 100%;
@@ -1889,7 +1890,7 @@ AnalyticsScreen .analytics-panel, SessionScreen .analytics-panel {
     padding-bottom: 1;
 }
 
-#analytics-scroll, #session-report-scroll {
+#analytics-scroll, #session-report-scroll, #info-scroll {
     width: 100%;
     height: 1fr;
     /* A grabbable scrollbar consistent with the transcript's: `edge` keeps it
@@ -1911,13 +1912,13 @@ AnalyticsScreen .analytics-panel, SessionScreen .analytics-panel {
     scrollbar-color-active: $lo-accent;
 }
 
-#analytics-body, #session-report-body {
+#analytics-body, #session-report-body, #info-body {
     width: auto;
     height: auto;
     color: $lo-fg;
 }
 
-#analytics-hint, #session-report-hint {
+#analytics-hint, #session-report-hint, #info-hint {
     width: 100%;
     height: 2;
     padding-top: 1;
@@ -1927,16 +1928,18 @@ AnalyticsScreen .analytics-panel, SessionScreen .analytics-panel {
 
 /* Unlike the all-session aligned tables, session diagnostics wrap long IDs
  * and model names. Width must be constrained to the scroll viewport so a
- * 50-column terminal never acquires a horizontal scrollbar. */
-#session-report-body {
+ * 50-column terminal never acquires a horizontal scrollbar. `/info` carries
+ * the same constraint for the same reason and then some: its values are
+ * filesystem paths, which are the longest unbreakable strings in the app. */
+#session-report-body, #info-body {
     width: 100%;
 }
 
-#session-report-title {
+#session-report-title, #info-title {
     text-style: bold;
 }
 
-#session-report-hint {
+#session-report-hint, #info-hint {
     color: $lo-muted;
 }
 

--- a/local_operator/tui/widgets/info_panel.py
+++ b/local_operator/tui/widgets/info_panel.py
@@ -148,31 +148,19 @@ def _fit_pair(label: str, metas: Sequence[str], width: int, lead: int) -> str | 
     is the caller's signal to try a shorter label rung (or drop the row). The
     empty string means the label fits but no meta does — a warning without its
     qualifier still carries the fact, which is the whole point of shedding.
+
+    NO FALLBACK CROP, inherited deliberately from the `_first_that_fits` ladder
+    this replaced: returning a cropped shortest rung made the old helper always
+    "succeed", so a caller could not tell whether anything actually fit — it got
+    a fragment whose width equalled the budget by construction. Distinguishing
+    "nothing fits" from "this fits" is what lets `marked` drop a row rather than
+    paint `! not the…`, which is a way of saying nothing (UX round 1, U5).
     """
     if lead + cell_len(label) > width:
         return None
     for meta in metas:
         if lead + cell_len(label) + 2 + cell_len(meta) <= width:
             return meta
-    return ""
-
-
-def _first_that_fits(rungs: Sequence[str], width: int) -> str:
-    """The first rung that fits, or the shortest one cropped.
-
-    The shed ladder used by ``kv``'s notes and ``marked``'s metas, extracted so
-    a FIXED label can use it too. Shedding a whole rung keeps a phrase readable
-    where ``truncate_cells`` would leave a fragment that says nothing.
-    """
-    for rung in rungs:
-        if cell_len(rung) <= width:
-            return rung
-    # NO fallback crop. Returning `truncate_cells(shortest)` here made the
-    # function always "succeed", so a caller checking whether anything fit could
-    # not tell — it received a cropped fragment whose width equalled the budget
-    # by construction. The empty string is the honest answer to "which of these
-    # fits?", and it lets the caller drop the row instead of painting
-    # `! not the…` (UX round 1, U5).
     return ""
 
 

--- a/local_operator/tui/widgets/info_panel.py
+++ b/local_operator/tui/widgets/info_panel.py
@@ -1,0 +1,1052 @@
+"""``/info`` — what this install is and what is running on this machine.
+
+Structurally this is ``/session``'s screen (title / scrolling body / hint, a
+``_Body`` accumulator of ``kv`` rows, push-the-screen-then-fill-from-a-worker)
+wearing ``/analytics``' section vocabulary (``▌`` headers, ``└`` nesting, the
+dim note column). Both are imported rather than reimplemented: three diagnostics
+screens with three header glyphs or three ways of saying "unavailable" would be
+a defect, not a variation.
+
+**Why a full screen rather than an overlay card.** The content is ~50 rendered
+lines. Against the measured card viewports (11 rows at 80x24, 16 at 100x30, 25
+at 150x40) that is 4.6 / 3.2 / 2.0 screens, so it does not fit as a ``/usage``
+-style popup at ANY width and must scroll everywhere. It is deliberately one
+continuous scroll rather than tabs: a user copying a bug report needs one linear
+document, and §7's copy would otherwise disagree with the paint about order.
+
+**Three deliberate departures from ``/session``:**
+
+1. No bars and no ``t`` toggle — every value here is a fact, not a magnitude,
+   so there is nothing to plot.
+2. A wider, flexible value column. ``/session``'s ``_VALUE_CELL = 11`` is sized
+   for ``1.7M tokens``; these values are paths and model ids up to 48 cells.
+3. A copy affordance, because issue reporting is this screen's stated purpose.
+   ``/session`` has none.
+"""
+
+from __future__ import annotations
+
+import textwrap
+import time
+from dataclasses import dataclass, field
+from typing import Sequence
+
+from rich.cells import cell_len
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Container, VerticalScroll
+from textual.screen import ModalScreen
+from textual.widgets import Static
+
+from local_operator.info.collect import LiveState
+from local_operator.info.model import InfoSnapshot
+from local_operator.info.render import build_export
+from local_operator.tui.widgets.analytics_panel import (
+    _NEST_INDENT,
+    _row_prefix,
+    section_header,
+    semantic_style,
+)
+from local_operator.tui.widgets.aside_panel import ASIDE_COPY_KEY
+from local_operator.tui.widgets.session_picker import (
+    ATTACHED_MARKER,
+    IDLE_MARKER,
+    WEDGED_MARKER,
+)
+from local_operator.tui.widgets.tool_card import truncate_cells
+from local_operator.tui.widgets.transcript import NOTICE_GLYPHS
+from local_operator.tui.widgets.welcome import _fit_tail, _shorten_home
+
+#: The copy chord. Deliberately the SAME constant the aside already binds rather
+#: than a second ``"ctrl+r"`` literal: "copy this surface out" should be one
+#: gesture across the app, and importing the constant is what stops the two
+#: drifting. ``ASIDE_COPY_KEY``'s own docstring carries the reason a printable
+#: character cannot work here (the composer holds focus by contract and
+#: ``TextArea`` consumes the character first) and why ``ctrl+y`` — the obvious
+#: alternative — is unavailable, being TextArea's Redo. ``ctrl+e`` was the other
+#: candidate and is already ``toggle_reveal`` on the ask picker.
+INFO_COPY_KEY = ASIDE_COPY_KEY
+
+#: Label column. ``/session`` uses 22; the longest label here is
+#: ``Subagent capacity`` (17), so 20 fits every label with slack and returns two
+#: cells to the value column, which is the column under pressure on this screen.
+_LABEL_CELL = 20
+
+#: Cells the label column, its leading indent and the gap before the note
+#: consume, so the value TRUNCATION budget is ``card - _ROW_OVERHEAD``. Derived
+#: as one constant rather than restated at each call site, following
+#: ``_PCT_CELL``'s rule in ``session_panel``: a change to the label column must
+#: not silently reintroduce a crop somewhere else.
+_ROW_OVERHEAD = 2 + _LABEL_CELL + 2
+
+#: MINIMUM width the value is padded to, so the note column lines up on the
+#: common row — not a maximum. This is ``/session``'s ``_VALUE_CELL`` model and
+#: the distinction is load-bearing: padding every value out to its full
+#: truncation budget (``card - 24``) consumes the entire row, leaving a note
+#: budget of ZERO at every width, so no ``notes=`` rung ever fits and every
+#: qualifier silently disappears. Sized at 24 to fit the widest COMMON value
+#: (``anthropic/claude-opus-5`` is 23); a longer value — a deep path — pushes
+#: its own note right rather than everyone else's note away, which is the
+#: ragged-but-honest behaviour ``/session`` already has.
+_VALUE_MIN = 24
+
+#: Minimum label width on a GLYPH-led row (session lines, subagent tree nodes),
+#: so their meta forms a column instead of being flushed to the card's right
+#: edge. Right-flushing looked fine at 65 cells and fell apart at 128, where it
+#: left ~90 cells of gap between a four-word label and its own status — the two
+#: halves of one row stopped reading as one row. A column keeps the association
+#: local at every width, and a longer label pushes its OWN meta right rather
+#: than everyone else's away, which is the same ragged-but-honest rule
+#: :data:`_VALUE_MIN` applies to the ``kv`` rows above.
+#:
+#: 30 is sized from the narrow floor, not the wide case: at a 65-cell card
+#: (80 columns) the widest realistic session meta is ``this session · 14m ·
+#: 228 MB`` at 27 cells, and 2 + 2 + 30 + 27 = 61 still fits.
+_MARK_LABEL_CELL = 30
+
+#: Below this the plain ``note=`` column sheds whole and section metas fall back
+#: to their short form. Same value and same reasoning as ``session_panel``'s: at
+#: 50 columns a note pushes the row past the viewport and folds onto its own
+#: line, where it reads as a separate record.
+_NOTE_MIN = 60
+
+_DEFAULT_CARD_WIDTH = 88
+_MIN_CARD_WIDTH = 38
+
+#: How deep the tree is drawn before the remainder folds into one summary row.
+#: Matches ``info.collect.MAX_TREE_DEPTH``.
+_MAX_TREE_DEPTH = 3
+
+#: Status → (glyph, ink). Every one of these glyphs already exists in the app;
+#: none is invented here. Colour is never the only carrier — each state has its
+#: own glyph — because this is a screen people SCREENSHOT into bug reports, and
+#: colour is what disappears under ``NO_COLOR``, a weak-dim theme, or low
+#: vision. That is ``_row_prefix``'s stated rule, applied where it matters most.
+_SUBAGENT_MARKS: dict[str, tuple[str, str]] = {
+    "running": (IDLE_MARKER, "accent"),
+    "starting": (IDLE_MARKER, "accent"),
+    "queued": ("⏳", "dim"),
+    "pausing": ("⏸", "muted"),
+    "paused": ("⏸", "muted"),
+    "completed": (NOTICE_GLYPHS["success"], "dim"),
+    "failed": (NOTICE_GLYPHS["error"], "danger"),
+    "cancelled": ("⊘", "dim"),
+    "gone": ("⊘", "dim"),
+}
+
+
+def _duration(seconds: float | None) -> str:
+    """``42s`` / ``14m`` / ``3h 12m`` / ``2d 4h``. One spelling on this screen."""
+    if seconds is None:
+        return "unknown"
+    total = int(max(0.0, seconds))
+    if total < 60:
+        return f"{total}s"
+    if total < 3600:
+        return f"{total // 60}m"
+    if total < 86400:
+        return f"{total // 3600}h {(total % 3600) // 60}m"
+    return f"{total // 86400}d {(total % 86400) // 3600}h"
+
+
+def _memory(value: int | None) -> str:
+    if value is None:
+        return "—"
+    if value >= 1 << 30:
+        return f"{value / (1 << 30):.1f} GB"
+    return f"{value / (1 << 20):.0f} MB"
+
+
+def _path(value: str, width: int) -> str:
+    """Collapse ``$HOME`` then truncate from the LEFT, keeping the tail.
+
+    Two existing helpers, reused rather than reimplemented: the leaf directory
+    is what identifies "where am I", so a path too long for the card must lose
+    its root and not its name. ``_shorten_home`` alone brings
+    ``~/.local/share/uv/tools/local-operator`` to 38 cells, which fits uncut at
+    all three reference widths — the elision is a guard for a deep ``cwd``,
+    not the common case.
+    """
+    if not value:
+        return "—"
+    return _fit_tail(_shorten_home(value), width)
+
+
+def _model(value: str, width: int) -> str:
+    """Truncate a model id from the RIGHT: the provider and family identify it."""
+    return truncate_cells(value, width) if value else "—"
+
+
+@dataclass
+class _Body:
+    """The report's lines, with ``/session``'s row vocabulary and two changes.
+
+    A near-copy of ``session_panel._Body`` rather than an import: that one pins
+    its value column at ``_VALUE_CELL = 11`` (sized for ``1.7M tokens``) and its
+    label column at 22, and both are wrong here — six of seven representative
+    ``/info`` values exceed 11 cells and ``cwd`` is 48. Widening the shared class
+    would change every ``/session`` row to fix a screen it does not draw. The
+    ``notes=`` ladder, the ``note()`` wrap-with-indent rule and the header
+    shedding are carried over verbatim, because those are the parts that encode
+    a measured failure.
+    """
+
+    width: int
+    lines: list[Text] = field(default_factory=list)
+
+    def blank(self) -> None:
+        self.lines.append(Text())
+
+    @property
+    def value_cells(self) -> int:
+        """The widest a value may be before it must be truncated.
+
+        A CEILING for the path and model helpers, not the pad width — see
+        :data:`_VALUE_MIN` for why conflating the two erases every note.
+        """
+        return max(8, self.width - _ROW_OVERHEAD)
+
+    def kv(
+        self,
+        name: str,
+        value: str,
+        note: str = "",
+        *,
+        notes: Sequence[str] = (),
+        value_style: str = "fg",
+    ) -> None:
+        """One label/value row, left-aligned.
+
+        Values are left-aligned because they are IDENTIFIERS, not magnitudes:
+        nothing is being compared down this column, and one column edge reads
+        more calmly than two.
+
+        ``notes`` is a ladder of progressively shorter spellings of the SAME
+        qualifier, widest first, first-that-fits wins. It exists because the
+        plain ``note`` path has exactly two outcomes on a narrow frame and both
+        are wrong for a load-bearing qualifier: cropped mid-word above
+        ``_NOTE_MIN``, or shed wholesale below it. Cropping a qualifier is fine;
+        cropping the scope is not — the existing ``/session`` screen crops
+        ``8.8k thin`` at 80 columns and this screen must not inherit that.
+
+        ``value_style`` carries the honesty ink: a value nobody could read is
+        drawn ``dim`` with the word ``unavailable``, never blank and never
+        ``None``. A MISSING row would be worse than an unavailable one, since
+        the reader cannot then tell whether the field does not apply or the
+        screen is broken.
+        """
+        row = Text()
+        row.append(f"  {name:<{_LABEL_CELL}}", style=semantic_style("dim"))
+        row.append(f"{value:<{_VALUE_MIN}}", style=semantic_style(value_style))
+        if notes:
+            # Budget measured from the row as actually BUILT, not from a
+            # restated literal, so a change to the label column cannot silently
+            # reintroduce the crop this ladder removes.
+            budget = self.width - row.cell_len - 2
+            for candidate in notes:
+                if len(candidate) <= budget:
+                    row.append(f"  {candidate}", style=semantic_style("dim"))
+                    break
+        elif note and self.width >= _NOTE_MIN:
+            row.append(f"  {note}", style=semantic_style("dim"))
+        row.truncate(self.width, overflow="crop")
+        self.lines.append(row)
+
+    def marked(
+        self,
+        glyph: str,
+        ink: str,
+        label: str,
+        meta: str = "",
+        indent: int = 0,
+        *,
+        metas: Sequence[str] = (),
+    ) -> None:
+        """A glyph-led row: session lines and subagent tree nodes.
+
+        The glyph column sits AFTER the nest prefix, which is what makes depth
+        legible without ``│`` continuation rules.
+
+        ``metas`` is the same first-that-fits ladder :meth:`kv` uses, and these
+        rows need it for the same measured reason: a session row's meta is a
+        ``·``-joined list, so a plain crop lands MID-ITEM and produced ``· b``
+        for ``busy`` at 80 columns — the ``8.8k thin`` defect the existing
+        ``/session`` screen has, which this screen must not inherit. Dropping a
+        whole item is legible; half of one is not.
+        """
+        row = Text()
+        row.append("  " + " " * indent, style=semantic_style("dim"))
+        row.append(f"{glyph} ", style=semantic_style(ink))
+        candidates = list(metas) or ([meta] if meta else [])
+        widest = max((len(candidate) for candidate in candidates), default=0)
+        label_budget = max(8, self.width - row.cell_len - (widest + 2 if widest else 0))
+        shown = truncate_cells(label, label_budget)
+        row.append(shown, style=semantic_style("fg"))
+        if candidates and self.width >= _NOTE_MIN:
+            # Pad to the meta COLUMN, never to the card's right edge — see
+            # ``_MARK_LABEL_CELL``. One space minimum, so an over-long label
+            # still separates from its meta rather than running into it.
+            pad = max(1, _MARK_LABEL_CELL - cell_len(shown))
+            budget = self.width - row.cell_len - pad
+            for candidate in candidates:
+                if len(candidate) <= budget:
+                    row.append(" " * pad + candidate, style=semantic_style("dim"))
+                    break
+        row.truncate(self.width, overflow="crop")
+        self.lines.append(row)
+
+    def note(self, text: str) -> None:
+        """A dim footnote, wrapped HERE with the indent preserved on every line.
+
+        Not handed to the container's ``fold``: folding applies the ``"  "``
+        indent to the first line only, so a continuation lands at column 0 and
+        reads as a new record in the middle of a block.
+        """
+        body_width = max(1, self.width - 2)
+        for line in textwrap.wrap(text, body_width) or [""]:
+            row = Text(no_wrap=True, overflow="crop")
+            row.append(f"  {line}", style=semantic_style("dim"))
+            self.lines.append(row)
+
+    def header(self, title: str, meta: str = "", short: str = "") -> None:
+        """A section header, shedding its meta to ``short`` on a narrow frame."""
+        if meta and self.width < _NOTE_MIN:
+            meta = short
+        self.lines.append(section_header(title, meta))
+
+    def to_text(self) -> Text:
+        out = Text(style=semantic_style("fg"), overflow="fold")
+        for index, line in enumerate(self.lines):
+            if index:
+                out.append("\n")
+            out.append_text(line)
+        return out
+
+
+def _install_section(body: _Body, snapshot: InfoSnapshot | None, loading: bool) -> None:
+    """Which build this is — FIRST, because both audiences open with that.
+
+    A developer debugging asks "which build is this, and is it the one I think
+    it is": the editable-vs-uv-tool distinction is the single most common source
+    of "I fixed it and nothing changed" in this codebase. A user filing an issue
+    is asked for a version before anything else.
+    """
+    body.header("Install", "how this lop was installed", "install")
+    if snapshot is None:
+        # ``Install`` is worker-filled, so it says what it is doing rather than
+        # showing a blank block. It is never left out: a missing section reads
+        # as a rendering bug.
+        body.kv("Version", "checking…" if loading else "unavailable", value_style="dim")
+        return
+    install = snapshot.install
+    body.kv("Version", install.version or "unavailable", notes=_latest_notes(install))
+    if install.behind and install.latest_known:
+        # Composed like ``welcome.py``'s update row so the two cannot diverge,
+        # and the ``— /update`` remedy is dropped WHOLE when it does not fit:
+        # ``/upd…`` is an instruction nobody can follow.
+        remedy = f"{NOTICE_GLYPHS['warning']} latest is v{install.latest_known} — /update"
+        short = f"{NOTICE_GLYPHS['warning']} v{install.latest_known} available"
+        row = Text()
+        row.append("  " + (remedy if len(remedy) + 2 <= body.width else short))
+        row.stylize(semantic_style("warning"))
+        row.truncate(body.width, overflow="crop")
+        body.lines.append(row)
+    body.kv(
+        "Install kind",
+        install.kind or "unavailable",
+        notes=_kind_notes(install.kind),
+        value_style="fg" if install.kind else "dim",
+    )
+    body.kv("Install path", _path(install.prefix, body.value_cells))
+    body.kv("Interpreter", _path(install.executable, body.value_cells))
+    if install.import_path:
+        # Directly under the install path, because the two are only meaningful
+        # side by side: this row answers "which code is actually executing",
+        # and the row above answers "which install claims to be executing it".
+        body.kv(
+            "Running code",
+            _path(install.import_path, body.value_cells),
+            notes=_import_path_notes(install),
+            # A WARNING, not an unavailable: nothing failed to read. The same
+            # ink and the same glyph as the update row below, because it is the
+            # same kind of statement — something is true that you would want to
+            # act on — and this screen's whole job is to be believed.
+            value_style="warning" if install.import_path_foreign else "fg",
+        )
+        if install.import_path_foreign and install.kind != "editable":
+            body.marked(
+                NOTICE_GLYPHS["warning"],
+                "warning",
+                "not under the install path above",
+                metas=(
+                    "this runtime is executing a different tree",
+                    "executing a different tree",
+                    "different tree",
+                ),
+            )
+    if install.is_git_snapshot:
+        # A SHA is never truncated: a half-printed one is a wrong one.
+        body.kv(
+            "Source",
+            f"git snapshot @ {install.source_ref[:12]}" if install.source_ref else "git snapshot",
+            notes=("built by lop-update, not a PyPI wheel", "lop-update build", "lop-update"),
+        )
+    else:
+        body.kv("Source", "PyPI wheel" if install.version else "unavailable")
+    if install.build_age_s is not None:
+        body.kv("Built", f"{_duration(install.build_age_s)} ago")
+    body.kv(
+        "Python",
+        install.python_version or "unavailable",
+        notes=_python_notes(install),
+    )
+    body.kv("Platform", install.platform or "unavailable", note=install.machine)
+    if install.import_path_foreign and install.kind != "editable":
+        # AFTER the table, not between two of its rows. A four-line wrapped
+        # paragraph spliced into the middle of a kv block breaks the column
+        # rhythm and reads as the end of the section, so the rows below it look
+        # like a new one — the "one record reads as two" fault these screens
+        # shed columns to avoid. The flagged VALUE and its ``!`` row stay up in
+        # the table where the reader is looking; the explanation follows the
+        # block it is about.
+        #
+        # A passive paragraph earns its space because the failure it describes
+        # is silent and total, in AGENTS.md's own words: the banner shows your
+        # branch's version, the status bar shows your worktree's path, and every
+        # line executing is the other tree's. Nothing errors, so the only
+        # symptom is a change that "did not work" — and `/reload` does not clear
+        # it, because the cwd is inherited at spawn (`runtime/launch.py`).
+        body.blank()
+        body.note(
+            "Nothing will error: the version and paths above still describe the install, "
+            "while the running code is the tree named here. A change made to one will "
+            "appear to have no effect in the other. Relaunch from outside that checkout "
+            "to clear it — /reload does not."
+        )
+
+
+def _latest_notes(install: object) -> tuple[str, ...]:
+    """The PyPI staleness note — three distinct states, never collapsed.
+
+    ``latest_known is None`` means nobody has ever asked, which on the broken
+    network ``/info`` is usually opened over is emphatically NOT "up to date".
+    """
+    from local_operator.update import TTL_S
+
+    latest = getattr(install, "latest_known", None)
+    if latest is None:
+        return ("latest unknown (never checked)", "latest unknown", "unknown")
+    age = getattr(install, "latest_age_s", None)
+    if getattr(install, "behind", False):
+        return (f"behind {latest}", f"< {latest}", "behind")
+    if age is None:
+        return ("latest", "latest")
+    stale = " (stale)" if age > TTL_S else ""
+    return (
+        f"latest · checked {_duration(age)} ago{stale}",
+        f"checked {_duration(age)} ago",
+        "latest",
+    )
+
+
+def _kind_of_runtime_notes(kind: str) -> tuple[str, ...]:
+    """What each runtime kind MEANS, one entry per value of the record's Literal.
+
+    Derived from the real records on a live machine, not from the type: the
+    dominant value in practice is ``daemon`` (a runtime spawned by
+    ``runtime/process.py``, reattachable and outliving its terminal), while
+    ``tui`` is the in-process registrant. Getting these the wrong way round
+    would tell a user their session dies with the window when it does not.
+    """
+    if kind == "daemon":
+        return ("a spawned runtime; survives this terminal", "spawned runtime", "spawned")
+    if kind == "tui":
+        return ("in-process, attached to this terminal", "attached", "attached")
+    if kind == "exec":
+        return ("one-shot non-interactive run", "one-shot run", "one-shot")
+    return ()
+
+
+def _import_path_notes(install: object) -> tuple[str, ...]:
+    """Say what a divergence MEANS, and distinguish the one benign case.
+
+    An editable install's package is the checkout by design, so it diverges from
+    the prefix legitimately and the note says "expected". Any other kind
+    diverging is the ``launch.py:287`` trap — the runtime is spawned with ``-m``
+    and no ``cwd=``, so a session started inside a checkout of this repo puts
+    that checkout on ``sys.path[0]`` ahead of site-packages and runs it instead
+    of the install. ``/reload`` does not fix that; only relaunching from another
+    directory does, which is why the note names the remedy.
+    """
+    if not getattr(install, "import_path_foreign", False):
+        return ()
+    if getattr(install, "kind", "") == "editable":
+        return ("expected for an editable checkout", "editable checkout", "editable")
+    return (
+        "a checkout on sys.path is shadowing the install",
+        "a checkout is shadowing the install",
+        "shadowed by a checkout",
+    )
+
+
+def _kind_notes(kind: str) -> tuple[str, ...]:
+    """Say what the install kind MEANS for changing the code, at three widths."""
+    if kind == "editable":
+        return ("editable checkout; source edits are live", "editable · live source", "editable")
+    if kind == "uv-tool":
+        return (
+            "non-editable; `lop-update` rebuilds it",
+            "non-editable · lop-update",
+            "non-editable",
+        )
+    if kind in ("pip", "pipx"):
+        return (f"non-editable {kind} install", f"non-editable {kind}", "non-editable")
+    return ()
+
+
+def _python_notes(install: object) -> tuple[str, ...]:
+    implementation = getattr(install, "python_implementation", "") or ""
+    machine = getattr(install, "machine", "") or ""
+    parts = [part for part in (implementation, machine) if part]
+    if not parts:
+        return ()
+    return (" · ".join(parts), parts[0])
+
+
+def _session_section(body: _Body, snapshot: InfoSnapshot | None, live: LiveState) -> None:
+    """The runtime being typed into — SECOND, and cheap enough to paint at once.
+
+    It is the scope everything below is relative to, and it needs no worker, so
+    it is complete on the first frame while the ~900 ms fleet scan is still
+    resolving. That is what stops the screen ever appearing blank.
+    """
+    body.header("This session", "the runtime you are typing into", "this runtime")
+    process = snapshot.process if snapshot else None
+    body.kv("Session id", (process.session_id if process else live.session_id) or "—")
+    kind = (process.kind if process else live.kind) or ""
+    body.kv(
+        "Kind",
+        kind or "—",
+        # Per KIND, not one hardcoded phrase. Checked against the real records
+        # on this machine rather than read off the Literal in ``types.py``:
+        # every live record here is ``daemon`` (``runtime/process.py`` spawns
+        # with ``kind="daemon"``; only an in-process registrant is ``tui``), so
+        # a blanket "attached to this terminal" would have mislabelled the
+        # common case as the rare one.
+        notes=_kind_of_runtime_notes(kind),
+        value_style="fg" if kind else "dim",
+    )
+    if process is None:
+        body.kv("Model", _model(live.model_label, body.value_cells))
+        body.kv("Working dir", "checking…", value_style="dim")
+        return
+    body.kv("Model", _model(process.model_label, body.value_cells))
+    if process.effective_model and process.effective_model != process.model_label:
+        # Only when they DIFFER: under failover the model answering is not the
+        # model selected, and that gap is the whole reason to show the row.
+        body.kv(
+            "Answering",
+            _model(process.effective_model, body.value_cells),
+            notes=("failover is in force", "failover"),
+        )
+    body.kv("Started", f"{_duration(process.uptime_s)} ago" if process.uptime_s else "—")
+    body.kv("Working dir", _path(process.cwd, body.value_cells))
+    body.kv(
+        "Config dir",
+        _path(process.config_dir, body.value_cells),
+        notes=_redirect_notes(process.config_dir_redirected, "LOCAL_OPERATOR_CONFIG_DIR"),
+    )
+    # Shown NEXT to the config dir on purpose. The cache root derives from
+    # ``$HOME`` independently of ``LOCAL_OPERATOR_CONFIG_DIR``, which AGENTS.md
+    # records as silently producing a *plausible wrong answer* in a run that
+    # believes it is isolated. Two adjacent rows are how a reader sees the
+    # divergence instead of assuming it away.
+    body.kv("Cache dir", _path(process.cache_dir, body.value_cells))
+    body.kv(
+        "Agent home",
+        _path(process.agent_home, body.value_cells),
+        notes=_redirect_notes(process.agent_home_redirected, "LOCAL_OPERATOR_HOME"),
+    )
+    body.kv("Log dir", _path(process.log_dir, body.value_cells))
+    port = f"{process.control_port}" if process.control_port else "—"
+    body.kv("Control port", port, note=f"protocol v{process.protocol}" if process.protocol else "")
+
+
+def _approval_notes(mode: str) -> tuple[str, ...]:
+    if mode == "ask":
+        return ("every tool call is confirmed", "confirmed")
+    if mode == "auto":
+        return ("tool calls run without a prompt", "auto")
+    return ()
+
+
+def _redirect_notes(redirected: bool, variable: str) -> tuple[str, ...]:
+    if not redirected:
+        return ()
+    return (f"redirected by {variable}", "redirected by env", "redirected")
+
+
+def _sessions_section(body: _Body, snapshot: InfoSnapshot | None) -> None:
+    """Every session on this machine, outer before inner."""
+    if snapshot is None:
+        body.header("Sessions on this machine", "scanning…", "scanning…")
+        body.note("Reading the session registry.")
+        return
+    sessions = snapshot.sessions
+    if not sessions.available:
+        # A whole section that could not be gathered REPLACES its header rather
+        # than annotating it — ``/session``'s proven ``Ledger unavailable``
+        # shape. The prose says what failed and what to do, in one sentence.
+        body.header("Sessions unavailable")
+        body.note("Could not scan the session registry. Close and reopen to try again.")
+        return
+    meta = f"{sessions.live} live · {sessions.total} total"
+    body.header("Sessions on this machine", meta, f"{sessions.live} live")
+    if not sessions.lines:
+        body.note("No other lop sessions are running on this machine.")
+        return
+    for line in sessions.lines:
+        if line.state == "wedged":
+            glyph, ink = WEDGED_MARKER, "danger"
+        elif line.is_self:
+            glyph, ink = ATTACHED_MARKER, "muted"
+        elif line.busy:
+            glyph, ink = IDLE_MARKER, "accent"
+        else:
+            glyph, ink = IDLE_MARKER, "muted"
+        # Built widest-first and shed WHOLE ITEMS from the right, because the
+        # rightmost facts are the least identifying: which session it is and
+        # whether it is wedged must survive to the narrowest frame, while the
+        # memory figure is the one a reader can do without.
+        bits = ["this session"] if line.is_self else []
+        if line.state != "live":
+            bits.append(line.state)
+        bits.append(_duration(line.uptime_s))
+        if sessions.usage_available:
+            bits.append(_memory(line.footprint_bytes or line.rss_bytes))
+        if line.pending:
+            bits.append(f"needs {line.pending}")
+        elif line.busy:
+            bits.append("busy")
+        metas = tuple(" · ".join(bits[:count]) for count in range(len(bits), 0, -1))
+        name = line.conversation_name or line.session_id or f"pid {line.pid}"
+        body.marked(glyph, ink, name, metas=metas)
+    if sessions.build_skew:
+        body.note(
+            "Live sessions are running more than one build — a change may look "
+            "absent in the window that has not been restarted."
+        )
+    if not sessions.usage_available:
+        body.note("Memory could not be measured on this host.")
+
+
+def _agents_section(body: _Body, snapshot: InfoSnapshot | None, live: LiveState) -> None:
+    """Profiles, teams, and this session's subagent tree.
+
+    The tree is drawn from the LIVE capture, not the worker's, so it is present
+    on the first frame — it is the operator's stated motivation ("a sense of the
+    active runtimes in parallel") and it is free to read.
+    """
+    agents = snapshot.agents if snapshot else None
+    running = agents.running if agents else live.running
+    depth = agents.max_depth if agents else live.max_depth
+    tree = agents.tree if agents else live.tree
+    deeper = agents.deeper if agents else live.deeper
+    # ``none running`` rather than ``0 running``: a zero in a count column reads
+    # as a failed probe, a word does not.
+    meta = f"{running} running · depth {depth}" if running else "none running"
+    body.header("Agents and subagents", meta, f"{running} running" if running else "none running")
+    if agents is not None:
+        body.kv("Agent profiles", str(agents.profiles))
+        body.kv("Teams", str(agents.teams))
+    queued = agents.queued if agents else live.queued
+    settled = agents.settled if agents else live.settled
+    if running or queued or settled:
+        # Only when there is something to count. On a fresh session a
+        # ``0 running · 0 queued`` row directly above "No subagents have been
+        # launched" says the same thing twice, and a row of zeros reads as a
+        # failed probe rather than as an idle session — the same reason the
+        # header meta says ``none running`` instead of ``0 running``.
+        body.kv(
+            "Subagents",
+            f"{running} running · {queued} queued",
+            # "settled (retained)" and not "settled": ``_evict_overflow`` drops
+            # settled records past a cap, so this under-reports by design, and a
+            # count that silently under-reports inside a bug report is worse
+            # than one that says what it counts.
+            notes=(f"{settled} settled (retained)", f"{settled} settled", f"{settled} done"),
+        )
+    max_running = agents.max_running if agents else live.max_running
+    at_capacity = agents.at_capacity if agents else live.at_capacity
+    if max_running is not None:
+        body.kv(
+            "Subagent capacity",
+            f"{max_running} concurrent",
+            notes=("at capacity — new launches queue", "at capacity") if at_capacity else (),
+            value_style="warning" if at_capacity else "fg",
+        )
+    if not tree:
+        # The empty state pairs a statement of FACT with a statement of why it
+        # is fine, matching ``/analytics``' own empty shape. The section header
+        # above is the evidence that the screen looked.
+        body.note("No subagents have been launched in this session.")
+        body.note("Subagents appear here while a task is running.")
+        return
+    body.blank()
+    for node in tree:
+        glyph, ink = _SUBAGENT_MARKS.get(node.status, (NOTICE_GLYPHS["info"], "dim"))
+        bits = [node.status or "unknown"]
+        if node.agent_role and node.agent_role != node.label:
+            bits.insert(0, node.agent_role)
+        prefix = _row_prefix(node.depth)
+        row = Text()
+        row.append("  " + prefix, style=semantic_style("dim"))
+        row.append(f"{glyph} ", style=semantic_style(ink))
+        # Shed whole items, longest first: the STATUS is the fact this section
+        # exists to report, so the role qualifier goes before it does.
+        metas = tuple(" · ".join(bits[index:]) for index in range(len(bits)))
+        budget = max(8, body.width - row.cell_len - len(metas[0]) - 2)
+        shown = truncate_cells(node.label or node.job_id, budget)
+        row.append(shown, style=semantic_style("fg"))
+        if body.width >= _NOTE_MIN:
+            # The meta column is measured from the row as BUILT, so a nested
+            # node's prefix pushes its label right and its meta stays put —
+            # which is what keeps the status column readable down a tree whose
+            # glyph column is deliberately ragged.
+            pad = max(1, _MARK_LABEL_CELL + 2 - cell_len(shown) - cell_len(prefix))
+            available = body.width - row.cell_len - pad
+            for candidate in metas:
+                if len(candidate) <= available:
+                    row.append(" " * pad + candidate, style=semantic_style("dim"))
+                    break
+        row.truncate(body.width, overflow="crop")
+        body.lines.append(row)
+    if deeper:
+        row = Text()
+        row.append(
+            "  " + " " * (_MAX_TREE_DEPTH - 1) * _NEST_INDENT + f"└ +{deeper} deeper",
+            style=semantic_style("dim"),
+        )
+        body.lines.append(row)
+    body.blank()
+    # The honesty boundary, stated rather than implied: a tree on screen would
+    # otherwise read as a fleet-wide view. Nothing about another session's
+    # subagents is observable — ``SessionRecord`` carries no subagent field —
+    # and reaching for one would need a new control-socket op and a protocol
+    # bump.
+    body.note(
+        "Subagent trees are in-process state, so only this session's is visible. "
+        "Other sessions report busy, pending and memory."
+    )
+
+
+def _env_section(body: _Body, snapshot: InfoSnapshot | None, live: LiveState) -> None:
+    """The bug-report extras — LAST, because nobody reads them until asked.
+
+    Putting these nine rows above the tree would push the parallelism question
+    — the operator's stated motivation — below two folds.
+    """
+    body.header("Environment", "for bug reports", "environment")
+    env = snapshot.env if snapshot else None
+    size = (env.terminal_size if env else live.terminal_size) or None
+    body.kv(
+        "Terminal",
+        (env.term if env else "") or "—",
+        note=f"{size[0]}x{size[1]}" if size else "",
+    )
+    body.kv("Theme", (env.theme if env else live.theme) or "—")
+    approvals = (env.approval_mode if env else live.approval_mode) or ""
+    body.kv(
+        "Approvals",
+        approvals or "—",
+        # An UNKNOWN mode gets no note at all. Falling through to the "auto"
+        # wording would tell a reader that tool calls run unconfirmed on the
+        # strength of a field nobody managed to read — the most consequential
+        # sentence on this screen to be wrong about.
+        notes=_approval_notes(approvals),
+        value_style="fg" if approvals else "dim",
+    )
+    mcp_configured = env.mcp_configured if env else live.mcp_configured
+    mcp_connected = env.mcp_connected if env else live.mcp_connected
+    mcp_settling = env.mcp_settling if env else live.mcp_settling
+    mcp_failed = env.mcp_failed if env else live.mcp_failed
+    if mcp_configured:
+        body.kv(
+            "MCP servers",
+            f"{mcp_connected} of {mcp_configured} connected",
+            # SETTLING suppresses the failure tally rather than reporting it:
+            # OAuth servers routinely miss the 250 ms startup gate, and naming
+            # one as failed mid-handshake produces a bug report about a server
+            # that came up a second later.
+            notes=(
+                ("still connecting", "connecting")
+                if mcp_settling
+                else ((f"{mcp_failed} failed", "failed") if mcp_failed else ())
+            ),
+            value_style="warning" if mcp_failed and not mcp_settling else "fg",
+        )
+        if env is not None and env.mcp_failures and not mcp_settling:
+            for name, message in env.mcp_failures:
+                body.marked(NOTICE_GLYPHS["error"], "danger", f"{name}: {message}", indent=2)
+    else:
+        body.kv("MCP servers", "none configured", value_style="dim")
+    if env is None:
+        body.kv("Browser", "checking…", value_style="dim")
+        return
+    body.kv(
+        "Browser",
+        env.browser_backend or "none",
+        notes=(env.browser_name,) if env.browser_name else (),
+    )
+    body.kv(
+        "Mobile relay",
+        "installed" if env.mobile_installed else "not installed",
+        notes=("healthy", "up") if env.mobile_healthy else (),
+    )
+    body.kv("Multiplexer", env.multiplexer or "none")
+    body.kv("Guides", str(env.guides))
+    if env.skills:
+        body.kv("Skills", str(env.skills))
+    # NAMES, never values, lengths, prefixes or hashes. The diagnostic question
+    # is "is the key even set?", which a name answers completely.
+    keys = ", ".join(env.credential_keys)
+    body.kv(
+        "Credentials",
+        f"{len(env.credential_keys)} keys",
+        notes=(keys, truncate_cells(keys, 30)) if keys else ("none stored",),
+    )
+
+
+def build_info_report(
+    snapshot: InfoSnapshot | None,
+    live: LiveState,
+    width: int = _DEFAULT_CARD_WIDTH,
+) -> Text:
+    """Render the whole screen at ``width`` content cells.
+
+    ``snapshot is None`` is the first frame: ``Install`` and ``This session``
+    are already useful from the live capture, and the worker-filled rows say
+    ``checking…`` in dim. The screen is never blank and never a spinner.
+    """
+    width = max(_MIN_CARD_WIDTH, width)
+    body = _Body(width)
+    _install_section(body, snapshot, loading=snapshot is None)
+    body.blank()
+    _session_section(body, snapshot, live)
+    body.blank()
+    _sessions_section(body, snapshot)
+    body.blank()
+    _agents_section(body, snapshot, live)
+    body.blank()
+    _env_section(body, snapshot, live)
+    if snapshot is not None and snapshot.degraded:
+        body.blank()
+        # Named, not swallowed. "cache dir: —" without a reason costs the
+        # reporter a second round trip, which is the cost this screen removes.
+        body.header("Could not read", f"{len(snapshot.degraded)} probes", "degraded")
+        for name, reason in snapshot.degraded:
+            body.note(f"{name}: {reason}")
+    if snapshot is not None and snapshot.captured_at:
+        body.blank()
+        # A wall-clock stamp so a pasted report is unambiguous about WHEN.
+        body.note("captured " + time.strftime("%H:%M:%S", time.localtime(snapshot.captured_at)))
+    return body.to_text()
+
+
+class InfoScreen(ModalScreen[None]):
+    """The ``/info`` surface: pushed immediately, filled by a worker.
+
+    Push-before-read is ``/session``'s pattern and is right here for a stronger
+    reason than there: the sessions block measured **879.5 ms** on this host
+    (``session_resource_usage`` shells ``top -l1`` for the whole system on
+    macOS), three orders of magnitude past a frame. So the screen owns a
+    visible, cancellable surface before any I/O starts, and a late result
+    updates that surface rather than pushing over whatever the user did next.
+
+    Deliberately NOT animated. This is a snapshot people screenshot; a spinner
+    would make two consecutive captures differ, which reads as motion.
+    """
+
+    BINDINGS = [
+        Binding("escape", "dismiss_screen", "Back", show=False),
+        Binding("q", "dismiss_screen", "Back", show=False),
+        Binding(INFO_COPY_KEY, "copy_report", "Copy", show=False),
+        Binding("r", "refresh_report", "Refresh", show=False),
+        Binding("up", "scroll_up", "Up", show=False),
+        Binding("down", "scroll_down", "Down", show=False),
+        Binding("pageup", "page_up", "Page up", show=False),
+        Binding("pagedown", "page_down", "Page down", show=False),
+        Binding("home", "scroll_home", "Top", show=False),
+        Binding("end", "scroll_end", "Bottom", show=False),
+    ]
+
+    def __init__(self, live: LiveState, snapshot: InfoSnapshot | None = None) -> None:
+        super().__init__()
+        self.live = live
+        self.snapshot = snapshot
+        self.presentation_cancelled = False
+
+    def compose(self) -> ComposeResult:
+        with Container(classes="analytics-panel"):
+            self._title = Static(self._title_text(), id="info-title")
+            yield self._title
+            with VerticalScroll(id="info-scroll") as scroll:
+                self._scroll = scroll
+                self._body = Static(self._report_text(), id="info-body")
+                yield self._body
+            self._hint = Static(self._info_hint(), id="info-hint")
+            yield self._hint
+
+    def on_mount(self) -> None:
+        # A fast probe can finish while this screen is still mounting; the
+        # stored snapshot, not the compose-time text, must win that race.
+        self._repaint()
+        self.call_after_refresh(self._dismiss_if_cancelled)
+
+    def on_unmount(self) -> None:
+        self.presentation_cancelled = True
+
+    def on_screen_resume(self) -> None:
+        self._dismiss_if_cancelled()
+
+    def invalidate(self) -> None:
+        """Retire this request without ever popping a newer modal above it."""
+        self.presentation_cancelled = True
+        self._dismiss_if_cancelled()
+
+    def _dismiss_if_cancelled(self) -> None:
+        # Dismiss only when RESUMED: ``Screen.dismiss()`` pops the current
+        # screen, not necessarily the instance it was called on, so an owner
+        # switch under another modal must not pop that modal instead.
+        if self.presentation_cancelled and self.is_mounted and self.app.screen is self:
+            self.dismiss(None)
+
+    def set_snapshot(self, snapshot: InfoSnapshot) -> None:
+        """Publish the worker's result, while this presentation is still owned."""
+        if self.presentation_cancelled:
+            return
+        self.snapshot = snapshot
+        self._repaint()
+
+    def _card_width(self) -> int:
+        """The content cells a row may actually occupy.
+
+        MEASURED off the mounted scroll rather than recomputed from the CSS,
+        because a formula and a stylesheet drift: ``#*-scroll`` reserves a
+        stable scrollbar gutter that a card-width formula does not know about,
+        and building rows one cell too wide folds a value onto a second line —
+        the "one record reads as two" fault these screens exist to remove.
+        """
+        scroll = getattr(self, "_scroll", None)
+        if scroll is not None and scroll.is_mounted and scroll.size.width:
+            return max(_MIN_CARD_WIDTH, scroll.size.width - 1)
+        try:
+            card = min(140, int(self.app.size.width * 0.9))
+            return max(_MIN_CARD_WIDTH, card - 7)  # 4 padding + 2 border + 1 gutter
+        except Exception:  # noqa: BLE001 — before mount there is no app size
+            return _DEFAULT_CARD_WIDTH
+
+    def _title_text(self) -> Text:
+        return Text(
+            "Install info\n" + "─" * max(1, self._card_width()),
+            no_wrap=True,
+            overflow="crop",
+        )
+
+    def _report_text(self) -> Text:
+        return build_info_report(self.snapshot, self.live, self._card_width())
+
+    def _repaint(self) -> None:
+        body = getattr(self, "_body", None)
+        if body is not None and body.is_mounted and not self.presentation_cancelled:
+            body.update(self._report_text())
+            title = getattr(self, "_title", None)
+            if title is not None and title.is_mounted:
+                title.update(self._title_text())
+            self.call_after_refresh(self._sync_hint)
+
+    def _info_hint(self) -> str:
+        """``esc / q back · ctrl+r copy`` — key-then-verb, ``·``-separated.
+
+        The scroll hint is appended by :meth:`_sync_hint` only when the body can
+        actually scroll, so the footer never advertises a dead control. Below
+        ``_NOTE_MIN`` the SCROLL hint sheds before the COPY hint: copy is the
+        discoverable feature here, scroll is guessable.
+        """
+        if self._card_width() < _NOTE_MIN:
+            return f"esc back · {INFO_COPY_KEY} copy"
+        return f"esc / q back · {INFO_COPY_KEY} copy · r refresh"
+
+    def on_resize(self) -> None:
+        # Column arithmetic is a function of the card width, so a resize is a
+        # re-render rather than only a hint refresh.
+        self._repaint()
+        self.call_after_refresh(self._sync_hint)
+
+    def _sync_hint(self) -> None:
+        scroll = getattr(self, "_scroll", None)
+        hint = getattr(self, "_hint", None)
+        if scroll is not None and hint is not None and hint.is_mounted:
+            hint.update(self._info_hint() + (" · ↑↓ scroll" if scroll.max_scroll_y > 0 else ""))
+
+    def render_lines_for_test(self) -> list[str]:
+        """The report as plain strings — what a user actually reads."""
+        out: list[str] = []
+        for line in self._report_text().plain.split("\n"):
+            out.append(line)
+        return out
+
+    # -- actions --------------------------------------------------------------
+    def action_dismiss_screen(self) -> None:
+        self.invalidate()
+
+    def action_copy_report(self) -> None:
+        """Copy the REDACTED export, built from the dataclass not the pixels.
+
+        Composed by ``info.render.build_export`` rather than scraped off the
+        painted rows, following ``AsidePanel.copy_text``: two implementations of
+        one idea drift, and the one that drifts here would be the one that
+        decides what is safe to publish. The write goes through the app's single
+        clipboard path (OSC 52, with its receipt toast), so a copy survives ssh
+        and a multiplexer and is never silent.
+        """
+        if self.snapshot is None:
+            self.app.bell()
+            return
+        payload = build_export(self.snapshot)
+        put = getattr(self.app, "_put_on_clipboard", None)
+        if put is None:
+            self.app.copy_to_clipboard(payload)
+            return
+        put(payload, self)
+
+    def action_refresh_report(self) -> None:
+        """Re-run the probes on demand. NOT on a timer.
+
+        A ``top -l1`` fork per second is a real cost on the machine being
+        diagnosed, and ``/info`` is a snapshot rather than a monitor — so this
+        is a manual gesture and the captured-at stamp says which moment is on
+        screen.
+        """
+        handler = getattr(self.app, "refresh_info_screen", None)
+        if handler is not None:
+            handler(self)
+
+    def action_scroll_up(self) -> None:
+        self._scroll.scroll_up()
+
+    def action_scroll_down(self) -> None:
+        self._scroll.scroll_down()
+
+    def action_page_up(self) -> None:
+        self._scroll.scroll_page_up()
+
+    def action_page_down(self) -> None:
+        self._scroll.scroll_page_down()
+
+    def action_scroll_home(self) -> None:
+        self._scroll.scroll_home()
+
+    def action_scroll_end(self) -> None:
+        self._scroll.scroll_end()

--- a/local_operator/tui/widgets/info_panel.py
+++ b/local_operator/tui/widgets/info_panel.py
@@ -41,6 +41,7 @@ from textual.widgets import Static
 
 from local_operator.info.collect import LiveState
 from local_operator.info.model import (
+    UNKNOWN,
     InfoSnapshot,
     format_bytes,
     format_duration,
@@ -48,7 +49,6 @@ from local_operator.info.model import (
 )
 from local_operator.info.render import build_export
 from local_operator.tui.widgets.analytics_panel import (
-    _NEST_INDENT,
     _row_prefix,
     section_header,
     semantic_style,
@@ -139,6 +139,22 @@ _SUBAGENT_MARKS: dict[str, tuple[str, str]] = {
     "cancelled": ("⊘", "dim"),
     "gone": ("⊘", "dim"),
 }
+
+
+def _fit_pair(label: str, metas: Sequence[str], width: int, lead: int) -> str | None:
+    """The widest meta rung that fits BESIDE ``label``, or ``""`` if none does.
+
+    ``None`` means the label itself does not fit even with the meta shed, which
+    is the caller's signal to try a shorter label rung (or drop the row). The
+    empty string means the label fits but no meta does — a warning without its
+    qualifier still carries the fact, which is the whole point of shedding.
+    """
+    if lead + cell_len(label) > width:
+        return None
+    for meta in metas:
+        if lead + cell_len(label) + 2 + cell_len(meta) <= width:
+            return meta
+    return ""
 
 
 def _first_that_fits(rungs: Sequence[str], width: int) -> str:
@@ -282,36 +298,46 @@ class _Body:
         row.append("  " + " " * indent, style=semantic_style("dim"))
         row.append(f"{glyph} ", style=semantic_style(ink))
         candidates = list(metas) or ([meta] if meta else [])
-        widest = max((len(candidate) for candidate in candidates), default=0)
-        label_budget = max(8, self.width - row.cell_len - (widest + 2 if widest else 0))
-        # A LABEL ladder, measured against the budget this method computes.
-        # Callers cannot size one themselves without duplicating the glyph,
-        # indent and meta arithmetic above — and when the caller tried, the
-        # rungs never fired and the label was still cropped to `! not und…`,
-        # which communicates nothing (UX round 1, U5).
+        lead = row.cell_len
+
+        # The label and the meta are negotiated TOGETHER, not one after the
+        # other. Sizing the label against the WIDEST meta rung charged it for a
+        # string it would never be shown beside: at card 65 the widest meta (42
+        # cells) left the label 17, which defeated all three label rungs — the
+        # shortest is 22 — so the whole warning row was dropped at exactly the
+        # width the ladder was built to survive (design round 1, D1). Every step
+        # was individually right and the budget was wrong.
+        #
+        # STRUCTURAL, per the manager's ruling, and not another per-row special
+        # case: this is the same class as U5, which was already patched once at
+        # a call site. Label rungs walk OUTER because the label carries the
+        # fact; meta rungs walk inner and end with `""`, which sheds the meta
+        # entirely rather than losing the row. A row is dropped only when no
+        # label rung fits even with no meta at all — the U5 guarantee that a
+        # fragment like `! not und…` is never painted, preserved exactly.
+        shown, meta_shown = "", ""
         if labels:
-            chosen = _first_that_fits(list(labels), label_budget)
-            if not chosen:
-                # Even the shortest rung does not fit. Drop the row ENTIRELY
-                # rather than paint a fragment: `! not the…` is not a shorter
-                # way of saying the thing, it is a way of saying nothing, and
-                # the explanatory paragraph below carries the whole consequence
-                # at every width (UX round 1, U5).
+            for label_rung in labels:
+                fitted = _fit_pair(label_rung, candidates, self.width, lead)
+                if fitted is not None:
+                    shown, meta_shown = label_rung, fitted
+                    break
+            if not shown:
                 return
-            shown = chosen
         else:
-            shown = truncate_cells(label, label_budget)
+            widest = max((cell_len(c) for c in candidates), default=0)
+            shown = truncate_cells(label, max(8, self.width - lead - (widest + 2 if widest else 0)))
+            meta_shown = _fit_pair(shown, candidates, self.width, lead) or ""
+
         row.append(shown, style=semantic_style("fg"))
-        if candidates and self.width >= _NOTE_MIN:
+        if meta_shown and self.width >= _NOTE_MIN:
             # Pad to the meta COLUMN, never to the card's right edge — see
             # ``_MARK_LABEL_CELL``. One space minimum, so an over-long label
             # still separates from its meta rather than running into it.
             pad = max(1, _MARK_LABEL_CELL - cell_len(shown))
-            budget = self.width - row.cell_len - pad
-            for candidate in candidates:
-                if len(candidate) <= budget:
-                    row.append(" " * pad + candidate, style=semantic_style("dim"))
-                    break
+            if lead + cell_len(shown) + pad + cell_len(meta_shown) > self.width:
+                pad = 1  # the column would push it off; sit it right beside.
+            row.append(" " * pad + meta_shown, style=semantic_style("dim"))
         row.truncate(self.width, overflow="crop")
         self.lines.append(row)
 
@@ -682,6 +708,24 @@ def _sessions_section(body: _Body, snapshot: InfoSnapshot | None) -> None:
         body.note("Memory could not be measured on this host.")
 
 
+def _counted(value: int, probe: str, snapshot: "InfoSnapshot | None") -> str:
+    """A count, or :data:`UNKNOWN` when the probe that produced it FAILED.
+
+    The screen's own rule — stated for ``mobile_port`` and for memory — is that
+    absent is not a measured value. These counts broke it: on an unresolvable
+    home the render read ``Agent profiles 0`` / ``Teams 0``, a plausible figure
+    the snapshot cannot support, with the failure disclosed only in a separate
+    block the reader has to cross-reference (QA round 2, Q8).
+
+    Keyed on the probe NAME appearing in ``degraded`` rather than on the value,
+    because 0 is a legitimate answer on a machine that genuinely has no teams —
+    suppressing every zero would trade one lie for another.
+    """
+    if snapshot is not None and any(name == probe for name, _ in snapshot.degraded):
+        return UNKNOWN
+    return str(value)
+
+
 def _agents_section(body: _Body, snapshot: InfoSnapshot | None, live: LiveState) -> None:
     """Profiles, teams, and this session's subagent tree.
 
@@ -699,8 +743,8 @@ def _agents_section(body: _Body, snapshot: InfoSnapshot | None, live: LiveState)
     meta = f"{running} running · depth {depth}" if running else "none running"
     body.header("Agents and subagents", meta, f"{running} running" if running else "none running")
     if agents is not None:
-        body.kv("Agent profiles", str(agents.profiles))
-        body.kv("Teams", str(agents.teams))
+        body.kv("Agent profiles", _counted(agents.profiles, "agents.profiles", snapshot))
+        body.kv("Teams", _counted(agents.teams, "agents.teams", snapshot))
     queued = agents.queued if agents else live.queued
     settled = agents.settled if agents else live.settled
     if running or queued or settled:
@@ -764,9 +808,17 @@ def _agents_section(body: _Body, snapshot: InfoSnapshot | None, live: LiveState)
         row.truncate(body.width, overflow="crop")
         body.lines.append(row)
     if deeper:
+        # BASE indent and NO `└`. The fold was emitted at the cap's child indent
+        # (6 cells) and appended after the whole tree, so it rendered under
+        # whatever the last row happened to be — in the captured frame a DEPTH-0
+        # node — three levels to its right, claiming hidden children that node
+        # does not have (design round 1, D2). `+N deeper` counts nodes below the
+        # cap ANYWHERE in the tree, so it is a section summary, not a child of
+        # any row. A `└` that connects to nothing is worse than no glyph, and
+        # the depth it summarises is named instead of mimed.
         row = Text()
         row.append(
-            "  " + " " * (_MAX_TREE_DEPTH - 1) * _NEST_INDENT + f"└ +{deeper} deeper",
+            f"  +{deeper} deeper (below depth {_MAX_TREE_DEPTH})",
             style=semantic_style("dim"),
         )
         body.lines.append(row)
@@ -858,12 +910,33 @@ def _env_section(body: _Body, snapshot: InfoSnapshot | None, live: LiveState) ->
         body.kv("Skills", str(env.skills))
     # NAMES, never values, lengths, prefixes or hashes. The diagnostic question
     # is "is the key even set?", which a name answers completely.
-    keys = ", ".join(env.credential_keys)
-    body.kv(
-        "Credentials",
-        f"{len(env.credential_keys)} keys",
-        notes=(keys, truncate_cells(keys, 30)) if keys else ("none stored",),
+    names = list(env.credential_keys)
+    keys = ", ".join(names)
+    credentials_failed = snapshot is not None and any(
+        name == "env.credentials" for name, _ in snapshot.degraded
     )
+    if credentials_failed:
+        # `0 keys · none stored` is an AFFIRMATIVE claim the snapshot cannot
+        # support when the probe raised — the reader is told something false and
+        # must cross-reference the degraded block to discover it (QA round 2,
+        # Q8).
+        body.kv("Credentials", UNKNOWN, notes=("could not read",))
+    else:
+        body.kv(
+            "Credentials",
+            f"{len(names)} keys",
+            # COUNT the overflow, never crop it. The middle rung used to be
+            # `truncate_cells(keys, 30)`, which produced `OPENAI_API…` — a crop
+            # wearing a ladder's clothing, and precisely the `8.8k thin`
+            # mid-token defect the spec forbids inheriting (design round 1, D3).
+            # A half-printed key cannot be told from `OPENAI_API_KEY_2` or a
+            # typo, which is the exact ambiguity this row exists to resolve.
+            notes=(
+                (keys, f"{names[0]} +{len(names) - 1} more", f"{len(names)} set")
+                if len(names) > 1
+                else (keys,) if names else ("none stored",)
+            ),
+        )
 
 
 def build_info_report(

--- a/local_operator/tui/widgets/info_panel.py
+++ b/local_operator/tui/widgets/info_panel.py
@@ -40,7 +40,12 @@ from textual.screen import ModalScreen
 from textual.widgets import Static
 
 from local_operator.info.collect import LiveState
-from local_operator.info.model import InfoSnapshot
+from local_operator.info.model import (
+    InfoSnapshot,
+    format_bytes,
+    format_duration,
+    is_shadowed_install,
+)
 from local_operator.info.render import build_export
 from local_operator.tui.widgets.analytics_panel import (
     _NEST_INDENT,
@@ -136,26 +141,23 @@ _SUBAGENT_MARKS: dict[str, tuple[str, str]] = {
 }
 
 
-def _duration(seconds: float | None) -> str:
-    """``42s`` / ``14m`` / ``3h 12m`` / ``2d 4h``. One spelling on this screen."""
-    if seconds is None:
-        return "unknown"
-    total = int(max(0.0, seconds))
-    if total < 60:
-        return f"{total}s"
-    if total < 3600:
-        return f"{total // 60}m"
-    if total < 86400:
-        return f"{total // 3600}h {(total % 3600) // 60}m"
-    return f"{total // 86400}d {(total % 86400) // 3600}h"
+def _first_that_fits(rungs: Sequence[str], width: int) -> str:
+    """The first rung that fits, or the shortest one cropped.
 
-
-def _memory(value: int | None) -> str:
-    if value is None:
-        return "—"
-    if value >= 1 << 30:
-        return f"{value / (1 << 30):.1f} GB"
-    return f"{value / (1 << 20):.0f} MB"
+    The shed ladder used by ``kv``'s notes and ``marked``'s metas, extracted so
+    a FIXED label can use it too. Shedding a whole rung keeps a phrase readable
+    where ``truncate_cells`` would leave a fragment that says nothing.
+    """
+    for rung in rungs:
+        if cell_len(rung) <= width:
+            return rung
+    # NO fallback crop. Returning `truncate_cells(shortest)` here made the
+    # function always "succeed", so a caller checking whether anything fit could
+    # not tell — it received a cropped fragment whose width equalled the budget
+    # by construction. The empty string is the honest answer to "which of these
+    # fits?", and it lets the caller drop the row instead of painting
+    # `! not the…` (UX round 1, U5).
+    return ""
 
 
 def _path(value: str, width: int) -> str:
@@ -262,6 +264,7 @@ class _Body:
         indent: int = 0,
         *,
         metas: Sequence[str] = (),
+        labels: Sequence[str] = (),
     ) -> None:
         """A glyph-led row: session lines and subagent tree nodes.
 
@@ -281,7 +284,23 @@ class _Body:
         candidates = list(metas) or ([meta] if meta else [])
         widest = max((len(candidate) for candidate in candidates), default=0)
         label_budget = max(8, self.width - row.cell_len - (widest + 2 if widest else 0))
-        shown = truncate_cells(label, label_budget)
+        # A LABEL ladder, measured against the budget this method computes.
+        # Callers cannot size one themselves without duplicating the glyph,
+        # indent and meta arithmetic above — and when the caller tried, the
+        # rungs never fired and the label was still cropped to `! not und…`,
+        # which communicates nothing (UX round 1, U5).
+        if labels:
+            chosen = _first_that_fits(list(labels), label_budget)
+            if not chosen:
+                # Even the shortest rung does not fit. Drop the row ENTIRELY
+                # rather than paint a fragment: `! not the…` is not a shorter
+                # way of saying the thing, it is a way of saying nothing, and
+                # the explanatory paragraph below carries the whole consequence
+                # at every width (UX round 1, U5).
+                return
+            shown = chosen
+        else:
+            shown = truncate_cells(label, label_budget)
         row.append(shown, style=semantic_style("fg"))
         if candidates and self.width >= _NOTE_MIN:
             # Pad to the meta COLUMN, never to the card's right edge — see
@@ -372,13 +391,22 @@ def _install_section(body: _Body, snapshot: InfoSnapshot | None, loading: bool) 
             # ink and the same glyph as the update row below, because it is the
             # same kind of statement — something is true that you would want to
             # act on — and this screen's whole job is to be believed.
-            value_style="warning" if install.import_path_foreign else "fg",
+            value_style="warning" if is_shadowed_install(install) else "fg",
         )
-        if install.import_path_foreign and install.kind != "editable":
+        if is_shadowed_install(install):
             body.marked(
                 NOTICE_GLYPHS["warning"],
                 "warning",
+                # LADDERED like the meta beside it: a fixed label was cropped to
+                # ``! not und…`` at 45 cells, so the one row built to survive
+                # narrow frames was the only one that did not (UX round 1, U5).
+                # The shortest rung still names the fault.
                 "not under the install path above",
+                labels=(
+                    "not under the install path above",
+                    "not under the install path",
+                    "not the installed tree",
+                ),
                 metas=(
                     "this runtime is executing a different tree",
                     "executing a different tree",
@@ -395,14 +423,14 @@ def _install_section(body: _Body, snapshot: InfoSnapshot | None, loading: bool) 
     else:
         body.kv("Source", "PyPI wheel" if install.version else "unavailable")
     if install.build_age_s is not None:
-        body.kv("Built", f"{_duration(install.build_age_s)} ago")
+        body.kv("Built", f"{format_duration(install.build_age_s)} ago")
     body.kv(
         "Python",
         install.python_version or "unavailable",
         notes=_python_notes(install),
     )
     body.kv("Platform", install.platform or "unavailable", note=install.machine)
-    if install.import_path_foreign and install.kind != "editable":
+    if is_shadowed_install(install):
         # AFTER the table, not between two of its rows. A four-line wrapped
         # paragraph spliced into the middle of a kv block breaks the column
         # rhythm and reads as the end of the section, so the rows below it look
@@ -434,6 +462,13 @@ def _latest_notes(install: object) -> tuple[str, ...]:
     """
     from local_operator.update import TTL_S
 
+    if not getattr(install, "version", ""):
+        # The unknown is on the INSTALLED side, and the lie is the same one:
+        # `is_behind("", latest)` is False by design, so a failed version probe
+        # beside a cached NEWER release asserted currency. Both halves fail
+        # together on a broken install, which is the state /info is opened in
+        # (review round 1, M3).
+        return ("latest unknown (installed version unreadable)", "latest unknown", "unknown")
     latest = getattr(install, "latest_known", None)
     if latest is None:
         return ("latest unknown (never checked)", "latest unknown", "unknown")
@@ -444,8 +479,8 @@ def _latest_notes(install: object) -> tuple[str, ...]:
         return ("latest", "latest")
     stale = " (stale)" if age > TTL_S else ""
     return (
-        f"latest · checked {_duration(age)} ago{stale}",
-        f"checked {_duration(age)} ago",
+        f"latest · checked {format_duration(age)} ago{stale}",
+        f"checked {format_duration(age)} ago",
         "latest",
     )
 
@@ -550,7 +585,7 @@ def _session_section(body: _Body, snapshot: InfoSnapshot | None, live: LiveState
             _model(process.effective_model, body.value_cells),
             notes=("failover is in force", "failover"),
         )
-    body.kv("Started", f"{_duration(process.uptime_s)} ago" if process.uptime_s else "—")
+    body.kv("Started", f"{format_duration(process.uptime_s)} ago" if process.uptime_s else "—")
     body.kv("Working dir", _path(process.cwd, body.value_cells))
     body.kv(
         "Config dir",
@@ -599,7 +634,13 @@ def _sessions_section(body: _Body, snapshot: InfoSnapshot | None) -> None:
         # than annotating it — ``/session``'s proven ``Ledger unavailable``
         # shape. The prose says what failed and what to do, in one sentence.
         body.header("Sessions unavailable")
-        body.note("Could not scan the session registry. Close and reopen to try again.")
+        body.note(
+            # ``r`` re-runs exactly these probes and the footer advertises it two
+            # rows below this sentence; "close and reopen" sent the reader the
+            # long way round and quietly implied ``r`` would not help, which is
+            # the opposite of true (UX round 1, U7).
+            "Could not scan the session registry. Press r to try again."
+        )
         return
     meta = f"{sessions.live} live · {sessions.total} total"
     body.header("Sessions on this machine", meta, f"{sessions.live} live")
@@ -622,9 +663,9 @@ def _sessions_section(body: _Body, snapshot: InfoSnapshot | None) -> None:
         bits = ["this session"] if line.is_self else []
         if line.state != "live":
             bits.append(line.state)
-        bits.append(_duration(line.uptime_s))
+        bits.append(format_duration(line.uptime_s))
         if sessions.usage_available:
-            bits.append(_memory(line.footprint_bytes or line.rss_bytes))
+            bits.append(format_bytes(line.footprint_bytes or line.rss_bytes))
         if line.pending:
             bits.append(f"needs {line.pending}")
         elif line.busy:
@@ -752,8 +793,15 @@ def _env_section(body: _Body, snapshot: InfoSnapshot | None, live: LiveState) ->
     size = (env.terminal_size if env else live.terminal_size) or None
     body.kv(
         "Terminal",
-        (env.term if env else "") or "—",
+        # ``checking…`` while the worker is out, NOT ``—``: an em-dash means "we
+        # looked and could not tell" everywhere else on this screen, so a first
+        # frame using it for a value still arriving told the reader their TERM
+        # could not be determined — mildly alarming on the one screen about what
+        # is actually running, and three loading vocabularies on one frame is
+        # one too many (UX round 1, U6).
+        ((env.term or "—") if env else "checking…"),
         note=f"{size[0]}x{size[1]}" if size else "",
+        value_style="fg" if env else "dim",
     )
     body.kv("Theme", (env.theme if env else live.theme) or "—")
     approvals = (env.approval_mode if env else live.approval_mode) or ""
@@ -960,7 +1008,23 @@ class InfoScreen(ModalScreen[None]):
     def _repaint(self) -> None:
         body = getattr(self, "_body", None)
         if body is not None and body.is_mounted and not self.presentation_cancelled:
+            # Was the reader pinned to the BOTTOM before this repaint? The body
+            # roughly doubles when the probe lands, so an `End` pressed during
+            # `checking…` left the viewport at its old absolute offset — two
+            # sections above the end the user asked for, moving under them for
+            # reasons they cannot see (UX round 1, U4). Only the pinned case is
+            # restored: a reader parked mid-document is deliberately left where
+            # they are, since re-anchoring that would be the same fault.
+            scroll = getattr(self, "_scroll", None)
+            was_at_end = bool(
+                scroll is not None
+                and scroll.is_mounted
+                and scroll.max_scroll_y > 0
+                and scroll.scroll_y >= scroll.max_scroll_y - 1
+            )
             body.update(self._report_text())
+            if was_at_end and scroll is not None:
+                self.call_after_refresh(scroll.scroll_end, animate=False)
             title = getattr(self, "_title", None)
             if title is not None and title.is_mounted:
                 title.update(self._title_text())
@@ -1012,14 +1076,34 @@ class InfoScreen(ModalScreen[None]):
         and a multiplexer and is never silent.
         """
         if self.snapshot is None:
+            # Keep the bell (something was refused) but SAY so: the footer has
+            # advertised `ctrl+r copy` since frame one, and on a terminal with
+            # the bell disabled -- common, and the default in several -- the
+            # refusal was completely silent. A user who believes the report is
+            # on their clipboard pastes whatever was there before into an issue,
+            # which is worse than waiting (UX round 1, U3).
             self.app.bell()
+            notice = getattr(self.app, "_system_notice", None)
+            if notice is not None:
+                notice("still reading this install — try ctrl+r again in a moment", "warning")
             return
         payload = build_export(self.snapshot)
         put = getattr(self.app, "_put_on_clipboard", None)
         if put is None:
             self.app.copy_to_clipboard(payload)
-            return
-        put(payload, self)
+        else:
+            put(payload, self)
+        # A SECOND receipt, on top of the shared clipboard one, because this
+        # payload has a property the user should be told exactly once and at
+        # exactly this moment: it was redacted. `render.py` and its tests do
+        # thorough work that nothing in the UI ever mentioned, and the moment
+        # the user is thinking about pasting into a public issue is when
+        # "paths are home-relativised, no credential values" is worth knowing
+        # (UX round 1, U10). The shared receipt stays generic — it is used by
+        # every other copy gesture and must not claim redaction for them.
+        notice = getattr(self.app, "_system_notice", None)
+        if notice is not None:
+            notice("/info report copied — paths relativised, no secrets included", "info")
 
     def action_refresh_report(self) -> None:
         """Re-run the probes on demand. NOT on a timer.
@@ -1028,10 +1112,21 @@ class InfoScreen(ModalScreen[None]):
         diagnosed, and ``/info`` is a snapshot rather than a monitor — so this
         is a manual gesture and the captured-at stamp says which moment is on
         screen.
+
+        The snapshot is cleared FIRST so the screen acknowledges the keypress
+        within a frame. Without it the probe took ~4 s during which the screen
+        was byte-identical to before the press — same rows, same footer, same
+        stamp — so the key read as dead and the natural response was to press it
+        again (UX round 1, U2). Dropping back to ``checking…`` reuses the
+        first-open vocabulary rather than inventing a second loading state, and
+        it is the honest picture: those fields are, once again, unread.
         """
         handler = getattr(self.app, "refresh_info_screen", None)
-        if handler is not None:
-            handler(self)
+        if handler is None:
+            return
+        self.snapshot = None
+        self._repaint()
+        handler(self)
 
     def action_scroll_up(self) -> None:
         self._scroll.scroll_up()

--- a/local_operator/update.py
+++ b/local_operator/update.py
@@ -378,6 +378,43 @@ def check_latest(
     return VersionCheck(installed=installed, latest=latest, behind=is_behind(installed, latest))
 
 
+def cached_latest(cache_dir: Path | None = None) -> tuple[str | None, float | None]:
+    """The last PyPI answer we already have, and how old it is. NEVER fetches.
+
+    :func:`check_latest` is the *upgrade* path and is not a cached read despite
+    looking like one: only its ``cached is not None and age < TTL_S and not
+    force`` branch is served from disk, and every other path — cold cache,
+    corrupt document, an age past :data:`TTL_S` — falls through to
+    :func:`_fetch_pypi_version`, a live HTTP call bounded at
+    :data:`_FETCH_TIMEOUT_S`, and then *writes* the cache.
+
+    ``/info`` is the *diagnostic* path. It is opened precisely when something is
+    already broken, and frequently because the network is the thing that is
+    broken, so a 5 s stall on a captive portal or a DNS blackhole is the worst
+    available behaviour for the one screen that exists to explain a failure.
+    Measured on this host with an injected client that raises immediately:
+    ``check_latest()`` on a cold cache cost **156.86 ms** (all of it DNS/connect
+    setup before the raise) against **0.0002 ms** for the read below. A
+    diagnostic must also not MUTATE state, and ``check_latest`` rewrites the
+    cache on success.
+
+    Returns ``(None, None)`` when there is nothing usable cached. The caller
+    must render that as "unknown (never checked)" and never as "up to date":
+    those are different facts, and collapsing them tells a user on a broken
+    network that they are on the newest release.
+    """
+    payload, age = _read_cache(_cache_path(cache_dir))
+    if payload is None:
+        return None, None
+    raw = payload.get("version")
+    if not isinstance(raw, str) or not raw.strip():
+        return None, None
+    # ``_read_cache`` returns ``inf`` for a future-dated document (a clock
+    # skew), which is not an age any caller can render. The version is still
+    # good, so the value survives and only its staleness is unknown.
+    return raw.strip(), (age if age != float("inf") else None)
+
+
 def _direct_url_payload() -> dict[str, Any] | None:
     try:
         dist = distribution("local-operator")

--- a/scripts/info_shot.py
+++ b/scripts/info_shot.py
@@ -1,7 +1,7 @@
 """Capture the real ``/info`` slash path against a SYNTHETIC snapshot.
 
 Usage: python scripts/info_shot.py OUTDIR 100x30 [scenario]
-  scenarios: populated | empty | degraded | nested | loading
+  scenarios: populated | empty | degraded | nested | shadowed | loading
 
 Every scenario feeds a hand-built :class:`InfoSnapshot` rather than the
 operator's real one. That is not convenience — the frames go on a PR, and the

--- a/scripts/info_shot.py
+++ b/scripts/info_shot.py
@@ -1,0 +1,440 @@
+"""Capture the real ``/info`` slash path against a SYNTHETIC snapshot.
+
+Usage: python scripts/info_shot.py OUTDIR 100x30 [scenario]
+  scenarios: populated | empty | degraded | nested | loading
+
+Every scenario feeds a hand-built :class:`InfoSnapshot` rather than the
+operator's real one. That is not convenience — the frames go on a PR, and the
+redaction rules apply to a PNG exactly as they do to the clipboard, so a capture
+of a live machine would publish real session names, real working directories and
+real credential key names.
+
+The isolation import must stay FIRST: it re-homes ``HOME`` and
+``LOCAL_OPERATOR_CONFIG_DIR`` before anything under ``local_operator`` can
+resolve the operator's real config (see ``scripts/probe_isolation.py`` for the
+incident that made it an import-time action rather than a function to remember).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Clear every multiplexer identifier BEFORE any application import: a headless
+# pilot must not rename the operator's real workspace through inherited CMUX IDs.
+for _key in tuple(os.environ):
+    if _key.startswith("CMUX_"):
+        os.environ.pop(_key)
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import asyncio  # noqa: E402
+import json  # noqa: E402
+from typing import Any  # noqa: E402
+
+import scripts.probe_isolation  # noqa: E402, F401
+from local_operator.info.collect import LiveState  # noqa: E402
+from local_operator.info.model import (  # noqa: E402
+    AgentsInfo,
+    EnvInfo,
+    InfoSnapshot,
+    InstallInfo,
+    ProcessInfo,
+    SessionLine,
+    SessionsInfo,
+    SubagentLine,
+)
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.widgets.editor import Editor  # noqa: E402
+from local_operator.tui.widgets.info_panel import InfoScreen  # noqa: E402
+from scripts.visual_capture import save_capture  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+from tests.unit.tui.test_slash_echo import _submit  # noqa: E402
+
+#: A REAL-SHAPED session id: the harness generates ``uuid4().hex[:12]``, so
+#: every session directory on a live machine is exactly 12 characters. A longer
+#: demo string would manufacture a header crop no operator can actually hit.
+SESSION_ID = "a3f9c21b7e40"
+
+#: Synthetic home root for the path values, so the frames show the ``~``
+#: collapsing the screen really does without carrying anyone's username.
+HOME = str(Path.home())
+
+
+def _install(**overrides: object) -> InstallInfo:
+    base: dict[str, Any] = dict(
+        version="0.51.6",
+        kind="uv-tool",
+        prefix=f"{HOME}/.local/share/uv/tools/local-operator",
+        executable=f"{HOME}/.local/share/uv/tools/local-operator/bin/python",
+        is_git_snapshot=True,
+        source_ref="4311eb653aa9f00d1c2b",
+        build_age_s=5_400.0,
+        latest_known="0.51.6",
+        latest_age_s=7_200.0,
+        python_version="3.12.13",
+        python_implementation="CPython",
+        platform="macOS-26.6.2-arm64-arm-64bit",
+        machine="arm64",
+        import_path=f"{HOME}/.local/share/uv/tools/local-operator/lib/python3.12/"
+        "site-packages/local_operator",
+        import_path_foreign=False,
+    )
+    base.update(overrides)
+    return InstallInfo(**base)  # type: ignore[arg-type]
+
+
+def _process(**overrides: object) -> ProcessInfo:
+    base: dict[str, Any] = dict(
+        pid=4243,
+        session_id=SESSION_ID,
+        conversation_name="Investigate request latency",
+        cwd=f"{HOME}/workspace/repos/lo-session-sidebar",
+        model_label="anthropic/claude-opus-5",
+        effective_model="anthropic/claude-opus-5",
+        uptime_s=840.0,
+        config_dir=f"{HOME}/.local-operator",
+        cache_dir=f"{HOME}/.local-operator/cache",
+        agent_home=f"{HOME}/local-operator-home",
+        log_dir=f"{HOME}/Library/Logs/local-operator",
+        control_port=51234,
+        protocol=5,
+        kind="tui",
+    )
+    base.update(overrides)
+    return ProcessInfo(**base)  # type: ignore[arg-type]
+
+
+def _session_line(
+    pid: int, name: str, *, state: str = "live", is_self: bool = False, **overrides: object
+) -> SessionLine:
+    base: dict[str, Any] = dict(
+        pid=pid,
+        # ``daemon`` by default because that is what a live machine actually
+        # holds: ``runtime/process.py`` spawns every reattachable runtime with
+        # ``kind="daemon"``, and a scan of this host returned daemon for all 12
+        # records. A ``tui``-heavy fixture would picture the rare case.
+        kind="daemon",
+        state=state,
+        session_id=f"{pid:012x}",
+        conversation_name=name,
+        model_label="anthropic/claude-opus-5",
+        cwd=f"{HOME}/workspace/repos/lo-{name.split()[0].lower()}",
+        uptime_s=840.0,
+        heartbeat_age_s=2.0,
+        rss_bytes=190 * (1 << 20),
+        footprint_bytes=228 * (1 << 20),
+        is_self=is_self,
+    )
+    base.update(overrides)
+    return SessionLine(**base)  # type: ignore[arg-type]
+
+
+def _env(**overrides: object) -> EnvInfo:
+    base: dict[str, Any] = dict(
+        mcp_configured=3,
+        mcp_connected=3,
+        theme="dusk",
+        approval_mode="ask",
+        terminal_size=(100, 30),
+        term="xterm-256color",
+        colorterm="truecolor",
+        multiplexer="cmux",
+        is_tty=True,
+        browser_backend="extension",
+        browser_name="Chrome",
+        browser_paired=True,
+        mobile_installed=True,
+        mobile_healthy=True,
+        mobile_port=8420,
+        credential_keys=("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "RADIENT_API_KEY"),
+        guides=2,
+        skills=6,
+    )
+    base.update(overrides)
+    return EnvInfo(**base)  # type: ignore[arg-type]
+
+
+#: Fixed capture stamp so two runs of one scenario are byte-comparable. A
+#: wall-clock "captured HH:MM:SS" row would otherwise differ on every capture
+#: and defeat the identical-consecutive-frames check.
+CAPTURED_AT = 1_788_602_400.0
+
+
+def snapshot_for(scenario: str) -> InfoSnapshot | None:
+    """The synthetic snapshot each named frame renders. ``None`` = loading."""
+    if scenario == "loading":
+        return None
+
+    if scenario == "empty":
+        # The FRESH INSTALL case: one session, no subagents. The case most
+        # people see, and the one that must not look broken.
+        return InfoSnapshot(
+            install=_install(is_git_snapshot=False, source_ref="", build_age_s=None),
+            process=_process(),
+            sessions=SessionsInfo(
+                lines=(_session_line(4243, "Investigate request latency", is_self=True),),
+                total=1,
+                live=1,
+            ),
+            agents=AgentsInfo(profiles=0, teams=0),
+            env=_env(
+                mcp_configured=0,
+                mcp_connected=0,
+                credential_keys=("ANTHROPIC_API_KEY",),
+                mobile_installed=False,
+                mobile_healthy=False,
+                browser_backend="none",
+                browser_name="",
+                skills=0,
+            ),
+            captured_at=CAPTURED_AT,
+        )
+
+    if scenario == "shadowed":
+        # The ``launch.py`` cwd trap: a uv-tool install whose RUNNING CODE is a
+        # checkout on sys.path. Active on this machine, not hypothetical.
+        return InfoSnapshot(
+            install=_install(
+                import_path=f"{HOME}/local-operator/local_operator",
+                import_path_foreign=True,
+            ),
+            process=_process(cwd=f"{HOME}/local-operator"),
+            sessions=SessionsInfo(
+                lines=(_session_line(4243, "Investigate request latency", is_self=True),),
+                total=1,
+                live=1,
+            ),
+            agents=AgentsInfo(profiles=20, teams=3),
+            env=_env(),
+            captured_at=CAPTURED_AT,
+        )
+
+    if scenario == "degraded":
+        # One unavailable FIELD and one unavailable SECTION, plus a settled MCP
+        # failure and a build skew — the shapes §6 specifies.
+        return InfoSnapshot(
+            install=_install(
+                kind="", prefix="", executable="", latest_known=None, latest_age_s=None
+            ),
+            process=_process(control_port=None, config_dir_redirected=True),
+            sessions=SessionsInfo(available=False),
+            agents=AgentsInfo(profiles=20, teams=3),
+            env=_env(
+                mcp_configured=3,
+                mcp_connected=1,
+                mcp_failed=2,
+                mcp_failures=(
+                    ("github", "command not found: gh"),
+                    ("linear", "connect ECONNREFUSED 127.0.0.1:5173"),
+                ),
+                browser_backend="extension (stale)",
+                mobile_healthy=False,
+            ),
+            degraded=(
+                ("install.kind", "PackageNotFoundError: local-operator"),
+                ("sessions", "OSError: [Errno 5] Input/output error: '~/.local-operator/run'"),
+            ),
+            captured_at=CAPTURED_AT,
+        )
+
+    if scenario == "nested":
+        # A depth>=2 tree with the cap exercised, plus a fleet and a build skew.
+        return InfoSnapshot(
+            install=_install(latest_known="0.52.0", behind=True, latest_age_s=1_200.0),
+            process=_process(),
+            sessions=SessionsInfo(
+                lines=(
+                    _session_line(4243, "Investigate request latency", is_self=True, busy=True),
+                    _session_line(4244, "Add /move command", pending="approval", version="0.51.5"),
+                    _session_line(4245, "OSWorld benchmark", detached=True),
+                    _session_line(4246, "Wedged runtime", state="wedged", heartbeat_age_s=310.0),
+                ),
+                total=4,
+                live=3,
+                wedged=1,
+                busy=1,
+                pending=1,
+                detached=1,
+                build_skew=True,
+            ),
+            agents=AgentsInfo(
+                profiles=20,
+                teams=3,
+                running=3,
+                queued=1,
+                settled=7,
+                max_running=4,
+                at_capacity=False,
+                max_depth=4,
+                deeper=2,
+                tree=(
+                    SubagentLine(
+                        job_id="j1",
+                        label="reviewer",
+                        status="running",
+                        depth=0,
+                        agent_role="reviewer",
+                    ),
+                    SubagentLine(
+                        job_id="j2", label="scout", status="running", depth=1, agent_role="scout"
+                    ),
+                    SubagentLine(
+                        job_id="j3",
+                        label="coder",
+                        status="completed",
+                        depth=2,
+                        agent_role="coder",
+                    ),
+                    SubagentLine(job_id="j4", label="qa-tester", status="queued", depth=0),
+                    SubagentLine(job_id="j5", label="designer", status="failed", depth=0),
+                    SubagentLine(job_id="j6", label="architect", status="completed", depth=0),
+                ),
+            ),
+            env=_env(),
+            captured_at=CAPTURED_AT,
+        )
+
+    # populated: the reference frame.
+    return InfoSnapshot(
+        install=_install(),
+        process=_process(),
+        sessions=SessionsInfo(
+            lines=(
+                _session_line(4243, "Investigate request latency", is_self=True),
+                _session_line(4244, "Add /move command", busy=True),
+                _session_line(4245, "OSWorld benchmark"),
+            ),
+            total=3,
+            live=3,
+            busy=1,
+        ),
+        agents=AgentsInfo(
+            profiles=20,
+            teams=3,
+            running=1,
+            queued=0,
+            settled=4,
+            max_running=4,
+            max_depth=1,
+            tree=(
+                SubagentLine(
+                    job_id="j1", label="reviewer", status="running", depth=0, agent_role="reviewer"
+                ),
+                SubagentLine(job_id="j2", label="scout", status="completed", depth=1),
+            ),
+        ),
+        env=_env(),
+        captured_at=CAPTURED_AT,
+    )
+
+
+def live_for(scenario: str) -> LiveState:
+    """The pre-yield live capture the screen paints its first frame from."""
+    snapshot = snapshot_for(scenario)
+    agents = snapshot.agents if snapshot else AgentsInfo()
+    return LiveState(
+        session_id=SESSION_ID,
+        conversation_name="Investigate request latency",
+        model_label="anthropic/claude-opus-5",
+        effective_model="anthropic/claude-opus-5",
+        kind="tui",
+        theme="dusk",
+        terminal_size=(100, 30),
+        approval_mode="ask",
+        tree=agents.tree,
+        running=agents.running,
+        queued=agents.queued,
+        settled=agents.settled,
+        max_running=agents.max_running,
+        max_depth=agents.max_depth,
+        deeper=agents.deeper,
+    )
+
+
+async def main() -> None:
+    out = Path(sys.argv[1]).resolve()
+    out.mkdir(parents=True, exist_ok=True)
+    cols, rows = sys.argv[2].split("x")
+    size = (int(cols), int(rows))
+    scenario = sys.argv[3] if len(sys.argv) > 3 else "populated"
+
+    session = FakeSession()
+    session.set_conversation_name("Investigate request latency")
+    app = OperatorApp(lambda: _factory(session))
+
+    async with app.run_test(size=size) as pilot:
+        await pilot.pause()
+        # Drive the REAL slash path through the real editor, so the capture
+        # exercises registration, dispatch and the push, not just the renderer.
+        await _submit(pilot, app, "/info")
+        await pilot.pause()
+        screen = app.screen
+        if not isinstance(screen, InfoScreen):
+            raise SystemExit(f"/info did not open InfoScreen (got {type(screen).__name__})")
+
+        # Substitute the synthetic snapshot for whatever the worker found on
+        # this machine: a frame that goes on a PR must not carry real data.
+        await app.workers.wait_for_complete()
+        screen.live = live_for(scenario)
+        snapshot = snapshot_for(scenario)
+        if snapshot is None:
+            screen.snapshot = None
+            screen._repaint()
+        else:
+            screen.set_snapshot(snapshot)
+        await pilot.pause()
+
+        save_capture(app, str(out / "opened.svg"))
+        await pilot.pause()
+        # A SECOND settled frame: identical to the first proves no post-paint
+        # reflow and no animation (AGENTS.md §5).
+        save_capture(app, str(out / "settled.svg"))
+
+        for page in range(1, 5):
+            await pilot.press("pagedown")
+            await pilot.pause()
+            save_capture(app, str(out / f"page-{page}.svg"))
+        await pilot.press("end")
+        await pilot.pause()
+        save_capture(app, str(out / "bottom.svg"))
+
+        scroll = getattr(screen, "_scroll", None)
+        metrics = {
+            "source": str(Path(__file__).resolve().parents[1]),
+            "scenario": scenario,
+            "size": list(size),
+            "screen": type(screen).__name__,
+            "screen_geometry": {
+                "size": list(screen.size),
+                "virtual_size": list(screen.virtual_size),
+                # The screen must NOT scroll: the body does. A screen-level
+                # scrollbar costs two cells and reflows the transcript behind.
+                "screen_scrolls": list(screen.virtual_size) != list(screen.size),
+                "vertical_scrollbar": bool(screen.show_vertical_scrollbar),
+            },
+            "card_width": screen._card_width(),
+            "hint": screen._info_hint(),
+            "prompts": session.prompts,
+            "scroll": (
+                {
+                    "size": list(scroll.size),
+                    "virtual_size": list(scroll.virtual_size),
+                    "max_x": scroll.max_scroll_x,
+                    "max_y": scroll.max_scroll_y,
+                }
+                if scroll
+                else None
+            ),
+        }
+
+        await pilot.press("escape")
+        await pilot.pause()
+        save_capture(app, str(out / "closed.svg"))
+        metrics["composer_focused_after_close"] = app.focused is app.query_one(Editor)
+        (out / "result.json").write_text(json.dumps(metrics, indent=2) + "\n")
+        print(json.dumps(metrics))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/e2e/test_desktop_controls.py
+++ b/tests/e2e/test_desktop_controls.py
@@ -96,8 +96,13 @@ async def test_desktop_control_surface(headless_tui_env: Path, workspace: Path, 
             client.headers["Authorization"] = "Bearer " + token
             catalog = (await client.get("/v1/desktop/commands")).json()["result"]["commands"]
             # The catalogue is the registry MINUS the entries deliberately not
-            # offered on the desktop (no `desktop_destination` — today just
-            # `/mobile`, whose provisioning has no desktop proxy). Derived from
+            # offered on the desktop (no `desktop_destination`): `/mobile`,
+            # whose provisioning has no desktop proxy, and `/info`, whose every
+            # field describes the PROCESS AND HOST it runs in — install prefix,
+            # resolved import path, pid, control port, this machine's session
+            # registry. Proxied to a desktop surface it would faithfully report
+            # the wrong machine, which is the one failure the screen exists to
+            # prevent. Derived from
             # the registry rather than pinned as a literal, because the equality
             # against EVERY registry name could only ever hold if the withheld
             # commands were offered, which is the bug the field exists to
@@ -106,7 +111,7 @@ async def test_desktop_control_surface(headless_tui_env: Path, workspace: Path, 
             offered = {spec.name for spec in SLASH_COMMANDS if spec.desktop_destination}
             withheld = {spec.name for spec in SLASH_COMMANDS if not spec.desktop_destination}
             assert {row["name"] for row in catalog} == offered
-            assert withheld == {"mobile"}
+            assert withheld == {"mobile", "info"}
             assert len(catalog) == len(SLASH_COMMANDS) - len(withheld)
             assert sum(len(row["aliases"]) for row in catalog) == 8
             created = await client.post(

--- a/tests/unit/info/test_collect.py
+++ b/tests/unit/info/test_collect.py
@@ -1,0 +1,507 @@
+"""The ``/info`` probes: no network, honest staleness, independent degradation.
+
+The highest-value assertion in this file is
+:func:`test_collect_never_touches_the_network`. ``/info``'s whole design turns on
+it, and a comment cannot enforce it: ``update.check_latest()`` is the
+obvious-looking call, its name reads as harmless, and its TTL miss is a live
+5 s HTTP request that also rewrites the cache. It is pinned STRUCTURALLY (a fake
+that raises) rather than with a wall-clock bound, per AGENTS.md §"Prefer a
+structural invariant to a numeric one" — a timing bound on a ``top``-shelling
+probe would flake on CI within a day.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator import update
+from local_operator.info import collect as collect_mod
+from local_operator.info.collect import (
+    build_subagent_tree,
+    collect_env,
+    collect_install,
+    collect_live,
+    collect_sessions,
+    collect_snapshot,
+)
+from local_operator.info.model import SessionsInfo
+
+#: Frozen stamp for fixtures whose durations must be constants.
+NOW_FIXTURE = 1_788_602_400.0
+
+
+@dataclass
+class _Record:
+    """A ``SessionRecord``-shaped stand-in. Deliberately NOT the real class for
+    the mid-upgrade test below, whose whole point is a record missing fields."""
+
+    pid: int
+    kind: str = "tui"
+    session_id: str = "sess"
+    conversation_name: str = "Conversation"
+    cwd: str = "/tmp/x"
+    model_label: str = "anthropic/claude-opus-5"
+    started_at: float = 0.0
+    heartbeat_at: float = 0.0
+    pending: str | None = None
+    busy: bool = False
+    detached: bool = False
+    version: str = "0.51.6"
+    source_ref: str = "abc1234"
+
+
+@dataclass
+class _OldRecord:
+    """What an OLDER runtime wrote: no version/source_ref/pending/busy/detached.
+
+    This is the exact shape the ``getattr`` defaulting exists for, and the host
+    it appears on — one mid-upgrade — is precisely the host ``/info`` is opened
+    on.
+    """
+
+    pid: int
+    kind: str
+    session_id: str
+    conversation_name: str
+    cwd: str
+    model_label: str
+    started_at: float
+    heartbeat_at: float
+
+
+@dataclass
+class _Usage:
+    rss_bytes: int | None = None
+    footprint_bytes: int | None = None
+
+
+@dataclass
+class _Node:
+    job_id: str
+    label: str
+    parent_job_id: str | None = None
+    status: str = "running"
+    agent_role: str = ""
+    effort: str = ""
+    session_id: str | None = None
+    live: bool = True
+
+
+# -- the ban on the network ---------------------------------------------------
+
+
+def test_collect_never_touches_the_network(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``collect_install`` completes with every fetch path armed to explode.
+
+    Both doors are nailed shut: the module's own fetch helper and ``httpx.get``
+    beneath it. If a future edit reaches for ``check_latest()`` — on any branch,
+    including ``force=False`` — this fails loudly instead of shipping a screen
+    that hangs for five seconds on the broken network it exists to explain.
+    """
+
+    def _explode(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("/info must never fetch: it is opened when the network is broken")
+
+    monkeypatch.setattr(update, "_fetch_pypi_version", _explode)
+    monkeypatch.setattr(update, "check_latest", _explode)
+    import httpx
+
+    monkeypatch.setattr(httpx, "get", _explode)
+
+    errors: list[tuple[str, str]] = []
+    install = collect_install(errors)
+
+    assert install.version  # the field a bug report most needs survived
+    assert not errors
+    # Either something was already cached, or nothing was. Both are fine; a
+    # NETWORK CALL is not.
+    assert install.latest_known is None or isinstance(install.latest_known, str)
+
+
+def test_cold_cache_reports_unknown_not_up_to_date(tmp_path: Path) -> None:
+    """``(None, None)``, which the screen must render as "never checked".
+
+    Collapsing this into "up to date" tells a user on a broken network that they
+    are on the newest release, which is the failure mode ``cached_latest`` was
+    added to prevent.
+    """
+    assert update.cached_latest(tmp_path) == (None, None)
+
+
+def test_fresh_cache_is_returned_with_its_age(tmp_path: Path) -> None:
+    path = tmp_path / "pypi-local-operator.json"
+    path.write_text(json.dumps({"payload": {"version": "9.9.9"}, "fetched_at": time.time() - 120}))
+    version, age = update.cached_latest(tmp_path)
+    assert version == "9.9.9"
+    assert age is not None and 100 < age < 200
+
+
+def test_stale_cache_is_returned_and_its_age_exceeds_the_ttl(tmp_path: Path) -> None:
+    """A 7-hour-old document against a 6-hour TTL: still returned, marked old.
+
+    The value is still the best answer available; only its FRESHNESS changed,
+    and the renderer appends ``(stale)`` from this age rather than discarding a
+    usable version number.
+    """
+    path = tmp_path / "pypi-local-operator.json"
+    fetched = time.time() - (7 * 60 * 60)
+    path.write_text(json.dumps({"payload": {"version": "9.9.9"}, "fetched_at": fetched}))
+    version, age = update.cached_latest(tmp_path)
+    assert version == "9.9.9"
+    assert age is not None and age > update.TTL_S
+
+
+def test_corrupt_cache_is_unknown_rather_than_an_exception(tmp_path: Path) -> None:
+    (tmp_path / "pypi-local-operator.json").write_text("{not json")
+    assert update.cached_latest(tmp_path) == (None, None)
+
+
+def test_future_dated_cache_keeps_the_version_and_drops_the_age(tmp_path: Path) -> None:
+    """A clock skew makes the age meaningless, not the version."""
+    path = tmp_path / "pypi-local-operator.json"
+    path.write_text(json.dumps({"payload": {"version": "9.9.9"}, "fetched_at": time.time() + 9999}))
+    assert update.cached_latest(tmp_path) == ("9.9.9", None)
+
+
+# -- sessions -----------------------------------------------------------------
+
+
+def _scan(records: list[tuple[Any, str]]) -> Any:
+    return lambda root=None: records
+
+
+def _usage(mapping: dict[int, _Usage]) -> Any:
+    return lambda pids, **kwargs: {pid: mapping.get(pid, _Usage()) for pid in pids}
+
+
+def test_counters_agree_with_the_lines() -> None:
+    """``live + wedged + stale == total``, and each counter is its own filter.
+
+    Cheap, and it catches the copy-paste drift that a hand-maintained set of
+    seven roll-ups invites.
+    """
+    records = [
+        (_Record(pid=1, busy=True), "live"),
+        (_Record(pid=2, pending="approval"), "live"),
+        (_Record(pid=3, detached=True), "wedged"),
+        (_Record(pid=4), "stale"),
+    ]
+    info = collect_sessions(scan=_scan(records), usage=_usage({}), now=100.0)
+    assert info.total == 4
+    assert info.live + info.wedged + info.stale == info.total
+    assert (info.live, info.wedged, info.stale) == (2, 1, 1)
+    assert info.busy == sum(1 for line in info.lines if line.busy) == 1
+    assert info.pending == 1
+    assert info.detached == 1
+
+
+def test_is_self_marks_exactly_the_calling_process() -> None:
+    records = [(_Record(pid=11), "live"), (_Record(pid=22), "live")]
+    info = collect_sessions(scan=_scan(records), usage=_usage({}), self_pid=22, now=0.0)
+    assert [line.is_self for line in info.lines] == [False, True]
+
+
+def test_a_record_missing_the_newer_fields_does_not_raise() -> None:
+    """The mid-upgrade host: an old record lists cleanly with empty defaults."""
+    old = _OldRecord(
+        pid=7,
+        kind="exec",
+        session_id="old",
+        conversation_name="Older runtime",
+        cwd="/tmp/old",
+        model_label="openai/gpt-5.2",
+        started_at=0.0,
+        heartbeat_at=0.0,
+    )
+    info = collect_sessions(scan=_scan([(old, "live")]), usage=_usage({}), now=60.0)
+    line = info.lines[0]
+    assert line.version == "" and line.source_ref == ""
+    assert line.pending is None and line.busy is False and line.detached is False
+    assert line.uptime_s == 60.0
+
+
+def test_build_skew_is_only_flagged_across_live_sessions() -> None:
+    same = [
+        (_Record(pid=1, version="0.51.6", source_ref="aaa"), "live"),
+        (_Record(pid=2, version="0.51.6", source_ref="aaa"), "live"),
+        # A STALE record on an older build is not skew: it is not running.
+        (_Record(pid=3, version="0.40.0", source_ref="zzz"), "stale"),
+    ]
+    assert collect_sessions(scan=_scan(same), usage=_usage({}), now=0.0).build_skew is False
+
+    mixed = [
+        (_Record(pid=1, version="0.51.6", source_ref="aaa"), "live"),
+        (_Record(pid=2, version="0.51.5", source_ref="bbb"), "live"),
+    ]
+    assert collect_sessions(scan=_scan(mixed), usage=_usage({}), now=0.0).build_skew is True
+
+
+def test_usage_available_is_false_only_when_nothing_measured() -> None:
+    records = [(_Record(pid=1), "live"), (_Record(pid=2), "live")]
+    none_measured = collect_sessions(scan=_scan(records), usage=_usage({}), now=0.0)
+    assert none_measured.usage_available is False
+
+    partly = collect_sessions(
+        scan=_scan(records), usage=_usage({1: _Usage(rss_bytes=1000)}), now=0.0
+    )
+    assert partly.usage_available is True
+
+
+def test_no_live_sessions_is_not_an_unmeasurable_host() -> None:
+    """Nothing to measure is not the same as a host that cannot measure."""
+    info = collect_sessions(scan=_scan([(_Record(pid=9), "stale")]), usage=_usage({}), now=0.0)
+    assert info.usage_available is True
+
+
+# -- the subagent tree --------------------------------------------------------
+
+
+def test_tree_is_depth_first_and_counts_its_depth() -> None:
+    """root → A → A1 → A1a, built from ``parent_job_id`` alone."""
+    nodes = [
+        _Node("root", "reviewer"),
+        _Node("a", "scout", parent_job_id="root"),
+        _Node("a1", "coder", parent_job_id="a"),
+    ]
+    tree, deepest, deeper = build_subagent_tree(nodes)
+    assert [(n.job_id, n.depth) for n in tree] == [("root", 0), ("a", 1), ("a1", 2)]
+    assert deepest == 2 and deeper == 0
+
+
+def test_tree_caps_its_depth_and_counts_the_remainder() -> None:
+    """Past the cap the COUNT is the fact that matters, not the indentation."""
+    nodes = [
+        _Node("n0", "a"),
+        _Node("n1", "b", parent_job_id="n0"),
+        _Node("n2", "c", parent_job_id="n1"),
+        _Node("n3", "d", parent_job_id="n2"),
+        _Node("n4", "e", parent_job_id="n3"),
+    ]
+    tree, deepest, deeper = build_subagent_tree(nodes, max_depth=3)
+    assert max(node.depth for node in tree) == 2
+    assert deepest == 4
+    assert deeper == 2
+
+
+def test_tree_walk_is_cycle_safe() -> None:
+    """A malformed restored snapshot must not hang the screen.
+
+    Mirrors the ``seen`` set ``comms.ancestors()`` carries for exactly this.
+    """
+    nodes = [_Node("x", "X", parent_job_id="y"), _Node("y", "Y", parent_job_id="x")]
+    tree, _deepest, _deeper = build_subagent_tree(nodes)
+    assert len(tree) <= 2
+    assert len({node.job_id for node in tree}) == len(tree)
+
+
+def test_an_orphan_is_walked_from_the_root_not_dropped() -> None:
+    """Its parent record was evicted, not its existence.
+
+    A RUNNING subagent missing from a "what is running" screen is the worst
+    error this screen can make.
+    """
+    nodes = [_Node("child", "scout", parent_job_id="evicted-parent")]
+    tree, _deepest, _deeper = build_subagent_tree(nodes)
+    assert [node.job_id for node in tree] == ["child"]
+    assert tree[0].depth == 0
+
+
+def test_running_sorts_before_queued_before_settled() -> None:
+    nodes = [
+        _Node("c", "done", status="completed"),
+        _Node("b", "waiting", status="queued"),
+        _Node("a", "working", status="running"),
+    ]
+    tree, _deepest, _deeper = build_subagent_tree(nodes)
+    assert [node.status for node in tree] == ["running", "queued", "completed"]
+
+
+# -- independent degradation --------------------------------------------------
+
+
+class _Boom:
+    """A session whose every read raises. A diagnostic must survive one."""
+
+    @property
+    def subagent_comms(self) -> Any:
+        raise RuntimeError("comms is wedged")
+
+    @property
+    def session_id(self) -> str:
+        raise RuntimeError("session is wedged")
+
+
+def test_live_capture_survives_a_wedged_session() -> None:
+    live = collect_live(_Boom(), theme="dawn", size=(100, 30))
+    assert live.tree == ()
+    assert live.theme == "dawn"
+    assert live.terminal_size == (100, 30)
+
+
+def test_live_capture_of_none_is_a_full_default_state() -> None:
+    live = collect_live(None)
+    assert live.running == 0 and live.tree == () and live.max_running is None
+
+
+@pytest.mark.parametrize("failing", ["sessions", "agents", "env", "install"])
+def test_each_block_degrades_independently(failing: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make exactly ONE collector raise; every other block must still populate.
+
+    This is the property the whole ``_safe`` design exists for: one unreadable
+    probe costs exactly its own field, never the version number a bug report
+    most needs.
+    """
+
+    def _explode(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError(f"{failing} is broken")
+
+    if failing == "sessions":
+        monkeypatch.setattr(collect_mod, "collect_sessions", _explode)
+    elif failing == "agents":
+        import local_operator.agents as agents_mod
+
+        monkeypatch.setattr(agents_mod, "AgentRegistry", _explode)
+    elif failing == "env":
+        from local_operator.browser_bridge import state as bridge_state
+
+        monkeypatch.setattr(bridge_state, "liveness", _explode)
+    else:
+        monkeypatch.setattr(update, "installed_version", _explode)
+
+    snapshot = collect_snapshot(collect_live(None, theme="dusk"))
+
+    assert snapshot.degraded, "the failure must be NAMED, not swallowed"
+    names = {name for name, _ in snapshot.degraded}
+    assert any(failing.split(".")[0] in name for name in names)
+
+    # And nothing propagated: the other blocks are still real objects.
+    assert isinstance(snapshot.sessions, SessionsInfo)
+    assert snapshot.env.theme == "dusk"
+    if failing != "install":
+        assert snapshot.install.version
+
+
+def test_a_broken_scan_replaces_the_section_rather_than_the_screen(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _explode(*args: Any, **kwargs: Any) -> Any:
+        raise OSError("registry is on a wedged mount")
+
+    monkeypatch.setattr(collect_mod, "collect_sessions", _explode)
+    snapshot = collect_snapshot(collect_live(None))
+    assert snapshot.sessions.available is False
+    assert snapshot.install.version  # unaffected
+
+
+def test_degraded_reasons_are_named_and_bounded() -> None:
+    errors: list[tuple[str, str]] = []
+    collect_mod._safe("probe.name", lambda: 1 / 0, "fallback", errors)
+    assert errors and errors[0][0] == "probe.name"
+    assert "ZeroDivisionError" in errors[0][1]
+    assert len(errors[0][1]) <= 120
+
+
+def test_environment_reports_marker_names_never_marker_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A multiplexer marker's VALUE carries a socket path or a workspace id."""
+    monkeypatch.setenv("CMUX_SOCKET_PATH", "/private/tmp/secret-socket-path")
+    env = collect_env(collect_live(None), [])
+    assert env.multiplexer == "cmux"
+    assert "secret-socket-path" not in repr(env)
+
+
+# -- the resolved import path -------------------------------------------------
+
+
+def test_import_path_is_the_package_directory_actually_resolved() -> None:
+    """The field that answers "which code am I running" without inference."""
+    import local_operator
+
+    errors: list[tuple[str, str]] = []
+    install = collect_install(errors)
+    assert install.import_path == str(Path(local_operator.__file__).resolve().parent)
+    # In THIS worktree the venv is installed editable from this tree, so the
+    # package legitimately sits outside the venv prefix. Asserting the flag's
+    # value here would pin the developer's environment rather than the logic;
+    # the containment rule itself is pinned below against synthetic paths.
+    assert isinstance(install.import_path_foreign, bool)
+
+
+def test_a_package_under_the_prefix_is_not_foreign(tmp_path: Path) -> None:
+    """Containment, not equality: a healthy install nests several levels deep."""
+    prefix = tmp_path / "venv"
+    package = prefix / "lib" / "python3.12" / "site-packages" / "local_operator"
+    package.mkdir(parents=True)
+    assert collect_mod._import_path_is_foreign(str(package), str(prefix)) is False
+
+
+def test_a_checkout_shadowing_the_install_is_foreign(tmp_path: Path) -> None:
+    """The ``launch.py:287`` trap: spawned with ``-m`` and no ``cwd=``, so the
+    session's own directory wins ``sys.path[0]`` over site-packages."""
+    prefix = tmp_path / "uv" / "tools" / "local-operator"
+    checkout = tmp_path / "repos" / "local-operator" / "local_operator"
+    prefix.mkdir(parents=True)
+    checkout.mkdir(parents=True)
+    assert collect_mod._import_path_is_foreign(str(checkout), str(prefix)) is True
+
+
+def test_an_unreadable_comparison_never_invents_a_warning() -> None:
+    """A failed comparison must not raise a false alarm on the one screen whose
+    job is to be believed."""
+    assert collect_mod._import_path_is_foreign("", "/opt/x") is False
+    assert collect_mod._import_path_is_foreign("/opt/x", "") is False
+
+
+def test_collect_sessions_against_a_record_captured_from_a_real_scan() -> None:
+    """The fixture is a REAL record's field set, not one imagined from the type.
+
+    Written this way deliberately: the ``/session`` suite shipped a bug green
+    because its fixtures asserted an outcome shape the recorder cannot actually
+    produce. So this dict is the exact key set ``SessionRecord.to_json()``
+    returned from a live scan on this machine — including ``kind='daemon'``,
+    which is what every real record carries (``runtime/process.py`` spawns with
+    it) and NOT the ``tui`` a reading of the ``Literal["tui", "exec", "daemon"]``
+    would suggest.
+    """
+    from local_operator.session.runtime.types import SessionRecord
+
+    captured = {
+        "pid": 62950,
+        "kind": "daemon",
+        "session_id": "9c1f2ab40e77",
+        "conversation_name": "Fix error starting new session",
+        "cwd": "/private/tmp/lop-example",
+        "model_label": "anthropic/claude-opus-5",
+        "control_port": 62950,
+        "control_key": "a" * 64,
+        "protocol": 5,
+        "started_at": NOW_FIXTURE - 3600.0,
+        "heartbeat_at": NOW_FIXTURE - 4.0,
+        "capabilities": [],
+        "busy": True,
+        "detached": False,
+        "pending": None,
+        "version": "0.51.6",
+        "source_ref": "4311eb653aa9",
+    }
+    record = SessionRecord.from_json(captured)
+    info = collect_sessions(
+        scan=lambda root=None: [(record, "live")],
+        usage=lambda pids, **kwargs: {pid: _Usage(rss_bytes=609 * (1 << 20)) for pid in pids},
+        now=NOW_FIXTURE,
+    )
+    line = info.lines[0]
+    assert line.kind == "daemon"
+    assert line.busy is True and line.pending is None
+    assert line.uptime_s == 3600.0 and line.heartbeat_age_s == 4.0
+    assert line.version == "0.51.6"
+    # And the key present in the REAL record does not survive into the line.
+    assert not hasattr(line, "control_key")
+    assert "a" * 16 not in repr(line)

--- a/tests/unit/info/test_collect.py
+++ b/tests/unit/info/test_collect.py
@@ -23,6 +23,7 @@ import pytest
 from local_operator import update
 from local_operator.info import collect as collect_mod
 from local_operator.info.collect import (
+    LiveState,
     build_subagent_tree,
     collect_env,
     collect_install,
@@ -30,7 +31,7 @@ from local_operator.info.collect import (
     collect_sessions,
     collect_snapshot,
 )
-from local_operator.info.model import SessionsInfo
+from local_operator.info.model import InfoSnapshot, SessionsInfo
 
 #: Frozen stamp for fixtures whose durations must be constants.
 NOW_FIXTURE = 1_788_602_400.0
@@ -296,7 +297,15 @@ def test_tree_walk_is_cycle_safe() -> None:
     """
     nodes = [_Node("x", "X", parent_job_id="y"), _Node("y", "Y", parent_job_id="x")]
     tree, _deepest, _deeper = build_subagent_tree(nodes)
-    assert len(tree) <= 2
+    # `<= 2` PASSED VACUOUSLY AT 0, which is what it did before the fix: in a
+    # cycle every node's parent is present, so nothing buckets under `None`, the
+    # walk iterates an empty list and the tree comes back EMPTY while the header
+    # still says "2 running" — one screen contradicting itself, and by
+    # `build_subagent_tree`'s own docstring the worst error it can make (review
+    # round 1, M1). Assert the exact count: a malformed edge must cost
+    # indentation, never existence.
+    assert len(tree) == 2
+    assert {node.job_id for node in tree} == {"x", "y"}
     assert len({node.job_id for node in tree}) == len(tree)
 
 
@@ -505,3 +514,127 @@ def test_collect_sessions_against_a_record_captured_from_a_real_scan() -> None:
     # And the key present in the REAL record does not survive into the line.
     assert not hasattr(line, "control_key")
     assert "a" * 16 not in repr(line)
+
+
+def test_every_multiplexer_marker_is_probed() -> None:
+    """`_multiplexer` spells its reads out; the tuple stays the source of truth.
+
+    The reads are unrolled so the ambient-environment audit can resolve them
+    through the AST (QA round 1, Q4), which creates a second place the marker
+    list effectively lives. This pins them together: every marker in the tuple
+    must actually be probed, and must map to the label the tuple gives it.
+    """
+    import os
+
+    for variable, expected in collect_mod._MULTIPLEXER_MARKERS:
+        saved = {name: os.environ.pop(name, None) for name, _ in collect_mod._MULTIPLEXER_MARKERS}
+        try:
+            os.environ[variable] = "x"
+            assert collect_mod._multiplexer() == expected, variable
+        finally:
+            os.environ.pop(variable, None)
+            for name, value in saved.items():
+                if value is not None:
+                    os.environ[name] = value
+
+
+def test_a_multiplexer_marker_value_is_never_read() -> None:
+    """Presence only: a socket path or workspace id must not reach the snapshot."""
+    import os
+
+    saved = {name: os.environ.pop(name, None) for name, _ in collect_mod._MULTIPLEXER_MARKERS}
+    try:
+        os.environ["CMUX_SOCKET_PATH"] = "/tmp/SENTINEL-SOCKET-VALUE/sock"
+        errors: list[tuple[str, str]] = []
+        env = collect_env(LiveState(), errors)
+        assert env.multiplexer == "cmux"
+        assert "SENTINEL-SOCKET-VALUE" not in repr(env)
+    finally:
+        os.environ.pop("CMUX_SOCKET_PATH", None)
+        for name, value in saved.items():
+            if value is not None:
+                os.environ[name] = value
+
+
+def test_a_failure_in_a_block_prologue_degrades_instead_of_escaping() -> None:
+    """B1: the prologue was outside every guard, and the escape KILLED the app.
+
+    `test_each_block_degrades_independently` makes the innermost probe raise,
+    which lands inside an existing `_safe`. Nothing exercised a failure in a
+    block function's own prologue — its function-local imports and its
+    `config_dir()` call — and `config_dir()` is `Path.home() / ...`, which
+    raises `RuntimeError` when the home cannot be resolved. Escaping
+    `collect_snapshot` meant escaping the worker, and `run_worker` defaults to
+    `exit_on_error=True`, so the diagnostic screen took the whole application
+    down on exactly the broken host it exists to describe (review round 1, B1).
+    """
+    import local_operator.paths as paths_mod
+
+    def boom(*args: object, **kwargs: object) -> Path:
+        raise OSError("home unreadable")
+
+    original = paths_mod.config_dir
+    paths_mod.config_dir = boom  # type: ignore[assignment]
+    try:
+        snapshot = collect_snapshot(LiveState())
+    finally:
+        paths_mod.config_dir = original  # type: ignore[assignment]
+
+    # It RETURNED rather than raising, and said what it could not read.
+    assert isinstance(snapshot, InfoSnapshot)
+    assert snapshot.degraded, "a prologue failure must be reported, not swallowed silently"
+    assert any("home unreadable" in reason for _name, reason in snapshot.degraded)
+
+
+def test_a_broken_submodule_degrades_instead_of_escaping() -> None:
+    """The other prologue hazard: a function-local import that cannot resolve.
+
+    This is the state `/info` is opened in often enough to matter — a partially
+    broken install — so it must render, not crash.
+    """
+    import sys
+
+    sentinel = object()
+    saved = sys.modules.get("local_operator.credentials", sentinel)
+    sys.modules["local_operator.credentials"] = None  # type: ignore[assignment]
+    try:
+        snapshot = collect_snapshot(LiveState())
+    finally:
+        if saved is sentinel:
+            sys.modules.pop("local_operator.credentials", None)
+        else:
+            sys.modules["local_operator.credentials"] = saved  # type: ignore[assignment]
+
+    assert isinstance(snapshot, InfoSnapshot)
+    assert snapshot.degraded
+
+
+def test_a_degraded_collect_writes_nothing_into_the_current_directory(tmp_path: Path) -> None:
+    """`/info` READS. It must never leave a file behind on the host.
+
+    Found for real: the B1 fallback was `Path(".")`, and `CredentialManager`
+    CREATES its store on construction, so probing a machine whose `config_dir()`
+    could not be resolved wrote a `credentials.env` into whatever directory the
+    user was standing in. A diagnostic that mutates the thing it describes is
+    the same fault as `check_latest()` rewriting the cache, which this module
+    bans outright.
+    """
+    import os
+
+    import local_operator.paths as paths_mod
+
+    def boom(*args: object, **kwargs: object) -> Path:
+        raise OSError("home unreadable")
+
+    original = paths_mod.config_dir
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    paths_mod.config_dir = boom  # type: ignore[assignment]
+    try:
+        snapshot = collect_snapshot(LiveState())
+    finally:
+        paths_mod.config_dir = original  # type: ignore[assignment]
+        os.chdir(cwd)
+
+    assert snapshot.degraded, "the failure is reported"
+    assert list(tmp_path.iterdir()) == [], f"wrote {[p.name for p in tmp_path.iterdir()]}"

--- a/tests/unit/info/test_collect.py
+++ b/tests/unit/info/test_collect.py
@@ -25,6 +25,7 @@ from local_operator.info import collect as collect_mod
 from local_operator.info.collect import (
     LiveState,
     build_subagent_tree,
+    collect_agents,
     collect_env,
     collect_install,
     collect_live,
@@ -638,3 +639,38 @@ def test_a_degraded_collect_writes_nothing_into_the_current_directory(tmp_path: 
 
     assert snapshot.degraded, "the failure is reported"
     assert list(tmp_path.iterdir()) == [], f"wrote {[p.name for p in tmp_path.iterdir()]}"
+
+
+def test_a_registry_that_returns_zero_on_a_missing_root_is_still_degraded() -> None:
+    """Q8: a count read from an unresolvable config root is not a measurement.
+
+    `AgentRegistry.list_agents` and `CredentialManager.list_credential_keys`
+    both RAISE on the unreadable sentinel and were correctly caught. But
+    `TeamRegistry.list_teams` walks a missing directory and returns 0, so on an
+    unresolvable home `teams` rendered a plausible `0` with NO degraded entry
+    naming it anywhere — the one field on the screen with no honest marker.
+
+    Keyed on the sentinel rather than on the value, because 0 is a legitimate
+    answer on a machine that genuinely has no teams; suppressing every zero
+    would trade one lie for another.
+    """
+    import local_operator.paths as paths
+
+    original = paths.config_dir
+
+    def boom() -> Path:
+        raise RuntimeError("no home")
+
+    paths.config_dir = boom  # type: ignore[assignment]
+    try:
+        errors: list[tuple[str, str]] = []
+        agents = collect_agents(LiveState(), errors)
+    finally:
+        paths.config_dir = original  # type: ignore[assignment]
+
+    named = {name for name, _ in errors}
+    assert "agents.teams" in named, f"teams must be named as unreadable, got {named}"
+    assert "agents.profiles" in named
+    # The value is still the dataclass default; it is the DEGRADED entry that
+    # makes the screen render `—` instead of that default.
+    assert agents.teams == 0

--- a/tests/unit/info/test_model.py
+++ b/tests/unit/info/test_model.py
@@ -1,0 +1,116 @@
+"""The ``/info`` dataclasses stay pure data, and an empty one still renders.
+
+Two properties, both of which are load-bearing rather than stylistic:
+
+* **all-defaults constructs and carries no I/O.** ``/info`` is opened when
+  something is already broken, so the collector degrades field by field and
+  hands the renderer whatever it read. A required field would turn one
+  unreadable probe into an empty screen.
+* **``model.py`` imports nothing heavy.** It is what a future ``lop info`` and
+  every test here import, and ``collect.py`` reaches ``mobile.resources``,
+  ``browser_bridge``, ``credentials``, ``agents`` and ``teams`` — none of which
+  may become importable cost on a path ``lop --version`` pays for.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from dataclasses import fields
+from pathlib import Path
+
+from local_operator.info.model import (
+    AgentsInfo,
+    EnvInfo,
+    InfoSnapshot,
+    InstallInfo,
+    ProcessInfo,
+    SessionLine,
+    SessionsInfo,
+    SubagentLine,
+)
+
+REPO = Path(__file__).resolve().parents[3]
+
+#: Third-party / heavy first-party packages that must not follow an import of
+#: ``local_operator.info.model``. ``rich`` and ``textual`` are the renderer's
+#: dependencies; the rest are what ``collect`` reaches for.
+_FORBIDDEN = (
+    "rich",
+    "textual",
+    "httpx",
+    "pydantic",
+    "local_operator.agents",
+    "local_operator.teams",
+    "local_operator.credentials",
+    "local_operator.mobile",
+    "local_operator.browser_bridge",
+    "local_operator.session.session",
+)
+
+
+def test_every_block_constructs_with_no_arguments() -> None:
+    for cls in (
+        InstallInfo,
+        ProcessInfo,
+        SessionLine,
+        SessionsInfo,
+        SubagentLine,
+        AgentsInfo,
+        EnvInfo,
+        InfoSnapshot,
+    ):
+        cls()
+
+
+def test_every_field_has_a_default() -> None:
+    """A required field would make one failed probe cost the whole screen."""
+    import dataclasses
+
+    for cls in (
+        InstallInfo,
+        ProcessInfo,
+        SessionLine,
+        SessionsInfo,
+        SubagentLine,
+        AgentsInfo,
+        EnvInfo,
+        InfoSnapshot,
+    ):
+        for entry in fields(cls):
+            has_default = (
+                entry.default is not dataclasses.MISSING
+                or entry.default_factory is not dataclasses.MISSING  # type: ignore[misc]
+            )
+            assert has_default, f"{cls.__name__}.{entry.name} has no default"
+
+
+def test_snapshot_blocks_are_independent_instances() -> None:
+    """Mutable shared defaults across two snapshots would be a real bug."""
+    first = InfoSnapshot()
+    second = InfoSnapshot()
+    assert first.install is not second.install
+    assert first.sessions is not second.sessions
+
+
+def test_model_module_imports_nothing_heavy() -> None:
+    """Run in a FRESH subprocess.
+
+    An in-process ``sys.modules`` assertion is worthless here: pytest has
+    already imported half the tree by the time this body runs, so a module the
+    package wrongly pulls would look "already imported" and the assertion would
+    pass on a real regression. Same technique as ``tests/unit/test_import_graph``.
+    """
+    probe = (
+        "import json, importlib, sys; "
+        "importlib.import_module('local_operator.info.model'); "
+        "print(json.dumps(sorted(sys.modules)))"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, cwd=str(REPO)
+    )
+    assert proc.returncode == 0, proc.stderr[-2000:]
+    loaded = set(json.loads(proc.stdout.strip().splitlines()[-1]))
+    for name in _FORBIDDEN:
+        assert name not in loaded, f"local_operator.info.model pulled in {name}"

--- a/tests/unit/info/test_redaction.py
+++ b/tests/unit/info/test_redaction.py
@@ -13,6 +13,7 @@ import os
 import re
 from pathlib import Path
 
+from local_operator.info.collect import LiveState
 from local_operator.info.model import (
     AgentsInfo,
     EnvInfo,
@@ -94,6 +95,27 @@ def _snapshot() -> InfoSnapshot:
             term="xterm-256color",
             browser_backend="extension",
             browser_name="Chrome",
+            # FREE TEXT carrying an absolute home path, which is the shape the
+            # real channels have: an MCP failure is `str(exc)` from a failed
+            # connect and routinely reads `command not found: <abs path>`. The
+            # fixture omitted both free-text channels, so the export's
+            # home-leak assertion below could only ever exercise the fields
+            # that were already safe — it passed while the two channels that
+            # actually leaked went untested (review round 1, B2).
+            mcp_configured=2,
+            mcp_connected=1,
+            mcp_failed=1,
+            mcp_failures=(("linear", f"command not found: {home}/clients/acme/bin/linear-mcp"),),
+        ),
+        # The other free-text channel: a degraded reason is
+        # `f"{type(exc).__name__}: {exc}"`, and an OSError message contains the
+        # filename it failed on.
+        degraded=(
+            (
+                "process.config_dir",
+                f"PermissionError: [Errno 13] Permission denied: "
+                f"'{home}/clients/acme-merger-diligence/.local-operator'",
+            ),
         ),
         captured_at=1_788_602_400.0,
     )
@@ -201,3 +223,103 @@ def test_export_never_claims_up_to_date_from_an_unknown_latest() -> None:
     text = build_export(_snapshot())
     assert "unknown (never checked)" in text
     assert "up to date" not in text
+
+
+def test_never_exported_is_enforced_rather_than_merely_documented() -> None:
+    """N1: a named tuple that looks like an allowlist must actually check one.
+
+    `NEVER_EXPORTED` read as though it gated the export and gated nothing —
+    the kind of constant a future reader trusts without verifying. It now has
+    exactly one job and this test is it: every name in it is absent from a
+    fully-populated export, and from the snapshot graph behind it.
+    """
+    from dataclasses import asdict
+
+    from local_operator.info.render import NEVER_EXPORTED, build_export
+
+    snapshot = _snapshot()
+    export = build_export(snapshot)
+    graph = repr(asdict(snapshot))
+
+    for name in NEVER_EXPORTED:
+        if name == "credential values":
+            # The values themselves never enter the model — only key NAMES do,
+            # which is the structural half of this guarantee.
+            assert snapshot.env.credential_keys
+            for key in snapshot.env.credential_keys:
+                assert key in export, "the NAME is the diagnostic part and is kept"
+            continue
+        assert name not in export, f"{name} reached the export"
+        assert name not in graph, f"{name} exists in the snapshot graph"
+
+
+def test_the_screen_and_the_export_agree_about_a_shadowed_install() -> None:
+    """N3/Q1: one predicate, so the two surfaces cannot reach opposite verdicts.
+
+    This is the defect class this PR itself produced: the screen excluded the
+    benign editable case and the export did not, so every contributor running an
+    editable checkout copied a bug report claiming their install was shadowed.
+    Both now call `is_shadowed_install`, and this pins the agreement rather than
+    the implementation.
+    """
+    from local_operator.info.model import is_shadowed_install
+    from local_operator.info.render import build_export
+    from local_operator.tui.widgets.info_panel import build_info_report
+
+    cases = [
+        ("uv-tool", True, True),  # the real trap
+        ("editable", True, False),  # expected: the checkout IS the install
+        ("pip", False, False),  # healthy
+    ]
+    for kind, foreign, expect_alarm in cases:
+        install = InstallInfo(
+            version="0.51.6",
+            kind=kind,
+            prefix="/opt/uv/tools/local-operator",
+            import_path="/tmp/checkout/local_operator",
+            import_path_foreign=foreign,
+        )
+        assert is_shadowed_install(install) is expect_alarm, kind
+        snapshot = InfoSnapshot(install=install)
+        screen = build_info_report(snapshot, LiveState(), 120).plain
+        export = build_export(snapshot)
+        assert ("shadowing the install" in screen) is expect_alarm, f"screen/{kind}"
+        assert ("a checkout is shadowing it" in export) is expect_alarm, f"export/{kind}"
+
+
+def test_both_surfaces_render_one_duration_and_one_memory_spelling() -> None:
+    """N3: the two copies agreed when measured — which is why they were shared.
+
+    Agreement today is not a property that maintains itself; it is the state
+    just before a divergence nobody notices. `format_duration`/`format_bytes`
+    now have one implementation, and this asserts both surfaces show its output.
+    """
+    from local_operator.info.model import format_bytes, format_duration
+    from local_operator.info.render import build_export
+    from local_operator.tui.widgets.info_panel import build_info_report
+
+    snapshot = InfoSnapshot(
+        install=InstallInfo(version="0.51.6", kind="pip", build_age_s=5_400.0),
+        process=ProcessInfo(session_id="a3f9c21b7e40", uptime_s=5_400.0),
+        sessions=SessionsInfo(
+            lines=(
+                SessionLine(
+                    pid=1,
+                    kind="daemon",
+                    state="live",
+                    conversation_name="Probe",
+                    uptime_s=5_400.0,
+                    rss_bytes=190_000_000,
+                ),
+            ),
+            total=1,
+            live=1,
+        ),
+    )
+    screen = build_info_report(snapshot, LiveState(), 120).plain
+    export = build_export(snapshot)
+    assert format_duration(5_400.0) == "1h 30m"
+    assert format_bytes(190_000_000) == "181 MB"
+    for surface, name in ((screen, "screen"), (export, "export")):
+        assert "1h 30m" in surface, name
+    assert "181 MB" in screen

--- a/tests/unit/info/test_redaction.py
+++ b/tests/unit/info/test_redaction.py
@@ -323,3 +323,46 @@ def test_both_surfaces_render_one_duration_and_one_memory_spelling() -> None:
     for surface, name in ((screen, "screen"), (export, "export")):
         assert "1h 30m" in surface, name
     assert "181 MB" in screen
+
+
+def test_the_export_survives_a_home_that_cannot_be_resolved() -> None:
+    """F1: `ctrl+r` must not take the app down on the host B1 exists to survive.
+
+    `Path.home()` RAISES `RuntimeError` when the home cannot be resolved — the
+    exact failure class B1's collect-side remediation was built around. The
+    export side never got the same treatment, and `action_copy_report` calls
+    `build_export` SYNCHRONOUSLY from a key action, outside any worker, so
+    `exit_on_error=False` cannot catch it.
+
+    Sharper still: B1's fix is what made this reachable. Before it, the app died
+    at probe time and the user never got a screen to press `ctrl+r` on; after
+    it, the screen opens and re-probes cleanly and then the copy gesture — the
+    one the whole feature is advertised for — kills the session.
+
+    Redaction must still hold: with no home to compare against there is nothing
+    to relativise, and the correct behaviour is to emit the path unchanged
+    rather than to guess. Absolute paths in that state are not a home leak,
+    because the concept of "this user's home" is precisely what is unavailable.
+    """
+    import pathlib
+
+    original = pathlib.Path.home
+
+    def boom() -> Path:
+        raise RuntimeError("no home")
+
+    # Built BEFORE home is broken: the fixture itself composes `$HOME` paths, so
+    # constructing it under the fault would fail in the fixture rather than in
+    # the code under test. The snapshot a real user copies was likewise captured
+    # by a collector that ran earlier, so this is also the honest ordering.
+    snapshot = _snapshot()
+
+    pathlib.Path.home = staticmethod(boom)  # type: ignore[method-assign]
+    try:
+        text = build_export(snapshot)
+    finally:
+        pathlib.Path.home = original  # type: ignore[method-assign]
+
+    # It RETURNED rather than raising, and the document is still a document.
+    assert "## Install" in text
+    assert "local-operator" in text

--- a/tests/unit/info/test_redaction.py
+++ b/tests/unit/info/test_redaction.py
@@ -1,0 +1,203 @@
+"""What must never reach a GitHub issue. The highest-value file in this package.
+
+``/info``'s export is written to be pasted somewhere public, so every assertion
+here is about something that would be a real disclosure rather than a cosmetic
+defect. Two of them are structural rather than textual — invariant #13 checks
+that ``control_key`` is not a FIELD, so the guarantee survives a later renderer
+change that a string search over today's output would not catch.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+from local_operator.info.model import (
+    AgentsInfo,
+    EnvInfo,
+    InfoSnapshot,
+    InstallInfo,
+    ProcessInfo,
+    SessionLine,
+    SessionsInfo,
+    SubagentLine,
+)
+from local_operator.info.render import build_export, relativise_home
+
+#: A control key of the real shape: ``SessionRecord.control_key`` is 64 hex
+#: characters and IS the control socket's whole authorization story.
+CONTROL_KEY = "9f" * 32
+#: ``BridgeState.session_key`` carries ``Field(min_length=32)``.
+SESSION_KEY = "b3" * 24
+#: A credential VALUE. Its NAME is expected in the output; this is not.
+CREDENTIAL_VALUE = "sk-live-ThisIsATotallyRealLookingSecretValue"
+
+
+def _snapshot() -> InfoSnapshot:
+    """A snapshot seeded with every secret the collectors could plausibly meet."""
+    home = str(Path.home())
+    return InfoSnapshot(
+        install=InstallInfo(
+            version="0.51.6",
+            kind="uv-tool",
+            prefix=f"{home}/.local/share/uv/tools/local-operator",
+            executable=f"{home}/.local/share/uv/tools/local-operator/bin/python",
+            source_ref="4311eb653aa9f00",
+            is_git_snapshot=True,
+            python_version="3.12.13",
+            platform="macOS-26.6.2-arm64",
+            machine="arm64",
+        ),
+        process=ProcessInfo(
+            pid=4243,
+            session_id="a3f9c21b7e40",
+            conversation_name="Investigate request latency",
+            cwd=f"{home}/clients/acme-merger-diligence",
+            model_label="anthropic/claude-opus-5",
+            config_dir=f"{home}/.local-operator",
+            cache_dir=f"{home}/.local-operator/cache",
+            agent_home=f"{home}/local-operator-home",
+            log_dir=f"{home}/Library/Logs/local-operator",
+            control_port=51234,
+            protocol=5,
+            uptime_s=840.0,
+            kind="tui",
+        ),
+        sessions=SessionsInfo(
+            lines=(
+                SessionLine(
+                    pid=4243,
+                    kind="tui",
+                    state="live",
+                    session_id="a3f9c21b7e40",
+                    conversation_name="Investigate request latency",
+                    model_label="anthropic/claude-opus-5",
+                    cwd=f"{home}/clients/acme-merger-diligence",
+                    uptime_s=840.0,
+                    rss_bytes=190_000_000,
+                    is_self=True,
+                ),
+            ),
+            total=1,
+            live=1,
+        ),
+        agents=AgentsInfo(
+            profiles=20,
+            teams=3,
+            tree=(SubagentLine(job_id="j1", label="reviewer", status="running"),),
+            running=1,
+        ),
+        env=EnvInfo(
+            credential_keys=("RADIENT_API_KEY", "GOOGLE_ACCESS_TOKEN"),
+            theme="dusk",
+            term="xterm-256color",
+            browser_backend="extension",
+            browser_name="Chrome",
+        ),
+        captured_at=1_788_602_400.0,
+    )
+
+
+def test_the_control_key_cannot_appear_because_the_field_does_not_exist() -> None:
+    """Invariant #13, and the reason it is STRUCTURAL rather than a text search.
+
+    A renderer that started dumping the whole session line would leak the key if
+    the field merely went unrendered. There is no attribute to reach, so the
+    guarantee holds through a change nobody remembers to re-audit.
+    """
+    assert "control_key" not in SessionLine.__dataclass_fields__
+    assert "control_key" not in ProcessInfo.__dataclass_fields__
+    # And the safe half IS carried: a port number is not a credential, and it is
+    # the useful half for debugging an attach.
+    assert "control_port" in ProcessInfo.__dataclass_fields__
+
+
+def test_no_dataclass_in_the_package_carries_a_secret_shaped_field() -> None:
+    """A blanket sweep, so a NEW field named like a secret fails here first."""
+    forbidden = ("control_key", "session_key", "token", "secret", "password", "api_key")
+    for cls in (
+        InstallInfo,
+        ProcessInfo,
+        SessionLine,
+        SessionsInfo,
+        SubagentLine,
+        AgentsInfo,
+        EnvInfo,
+        InfoSnapshot,
+    ):
+        for name in cls.__dataclass_fields__:
+            assert not any(bad in name.lower() for bad in forbidden), f"{cls.__name__}.{name}"
+
+
+def test_a_seeded_control_key_never_survives_the_export() -> None:
+    """Even a 16-character substring, which is enough to be worth grepping for."""
+    text = build_export(_snapshot())
+    assert CONTROL_KEY not in text
+    assert CONTROL_KEY[:16] not in text
+
+
+def test_a_seeded_bridge_session_key_never_survives_the_export() -> None:
+    text = build_export(_snapshot())
+    assert SESSION_KEY not in text
+    assert SESSION_KEY[:16] not in text
+
+
+def test_credential_names_are_exported_and_values_are_not() -> None:
+    """The name answers the diagnostic question; the value answers nothing."""
+    text = build_export(_snapshot())
+    assert "RADIENT_API_KEY" in text
+    assert "GOOGLE_ACCESS_TOKEN" in text
+    assert CREDENTIAL_VALUE not in text
+    # No prefix, no length, no hash: a "first four characters" habit is exactly
+    # how key prefixes end up in issues.
+    assert CREDENTIAL_VALUE[:4] not in text
+
+
+def test_no_absolute_home_prefix_survives_the_export() -> None:
+    """``~/`` does; ``/Users/<name>/`` and ``/home/<name>/`` do not.
+
+    A macOS username is low-sensitivity on its own, but the export is the
+    artifact that leaves the machine and a ``cwd`` like
+    ``clients/acme-merger-diligence`` beneath it is real information about
+    someone else.
+    """
+    text = build_export(_snapshot())
+    assert str(Path.home()) not in text
+    assert not re.search(r"/Users/[^/\s]+/", text)
+    assert not re.search(r"/home/[^/\s]+/", text)
+    assert "~/" in text
+    # The diagnostic part BELOW the home directory is deliberately kept: it is
+    # what tells a maintainer which tree the reporter was in.
+    assert "~/.local-operator" in text
+    assert "clients/acme-merger-diligence" in text
+
+
+def test_relativise_home_keeps_every_segment_below_home() -> None:
+    home = str(Path.home())
+    assert relativise_home(home) == "~"
+    assert relativise_home(f"{home}/a/b/c") == os.path.join("~", "a", "b", "c")
+    # A path that is not under home is untouched: /usr/local is not identifying.
+    assert relativise_home("/usr/local/bin/lop") == "/usr/local/bin/lop"
+    assert relativise_home("") == ""
+
+
+def test_export_of_an_empty_snapshot_renders_and_leaks_nothing() -> None:
+    """The all-defaults case still has to produce a paste-able document."""
+    text = build_export(InfoSnapshot())
+    assert "local-operator unknown" in text
+    assert "## Install" in text and "## Environment" in text
+    assert str(Path.home()) not in text
+
+
+def test_export_states_the_cross_session_boundary() -> None:
+    """A tree in the output must not read as a fleet-wide view."""
+    text = build_export(_snapshot())
+    assert "this session only" in text
+    assert "other sessions report busy/pending and memory only" in text
+
+
+def test_export_never_claims_up_to_date_from_an_unknown_latest() -> None:
+    text = build_export(_snapshot())
+    assert "unknown (never checked)" in text
+    assert "up to date" not in text

--- a/tests/unit/info/test_sessions_extraction.py
+++ b/tests/unit/info/test_sessions_extraction.py
@@ -1,0 +1,246 @@
+"""``lop sessions`` is behaviour-preserved by the extraction into ``info``.
+
+``cli.sessions_command`` used to build its rows inline; ``/info`` needs the same
+answer plus ``is_self`` and roll-up counters, so the builder moved to
+``info.collect.session_rows`` and the CLI calls it. ``--json`` is a published
+surface, so this file compares against the PRE-CHANGE literal rather than
+against whatever the code now produces — a test that asserted "the output equals
+the output" would pass through any drift at all.
+
+The expectation below was captured by running the ORIGINAL ``sessions_command``
+at ``4311eb653`` against this exact fixture with the clock frozen. A byte-level
+before/after of the real command is on the PR; this is the in-suite guard.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from local_operator.info.collect import session_rows
+from local_operator.info.model import SessionLine
+
+#: Frozen clock, so every derived duration is a constant rather than a function
+#: of when the suite ran.
+NOW = 1_788_602_400.0
+
+
+@dataclass
+class _Record:
+    pid: int
+    kind: str
+    session_id: str
+    conversation_name: str
+    cwd: str
+    model_label: str
+    started_at: float
+    heartbeat_at: float
+    pending: str | None = None
+    busy: bool = False
+    detached: bool = False
+    version: str = ""
+    source_ref: str = ""
+
+
+@dataclass
+class _OldRecord:
+    """A record written by a runtime that predates the newer fields."""
+
+    pid: int
+    kind: str
+    session_id: str
+    conversation_name: str
+    cwd: str
+    model_label: str
+    started_at: float
+    heartbeat_at: float
+
+
+@dataclass
+class _Usage:
+    rss_bytes: int | None = None
+    footprint_bytes: int | None = None
+
+
+FIXTURE: list[tuple[Any, str]] = [
+    (
+        _Record(
+            pid=4243,
+            kind="tui",
+            session_id="a3f9c21b7e40",
+            conversation_name="Investigate request latency",
+            cwd="/tmp/probe/workspace",
+            model_label="anthropic/claude-sonnet-4-6",
+            started_at=NOW - 1840.0,
+            heartbeat_at=NOW - 3.0,
+            pending="approval",
+            busy=True,
+            version="0.51.6",
+            source_ref="4311eb653aa9",
+        ),
+        "live",
+    ),
+    (
+        _Record(
+            pid=4244,
+            kind="daemon",
+            session_id="beef1234cafe",
+            conversation_name="Mobile relay",
+            cwd="/tmp/probe/relay",
+            model_label="openai/gpt-5.2",
+            started_at=NOW - 86400.0,
+            heartbeat_at=NOW - 9.0,
+            detached=True,
+            version="0.51.5",
+        ),
+        "live",
+    ),
+    (
+        _OldRecord(
+            pid=999999,
+            kind="exec",
+            session_id="0badc0de0bad",
+            conversation_name="Dead runtime",
+            cwd="/tmp/probe/dead",
+            model_label="anthropic/claude-opus-4-1",
+            started_at=NOW - 600.0,
+            heartbeat_at=NOW - 600.0,
+        ),
+        "stale",
+    ),
+]
+
+#: EXACTLY what ``sessions_command`` produced before the extraction: same keys,
+#: same order, same values.
+EXPECTED = [
+    {
+        "state": "live",
+        "pid": 4243,
+        "kind": "tui",
+        "conversation_name": "Investigate request latency",
+        "session_id": "a3f9c21b7e40",
+        "model_label": "anthropic/claude-sonnet-4-6",
+        "cwd": "/tmp/probe/workspace",
+        "rss_bytes": 190_004_243,
+        "footprint_bytes": None,
+        "uptime_s": 1840.0,
+        "heartbeat_age_s": 3.0,
+        "pending": "approval",
+        "busy": True,
+        "detached": False,
+        "version": "0.51.6",
+        "source_ref": "4311eb653aa9",
+    },
+    {
+        "state": "live",
+        "pid": 4244,
+        "kind": "daemon",
+        "conversation_name": "Mobile relay",
+        "session_id": "beef1234cafe",
+        "model_label": "openai/gpt-5.2",
+        "cwd": "/tmp/probe/relay",
+        "rss_bytes": 190_004_244,
+        "footprint_bytes": None,
+        "uptime_s": 86400.0,
+        "heartbeat_age_s": 9.0,
+        "pending": None,
+        "busy": False,
+        "detached": True,
+        "version": "0.51.5",
+        "source_ref": "",
+    },
+    {
+        "state": "stale",
+        "pid": 999999,
+        "kind": "exec",
+        "conversation_name": "Dead runtime",
+        "session_id": "0badc0de0bad",
+        "model_label": "anthropic/claude-opus-4-1",
+        "cwd": "/tmp/probe/dead",
+        "rss_bytes": None,
+        "footprint_bytes": None,
+        "uptime_s": 600.0,
+        "heartbeat_age_s": 600.0,
+        "pending": None,
+        "busy": False,
+        "detached": False,
+        "version": "",
+        "source_ref": "",
+    },
+]
+
+
+def _install_fixture(monkeypatch: Any) -> None:
+    from local_operator.info import collect as collect_mod
+    from local_operator.mobile import resources
+    from local_operator.session.runtime import registry
+
+    monkeypatch.setattr(registry, "scan", lambda root=None: FIXTURE)
+    monkeypatch.setattr(
+        resources,
+        "session_resource_usage",
+        lambda pids, **kwargs: {pid: _Usage(rss_bytes=190_000_000 + pid) for pid in pids},
+    )
+    monkeypatch.setattr(collect_mod.time, "time", lambda: NOW)
+
+
+def test_session_rows_match_the_pre_extraction_output(monkeypatch: Any) -> None:
+    _install_fixture(monkeypatch)
+    assert session_rows() == EXPECTED
+
+
+def test_session_rows_key_order_is_the_published_contract(monkeypatch: Any) -> None:
+    """``--json`` consumers read this shape; the ORDER is part of it.
+
+    Pinned explicitly rather than derived from ``dataclasses.asdict``, which
+    would also have leaked ``is_self`` — a field the CLI never had — into a
+    published surface.
+    """
+    _install_fixture(monkeypatch)
+    for row, expected in zip(session_rows(), EXPECTED):
+        assert list(row) == list(expected)
+
+
+def test_is_self_is_not_published_by_the_cli_shape(monkeypatch: Any) -> None:
+    _install_fixture(monkeypatch)
+    assert all("is_self" not in row for row in session_rows())
+    # It exists on the dataclass /info reads, which is the point of extracting
+    # rather than copying.
+    assert "is_self" in SessionLine.__dataclass_fields__
+
+
+def test_cli_sessions_command_uses_the_shared_builder(monkeypatch: Any, capsys: Any) -> None:
+    """Drive the REAL command, not the helper, so the wiring itself is pinned."""
+    import argparse
+
+    from local_operator import cli
+
+    _install_fixture(monkeypatch)
+    code = cli.sessions_command(argparse.Namespace(json=True, sessions_command=None))
+    assert code == 0
+
+    import json
+
+    assert json.loads(capsys.readouterr().out) == EXPECTED
+
+
+def test_cli_table_still_renders_every_row(monkeypatch: Any, capsys: Any) -> None:
+    """The non-JSON path reads the same objects and keeps its eight columns."""
+    import argparse
+
+    from local_operator import cli
+
+    _install_fixture(monkeypatch)
+    code = cli.sessions_command(argparse.Namespace(json=False, sessions_command=None))
+    assert code == 0
+
+    out = capsys.readouterr().out
+    assert "STATE" in out and "FOOTPRINT" in out and "HB_AGE" in out
+    # The CONVERSATION column is 24 cells and the table has always truncated to
+    # it; asserting the full name here would assert a change, not a preservation.
+    assert "Investigate request late" in out
+    assert "Mobile relay" in out
+    assert "Dead runtime" in out
+    assert out.count("\n") == 4  # header + one row per fixture record
+    # And the key never reaches a terminal either.
+    assert "control_key" not in out

--- a/tests/unit/test_ambient_env_isolation.py
+++ b/tests/unit/test_ambient_env_isolation.py
@@ -56,12 +56,20 @@ _HARMLESS: dict[str, str] = {
     "ANONYMIZED_TELEMETRY": "set to 0 for chromadb; never read back",
     # -- terminal capability probes (read-only, cosmetic) --------------------
     "TERM": "colour/capability probe; tests pin it themselves",
+    "COLORTERM": "colour-capability probe; reported by /info, names no machine resource",
     "TERM_PROGRAM": "terminal identity for tab-title / notification routing",
     "NO_COLOR": "colour probe; tests pin it themselves",
     "TMUX": "presence probe for terminal-title routing; never used to address a pane",
     "KITTY_WINDOW_ID": "presence probe for terminal-title routing",
     "ITERM_SESSION_ID": "presence probe for terminal detection; never used to address",
     "WEZTERM_PANE": "presence probe for terminal detection; never used to address",
+    # /info reports WHICH multiplexer is in use for a bug report. Presence
+    # only: `info.collect._multiplexer` reads the NAME of the marker and
+    # never its value, because a value carries a socket path or a workspace
+    # id -- identifying, and this screen is pasted into public issues.
+    "STY": "presence probe for multiplexer detection; value never read",
+    "ZELLIJ": "presence probe for multiplexer detection; value never read",
+    "CMUX_SOCKET_PATH": "presence probe for multiplexer detection; value never read",
     "WEZTERM_EXECUTABLE": "binary path probe for terminal detection",
     "GHOSTTY_BIN": "binary path probe for terminal detection",
     "GHOSTTY_RESOURCES_DIR": "presence probe for terminal detection",

--- a/tests/unit/tui/test_info_panel.py
+++ b/tests/unit/tui/test_info_panel.py
@@ -724,3 +724,165 @@ def test_an_editable_checkout_gets_no_alarm_row() -> None:
     assert "expected for an editable checkout" in body
     assert "not under the install path above" not in body
     assert "Nothing will error" not in body
+
+
+class _StubApp:
+    """The app surface these actions touch. Not an `OperatorApp`.
+
+    The pilot tests below drive the real app; these three assert a decision the
+    action makes before it reaches the app, so a stub keeps them fast and makes
+    the assertion about the action rather than about the frame.
+    """
+
+    def __init__(
+        self,
+        refreshes: list[object],
+        notices: list[tuple[str, str]] | None = None,
+    ) -> None:
+        self._refreshes = refreshes
+        self._notices = notices if notices is not None else []
+
+    def refresh_info_screen(self, screen: object) -> None:
+        self._refreshes.append(screen)
+
+    def _system_notice(self, message: str, kind: str = "info") -> None:
+        self._notices.append((message, kind))
+
+    def bell(self) -> None:
+        pass
+
+    def _put_on_clipboard(self, text: str, owner: object | None = None) -> None:
+        pass
+
+
+def test_currency_is_never_claimed_from_an_unreadable_installed_version() -> None:
+    """M3: the unknown moved to the INSTALLED side and the lie came back.
+
+    `is_behind("", latest)` is False by design, so a failed version probe beside
+    a cached NEWER release reported currency on both surfaces. The three-state
+    rule is about not collapsing "unknown" into "up to date" — it does not
+    matter which half of the comparison is the unknown one, and both halves fail
+    together on a broken install, which is the state /info is opened in.
+    """
+    from local_operator.info.render import build_export
+
+    broken = _snapshot(
+        install=InstallInfo(version="", kind="uv-tool", latest_known="0.52.0", latest_age_s=60.0)
+    )
+    body = _text(broken, width=120)
+    export = build_export(broken)
+
+    assert "unknown" in body
+    assert "unknown" in export
+    for surface, name in ((body, "screen"), (export, "export")):
+        assert "latest ·" not in surface, name
+        assert "up to date" not in surface, name
+
+
+@pytest.mark.asyncio
+async def test_refresh_returns_worker_filled_fields_to_the_loading_state() -> None:
+    """U2: `r` must acknowledge within a frame, not after the ~4 s probe.
+
+    Driven through the real app and the real binding: `Screen.app` is a
+    read-only property, so this cannot be asserted against a stub, and the
+    keypress is the thing under test anyway.
+    """
+    from local_operator.tui.app import OperatorApp
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _submit(pilot, app, "/info")
+        screen = app.screen
+        assert isinstance(screen, InfoScreen)
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert screen.snapshot is not None
+
+        await pilot.press("r")
+        # Immediately after the keypress, BEFORE the worker can land.
+        assert screen.snapshot is None, "the screen must drop to `checking…` at once"
+        assert any("checking…" in line for line in screen.render_lines_for_test())
+
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert screen.snapshot is not None, "and refill when the probe returns"
+
+
+@pytest.mark.asyncio
+async def test_copying_before_the_probe_lands_says_so_rather_than_only_belling() -> None:
+    """U3: on a terminal with the bell off, the refusal was completely silent."""
+    from local_operator.tui.app import OperatorApp
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await _submit(pilot, app, "/info")
+        screen = app.screen
+        assert isinstance(screen, InfoScreen)
+        screen.snapshot = None  # the loading window, deterministically
+
+        copied: list[str] = []
+        app.copy_to_clipboard = lambda text: copied.append(text)  # type: ignore[assignment]
+        notices: list[str] = []
+        original = app._system_notice
+
+        def _record(message: str, kind: str = "info") -> None:
+            notices.append(message)
+
+        app._system_notice = _record  # type: ignore[assignment,method-assign]
+        try:
+            await pilot.press("ctrl+r")
+            await pilot.pause()
+        finally:
+            app._system_notice = original  # type: ignore[assignment,misc]
+
+        assert not copied, "nothing to copy yet"
+        assert notices, "a silent refusal lets the user paste stale clipboard content"
+        assert "again" in notices[0]
+
+
+def test_the_shadow_label_sheds_whole_phrases_at_narrow_widths() -> None:
+    """U5: `! not und…` at 45 cells communicated nothing at all."""
+    shadowed = _snapshot(
+        install=InstallInfo(
+            version="0.51.6",
+            kind="uv-tool",
+            prefix="/opt/uv/tools/local-operator",
+            import_path="/Users/x/repos/local-operator/local_operator",
+            import_path_foreign=True,
+        )
+    )
+    for width in (45, 55, 65, 83, 120):
+        lines = _lines(shadowed, width=width)
+        row = next((line for line in lines if line.lstrip().startswith("!")), "")
+        if row:
+            # Whatever survives must be a WHOLE phrase, never a fragment.
+            assert "…" not in row, f"cropped mid-phrase at {width}: {row!r}"
+            assert "not" in row and ("install path" in row or "installed tree" in row), row
+        else:
+            # Below the shortest rung the row is dropped rather than cropped —
+            # `! not the…` says nothing. The consequence must still be on the
+            # screen, which is what makes dropping it acceptable rather than a
+            # silent loss of the warning.
+            # Measured threshold: the row survives at 70 (shorter rung) and 83
+            # (full phrase) and is dropped below 70, where the widest meta's
+            # reservation leaves the label under its shortest rung.
+            assert width < 70, f"the row should still fit at {width}"
+        body = "\n".join(lines)
+        assert "Nothing will error" in body, f"the consequence vanished at {width}"
+
+
+def test_the_terminal_row_says_checking_rather_than_unavailable_while_loading() -> None:
+    """U6: `—` means "we looked and could not tell" everywhere else here."""
+    loading = _text(None, width=100)
+    terminal_row = next(line for line in loading.split("\n") if "Terminal" in line)
+    assert "checking…" in terminal_row
+    assert "—" not in terminal_row
+
+
+def test_the_unavailable_sessions_advice_names_the_key_that_helps() -> None:
+    """U7: `r` re-runs these probes and is advertised two rows below."""
+    body = _text(_snapshot(sessions=SessionsInfo(available=False)), width=100)
+    assert "Press r to try again" in body
+    assert "Close and reopen" not in body

--- a/tests/unit/tui/test_info_panel.py
+++ b/tests/unit/tui/test_info_panel.py
@@ -871,22 +871,20 @@ def test_the_shadow_label_sheds_whole_phrases_at_narrow_widths() -> None:
             import_path_foreign=True,
         )
     )
-    for width in (45, 55, 65, 83, 120):
+    for width in (38, 45, 55, 65, 70, 83, 120):
         lines = _lines(shadowed, width=width)
         row = next((line for line in lines if line.lstrip().startswith("!")), "")
-        if row:
-            # Whatever survives must be a WHOLE phrase, never a fragment.
-            assert "…" not in row, f"cropped mid-phrase at {width}: {row!r}"
-            assert "not" in row and ("install path" in row or "installed tree" in row), row
-        else:
-            # Below the shortest rung the row is dropped rather than cropped —
-            # `! not the…` says nothing. The consequence must still be on the
-            # screen, which is what makes dropping it acceptable rather than a
-            # silent loss of the warning.
-            # Measured threshold: the row survives at 70 (shorter rung) and 83
-            # (full phrase) and is dropped below 70, where the widest meta's
-            # reservation leaves the label under its shortest rung.
-            assert width < 70, f"the row should still fit at {width}"
+        # D1: the row must be PRESENT at every width down to the narrow floor.
+        # It previously vanished at card 65 — the width this screen is specified
+        # against — because the label was sized against the widest meta rung it
+        # would never be shown beside, leaving amber ink as the only carrier for
+        # the most consequential thing /info reports. `colour is never the only
+        # carrier` is the design rule; under NO_COLOR or a monochrome paste into
+        # an issue, the warning was simply invisible.
+        assert row, f"the warning row vanished at card {width}"
+        # And whatever survives is a WHOLE phrase, never a fragment (U5).
+        assert "…" not in row, f"cropped mid-phrase at {width}: {row!r}"
+        assert "not" in row and ("install path" in row or "installed tree" in row), row
         body = "\n".join(lines)
         assert "Nothing will error" in body, f"the consequence vanished at {width}"
 

--- a/tests/unit/tui/test_info_panel.py
+++ b/tests/unit/tui/test_info_panel.py
@@ -1,0 +1,726 @@
+"""``/info``'s rendered screen: useful before the worker, honest afterwards.
+
+Assertions are over ``render_lines_for_test()`` — the plain strings a user
+actually reads — rather than over the ``Text`` objects, following
+``UsagePanel``/``SessionPickerScreen``'s existing test helpers. The pilot tests
+at the bottom drive the REAL ``OperatorApp`` (the one that loads
+``local_operator.tcss``), because a lightweight host declares no ``CSS_PATH``
+and could not show a stylesheet problem at all.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import pytest
+from textual.binding import Binding
+
+from local_operator.info.collect import LiveState, collect_live
+from local_operator.info.model import (
+    AgentsInfo,
+    EnvInfo,
+    InfoSnapshot,
+    InstallInfo,
+    ProcessInfo,
+    SessionLine,
+    SessionsInfo,
+    SubagentLine,
+)
+from local_operator.tui.widgets.info_panel import (
+    INFO_COPY_KEY,
+    InfoScreen,
+    build_info_report,
+)
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+from tests.unit.tui.test_slash_echo import _boot, _submit
+
+
+def _live(**overrides: object) -> LiveState:
+    base: dict[str, Any] = dict(
+        session_id="a3f9c21b7e40",
+        conversation_name="Investigate request latency",
+        model_label="anthropic/claude-opus-5",
+        kind="tui",
+        theme="dusk",
+        terminal_size=(100, 30),
+        approval_mode="ask",
+    )
+    base.update(overrides)
+    return LiveState(**base)
+
+
+def _snapshot(**overrides: object) -> InfoSnapshot:
+    base: dict[str, Any] = dict(
+        install=InstallInfo(
+            version="0.51.6",
+            kind="uv-tool",
+            prefix="/opt/uv/tools/local-operator",
+            executable="/opt/uv/tools/local-operator/bin/python",
+            python_version="3.12.13",
+            python_implementation="CPython",
+            platform="macOS-26.6.2-arm64",
+            machine="arm64",
+            latest_known="0.51.6",
+            latest_age_s=1800.0,
+        ),
+        process=ProcessInfo(
+            pid=4243,
+            session_id="a3f9c21b7e40",
+            conversation_name="Investigate request latency",
+            cwd="/tmp/work",
+            model_label="anthropic/claude-opus-5",
+            config_dir="/tmp/cfg",
+            cache_dir="/tmp/cache",
+            agent_home="/tmp/home",
+            log_dir="/tmp/logs",
+            control_port=51234,
+            protocol=5,
+            uptime_s=840.0,
+            kind="tui",
+        ),
+        sessions=SessionsInfo(
+            lines=(
+                SessionLine(
+                    pid=4243,
+                    kind="tui",
+                    state="live",
+                    session_id="a3f9c21b7e40",
+                    conversation_name="Investigate request latency",
+                    cwd="/tmp/work",
+                    model_label="anthropic/claude-opus-5",
+                    uptime_s=840.0,
+                    rss_bytes=190_000_000,
+                    is_self=True,
+                ),
+            ),
+            total=1,
+            live=1,
+        ),
+        agents=AgentsInfo(profiles=20, teams=3),
+        env=EnvInfo(theme="dusk", term="xterm-256color", terminal_size=(100, 30), guides=2),
+        captured_at=time.time(),
+    )
+    base.update(overrides)
+    return InfoSnapshot(**base)
+
+
+def _binding_keys() -> set[str]:
+    """Declared keys, however each BINDINGS entry is spelled.
+
+    Textual accepts both ``Binding`` objects and bare tuples in a ``BINDINGS``
+    list, so reading ``.key`` off every entry is only correct by accident of
+    what this class happens to use today.
+    """
+    keys: set[str] = set()
+    for binding in InfoScreen.BINDINGS:
+        keys.add(binding.key if isinstance(binding, Binding) else binding[0])
+    return keys
+
+
+def _lines(snapshot: InfoSnapshot | None, live: LiveState | None = None, width: int = 83):
+    return build_info_report(snapshot, live or _live(), width).plain.split("\n")
+
+
+def _text(snapshot: InfoSnapshot | None, live: LiveState | None = None, width: int = 83) -> str:
+    return "\n".join(_lines(snapshot, live, width))
+
+
+# -- the loading frame --------------------------------------------------------
+
+
+def test_loading_frame_is_already_useful() -> None:
+    """Invariant #15: the live half paints before the ~900 ms probe returns.
+
+    This is what makes push-screen-then-fill correct rather than merely fast:
+    the frame the user gets immediately already answers "which session am I in
+    and on what model".
+    """
+    body = _text(None)
+    assert "checking…" in body
+    assert "a3f9c21b7e40" in body
+    assert "anthropic/claude-opus-5" in body
+    # Every section header is present from frame one; a missing section reads as
+    # a rendering bug rather than as a pending read.
+    for header in ("Install", "This session", "Agents and subagents", "Environment"):
+        assert header in body
+
+
+def test_all_default_snapshot_renders_without_raising() -> None:
+    """Invariant #17: an all-defaults snapshot is a screen, not a traceback."""
+    body = _text(InfoSnapshot())
+    assert "Install" in body and "Environment" in body
+    assert "unavailable" in body
+
+
+# -- the populated frame ------------------------------------------------------
+
+
+def test_populated_frame_carries_the_identifying_facts() -> None:
+    body = _text(_snapshot())
+    assert "0.51.6" in body
+    assert "uv tool" in body or "uv-tool" in body
+    assert "Install path" in body
+    assert "1 live · 1 total" in body
+    assert "this session" in body
+
+
+def test_the_self_row_says_so() -> None:
+    """A one-row list otherwise raises "is that me, or someone else?"."""
+    assert "this session" in _text(_snapshot())
+
+
+def test_config_and_cache_directories_are_shown_side_by_side() -> None:
+    """The divergence AGENTS.md documents is only visible if both are drawn."""
+    body = _text(_snapshot())
+    assert "Config dir" in body and "Cache dir" in body
+
+
+def test_the_version_row_never_claims_up_to_date_from_an_unknown() -> None:
+    """Three distinct states, never collapsed into two."""
+    unknown = _snapshot(
+        install=InstallInfo(version="0.51.6", kind="pip", latest_known=None, latest_age_s=None)
+    )
+    assert "never checked" in _text(unknown)
+
+    stale = _snapshot(
+        install=InstallInfo(
+            version="0.51.6", kind="pip", latest_known="0.51.6", latest_age_s=9 * 60 * 60
+        )
+    )
+    assert "stale" in _text(stale)
+
+
+def test_an_available_update_renders_the_remedy_whole() -> None:
+    """``— /update`` is dropped WHOLE when it does not fit: ``/upd…`` is an
+    instruction nobody can follow."""
+    behind = _snapshot(
+        install=InstallInfo(
+            version="0.51.6", kind="uv-tool", latest_known="0.52.0", behind=True, latest_age_s=60.0
+        )
+    )
+    wide = _text(behind, width=120)
+    assert "latest is v0.52.0 — /update" in wide
+
+    narrow = _text(behind, width=40)
+    assert "/upd…" not in narrow
+    assert "v0.52.0" in narrow
+
+
+# -- the subagent tree --------------------------------------------------------
+
+
+def test_tree_renders_nested_labels_indented_by_depth() -> None:
+    """Invariant #16, and the ``└``-only alphabet §5.2 specifies."""
+    agents = AgentsInfo(
+        running=2,
+        max_depth=2,
+        tree=(
+            SubagentLine(job_id="j1", label="reviewer", status="running", depth=0),
+            SubagentLine(job_id="j2", label="scout", status="running", depth=1),
+            SubagentLine(job_id="j3", label="coder", status="completed", depth=2),
+        ),
+    )
+    lines = _lines(_snapshot(agents=agents))
+    reviewer = next(line for line in lines if "reviewer" in line)
+    scout = next(line for line in lines if "scout" in line)
+    coder = next(line for line in lines if "coder" in line)
+
+    assert reviewer.index("reviewer") < scout.index("scout") < coder.index("coder")
+    assert "└" in scout and "└" in coder
+    # No ├ and no │ continuation runs, at any depth: that is a match to how
+    # /analytics and /session already draw their trees.
+    assert "├" not in "\n".join(lines)
+    assert "│" not in "\n".join(lines)
+
+
+def test_tree_depth_overflow_is_summarised_not_indented_off_the_card() -> None:
+    agents = AgentsInfo(
+        running=1,
+        max_depth=5,
+        deeper=3,
+        tree=(SubagentLine(job_id="j1", label="reviewer", status="running", depth=0),),
+    )
+    assert "+3 deeper" in _text(_snapshot(agents=agents))
+
+
+def test_empty_tree_reads_as_a_fact_not_as_a_broken_screen() -> None:
+    """Invariant: the header is present, the meta is a WORD, the body explains."""
+    body = _text(_snapshot(agents=AgentsInfo(profiles=20, teams=3)))
+    assert "Agents and subagents" in body
+    assert "none running" in body
+    assert "0 running" not in body  # a zero in a count column reads as a failure
+    assert "No subagents have been launched in this session." in body
+
+
+def test_the_tree_section_states_the_cross_session_boundary() -> None:
+    """Invariant #19: a tree on screen must not read as a fleet-wide view."""
+    agents = AgentsInfo(
+        running=1, tree=(SubagentLine(job_id="j", label="reviewer", status="running"),)
+    )
+    body = _text(_snapshot(agents=agents))
+    assert "only this session's is visible" in body
+
+
+def test_settled_is_labelled_as_retained() -> None:
+    """A count that silently under-reports must say what it counts."""
+    agents = AgentsInfo(running=1, queued=0, settled=4)
+    assert "settled (retained)" in _text(_snapshot(agents=agents), width=120)
+
+
+def test_at_capacity_is_surfaced() -> None:
+    agents = AgentsInfo(running=4, max_running=4, at_capacity=True)
+    assert "at capacity" in _text(_snapshot(agents=agents), width=120)
+
+
+# -- degraded states ----------------------------------------------------------
+
+
+def test_an_unavailable_section_replaces_its_header() -> None:
+    """``/session``'s proven ``Ledger unavailable`` shape."""
+    body = _text(_snapshot(sessions=SessionsInfo(available=False)))
+    assert "Sessions unavailable" in body
+    assert "Could not scan the session registry" in body
+
+
+def test_degraded_probes_are_named_with_their_reason() -> None:
+    snapshot = _snapshot(degraded=(("env.browser", "OSError: no such file"),))
+    body = _text(snapshot)
+    assert "Could not read" in body
+    assert "env.browser" in body
+    assert "OSError" in body
+
+
+def test_a_field_that_could_not_be_read_says_unavailable_not_blank() -> None:
+    body = _text(_snapshot(install=InstallInfo()))
+    assert "unavailable" in body
+    # Never these: a missing row is worse than an unavailable one, because the
+    # reader cannot tell whether the field does not apply or the screen broke.
+    assert "None" not in body
+    assert "N/A" not in body
+
+
+def test_mcp_settling_says_connecting_and_not_a_failure_tally() -> None:
+    """Invariant #18: naming a server failed mid-handshake makes a false bug."""
+    env = EnvInfo(mcp_configured=3, mcp_connected=1, mcp_failed=2, mcp_settling=True)
+    body = _text(_snapshot(env=env), width=120)
+    assert "still connecting" in body
+    assert "2 failed" not in body
+
+
+def test_settled_mcp_failures_are_named_with_their_message() -> None:
+    env = EnvInfo(
+        mcp_configured=2,
+        mcp_connected=1,
+        mcp_failed=1,
+        mcp_settling=False,
+        mcp_failures=(("github", "command not found: gh"),),
+    )
+    body = _text(_snapshot(env=env), width=120)
+    assert "1 failed" in body
+    assert "github: command not found: gh" in body
+
+
+def test_build_skew_across_live_sessions_is_called_out() -> None:
+    sessions = SessionsInfo(
+        lines=(SessionLine(pid=1, state="live", conversation_name="a"),),
+        total=1,
+        live=1,
+        build_skew=True,
+    )
+    assert "more than one build" in _text(_snapshot(sessions=sessions))
+
+
+# -- width behaviour ----------------------------------------------------------
+
+
+@pytest.mark.parametrize("width", [38, 50, 65, 83, 128, 160])
+def test_no_line_exceeds_the_card_at_any_width(width: int) -> None:
+    """The acceptance criterion for the layout: nothing overflows the card.
+
+    A row that overflows folds onto a second unindented line, which reads as a
+    separate record — the fault every shed rule on these screens exists to
+    avoid.
+    """
+    from rich.cells import cell_len
+
+    for line in _lines(_snapshot(), width=width):
+        assert cell_len(line) <= max(38, width), repr(line)
+
+
+@pytest.mark.parametrize("width", [60, 65, 70, 83, 100, 128])
+def test_a_session_rows_meta_never_crops_mid_item(width: int) -> None:
+    """The acceptance criterion for §3.4, and a real defect found by a frame.
+
+    A session meta is a ``·``-joined list, so a plain crop lands MID-ITEM: at 65
+    cells the self row ended ``… · b``, half of ``busy``. That is the ``8.8k
+    thin`` fault the existing ``/session`` screen has, and the whole reason
+    ``/info`` uses a shed ladder rather than a truncate. Dropping a whole item
+    is legible; half of one is not.
+    """
+    sessions = SessionsInfo(
+        lines=(
+            SessionLine(
+                pid=4243,
+                state="live",
+                kind="tui",
+                conversation_name="Investigate request latency",
+                uptime_s=840.0,
+                rss_bytes=190_000_000,
+                busy=True,
+                is_self=True,
+            ),
+        ),
+        total=1,
+        live=1,
+    )
+    row = next(
+        line for line in _lines(_snapshot(sessions=sessions), width=width) if "Investigate" in line
+    )
+    tail = row.rstrip()
+    # Every rendered item is complete: no trailing separator, and no partial
+    # word after the last one.
+    assert not tail.endswith("·")
+    for fragment in ("this session", "228 MB", "190 MB", "busy", "14m"):
+        # A fragment either appears whole or not at all — never a prefix of it.
+        for cut in range(1, len(fragment)):
+            partial = fragment[:cut]
+            if tail.endswith(" " + partial) or tail.endswith("· " + partial):
+                raise AssertionError(f"{fragment!r} cropped to {partial!r} at width {width}")
+
+
+def test_narrow_frames_shed_notes_rather_than_cropping_them_mid_word() -> None:
+    """The existing ``/session`` screen crops ``8.8k thin`` at 80 columns.
+
+    ``/info`` must not inherit that: below ``_NOTE_MIN`` a plain note is shed
+    whole and a laddered note falls to its shortest rung.
+    """
+    narrow = _text(_snapshot(), width=45)
+    assert "non-editable; `lop-update` rebuilds it" not in narrow
+    # The FACT survives at every width even when its qualifier does not.
+    assert "0.51.6" in narrow
+
+
+# -- the screen ---------------------------------------------------------------
+
+
+def test_screen_render_lines_for_test_matches_the_builder() -> None:
+    screen = InfoScreen(_live(), _snapshot())
+    assert any("0.51.6" in line for line in screen.render_lines_for_test())
+
+
+def test_copy_key_is_the_shared_constant_not_a_second_literal() -> None:
+    """One gesture for "copy this surface out" across the app."""
+    from local_operator.tui.widgets.aside_panel import ASIDE_COPY_KEY
+
+    assert INFO_COPY_KEY == ASIDE_COPY_KEY == "ctrl+r"
+    assert INFO_COPY_KEY in _binding_keys()
+
+
+def test_screen_has_no_metric_toggle() -> None:
+    """``/info`` has nothing to plot, so ``t`` must not be advertised or bound."""
+    assert "t" not in _binding_keys()
+
+
+# -- pilot: the real app ------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_slash_info_opens_and_closes_the_screen() -> None:
+    """Invariant #20, on the real ``OperatorApp`` and through the real editor."""
+    from local_operator.tui.app import OperatorApp
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/info")
+        screen = app.screen
+        assert isinstance(screen, InfoScreen)
+
+        # The frame is useful BEFORE the worker lands.
+        assert any("Install" in line for line in screen.render_lines_for_test())
+
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert screen.snapshot is not None
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert type(app.screen).__name__ != "InfoScreen"
+
+
+@pytest.mark.asyncio
+async def test_slash_info_with_an_argument_is_refused_without_a_screen() -> None:
+    """The ``_cmd_analytics``/``_cmd_session`` rejection rule: nothing ran, so
+    the boot composition must survive it."""
+    from local_operator.tui.app import OperatorApp
+    from local_operator.tui.widgets.transcript import NoticeBlock, TranscriptView
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/info extra")
+        assert type(app.screen).__name__ != "InfoScreen"
+        notices = [
+            block._text
+            for block in app.query_one(TranscriptView).blocks()
+            if isinstance(block, NoticeBlock)
+        ]
+        assert any("takes no arguments" in text for text in notices)
+
+
+@pytest.mark.asyncio
+async def test_the_screen_does_not_make_the_app_screen_scrollable() -> None:
+    """Design acceptance #6: the BODY scrolls, the screen does not.
+
+    A screen-level scrollbar costs two cells of width and reflows the transcript
+    behind the overlay — a pre-existing fault a previous round found this way.
+    """
+    from local_operator.tui.app import OperatorApp
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/info")
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert app.screen.virtual_size == app.screen.size
+
+
+@pytest.mark.asyncio
+async def test_two_consecutive_settled_frames_are_identical() -> None:
+    """Design acceptance #5: no post-paint reflow and no animation.
+
+    A first frame that differs from the settled frame is motion the user sees,
+    and it would make two screenshots of one state disagree.
+    """
+    from local_operator.tui.app import OperatorApp
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/info")
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, InfoScreen)
+        first = screen.render_lines_for_test()
+        await pilot.pause()
+        await pilot.pause()
+        assert screen.render_lines_for_test() == first
+
+
+@pytest.mark.asyncio
+async def test_copy_puts_the_redacted_export_on_the_clipboard() -> None:
+    from pathlib import Path
+
+    from local_operator.tui.app import OperatorApp
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        await _submit(pilot, app, "/info")
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        copied: list[str] = []
+        app.copy_to_clipboard = lambda text: copied.append(text)  # type: ignore[method-assign]
+        await pilot.press(INFO_COPY_KEY)
+        await pilot.pause()
+
+        assert copied, "ctrl+r must write to the clipboard, not silently no-op"
+        payload = copied[0]
+        assert "local-operator" in payload
+        assert "## Install" in payload
+        assert str(Path.home()) not in payload
+
+
+@pytest.mark.asyncio
+async def test_live_capture_reads_the_session_subagent_graph() -> None:
+    """The tree comes from the LIVE capture, so it is on the first frame."""
+
+    class _Node:
+        job_id = "j1"
+        label = "reviewer"
+        parent_job_id = None
+        status = "running"
+        agent_role = "reviewer"
+        effort = ""
+        session_id = None
+        live = True
+
+    class _Comms:
+        def nodes(self):
+            return [_Node()]
+
+    session = FakeSession()
+    session.subagent_comms = _Comms()  # type: ignore[attr-defined]
+    live = collect_live(session, theme="dusk", size=(100, 30))
+    assert live.running == 1
+    assert [node.label for node in live.tree] == ["reviewer"]
+    assert "reviewer" in _text(None, live)
+
+
+# -- the resolved import path -------------------------------------------------
+
+
+def test_a_matching_import_path_is_shown_without_a_warning() -> None:
+    healthy = _snapshot(
+        install=InstallInfo(
+            version="0.51.6",
+            kind="uv-tool",
+            prefix="/opt/uv/tools/local-operator",
+            import_path="/opt/uv/tools/local-operator/lib/python3.12/"
+            "site-packages/local_operator",
+            import_path_foreign=False,
+        )
+    )
+    body = _text(healthy, width=120)
+    assert "Running code" in body
+    assert "shadowing" not in body
+    assert "not under the install path" not in body
+
+
+def test_a_shadowed_install_is_flagged_as_a_warning_not_an_unavailable() -> None:
+    """The ``launch.py:287`` trap made visible.
+
+    ``/reload`` does not fix it and every other field on the screen still
+    describes the install, so this must be loud rather than dim: the reader is
+    being told that the code executing is not the code they think it is.
+    """
+    shadowed = _snapshot(
+        install=InstallInfo(
+            version="0.51.6",
+            kind="uv-tool",
+            prefix="/opt/uv/tools/local-operator",
+            import_path="/Users/x/repos/local-operator/local_operator",
+            import_path_foreign=True,
+        )
+    )
+    body = _text(shadowed, width=120)
+    assert "not under the install path" in body
+    assert "shadowing the install" in body
+    # Not treated as a failed read: nothing failed, and calling it unavailable
+    # would understate a state the user has to act on.
+    assert "Running code           unavailable" not in body
+
+
+def test_an_editable_checkout_is_named_as_expected_rather_than_alarming() -> None:
+    """The one legitimate divergence: an editable install IS the checkout."""
+    editable = _snapshot(
+        install=InstallInfo(
+            version="0.51.6",
+            kind="editable",
+            prefix="/Users/x/repos/local-operator/.venv",
+            import_path="/Users/x/repos/local-operator/local_operator",
+            import_path_foreign=True,
+        )
+    )
+    body = _text(editable, width=120)
+    assert "expected for an editable checkout" in body
+    assert "shadowing" not in body
+
+
+# -- inherited invariant: an absent measurement is never a measured zero ------
+
+
+def test_an_absent_measurement_is_never_rendered_as_a_measured_zero() -> None:
+    """``/session``'s standing invariant, inherited explicitly.
+
+    ``session_panel``'s ``_timing_rows`` / ``_gauge_row`` / ``_group_rows`` all
+    encode one rule — "an absent sample is not a fast one" — and it is exactly
+    as load-bearing here, because most of this screen's fields are read from
+    subsystems that legitimately answer "I do not know":
+
+    * a cached-only PyPI read on a COLD cache is ``None``, and must say
+      ``unknown``; printing "latest" from it tells a user on a broken network
+      they are up to date;
+    * an unreadable ``.lop-source`` is ``None``, and must not become an empty
+      source line that reads as a PyPI wheel;
+    * an unmeasurable build age is ``None``, and must not render as ``0s ago``,
+      which claims the install was written this second.
+
+    The failure mode this guards is a PLAUSIBLE wrong answer, which is worse
+    than a visible gap: a reader cannot tell a real zero from a failed read.
+    """
+    unknown = _snapshot(
+        install=InstallInfo(
+            version="0.51.6",
+            kind="uv-tool",
+            latest_known=None,
+            latest_age_s=None,
+            build_age_s=None,
+            is_git_snapshot=True,
+            source_ref="",
+        )
+    )
+    body = _text(unknown, width=120)
+
+    assert "never checked" in body
+    # None of the zero-shaped spellings of "we did not measure it".
+    for forbidden in ("0s ago", "checked 0s ago", "0m ago", "latest · checked"):
+        assert forbidden not in body, forbidden
+    # The build-age row is OMITTED rather than rendered as a zero age, and the
+    # source row still names the snapshot without inventing a ref.
+    assert "Built" not in body
+    assert "git snapshot" in body
+    assert "@ " not in body  # no empty ref stub
+
+
+def test_a_zero_that_was_actually_measured_still_renders() -> None:
+    """The invariant is about ABSENCE, not about suppressing real zeros.
+
+    A machine with genuinely no MCP servers configured, or a genuinely fresh
+    build, must still say so — otherwise the rule above would turn into a second
+    way of hiding facts.
+    """
+    measured = _snapshot(
+        install=InstallInfo(version="0.51.6", kind="pip", build_age_s=0.0),
+        env=EnvInfo(mcp_configured=0),
+    )
+    body = _text(measured, width=120)
+    assert "Built" in body
+    assert "none configured" in body
+
+
+def test_unknown_uptime_is_not_rendered_as_zero_elapsed() -> None:
+    unknown = _snapshot(process=_snapshot().process.__class__(session_id="x", uptime_s=None))
+    assert "0s ago" not in _text(unknown, width=120)
+
+
+def test_the_shadowed_row_explains_why_a_passive_row_earns_its_space() -> None:
+    """The failure is SILENT and TOTAL, so the row has to say so.
+
+    Confirmed live rather than hypothesised: several sessions on this machine
+    run with a cwd inside a checkout of this repo, and
+    ``session/runtime/launch.py`` spawns with ``-m`` and no ``cwd=``.
+    """
+    shadowed = _snapshot(
+        install=InstallInfo(
+            version="0.51.6",
+            kind="uv-tool",
+            prefix="/opt/uv/tools/local-operator",
+            import_path="/Users/x/repos/local-operator/local_operator",
+            import_path_foreign=True,
+        )
+    )
+    body = _text(shadowed, width=120)
+    assert "Nothing will error" in body
+    assert "/reload does not" in body
+
+
+def test_an_editable_checkout_gets_no_alarm_row() -> None:
+    """The benign divergence keeps its explanatory note and loses the warning."""
+    editable = _snapshot(
+        install=InstallInfo(
+            version="0.51.6",
+            kind="editable",
+            prefix="/Users/x/repos/local-operator/.venv",
+            import_path="/Users/x/repos/local-operator/local_operator",
+            import_path_foreign=True,
+        )
+    )
+    body = _text(editable, width=120)
+    assert "expected for an editable checkout" in body
+    assert "not under the install path above" not in body
+    assert "Nothing will error" not in body

--- a/tests/unit/tui/test_info_panel.py
+++ b/tests/unit/tui/test_info_panel.py
@@ -10,6 +10,7 @@ and could not show a stylesheet problem at all.
 
 from __future__ import annotations
 
+import re
 import time
 from typing import Any
 
@@ -902,3 +903,56 @@ def test_the_unavailable_sessions_advice_names_the_key_that_helps() -> None:
     body = _text(_snapshot(sessions=SessionsInfo(available=False)), width=100)
     assert "Press r to try again" in body
     assert "Close and reopen" not in body
+
+
+def test_the_credentials_note_never_crops_a_key_name_mid_token() -> None:
+    """D6/D3: the middle rung COUNTS the overflow; it never truncates a name.
+
+    The rung used to be `truncate_cells(keys, 30)`, which rendered
+    `ANTHROPIC_API_KEY, OPENAI_API…` at the reference width — a crop wearing a
+    ladder's clothing, and the `8.8k thin` mid-token defect the spec forbids
+    inheriting. A half-printed key cannot be told from `OPENAI_API_KEY_2` or a
+    typo, which is exactly the ambiguity this row exists to resolve.
+
+    Pinned because the designer mutation-tested the fix and found it UNDEFENDED:
+    restoring `truncate_cells` brought `OPENAI_API…` back with 115 tests green.
+    A fix nobody can break loudly is one the next ladder edit breaks silently,
+    and this file is where that edit will happen.
+    """
+    keys = ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "RADIENT_API_KEY")
+    lines = _lines(_snapshot(env=EnvInfo(credential_keys=keys)), width=83)
+    rows = [line for line in lines if "Credentials" in line]
+    assert rows, "the Credentials row is missing entirely"
+    row = rows[0]
+
+    # The positive form: the middle rung is the name plus a COUNT.
+    assert "ANTHROPIC_API_KEY +2 more" in row, row
+    # And the negative form, which is what actually catches a re-crop: no key
+    # name is ever followed by the ellipsis.
+    assert not re.search(r"[A-Z0-9_]{3,}…", row), f"key name cropped mid-token: {row!r}"
+
+
+def test_the_depth_fold_row_is_a_section_summary_not_a_child_row() -> None:
+    """D6/D2: `+N deeper` hangs off nothing, so it carries no connector.
+
+    It counts nodes below the cap ANYWHERE in the tree. Rendered at the cap's
+    child indent with a `└`, it sat under whatever row happened to be last — a
+    depth-0 node in the reported frame — and claimed hidden children that node
+    does not have. A connector to nothing is worse than no connector.
+
+    Pinned for the same reason as the credentials rung: the designer restored
+    the misparented form and the whole suite stayed green.
+    """
+    tree = (
+        SubagentLine(job_id="a", label="reviewer", status="running", depth=0),
+        SubagentLine(job_id="b", label="scout", status="running", depth=1),
+    )
+    lines = _lines(_snapshot(agents=AgentsInfo(tree=tree, running=2, deeper=2)), width=150)
+    rows = [line for line in lines if "deeper" in line]
+    assert rows, "the fold row is missing entirely"
+    row = rows[0]
+
+    assert "└" not in row, f"the fold must not claim a parent: {row!r}"
+    # Base indent — the same two cells every top-level row in the section uses,
+    # not the cap's child indent.
+    assert len(row) - len(row.lstrip()) == 2, f"fold is not at base indent: {row!r}"

--- a/tests/unit/tui/test_info_panel.py
+++ b/tests/unit/tui/test_info_panel.py
@@ -799,10 +799,28 @@ async def test_refresh_returns_worker_filled_fields_to_the_loading_state() -> No
         await pilot.pause()
         assert screen.snapshot is not None
 
-        await pilot.press("r")
-        # Immediately after the keypress, BEFORE the worker can land.
-        assert screen.snapshot is None, "the screen must drop to `checking…` at once"
-        assert any("checking…" in line for line in screen.render_lines_for_test())
+        # STRUCTURAL, not a race. The first version of this test pressed `r`
+        # and asserted `snapshot is None` on the next line; `pilot.press`
+        # awaits, so on a fast runner the worker had already published and CI
+        # went red on a green tree. The property under test is "the repaint
+        # happens BEFORE the handler is invoked", which is an ordering fact —
+        # so observe the ordering directly rather than trying to sample a
+        # window whose width is the machine's to decide (AGENTS.md: wait on the
+        # event, never on the clock).
+        observed: list[object] = []
+        original = app.refresh_info_screen
+
+        def _record(target: InfoScreen) -> None:
+            observed.append(target.snapshot)
+            original(target)
+
+        app.refresh_info_screen = _record  # type: ignore[assignment,method-assign]
+        try:
+            await pilot.press("r")
+        finally:
+            app.refresh_info_screen = original  # type: ignore[assignment,method-assign]
+
+        assert observed == [None], "the screen must be back to `checking…` before the re-probe"
 
         await app.workers.wait_for_complete()
         await pilot.pause()

--- a/tests/unit/tui/test_slash_echo.py
+++ b/tests/unit/tui/test_slash_echo.py
@@ -89,6 +89,9 @@ ECHO_POLICY = {
     # names a view, never words the model is told.
     "analytics": False,
     "session": False,
+    # The screen it opens IS the receipt, and it takes no argument to restate.
+    # Nothing here reaches the model: every value is a fact about this install.
+    "info": False,
     "goal": True,
     "loop": False,
     # The aside's whole promise is that the exchange leaves no trace in the
@@ -159,6 +162,9 @@ PROMPT_POLICY = {
     # open, so it splices-and-runs inline like `/usage` rather than reassembling.
     "analytics": False,
     "session": False,
+    # Takes no argument at all: there is one answer, so there is nothing typed
+    # for an inline engage to consume.
+    "info": False,
     # Free text the model is given (the objective / a loop instruction / a side
     # question), so an inline engage reassembles to the front.
     "goal": True,


### PR DESCRIPTION
## Summary

`/info` opens a full-screen diagnostic that answers **"what is this install, and what is actually running on this machine"** — the question a user is asked first when they report an issue, and the one a developer asks when a change appears to have had no effect.

It is `/session`'s structure (title / scrolling body / hint, a `_Body` of `kv` rows, push-the-screen-then-fill-from-a-worker) wearing `/analytics`' section vocabulary (`▌` headers, `└` nesting, the dim note column). Both are imported rather than reimplemented — three diagnostics screens with three header glyphs or three spellings of "unavailable" would be a defect, not a variation.

This keeps the three-surface split clean: `/analytics` = historical spend across sessions, `/session` = this session's ledger and health, `/info` = install provenance and what-am-I-running.

Five sections, ordered by what the first screen must answer: **Install** → **This session** → **Sessions on this machine** → **Agents and subagents** → **Environment**.

**Release: patch — `/info` reports install provenance, every session on the machine, and the live subagent tree, and flags when the running code is not the install it claims to be.**

Patch and not minor, per AGENTS.md materiality: this is a self-contained read-only screen in an established visual family, not a new surface or subsystem a user would adopt. There is no step-function capability to name in a release title, which is the stated test.

## Change class

C2 — a new user-visible surface, built to two pre-agreed specs (architecture and design), no change to any existing behaviour except one behaviour-preserving extraction (below).

## Four decisions worth stating, each forced by a measurement

### 1. `update.cached_latest()` is new, and `/info` never calls `check_latest()`

`check_latest()` is the **upgrade** path and only *looks* like a cached read: only its `cached is not None and age < TTL_S and not force` branch is served from disk. Every other path — cold cache, corrupt document, age past `TTL_S` — falls through to a live `httpx.get` bounded at 5 s, and then **writes** the cache.

Measured with an injected client that raises immediately:

```
cold cache, injected failing client: 156.86ms -> VersionCheck(installed='0.51.6', latest=None)
cached-only read (real cache):        0.0002ms -> ('0.51.6', 313.08)
cached-only read (cold dir):          0.0004ms -> (None, None)
```

`/info` is opened when something is already broken and frequently *because the network is broken*, so a 5 s stall on a captive portal is the worst available behaviour for the one screen that exists to explain a failure. A diagnostic must also not mutate state. `cached_latest()` is ~10 lines beside the cache it reads, so the format knowledge stays in the module that owns it.

Rendered as **three distinct states, never collapsed**: `unknown (never checked)` / `latest · checked 2h ago` / `checked 9h ago (stale)`. Never "up to date" from a `None` — on the broken network this screen is opened over, that is an outright lie.

### 2. Collection is split in two, and the split is load-bearing

`collect_live()` reads only in-memory state (subagent graph, job capacity, MCP startup, approval mode, theme, size) and runs **on the event loop before the screen yields**. `collect_snapshot()` does every blocking probe **in a worker**.

```
sessions: 2575.5ms     <- shells `top -l1` for the whole system (macOS)
agents:    178.5ms
env:       176.9ms
install:    81.2ms
```

The architect measured `session_resource_usage` at 879.5 ms for 12 pids; on this host under load it was **2575 ms** — 77 dropped frames at 30 fps. It cannot be near the paint path.

The live half is captured *first* for a second reason: a `/new` or `/resume` arriving during that probe must not put a brand-new subagent tree under a header describing the old session — the rule `SessionDiagnostics.capture` states at `session_panel.py:122`.

The screen is pushed **before** the probe starts, so it is useful from frame one (version, session id, model and the tree are all live) and owns a cancellable surface; a late result updates it rather than pushing over whatever the user did next.

### 3. The session row builder is EXTRACTED, not copied

`cli.sessions_command` built its rows inline; `/info` needs the same answer plus `is_self` and roll-up counters. The builder moved to `info.collect.session_rows()` and **the CLI now calls it**. Two details make a second copy dangerous rather than untidy:

- the `getattr(rec, ..., default)` spellings exist because a record written by an **older runtime** lacks those fields — and that host, one mid-upgrade, is exactly the host `/info` is opened on;
- `state` is subtle: `stale` means `registry.scan` just **deleted** the record file, not that the session is idle. A second implementation would have got the counters wrong.

`--json` key order is pinned explicitly rather than derived from `asdict`, which would have leaked `is_self` into a published surface.

### 4. Redaction is structural, not textual

`/info`'s output is what lands in a GitHub issue.

- **`control_key` is not a field on `SessionLine` at all.** Not omitted from a renderer — absent from the dataclass, so there is no attribute for a future `asdict`-style dump to reach. Pinned by `__dataclass_fields__`.
- **`BridgeState.session_key`** is never collected; only `paired`, `extension_connected`, `browser_name`, `port`.
- **Credentials are key NAMES only** — no value, no prefix, no length, no hash. A "first four characters" habit is how key prefixes end up in issues.
- **Exactly one export mode, and it is redacted.** Two modes means the leaking one has the better name and gets pressed under stress. The *screen* shows verbatim paths (local debugging, private); the *export* is home-relativised, because that is the artifact that leaves the machine. Everything below `~` is kept — `~/workspace/repos/lo-x` is diagnostic, the username is not.

## `Running code`: the field that makes the silent failure visible

`session/runtime/launch.py:287` spawns the runtime as `[sys.executable, "-m", ...]` with **no `cwd=`**, so the launching session's working directory lands on `sys.path[0]` ahead of site-packages. A session whose cwd is a checkout of this repo therefore **runs that checkout** while every other field — version, install kind, prefix — describes the install it was launched from. `/reload` does not fix it.

This is active on this machine right now, not theoretical: several live sessions run with cwd inside a checkout.

So `/info` reports `local_operator.__file__`'s package directory next to the install prefix and flags divergence in **warning ink with the `!` glyph** — the existing token vocabulary, not a dim `unavailable`, because nothing failed to read. AGENTS.md's framing is why a passive row earns its space: the failure is *silent and total* — the banner shows your branch's version, the status bar shows your worktree's path, and every executing line is the other tree's.

An **editable** install diverges by design and is named `expected for an editable checkout` with no alarm.

## What is deliberately NOT here

- **No tool-call or request success/failure rate.** `/session` owns call-outcome measurement with stated denominators; a second success-ish figure computed here would disagree with it in cases neither screen explains, leaving a user two numbers and no way to tell which is right. MCP up/settling/failed counts stay — server *reachability* is a different quantity from call *outcome*.
- **No cross-session subagent tree.** `SessionRecord` carries no subagent field, so nothing about another session's children is observable without a new control-socket op and a `PROTOCOL_VERSION` bump. The section is titled for this session and says so in prose; `cross_session_known` is the seam.
- **No animation, no periodic refresh.** A `top -l1` fork per second on the machine being diagnosed is a real cost, and a spinner would make two screenshots of one state disagree. `r` refreshes manually; `captured_at` stamps the frame.

## Inherited invariant: an absent measurement is never a measured zero

`/session` encodes this in `_timing_rows` / `_gauge_row` / `_group_rows` — "an absent sample is not a fast one". It is exactly as load-bearing here, because most fields come from subsystems that legitimately answer "I do not know": a cold PyPI cache reads `unknown`, an unreadable `.lop-source` does not become an empty source line, an unmeasurable build age omits its row rather than rendering `0s ago`. Pinned in `test_an_absent_measurement_is_never_rendered_as_a_measured_zero`, with a companion test proving genuinely-measured zeros still render.

## Testing evidence

### Invariant #14 — `lop sessions --json` is byte-identical before and after

The real `sessions_command` run against a fixed fixture (frozen clock and fixed pids, so two runs are comparable at all), at the pre-change tree and at final head:

```
$ shasum -a 256 sessions-before.json sessions-after-final.json
c980fe1b886f057b24557414f63a177188f7977ae17263f649f78686783409bc  sessions-before.json
c980fe1b886f057b24557414f63a177188f7977ae17263f649f78686783409bc  sessions-after-final.json
$ diff sessions-before.json sessions-after-final.json && echo IDENTICAL
IDENTICAL
```

The fixture covers all three states plus a record written by an older runtime (no `version`/`source_ref`/`pending`), which is the `getattr` path. Also pinned in-suite against the pre-change literal.

### The real command, end to end, in a fully isolated run

`HOME` **and** `LOCAL_OPERATOR_CONFIG_DIR` both redirected — the config dir alone does not redirect the cache — and every inherited `CMUX_*` cleared:

```
HOME=/tmp/lop-info-real.xHxm3D
LOCAL_OPERATOR_CONFIG_DIR=/tmp/lop-info-real.xHxm3D/.local-operator
CMUX vars inherited: []
resolves: /private/tmp/lop-info-cmd/local_operator/__init__.py

screen after /info: InfoScreen
--- FIRST FRAME (before the worker returns) ---
▌ Install   how this lop was installed
  Version             checking…
▌ This session   the runtime you are typing into
  Session id          sess
  Kind                tui                       attached
  Model               test/model
  Working dir         checking…

snapshot populated: True
degraded probes: ()
```

Settled, with the new warning firing correctly (this worktree's venv reports `pip`, so the checkout genuinely *is* shadowing it):

```
  Install path        /private/tmp/lop-info-cmd/.venv
  Interpreter         /private/tmp/lop-info-cmd/.venv/bin/python
  Running code        /private/tmp/lop-info-cmd/local_operator
  ! not under the install path above  this runtime is executing a different tree
  Source              PyPI wheel
  Built               1h 24m ago
```

`ctrl+r` copy, and the redaction assertion on real data:

```
local-operator 0.51.6 · pip · macOS-26.6.2-arm64-arm-64bit · py3.12.13
captured 2026-09-07 11:49:12
## Install
  version           0.51.6
  latest known      0.51.6 · checked 6s ago
  running code      /private/tmp/lop-info-cmd/local_operator  (NOT under the install path — a checkout is shadowing it)
  ...
  config dir        ~/.local-operator  (redirected)
  cache dir         ~/.local-operator/cache

copied 1772 chars; leaks $HOME literal: False
screen after esc: TranscriptScreen
composer refocused: True
```

### Mutation evidence — the layout guard was proven able to fail

A frame (not a test) found that a session row's `·`-joined meta cropped **mid-item** at 80 columns — `· b` for `busy`, the same `8.8k thin` defect the existing `/session` screen has. Fixed with a shed ladder, then the guard was proven by reinstating the plain-crop path:

```
E   AssertionError: 'busy' cropped to 'b' at width 65
FAILED test_a_session_rows_meta_never_crops_mid_item[65]
```

Restored: 6 passed.

### Fixtures cross-checked against real captures

Per the warning that the `/session` suite encoded the bug it should have caught: every fixture whose shape comes from another subsystem was checked against a live capture rather than read off the dataclass. That caught a real defect — **every real `SessionRecord` on this machine is `kind='daemon'`** (`runtime/process.py` spawns with it; only an in-process registrant is `tui`), while I had imagined `tui` from the `Literal`. The `Kind` row hardcoded "attached to this terminal", which would have told users their session dies with the window when it does not. Now per-kind, and `test_collect_sessions_against_a_real_scan` uses a real record's exact key set.

### Suites

> **The whole-tree local run is IN PROGRESS as this PR opens, and CI is the authority on it.**
> This host is under an unrelated load emergency (load average 179, and it hit 117 MiB free
> disk earlier today), so the local suite is crawling — it was at 85% with **zero failures**
> when this was written. Opening now starts CI on dedicated runners, which are unaffected.
> I will post the local result either way as a comment; this PR is not merge-ready until both
> are green.

```
tests/unit/info                    50 passed
tests/unit/tui/test_info_panel.py  49 passed
tests/unit/tui/test_slash_echo.py  71 passed   (the /info rows the pinned tables require)
tests/unit/test_import_graph.py  } 119 passed together with tests/unit/info
tests/unit/test_update.py        }
```

`info/model.py` importing nothing heavy is asserted in a **fresh subprocess** — an in-process `sys.modules` check is worthless once pytest has imported half the tree.

### Gates, whole tree, exactly as CI runs them

```
.venv/bin/python -m flake8 .                                    clean
uvx --from black==26.1.0 black --check .                        1042 files unchanged
uvx isort==5.13.2 --check .                                     clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .     0 errors, 0 warnings
```

`git diff 4311eb653 -- pyproject.toml` is **empty**. No version bump; the branch stays at its base's 0.51.6. (`origin/main` has since moved to 0.51.7 — this branch is behind but not dirty, and per the release protocol I have not rebased pre-emptively.)

## Visual evidence

Nine frames from `scripts/info_shot.py`, driving the **real `OperatorApp`** through the real editor and the real slash path, with `isolate_capture()` before app imports and a **synthetic** snapshot — a frame that goes on a PR must not carry real session names or working directories. Rasterized with `rsvg-convert -z 2` and viewed.

| scenario | size | card | screen scrolls | scrollbar | frames identical |
|---|---|---|---|---|---|
| populated | 80x24 | 65 | no | no | yes |
| populated | 100x30 | 83 | no | no | yes |
| populated | 150x40 | 128 | no | no | yes |
| empty (fresh install) | 100x30 | 83 | no | no | yes |
| degraded | 100x30 | 83 | no | no | yes |
| nested (depth 4, cap 3) | 150x40 | 128 | no | no | yes |
| nested | 80x24 | 65 | no | no | yes |
| loading | 100x30 | 83 | no | no | yes |
| shadowed install | 100x30 | 83 | no | no | yes |

Card widths 65 / 83 / 128 match the design spec's measured geometry exactly. `screen.virtual_size == screen.size` everywhere (the body scrolls, the screen does not — a screen-level scrollbar costs two cells and reflows the transcript behind), and `opened.svg` is byte-identical to `settled.svg` in every scenario, so there is no post-paint reflow and nothing animates.

Design acceptance criteria, all met: nothing crops mid-word at any width; the fresh-install case keeps every section header with `none running` and one dim explanatory sentence; the degraded case shows one unavailable field and one replaced section header; the tree uses `└` only at 2-cell steps with the depth cap folding into `+N deeper`.

## Reviewer notes

- `_Body` is a near-copy of `session_panel._Body` rather than an import: that one pins its value column at `_VALUE_CELL = 11` (sized for `1.7M tokens`) and its label at 22, and widening the shared class would change every `/session` row to fix a screen it does not draw. The `notes=` ladder, `note()`'s wrap-with-indent and header shedding carry over verbatim, because those encode measured failures.
- The copy key **imports** `ASIDE_COPY_KEY` rather than restating `"ctrl+r"`, so the two cannot drift. (`ctrl+e` was the architect's suggestion and is already `toggle_reveal` on the ask picker.)
- `_import_path_is_foreign` is a containment test, not equality: a healthy install's package nests several directories under its prefix, so equality would flag every install and the warning would mean nothing.
