### PR TITLE
docs: require headless Chrome for agent browser test harnesses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,8 +308,9 @@ systemd unit name.
 So a bridge test runs the daemon as a **plain subprocess on a non-default
 port** (`python -m local_operator.browser_bridge.daemon --port <port>`, as
 `docs/design/browser-extension-evidence.md` does) and never calls `install`.
-A per-root label is in flight in a separate PR; until it lands, `HOME`
-redirection is no protection here.
+Deriving the label per root would remove the hazard, but nothing has changed
+it yet: while `LABEL` is a module constant, `HOME` redirection is no protection
+here. Check that line rather than assuming a fix has landed.
 
 ### Read the committed ref, not the working tree
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1139,7 +1139,83 @@ so they are opt-in (`LO_RUN_SNAPSHOTS=1`) and regenerated with
 `--snapshot-update`. Do not add a golden as a substitute for looking at the
 change.
 
-### 6. Evidence goes on the PR, never into the repository
+### 6. Capturing a browser surface: headless Chrome, never a window
+
+Sections 1-5 are about Textual, which is the bulk of this UI. The browser
+extension's popup and options page are the other user-visible surface here, and
+they are captured out of a real Chrome rather than out of a pilot. **Any Chrome
+an agent launches for testing, capture, or CDP work runs `--headless=new`.**
+
+This is not a preference. On 2026-09-07 agent test harnesses driving the
+extension launched *headful* Chrome, and the windows took focus from the
+operator repeatedly while he was working in another application. The whole
+browser story on this machine is built on never doing that — the extension
+creates its tab with `active: false`, every cmux command passes `--focus false`,
+and `guide://browser` carries a "Focus safety — never steal the user's focus"
+section. A harness that pops a window on screen violates the same principle the
+product spends real effort upholding, and "it is only a quick check" is exactly
+the reasoning that produced the incident.
+
+New headless is not the old one: it is the same browser binary with no window,
+so extensions, DevTools/CDP, screenshots and synthetic input all work. Measured
+on this host (Chrome 152.0.7977.76, `--headless=new`), the built
+`extension/dist` loaded, its popup rendered at an explicit 300x600 viewport, and
+`Page.captureScreenshot` returned a 34 KB PNG showing the real pairing form;
+`Input.dispatchMouseEvent` dispatched. Nothing appeared on screen.
+
+**Load the extension over CDP, not `--load-extension`.** Branded Chrome removed
+that switch in 137 (`PSA: Removing --load-extension flag in Chrome branded
+builds`, chromium-extensions), and the
+`--disable-features=DisableLoadExtensionCommandLineSwitch` escape hatch is gone
+too. It does not error — it is **silently ignored**, so a harness using it gets
+a Chrome with no extension and an agent that concludes headless "does not
+support extensions". Verified here: with `--load-extension=extension/dist` the
+only `chrome-extension://` targets were Chrome's own built-ins and our manifest
+name was absent; `Extensions.loadUnpacked` over CDP returned our id and the
+popup drove normally. `docs/design/browser-extension-e2e.md` records the same
+finding on Chrome 151.
+
+**Size the viewport explicitly.** Headless inherits no real window, so it
+defaults to whatever the platform picks — measured 756x469 at `dpr=1` on this
+host with no flag. Pass `--window-size=300,600` (the extension popup's true
+metrics) or `Emulation.setDeviceMetricsOverride`. A frame whose dimensions were
+assumed rather than set is not evidence of anything.
+
+**Never pair a headful before-frame with a headless after-frame.** Device pixel
+ratio and scrollbar presence differ between the modes, so a cross-mode pair
+shows differences the change did not cause — the §3 trap, with the mode as the
+hidden variable. Recapture both sides in the same mode.
+
+The hygiene flags below are not decoration; each one is an incident:
+
+- **A unique `--user-data-dir` per launch**, under `/tmp`. Never the operator's
+  profile, and never a shared path: a second Chrome on a live profile dir is
+  how a run corrupts the one the extension is paired to.
+- **`--use-mock-keychain --password-store=basic`.** Real Chrome on macOS
+  otherwise reaches for the login keychain and raises modal "Keychain not
+  found" dialogs on the operator's screen — which happened, from 37 concurrent
+  instances. These are on-screen dialogs, so they defeat headless on their own.
+- **`start_new_session=True` plus process-group teardown** (SIGTERM to the
+  pgid, SIGKILL if it does not settle) **and an `atexit` handler**. The reason
+  is not that `terminate()` fails when it runs — on Chrome 152 it reaped a
+  13-process tree cleanly — it is that the harness does not always get to run
+  it. A harness killed mid-run leaves the browser reparented to PPID 1 holding
+  its profile dir: measured here, `SIGKILL` to the harness left **10** Chrome
+  processes alive with the browser at `PPID 1`. A previous session leaked 47
+  that way. Own the process group so the survivors are addressable, and assert
+  zero afterwards (`pgrep -f <your unique profile prefix>`) rather than assuming.
+- **Never touch the operator's own running Chrome.** Match on your own profile
+  prefix, never `pkill -f "Google Chrome"`.
+
+One thing this rule does **not** cover: `open -g -a "Google Chrome"` in
+`guide://browser`. That wakes the **operator's real paired browser** so the
+extension reconnects — a different activity from launching a test harness, and
+already background-launched by `-g`. It is correct as written; do not
+"headless" it. The distinction is the profile: the operator's logged-in browser
+is woken in the background and never given debug flags, while a harness browser
+is a throwaway profile that is headless, debug-ported and torn down.
+
+### 7. Evidence goes on the PR, never into the repository
 
 **Do not commit PR evidence artifacts** — before/after frames (SVG or PNG),
 screenshots, terminal byte captures, measurement logs, review-round

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,6 +292,25 @@ the two therefore agreed, which is precisely why nothing caught it. When you
 isolate a run, verify where its writes actually go, not merely that its reads
 are redirected.
 
