### PR TITLE
feat(context): ship large repo guidance as head + section index

### DIFF
--- a/local_operator/context_files.py
+++ b/local_operator/context_files.py
@@ -39,6 +39,14 @@ LINE boundary) followed by a generated index of every remaining section with
 its line range, plus an imperative to read that range before acting on its
 subject.
 
+THE ONE INVARIANT: an oversized file NEVER renders without disclosure. Some
+files yield no listable sections at all — no headings, only H1s, or every
+heading inside the head — and for those the index degrades to a bare pointer
+(path, line count, the range to read) rather than to silence. Emitting a bare
+head with nothing saying the file continues would drop the operator's rules
+both invisibly and unrecoverably, which is worse than the byte cut this
+replaces: that at least admitted it had truncated.
+
 This is a CORRECTNESS FIX before it is a token saving. The previous contract
 kept the first 64KiB of each file and appended a one-line "truncated" note.
 For this repository's own AGENTS.md — 93,355 bytes, 11 top-level sections —
@@ -73,41 +81,63 @@ import hashlib
 import os
 import stat
 from pathlib import Path
+from typing import BinaryIO
 
 #: How many guidance files ride one system prompt. Nearest wins; deeper
 #: ancestors beyond this are dropped rather than silently overflowing the
 #: start-context budget (the 30k contract in docs/REWRITE.md).
 MAX_CONTEXT_FILES = 5
 
-#: Per-file ingest cap for the *resident* text and for the discovery digest.
-#: A guidance file is instructions, not documentation; past this the file is
-#: read on demand (it is on disk and grep-able) instead of occupying every
-#: turn's cached prefix.
-MAX_FILE_BYTES = 64 * 1024
+#: Bytes hashed when deciding whether two discovered files are the same file.
+#: This does NOT bound the resident text -- :data:`GUIDANCE_HEAD_BYTES` does.
+#: It is only the dedup probe, kept bounded so a nested tree of large guidance
+#: files cannot be made to read gigabytes during discovery.
+#:
+#: Consequence worth knowing: two files identical in their first 64KiB but
+#: differing afterwards collapse to one. That is pre-existing behaviour; the
+#: file's length is folded into the digest so the common "same prefix,
+#: different length" case stays distinguishable.
+MAX_DIGEST_BYTES = 64 * 1024
 
 #: How much of an oversized guidance file stays resident in the prompt.
 #:
-#: The trade-off is adherence against cost, and it is asymmetric. Rules the
-#: agent breaks *without knowing it should have looked something up* — a
-#: release gate, a review gate, "never symlink a venv", "read the committed
-#: ref, not the working tree" — only work when they are resident; a head too
-#: small silently converts those into rules nobody consults. Reference
-#: material (timing analysis, widget conventions, subsystem internals) is safe
-#: to leave lazy: the agent knows it is about to edit a widget, so an index
-#: entry is enough to send it to the file.
+#: The trade-off is adherence against cost, and it is asymmetric in PRINCIPLE:
+#: rules the agent breaks *without knowing it should have looked something up*
+#: want to be resident, while reference material (timing analysis, widget
+#: conventions, subsystem internals) is safe to leave lazy, because an agent
+#: about to edit a widget knows to consult the widget section.
 #:
-#: 8KiB was chosen over 6KiB and 12KiB against this repository's own 93KiB
-#: AGENTS.md: it carries the environment/test/lint gates that apply to every
-#: task regardless of subject, while cutting ~20.7k tokens from a fresh
-#: session. Raising it buys progressively less — the material past 8KiB is
-#: increasingly subject-specific, which is exactly the material an index
-#: serves well. Lowering it starts evicting unconditional gates.
+#: WHAT THIS MODULE CAN ACTUALLY DELIVER IS NARROWER, and the difference has
+#: been measured rather than assumed. The head is necessarily the file's first
+#: N bytes: this module renders whatever the operator wrote, in the order they
+#: wrote it, and MUST NOT reorder or edit their file to suit its own budget.
+#: So the head holds the unconditional rules only where the file happens to
+#: front-load them. On this repository's own AGENTS.md it largely does not —
+#: measured at 8KiB, the head carries the test/lint/e2e gates and the xdist
+#: worker-count rationale, while "never symlink a venv", "read the committed
+#: ref", the version-bump rule, the merge tiers and the release-owner protocol
+#: are all INDEX-ONLY. That is a property of the file's ordering, not a defect
+#: this module may fix; front-loading is the file owner's call.
 #:
-#: NOTE this is a byte offset into the file as the operator wrote it. It is
-#: NOT a claim that the first 8KiB of an arbitrary AGENTS.md are its most
-#: important bytes — that is a property of how the file is ordered, which is
-#: the file owner's business and not something this module edits or reorders.
+#: The index is what makes that acceptable rather than fatal: those sections
+#: carry imperative headings ("Never symlink one", "Read the committed ref,
+#: not the working tree") which state the rule's gist in the row itself, and
+#: they are one addressed read away. Note also that on this file they are past
+#: the old 64KiB byte cut anyway, so they move from absent-and-invisible to
+#: named-and-reachable.
+#:
+#: 8KiB was chosen over 6KiB and 12KiB: it carries the gates that apply to
+#: every task regardless of subject while cutting ~19.7k billed tokens from a
+#: fresh session. Raising it buys progressively less, since material further
+#: in is increasingly subject-specific — exactly what an index serves well.
 GUIDANCE_HEAD_BYTES = 8 * 1024
+
+#: Deepest heading level the index lists. H3 is a real tuning knob rather than
+#: an arbitrary depth: on this repository's own AGENTS.md it is the difference
+#: between 11 rows and 33, and the H3s are where the individually actionable
+#: rules live ("Never symlink one", "Read the committed ref"). Going deeper
+#: costs index size for headings too fine-grained to be worth a separate read.
+INDEX_MAX_HEADING_LEVEL = 3
 
 #: Ceiling on the streaming scan that builds the section index. The scan
 #: keeps only headings (a few hundred bytes) in memory, so this bounds I/O
@@ -124,12 +154,12 @@ def _read_bounded(path: Path) -> tuple[bytes, bool]:
 
     ``Path.is_symlink`` followed by ``open`` has a swap window. ``O_NOFOLLOW``
     makes the kernel enforce the trust boundary at the actual read, while the
-    ``MAX_FILE_BYTES + 1`` probe determines truncation without ingesting the
+    ``MAX_DIGEST_BYTES + 1`` probe determines truncation without ingesting the
     rest of an attacker-controlled file.
     """
     with _open_nofollow(path) as stream:
-        probe = stream.read(MAX_FILE_BYTES + 1)
-    return probe[:MAX_FILE_BYTES], len(probe) > MAX_FILE_BYTES
+        probe = stream.read(MAX_DIGEST_BYTES + 1)
+    return probe[:MAX_DIGEST_BYTES], len(probe) > MAX_DIGEST_BYTES
 
 
 class _Section:
@@ -152,40 +182,72 @@ class _Section:
         return f"_Section(L{self.start}-{self.end}, {'#' * self.level} {self.title})"
 
 
-def _scan_sections(path: Path, max_level: int = 3) -> tuple[list[_Section], int, bool]:
-    """Headings, total line count, and whether the scan hit its ceiling.
+def _split_lines_like_read(data: bytes) -> list[str]:
+    """Split exactly as the ``read`` tool does, because it is the consumer.
 
-    Streams the file line by line: the index must describe a file far larger
-    than the prompt can hold, so nothing but the headings is retained. Fenced
-    code blocks are tracked because ``#`` starts a comment in most of the
-    shell snippets these files carry, and a comment indexed as a section
-    sends a later ``read`` to the wrong range.
+    THE INDEX'S LINE NUMBERS ARE A CONTRACT WITH ``read``. That tool decodes
+    UTF-8 and calls ``str.splitlines()`` (``tools/builtin.py``
+    ``_decode_text_lines``), then slices ``lines[start - 1 : end]``. Counting
+    on ``\\n`` alone instead would disagree on SIX further separators that
+    ``splitlines`` also breaks on -- ``\\v``, ``\\f``, ``\\x1c``-``\\x1e``,
+    NEL, LS (U+2028) and PS (U+2029) -- and every occurrence before a heading
+    shifts that heading's number by one, compounding down the file.
+
+    That failure is silent and confident: the model lands on a plausible but
+    WRONG range and follows the wrong rule, which is worse than finding
+    nothing. A form feed or NEL pasted in from a table or a word processor is
+    not exotic. So the split is not merely "similar" to read's, it is the
+    same call on the same bytes; ``test_line_numbering_matches_the_read_tool``
+    pins the two together so a change to either side breaks loudly.
+    """
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        text = data.decode("utf-8", errors="replace")
+    return text.splitlines()
+
+
+def _scan_sections(
+    path: Path, max_level: int = INDEX_MAX_HEADING_LEVEL
+) -> tuple[list[_Section], int, bool, bool]:
+    """Headings, total line count, whether the scan hit its ceiling, and
+    whether a code fence was left open at EOF.
+
+    Reads the file in bounded chunks and splits with :func:`_split_lines_like_read`
+    so the emitted ranges resolve under ``read``. Only headings are retained,
+    because the index must describe a file far larger than the prompt can
+    hold. Fenced code blocks are tracked because ``#`` starts a comment in
+    most of the shell snippets these files carry, and a comment indexed as a
+    section sends a later ``read`` to the wrong range.
     """
     sections: list[_Section] = []
     total_lines = 0
-    scanned = 0
     truncated_scan = False
     fence: str | None = None
 
     with _open_nofollow(path) as stream:
