### PR TITLE
docs(agents): name whole-file undo as a shared-checkout hazard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1102,6 +1102,35 @@ that makes that test type-check landed 3m24s later in the peer's own commit
 `06ee21d9e`. The PR's head was red for a defect its own intended change did
 not contain.
 
+**Reaching for one of these as an *undo* evades everything above.** The rules
+so far are written against a deliberate act — clearing the tree to get a
+before-frame — so they do not intercept the reflex thirty seconds after you
+notice you edited the wrong thing, when the goal is just to put it back and
+`git checkout HEAD -- <path>` is the first command to hand. Same hazard,
+different mental context, and an agent who had read the rule above walked into
+it today. What makes an operation unsafe here is that **its unit is the whole
+file rather than your hunk**; the list is examples and deliberately not
+exhaustive, since enumerating commands is how `git add -A` stayed unnamed until
+someone hit it. `git checkout`/`restore`/`reset`/`clean` on a path, a `>`
+redirect, a `cp` over the file, an editor "revert", and a `write` tool call
+that re-emits a whole file all qualify. Undo your own change the way you made
+it: a targeted reverse edit of exactly the lines you touched, leaving every
+other line as you found it. Better, avoid needing the undo — check
+`git rev-parse --show-toplevel` before a write and confirm it is the tree you
+mean, because the mistake that provokes the panic is usually aiming the edit at
+the wrong checkout. The undo rule limits the blast radius; the path check
+prevents the event. Measured today: a subagent editing
+`.github/workflows/ci.yml` in the shared checkout rather than its own worktree
+ran `git checkout HEAD -- .github/workflows/ci.yml` to take it back. That path
+was +23/-37 against HEAD beforehand and the subagent's own edit accounted for
++19/-10 of it, so roughly 27 lines of another session's unstaged work went with
+it — unrecoverably, because unstaged content is never hashed into the object
+store: `git diff --cached` on the path was empty, the 283 dangling blobs under
+`.git/lost-found` yielded no candidate, and no commit after `f1cd77900` touches
+the path. That checkout currently holds 1,611 uncommitted paths from concurrent
+sessions, which is why a whole-file operation there has a blast radius you
+cannot see before you run it.
+
 Two stills side by side catch what a single "looks fine" never does. The
 usage-card round found a **pre-existing** bug this way: the after-frame had a
 scrollbar the before-frame did not, which turned out to be any tall overlay

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1109,31 +1109,34 @@ thirty seconds after you notice you edited the wrong thing, when the goal is
 just to put it back and `git checkout HEAD -- <path>` is the first command to
 hand. Same hazard, different mental context, and an agent who had read the rule
 above walked into it today. What makes an operation unsafe is that **its unit
-is the whole file rather than your hunk** — every command listed above, plus a
-`write` that re-emits a whole file. Treat the list as examples and not as the
-rule, since enumerating is how `git add -A` stayed unnamed until someone hit
-it. The ban lifts where the others do: in your own worktree, or a throwaway
-nobody else touches, all of these are ordinary. Where you are not alone, undo
-your own change the way you made it — a targeted reverse edit of exactly the
-lines you touched, leaving every other line as you found it — and better still,
-avoid needing the undo by checking `git rev-parse --show-toplevel` before a
-write, since the mistake that provokes the panic is usually aiming the edit at
-the wrong checkout. The undo rule limits the blast radius; the path check
-prevents the event. Today a subagent editing `.github/workflows/ci.yml` in the
-shared checkout instead of its own worktree ran
+is the whole file rather than your hunk** — every command listed at the top of
+this block, plus a `write` that re-emits a whole file. Treat the list as
+examples and not as the rule, since enumerating is how `git add -A` stayed
+unnamed until someone hit it. The ban lifts where the others do: in a worktree
+nobody else is working in, or a throwaway, all of these are ordinary — the test
+is exclusivity, not ownership, because a worktree can be yours and still have a
+peer in it, which is exactly how #727 above happened. Where you are not alone,
+undo your own change the way you made it — a targeted reverse edit of exactly
+the lines you touched, leaving every other line as you found it — and better
+still, avoid needing the undo by checking `git rev-parse --show-toplevel`
+before a write, since the mistake that provokes the panic is usually aiming the
+edit at the wrong checkout. The undo rule limits the blast radius; the path
+check prevents the event. Today a subagent editing `.github/workflows/ci.yml`
+in the shared checkout instead of its own worktree ran
 `git checkout HEAD -- .github/workflows/ci.yml` to take it back, and destroyed
 a peer's unstaged work with its own: on the order of 27 lines, from a diffstat
 of roughly +23/−37 against HEAD of which its own edit was about +19/−10 —
 figures reconstructed from the session log, not re-derived, because the content
 is gone. Unstaged content is never hashed into the object store, so nothing
