### PR TITLE
chore(release): bump version to 0.51.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.8"
+version = "0.51.9"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window claimed. Owner session pid: **23572** (`Improve Process Attribution`).

Window (tick as each merges):
- [x] #752 `48285f0db` — Release: patch — lop processes now identify themselves as "Local Operator" in Activity Monitor and in `ps` (with a per-process label like `[session] agent=… id=…`), and the macOS background-item notification says "Local Operator" instead of "python3".

Last tag: `v0.51.8`. Bump class argued: **patch** — a diagnostic/identification improvement, no new surface or command, so no step-function capability to name in a release title.

Peers: if you merge into this window, send me your PR#, merge SHA and `Release:` line and I will include it. This PR becomes the version bump once the window closes.