-        for raw in stream:
-            scanned += len(raw)
-            if scanned > MAX_SCAN_BYTES:
-                truncated_scan = True
-                break
-            total_lines += 1
-            line = raw.decode("utf-8", errors="replace").rstrip("\n")
+        raw_bytes = stream.read(MAX_SCAN_BYTES + 1)
+    if len(raw_bytes) > MAX_SCAN_BYTES:
+        truncated_scan = True
+        raw_bytes = raw_bytes[:MAX_SCAN_BYTES]
+
+    def collect(track_fences: bool) -> list[_Section]:
+        """One pass. ``track_fences=False`` is the recovery pass below."""
+        found: list[_Section] = []
+        nonlocal fence
+        fence = None
+        for number, line in enumerate(lines, 1):
             stripped = line.lstrip()
             # ``` or ~~~ toggles; the closing fence must match the opener so a
             # ```python block containing ``` in prose does not end it early.
-            if stripped.startswith("```") or stripped.startswith("~~~"):
+            if track_fences and (stripped.startswith("```") or stripped.startswith("~~~")):
                 marker = stripped[:3]
                 if fence is None:
                     fence = marker
                 elif fence == marker:
                     fence = None
                 continue
-            if fence is not None or not line.startswith("#"):
+            if (track_fences and fence is not None) or not line.startswith("#"):
                 continue
             level = len(line) - len(line.lstrip("#"))
             if level > max_level or not line[level:].startswith(" "):