-recovers it: `git diff --cached` on the path was empty, the 28 dangling blobs
-among the 283 entries under `.git/lost-found/other` held no candidate, and no
-commit after the incident touches the path. Reach for `git fsck --lost-found`
-there and note that it **writes** those entries rather than reporting them,
-which makes it a poor first probe in the tree whose accident you are
-investigating. That checkout held 1,611 uncommitted paths from concurrent
-sessions when this was written, which is why a whole-file operation there has a
-blast radius you cannot see before you run it.
+recovers it: `git diff --cached` on the path was empty, all 283 entries under
+`.git/lost-found/other` were searched and held no candidate, and no commit
+after the incident touches the path. That checkout held 1,611 uncommitted paths
+from concurrent sessions when this was written, which is why a whole-file
+operation there has a blast radius you cannot see before you run it. One probe
+to avoid while investigating such an accident: `git fsck --lost-found`
+**writes** those entries rather than reporting them, so it mutates the very
+tree under investigation — plain `git fsck` lists the same dangling objects and
+creates nothing.
 
 Two stills side by side catch what a single "looks fine" never does. The
 usage-card round found a **pre-existing** bug this way: the after-frame had a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1102,34 +1102,38 @@ that makes that test type-check landed 3m24s later in the peer's own commit
 `06ee21d9e`. The PR's head was red for a defect its own intended change did
 not contain.
 
-**Reaching for one of these as an *undo* evades everything above.** The rules
-so far are written against a deliberate act — clearing the tree to get a
-before-frame — so they do not intercept the reflex thirty seconds after you
-notice you edited the wrong thing, when the goal is just to put it back and
-`git checkout HEAD -- <path>` is the first command to hand. Same hazard,
-different mental context, and an agent who had read the rule above walked into
-it today. What makes an operation unsafe here is that **its unit is the whole
-file rather than your hunk**; the list is examples and deliberately not
-exhaustive, since enumerating commands is how `git add -A` stayed unnamed until
-someone hit it. `git checkout`/`restore`/`reset`/`clean` on a path, a `>`
-redirect, a `cp` over the file, an editor "revert", and a `write` tool call
-that re-emits a whole file all qualify. Undo your own change the way you made
-it: a targeted reverse edit of exactly the lines you touched, leaving every
-other line as you found it. Better, avoid needing the undo — check
-`git rev-parse --show-toplevel` before a write and confirm it is the tree you
-mean, because the mistake that provokes the panic is usually aiming the edit at
+**The undo for a mistaken edit is a reverse edit of your own hunk, never a
+whole-file operation.** Everything above is written against a deliberate act —
+clearing the tree to get a before-frame — so none of it intercepts the reflex
+thirty seconds after you notice you edited the wrong thing, when the goal is
+just to put it back and `git checkout HEAD -- <path>` is the first command to
+hand. Same hazard, different mental context, and an agent who had read the rule
+above walked into it today. What makes an operation unsafe is that **its unit
+is the whole file rather than your hunk** — every command listed above, plus a
+`write` that re-emits a whole file. Treat the list as examples and not as the
+rule, since enumerating is how `git add -A` stayed unnamed until someone hit
+it. The ban lifts where the others do: in your own worktree, or a throwaway
+nobody else touches, all of these are ordinary. Where you are not alone, undo
+your own change the way you made it — a targeted reverse edit of exactly the
+lines you touched, leaving every other line as you found it — and better still,
+avoid needing the undo by checking `git rev-parse --show-toplevel` before a
+write, since the mistake that provokes the panic is usually aiming the edit at
 the wrong checkout. The undo rule limits the blast radius; the path check
