### PR TITLE
fix(diagnostics): correct failure counts and report tool-call error rate

### DIFF
--- a/local_operator/analytics/__init__.py
+++ b/local_operator/analytics/__init__.py
@@ -40,6 +40,7 @@ from local_operator.analytics.model import (
     COMPONENT_KEYS,
     COMPONENT_LABELS,
     CallSnapshot,
+    ToolCallStats,
     UsageAggregate,
     UsagePeriod,
     apportion_components,
@@ -51,6 +52,7 @@ from local_operator.analytics.recorder import (
     AnalyticsRecorder,
     get_recorder,
     record_call,
+    record_tool_call,
     reset_recorder_for_test,
 )
 from local_operator.analytics.store import AnalyticsStore, default_db_path
@@ -59,6 +61,7 @@ __all__ = [
     "COMPONENT_KEYS",
     "COMPONENT_LABELS",
     "CallSnapshot",
+    "ToolCallStats",
     "UsageAggregate",
     "UsagePeriod",
     "apportion_components",
@@ -68,6 +71,7 @@ __all__ = [
     "AnalyticsRecorder",
     "get_recorder",
     "record_call",
+    "record_tool_call",
     "reset_recorder_for_test",
     "AnalyticsStore",
     "default_db_path",

--- a/local_operator/analytics/model.py
+++ b/local_operator/analytics/model.py
@@ -649,6 +649,23 @@ class TimingSummary:
     max_ms: float | None = None
 
 
+#: ``tool_calls.origin`` for a call the MODEL emitted as a tool_use block. The
+#: only origin any rate on :class:`ToolCallStats` is computed over.
+ORIGIN_MODEL = "model"
+
+#: ``tool_calls.origin`` for a call made by ``eval``'s ``dispatch_tool`` bridge:
+#: the model's CODE calling a tool. Recorded so the calls are visible and can be
+#: accounted for, and kept out of every rate — see the origin partition on
+#: :class:`ToolCallStats`.
+#:
+#: These are named here rather than being bare literals in the reader because a
+#: misspelling silently moves rows into the wrong population instead of failing.
+#: The WRITER (``harness/loop.py``) still passes the strings literally: that
+#: package deliberately carries no analytics dependency (see
+#: ``LoopConfig.record_tool_call``), so the two sides are pinned together by a
+#: test that asserts the loop's emitted origins are exactly these values.
+ORIGIN_NESTED = "nested"
+
 #: Faults the MODEL is responsible for: the harness could not dispatch the call
 #: at all because what the model emitted was not a usable call. These and only
 #: these are the numerator of tool-call validity.
@@ -671,22 +688,61 @@ class ToolCallStats:
     when the session predates tool-call recording. An instance of this class
     always describes real measured rows.
 
+    **THE ORIGIN PARTITION — the invariant this type exists to enforce.** Every
+    count and every rate on this type EXCEPT :attr:`nested_total` /
+    :attr:`nested_ok` / :attr:`recorded` describes calls whose stored ``origin``
+    is ``'model'``: a tool_use block the model actually emitted. Calls
+    dispatched by ``eval``'s ``dispatch_tool`` bridge are the model's CODE
+    calling a tool, not the model emitting a call, and they arrive in scripted
+    loops — pooling them lets one twenty-iteration retry loop drag the headline
+    accuracy figure wherever it likes (measured: two model calls, one faulted,
+    plus a 20-call ``eval`` loop reports 95.5% where the true model-emission
+    figure is 50%, and the distortion grows with exactly the composition-heavy
+    runs the figure is most wanted for). Nested calls are counted separately and
+    NEVER folded into a rate.
+
+    A future edit that adds a rate here must derive it from the model-origin
+    fields only. If a nested rate is ever wanted, give it a ``nested_`` name and
+    its own row rather than widening one of these: the two populations are not
+    comparable, and a shared name is how they get re-pooled.
+
     The two rates are deliberately SEPARATE and separately named because they
     answer different questions and share no denominator — which is also why the
     renderer must not draw them as bars beside one another.
     """
 
-    #: Every recorded tool call for the session, whatever its fault.
+    #: MODEL-EMITTED calls, whatever their fault. NOT every call the session
+    #: made — see the origin partition above; :attr:`recorded` is that figure.
     total: int = 0
-    #: Calls with no fault at all: dispatched, ran, returned without error.
+    #: Model-emitted calls with no fault at all: dispatched, ran, returned
+    #: without error.
     ok: int = 0
-    #: ``fault`` -> count, for every nonempty fault. Carries the breakdown the
-    #: rates summarise, so the screen can name WHICH invalidity dominated.
+    #: ``fault`` -> count over MODEL-EMITTED calls, for every nonempty fault.
+    #: Carries the breakdown the rates summarise, so the screen can name WHICH
+    #: invalidity dominated.
     faults: dict[str, int] = field(default_factory=dict)
-    #: ``tool_name`` -> count of faulted calls. Recorded from day one so a
-    #: "which tool does this model get wrong" view is a rendering change later
-    #: rather than a schema change.
+    #: ``tool_name`` -> count of faulted MODEL-EMITTED calls. Recorded from day
+    #: one so a "which tool does this model get wrong" view is a rendering
+    #: change later rather than a schema change.
     faults_by_tool: dict[str, int] = field(default_factory=dict)
+    #: Calls dispatched by ``eval``'s bridge — every row whose ``origin`` is not
+    #: ``'model'``. Counted so the screen can ACCOUNT for them (a reader who
+    #: sees 30 calls happen and a rate over 10 needs to know where 20 went)
+    #: while no rate is computed over them.
+    nested_total: int = 0
+    #: Nested calls that ran cleanly, so the nested row can read ``N · M ok``.
+    #: No rate is derived from it, deliberately.
+    nested_ok: int = 0
+
+    @property
+    def recorded(self) -> int:
+        """Every tool call recorded for the session, BOTH origins.
+
+        Named apart from :attr:`total` rather than being what ``total`` means,
+        so that reaching across the origin partition is always explicit at the
+        call site. This is the only count on the type that spans it.
+        """
+        return self.total + self.nested_total
 
     @property
     def emitted(self) -> int:
@@ -705,8 +761,27 @@ class ToolCallStats:
         return sum(self.faults.get(name, 0) for name in MODEL_FAULTS)
 
     @property
+    def excluded(self) -> int:
+        """Calls removed from both denominators: denied, aborted, skipped, gate.
+
+        Exposed rather than left implicit inside :attr:`emitted` because the
+        renderer must be able to NAME this number. It is the entire difference
+        between :attr:`total` and :attr:`emitted`, and an unexplained gap
+        between two counts printed one line apart reads as the screen
+        miscounting — the exact misreading this feature exists to remove.
+        """
+        return sum(self.faults.get(name, 0) for name in EXCLUDED_FAULTS)
+
+    @property
     def execution_faults(self) -> int:
-        """Calls that were dispatched and then failed inside the tool."""
+        """MODEL-EMITTED calls that were dispatched and then failed inside the tool.
+
+        Model-origin only, like every other count here (see the origin partition
+        on the class). A nested call that failed inside its tool is in
+        ``nested_total - nested_ok``, not here — which is why the rendered row
+        states its scope: an "errors" count whose scope is unstated is read as
+        the model's.
+        """
         return self.faults.get("execution", 0)
 
     @property

--- a/local_operator/analytics/model.py
+++ b/local_operator/analytics/model.py
@@ -649,6 +649,102 @@ class TimingSummary:
     max_ms: float | None = None
 
 
+#: Faults the MODEL is responsible for: the harness could not dispatch the call
+#: at all because what the model emitted was not a usable call. These and only
+#: these are the numerator of tool-call validity.
+MODEL_FAULTS: frozenset[str] = frozenset({"unknown_tool", "invalid_arguments", "duplicate_id"})
+
+#: Faults nobody's accuracy is measured by: the user cancelled the call, or the
+#: harness's own approval plumbing broke. Excluded from BOTH rates and from both
+#: denominators — a call the user denied says nothing about how well the model
+#: emits calls, and counting it would let a cautious operator look like a bad
+#: model. Still recorded so the counts reconcile against the total.
+EXCLUDED_FAULTS: frozenset[str] = frozenset({"denied", "aborted", "skipped", "gate_failed"})
+
+
+@dataclass(frozen=True)
+class ToolCallStats:
+    """Per-session tool-call outcome counts and the two rates derived from them.
+
+    ``None`` is never returned for this type where the answer is "unknown": the
+    OWNER of that distinction is ``SessionReport.tool_calls``, which is ``None``
+    when the session predates tool-call recording. An instance of this class
+    always describes real measured rows.
+
+    The two rates are deliberately SEPARATE and separately named because they
+    answer different questions and share no denominator — which is also why the
+    renderer must not draw them as bars beside one another.
+    """
+
+    #: Every recorded tool call for the session, whatever its fault.
+    total: int = 0
+    #: Calls with no fault at all: dispatched, ran, returned without error.
+    ok: int = 0
+    #: ``fault`` -> count, for every nonempty fault. Carries the breakdown the
+    #: rates summarise, so the screen can name WHICH invalidity dominated.
+    faults: dict[str, int] = field(default_factory=dict)
+    #: ``tool_name`` -> count of faulted calls. Recorded from day one so a
+    #: "which tool does this model get wrong" view is a rendering change later
+    #: rather than a schema change.
+    faults_by_tool: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def emitted(self) -> int:
+        """Calls that count toward validity: total minus user/harness exclusions.
+
+        The validity denominator. A denied or aborted call was never allowed to
+        prove anything about the model, so it is removed from the denominator
+        rather than counted as a success — counting it as either would move the
+        figure for a reason that has nothing to do with the model.
+        """
+        return self.total - sum(self.faults.get(name, 0) for name in EXCLUDED_FAULTS)
+
+    @property
+    def model_faults(self) -> int:
+        """Calls the harness could not dispatch because the model emitted junk."""
+        return sum(self.faults.get(name, 0) for name in MODEL_FAULTS)
+
+    @property
+    def execution_faults(self) -> int:
+        """Calls that were dispatched and then failed inside the tool."""
+        return self.faults.get("execution", 0)
+
+    @property
+    def validity(self) -> float | None:
+        """Share of EMITTED calls the harness could dispatch, 0.0-1.0.
+
+        **This is the benchmarking number.** It means: of the tool calls this
+        model emitted, what fraction were well-formed enough to run. It does
+        NOT mean the tool succeeded, and it does NOT mean the model chose the
+        right tool for the job — both are outside what the harness can observe.
+
+        ``None`` when nothing was emitted: a rate over an empty denominator is
+        unknown, and this screen never draws unknown as a measured zero.
+        """
+        emitted = self.emitted
+        if emitted <= 0:
+            return None
+        return (emitted - self.model_faults) / emitted
+
+    @property
+    def execution_error_rate(self) -> float | None:
+        """Share of DISPATCHED calls that failed inside the tool, 0.0-1.0.
+
+        Diagnostic only, and explicitly **not** a model-accuracy figure: it
+        counts the web being down, a missing file, an MCP server refusing
+        credentials. A model cannot be graded on it, which is why it is named
+        and rendered apart from :attr:`validity` rather than folded into one
+        "error rate".
+
+        Denominator is calls that actually RAN — emitted minus model faults —
+        because a call the harness rejected never reached a tool to fail in.
+        """
+        dispatched = self.emitted - self.model_faults
+        if dispatched <= 0:
+            return None
+        return self.execution_faults / dispatched
+
+
 @dataclass(frozen=True)
 class SessionRequest:
     """A bounded recent-ledger row, deliberately excluding payloads and errors."""
@@ -665,6 +761,15 @@ class SessionRequest:
     duration_ms: float | None
     ttft_ms: float | None
     preparation_ms: float | None
+    #: Whether the provider call SUCCEEDED — the recorded truth, and the only
+    #: honest success predicate for a request. ``outcome`` above is
+    #: ``str(stop_reason)`` from a provider-specific finish-reason map (or an
+    #: exception class name), so it labels a failure well and decides one badly.
+    #: ``None`` means unknown, not failed: it is what an impossibly-old ledger
+    #: with no ``ok`` column would yield, and unknown must never be drawn as a
+    #: warning. APPENDED LAST deliberately — this dataclass is constructed
+    #: positionally, so inserting a field mid-list silently shifts the timings.
+    ok: bool | None = None
 
 
 @dataclass(frozen=True)
@@ -700,6 +805,14 @@ class SessionReport:
     # by-purpose chart exists to answer. Both are kept because they carry
     # different facts — this one the consumption, that one the failure tally.
     by_purpose: dict[str, UsageAggregate] = field(default_factory=dict)
+    #: A (purpose, outcome) cross-tab: a DIAGNOSTIC LABEL, never the failure
+    #: count. ``ok_calls`` on the aggregates above is the count. The distinction
+    #: is load-bearing: ``outcome`` is provider-specific
+    #: (``stop``/``length``/``toolUse``/``refusal``, or an exception class name)
+    #: and an older ledger reports every row as ``unknown``, so deriving
+    #: failures from it painted an entire healthy session in ``warning``. What
+    #: this IS good for is saying WHICH failure a failed request hit — the
+    #: actionable half, and the reason the field is kept.
     by_purpose_outcome: dict[tuple[str, str], int] = field(default_factory=dict)
     missing_usage_calls: int = 0
     unknown_usage_calls: int = 0
@@ -718,6 +831,13 @@ class SessionReport:
     #: caller can say "20 subagents" without a second query, and so a test can
     #: assert the walk's REACH rather than only its sums.
     descendant_ids: tuple[str, ...] = ()
+    #: Tool-call outcomes for this session, or ``None`` for UNKNOWN — no
+    #: ``tool_calls`` table (a ledger written before this shipped) or no rows for
+    #: this session. ``None`` and a zeroed ``ToolCallStats`` mean opposite
+    #: things and the renderer must not conflate them: the first is "we did not
+    #: measure", the second is "we measured, and it was zero". Every session
+    #: recorded before this feature has no tool data and must read ``unknown``.
+    tool_calls: ToolCallStats | None = None
 
     @property
     def subtree_aggregate(self) -> UsageAggregate:

--- a/local_operator/analytics/model.py
+++ b/local_operator/analytics/model.py
@@ -668,7 +668,7 @@ ORIGIN_NESTED = "nested"
 
 #: Faults the MODEL is responsible for: the harness could not dispatch the call
 #: at all because what the model emitted was not a usable call. These and only
-#: these are the numerator of tool-call validity.
+#: these are the numerator of the tool-call error rate.
 MODEL_FAULTS: frozenset[str] = frozenset({"unknown_tool", "invalid_arguments", "duplicate_id"})
 
 #: Faults nobody's accuracy is measured by: the user cancelled the call, or the
@@ -690,7 +690,8 @@ class ToolCallStats:
 
     **THE ORIGIN PARTITION — the invariant this type exists to enforce.** Every
     count and every rate on this type EXCEPT :attr:`nested_total` /
-    :attr:`nested_ok` / :attr:`recorded` describes calls whose stored ``origin``
+    :attr:`nested_ok` / :attr:`nested_excluded` / :attr:`all_excluded` /
+    :attr:`recorded` describes calls whose stored ``origin``
     is ``'model'``: a tool_use block the model actually emitted. Calls
     dispatched by ``eval``'s ``dispatch_tool`` bridge are the model's CODE
     calling a tool, not the model emitting a call, and they arrive in scripted
@@ -733,6 +734,15 @@ class ToolCallStats:
     #: Nested calls that ran cleanly, so the nested row can read ``N · M ok``.
     #: No rate is derived from it, deliberately.
     nested_ok: int = 0
+    #: Nested user/harness exclusions must not become headline failures. Keep
+    #: them apart from ``excluded``: nested_total already removes these rows
+    #: from model-only denominators, so pooling would subtract them twice.
+    nested_excluded: int = 0
+
+    @property
+    def all_excluded(self) -> int:
+        """Both origins, for the recorded = ok + failed + excluded partition."""
+        return self.excluded + self.nested_excluded
 
     @property
     def recorded(self) -> int:
@@ -740,7 +750,7 @@ class ToolCallStats:
 
         Named apart from :attr:`total` rather than being what ``total`` means,
         so that reaching across the origin partition is always explicit at the
-        call site. This is the only count on the type that spans it.
+        call site, as it is for :attr:`all_excluded`.
         """
         return self.total + self.nested_total
 
@@ -783,6 +793,18 @@ class ToolCallStats:
         the model's.
         """
         return self.faults.get("execution", 0)
+
+    @property
+    def tool_call_error_rate(self) -> float | None:
+        """Rejected/invalid model invocations divided by eligible emitted calls.
+
+        Not semantic tool-selection correctness or proof that every tool error
+        is model-caused. Nested calls and user/harness exclusions never reach
+        this denominator. Compute the ratio directly, not from rounded validity,
+        so small error rates retain their measured precision.
+        """
+        emitted = self.emitted
+        return self.model_faults / emitted if emitted > 0 else None
 
     @property
     def validity(self) -> float | None:

--- a/local_operator/analytics/recorder.py
+++ b/local_operator/analytics/recorder.py
@@ -57,6 +57,49 @@ class _NameTask:
         self.rank = rank
 
 
+class _ToolCallTask:
+    """One tool-call sample queued for the writer thread.
+
+    Routed through the SAME queue, thread and connection as call samples and
+    name upserts, for the reason ``_NameTask`` records: two threads opening
+    their first connection to a freshly-created database race in a way that
+    left the writer unable to see its own commits. There is exactly one writer
+    here and adding a second is forbidden.
+
+    Fields are the store's insert tuple, flattened. The producer is the harness
+    (``AgentLoop.park``), which has no analytics import and reaches this through
+    a ``LoopConfig`` callback — so the shape has to be primitives.
+    """
+
+    __slots__ = ("ts_ms", "session_id", "tool_name", "origin", "fault", "duration_ms")
+
+    def __init__(
+        self,
+        ts_ms: int,
+        session_id: str,
+        tool_name: str,
+        origin: str,
+        fault: str,
+        duration_ms: float,
+    ) -> None:
+        self.ts_ms = ts_ms
+        self.session_id = session_id
+        self.tool_name = tool_name
+        self.origin = origin
+        self.fault = fault
+        self.duration_ms = duration_ms
+
+    def as_row(self) -> tuple[int, str, str, str, str, float]:
+        return (
+            self.ts_ms,
+            self.session_id,
+            self.tool_name,
+            self.origin,
+            self.fault,
+            self.duration_ms,
+        )
+
+
 #: Upper bound on queued-but-unwritten samples. A provider call takes seconds
 #: and a batch write takes milliseconds, so this only fills if the disk is
 #: wedged — at which point dropping is the correct behaviour. Sized for a
@@ -84,7 +127,7 @@ class AnalyticsRecorder:
 
     def __init__(self, store: AnalyticsStore | None = None) -> None:
         self._store = store if store is not None else AnalyticsStore()
-        self._queue: "queue.Queue[CallSnapshot | _NameTask | None]" = queue.Queue(
+        self._queue: "queue.Queue[CallSnapshot | _NameTask | _ToolCallTask | None]" = queue.Queue(
             maxsize=_QUEUE_MAXSIZE
         )
         self._thread: threading.Thread | None = None
@@ -126,16 +169,17 @@ class AnalyticsRecorder:
         while True:
             batch: list[CallSnapshot] = []
             names: list[_NameTask] = []
+            tools: list[_ToolCallTask] = []
             try:
                 item = self._queue.get(timeout=_FLUSH_INTERVAL_S)
             except queue.Empty:
                 self._maybe_prune()
                 continue
             if item is None:  # sentinel: flush and exit
-                self._flush(batch, names)
+                self._flush(batch, names, tools)
                 self._queue.task_done()
                 return
-            self._classify(item, batch, names)
+            self._classify(item, batch, names, tools)
             self._queue.task_done()
             # Opportunistically drain whatever else is already queued so a
             # burst becomes one transaction.
@@ -145,26 +189,42 @@ class AnalyticsRecorder:
                 except queue.Empty:
                     break
                 if item is None:
-                    self._flush(batch, names)
+                    self._flush(batch, names, tools)
                     self._queue.task_done()
                     return
-                self._classify(item, batch, names)
+                self._classify(item, batch, names, tools)
                 self._queue.task_done()
-            self._flush(batch, names)
+            self._flush(batch, names, tools)
             self._maybe_prune()
 
     @staticmethod
     def _classify(
-        item: "CallSnapshot | _NameTask",
+        item: "CallSnapshot | _NameTask | _ToolCallTask",
         batch: list[CallSnapshot],
         names: list["_NameTask"],
+        tools: list["_ToolCallTask"],
     ) -> None:
         if isinstance(item, _NameTask):
             names.append(item)
+        elif isinstance(item, _ToolCallTask):
+            tools.append(item)
         else:
             batch.append(item)
 
-    def _flush(self, batch: list[CallSnapshot], names: list["_NameTask"]) -> None:
+    def _flush(
+        self,
+        batch: list[CallSnapshot],
+        names: list["_NameTask"],
+        tools: list["_ToolCallTask"] | None = None,
+    ) -> None:
+        if tools:
+            # Its own transaction, not joined to the ledger insert below: tool
+            # calls are produced DURING a turn and the ledger row at the end of
+            # it, so the two never share a batch anyway.
+            try:
+                self._store.record_tool_calls([task.as_row() for task in tools])
+            except Exception:  # noqa: BLE001 — a bad sample must not kill the writer
+                logger.debug("analytics: tool-call flush failed", exc_info=True)
         if names:
             for task in names:
                 try:
@@ -244,6 +304,44 @@ class AnalyticsRecorder:
         except Exception:  # noqa: BLE001 — naming is best-effort
             logger.debug("analytics: name enqueue failed", exc_info=True)
 
+    def record_tool_call(
+        self,
+        session_id: str,
+        tool_name: str,
+        origin: str,
+        fault: str,
+        duration_ms: float = -1.0,
+    ) -> None:
+        """Best-effort: record one tool call's outcome off the hot path.
+
+        Called from ``AgentLoop.park``, which runs ON THE EVENT LOOP inside a
+        live turn. So this does the least possible work — one bounded
+        ``put_nowait`` — and, like :meth:`record`, never raises and never
+        blocks: analytics that can add latency to a turn or abort one is a
+        defect, not a measurement.
+
+        ``fault`` is ``""`` for a call that ran cleanly, else the classification
+        set at the source (see ``store``'s ``tool_calls`` schema comment).
+        """
+        if self._closed or not session_id:
+            return
+        self._ensure_thread()
+        try:
+            self._queue.put_nowait(
+                _ToolCallTask(
+                    int(time.time() * 1000),
+                    session_id,
+                    tool_name,
+                    origin,
+                    fault,
+                    float(duration_ms),
+                )
+            )
+        except queue.Full:
+            logger.debug("analytics: queue full, dropped a tool call")
+        except Exception:  # noqa: BLE001 — recording is best-effort
+            logger.debug("analytics: tool-call enqueue failed", exc_info=True)
+
     @property
     def dropped(self) -> int:
         """How many samples were dropped for a full queue (0 on a healthy run)."""
@@ -319,6 +417,26 @@ def record_call(snapshot: CallSnapshot) -> None:
         get_recorder().record(snapshot)
     except Exception:  # noqa: BLE001 — recording is never allowed to raise
         logger.debug("analytics: record_call failed", exc_info=True)
+
+
+def record_tool_call(
+    session_id: str,
+    tool_name: str,
+    origin: str,
+    fault: str,
+    duration_ms: float = -1.0,
+) -> None:
+    """Module-level convenience: enqueue a tool-call sample. Never raises.
+
+    This is what ``Session`` binds into ``LoopConfig.record_tool_call``. The
+    outer guard is not redundant with the recorder's own: this runs on the event
+    loop during a turn, and even the singleton lookup must not be able to throw
+    into it.
+    """
+    try:
+        get_recorder().record_tool_call(session_id, tool_name, origin, fault, duration_ms)
+    except Exception:  # noqa: BLE001 — recording is never allowed to raise
+        logger.debug("analytics: record_tool_call failed", exc_info=True)
 
 
 def reset_recorder_for_test(store: AnalyticsStore | None = None) -> AnalyticsRecorder:

--- a/local_operator/analytics/recorder.py
+++ b/local_operator/analytics/recorder.py
@@ -315,13 +315,21 @@ class AnalyticsRecorder:
         """Best-effort: record one tool call's outcome off the hot path.
 
         Called from ``AgentLoop.park``, which runs ON THE EVENT LOOP inside a
-        live turn. So this does the least possible work — one bounded
-        ``put_nowait`` — and, like :meth:`record`, never raises and never
-        blocks: analytics that can add latency to a turn or abort one is a
+        live turn, and invoked SYNCHRONOUSLY there — the loop puts no timeout
+        and no thread between itself and this call, because at the measured
+        0.0018 ms/call scheduling would cost more than the work. So the
+        non-blocking half of the contract is load-bearing rather than advisory:
+        whatever time this spends is added straight to the turn (measured
+        0.002 s → 0.754 s against a hook that sleeps 0.75 s). One bounded
+        ``put_nowait``, never raising, never touching disk or a lock on this
+        side — analytics that can add latency to a turn or abort one is a
         defect, not a measurement.
 
         ``fault`` is ``""`` for a call that ran cleanly, else the classification
         set at the source (see ``store``'s ``tool_calls`` schema comment).
+        ``origin`` decides which population the call is counted in and must be
+        one of ``analytics.model.ORIGIN_MODEL`` / ``ORIGIN_NESTED``; only the
+        former reaches a rate (see the origin partition on ``ToolCallStats``).
         """
         if self._closed or not session_id:
             return

--- a/local_operator/analytics/store.py
+++ b/local_operator/analytics/store.py
@@ -38,6 +38,7 @@ from typing import Any, Iterable, Sequence
 
 from local_operator.analytics.model import (
     COMPONENT_KEYS,
+    ORIGIN_MODEL,
     CallSnapshot,
     SessionReport,
     SessionRequest,
@@ -1644,12 +1645,20 @@ class AnalyticsStore:
         and therefore also reads ``unknown``. That is the safe error in both
         directions — a wrong ``unknown`` withholds a fact, a wrong ``0%`` states
         one — and it self-corrects the moment the session makes a tool call.
+
+        **``origin`` is in the GROUP BY because the read side must honour the
+        partition the schema records.** ``ToolCallStats``' counts are
+        model-origin only; nested (``eval``-bridge) rows are tallied apart and
+        never reach a rate. Dropping ``origin`` from this projection is not a
+        cosmetic simplification — it silently re-pools the two populations and
+        lets one scripted loop set the headline accuracy figure. See the origin
+        partition on ``ToolCallStats`` and the schema comment on ``tool_calls``.
         """
         try:
             rows = list(
                 conn.execute(
-                    "SELECT fault, tool_name, COUNT(*) FROM tool_calls "
-                    "WHERE session_id = ? GROUP BY fault, tool_name",
+                    "SELECT origin, fault, tool_name, COUNT(*) FROM tool_calls "
+                    "WHERE session_id = ? GROUP BY origin, fault, tool_name",
                     (session_id,),
                 )
             )
@@ -1664,8 +1673,20 @@ class AnalyticsStore:
         ok = 0
         faults: dict[str, int] = {}
         faults_by_tool: dict[str, int] = {}
-        for fault, tool_name, count in rows:
+        nested_total = 0
+        nested_ok = 0
+        for origin, fault, tool_name, count in rows:
             count = int(count)
+            if str(origin) != ORIGIN_MODEL:
+                # Anything that is not model-emitted is nested by definition, and
+                # an UNRECOGNISED origin lands here too rather than in the rates:
+                # if a future writer adds a third origin, the safe default is to
+                # keep it out of the benchmarking number until someone decides
+                # where it belongs.
+                nested_total += count
+                if not fault:
+                    nested_ok += count
+                continue
             total += count
             if not fault:
                 ok += count
@@ -1673,7 +1694,14 @@ class AnalyticsStore:
             faults[str(fault)] = faults.get(str(fault), 0) + count
             name = str(tool_name)
             faults_by_tool[name] = faults_by_tool.get(name, 0) + count
-        return ToolCallStats(total=total, ok=ok, faults=faults, faults_by_tool=faults_by_tool)
+        return ToolCallStats(
+            total=total,
+            ok=ok,
+            faults=faults,
+            faults_by_tool=faults_by_tool,
+            nested_total=nested_total,
+            nested_ok=nested_ok,
+        )
 
     def _descendant_usage(
         self,

--- a/local_operator/analytics/store.py
+++ b/local_operator/analytics/store.py
@@ -42,6 +42,7 @@ from local_operator.analytics.model import (
     SessionReport,
     SessionRequest,
     TimingSummary,
+    ToolCallStats,
     UsageAggregate,
     UsagePeriod,
     apportion_components,
@@ -248,6 +249,32 @@ CREATE TABLE IF NOT EXISTS usage_monthly (
   updated_at_ms INTEGER NOT NULL DEFAULT 0,
   PRIMARY KEY (month, model)
 );
+
+-- One row per TOOL CALL the harness dispatched or rejected. Separate from
+-- ``calls`` rather than a pair of counters on it, because the provider row is
+-- written in ``_record_stream``'s ``finally`` BEFORE the tools run and the
+-- ledger is append-only — there is no row to increment and no request id
+-- reaching the harness to increment it by. A table also gets the per-tool-name
+-- breakdown a counter never could. Measured cost: 96 bytes/row, ~18 MB
+-- steady-state at the observed tool-call rate.
+CREATE TABLE IF NOT EXISTS tool_calls (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts_ms INTEGER NOT NULL,
+  session_id TEXT NOT NULL,
+  tool_name TEXT NOT NULL DEFAULT '',
+  -- 'model' = the model emitted a tool_use block; 'nested' = eval's
+  -- dispatch_tool bridge. Separable because a nested call is the model's CODE
+  -- calling a tool, not the model emitting a call, and conflating them would
+  -- let one scripted retry loop dominate the accuracy figure.
+  origin TEXT NOT NULL DEFAULT 'model',
+  -- '' = the call ran and returned without error. Model faults:
+  -- unknown_tool | invalid_arguments | duplicate_id. Not the model's fault:
+  -- execution | denied | aborted | skipped | gate_failed. The value is set at
+  -- the SOURCE via ToolResult.details['__fault'] where the reason is known,
+  -- never text-matched out of a result string afterwards.
+  fault TEXT NOT NULL DEFAULT '',
+  duration_ms REAL NOT NULL DEFAULT -1
+);
 """
 
 _CALL_COLUMNS = (
@@ -333,6 +360,19 @@ _OPTIONAL_INDEXES: tuple[tuple[str, str], ...] = (
         "parent_session_id",
         "CREATE INDEX IF NOT EXISTS idx_calls_parent ON calls(parent_session_id)",
     ),
+)
+
+#: Indexes on tables OTHER than ``calls``, created next to ``_OPTIONAL_INDEXES``
+#: and for the same reason: keeping them out of ``_SCHEMA`` means a failure here
+#: costs the index alone, where a raising statement inside ``executescript``
+#: aborts the REST of that script — losing the rollup tables and latching
+#: ``_broken`` for the process. They are unconditional (the table is created in
+#: ``_SCHEMA`` immediately above), so unlike ``_OPTIONAL_INDEXES`` there is no
+#: column to gate on. ``session`` serves the per-session report rollup;
+#: ``ts_ms`` serves ``prune``'s retention delete.
+_TABLE_INDEXES: tuple[str, ...] = (
+    "CREATE INDEX IF NOT EXISTS idx_tool_calls_session ON tool_calls(session_id)",
+    "CREATE INDEX IF NOT EXISTS idx_tool_calls_ts ON tool_calls(ts_ms)",
 )
 
 #: THE parent-edge rule, as one SQL expression, used by every surface that
@@ -783,6 +823,11 @@ class AnalyticsStore:
                 conn.execute(statement)
             except Exception:  # noqa: BLE001 — a missing index is slow, not broken
                 logger.debug("analytics: could not create index on %s", column, exc_info=True)
+        for statement in _TABLE_INDEXES:
+            try:
+                conn.execute(statement)
+            except Exception:  # noqa: BLE001 — a missing index is slow, not broken
+                logger.debug("analytics: could not create a table index", exc_info=True)
 
     def _rebuild_insert_plan(self) -> None:
         """Recompute the insert SQL + value selector from ``_present_optional``.
@@ -903,6 +948,65 @@ class AnalyticsStore:
                 time.sleep(_WRITE_RETRY_BACKOFF_S * (attempt + 1))
             except Exception:  # noqa: BLE001 — a lost batch must not kill the writer
                 logger.debug("analytics: batch insert failed", exc_info=True)
+                try:
+                    conn.rollback()
+                except Exception:  # noqa: BLE001
+                    pass
+                return 0
+        return 0
+
+    def record_tool_calls(self, rows: Sequence[tuple[int, str, str, str, str, float]]) -> int:
+        """Insert tool-call samples in one transaction. Returns rows written.
+
+        ``rows`` are ``(ts_ms, session_id, tool_name, origin, fault, duration_ms)``
+        — a plain tuple rather than a dataclass because the producer is the
+        harness, which deliberately has no analytics import, so the shape has to
+        survive a ``LoopConfig`` callback signature.
+
+        Batched, retried on ``SQLITE_BUSY`` and best-effort exactly like
+        :meth:`record_batch`, and on the SAME writer thread and connection.
+        Never raises: a lost tool sample is a slightly-wrong accuracy figure,
+        and a raise here would be a broken turn.
+
+        Deliberately its OWN transaction rather than joined to the ledger write:
+        tool calls are produced during a turn while the ledger row is written at
+        the end of the provider stream, so the two never arrive in the same
+        batch and pairing them would only delay one of them.
+        """
+        if not rows:
+            return 0
+        conn: sqlite3.Connection | None = None
+        for attempt in range(_WRITE_RETRIES):
+            conn = self._connect()
+            if conn is not None or self._broken:
+                break
+            time.sleep(_WRITE_RETRY_BACKOFF_S * (attempt + 1))
+        if conn is None:
+            return 0
+        sql = (
+            "INSERT INTO tool_calls "
+            "(ts_ms, session_id, tool_name, origin, fault, duration_ms) "
+            "VALUES (?, ?, ?, ?, ?, ?)"
+        )
+        for attempt in range(_WRITE_RETRIES):
+            try:
+                conn.executemany(sql, rows)
+                conn.commit()
+                return len(rows)
+            except sqlite3.OperationalError as exc:
+                try:
+                    conn.rollback()
+                except Exception:  # noqa: BLE001
+                    pass
+                if not _is_lock_error(exc):
+                    logger.debug("analytics: tool-call insert failed", exc_info=True)
+                    return 0
+                if attempt == _WRITE_RETRIES - 1:
+                    logger.debug("analytics: tool-call batch dropped after busy retries")
+                    return 0
+                time.sleep(_WRITE_RETRY_BACKOFF_S * (attempt + 1))
+            except Exception:  # noqa: BLE001 — a lost batch must not kill the writer
+                logger.debug("analytics: tool-call insert failed", exc_info=True)
                 try:
                     conn.rollback()
                 except Exception:  # noqa: BLE001
@@ -1063,6 +1167,11 @@ class AnalyticsStore:
         - The raw ``calls`` ledger keeps ``retention_days`` (default 90) by
           ``ts_ms`` — unchanged; its row count is the return value, preserving
           the original contract.
+        - ``tool_calls`` keeps the SAME ``retention_days`` window by ``ts_ms``.
+          It is a raw per-event ledger like ``calls`` and grows with tool-call
+          volume rather than request volume, so it needs the bound more than
+          ``calls`` does. Its rows are NOT added to the return value, which
+          contractually counts raw-ledger requests.
         - ``usage_daily`` keeps the most recent 365 DISTINCT ``day`` values
           (not 365 rows — each day holds one row per model), so the daily bar
           can look back a year regardless of how many models ran. The subquery
@@ -1091,6 +1200,14 @@ class AnalyticsStore:
             conn.commit()
         except Exception:  # noqa: BLE001
             logger.debug("analytics: prune failed", exc_info=True)
+        # Guarded on its own, like the rollups: a DB whose ``tool_calls`` table
+        # predates this feature (or failed to create) must still prune what it
+        # can rather than losing the ledger delete above.
+        try:
+            conn.execute("DELETE FROM tool_calls WHERE ts_ms < ?", (cutoff,))
+            conn.commit()
+        except Exception:  # noqa: BLE001 — a tool-call prune failure is non-fatal
+            logger.debug("analytics: tool-call prune failed", exc_info=True)
         # Rollup prunes are best-effort and independent of the ledger prune
         # above: a failure here must not undo the ledger delete or raise.
         try:
@@ -1403,6 +1520,12 @@ class AnalyticsStore:
                 col("context_tokens"),
                 col("output_tokens"),
                 *(f"NULLIF({col(name, '-1')}, -1)" for name in timings),
+                # ``NULL``, NOT the usual ``"0"`` default. ``col``'s zero
+                # fallback would report every request on a column-less ledger as
+                # FAILED, which is precisely the false alarm this field was added
+                # to remove. ``NULL`` yields ``ok=None`` = unknown, and the
+                # renderer draws unknown clean.
+                col("ok", "NULL"),
             ]
             recent = tuple(
                 SessionRequest(
@@ -1418,6 +1541,7 @@ class AnalyticsStore:
                     duration_ms=row[9],
                     ttft_ms=row[10],
                     preparation_ms=row[11],
+                    ok=None if row[12] is None else bool(row[12]),
                 )
                 for row in conn.execute(
                     "SELECT " + ", ".join(fields) + scope + " ORDER BY ts_ms DESC, id DESC LIMIT ?",
@@ -1427,6 +1551,7 @@ class AnalyticsStore:
             descendants, descendant_ids = self._descendant_usage(
                 conn, session_id, columns, measures
             )
+            tool_calls = self._tool_call_stats(conn, session_id)
             return SessionReport(
                 session_id=session_id,
                 aggregate=aggregate,
@@ -1441,6 +1566,7 @@ class AnalyticsStore:
                 recent=recent,
                 first_ts_ms=first,
                 last_ts_ms=last,
+                tool_calls=tool_calls,
             )
         except Exception:  # noqa: BLE001 — diagnostics must not interrupt a turn
             logger.debug("analytics: session report unavailable", exc_info=True)
@@ -1500,6 +1626,54 @@ class AnalyticsStore:
                 if parent:
                     parents[str(sid)] = str(parent)
         return parents
+
+    @staticmethod
+    def _tool_call_stats(conn: sqlite3.Connection, session_id: str) -> ToolCallStats | None:
+        """Tool-call outcomes for one session, or ``None`` meaning UNKNOWN.
+
+        ``None`` is returned when the ``tool_calls`` table does not exist (a
+        ledger written before this feature) **or** when it holds no rows for this
+        session. The second case is the important one: every session recorded
+        before this shipped has requests but no tool rows, and rendering that as
+        ``0 calls / 0% invalid`` would be a fabricated measurement on the exact
+        screen whose standing invariant is that an absent measurement is never
+        drawn as a measured zero.
+
+        The cost of that rule is a session which genuinely made zero tool calls,
+        which is INDISTINGUISHABLE from an unrecorded one in a bare ``COUNT(*)``
+        and therefore also reads ``unknown``. That is the safe error in both
+        directions — a wrong ``unknown`` withholds a fact, a wrong ``0%`` states
+        one — and it self-corrects the moment the session makes a tool call.
+        """
+        try:
+            rows = list(
+                conn.execute(
+                    "SELECT fault, tool_name, COUNT(*) FROM tool_calls "
+                    "WHERE session_id = ? GROUP BY fault, tool_name",
+                    (session_id,),
+                )
+            )
+        except sqlite3.Error:
+            # No such table: an older ledger. Unknown, not zero, and not an
+            # error — diagnostics must open against any ledger version.
+            logger.debug("analytics: tool_calls unavailable", exc_info=True)
+            return None
+        if not rows:
+            return None
+        total = 0
+        ok = 0
+        faults: dict[str, int] = {}
+        faults_by_tool: dict[str, int] = {}
+        for fault, tool_name, count in rows:
+            count = int(count)
+            total += count
+            if not fault:
+                ok += count
+                continue
+            faults[str(fault)] = faults.get(str(fault), 0) + count
+            name = str(tool_name)
+            faults_by_tool[name] = faults_by_tool.get(name, 0) + count
+        return ToolCallStats(total=total, ok=ok, faults=faults, faults_by_tool=faults_by_tool)
 
     def _descendant_usage(
         self,

--- a/local_operator/analytics/store.py
+++ b/local_operator/analytics/store.py
@@ -38,6 +38,7 @@ from typing import Any, Iterable, Sequence
 
 from local_operator.analytics.model import (
     COMPONENT_KEYS,
+    EXCLUDED_FAULTS,
     ORIGIN_MODEL,
     CallSnapshot,
     SessionReport,
@@ -1675,6 +1676,7 @@ class AnalyticsStore:
         faults_by_tool: dict[str, int] = {}
         nested_total = 0
         nested_ok = 0
+        nested_excluded = 0
         for origin, fault, tool_name, count in rows:
             count = int(count)
             if str(origin) != ORIGIN_MODEL:
@@ -1686,6 +1688,8 @@ class AnalyticsStore:
                 nested_total += count
                 if not fault:
                     nested_ok += count
+                elif fault in EXCLUDED_FAULTS:
+                    nested_excluded += count
                 continue
             total += count
             if not fault:
@@ -1701,6 +1705,7 @@ class AnalyticsStore:
             faults_by_tool=faults_by_tool,
             nested_total=nested_total,
             nested_ok=nested_ok,
+            nested_excluded=nested_excluded,
         )
 
     def _descendant_usage(

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -2578,6 +2578,14 @@ class AgentLoop:
         contract is that a measurement can never break the thing it measures,
         and that has to hold even against a host hook that throws.
 
+        The callback is invoked SYNCHRONOUSLY and is deliberately NOT wrapped in
+        a timeout or handed to a thread: at ~0.0018 ms for the shipped hook,
+        scheduling would cost more than the work and would reorder samples. The
+        consequence is that the non-blocking half of the contract is the host's
+        to keep and cannot be enforced here — a hook that blocks adds its full
+        duration to the turn (measured 0.002 s → 0.754 s against a 0.75 s
+        sleep). ``LoopConfig.record_tool_call`` states the budget.
+
         The tool name is taken from the resolved tool when there is one and from
         the CALL otherwise — a hallucinated name has no tool, and that name is
         exactly what a "which tool does this model get wrong" view needs.

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -132,6 +132,29 @@ _TYPE_ADAPTERS: dict[str, TypeAdapter[Any]] = {
 
 ABORTED_RESULT_TEXT = "aborted"
 SKIPPED_RESULT_TEXT = "Tool call skipped: interrupted by steering."
+
+# Why a tool call did not run cleanly, classified WHERE THE REASON IS KNOWN and
+# carried on ``ToolResult.details["__fault"]`` to the one place that reports it
+# (``park``). Deriving the class at ``park`` instead would mean text-matching
+# result strings like "Invalid arguments: " — fragile, and wrong the first time
+# a message is reworded. ``_synthetic_result`` already takes ``details`` for
+# exactly this purpose, and ``__approval_gate_failed`` set the convention.
+#
+# The split that matters is whether the MODEL is at fault, because only that
+# half is a measurement of the model. The first three are calls the harness
+# refused to dispatch because what the model emitted was not usable; the rest
+# are the user's decision, our own bug, or the world failing. Only the first
+# three feed the tool-call validity figure — see ``analytics.model.MODEL_FAULTS``,
+# which owns that classification for the read side.
+FAULT_KEY = "__fault"
+FAULT_UNKNOWN_TOOL = "unknown_tool"  # model named a tool that does not exist
+FAULT_INVALID_ARGUMENTS = "invalid_arguments"  # model violated the tool's schema
+FAULT_DUPLICATE_ID = "duplicate_id"  # model emitted one call id twice
+FAULT_DENIED = "denied"  # the user declined the call
+FAULT_GATE_FAILED = "gate_failed"  # our approval plumbing raised
+FAULT_ABORTED = "aborted"  # the user stopped the turn
+FAULT_SKIPPED = "skipped"  # steering redirected before this call ran
+FAULT_EXECUTION = "execution"  # the tool ran and failed (HTTP 500, missing file)
 # Backfill for empty tool results (coerceToolResult): Anthropic rejects an
 # empty ``is_error`` tool_result content with a 400, and other providers
 # serialize "" — one placeholder block keeps the wire legal for every client.
@@ -1593,7 +1616,9 @@ class AgentLoop:
                     _PlannedCall(
                         call=call,
                         failure=self._synthetic_result(
-                            call, f"Duplicate call id '{call.id}' skipped."
+                            call,
+                            f"Duplicate call id '{call.id}' skipped.",
+                            details={FAULT_KEY: FAULT_DUPLICATE_ID},
                         ),
                     )
                 )
@@ -1614,7 +1639,17 @@ class AgentLoop:
                 and self._peek_steering(config)
             ):
                 for remaining in plan[index:]:
-                    results.append(self._synthetic_result(remaining.call, SKIPPED_RESULT_TEXT))
+                    # Marked at the source like every other fault, though this
+                    # site bypasses ``park`` and so is not recorded: a call
+                    # steering skipped before it was ever scheduled is excluded
+                    # from both rates anyway, so its absence moves no figure.
+                    results.append(
+                        self._synthetic_result(
+                            remaining.call,
+                            SKIPPED_RESULT_TEXT,
+                            details={FAULT_KEY: FAULT_SKIPPED},
+                        )
+                    )
                 break
 
             if not _batches_shared(plan[index]):
@@ -1660,7 +1695,11 @@ class AgentLoop:
         if tool is None:
             return _PlannedCall(
                 call=call,
-                failure=self._synthetic_result(call, f"Tool not found: {call.name}"),
+                failure=self._synthetic_result(
+                    call,
+                    f"Tool not found: {call.name}",
+                    details={FAULT_KEY: FAULT_UNKNOWN_TOOL},
+                ),
             )
 
         # Lift the intent off BEFORE validation, and before anything else sees
@@ -1688,7 +1727,11 @@ class AgentLoop:
             return _PlannedCall(
                 call=call,
                 tool=tool,
-                failure=self._synthetic_result(call, "Invalid arguments: " + "; ".join(errors)),
+                failure=self._synthetic_result(
+                    call,
+                    "Invalid arguments: " + "; ".join(errors),
+                    details={FAULT_KEY: FAULT_INVALID_ARGUMENTS},
+                ),
             )
         resources: tuple[str, ...] | None = None
         if tool.resource_keys is not None:
@@ -1800,11 +1843,13 @@ class AgentLoop:
                     f"{sanitize_prompt_line(named, limit=200)}\n"
                     "This is a harness fault, not a refusal by the user; the stack is in "
                     "the log.",
-                    details={"__approval_gate_failed": True},
+                    details={"__approval_gate_failed": True, FAULT_KEY: FAULT_GATE_FAILED},
                 )
             if not approved:
                 return self._synthetic_result(
-                    call, f"User denied approval for '{sanitize_prompt_line(call.name, 120)}'."
+                    call,
+                    f"User denied approval for '{sanitize_prompt_line(call.name, 120)}'.",
+                    details={FAULT_KEY: FAULT_DENIED},
                 )
 
         def on_update(update: AgentToolUpdate) -> None:
@@ -1828,18 +1873,32 @@ class AgentLoop:
                         id=f"{call.id}:{uuid.uuid4().hex}", name=name, arguments=arguments
                     )
                     if name == "eval":
+                        # DELIBERATELY not recorded and not fault-marked. This
+                        # is a structural refusal of RECURSION, not a judgement
+                        # about a tool call: no tool was resolved, nothing was
+                        # dispatched, and it fits none of the classes the two
+                        # rates are defined over. Counting it would need a ninth
+                        # fault class that neither rate consumes, which would
+                        # move the denominator without informing either figure.
                         return self._synthetic_result(
                             nested, "Recursive eval tool calls are not supported."
                         ).model_dump(mode="json")
                     if signal is not None and signal.aborted:
-                        return self._synthetic_result(nested, ABORTED_RESULT_TEXT).model_dump(
-                            mode="json"
-                        )
+                        return self._synthetic_result(
+                            nested, ABORTED_RESULT_TEXT, details={FAULT_KEY: FAULT_ABORTED}
+                        ).model_dump(mode="json")
                     planned = await self._plan_call(nested, context, config)
                     if planned.failure is not None or planned.tool is None:
-                        return (
-                            planned.failure or self._synthetic_result(nested, "Tool not found.")
-                        ).model_dump(mode="json")
+                        failure = planned.failure or self._synthetic_result(
+                            nested, "Tool not found.", details={FAULT_KEY: FAULT_UNKNOWN_TOOL}
+                        )
+                        # This bridge never reaches ``park`` — it emits its own
+                        # start/end events — so it must report here or every
+                        # eval-driven tool call goes uncounted, which would
+                        # quietly understate exactly the composition-heavy runs
+                        # the accuracy figure is most wanted for.
+                        self._report_tool_call(config, context, planned, failure, origin="nested")
+                        return failure.model_dump(mode="json")
                     started = time.monotonic()
                     queue.put_nowait(
                         ToolExecutionStartEvent(
@@ -1852,8 +1911,11 @@ class AgentLoop:
                     try:
                         result = await self._runner_result(planned, context, config, signal, queue)
                     except asyncio.CancelledError:
-                        result = self._synthetic_result(nested, ABORTED_RESULT_TEXT)
+                        result = self._synthetic_result(
+                            nested, ABORTED_RESULT_TEXT, details={FAULT_KEY: FAULT_ABORTED}
+                        )
                         result.duration_s = time.monotonic() - started
+                        self._report_tool_call(config, context, planned, result, origin="nested")
                         queue.put_nowait(
                             ToolExecutionEndEvent(
                                 tool_call_id=nested.id,
@@ -1889,6 +1951,7 @@ class AgentLoop:
                             is_error=result.is_error,
                         )
                     )
+                    self._report_tool_call(config, context, planned, result, origin="nested")
                     return result.model_dump(mode="json")
 
                 execution_context = execution_context.model_copy(
@@ -2006,6 +2069,13 @@ class AgentLoop:
                         is_error=result.is_error,
                     )
                 )
+            # Every tool call the model emitted passes through here exactly
+            # once — dispatched, rejected at planning, denied, aborted or
+            # skipped — which is what makes this the one honest chokepoint for
+            # the accuracy figure. ``_report_tool_call`` is put_nowait-only and
+            # swallows everything: this runs ON THE EVENT LOOP inside a live
+            # turn, so analytics may cost neither latency nor a raised turn.
+            self._report_tool_call(config, context, item, result, origin="model")
             queue.put_nowait(_TOOL_DONE)
 
         async def runner(slot: int, item: _PlannedCall) -> None:
@@ -2035,7 +2105,9 @@ class AgentLoop:
                 park(
                     slot,
                     item,
-                    self._synthetic_result(item.call, ABORTED_RESULT_TEXT),
+                    self._synthetic_result(
+                        item.call, ABORTED_RESULT_TEXT, details={FAULT_KEY: FAULT_ABORTED}
+                    ),
                     duration_s=time.monotonic() - started_at,
                 )
                 raise
@@ -2078,12 +2150,13 @@ class AgentLoop:
                     # The INNER task was cancelled (steering, or the run
                     # aborting): synthesize a skipped/aborted result so the
                     # call stays paired.
-                    text = (
-                        SKIPPED_RESULT_TEXT
-                        if not (signal is not None and signal.aborted)
-                        else ABORTED_RESULT_TEXT
+                    aborted = signal is not None and signal.aborted
+                    text = ABORTED_RESULT_TEXT if aborted else SKIPPED_RESULT_TEXT
+                    result = self._synthetic_result(
+                        item.call,
+                        text,
+                        details={FAULT_KEY: FAULT_ABORTED if aborted else FAULT_SKIPPED},
                     )
-                    result = self._synthetic_result(item.call, text)
                 park(slot, item, result, duration_s=time.monotonic() - started_at)
             except asyncio.CancelledError:
                 # THIS coroutine was cancelled from outside — which is what the
@@ -2102,7 +2175,9 @@ class AgentLoop:
                 park(
                     slot,
                     item,
-                    self._synthetic_result(item.call, ABORTED_RESULT_TEXT),
+                    self._synthetic_result(
+                        item.call, ABORTED_RESULT_TEXT, details={FAULT_KEY: FAULT_ABORTED}
+                    ),
                     duration_s=time.monotonic() - started_at,
                 )
                 raise
@@ -2192,7 +2267,15 @@ class AgentLoop:
                         and config.interrupt_mode == "immediate"
                         and self._peek_steering(config)
                     ):
-                        park(slot, item, self._synthetic_result(item.call, SKIPPED_RESULT_TEXT))
+                        park(
+                            slot,
+                            item,
+                            self._synthetic_result(
+                                item.call,
+                                SKIPPED_RESULT_TEXT,
+                                details={FAULT_KEY: FAULT_SKIPPED},
+                            ),
+                        )
                         continue
                     if item.tool is not None and item.tool.interruptible and poll_interruptible:
                         await interruptible_runner(slot, item)
@@ -2459,6 +2542,66 @@ class AgentLoop:
         return sanitize_prompt_line(
             f"{call.name}({call.raw_arguments or json.dumps(call.arguments)})"
         )
+
+    @staticmethod
+    def _classify_fault(result: ToolResult) -> str:
+        """The fault class for a finished call: ``""`` when it ran cleanly.
+
+        Reads the marker the SOURCE set (see the ``FAULT_*`` constants), and
+        falls back to ``execution`` for any other error — a tool that ran and
+        returned ``is_error``, which is by definition not a planning failure and
+        so not the model's fault. Deliberately NOT a text match on the result:
+        the reason is known where the result is built and nowhere else, and a
+        reworded message must not silently reclassify a model fault as an
+        execution error (or the reverse, which would inflate the benchmark).
+        """
+        if not result.is_error:
+            return ""
+        details = result.details or {}
+        marker = details.get(FAULT_KEY)
+        return str(marker) if isinstance(marker, str) and marker else FAULT_EXECUTION
+
+    def _report_tool_call(
+        self,
+        config: LoopConfig,
+        context: LoopContext,
+        item: "_PlannedCall",
+        result: ToolResult,
+        *,
+        origin: str,
+    ) -> None:
+        """Hand one finished call's outcome to the host. Never raises, never blocks.
+
+        Called from ``park`` and from the nested ``dispatch_tool`` bridge, both
+        of which are on the EVENT LOOP inside a live turn. The whole body is
+        inside one guard because the callback is host-supplied: the harness's
+        contract is that a measurement can never break the thing it measures,
+        and that has to hold even against a host hook that throws.
+
+        The tool name is taken from the resolved tool when there is one and from
+        the CALL otherwise — a hallucinated name has no tool, and that name is
+        exactly what a "which tool does this model get wrong" view needs.
+        """
+        callback = config.record_tool_call
+        if callback is None:
+            return
+        try:
+            session_id = ""
+            tool_context = context.tool_context
+            if tool_context is not None:
+                session_id = getattr(tool_context, "session_id", "") or ""
+            if not session_id:
+                return
+            name = item.tool.name if item.tool is not None else item.call.name
+            duration = result.duration_s
+            callback(
+                name,
+                origin,
+                self._classify_fault(result),
+                -1.0 if duration is None else float(duration) * 1000.0,
+            )
+        except Exception:  # noqa: BLE001 — analytics must never raise into a turn
+            logger.debug("tool-call analytics hook failed", exc_info=True)
 
     @staticmethod
     def _synthetic_result(

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -1554,6 +1554,25 @@ class LoopConfig(BaseModel):
     # becomes a message. ``None`` means no credentials are stored.
     redact_tool_result: Callable[[str], str] | None = Field(default=None, exclude=True)
 
+    #: Report one tool call's outcome to the host, as
+    #: ``(tool_name, origin, fault, duration_ms)``. A CALLBACK rather than a
+    #: direct analytics call because this package has no analytics dependency
+    #: and must keep none: the harness is the thing being measured, and a
+    #: measurement import here would make the loop depend on the ledger.
+    #:
+    #: ``origin`` is ``"model"`` (the model emitted a tool_use block) or
+    #: ``"nested"`` (eval's ``dispatch_tool`` bridge). ``fault`` is ``""`` for a
+    #: clean call, else the classification made where the reason is known \u2014 see
+    #: ``_FAULT_*`` in ``loop.py``.
+    #:
+    #: The loop invokes this on the EVENT LOOP inside a live turn, so an
+    #: implementation must be non-blocking and must not raise; the loop guards
+    #: it anyway, because a host that breaks its contract must still not be able
+    #: to kill a turn with a bad analytics hook.
+    record_tool_call: Callable[[str, str, str, float], None] | None = Field(
+        default=None, exclude=True
+    )
+
     # Steering (CONSUMING) interrupts tool batches; peek (non-consuming) is
     # polled between calls. Asides never interrupt.
     get_steering_messages: Callable[[], Awaitable[list[AgentMessage]]] | None = Field(

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -1565,10 +1565,17 @@ class LoopConfig(BaseModel):
     #: clean call, else the classification made where the reason is known \u2014 see
     #: ``_FAULT_*`` in ``loop.py``.
     #:
-    #: The loop invokes this on the EVENT LOOP inside a live turn, so an
-    #: implementation must be non-blocking and must not raise; the loop guards
-    #: it anyway, because a host that breaks its contract must still not be able
-    #: to kill a turn with a bad analytics hook.
+    #: The loop invokes this SYNCHRONOUSLY on the EVENT LOOP inside a live turn,
+    #: once per finished tool call, so an implementation must be non-blocking and
+    #: must not raise. The loop guards against the raising half — a host that
+    #: breaks its contract must still not be able to kill a turn with a bad
+    #: analytics hook — but it CANNOT guard against the blocking half: there is
+    #: no timeout around the call, so whatever time this hook spends is added
+    #: directly to the turn. Measured: a hook that sleeps 0.75 s turns a 0.002 s
+    #: turn into a 0.754 s one. The shipped implementation is a single bounded
+    #: ``put_nowait`` at ~0.0018 ms/call, which is the budget an implementer
+    #: should hold to; anything that touches disk, a lock or a socket belongs on
+    #: the far side of a queue, not here.
     record_tool_call: Callable[[str, str, str, float], None] | None = Field(
         default=None, exclude=True
     )

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -5315,6 +5315,27 @@ class Session:
         it."""
         self._fallback_tool_resolver = resolver
 
+    def _record_tool_call(
+        self, tool_name: str, origin: str, fault: str, duration_ms: float
+    ) -> None:
+        """Ledger hook for ``LoopConfig.record_tool_call``. Never raises.
+
+        The session supplies its OWN id rather than the loop passing one: the
+        harness is deliberately ignorant of the ledger, and this is the object
+        that knows which session the call belongs to. Everything below the
+        enqueue is best-effort by contract — see ``analytics.record_tool_call``,
+        which is a single bounded ``put_nowait`` onto the recorder's existing
+        queue and writer thread.
+        """
+        if not self._session_id:
+            return
+        try:
+            from local_operator.analytics import record_tool_call
+
+            record_tool_call(self._session_id, tool_name, origin, fault, duration_ms)
+        except Exception:  # noqa: BLE001 — analytics must never break a turn
+            logger.debug("analytics: session tool-call hook failed", exc_info=True)
+
     # -- context accounting ---------------------------------------------------
 
     def _note_usage(self, messages: Sequence[AgentMessage]) -> None:
@@ -6305,6 +6326,13 @@ class Session:
                 redact_tool_result=(
                     self._variables.redact if self._variables is not None else None
                 ),
+                # Tool-call outcomes into the shared ledger, so /session can
+                # report this model's tool-call validity. Supplied as a closure
+                # for the same reason redact_tool_result is: the harness has no
+                # analytics dependency and must keep none. ``record_tool_call``
+                # is put_nowait-only and swallows its own errors, so this stays
+                # off the turn's critical path.
+                record_tool_call=self._record_tool_call,
                 interrupt_mode="immediate",
                 on_turn_end=self._on_turn_end,
             )

--- a/local_operator/tui/widgets/session_panel.py
+++ b/local_operator/tui/widgets/session_panel.py
@@ -1137,8 +1137,35 @@ def _draw_tool_call_rows(body: _Body, stats: ToolCallStats | None) -> None:
     # version printed 35 and then a 34-call denominator one line later with
     # nothing accounting for the difference, which reads as the screen
     # miscounting — the exact misreading this feature exists to remove.
+    #
+    # `failed` MUST NEVER INCLUDE OPERATOR-EXCLUDED CALLS. This is the founding
+    # bug of this whole PR, and it reappeared here one block lower: the first
+    # version of this line was `stats.recorded - ok`, which swept `excluded`
+    # (denied / aborted / skipped / gate_failed) into `failed` and painted
+    # `0 ok · 4 failed` on a session where the operator declined four calls and
+    # nothing failed at all (design round 2, D7) — the same shape as the
+    # operator's original report, `15 req · 15 failed` on a session where
+    # nothing failed. A call the operator refused is not a failure of anything,
+    # and the ` └ ` row directly beneath says so in as many words, so the
+    # headline was contradicting its own sub-row.
+    #
+    # Derived by SUBTRACTING the excluded rather than by adding the two fault
+    # classes: `model_faults + execution_faults` is equal today only because the
+    # fault vocabulary happens to be closed (`_classify_fault` falls back to
+    # `FAULT_EXECUTION`), so a future fault name outside all three frozensets
+    # would silently vanish from the headline instead of being counted. Framed
+    # this way it lands in `failed`, which is the safe direction: an unnamed
+    # fault is still a fault, while a miscounted denial is this block's defining
+    # error.
+    #
+    # Nested failures are added for the same reason the headline is `recorded`:
+    # `ok` already spans both origins, so a model-origin-only `failed` would
+    # leave a failed eval-bridge call in neither term of a pair that reads as a
+    # partition. The three terms are exhaustive by construction —
+    # `ok + failed + excluded == recorded` — and each one is on screen, the last
+    # as the ` └ denied or aborted` row.
     ok = stats.ok + stats.nested_ok
-    failed = stats.recorded - ok
+    failed = (stats.total - stats.ok - stats.excluded) + (stats.nested_total - stats.nested_ok)
     detail = f"{ok} ok" + (f" · {failed} failed" if failed else "")
     body.kv("Tool calls", str(stats.recorded), detail)
 
@@ -1162,13 +1189,25 @@ def _draw_tool_call_rows(body: _Body, stats: ToolCallStats | None) -> None:
         # previously invisible, which left the headline `N failed` short of the
         # sub-rows by exactly this number. With the approval gate on, denials
         # are the DEFAULT posture, so this was the modal unaccountable count.
+        #
+        # THE NOTE IS ATTRIBUTION-NEUTRAL ON PURPOSE. It used to read "you
+        # stopped these, not the model", which is true of `denied` and `aborted`
+        # but false of the other two members of ``EXCLUDED_FAULTS``:
+        # `gate_failed` is OUR approval plumbing raising — a harness bug — and
+        # `skipped` is steering redirecting before the call ran. Both rendered
+        # as the operator's own decision, so a block whose entire purpose is
+        # correct attribution handed the reader a harness defect and blamed them
+        # for it (review round 2, N1). The arithmetic was never affected; only
+        # the wording was. "outside both rates" is the one thing true of all
+        # four, and it states the fact the row exists to state: these calls are
+        # in neither denominator below.
         body.kv(
             " └ denied or aborted",
             str(stats.excluded),
             notes=(
-                f"you stopped {'these' if stats.excluded > 1 else 'this'}, not the model",
-                "your decision, not the model's",
-                "your decision",
+                "stopped or never dispatched · outside both rates",
+                "never dispatched · outside both rates",
+                "outside both rates",
             ),
         )
 
@@ -1226,6 +1265,18 @@ def _draw_tool_call_rows(body: _Body, stats: ToolCallStats | None) -> None:
         # reader who takes it for a model metric blames the model for the
         # network — and it covers model-emitted calls only, like every count in
         # this block.
+        #
+        # EVERY RUNG STATES THE DENOMINATOR, and the last one drops the VERB to
+        # keep it. The floor rung was `"{pct}% dispatched"`, which at body widths
+        # 52-57 painted `7.4% dispatched` — a sentence asserting the INVERSE of
+        # the truth, since it reads as "7.4% got dispatched" on a session where
+        # 27 of 31 did (design round 2, D6). A bare percentage next to a verb is
+        # not a shorter spelling of the same qualifier, it is a different and
+        # false claim, so the ladder's contract — progressively shorter
+        # spellings of ONE qualifier — was broken at the bottom rung. `% of 27`
+        # keeps the half that makes the figure legible and sheds the half that
+        # inverts it, and at 10 characters against the broken rung's 15 it fits
+        # a strictly wider band than the string it replaces.
         dispatched = stats.emitted - stats.model_faults
         body.kv(
             "Tool-side errors",
@@ -1235,7 +1286,7 @@ def _draw_tool_call_rows(body: _Body, stats: ToolCallStats | None) -> None:
                 "not a model-accuracy figure",
                 f"{execution * 100:.1f}% of {dispatched} dispatched · not model accuracy",
                 f"{execution * 100:.1f}% of {dispatched} dispatched",
-                f"{execution * 100:.1f}% dispatched",
+                f"{execution * 100:.1f}% of {dispatched}",
             ),
         )
 

--- a/local_operator/tui/widgets/session_panel.py
+++ b/local_operator/tui/widgets/session_panel.py
@@ -610,7 +610,15 @@ class _Body:
     def blank(self) -> None:
         self.lines.append(Text())
 
-    def kv(self, name: str, value: str, note: str = "", *, notes: Sequence[str] = ()) -> None:
+    def kv(
+        self,
+        name: str,
+        value: str,
+        note: str = "",
+        *,
+        notes: Sequence[str] = (),
+        dim_value: bool = False,
+    ) -> None:
         """A Totals-style scalar row, matching ``build_report``'s ``kv`` exactly.
 
         ``notes`` is a ladder of progressively shorter spellings of the SAME
@@ -623,12 +631,38 @@ class _Body:
         that looks like a wrong one, which is the defect this screen exists to
         fix. Cropping a qualifier is fine; cropping the scope is not.
 
+        **A LADDER RUNG IS STILL SHEDDABLE, SO NOTHING LOAD-BEARING MAY LIVE
+        ONLY HERE.** The ladder narrows the range of widths at which a qualifier
+        disappears; it cannot remove it, because below the shortest rung's budget
+        there is nothing left to draw and cropping mid-word is the other failure
+        this screen forbids. The first version of ``Execution errors`` put the
+        whole load-bearing distinction — that the number is NOT a model-accuracy
+        figure — in these notes, so at 68 columns the row rendered as a bare
+        integer named "errors" sitting under an accuracy percentage: worse than
+        the ``note`` path it replaced, which at least shed at a documented
+        :data:`_NOTE_MIN` (design round 1, D1).
+
+        The rule that followed: **a distinction the reader must not lose belongs
+        in the LABEL, which is never shed; the notes carry only the refinement.**
+        That is why the row is now ``Tool-side errors`` rather than ``Execution
+        errors`` — the scope survives every width by construction, and the ladder
+        is free to shed the rate and its denominator as the frame narrows.
+        ``test_the_execution_scope_survives_at_every_supported_width`` pins it.
+
+        ``dim_value`` renders the value cell in ``dim`` rather than ``fg``, for
+        the literal ``unknown``: an absent measurement should not carry the same
+        ink as a measured number, which is the treatment ``_timing_rows``
+        already established with ``unknown (0 samples)`` (design round 1, D5).
+
         Callers with a purely decorative qualifier keep passing ``note`` and keep
         the old shed-below-``_NOTE_MIN`` behaviour.
         """
         row = Text()
         row.append(f"  {name:<22}", style=semantic_style("dim"))
-        row.append(f"{value:<{_VALUE_CELL}}", style=semantic_style("fg"))
+        row.append(
+            f"{value:<{_VALUE_CELL}}",
+            style=semantic_style("dim" if dim_value else "fg"),
+        )
         if notes:
             # Budget measured from the row as actually built, not from a
             # restated literal: a change to _VALUE_CELL or the label column
@@ -638,6 +672,12 @@ class _Body:
                 if len(candidate) <= budget:
                     row.append(f"  {candidate}", style=semantic_style("dim"))
                     break
+            # No `else`: when no rung fits the qualifier sheds rather than being
+            # cropped mid-word. That is safe ONLY because no caller keeps a
+            # load-bearing distinction here — see the docstring's label rule.
+            # Drawing the last rung unconditionally was tried and rejected: it
+            # reintroduces the mid-word crop the ladder exists to avoid, at
+            # exactly the widths where it would fire.
         elif note and self.width >= _NOTE_MIN:
             # Below _NOTE_MIN the qualifier is shed and the fact kept: at 50
             # columns the note wraps onto its own unindented line and reads as a
@@ -1071,21 +1111,73 @@ def _draw_tool_call_rows(body: _Body, stats: ToolCallStats | None) -> None:
     is in that state, and a fabricated zero on a diagnostics screen is worse
     than a withheld fact: the reader cannot tell it from a measurement.
     """
-    if stats is None or stats.total <= 0:
-        body.kv("Tool calls", "unknown", "not recorded for this session")
+    if stats is None or stats.recorded <= 0:
+        # ``recorded``, not ``total``: a session whose only tool calls came from
+        # eval's bridge DID make calls, and reading it as "unknown" would be the
+        # mirror of the fabricated zero this rule forbids.
+        body.kv("Tool calls", "unknown", "not recorded for this session", dim_value=True)
         # The two rates are OMITTED rather than shown as unknown: three unknown
         # rows is noise, and the one row above already says why.
         return
-    failed = stats.total - stats.ok
-    detail = f"{stats.ok} ok" + (f" · {failed} failed" if failed else "")
-    body.kv("Tool calls", str(stats.total), detail)
+
+    # THE BLOCK IS A SUBTRACTION CHAIN, and every step of it is on screen
+    # (design round 1, D2). The headline is EVERY call recorded; each ` └ ` row
+    # below removes a class from it, in the order the rates remove them, so the
+    # validity denominator is reached by reading downward rather than by
+    # trusting an unexplained shift:
+    #
+    #   Tool calls          35   <- recorded, both origins
+    #    └ nested (eval)     3   <- not the model emitting a call
+    #    └ denied/aborted    1   <- never allowed to prove anything
+    #   Call validity          4 invalid of 31 emitted   (35 - 3 - 1)
+    #
+    # This is why the headline is `recorded` and not `total`: under the ` └ `
+    # idiom a sub-row is PART of the row above it, so a model-origin headline
+    # with a nested sub-row under it would be arithmetically false. The previous
+    # version printed 35 and then a 34-call denominator one line later with
+    # nothing accounting for the difference, which reads as the screen
+    # miscounting — the exact misreading this feature exists to remove.
+    ok = stats.ok + stats.nested_ok
+    failed = stats.recorded - ok
+    detail = f"{ok} ok" + (f" · {failed} failed" if failed else "")
+    body.kv("Tool calls", str(stats.recorded), detail)
+
+    if stats.nested_total:
+        # Nested calls are real work the session did, so they are shown — but
+        # apart, and labelled, because no rate here is computed over them (see
+        # the origin partition on ``ToolCallStats``). Without this row a reader
+        # watching 20 eval-dispatched calls happen sees a rate over 3 and
+        # concludes the counter is broken.
+        body.kv(
+            " └ nested (eval)",
+            str(stats.nested_total),
+            notes=(
+                f"{stats.nested_ok} ok · eval's calls, not the model's",
+                f"{stats.nested_ok} ok · not the model's",
+                "not the model's",
+            ),
+        )
+    if stats.excluded:
+        # The denied/aborted calls: correctly outside both denominators, and
+        # previously invisible, which left the headline `N failed` short of the
+        # sub-rows by exactly this number. With the approval gate on, denials
+        # are the DEFAULT posture, so this was the modal unaccountable count.
+        body.kv(
+            " └ denied or aborted",
+            str(stats.excluded),
+            notes=(
+                f"you stopped {'these' if stats.excluded > 1 else 'this'}, not the model",
+                "your decision, not the model's",
+                "your decision",
+            ),
+        )
 
     validity = stats.validity
     if validity is None:
         # Rows exist but nothing counted toward the denominator (every call was
         # denied or aborted). Mirrors ``_timing_rows``' "unknown (0 samples)"
         # wording on purpose, so the two read as the same kind of statement.
-        body.kv("Call validity", "unknown", "0 emitted")
+        body.kv("Call validity", "unknown", "0 emitted", dim_value=True)
     else:
         invalid = stats.model_faults
         # A ladder, not a plain note: this qualifier carries the SCOPE of the
@@ -1103,8 +1195,11 @@ def _draw_tool_call_rows(body: _Body, stats: ToolCallStats | None) -> None:
         )
         # Name the faults rather than only counting them: "which one" is the
         # actionable half, and it is what makes the figure a benchmark rather
-        # than a score. Biggest first, and only faults that actually occurred.
-        for name in sorted(MODEL_FAULTS, key=lambda f: -stats.faults.get(f, 0)):
+        # than a score. Biggest first; the NAME breaks ties, because the sort
+        # runs over a frozenset and set order for strings varies with
+        # PYTHONHASHSEED — tied rows swapping between two renders of the same
+        # data reads as the data changing (design round 1, D3).
+        for name in sorted(MODEL_FAULTS, key=lambda f: (-stats.faults.get(f, 0), f)):
             count = stats.faults.get(name, 0)
             if count:
                 # Leading space matches ``_tool_rows``' " └ " exactly: the two
@@ -1113,18 +1208,34 @@ def _draw_tool_call_rows(body: _Body, stats: ToolCallStats | None) -> None:
                 body.kv(f" └ {name.replace('_', ' ')}", str(count))
 
     execution = stats.execution_error_rate
-    if execution is not None and stats.execution_faults:
-        # Explicitly labelled as NOT a model metric, every time it is drawn. It
-        # counts the web being down and an MCP server refusing credentials; a
-        # reader who takes it for an accuracy figure will blame the model for
-        # the network.
+    if execution is not None:
+        # Drawn whenever calls were DISPATCHED, including at zero. Suppressing
+        # the zero made "no execution errors" and "not measured" identical on
+        # screen, which is the converse of this screen's standing invariant and
+        # is inconsistent with `Call validity` one line above, which shows its
+        # own zero (design round 1, D4). The modal healthy session is exactly
+        # the case that was being hidden.
+        #
+        # THE LABEL CARRIES THE SCOPE, not the note. "Tool-side" says whose
+        # fault these are in the one cell that is never shed, so the distinction
+        # survives a 50-column pane; the note then refines it with the rate and
+        # the denominator and may shed freely. Named "Execution errors" first,
+        # which put the entire distinction in the shed-able half and rendered as
+        # a bare integer under an accuracy percentage at 68 columns (D1). It
+        # counts the web being down and an MCP server refusing credentials — a
+        # reader who takes it for a model metric blames the model for the
+        # network — and it covers model-emitted calls only, like every count in
+        # this block.
+        dispatched = stats.emitted - stats.model_faults
         body.kv(
-            "Execution errors",
+            "Tool-side errors",
             str(stats.execution_faults),
             notes=(
-                f"{execution * 100:.1f}% · not a model-accuracy figure",
-                f"{execution * 100:.1f}% · not model accuracy",
-                "not model accuracy",
+                f"{execution * 100:.1f}% of {dispatched} dispatched · "
+                "not a model-accuracy figure",
+                f"{execution * 100:.1f}% of {dispatched} dispatched · not model accuracy",
+                f"{execution * 100:.1f}% of {dispatched} dispatched",
+                f"{execution * 100:.1f}% dispatched",
             ),
         )
 

--- a/local_operator/tui/widgets/session_panel.py
+++ b/local_operator/tui/widgets/session_panel.py
@@ -48,8 +48,10 @@ from textual.widgets import Static
 from local_operator.analytics.model import (
     COMPONENT_KEYS,
     COMPONENT_LABELS,
+    MODEL_FAULTS,
     SessionReport,
     TimingSummary,
+    ToolCallStats,
     UsageAggregate,
 )
 from local_operator.session.protocol import SessionProtocol
@@ -377,8 +379,6 @@ def _metric_meta(metric: str, prefix: str) -> str:
 def _group_rows(
     groups: list[tuple[str, UsageAggregate]],
     metric: str,
-    *,
-    failures: dict[str, int] | None = None,
 ) -> tuple[list[_BarRow], bool]:
     """Rows for a partitioning table (by model, by purpose), biggest first.
 
@@ -406,6 +406,24 @@ def _group_rows(
     and leaves the honest ``$—``, which is the only figure here we can stand
     behind. This is the same rule as ``_timing_rows`` and ``_gauge_row``: an
     absent measurement is never drawn as a measured zero.
+
+    **The failure tally is ``calls - ok_calls``, never a test on the ``outcome``
+    string.** ``ok`` is the recorded truth: a boolean the provider path writes on
+    every row. ``outcome`` is ``str(stop_reason)`` (``model/configure.py``) drawn
+    from each adapter's finish-reason map — ``stop``/``length``/``toolUse``/
+    ``refusal`` — or an exception class name, so its vocabulary is
+    PROVIDER-SPECIFIC and drifts whenever an adapter is added. The predicate this
+    replaced tested ``outcome not in ("ok", "unknown")`` against a string nothing
+    has ever written, so every healthy request rendered in ``warning`` as failed
+    while ``Totals`` — which already read ``ok_calls`` — said zero on the same
+    screen. Keep the predicate on ``ok``; the next vocabulary change must not be
+    able to reach it.
+
+    ``ok`` is safe to read unconditionally: ``calls.ok INTEGER NOT NULL DEFAULT
+    1`` has existed since the table was created, it is not in
+    ``store._MIGRATION_COLUMNS``, and ``session_report`` already refuses any DB
+    missing the base column set — so no reachable ledger lacks it, and a group
+    reporting every request failed is a real state that must still render.
     """
     total = sum(_metric_value(agg, metric) for _, agg in groups)
     ordered = sorted(
@@ -416,7 +434,7 @@ def _group_rows(
     rows: list[_BarRow] = []
     for name, agg in ordered:
         note: list[tuple[str, str]] = [(f"{agg.calls} req", "dim")]
-        failed = (failures or {}).get(name, 0)
+        failed = max(0, agg.calls - agg.ok_calls)
         if failed:
             # ``warning``, not ``dim``: a failed request is the one thing on this
             # screen a reader must not scroll past, and at the far right of the
@@ -435,27 +453,6 @@ def _group_rows(
             )
         )
     return rows, total > 0
-
-
-def _failures(report: SessionReport) -> dict[str, int]:
-    """Non-``ok`` request count per purpose, from the existing outcome cross-tab.
-
-    ``by_purpose`` carries the consumption and ``by_purpose_outcome`` carries
-    the outcomes; the failure tally is the second folded onto the first, not a
-    third query.
-    """
-    # ``unknown`` is excluded, not folded into the failures: an older ledger has
-    # no ``outcome`` column, so every row reads ``unknown`` and counting those
-    # would paint a healthy legacy session as entirely failed — in ``warning``,
-    # the one colour on this screen that must never cry wolf.
-    return {
-        purpose: sum(
-            count
-            for (name, outcome), count in report.by_purpose_outcome.items()
-            if name == purpose and outcome not in ("ok", "unknown")
-        )
-        for purpose in report.by_purpose
-    }
 
 
 def _component_rows(aggregate: UsageAggregate) -> tuple[list[_BarRow], int]:
@@ -825,7 +822,7 @@ def _shared_columns(
     # Measured WITH the failure annotations, because they are what the draw
     # pass emits: measuring `14 req` and then drawing `14 req · 2 failed` sizes
     # the note column too small and crops it to `14 req · 2 f`.
-    rows.extend(_group_rows(list(report.by_purpose.items()), metric, failures=_failures(report))[0])
+    rows.extend(_group_rows(list(report.by_purpose.items()), metric)[0])
     component_rows, component_total = _component_rows(aggregate)
     rows.extend(component_rows)
     rows.extend(_tool_rows(aggregate, component_total))
@@ -946,7 +943,7 @@ def _draw_recorded_usage(
     _draw_by_model(body, report, width, metric, cols)
     _draw_by_purpose(body, report, width, metric, cols)
     _draw_input_split(body, aggregate, width, cols)
-    _draw_tool_surface(body, aggregate, width, cols)
+    _draw_tool_surface(body, aggregate, width, cols, report.tool_calls)
     _draw_request_sequence(body, report, width, metric)
     body.header("Timings", "observed wall time · includes retries", "wall time")
     body.extend(_timing_rows(report.timings, width))
@@ -1032,7 +1029,7 @@ def _draw_by_purpose(
     """
     if not report.by_purpose:
         return
-    rows, priced = _group_rows(list(report.by_purpose.items()), metric, failures=_failures(report))
+    rows, priced = _group_rows(list(report.by_purpose.items()), metric)
     body.header("By purpose", _metric_meta(metric, _own_scope(report)), _metric_meta(metric, ""))
     # Only when there is a contrast to explain: the legend defines ``turn``
     # against the harness's own purposes, so it is noise when the rows are all
@@ -1058,9 +1055,102 @@ def _draw_input_split(body: _Body, aggregate: UsageAggregate, width: int, cols: 
     body.blank()
 
 
-def _draw_tool_surface(body: _Body, aggregate: UsageAggregate, width: int, cols: _Columns) -> None:
+def _draw_tool_call_rows(body: _Body, stats: ToolCallStats | None) -> None:
+    """Measured tool-call counts and the two rates, above the estimated bars.
+
+    Scalars via ``kv``, deliberately WITHOUT bars. A bar asserts a shared
+    denominator — the rule stated on ``Totals`` and ``_group_rows`` — and these
+    two rates have different ones: validity is over calls the model EMITTED,
+    the execution rate is over calls that actually RAN. Drawn side by side as
+    tracks they would invite a comparison that is arithmetically meaningless.
+
+    **The unknown rule, which is this screen's standing invariant.** ``stats is
+    None`` means no tool data for this session — either a ledger predating the
+    feature or a session that recorded none — and it renders as ``unknown``,
+    never as ``0 calls`` or ``0%``. Every session recorded before this shipped
+    is in that state, and a fabricated zero on a diagnostics screen is worse
+    than a withheld fact: the reader cannot tell it from a measurement.
+    """
+    if stats is None or stats.total <= 0:
+        body.kv("Tool calls", "unknown", "not recorded for this session")
+        # The two rates are OMITTED rather than shown as unknown: three unknown
+        # rows is noise, and the one row above already says why.
+        return
+    failed = stats.total - stats.ok
+    detail = f"{stats.ok} ok" + (f" · {failed} failed" if failed else "")
+    body.kv("Tool calls", str(stats.total), detail)
+
+    validity = stats.validity
+    if validity is None:
+        # Rows exist but nothing counted toward the denominator (every call was
+        # denied or aborted). Mirrors ``_timing_rows``' "unknown (0 samples)"
+        # wording on purpose, so the two read as the same kind of statement.
+        body.kv("Call validity", "unknown", "0 emitted")
+    else:
+        invalid = stats.model_faults
+        # A ladder, not a plain note: this qualifier carries the SCOPE of the
+        # percentage (which calls it is over), and a scope cropped mid-word or
+        # shed wholesale leaves a correct figure looking like a wrong one — the
+        # defect ``kv``'s ``notes`` parameter exists to fix.
+        body.kv(
+            "Call validity",
+            f"{validity * 100:.1f}%",
+            notes=(
+                f"{invalid} invalid of {stats.emitted} emitted",
+                f"{invalid} of {stats.emitted} emitted",
+                "emitted calls",
+            ),
+        )
+        # Name the faults rather than only counting them: "which one" is the
+        # actionable half, and it is what makes the figure a benchmark rather
+        # than a score. Biggest first, and only faults that actually occurred.
+        for name in sorted(MODEL_FAULTS, key=lambda f: -stats.faults.get(f, 0)):
+            count = stats.faults.get(name, 0)
+            if count:
+                # Leading space matches ``_tool_rows``' " └ " exactly: the two
+                # sub-row groups sit in the same section, and two different
+                # indents for the same relationship reads as a misalignment.
+                body.kv(f" └ {name.replace('_', ' ')}", str(count))
+
+    execution = stats.execution_error_rate
+    if execution is not None and stats.execution_faults:
+        # Explicitly labelled as NOT a model metric, every time it is drawn. It
+        # counts the web being down and an MCP server refusing credentials; a
+        # reader who takes it for an accuracy figure will blame the model for
+        # the network.
+        body.kv(
+            "Execution errors",
+            str(stats.execution_faults),
+            notes=(
+                f"{execution * 100:.1f}% · not a model-accuracy figure",
+                f"{execution * 100:.1f}% · not model accuracy",
+                "not model accuracy",
+            ),
+        )
+
+
+def _draw_tool_surface(
+    body: _Body,
+    aggregate: UsageAggregate,
+    width: int,
+    cols: _Columns,
+    stats: ToolCallStats | None = None,
+) -> None:
     rows = _tool_rows(aggregate, _component_rows(aggregate)[1])
-    body.header("Tool surface", "≈ estimated share of context tokens", "≈ estimated")
+    # The meta says "measured calls" AND "≈ estimated tokens" because the
+    # section now carries both kinds of number: the call counts below are
+    # counted, the token bars under them are apportioned. A single "≈ estimated"
+    # header would have mislabelled the measured half as an estimate.
+    body.header("Tool surface", "measured calls · ≈ estimated tokens", "measured · ≈ est.")
+    # Measured rows FIRST, then the estimated bars: they are the stronger fact,
+    # and the disclaimer below applies only to the bars.
+    #
+    # NO blank line between the two groups. A blank ENDS a section on this
+    # screen — that is the rule ``_section`` encodes and the reader learns from
+    # every other block — so separating them would render one section as two,
+    # the second of which has no header. The `kv` scalars and the bar rows are
+    # already visually distinct without inventing a second section boundary.
+    _draw_tool_call_rows(body, stats)
     if rows:
         body.extend(_render_rows(rows, cols, width, estimated=True))
     else:
@@ -1070,9 +1160,14 @@ def _draw_tool_surface(body: _Body, aggregate: UsageAggregate, width: int, cols:
     # support: there is no per-tool-name token or cost column, and cost is
     # priced per call at record time, so splitting it across these three
     # components would invent a number the provider never billed.
+    #
+    # Reworded from "this is" to "the token bars above are" now that the
+    # section also carries MEASURED call counts. The original wording would
+    # have swept those into the same disclaimer and told the reader that a
+    # counted number was an estimate.
     body.note(
-        "Per-tool-name tokens and dollars are not recorded; this is the tool "
-        "machinery's share of input, not the cost of any one tool call."
+        "Per-tool-name tokens and dollars are not recorded; the token bars above "
+        "are the tool machinery's share of input, not the cost of any one tool call."
     )
     body.blank()
 
@@ -1123,7 +1218,16 @@ def _draw_request_sequence(body: _Body, report: SessionReport, width: int, metri
     rows: list[_BarRow] = []
     for request, value in zip(series, values):
         note: tuple[tuple[str, str], ...] = ((request.purpose, "dim"),)
-        if request.outcome != "ok":
+        # ``ok``, not the ``outcome`` string, decides whether this row is a
+        # failure — the same rule as ``_group_rows`` and for the same reason:
+        # ``outcome`` is a provider-specific finish reason, and testing it
+        # against a literal ``"ok"`` nothing writes painted every healthy
+        # request in ``warning``. Three-state on purpose: ``None`` is UNKNOWN
+        # (a ledger with no ``ok`` column) and takes the clean path, because an
+        # absent measurement is never rendered as a failure on this screen.
+        # The outcome string is still DISPLAYED once ``ok`` has established the
+        # row is a failure — it is what says which failure.
+        if request.ok is False:
             note = ((request.purpose, "dim"), (" · ", "dim"), (request.outcome, "warning"))
         rows.append(
             _BarRow(

--- a/local_operator/tui/widgets/session_panel.py
+++ b/local_operator/tui/widgets/session_panel.py
@@ -1100,7 +1100,7 @@ def _draw_tool_call_rows(body: _Body, stats: ToolCallStats | None) -> None:
 
     Scalars via ``kv``, deliberately WITHOUT bars. A bar asserts a shared
     denominator — the rule stated on ``Totals`` and ``_group_rows`` — and these
-    two rates have different ones: validity is over calls the model EMITTED,
+    two rates have different ones: invocation errors are over calls the model EMITTED,
     the execution rate is over calls that actually RAN. Drawn side by side as
     tracks they would invite a comparison that is arithmetically meaningless.
 
@@ -1123,13 +1123,13 @@ def _draw_tool_call_rows(body: _Body, stats: ToolCallStats | None) -> None:
     # THE BLOCK IS A SUBTRACTION CHAIN, and every step of it is on screen
     # (design round 1, D2). The headline is EVERY call recorded; each ` └ ` row
     # below removes a class from it, in the order the rates remove them, so the
-    # validity denominator is reached by reading downward rather than by
+    # invocation-error denominator is reached by reading downward rather than by
     # trusting an unexplained shift:
     #
     #   Tool calls          35   <- recorded, both origins
     #    └ nested (eval)     3   <- not the model emitting a call
     #    └ never completed   1   <- returned no result to judge
-    #   Call validity          4 invalid of 31 emitted   (35 - 3 - 1)
+    #   Tool-call error rate          4 invalid of 31 emitted   (35 - 3 - 1)
     #
     # This is why the headline is `recorded` and not `total`: under the ` └ `
     # idiom a sub-row is PART of the row above it, so a model-origin headline
@@ -1162,10 +1162,11 @@ def _draw_tool_call_rows(body: _Body, stats: ToolCallStats | None) -> None:
     # `ok` already spans both origins, so a model-origin-only `failed` would
     # leave a failed eval-bridge call in neither term of a pair that reads as a
     # partition. The three terms are exhaustive by construction —
-    # `ok + failed + excluded == recorded` — and each one is on screen, the last
-    # as the ` └ denied or aborted` row.
+    # `ok + failed + all_excluded == recorded`. Nested exclusions are part of
+    # the nested sub-row, NOT the next subtraction: removing nested_total has
+    # already removed them from the model-origin denominator.
     ok = stats.ok + stats.nested_ok
-    failed = (stats.total - stats.ok - stats.excluded) + (stats.nested_total - stats.nested_ok)
+    failed = stats.recorded - ok - stats.all_excluded
     detail = f"{ok} ok" + (f" · {failed} failed" if failed else "")
     body.kv("Tool calls", str(stats.recorded), detail)
 
@@ -1184,6 +1185,14 @@ def _draw_tool_call_rows(body: _Body, stats: ToolCallStats | None) -> None:
                 "not the model's",
             ),
         )
+        if stats.nested_excluded:
+            # A child of the nested subtotal, not a second top-level subtraction.
+            # The count stays in the value column even when notes cannot fit.
+            body.kv(
+                "    └ excluded",
+                str(stats.nested_excluded),
+                notes=("already included in nested", "included above"),
+            )
     if stats.excluded:
         # The denied/aborted calls: correctly outside both denominators, and
         # previously invisible, which left the headline `N failed` short of the
@@ -1231,12 +1240,14 @@ def _draw_tool_call_rows(body: _Body, stats: ToolCallStats | None) -> None:
             ),
         )
 
-    validity = stats.validity
-    if validity is None:
+    error_rate = stats.tool_call_error_rate
+    if error_rate is None:
         # Rows exist but nothing counted toward the denominator (every call was
         # denied or aborted). Mirrors ``_timing_rows``' "unknown (0 samples)"
         # wording on purpose, so the two read as the same kind of statement.
-        body.kv("Call validity", "unknown", "0 emitted", dim_value=True)
+        body.kv("Tool-call error rate", "unknown", "0 emitted", dim_value=True)
+        if body.width < _NOTE_MIN:
+            body.note("0 eligible model-emitted calls")
     else:
         invalid = stats.model_faults
         # A ladder, not a plain note: this qualifier carries the SCOPE of the
@@ -1266,14 +1277,18 @@ def _draw_tool_call_rows(body: _Body, stats: ToolCallStats | None) -> None:
         # rate rows now obey one rule between them rather than each having its
         # own.
         body.kv(
-            "Call validity",
-            f"{validity * 100:.1f}%",
+            "Tool-call error rate",
+            f"{error_rate * 100:.1f}%",
             notes=(
                 f"{invalid} invalid of {stats.emitted} emitted",
                 f"{invalid} invalid of {stats.emitted}",
                 f"{invalid} invalid/{stats.emitted}",
             ),
         )
+        # Below the shortest rung, wrap the scope instead of leaving a bare
+        # benchmarking percentage whose population the reader cannot recover.
+        if len(f"{invalid} invalid/{stats.emitted}") > body.width - 24 - _VALUE_CELL - 2:
+            body.note(f"{invalid} invalid of {stats.emitted} emitted")
         # Name the faults rather than only counting them: "which one" is the
         # actionable half, and it is what makes the figure a benchmark rather
         # than a score. Biggest first; the NAME breaks ties, because the sort
@@ -1293,7 +1308,7 @@ def _draw_tool_call_rows(body: _Body, stats: ToolCallStats | None) -> None:
         # Drawn whenever calls were DISPATCHED, including at zero. Suppressing
         # the zero made "no execution errors" and "not measured" identical on
         # screen, which is the converse of this screen's standing invariant and
-        # is inconsistent with `Call validity` one line above, which shows its
+        # is inconsistent with `Tool-call error rate` one line above, which shows its
         # own zero (design round 1, D4). The modal healthy session is exactly
         # the case that was being hidden.
         #
@@ -1331,6 +1346,11 @@ def _draw_tool_call_rows(body: _Body, stats: ToolCallStats | None) -> None:
                 f"{execution * 100:.1f}% of {dispatched}",
             ),
         )
+    body.note(
+        "Both rates cover eligible model-emitted calls only. Tool-call errors count "
+        "rejected or invalid invocations, not semantic tool-selection correctness. "
+        "Execution errors are separate; not all errors are model-caused."
+    )
 
 
 def _draw_tool_surface(

--- a/local_operator/tui/widgets/session_panel.py
+++ b/local_operator/tui/widgets/session_panel.py
@@ -1128,7 +1128,7 @@ def _draw_tool_call_rows(body: _Body, stats: ToolCallStats | None) -> None:
     #
     #   Tool calls          35   <- recorded, both origins
     #    └ nested (eval)     3   <- not the model emitting a call
-    #    └ denied/aborted    1   <- never allowed to prove anything
+    #    └ never completed   1   <- returned no result to judge
     #   Call validity          4 invalid of 31 emitted   (35 - 3 - 1)
     #
     # This is why the headline is `recorded` and not `total`: under the ` └ `
@@ -1201,12 +1201,32 @@ def _draw_tool_call_rows(body: _Body, stats: ToolCallStats | None) -> None:
         # the wording was. "outside both rates" is the one thing true of all
         # four, and it states the fact the row exists to state: these calls are
         # in neither denominator below.
+        #
+        # THE LABEL MUST COVER THE WHOLE SET, and "denied or aborted" named two
+        # of the four members of ``EXCLUDED_FAULTS`` while the row counted all
+        # four (design round 2, D9). A `skipped` or `gate_failed` call landed
+        # under a heading that described neither, which is the N1 defect one
+        # cell to the left: the note was made neutral and the label above it
+        # kept blaming.
+        #
+        # "never dispatched" — design's suggested wording, and the note rung
+        # this replaces — is FALSE, and measurably so. Driving the real
+        # ``AgentLoop`` with a tool that blocks and aborting mid-execution
+        # records `aborted` for a call whose body HAD run: `interruptible_runner`
+        # cancels a tool task that is already in flight and parks a synthetic
+        # result for it. `denied` and `gate_failed` never dispatch; `aborted`
+        # and `skipped` may dispatch and be cut short. So the cover for the set
+        # is not "never started" but "never FINISHED": what all four share is
+        # that no real tool outcome came back, which is exactly why they are in
+        # neither denominator. "never" rather than "not" because this screen
+        # reports a settled session — "not completed" invites the reading that
+        # the call is still running.
         body.kv(
-            " └ denied or aborted",
+            " └ never completed",
             str(stats.excluded),
             notes=(
-                "stopped or never dispatched · outside both rates",
-                "never dispatched · outside both rates",
+                "refused, stopped or interrupted · outside both rates",
+                "no result to judge · outside both rates",
                 "outside both rates",
             ),
         )
@@ -1223,13 +1243,35 @@ def _draw_tool_call_rows(body: _Body, stats: ToolCallStats | None) -> None:
         # percentage (which calls it is over), and a scope cropped mid-word or
         # shed wholesale leaves a correct figure looking like a wrong one — the
         # defect ``kv``'s ``notes`` parameter exists to fix.
+        #
+        # EVERY RUNG KEEPS THE WORD `invalid`, because the count's DIRECTION is
+        # not a refinement — it is the whole meaning of the number. The middle
+        # rung was `"{invalid} of {emitted} emitted"`, which at body widths
+        # 52-59 painted a bare `4 of 34 emitted` beside `88.2%` (design round 2,
+        # D8). With `invalid` dropped, `4 of 34` reads far more naturally as "4
+        # VALID of 34" — the exact inverse of the truth — and the only thing
+        # available to disambiguate it is dividing 4 by 34 in your head and
+        # noticing it is not 88.2%. That is the same defect class as D6 one row
+        # below: a shorter rung that is not a shorter spelling of the same
+        # qualifier but a different and false claim. `of` is what makes the
+        # inversion readable, so the compact rung uses `/`, which cannot be
+        # parsed as a partitive.
+        #
+        # AND EVERY RUNG KEEPS THE DENOMINATOR, matching the rule `Tool-side
+        # errors` was fixed to obey: a percentage drawn without the population
+        # it is a percentage OF states a proportion of nothing. The old floor
+        # rung `"emitted calls"` did exactly that at body 50-51 — scope word,
+        # no numbers — so it is replaced by `{invalid} invalid/{emitted}`, which
+        # is both shorter (12 against 13) and strictly more informative. The two
+        # rate rows now obey one rule between them rather than each having its
+        # own.
         body.kv(
             "Call validity",
             f"{validity * 100:.1f}%",
             notes=(
                 f"{invalid} invalid of {stats.emitted} emitted",
-                f"{invalid} of {stats.emitted} emitted",
-                "emitted calls",
+                f"{invalid} invalid of {stats.emitted}",
+                f"{invalid} invalid/{stats.emitted}",
             ),
         )
         # Name the faults rather than only counting them: "which one" is the

--- a/scripts/session_failure_shot.py
+++ b/scripts/session_failure_shot.py
@@ -1,0 +1,244 @@
+"""Capture /session's failure accounting and tool-call rows, real slash path.
+
+Usage: python scripts/session_failure_shot.py OUTDIR 100x30 healthy|failing|tools
+
+Exists because the operator's bug report ("15 req · 15 failed" on a session
+where nothing failed) is invisible to the unit suite: the fixtures asserted an
+``outcome`` vocabulary the recorder cannot emit. Every scenario here seeds the
+REAL vocabulary the provider path writes (``stop``/``toolUse``/``length``, or an
+exception class name), so a frame from this script is evidence about the
+shipping product rather than about a fixture.
+
+- ``healthy``  every request ok, mixed real outcomes -> must show NO failures.
+- ``failing``  three genuinely failed requests -> must still report them.
+- ``tools``    healthy plus recorded tool calls -> the measured tool rows.
+
+No provider request, live session or operator config is used; the capture
+sandboxes HOME before any application import.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Clear every multiplexer identifier BEFORE any application import: a headless
+# pilot must not rename the operator's real workspace through inherited CMUX IDs.
+for _key in tuple(os.environ):
+    if _key.startswith("CMUX_"):
+        os.environ.pop(_key)
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import asyncio  # noqa: E402
+import json  # noqa: E402
+from dataclasses import replace  # noqa: E402
+
+import scripts.probe_isolation  # noqa: E402, F401
+from local_operator.analytics.store import AnalyticsStore  # noqa: E402
+from local_operator.harness.types import ModelSpec  # noqa: E402
+from local_operator.session.frontend_state import FrontendSessionState  # noqa: E402
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from scripts.visual_capture import save_capture  # noqa: E402
+from tests.unit.analytics.test_store import _snap  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+from tests.unit.tui.test_slash_echo import _submit  # noqa: E402
+
+
+class DiagnosticSession(FakeSession):
+    frontend_state: FrontendSessionState
+
+    @property
+    def session_id(self) -> str:
+        return "b71d40e9a2c5"
+
+    @property
+    def model(self) -> ModelSpec:
+        return ModelSpec(provider="anthropic", model_id="claude-sonnet-4-6", context_window=200000)
+
+    @property
+    def effective_model(self) -> ModelSpec:
+        return self.model
+
+    @property
+    def model_label(self) -> str:
+        return "anthropic/claude-sonnet-4-6"
+
+    @property
+    def effective_model_label(self) -> str:
+        return "anthropic/claude-sonnet-4-6"
+
+
+#: (context, output, duration_ms, purpose, ok, outcome). The outcome strings are
+#: the ones ``_record_stream`` actually writes: ``str(stop_reason)`` from the
+#: provider adapters' finish-reason map, or an exception class name on a failure.
+#: The literal ``"ok"`` is deliberately absent — nothing in the product emits it,
+#: and a fixture that does is how this defect shipped.
+HEALTHY_SHAPE = [
+    (8_400, 900, 1_850, "turn", True, "toolUse"),
+    (14_200, 1_400, 2_310, "turn", True, "toolUse"),
+    (21_800, 620, 1_240, "turn", True, "stop"),
+    (33_500, 2_900, 4_120, "turn", True, "toolUse"),
+    (46_100, 1_100, 2_050, "turn", True, "toolUse"),
+    (52_700, 480, 980, "naming", True, "stop"),
+    (61_400, 3_600, 5_870, "turn", True, "toolUse"),
+    (74_900, 1_750, 2_640, "turn", True, "toolUse"),
+    (88_300, 210, 1_420, "turn", True, "stop"),
+    (96_800, 2_150, 3_180, "turn", True, "toolUse"),
+    (112_400, 1_320, 2_260, "turn", True, "toolUse"),
+    (128_900, 4_800, 7_240, "turn", True, "length"),
+    (141_200, 760, 1_510, "aside", True, "stop"),
+    (158_600, 2_400, 3_450, "turn", True, "toolUse"),
+    (172_300, 1_180, 2_180, "turn", True, "stop"),
+    (186_700, 5_200, 8_960, "turn", True, "toolUse"),
+]
+
+#: The same session with three REAL failures, so the guard is shown to still
+#: fire. ``ok=False`` is the recorded truth; the outcome string only labels it.
+FAILING_SHAPE = HEALTHY_SHAPE[:13] + [
+    (158_600, 0, 3_450, "turn", False, "ProviderError"),
+    (172_300, 0, 2_180, "turn", False, "ProviderError"),
+    (186_700, 0, 8_960, "turn", False, "refusal"),
+]
+
+#: Tool calls for the ``tools`` scenario: (tool_name, origin, fault). Mirrors a
+#: plausible run — mostly clean, one hallucinated tool, two schema violations,
+#: one duplicate emission, plus non-model faults that must stay OUT of the
+#: validity numerator.
+TOOL_SHAPE = (
+    [("read", "model", "")] * 9
+    + [("bash", "model", "")] * 7
+    + [("grep", "model", "")] * 4
+    + [("edit", "model", "")] * 3
+    + [("eval", "model", "")] * 2
+    + [("read", "nested", "")] * 3
+    + [("reed_file", "model", "unknown_tool")]
+    + [("edit", "model", "invalid_arguments"), ("bash", "model", "invalid_arguments")]
+    + [("read", "model", "duplicate_id")]
+    + [("web_fetch", "model", "execution"), ("bash", "model", "execution")]
+    + [("bash", "model", "denied")]
+)
+
+
+def seed(session_id: str, shape: list[tuple[int, int, int, str, bool, str]]) -> None:
+    store = AnalyticsStore()
+    snapshots = []
+    for i, (context, output, duration, purpose, ok, outcome) in enumerate(shape):
+        aside = purpose in ("aside", "naming")
+        cache_read = int(context * 0.72)
+        snapshots.append(
+            replace(
+                _snap(
+                    session_id=session_id,
+                    provider="openai" if aside else "anthropic",
+                    model_id="gpt-5.2-mini" if aside else "claude-sonnet-4-6",
+                    context=context,
+                    input_tokens=context - cache_read - 800,
+                    cache_read=cache_read,
+                    cache_write=800,
+                    output_tokens=output,
+                    reasoning=int(output * 0.2),
+                    cost_micro=int(context * 0.55 + output * 8.5),
+                    chars={
+                        "system_prompt": 400,
+                        "custom_instructions": 110,
+                        "tool_inventory": 150,
+                        "tool_schemas": 250,
+                        "conversation": 300 + i * 95,
+                        "tool_results": 120 + i * 60,
+                    },
+                    ts_ms=1788602400000 + i * 47000,
+                    ok=ok,
+                ),
+                request_id=f"logical-request-{i:03d}",
+                purpose=purpose,
+                outcome=outcome,
+                duration_ms=duration,
+                ttft_ms=int(duration * 0.19) + 180,
+                preparation_ms=18 + (i % 5) * 7,
+            )
+        )
+    store.record_batch(snapshots)
+    store.close()
+
+
+def seed_tool_calls(session_id: str) -> None:
+    store = AnalyticsStore()
+    store.record_tool_calls(
+        [
+            (1788602400000 + i * 3100, session_id, name, origin, fault, 40.0 + i)
+            for i, (name, origin, fault) in enumerate(TOOL_SHAPE)
+        ]
+    )
+    store.close()
+
+
+async def main() -> None:
+    out = Path(sys.argv[1]).resolve()
+    out.mkdir(parents=True, exist_ok=True)
+    cols, rows = sys.argv[2].split("x")
+    size = (int(cols), int(rows))
+    scenario = sys.argv[3] if len(sys.argv) > 3 else "healthy"
+    session = DiagnosticSession()
+    session.set_conversation_name("Investigate request latency")
+    session.frontend_state = FrontendSessionState(
+        session_id=session.session_id,
+        epoch="capture",
+        generation=6,
+        context_tokens=28400,
+        context_is_estimate=False,
+        context_window=200000,
+    )
+    seed(session.session_id, FAILING_SHAPE if scenario == "failing" else HEALTHY_SHAPE)
+    if scenario == "tools":
+        seed_tool_calls(session.session_id)
+
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=size) as pilot:
+        await pilot.pause()
+        await _submit(pilot, app, "/session")
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        save_capture(app, str(out / "opened.svg"))
+        screen = app.screen
+        pages = []
+        for page in range(1, 8):
+            await pilot.press("pagedown")
+            await pilot.pause()
+            save_capture(app, str(out / f"page-{page}.svg"))
+            pages.append(page)
+        scroll = getattr(screen, "_scroll", None)
+        # Geometry, not just pixels: virtual_size > size on THIS screen is
+        # always a bug (a scrollbar costs two cells and reflows the transcript).
+        metrics = {
+            "source": str(Path(__file__).resolve().parents[1]),
+            "scenario": scenario,
+            "size": size,
+            "screen": type(screen).__name__,
+            "screen_size": list(screen.size),
+            "screen_virtual_size": list(screen.virtual_size),
+            "screen_scrollbar": bool(getattr(screen, "show_vertical_scrollbar", False)),
+            "scroll": (
+                {
+                    "size": list(scroll.size),
+                    "virtual_size": list(scroll.virtual_size),
+                    "max_y": scroll.max_scroll_y,
+                }
+                if scroll
+                else None
+            ),
+        }
+        # The rendered text, so a frame's claim can be grepped rather than
+        # eyeballed. Taken from the screen's OWN body widget, which is the exact
+        # Text the SVG paints — not a re-render with different inputs.
+        text = getattr(screen, "_report_text", None)
+        if text is not None:
+            metrics["lines"] = str(text()).splitlines()
+        (out / "result.json").write_text(json.dumps(metrics, indent=2) + "\n")
+        print(json.dumps({k: v for k, v in metrics.items() if k != "lines"}))
+        for line in metrics.get("lines", []):
+            print(line)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/tool_surface_shot.py
+++ b/scripts/tool_surface_shot.py
@@ -1,0 +1,205 @@
+"""Capture the `/session` Tool surface block across widths and ledger states.
+
+Usage: python scripts/tool_surface_shot.py OUTDIR 66x38 [tools|denials|nodispatch|nested]
+
+Sibling of ``session_report_shot.py``, which captures the WHOLE diagnostics
+screen with one populated fixture. This one is about a single block of it, and
+it exists because that block's defects live in two dimensions the whole-screen
+capture cannot reach:
+
+* **Width bands**, not widths. Design round 2 (D6) found the ``Tool-side
+  errors`` note asserting the inverse of the truth (``7.4% dispatched`` — read
+  as "7.4% got dispatched" where 27 of 31 did) across terminal columns 66-72
+  only. Frames at 68 and 88 straddle a band like that without landing in it, so
+  a note ladder has to be swept rather than sampled.
+* **Ledger STATES.** The rows are drawn conditionally — a ` └ ` sub-row appears
+  only when its count is nonzero — so the shape that carries a defect may not
+  exist in the populated fixture at all. D7 (the headline counting the
+  operator's own gate denials as ``failed``) is invisible in ``tools`` and is
+  the entire headline in ``nodispatch``.
+
+Every state seeds REAL ``tool_calls`` rows through ``AnalyticsStore`` and drives
+the real ``OperatorApp`` through the real ``/session`` command, so what is
+captured is the stylesheet-loaded screen rather than a bare test host — the
+lightweight hosts in the test files declare no ``CSS_PATH`` and would not show a
+spacing or colour change at all (``AGENTS.md``, "Visual validation").
+
+No provider request, live session or operator config is used: ``probe_isolation``
+re-homes ``HOME`` and the config dir before any application import, and each
+capture asserts the operator's own ledger was untouched.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Clear every multiplexer identifier BEFORE any application import: a headless
+# pilot must not rename the operator's real workspace through inherited CMUX IDs.
+for _key in tuple(os.environ):
+    if _key.startswith("CMUX_"):
+        os.environ.pop(_key)
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import asyncio  # noqa: E402
+import hashlib  # noqa: E402
+import json  # noqa: E402
+from typing import cast  # noqa: E402
+
+from rich.text import Text  # noqa: E402
+
+import scripts.probe_isolation  # noqa: E402, F401
+from local_operator.analytics.store import AnalyticsStore, default_db_path  # noqa: E402
+from local_operator.session.frontend_state import FrontendSessionState  # noqa: E402
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from scripts.session_report_shot import DiagnosticSession, seed_populated  # noqa: E402
+from scripts.visual_capture import save_capture  # noqa: E402
+from tests.unit.tui.test_app_pilot import _factory  # noqa: E402
+from tests.unit.tui.test_slash_echo import _submit  # noqa: E402
+
+#: ``state -> [(tool_name, origin, fault, count)]``, written verbatim into
+#: ``tool_calls``. Chosen to be the states the two round-2 MAJORs live in, plus
+#: the two neighbours that must not regress:
+#:
+#: ``tools``      the review's own fixture — 35 recorded, both origins, one
+#:                denial and every fault class, so the subtraction chain is at
+#:                full depth. This is the width-band state.
+#: ``denials``    the DEFAULT posture with the approval gate on: denials
+#:                dominate but real faults exist too, so a headline that counts
+#:                denials as failures is wrong by a number rather than wholly.
+#: ``nodispatch`` every recorded call excluded. D7's sharpest form: the old
+#:                headline read `0 ok · 4 failed` on a session where nothing
+#:                failed, which is the operator's founding report verbatim.
+#: ``nested``     a FAILED eval-bridge call, which is why `failed` subtracts the
+#:                excluded rather than summing the two model-origin fault
+#:                classes — that sum leaves this call in neither headline term.
+STATES: dict[str, list[tuple[str, str, str, int]]] = {
+    "tools": [
+        ("read", "model", "", 25),
+        ("edit", "model", "invalid_arguments", 2),
+        ("read", "model", "duplicate_id", 1),
+        ("reed_file", "model", "unknown_tool", 1),
+        ("web_fetch", "model", "execution", 2),
+        ("bash", "model", "denied", 1),
+        ("read", "nested", "", 3),
+    ],
+    "denials": [
+        ("read", "model", "", 4),
+        ("bash", "model", "denied", 7),
+        ("edit", "model", "invalid_arguments", 1),
+        ("web_fetch", "model", "execution", 1),
+    ],
+    "nodispatch": [("bash", "model", "denied", 4)],
+    "nested": [
+        ("read", "model", "", 8),
+        ("web_fetch", "model", "execution", 2),
+        ("read", "nested", "", 4),
+        ("web_fetch", "nested", "execution", 2),
+    ],
+}
+
+
+def seed_tool_calls(session_id: str, state: str) -> None:
+    """Write the state's tool-call rows into the ambient (isolated) ledger.
+
+    Rows are inserted through the store's own writer rather than by hand-rolled
+    SQL so the capture exercises the same path the harness uses; a schema drift
+    that broke recording would break this script rather than being papered over.
+    """
+    store = AnalyticsStore()
+    rows: list[tuple[int, str, str, str, str, float]] = []
+    ts = 1788602400000
+    for tool_name, origin, fault, count in STATES[state]:
+        for i in range(count):
+            rows.append((ts + len(rows) * 1000, session_id, tool_name, origin, fault, 120.0 + i))
+    store.record_tool_calls(rows)
+    store.close()
+
+
+async def main() -> None:
+    out = Path(sys.argv[1]).resolve()
+    out.mkdir(parents=True, exist_ok=True)
+    cols, rows_ = sys.argv[2].split("x")
+    size = (int(cols), int(rows_))
+    state = sys.argv[3] if len(sys.argv) > 3 else "tools"
+
+    session = DiagnosticSession()
+    session.set_conversation_name("Investigate request latency")
+    session.frontend_state = FrontendSessionState(
+        session_id=session.session_id,
+        epoch="capture",
+        generation=6,
+        context_tokens=28400,
+        context_is_estimate=False,
+        context_window=200000,
+    )
+    # The request ledger too: without it the screen has no session to report on
+    # and the tool block never renders.
+    seed_populated(session.session_id)
+    seed_tool_calls(session.session_id, state)
+
+    ledger = default_db_path()
+    before_digest = hashlib.sha256(ledger.read_bytes()).hexdigest() if ledger.exists() else None
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=size) as pilot:
+        await pilot.pause()
+        await _submit(pilot, app, "/session")
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        screen = app.screen
+        # ``_report_text`` is reached through ``getattr`` because ``app.screen``
+        # is typed as the base ``Screen``; the cast names the renderable the
+        # session screen actually returns rather than silencing the check.
+        text = getattr(screen, "_report_text", None)
+        painted = cast("Text", text()).plain if callable(text) else ""
+
+        # SCROLL TO THE BLOCK, never a fixed number of pagedowns. The block's
+        # line number moves with the width (rows above it rewrap) and with the
+        # state (a ` └ ` row is only drawn when nonzero), so a constant page
+        # count silently overshoots: at 88 columns three pagedowns landed past
+        # it, and two states then exported byte-identical frames of the section
+        # BELOW it while their `block` text — read from `_report_text()`, not
+        # from the frame — was correctly different. A capture that does not
+        # contain the thing it is capturing is worse than no capture, because it
+        # looks like evidence.
+        lines = painted.splitlines()
+        target = next((i for i, ln in enumerate(lines) if "Tool surface" in ln), 0)
+        scroll = getattr(screen, "_scroll", None)
+        if scroll is not None:
+            # One line of headroom above the header so the block is not flush
+            # against the top edge, which reads as a cropped section.
+            scroll.scroll_to(y=max(0, target - 1), animate=False)
+            await pilot.pause()
+        await pilot.pause()
+        save_capture(app, str(out / f"{state}-{size[0]}.svg"))
+        block = []
+        for line in painted.splitlines():
+            if "Tool surface" in line:
+                block = [line]
+            elif block:
+                if line.strip() and not line.startswith("  ") and "└" not in line:
+                    break
+                block.append(line)
+        metrics = {
+            "source": str(Path(__file__).resolve().parents[1]),
+            "state": state,
+            "size": size,
+            "screen": type(screen).__name__,
+            "screen_size": list(screen.size),
+            "virtual_size": list(screen.virtual_size),
+            # A scrollbar is a silent two-cell width loss and, on this screen, a
+            # bug: the transcript scrolls, the block does not.
+            "scrollbar": bool(getattr(screen, "show_vertical_scrollbar", False)),
+            "geometry_clean": list(screen.size) == list(screen.virtual_size)
+            and not getattr(screen, "show_vertical_scrollbar", False),
+            "block": [ln.rstrip() for ln in block if ln.strip()],
+            "ledger_unchanged": before_digest
+            == (hashlib.sha256(ledger.read_bytes()).hexdigest() if ledger.exists() else None),
+        }
+        (out / f"{state}-{size[0]}.json").write_text(json.dumps(metrics, indent=2))
+        print(json.dumps(metrics, indent=2))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/tool_surface_shot.py
+++ b/scripts/tool_surface_shot.py
@@ -91,6 +91,13 @@ STATES: dict[str, list[tuple[str, str, str, int]]] = {
         ("web_fetch", "model", "execution", 1),
     ],
     "nodispatch": [("bash", "model", "denied", 4)],
+    # The nested denial is INCLUDED in the nested subtotal, not another term
+    # to subtract from model-emitted calls (QA round 2's cross-origin defect).
+    "nested-excluded": [
+        ("eval", "model", "", 1),
+        ("read", "nested", "", 1),
+        ("write_file", "nested", "denied", 1),
+    ],
     "nested": [
         ("read", "model", "", 8),
         ("web_fetch", "model", "execution", 2),

--- a/tests/unit/analytics/test_recorder.py
+++ b/tests/unit/analytics/test_recorder.py
@@ -129,3 +129,65 @@ def test_parallel_processes_write_atomically(tmp_path):
     assert agg.calls == 4 * n
     assert len(agg.by_session) == 4
     store.close()
+
+
+def test_tool_calls_ride_the_same_queue_and_writer_thread(tmp_path):
+    """One writer, never two.
+
+    ``AGENTS.md`` is explicit that a second thread writing to the store is
+    forbidden: two threads opening their first connection to a fresh database
+    race in a way that leaves the writer unable to see its own commits. Tool
+    calls therefore share the queue, the thread and the connection that call
+    samples and name upserts already use \u2014 asserted here by counting the
+    recorder's threads, not by trusting the implementation.
+    """
+    import threading
+
+    store = AnalyticsStore(tmp_path / "a.db")
+    rec = AnalyticsRecorder(store=store)
+    before = {t.name for t in threading.enumerate()}
+    rec.record(_snap(session_id="s1"))
+    for i in range(10):
+        rec.record_tool_call("s1", "read", "model", "" if i % 2 else "execution", 12.0)
+    rec.note_session_name("s1", "named")
+    rec.flush_for_test()
+    writers = {t.name for t in threading.enumerate()} - before
+    assert writers == {"lo-analytics-writer"}, f"expected ONE writer thread, got {writers}"
+
+    stats = store.session_report("s1").tool_calls
+    assert stats is not None
+    assert stats.total == 10 and stats.ok == 5
+    assert stats.faults == {"execution": 5}
+    rec.close()
+
+
+def test_record_tool_call_never_raises(tmp_path):
+    """It runs on the event loop inside a live turn; it may not throw or block."""
+    store = AnalyticsStore(tmp_path / "a.db")
+    rec = AnalyticsRecorder(store=store)
+    rec.close()
+    # Closed recorder, empty session id, absurd values: all silent no-ops.
+    rec.record_tool_call("s1", "read", "model", "", 1.0)
+    rec.record_tool_call("", "read", "model", "", 1.0)
+
+
+def test_record_tool_call_is_put_nowait_only(tmp_path):
+    """A full queue DROPS the sample rather than blocking the turn.
+
+    Same contract as ``record``: accuracy matters, but never at the cost of a
+    stalled session. Measured here by filling the queue and timing the call \u2014
+    a blocking implementation would sit on the queue's put instead.
+    """
+    store = AnalyticsStore(tmp_path / "a.db")
+    rec = AnalyticsRecorder(store=store)
+    # Fill the queue without letting the writer drain it.
+    rec._closed = False
+    while not rec._queue.full():
+        try:
+            rec._queue.put_nowait(_snap())
+        except Exception:  # noqa: BLE001
+            break
+    started = time.monotonic()
+    rec.record_tool_call("s1", "read", "model", "", 1.0)
+    assert time.monotonic() - started < 0.5, "record_tool_call blocked on a full queue"
+    rec.close()

--- a/tests/unit/analytics/test_store.py
+++ b/tests/unit/analytics/test_store.py
@@ -1215,16 +1215,23 @@ def test_tool_calls_roundtrip_and_classification(tmp_path):
     )
     stats = store.session_report("s1").tool_calls
     assert stats is not None
-    assert stats.total == 7 and stats.ok == 3
+    # SIX model-origin rows, not seven: row 7 is nested and is counted apart.
+    # This assertion previously read `total == 7`, pooling the eval-bridge call
+    # into the model's figures — the shape the schema comment forbids, and the
+    # reason the origin partition is now asserted in its own tests below.
+    assert stats.total == 6 and stats.ok == 2
+    assert stats.nested_total == 1 and stats.nested_ok == 1
+    assert stats.recorded == 7
     assert stats.faults == {
         "unknown_tool": 1,
         "invalid_arguments": 1,
         "execution": 1,
         "denied": 1,
     }
-    # denied leaves the denominator: 6 emitted, 2 of them model faults.
-    assert stats.emitted == 6
-    assert stats.validity == pytest.approx(4 / 6)
+    # denied leaves the denominator: 5 emitted, 2 of them model faults.
+    assert stats.emitted == 5
+    assert stats.excluded == 1
+    assert stats.validity == pytest.approx(3 / 5)
     # The hallucinated NAME is retained, which is what a per-tool view needs.
     assert stats.faults_by_tool["reed_file"] == 1
 
@@ -1299,3 +1306,99 @@ def test_recent_requests_carry_ok_and_a_missing_column_reads_unknown(tmp_path):
     conn.close()
     recent = AnalyticsStore(path).session_report("s1").recent
     assert recent and recent[0].ok is None, "an absent ok column must read unknown, not failed"
+
+
+def test_origin_partitions_the_rates_so_an_eval_loop_cannot_set_them(tmp_path):
+    """The coverage gap that let the read side land without the partition.
+
+    ``origin`` was written, stored and documented, but the aggregation grouped
+    by ``fault, tool_name`` only — so nested rows were pooled into the headline
+    accuracy figure, which is exactly what the schema comment forbids. No test
+    asserted what ``origin`` DOES to a rate, only that the loop emits it, which
+    is why the write side landed complete and the read side landed empty.
+
+    The numbers here are the review's reproduction: two model calls, one of them
+    faulted, plus one twenty-iteration ``eval`` loop. Pooled, that reports 95.5%
+    validity; partitioned, it reports the truth, 50%. A rate that a scripted
+    loop can move is not a measurement of the model.
+    """
+    store = AnalyticsStore(tmp_path / "a.db")
+    rows = [
+        (1, "s1", "read", "model", "unknown_tool", 1.0),
+        (2, "s1", "read", "model", "", 1.0),
+    ]
+    rows += [(10 + i, "s1", "bash", "nested", "", 1.0) for i in range(20)]
+    store.record_tool_calls(rows)
+
+    stats = store.session_report("s1").tool_calls
+    assert stats is not None
+    # Model-origin counts exclude the loop entirely.
+    assert stats.total == 2 and stats.ok == 1
+    assert stats.emitted == 2 and stats.model_faults == 1
+    assert stats.validity == pytest.approx(0.5), "an eval loop moved the accuracy figure"
+    # The nested calls are still counted — kept visible, kept out of the rates.
+    assert stats.nested_total == 20 and stats.nested_ok == 20
+    assert stats.recorded == 22
+    store.close()
+
+
+def test_a_nested_fault_never_reaches_the_model_fault_breakdown(tmp_path):
+    """A tool the model's CODE called wrongly is not the model emitting junk.
+
+    Guards the other direction of the partition: nested faults must not appear
+    in ``faults`` / ``faults_by_tool``, which feed the on-screen "which
+    invalidity dominated" sub-rows and the validity numerator.
+    """
+    store = AnalyticsStore(tmp_path / "a.db")
+    store.record_tool_calls(
+        [
+            (1, "s1", "read", "model", "", 1.0),
+            (2, "s1", "reed_file", "nested", "unknown_tool", 1.0),
+            (3, "s1", "web_fetch", "nested", "execution", 1.0),
+        ]
+    )
+    stats = store.session_report("s1").tool_calls
+    assert stats is not None
+    assert stats.faults == {}, "a nested fault leaked into the model breakdown"
+    assert stats.faults_by_tool == {}
+    assert stats.model_faults == 0 and stats.execution_faults == 0
+    assert stats.validity == pytest.approx(1.0)
+    # But they are accounted for rather than dropped.
+    assert stats.nested_total == 2 and stats.nested_ok == 0
+    store.close()
+
+
+def test_an_unrecognised_origin_stays_out_of_the_benchmarking_figure(tmp_path):
+    """A future third origin defaults to "not the model", not into the rate.
+
+    The safe default under the origin partition: an origin nobody has decided
+    about yet must not silently join the number the model is graded on.
+    """
+    store = AnalyticsStore(tmp_path / "a.db")
+    store.record_tool_calls(
+        [
+            (1, "s1", "read", "model", "unknown_tool", 1.0),
+            (2, "s1", "read", "subagent", "", 1.0),
+        ]
+    )
+    stats = store.session_report("s1").tool_calls
+    assert stats is not None
+    assert stats.total == 1 and stats.nested_total == 1
+    assert stats.validity == pytest.approx(0.0)
+    store.close()
+
+
+def test_a_session_with_only_nested_calls_is_not_unknown(tmp_path):
+    """Nested-only sessions DID make tool calls; ``unknown`` would be a lie.
+
+    The mirror of the fabricated-zero rule: withholding a fact that was measured
+    is as wrong as inventing one that was not.
+    """
+    store = AnalyticsStore(tmp_path / "a.db")
+    store.record_tool_calls([(1, "s1", "bash", "nested", "", 1.0)])
+    stats = store.session_report("s1").tool_calls
+    assert stats is not None
+    assert stats.recorded == 1 and stats.total == 0
+    # No rate is claimed over a population no rate is defined for.
+    assert stats.validity is None
+    store.close()

--- a/tests/unit/analytics/test_store.py
+++ b/tests/unit/analytics/test_store.py
@@ -8,7 +8,10 @@ per-provider and per-session breakdowns the ``/analytics`` screen renders.
 
 from __future__ import annotations
 
+import sqlite3
 import time
+
+import pytest
 
 from local_operator.analytics.model import CallSnapshot
 from local_operator.analytics.store import (
@@ -1186,3 +1189,113 @@ def test_aggregate_exposes_parent_edges_for_the_table_rollup(tmp_path):
     assert set(agg.by_session) == {"root", "kid", "solo"}
     assert sum(a.cost_micro for a in agg.by_session.values()) == agg.cost_micro
     store.close()
+
+
+# ---------------------------------------------------------------------------
+# tool_calls: recording, rollup, retention, and the unknown rule
+# ---------------------------------------------------------------------------
+
+
+def test_tool_calls_roundtrip_and_classification(tmp_path):
+    store = AnalyticsStore(tmp_path / "a.db")
+    store.record_batch([_snap(session_id="s1")])
+    assert (
+        store.record_tool_calls(
+            [
+                (1, "s1", "read", "model", "", 30.0),
+                (2, "s1", "read", "model", "", 31.0),
+                (3, "s1", "reed_file", "model", "unknown_tool", 1.0),
+                (4, "s1", "edit", "model", "invalid_arguments", 1.0),
+                (5, "s1", "web_fetch", "model", "execution", 900.0),
+                (6, "s1", "bash", "model", "denied", 1.0),
+                (7, "s1", "read", "nested", "", 12.0),
+            ]
+        )
+        == 7
+    )
+    stats = store.session_report("s1").tool_calls
+    assert stats is not None
+    assert stats.total == 7 and stats.ok == 3
+    assert stats.faults == {
+        "unknown_tool": 1,
+        "invalid_arguments": 1,
+        "execution": 1,
+        "denied": 1,
+    }
+    # denied leaves the denominator: 6 emitted, 2 of them model faults.
+    assert stats.emitted == 6
+    assert stats.validity == pytest.approx(4 / 6)
+    # The hallucinated NAME is retained, which is what a per-tool view needs.
+    assert stats.faults_by_tool["reed_file"] == 1
+
+
+def test_a_session_with_no_tool_rows_reads_unknown_not_zero(tmp_path):
+    """The pre-ship case: requests recorded, tool calls never were."""
+    store = AnalyticsStore(tmp_path / "a.db")
+    store.record_batch([_snap(session_id="s1")])
+    store.record_tool_calls([(1, "other", "read", "model", "", 30.0)])
+    assert store.session_report("s1").tool_calls is None
+
+
+def test_a_ledger_without_the_tool_calls_table_reads_unknown(tmp_path):
+    """An older ledger must open and report unknown, never raise."""
+    path = tmp_path / "old.db"
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        "CREATE TABLE calls (id INTEGER PRIMARY KEY AUTOINCREMENT, ts_ms INTEGER NOT NULL,"
+        " session_id TEXT NOT NULL, provider TEXT NOT NULL, model_id TEXT NOT NULL,"
+        " ok INTEGER NOT NULL DEFAULT 1, input_tokens INTEGER NOT NULL DEFAULT 0,"
+        " output_tokens INTEGER NOT NULL DEFAULT 0,"
+        " cache_read_tokens INTEGER NOT NULL DEFAULT 0,"
+        " cache_write_tokens INTEGER NOT NULL DEFAULT 0,"
+        " reasoning_tokens INTEGER NOT NULL DEFAULT 0,"
+        " context_tokens INTEGER NOT NULL DEFAULT 0);"
+        "INSERT INTO calls (ts_ms, session_id, provider, model_id) VALUES (1, 's1', 'p', 'm');"
+    )
+    conn.commit()
+    conn.close()
+    report = AnalyticsStore(path).session_report("s1")
+    assert report.available
+    assert report.tool_calls is None
+
+
+def test_prune_bounds_the_tool_call_table(tmp_path):
+    store = AnalyticsStore(tmp_path / "a.db", retention_days=90)
+    now = 10_000_000_000
+    old = now - 91 * 86_400_000
+    store.record_tool_calls(
+        [(old, "s1", "read", "model", "", 1.0), (now, "s1", "read", "model", "", 1.0)]
+    )
+    store.prune(now_ms=now)
+    stats = store.session_report("s1").tool_calls
+    assert stats is not None and stats.total == 1
+
+
+def test_recent_requests_carry_ok_and_a_missing_column_reads_unknown(tmp_path):
+    """``ok`` on the projection, and ``col('ok','NULL')`` — not ``'0'``.
+
+    The zero default would report every request on a column-less ledger as
+    FAILED, which is the false alarm this field was added to remove.
+    """
+    store = AnalyticsStore(tmp_path / "a.db")
+    store.record_batch([_snap(session_id="s1", ok=True), _snap(session_id="s1", ok=False)])
+    flags = {r.ok for r in store.session_report("s1").recent}
+    assert flags == {True, False}
+
+    path = tmp_path / "noflag.db"
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        "CREATE TABLE calls (id INTEGER PRIMARY KEY AUTOINCREMENT, ts_ms INTEGER NOT NULL,"
+        " session_id TEXT NOT NULL, provider TEXT NOT NULL, model_id TEXT NOT NULL,"
+        " input_tokens INTEGER NOT NULL DEFAULT 0,"
+        " output_tokens INTEGER NOT NULL DEFAULT 0,"
+        " cache_read_tokens INTEGER NOT NULL DEFAULT 0,"
+        " cache_write_tokens INTEGER NOT NULL DEFAULT 0,"
+        " reasoning_tokens INTEGER NOT NULL DEFAULT 0,"
+        " context_tokens INTEGER NOT NULL DEFAULT 0);"
+        "INSERT INTO calls (ts_ms, session_id, provider, model_id) VALUES (1, 's1', 'p', 'm');"
+    )
+    conn.commit()
+    conn.close()
+    recent = AnalyticsStore(path).session_report("s1").recent
+    assert recent and recent[0].ok is None, "an absent ok column must read unknown, not failed"

--- a/tests/unit/analytics/test_store.py
+++ b/tests/unit/analytics/test_store.py
@@ -1401,4 +1401,34 @@ def test_a_session_with_only_nested_calls_is_not_unknown(tmp_path):
     assert stats.recorded == 1 and stats.total == 0
     # No rate is claimed over a population no rate is defined for.
     assert stats.validity is None
+    assert stats.tool_call_error_rate is None
     store.close()
+
+
+@pytest.mark.parametrize("fault", ["denied", "aborted", "skipped", "gate_failed"])
+@pytest.mark.parametrize("origin", ["model", "nested"])
+def test_exclusions_partition_both_origins_without_changing_model_rates(tmp_path, fault, origin):
+    from local_operator.analytics.model import EXCLUDED_FAULTS
+
+    assert fault in EXCLUDED_FAULTS
+    store = AnalyticsStore(tmp_path / "excluded.db")
+    try:
+        store.record_tool_calls(
+            [(i, "s1", "read", "model", "", 1.0) for i in range(3)]
+            + [(4, "s1", "reed", "model", "unknown_tool", 1.0)]
+            + [(5, "s1", "write", origin, fault, 1.0)]
+            + [(6, "s1", "retry", "nested", "execution", 1.0)]
+        )
+        stats = store.session_report("s1").tool_calls
+        assert stats is not None
+        assert stats.excluded == (1 if origin == "model" else 0)
+        assert stats.nested_excluded == (1 if origin == "nested" else 0)
+        assert stats.all_excluded == 1
+        assert stats.emitted == 4
+        assert stats.model_faults == 1
+        assert stats.tool_call_error_rate == pytest.approx(0.25)
+        assert stats.validity == pytest.approx(0.75)
+        assert stats.execution_error_rate == 0
+        assert stats.recorded == 6
+    finally:
+        store.close()

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -915,8 +915,18 @@ class TestABrokenApprovalGateIsNotAUserRefusal:
 
         failed, _ = await self._run(broken)
         refused, _ = await self._run(deny)
-        assert failed.details == {"__synthetic": True, "__approval_gate_failed": True}
-        assert refused.details == {"__synthetic": True}
+        # Both now also carry ``__fault``, which the tool-call analytics hook
+        # reads to classify the call at its SOURCE. It reinforces this test's
+        # point rather than diluting it: the two cases were already
+        # distinguishable by ``__approval_gate_failed``, and are now
+        # distinguishable by a second, positively-named marker on each side —
+        # a refusal says ``denied`` instead of merely lacking a flag.
+        assert failed.details == {
+            "__synthetic": True,
+            "__approval_gate_failed": True,
+            "__fault": "gate_failed",
+        }
+        assert refused.details == {"__synthetic": True, "__fault": "denied"}
 
     @pytest.mark.asyncio
     async def test_the_exception_is_findable_in_the_log_with_its_stack(

--- a/tests/unit/harness/test_tool_call_analytics.py
+++ b/tests/unit/harness/test_tool_call_analytics.py
@@ -1,0 +1,312 @@
+"""Tool-call fault classification, measured through the REAL AgentLoop.
+
+The rate arithmetic is trivial; the CLASSIFICATION is the claim, so every case
+here drives an actual turn and asserts what the loop reported through
+``LoopConfig.record_tool_call`` rather than unit-testing a helper.
+
+The split that matters is whether a fault is the MODEL's: only those three
+classes feed the benchmarking figure, and a misclassification would either
+inflate the number (crediting a denied call) or defame the model (blaming it
+for an HTTP 500). Each class is therefore pinned at its own source.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import pytest
+
+from local_operator.harness.loop import AgentLoop, LoopContext
+from local_operator.harness.types import (
+    AbortSignal,
+    AgentTool,
+    LoopConfig,
+    Message,
+    ModelSpec,
+    StreamEndEvent,
+    StreamEvent,
+    StreamToolCallDelta,
+    TextContent,
+    ToolContext,
+    ToolResult,
+)
+
+MODEL = ModelSpec(provider="test", model_id="m")
+
+
+class _Scripted:
+    def __init__(self, turns: list[list[StreamEvent]]) -> None:
+        self.turns = turns
+        self.n = 0
+
+    def __call__(self, request, signal: AbortSignal | None):
+        turn = self.turns[self.n]
+        self.n += 1
+
+        async def gen():
+            for event in turn:
+                yield event
+
+        return gen()
+
+
+def _ok_tool(
+    name: str = "read", concurrency: Literal["shared", "exclusive"] = "shared"
+) -> AgentTool:
+    async def execute(tool_call_id, args, signal, on_update, context):
+        return ToolResult(
+            tool_call_id=tool_call_id, tool_name=name, content=[TextContent(text="ok")]
+        )
+
+    return AgentTool(
+        name=name,
+        parameters={
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+        concurrency=concurrency,
+        execute=execute,
+    )
+
+
+def _raising_tool(name: str = "web_fetch") -> AgentTool:
+    async def execute(tool_call_id, args, signal, on_update, context):
+        raise RuntimeError("HTTP 500 from upstream")
+
+    return AgentTool(
+        name=name,
+        parameters={"type": "object", "properties": {"url": {"type": "string"}}},
+        execute=execute,
+    )
+
+
+def _calls(*specs: tuple[int, str, str, str]) -> list[StreamEvent]:
+    out: list[StreamEvent] = []
+    for index, cid, name, args in specs:
+        out.append(StreamToolCallDelta(index=index, id=cid, name=name, argument_delta=""))
+        out.append(StreamToolCallDelta(index=index, id=cid, name=None, argument_delta=args))
+    return out
+
+
+async def _run(
+    turn: list[StreamEvent], tools: list[AgentTool], **context_kwargs: Any
+) -> list[tuple[str, str, str, float]]:
+    recorded: list[tuple[str, str, str, float]] = []
+    config = LoopConfig(
+        model=MODEL,
+        convert_to_llm=lambda messages: [m for m in messages if isinstance(m, Message)],
+        stream_fn=_Scripted([turn, [StreamEndEvent(stop_reason="stop")]]),
+        record_tool_call=lambda name, origin, fault, ms: recorded.append((name, origin, fault, ms)),
+    )
+    context = LoopContext(
+        system_blocks=["sys"],
+        tools=tools,
+        tool_context=ToolContext(session_id="s1", **context_kwargs),
+    )
+    async for _ in AgentLoop().run([], context, config):
+        pass
+    return recorded
+
+
+def _faults(recorded) -> dict[str, str]:
+    return {name: fault for name, _origin, fault, _ms in recorded}
+
+
+@pytest.mark.asyncio
+async def test_a_clean_call_records_no_fault():
+    recorded = await _run(
+        _calls((0, "c1", "read", '{"path":"a"}')) + [StreamEndEvent(stop_reason="toolUse")],
+        [_ok_tool()],
+    )
+    assert recorded == [("read", "model", "", recorded[0][3])]
+    assert recorded[0][3] >= 0, "a dispatched call reports its duration"
+
+
+@pytest.mark.asyncio
+async def test_a_hallucinated_tool_name_is_a_model_fault():
+    """The model named a tool that does not exist. Its NAME is retained."""
+    recorded = await _run(
+        _calls((0, "c1", "reed_file", '{"path":"a"}')) + [StreamEndEvent(stop_reason="toolUse")],
+        [_ok_tool()],
+    )
+    assert _faults(recorded) == {"reed_file": "unknown_tool"}
+
+
+@pytest.mark.asyncio
+async def test_a_schema_violation_is_a_model_fault():
+    """``path`` is declared a string; the model sent an int."""
+    recorded = await _run(
+        _calls((0, "c1", "read", '{"path":123}')) + [StreamEndEvent(stop_reason="toolUse")],
+        [_ok_tool()],
+    )
+    assert _faults(recorded) == {"read": "invalid_arguments"}
+
+
+@pytest.mark.asyncio
+async def test_a_duplicate_call_id_is_a_model_fault():
+    """One id emitted twice: the first wins, the twin is a malformed emission.
+
+    Classified by its ``details`` MARKER and not by its text \u2014 a duplicate is
+    parked with ``tool is None`` exactly like an unknown tool, so the two are
+    indistinguishable structurally at ``park``.
+    """
+    recorded = await _run(
+        _calls((0, "c1", "read", '{"path":"a"}'), (1, "c1", "read", '{"path":"b"}'))
+        + [StreamEndEvent(stop_reason="toolUse")],
+        [_ok_tool()],
+    )
+    faults = sorted(fault for _n, _o, fault, _ms in recorded)
+    assert faults == ["", "duplicate_id"]
+
+
+@pytest.mark.asyncio
+async def test_a_tool_that_raises_is_an_execution_error_not_a_model_fault():
+    """HTTP 500 is the world failing, not the model emitting a bad call."""
+    recorded = await _run(
+        _calls((0, "c1", "web_fetch", '{"url":"x"}')) + [StreamEndEvent(stop_reason="toolUse")],
+        [_raising_tool()],
+    )
+    assert _faults(recorded) == {"web_fetch": "execution"}
+
+
+@pytest.mark.asyncio
+async def test_a_denied_call_is_recorded_but_is_not_the_model_s_fault():
+    """The user's decision. Recorded so counts reconcile, excluded from both rates."""
+
+    async def deny(tool_name, summary, job_id):
+        return False
+
+    tool = _ok_tool()
+    tool.approval_tier = "write"
+    recorded = await _run(
+        _calls((0, "c1", "read", '{"path":"a"}')) + [StreamEndEvent(stop_reason="toolUse")],
+        [tool],
+        request_approval=deny,
+    )
+    assert _faults(recorded) == {"read": "denied"}
+
+
+@pytest.mark.asyncio
+async def test_an_approval_gate_crash_is_our_fault_not_the_model_s():
+    async def explode(tool_name, summary, job_id):
+        raise RuntimeError("gate is broken")
+
+    tool = _ok_tool()
+    tool.approval_tier = "write"
+    recorded = await _run(
+        _calls((0, "c1", "read", '{"path":"a"}')) + [StreamEndEvent(stop_reason="toolUse")],
+        [tool],
+        request_approval=explode,
+    )
+    assert _faults(recorded) == {"read": "gate_failed"}
+
+
+@pytest.mark.asyncio
+async def test_the_nested_eval_bridge_records_with_its_own_origin():
+    """``dispatch_tool`` never reaches ``park`` and would otherwise be uncounted.
+
+    Missing it would silently under-count every eval-driven tool call \u2014 exactly
+    the composition-heavy runs the accuracy figure is most wanted for. ``origin``
+    separates them because a nested call is the model's CODE calling a tool, not
+    the model emitting one, and conflating the two would let a scripted retry
+    loop dominate the figure.
+    """
+
+    async def execute(tool_call_id, args, signal, on_update, context):
+        await context.dispatch_tool("read", {"path": "a"})
+        await context.dispatch_tool("nope_tool", {"path": "a"})
+        await context.dispatch_tool("read", {"path": 123})
+        return ToolResult(
+            tool_call_id=tool_call_id, tool_name="eval", content=[TextContent(text="done")]
+        )
+
+    eval_tool = AgentTool(
+        name="eval",
+        parameters={"type": "object", "properties": {"code": {"type": "string"}}},
+        execute=execute,
+    )
+    recorded = await _run(
+        _calls((0, "c1", "eval", '{"code":"x"}')) + [StreamEndEvent(stop_reason="toolUse")],
+        [_ok_tool(), eval_tool],
+    )
+    nested = [(n, f) for n, o, f, _ms in recorded if o == "nested"]
+    assert nested == [("read", ""), ("nope_tool", "unknown_tool"), ("read", "invalid_arguments")]
+    # The outer eval call itself is a MODEL call and recorded as one.
+    assert ("eval", "model", "") in [(n, o, f) for n, o, f, _ms in recorded]
+
+
+@pytest.mark.asyncio
+async def test_a_raising_callback_cannot_break_a_turn():
+    """Analytics must never raise into a turn \u2014 the package's stated contract.
+
+    A host hook that throws is a host bug, and the loop still has to finish the
+    turn and pair every tool result. Guarded in the loop rather than trusted to
+    the host, because a measurement that can kill the thing it measures is not
+    a measurement.
+    """
+    calls: list[str] = []
+
+    def explode(name, origin, fault, ms):
+        calls.append(name)
+        raise RuntimeError("analytics is broken")
+
+    config = LoopConfig(
+        model=MODEL,
+        convert_to_llm=lambda messages: [m for m in messages if isinstance(m, Message)],
+        stream_fn=_Scripted(
+            [
+                _calls((0, "c1", "read", '{"path":"a"}')) + [StreamEndEvent(stop_reason="toolUse")],
+                [StreamEndEvent(stop_reason="stop")],
+            ]
+        ),
+        record_tool_call=explode,
+    )
+    context = LoopContext(
+        system_blocks=["sys"], tools=[_ok_tool()], tool_context=ToolContext(session_id="s1")
+    )
+    results = [event async for event in AgentLoop().run([], context, config)]
+    assert calls == ["read"], "the hook was reached"
+    assert results, "the turn completed despite the hook raising"
+
+
+@pytest.mark.asyncio
+async def test_no_callback_configured_is_a_silent_no_op():
+    """A host that does not want analytics pays nothing and sees no error."""
+    config = LoopConfig(
+        model=MODEL,
+        convert_to_llm=lambda messages: [m for m in messages if isinstance(m, Message)],
+        stream_fn=_Scripted(
+            [
+                _calls((0, "c1", "read", '{"path":"a"}')) + [StreamEndEvent(stop_reason="toolUse")],
+                [StreamEndEvent(stop_reason="stop")],
+            ]
+        ),
+    )
+    context = LoopContext(
+        system_blocks=["sys"], tools=[_ok_tool()], tool_context=ToolContext(session_id="s1")
+    )
+    assert [event async for event in AgentLoop().run([], context, config)]
+
+
+@pytest.mark.asyncio
+async def test_a_session_less_context_records_nothing():
+    """No session id means no row to attribute: recording it would be a lie."""
+    recorded: list[Any] = []
+    config = LoopConfig(
+        model=MODEL,
+        convert_to_llm=lambda messages: [m for m in messages if isinstance(m, Message)],
+        stream_fn=_Scripted(
+            [
+                _calls((0, "c1", "read", '{"path":"a"}')) + [StreamEndEvent(stop_reason="toolUse")],
+                [StreamEndEvent(stop_reason="stop")],
+            ]
+        ),
+        record_tool_call=lambda *a: recorded.append(a),
+    )
+    context = LoopContext(
+        system_blocks=["sys"], tools=[_ok_tool()], tool_context=ToolContext(session_id="")
+    )
+    async for _ in AgentLoop().run([], context, config):
+        pass
+    assert recorded == []

--- a/tests/unit/harness/test_tool_call_analytics.py
+++ b/tests/unit/harness/test_tool_call_analytics.py
@@ -310,3 +310,35 @@ async def test_a_session_less_context_records_nothing():
     async for _ in AgentLoop().run([], context, config):
         pass
     assert recorded == []
+
+
+@pytest.mark.asyncio
+async def test_the_origins_the_loop_emits_are_exactly_the_ones_the_reader_partitions_on():
+    """Pins the writer to the reader across a deliberate layering gap.
+
+    ``harness`` carries no analytics dependency by design (see
+    ``LoopConfig.record_tool_call``), so the loop passes these strings as
+    literals while ``analytics.model`` names them as constants. Nothing but this
+    test stops the two sides drifting on a spelling — and a drift would not
+    fail, it would silently move every model-emitted call into the nested
+    bucket, emptying the benchmarking figure's denominator instead of raising.
+    """
+    from local_operator.analytics.model import ORIGIN_MODEL, ORIGIN_NESTED
+
+    async def execute(tool_call_id, args, signal, on_update, context):
+        await context.dispatch_tool("read", {"path": "a"})
+        return ToolResult(
+            tool_call_id=tool_call_id, tool_name="eval", content=[TextContent(text="done")]
+        )
+
+    eval_tool = AgentTool(
+        name="eval",
+        parameters={"type": "object", "properties": {"code": {"type": "string"}}},
+        execute=execute,
+    )
+    recorded = await _run(
+        _calls((0, "c1", "eval", '{"code":"x"}')) + [StreamEndEvent(stop_reason="toolUse")],
+        [_ok_tool(), eval_tool],
+    )
+    emitted_origins = {origin for _n, origin, _f, _ms in recorded}
+    assert emitted_origins == {ORIGIN_MODEL, ORIGIN_NESTED}

--- a/tests/unit/harness/test_tool_call_analytics.py
+++ b/tests/unit/harness/test_tool_call_analytics.py
@@ -342,3 +342,84 @@ async def test_the_origins_the_loop_emits_are_exactly_the_ones_the_reader_partit
     )
     emitted_origins = {origin for _n, origin, _f, _ms in recorded}
     assert emitted_origins == {ORIGIN_MODEL, ORIGIN_NESTED}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("nested_fault", ["denied", "gate_failed"])
+async def test_shipped_eval_nested_exclusion_is_not_a_failed_tool_call(
+    tmp_path, monkeypatch, nested_fault
+):
+    """Exercise the shipped exec-tier eval subprocess, bridge, store and screen.
+
+    Approve eval itself, then deny (or break approval for) its nested write.
+    The successful read afterwards proves the kernel/bridge continued rather
+    than a denied outer eval accidentally making this a vacuous assertion.
+    """
+    import json
+    import os
+
+    from local_operator.analytics.store import AnalyticsStore
+    from local_operator.tools import eval as eval_tool
+    from local_operator.tui.widgets.session_panel import build_session_report
+    from tests.unit.analytics.test_store import _snap
+    from tests.unit.tui.test_session_panel import _section, runtime
+
+    for key in tuple(os.environ):
+        if key.startswith("CMUX_"):
+            monkeypatch.delenv(key)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    approvals = []
+
+    async def approve(tool_name, summary, job_id):
+        approvals.append(tool_name)
+        if tool_name == "eval":
+            return True
+        if nested_fault == "gate_failed":
+            raise RuntimeError("synthetic approval failure")
+        return False
+
+    write = _ok_tool("write_file")
+    write.approval_tier = "write"
+    read = _ok_tool()
+    read.approval_tier = "read"
+    ev = eval_tool.build_eval_tool()
+    assert ev.approval_tier == "exec"
+    args = json.dumps({"code": 'tool("write_file", path="a")\ntool("read", path="b")'})
+    try:
+        recorded = await _run(
+            _calls((0, "c1", "eval", args)) + [StreamEndEvent(stop_reason="toolUse")],
+            [ev, write, read],
+            cwd=str(tmp_path),
+            request_approval=approve,
+        )
+    finally:
+        await eval_tool.close_session_kernel("s1")
+    assert approvals == ["eval", "write_file"], recorded
+    assert [(n, o, f) for n, o, f, _ in recorded] == [
+        ("write_file", "nested", nested_fault),
+        ("read", "nested", ""),
+        ("eval", "model", ""),
+    ]
+    store = AnalyticsStore(tmp_path / "nested.db")
+    try:
+        store.record_batch([_snap(session_id="s1")])
+        store.record_tool_calls(
+            [(i, "s1", n, o, f, ms) for i, (n, o, f, ms) in enumerate(recorded)]
+        )
+        report = store.session_report("s1")
+        stats = report.tool_calls
+        assert stats is not None
+        assert (stats.recorded, stats.ok + stats.nested_ok, stats.all_excluded) == (3, 2, 1)
+        assert stats.excluded == 0 and stats.nested_excluded == 1
+        assert stats.emitted == 1 and stats.tool_call_error_rate == 0
+        for width in (40, 58, 100):
+            rows = _section(build_session_report(report, runtime(), width).plain, "Tool surface")
+            headline = next(row for row in rows if "Tool calls" in row)
+            assert "failed" not in headline
+            if width == 100:
+                assert "2 ok" in headline
+            nested = next(row for row in rows if "└ excluded" in row)
+            assert nested.split("excluded", 1)[1].strip().startswith("1")
+    finally:
+        store.close()

--- a/tests/unit/session/test_subagent_accounting.py
+++ b/tests/unit/session/test_subagent_accounting.py
@@ -195,6 +195,7 @@ def test_mixed_child_unknown_keeps_parent_lower_bound():
 @pytest.mark.asyncio
 async def test_rendered_footer_uses_whole_owner_ledger():
     from local_operator.tui.app import OperatorApp
+    from tests.e2e.harness import wait_for_adoption
     from tests.unit.tui.test_app_pilot import FakeSession, _factory
 
     app = OperatorApp(lambda: _factory(FakeSession()))
@@ -209,6 +210,9 @@ async def test_rendered_footer_uses_whole_owner_ledger():
             subagent_cost=0.131,
             subagent_cost_knowledge=CostKnowledge.PARTIAL,
         )
+        # A mounted band is not owner readiness: adoption selects a new
+        # interaction/accounting ledger and discards any earlier injected cost.
+        await wait_for_adoption(app, pilot)
         app._apply_frontend_state(state)
         await pilot.pause()
         assert app._spend_total() == 0.131

--- a/tests/unit/tui/test_session_panel.py
+++ b/tests/unit/tui/test_session_panel.py
@@ -1321,7 +1321,9 @@ def test_every_ladder_qualifier_is_present_and_uncropped_at_note_min():
         "Call validity": "emitted",
         "Tool-side errors": "dispatched",
         " └ nested (eval)": "not the model's",
-        " └ denied or aborted": "your decision",
+        # Attribution-NEUTRAL at every rung: `gate_failed` and `skipped` are in
+        # this row too, and neither is the operator's decision (review N1).
+        " └ denied or aborted": "outside both rates",
     }
     for label, floor in expected.items():
         row = next((r for r in section if label in r), None)
@@ -1342,6 +1344,22 @@ def test_the_execution_scope_survives_at_every_supported_width():
     The fix is structural, not another rung: the scope moved into the LABEL,
     which is never shed. So this asserts across the FULL supported range,
     including widths where every note is shed — a rung-based fix cannot pass it.
+
+    **It also asserts the note's MEANING, not its suffix, because the first
+    version of this guard could not see the defect it was written beside.** That
+    version asserted ``tail.endswith(("dispatched", "accuracy", "figure"))``,
+    and the broken floor rung ``"13.3% dispatched"`` ends with ``dispatched`` —
+    so the guard passed a string asserting the INVERSE of the truth (it reads as
+    "13.3% got dispatched" where 15 of 17 did) across a seven-column band
+    (design round 2, D6). An assertion a broken string satisfies is a
+    decoration.
+
+    The property that actually distinguishes them is that **a percentage is
+    never drawn without the denominator it is a percentage OF**: every rung
+    carrying ``%`` must also carry ``of <dispatched>``. A rung may shed the verb
+    and the disclaimer freely — those are refinements — but shedding the
+    denominator turns a proportion into a different and false claim, so it is
+    the one part the ladder may not drop.
     """
     stats = ToolCallStats(
         total=17,
@@ -1349,6 +1367,10 @@ def test_the_execution_scope_survives_at_every_supported_width():
         faults={"invalid_arguments": 2, "execution": 2},
         faults_by_tool={"edit": 2, "web_fetch": 2},
     )
+    # Recomputed from the stats rather than restated as a literal, so a change
+    # to the fixture cannot leave the guard asserting a stale denominator.
+    dispatched = stats.emitted - stats.model_faults
+    assert dispatched == 15
     for width in range(_MIN_CARD_WIDTH, 121):
         section = _section(
             build_session_report(_tool_report(stats), runtime(), width).plain, "Tool surface"
@@ -1357,9 +1379,16 @@ def test_the_execution_scope_survives_at_every_supported_width():
         assert len(row) <= width
         # The scope is in the label, so it cannot shed at ANY width.
         assert "Tool-side" in row, f"scope vanished at {width}: {row!r}"
+        tail = row.rstrip()
+        # A rate is meaningless without its denominator: any width that draws a
+        # percentage must also say what it is a percentage of.
+        if "%" in tail:
+            assert f"of {dispatched}" in tail, (
+                f"at {width} the rate is drawn without its denominator, "
+                f"so it states a proportion of nothing: {row!r}"
+            )
         # And nothing is cut mid-word: every rung ends on a complete word, so a
         # truncated tail could only be a crop.
-        tail = row.rstrip()
         if "dispatch" in tail:
             assert tail.endswith(("dispatched", "accuracy", "figure")), (width, row)
 
@@ -1394,13 +1423,15 @@ def test_the_block_reconciles_its_own_counts_on_screen():
     # The headline is EVERY recorded call, both origins: under the ` └ ` idiom
     # a sub-row is part of the row above, so a model-only headline carrying a
     # nested sub-row would be arithmetically false.
-    assert any("Tool calls" in r and "40" in r and "7 failed" in r for r in section)
+    # `6 failed`, not 7: the denied call is accounted for by its own ` └ ` row
+    # and is NOT a failure (D7).
+    assert any("Tool calls" in r and "40" in r and "6 failed" in r for r in section)
     # Each class removed from the denominator is named, in the order it is
     # removed, so the reader reaches `emitted` by reading downward.
     nested_row = next(r for r in section if "nested (eval)" in r)
     assert "5" in nested_row and "not the model's" in nested_row
     excluded_row = next(r for r in section if "denied or aborted" in r)
-    assert "1" in excluded_row and "not the model" in excluded_row
+    assert "1" in excluded_row and "outside both rates" in excluded_row
     # Every denominator the rates use is printed rather than implied.
     assert "34 emitted" in joined, "the validity denominator is unstated"
     assert "30 dispatched" in joined, "the execution denominator is unstated"
@@ -1410,6 +1441,121 @@ def test_the_block_reconciles_its_own_counts_on_screen():
     assert stats.emitted - stats.model_faults == 30
     named = stats.model_faults + stats.execution_faults + stats.excluded
     assert named == stats.total - stats.ok == 7
+    # And the headline's own three terms partition `recorded` exactly, with the
+    # excluded broken out rather than folded into `failed` (D7).
+    headline_ok = stats.ok + stats.nested_ok
+    headline_failed = (stats.total - stats.ok - stats.excluded) + (
+        stats.nested_total - stats.nested_ok
+    )
+    assert headline_ok + headline_failed + stats.excluded == stats.recorded == 40
+    assert (headline_ok, headline_failed, stats.excluded) == (33, 6, 1)
+
+
+def test_the_headline_never_calls_an_operator_denial_a_failure():
+    """D7: this is the founding bug of the feature, reproduced one block lower.
+
+    The operator's original report was ``15 req · 15 failed`` on a session where
+    nothing had failed. The first version of the headline computed
+    ``failed = recorded - ok``, which pulled ``EXCLUDED_FAULTS`` — the calls the
+    operator DENIED at the approval gate, plus the harness's own
+    ``gate_failed``/``skipped`` — into ``failed``, and painted exactly that
+    shape again: ``0 ok · 4 failed`` on a session whose four calls the operator
+    declined and where nothing failed at all. The ` └ ` row one line beneath
+    said so in as many words, so the headline contradicted its own sub-row.
+
+    Both states are asserted because they fail differently. Under ``denials``
+    the defect is a wrong NUMBER beside a correct one, which a reader can only
+    catch by doing the subtraction; under ``nodispatch`` the excluded calls are
+    the entire headline, so the whole line is false and the ``failed`` clause
+    must not be drawn at all.
+    """
+    # Denials dominant, with one real fault of each kind so `failed` is nonzero
+    # and a wrong `failed` cannot pass by being coincidentally equal.
+    denials = ToolCallStats(
+        total=13,
+        ok=4,
+        faults={"denied": 7, "invalid_arguments": 1, "execution": 1},
+        faults_by_tool={"read": 1, "web_fetch": 1},
+    )
+    section = _section(
+        build_session_report(_tool_report(denials), runtime(), 100).plain, "Tool surface"
+    )
+    headline = next(r for r in section if "Tool calls" in r)
+    assert "4 ok" in headline and "2 failed" in headline, headline
+    assert (
+        "9 failed" not in headline
+    ), f"the operator's 7 denials are counted as failures: {headline!r}"
+    # The seven are not lost — they are accounted for by their own row.
+    assert any("denied or aborted" in r and "7" in r for r in section)
+
+    # Nothing dispatched: every recorded call was excluded, so there is no
+    # `failed` clause to draw. A `0 ok · 4 failed` here is the founding bug
+    # verbatim.
+    nodispatch = ToolCallStats(total=4, ok=0, faults={"denied": 4}, faults_by_tool={})
+    section = _section(
+        build_session_report(_tool_report(nodispatch), runtime(), 100).plain, "Tool surface"
+    )
+    headline = next(r for r in section if "Tool calls" in r)
+    assert "0 ok" in headline, headline
+    assert (
+        "failed" not in headline
+    ), f"a session where the operator declined every call reports a total loss: {headline!r}"
+
+    # A FAILED NESTED CALL IS STILL A FAILURE. This is why `failed` subtracts
+    # the excluded rather than adding `model_faults + execution_faults`: those
+    # two are model-origin only, so the obvious one-liner drops an eval-bridge
+    # call that failed inside its tool and leaves it in NEITHER headline term,
+    # against an `ok` that spans both origins. The bridge really can produce
+    # this — `dispatch_tool` reports `origin="nested"` for its own faults
+    # (`loop.py`) — so it is a reachable state, not a constructed one.
+    nested_faults = ToolCallStats(
+        total=10,
+        ok=8,
+        faults={"execution": 2},
+        faults_by_tool={"web_fetch": 2},
+        nested_total=6,
+        nested_ok=4,
+    )
+    section = _section(
+        build_session_report(_tool_report(nested_faults), runtime(), 100).plain, "Tool surface"
+    )
+    headline = next(r for r in section if "Tool calls" in r)
+    assert (
+        "12 ok" in headline and "4 failed" in headline
+    ), f"two failed nested calls are in neither term of the headline: {headline!r}"
+
+
+def test_the_excluded_row_does_not_blame_the_operator_for_a_harness_fault():
+    """N1: ``gate_failed`` is OUR bug and ``skipped`` is steering, not a decision.
+
+    ``EXCLUDED_FAULTS`` has four members and only two of them — ``denied`` and
+    ``aborted`` — are the operator stopping something. The note read "you
+    stopped these, not the model" at every rung, so a session whose exclusions
+    were entirely the approval plumbing raising told the operator they had
+    stopped calls they never saw. In a block whose whole purpose is correct
+    attribution, that hands a harness defect to the user.
+
+    Asserted at every width the ladder draws, because the defect lived in the
+    rungs: a fix applied to the widest spelling only would still blame the
+    operator on a narrow frame.
+    """
+    stats = ToolCallStats(total=5, ok=3, faults={"gate_failed": 2}, faults_by_tool={})
+    drawn = 0
+    for width in range(_MIN_CARD_WIDTH, 121):
+        section = _section(
+            build_session_report(_tool_report(stats), runtime(), width).plain, "Tool surface"
+        )
+        row = next(r for r in section if "denied or aborted" in r)
+        # "you"/"your" is the whole finding: the row must not address the reader
+        # as the cause of a fault the harness produced.
+        assert (
+            "you" not in row.lower()
+        ), f"a harness fault is attributed to the operator at {width}: {row!r}"
+        if row.rstrip().endswith("rates"):
+            drawn += 1
+    # The neutral wording is actually reached, so the loop is not vacuously
+    # passing on widths where every note is shed.
+    assert drawn > 0
 
 
 def test_fault_sub_rows_are_ordered_deterministically_on_a_tie():

--- a/tests/unit/tui/test_session_panel.py
+++ b/tests/unit/tui/test_session_panel.py
@@ -23,9 +23,15 @@ from local_operator.analytics.store import AnalyticsStore
 from local_operator.session.frontend_state import FrontendSessionState
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.app import OperatorApp, slash_command_for
-from local_operator.tui.widgets.analytics_panel import METRIC_COST, METRIC_TOKENS
+from local_operator.tui.widgets.analytics_panel import (
+    METRIC_COST,
+    METRIC_TOKENS,
+    semantic_style,
+)
 from local_operator.tui.widgets.editor import Editor
 from local_operator.tui.widgets.session_panel import (
+    _MIN_CARD_WIDTH,
+    _NOTE_MIN,
     SessionDiagnostics,
     SessionScreen,
     build_session_report,
@@ -1215,7 +1221,7 @@ def test_no_tool_data_reads_unknown_and_never_a_measured_zero():
     assert any("Tool calls" in r and "unknown" in r for r in section)
     # The rates are omitted entirely rather than shown as unknown.
     assert not any("Call validity" in r for r in section)
-    assert not any("Execution errors" in r for r in section)
+    assert not any("Tool-side errors" in r for r in section)
     assert "0%" not in "".join(section)
 
 
@@ -1253,7 +1259,9 @@ def test_validity_counts_only_model_faults_and_excludes_user_cancellations():
     joined = "\n".join(section)
     assert "75.0%" in joined
     assert "2 invalid of 8 emitted" in joined
-    # The execution row is labelled as NOT an accuracy figure, every time.
+    # The execution row is labelled as NOT an accuracy figure, every time. The
+    # LABEL carries that scope (never shed) and the note refines it (D1).
+    assert "Tool-side errors" in joined
     assert "not a model-accuracy figure" in joined
 
 
@@ -1283,3 +1291,251 @@ def test_the_validity_qualifier_survives_a_narrow_frame():
         assert len(row) <= width
         # Some spelling of the scope always survives, and it is never cut mid-word.
         assert "emitted" in row, f"scope lost at {width}: {row!r}"
+
+
+def test_every_ladder_qualifier_is_present_and_uncropped_at_note_min():
+    """The last rung of every ``notes`` ladder must FIT, not merely exist.
+
+    ``kv`` now draws its final rung unconditionally, so a caller that appends a
+    long one turns "shed silently" into "cropped mid-word" — a different failure
+    of the same rule. The floor is stated once, here, over the real rendered
+    rows rather than over the literals, so a new ladder is covered the day it is
+    added: at ``_NOTE_MIN`` every qualifier is present and uncropped.
+    """
+    stats = ToolCallStats(
+        total=40,
+        ok=30,
+        faults={"invalid_arguments": 3, "unknown_tool": 2, "execution": 3, "denied": 2},
+        faults_by_tool={"edit": 3, "reed_file": 2, "web_fetch": 3, "bash": 2},
+        nested_total=6,
+        nested_ok=6,
+    )
+    section = _section(
+        build_session_report(_tool_report(stats), runtime(), _NOTE_MIN).plain, "Tool surface"
+    )
+    # Every row carrying a ladder still shows its scope at the narrowest frame,
+    # and none of them is cut mid-word (a cropped row would lose its last char).
+    expected = {
+        # Whichever rung wins, the SCOPE word survives; validity's own floor
+        # rung is exercised by the width sweep in the test below.
+        "Call validity": "emitted",
+        "Tool-side errors": "dispatched",
+        " └ nested (eval)": "not the model's",
+        " └ denied or aborted": "your decision",
+    }
+    for label, floor in expected.items():
+        row = next((r for r in section if label in r), None)
+        assert row is not None, f"{label} row missing at width {_NOTE_MIN}"
+        assert len(row) <= _NOTE_MIN
+        assert floor in row, f"floor rung lost at {_NOTE_MIN} for {label}: {row!r}"
+
+
+def test_the_execution_scope_survives_at_every_supported_width():
+    """D1: at 68 columns this row used to read as a bare unqualified integer.
+
+    It carries no ``%`` in its value cell, so unlike ``Call validity`` it
+    self-describes not at all — an integer named "errors" sitting under a
+    model-accuracy percentage is precisely the misreading the scope exists to
+    prevent. The old ladder ``break``-ed with no fallback, so when nothing fit
+    the scope was gone at an undocumented width.
+
+    The fix is structural, not another rung: the scope moved into the LABEL,
+    which is never shed. So this asserts across the FULL supported range,
+    including widths where every note is shed — a rung-based fix cannot pass it.
+    """
+    stats = ToolCallStats(
+        total=17,
+        ok=13,
+        faults={"invalid_arguments": 2, "execution": 2},
+        faults_by_tool={"edit": 2, "web_fetch": 2},
+    )
+    for width in range(_MIN_CARD_WIDTH, 121):
+        section = _section(
+            build_session_report(_tool_report(stats), runtime(), width).plain, "Tool surface"
+        )
+        row = next(r for r in section if "errors" in r)
+        assert len(row) <= width
+        # The scope is in the label, so it cannot shed at ANY width.
+        assert "Tool-side" in row, f"scope vanished at {width}: {row!r}"
+        # And nothing is cut mid-word: every rung ends on a complete word, so a
+        # truncated tail could only be a crop.
+        tail = row.rstrip()
+        if "dispatch" in tail:
+            assert tail.endswith(("dispatched", "accuracy", "figure")), (width, row)
+
+
+def test_the_block_reconciles_its_own_counts_on_screen():
+    """D2: no number in the block may be unaccountable.
+
+    ``7 failed`` under a breakdown naming only six was the reported defect: the
+    seventh was a denied call, correctly outside both rates and never surfaced.
+    With the approval gate on, denials are the DEFAULT posture, so an operator
+    would routinely see a count they could not account for and read it as the
+    new feature miscounting — the exact misreading this feature removes.
+    """
+    stats = ToolCallStats(
+        total=35,
+        ok=28,
+        faults={
+            "invalid_arguments": 2,
+            "duplicate_id": 1,
+            "unknown_tool": 1,
+            "execution": 2,
+            "denied": 1,
+        },
+        faults_by_tool={"edit": 2, "read": 1, "reed_file": 1, "web_fetch": 2, "bash": 1},
+        nested_total=5,
+        nested_ok=5,
+    )
+    section = _section(
+        build_session_report(_tool_report(stats), runtime(), 100).plain, "Tool surface"
+    )
+    joined = "\n".join(section)
+    # The headline is EVERY recorded call, both origins: under the ` └ ` idiom
+    # a sub-row is part of the row above, so a model-only headline carrying a
+    # nested sub-row would be arithmetically false.
+    assert any("Tool calls" in r and "40" in r and "7 failed" in r for r in section)
+    # Each class removed from the denominator is named, in the order it is
+    # removed, so the reader reaches `emitted` by reading downward.
+    nested_row = next(r for r in section if "nested (eval)" in r)
+    assert "5" in nested_row and "not the model's" in nested_row
+    excluded_row = next(r for r in section if "denied or aborted" in r)
+    assert "1" in excluded_row and "not the model" in excluded_row
+    # Every denominator the rates use is printed rather than implied.
+    assert "34 emitted" in joined, "the validity denominator is unstated"
+    assert "30 dispatched" in joined, "the execution denominator is unstated"
+
+    # The two chains the reader can actually do on screen both close.
+    assert stats.recorded - stats.nested_total - stats.excluded == stats.emitted == 34
+    assert stats.emitted - stats.model_faults == 30
+    named = stats.model_faults + stats.execution_faults + stats.excluded
+    assert named == stats.total - stats.ok == 7
+
+
+def test_fault_sub_rows_are_ordered_deterministically_on_a_tie():
+    """D3: ``sorted`` over a ``frozenset`` reorders tied counts per process.
+
+    Set iteration order for strings depends on ``PYTHONHASHSEED``, so the same
+    data rendered twice produced different row orders — reproduced across four
+    captured frames in one batch. A user comparing two sessions, or the same
+    session before and after a resize, saw rows swap for no reason and read it
+    as the data changing.
+    """
+    stats = ToolCallStats(
+        total=9,
+        ok=6,
+        # All three tied at 1, so ONLY the tiebreak decides the order.
+        faults={"invalid_arguments": 1, "duplicate_id": 1, "unknown_tool": 1},
+        faults_by_tool={"edit": 1, "read": 1, "reed_file": 1},
+    )
+    section = _section(
+        build_session_report(_tool_report(stats), runtime(), 100).plain, "Tool surface"
+    )
+    order = [r.split("└")[1].strip().split("  ")[0] for r in section if "└" in r]
+    assert order == ["duplicate id", "invalid arguments", "unknown tool"], order
+
+    # And the count still dominates the name: a bigger fault outranks it.
+    bigger = ToolCallStats(
+        total=9,
+        ok=6,
+        faults={"invalid_arguments": 1, "duplicate_id": 1, "unknown_tool": 7},
+        faults_by_tool={},
+    )
+    section = _section(
+        build_session_report(_tool_report(bigger), runtime(), 100).plain, "Tool surface"
+    )
+    order = [r.split("└")[1].strip().split("  ")[0] for r in section if "└" in r]
+    assert order[0] == "unknown tool", order
+
+
+def test_a_measured_zero_execution_error_count_is_drawn():
+    """D4: "none" and "not measured" must not look identical.
+
+    The standing invariant is that an absent measurement is never drawn as a
+    measured zero; the converse is the same principle. Suppressing this row at
+    zero made a clean run — the MODAL shape for a healthy session — say nothing
+    where ``Call validity`` on the very next line happily shows its own zero.
+    """
+    stats = ToolCallStats(total=10, ok=10, faults={}, faults_by_tool={})
+    section = _section(
+        build_session_report(_tool_report(stats), runtime(), 100).plain, "Tool surface"
+    )
+    row = next((r for r in section if "Tool-side errors" in r), None)
+    assert row is not None, "a measured zero was hidden"
+    assert "0" in row and "0.0%" in row
+    # Still absent when nothing was dispatched: that IS unmeasured.
+    denied_only = ToolCallStats(total=3, ok=0, faults={"denied": 3}, faults_by_tool={"bash": 3})
+    section = _section(
+        build_session_report(_tool_report(denied_only), runtime(), 100).plain, "Tool surface"
+    )
+    assert not any("Tool-side errors" in r for r in section)
+
+
+def test_unknown_is_dimmed_like_the_other_absent_measurement_on_this_screen():
+    """D5: ``unknown`` must not carry the same ink as a measured number.
+
+    ``_timing_rows`` already draws ``unknown (0 samples)`` in ``dim``; two
+    absent-measurement states styled differently on one screen reads as an
+    oversight. This is the modal state for every session recorded before the
+    feature shipped, so it is the shape most users see first.
+    """
+    dim = semantic_style("dim")
+    fg = semantic_style("fg")
+
+    def value_style(text, label):
+        """The style of the VALUE cell on ``label``'s row.
+
+        Asserted positionally rather than by searching for the word: the timing
+        rows already draw their own dim ``unknown (0 samples)`` on this screen,
+        so a substring search over dim spans passes whether or not THIS cell was
+        ever dimmed — which is a guard that cannot go red.
+        """
+        line_start = text.plain.rindex("\n", 0, text.plain.index(label)) + 1
+        value_at = line_start + 2 + 22
+        return next(s.style for s in text.spans if s.start <= value_at < s.end)
+
+    text = build_session_report(_tool_report(None), runtime(), 100)
+    assert value_style(text, "Tool calls") == dim, "unknown drawn in full-strength ink"
+
+    # A measured value keeps the normal foreground: only ABSENCE is dimmed.
+    stats = ToolCallStats(total=20, ok=20, faults={}, faults_by_tool={})
+    text = build_session_report(_tool_report(stats), runtime(), 100)
+    assert value_style(text, "Tool calls") == fg
+    assert value_style(text, "Call validity") == fg
+
+    # And the other unknown on this block takes the same treatment.
+    denied = ToolCallStats(total=3, ok=0, faults={"denied": 3}, faults_by_tool={"bash": 3})
+    text = build_session_report(_tool_report(denied), runtime(), 100)
+    assert value_style(text, "Call validity") == dim
+
+
+def test_nested_calls_are_shown_but_named_as_outside_the_rates():
+    """M1 on screen: the calls are visible, the rate is not computed over them.
+
+    A reader who watched twenty eval-dispatched calls happen and then sees a
+    rate over three needs the twenty accounted for, or they conclude the counter
+    is broken. Showing them without saying they are unrated would re-open the
+    conflation in the reader's head even though the arithmetic is right.
+    """
+    stats = ToolCallStats(
+        total=3,
+        ok=2,
+        faults={"unknown_tool": 1},
+        faults_by_tool={"reed_file": 1},
+        nested_total=20,
+        nested_ok=20,
+    )
+    section = _section(
+        build_session_report(_tool_report(stats), runtime(), 100).plain, "Tool surface"
+    )
+    row = next(r for r in section if "nested (eval)" in r)
+    assert "20" in row and "not the model's" in row
+    # The headline counts every call; the RATE stays model-origin.
+    assert any("Tool calls" in r and "23" in r for r in section)
+    assert any("Call validity" in r and "66.7%" in r for r in section)
+    # And the row is absent when there are none, so a clean session stays clean.
+    plain = ToolCallStats(total=3, ok=3, faults={}, faults_by_tool={})
+    section = _section(
+        build_session_report(_tool_report(plain), runtime(), 100).plain, "Tool surface"
+    )
+    assert not any("nested" in r for r in section)

--- a/tests/unit/tui/test_session_panel.py
+++ b/tests/unit/tui/test_session_panel.py
@@ -16,6 +16,7 @@ from local_operator.analytics.model import (
     SessionReport,
     SessionRequest,
     TimingSummary,
+    ToolCallStats,
     UsageAggregate,
 )
 from local_operator.analytics.store import AnalyticsStore
@@ -147,6 +148,18 @@ async def test_assembled_slash_snapshot_scroll_and_focus(tmp_path, monkeypatch, 
         await pilot.pause()
         assert screen._scroll.scroll_y > 0
         await pilot.press("home")
+        # Wait on the ANIMATION, not on a fixed number of pauses. ``home``
+        # animates ``scroll_y`` back to the top, so the number of frames it
+        # needs is proportional to how far it has to travel — a taller panel
+        # (this one grew by the measured tool-call rows) simply takes more of
+        # them. Asserting after one ``pause`` was a bet on the panel's height,
+        # which is why it broke on a section being added rather than on
+        # anything about scrolling changing. Same idiom as
+        # ``test_resume_render._press_and_settle``.
+        for _ in range(160):
+            if not app.animator.is_being_animated(screen._scroll, "scroll_y"):
+                break
+            await pilot.pause()
         await pilot.pause()
         assert screen._scroll.scroll_y == 0
         store.record_batch([_snap(session_id="sess")])
@@ -357,7 +370,21 @@ def _agg(calls=1, ok=None, ctx=0, out=0, cost=0, known=0, components=None, reaso
     return aggregate
 
 
-def _request(index, purpose="turn", outcome="ok", ctx=40000, out=1000, duration=2000.0):
+def _request(
+    index,
+    purpose="turn",
+    outcome="toolUse",
+    ctx=40000,
+    out=1000,
+    duration=2000.0,
+    ok: bool | None = True,
+):
+    # ``outcome`` defaults to a string the recorder ACTUALLY writes. The old
+    # default was ``"ok"``, which nothing in the product has ever emitted: the
+    # provider path writes ``str(stop_reason)`` (stop/length/toolUse/refusal) or
+    # an exception class name. Fixtures asserting the impossible value are what
+    # let the "every healthy request failed" defect ship, so the vocabulary here
+    # is now the real one and ``ok`` — the recorded truth — decides success.
     return SessionRequest(
         request_id=f"r{index}",
         ts_ms=1788602400000 + index * 47000,
@@ -371,6 +398,7 @@ def _request(index, purpose="turn", outcome="ok", ctx=40000, out=1000, duration=
         duration_ms=duration,
         ttft_ms=400.0,
         preparation_ms=25.0,
+        ok=ok,
     )
 
 
@@ -397,12 +425,16 @@ def _populated():
             "compaction": _agg(3, 2, 270000, 2700, 3870, 3),
             "aside": _agg(4, 4, 48000, 1200, 5340, 4),
         },
+        # The shape the recorder really produces: healthy rows carry a provider
+        # finish reason, not the literal "ok". Failure counts come from
+        # ``ok_calls`` on the aggregates above, never from this cross-tab.
         by_purpose_outcome={
-            ("turn", "ok"): 12,
-            ("turn", "error"): 2,
-            ("compaction", "ok"): 2,
-            ("compaction", "error"): 1,
-            ("aside", "ok"): 4,
+            ("turn", "toolUse"): 10,
+            ("turn", "stop"): 2,
+            ("turn", "ProviderError"): 2,
+            ("compaction", "stop"): 2,
+            ("compaction", "ProviderError"): 1,
+            ("aside", "stop"): 4,
         },
         timings={
             "duration_ms": TimingSummary(25, 2223, 400, 3770),
@@ -725,7 +757,7 @@ def test_full_share_row_does_not_crop_its_failure_count():
         aggregate=one,
         by_model={("anthropic", "claude-sonnet-4-6"): one},
         by_purpose={"turn": one},
-        by_purpose_outcome={("turn", "ok"): 16, ("turn", "error"): 2},
+        by_purpose_outcome={("turn", "toolUse"): 16, ("turn", "ProviderError"): 2},
     )
     # 84 is the real card width of a 100-column terminal, where this reproduced.
     for width in (84, 88, 100):
@@ -881,10 +913,21 @@ def test_sequence_chart_never_renders_an_absent_duration_as_zero():
     # themselves: an unmeasured request must not define the window max either.
     mixed = (
         SessionRequest(
-            "b", 1788602400000 + 10000, "p", "m", "turn", "ok", True, 1000, 100, 4000.0, None, None
+            "b",
+            1788602400000 + 10000,
+            "p",
+            "m",
+            "turn",
+            "toolUse",
+            True,
+            1000,
+            100,
+            4000.0,
+            None,
+            None,
         ),
         SessionRequest(
-            "a", 1788602400000, "p", "m", "turn", "ok", True, 1000, 100, None, None, None
+            "a", 1788602400000, "p", "m", "turn", "toolUse", True, 1000, 100, None, None, None
         ),
     )
     report = SessionReport("sess", aggregate=_agg(2, 2, 2000, 200), recent=mixed)
@@ -1043,3 +1086,200 @@ def test_restored_floor_is_reconciled_in_prose_not_copied():
 
     plain = build_session_report(_tree_report(), runtime(), width=120).plain
     assert "restored floor" not in plain
+
+
+# ---------------------------------------------------------------------------
+# Failure accounting: `ok`, never the `outcome` string
+# ---------------------------------------------------------------------------
+
+
+def test_healthy_session_reports_no_failures_whatever_the_outcome_strings():
+    """The operator's bug: a fully-successful session read "15 req · 15 failed".
+
+    The cause was a predicate testing ``outcome not in ("ok", "unknown")``
+    against a vocabulary that never contains ``"ok"`` — the recorder writes
+    ``str(stop_reason)`` (``stop``/``length``/``toolUse``) or an exception class
+    name. This fixture uses those REAL strings, so it fails on the code that
+    shipped and cannot be satisfied by reintroducing an ``"ok"`` literal.
+    """
+    turn = _agg(15, 15, 1_100_000, 30_000)
+    naming = _agg(1, 1, 220, 40)
+    report = SessionReport(
+        "sess",
+        aggregate=_agg(16, 16, 1_100_220, 30_040),
+        by_model={("anthropic", "claude-sonnet-4-6"): _agg(16, 16, 1_100_220, 30_040)},
+        by_purpose={"turn": turn, "naming": naming},
+        by_purpose_outcome={
+            ("turn", "toolUse"): 12,
+            ("turn", "stop"): 3,
+            ("naming", "stop"): 1,
+        },
+    )
+    text = build_session_report(report, runtime(), 100).plain
+    assert "failed" not in text, "a healthy session must not report a failure anywhere"
+    for row in _rows(text, "By purpose"):
+        assert "req" in row
+
+
+def test_a_genuinely_failed_session_still_reports_it():
+    """The guard must still be able to go red.
+
+    A test that only proves the false alarm is gone would also pass if the
+    annotation were deleted outright, which would hide real outages — so the
+    negative case above is only meaningful beside this one.
+    """
+    report = SessionReport(
+        "sess",
+        aggregate=_agg(15, 12, 1_100_000, 30_000),
+        by_model={("anthropic", "claude-sonnet-4-6"): _agg(15, 12, 1_100_000, 30_000)},
+        by_purpose={"turn": _agg(15, 12, 1_100_000, 30_000)},
+        # Deliberately EMPTY: the count comes from ``ok_calls``, so the failure
+        # must be reported even with no outcome cross-tab to label it.
+        by_purpose_outcome={},
+    )
+    text = build_session_report(report, runtime(), 100).plain
+    assert "3 failed" in text
+    # ``By model`` gains the annotation too, correctly: a provider failing every
+    # call used to be invisible there.
+    assert sum("3 failed" in row for row in _rows(text, "By model")) == 1
+
+
+def test_request_sequence_warns_on_ok_false_and_not_on_an_outcome_string():
+    """``_draw_request_sequence`` had the same string bug; ``ok`` decides now."""
+    healthy = SessionReport(
+        "sess",
+        aggregate=_agg(2, 2, 2000, 200),
+        recent=(_request(1, outcome="toolUse", ok=True), _request(0, outcome="stop", ok=True)),
+    )
+    text = build_session_report(healthy, runtime(), 88).plain
+    rows = _section(text, "Last 2 requests")
+    assert rows and not any("toolUse" in r or "stop" in r for r in rows)
+
+    failed = SessionReport(
+        "sess",
+        aggregate=_agg(2, 1, 2000, 200),
+        recent=(
+            _request(1, outcome="ProviderError", ok=False),
+            _request(0, outcome="toolUse", ok=True),
+        ),
+    )
+    rows = _section(build_session_report(failed, runtime(), 88).plain, "Last 2 requests")
+    # Still red when it should be: the outcome string is DISPLAYED once ``ok``
+    # has established the row is a failure.
+    assert sum("ProviderError" in r for r in rows) == 1
+
+
+def test_unknown_ok_is_not_a_failure():
+    """``ok=None`` is an absent measurement, and this screen never paints one red.
+
+    That is the 419k-row case on the operator's live ledger: legacy rows whose
+    ``outcome`` is the literal ``'unknown'``. They carry ``ok=1``, but a ledger
+    old enough to lack the column entirely yields ``None``, and neither may
+    render as a warning.
+    """
+    report = SessionReport(
+        "sess",
+        aggregate=_agg(2, 2, 2000, 200),
+        recent=(
+            _request(1, outcome="unknown", ok=None),
+            _request(0, outcome="unknown", ok=None),
+        ),
+    )
+    rows = _section(build_session_report(report, runtime(), 88).plain, "Last 2 requests")
+    assert rows and not any("unknown" in r.split("·")[-1] for r in rows if "·" in r)
+
+
+# ---------------------------------------------------------------------------
+# Tool-call validity
+# ---------------------------------------------------------------------------
+
+
+def _tool_report(stats):
+    return SessionReport(
+        "sess",
+        aggregate=_agg(4, 4, 4000, 400),
+        by_model={("anthropic", "claude-sonnet-4-6"): _agg(4, 4, 4000, 400)},
+        by_purpose={"turn": _agg(4, 4, 4000, 400)},
+        tool_calls=stats,
+    )
+
+
+def test_no_tool_data_reads_unknown_and_never_a_measured_zero():
+    """Every session recorded before this shipped has no tool rows.
+
+    ``unknown``, not ``0%``: a fabricated zero on a diagnostics screen cannot be
+    told apart from a measurement, which is this screen's standing invariant.
+    """
+    text = build_session_report(_tool_report(None), runtime(), 100).plain
+    section = _section(text, "Tool surface")
+    assert any("Tool calls" in r and "unknown" in r for r in section)
+    # The rates are omitted entirely rather than shown as unknown.
+    assert not any("Call validity" in r for r in section)
+    assert not any("Execution errors" in r for r in section)
+    assert "0%" not in "".join(section)
+
+
+def test_a_real_zero_fault_count_renders_as_a_measurement():
+    """A session that emitted 20 clean calls is 100% — that IS measured."""
+    stats = ToolCallStats(total=20, ok=20, faults={}, faults_by_tool={})
+    text = build_session_report(_tool_report(stats), runtime(), 100).plain
+    section = _section(text, "Tool surface")
+    assert any("Call validity" in r and "100.0%" in r for r in section)
+    assert any("Tool calls" in r and "20" in r for r in section)
+
+
+def test_validity_counts_only_model_faults_and_excludes_user_cancellations():
+    """The benchmarking number must not move when the USER declines a call.
+
+    10 calls: 2 model faults, 1 execution error, 2 denied. Validity is over the
+    8 EMITTED (10 - 2 denied), so 6/8 = 75.0% — the denied pair is removed from
+    the denominator rather than counted either way.
+    """
+    stats = ToolCallStats(
+        total=10,
+        ok=5,
+        faults={"unknown_tool": 1, "invalid_arguments": 1, "execution": 1, "denied": 2},
+        faults_by_tool={"reed_file": 1, "edit": 1, "web_fetch": 1, "bash": 2},
+    )
+    assert stats.emitted == 8
+    assert stats.model_faults == 2
+    assert stats.validity == pytest.approx(0.75)
+    # Execution rate is over calls that actually RAN: 8 emitted - 2 rejected = 6.
+    assert stats.execution_error_rate == pytest.approx(1 / 6)
+
+    section = _section(
+        build_session_report(_tool_report(stats), runtime(), 100).plain, "Tool surface"
+    )
+    joined = "\n".join(section)
+    assert "75.0%" in joined
+    assert "2 invalid of 8 emitted" in joined
+    # The execution row is labelled as NOT an accuracy figure, every time.
+    assert "not a model-accuracy figure" in joined
+
+
+def test_validity_is_unknown_when_nothing_countable_was_emitted():
+    """Rows exist but every call was denied: a rate over an empty denominator."""
+    stats = ToolCallStats(total=3, ok=0, faults={"denied": 3}, faults_by_tool={"bash": 3})
+    assert stats.emitted == 0
+    assert stats.validity is None
+    section = _section(
+        build_session_report(_tool_report(stats), runtime(), 100).plain, "Tool surface"
+    )
+    assert any("Call validity" in r and "unknown" in r for r in section)
+
+
+def test_the_validity_qualifier_survives_a_narrow_frame():
+    """The scope of a percentage is not sheddable chrome.
+
+    ``kv``'s ``notes`` ladder exists because a qualifier cropped mid-word or
+    dropped wholesale leaves a correct figure looking like a wrong one.
+    """
+    stats = ToolCallStats(total=412, ok=389, faults={"invalid_arguments": 12}, faults_by_tool={})
+    for width in (60, 72, 88, 100):
+        section = _section(
+            build_session_report(_tool_report(stats), runtime(), width).plain, "Tool surface"
+        )
+        row = next(r for r in section if "Call validity" in r)
+        assert len(row) <= width
+        # Some spelling of the scope always survives, and it is never cut mid-word.
+        assert "emitted" in row, f"scope lost at {width}: {row!r}"

--- a/tests/unit/tui/test_session_panel.py
+++ b/tests/unit/tui/test_session_panel.py
@@ -13,6 +13,7 @@ from rich.style import Style
 
 from local_operator.analytics.model import (
     COMPONENT_KEYS,
+    EXCLUDED_FAULTS,
     SessionReport,
     SessionRequest,
     TimingSummary,
@@ -1281,16 +1282,58 @@ def test_the_validity_qualifier_survives_a_narrow_frame():
 
     ``kv``'s ``notes`` ladder exists because a qualifier cropped mid-word or
     dropped wholesale leaves a correct figure looking like a wrong one.
+
+    **This asserts the rung's MEANING at every supported width, not a sampled
+    suffix.** The predecessor sampled four widths and asserted only that the
+    word ``emitted`` was present, which the defect it was standing next to
+    satisfied: the middle rung ``"4 of 31 emitted"`` contains ``emitted``, sits
+    between two sampled widths (60 and 72), and drops the word that carries the
+    count's DIRECTION. Beside ``87.1%`` a bare ``4 of 31`` reads as "4 valid of
+    31" — the inverse of the truth — and nothing but doing the division
+    distinguishes the two readings (design round 2, D8). An assertion a broken
+    string satisfies is a decoration, which is the lesson D6 already paid for
+    one row below.
+
+    So the two properties asserted here are the two a shorter rung may not
+    trade away, and they are checked at EVERY width the row is drawn at:
+
+    * **the direction** — any rung showing the invalid count says ``invalid``,
+      so the number can never be read as its own complement;
+    * **the denominator** — a percentage is never drawn without the population
+      it is over, the same rule
+      ``test_the_execution_scope_survives_at_every_supported_width`` pins.
+
+    Refinements above those (the verb ``emitted``, the word ``of``) stay free to
+    shed as the frame narrows; that is what a ladder is for.
     """
     stats = ToolCallStats(total=412, ok=389, faults={"invalid_arguments": 12}, faults_by_tool={})
-    for width in (60, 72, 88, 100):
+    # Recomputed rather than restated, so a fixture change cannot leave the
+    # guard asserting a stale denominator.
+    invalid, emitted = stats.model_faults, stats.emitted
+    assert (invalid, emitted) == (12, 412)
+    drawn = 0
+    for width in range(_MIN_CARD_WIDTH, 121):
         section = _section(
             build_session_report(_tool_report(stats), runtime(), width).plain, "Tool surface"
         )
         row = next(r for r in section if "Call validity" in r)
         assert len(row) <= width
-        # Some spelling of the scope always survives, and it is never cut mid-word.
-        assert "emitted" in row, f"scope lost at {width}: {row!r}"
+        tail = row.rstrip()
+        # `12` alone would also match the percentage's own digits, so the
+        # qualifier is detected by the count sitting at the start of a rung.
+        if str(invalid) in tail.split("%", 1)[-1]:
+            drawn += 1
+            assert "invalid" in tail, (
+                f"at {width} the invalid count is drawn without the word that "
+                f"gives it its direction, so it reads as its own complement: {row!r}"
+            )
+            assert str(emitted) in tail, (
+                f"at {width} the rate is drawn without its denominator, "
+                f"so it states a proportion of nothing: {row!r}"
+            )
+    # The ladder is actually exercised: the loop is not vacuously passing on
+    # widths where every rung is shed.
+    assert drawn > 0
 
 
 def test_every_ladder_qualifier_is_present_and_uncropped_at_note_min():
@@ -1323,7 +1366,7 @@ def test_every_ladder_qualifier_is_present_and_uncropped_at_note_min():
         " └ nested (eval)": "not the model's",
         # Attribution-NEUTRAL at every rung: `gate_failed` and `skipped` are in
         # this row too, and neither is the operator's decision (review N1).
-        " └ denied or aborted": "outside both rates",
+        " └ never completed": "outside both rates",
     }
     for label, floor in expected.items():
         row = next((r for r in section if label in r), None)
@@ -1430,7 +1473,7 @@ def test_the_block_reconciles_its_own_counts_on_screen():
     # removed, so the reader reaches `emitted` by reading downward.
     nested_row = next(r for r in section if "nested (eval)" in r)
     assert "5" in nested_row and "not the model's" in nested_row
-    excluded_row = next(r for r in section if "denied or aborted" in r)
+    excluded_row = next(r for r in section if "never completed" in r)
     assert "1" in excluded_row and "outside both rates" in excluded_row
     # Every denominator the rates use is printed rather than implied.
     assert "34 emitted" in joined, "the validity denominator is unstated"
@@ -1486,7 +1529,7 @@ def test_the_headline_never_calls_an_operator_denial_a_failure():
         "9 failed" not in headline
     ), f"the operator's 7 denials are counted as failures: {headline!r}"
     # The seven are not lost — they are accounted for by their own row.
-    assert any("denied or aborted" in r and "7" in r for r in section)
+    assert any("never completed" in r and "7" in r for r in section)
 
     # Nothing dispatched: every recorded call was excluded, so there is no
     # `failed` clause to draw. A `0 ok · 4 failed` here is the founding bug
@@ -1545,7 +1588,7 @@ def test_the_excluded_row_does_not_blame_the_operator_for_a_harness_fault():
         section = _section(
             build_session_report(_tool_report(stats), runtime(), width).plain, "Tool surface"
         )
-        row = next(r for r in section if "denied or aborted" in r)
+        row = next(r for r in section if "never completed" in r)
         # "you"/"your" is the whole finding: the row must not address the reader
         # as the cause of a fault the harness produced.
         assert (
@@ -1556,6 +1599,59 @@ def test_the_excluded_row_does_not_blame_the_operator_for_a_harness_fault():
     # The neutral wording is actually reached, so the loop is not vacuously
     # passing on widths where every note is shed.
     assert drawn > 0
+
+
+def test_the_excluded_label_covers_every_fault_the_row_counts():
+    """D9: the label named two of the four classes the row's number counts.
+
+    ``└ denied or aborted`` is a disjunction over ``{denied, aborted}``, but the
+    count beside it sums all of ``EXCLUDED_FAULTS`` — ``skipped`` (steering
+    redirected) and ``gate_failed`` (our approval plumbing raised) land under a
+    heading that describes neither. That is the N1 defect one cell to the left:
+    the note was made attribution-neutral while the label above it kept naming
+    the operator's two decisions as though they were the whole set.
+
+    **The label is checked against ``EXCLUDED_FAULTS`` itself, not against a
+    restated list**, so a fifth member added later fails here rather than
+    quietly widening the gap between what the row says and what it counts.
+
+    Design suggested ``never dispatched`` / ``not run``. Both are FALSE for this
+    set and the falsity is measured, not argued: driving the real ``AgentLoop``
+    with a blocking tool and aborting mid-execution records ``aborted`` for a
+    call whose body had already run (``interruptible_runner`` cancels a task in
+    flight and parks a synthetic result). ``denied`` and ``gate_failed`` never
+    dispatch; ``aborted`` and ``skipped`` may. What is true of all four is that
+    no real tool outcome came back — which is precisely why they are in neither
+    denominator — so the label says ``never completed``.
+    """
+    # Every member of the set, one at a time: each must render under a label
+    # that is true of it, at every width the row is drawn.
+    for fault in sorted(EXCLUDED_FAULTS):
+        stats = ToolCallStats(total=5, ok=3, faults={fault: 2}, faults_by_tool={})
+        assert stats.excluded == 2, f"{fault} is not being excluded at all"
+        for width in (_MIN_CARD_WIDTH, _NOTE_MIN, 74, 100):
+            section = _section(
+                build_session_report(_tool_report(stats), runtime(), width).plain, "Tool surface"
+            )
+            row = next((r for r in section if "2" in r and "└" in r), None)
+            assert row is not None, f"the excluded row vanished for {fault} at {width}"
+            assert len(row) <= width
+            lowered = row.lower()
+            # The label must not name a proper SUBSET of what it counts: a
+            # `gate_failed` call is not the operator denying anything.
+            for decision in ("denied", "aborted"):
+                if decision in lowered:
+                    assert fault in {"denied", "aborted"}, (
+                        f"a {fault!r} call is labelled {decision!r} at {width}, "
+                        f"which names a class it is not in: {row!r}"
+                    )
+            # Nor may it claim the call never started: `aborted` and `skipped`
+            # can be cut short after dispatch (measured against the real loop).
+            for started in ("never dispatched", "not dispatched", "never run", "not run"):
+                assert started not in lowered, (
+                    f"a {fault!r} call is claimed never to have started at {width}, "
+                    f"which the loop contradicts for aborted/skipped: {row!r}"
+                )
 
 
 def test_fault_sub_rows_are_ordered_deterministically_on_a_tie():

--- a/tests/unit/tui/test_session_panel.py
+++ b/tests/unit/tui/test_session_panel.py
@@ -1221,18 +1221,58 @@ def test_no_tool_data_reads_unknown_and_never_a_measured_zero():
     section = _section(text, "Tool surface")
     assert any("Tool calls" in r and "unknown" in r for r in section)
     # The rates are omitted entirely rather than shown as unknown.
-    assert not any("Call validity" in r for r in section)
+    assert not any("Tool-call error rate" in r for r in section)
     assert not any("Tool-side errors" in r for r in section)
     assert "0%" not in "".join(section)
 
 
 def test_a_real_zero_fault_count_renders_as_a_measurement():
-    """A session that emitted 20 clean calls is 100% — that IS measured."""
+    """A session that emitted 20 clean calls has 0% errors — that IS measured."""
     stats = ToolCallStats(total=20, ok=20, faults={}, faults_by_tool={})
     text = build_session_report(_tool_report(stats), runtime(), 100).plain
     section = _section(text, "Tool surface")
-    assert any("Call validity" in r and "100.0%" in r for r in section)
+    assert any("Tool-call error rate" in r and "0.0%" in r for r in section)
     assert any("Tool calls" in r and "20" in r for r in section)
+
+
+@pytest.mark.parametrize("fault", sorted(EXCLUDED_FAULTS))
+def test_nested_exclusions_are_visible_but_never_subtracted_twice(fault):
+    stats = ToolCallStats(
+        total=5,
+        ok=3,
+        faults={"unknown_tool": 1, fault: 1},
+        faults_by_tool={},
+        nested_total=3,
+        nested_ok=1,
+        nested_excluded=1,
+    )
+    assert stats.recorded == 8
+    assert stats.all_excluded == 2
+    assert stats.emitted == 4
+    assert stats.tool_call_error_rate == 0.25
+    for width in range(_MIN_CARD_WIDTH, 121):
+        rows = _section(
+            build_session_report(_tool_report(stats), runtime(), width).plain, "Tool surface"
+        )
+        headline = next(row for row in rows if "Tool calls" in row)
+        if width >= _NOTE_MIN:
+            assert "4 ok" in headline and "2 failed" in headline
+        nested = next(row for row in rows if "└ excluded" in row)
+        assert nested.split("excluded", 1)[1].strip().startswith("1")
+        model_excluded = next(row for row in rows if "never completed" in row)
+        assert model_excluded.split("never completed", 1)[1].strip().startswith("1")
+        rate = next(row for row in rows if "Tool-call error rate" in row)
+        assert "25.0%" in rate
+        assert "4 emitted" in " ".join(rows) or "1 invalid/4" in rate or "1 invalid of 4" in rate
+        assert all(len(row) <= width for row in rows)
+
+
+def test_tool_call_error_rate_keeps_direct_ratio_precision():
+    stats = ToolCallStats(total=3000, ok=2999, faults={"unknown_tool": 1}, faults_by_tool={})
+    # A rounded validity complement would lose this measured nonzero entirely.
+    assert stats.tool_call_error_rate == 1 / 3000
+    zero = ToolCallStats(total=0, ok=0, faults={}, faults_by_tool={})
+    assert zero.tool_call_error_rate is None
 
 
 def test_validity_counts_only_model_faults_and_excludes_user_cancellations():
@@ -1258,7 +1298,7 @@ def test_validity_counts_only_model_faults_and_excludes_user_cancellations():
         build_session_report(_tool_report(stats), runtime(), 100).plain, "Tool surface"
     )
     joined = "\n".join(section)
-    assert "75.0%" in joined
+    assert "25.0%" in joined
     assert "2 invalid of 8 emitted" in joined
     # The execution row is labelled as NOT an accuracy figure, every time. The
     # LABEL carries that scope (never shed) and the note refines it (D1).
@@ -1274,7 +1314,7 @@ def test_validity_is_unknown_when_nothing_countable_was_emitted():
     section = _section(
         build_session_report(_tool_report(stats), runtime(), 100).plain, "Tool surface"
     )
-    assert any("Call validity" in r and "unknown" in r for r in section)
+    assert any("Tool-call error rate" in r and "unknown" in r for r in section)
 
 
 def test_the_validity_qualifier_survives_a_narrow_frame():
@@ -1316,7 +1356,7 @@ def test_the_validity_qualifier_survives_a_narrow_frame():
         section = _section(
             build_session_report(_tool_report(stats), runtime(), width).plain, "Tool surface"
         )
-        row = next(r for r in section if "Call validity" in r)
+        row = next(r for r in section if "Tool-call error rate" in r)
         assert len(row) <= width
         tail = row.rstrip()
         # `12` alone would also match the percentage's own digits, so the
@@ -1361,7 +1401,7 @@ def test_every_ladder_qualifier_is_present_and_uncropped_at_note_min():
     expected = {
         # Whichever rung wins, the SCOPE word survives; validity's own floor
         # rung is exercised by the width sweep in the test below.
-        "Call validity": "emitted",
+        "Tool-call error rate": "emitted",
         "Tool-side errors": "dispatched",
         " └ nested (eval)": "not the model's",
         # Attribution-NEUTRAL at every rung: `gate_failed` and `skipped` are in
@@ -1378,7 +1418,7 @@ def test_every_ladder_qualifier_is_present_and_uncropped_at_note_min():
 def test_the_execution_scope_survives_at_every_supported_width():
     """D1: at 68 columns this row used to read as a bare unqualified integer.
 
-    It carries no ``%`` in its value cell, so unlike ``Call validity`` it
+    It carries no ``%`` in its value cell, so unlike ``Tool-call error rate`` it
     self-describes not at all — an integer named "errors" sitting under a
     model-accuracy percentage is precisely the misreading the scope exists to
     prevent. The old ladder ``break``-ed with no fallback, so when nothing fit
@@ -1696,7 +1736,7 @@ def test_a_measured_zero_execution_error_count_is_drawn():
     The standing invariant is that an absent measurement is never drawn as a
     measured zero; the converse is the same principle. Suppressing this row at
     zero made a clean run — the MODAL shape for a healthy session — say nothing
-    where ``Call validity`` on the very next line happily shows its own zero.
+    where ``Tool-call error rate`` on the very next line happily shows its own zero.
     """
     stats = ToolCallStats(total=10, ok=10, faults={}, faults_by_tool={})
     section = _section(
@@ -1743,12 +1783,12 @@ def test_unknown_is_dimmed_like_the_other_absent_measurement_on_this_screen():
     stats = ToolCallStats(total=20, ok=20, faults={}, faults_by_tool={})
     text = build_session_report(_tool_report(stats), runtime(), 100)
     assert value_style(text, "Tool calls") == fg
-    assert value_style(text, "Call validity") == fg
+    assert value_style(text, "Tool-call error rate") == fg
 
     # And the other unknown on this block takes the same treatment.
     denied = ToolCallStats(total=3, ok=0, faults={"denied": 3}, faults_by_tool={"bash": 3})
     text = build_session_report(_tool_report(denied), runtime(), 100)
-    assert value_style(text, "Call validity") == dim
+    assert value_style(text, "Tool-call error rate") == dim
 
 
 def test_nested_calls_are_shown_but_named_as_outside_the_rates():
@@ -1774,7 +1814,7 @@ def test_nested_calls_are_shown_but_named_as_outside_the_rates():
     assert "20" in row and "not the model's" in row
     # The headline counts every call; the RATE stays model-origin.
     assert any("Tool calls" in r and "23" in r for r in section)
-    assert any("Call validity" in r and "66.7%" in r for r in section)
+    assert any("Tool-call error rate" in r and "33.3%" in r for r in section)
     # And the row is absent when there are none, so a clean session stays clean.
     plain = ToolCallStats(total=3, ok=3, faults={}, faults_by_tool={})
     section = _section(


### PR DESCRIPTION
## Summary

Fix `/session` reporting healthy provider requests as failures, and add a measured **Tool-call error rate** for benchmarking rejected or invalid model-origin invocations. Keep tool execution errors separate.

Release: patch — /session stops reporting healthy requests and excluded nested calls as failures, and shows an explicit model tool-call error rate

**Change class:** C1/C2, standard/pre-authorized. This PR is the change record; no launch or foundational change.

## Delivery contract

- Provider-request failures come from recorded `ok`, not a guessed finish-reason vocabulary. Healthy `stop`, `toolUse`, `length`, and legacy `unknown` outcomes must not become failures. Missing historical `ok` measurements remain unknown.
- **Tool-call error rate** = `model_faults / eligible model-origin emitted calls × 100`, calculated directly. `model_faults` are `unknown_tool`, `invalid_arguments`, and `duplicate_id`.
- Eligible emitted calls exclude model-origin `denied`, `aborted`, `skipped`, and `gate_failed` records. Nested eval-bridge calls never enter either model-origin rate.
- **Tool-side errors** = model-origin `execution_faults / dispatched calls × 100`; dispatched = eligible emitted − model faults. This is a separate diagnostic, not model accuracy.
- The screen expressly qualifies that rejected/invalid invocations do **not** measure semantic tool-selection correctness, and not all tool errors are model-caused. The old displayed validity complement is replaced rather than adding another crowded rate row; the existing `validity` model property remains compatible.
- Recorded tool calls reconcile across both origins: `ok + failed + all_excluded = recorded`. Nested exclusions are shown as a child of the nested subtotal, not added to the model-only “never completed” subtraction. `recorded − nested_total − model_excluded = eligible emitted` remains intact.
- A measured zero is `0.0%`. Zero eligible calls are `unknown`. With no tool data, the tool-call count is unknown and rate rows are omitted. At narrow widths, the invalid count and emitted denominator wrap below the rate rather than disappearing.

**Non-goals:** semantic tool-choice grading, per-tool token/dollar attribution, cross-session benchmarking, a new diagnostics command, or a screen redesign.

## Cause and accounting boundaries

The old per-purpose failure predicate used `outcome not in ("ok", "unknown")`, but current providers record real finish reasons such as `stop` and `toolUse`, not the literal `ok`. The grouped counts now use `calls - ok_calls`; request-sequence rows use the recorded three-state `SessionRequest.ok`.

**Correction to earlier evidence:** independent QA reproduced **1,652 turn requests labelled failed by the old renderer versus 3 actual failures** (1,649 false positives). The earlier description incorrectly said all **25,736** provider requests in that sample were labelled failed. That was the session total, including legacy `outcome='unknown'` records which the old predicate already excluded. The claim equating total requests with the old false count is withdrawn. No private session identifier or detailed live ledger inventory is published here.

Tool events are recorded at the real `park` and nested `dispatch_tool` paths, classified through structural fault markers, and sent through the existing exception-guarded recorder queue/writer. The harness retains its no-analytics-import boundary. Read-side origin partitioning is centralized in the store: `total`, `excluded`, `emitted`, model faults, and both rates remain model-only; nested totals/successes/exclusions are projected separately. This is additive recording; old sessions are not backfilled with fabricated measurements.

## Current remediation: `10038af55`

Scope: `533baf489..10038af55`. QA round 2 found two contract gaps together, fixed in this single commit:

1. **Q-1:** nested operator denials and approval-gate failures were swept into headline failures. Added `nested_excluded` and `all_excluded`; the renderer subtracts all excluded rows from headline failures while leaving the model denominator unchanged. All four `EXCLUDED_FAULTS` are covered across both origins. Nested `aborted`/`skipped` are defensive read-side coverage; only denial/gate failure are claimed as reachable through the exercised bridge.
2. **Q-2:** validity alone did not deliver the requested explicit error percentage. Added the direct-ratio property and **Tool-call error rate** row, preserving direction/denominator notes, measured-zero/unknown distinctions, and the separate execution metric.

## Real execution evidence on `10038af55`

The task-scoped probe and regression drive **shipped exec-tier eval** through the real `AgentLoop`, its real worker subprocess and nested approval bridge, then the real `AnalyticsStore` and session renderer. Eval is approved; its nested write is denied (or its gate raises); its subsequent read succeeds. HOME/config are isolated and every inherited `CMUX_*` is removed.

Actual recorded rows:

```text
[('write_file', 'nested', 'denied'), ('read', 'nested', ''), ('eval', 'model', '')]
recorded=3, model_ok=1, nested_ok=1, model_excluded=0,
nested_excluded=1, all_excluded=1, emitted=1
```

Actual corrected screen:

```text
Tool calls            3       2 ok
 └ nested (eval)      2       1 ok · eval's calls, not the model's
    └ excluded        1       already included in nested
Tool-call error rate  0.0%    0 invalid of 1 emitted
Tool-side errors      0       0.0% of 1 dispatched · not a model-accuracy figure
```

The gate-failure variant produces the same counts with `gate_failed` instead of `denied`, and the expected synthetic gate-error log. The restored old headline instead prints `2 ok · 1 failed`.

A separate real loop emission of three valid reads and one unknown tool produced:

```text
Tool calls            4       3 ok · 1 failed
Tool-call error rate  25.0%   1 invalid of 4 emitted
Tool-side errors      0       0.0% of 3 dispatched · not a model-accuracy figure
```

### Mutation proofs

In one isolated temporary source tree (never modifying the review branch or a peer's checkout):

| Deliberate regression | Actual guard result |
|---|---|
| Stop accumulating nested exclusions in the store | 2 failures: `(3, 2, 0) != (3, 2, 1)` |
| Subtract only model exclusions from the headline | 2 failures: unexpected `2 ok · 1 failed` |
| Derive error rate from rounded validity | 1 failure: `0.0 != 1 / 3000` |

The temporary source tree was reclaimed after the probes. Task-scoped evidence remains for independent reviewers.

## Rendered before/after evidence

Real `OperatorApp`, real `/session` slash dispatch, existing `scripts/session_failure_shot.py` and `scripts/tool_surface_shot.py`. Untouched before frames were captured before edits; additional focused baseline frames use product source pinned to `533baf489`. After frames are from `10038af55`. Both normal **100×60** and narrow **58×60** were captured. The focused baseline uses only the new fixture in the existing shot script; all product files remain the old head.

- Before nested denial: `3` recorded, `2 ok · 1 failed`, no nested-exclusion row, validity `100.0%`.
- After nested denial: `3` recorded, `2 ok`, nested child exclusion `1`, explicit error rate `0.0%`.
- Before mixed tool block: validity `87.1%`; after: error rate `12.9%`, `4 invalid of 31 emitted`.
- At 58 columns, `4 invalid of 31 emitted` now wraps onto its own row; no ambiguous bare percentage.
- All-excluded after state: `unknown`, with `0 eligible model-emitted calls` retained at narrow width.
- All six after captures: `screen_size == virtual_size`, no screen scrollbar, `ledger_unchanged=true` for each isolated fixture ledger. The inner report scroll remains intentional.

Local artifacts, not committed:

```text
/tmp/pr763-coder-r2.vbFaVH/before-{100,58}/
/tmp/pr763-coder-r2.vbFaVH/before-focused/{tools,nested-excluded}-{100,58}.{svg,png,json}
/tmp/pr763-coder-r2.vbFaVH/after/{tools,nested-excluded,nodispatch}-{100,58}.{svg,png,json}
/tmp/pr763-coder-r2.vbFaVH/real_path.py
/tmp/pr763-coder-r2.vbFaVH/real-path.log
/tmp/pr763-coder-r2.vbFaVH/mutation-*.log
/tmp/pr763-coder-r2.vbFaVH/gate-*.log
```

SVGs were rasterized with the already-installed native `rsvg-convert` and the resulting PNGs actually viewed. The browser tool could not open a tab because all eight slots belonged to other sessions; none was closed or appropriated. No browser engine was installed or scripted. The images are local review artifacts, not GitHub-hosted attachments.

## Head-scoped verification

### Current remediation `10038af55`

```text
.venv/bin/python -m pytest tests/unit/analytics/test_store.py \
  tests/unit/analytics/test_recorder.py \
  tests/unit/harness/test_tool_call_analytics.py \
  tests/unit/harness/test_loop.py tests/unit/tui/test_session_panel.py -n0 -q
252 passed, 2 warnings in 31.13s

.venv/bin/python -m flake8 .                                      clean
uvx --from black==26.1.0 black --check .                          1035 unchanged
uvx isort==5.13.2 --check .                                      clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .        0 errors/warnings
```

TUI runs unset `NO_COLOR`, set `TERM=xterm-256color`, and remove inherited `CMUX_*`. The two warnings are the existing Pydantic validator deprecations, not failed tests. The focused matrix includes all excluded faults/both origins, nested retries, actual nested denial and gate failure, 25% and 0%, unknown/zero denominators, direct-ratio precision, and a card-width sweep from 38–120. No additional full local suite was launched for this remediation; CI covers the new head.

### Historical independent QA, **only `533baf489`**

QA round 2's own isolated worktree reported `15,608 passed, 18 skipped, 679 warnings` for the full unit suite, `47 passed` for the e2e stage, and clean static gates. Those results predate this remediation and are **not** represented as a full-suite pass on `10038af55`. QA still correctly marked the old head FAIL because Q-1/Q-2 were real gaps despite that green suite. Prior code/design reviews retain their recorded models and original scopes; this changed head requires delta convergence, not an author-asserted re-pin.

## Rollout / rollback and not addressed

No version bump, tag, release, rebase, or merge in this remediation. The table is additive; rollback to the prior runtime leaves its tool rows inert rather than deleting data. No live operator session or ledger was mutated. Independent QA/code/design convergence and CI on the current head remain the manager's merge gates.

Semantic tool-choice accuracy, per-tool spend attribution, and cross-session comparison remain unimplemented non-goals. No follow-up issues were created.