@@ -193,7 +255,26 @@ def _scan_sections(path: Path, max_level: int = 3) -> tuple[list[_Section], int,
             title = line[level:].strip()
             if not title:
                 continue
-            sections.append(_Section(level, title, total_lines))
+            found.append(_Section(level, title, number))
+        return found
+
+    lines = _split_lines_like_read(raw_bytes)
+    total_lines = len(lines)
+    sections = collect(track_fences=True)
+    unterminated_fence = fence is not None
+
+    # A fence still open at EOF is far more often a formatting slip -- a
+    # snippet whose closing ``` was forgotten -- than a genuine multi-KB code
+    # block running to the end of a rules file. Believing it swallows every
+    # heading after the slip and strands that whole tail unnamed, which is the
+    # silent-loss failure this module exists to prevent. So when the file ends
+    # mid-fence AND that cost us headings, re-scan ignoring fences: a spurious
+    # row pointing at a shell comment is a far cheaper error than an
+    # unreachable half of the operator's rules.
+    if unterminated_fence:
+        recovered = collect(track_fences=False)
+        if len(recovered) > len(sections):
+            sections = recovered
 
     # A section's span ends where the next same-or-higher heading begins.
     for index, section in enumerate(sections):
@@ -203,10 +284,10 @@ def _scan_sections(path: Path, max_level: int = 3) -> tuple[list[_Section], int,
                 end = later.start - 1
                 break
         section.end = end
-    return sections, total_lines, truncated_scan
+    return sections, total_lines, truncated_scan, unterminated_fence
 
 
-def _open_nofollow(path: Path):
+def _open_nofollow(path: Path) -> BinaryIO:
     """``open`` that the kernel refuses to point at a symlink."""
     if path.is_symlink():
         raise OSError(f"refusing symlinked guidance: {path}")
@@ -252,6 +333,11 @@ def discover_context_files(cwd: str | Path) -> list[Path]:
                 digest_state = hashlib.sha256()
                 digest_state.update(bounded)
                 digest_state.update(b"\x01" if truncated else b"\x00")
+                # Length is folded in because only the first MAX_DIGEST_BYTES
+                # are hashed: without it, two oversized files sharing a 64KiB
+                # prefix but differing in length dedup to one, and the survivor
+                # would carry an index describing the wrong file.
+                digest_state.update(str(found_here.stat().st_size).encode())
                 digest = digest_state.hexdigest()
             except OSError:
                 digest = None  # unreadable/link/non-regular: never inject
@@ -281,27 +367,74 @@ def _read_head(path: Path) -> tuple[str, int, bool]:
         probe = stream.read(GUIDANCE_HEAD_BYTES + 1)
     if len(probe) <= GUIDANCE_HEAD_BYTES:
         text = probe.decode("utf-8", errors="replace")
-        return text, text.count("\n") + (0 if text.endswith("\n") or not text else 1), False
+        return text, len(_split_lines_like_read(probe)), False
     head = probe[:GUIDANCE_HEAD_BYTES]
+    # ``cut > 0``, not ``>= 0``: a file whose FIRST byte is a newline has its
+    # only boundary at 0, and cutting there would empty the head entirely. In
+    # that case the raw byte cut is the lesser evil, and the head is one
+    # partial line -- which is why the count below is taken from the text that
+    # actually ships rather than assumed to be whole lines.
     cut = head.rfind(b"\n")
     if cut > 0:
         head = head[:cut]
     text = head.decode("utf-8", errors="replace")
-    return text, text.count("\n") + 1, True
+    # Counted with read's own splitter so head_lines and the index's numbering
+    # come from one basis; see _split_lines_like_read.
+    return text, len(_split_lines_like_read(head)), True
+
+
+def _render_bare_pointer(shown: str, head_lines: int, total_lines: int | None) -> str:
+    """Disclosure for an oversized file that yielded no listable sections.
+
+    The floor this module must never fall below: the reader learns the file
+    continues, where it is, and what to read. Without a section list the range
+    is simply everything after the head.
+    """
+    if total_lines is not None and total_lines > head_lines:
+        where = (
+            f"`{shown}` ({total_lines} lines); the part not shown is "
+            f"L{head_lines + 1}-{total_lines}"
+        )
+    else:
+        where = f"`{shown}`; the part not shown begins at L{head_lines + 1}"
+    return (
+        f"\nThe rest of this file is NOT included above. It has no further "
+        f"headings to index, so it cannot be listed by section. It is on disk "
+        f"at {where}.\n\n"
+        f"Before acting or answering on anything this file governs, you MUST "
+        f"`read` that range \u2014 even when you believe you already know the "
+        f"answer, and even when the part shown above seems to cover it. "
+        f"Unlisted does not mean unimportant: this project's specific gates "
+        f"and landmines may be stated only in the part you have not read."
+    )
 
 
 def _render_index(path: Path, shown: str, head_lines: int) -> str:
-    """The section index that makes the non-resident remainder reachable."""
+    """The section index that makes the non-resident remainder reachable.
+
+    NEVER returns ``""`` for a file that has more content than the head. The
+    caller appends whatever this returns, so an empty string there would ship
+    a bare head with no path, no line count and no hint that the file
+    continues -- content silently dropped AND unnamed, which is the exact
+    failure this module exists to invert, and strictly worse than the byte cut
+    it replaced (that at least said "truncated"). When there is nothing to
+    list, this degrades to a bare pointer rather than to silence.
+    """
     try:
-        sections, total_lines, scan_truncated = _scan_sections(path)
+        sections, total_lines, scan_truncated, unterminated = _scan_sections(path)
     except OSError:
-        return ""
+        # The head still shipped, so say the file continues even though its
+        # shape is unknown; total_lines is unavailable, hence the bare form.
+        return _render_bare_pointer(shown, head_lines, None)
     # Level 1 is the document's title, not a section: it spans the whole file,
     # so an index row for it says nothing the path and line count do not. Its
     # span is still scanned, because an H2's range must end at the next H1 too.
     remaining = [s for s in sections if s.end > head_lines and s.level >= 2]
     if not remaining:
-        return ""
+        # H1-only files, heading-free files, and files whose every heading sits
+        # inside the head all land here. Nothing to index, but the tail is
+        # still real and must stay reachable.
+        return _render_bare_pointer(shown, head_lines, total_lines)
     rows = []
     for section in remaining:
         # A section that STARTS inside the head is still listed: the model saw
@@ -316,6 +449,25 @@ def _render_index(path: Path, shown: str, head_lines: int) -> str:
         if scan_truncated
         else ""
     )
+    # Belt and braces against the silent-loss class generally: if the listed
+    # rows do not actually reach the end of the file, say so with the range
+    # that does. A row set can be non-empty and still leave a tail unlisted
+    # (e.g. every heading sits inside the head, or the scan stopped early), and
+    # an unreachable tail is the one outcome this module must never produce.
+    covered_to = max(section.end for section in remaining)
+    if covered_to < total_lines:
+        note += (
+            f"\n(L{covered_to + 1}-{total_lines} is not under any listed "
+            f"heading; read it directly)"
+        )
+    if unterminated:
+        # Disclosed rather than silently absorbed: the reader should know the
+        # index was built through a formatting slip, so a surprising-looking
+        # row is explainable rather than mistaken for a real section.
+        note += (
+            "\n(this file ends inside an unclosed code fence; headings after "
+            "it were indexed anyway so the tail stays reachable)"
+        )
     # The imperative is deliberately as strong as the one <guides> carries,
     # and for the same reason: a section the model believes it already knows
     # is exactly the section whose local amendment it is about to violate.

--- a/local_operator/context_files.py
+++ b/local_operator/context_files.py
@@ -73,6 +73,21 @@ turn — strictly worse than a one-time re-cache when the file changes.
 The whole feature can be switched off with ``LOCAL_OPERATOR_CONTEXT_FILES=0``
 when a directory's guidance files should not be trusted or the context budget
 matters more than the conventions.
+
+Measuring this block: two traps that produce plausible wrong numbers
+---------------------------------------------------------------------
+
+Both were hit by real measurement passes on this module, and both fail
+silently with a believable figure rather than an error.
+
+1. ``create_session()`` returns with block 0 UNRENDERED -- the system-blocks
+   provider builds it lazily. Reading ``_context.system_blocks`` straight
+   after boot reports ``block0_chars = 0`` and understates this block's cost
+   as nothing. Await the provider first (the call ``build_initial_blocks``
+   makes), then read ``context_breakdown()``.
+2. A guidance file differs between git refs, so rendering "the repo's
+   AGENTS.md" under two code versions measures two different inputs. Copy one
+   md5-verified file into a fixture directory and render THAT under both.
 """
 
 from __future__ import annotations
@@ -268,9 +283,17 @@ def _scan_sections(
     # block running to the end of a rules file. Believing it swallows every
     # heading after the slip and strands that whole tail unnamed, which is the
     # silent-loss failure this module exists to prevent. So when the file ends
-    # mid-fence AND that cost us headings, re-scan ignoring fences: a spurious
-    # row pointing at a shell comment is a far cheaper error than an
-    # unreachable half of the operator's rules.
+    # mid-fence AND that cost us headings, re-scan ignoring fences.
+    #
+    # The price is paid in LABELLING, not in reachability, and it is worse than
+    # just "a spurious row": a `## ...` line inside the unclosed block becomes a
+    # row, which also TRUNCATES the preceding real section's range at that
+    # point. A reader following the real section's offered range can get a
+    # fraction of it and miss the rest of the rule. No content becomes
+    # unreachable -- the spurious row's own range covers the remainder, and the
+    # rescan is disclosed in the index -- so this is mislabelling rather than
+    # loss, and mislabelling a range is strictly better than stranding the
+    # whole tail with no range at all.
     if unterminated_fence:
         recovered = collect(track_fences=False)
         if len(recovered) > len(sections):
@@ -383,14 +406,35 @@ def _read_head(path: Path) -> tuple[str, int, bool]:
     return text, len(_split_lines_like_read(head)), True
 
 
-def _render_bare_pointer(shown: str, head_lines: int, total_lines: int | None) -> str:
+def _render_bare_pointer(
+    shown: str,
+    head_lines: int,
+    total_lines: int | None,
+    scan_truncated: bool = False,
+) -> str:
     """Disclosure for an oversized file that yielded no listable sections.
 
     The floor this module must never fall below: the reader learns the file
     continues, where it is, and what to read. Without a section list the range
     is simply everything after the head.
+
+    ``scan_truncated`` is NOT optional information. ``total_lines`` is counted
+    over the bytes the scan actually read, so when the scan stopped at
+    :data:`MAX_SCAN_BYTES` that count is a FLOOR, not the file's length.
+    Presenting it as the length states a confident wrong number and caps the
+    offered range short of EOF -- silent loss plus a plausible-looking figure,
+    which is both failure classes this module exists to prevent, reappearing
+    in the branch added to close the first one. So a clipped count is always
+    labelled as a floor and the range is left open-ended.
     """
-    if total_lines is not None and total_lines > head_lines:
+    if total_lines is not None and scan_truncated:
+        where = (
+            f"`{shown}` (MORE than {total_lines} lines: the index scan stopped "
+            f"at {MAX_SCAN_BYTES // 1024}KiB, so that count is a floor, not the "
+            f"file's length); the part not shown runs from L{head_lines + 1} to "
+            f"the END of the file"
+        )
+    elif total_lines is not None and total_lines > head_lines:
         where = (
             f"`{shown}` ({total_lines} lines); the part not shown is "
             f"L{head_lines + 1}-{total_lines}"
@@ -426,21 +470,54 @@ def _render_index(path: Path, shown: str, head_lines: int) -> str:
         # The head still shipped, so say the file continues even though its
         # shape is unknown; total_lines is unavailable, hence the bare form.
         return _render_bare_pointer(shown, head_lines, None)
-    # Level 1 is the document's title, not a section: it spans the whole file,
-    # so an index row for it says nothing the path and line count do not. Its
-    # span is still scanned, because an H2's range must end at the next H1 too.
-    remaining = [s for s in sections if s.end > head_lines and s.level >= 2]
+    # A SINGLE level-1 heading is the document's title: it spans the whole
+    # file, so a row for it says nothing the path and line count do not, and
+    # listing it would just restate the bare pointer less precisely. But a file
+    # with SEVERAL H1s is sectioning with them rather than titling with them (a
+    # legitimate style -- "# Alpha" / "# Beta rules" / "# Gamma"), and there
+    # the H1s are the only structure the reader has. Excluding them
+    # unconditionally handed those files one undifferentiated range covering
+    # hundreds of lines while the module held the section names all along.
+    # Their spans are scanned either way, because an H2's range must end at the
+    # next H1 too.
+    titles_only = sum(1 for s in sections if s.level == 1) < 2
+    floor = 2 if titles_only else 1
+    remaining = [s for s in sections if s.end > head_lines and s.level >= floor]
     if not remaining:
         # H1-only files, heading-free files, and files whose every heading sits
         # inside the head all land here. Nothing to index, but the tail is
         # still real and must stay reachable.
-        return _render_bare_pointer(shown, head_lines, total_lines)
+        return _render_bare_pointer(shown, head_lines, total_lines, scan_truncated)
+    return _render_index_rows(
+        shown, head_lines, remaining, total_lines, scan_truncated, unterminated, floor
+    )
+
+
+def _render_index_rows(
+    shown: str,
+    head_lines: int,
+    sections: list[_Section],
+    total_lines: int,
+    scan_truncated: bool,
+    unterminated: bool,
+    floor: int = 2,
+) -> str:
+    """Format listable sections as the index block.
+
+    Split from :func:`_render_index` so the disclosure branches below can be
+    driven directly. The unlisted-tail guard in particular is unreachable
+    through a file fixture -- the last section always spans to EOF -- so
+    testing it through discovery would leave it unexecuted and therefore a
+    decoration rather than a guard.
+    """
     rows = []
-    for section in remaining:
+    for section in sections:
         # A section that STARTS inside the head is still listed: the model saw
         # its opening and not its rest, so the range offered is the remainder.
         start = max(section.start, head_lines + 1)
-        indent = "  " * (section.level - 2)
+        # Indent relative to the shallowest level actually listed, so the tree
+        # reads the same whether the file sections with H1 or with H2.
+        indent = "  " * (section.level - floor)
         rows.append(f"{indent}- L{start}-{section.end}: {section.title}")
     listing = "\n".join(rows)
     note = (
@@ -454,7 +531,7 @@ def _render_index(path: Path, shown: str, head_lines: int) -> str:
     # that does. A row set can be non-empty and still leave a tail unlisted
     # (e.g. every heading sits inside the head, or the scan stopped early), and
     # an unreachable tail is the one outcome this module must never produce.
-    covered_to = max(section.end for section in remaining)
+    covered_to = max(section.end for section in sections)
     if covered_to < total_lines:
         note += (
             f"\n(L{covered_to + 1}-{total_lines} is not under any listed "

--- a/local_operator/context_files.py
+++ b/local_operator/context_files.py
@@ -30,6 +30,38 @@ read most prominently. Precedence is stated in the wrapper: repo guidance
 describes the project's defaults; a direct instruction in the conversation
 still wins, as it does over every standing instruction.
 
+Large files ship as HEAD + SECTION INDEX, not as a byte-truncated dump
+--------------------------------------------------------------------
+
+A guidance file up to :data:`GUIDANCE_HEAD_BYTES` ships whole, unchanged. A
+file larger than that ships as its first ``GUIDANCE_HEAD_BYTES`` (cut on a
+LINE boundary) followed by a generated index of every remaining section with
+its line range, plus an imperative to read that range before acting on its
+subject.
+
+This is a CORRECTNESS FIX before it is a token saving. The previous contract
+kept the first 64KiB of each file and appended a one-line "truncated" note.
+For this repository's own AGENTS.md — 93,355 bytes, 11 top-level sections —
+that silently dropped FIVE whole sections from every session, chosen by byte
+offset rather than by meaning: the timing/flake rules, the TUI widget
+conventions, "Adding a configuration key", the analytics section and the
+tool-surface footprint ladder. A rule past the cut was not merely absent, it
+was *unfindable*: nothing in the prompt said it existed, so the model could
+not know to go looking. The head/index form inverts that — every section is
+named and addressable even though only the head is resident.
+
+The pattern is deliberately the one the harness already ships for its own
+procedures: ``<guides>`` lists guides "by name and description only — the
+body loads on demand" and instructs the model that it MUST read the body
+before acting. That works in practice, and it needs NO new resolver here: a
+guidance file is a real path on disk and the ``read`` tool already takes a
+path and a line range, so the index emits exactly what ``read`` consumes.
+
+Why the head stays in this block rather than moving to a later, cheaper one:
+this block is part of the cached prefix. Blocks after it are deliberately
+kept breakpoint-free, so anything moved there is re-sent UNCACHED on every
+turn — strictly worse than a one-time re-cache when the file changes.
+
 The whole feature can be switched off with ``LOCAL_OPERATOR_CONTEXT_FILES=0``
 when a directory's guidance files should not be trusted or the context budget
 matters more than the conventions.
@@ -47,10 +79,41 @@ from pathlib import Path
 #: start-context budget (the 30k contract in docs/REWRITE.md).
 MAX_CONTEXT_FILES = 5
 
-#: Per-file byte cap. A guidance file is instructions, not documentation;
-#: past this the file is read on demand (it is on disk and grep-able) instead
-#: of occupying every turn's cached prefix.
+#: Per-file ingest cap for the *resident* text and for the discovery digest.
+#: A guidance file is instructions, not documentation; past this the file is
+#: read on demand (it is on disk and grep-able) instead of occupying every
+#: turn's cached prefix.
 MAX_FILE_BYTES = 64 * 1024
+
+#: How much of an oversized guidance file stays resident in the prompt.
+#:
+#: The trade-off is adherence against cost, and it is asymmetric. Rules the
+#: agent breaks *without knowing it should have looked something up* — a
+#: release gate, a review gate, "never symlink a venv", "read the committed
+#: ref, not the working tree" — only work when they are resident; a head too
+#: small silently converts those into rules nobody consults. Reference
+#: material (timing analysis, widget conventions, subsystem internals) is safe
+#: to leave lazy: the agent knows it is about to edit a widget, so an index
+#: entry is enough to send it to the file.
+#:
+#: 8KiB was chosen over 6KiB and 12KiB against this repository's own 93KiB
+#: AGENTS.md: it carries the environment/test/lint gates that apply to every
+#: task regardless of subject, while cutting ~20.7k tokens from a fresh
+#: session. Raising it buys progressively less — the material past 8KiB is
+#: increasingly subject-specific, which is exactly the material an index
+#: serves well. Lowering it starts evicting unconditional gates.
+#:
+#: NOTE this is a byte offset into the file as the operator wrote it. It is
+#: NOT a claim that the first 8KiB of an arbitrary AGENTS.md are its most
+#: important bytes — that is a property of how the file is ordered, which is
+#: the file owner's business and not something this module edits or reorders.
+GUIDANCE_HEAD_BYTES = 8 * 1024
+
+#: Ceiling on the streaming scan that builds the section index. The scan
+#: keeps only headings (a few hundred bytes) in memory, so this bounds I/O
+#: rather than allocation, but a guidance file is not a corpus: past this the
+#: index simply stops and says so.
+MAX_SCAN_BYTES = 2 * 1024 * 1024
 
 #: Filenames considered, in priority order per directory.
 CANDIDATE_NAMES = ("AGENTS.md", "CLAUDE.md")
@@ -64,21 +127,95 @@ def _read_bounded(path: Path) -> tuple[bytes, bool]:
     ``MAX_FILE_BYTES + 1`` probe determines truncation without ingesting the
     rest of an attacker-controlled file.
     """
+    with _open_nofollow(path) as stream:
+        probe = stream.read(MAX_FILE_BYTES + 1)
+    return probe[:MAX_FILE_BYTES], len(probe) > MAX_FILE_BYTES
+
+
+class _Section:
+    """One markdown heading and the line span it owns.
+
+    ``end`` is inclusive and is the line before the next heading of the same
+    or higher level, so a section's span is exactly what ``read`` should be
+    given to see that section and nothing else.
+    """
+
+    __slots__ = ("level", "title", "start", "end")
+
+    def __init__(self, level: int, title: str, start: int) -> None:
+        self.level = level
+        self.title = title
+        self.start = start
+        self.end = start
+
+    def __repr__(self) -> str:  # pragma: no cover - diagnostics only
+        return f"_Section(L{self.start}-{self.end}, {'#' * self.level} {self.title})"
+
+
+def _scan_sections(path: Path, max_level: int = 3) -> tuple[list[_Section], int, bool]:
+    """Headings, total line count, and whether the scan hit its ceiling.
+
+    Streams the file line by line: the index must describe a file far larger
+    than the prompt can hold, so nothing but the headings is retained. Fenced
+    code blocks are tracked because ``#`` starts a comment in most of the
+    shell snippets these files carry, and a comment indexed as a section
+    sends a later ``read`` to the wrong range.
+    """
+    sections: list[_Section] = []
+    total_lines = 0
+    scanned = 0
+    truncated_scan = False
+    fence: str | None = None
+
+    with _open_nofollow(path) as stream:
+        for raw in stream:
+            scanned += len(raw)
+            if scanned > MAX_SCAN_BYTES:
+                truncated_scan = True
+                break
+            total_lines += 1
+            line = raw.decode("utf-8", errors="replace").rstrip("\n")
+            stripped = line.lstrip()
+            # ``` or ~~~ toggles; the closing fence must match the opener so a
+            # ```python block containing ``` in prose does not end it early.
+            if stripped.startswith("```") or stripped.startswith("~~~"):
+                marker = stripped[:3]
+                if fence is None:
+                    fence = marker
+                elif fence == marker:
+                    fence = None
+                continue
+            if fence is not None or not line.startswith("#"):
+                continue
+            level = len(line) - len(line.lstrip("#"))
+            if level > max_level or not line[level:].startswith(" "):
+                continue
+            title = line[level:].strip()
+            if not title:
+                continue
+            sections.append(_Section(level, title, total_lines))
+
+    # A section's span ends where the next same-or-higher heading begins.
+    for index, section in enumerate(sections):
+        end = total_lines
+        for later in sections[index + 1 :]:
+            if later.level <= section.level:
+                end = later.start - 1
+                break
+        section.end = end
+    return sections, total_lines, truncated_scan
+
+
+def _open_nofollow(path: Path):
+    """``open`` that the kernel refuses to point at a symlink."""
     if path.is_symlink():
         raise OSError(f"refusing symlinked guidance: {path}")
-    flags = os.O_RDONLY
-    nofollow = getattr(os, "O_NOFOLLOW", 0)
-    if nofollow:
-        flags |= nofollow
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
     descriptor = os.open(path, flags)
-    try:
-        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
-            raise OSError(f"not a regular file: {path}")
-        with os.fdopen(descriptor, "rb", closefd=False) as stream:
-            probe = stream.read(MAX_FILE_BYTES + 1)
-    finally:
+    if not stat.S_ISREG(os.fstat(descriptor).st_mode):
         os.close(descriptor)
-    return probe[:MAX_FILE_BYTES], len(probe) > MAX_FILE_BYTES
+        raise OSError(f"not a regular file: {path}")
+    return os.fdopen(descriptor, "rb")
 
 
 def _git_root(start: Path) -> Path | None:
@@ -131,25 +268,96 @@ def discover_context_files(cwd: str | Path) -> list[Path]:
     return found
 
 
+def _read_head(path: Path) -> tuple[str, int, bool]:
+    """Leading text cut on a LINE boundary, its line count, and whether more
+    of the file remains.
+
+    Cutting on a line boundary rather than at the raw byte offset is the point:
+    the previous contract sliced mid-sentence (and mid-word), so the last thing
+    the model read was a fragment it could neither act on nor recognise as
+    incomplete.
+    """
+    with _open_nofollow(path) as stream:
+        probe = stream.read(GUIDANCE_HEAD_BYTES + 1)
+    if len(probe) <= GUIDANCE_HEAD_BYTES:
+        text = probe.decode("utf-8", errors="replace")
+        return text, text.count("\n") + (0 if text.endswith("\n") or not text else 1), False
+    head = probe[:GUIDANCE_HEAD_BYTES]
+    cut = head.rfind(b"\n")
+    if cut > 0:
+        head = head[:cut]
+    text = head.decode("utf-8", errors="replace")
+    return text, text.count("\n") + 1, True
+
+
+def _render_index(path: Path, shown: str, head_lines: int) -> str:
+    """The section index that makes the non-resident remainder reachable."""
+    try:
+        sections, total_lines, scan_truncated = _scan_sections(path)
+    except OSError:
+        return ""
+    # Level 1 is the document's title, not a section: it spans the whole file,
+    # so an index row for it says nothing the path and line count do not. Its
+    # span is still scanned, because an H2's range must end at the next H1 too.
+    remaining = [s for s in sections if s.end > head_lines and s.level >= 2]
+    if not remaining:
+        return ""
+    rows = []
+    for section in remaining:
+        # A section that STARTS inside the head is still listed: the model saw
+        # its opening and not its rest, so the range offered is the remainder.
+        start = max(section.start, head_lines + 1)
+        indent = "  " * (section.level - 2)
+        rows.append(f"{indent}- L{start}-{section.end}: {section.title}")
+    listing = "\n".join(rows)
+    note = (
+        f"\n(index scan stopped at {MAX_SCAN_BYTES // 1024}KiB; later sections "
+        "are not listed \u2014 read the file directly)"
+        if scan_truncated
+        else ""
+    )
+    # The imperative is deliberately as strong as the one <guides> carries,
+    # and for the same reason: a section the model believes it already knows
+    # is exactly the section whose local amendment it is about to violate.
+    return (
+        f"\nThe rest of this file is NOT included above. It is on disk at "
+        f"`{shown}` ({total_lines} lines); these are its remaining sections "
+        f"with the line ranges to read:\n\n"
+        f"{listing}{note}\n\n"
+        f"When a task touches any subject listed here, you MUST `read` that "
+        f"line range of `{shown}` BEFORE acting or answering \u2014 even when you "
+        f"believe you already know the answer, and even when the rules above "
+        f"seem to cover it. These sections state this project's specific "
+        f"gates, measured numbers and landmines; assuming the general case is "
+        f"how an agent confidently does the wrong thing here."
+    )
+
+
 def render_context_files(files: list[Path], cwd: str | Path) -> str:
-    """The ``<repo-guidance>`` block for the system prompt head."""
+    """The ``<repo-guidance>`` block for the system prompt head.
+
+    A file within :data:`GUIDANCE_HEAD_BYTES` ships whole with no index \u2014 a
+    2KB AGENTS.md needs no ceremony, and an index of sections the model can
+    already see is pure noise. Larger files ship head + index; see the module
+    docstring for why that beats the byte-truncated dump it replaces.
+    """
     if not files:
         return ""
     base = Path(cwd).resolve()
     parts: list[str] = []
     for path in files:
         try:
-            bounded, truncated = _read_bounded(path)
+            text, head_lines, has_more = _read_head(path)
         except OSError:
             continue
-        text = bounded.decode("utf-8", errors="replace")
-        if truncated:
-            text += "\n[...truncated at 64KiB; read the file for the rest]"
         try:
             shown = str(path.relative_to(base))
         except ValueError:
             shown = str(path)
-        parts.append(f'<file path="{shown}">\n{text.strip()}\n</file>')
+        body = text.strip()
+        if has_more:
+            body += "\n" + _render_index(path, shown, head_lines)
+        parts.append(f'<file path="{shown}">\n{body}\n</file>')
     if not parts:
         return ""
     return (

--- a/local_operator/context_files.py
+++ b/local_operator/context_files.py
@@ -505,10 +505,18 @@ def _render_index_rows(
     """Format listable sections as the index block.
 
     Split from :func:`_render_index` so the disclosure branches below can be
-    driven directly. The unlisted-tail guard in particular is unreachable
-    through a file fixture -- the last section always spans to EOF -- so
-    testing it through discovery would leave it unexecuted and therefore a
-    decoration rather than a guard.
+    driven directly with synthetic sections, without having to construct a file
+    that produces each shape.
+
+    The unlisted-tail guard below IS reachable from real input, and the way it
+    is reached is worth naming because it is not obvious. A section's span ends
+    at the next same-or-higher heading or at EOF, so the last *scanned* section
+    always reaches EOF -- but the last *listed* one need not, because the H1
+    filter in :func:`_render_index` can drop it. A file with exactly ONE H1
+    that is not its first heading (H2 sections, then a trailing ``# ...``) has
+    ``titles_only`` true, so ``floor`` is 2 and that trailing H1 is excluded
+    from the listing while still owning every line to EOF. The rows then stop
+    short with no scan ceiling and no fence slip involved.
     """
     rows = []
     for section in sections:

--- a/tests/unit/test_context_files.py
+++ b/tests/unit/test_context_files.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from local_operator.context_files import (
+    _read_head,
     discover_context_files,
     load_repo_guidance,
     render_context_files,
@@ -130,18 +131,163 @@ def test_index_line_ranges_address_the_real_lines(tmp_path: Path) -> None:
 
     found = re.findall(r"- L(\d+)-(\d+): (.+)", rendered)
     assert found, "expected an index"
+
+    # The head boundary is computed, NOT sniffed from the span's first line.
+    # Guarding the identity assertion behind `if span[0].startswith("#")` makes
+    # the test self-disabling in exactly the failure it exists to catch: a
+    # start that drifts off its heading lands on body text, the guard goes
+    # false, and the assertion is skipped. A start+1 mutant passed the whole
+    # suite that way. Every row is now checked unconditionally, in the one of
+    # two modes its start determines.
+    _, head_lines, _ = _read_head(guidance)
+
+    straddling = 0
     for raw_start, raw_end, title in found:
         start, end = int(raw_start), int(raw_end)
         span = lines[start - 1 : end]
         assert span, f"empty span for {title}"
-        # A section wholly past the head is addressed from its own heading. A
-        # section straddling the cut is offered as its REMAINDER instead, so
-        # its range starts at body text rather than at the heading the model
-        # has already read.
-        if span[0].startswith("#"):
-            assert span[0].lstrip("#").strip() == title
+        if start == head_lines + 1:
+            # The straddling section: its heading is already resident, so the
+            # range offered is the REMAINDER and must NOT start on a heading.
+            # Pinning this stops the exemption from becoming a loophole.
+            straddling += 1
+            assert not span[0].startswith("#"), (
+                f"{title!r} was offered from the head boundary, so it should "
+                f"start at body text, not at {span[0]!r}"
+            )
+        else:
+            # Every other row must land exactly on its own heading line.
+            assert span[0].lstrip("#").strip() == title, (
+                f"index row {title!r} points at L{start} but read() sees " f"{span[0]!r} there"
+            )
         # Either way the span stops before the next same-or-higher heading.
         assert not any(line.startswith("## ") for line in span[1:])
+    assert straddling <= 1, "at most one section can straddle the head cut"
+
+
+@pytest.mark.parametrize(
+    "name,body",
+    [
+        # No heading of any level.
+        (
+            "no headings",
+            "\n".join(f"prose line {i}" for i in range(1200)) + "\nNEVER delete prod.\n",
+        ),
+        # Only H1s: the index lists H2/H3, so this yields no listable rows.
+        (
+            "only H1",
+            "# Alpha\n"
+            + "background prose here\n" * 400
+            + "\n# Beta rules\n"
+            + "detail line\n" * 400
+            + "\n# Gamma\nnever do X\n",
+        ),
+        # Every heading inside the head, prose continuing well past it.
+        ("headings only in head", "# Doc\n\n## Only\n\n" + "tail prose line\n" * 900),
+    ],
+)
+def test_oversized_file_never_renders_without_disclosure(
+    name: str, body: str, tmp_path: Path
+) -> None:
+    """The module's one invariant: content is never dropped silently.
+
+    Each shape here yields NO listable section, which used to make the index
+    render as "" and the caller emit a bare head — the tail gone AND unnamed,
+    with not even the file's path to find it by. ``main`` shipped these files
+    WHOLE, so that was a content regression as well as the exact
+    absent-and-invisible failure this module exists to invert.
+    """
+    from local_operator.context_files import GUIDANCE_HEAD_BYTES
+
+    repo = _make_repo(tmp_path)
+    assert len(body.encode()) > GUIDANCE_HEAD_BYTES, f"{name} fixture is not oversized"
+    (repo / "AGENTS.md").write_text(body)
+    rendered = load_repo_guidance(repo)
+
+    assert "NOT included above" in rendered, f"{name}: tail dropped with no disclosure"
+    assert "AGENTS.md" in rendered, f"{name}: no path to read"
+    assert re.search(r"L\d+", rendered), f"{name}: no line range to read"
+    assert "you MUST" in rendered, f"{name}: no imperative to read the rest"
+
+
+def test_unterminated_code_fence_still_indexes_the_tail(tmp_path: Path) -> None:
+    """A fence left open at EOF is a formatting slip, not a 60KB code block.
+
+    Believing it swallows every later heading and strands the tail unnamed.
+    The scan retries without fence tracking and discloses that it did so.
+    """
+    repo = _make_repo(tmp_path)
+    (repo / "AGENTS.md").write_text(
+        "# Team rules\n\n## Setup\n\n```sh\necho hi\n"
+        + "prose line here\n" * 700
+        + "\n## Deploy policy\n\nNEVER deploy to production on a Friday.\n"
+    )
+    rendered = load_repo_guidance(repo)
+
+    assert "Deploy policy" in rendered, "heading after an unclosed fence went unnamed"
+    assert "unclosed code fence" in rendered, "the recovery was not disclosed"
+
+
+@pytest.mark.parametrize(
+    "separator",
+    ["\u2028", "\u2029", "\x85", "\x0c", "\x0b", "\x1c", "\x1d", "\x1e"],
+)
+def test_line_numbering_matches_the_read_tool(separator: str, tmp_path: Path) -> None:
+    """The index's line numbers are a CONTRACT with the ``read`` tool.
+
+    ``read`` decodes and calls ``str.splitlines()``, which breaks on six
+    separators beyond ``\\n``. Counting on ``\\n`` alone drifts every later
+    range by one per occurrence, compounding down the file — and the model
+    then lands on a plausible WRONG range and follows the wrong rule, which is
+    worse than finding nothing. This pins both sides to one splitter, so a
+    change to either breaks loudly instead of drifting.
+    """
+    from local_operator.tools.builtin import _decode_text_lines
+
+    repo = _make_repo(tmp_path)
+    guidance = repo / "AGENTS.md"
+    guidance.write_text(
+        "# Doc\n\n## Head\n\n"
+        + f"prose line with{separator}a separator in it\n" * 400
+        + "\n## Late section\n\nTHE RULE.\n"
+    )
+    rendered = load_repo_guidance(repo)
+
+    # Resolve the emitted range through the REAL consumer, not a local split.
+    _, lines = _decode_text_lines(guidance.read_bytes())
+    match = re.search(r"- L(\d+)-(\d+): Late section", rendered)
+    assert match, f"late section not indexed with separator {separator!r}"
+    start, end = int(match.group(1)), int(match.group(2))
+    assert lines[start - 1] == "## Late section", (
+        f"separator {separator!r}: index says L{start}, read() sees " f"{lines[start - 1]!r}"
+    )
+    assert any("THE RULE." in line for line in lines[start - 1 : end])
+
+
+def test_every_index_range_round_trips_through_the_real_read_path(tmp_path: Path) -> None:
+    """The PR's thesis, mechanically: if the pointer is followed, does it land?
+
+    Whether a model *chooses* to follow the pointer is not testable here. That
+    it resolves correctly when followed is, and it is the half that silently
+    broke — so it is asserted against ``read``'s own splitter rather than a
+    reimplementation of it.
+    """
+    from local_operator.tools.builtin import _decode_text_lines
+
+    repo = _make_repo(tmp_path)
+    guidance = repo / "AGENTS.md"
+    guidance.write_text(_oversized(tail_sections=6))
+    rendered = load_repo_guidance(repo)
+
+    _, lines = _decode_text_lines(guidance.read_bytes())
+    _, head_lines, _ = _read_head(guidance)
+    rows = re.findall(r"- L(\d+)-(\d+): (.+)", rendered)
+    assert rows, "expected an index"
+    for raw_start, raw_end, title in rows:
+        start, end = int(raw_start), int(raw_end)
+        assert 1 <= start <= end <= len(lines), f"{title}: range outside the file"
+        if start != head_lines + 1:
+            assert lines[start - 1].lstrip("#").strip() == title
 
 
 def test_file_within_head_size_ships_whole_without_ceremony(tmp_path: Path) -> None:
@@ -233,9 +379,14 @@ def test_guidance_cap_bounds_ingestion_before_hash_and_render(
     rendered = load_repo_guidance(repo)
 
     # One enormous line: nothing to cut on, so the head is the byte prefix and
-    # the render stays bounded regardless of how large the file is.
-    assert rendered.count("x") <= GUIDANCE_HEAD_BYTES
+    # the render stays bounded regardless of how large the file is. Counted on
+    # the run of file bytes rather than on every "x" in the render, since the
+    # disclosure prose legitimately contains the letter too.
+    longest_run = max(len(run) for run in re.findall(r"x+", rendered))
+    assert longest_run <= GUIDANCE_HEAD_BYTES
     assert len(rendered.encode()) < GUIDANCE_HEAD_BYTES + 2_000
+    # A heading-free oversized file must still say the tail exists.
+    assert "NOT included above" in rendered
 
 
 def test_scan_ceiling_is_disclosed_rather_than_silently_dropping_sections(

--- a/tests/unit/test_context_files.py
+++ b/tests/unit/test_context_files.py
@@ -478,12 +478,10 @@ def test_tail_beyond_the_last_listed_section_is_disclosed(tmp_path: Path) -> Non
     """Rows can be non-empty and still not reach EOF; that remainder is offered
     explicitly rather than left implied.
 
-    On real input the last listed section always spans to EOF (a section ends
-    at the next same-or-higher heading, else at the last line), so this is a
-    DEFENSIVE guard rather than a live path -- which is exactly why it is
-    asserted directly on the renderer instead of through a file fixture that
-    cannot reach it. Driving it via ``_render_index`` would leave the branch
-    unexecuted and the guard a decoration.
+    Driven directly on the renderer so the boundary itself is pinned with
+    arbitrary spans. The companion test below reaches the same branch through
+    ``load_repo_guidance`` on a real file, which is what proves the guard
+    protects a live path rather than a hypothetical one.
     """
     from local_operator.context_files import _render_index_rows, _Section
 
@@ -503,6 +501,36 @@ def test_tail_beyond_the_last_listed_section_is_disclosed(tmp_path: Path) -> Non
     assert re.search(r"- L\d+-\d+: Seen", rendered), "expected a listed section"
     assert "not under any listed heading" in rendered, "unlisted tail was not disclosed"
     assert "L401-900" in rendered, "the unlisted range itself must be offered"
+
+
+def test_a_single_late_h1_leaves_a_tail_that_must_be_disclosed(tmp_path: Path) -> None:
+    """The unlisted-tail guard on a REAL file, with no ceiling and no fence.
+
+    Exactly one H1 that is not the first heading makes ``titles_only`` true, so
+    ``floor`` is 2 and that trailing H1 is dropped from the listing -- while it
+    still owns every line to EOF. The listed rows therefore stop short, and the
+    lines the H1 covers would be unreachable if the guard did not fire.
+
+    This pins the reachability claim by execution: the guard was previously
+    documented as unreachable from a file fixture, which was wrong, because
+    that reasoning predated the H1 filter it interacts with.
+    """
+    repo = _make_repo(tmp_path)
+    (repo / "AGENTS.md").write_text(
+        "## Alpha\n\n" + "pad line here\n" * 800 + "\n# Late title\n\n" + "tail line\n" * 400
+    )
+    rendered = load_repo_guidance(repo)
+
+    match = re.search(r"\(L(\d+)-(\d+) is not under any listed heading", rendered)
+    assert match, "a tail outside every listed row was not disclosed"
+    # The disclosed range must start right after the last listed row and run to
+    # the end of the file, or the lines in between stay unreachable.
+    last_listed = max(int(end) for _, end in re.findall(r"- L(\d+)-(\d+):", rendered))
+    assert int(match.group(1)) == last_listed + 1
+    from local_operator.tools.builtin import _decode_text_lines
+
+    _, lines = _decode_text_lines((repo / "AGENTS.md").read_bytes())
+    assert int(match.group(2)) == len(lines)
 
 
 def test_files_sharing_a_digest_prefix_but_differing_in_length_are_kept_apart(

--- a/tests/unit/test_context_files.py
+++ b/tests/unit/test_context_files.py
@@ -210,6 +210,38 @@ def test_oversized_file_never_renders_without_disclosure(
     assert "you MUST" in rendered, f"{name}: no imperative to read the rest"
 
 
+def test_a_file_that_sections_with_h1_gets_those_sections_named(tmp_path: Path) -> None:
+    """Several H1s mean the file sections with them; one means it titles with it.
+
+    Excluding H1 unconditionally handed an H1-sectioned file a single
+    undifferentiated range covering hundreds of lines, while the scan already
+    held the section names. A lone H1 is still excluded: a row spanning the
+    whole file only restates the bare pointer.
+    """
+    repo = _make_repo(tmp_path)
+    (repo / "AGENTS.md").write_text(
+        "# Alpha\n"
+        + "background prose here\n" * 400
+        + "\n# Beta rules\n"
+        + "detail line\n" * 400
+        + "\n# Gamma\nnever do X\n"
+    )
+    rendered = load_repo_guidance(repo)
+
+    assert re.search(r"- L\d+-\d+: Beta rules", rendered)
+    assert re.search(r"- L\d+-\d+: Gamma", rendered)
+
+    # A single H1 (the title) plus H2 sections must be unaffected: the title
+    # spans the file, so listing it adds nothing.
+    other = _make_repo(tmp_path / "other")
+    (other / "AGENTS.md").write_text(
+        "# The Title\n\n## Head\n\n" + "padding prose line here\n" * 500 + "\n## Late\n\nrule\n"
+    )
+    rendered_titled = load_repo_guidance(other)
+    assert re.search(r"- L\d+-\d+: Late", rendered_titled)
+    assert not re.search(r"- L\d+-\d+: The Title", rendered_titled)
+
+
 def test_unterminated_code_fence_still_indexes_the_tail(tmp_path: Path) -> None:
     """A fence left open at EOF is a formatting slip, not a 60KB code block.
 
@@ -387,6 +419,180 @@ def test_guidance_cap_bounds_ingestion_before_hash_and_render(
     assert len(rendered.encode()) < GUIDANCE_HEAD_BYTES + 2_000
     # A heading-free oversized file must still say the tail exists.
     assert "NOT included above" in rendered
+
+
+def test_bare_pointer_discloses_the_scan_ceiling_instead_of_a_wrong_length(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A clipped line count must be labelled a floor, never stated as a length.
+
+    ``total_lines`` is counted over the bytes the scan read, so under the
+    ceiling it is short. Passing it to the bare pointer unqualified announced a
+    confident WRONG length and capped the offered range there -- silently
+    stranding everything past it, inside the very branch added to guarantee
+    nothing is stranded silently.
+    """
+    import local_operator.context_files as module
+
+    monkeypatch.setattr(module, "MAX_SCAN_BYTES", 9_000)
+    repo = _make_repo(tmp_path)
+    body = "\n".join(f"prose line {i}" for i in range(900))  # heading-free
+    (repo / "AGENTS.md").write_text(body)
+    rendered = load_repo_guidance(repo)
+
+    assert "NOT included above" in rendered
+    # No bare "(N lines)" claim: that number would be the ceiling's, not the
+    # file's, and the reader cannot tell the difference.
+    assert not re.search(r"\(\d+ lines\)", rendered), "clipped count stated as the length"
+    assert "floor" in rendered and "scan stopped" in rendered
+    # The range must not stop at the clipped count either.
+    assert "END of the file" in rendered
+    assert not re.search(rf"L\d+-{len(body.splitlines())}\b", rendered)
+
+
+def test_index_falls_back_to_a_pointer_when_the_scan_cannot_read_the_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The head can be read and the scan then fail (a race, or a permission
+    change between the two opens). That path is the blocker's own code path, so
+    it must still disclose rather than return an empty index."""
+    import local_operator.context_files as module
+
+    repo = _make_repo(tmp_path)
+    (repo / "AGENTS.md").write_text(_oversized())
+    real_scan = module._scan_sections
+
+    def fail_after_head(*args: object, **kwargs: object) -> object:
+        raise OSError("vanished between head and scan")
+
+    monkeypatch.setattr(module, "_scan_sections", fail_after_head)
+    rendered = load_repo_guidance(repo)
+    monkeypatch.setattr(module, "_scan_sections", real_scan)
+
+    assert "NOT included above" in rendered, "scan failure dropped the tail silently"
+    assert "AGENTS.md" in rendered
+    assert "you MUST" in rendered
+
+
+def test_tail_beyond_the_last_listed_section_is_disclosed(tmp_path: Path) -> None:
+    """Rows can be non-empty and still not reach EOF; that remainder is offered
+    explicitly rather than left implied.
+
+    On real input the last listed section always spans to EOF (a section ends
+    at the next same-or-higher heading, else at the last line), so this is a
+    DEFENSIVE guard rather than a live path -- which is exactly why it is
+    asserted directly on the renderer instead of through a file fixture that
+    cannot reach it. Driving it via ``_render_index`` would leave the branch
+    unexecuted and the guard a decoration.
+    """
+    from local_operator.context_files import _render_index_rows, _Section
+
+    # Sections that stop well short of the file's end.
+    sections = [_Section(2, "Early", 200), _Section(2, "Seen", 300)]
+    sections[0].end = 299
+    sections[1].end = 400
+    rendered = _render_index_rows(
+        "AGENTS.md",
+        head_lines=150,
+        sections=sections,
+        total_lines=900,
+        scan_truncated=False,
+        unterminated=False,
+    )
+
+    assert re.search(r"- L\d+-\d+: Seen", rendered), "expected a listed section"
+    assert "not under any listed heading" in rendered, "unlisted tail was not disclosed"
+    assert "L401-900" in rendered, "the unlisted range itself must be offered"
+
+
+def test_files_sharing_a_digest_prefix_but_differing_in_length_are_kept_apart(
+    tmp_path: Path,
+) -> None:
+    """Only the first MAX_DIGEST_BYTES are hashed, so length is folded in.
+
+    Without it, a nested repo whose two guidance files share a long prefix
+    dedups to one, and the survivor ships an index describing the OTHER file --
+    every range off by however much they differ.
+    """
+    from local_operator.context_files import MAX_DIGEST_BYTES
+
+    repo = _make_repo(tmp_path)
+    nested = repo / "pkg"
+    nested.mkdir()
+    shared = "# Shared\n\n" + "x" * (MAX_DIGEST_BYTES + 1000)
+    (repo / "AGENTS.md").write_text(shared)
+    (nested / "AGENTS.md").write_text(shared + "\n## Only in the deeper file\n\nrule\n")
+
+    assert len(discover_context_files(nested)) == 2, "same-prefix files collapsed"
+    # Identical files still dedup: the fold must not defeat that.
+    (nested / "AGENTS.md").write_text(shared)
+    assert len(discover_context_files(nested)) == 1
+
+
+def test_index_lists_h3_rows_not_only_top_level_sections(tmp_path: Path) -> None:
+    """INDEX_MAX_HEADING_LEVEL is a real knob: H3 is where the individually
+    actionable rules live, so lowering it to 2 would quietly coarsen every
+    index. Pinned as a property -- deeper rows exist and nest -- rather than as
+    a row count, which would break on any edit to the fixture."""
+    from local_operator.context_files import INDEX_MAX_HEADING_LEVEL
+
+    assert INDEX_MAX_HEADING_LEVEL >= 3
+    repo = _make_repo(tmp_path)
+    (repo / "AGENTS.md").write_text(
+        "# Doc\n\n## Head\n\n"
+        + "padding prose line here\n" * 500
+        + "\n## Gates\n\ntext\n\n### Never skip QA\n\nrule\n\n### Never force push\n\nrule\n"
+    )
+    rendered = load_repo_guidance(repo)
+
+    assert re.search(r"- L\d+-\d+: Gates", rendered)
+    assert re.search(r"  - L\d+-\d+: Never skip QA", rendered), "H3 rows missing or unindented"
+    assert "Never force push" in rendered
+
+
+def test_head_retains_the_start_of_the_file_that_adherence_depends_on(
+    tmp_path: Path,
+) -> None:
+    """The head size is load-bearing and nothing else pins it.
+
+    Halving GUIDANCE_HEAD_BYTES passed the whole suite, which would silently
+    evict the unconditional gates the constant's docstring reasons about -- the
+    same overstatement Q2 was raised about, arriving by a different route. This
+    pins the PROPERTY (an early-file gate is resident, and the head is a
+    meaningful fraction of the budget) rather than the literal number, so the
+    constant stays tunable but not quietly halvable.
+    """
+    from local_operator.context_files import GUIDANCE_HEAD_BYTES
+
+    repo = _make_repo(tmp_path)
+    marker = "NEVER merge without a green pipeline."
+    # The marker sits at a FIXED offset just under 8 KiB -- deliberately not
+    # derived from GUIDANCE_HEAD_BYTES, because a fixture that scales with the
+    # constant shrinks along with a mutant and pins nothing (8K->4K and 8K->6K
+    # both left the suite green that way). This asserts the shipped contract:
+    # roughly the first 8 KiB of a guidance file stays resident, so a gate
+    # written there is not silently evicted by a future retuning.
+    preamble = "# Project\n\n## Gates\n\nreference material line\n"
+    target_offset = 8 * 1024 - 200
+    filler = "reference material line\n" * (
+        (target_offset - len(preamble.encode())) // len("reference material line\n")
+    )
+    (repo / "AGENTS.md").write_text(
+        preamble + filler + f"{marker}\n" + "trailing reference line\n" * 2000
+    )
+    rendered = load_repo_guidance(repo)
+    head = rendered.split("\nThe rest of this file is NOT included")[0]
+
+    assert marker in head, (
+        "a gate lying inside the documented head budget was evicted; "
+        f"GUIDANCE_HEAD_BYTES={GUIDANCE_HEAD_BYTES} is smaller than the "
+        "docstring's reasoning assumes"
+    )
+    resident = len(head.encode())
+    assert resident >= GUIDANCE_HEAD_BYTES * 0.75, (
+        f"head shipped {resident} B against a {GUIDANCE_HEAD_BYTES} B budget; "
+        "the constant is being under-spent"
+    )
 
 
 def test_scan_ceiling_is_disclosed_rather_than_silently_dropping_sections(

--- a/tests/unit/test_context_files.py
+++ b/tests/unit/test_context_files.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -92,11 +93,93 @@ def test_env_kill_switch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
     assert load_repo_guidance(repo) == ""
 
 
-def test_truncates_oversized_file(tmp_path: Path) -> None:
+def _oversized(head: str = "", tail_sections: int = 3) -> str:
+    """A guidance file whose head exceeds GUIDANCE_HEAD_BYTES, with real
+    sections after the cut."""
+    filler = "\n".join(f"padding line {i}" for i in range(900))
+    body = f"# Project\n\n## Head section\n\n{head}\n{filler}\n"
+    for index in range(tail_sections):
+        body += f"\n## Late section {index}\n\nrule {index} lives here.\n"
+    return body
+
+
+def test_oversized_file_ships_head_plus_section_index(tmp_path: Path) -> None:
     repo = _make_repo(tmp_path)
-    (repo / "AGENTS.md").write_text("x" * (64 * 1024 + 100))
+    (repo / "AGENTS.md").write_text(_oversized())
     rendered = load_repo_guidance(repo)
-    assert "truncated at 64KiB" in rendered
+
+    # The head is resident...
+    assert "## Head section" in rendered
+    # ...the tail is not...
+    assert "rule 2 lives here." not in rendered
+    # ...but every late section is NAMED with a line range, which is the whole
+    # point: a rule past the cut used to be invisible AND unreachable.
+    for index in range(3):
+        assert f"Late section {index}" in rendered
+    assert re.search(r"- L\d+-\d+: Late section 0", rendered)
+    assert "you MUST `read`" in rendered
+
+
+def test_index_line_ranges_address_the_real_lines(tmp_path: Path) -> None:
+    """The emitted ranges must be what ``read`` needs to see that section."""
+    repo = _make_repo(tmp_path)
+    guidance = repo / "AGENTS.md"
+    guidance.write_text(_oversized())
+    rendered = load_repo_guidance(repo)
+    lines = guidance.read_text().splitlines()
+
+    found = re.findall(r"- L(\d+)-(\d+): (.+)", rendered)
+    assert found, "expected an index"
+    for raw_start, raw_end, title in found:
+        start, end = int(raw_start), int(raw_end)
+        span = lines[start - 1 : end]
+        assert span, f"empty span for {title}"
+        # A section wholly past the head is addressed from its own heading. A
+        # section straddling the cut is offered as its REMAINDER instead, so
+        # its range starts at body text rather than at the heading the model
+        # has already read.
+        if span[0].startswith("#"):
+            assert span[0].lstrip("#").strip() == title
+        # Either way the span stops before the next same-or-higher heading.
+        assert not any(line.startswith("## ") for line in span[1:])
+
+
+def test_file_within_head_size_ships_whole_without_ceremony(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    (repo / "AGENTS.md").write_text("# Tiny\n\n## Rules\n\nBe nice.\n")
+    rendered = load_repo_guidance(repo)
+    assert "Be nice." in rendered
+    # No index, no read-the-file imperative: the model can already see it all.
+    assert "NOT included above" not in rendered
+    assert "you MUST `read`" not in rendered
+
+
+def test_head_is_cut_on_a_line_boundary_never_mid_sentence(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    # Long lines so a byte cut would land mid-line with near-certainty.
+    body = "# P\n\n## S\n\n" + "".join(f"{'sentence ' * 20}end-{i}.\n" for i in range(200))
+    (repo / "AGENTS.md").write_text(body)
+    rendered = load_repo_guidance(repo)
+    head = rendered.split("\nThe rest of this file is NOT included")[0]
+    resident = [line for line in head.splitlines() if line.startswith("sentence ")]
+    assert resident, "expected some body lines resident"
+    # Every resident body line is a COMPLETE line from the source.
+    source = set(body.splitlines())
+    assert all(line in source for line in resident)
+
+
+def test_index_ignores_headings_inside_fenced_code_blocks(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    filler = "\n".join(f"padding {i}" for i in range(900))
+    body = (
+        f"# P\n\n## Head\n\n{filler}\n\n## Real section\n\n"
+        "```sh\n# not a heading, a shell comment\n## also not a heading\n```\n"
+    )
+    (repo / "AGENTS.md").write_text(body)
+    rendered = load_repo_guidance(repo)
+    assert "Real section" in rendered
+    assert "a shell comment" not in rendered
+    assert "also not a heading" not in rendered
 
 
 def test_empty_when_no_files(tmp_path: Path) -> None:
@@ -135,11 +218,11 @@ def test_symlinked_guidance_is_never_discovered_or_rendered(tmp_path: Path) -> N
 def test_guidance_cap_bounds_ingestion_before_hash_and_render(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from local_operator.context_files import MAX_FILE_BYTES
+    from local_operator.context_files import GUIDANCE_HEAD_BYTES
 
     repo = _make_repo(tmp_path)
     guidance = repo / "AGENTS.md"
-    guidance.write_bytes(b"x" * (MAX_FILE_BYTES + 10_000_000))
+    guidance.write_bytes(b"x" * (GUIDANCE_HEAD_BYTES + 10_000_000))
 
     def forbidden(*_args: object, **_kwargs: object) -> bytes:
         raise AssertionError("unbounded Path read API used")
@@ -149,6 +232,22 @@ def test_guidance_cap_bounds_ingestion_before_hash_and_render(
     monkeypatch.setattr(Path, "read_text", forbidden)
     rendered = load_repo_guidance(repo)
 
-    assert rendered.count("x") == MAX_FILE_BYTES
-    assert "truncated at 64KiB" in rendered
-    assert len(rendered.encode()) < MAX_FILE_BYTES + 1_000
+    # One enormous line: nothing to cut on, so the head is the byte prefix and
+    # the render stays bounded regardless of how large the file is.
+    assert rendered.count("x") <= GUIDANCE_HEAD_BYTES
+    assert len(rendered.encode()) < GUIDANCE_HEAD_BYTES + 2_000
+
+
+def test_scan_ceiling_is_disclosed_rather_than_silently_dropping_sections(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The failure this module exists to fix is a SILENT omission, so the one
+    remaining bound must announce itself."""
+    import local_operator.context_files as module
+
+    monkeypatch.setattr(module, "MAX_SCAN_BYTES", 9_000)
+    repo = _make_repo(tmp_path)
+    filler = "\n".join(f"padding line {i}" for i in range(4000))
+    (repo / "AGENTS.md").write_text(f"# P\n\n## Head\n\n{filler}\n\n## Way past the scan\n\nx\n")
+    rendered = load_repo_guidance(repo)
+    assert "index scan stopped at" in rendered


### PR DESCRIPTION
## Summary

Repository guidance (`AGENTS.md`/`CLAUDE.md`) rode the system prompt as a raw
64KiB byte slice. This makes an oversized file ship as **head + generated
section index** instead, mirroring the `<guides>` pattern the harness already
ships for its own procedures.

**This is a correctness fix before it is a token saving.** On `origin/main`,
this repo's own AGENTS.md is 93,355 bytes with 11 top-level sections. Only 6
fall inside the 64KiB cap, so **five whole sections are silently absent from
every session today**, chosen by byte offset rather than by meaning, with the
last one cut mid-sentence:

| section | line | status on `main` |
|---|---|---|
| Environment | 8 | resident |
| Releasing the stable `lop` runtime | 385 | resident |
| Who may merge: two tiers | 758 | resident |
| Security advisories | 890 | resident |
| Versioning: materiality | 905 | resident |
| Visual validation | 944 | resident |
| **Timing, flakes, and how to assert something is fast** | 1182 | **CUT** |
| **TUI conventions** | 1386 | **CUT** |
| **Adding a configuration key** | 1473 | **CUT** |
| **Usage analytics** | 1505 | **CUT** |
| **The tool-surface footprint ladder** | 1597 | **CUT** |

A rule past the cut was not merely absent — it was *unfindable*. Nothing in the
prompt said it existed, so the model could not know to go looking. After this
change every section is named, line-addressed and reachable.

`Release: patch — repo guidance loads lazily; all AGENTS.md sections become reachable instead of 5 being silently dropped past a 64KiB byte cut.`

## Design

- **No new resolver.** Guidance is a real path on disk and `read` already takes
  a path and a line range, so the index emits exactly what `read` consumes.
- **`GUIDANCE_HEAD_BYTES = 8 * 1024`**, a named constant with the trade-off
  documented — not a magic number.
- **Index is mandatory for oversized files.** Lazy loading only works when the
  model can *see* a section exists; that is precisely why `guide://` ships
  descriptions.
- **Cut on a line boundary**, never mid-sentence.
- **Small files ship whole, no index.** A 2KB AGENTS.md gets no ceremony.
- **Stays in cached block 0.** Moving it to blocks 2–3 would re-send it
  *uncached* every turn (those are deliberately breakpoint-free) — strictly
  worse. One re-cache when the file changes is the correct trade.
- **Fenced code blocks are tracked** so a `# comment` in a shell snippet is not
  indexed as a section, which would send a later `read` to the wrong range.

## Measured impact

Assembled system prompt, real 93KB AGENTS.md, isolated `HOME` + config dir:

```
OLD (origin/main)    block0= 83,885 ch   ALL BLOCKS= 84,349 ch   ~30,341 billed tok
NEW (this PR)        block0= 29,026 ch   ALL BLOCKS= 29,490 ch   ~10,608 billed tok

SAVED per call: 54,859 chars = 19,733 billed tokens (65.0% of the assembled system prompt)
```

Exact cl100k on the guidance block alone: **16,261 → 2,896 tok**.

Subagents inherit the same rendered string (`subagent.py:1718` reads
`repo_guidance` off the parent and passes it to `build_system_blocks`), so the
saving multiplies across the 84% of calls that are children — no plumbing
change was required for that path, and it is verified below.

| path | calls / 2 days | billed tokens saved |
|---|---|---|
| top-level | 10,141 | 200.1M |
| subagent | 53,054 | 1,046.9M |
| **combined** | 63,195 | **1,247.1M** |

## Evidence

<details><summary>Rendered block for the real 93KB AGENTS.md (head + index)</summary>

```
The rest of this file is NOT included above. It is on disk at `AGENTS.md` (1638 lines); these are its remaining sections with the line ranges to read:

- L153-384: Environment
  - L180-235: Every feature worktree owns its own venv. Never symlink one.
  - L236-260: A dead venv fails loudly; a wrong one does not
  - L261-294: Isolating a run: `LOCAL_OPERATOR_CONFIG_DIR` alone is not enough
  - L295-384: Read the committed ref, not the working tree
- L385-757: Releasing the stable `lop` runtime
  - L400-451: PRs do not bump the version; merging is not releasing
  - L452-516: One release owner per window
  - L517-557: What the release owner does
  - L558-757: Mechanics, in order
- L758-889: Who may merge: two tiers, by code ownership
  - L841-889: Scope round N+1 to the remediation delta
- L890-904: Security advisories
- L905-943: Versioning: choose the bump by materiality, not commit type
- L944-1181: Visual validation: how to actually look at a UI change
  - L952-1039: 1. Render the screen to an SVG still
  ...
- L1182-1385: Timing, flakes, and how to assert that something is fast
  - L1193-1230: Wait on the event, never on the clock
  ...
- L1386-1472: TUI conventions worth knowing before you edit a widget
- L1473-1504: Adding a configuration key
- L1505-1596: Usage analytics (`local_operator/analytics/`)
- L1597-1638: The tool-surface footprint ladder

When a task touches any subject listed here, you MUST `read` that line range of `AGENTS.md` BEFORE acting or answering — even when you believe you already know the answer, and even when the rules above seem to cover it. These sections state this project's specific gates, measured numbers and landmines; assuming the general case is how an agent confidently does the wrong thing here.
```
</details>

**All 11 sections reachable, ranges verified exact** (`33` index rows incl. H3s):

```
index rows: 33
file has 11 top-level sections
unreachable: NONE — all reachable

index says: L1597-1638: The tool-surface footprint ladder
read of that range -> 42 lines, first: '## The tool-surface footprint ladder'
rung 3 present in that range: True
```

**Old vs new on a question only answerable past the 64KiB cut**
("what is rung 3 of the tool-surface footprint ladder?"):

```
--- OLD (origin/main byte-truncated block) ---
  answer text resident:  False
  section even NAMED:    False
  => model cannot answer and cannot know to look. Silent wrong answer.

--- NEW (head + index) ---
  answer text resident:  False
  section NAMED w/ range: True ('1597', '1638')
  imperative to read it:  True
  following that pointer -> read AGENTS.md L1597-1638 (42 lines)
  rung 3 recovered: 3. **A `createIf`-gated tool.** If the capability genuinely needs structured...
  contains the createIf rule: True
```

**Isolated real boot** (`HOME` redirected too — the config dir alone is not
enough, since the catalogue cache derives from `HOME`):

```
HOME = /tmp/lg-iso
cwd  = /private/tmp/lg-iso/proj
rendered repo-guidance chars: 10768
contains head: True
contains index imperative: True
contains truncated-mid-sentence marker (old): False
```

**Small-file and nested multi-file cases:**

```
files rendered: 2
   /private/tmp/lgnest/AGENTS.md      <- 93KB, indexed
   AGENTS.md                          <- small, whole

big file indexed: True
small nested file whole: True
order ok (root before sub): True
```

## Finding: this AGENTS.md does not front-load its unconditional rules

The head is necessarily the file's **first N bytes** — this module renders what
the operator wrote, in the order they wrote it, and must not reorder or edit
their file to suit its own budget. QA measured what that means here:

```
HEAD         lint gate commands, test command, e2e stage
INDEX-ONLY   never symlink a venv
INDEX-ONLY   read the committed ref
INDEX-ONLY   PRs do not bump the version
INDEX-ONLY   merge tiers / code ownership
INDEX-ONLY   release owner per window
```

The head is spent largely on the xdist worker-count rationale, so for *this*
file the 8KiB cut retains reference material and indexes the unconditional
gates — the inverse of the criterion the constant's docstring argues for. The
docstring has been softened to say what actually ships rather than what would
be ideal.

Reporting rather than fixing: the remedy is reordering the operator's AGENTS.md,
which is their call, and both reviewer and QA agreed a module that rewrites the
file it ships would be worse than the bug. Two mitigations apply — those
sections are named in the index with imperative headings that carry the rule's
gist ("Never symlink one", "Read the committed ref, not the working tree"), and
on this file they sit past the 64KiB cut today, so they move from
absent-and-invisible to named-and-one-read-away.

**Qualifying the "strictly better than today" claim** (reviewer's caution): that
held only where the index emits. Round 1 found a case where it was strictly
*worse* — an oversized file yielding no listable sections dropped its tail with
no notice at all, where `main` shipped it whole. That is fixed in `5cc30c63a`;
with the bare-pointer fallback the claim is now true across all measured
shapes, which is the basis on which it is made here.

## Gates

```
.venv/bin/python -m flake8 .                                  -> clean
uvx --from black==26.1.0 black --check .                      -> 1033 files unchanged
uvx isort==5.13.2 --check .                                   -> clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .   -> 0 errors, 0 warnings
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
                                                              -> 15600 passed, 18 skipped (28:42)
```

Nine tests rewritten/added in `tests/unit/test_context_files.py`: head+index
shape, index ranges addressing real lines, small-file-ships-whole,
line-boundary cut, fenced-code-block immunity, bounded ingestion, and the scan
ceiling disclosing itself rather than silently dropping sections.

## Not done / limitations

- **The live-LLM adherence run is BLOCKED, not skipped.** The intent was to ask
  a real isolated session a question only answerable past the cut and capture
  the transcript. The Radient gateway returns `HTTP 402 billing account is not
  active` and every configured fallback (`zai`, `kimi`, `alibaba`, `xai`,
  `openai`) has no key in the credential store; QA independently confirmed this
  with a real call rather than taking it on faith. So whether a model *chooses*
  to follow the pointer has **no execution evidence**, and I have not
  substituted a string-contains check for it.

  The **mechanical** half — if the pointer is followed, does it land on the
  right content? — is testable, was untested in round 1 (which is how the
  line-numbering bug survived), and is now covered:
  `test_every_index_range_round_trips_through_the_real_read_path` resolves every
  emitted range through the `read` tool's own `_decode_text_lines` and asserts
  it lands on its heading. Adherence-by-a-live-model should still be confirmed
  on a box with a funded provider before this is relied upon.

- No version bump (per the combined-release protocol).
- Stayed out of `prompts_api.py::_render_tool_inventory`, `tools/registry.py`,
  `tools/intent.py` and `system.md`'s browser section, per the PR1 scope
  boundary. The diff is 2 files: `context_files.py` and its test.