-prevents the event. Measured today: a subagent editing
-`.github/workflows/ci.yml` in the shared checkout rather than its own worktree
-ran `git checkout HEAD -- .github/workflows/ci.yml` to take it back. That path
-was +23/-37 against HEAD beforehand and the subagent's own edit accounted for
-+19/-10 of it, so roughly 27 lines of another session's unstaged work went with
-it — unrecoverably, because unstaged content is never hashed into the object
-store: `git diff --cached` on the path was empty, the 283 dangling blobs under
-`.git/lost-found` yielded no candidate, and no commit after `f1cd77900` touches
-the path. That checkout currently holds 1,611 uncommitted paths from concurrent
-sessions, which is why a whole-file operation there has a blast radius you
-cannot see before you run it.
+prevents the event. Today a subagent editing `.github/workflows/ci.yml` in the
+shared checkout instead of its own worktree ran
+`git checkout HEAD -- .github/workflows/ci.yml` to take it back, and destroyed
+a peer's unstaged work with its own: on the order of 27 lines, from a diffstat
+of roughly +23/−37 against HEAD of which its own edit was about +19/−10 —
+figures reconstructed from the session log, not re-derived, because the content
+is gone. Unstaged content is never hashed into the object store, so nothing
+recovers it: `git diff --cached` on the path was empty, the 28 dangling blobs
+among the 283 entries under `.git/lost-found/other` held no candidate, and no
+commit after the incident touches the path. Reach for `git fsck --lost-found`
+there and note that it **writes** those entries rather than reporting them,
+which makes it a poor first probe in the tree whose accident you are
+investigating. That checkout held 1,611 uncommitted paths from concurrent
+sessions when this was written, which is why a whole-file operation there has a
+blast radius you cannot see before you run it.
 
 Two stills side by side catch what a single "looks fine" never does. The
 usage-card round found a **pre-existing** bug this way: the after-frame had a


### PR DESCRIPTION
## What

Adds one rule to the shared-checkout block in `AGENTS.md`: **the correct undo for a mistaken edit in a shared checkout is a targeted reverse edit of exactly your own hunk — never an operation whose unit is the whole file.**

29 added lines in `AGENTS.md`, nothing else. It extends the existing paragraph rather than opening a new section, so the block still reads as one policy.

## Why it is not already covered

The existing prohibition names `git checkout -- <path>`, `restore`, `reset --hard`, `clean` and whole-file overwrites — but frames them as things you must not reach for **to get a before-frame**. That is a deliberate, planned action. The reflexive reach is as an **undo**, thirty seconds after realising you edited the wrong thing, under pressure. Different mental context, and the rule as written does not intercept it: an agent that had read it did exactly this today.

The paragraph also states the **class** rather than leaning on the enumeration — *any operation whose unit is the whole file rather than your hunk* — because the enumeration is what let `git add -A` slip through until #749. Examples are given explicitly as non-exhaustive: `git checkout`/`restore`/`reset`/`clean` on a path, a `>` redirect, a `cp` over the file, an editor "revert", and a `write` tool call that re-emits a whole file. And it adds the prevention as well as the containment: check `git rev-parse --show-toplevel` before writing, since the mistake that provoked the undo was aiming an edit at the wrong tree.

## The incident, as verified in this session

A subagent aimed an `edit` at `.github/workflows/ci.yml` in the **shared** checkout instead of its own worktree copy, then ran `git checkout HEAD -- .github/workflows/ci.yml` to undo it. That reverted a peer's uncommitted work along with its own: the path was +23/−37 versus HEAD beforehand, the subagent's own edit accounted for +19/−10, so roughly 27 lines of another session's unstaged work were destroyed.

Facts re-verified rather than taken on report, all against `~/local-operator`:

| Claim | Command | Result |
|---|---|---|
| path is clean now | `git status --porcelain .github/workflows/ci.yml` | empty |
| never staged, so never hashed into the object store | `git diff --cached --stat -- <path>` | empty |
| no later commit carries the content | `git log f1cd77900..origin/main -- <path>` | no commits |
| dangling blobs, no candidate | `ls .git/lost-found/other \| wc -l` | `283` |
| blast radius of the shared checkout | `git status --porcelain \| wc -l` | `1611` |

Both numbers in the prose (283, 1,611) are the ones measured here, not copied from the report.

## Testing

Docs-only; there is no code in this diff and no suite was run (the host is recovering from congestion collapse). Verification is that the change says what is true and reads correctly in place:

- `git diff --stat origin/main..HEAD` → `AGENTS.md | 29 ++++` , one file, 29 insertions, 0 deletions.
- `pyproject.toml` untouched — confirmed by `git diff --name-only origin/main..HEAD | grep -c pyproject` → `0`. Main stays at v0.51.7; no bump rides this PR.
- Every added line is ≤79 columns, matching the file's wrap.
- Read back at `AGENTS.md:1105-1132` in context to confirm it continues the `git add -A` paragraph and flows into the "Two stills side by side" text without restating the existing rules.

## Practising the rule

This PR was written under its own policy: a fresh worktree cut from `origin/main` on a unique path (removed at the end, never the shared checkout), every write path checked against `git rev-parse --show-toplevel` first, the commit staged with an explicit pathspec (`git add AGENTS.md`, never `-A`).

Release: patch — documents the correct undo for a mistaken edit in a shared checkout, closing the gap that cost a peer session ~27 lines of unstaged work today.
