### PR TITLE
fix(tui): put the boot notice on one column, on the card

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -19326,14 +19326,23 @@ class OperatorApp(App[None]):
         # warning: nothing is wrong and nothing is asked of the user; not
         # ``info`` either, whose dim ink the widget reserves for a receipt
         # nobody has to read \u2014 this answers "why is my session on an older
-        # version?") saying it will move over when its work finishes, which
-        # the runtime's own reaper does.
+        # version?") saying it will switch over once it is idle, which the
+        # runtime's own reaper does.
+        #
+        # "when it is next idle", NOT "when its current work finishes": the
+        # notice paints on a brand-new ``/new`` splash with no work in flight,
+        # where promising the end of work that does not exist is confusing and
+        # arguably untrue. ``may_refresh`` gates the retire on ``is_busy()``
+        # being false, so idleness \u2014 not the completion of a particular task \u2014
+        # is literally the condition the runtime waits for, and it is the one
+        # that is also true of a session sitting at an empty prompt (design
+        # review round 1, D3).
         idle_probe = getattr(session, "owner_idle", None)
         ask = getattr(session, "request_refresh", None)
         owner_idle = bool(idle_probe()) if callable(idle_probe) else False
 
         def announce_stale() -> None:
-            """C\u2032: this session is on an older build and will move on its own.
+            """C\u2032: this session is on an older build and will switch on its own.
 
             One function, two callers (the busy branch and the ``kept`` answer
             of the idle branch) so the two states cannot drift into two
@@ -19361,7 +19370,7 @@ class OperatorApp(App[None]):
                     "",
                     loaded.label(),
                     f"{subject} is running an older version than this window \u2014 it "
-                    f"will move to the new version when its current work finishes.",
+                    f"will switch to the new version when it is next idle.",
                     scope,
                     notice_kind="note",
                 )
@@ -19371,7 +19380,7 @@ class OperatorApp(App[None]):
                 owner.label(),
                 loaded.label(),
                 f"{subject} is running {_build_change(owner, loaded)} \u2014 it will "
-                f"move to the new version when its current work finishes.",
+                f"switch to the new version when it is next idle.",
                 scope,
                 notice_kind="note",
             )

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -11217,18 +11217,26 @@ class OperatorApp(App[None]):
         transcript = self._transcript_view()
         card = boot_card_width(box)
         card_up = self.screen.has_class(BOOT_CARD_CLASS) and box - card >= BOOT_CARD_MIN_INSET
