### PR TITLE
fix(tui): give interrupted sessions their own glyph and let live work outrank a stale mark

### DIFF
--- a/local_operator/tui/session_catalog.py
+++ b/local_operator/tui/session_catalog.py
@@ -91,6 +91,36 @@ class CatalogEntry:
           previous turn's outcome over its own spinner made seven resumed,
           healthy sessions read as seven failures.
 
+        THE COST OF THE ``busy`` RULE, stated plainly because it is a real
+        trade and not a free win: it suppresses an unread ``error`` exactly as
+        it suppresses an unread ``interrupted``. A turn that FAILED, was
+        resumed without being read, and is now running shows a spinner and a
+        :attr:`status` of "Working" — the failure has no residue anywhere on
+        the row, and the only route back to it is opening the session.
+
+        That is accepted here, deliberately, on three grounds:
+
+        1. Nothing is destroyed. This is a pure function of CURRENT state, not
+           a latch: the instant the row stops being ``busy`` the ``✗`` and
+           "Unseen error" come back, because ``unseen`` stays true until
+           somebody actually reads the session.
+        2. The row does not sink. :attr:`rank` does not consult this predicate,
+           so a suppressed row holds its unseen tier and its place near the top
+           of "Active Sessions" for the whole time it is suppressed. It is
+           de-emphasised, never lost.
+        3. The alternative IS the reported bug, one class down. Painting an
+           error mark over a running session's spinner is the same lie about
+           the same row — "this is broken" over a session that is working.
+
+        So the failure mode being accepted (a genuine error is quiet while its
+        session runs, and returns when it stops) is strictly milder and strictly
+        shorter-lived than the one being fixed (every resumed session claims to
+        have failed, indefinitely, until read). If that trade ever needs
+        revisiting, the cheap remedy is INK rather than shape — keep the
+        spinner, tint it ``danger`` when ``completion_kind == "error"``, or
+        widen the tooltip to "Working (last turn failed, unread)". Both are new
+        design surface and belong in a round of their own, not here.
+
         Everything BELOW stays outranked by the mark, deliberately. ``attached``,
         an armed wake and ``idle`` are all facts about residency — true of a
         session that is merely sitting there — while "this finished and you

--- a/local_operator/tui/session_catalog.py
+++ b/local_operator/tui/session_catalog.py
@@ -66,17 +66,62 @@ class CatalogEntry:
         return tier, -self.row.mtime, self.id
 
     @property
+    def shows_completion_mark(self) -> bool:
+        """Does an unread completion win the glyph, or does live state?
+
+        THE single arbiter for that question: the sidebar reads it to decide
+        whether to override :func:`row_state_mark`, and :attr:`status` reads it
+        to decide whether to say "Unseen …". They used to make the decision
+        separately, in matching order, held together by a comment asking the
+        next author to keep them in step. That is what broke — and the pairing
+        invariant this file already treats as load-bearing deserves a predicate
+        rather than a promise.
+
+        ``unseen`` is a LEVEL, not an edge: it is true from the moment a turn
+        completes until somebody READS that session, and resuming a session
+        does not acknowledge it. So the mark alone cannot be allowed to win —
+        it says what the session did LAST, and the states below say what it is
+        doing NOW:
+
+        * ``pending`` — a parked gate. Already outranked unseen, and still
+          does: a person is blocked on this row right now.
+        * ``wedged`` — broken NOW. A stale mark from a turn that did finish
+          must not hide a runtime that has since stopped answering.
+        * ``busy`` — the reported bug. The session is working; painting the
+          previous turn's outcome over its own spinner made seven resumed,
+          healthy sessions read as seven failures.
+
+        Everything BELOW stays outranked by the mark, deliberately. ``attached``,
+        an armed wake and ``idle`` are all facts about residency — true of a
+        session that is merely sitting there — while "this finished and you
+        have not read it" is a fact about work that is waiting for the
+        operator. An unseen completion on a now-idle session is exactly the
+        information the sidebar exists to keep, so it is kept.
+
+        Note this changes the GLYPH only, never :attr:`rank`: the row stays in
+        its unseen tier and keeps its place in "Active Sessions". Ranking
+        answers "how far up the list", which the completion still earns; this
+        answers "what is it doing", which the spinner owns while it runs.
+        """
+        return (
+            self.unseen and not self.row.pending and self.row.live_state not in ("wedged", "busy")
+        )
+
+    @property
     def status(self) -> str:
         if self.row.pending:
             return "Approval needed" if self.row.pending == "approval" else "Answer needed"
-        if self.unseen:
-            return {"error": "Unseen error", "interrupted": "Unseen interruption"}.get(
-                self.completion_kind, "Unseen completion"
-            )
+        # BEFORE the unseen branch, and mirrored by `shows_completion_mark`,
+        # which is what the sidebar suppresses the mark on. A row that is
+        # wedged or busy describes itself by what it is doing now.
         if self.row.live_state == "wedged":
             return "Not responding"
         if self.row.live_state == "busy":
             return "Working"
