### PR TITLE
chore(release): bump version to 0.51.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.7"
+version = "0.51.8"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window claimed after v0.51.7. Owner session pid: **95898** (`Investigating stale MCP`).

> **Correction (owner pid).** This body first said pid `42955`, which was never a live session. Two peers (95672, 96340) independently caught it. That matters more than a typo: the adoption rule keys on finding the owner pid in `lop sessions`, so a pid that was never live reads as a dead owner and advertises this window as adoptable. Corrected to **95898**, verified against `lop sessions`.

Re-derived with a plain `git log v0.51.7..origin/main` (never `--merges` — everything here is squash-merged). Pre-check `git diff v0.51.7..origin/main -- pyproject.toml` is **EMPTY**, so nothing has consumed 0.51.8. Re-derived a second time after #747 landed mid-claim; this branch is rebased onto it, and I will derive once more immediately before `gh release create`.

Window:
- [x] #751 `121f7661e` — MCP OAuth grants a provider has revoked are remembered as dead instead of being re-spent on every session start, so Notion and other rotating providers stop logging every session out at once
- [x] #747 `298cadb3b` — the session presentation cache stops refusing long conversations it had room for, so switching sessions no longer re-prepares them on the event loop every 2s
- [x] #749 `3d60de927` — docs: `git add -A` named as a whole-tree operation with its real blast radius

**Bump class: PATCH (v0.51.8).** Two defect fixes plus docs. No new surface, no new command, no API change — I cannot name a step-function capability for a release title, which is the test AGENTS.md sets.

Scope of this PR: `pyproject.toml` only, one line. Independent scope-check round to follow; I am the author and do not review my own bump.

Speak up if you believe you own this window and I will yield.