-        # The card sits inside the transcript's content box with equal ground on
-        # both sides, so a notice given the card's width and offset by the same
-        # half-difference lands on the card's exact column. The transcript's own
-        # one-cell left gutter is inside that box, so the centre of the CONTENT
-        # is what the offset aims at. The block cannot be centred BY the
-        # stylesheet: `align-horizontal` aligns a container's children, never the
-        # node carrying it, so the offset is computed here alongside the width
-        # the same clamp resolves. When the card is gone the width is RESET to
-        # `1fr` — left at the boot value it narrowed the notice for the rest of
-        # the session, dead space to its right at any width.
-        content_box = box - transcript.styles.gutter.width
-        offset = max(0, (content_box - card) // 2)
+        # The card is centred by the stylesheet in `box` — the screen's own
+        # content box — so the offset that lands a notice on the card's column
+        # has to be computed against THAT box, then rebased into the transcript's
+        # coordinate space. The block cannot be centred BY the stylesheet:
+        # `align-horizontal` aligns a container's children, never the node
+        # carrying it, so the offset is computed here alongside the width the
+        # same clamp resolves. When the card is gone the width is RESET to `1fr`
+        # — left at the boot value it narrowed the notice for the rest of the
+        # session, dead space to its right at any width.
+        #
+        # The gutter is SUBTRACTED rather than excluded from the centring, and
+        # the distinction is the whole bug. An offset is relative to the block's
+        # own parent, so the transcript's one-cell left gutter is already spent
+        # before the offset applies; centring inside `box - gutter` instead
+        # centred the notice in a box the card is not centred in, and the two
+        # agreed only where `box - card` happened to be odd. Measured on the
+        # unfixed code: one cell of drift at 70, 80, 90, 100 and 110 columns,
+        # zero at 120, 140, 160 and 190 — a defect that hides at exactly the
+        # width its own regression test ran at.
+        offset = max(0, (box - card) // 2 - transcript.styles.gutter.left)
         for block in transcript.query(".notice-block"):
             block.set_class(card_up, BOOT_COLUMN_CLASS)
             if card_up:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -11231,11 +11231,21 @@ class OperatorApp(App[None]):
         # the distinction is the whole bug. An offset is relative to the block's
         # own parent, so the transcript's one-cell left gutter is already spent
         # before the offset applies; centring inside `box - gutter` instead
-        # centred the notice in a box the card is not centred in, and the two
-        # agreed only where `box - card` happened to be odd. Measured on the
-        # unfixed code: one cell of drift at 70, 80, 90, 100 and 110 columns,
-        # zero at 120, 140, 160 and 190 — a defect that hides at exactly the
-        # width its own regression test ran at.
+        # centred the notice in a box the card is not centred in. The old form
+        # resolved to `(box - card - 1) // 2` against this one's `(box - card)
+        # // 2`, so the two agreed only where `box - card` happened to be EVEN:
+        # `(d - 1) // 2 == d // 2 - 1` holds for even `d` alone.
+        #
+        # Measured on the unfixed code, over the CARDED widths only — below the
+        # card threshold this offset never applies at all, so 70 and 80 (no
+        # card) say nothing about it either way. One cell of drift at 86, 88,
+        # 90, 100 and 110 (`box - card` odd), zero at 85, 87, 120, 140, 160 and
+        # 190 (even) — a defect that hides at exactly the width its own
+        # regression test ran at, which is why the guard is parametrized across
+        # both parities. The threshold itself: 85 is the FIRST carded width
+        # (`box=83`, `card=75`, `d=8 == BOOT_CARD_MIN_INSET`) and 84 (`d=7`) the
+        # last uncarded one; 86 is merely the lowest carded width that drifts,
+        # since 85's `d` is even.
         offset = max(0, (box - card) // 2 - transcript.styles.gutter.left)
         for block in transcript.query(".notice-block"):
             block.set_class(card_up, BOOT_COLUMN_CLASS)
@@ -19198,8 +19208,8 @@ class OperatorApp(App[None]):
           a fresh one on its ``retiring`` frame with no notice at all. Every
           other outcome \u2014 a busy runtime, a ``kept`` answer, an old runtime
           that does not know the op \u2014 is a runtime that is STAYING on the old
-          build, and earns one ``note`` line saying it will move over when its
-          current work finishes. No notice ever asks the user to ``/stop``
+          build, and earns one ``note`` line saying it will switch over once it
+          is next idle. No notice ever asks the user to ``/stop``
           (design-runtime-autorefresh \u00a73.3/\u00a73.5).
 
         The COPY deliberately says "session" and "window" rather than
@@ -19370,7 +19380,7 @@ class OperatorApp(App[None]):
                     "",
                     loaded.label(),
                     f"{subject} is running an older version than this window \u2014 it "
-                    f"will switch to the new version when it is next idle.",
+                    "will switch to the new version when it is next idle.",
                     scope,
                     notice_kind="note",
                 )
@@ -19380,7 +19390,7 @@ class OperatorApp(App[None]):
                 owner.label(),
                 loaded.label(),
                 f"{subject} is running {_build_change(owner, loaded)} \u2014 it will "
-                f"switch to the new version when it is next idle.",
+                "switch to the new version when it is next idle.",
                 scope,
                 notice_kind="note",
             )
@@ -19547,10 +19557,19 @@ class OperatorApp(App[None]):
                 # against whatever runtime is live by then (design review
                 # round 1, D2). Kept ``warning`` because the lost attach is
                 # still the headline; the tail states the automatic repair.
+                #
+                # "once it is next idle", NOT "when its current work finishes",
+                # for the reason the build-skew notices give at the same wording
+                # (design review round 1, D3): ``may_refresh`` gates the retire
+                # on ``is_busy()`` being false, so idleness is literally the
+                # condition, and a session that has no work in flight is told
+                # about the end of work that does not exist. This notice paints
+                # on the same runtime-refresh mechanism as those two, so it
+                # states the same promise in the same words.
                 self._notice(
                     "this session is running a version too old to attach a team "
                     "(before 0.46.25); nothing was attached. It will move to the new "
-                    "version on its own when its current work finishes.",
+                    "version on its own once it is next idle.",
                     "warning",
                 )
                 return

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -11211,8 +11211,11 @@ class OperatorApp(App[None]):
         membership FOLLOW the card rather than the moment the notice was
         written: a notice gains the class and the card's exact width while the
         card is up, and sheds both — back to the full-width spine — when it is
-        not. ``set_class`` only fires the block's re-centre (``NoticeBlock.set_class``)
-        on a real change, so an unchanged sync costs nothing.
+        not. An unchanged sync still costs nothing, but the guard is Textual's
+        own: ``add_class``/``remove_class`` return early when the class set is
+        already what was asked for, so no style update is queued. The block has
+        no ``set_class`` override to fire — the re-wrap comes from ``on_resize``,
+        which is how the width assigned below arrives.
         """
         transcript = self._transcript_view()
         card = boot_card_width(box)

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -1040,8 +1040,10 @@ Screen.boot.boot-card #input-shell {
  * is moved: the notice's text keeps one left edge, landing on the composer's
  * text column below it. `text-align` must not be added here either — the block
  * pins its own height and a stylesheet re-wrap would reflow the hanging indent
- * it cannot see. The `.boot-column` class is the marker the block reads to
- * re-wrap at the card's width. */
+ * it cannot see. The `.boot-column` class carries NO rule and no behaviour: it
+ * is the app's own reconciliation marker for which blocks it has moved onto the
+ * card. The re-wrap at the card's width comes from the block's `on_resize`,
+ * which is what the assigned width arrives as. */
 
 /* ── slash-command picker ────────────────────────────────────────────────
  *

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -1036,11 +1036,12 @@ Screen.boot.boot-card #input-shell {
  * width and its offset onto the card's column are computed by the app
  * (OperatorApp._sync_boot_column_width) because both are cell counts the sheet
  * cannot ask for, and because `align-horizontal` aligns a container's CHILDREN,
- * never the node carrying it — a rule here would centre nothing. The notice's
- * TEXT is centred by the block itself (NoticeBlock._build), not by `text-align`:
- * the block pins its own height and a stylesheet re-wrap would reflow the
- * hanging indent it cannot see. The `.boot-column` class is only the marker the
- * block reads to decide between the spine and the centred axis. */
+ * never the node carrying it — a rule here would centre nothing. Only the BLOCK
+ * is moved: the notice's text keeps one left edge, landing on the composer's
+ * text column below it. `text-align` must not be added here either — the block
+ * pins its own height and a stylesheet re-wrap would reflow the hanging indent
+ * it cannot see. The `.boot-column` class is the marker the block reads to
+ * re-wrap at the card's width. */
 
 /* ── slash-command picker ────────────────────────────────────────────────
  *

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -245,10 +245,13 @@ GAP_CLASS = "gap-above"
 
 #: Class the app puts on a transcript block that joins the centred boot
 #: composition (a system notice under the splash). The app writes the card's
-#: width onto the block (``OperatorApp._sync_boot_column_width``); the block
-#: centres its own content on that axis (``NoticeBlock._build``). Defined here,
-#: with the block that reads it, because app.py already imports this module and
-#: the reverse would be a cycle.
+#: width AND its offset onto the block (``OperatorApp._sync_boot_column_width``),
+#: which is the whole of the centring: the block is moved onto the card's column,
+#: while its TEXT keeps the same left edge it has on the spine. The class remains
+#: a content signal rather than only a style one, because the width it carries
+#: changes where the text folds and so needs a re-wrap (``NoticeBlock.set_class``).
+#: Defined here, with the block that reads it, because app.py already imports
+#: this module and the reverse would be a cycle.
 BOOT_COLUMN_CLASS = "boot-column"
 
 
@@ -1253,13 +1256,15 @@ class NoticeBlock(TranscriptBlock):
             parent.refresh_gap_around(self)
 
     def set_class(self, add: bool, *class_names: str, update: bool = True) -> "NoticeBlock":
-        """Add/remove a class, re-centring when the boot column comes or goes.
+        """Add/remove a class, re-wrapping when the boot column comes or goes.
 
-        ``_build`` reads ``BOOT_COLUMN_CLASS`` to decide between the spine and
-        the centred card axis, so a class flip is a content change, not only a
-        style one. Rebuilding here keeps the drawn text in step with the class
-        whatever the caller (the app's reconciliation pass, a test, a resize
-        crossing the card threshold), instead of trusting each to re-render.
+        The class carries the card's WIDTH, so a flip changes the column the text
+        folds at even though it no longer changes the text's alignment: a notice
+        wrapped for the full-width spine has the wrong row count the moment it is
+        narrowed to the card. Rebuilding here keeps the drawn text in step with
+        the class whatever the caller (the app's reconciliation pass, a test, a
+        resize crossing the card threshold), instead of trusting each to
+        re-render.
         """
         had = self.has_class(BOOT_COLUMN_CLASS)
         super().set_class(add, *class_names, update=update)
@@ -1272,8 +1277,8 @@ class NoticeBlock(TranscriptBlock):
 
         The same three steps ``on_resize`` takes for a re-wrap — unfreeze,
         rebuild, refreeze — factored out so a class change (``set_class``) can
-        share them. The gap is re-asked afterwards because a re-centre can move
-        the row count exactly as a re-wrap can.
+        share them. The gap is re-asked afterwards because the width the class
+        carries can move the row count exactly as a resize can.
         """
         was_finalized = self._finalized
         self._finalized = False
@@ -1406,24 +1411,27 @@ class NoticeBlock(TranscriptBlock):
         one statement instead of as several.
 
         A ``boot-column`` notice (one under the boot splash, an MCP server that
-        failed to connect) is CENTRED instead: it belongs to the same composition
-        as the centred card below it, whose width the app writes onto the block,
-        and the wordmark and the card's caret are centred masses, not left edges —
-        so the row is centred on that axis the same way the splash centres its own
-        lines. Left at the spine it drew flush against the terminal's left edge
-        beside a centred card. The centre is computed HERE, in the build, rather
-        than left to ``text-align``: this block pins its own height and a
-        stylesheet re-wrap would also reflow the hanging indent it cannot see.
-        Every wrapped row is centred on its own width, so a notice that folds to
-        two or three lines still reads as one centred block rather than a centred
-        first line with ragged continuations — and a row is a row whether the
-        break was the wrap's or the author's, so :meth:`_rows` feeds this loop
-        the same list either way.
+        failed to connect) wraps exactly the same way. It joins the centred boot
+        composition as a BLOCK — the app gives it the card's width and offsets it
+        onto the card's column (``OperatorApp._sync_boot_column_width``) — but its
+        text keeps this one left edge, so the sentence starts on the composer's
+        text column directly below it.
+
+        It used to centre each row on its own width, and that is the one thing
+        this method must not do again. The left edge of the ink then became a
+        function of the sentence's LENGTH: a stack of three notices at 100 columns
+        drew four different left edges (``[16, 17, 24, 31]``), a visible zigzag,
+        and a wrapped continuation at 160 columns floated 34 cells right of its
+        own first row as a centred orphan. ``welcome.py::_center_blocks`` rejected
+        precisely this for the splash above it — "centring each line on its own
+        width produced a diamond of four ragged edges" — and block-centres on ONE
+        shared left edge instead. A notice is prose, not a centred mass like the
+        wordmark or the card's caret, so it gets the same treatment: one column,
+        found by the block's offset rather than by each row's own width.
         """
         style = Style(color=theme_mod.semantic_color(self._token))
         indent = " " * SPINE_INDENT
         hanging = " " * (SPINE_INDENT + 2)
-        width = max((self.size.width or 80) - 2, 12)
         body = self.body_budget(self.size.width or 80)
         rows = self._rows(body)
         # PINNED to the authored row count, for the reason ``UserBlock._build``
@@ -1446,20 +1454,16 @@ class NoticeBlock(TranscriptBlock):
         # ``test_a_timer_delivered_notice_keeps_the_wordmark_in_frame`` pins
         # the timer path so a future un-pin is caught there too.
         self._set_authored_height(len(rows))
-        centred = self.has_class(BOOT_COLUMN_CLASS)
         line = Text(no_wrap=True, overflow="ellipsis")
         for index, row in enumerate(rows):
-            # First row reserves the glyph column; continuations the hanging one.
-            # Centring takes the pad out of the SLACK beside the text, so each
-            # row lands on the block's axis give or take the odd cell.
-            prefix = SPINE_INDENT + 2 if index == 0 else cell_len(hanging)
-            pad = max(0, (width - prefix - cell_len(row)) // 2) if centred else 0
+            # First row reserves the glyph column; continuations the hanging one,
+            # which is the same width blank — that is what puts every row of one
+            # notice on a single text column.
             if index:
                 line.append("\n")
-                line.append((" " * (prefix + pad)) if centred else hanging, style=style)
+                line.append(hanging, style=style)
             else:
-                lead = indent if not centred else " " * (prefix - 2 + pad)
-                line.append(lead, style=style)
+                line.append(indent, style=style)
                 line.append(f"{self._glyph} ", style=style)
             line.append(row, style=style)
         return line

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -247,10 +247,12 @@ GAP_CLASS = "gap-above"
 #: composition (a system notice under the splash). The app writes the card's
 #: width AND its offset onto the block (``OperatorApp._sync_boot_column_width``),
 #: which is the whole of the centring: the block is moved onto the card's column,
-#: while its TEXT keeps the same left edge it has on the spine. The class remains
-#: a content signal rather than only a style one, because the width it carries
-#: changes where the text folds and so needs a re-wrap (``NoticeBlock.set_class``).
-#: Defined here, with the block that reads it, because app.py already imports
+#: while its TEXT keeps the same left edge it has on the spine. The class itself
+#: carries NO rule and no behaviour — it is the app's reconciliation marker for
+#: which blocks it has already moved. The re-wrap at the card's width comes from
+#: the block's ``on_resize``, which is how the assigned width arrives; see the
+#: tombstone on :class:`NoticeBlock` for why no ``set_class`` override does it.
+#: Defined here, beside the block the app marks, because app.py already imports
 #: this module and the reverse would be a cycle.
 BOOT_COLUMN_CLASS = "boot-column"
 

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -1255,40 +1255,28 @@ class NoticeBlock(TranscriptBlock):
         if isinstance(parent, TranscriptView):
             parent.refresh_gap_around(self)
 
-    def set_class(self, add: bool, *class_names: str, update: bool = True) -> "NoticeBlock":
-        """Add/remove a class, re-wrapping when the boot column comes or goes.
-
-        The class carries the card's WIDTH, so a flip changes the column the text
-        folds at even though it no longer changes the text's alignment: a notice
-        wrapped for the full-width spine has the wrong row count the moment it is
-        narrowed to the card. Rebuilding here keeps the drawn text in step with
-        the class whatever the caller (the app's reconciliation pass, a test, a
-        resize crossing the card threshold), instead of trusting each to
-        re-render.
-        """
-        had = self.has_class(BOOT_COLUMN_CLASS)
-        super().set_class(add, *class_names, update=update)
-        if self.has_class(BOOT_COLUMN_CLASS) != had:
-            self._rebuild()
-        return self
-
-    def _rebuild(self) -> None:
-        """Re-run :meth:`_build` through the finalize discipline.
-
-        The same three steps ``on_resize`` takes for a re-wrap — unfreeze,
-        rebuild, refreeze — factored out so a class change (``set_class``) can
-        share them. The gap is re-asked afterwards because the width the class
-        carries can move the row count exactly as a resize can.
-        """
-        was_finalized = self._finalized
-        self._finalized = False
-        try:
-            self.set_content(self._build())
-        finally:
-            self._finalized = was_finalized
-        parent = self.parent
-        if isinstance(parent, TranscriptView):
-            parent.refresh_gap_around(self)
+    # NO ``set_class`` override here, deliberately — see below before adding one.
+    #
+    # There used to be one: it detected a ``boot-column`` flip and re-ran
+    # ``_build``, on the rationale that the class carries the card's WIDTH, so a
+    # flip changes the column the text folds at. That rationale died when
+    # ``_build`` stopped reading the class (the block is now offset onto the
+    # card as a whole, and every row keeps ONE left edge), and the mechanism was
+    # measurably doing nothing: ``_build`` reads ``self.size.width`` and nothing
+    # else, and the app sets the class one line BEFORE it assigns
+    # ``styles.width`` (``OperatorApp._sync_boot_column_width``), so the flip
+    # rebuild only ever saw the STALE pre-resize width. Instrumented across
+    # 100→80→100→160→86→120 with a wrapping notice: on a down-cross it rebuilt
+    # at 75 (the old card width) and Textual's own ``on_resize`` then rebuilt at
+    # 96 and 76; on an up-cross it rebuilt at 76 (stale) and ``on_resize`` at
+    # 75. ``on_resize`` is what actually re-wraps, in both directions and across
+    # the card threshold, because the width lands as a resize.
+    #
+    # So the flip rebuild was a redundant build at a width nothing draws at,
+    # explained by a mechanism that does not happen. It is removed rather than
+    # re-documented: a rebuild kept "just in case" is one no test can lose, and
+    # the resize path it duplicated is the one with the guards on it
+    # (``test_boot_layout.py``'s parametrized column tests).
 
     #: The kind field: the spine indent plus the glyph and its space. Every row
     #: reserves exactly this — :meth:`_build` writes ``indent + glyph + " "`` on

--- a/scripts/boot_notice_shot.py
+++ b/scripts/boot_notice_shot.py
@@ -1,0 +1,92 @@
+"""Capture a system notice under the boot splash, at any terminal width.
+
+Usage::
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/boot_notice_shot.py out.svg [WIDTHxHEIGHT] [STATE]
+
+States:
+
+``skew``       one long build-skew notice — the shape the operator reported.
+``stack``      three notices of different lengths — the case that showed the
+               per-row centring as a visible zigzag of four ragged left edges.
+``short``      one short notice, the shape the block was first measured on.
+``populated``  the same notice with the splash retired by a conversation
+               block: the OFF-splash rendering, which this change must leave
+               alone.
+
+The boot notice is the one transcript block that used to carry its own text
+alignment (``NoticeBlock._build`` centred every row on its own width), so a
+frame is the only way to judge it: the column it lands in is a function of the
+sentence's length, which no unit assertion about a single width can show. Pair
+a ``stack`` frame with a ``skew`` frame to see both defects at once — the
+zigzag between rows, and the block's own one-cell drift off the card.
+
+Isolates HOME and the config dir before importing the app (``isolate_capture``)
+so the frame never depends on the developer's own providers or MCP roster, and
+so a capture cannot touch a live session.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.visual_capture import isolate_capture, save_capture  # noqa: E402
+
+isolate_capture()  # BEFORE the app imports: it reads HOME/config at import time.
+
+from local_operator.tui.widgets.transcript import UserBlock  # noqa: E402
+
+#: The operator's reported notice, verbatim in shape: two stamps and a clause.
+#: Long enough to wrap at every width the splash is used at, which is what
+#: makes it the frame that shows a continuation row's alignment.
+SKEW = (
+    "this session is running 0.51.0@ad6db35 \u2192 0.51.5@ad6db35 \u2014 it will "
+    "switch to the new version when it is next idle."
+)
+SHORT = "MCP cloudflare failed: needs authorization"
+STACK = [
+    SHORT,
+    "MCP linear failed: connection refused after three attempts",
+    "MCP notion failed: the server exited before it answered initialize",
+]
+
+STATES: dict[str, list[str]] = {
+    "skew": [SKEW],
+    "stack": STACK,
+    "short": [SHORT],
+    "populated": [SKEW],
+}
+
+
+async def main() -> None:
+    out = Path(sys.argv[1]).resolve()
+    size = sys.argv[2] if len(sys.argv) > 2 else "100x30"
+    state = sys.argv[3] if len(sys.argv) > 3 else "skew"
+    width, height = (int(part) for part in size.split("x"))
+
+    from tests.unit.tui.test_boot_layout import _make_app, _settle
+
+    app = _make_app()
+    async with app.run_test(size=(width, height)) as pilot:
+        await pilot.pause()
+        await _settle(pilot)
+        if state == "populated":
+            # Retire the splash FIRST, so the notice is appended to a real
+            # conversation rather than to the empty state: this is the
+            # full-width spine rendering, not the boot column.
+            app._append_block(UserBlock("what changed in the last release?"))
+            await _settle(pilot)
+        for body in STATES[state]:
+            app._system_notice(body, "error")
+        await _settle(pilot)
+        save_capture(app, out)
+        print(f"state={state} size={width}x{height} -> {out}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/unit/tui/test_boot_layout.py
+++ b/tests/unit/tui/test_boot_layout.py
@@ -618,10 +618,13 @@ async def test_notices_under_the_splash_never_scroll_the_region(notices: int) ->
 #: must stay — dropping the odd ones disarms the guard, dropping the even ones
 #: stops it proving the fix did not simply move the error.
 #:
-#: 86 is the lowest width that HAS a card: below it `box - card` is under
-#: `BOOT_CARD_MIN_INSET` and the app deliberately leaves the notice on the
-#: full-width spine, where there is no card column to share. A narrower
-#: terminal is covered by the spine tests instead, not by these.
+#: 86 is the lowest carded width at which the defect APPEARS, which is why the
+#: list starts there. The first carded width is 85 (`box=83`, `card=75`,
+#: `d=8 == BOOT_CARD_MIN_INSET`; 84 with `d=7` is the last uncarded one), but
+#: 85's `box - card` is even, so it sits on the parity that hides the bug.
+#: Below the threshold the app deliberately leaves the notice on the full-width
+#: spine, where there is no card column to share; a narrower terminal is
+#: covered by the spine tests instead, not by these.
 BOOT_NOTICE_WIDTHS = (86, 90, 100, 110, 120, 160)
 
 

--- a/tests/unit/tui/test_boot_layout.py
+++ b/tests/unit/tui/test_boot_layout.py
@@ -61,6 +61,7 @@ from local_operator.tui.widgets.editor import Editor
 from local_operator.tui.widgets.transcript import (
     BOOT_COLUMN_CLASS,
     GAP_CLASS,
+    SPINE_INDENT,
     NoticeBlock,
     TranscriptView,
     UserBlock,
@@ -604,41 +605,112 @@ async def test_notices_under_the_splash_never_scroll_the_region(notices: int) ->
         assert welcome.region.height > 0
 
 
-@pytest.mark.asyncio
-async def test_a_notice_under_the_splash_sits_on_the_card_not_the_spine() -> None:
-    """A boot notice is part of the centred composition, not the full-width spine.
+#: Widths the boot-notice column is asserted at. The parametrization is the
+#: POINT of these two tests, not thoroughness for its own sake: the offset
+#: defect they guard CANCELLED at exactly the width the older single-width test
+#: ran at (120). `_sync_boot_column_width` centred the block in `box - gutter`
+#: while the stylesheet centres the card in `box`, so the two agreed only where
+#: `box - card` happened to be EVEN — and a real invariant was pinned at one of
+#: the widths that hides its own violation.
+#:
+#: Measured on the unfixed tree: one cell of drift at 86/90/100/110 (`box - card`
+#: odd), zero at 120/160 (even). Both parities are therefore represented and
+#: must stay — dropping the odd ones disarms the guard, dropping the even ones
+#: stops it proving the fix did not simply move the error.
+#:
+#: 86 is the lowest width that HAS a card: below it `box - card` is under
+#: `BOOT_CARD_MIN_INSET` and the app deliberately leaves the notice on the
+#: full-width spine, where there is no card column to share. A narrower
+#: terminal is covered by the spine tests instead, not by these.
+BOOT_NOTICE_WIDTHS = (86, 90, 100, 110, 120, 160)
 
-    The splash above it and the card below it are both centred, so a notice left
-    at `1fr` drew flush against the terminal's left edge — one line visibly out
-    of column on the first frame a user with a broken MCP server sees. The fix
-    gives it the card's width and centres its TEXT within that width: the
-    wordmark and the card's caret are centred masses, not left edges, so
-    edge-aligning the row still read as "off to the left". Asserted off the
-    notice's own geometry: its block is the card's width and its text is centred
-    in it (equal slack on both sides, give or take the odd cell).
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_width", BOOT_NOTICE_WIDTHS)
+async def test_a_notice_under_the_splash_sits_on_the_card_not_the_spine(
+    terminal_width: int,
+) -> None:
+    """A boot notice shares the card's COLUMN, and keeps one left edge in it.
+
+    Two separate claims, both of which were once wrong at some width.
+
+    The BLOCK joins the centred composition: left at `1fr` it drew flush against
+    the terminal's left edge while the splash and the card sat centred. So it
+    takes the card's width and the card's exact `x` — asserted here at six
+    widths rather than one, because the offset that places it used to be
+    computed against a different box than the card's own and drifted a cell at
+    four of them.
+
+    The TEXT inside it is left-aligned on the hanging indent, NOT centred. Rows
+    centred on their own widths made the ink's left edge a function of sentence
+    length — a stack of three notices drew four ragged edges, the same "diamond"
+    `welcome.py::_center_blocks` rejected for the splash above it. One column,
+    landing on the composer's own text column below.
     """
     app = _make_app()
-    async with app.run_test(size=(120, 36)) as pilot:
+    async with app.run_test(size=(terminal_width, 36)) as pilot:
         await pilot.pause()
         await _settle(pilot)
         app._system_notice("MCP cloudflare failed: needs authorization", "error")
         await _settle(pilot)
         card = app.query_one("#input-shell").region
         notice = app.query_one(NoticeBlock).region
-        assert card.width == _expected_card_width(120) < 120 - 2
+        assert card.width == _expected_card_width(terminal_width)
         assert notice.width == card.width, (notice.width, card.width)
-        # The BLOCK shares the card's column, not only its width: an offset the
-        # test below cannot see (it measures slack within the block) would leave
-        # the block left of the card with its text centred in the wrong place.
-        assert notice.x == card.x, (notice.x, card.x)
-        # The text is centred in the card-wide block: the slack left and right of
-        # the row's ink, measured WITHIN the block's own span, differs by at most
-        # the odd cell a centred row leaves.
+        # The BLOCK shares the card's column, not only its width.
+        assert notice.x == card.x, (terminal_width, notice.x, card.x)
+        # And its text starts on ONE column: the glyph field's width in from the
+        # block's own left edge, exactly as a spine notice does.
         line = _rows(app)[notice.y]
         span = line[notice.x : notice.x + notice.width]
         left = len(span) - len(span.lstrip())
-        right = len(span) - len(span.rstrip())
-        assert abs(left - right) <= 1, (left, right, span)
+        assert left == SPINE_INDENT, (terminal_width, left, span)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_width", BOOT_NOTICE_WIDTHS)
+async def test_a_boot_notice_starts_on_the_composers_own_text_column(
+    terminal_width: int,
+) -> None:
+    """The notice's sentence begins where the user's typing begins.
+
+    This is the invariant that makes the notice read as part of the composition
+    rather than as a stray fragment above it, and nothing pinned it before: the
+    block's placement and the composer's placement are computed in different
+    places (`_sync_boot_column_width` against the card, the composer by the
+    stylesheet), so they can drift apart without either looking wrong alone.
+
+    Measured against the editor's CONTENT box rather than `chevron.x + 2`: the
+    editor carries its own one-cell left padding, so the chevron-relative form
+    is off by one and would pin the wrong column.
+    """
+    app = _make_app()
+    async with app.run_test(size=(terminal_width, 36)) as pilot:
+        await pilot.pause()
+        await _settle(pilot)
+        app._system_notice(
+            "this session is running 0.51.0@ad6db35 \u2192 0.51.5@ad6db35 \u2014 it will "
+            "switch to the new version when it is next idle.",
+            "note",
+        )
+        await _settle(pilot)
+        notice = app.query_one(NoticeBlock).region
+        sentence_x = notice.x + NoticeBlock.GLYPH_COLS
+        composer_text_x = app.query_one(Editor).content_region.x
+        assert sentence_x == composer_text_x, (
+            terminal_width,
+            sentence_x,
+            composer_text_x,
+        )
+        # Every wrapped continuation lands on that same column — the property a
+        # per-row centre destroyed, where a 4-word orphan floated 34 cells right
+        # of its own first row at 160 columns.
+        rows = _rows(app)
+        for row_index in range(notice.y + 1, notice.y + notice.height):
+            span = rows[row_index][notice.x : notice.x + notice.width]
+            if not span.strip():
+                continue
+            assert notice.x + (len(span) - len(span.lstrip())) == sentence_x, span
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_build_skew.py
+++ b/tests/unit/tui/test_build_skew.py
@@ -69,7 +69,7 @@ DRIFT = "was updated after this window opened"
 # row and quietly stopped meaning "no owner notice" (review round 2, R2-3).
 OWNER_SKEW = "is running "
 OWNER_UNKNOWN = "running an older version than this window"
-MOVES_OVER = "will move to the new version when its current work finishes"
+MOVES_OVER = "will switch to the new version when it is next idle"
 
 
 class _BoundViewer(FakeSession):

--- a/tests/unit/tui/test_transcript_selection.py
+++ b/tests/unit/tui/test_transcript_selection.py
@@ -81,6 +81,7 @@ from local_operator.tui.widgets.toast import TOAST_FAILURE_MS, Toast
 from local_operator.tui.widgets.tool_card import OUTPUT_INDENT, ToolCard
 from local_operator.tui.widgets.transcript import (
     BOOT_COLUMN_CLASS,
+    SPINE_INDENT,
     NoticeBlock,
     RichBlock,
     TranscriptBlock,
@@ -571,14 +572,15 @@ async def test_a_long_single_line_notice_still_hangs_under_its_first_word() -> N
 
 
 @pytest.mark.asyncio
-async def test_a_centred_boot_notice_centres_every_authored_line() -> None:
-    """The boot column keeps working, per row, once rows can be authored.
+async def test_a_boot_notice_keeps_one_text_column_for_every_authored_line() -> None:
+    """The boot column moves the BLOCK, never the text inside it.
 
-    A boot notice (the splash's MCP connect failure) is centred on the card's
-    axis rather than hung on the spine, and each row is centred on its OWN
-    width. The split adds rows the centring never saw, so it is asserted on the
-    slack either side of each one — including the indented line, whose authored
-    indent is part of the row it centres.
+    A boot notice used to centre each row on its own width, which made the left
+    edge of the ink a function of the sentence's length: an authored two-line
+    notice drew two different left edges from one statement. The block is still
+    offset onto the card's column by the app, but its text keeps the same
+    hanging indent it has on the spine, so every row of one notice — authored
+    split or wrap, indented continuation or not — starts in one column.
     """
     rows = await _notice_rows(
         app_size=(70, 30),
@@ -587,16 +589,16 @@ async def test_a_centred_boot_notice_centres_every_authored_line() -> None:
         centred=True,
     )
     assert len(rows) == 2
-    for row in rows:
-        assert row.startswith(" "), f"a centred row sits at the spine: {row!r}"
+    # Row 0 carries the glyph field; every continuation carries the same width
+    # blank. That, and not a per-row centre, is what puts them on one column.
+    assert rows[0].startswith(f"{' ' * SPINE_INDENT}\u2717 "), rows[0]
+    for row in rows[1:]:
+        assert row.startswith(" " * NoticeBlock.GLYPH_COLS), row
         assert "\n" not in row
-    # Centred on the axis, not left-aligned in a wide block: the ink is roughly
-    # equidistant from both edges of the notice's own span. Compared against the
-    # widest row's own slack rather than a pinned column, so the assertion
-    # survives a copy change.
-    inks = [(len(row) - len(row.lstrip(" ")), cell_len(row)) for row in rows]
-    for left, painted in inks:
-        assert left > 0 and painted > left
+    # The authored indent survives INSIDE that column rather than being folded
+    # into a centre: the second line is the authored "  run: …", still indented
+    # relative to the first, not re-centred against it.
+    assert rows[1][NoticeBlock.GLYPH_COLS :] == "  run: lop mcp login cloudflare"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The operator reported a build-skew notice rendering as two centred lines floating above the composer on a `/new` splash — it read as a stray fragment rather than as a system message. A designer round confirmed it and found a second, independent defect underneath it.

Three fixes in two commits. D1 and D2 ship together because **D2 is only visible once D1 lands**: splitting them would ship a frame with a known one-cell error.

**Frames (before/after, rendered and viewed as images):** https://gist.github.com/damianvtran/bce9e7a1dac3322924087173e0378661

| | before | after |
|---|---|---|
| stack of three, 100x30 — the zigzag | [BEFORE](https://gist.githubusercontent.com/damianvtran/bce9e7a1dac3322924087173e0378661/raw/8c8e2d3dae81493b20a904b45fe3d40c5dbd0d1e/BEFORE-stack-100x30.svg) | [AFTER](https://gist.githubusercontent.com/damianvtran/bce9e7a1dac3322924087173e0378661/raw/b1ff701337d0c2a5cf377c273bf13aa5f533aca4/AFTER-stack-100x30.svg) |
| long wrap, 100x30 | [BEFORE](https://gist.githubusercontent.com/damianvtran/bce9e7a1dac3322924087173e0378661/raw/585654aa2185dba4a91a0074b1ae89a7d5f47b75/BEFORE-skew-100x30.svg) | [AFTER](https://gist.githubusercontent.com/damianvtran/bce9e7a1dac3322924087173e0378661/raw/3ff93a18bf1220d869ece3dfdbc6a8f264ca268f/AFTER-skew-100x30.svg) |
| wide, 160x40 — the 34-cell orphan | [BEFORE](https://gist.githubusercontent.com/damianvtran/bce9e7a1dac3322924087173e0378661/raw/c5d4148cc2bcfb2afce99d299ccff68e5ca5a335/BEFORE-skew-160x40.svg) | [AFTER](https://gist.githubusercontent.com/damianvtran/bce9e7a1dac3322924087173e0378661/raw/3eb0abf4d3fcdcdf1f6f8fe1527d86e78b5ef1ff/AFTER-skew-160x40.svg) |
| narrow, 80x30 — below the card threshold | [BEFORE](https://gist.githubusercontent.com/damianvtran/bce9e7a1dac3322924087173e0378661/raw/fe04bf839251c78a8a7d2d249ac69bc3f3b372f8/BEFORE-skew-80x30.svg) | **byte-identical** |
| populated transcript, 100x30 — off the splash | [BEFORE](https://gist.githubusercontent.com/damianvtran/bce9e7a1dac3322924087173e0378661/raw/484abc43f5518da3ba4b82e7b4d40e0ce3d6dca0/BEFORE-populated-100x30.svg) | **byte-identical** |
| D3 copy, 100x30 | [BEFORE](https://gist.githubusercontent.com/damianvtran/bce9e7a1dac3322924087173e0378661/raw/3a8cd9bff16bf30d2ec411b508d94ca0682bab3f/COPY-BEFORE-100x30.svg) | [AFTER](https://gist.githubusercontent.com/damianvtran/bce9e7a1dac3322924087173e0378661/raw/3ff93a18bf1220d869ece3dfdbc6a8f264ca268f/COPY-AFTER-100x30.svg) |

The two "byte-identical" rows are not a claim, they are the gist's own behaviour: GitHub deduplicates identical blobs, and those before/after files resolve to the **same raw URL**. The unchanged surfaces are provably unchanged.

## D1 (blocker) — per-row centring destroyed the notice column

`NoticeBlock._build` centred **each row on its own width**, so the left edge of the ink was a function of sentence length. A stack of three notices at 100 columns drew four different left edges; at 160 columns a wrapped continuation floated 34 cells right of its own first row as a centred orphan.

This contradicted the repo's own convention in two places — `welcome.py::_center_blocks` rejected exactly this for the splash directly above it ("a diamond of four ragged edges — un-designed, on the first frame every user sees") and block-centres on one shared left edge, and `test_boot_layout.py` already stated the rule for the `/clear` receipt: *"left-aligned, because a centred notice would be a second alignment convention."*

The block still joins the centred composition — the app gives it the card's width and offsets it onto the card's column — but its **text** keeps the hanging indent it has on the spine.

## D2 (major) — the block sat one cell off the card at half of all widths

`_sync_boot_column_width` computed `content_box = box - transcript.styles.gutter.width` then `offset = (content_box - card) // 2`, but the **stylesheet centres the card in `box`**, not in `box - gutter`. An offset is relative to the block's parent, so the transcript's one-cell gutter is already spent before the offset applies; centring inside a box the card is not centred in made the two agree only where `box - card` happened to be even.

It is now `offset = max(0, (box - card) // 2 - transcript.styles.gutter.left)` — the gutter **subtracted** rather than excluded from the centring — with the reasoning in a comment.

`test_a_notice_under_the_splash_sits_on_the_card_not_the_spine` asserted `notice.x == card.x` and passed only because it ran at 120 alone, one of the widths where the bug cancels. That is a real invariant pinned at a width that hides its own violation, so it is now parametrized across both parities.

### Width probe, before and after

Ten widths, headless pilot, measuring the notice block's `x` against the card's:

| width | carded | card.x | notice.x BEFORE | drift BEFORE | notice.x AFTER | drift AFTER |
|---:|:---:|---:|---:|---:|---:|---:|
| 70 | no (spine) | 1 | 2 | n/a | 2 | n/a |
| 80 | no (spine) | 1 | 2 | n/a | 2 | n/a |
| 90 | yes | 7 | 8 | **+1** | 7 | 0 |
| 100 | yes | 12 | 13 | **+1** | 12 | 0 |
| 110 | yes | 17 | 18 | **+1** | 17 | 0 |
| 120 | yes | 19 | 19 | 0 | 19 | 0 |
| 140 | yes | 22 | 22 | 0 | 22 | 0 |
| 160 | yes | 30 | 30 | 0 | 30 | 0 |
| 190 | yes | 45 | 45 | 0 | 45 | 0 |
| 224 | yes | 62 | 62 | 0 | 62 | 0 |

**Correction to the reported reproduction, worth stating because it changed the test's width set.** The brief listed 80 as a drifting width and said the bug cancels at odd `box - card`. Measured, both are the other way round: **86 is the lowest width that has a card at all** (below it `box - card < BOOT_CARD_MIN_INSET` and the app deliberately leaves the notice on the full-width spine, where there is no card column to share), and the drift occurs at **odd** `box - card`, cancelling at even. The 70/80 rows above are the spine case and their `notice.x` is unchanged by this PR. The parametrization is therefore `(86, 90, 100, 110, 120, 160)` — 86/90/100/110 drift, 120/160 cancel — so the guard covers both parities rather than the four widths a wrong parity reading would have picked.

Left-edge columns of the ink (the D1 symptom), same probe:

| case | width | first-ink columns BEFORE | first-ink columns AFTER |
|---|---:|---|---|
| single long notice | 100 | `[17, 24]` | `[14, 16]` |
| single long notice | 160 | `[32, 68]` | `[32, 34]` |
| stack of three | 100 | `[28, 20, 16]` — three ragged edges | `[14, 14, 14]` |
| stack of three | 160 | `[58, 50, 46]` — three ragged edges | `[32, 32, 32]` |
| stack of three | 80 (spine) | `[4, 4, 4]` | `[4, 4, 4]` unchanged |

After the fix every notice row starts on **the composer's own text column** at every carded width.

## D3 — the copy promised work that does not exist

The notice said the session *"will move to the new version when its current work finishes."* It paints on a brand-new `/new` splash with nothing in flight, where that promises the end of work that does not exist.

Idleness is what the runtime actually waits for: `may_refresh` gates the retire on `is_busy()` being false, not on any particular task completing, and that condition is equally true of a session sitting at an empty prompt. The copy now says what the mechanism does — **"it will switch to the new version when it is next idle."** Both announce sites, including the `owner-unknown` variant.

**Not addressed, deliberately:** the team-attach notice at `app.py:18532` (*"version on its own when its current work finishes"*) carries similar wording about a **different** event on a populated transcript, and is out of scope for this PR. Follow-up if we want the phrasing unified.

## D4 — no action

The `/clear` receipt inherits the same centring and is repaired for free by D1. Recorded so the change in its rendering is not read as a regression.

## Mutation evidence

Every new guard was proven able to fail by reintroducing the defect it guards, separately for each.

**Reintroduced the D2 offset arithmetic** (`(box - gutter - card) // 2`):

```
FAILED test_a_notice_under_the_splash_sits_on_the_card_not_the_spine[86]  - AssertionError: (86, 6, 5)
FAILED test_a_notice_under_the_splash_sits_on_the_card_not_the_spine[90]  - AssertionError: (90, 8, 7)
FAILED test_a_notice_under_the_splash_sits_on_the_card_not_the_spine[100] - AssertionError: (100, 13, 12)
FAILED test_a_notice_under_the_splash_sits_on_the_card_not_the_spine[110] - AssertionError: (110, 18, 17)
FAILED test_a_boot_notice_starts_on_the_composers_own_text_column[86/90/100/110]
8 failed, 4 passed
```

Note **which** 4 passed: 120 and 160, both parametrizations. That is the parametrization earning its place — the old single-width test at 120 would have gone green against this mutation.

**Reintroduced the D1 per-row centring:**

```
FAILED test_a_notice_under_the_splash_sits_on_the_card_not_the_spine[86..160]   (6/6 widths)
FAILED test_a_boot_notice_starts_on_the_composers_own_text_column[86..160]      (6/6 widths)
FAILED test_a_boot_notice_keeps_one_text_column_for_every_authored_line
13 failed
```

Restored both: `281 passed` across the two files.

## Tests

- `test_a_notice_under_the_splash_sits_on_the_card_not_the_spine` — parametrized over six widths; the centring assertion (`abs(left - right) <= 1`) replaced with a left-edge one. Its docstring argued **for** centring, which is now false, so it is rewritten — a docstring arguing the opposite of its code is worse than none.
- `test_a_centred_boot_notice_centres_every_authored_line` → `test_a_boot_notice_keeps_one_text_column_for_every_authored_line`, inverted: authored lines keep the hanging indent, and the authored indent survives *inside* that column rather than being folded into a centre.
- **New:** `test_a_boot_notice_starts_on_the_composers_own_text_column` — the invariant nothing pinned before. Measured against the editor's **content box**, not `chevron.x + 2`: the editor carries its own one-cell left padding, so the chevron-relative form is off by one and would have pinned the wrong column. Verified by typing into the real composer and reading the column the glyphs actually landed in.
- `test_build_skew.py`'s `MOVES_OVER` fragment follows the D3 wording; it exists to identify the notice, not to pin its prose.

## Geometry (per AGENTS.md)

Across all ten widths, single notice and stack-of-three: `virtual_size.height == size.height` (34 == 34), `show_vertical_scrollbar` **False**, notice `region.height == 2` matching its content rows. No overlay-induced scrollbar and no two-cell width loss — the designer's "no scrollbar across 1–12 stacked notices" holds.

## Gates, as CI runs them

Run on the **remediated head `ddca24c1f`** (rebased onto `origin/main` at v0.51.9), each under a private `TMPDIR`:

| gate | result |
|---|---|
| `flake8 .` | rc=0 |
| `black --check .` (26.1.0) | `1031 files would be left unchanged`, rc=0 |
| `isort --check .` (5.13.2) | rc=0 |
| `pyright` | `0 errors, 0 warnings, 0 informations`, rc=0 |
| `pytest tests/e2e -m e2e -n0` | `47 passed`, rc=0 |
| `pytest tests/unit` | `3 failed, 15860 passed, 18 skipped` — all three unrelated, see below |
| touched suites (`test_boot_layout` + `test_build_skew` + `test_transcript_selection`) | `314 passed`, rc=0 |

**The three failures on the remediated head are unrelated to this diff, and are reported as measured rather than characterised as "pre-existing".** All three passed when re-run together in isolation on the same tree (`3 passed in 7.35s`), and the run that produced them sat on a host at load average 122 with sibling suites running (55m16s wall for a suite that takes ~3.5 min on a quiet host):

| test | failure | reachable from this diff? |
|---|---|---|
| `test_resume_subagents_todos.py::test_snapshot_entry_is_written_for_a_launched_child` | `assert 2089 == 1805` on transcript `st_size` | no — 0 occurrences of `NoticeBlock`/`boot_column` in the file |
| `test_tui_responsiveness.py::test_s3_harvest_with_unlisted_model_and_cold_memo_keeps_the_loop_free` | `harvest blocked for 2909 ms` against a 500 ms bar | no — a loop-CPU bound of exactly the shape AGENTS.md documents as load-sensitive; 0 notice references |
| `test_steering_approval.py::test_ctrl_c_twice_exits_and_offers_the_resume_command` | `assert not True` on `app.is_running` | no — the file imports `NoticeBlock` for two *other* tests; this test's body has 0 references and asserts app-exit timing |

CI shows the same pattern from the other direction: shard `test (3.12, 1)` failed once on `test_subagent_stats.py::test_a_job_that_refuses_to_be_read_does_not_reach_the_timer` and, on rerun, on a *different* test (`test_subagent_accounting.py::test_rendered_footer_uses_whole_owner_ledger`) — which also failed on **`origin/main` itself** in two separate runs today (`34163736897`, `34162890846`), alongside a third main run failing a third unrelated test. A different test each run, each passing in isolation, is host contention rather than a property of any branch.

**Correction (QA round 1, Q1): the earlier "2 pre-existing failures" claim in this body did not reproduce and has been withdrawn.**

QA ran the full suite on the unmodified base `3d60de927` and measured it **completely green — 15595 passed, 0 failed**, with `test_snapshot_entry_is_written_for_a_launched_child` passing there both in the full suite and in isolation. So there were no two pre-existing failures to confirm, and the original claim should not be relied on as written. The failures this body first reported were local to that run's host conditions (load average 24–216, and a disk-exhaustion episode noted below), not properties of the tree.

On the PR head QA saw a **single** unrelated failure, `tests/unit/tui/test_stream_anchor.py::test_a_parked_page_survives_a_streaming_delta`, and demonstrated the diff cannot reach it: the subagent body geometry is byte-identical on base and head (`virtual_h_before_page=43`, `offset_before_page=30.0`, `parked=17.0`, `final_offset=17.0`, `virtual_h_final=59` on both), the one `NoticeBlock` in that scenario has `boot_card_class=False` so it is not in the boot column this diff touches, `test_stream_anchor.py` contains zero occurrences of `notice`/`NoticeBlock`, and it passed 5/5 isolated, 4/4 under xdist, 18/18 whole-file serial, plus the entire `tests/unit/tui` suite green on head (5799 passed, 12 skipped). It is a load-sensitive settling assertion of the shape AGENTS.md warns about, in a file with documented flake history (`ddb142fd1`).

**Host note.** An earlier run showed 84 errors of `OSError: could not create numbered dir` — pytest's tmpdir allocator, not assertions — caused by host disk exhaustion: `/System/Volumes/Data` at **99% / 6.8 GiB free** (`df -h /` reads ~36% here and is the wrong probe; it is a sealed APFS snapshot). After the volume was reclaimed to **26 GiB free / 94%**, a clean re-run under a private `TMPDIR` produced **zero** such errors. Counts from the full-disk runs are not cited as evidence anywhere in this PR. Load average ran 24–216 during this work, so timings here are not comparable to a quiet host.

**CI note.** CI is fully green on `cd17424c7`. `test (3.12, 4)` passed at **20m0s** against its 20-minute `timeout-minutes` cap (19m37s on the pre-rebase head) — effectively zero headroom, and it passed on both. That is the known saturated-shard cluster, not this diff: the only file this PR adds is `scripts/boot_notice_shot.py`, which is outside the `tests/unit/**/test_*.py` shard glob, so the shard partition is unchanged. Flagged for the reviewer, not addressed here.

## Scope

No version bump: rebased onto `origin/main` at **v0.51.9**, so `pyproject.toml` reads exactly `0.51.9` as main has it, and `git diff origin/main...HEAD -- pyproject.toml` is empty.

The branch has been rebased twice. The latest rebase moves onto `origin/main` at v0.51.9, five PRs on (including `/move` and `/copy` picker work). Proven content-identical rather than assumed: `git range-diff` reports `=` on both original commits, and the width probe re-run on the rebased, remediated tree reports **drift 0 at every carded width** (85–190, both parities) with the sentence still on the composer's text column.

`scripts/boot_notice_shot.py` is the reusable capture script for these states (checked `visual_gallery.py --list` first — no existing script covered a boot notice). Per AGENTS.md the **frames** are not committed; they are attached above. It is the only added file, and it is outside the `tests/unit/**/test_*.py` shard glob, so this PR does not reshuffle CI's shard partition.

Not touched: `_system_notice`'s `ends_empty_state=False`, the card's own centring, `_sync_boot_composition`, `_reserve_boot_rows`, `wrap_cells` and `_rows`.

**Changed in round-1 remediation** (`ddca24c1f`), superseding two statements this body made earlier:

- `BOOT_COLUMN_CLASS`'s **rebuild hook is now removed** (review M2). This body previously said "a class flip still needs a re-wrap"; that was measured to be false. `_build` reads `self.size.width` alone and the app sets the class one line before it assigns `styles.width`, so the flip rebuild only ever ran at the stale width while `on_resize` did the real re-wrap. The class survives as the app's reconciliation marker; it carries no rule and no behaviour.
- The **third notice site is no longer untouched** (QA Q2). It carried the same retired "current work finishes" wording D3 removed, on the same `may_refresh`/`is_busy()` mechanism, and was the only site left contradicting the other two, so it now reads "once it is next idle". The D2 "on its own" tail is preserved.

Release: patch — a system notice under the boot splash now lines up with the card and the composer instead of drifting off-column, and the build-skew notice no longer promises work that may not exist.