+        if self.shows_completion_mark:
+            return {"error": "Unseen error", "interrupted": "Unseen interruption"}.get(
+                self.completion_kind, "Unseen completion"
+            )
         # Follows ``row_state_mark``'s precedence EXACTLY, so the tooltip can
         # never name a different state from the glyph beside it. The glyph is a
         # single character and the description is where a user finds out what it

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -242,6 +242,39 @@ IDLE_MARKER = "●"
 #: remedy differs: a wedged session is one to `lop stop`, not to reopen.
 WEDGED_MARKER = "✗"
 
+#: An unacknowledged completion, by kind. The sidebar paints these over the
+#: live-state glyph for a row whose last turn finished unread; they live here
+#: beside the other markers so one module owns the list's whole glyph
+#: vocabulary and a future author can see at a glance which cells are taken.
+#:
+#: ``⊘`` for interrupted is NOT a new invention — it is the glyph this
+#: codebase ALREADY uses for that exact state everywhere else it renders an
+#: outcome: ``tool_card.ICON_INTERRUPTED``, the subagent panel's
+#: ``⊘ cancelled`` and ``session_presentation``'s "shut `interrupted ⊘` row".
+#: The sidebar was the lone surface collapsing interrupted into ``✗``, so this
+#: removes a second vocabulary rather than adding one. ``tool_card``'s contract
+#: — "``✓``/``✗``/``⊘`` separate success, failure and interruption without a
+#: single colour" — is the reason the fix is a SHAPE and not a tint: a design
+#: round on the neighbouring markers measured `muted` against `dim` at 1.90:1
+#: and rejected distinguishing two states by ink alone, and an interruption
+#: against a failure is exactly that comparison.
+#:
+#: One cell each, like every marker above: ``STATE_COL_CELLS`` reserves glyph
+#: plus separator, and a two-cell glyph eats the separator (the ⏰ regression
+#: ``WAKE_MARKER`` records). Verified with ``rich.cells.cell_len``.
+COMPLETION_MARKERS: dict[str, tuple[str, str]] = {
+    # `complete` and `error` keep the ink they had. `interrupted` takes
+    # `warning` rather than `danger`: an interrupted turn is unfinished work,
+    # not a failure, and `danger` is the ramp's "something broke" hue — the
+    # exact false alarm the operator reported when seven interrupted sessions
+    # read as seven errors. `warning` is also the ink `NEEDS_YOU_MARKER`
+    # already carries for "this needs you to do something", which is precisely
+    # what an interrupted turn is asking for: somebody to resume it.
+    "complete": ("✓", "success"),
+    "error": ("✗", "danger"),
+    "interrupted": ("⊘", "warning"),
+}
+
 #: Cells reserved for the live-state column when ANY row in the result set
 #: carries state. One cell for the state glyph plus its separating space; the
 #: spinner frames, the wake glyph and the markers above are all one cell wide.

--- a/local_operator/tui/widgets/session_picker.py
+++ b/local_operator/tui/widgets/session_picker.py
@@ -259,6 +259,35 @@ WEDGED_MARKER = "✗"
 #: and rejected distinguishing two states by ink alone, and an interruption
 #: against a failure is exactly that comparison.
 #:
+#: WHY SHAPE IS THE SIGNAL AND INK IS ONLY REINFORCEMENT — the measurement,
+#: so the next author choosing a marker does not have to re-derive it. A design
+#: round simulated colour-vision deficiency over these three inks:
+#:
+#: ===========  =========  ==============  ============
+#: ink          actual     deuteranopia    protanopia
+#: ===========  =========  ==============  ============
+#: ``warning``  ``#e0b04b``  ``#bfbf47``   ``#b6b64b``
+#: ``danger``   ``#ef8078``  ``#aaaa73``   ``#929278``
+#: ``success``  ``#57c785``  ``#afaf87``   ``#bebe84``
+#: ===========  =========  ==============  ============
+#:
+#: Three near-identical olives. For a deuteranope these rows are told apart by
+#: ``⊘`` against ``✗`` against ``✓`` and by NOTHING ELSE — the hue separation
+#: that carries them for trichromatic vision (36.6° dark, 34.1° light) simply
+#: is not there. So a tint-only fix for the interrupted-wears-the-error-mark
+#: bug would have shipped a change that a colour-blind reader cannot see at
+#: all. Any future state added here must earn a distinct GLYPH; recolouring an
+#: existing one is not a fix.
+#:
+#: CONSTRAINT — ``warning`` is now a TWO-MEMBER class, not a synonym for
+#: "answer this gate". ``NEEDS_YOU_MARKER`` (``!``) and ``interrupted``
+#: (``⊘``) resolve to the identical fill and can sit rows apart in the same
+#: list. That is intended: both mean "this wants you", and ``!`` against ``⊘``
+#: is a large enough shape difference to carry it while the tooltips
+#: disambiguate. But the class is at its capacity — a THIRD amber marker would
+#: leave the eye grouping three states as one before it resolves any shape, so
+#: adding one needs a design round, not a free slot.
+#:
 #: One cell each, like every marker above: ``STATE_COL_CELLS`` reserves glyph
 #: plus separator, and a two-cell glyph eats the separator (the ⏰ regression
 #: ``WAKE_MARKER`` records). Verified with ``rich.cells.cell_len``.