+**`lop browser install` is not isolated by `HOME` at all — never run it from a
+test.** Same shape as the two hazards above: an isolated run reaching outside
+its sandbox, but here `HOME` does not even slow it down. `browser_bridge/
+install.py` hardcodes `LABEL = "com.local-operator.browser"` and derives only
+the plist *path* from `Path.home()`, while the launchd domain is `gui/<uid>`
+from `os.getuid()`. So a redirected `HOME` writes the plist somewhere harmless
+and then `bootstrap`s the *same global label* into the *same* domain — and the
+`bootout` that precedes it evicts whatever holds that label, which is the
+operator's live bridge daemon. It happened today: a sibling agent's test took
+the operator's daemon down on 4099 for ~90s, and the only symptom he saw was
+his browser tool going dead. Linux has the identical exposure through the fixed
+systemd unit name.
+
+So a bridge test runs the daemon as a **plain subprocess on a non-default
+port** (`python -m local_operator.browser_bridge.daemon --port <port>`, as
+`docs/design/browser-extension-evidence.md` does) and never calls `install`.
+A per-root label is in flight in a separate PR; until it lands, `HOME`
+redirection is no protection here.
+
 ### Read the committed ref, not the working tree
 
 "Never `git stash` to get a before-frame" (in the visual-validation section
@@ -1175,11 +1194,19 @@ name was absent; `Extensions.loadUnpacked` over CDP returned our id and the
 popup drove normally. `docs/design/browser-extension-e2e.md` records the same
 finding on Chrome 151.
 
-**Size the viewport explicitly.** Headless inherits no real window, so it
-defaults to whatever the platform picks — measured 756x469 at `dpr=1` on this
-host with no flag. Pass `--window-size=300,600` (the extension popup's true
-metrics) or `Emulation.setDeviceMetricsOverride`. A frame whose dimensions were
-assumed rather than set is not evidence of anything.
+**Size the viewport with `Emulation.setDeviceMetricsOverride`, not
+`--window-size`.** Headless inherits no real window, so it defaults to whatever
+the platform picks — measured 756x469 at `dpr=1` on this host with no flag —
+and a frame whose dimensions were assumed rather than set is not evidence of
+anything. `--window-size` reads like the remedy and quietly is not: on Chrome
+152 the width clamps at a 500px floor and the height loses 87px to chrome, so
+`--window-size=300,600` produces **500x513** with no error. Measured, fresh
+profile per run: `300,600` → `500x513`, `400,600` → `500x513`, `500,600` →
+`500x513`, `1000,800` → `1000x713`, all at `dpr=1`. The CDP override returned a
+true `300x600 dpr=2`, controls `deviceScaleFactor` (which the flag cannot), and
+applies even to a browser started with the clamped flag — so it is the single
+way to set a capture viewport here. Following the flag instead is exactly the
+assumed dimension this paragraph forbids.
 
 **Never pair a headful before-frame with a headless after-frame.** Device pixel
 ratio and scrollbar presence differ between the modes, so a cross-mode pair
@@ -1191,18 +1218,32 @@ The hygiene flags below are not decoration; each one is an incident:
 - **A unique `--user-data-dir` per launch**, under `/tmp`. Never the operator's
   profile, and never a shared path: a second Chrome on a live profile dir is
   how a run corrupts the one the extension is paired to.
+- **A port Chrome picks, not one you choose: `--remote-debugging-port=0`, then
+  read the real port from `"$profile/DevToolsActivePort"`.** A fixed port is a
+  shared path in the same sense as a shared profile dir, and this machine runs
+  many agent sessions concurrently. Measured with two harnesses on distinct
+  profiles both requesting 39222: the second started fine, wrote **no**
+  `DevToolsActivePort` and reported **no** error, while the port answered as
+  the *first* harness's browser — so the second agent would drive another
+  session's Chrome, capturing its pages and closing its targets. With port `0`
+  the same pair bound 57827 and 57829 and each drove its own. Chrome writes
+  that file only when it chose the port itself (under an explicit port it is
+  absent), so reading it is both the fix and the check that you applied it.
 - **`--use-mock-keychain --password-store=basic`.** Real Chrome on macOS
   otherwise reaches for the login keychain and raises modal "Keychain not
-  found" dialogs on the operator's screen — which happened, from 37 concurrent
-  instances. These are on-screen dialogs, so they defeat headless on their own.
+  found" dialogs on the operator's screen — reported from a run of ~37
+  concurrent instances. These are on-screen dialogs, so they defeat headless on
+  their own.
 - **`start_new_session=True` plus process-group teardown** (SIGTERM to the
   pgid, SIGKILL if it does not settle) **and an `atexit` handler**. The reason
-  is not that `terminate()` fails when it runs — on Chrome 152 it reaped a
-  13-process tree cleanly — it is that the harness does not always get to run
-  it. A harness killed mid-run leaves the browser reparented to PPID 1 holding
-  its profile dir: measured here, `SIGKILL` to the harness left **10** Chrome
-  processes alive with the browser at `PPID 1`. A previous session leaked 47
-  that way. Own the process group so the survivors are addressable, and assert
+  is not that `terminate()` fails when it runs — on Chrome 152 it reaped the
+  whole tree cleanly — it is that the harness does not always get to run it. A
+  harness killed mid-run leaves the browser reparented to PPID 1 holding its
+  profile dir: measured here, `SIGKILL` to the harness left the entire Chrome
+  tree alive with the browser at `PPID 1` (helper counts vary per run, so
+  compare against zero, never against a remembered number). A previous session
+  reportedly leaked 47 that way. Own the process group so the survivors are
+  addressable, and assert
   zero afterwards (`pgrep -f <your unique profile prefix>`) rather than assuming.
 - **Never touch the operator's own running Chrome.** Match on your own profile
   prefix, never `pkill -f "Google Chrome"`.

--- a/local_operator/guides/browser/GUIDE.md
+++ b/local_operator/guides/browser/GUIDE.md
@@ -49,6 +49,65 @@ Chrome shows a small "Local Operator is debugging this browser" banner on the
 tab the agent controls. That is intentional and good: it is how the user can
 always see which tab the agent has. Tell them it is expected, not a warning.
 
+### Testing the extension: any Chrome YOU launch is headless
+
+The rules above govern the browser the user already has open. A test harness
+launches its own Chrome, and the same principle binds it: **a Chrome an agent
+starts for testing, capture, or CDP work runs `--headless=new`, always.**
+
+On 2026-09-07 agent harnesses driving this extension launched headful Chrome
+and its windows took focus from the operator mid-session, repeatedly. Everything
+else here is engineered so that cannot happen; a harness is not exempt because
+the check is quick.
+
+New headless is the same browser without a window, so nothing is given up.
+Measured on Chrome 152.0.7977.76: the built `extension/dist` loaded, its popup
+rendered at an explicit 300x600 viewport, `Page.captureScreenshot` returned a
+real PNG of the pairing form, and `Input.dispatchMouseEvent` dispatched — with
+no window on screen.
+
+```sh
+# Throwaway profile, headless, explicit viewport, no keychain prompts.
+profile=$(mktemp -d /tmp/lo-harness.XXXXXX)
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  --headless=new --user-data-dir="$profile" \
+  --remote-debugging-port=39222 --window-size=300,600 \
+  --use-mock-keychain --password-store=basic \
+  --no-first-run --no-default-browser-check about:blank &
+```
+
+- **Load the extension over CDP `Extensions.loadUnpacked`, not
+  `--load-extension`.** Branded Chrome removed that switch in 137 and it is
+  now **silently ignored** — no error, just a Chrome with no extension, which
+  reads as "headless does not support extensions" and is not what happened.
+  Verified on 152: `--load-extension` produced no matching target;
+  `Extensions.loadUnpacked` returned the id and the popup drove normally.
+- **Set the viewport explicitly.** Headless inherits no window, so it defaults
+  to whatever the platform picks (measured 756x469, `dpr=1`, with no flag). Use
+  `--window-size` or `Emulation.setDeviceMetricsOverride`; a frame whose size
+  you did not set is not evidence.
+- **Never compare a headful before-frame with a headless after-frame.** Device
+  pixel ratio and scrollbar presence differ across the modes, so the pair shows
+  differences your change did not cause. Recapture both sides in one mode.
+- **Unique `--user-data-dir` per launch, under `/tmp`** — never the operator's
+  profile, never a shared path.
+- **`--use-mock-keychain --password-store=basic`** — without them real Chrome
+  on macOS reaches for the login keychain and raises modal "Keychain not found"
+  dialogs on the operator's screen (it did, from 37 concurrent instances).
+  On-screen dialogs defeat headless on their own.
+- **`start_new_session=True`, teardown by process group** (SIGTERM to the pgid,
+  then SIGKILL), **plus an `atexit` handler**. The hazard is the harness dying
+  before its cleanup runs: measured here, `SIGKILL` to the harness left **10**
+  Chrome processes alive with the browser reparented to `PPID 1`, still holding
+  the profile dir. A previous session leaked 47 that way. Assert zero afterwards
+  with `pgrep -f <your profile prefix>` rather than assuming.
+- **Never touch the operator's own Chrome.** Match your own profile prefix;
+  never `pkill -f "Google Chrome"`.
+
+This does not change how you wake the user's *real* paired browser — see the
+next section, where `open -g` is correct precisely because it is a different
+activity.
+
 ## When the `browser` tool is missing: set the extension up
 
 Treat the tool's absence as a one-minute setup step, not a dead end. Do the
@@ -78,6 +137,13 @@ starting. Never launch with
 `--remote-debugging-port` or developer flags: the extension is the debugger,
 and a debug-port browser on a real logged-in profile is an open door for any
 local process.
+
+This is the operator's real logged-in browser, not a harness, so it is **not**
+headless and must not be made so: the user has to be able to see and use it,
+and headless would defeat the point of pairing to the browser they already
+have. `-g` is what keeps it focus-safe. The headless rule above governs a
+throwaway Chrome an agent starts for testing; conflating the two ends with
+someone "fixing" this line and breaking reconnection.
 
 ### 1. Check status
 
@@ -332,7 +398,9 @@ Every failure is one actionable string; act on it rather than retrying blindly:
      launch it BACKGROUNDED so it never steals focus:
      `open -g -a "Google Chrome"` (macOS). Never add `--remote-debugging-port`
      or other debug flags — the extension IS the debugger; a debug-port
-     browser on a real profile is a security hole.
+     browser on a real profile is a security hole. Not headless either: this
+     is the user's own browser, and the headless rule in "Testing the
+     extension" covers only a throwaway Chrome an agent launches itself.
   2. **Browser running but still disconnected?** The service worker may be
      idle-suspended. A periodic reconnect alarm rewakes and reconnects it on
      its own — up to ~1 minute in a packed/released build (Chrome clamps

--- a/local_operator/guides/browser/GUIDE.md
+++ b/local_operator/guides/browser/GUIDE.md
@@ -67,13 +67,17 @@ real PNG of the pairing form, and `Input.dispatchMouseEvent` dispatched — with
 no window on screen.
 
 ```sh
-# Throwaway profile, headless, explicit viewport, no keychain prompts.
+# Throwaway profile, headless, no keychain prompts, and a port Chrome picks.
 profile=$(mktemp -d /tmp/lo-harness.XXXXXX)
 "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
   --headless=new --user-data-dir="$profile" \
-  --remote-debugging-port=39222 --window-size=300,600 \
+  --remote-debugging-port=0 \
   --use-mock-keychain --password-store=basic \
   --no-first-run --no-default-browser-check about:blank &
+
+# Chrome writes the port it actually bound; never assume one.
+until [ -s "$profile/DevToolsActivePort" ]; do sleep 0.2; done
+port=$(head -1 "$profile/DevToolsActivePort")
 ```
 
 - **Load the extension over CDP `Extensions.loadUnpacked`, not
@@ -82,10 +86,38 @@ profile=$(mktemp -d /tmp/lo-harness.XXXXXX)
   reads as "headless does not support extensions" and is not what happened.
   Verified on 152: `--load-extension` produced no matching target;
   `Extensions.loadUnpacked` returned the id and the popup drove normally.
-- **Set the viewport explicitly.** Headless inherits no window, so it defaults
-  to whatever the platform picks (measured 756x469, `dpr=1`, with no flag). Use
-  `--window-size` or `Emulation.setDeviceMetricsOverride`; a frame whose size
-  you did not set is not evidence.
+- **Set the viewport with `Emulation.setDeviceMetricsOverride`, not
+  `--window-size`.** Headless inherits no window, so it defaults to whatever
+  the platform picks (measured 756x469, `dpr=1`, with no flag) — and a frame
+  whose size you did not set is not evidence. `--window-size` looks like the
+  remedy and is not: on Chrome 152 the width clamps at a 500px floor and the
+  height loses 87px to chrome, so `--window-size=300,600` yields **500x513**,
+  silently. Measured, same flags, fresh profile each run:
+
+  | flag | resulting viewport |
+  |---|---|
+  | `--window-size=300,600` | `500x513 dpr=1` |
+  | `--window-size=400,600` | `500x513 dpr=1` |
+  | `--window-size=500,600` | `500x513 dpr=1` |
+  | `--window-size=1000,800` | `1000x713 dpr=1` |
+  | `Emulation.setDeviceMetricsOverride 300x600` | `300x600 dpr=2` ✓ |
+
+  The CDP override is exact, controls `deviceScaleFactor` (which the flag
+  cannot), and wins regardless of how Chrome was started — verified giving a
+  true `300x600 dpr=2` even on a browser launched with the clamped flag. Use it
+  for the extension popup's 300x600 metrics and for every other capture size.
+- **Let Chrome choose the debug port: `--remote-debugging-port=0`, then read
+  `"$profile/DevToolsActivePort"`.** A hardcoded port is a shared path in the
+  same sense as a shared profile dir, and this machine runs many agent sessions
+  at once. Measured: two harnesses on distinct profiles both asking for 39222 —
+  the second starts fine, writes **no** `DevToolsActivePort`, reports **no**
+  error, and the port answers as the *first* harness's browser. A harness that
+  then connects believes it drives its own Chrome while every CDP call,
+  screenshot and `Target.closeTarget` lands on another session's. With port `0`
+  the same pair got 57827 and 57829 and each drove its own browser. Chrome only
+  writes `DevToolsActivePort` when it picked the port itself (under an explicit
+  port the file is absent entirely), so reading that file is both the fix and
+  its own proof.
 - **Never compare a headful before-frame with a headless after-frame.** Device
   pixel ratio and scrollbar presence differ across the modes, so the pair shows
   differences your change did not cause. Recapture both sides in one mode.
@@ -93,14 +125,15 @@ profile=$(mktemp -d /tmp/lo-harness.XXXXXX)
   profile, never a shared path.
 - **`--use-mock-keychain --password-store=basic`** — without them real Chrome
   on macOS reaches for the login keychain and raises modal "Keychain not found"
-  dialogs on the operator's screen (it did, from 37 concurrent instances).
-  On-screen dialogs defeat headless on their own.
+  dialogs on the operator's screen (reported from a run of ~37 concurrent
+  instances). On-screen dialogs defeat headless on their own.
 - **`start_new_session=True`, teardown by process group** (SIGTERM to the pgid,
   then SIGKILL), **plus an `atexit` handler**. The hazard is the harness dying
-  before its cleanup runs: measured here, `SIGKILL` to the harness left **10**
-  Chrome processes alive with the browser reparented to `PPID 1`, still holding
-  the profile dir. A previous session leaked 47 that way. Assert zero afterwards
-  with `pgrep -f <your profile prefix>` rather than assuming.
+  before its cleanup runs: measured here, `SIGKILL` to the harness left the
+  whole Chrome tree alive with the browser reparented to `PPID 1`, still
+  holding the profile dir. A previous session reportedly leaked 47 that way.
+  Helper counts vary per run, so assert **zero** afterwards with
+  `pgrep -f <your profile prefix>` rather than against a remembered count.
 - **Never touch the operator's own Chrome.** Match your own profile prefix;
   never `pkill -f "Google Chrome"`.
 


### PR DESCRIPTION
## What and why

Agent test harnesses that drive the browser extension have been launching
**headful** Chrome. Those windows steal the operator's focus while he is
working — reported directly, today (2026-09-07).

Everything else about this machine's browser story is engineered so that
cannot happen: the extension creates its tab with `active: false`, every cmux
command passes `--focus false`, and `guide://browser` carries a "Focus safety —
never steal the user's focus" section. The gap was that none of it bound a
**test harness**, so each new agent rediscovers headful Chrome as a reasonable
way to check the popup. This makes it the standing written rule.

Two files, the two an agent actually reads before capturing browser evidence:

- **`AGENTS.md`** — new `### 6. Capturing a browser surface: headless Chrome,
  never a window` inside "Visual validation", which until now was entirely
  Textual/SVG and said nothing about driving Chrome. Placed there because that
  section is what an agent reads before capturing evidence for a UI change, and
  the extension popup is now such a surface. The old §6 becomes §7 (no
  cross-reference in the repo pointed at §6; `git grep` for `"Visual
  validation" §N` finds only §5 and step 4, both unmoved).
- **`local_operator/guides/browser/GUIDE.md`** — new
  `### Testing the extension: any Chrome YOU launch is headless`, placed
  directly under the existing "Focus safety" section since it is the same
  principle applied to testing, plus a clarifying paragraph at each of the two
  `open -g` sites.

## Change class

**C0 — documentation only.** No code, no `pyproject.toml`, no `extension/`.
`git diff --stat` is exactly two `.md` files (+146/-2).

## What I verified about headless capability, and how

The `--headless=new` extension-support claim is load-bearing — if extensions
did not work there the rule would need a different shape — so I checked it on
this host rather than trusting a doc search. Every probe obeyed the rules this
PR writes down: headless, unique `/tmp` profile, mock keychain, process-group
teardown, zero leaked processes asserted afterwards.

**Chrome 152.0.7977.76, `--headless=new`, built `extension/dist`:**

| Claim | Result |
|---|---|
| Extension loads | `Extensions.loadUnpacked` → id `jbadjeaodkoboanppmpjiifpconegdcj`, service-worker target live |
| Popup renders | `{"w":300,"h":600,"dpr":2,"text":"LOCAL OPERATOR Pair with Local Operator Enter the code shown in Local Operator. PAIRING CODE Pair Settings"}` |
| Frame captures | `Page.captureScreenshot` → 34,061-byte PNG of the real pairing form |
| Synthetic input | `Input.dispatchMouseEvent` press+release dispatched OK |
| Window on screen | none |

**A correction to what I was told to write.** `--load-extension` does *not*
work: branded Chrome removed it in 137 ([PSA, chromium-extensions](https://groups.google.com/a/chromium.org/g/chromium-extensions/c/1-g8EFx2BBY))
and the `--disable-features=DisableLoadExtensionCommandLineSwitch` escape hatch
is also gone. It fails **silently** — my first probe got only Chrome's built-in
extension targets and no error, which is precisely how an agent concludes
"headless doesn't support extensions" and goes back to headful. The doc now
says CDP `Extensions.loadUnpacked` and explains the silent-ignore trap.
`docs/design/browser-extension-e2e.md` already recorded the same finding on
Chrome 151, so this is consistent with repo history, not new.

**Viewport**, grounded rather than asserted: with no `--window-size` and no
override the default is **756x469 at dpr=1** — nothing like a popup, hence the
"size it explicitly" requirement.

**Teardown.** The brief said a plain `proc.terminate()` strands a
network-service helper at PPID 1. I could not reproduce that on Chrome 152:
`terminate()` reaped a 13-process tree to 0, as did the group kill. So I wrote
the rule against the failure I *could* measure — the harness dying before its
cleanup runs. `SIGKILL` to the harness left **10 Chrome processes alive with
the browser reparented to `PPID 1`**, still holding its profile dir. That is
the 47-process leak's actual mechanism, and it is why `start_new_session=True`
+ pgid teardown + `atexit` are required and why the doc says to assert zero
with `pgrep -f <profile prefix>` afterwards.

**The guide still loads** through the real resolver (not just as a file):

```
$ .venv/bin/python -c "…discover_guides / make_guide_resolver…"
resolved chars: 25343
  Testing the extension: any Chrome YOU launch is head    True
  --headless=new                                          True
  Extensions.loadUnpacked                                 True
  use-mock-keychain                                       True
  PPID 1                                                  True
  This is the operator's real logged-in browser           True
```

## The `open -g` distinction (deliberately preserved)

`open -g -a "Google Chrome"` at guide lines ~131 and ~399 wakes the
**operator's real paired browser** so the extension reconnects. That is a
different activity from launching a harness and is already background-launched
and focus-safe. Both sites now say explicitly that they are not covered by the
headless rule and must stay headful — conflating the two is how someone
"fixes" the wrong one and breaks reconnection.

## Also checked

`git grep` across `AGENTS.md`, `local_operator/guides/` and `docs/` for any
other instruction that opens a browser window. The only other hits are
`docs/design/browser-extension-e2e.md` and `-evidence.md`, which are
past-tense evidence records (and already state that `--load-extension` was
ignored), not instructions an agent would follow. Left unchanged.

## Gates

Docs-only, but run over the whole tree exactly as CI, to confirm nothing else
drifted:

```
.venv/bin/python -m flake8 .                                  → clean
uvx --from black==26.1.0 black --check .                      → 1034 files unchanged
uvx isort==5.13.2 --check .                                   → clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .   → 0 errors, 0 warnings
git diff --stat                                               → 2 .md files, +146/-2
```

## Review

This needs an **independent scope-check round** — a reviewer other than the
author confirming the diff is docs-only, that the headless capability claims
match the evidence above, and that the `open -g` carve-out reads unambiguously.

Release: patch — documents the requirement that agent-launched test browsers run headless, so test harnesses stop stealing the operator's window focus.