--- a/local_operator/tui/widgets/session_sidebar.py
+++ b/local_operator/tui/widgets/session_sidebar.py
@@ -25,7 +25,7 @@ from local_operator.tui import theme as theme_mod
 from local_operator.tui.animation import BLURRED_SPINNER_INTERVAL_S, animation_focused
 from local_operator.tui.session_catalog import CatalogEntry, rank_entries
 from local_operator.tui.terminal_title import SPINNER_FRAMES
-from local_operator.tui.widgets.session_picker import row_state_mark
+from local_operator.tui.widgets.session_picker import COMPLETION_MARKERS, row_state_mark
 from local_operator.tui.widgets.tool_card import truncate_cells
 
 SIDEBAR_WIDTH = 30
@@ -725,11 +725,23 @@ class SessionSidebar(Widget, can_focus=True):
                 # notice gets a spinner ON THE ROW, where the eye is. The
                 # footer "Opening…" stays as the textual counterpart.
                 mark, ink = SPINNER_FRAMES[self._frame % len(SPINNER_FRAMES)], "accent"
-            elif entry.unseen and not entry.row.pending:
-                mark, ink = (
-                    ("✗", "danger")
-                    if entry.completion_kind in ("error", "interrupted")
-                    else ("✓", "success")
+            elif entry.shows_completion_mark:
+                # `shows_completion_mark`, not `unseen`, is the test: an unread
+                # completion says what the session did LAST, and a busy or
+                # wedged row is saying what it is doing NOW. The old condition
+                # was `unseen and not pending`, which let a resumed session
+                # paint its previous turn's mark over its own spinner —
+                # `unseen` only clears on acknowledgement, and resuming does
+                # not acknowledge. That predicate is shared with
+                # `CatalogEntry.status` so this glyph and that tooltip cannot
+                # disagree; see its docstring for the whole ordering argument.
+                #
+                # `interrupted` no longer borrows the error glyph. It is the
+                # commonest of the three in practice — the operator's store
+                # held 41 interrupted and zero errors — so the shared `✗` meant
+                # the failure mark had, in practice, only ever been wrong.
+                mark, ink = COMPLETION_MARKERS.get(
+                    entry.completion_kind, COMPLETION_MARKERS["complete"]
                 )
             line.append(f"{mark or ' '} ", style=theme_mod.semantic_color(ink))
             age = (

--- a/scripts/sidebar_shot.py
+++ b/scripts/sidebar_shot.py
@@ -6,8 +6,9 @@ Run from the worktree root:
 
 Seeds ONE fixed catalog covering every state the list can draw — a live turn,
 an idle runtime, an attached viewer, an armed wake, a dormant wake, a parked
-gate, a wedged runtime and cold rows — so a single frame answers both questions
-this change is about:
+gate, a wedged runtime, cold rows, and (see ``UNSEEN_ROWS``) rows carrying an
+unacknowledged completion of each kind including one that has since been
+resumed — so a single frame answers both questions this change is about:
 
 * **Which glyph each state draws**, across every mark the list can produce.
 * **How much of a title survives.** The names here are real-length generated
@@ -93,9 +94,31 @@ ROWS = [
     ("aaaaaaaaaab3", "Address Local Operator packaging review", 35, "", None, 0, False),
 ]
 
+#: Rows carrying an UNACKNOWLEDGED completion, as
+#: ``(id, title, age_minutes, live_state, completion_kind)``.
+#:
+#: Kept as a separate table because `unseen` is a dimension the fixture above
+#: does not model at all — it is layered on by the attention store, not by the
+#: runtime record — and widening every tuple in ROWS to carry two more fields
+#: would touch fourteen rows to describe four.
+#:
+#: These are the states this change is about, and none of them could be framed
+#: before: the fixture had no unseen row whatsoever, so neither the shared
+#: `✗` nor the stale-mark bug was visible in any capture. The last entry is
+#: the operator's reported defect exactly — a session that finished a turn
+#: unread and has since been RESUMED and is working again. Before the fix it
+#: painted `✗` over its own spinner; after, the spinner wins and the mark
+#: returns when the turn ends.
+UNSEEN_ROWS = [
+    ("aaaaaaaaaac1", "Backfill customer cube contacts", 9, "idle", "complete"),
+    ("aaaaaaaaaac2", "Sanctions feed reconciliation run", 16, "idle", "error"),
+    ("aaaaaaaaaac3", "Nightly PEP screening sweep", 22, "idle", "interrupted"),
+    ("aaaaaaaaaac4", "Resumed adverse-media enrichment", 2, "busy", "interrupted"),
+]
+
 
 def _entries() -> list[CatalogEntry]:
-    return [
+    entries = [
         CatalogEntry(
             SessionRow(
                 id=session_id,
@@ -109,6 +132,15 @@ def _entries() -> list[CatalogEntry]:
         )
         for session_id, name, age, state, pending, wakes, dormant in ROWS
     ]
+    entries += [
+        CatalogEntry(
+            SessionRow(id=session_id, mtime=NOW - age * 60, name=name, live_state=state),
+            unseen=True,
+            completion_kind=kind,
+        )
+        for session_id, name, age, state, kind in UNSEEN_ROWS
+    ]
+    return entries
 
 
 async def main() -> None:

--- a/tests/unit/tui/test_session_sidebar.py
+++ b/tests/unit/tui/test_session_sidebar.py
@@ -1364,13 +1364,19 @@ async def test_an_unseen_row_pairs_its_completion_mark_with_completion_words():
     Raised as M2 in code review round 1: `CatalogEntry.status` returns "Unseen
     completion" ahead of every state branch, so pairing it with
     ``row_state_mark``'s answer would show `◷` beside those words. That pairing
-    never reaches a user — the sidebar substitutes its own `✓`/`✗` for an
+    never reaches a user — the sidebar substitutes its own mark for an
     unseen row — but the only thing establishing that is the render, so the
     render is what this test reads.
 
     Written as a pilot test rather than as a call to ``row_state_mark`` for
     exactly that reason: the helper's answer is not what is painted here, and a
     unit-level assertion would describe a surface that does not exist.
+
+    The row here is ``idle`` with a wake armed, which is the case M2 named AND
+    is now also the case where the mark still WINS. The states where live
+    activity outranks it (``busy``, ``wedged``) are enumerated by
+    ``test_no_reachable_unseen_row_pairs_a_glyph_with_the_wrong_words`` below,
+    which walks the whole product rather than these three hand-picked rows.
     """
     from textual.geometry import Region
 
@@ -1378,7 +1384,8 @@ async def test_an_unseen_row_pairs_its_completion_mark_with_completion_words():
     cases = [
         ("complete", "✓", "Unseen completion"),
         ("error", "✗", "Unseen error"),
-        ("interrupted", "✗", "Unseen interruption"),
+        # `⊘`, not `✗`: an interruption is unfinished work, not a failure.
+        ("interrupted", "⊘", "Unseen interruption"),
     ]
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(120, 30)) as pilot:
@@ -1410,3 +1417,186 @@ async def test_an_unseen_row_pairs_its_completion_mark_with_completion_words():
             assert entry.status == words, (kind, entry.status)
             # The wake glyph must NOT be what a user sees on an unseen row.
             assert "◷" not in row, (kind, row)
+
+
+@pytest.mark.asyncio
+async def test_a_busy_row_keeps_its_spinner_while_a_completion_is_unacknowledged():
+    """The operator's reported bug, as a test: a resumed session drew ``✗``.
+
+    ``unseen`` is a LEVEL, not an edge — it stays true from the moment a turn
+    completes until somebody READS that session, and resuming a session does
+    not acknowledge it (``AttentionStore`` clears it only when
+    ``receipts.acknowledged`` catches up to ``completions.sequence``). The
+    sidebar's unseen override sat unconditionally above the live-state mark,
+    so a session the operator had already resumed — actively streaming, its
+    runtime publishing ``busy`` — kept painting the mark from its PREVIOUS
+    turn over its own spinner. Seven such rows read as a screen of failures
+    while every one of them was working.
+
+    The row is asserted as still-unseen, because the fix is a precedence
+    change and not an acknowledgement: the completion is still unread, and
+    the moment the turn finishes the mark must come back.
+    """
+    from textual.geometry import Region
+
+    from local_operator.tui.terminal_title import SPINNER_FRAMES
+
+    now = time.time()
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        await pilot.press("ctrl+b")
+        await pilot.pause()
+        _quiesce_sidebar_refresh(app)
+        sidebar = app._session_sidebar
+        for kind in ("complete", "error", "interrupted"):
+            entry = CatalogEntry(
+                SessionRow("b" * 12, now, f"resumed {kind}", live_state="busy"),
+                unseen=True,
+                completion_kind=kind,
+            )
+            sidebar.set_entries([entry])
+            if sidebar._timer is not None:
+                sidebar._timer.stop()
+                sidebar._timer = None
+            sidebar._frame = 2
+            sidebar.refresh()
+            await pilot.pause()
+            painted = [
+                "".join(segment.text for segment in line)
+                for line in sidebar.render_lines(
+                    Region(0, 0, sidebar.size.width, sidebar.size.height)
+                )
+            ]
+            row = next(line for line in painted if f"resumed {kind}" in line)
+            assert SPINNER_FRAMES[2] in row, (kind, row)
+            # None of the completion marks may survive on a working row.
+            for stale in ("✓", "✗", "⊘"):
+                assert stale not in row, (kind, stale, row)
+            assert entry.status == "Working", (kind, entry.status)
+            # The completion is still UNREAD — this is precedence, not a receipt.
+            assert entry.unseen, kind
+
+
+@pytest.mark.asyncio
+async def test_an_interrupted_row_draws_its_own_glyph_and_not_the_error_mark():
+    """``✗`` is errors only; an interruption is not a failure.
+
+    The operator's store held 526 ``complete`` and 41 ``interrupted`` rows and
+    ZERO ``error`` rows, so before this every ``✗`` ever rendered in the
+    sidebar was an interruption wearing the failure glyph.
+    """
+    from textual.geometry import Region
+
+    now = time.time()
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        await pilot.press("ctrl+b")
+        await pilot.pause()
+        _quiesce_sidebar_refresh(app)
+        sidebar = app._session_sidebar
+        painted_by_kind = {}
+        for kind in ("complete", "error", "interrupted"):
+            entry = CatalogEntry(
+                SessionRow("c" * 12, now, f"idle {kind}", live_state="idle"),
+                unseen=True,
+                completion_kind=kind,
+            )
+            sidebar.set_entries([entry])
+            if sidebar._timer is not None:
+                sidebar._timer.pause()
+            await pilot.pause()
+            painted = [
+                "".join(segment.text for segment in line)
+                for line in sidebar.render_lines(
+                    Region(0, 0, sidebar.size.width, sidebar.size.height)
+                )
+            ]
+            painted_by_kind[kind] = next(line for line in painted if f"idle {kind}" in line)
+        assert "⊘" in painted_by_kind["interrupted"], painted_by_kind["interrupted"]
+        assert "✗" not in painted_by_kind["interrupted"], painted_by_kind["interrupted"]
+        assert "✗" in painted_by_kind["error"], painted_by_kind["error"]
+        assert "⊘" not in painted_by_kind["error"], painted_by_kind["error"]
+        assert "✓" in painted_by_kind["complete"], painted_by_kind["complete"]
+
+
+@pytest.mark.asyncio
+async def test_no_reachable_unseen_row_pairs_a_glyph_with_the_wrong_words():
+    """The ``unseen`` product, exhaustively, on the RENDERED row.
+
+    The sibling ``test_no_reachable_row_state_pairs_a_glyph_with_the_wrong_words``
+    excludes ``unseen`` on the grounds that it short-circuits ``status`` ahead
+    of every branch that function enumerates. That reasoning was sound and the
+    exclusion still cost us the reported bug: with the fourth dimension tested
+    only through three hand-picked rows, "unseen AND busy" — the combination
+    the operator actually hit, on seven rows at once — was covered by nothing.
+
+    So this is the same exhaustive treatment applied to the dimension that was
+    left out, driven through the real render because the sidebar's override is
+    the only place the pairing becomes real.
+    """
+    from textual.geometry import Region
+
+    from local_operator.tui.terminal_title import SPINNER_FRAMES
+
+    #: Which words may accompany each glyph on an unseen row.
+    ALLOWED = {
+        "✓": {"Unseen completion"},
+        "✗": {"Unseen error", "Not responding"},
+        "⊘": {"Unseen interruption"},
+        "!": {"Approval needed", "Answer needed"},
+    }
+    now = time.time()
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    checked = 0
+    async with app.run_test(size=(120, 30)) as pilot:
+        await pilot.pause()
+        await pilot.press("ctrl+b")
+        await pilot.pause()
+        _quiesce_sidebar_refresh(app)
+        sidebar = app._session_sidebar
+        for kind in ("complete", "error", "interrupted"):
+            for state in ("", "idle", "attached", "busy", "wedged"):
+                for pending in (None, "approval", "ask"):
+                    for wakes, dormant in ((0, False), (2, False), (1, True)):
+                        entry = CatalogEntry(
+                            SessionRow(
+                                "d" * 12,
+                                now,
+                                "pairing probe",
+                                live_state=state,
+                                pending=pending,
+                                wakes=wakes,
+                                wakes_dormant=dormant,
+                            ),
+                            unseen=True,
+                            completion_kind=kind,
+                        )
+                        sidebar.set_entries([entry])
+                        if sidebar._timer is not None:
+                            sidebar._timer.stop()
+                            sidebar._timer = None
+                        sidebar._frame = 2
+                        sidebar.refresh()
+                        await pilot.pause()
+                        painted = [
+                            "".join(segment.text for segment in line)
+                            for line in sidebar.render_lines(
+                                Region(0, 0, sidebar.size.width, sidebar.size.height)
+                            )
+                        ]
+                        row = next(line for line in painted if "pairing probe" in line)
+                        status = entry.status
+                        case = (kind, state, pending, wakes, dormant, row, status)
+                        glyph = next((g for g in ALLOWED if g in row), "")
+                        if SPINNER_FRAMES[2] in row:
+                            # Working outranks the mark, and says so.
+                            assert status == "Working", case
+                            assert not glyph, case
+                        else:
+                            assert glyph, case
+                            assert status in ALLOWED[glyph], case
+                        checked += 1
+    # 3 kinds x 5 states x 3 gates x 3 wake shapes.
+    assert checked == 135, checked


### PR DESCRIPTION
## Summary

The session sidebar showed a red `✗` on seven rows in "Active Sessions". Those sessions had been **interrupted** — a mass failure killed their turns — not errored. Worse, after they were resumed and were actively working again they **still** showed `✗`, so a screen of healthy running sessions read as a screen of failures.

Two defects, both in the unseen-completion override in `session_sidebar.render`:

1. **`interrupted` wore the error glyph.** It was collapsed into `("✗", "danger")` alongside `error`.
2. **A stale mark outranked live activity.** The override was gated on `unseen and not pending` and sat *above* the live-state mark, so a resumed, streaming session painted its previous turn's outcome over its own spinner.

## The error glyph had, in practice, never been correct

`unseen` is recorded correctly — this was never a missing-tracking problem. `AttentionStore.publish` accepts exactly `{"complete", "error", "interrupted"}`, and `bootstrap_transcript` publishes `interrupted` when a turn started and never finished. Reading the operator's real store:

```
$ sqlite3 -readonly ~/.local-operator/attention.db "select kind, count(*) from completions group by kind;"
complete|526
interrupted|41
```

**Zero `error` rows.** Every `✗` the sidebar has ever drawn was an interruption wearing the failure mark.

`⊘` is **not a new glyph**. It is already this codebase's interrupted mark everywhere else an outcome is rendered — `tool_card.ICON_INTERRUPTED`, the subagent panel's `⊘ cancelled`, `session_presentation`'s "shut `interrupted ⊘` row". The sidebar was the lone surface maintaining a second vocabulary, so this **removes** one rather than adding one. It follows `tool_card`'s existing contract that "`✓`/`✗`/`⊘` separate success, failure and interruption without a single colour": the distinction is carried by **shape**, not ink — deliberately, because the design round on the neighbouring presence markers measured `muted` vs `dim` at 1.90:1 and rejected separating two states by ink alone.

The ink still changes, as a second channel: `interrupted` takes `warning`, not `danger`. An interrupted turn is unfinished work asking to be resumed, not a failure — and `warning` is the ink `NEEDS_YOU_MARKER` already carries for exactly that meaning.

**Contrast, corrected.** An earlier revision of this description gave the floor as 4.03:1. That figure is measured against `surface` **only**, and a sidebar row takes four different grounds (`bg` when plain, `surface` when current, `tint-select` under the cursor or a requested row, `overlay` on hover — `session_sidebar.py:699`). Re-measured with WCAG relative luminance across **all 54 themes on every one of those four grounds**, the true floor for `warning` is **3.23:1**, on `overlay` (hover) in `one-light`:

| ground | worst `warning` | theme |
|---|---|---|
| `bg` | 4.26:1 | gruvbox-light |
| `surface` (current row) | 4.03:1 | one-light |
| `tint-select` (cursor / requested) | 3.77:1 | one-light |
| `overlay` (**hover**) | **3.23:1** | one-light |

3.23:1 clears the **3:1 WCAG AA floor for non-text / graphical objects**, which is the applicable threshold for a glyph of this kind. It is not an outlier introduced here: on the same worst-case grounds `success` bottoms out at 3.21:1 and `muted` at 3.23:1, and `danger` — the ink `interrupted` used to wear — is *worse*, at **2.45:1** on hover (`nightfox`), as is `accent` at 2.92:1. So `warning` is the best-behaved chromatic ink in this palette on the tightest ground, and the change does not regress contrast anywhere.

Reproduce it by iterating `theme.available_themes()` and comparing `semantic_color(ink)` against `semantic_color(ground)` for those four grounds. Independently measured twice — the QA round and this pass agree to the cent on all four rows.

None of this is load-bearing, and that is the point: the distinction is carried by **shape**. Under simulated deuteranopia `⊘`, `✗` and `✓` resolve to `#bfbf47`, `#aaaa73` and `#afaf87` — three near-identical olives — so a colour-blind reader separates these rows by glyph and by nothing else. A tint-only fix would have been invisible to them. That reasoning now lives in the code, at `COMPLETION_MARKERS`, where the next author picking a marker will read it.

## Precedence is now one predicate, not two copies

`unseen` is a **level**, not an edge: it stays true from completion until somebody *reads* the session, and resuming does not acknowledge. So the mark says what the session did **last**, while the live state says what it is doing **now**.

The glyph and the tooltip previously made this decision **twice**, in separate code, kept in step by a comment — and that is precisely what drifted. Both now read one property, `CatalogEntry.shows_completion_mark`, so they cannot disagree.

| state | outranks the mark? | why |
|---|---|---|
| `pending` | **yes** (unchanged) | a person is blocked on this row right now |
| `wedged` | **yes** (new) | broken *now*; a mark from a turn that did finish must not hide a runtime that stopped answering |
| `busy` | **yes** (new) | the reported bug — the session is working |
| `attached` / armed wake / `idle` | **no** | these are facts about *residency*, true of a session merely sitting there. "This finished and you have not read it" is work waiting for the operator, and is kept |

### A second, unreported bug this fixes

Making `wedged` outrank the mark repairs a defect nobody had filed. A wedged runtime carrying an **unread success** previously painted `✓ success` — the sidebar actively reassuring the operator about a session that had stopped answering. The differential probe over the full `live_state × pending × completion_kind × unseen` product shows it moving to `✗ danger`:

```
live=wedged  pend=  kind=complete  unseen=True   ('✓','success') -> ('✗','danger')
```

That is the safe direction, and it is the one cell in this change where the old behaviour was not merely confusing but misleading: a green tick on a session that cannot respond. Of the 9 cells that change out of 120, the two `wedged` rows move this way.

### The one cell that moves the other way

Full disclosure, since the same probe found it: an unread **`error`** on a **`busy`** row is now suppressed by the spinner, so a session whose last turn failed shows `Working` while it runs. That is a deliberate trade, not an oversight — the mark is unlatched and returns the instant the row leaves `busy`, `rank` is untouched so the row holds its unseen tier near the top of "Active Sessions" the whole time, and the alternative (an error mark painted over a running session's spinner) is the reported bug one class down. The reasoning, the cost and the cheaper remedies if it ever needs revisiting are recorded in `shows_completion_mark`'s docstring.

**Ranking is untouched.** `rank` still uses `unseen`, so the row keeps its tier in "Active Sessions" and its position in the list — verified `rank_tier=1` through the whole transition. This changes only *what the row says it is doing*.

`✗` is now errors only.

### What I deliberately did not do

I did **not** make resuming a session acknowledge its completion. It is a real behaviour change and the wrong one here: `attention.py`'s module contract is "a connection is not a read. Only an explicit acknowledgement advances the watermark", and acknowledging is destructive and irreversible. Resuming a session is not evidence the operator read the previous result — and the precedence fix already removes the misleading part without discarding the information. The mark correctly returns when the turn ends and the completion is still unread.

## Testing evidence

### The reported bug, reproduced first as a failing test

Both new tests were written before the fix and **fail on `origin/main`**:

```
FAILED test_a_busy_row_keeps_its_spinner_while_a_completion_is_unacknowledged
  AssertionError: ('complete', '   ✓ resumed complete             ')
  assert '⣻' in '   ✓ resumed complete             '
FAILED test_an_interrupted_row_draws_its_own_glyph_and_not_the_error_mark
  AssertionError:    ✗ idle interrupted
  assert '⊘' in '   ✗ idle interrupted             '
```

### The guard is proven able to go red

I reintroduced the regression (reverted the predicate to `unseen and not pending`) and confirmed the tests fail rather than silently passing, then restored:

```
FAILED test_no_reachable_row_state_pairs_a_glyph_with_the_wrong_words - AssertionError: ('busy', None, 0, False, 'Recent')
FAILED test_a_busy_row_keeps_its_spinner_while_a_completion_is_unacknowledged
2 failed, 1 passed
```

Note the pairing test stayed green under that probe while the precedence test failed — they guard different properties, which is why both exist.

### State pairing, read off the real render

`test_no_reachable_unseen_row_pairs_a_glyph_with_the_wrong_words` walks the **whole product** — 3 kinds × 5 live states × 3 gate states × 3 wake shapes = **135 combinations** — through `render_lines`, asserting every glyph pairs with words that agree. The existing exhaustive test deliberately excluded `unseen`; that exclusion is exactly why "unseen AND busy" was covered by nothing. Sample, generated from actual rendered rows:

| unseen kind | live state | glyph | tooltip |
|---|---|---|---|
| `complete` | `idle` | `✓` | Unseen completion |
| `complete` | `busy (resumed)` | `⣻` | Working |
| `complete` | `wedged` | `✗` | Not responding |
| `error` | `idle` | `✗` | Unseen error |
| `error` | `busy (resumed)` | `⣻` | Working |
| `interrupted` | `idle` | `⊘` | Unseen interruption |
| `interrupted` | `attached` | `⊘` | Unseen interruption |
| `interrupted` | `busy (resumed)` | `⣻` | Working |
| `interrupted` | `wedged` | `✗` | Not responding |

### The transition, driven through the real app

Sidebar driven through the operator's exact sequence:

```
1 interrupted, idle          glyph='⊘'  tooltip='Unseen interruption'  unseen=True  rank_tier=1
2 RESUMED (busy)             glyph='⣻'  tooltip='Working'              unseen=True  rank_tier=1
3 turn ends, still unread    glyph='⊘'  tooltip='Unseen interruption'  unseen=True  rank_tier=1
```

Glyph and tooltip move together, the mark returns when the turn ends, and the row never leaves its tier.

### `_ROW_CACHE` cannot freeze this — verified, not assumed

The cache stores the row **before** decoration; `live_state` and `unseen`/`kind` are layered on fresh by `load_catalog` on every poll. Proven against a real store, with the row served from cache (transcript bytes unchanged between polls):

```
poll 1 (interrupted published):           unseen=True  kind='interrupted'  cache_entries=1
poll 2 (kind changed, SAME transcript):   unseen=True  kind='complete'
poll 3 (acknowledged):                    unseen=False kind='complete'  status='Recent'
```

The kind flipped and `unseen` cleared through a cache hit. No cache change was needed.

### Gates

Run over the whole tree, exactly as CI:

```
.venv/bin/python -m flake8 .                                    # clean
uvx --from black==26.1.0 black --check .                        # 1033 files unchanged
uvx isort==5.13.2 --check .                                     # clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .     # 0 errors, 0 warnings
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
  tests/unit/tui/test_session_sidebar.py tests/unit/tui/test_session_picker.py -n2   # 139 passed
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest \
  tests/unit/tui/test_attention.py tests/unit/session/test_attention.py -n2          # included above, 117 passed
```

**The full unit suite was not run** — this machine is under severe load (load average ~100, swap near exhausted) and the task scoped runs to targeted files at `-n2`. CI is the check for the rest of the tree.

## Visual evidence

`scripts/sidebar_shot.py` had **no unseen row at all**, so neither defect was visible in any capture this repo could take. I extended its fixture with a `UNSEEN_ROWS` table covering an unseen completion, an unseen error, an unseen interruption, and — the operator's exact bug — a row that is unseen **and** busy.

Both frames were captured with the **same extended fixture**, the before-frame from a throwaway `origin/main` worktree, so the pair differs only by the fix. Geometry identical in both: `virtual=Size(98, 32) actual=Size(98, 32) scrollbar=False`, sidebar 33 cells, conversation 65 — no reflow, no scrollbar.

Rendered sidebar column, extracted from the two captured frames (identical fixture, identical geometry — only the glyph column differs):

```
BEFORE (origin/main)                 AFTER (this branch)
 Active Sessions                      Active Sessions
   ! Add Flavia's Adverse…  3           ! Add Flavia's Adverse…  3
   ✗ Resumed adverse-media… 2   <--     ⣻ Resumed adverse-media… 2   <-- the reported bug
   ✓ Backfill customer cub… 9           ✓ Backfill customer cub… 9
   ✗ Sanctions feed recon… 16           ✗ Sanctions feed recon… 16   <-- genuine error, unchanged
   ✗ Nightly PEP screenin… 22   <--     ⊘ Nightly PEP screenin… 22   <-- interrupted, own glyph
   ⣻ Fix sidebar activity…  1           ⣻ Fix sidebar activity…  1
   ○ Update Provider Onboa… 4           ○ Update Provider Onboa… 4
   ● Article search servic… 6           ● Article search servic… 6
   ○ Review provider onboa… 7           ○ Review provider onboa… 7
   ● OSWorld benchmark eva… 8           ● OSWorld benchmark eva… 8
   ● Article-search-svc s… 11           ● Article-search-svc s… 11
   ◷ Auto-update inactive… 13           ◷ Auto-update inactive… 13
   ● Debugging session co… 43           ● Debugging session co… 43
   ✗ Review and merge ope… 52           ✗ Review and merge ope… 52
 Previous Sessions                    Previous Sessions
     Address Local Operat… 35              Address Local Operat… 35
   ◷ Toggleable Sidebar f… 49           ◷ Toggleable Sidebar f… 49
   ◷ Stopped nightly catal… 2           ◷ Stopped nightly catal… 2
     Mark Focused TUI Sess… 5              Mark Focused TUI Sess… 5
```

Exactly two rows change and nothing else moves. In the before frame, "Resumed adverse-media…" is a **busy** session painting `✗` over its own spinner — the operator's report — and "Nightly PEP screenin…" is an interruption wearing the failure mark. In the after frame the busy row shows its spinner, the interruption shows `⊘`, and the one genuine `error` row keeps `✗`.

I rendered both SVGs to PNG at `rsvg-convert -z 2` and inspected them, including a 4x crop of the glyph column to confirm `⊘` is legible at one cell and reads as amber rather than red. GitHub attachments cannot be uploaded through `gh api`, and AGENTS.md forbids committing frames to the tree, so the text extraction above is the in-PR evidence; the SVG/PNG pair is reproducible with:

```sh
env -u NO_COLOR TERM=xterm-256color .venv/bin/python scripts/sidebar_shot.py out.svg 100x34
rsvg-convert -z 2 out.svg -o out.png
```

Release: patch — interrupted sessions show a distinct `⊘` instead of the error `✗`, and a resumed session shows its spinner instead of a stale completion mark.

