### PR TITLE
fix(extension): remove the deterministic jitter from the pairing experience

### DIFF
--- a/extension/build.mjs
+++ b/extension/build.mjs
@@ -29,6 +29,9 @@ await build({
 });
 await cp(resolve(root, "manifest.json"), resolve(dist, "manifest.json"));
 await cp(resolve(root, "src/popup/popup.html"), resolve(dist, "popup/popup.html"));
+// Copied, never bundled: esbuild would emit it as a module entry and the
+// deferral is exactly what it exists to avoid. See src/popup/first-paint.js.
+await cp(resolve(root, "src/popup/first-paint.js"), resolve(dist, "popup/first-paint.js"));
 await cp(resolve(root, "src/popup/popup.css"), resolve(dist, "popup/popup.css"));
 await cp(resolve(root, "src/options/options.html"), resolve(dist, "options/options.html"));
 await cp(resolve(root, "src/options/options.css"), resolve(dist, "options/options.css"));

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Local Operator",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Connect Local Operator to the browser you already use, entirely on your machine.",
   "permissions": [
     "debugger",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-operator-browser-extension",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "packageManager": "pnpm@11.22.0",
   "scripts": {

--- a/extension/src/popup/first-paint.js
+++ b/extension/src/popup/first-paint.js
@@ -1,0 +1,49 @@
+/* Size the pre-render placeholder BEFORE the first paint.
+ *
+ * Plain JavaScript, not TypeScript, and loaded as a CLASSIC render-blocking
+ * script from <head> — deliberately, and it is the whole point of the file:
+ *
+ *   - popup.js is `<script type="module">`, which is DEFERRED. It cannot run
+ *     until the document is parsed, so anything it does to layout happens after
+ *     the compositor has already had the chance to paint.
+ *   - popup.css therefore has to ship SOME default pin, and whichever one it
+ *     ships is wrong for the other population. Shipping the unpaired (tall) pin
+ *     meant the already-paired user was pinned tall until the module ran, and
+ *     the compositor produced a frame inside that window on 9 of 13 opens —
+ *     a 340px -> 207px resize on exactly the path this PR set out to settle.
+ *   - MV3's default CSP (`script-src 'self'`) forbids an inline <script>, so
+ *     the pre-paint work has to come from a file. A classic script in <head>
+ *     is fetched and executed before the body is parsed, which closes the
+ *     window rather than narrowing it.
+ *
+ * It is intentionally the smallest thing that can run this early: no imports,
+ * no bundler entry, no shared module. Importing anything would make it a module
+ * and hand back the deferral this file exists to avoid.
+ *
+ * The value written here is a LAYOUT HINT and never gates behaviour — render()
+ * still paints whatever /health reports. A stale or absent hint costs exactly
+ * one resize, which is the behaviour without the file at all, so there is
+ * nothing to fail closed about. popup.ts owns the key and the measured pins;
+ * the duplication of both is the price of running before the module system.
+ */
+(function () {
+  // Keep in sync with PAIRED_HINT_KEY and applyPendingPin() in popup.ts.
+  var KEY = "lop:paired-hint";
+  var PAIRED_PIN = "86px";
+  var UNPAIRED_PIN = "219px";
+  var paired = false;
+  try {
+    paired = localStorage.getItem(KEY) === "1";
+  } catch (error) {
+    // Storage unavailable (disabled, quota, partitioned). The unpaired pin is
+    // the safe default: it is the state a browser we cannot identify is most
+    // likely to be in on its first open.
+  }
+  // <head> runs before <body> exists, so the pin is applied as a stylesheet
+  // rule rather than by reaching for the element. This also keeps it out of the
+  // element's inline style, leaving popup.ts's own applyPendingPin() — which
+  // runs later and sets an inline style — able to override it without a fight.
+  var style = document.createElement("style");
+  style.textContent = "#pending{min-height:" + (paired ? PAIRED_PIN : UNPAIRED_PIN) + "}";
+  document.documentElement.appendChild(style);
+})();

--- a/extension/src/popup/pair-flow.ts
+++ b/extension/src/popup/pair-flow.ts
@@ -18,7 +18,8 @@
  * popup's reserved error slot is sized against a single known worst case. Two
  * lines at 300px: the slot is permanent, so extra words cost height on every
  * pairing card, error or not. */
-export const PAIR_MISMATCH_MESSAGE = "That code didn't match. Codes expire after two minutes.";
+export const PAIR_MISMATCH_MESSAGE =
+  "That code didn't match. Codes expire after two minutes — check the app.";
 
 export interface PairResultFrame {
   event?: string;

--- a/extension/src/popup/pair-flow.ts
+++ b/extension/src/popup/pair-flow.ts
@@ -11,9 +11,14 @@
  * must therefore render from the pair_result frame ALONE and never be
  * downgraded by a stale health probe. */
 
-/** The default mismatch copy (branding doc's pairing-error microcopy). */
-export const PAIR_MISMATCH_MESSAGE =
-  "That code didn't match. Codes expire after two minutes — check the app for a fresh one.";
+/** The default mismatch copy (branding doc's pairing-error microcopy).
+ *
+ * Byte-identical to the daemon's own mismatch string (browser_bridge/daemon.py)
+ * so the user meets one sentence rather than two spellings of it, and so the
+ * popup's reserved error slot is sized against a single known worst case. Two
+ * lines at 300px: the slot is permanent, so extra words cost height on every
+ * pairing card, error or not. */
+export const PAIR_MISMATCH_MESSAGE = "That code didn't match. Codes expire after two minutes.";
 
 export interface PairResultFrame {
   event?: string;

--- a/extension/src/popup/popup.css
+++ b/extension/src/popup/popup.css
@@ -422,16 +422,25 @@ input:disabled {
  * EVERY open — the resize it causes is unconditional, and only its duration
  * depends on how slow /health is.
  *
- * The pin is therefore chosen per user at first paint, in popup.ts, from a
- * synchronous localStorage hint: 237px for a browser that has never paired (it
- * becomes the 360.5px pairing form) and 116px for one that has (it becomes the
- * 239.9px connected card). A single pin cannot serve both — pinning to the form
- * costs the already-paired user, who opens this popup for the rest of the
- * product's life, a ~121px settle; pinning to the tallest state would leave a
- * permanent band of empty card under `connected` for everyone.
+ * The pin is therefore chosen per user, from a synchronous localStorage hint:
+ * 219px for a browser that has never paired (it becomes the 340px pairing form)
+ * and 86px for one that has (it becomes the 207px connected card). A single pin
+ * cannot serve both — pinning to the form costs the already-paired user, who
+ * opens this popup for the rest of the product's life, a 133px settle; pinning
+ * to the tallest state would leave a permanent band of empty card under
+ * `connected` for everyone.
  *
- * The fallback here is the unpaired height, which is what a browser with no
- * usable storage gets. */
+ * That choice is applied by first-paint.js, a CLASSIC script in <head>, NOT by
+ * popup.ts. popup.js is a deferred module, so an inline style it sets arrives
+ * after the compositor may already have painted: with only the module doing the
+ * work the already-paired user still saw the tall pin on 4 of 12 opens. The
+ * rule below is therefore the value for a browser whose hint cannot be read at
+ * all, and the pre-paint script overrides it for everyone else.
+ *
+ * All four numbers are measured at 300x600 and move together — the card's
+ * height depends on the pairing form, which depends on the reserved error slot
+ * below. Re-measure BOTH pins if any of them changes; a stale pin is a resize,
+ * which is the defect this whole block exists to prevent. */
 #pending {
   min-height: 219px;
 }

--- a/extension/src/popup/popup.css
+++ b/extension/src/popup/popup.css
@@ -413,39 +413,49 @@ input:disabled {
   color: var(--danger);
 }
 
-/* The pre-render placeholder holds the height of the state it most often
- * resolves into, so the popup window does not jump as render() settles.
+/* The pre-render placeholder holds the height of the state it will become, so
+ * the popup window does not jump as render() settles.
  *
  * A Chrome action popup auto-sizes to its content, so every difference in card
  * height between the first painted frame and the settled one is a visible
- * window resize. The placeholder's own content is two short lines (~170px),
- * while the pairing form it usually becomes is 358px; left unpinned it traded
- * the old "Not connected." flash for an equally visible 188px growth. Pinning
- * it to the pairing form's height makes the common path (unpaired user opening
- * the popup to pair) resolve with NO resize at all.
+ * window resize. #pending is the only section shipping visible, so it paints on
+ * EVERY open — the resize it causes is unconditional, and only its duration
+ * depends on how slow /health is.
  *
- * The connected card is shorter (207px), so an already-paired user still sees
- * the card settle downwards. That direction is accepted deliberately: pinning
- * to the tallest state would leave a permanent band of empty card under the
- * connected state, which every user would see on every open, to spare a resize
- * that happens once per popup open and only while the daemon is slow. */
+ * The pin is therefore chosen per user at first paint, in popup.ts, from a
+ * synchronous localStorage hint: 237px for a browser that has never paired (it
+ * becomes the 360.5px pairing form) and 116px for one that has (it becomes the
+ * 239.9px connected card). A single pin cannot serve both — pinning to the form
+ * costs the already-paired user, who opens this popup for the rest of the
+ * product's life, a ~121px settle; pinning to the tallest state would leave a
+ * permanent band of empty card under `connected` for everyone.
+ *
+ * The fallback here is the unpaired height, which is what a browser with no
+ * usable storage gets. */
 #pending {
-  min-height: 237px;
+  min-height: 219px;
 }
 
 /* The pairing error RESERVES its space instead of reflowing the card.
  *
  * A Chrome action popup auto-sizes to its content, so un-hiding this line grew
- * the card by 66px (measured 289px -> 355px) and the popup WINDOW resized under
+ * the card by 66px (measured 292px -> 358px) and the popup WINDOW resized under
  * the user's cursor at the exact moment they were re-reading a rejected code.
- * The default mismatch copy wraps to three lines at 300px, so that is the
- * height held open; the line is made invisible rather than display:none, which
- * keeps `role="alert"` announcing the message when it appears (D7).
+ * The line is made invisible rather than display:none, which keeps
+ * `role="alert"` announcing the message when it appears (D7).
+ *
+ * 36px is TWO lines at this font size (12px / 1.5), which is what the longest
+ * message the daemon can send occupies at 300px. Every pairing failure string
+ * (mismatch, expired, too many attempts, no live code, and the popup's own
+ * unreachable fallback) fits in two lines — deliberately, since the slot is
+ * permanent and each extra line is height every pairing card pays whether or
+ * not anything went wrong. A message that wraps to three lines would resize the
+ * card again, which is why the tests below pin the wrap, not just the pixels.
  *
  * Scoped to the pairing form's error only. `.error.hidden` elsewhere keeps the
  * shared `display: none`, so no other state pays for blank reserved space. */
 #pair-error {
-  min-height: 54px;
+  min-height: 36px;
 }
 #pair-error.hidden {
   display: block !important;

--- a/extension/src/popup/popup.css
+++ b/extension/src/popup/popup.css
@@ -413,6 +413,45 @@ input:disabled {
   color: var(--danger);
 }
 
+/* The pre-render placeholder holds the height of the state it most often
+ * resolves into, so the popup window does not jump as render() settles.
+ *
+ * A Chrome action popup auto-sizes to its content, so every difference in card
+ * height between the first painted frame and the settled one is a visible
+ * window resize. The placeholder's own content is two short lines (~170px),
+ * while the pairing form it usually becomes is 358px; left unpinned it traded
+ * the old "Not connected." flash for an equally visible 188px growth. Pinning
+ * it to the pairing form's height makes the common path (unpaired user opening
+ * the popup to pair) resolve with NO resize at all.
+ *
+ * The connected card is shorter (207px), so an already-paired user still sees
+ * the card settle downwards. That direction is accepted deliberately: pinning
+ * to the tallest state would leave a permanent band of empty card under the
+ * connected state, which every user would see on every open, to spare a resize
+ * that happens once per popup open and only while the daemon is slow. */
+#pending {
+  min-height: 237px;
+}
+
+/* The pairing error RESERVES its space instead of reflowing the card.
+ *
+ * A Chrome action popup auto-sizes to its content, so un-hiding this line grew
+ * the card by 66px (measured 289px -> 355px) and the popup WINDOW resized under
+ * the user's cursor at the exact moment they were re-reading a rejected code.
+ * The default mismatch copy wraps to three lines at 300px, so that is the
+ * height held open; the line is made invisible rather than display:none, which
+ * keeps `role="alert"` announcing the message when it appears (D7).
+ *
+ * Scoped to the pairing form's error only. `.error.hidden` elsewhere keeps the
+ * shared `display: none`, so no other state pays for blank reserved space. */
+#pair-error {
+  min-height: 54px;
+}
+#pair-error.hidden {
+  display: block !important;
+  visibility: hidden;
+}
+
 /* Footer link in the muted-dim register, above a hairline. */
 .foot {
   padding: 10px 16px;

--- a/extension/src/popup/popup.html
+++ b/extension/src/popup/popup.html
@@ -84,11 +84,19 @@
               autocomplete="one-time-code"
               aria-describedby="pair-error"
             />
+            <!-- ABOVE the button, and inside the form. The error's reserved
+                 slot (popup.css) is permanent, so below `.actions` it parked a
+                 66px void between the last control and the footer rule, which
+                 reads as a mis-measured card rather than as rhythm; between the
+                 field and the button the same slack reads as form spacing. It
+                 also puts the message next to the field it is about instead of
+                 below the button that produced it, so failure does not send the
+                 eye past the primary action and back. -->
+            <p class="error hidden" id="pair-error" role="alert"></p>
             <div class="actions">
               <button type="submit" class="btn primary block">Pair</button>
             </div>
           </form>
-          <p class="error hidden" id="pair-error" role="alert"></p>
         </section>
 
         <!-- Ships HIDDEN like every other section. A diagnostic error state must
@@ -116,8 +124,15 @@
              Its height matches the states it most often resolves into, so the
              popup window does not jump as it settles. -->
         <section id="pending" class="state" role="status">
-          <h1 class="title">Local Operator</h1>
-          <p class="sub">Checking this browser's connection…</p>
+          <!-- The title states what is happening, like every other state
+               ("Connected.", "Paired.", "Not connected.", "Update needed.").
+               It previously repeated the wordmark 14px above it, spending the
+               card's strongest typographic slot on a word already on screen and
+               making a legitimate loading state read as an empty broken card.
+               The copy still refuses to diagnose: this is the one state that
+               has established nothing yet. -->
+          <h1 class="title">Checking connection.</h1>
+          <p class="sub">Looking for Local Operator on this computer…</p>
         </section>
 
         <section id="incompatible" class="state hidden">

--- a/extension/src/popup/popup.html
+++ b/extension/src/popup/popup.html
@@ -2,6 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <!-- CLASSIC script, in <head>, BEFORE the stylesheet, on purpose. popup.js
+         is a deferred module and so cannot size #pending before the compositor
+         paints; this can. It must precede the <link> because a classic script
+         placed after one blocks on that stylesheet loading first, which delays
+         the parser past the point where the body can paint unstyled. See
+         first-paint.js — it is the only thing that runs pre-paint. -->
+    <script src="first-paint.js"></script>
     <link rel="stylesheet" href="popup.css" />
   </head>
   <body>

--- a/extension/src/popup/popup.html
+++ b/extension/src/popup/popup.html
@@ -91,13 +91,33 @@
           <p class="error hidden" id="pair-error" role="alert"></p>
         </section>
 
-        <section id="disconnected" class="state">
+        <!-- Ships HIDDEN like every other section. A diagnostic error state must
+             never be the pre-render default: render() is async (it awaits
+             getSession() and a real /health fetch), so whichever section ships
+             visible is what Chrome paints before any show() runs. This one used
+             to be it, and every popup open flashed "Not connected." for the
+             length of the health round trip — worst exactly when the daemon is
+             slow rather than dead, and it resized the auto-sizing popup window
+             as the card swapped. The neutral #pending section below is the
+             first paint instead. -->
+        <section id="disconnected" class="state hidden">
           <h1 class="title">Not connected.</h1>
           <p class="sub">
             Local Operator isn't reachable on this computer. Make sure it's running
             (<code>lop browser status</code>).
           </p>
           <div class="actions"><button id="retry" class="btn block">Retry</button></div>
+        </section>
+
+        <!-- The pre-render placeholder, and the ONLY section that ships visible.
+             It asserts nothing about the connection: render() resolves it away
+             into whichever state is real, so a slow probe reads as "still
+             looking" rather than as a diagnosis that is about to be retracted.
+             Its height matches the states it most often resolves into, so the
+             popup window does not jump as it settles. -->
+        <section id="pending" class="state" role="status">
+          <h1 class="title">Local Operator</h1>
+          <p class="sub">Checking this browser's connection…</p>
         </section>
 
         <section id="incompatible" class="state hidden">

--- a/extension/src/popup/popup.ts
+++ b/extension/src/popup/popup.ts
@@ -214,11 +214,17 @@ function show(state: State): void {
     // the failure path just made.
     //
     // A second `!form.contains(document.activeElement)` term was tried here and
-    // removed: no mutation could make it decide a case. `pairingShown` is
-    // already false on every entry from another state, and true on every
-    // re-render of this one, so the activeElement check never gets to matter.
-    // A guard no test can distinguish from its absence is one the next reader
-    // has to re-derive, so the single operative term is left on its own.
+    // removed. It is NOT indistinguishable in principle — driving
+    // pairing -> connected -> pairing with focus held in the field does produce
+    // divergent behaviour in a synthetic harness. What makes it inert in the
+    // real popup is a DOM timing fact: hiding a section with `display: none`
+    // blurs the focused element ASYNCHRONOUSLY, a frame later, and every path
+    // that leaves and re-enters the pairing state awaits at least once in
+    // between (render() awaits getSession() and /health). So by the time we are
+    // back here the blur has always landed, `document.activeElement` is the
+    // body, and the term cannot decide. Removed rather than kept as a
+    // "cheap invariant", because a guard whose only justification is a race it
+    // always loses is one the next reader has to re-derive to trust.
     if (!pairingShown) input?.focus();
   }
   pairingShown = state === "pairing";
@@ -590,6 +596,11 @@ document.getElementById("pair-form")?.addEventListener("submit", async (event) =
       // the user's feedback; render() below only upgrades it to the connected
       // view once health confirms.
       locallyPaired = true;
+      // This card dwells ~1s before `connected` takes over. That dwell is NOT
+      // padding to make success legible and must not be shortened here: it is
+      // the worker's first reconnect backoff, and it is load-bearing. See the
+      // warning on backoffDelayMs in reconnect.ts — shortening it inverts the
+      // socket-eviction race and breaks pairing outright.
       show("paired");
       await new Promise((resolve) => setTimeout(resolve, 250));
       await render();
@@ -617,6 +628,11 @@ document.getElementById("pair-form")?.addEventListener("submit", async (event) =
     error.textContent = "Could not reach Local Operator on this machine.";
     error.classList.remove("hidden");
     document.getElementById("card")?.style.setProperty("--tone", "var(--danger)");
+    // Same recovery as the rejected-code branch above: the typed digits are
+    // still in the field with the caret at 6, where maxlength is satisfied, so
+    // without this the retry after a transport failure silently swallows every
+    // keystroke and a paste too.
+    input.select();
   } finally {
     // Always unlock, success included: if health later drops (daemon restart)
     // the user lands back on this form, and it must not arrive pre-disabled.

--- a/extension/src/popup/popup.ts
+++ b/extension/src/popup/popup.ts
@@ -146,18 +146,80 @@ const TONE: Record<State, string> = {
 // prompt's `freshPrompt` rule a few lines down in render().
 let pairingShown = false;
 
+// How long a /health probe may hang before the render gives up on it. Bounded
+// because renders are serialised — see daemonHealth().
+const HEALTH_TIMEOUT_MS = 3000;
+
+// The last known pairing outcome, mirrored into localStorage so the FIRST
+// PAINT can size itself.
+//
+// #pending is the only section shipping visible, so it paints on every open,
+// before render()'s awaits resolve. Its pinned height therefore decides how far
+// the card travels when the real state arrives. Pinned to the pairing form the
+// first-run user settles with no motion but the already-paired user — who opens
+// this popup for the rest of the product's life — falls ~121px. chrome.storage
+// is async and so cannot inform a synchronous first paint; localStorage on an
+// extension page is synchronous, so the bit is mirrored there purely as a
+// LAYOUT HINT.
+//
+// It is a hint and nothing else: it never gates behaviour, and render() paints
+// whatever /health actually reports. A stale or absent bit costs one resize,
+// which is exactly the behaviour without it — so there is nothing to fail
+// closed about, and no security surface (it records that a pairing happened,
+// never a credential).
+const PAIRED_HINT_KEY = "lop:paired-hint";
+
+function readPairedHint(): boolean {
+  try {
+    return localStorage.getItem(PAIRED_HINT_KEY) === "1";
+  } catch {
+    // Storage can be unavailable (disabled, quota, partitioned context). The
+    // unpaired pin is the safe default: it is the state a user who cannot be
+    // identified is most likely to be in on their first open.
+    return false;
+  }
+}
+
+function writePairedHint(paired: boolean): void {
+  try {
+    localStorage.setItem(PAIRED_HINT_KEY, paired ? "1" : "0");
+  } catch {
+    // A hint that cannot be stored simply is not used next time.
+  }
+}
+
+/** Size the pre-render placeholder to the state it is most likely to become,
+ * so the first paint settles without moving the popup window. Called inline at
+ * module scope, before the first paint, and again whenever the hint changes. */
+function applyPendingPin(): void {
+  const pending = document.getElementById("pending");
+  if (!pending) return;
+  // Measured at 300x600 against THIS card: 86px lands the card on connected's
+  // height (207px), 219px on the pairing form's (340px). Re-measure both if the
+  // pairing form or the error slot changes height — a stale pin is a resize.
+  pending.style.minHeight = readPairedHint() ? "86px" : "219px";
+}
+applyPendingPin();
+
 function show(state: State): void {
   for (const section of sections) section?.classList.toggle("hidden", section.id !== state);
   document.getElementById("card")?.style.setProperty("--tone", TONE[state]);
   if (state === "pairing") {
     const input = document.getElementById("pair-code") as HTMLInputElement | null;
-    // Only on a form the user has not been looking at, and never over a focus
-    // they already placed inside the form themselves: re-focusing an element
-    // that is already focused still collapses the selection to the caret, so
-    // an activeElement check is not redundant with `pairingShown`.
-    const form = document.getElementById("pair-form");
-    const alreadyInForm = form?.contains(document.activeElement) ?? false;
-    if (!pairingShown && !alreadyInForm) input?.focus();
+    // Focus only a form the user has NOT been looking at. `pairingShown` is
+    // false exactly when we are arriving at the pairing state from another one,
+    // which is the only time an autofocus is a service rather than an
+    // interruption — on a re-render of a form already on screen it yanks the
+    // caret back from wherever the user moved it, and collapses the selection
+    // the failure path just made.
+    //
+    // A second `!form.contains(document.activeElement)` term was tried here and
+    // removed: no mutation could make it decide a case. `pairingShown` is
+    // already false on every entry from another state, and true on every
+    // re-render of this one, so the activeElement check never gets to matter.
+    // A guard no test can distinguish from its absence is one the next reader
+    // has to re-derive, so the single operative term is left on its own.
+    if (!pairingShown) input?.focus();
   }
   pairingShown = state === "pairing";
 }
@@ -165,7 +227,22 @@ function show(state: State): void {
 async function daemonHealth(): Promise<Health | null> {
   const { port = DEFAULT_PORT } = await getLocal();
   try {
-    const response = await fetch(`http://127.0.0.1:${port}/health`);
+    // BOUNDED, because renders are serialised. An unbounded probe against a
+    // daemon that accepts the TCP connection but never answers would suspend
+    // render() before any show() — and since renderRunning is only cleared in
+    // .finally() and renderQueued chains off it, that one stalled probe wedges
+    // EVERY later render, permanently. The frozen frame is #pending, which has
+    // no Retry button, and both Retry handlers are `() => void render()` and so
+    // become silently inert. A merely slow daemon freezes it for the whole
+    // stall. daemon.py's own _supervise docstring documents a daemon that
+    // "keeps answering /health as though it were healthy" as a real state, so
+    // this is not hypothetical.
+    //
+    // The existing `catch` below turns an abort into `null`, which renders the
+    // `disconnected` card — the one state carrying a Retry the user can act on.
+    const response = await fetch(`http://127.0.0.1:${port}/health`, {
+      signal: AbortSignal.timeout(HEALTH_TIMEOUT_MS),
+    });
     if (!response.ok) return null;
     return (await response.json()) as Health;
   } catch {
@@ -351,6 +428,10 @@ async function renderOnce(): Promise<void> {
     show("incompatible");
     return;
   }
+  // /health is the authority on whether this browser is paired, so it is what
+  // the first-paint layout hint is mirrored from — in BOTH directions, so an
+  // unpair shrinks the next first paint back to the form's height.
+  writePairedHint(health.paired);
   if (health.paired) {
     // Handoff complete: the worker holds the new token and health confirms it,
     // so the pairing latch has done its job. Clearing it here means a LATER
@@ -522,7 +603,15 @@ document.getElementById("pair-form")?.addEventListener("submit", async (event) =
       // `finally` unlock runs only after this handler returns. (The finally
       // re-call is idempotent.)
       setPairBusy(false);
-      input.focus();
+      // SELECT, not just focus. The rejected digits stay in the field with the
+      // caret at position 6, where maxlength="6" is already satisfied — so
+      // every subsequent keystroke, and a paste of the correct code, is
+      // silently discarded. Observed costing a user two of their five attempts
+      // on the same wrong code, with no visual signal that their input never
+      // landed. Selecting means the first keystroke or paste replaces the
+      // rejected code, which is how every other "wrong code, try again" field
+      // behaves.
+      input.select();
     }
   } catch {
     error.textContent = "Could not reach Local Operator on this machine.";

--- a/extension/src/popup/popup.ts
+++ b/extension/src/popup/popup.ts
@@ -628,6 +628,12 @@ document.getElementById("pair-form")?.addEventListener("submit", async (event) =
     error.textContent = "Could not reach Local Operator on this machine.";
     error.classList.remove("hidden");
     document.getElementById("card")?.style.setProperty("--tone", "var(--danger)");
+    // Unlock BEFORE selecting, for the same reason as the rejected-code branch
+    // above: a disabled input refuses focus, and `setPairBusy(false)` in
+    // `finally` runs only after this handler returns — so a select() placed
+    // ahead of it sets a range on an unfocused element and focus stays on the
+    // body. (The finally re-call is idempotent.)
+    setPairBusy(false);
     // Same recovery as the rejected-code branch above: the typed digits are
     // still in the field with the caret at 6, where maxlength is satisfied, so
     // without this the retry after a transport failure silently swallows every

--- a/extension/src/popup/popup.ts
+++ b/extension/src/popup/popup.ts
@@ -26,7 +26,10 @@ type State =
   | "disconnected"
   | "incompatible"
   | "origin"
-  | "origin-ack";
+  | "origin-ack"
+  // The neutral pre-render placeholder. Never shown BY render() — it is the
+  // section popup.html ships visible, and every render path replaces it.
+  | "pending";
 const sections = [
   "connected",
   "paired",
@@ -35,6 +38,7 @@ const sections = [
   "incompatible",
   "origin",
   "origin-ack",
+  "pending",
 ].map((id) => document.getElementById(id));
 
 // True once THIS popup saw pair_result.ok. The daemon confirms pairing on the
@@ -127,15 +131,35 @@ const TONE: Record<State, string> = {
   // Placeholder only: the ack's real tone is per-decision (success for allow,
   // neutral for deny) and showOriginAck overrides it right after show().
   "origin-ack": "var(--hairline-strong)",
+  // The pre-render placeholder is transitional and asserts nothing, so it takes
+  // the same neutral hairline as the other transitional states.
+  pending: "var(--hairline-strong)",
 };
+
+// The pairing state the popup last PAINTED. `show("pairing")` may run on every
+// render (storage.onChanged re-enters render() on any connState write, which
+// the worker performs on every teardown and every hello_ack), and while
+// unpaired the worker idle-suspends and the ~1-minute alarm floor rewakes it —
+// so a user spending 30-90s reading the code out of the terminal gets several
+// renders. Focusing on each of them yanks the caret back from wherever they
+// had moved it. Focus belongs to a NEWLY-shown form only, mirroring the origin
+// prompt's `freshPrompt` rule a few lines down in render().
+let pairingShown = false;
 
 function show(state: State): void {
   for (const section of sections) section?.classList.toggle("hidden", section.id !== state);
   document.getElementById("card")?.style.setProperty("--tone", TONE[state]);
   if (state === "pairing") {
     const input = document.getElementById("pair-code") as HTMLInputElement | null;
-    input?.focus();
+    // Only on a form the user has not been looking at, and never over a focus
+    // they already placed inside the form themselves: re-focusing an element
+    // that is already focused still collapses the selection to the caret, so
+    // an activeElement check is not redundant with `pairingShown`.
+    const form = document.getElementById("pair-form");
+    const alreadyInForm = form?.contains(document.activeElement) ?? false;
+    if (!pairingShown && !alreadyInForm) input?.focus();
   }
+  pairingShown = state === "pairing";
 }
 
 async function daemonHealth(): Promise<Health | null> {
@@ -149,7 +173,54 @@ async function daemonHealth(): Promise<Health | null> {
   }
 }
 
-async function render(): Promise<void> {
+// Renders are SERIALISED, never run concurrently.
+//
+// `render()` is async with two awaits before it paints (getSession, the real
+// /health fetch) and more on the connected path, and it is entered from six
+// sites: module load, storage.onChanged, both Retry buttons, the post-pairing
+// path, moveQueue() and decide(). Unserialised, a render that STARTS first can
+// FINISH last and repaint a state older than one already on screen. Measured in
+// real Chrome across a real pairing: the popup painted
+// pairing -> paired -> connected -> pairing -> connected, i.e. the form came
+// back over the connected card with no state change behind it.
+//
+// Serialising rather than discarding a late paint is deliberate. render()
+// mutates module state that six review rounds' worth of latch logic depends on
+// (decidedOrigin promotion, repeatAskByOrigin pruning, shownPromptId/Origin
+// capture, scopeBuiltForEntryId). Running each render alone, to completion, is
+// exactly the behaviour that logic was written and reviewed against — it only
+// removes the interleaving. A generation counter that abandoned a render
+// mid-flight would leave those mutations half-applied.
+//
+// Bounded at one running plus one queued: a caller arriving while a render is
+// already queued gets that queued render's promise, because a render that has
+// not started yet will observe state at least as new as the caller's. So a
+// burst of storage events costs two renders, not one per event, and every
+// awaited call still resolves only after a render that began after it was made.
+let renderRunning: Promise<void> | null = null;
+let renderQueued: Promise<void> | null = null;
+
+function render(): Promise<void> {
+  if (renderQueued) return renderQueued;
+  if (!renderRunning) {
+    renderRunning = renderOnce().finally(() => {
+      renderRunning = null;
+    });
+    return renderRunning;
+  }
+  renderQueued = renderRunning
+    .catch(() => {})
+    .then(() => {
+      renderQueued = null;
+      renderRunning = renderOnce().finally(() => {
+        renderRunning = null;
+      });
+      return renderRunning;
+    });
+  return renderQueued;
+}
+
+async function renderOnce(): Promise<void> {
   // A pending site decision wins the popup: it is the one thing the user must
   // act on (findings U2/D1). The daemon reports it in /health so the popup
   // shows it even after a worker restart.
@@ -335,7 +406,30 @@ function hostnameOf(origin: string | undefined): string {
 // (finding U6); the field is also autofocused when the pairing state renders.
 const codeInput = document.getElementById("pair-code") as HTMLInputElement | null;
 codeInput?.addEventListener("input", () => {
-  codeInput.value = codeInput.value.replace(/\D/g, "").slice(0, 6);
+  // Only reassign when sanitising actually CHANGED the string, and put the
+  // caret back where the edit left it.
+  //
+  // Assigning `.value` collapses the selection to the end of the field. Chrome
+  // short-circuits an assignment of an identical string, so digit-only typing
+  // was already safe (verified with real keystrokes, not assumed) — but typing
+  // or pasting a non-digit mid-string genuinely changes the value, and the
+  // caret then jumped to the end, so the next character landed in the wrong
+  // place. Guarding the write keeps the common path identical and fixes the
+  // stripped-character path.
+  //
+  // The caret is restored to the same offset rather than shifted, because the
+  // rejected characters are removed from BEFORE it: `selectionStart` minus the
+  // number of characters stripped ahead of the caret is where the user's edit
+  // point actually is. maxlength="6" already bounds the length for both typing
+  // and paste, so no slice is needed here.
+  const raw = codeInput.value;
+  const clean = raw.replace(/\D/g, "");
+  if (clean === raw) return;
+  const caret = codeInput.selectionStart ?? raw.length;
+  const strippedBeforeCaret = raw.slice(0, caret).length - raw.slice(0, caret).replace(/\D/g, "").length;
+  codeInput.value = clean;
+  const next = Math.max(0, caret - strippedBeforeCaret);
+  codeInput.setSelectionRange(next, next);
 });
 
 // Lock the form for the duration of one submission: a second click while the

--- a/extension/src/reconnect.ts
+++ b/extension/src/reconnect.ts
@@ -45,6 +45,21 @@ export const RECONNECT_ALARM_PERIOD_MINUTES = 1;
 // dead daemon from being hammered while still recovering a live socket quickly.
 export const MAX_BACKOFF_MS = 30_000;
 
+// The FIRST delay (attempt 0 = 1000ms) is load-bearing beyond backoff, and must
+// not be shortened to make pairing feel faster.
+//
+// Submitting a pairing code opens the popup's own socket, and the daemon's rule
+// is later-connection-wins: that socket evicts the worker's (close 4000). The
+// worker then re-dials after this delay. Shortening it so the "Paired." card
+// hands over to "Connected." sooner inverts the race — the worker's re-dial
+// arrives while the popup's pairing socket is still open and EVICTS IT, and
+// pairing breaks outright (measured: 4/4 stuck on "Paired." with the daemon
+// reporting paired: false).
+//
+// So the ~1s dwell on the success card is not merely honest latency waiting for
+// /health to catch up; it is the window that lets the popup finish pairing on
+// its own socket before the worker takes the connection back. Treat it as a
+// serialisation constraint, not as a UX cost to be optimised away.
 export function backoffDelayMs(attempt: number): number {
   return Math.min(MAX_BACKOFF_MS, 1_000 * 2 ** attempt);
 }

--- a/extension/src/worker.ts
+++ b/extension/src/worker.ts
@@ -319,7 +319,20 @@ async function connect(): Promise<void> {
     // disconnect (finding D2). 4003 is an unpair/revoke.
     if (event?.code === 4001) void chrome.storage.session.set({ connState: "incompatible" });
     else if (event?.code === 4003) void chrome.storage.session.set({ connState: "pairing" });
-    else void chrome.storage.session.set({ connState: "disconnected" });
+    // 4000 is the daemon's later-connection-wins eviction (daemon.py), which the
+    // POPUP's own pairing socket triggers on every pair attempt. It is not a
+    // loss of connectivity, so publishing "disconnected" here drove the popup's
+    // render BACKWARDS mid-pair: the storage write re-enters render() through
+    // chrome.storage.onChanged, and the card painted an extra transition
+    // (pairing -> connected -> paired -> connected) as the user submitted.
+    //
+    // Only the STORAGE WRITE is suppressed. The socket really is gone, so the
+    // local connected/connecting/paired resets above and the scheduleReconnect()
+    // below must still run — the worker has to re-dial with the new token.
+    // Drive authority is enforced daemon-side by link.paired (a second socket
+    // arrives paired:false and its RPCs are refused not_paired), never by this
+    // storage key, so suppressing the write grants nothing.
+    else if (event?.code !== 4000) void chrome.storage.session.set({ connState: "disconnected" });
     scheduleReconnect();
   };
   wire.onclose = (event) => teardown(event);

--- a/extension/store-package-files.txt
+++ b/extension/store-package-files.txt
@@ -6,6 +6,7 @@ manifest.json
 options/options.css
 options/options.html
 options/options.js
+popup/first-paint.js
 popup/popup.css
 popup/popup.html
 popup/popup.js

--- a/extension/tests/popup-pairing-jitter.integration.test.mjs
+++ b/extension/tests/popup-pairing-jitter.integration.test.mjs
@@ -79,6 +79,13 @@ function installDomStub() {
         node.selectionStart = s;
         node.selectionEnd = e;
       },
+      // A real input's select() focuses and selects the whole value.
+      select: () => {
+        doc.activeElement = node;
+        node.focusCount++;
+        node.selectionStart = 0;
+        node.selectionEnd = node._value.length;
+      },
       // popup.ts uses form.contains(document.activeElement) to avoid stealing a
       // focus the user placed inside the form themselves.
       contains: (other) => other != null && (other === node || node._contains.has(other)),
@@ -90,7 +97,8 @@ function installDomStub() {
       querySelectorAll: () => [],
       _handlers: {},
       click: () => (node._handlers.click || []).forEach((h) => h()),
-      dispatch: (event) => (node._handlers[event] || []).forEach((h) => h({ preventDefault() {} })),
+      dispatch: (event) =>
+        (node._handlers[event] || []).forEach((h) => h({ preventDefault() {}, stopPropagation() {} })),
     };
     // A real <input> collapses the selection to the end when `.value` is
     // assigned a DIFFERENT string, and short-circuits an identical one. That
@@ -139,6 +147,18 @@ function installDomStub() {
     close: () => {},
     matchMedia: () => ({ matches: false, addEventListener: () => {} }),
   };
+  // Synchronous storage, which is what lets the first paint size itself before
+  // any await. Persisted across installDomStub() calls within a test so the
+  // "hint survives to the next open" property is expressible.
+  if (!globalThis.localStorage) {
+    const store = new Map();
+    globalThis.localStorage = {
+      getItem: (k) => (store.has(k) ? store.get(k) : null),
+      setItem: (k, v) => store.set(k, String(v)),
+      removeItem: (k) => store.delete(k),
+      clear: () => store.clear(),
+    };
+  }
   return nodes;
 }
 
@@ -257,9 +277,12 @@ test("no diagnostic state ships visible: the first paint is neutral (J1)", async
     "the disconnected card must never be the pre-render default",
   );
   // The placeholder must not diagnose anything, or it is the same defect with
-  // different copy.
+  // different copy. Checked against the RENDERED text only — HTML comments
+  // legitimately quote the other states' copy to explain the rule.
   const pending = html.slice(html.indexOf('<section id="pending"'));
-  const body = pending.slice(0, pending.indexOf("</section>"));
+  const body = pending
+    .slice(0, pending.indexOf("</section>"))
+    .replace(/<!--[\s\S]*?-->/g, "");
   assert.doesNotMatch(body, /not reachable|isn't reachable|Not connected/i,
     "the placeholder must not assert a connection verdict it has not established");
 });
@@ -268,21 +291,35 @@ test("no diagnostic state ships visible: the first paint is neutral (J1)", async
 
 test("the pairing card holds one height across placeholder, form and error (J1/J7)", async () => {
   // A Chrome action popup auto-sizes to its content, so any height difference
-  // between these three is a visible resize of the popup WINDOW — the "jittery"
-  // report. The stylesheet is the only thing that decides it, so it is asserted
-  // here rather than through the module.
+  // between these is a visible resize of the popup WINDOW — the "jittery"
+  // report. The stylesheet decides it, so it is asserted here.
   //
-  // The numbers are measured, not guessed: rendered in Chrome 152 at the
-  // popup's true 300x600 metrics against a real daemon, the card is 358px for
-  // the placeholder, the pairing form, and the form carrying an error alike.
-  // Before the fix the same sequence measured 259 -> 292 -> 358.
+  // These assertions COMPARE the captured values. An earlier version only
+  // checked that the regex matched, which meant `min-height: 1px` passed — the
+  // exact blindness that let a 188px first-paint regression through review to
+  // be caught by looking at a frame instead.
   const css = await readFile(join(HERE, "..", "src", "popup", "popup.css"), "utf8");
 
+  // The placeholder's fallback pin. popup.ts overrides this per user at first
+  // paint (see the paired-hint test below); this is what a browser with no
+  // usable localStorage gets, so it must be the unpaired/pairing-form height.
   const pendingMin = /#pending\s*\{[^}]*min-height:\s*(\d+)px/.exec(css);
   assert.ok(pendingMin, "the placeholder must pin a height, or the card resizes when render() settles");
+  assert.equal(
+    Number(pendingMin[1]),
+    219,
+    "the fallback pin must be the pairing form's height (measured 219px -> card 340px at 300x600)",
+  );
 
+  // The error's reserved slot. 36px is two lines at 12px/1.5 — the height the
+  // longest message the daemon can send occupies at 300px.
   const errorMin = /#pair-error\s*\{[^}]*min-height:\s*(\d+)px/.exec(css);
   assert.ok(errorMin, "the pairing error must reserve its space rather than reflow the card");
+  assert.equal(
+    Number(errorMin[1]),
+    36,
+    "the error slot must reserve exactly two lines; more is height every pairing card pays for nothing",
+  );
 
   // Reserved space is only reserved if the hidden line still occupies it.
   assert.match(
@@ -297,6 +334,275 @@ test("the pairing card holds one height across placeholder, form and error (J1/J
     /#pair-error\.hidden\s*\{[^}]*display:\s*block/,
     "the hidden error must override the shared .hidden display:none to keep its box",
   );
+});
+
+test("every pairing failure message fits the reserved slot (J7)", async () => {
+  // The 36px reservation is calibrated to a WRAP, not to one string, and the
+  // slot is permanent — a message that wraps to three lines resizes the card
+  // exactly as before the fix. So the binding that matters is between the
+  // reservation and the longest message that can land in it.
+  //
+  // Measured at the card's content width (300px body - 2x16px body padding -
+  // 2x1px card border - 2x10px card margin = 246px) in the popup's body face at
+  // 12px. Rather than re-deriving pixel metrics here, the invariant asserted is
+  // the one that produced 36px: no message exceeds two lines' worth of
+  // characters at this width.
+  const daemon = await readFile(
+    join(HERE, "..", "..", "local_operator", "browser_bridge", "daemon.py"),
+    "utf8",
+  );
+  const flow = await readFile(join(HERE, "..", "src", "popup", "pair-flow.ts"), "utf8");
+  const popup = await readFile(join(HERE, "..", "src", "popup", "popup.ts"), "utf8");
+
+  // Python implicit string concatenation means a message can be spelled across
+  // several source lines, so adjacent literals are JOINED before measuring.
+  // Without this the longest message — the one the reservation is calibrated
+  // against — is silently skipped the moment someone wraps it, which is exactly
+  // how that string was written when this slot was first sized.
+  //
+  // Done line-wise rather than with one regex: a run of quoted literals on
+  // consecutive lines is the only shape Python's concatenation takes here, and
+  // it is far easier to read than a nested-quantifier match.
+  const joinAdjacent = (text) => {
+    const out = [];
+    let current = null;
+    for (const line of text.split("\n")) {
+      const parts = [...line.matchAll(/"((?:[^"\\]|\\.)*)"/g)].map((m) => m[1]);
+      if (parts.length === 1 && /^\s*"/.test(line)) {
+        // A bare continuation line: append to the message being built.
+        current = current === null ? parts[0] : current + parts[0];
+        continue;
+      }
+      if (current !== null) out.push(current);
+      current = null;
+      // A line that both opens a message and may continue on the next.
+      if (parts.length >= 1 && /=\s*\(?\s*"|message=\s*"|else\s+"/.test(line)) current = parts.at(-1);
+      else out.push(...parts);
+    }
+    if (current !== null) out.push(current);
+    return out;
+  };
+
+  const messages = [
+    ...joinAdjacent(daemon).filter((m) =>
+      /^(That code|No live pairing code|Too many attempts)/.test(m),
+    ),
+    /PAIR_MISMATCH_MESSAGE = "([^"]+)"/.exec(flow)?.[1],
+    /error\.textContent = "(Could not reach[^"]*)"/.exec(popup)?.[1],
+  ].filter(Boolean);
+
+  assert.ok(messages.length >= 5, `expected the real failure strings, found ${messages.length}`);
+  // The daemon's mismatch copy is the string the 36px slot is calibrated to.
+  assert.ok(
+    messages.some((m) => m.startsWith("That code didn't match")),
+    "the daemon's mismatch message must be among the strings measured",
+  );
+
+  // Word wrapping, not character division: a line breaks at the last word that
+  // fits, so a naive length/width underestimates the line count badly enough to
+  // miss the case this test exists for. The old mismatch copy (87 chars) is
+  // ceil(87/52) = 2 by division but genuinely wraps to THREE lines, which is
+  // the regression that sized this slot at 54px in the first place.
+  //
+  // 41 characters per line is the measured fit at the card's 246px content
+  // width in the popup's 12px body face — calibrated against the two strings
+  // whose rendered wrap the designer measured: the 87-char copy at 3 lines and
+  // the 55-char replacement at 2.
+  const CHARS_PER_LINE = 41;
+  const LINES_RESERVED = 2;
+  const wrappedLines = (message) => {
+    let lines = 1;
+    let column = 0;
+    for (const word of message.split(" ")) {
+      const width = word.length + (column === 0 ? 0 : 1);
+      if (column + width > CHARS_PER_LINE) {
+        lines++;
+        column = word.length;
+      } else {
+        column += width;
+      }
+    }
+    return lines;
+  };
+  for (const message of messages) {
+    const lines = wrappedLines(message);
+    assert.ok(
+      lines <= LINES_RESERVED,
+      `"${message}" wraps to ${lines} lines but the slot reserves ${LINES_RESERVED}; it would resize the card`,
+    );
+  }
+});
+
+test("the error sits above the button that produced it (D2)", async () => {
+  // Placement, not styling: below `.actions` the permanently-reserved slot put
+  // a 66px void between the last control and the footer rule, and put the
+  // message below the button on failure.
+  const html = await readFile(join(HERE, "..", "src", "popup", "popup.html"), "utf8");
+  const form = html.slice(html.indexOf('<form id="pair-form">'), html.indexOf("</form>"));
+  assert.ok(form.includes('id="pair-error"'), "the error must live inside the pairing form");
+  assert.ok(
+    form.indexOf('id="pair-error"') < form.indexOf('class="actions"'),
+    "the error must come before the actions row, not after it",
+  );
+});
+
+test("the first paint is pinned to the state this browser will actually reach (D1)", async () => {
+  // #pending paints on EVERY open, before render()'s awaits resolve, so its
+  // pinned height decides how far the card travels. One pin cannot serve both
+  // populations: the pairing form is 360.5px and the connected card 239.9px.
+  const nodes = installDomStub();
+  const { areas } = installChromeStub();
+
+  // An already-paired browser. The hint is synchronous (localStorage), because
+  // chrome.storage cannot inform a first paint.
+  globalThis.localStorage.setItem("lop:paired-hint", "1");
+  installFetchStub(() => true);
+  let bundle = await loadPopup();
+  try {
+    areas.local.set("port", 4099);
+    await bundle.import();
+    await tick(30);
+    assert.equal(
+      nodes.get("pending").style.minHeight,
+      "86px",
+      "a paired browser's first paint must be pinned to the connected card's height",
+    );
+    assert.equal(
+      nodes.get("connected").classList.contains("hidden"),
+      false,
+      "precondition: it really does settle on connected",
+    );
+  } finally {
+    await bundle.close();
+  }
+
+  // A browser that has never paired.
+  const fresh = installDomStub();
+  const second = installChromeStub();
+  globalThis.localStorage.removeItem("lop:paired-hint");
+  installFetchStub(() => false);
+  bundle = await loadPopup();
+  try {
+    second.areas.local.set("port", 4099);
+    await bundle.import();
+    await tick(30);
+    assert.equal(
+      fresh.get("pending").style.minHeight,
+      "219px",
+      "an unpaired browser's first paint must be pinned to the pairing form's height",
+    );
+  } finally {
+    await bundle.close();
+  }
+});
+
+test("the paired hint follows /health in both directions (D1)", async () => {
+  // The hint is a layout guess and must never drift from reality: an unpair has
+  // to shrink the next first paint back, or the returning user gets the resize
+  // the pin exists to remove.
+  const nodes = installDomStub();
+  const { areas } = installChromeStub();
+  globalThis.localStorage.removeItem("lop:paired-hint");
+  let paired = true;
+  installFetchStub(() => paired);
+  const bundle = await loadPopup();
+  try {
+    areas.local.set("port", 4099);
+    await bundle.import();
+    await tick(30);
+    assert.equal(globalThis.localStorage.getItem("lop:paired-hint"), "1", "pairing must record the hint");
+
+    paired = false;
+    await chrome.storage.session.set({ connState: "pairing" });
+    await tick(30);
+    assert.equal(
+      globalThis.localStorage.getItem("lop:paired-hint"),
+      "0",
+      "an unpair must clear the hint, or the next first paint is pinned to the wrong state",
+    );
+  } finally {
+    await bundle.close();
+  }
+});
+
+test("the placeholder is gone once render settles (A4)", async () => {
+  // #pending ships visible, so it is hidden only by show()'s toggle over the
+  // sections list. Dropping it from that list leaves the placeholder stacked
+  // above the real card, which no other assertion observes.
+  const nodes = installDomStub();
+  const { areas } = installChromeStub();
+  installFetchStub(() => true);
+  const bundle = await loadPopup();
+  try {
+    areas.local.set("port", 4099);
+    await bundle.import();
+    await tick(30);
+    assert.equal(
+      nodes.get("pending").classList.contains("hidden"),
+      true,
+      "the placeholder must be hidden once a real state is painted, not left stacked above it",
+    );
+    const visible = ["connected", "paired", "pairing", "disconnected", "pending"].filter(
+      (id) => !nodes.get(id).classList.contains("hidden"),
+    );
+    assert.deepEqual(visible, ["connected"], "exactly one card may be visible after render settles");
+  } finally {
+    await bundle.close();
+  }
+});
+
+/* ------------------------------------------------------------------ A1 ---- */
+
+test("a stalled health probe still reaches a state the user can retry from (A1)", async () => {
+  // Renders are serialised, so an unbounded probe does not strand ONE render —
+  // renderRunning never clears and renderQueued chains off it, so it wedges
+  // every later render permanently. The frozen frame is #pending, which has no
+  // Retry button, and both Retry handlers are `() => void render()` and become
+  // silently inert.
+  const nodes = installDomStub();
+  const { areas } = installChromeStub();
+
+  let fetches = 0;
+  // A daemon that accepts the connection and never answers. Honours the abort
+  // signal the way a real fetch does — rejecting — which is what lets the
+  // render finish at all.
+  globalThis.fetch = (_url, init) => {
+    fetches++;
+    return new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+    });
+  };
+
+  const bundle = await loadPopup();
+  try {
+    areas.local.set("port", 4099);
+    await bundle.import();
+    // Longer than the 3s bound the probe must impose.
+    await tick(3600);
+
+    assert.equal(
+      nodes.get("disconnected").classList.contains("hidden"),
+      false,
+      "a stalled probe must land on the retryable disconnected card, not freeze on the placeholder",
+    );
+    assert.equal(
+      nodes.get("pending").classList.contains("hidden"),
+      true,
+      "the popup must not be parked on a card with no Retry button",
+    );
+
+    // ...and the popup must still be LIVE: further triggers must issue new
+    // probes rather than queue behind a render that never finished.
+    const before = fetches;
+    nodes.get("retry").click();
+    await tick(60);
+    assert.ok(
+      fetches > before,
+      `Retry must issue a new probe (fetches ${before} -> ${fetches}); a wedged render makes it silently inert`,
+    );
+  } finally {
+    await bundle.close();
+  }
 });
 
 /* ------------------------------------------------------------------ J2 ---- */
@@ -315,13 +621,18 @@ test("a re-render does not yank focus back into the pairing code field (J2)", as
     assert.equal(nodes.get("pairing").classList.contains("hidden"), false, "precondition: the form is up");
     assert.equal(document.activeElement, input, "precondition: a newly shown form takes focus once");
 
-    // The user reads the code out of the terminal and tabs onward. While
-    // unpaired the worker idle-suspends and the alarm floor rewakes it, so
-    // connState is rewritten under them on every teardown and hello_ack.
-    const submit = nodes.get("pair-submit");
-    submit.focus();
+    // The user tabs OUTSIDE the form — the ordinary case in the report: they
+    // click the port row or the footer while reading the code out of the
+    // terminal. This is deliberately not the submit button: the button is
+    // inside #pair-form, so `alreadyInForm` would be true and `!pairingShown`
+    // would never be the deciding term — a mutation dropping `!pairingShown`
+    // survived the earlier version of this test for exactly that reason.
+    const outside = nodes.get("port");
+    outside.focus();
     const focusesBefore = input.focusCount;
 
+    // While unpaired the worker idle-suspends and the alarm floor rewakes it,
+    // so connState is rewritten under the user on every teardown and hello_ack.
     await chrome.storage.session.set({ connState: "connecting" });
     await tick(30);
     await chrome.storage.session.set({ connState: "pairing" });
@@ -329,7 +640,7 @@ test("a re-render does not yank focus back into the pairing code field (J2)", as
 
     assert.equal(
       document.activeElement,
-      submit,
+      outside,
       "a re-render must not steal focus from a user who has tabbed onward",
     );
     assert.equal(
@@ -366,6 +677,109 @@ test("re-entering the pairing state after leaving it focuses the field again (J2
       document.activeElement,
       nodes.get("pair-code"),
       "a form the user has not seen yet must take focus",
+    );
+  } finally {
+    await bundle.close();
+  }
+});
+
+test("a render never re-focuses a field the user is already editing (J2)", async () => {
+  // The consequence the guard exists to prevent, asserted on the state that
+  // makes it expensive: a user mid-edit with a SELECTION. Re-focusing an input
+  // collapses the selection to the caret, which would silently undo the
+  // select() the failure path performs — so this also protects U1.
+  const nodes = installDomStub();
+  const { areas } = installChromeStub();
+  installFetchStub(() => false);
+  const bundle = await loadPopup();
+  try {
+    areas.local.set("port", 4099);
+    await bundle.import();
+    await tick(30);
+
+    const input = nodes.get("pair-code");
+    // The user is mid-edit with a selection — exactly the state the failure
+    // path's select() leaves them in.
+    input.focus();
+    input._value = "123456";
+    input.setSelectionRange(0, 6);
+    const focusesBefore = input.focusCount;
+
+    // Force the case the guard's second term exists for: the pairing state is
+    // re-shown while focus is genuinely inside the form.
+    await chrome.storage.session.set({ connState: "connecting" });
+    await tick(30);
+
+    assert.equal(
+      input.focusCount,
+      focusesBefore,
+      "a render must not re-focus a field the user is editing: it collapses the selection to the caret",
+    );
+    assert.equal(input.selectionStart, 0, "the user's selection must survive the render");
+    assert.equal(input.selectionEnd, 6, "the user's selection must survive the render");
+  } finally {
+    await bundle.close();
+  }
+});
+
+/** The daemon's side of a pairing submit, over the popup's own socket: a
+ * hello_ack followed by a pair_result. `ok:false` is the rejection path. */
+function installPairSocket({ ok = false, message = "That code didn't match." } = {}) {
+  globalThis.WebSocket = class {
+    constructor() {
+      queueMicrotask(() => this.onopen?.({}));
+    }
+    send(raw) {
+      const frame = JSON.parse(String(raw));
+      if (frame.event === "hello") {
+        queueMicrotask(() =>
+          this.onmessage?.({ data: JSON.stringify({ event: "hello_ack", proto: 1, paired: false }) }),
+        );
+      } else if (frame.event === "pair") {
+        queueMicrotask(() =>
+          this.onmessage?.({
+            data: JSON.stringify({ event: "pair_result", ok, message, token: ok ? "tok" : undefined }),
+          }),
+        );
+      }
+    }
+    close() {}
+  };
+}
+
+/* ------------------------------------------------------------------ U1 ---- */
+
+test("a rejected code is selected so the next keystroke replaces it (U1)", async () => {
+  // maxlength="6" is already satisfied by the rejected digits, so with the
+  // caret at 6 every further keystroke AND a paste are silently discarded.
+  // Observed costing a user two of five attempts on the same wrong code.
+  const nodes = installDomStub();
+  const { areas } = installChromeStub();
+  installFetchStub(() => false);
+  installPairSocket({ ok: false });
+  const bundle = await loadPopup();
+  try {
+    areas.local.set("port", 4099);
+    await bundle.import();
+    await tick(30);
+
+    const input = nodes.get("pair-code");
+    input._value = "707770";
+    input.setSelectionRange(6, 6);
+
+    // The daemon rejects it over the popup's own socket.
+    nodes.get("pair-form").dispatch("submit");
+    await tick(120);
+
+    assert.equal(
+      nodes.get("pair-error").classList.contains("hidden"),
+      false,
+      "precondition: the attempt was rejected",
+    );
+    assert.equal(
+      input.selectionStart === 0 && input.selectionEnd === input.value.length,
+      true,
+      `the rejected code must be selected so typing replaces it (got ${input.selectionStart}-${input.selectionEnd} of "${input.value}")`,
     );
   } finally {
     await bundle.close();

--- a/extension/tests/popup-pairing-jitter.integration.test.mjs
+++ b/extension/tests/popup-pairing-jitter.integration.test.mjs
@@ -496,6 +496,82 @@ test("the first paint is pinned to the state this browser will actually reach (D
   }
 });
 
+test("the pin is applied BEFORE the first paint, not by the deferred module (Q4)", async () => {
+  // The D1 test below reads the inline style AFTER `await bundle.import()`, so
+  // it structurally cannot observe the pre-module paint — it passed while the
+  // already-paired user still saw a 340px -> 207px resize on 4 of 12 opens,
+  // measured off composited frames. popup.js is `<script type="module">` and
+  // therefore DEFERRED: anything it does to layout happens after the compositor
+  // may already have painted the stylesheet's default pin.
+  //
+  // The fix is structural, so this guard is too: it pins the load order that
+  // closes the window, which a DOM read after import can never distinguish.
+  // Chrome is not available in CI, so the composited-frame measurement stays a
+  // manual step (recorded on the PR); this is the part that must not silently
+  // regress on a refactor.
+  const html = await readFile(join(HERE, "..", "src", "popup", "popup.html"), "utf8");
+  const head = html.slice(html.indexOf("<head>"), html.indexOf("</head>"));
+
+  const preScript = /<script(?![^>]*\btype\s*=\s*"module")[^>]*src="first-paint\.js"/.exec(head);
+  assert.ok(
+    preScript,
+    "first-paint.js must load from <head> as a CLASSIC script; as a module it is deferred past first paint",
+  );
+  // Compared on the TAGS, not on the first mention of each filename: the
+  // comment above the script names it too, so an indexOf on the raw text finds
+  // the comment and reports the right order however the tags are actually
+  // arranged. (Confirmed: that spelling survived a mutation that moved the
+  // <link> above the <script>.)
+  const stripped = head.replace(/<!--[\s\S]*?-->/g, "");
+  assert.ok(
+    /<script[^>]*src="first-paint\.js"[\s\S]*<link[^>]*href="popup\.css"/.test(stripped),
+    "the pre-paint script must precede the stylesheet: a classic script after a <link> blocks on it loading",
+  );
+  assert.ok(
+    !/<script[^>]*src="popup\.js"/.test(head),
+    "the module must not be moved into <head> instead — it stays deferred wherever it is",
+  );
+
+  // It must stay import-free. A single import makes it a module, which hands
+  // back exactly the deferral it exists to avoid.
+  const source = await readFile(join(HERE, "..", "src", "popup", "first-paint.js"), "utf8");
+  assert.ok(
+    !/^\s*import\s/m.test(source) && !/\brequire\s*\(/.test(source),
+    "first-paint.js must have no imports; any import makes it a deferred module",
+  );
+
+  // Its pins and key must agree with popup.ts, which owns them. They are
+  // duplicated because nothing can be shared with code that runs this early,
+  // and a silent divergence is a resize for one of the two populations.
+  const popup = await readFile(join(HERE, "..", "src", "popup", "popup.ts"), "utf8");
+  const owned = /readPairedHint\(\) \? "(\d+)px" : "(\d+)px"/.exec(popup);
+  assert.ok(owned, "popup.ts must still own the measured pins");
+  const early = /paired \? PAIRED_PIN : UNPAIRED_PIN/.test(source) && {
+    paired: /PAIRED_PIN = "(\d+)px"/.exec(source)?.[1],
+    unpaired: /UNPAIRED_PIN = "(\d+)px"/.exec(source)?.[1],
+  };
+  assert.ok(early, "first-paint.js must choose between a paired and an unpaired pin");
+  assert.equal(early.paired, owned[1], "the paired pin must match popup.ts");
+  assert.equal(early.unpaired, owned[2], "the unpaired pin must match popup.ts");
+
+  const key = /PAIRED_HINT_KEY = "([^"]+)"/.exec(popup)?.[1];
+  assert.ok(source.includes(`"${key}"`), `first-paint.js must read the same key (${key}) popup.ts writes`);
+
+  // And the CSS fallback must be the unpaired pin: it is what a browser whose
+  // hint cannot be read at all gets.
+  const css = await readFile(join(HERE, "..", "src", "popup", "popup.css"), "utf8");
+  const fallback = /#pending\s*\{[^}]*min-height:\s*(\d+)px/.exec(css);
+  assert.equal(fallback?.[1], owned[2], "the CSS fallback must be the unpaired pin");
+
+  // The store package is an explicit allowlist; an unlisted file ships a popup
+  // whose <head> references a 404 and whose pin is never applied.
+  const shipped = await readFile(join(HERE, "..", "store-package-files.txt"), "utf8");
+  assert.ok(
+    shipped.split("\n").includes("popup/first-paint.js"),
+    "first-paint.js must be in the store package allowlist",
+  );
+});
+
 test("the paired hint follows /health in both directions (D1)", async () => {
   // The hint is a layout guess and must never drift from reality: an unpair has
   // to shrink the next first paint back, or the returning user gets the resize

--- a/extension/tests/popup-pairing-jitter.integration.test.mjs
+++ b/extension/tests/popup-pairing-jitter.integration.test.mjs
@@ -1,0 +1,496 @@
+/* Behavioural coverage for the popup's PAIRING-FLOW STABILITY.
+ *
+ * A user reported the pairing experience as "jittery". Every defect behind that
+ * word lives in render() sequencing or in DOM side effects, not in a predicate:
+ * which section ships visible, whether a re-render steals focus, whether two
+ * concurrent renders paint in order, and whether the caret survives sanitising.
+ * A predicate matrix structurally cannot fail on any of them — the same reason
+ * popup-render.integration.test.mjs exists — so this file drives the real
+ * module the same way, with only chrome.* and the DOM stubbed.
+ *
+ * Every test here was confirmed RED against the pre-fix bundle and green after,
+ * so each one can actually go red on the defect it names.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { build } from "esbuild";
+import { mkdtemp, rm, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/** The ids popup.ts touches, kept as a literal list for the same reason the
+ * sibling suite does: a test that silently stops covering an element is worse
+ * than one that fails when an id is renamed. */
+const IDS = [
+  "connected", "paired", "pairing", "disconnected", "incompatible", "origin", "origin-ack",
+  "pending", "origin-host", "origin-again", "origin-scope", "origin-scope-detail",
+  "origin-position", "origin-waiting", "origin-allow", "origin-deny", "origin-previous",
+  "origin-next", "origin-ack-title", "origin-ack-sub", "origin-ack-check", "card", "retry",
+  "retry-incompatible", "connected-all-sites", "connected-all-sites-off", "pair-form",
+  "pair-code", "pair-error", "port", "port-row", "connected-label", "connected-detail",
+];
+
+/** A DOM stub that models the two behaviours these defects live in: real focus
+ * (so a stolen focus is observable) and a real caret (so a value assignment
+ * collapsing the selection is observable). */
+function installDomStub() {
+  const nodes = new Map();
+  const doc = { activeElement: null };
+  const make = (id) => {
+    const node = {
+      id,
+      tagName: id === "pair-form" ? "FORM" : "DIV",
+      textContent: "",
+      hidden: false,
+      disabled: false,
+      children: [],
+      dataset: {},
+      _value: "",
+      selectionStart: 0,
+      selectionEnd: 0,
+      _classes: new Set(id === "origin-again" ? ["again", "hidden"] : ["state"]),
+      classList: {
+        add: (c) => node._classes.add(c),
+        remove: (c) => node._classes.delete(c),
+        contains: (c) => node._classes.has(c),
+        toggle: (c, force) => {
+          const on = force === undefined ? !node._classes.has(c) : force;
+          if (on) node._classes.add(c);
+          else node._classes.delete(c);
+          return on;
+        },
+      },
+      style: { setProperty: () => {}, removeProperty: () => {} },
+      setAttribute: () => {},
+      removeAttribute: () => {},
+      addEventListener: (event, handler) => {
+        (node._handlers[event] ||= []).push(handler);
+      },
+      // Real focus bookkeeping: this is what J2 is about.
+      focus: () => {
+        doc.activeElement = node;
+        node.focusCount++;
+      },
+      focusCount: 0,
+      setSelectionRange: (s, e) => {
+        node.selectionStart = s;
+        node.selectionEnd = e;
+      },
+      // popup.ts uses form.contains(document.activeElement) to avoid stealing a
+      // focus the user placed inside the form themselves.
+      contains: (other) => other != null && (other === node || node._contains.has(other)),
+      _contains: new Set(),
+      replaceChildren: (...kids) => {
+        node.children = kids;
+        node.value = kids[0]?.value ?? "";
+      },
+      querySelectorAll: () => [],
+      _handlers: {},
+      click: () => (node._handlers.click || []).forEach((h) => h()),
+      dispatch: (event) => (node._handlers[event] || []).forEach((h) => h({ preventDefault() {} })),
+    };
+    // A real <input> collapses the selection to the end when `.value` is
+    // assigned a DIFFERENT string, and short-circuits an identical one. That
+    // asymmetry IS the caret defect, so it has to be modelled, not assumed.
+    Object.defineProperty(node, "value", {
+      get: () => node._value,
+      set: (v) => {
+        const next = String(v);
+        if (next === node._value) return; // Chrome's identical-value short circuit.
+        node._value = next;
+        node.selectionStart = next.length;
+        node.selectionEnd = next.length;
+      },
+    });
+    Object.defineProperty(node, "options", { get: () => node.children });
+    Object.defineProperty(node, "selectedOptions", {
+      get: () => node.children.filter((c) => c.value === node.value),
+    });
+    return node;
+  };
+  for (const id of IDS) nodes.set(id, make(id));
+  // The pairing form really does contain the code input and the submit button.
+  nodes.get("pair-form")._contains.add(nodes.get("pair-code"));
+
+  const submit = make("pair-submit");
+  submit.tagName = "BUTTON";
+  nodes.set("pair-submit", submit);
+  nodes.get("pair-form")._contains.add(submit);
+
+  globalThis.document = {
+    getElementById: (id) => nodes.get(id) ?? null,
+    createElement: () => make("option"),
+    querySelectorAll: () => [],
+    querySelector: (sel) => (sel.includes("submit") ? submit : null),
+    addEventListener: () => {},
+    documentElement: make("html"),
+    body: make("body"),
+    get activeElement() {
+      return doc.activeElement;
+    },
+    set activeElement(v) {
+      doc.activeElement = v;
+    },
+  };
+  globalThis.window = {
+    close: () => {},
+    matchMedia: () => ({ matches: false, addEventListener: () => {} }),
+  };
+  return nodes;
+}
+
+function installChromeStub() {
+  const areas = { session: new Map(), local: new Map() };
+  const listeners = [];
+  const sent = [];
+  const makeArea = (name) => ({
+    get: async (keys) => {
+      const out = {};
+      for (const key of Array.isArray(keys) ? keys : [keys]) {
+        if (areas[name].has(key)) out[key] = areas[name].get(key);
+      }
+      return out;
+    },
+    set: async (obj) => {
+      const changes = {};
+      for (const [key, value] of Object.entries(obj)) {
+        changes[key] = { oldValue: areas[name].get(key), newValue: value };
+        areas[name].set(key, value);
+      }
+      for (const listener of listeners) listener(changes, name);
+    },
+    remove: async (keys) => {
+      const changes = {};
+      for (const key of Array.isArray(keys) ? keys : [keys]) {
+        changes[key] = { oldValue: areas[name].get(key), newValue: undefined };
+        areas[name].delete(key);
+      }
+      for (const listener of listeners) listener(changes, name);
+    },
+  });
+  globalThis.chrome = {
+    storage: {
+      session: makeArea("session"),
+      local: makeArea("local"),
+      onChanged: { addListener: (fn) => listeners.push(fn) },
+    },
+    runtime: {
+      sendMessage: async (message) => {
+        sent.push(message);
+        return { applied: true };
+      },
+      openOptionsPage: () => {},
+      getManifest: () => ({ version: "0.1.9" }),
+    },
+    tabs: { query: async () => [] },
+  };
+  return { areas, sent };
+}
+
+const tick = (n = 6) => new Promise((r) => setTimeout(r, n));
+
+async function loadPopup() {
+  const dir = await mkdtemp(join(tmpdir(), "lop-popup-jitter-"));
+  const outfile = join(dir, "popup.mjs");
+  await build({
+    entryPoints: [join(HERE, "..", "src", "popup", "popup.ts")],
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    outfile,
+  });
+  return {
+    import: () => import(pathToFileURL(outfile) + `?t=${Math.random()}`),
+    close: () => rm(dir, { recursive: true, force: true }),
+  };
+}
+
+/** A reachable daemon whose /health answer and LATENCY are both controllable.
+ * Latency is what puts two renders in flight at once, which is the whole of
+ * the ordering defect. */
+function installFetchStub(paired, delayMs = () => 0) {
+  globalThis.fetch = async () => {
+    const wait = delayMs();
+    // The answer is snapshotted when the request STARTS, exactly as a real
+    // /health round trip is: the daemon's reply describes the moment it was
+    // asked, not the moment it arrives. Reading the flag at resolve time
+    // instead makes a slow probe silently return the newest state, which is
+    // precisely the stale answer this test needs to exist.
+    const snapshot = paired();
+    if (wait) await new Promise((r) => setTimeout(r, wait));
+    return {
+      ok: true,
+      json: async () => ({
+        paired: snapshot,
+        extension_connected: true,
+        protocol_version: 1,
+        pending_origin: undefined,
+      }),
+    };
+  };
+}
+
+/* ------------------------------------------------------------------ J1 ---- */
+
+test("no diagnostic state ships visible: the first paint is neutral (J1)", async () => {
+  // This one is about the SHIPPED MARKUP, which is what the browser paints
+  // before render()'s awaits resolve. Asserted against popup.html itself
+  // because that file, not the module, decides the pre-render frame.
+  const html = await readFile(join(HERE, "..", "src", "popup", "popup.html"), "utf8");
+  const visible = [...html.matchAll(/<section\s+id="([\w-]+)"\s+class="state([^"]*)"/g)]
+    .filter((m) => !m[2].includes("hidden"))
+    .map((m) => m[1]);
+
+  assert.deepEqual(
+    visible,
+    ["pending"],
+    "exactly one section may ship visible, and it must be the neutral placeholder",
+  );
+  // The specific regression: the error card was the pre-render default, so
+  // every popup open flashed "Not connected." for the length of the /health
+  // round trip.
+  assert.ok(
+    !visible.includes("disconnected"),
+    "the disconnected card must never be the pre-render default",
+  );
+  // The placeholder must not diagnose anything, or it is the same defect with
+  // different copy.
+  const pending = html.slice(html.indexOf('<section id="pending"'));
+  const body = pending.slice(0, pending.indexOf("</section>"));
+  assert.doesNotMatch(body, /not reachable|isn't reachable|Not connected/i,
+    "the placeholder must not assert a connection verdict it has not established");
+});
+
+/* ------------------------------------------------------------------ J7 ---- */
+
+test("the pairing card holds one height across placeholder, form and error (J1/J7)", async () => {
+  // A Chrome action popup auto-sizes to its content, so any height difference
+  // between these three is a visible resize of the popup WINDOW — the "jittery"
+  // report. The stylesheet is the only thing that decides it, so it is asserted
+  // here rather than through the module.
+  //
+  // The numbers are measured, not guessed: rendered in Chrome 152 at the
+  // popup's true 300x600 metrics against a real daemon, the card is 358px for
+  // the placeholder, the pairing form, and the form carrying an error alike.
+  // Before the fix the same sequence measured 259 -> 292 -> 358.
+  const css = await readFile(join(HERE, "..", "src", "popup", "popup.css"), "utf8");
+
+  const pendingMin = /#pending\s*\{[^}]*min-height:\s*(\d+)px/.exec(css);
+  assert.ok(pendingMin, "the placeholder must pin a height, or the card resizes when render() settles");
+
+  const errorMin = /#pair-error\s*\{[^}]*min-height:\s*(\d+)px/.exec(css);
+  assert.ok(errorMin, "the pairing error must reserve its space rather than reflow the card");
+
+  // Reserved space is only reserved if the hidden line still occupies it.
+  assert.match(
+    css,
+    /#pair-error\.hidden\s*\{[^}]*visibility:\s*hidden/,
+    "the hidden error must stay in flow (visibility), not be removed from it (display:none)",
+  );
+  // ...and it must not become permanently invisible: role="alert" only
+  // announces a message the AT can reach.
+  assert.match(
+    css,
+    /#pair-error\.hidden\s*\{[^}]*display:\s*block/,
+    "the hidden error must override the shared .hidden display:none to keep its box",
+  );
+});
+
+/* ------------------------------------------------------------------ J2 ---- */
+
+test("a re-render does not yank focus back into the pairing code field (J2)", async () => {
+  const nodes = installDomStub();
+  const { areas } = installChromeStub();
+  installFetchStub(() => false);
+  const bundle = await loadPopup();
+  try {
+    areas.local.set("port", 4099);
+    await bundle.import();
+    await tick(30);
+
+    const input = nodes.get("pair-code");
+    assert.equal(nodes.get("pairing").classList.contains("hidden"), false, "precondition: the form is up");
+    assert.equal(document.activeElement, input, "precondition: a newly shown form takes focus once");
+
+    // The user reads the code out of the terminal and tabs onward. While
+    // unpaired the worker idle-suspends and the alarm floor rewakes it, so
+    // connState is rewritten under them on every teardown and hello_ack.
+    const submit = nodes.get("pair-submit");
+    submit.focus();
+    const focusesBefore = input.focusCount;
+
+    await chrome.storage.session.set({ connState: "connecting" });
+    await tick(30);
+    await chrome.storage.session.set({ connState: "pairing" });
+    await tick(30);
+
+    assert.equal(
+      document.activeElement,
+      submit,
+      "a re-render must not steal focus from a user who has tabbed onward",
+    );
+    assert.equal(
+      input.focusCount,
+      focusesBefore,
+      "the code field must not be re-focused by a render that changed nothing",
+    );
+  } finally {
+    await bundle.close();
+  }
+});
+
+test("re-entering the pairing state after leaving it focuses the field again (J2)", async () => {
+  // The other half of the rule: suppressing focus entirely would be a
+  // regression for the case the focus exists to serve.
+  const nodes = installDomStub();
+  const { areas } = installChromeStub();
+  let paired = true;
+  installFetchStub(() => paired);
+  const bundle = await loadPopup();
+  try {
+    areas.local.set("port", 4099);
+    await bundle.import();
+    await tick(30);
+    assert.equal(nodes.get("connected").classList.contains("hidden"), false, "precondition: connected");
+
+    // An unpair drops back to the form: this IS a newly-shown form.
+    paired = false;
+    await chrome.storage.session.set({ connState: "pairing" });
+    await tick(30);
+
+    assert.equal(nodes.get("pairing").classList.contains("hidden"), false, "the form is up again");
+    assert.equal(
+      document.activeElement,
+      nodes.get("pair-code"),
+      "a form the user has not seen yet must take focus",
+    );
+  } finally {
+    await bundle.close();
+  }
+});
+
+/* ------------------------------------------------------------------ J3 ---- */
+
+test("concurrent renders never paint an older state over a newer one (J3)", async () => {
+  const nodes = installDomStub();
+  const { areas } = installChromeStub();
+  // Render A sees UNPAIRED and is slow; render B sees PAIRED and is fast. A
+  // started first, so unserialised it finishes last and repaints the form over
+  // the connected card. Latency varying is the ordinary condition; only its
+  // size is amplified here.
+  //
+  // The delay is keyed on WHAT the probe will observe, not on a call index: a
+  // positional counter is consumed by whichever renders happen to run first
+  // (module load fires one immediately), so it stops landing on the render this
+  // test is about and the race silently never happens.
+  let paired = false;
+  installFetchStub(
+    () => paired,
+    () => (paired ? 0 : 120),
+  );
+  const bundle = await loadPopup();
+  try {
+    areas.local.set("port", 4099);
+
+    // Record every painted state transition. Only the states render() itself
+    // paints are tracked, so the sequence is comparable across trees whose
+    // shipped markup differs (the pre-fix tree has no `pending` section).
+    const TRACKED = ["connected", "paired", "pairing", "disconnected"];
+    const painted = [];
+    const watch = () => {
+      const shown = TRACKED.filter((id) => !nodes.get(id).classList.contains("hidden")).join(",");
+      if (!shown) return; // pre-render, before any show() has run
+      if (painted[painted.length - 1] !== shown) painted.push(shown);
+    };
+    const timer = setInterval(watch, 2);
+
+    // NOT awaited: the module-load render must still be in flight when the
+    // storage event fires, or there is only ever one render running and the
+    // race this test exists for cannot happen. Awaiting the import here made
+    // the test pass against the pre-fix bundle — it was guarding nothing.
+    void bundle.import();
+    // Long enough for that render to reach its slow /health await, short enough
+    // that it has not resolved (the unpaired probe takes 120ms).
+    await tick(20);
+    // The pairing lands while render A is still awaiting its slow /health.
+    paired = true;
+    await chrome.storage.session.set({ connState: "connected" });
+    await tick(600);
+    clearInterval(timer);
+    watch();
+
+    // The defect is a state the popup had already LEFT being painted again.
+    // Expressed as "no state repeats after a different one intervened", which
+    // is the bounce the user sees, rather than as a rank ordering — the set of
+    // states a tree can paint differs between trees, the bounce does not.
+    const bounces = [];
+    for (let i = 2; i < painted.length; i++) {
+      if (painted[i] === painted[i - 2] && painted[i] !== painted[i - 1]) {
+        bounces.push(`${painted[i - 2]} -> ${painted[i - 1]} -> ${painted[i]}`);
+      }
+    }
+    assert.deepEqual(
+      bounces,
+      [],
+      `a render that started earlier must not repaint a state the popup had left (sequence: ${JSON.stringify(painted)})`,
+    );
+    assert.equal(
+      nodes.get("connected").classList.contains("hidden"),
+      false,
+      `the settled card must be the newest state (sequence: ${JSON.stringify(painted)})`,
+    );
+  } finally {
+    await bundle.close();
+  }
+});
+
+/* ------------------------------------------------------------------ J8 ---- */
+
+test("sanitising the code keeps the caret where the edit happened (J8)", async () => {
+  const nodes = installDomStub();
+  const { areas } = installChromeStub();
+  installFetchStub(() => false);
+  const bundle = await loadPopup();
+  try {
+    areas.local.set("port", 4099);
+    await bundle.import();
+    await tick(30);
+
+    const input = nodes.get("pair-code");
+
+    // Digit-only typing: the value is unchanged, so Chrome's identical-value
+    // short circuit already protected this. Confirmed with real keystrokes in
+    // Chrome 152; asserted here so a "fix" cannot regress it.
+    input._value = "12934";
+    input.setSelectionRange(3, 3);
+    input.dispatch("input");
+    assert.equal(input.value, "12934", "digits are kept verbatim");
+    assert.equal(input.selectionStart, 3, "a digit-only edit must not move the caret");
+
+    // A stripped character mid-string: the assignment genuinely changes the
+    // value, so before the fix the caret jumped to the end and the next
+    // character landed in the wrong place.
+    input._value = "12x34";
+    input.setSelectionRange(3, 3);
+    input.dispatch("input");
+    assert.equal(input.value, "1234", "the non-digit is stripped");
+    assert.equal(
+      input.selectionStart,
+      2,
+      "the caret must stay at the edit point, not jump to the end of the field",
+    );
+
+    // A pasted mixed string: every stripped character before the caret shifts
+    // it left by one, and none after it do.
+    input._value = "1-2-3-4";
+    input.setSelectionRange(7, 7);
+    input.dispatch("input");
+    assert.equal(input.value, "1234", "separators are stripped");
+    assert.equal(input.selectionStart, 4, "the caret follows the surviving digits");
+  } finally {
+    await bundle.close();
+  }
+});

--- a/extension/tests/popup-pairing-jitter.integration.test.mjs
+++ b/extension/tests/popup-pairing-jitter.integration.test.mjs
@@ -70,7 +70,15 @@ function installDomStub() {
         (node._handlers[event] ||= []).push(handler);
       },
       // Real focus bookkeeping: this is what J2 is about.
+      //
+      // A DISABLED element refuses focus — the actual DOM rule, and the one the
+      // pairing form's unlock ordering depends on. Modelling it matters: with
+      // focus granted unconditionally, a `select()` called while the input is
+      // still disabled looks identical to one called after the unlock, and the
+      // U8 defect (select() before setPairBusy(false) in the catch branch, so
+      // the corrected code is still swallowed) is invisible to every assertion.
       focus: () => {
+        if (node.disabled) return;
         doc.activeElement = node;
         node.focusCount++;
       },
@@ -79,12 +87,16 @@ function installDomStub() {
         node.selectionStart = s;
         node.selectionEnd = e;
       },
-      // A real input's select() focuses and selects the whole value.
+      // A real input's select() focuses and selects the whole value — and, like
+      // focus(), gets nothing on a disabled element: the range is set on
+      // something that is not focused, so the next keystroke goes to the body.
+      // That asymmetry IS U8, so it has to be modelled rather than assumed.
       select: () => {
-        doc.activeElement = node;
-        node.focusCount++;
         node.selectionStart = 0;
         node.selectionEnd = node._value.length;
+        if (node.disabled) return;
+        doc.activeElement = node;
+        node.focusCount++;
       },
       // popup.ts uses form.contains(document.activeElement) to avoid stealing a
       // focus the user placed inside the form themselves.
@@ -843,6 +855,17 @@ test("a rejected code is selected so the next keystroke replaces it (U1)", async
     input._value = "707770";
     input.setSelectionRange(6, 6);
 
+    // Same spy as the U8 test on the sibling branch: the unlock must precede
+    // the selection here too. Without this the identical ordering defect could
+    // be introduced on THIS branch and every assertion below would still pass,
+    // because `finally` re-enables the input before they run.
+    let enabledWhenSelected = null;
+    const realSelect = input.select;
+    input.select = () => {
+      enabledWhenSelected = !input.disabled;
+      realSelect();
+    };
+
     // The daemon rejects it over the popup's own socket.
     nodes.get("pair-form").dispatch("submit");
     await tick(120);
@@ -853,9 +876,112 @@ test("a rejected code is selected so the next keystroke replaces it (U1)", async
       "precondition: the attempt was rejected",
     );
     assert.equal(
+      enabledWhenSelected,
+      true,
+      "the input must already be re-enabled when the rejected code is selected",
+    );
+    assert.equal(
       input.selectionStart === 0 && input.selectionEnd === input.value.length,
       true,
       `the rejected code must be selected so typing replaces it (got ${input.selectionStart}-${input.selectionEnd} of "${input.value}")`,
+    );
+  } finally {
+    await bundle.close();
+  }
+});
+
+test("a failed socket upgrade leaves the field usable for the retry (U8)", async () => {
+  // The transport-failure branch, which is NOT reached by killing the daemon:
+  // an unreachable daemon renders the `disconnected` card, where this copy and
+  // this recovery are off screen entirely. It is live only when /health is
+  // REACHABLE but the WebSocket upgrade fails — a refused upgrade, a daemon
+  // mid-restart still serving HTTP, a stale worker. So the fetch stub stays
+  // healthy and only the socket fails.
+  //
+  // The assertions are on the OPERATIVE facts — the input is enabled, it is
+  // focused, and a subsequently typed code actually reaches the field. Checking
+  // that `select()` was called would pass on the broken ordering, which is this
+  // PR's recurring failure mode: the guard names the right behaviour and
+  // measures the wrong quantity.
+  const nodes = installDomStub();
+  const { areas } = installChromeStub();
+  installFetchStub(() => false);
+  // Reachable daemon, refused upgrade: the socket errors after construction
+  // rather than opening, which is what lands the handler in `catch`.
+  globalThis.WebSocket = class {
+    constructor() {
+      queueMicrotask(() => this.onerror?.({}));
+    }
+    send() {}
+    close() {}
+  };
+
+  const bundle = await loadPopup();
+  try {
+    areas.local.set("port", 4099);
+    await bundle.import();
+    await tick(30);
+
+    const input = nodes.get("pair-code");
+    input._value = "707770";
+    input.setSelectionRange(6, 6);
+
+    // Record the input's state AT THE MOMENT the recovery runs. Sampling after
+    // the handler returns cannot see this defect: `finally` re-enables the
+    // input, so by then `disabled` is false either way. The ordering is the
+    // whole finding, so it has to be observed while it is happening.
+    //
+    // The browser refuses focus to a disabled element, so the observable
+    // consequence is that the selection is applied to something the user is not
+    // typing into. This spy records enablement at the instant of selection.
+    let enabledWhenSelected = null;
+    const realSelect = input.select;
+    input.select = () => {
+      enabledWhenSelected = !input.disabled;
+      realSelect();
+    };
+
+    nodes.get("pair-form").dispatch("submit");
+    await tick(150);
+
+    assert.equal(
+      nodes.get("pair-error").classList.contains("hidden"),
+      false,
+      "precondition: the transport failure surfaced an error",
+    );
+    assert.match(
+      nodes.get("pair-error").textContent,
+      /Could not reach/,
+      "precondition: this is the catch branch, not the mismatch branch",
+    );
+
+    // The ordering defect, stated directly: `setPairBusy(false)` runs in
+    // `finally`, i.e. AFTER the catch body, so a select() placed before it acts
+    // on a disabled input and the range lands on an element that cannot be
+    // typed into.
+    assert.equal(
+      enabledWhenSelected,
+      true,
+      "the input must already be re-enabled when the recovery selects it; " +
+        "select() on a disabled input sets a range the user cannot type over",
+    );
+    assert.equal(input.disabled, false, "the input must end the handler enabled");
+    assert.equal(document.activeElement, input, "the input must hold focus for the retry");
+    assert.equal(input.selectionStart, 0, "the typed code must be selected");
+    assert.equal(input.selectionEnd, 6, "the typed code must be selected");
+
+    // The consequence the user feels. maxlength="6" is already satisfied by the
+    // digits in the field, so unless the selection is live the corrected code
+    // is silently discarded — the exact defect U6 was filed for.
+    const typed = "707776";
+    if (document.activeElement === input && input.selectionEnd > input.selectionStart) {
+      input._value = typed; // the selection is replaced by what the user types
+      input.setSelectionRange(typed.length, typed.length);
+    }
+    assert.equal(
+      input.value,
+      typed,
+      "a corrected code typed over the selection must land, not be swallowed by maxlength",
     );
   } finally {
     await bundle.close();

--- a/extension/tests/release.test.mjs
+++ b/extension/tests/release.test.mjs
@@ -56,7 +56,13 @@ async function runRelease(args, handlers) {
 
 test("manifest requests tabGroups exactly once", async () => {
   const manifest = JSON.parse(await readFile(new URL("../manifest.json", import.meta.url), "utf8"));
-  assert.equal(manifest.version, "0.1.8");
+  // The invariant is that the two manifests AGREE, not that they sit at one
+  // hardcoded number: the store package is built from manifest.json while every
+  // release script reads package.json, so a bump applied to only one of them
+  // ships a zip whose version does not match what was promoted. A literal here
+  // just has to be edited on every release, and says nothing when it is.
+  assert.equal(manifest.version, VERSION, "manifest.json and package.json must carry the same version");
+  assert.match(manifest.version, /^\d+\.\d+\.\d+$/, "the manifest version must be a plain semver triple");
   assert.equal(manifest.permissions.filter((permission) => permission === "tabGroups").length, 1);
 });
 

--- a/extension/tests/worker-pairing-eviction.integration.test.mjs
+++ b/extension/tests/worker-pairing-eviction.integration.test.mjs
@@ -1,0 +1,214 @@
+/* Coverage for the worker's close-code handling during PAIRING (J4).
+ *
+ * When the user submits a pairing code, the POPUP opens its own socket to the
+ * daemon. The daemon's "later connection wins" rule evicts the worker's socket
+ * with close code 4000 — an ordinary, expected part of every pair, not a loss
+ * of connectivity. The worker nonetheless published `connState: "disconnected"`
+ * from its teardown, and because the popup re-enters render() on any connState
+ * write (chrome.storage.onChanged), the card painted an extra transition
+ * mid-pair. Measured in real Chrome against a real daemon: 4/15 baseline runs
+ * showed pairing -> connected -> paired -> connected or
+ * paired -> connected -> pairing -> connected.
+ *
+ * The fix suppresses ONLY the storage write for 4000. This file pins both
+ * halves: the write is gone, and the reconnect the worker still owes is not.
+ * Reverting the `!== 4000` guard turns the first test red.
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { build } from "esbuild";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const tick = (n = 4) => new Promise((r) => setTimeout(r, n));
+
+/** Load worker.ts against a socket whose close code the test controls, and
+ * record every chrome.storage.session write it makes. */
+async function loadWorker() {
+  const session = new Map();
+  const local = new Map([["token", "tok"], ["port", 4099]]);
+  const writes = [];
+  let socket;
+  let alarmsCreated = 0;
+  let socketsOpened = 0;
+
+  Object.defineProperty(globalThis, "navigator", {
+    value: { userAgent: "node-test" },
+    configurable: true,
+    writable: true,
+  });
+  globalThis.WebSocket = class {
+    static OPEN = 1;
+    readyState = 1;
+    constructor() {
+      socket = this;
+      socketsOpened++;
+      queueMicrotask(() => this.onopen?.());
+    }
+    send() {}
+    close() {}
+  };
+  const area = (map, name) => ({
+    get: async (keys) => {
+      const out = {};
+      for (const k of Array.isArray(keys) ? keys : [keys]) if (map.has(k)) out[k] = map.get(k);
+      return out;
+    },
+    set: async (obj) => {
+      if (name === "session") writes.push({ ...obj });
+      for (const [k, v] of Object.entries(obj)) map.set(k, v);
+    },
+    remove: async (keys) => {
+      for (const k of Array.isArray(keys) ? keys : [keys]) map.delete(k);
+    },
+  });
+  // The chrome surface worker.ts evaluates against, mirroring the one in
+  // driven-handles.integration.test.mjs. Only storage.session is instrumented:
+  // that is the channel the popup renders off, and so the one this defect
+  // travels down.
+  globalThis.chrome = {
+    storage: {
+      session: area(session, "session"),
+      local: area(local, "local"),
+      onChanged: { addListener: () => {} },
+    },
+    alarms: {
+      // The re-dial the worker still owes after an eviction is scheduled here,
+      // so counting these is how the test proves the fix did not suppress it.
+      create: () => {
+        alarmsCreated++;
+      },
+      clear: async () => {},
+      onAlarm: { addListener: () => {} },
+    },
+    action: Object.fromEntries(
+      ["setBadgeBackgroundColor", "setBadgeTextColor", "setBadgeText", "setTitle"].map((m) => [
+        m,
+        async () => {},
+      ]),
+    ),
+    debugger: {
+      attach: async () => {},
+      detach: async () => {},
+      sendCommand: async () => ({}),
+      onEvent: { addListener: () => {} },
+      onDetach: { addListener: () => {} },
+    },
+    tabs: {
+      get: async (tabId) => ({ id: tabId, url: "https://example.com/live", title: "Live" }),
+      remove: async () => {},
+      query: async () => [],
+      onRemoved: { addListener: () => {} },
+      onReplaced: { addListener: () => {} },
+      onUpdated: { addListener: () => {} },
+    },
+    tabGroups: undefined,
+    notifications: { create: async () => {}, clear: async () => {}, onClicked: { addListener: () => {} } },
+    windows: { get: async () => ({ id: 1 }), getCurrent: async () => ({ id: 1 }) },
+    runtime: {
+      getURL: (p) => `chrome-extension://test/${p}`,
+      getManifest: () => ({ version: "0.1.9" }),
+      onStartup: { addListener: () => {} },
+      onInstalled: { addListener: () => {} },
+      onMessage: { addListener: () => {} },
+      sendMessage: async () => {},
+    },
+  };
+
+  const dir = await mkdtemp(join(tmpdir(), "lop-worker-evict-"));
+  const outfile = join(dir, "worker.mjs");
+  await build({
+    entryPoints: [join(HERE, "..", "src", "worker.ts")],
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    outfile,
+  });
+  await import(pathToFileURL(outfile) + `?${Date.now()}`);
+  for (let i = 0; i < 60 && !socket; i++) await tick();
+  assert.ok(socket, "the worker opened a socket");
+  await tick(20);
+
+  return {
+    get writes() {
+      return writes;
+    },
+    get alarmsCreated() {
+      return alarmsCreated;
+    },
+    /** Close the worker's socket the way the daemon does, then wait out the
+     * reconnect fast path (backoffDelayMs(0)) and report whether the worker
+     * actually dialled again. scheduleReconnect uses setTimeout, not the
+     * alarm, so the re-dial is observed as a NEW SOCKET rather than inferred
+     * from chrome.alarms. */
+    evict: async (code) => {
+      const before = socketsOpened;
+      socket.onclose?.({ code });
+      await tick(1400);
+      return { reconnectScheduled: socketsOpened > before };
+    },
+    connState: () => session.get("connState"),
+    close: () => rm(dir, { recursive: true, force: true }),
+  };
+}
+
+test("the pairing socket's 4000 eviction does not publish a disconnect (J4)", async () => {
+  const worker = await loadWorker();
+  try {
+    const stateBefore = worker.connState();
+    const { reconnectScheduled } = await worker.evict(4000);
+
+    const disconnects = worker.writes.filter((w) => w.connState === "disconnected");
+    assert.deepEqual(
+      disconnects,
+      [],
+      "a 4000 eviction is the popup's own pairing socket winning, not a lost connection",
+    );
+    assert.equal(
+      worker.connState(),
+      stateBefore,
+      "the published state must not move: a render driven off this write repaints the card mid-pair",
+    );
+    // The other half. The socket really is gone, so suppressing the write must
+    // not suppress the re-dial — without it the worker never reconnects with
+    // the new token and pairing hangs on "Connecting…" forever.
+    assert.equal(reconnectScheduled, true, "the worker must still re-dial after a 4000 eviction");
+  } finally {
+    await worker.close();
+  }
+});
+
+test("an ordinary disconnect still publishes disconnected (J4 regression guard)", async () => {
+  // The suppression is scoped to 4000 alone. A real disconnect must still tell
+  // the popup, or the fix has traded a flicker for a silent dead connection.
+  const worker = await loadWorker();
+  try {
+    const { reconnectScheduled } = await worker.evict(1006);
+    assert.equal(
+      worker.connState(),
+      "disconnected",
+      "a genuine transport failure must still surface to the popup",
+    );
+    assert.equal(reconnectScheduled, true, "and must still re-dial");
+  } finally {
+    await worker.close();
+  }
+});
+
+test("protocol and unpair close codes keep their own states (J4 regression guard)", async () => {
+  for (const [code, expected] of [
+    [4001, "incompatible"],
+    [4003, "pairing"],
+  ]) {
+    const worker = await loadWorker();
+    try {
+      await worker.evict(code);
+      assert.equal(worker.connState(), expected, `close ${code} must still publish "${expected}"`);
+    } finally {
+      await worker.close();
+    }
+  }
+});

--- a/local_operator/browser_bridge/daemon.py
+++ b/local_operator/browser_bridge/daemon.py
@@ -618,10 +618,15 @@ class BridgeService:
             else:
                 pending["attempts"] = attempts
                 _private_write(_pending_path(self.root), pending)
-                message = (
-                    "That code did not match. Codes expire after two minutes; "
-                    "check the app for a fresh one."
-                )
+                # Two lines at the popup's 300px width, not three. The popup
+                # reserves a fixed slot for this message so a failed attempt
+                # cannot resize the window (extension/src/popup/popup.css), and
+                # the reservation is sized to the LONGEST string that can land
+                # in it — so every word here costs vertical space on a card that
+                # is showing no error at all. Kept byte-identical to the
+                # extension's own PAIR_MISMATCH_MESSAGE fallback, which is the
+                # string a user sees when the daemon sends none.
+                message = "That code didn't match. Codes expire after two minutes."
             return PairResult(ok=False, message=message)
         token = secrets.token_urlsafe(32)
         _private_write(

--- a/local_operator/browser_bridge/daemon.py
+++ b/local_operator/browser_bridge/daemon.py
@@ -626,7 +626,7 @@ class BridgeService:
                 # is showing no error at all. Kept byte-identical to the
                 # extension's own PAIR_MISMATCH_MESSAGE fallback, which is the
                 # string a user sees when the daemon sends none.
-                message = "That code didn't match. Codes expire after two minutes."
+                message = "That code didn't match. Codes expire after two minutes — check the app."
             return PairResult(ok=False, message=message)
         token = secrets.token_urlsafe(32)
         _private_write(


### PR DESCRIPTION
## What and why

A user reported the extension's pairing-code experience as "a bit jittery" and could not elaborate. A read-only scout audited the source and produced six candidate findings, all unreproduced. **Every one was reproduced by execution first** — in real Chrome 152 against a real bridge daemon, on an isolated `HOME` + config dir — and one of the scout's claims was partly wrong and is corrected below.

**Change class: C2** (user-visible behaviour fix, no schema/wire/permission change; no `PROTO_VERSION` bump, no manifest permission change).

Extension version bumped 0.1.8 → 0.1.9 (its own Chrome Web Store release line). **`pyproject.toml` is deliberately untouched** — the runtime version belongs to a release-window owner.

## Per-finding disposition

| ID | Verdict | Disposition |
|---|---|---|
| J1 | REPRODUCED | Fixed |
| J2 | REPRODUCED | Fixed |
| J3 | REPRODUCED | Fixed |
| J4 | REPRODUCED (mechanism), symptom REFUTED | Fixed |
| J5 | REPRODUCED | Deliberately not fixed |
| J7 | REPRODUCED | Fixed |
| J8 | PARTLY reproduced — scout's main hypothesis REFUTED | Fixed (the real half) |

### J1 (BLOCKER) — every popup open painted "Not connected." first — VERIFIED, FIXED

`popup.html` shipped `#disconnected` as the only section without `hidden`, and `render()` is async (it awaits `getSession()` then a real `/health` fetch), so Chrome painted a diagnostic error card before any `show()` ran.

Measured, per-animation-frame sampling of what the compositor actually showed:

```
BEFORE: [{"seen":"disconnected","h":259},{"seen":"pairing","h":292}]
AFTER:  [{"seen":"pending","h":358},{"seen":"pairing","h":358}]
```

**The scout's caveat about the paint COUNT is settled: it is exactly two painted styled frames, not more.** The fix ships every section hidden and adds a neutral `#pending` placeholder that asserts nothing about the connection; `render()` resolves it away.

### J2 (MAJOR) — `show("pairing")` re-focused the input on every render — VERIFIED, FIXED

`render()` is re-entered from `chrome.storage.onChanged` on any `connState` write, which the worker performs on every teardown and `hello_ack`. Reproduced by focusing the Pair button and writing `connState`:

```
BEFORE: focus was on "BUTTON"; a connState write yanked it to "pair-code" (caret 1)
AFTER:  focus stayed on "BUTTON" across the re-render
```

Fixed by mirroring the pattern **this same file already used for the sibling flow** (`freshPrompt`): focus is taken only by a newly-shown form, and never when `document.activeElement` is already inside `#pair-form`. A test pins the other half — a form the user has *not* seen still takes focus.

### J3 (MAJOR) — `render()` had no re-entrancy guard — VERIFIED, FIXED

With variable `/health` latency a render that starts first can finish last and repaint a state older than one already on screen. Reproduced **across a real pairing** (only the latency was amplified; latency varying is the ordinary condition):

```
BEFORE: pairing -> paired -> connected -> pairing -> connected
AFTER:  pairing -> paired -> connected
```

Fixed by **serialising** renders (one running, at most one queued) rather than discarding a late one mid-flight. That choice is deliberate and load-bearing: `render()` mutates the origin-consent state (`decidedOrigin`, `repeatAskByOrigin`, `shownPromptId`/`Origin`, `scopeBuiltForEntryId`) that six review rounds and five consecutive MAJORs were spent getting right. Running each render alone to completion is exactly the behaviour that logic was reviewed against — it only removes the interleaving. A generation counter that abandoned a render mid-flight would leave those mutations half-applied.

### J4 — the pairing socket's 4000 eviction drove the popup backwards — VERIFIED (mechanism), FIXED — but the predicted symptom is REFUTED

Per the architect's ruling. The popup's own pairing socket evicts the worker's with close 4000 (the daemon's later-connection-wins rule), and the worker published `connState: "disconnected"` for it, which re-enters `render()` and paints an extra transition mid-pair.

**Stated plainly: the predicted false "Could not reach Local Operator on this machine" error does NOT occur** (0/27 runs; pair round-trip median 17 ms against a 1000 ms re-dial). What the user actually sees is the extra paint. Suppressing only the storage write leaves the local resets and `scheduleReconnect()` intact — the socket really is gone and the worker must re-dial. Two regression tests pin that an ordinary disconnect (1006) and the 4001/4003 codes still publish their own states.

Security invariant untouched: drive authority is enforced daemon-side by `link.paired`, never by this storage key.

### J5 — "Connecting…" dwell — VERIFIED, DELIBERATELY NOT FIXED

Confirmed in my runs too; the `paired` card dwells ~1 s before `connected`, caused by `backoffDelayMs(0)`, not the ~1-minute alarm floor the scout feared. That second is honest (the daemon really does report `paired:false` until the worker reconnects) and reads as confirmation rather than a stall. Shortening it means detuning reconnect-storm backoff or handing the token to the worker — real complexity for one second on a once-per-install flow.

### J7 — the error line reflowed the card — VERIFIED, FIXED

```
BEFORE: card grew 292px -> 358px (+66px) when the error line un-hid
AFTER:  error shown, height unchanged at 358px
```

A Chrome action popup auto-sizes to content, so this resized the popup window under the cursor at the moment the user was re-reading a rejected code. The line now reserves its space and stays in flow (`visibility: hidden`, not `display: none`), which also keeps `role="alert"` announceable — scoped to `#pair-error` so no other state pays for blank space.

### J8 (NIT) — caret on mid-string typing — the scout's main hypothesis is REFUTED; the real half is fixed

The scout could not run this and asked for the thirty-second keystroke test. Run with real CDP keystrokes:

```
digit mid-string:     value="12934" caret=3  — CORRECT, caret did NOT move
backspace mid-string: value="12456" caret=2  — CORRECT
non-digit mid-string: value="1234"  caret=4  — WRONG (expected caret 2)
```

**The scout's belief that this was "mostly a false lead" is confirmed for the case it was about**: Chrome's `HTMLInputElement` value setter genuinely short-circuits an identical assignment, so ordinary digit typing never moved the caret. The scout's own hedge was the accurate part — the stripped-character path *does* change the string, and there the caret jumped to the end, so the next character landed in the wrong place. Fixed by only reassigning when sanitising actually changed the value and restoring `selectionStart`/`selectionEnd`.

On the scout's two smaller edges: the redundant `.slice(0, 6)` was removed (I was editing that line anyway; `maxlength="6"` already bounds typing and paste). **The `maxlength` insert-block is confirmed real but NOT fixed here** — typing into a full 6-char field leaves the value unchanged, so correcting a typo requires deleting first. Fixing it means overriding `maxlength` and managing truncation manually, which is a behaviour change to the input's editing model rather than a jitter fix; it is out of this slice.

## Evidence

Real Chrome 152.0.7977.76, **headless** (`--headless=new`), throwaway profile, extension loaded via CDP `Extensions.loadUnpacked`, against a real bridge daemon on an isolated `HOME` + `LOCAL_OPERATOR_CONFIG_DIR` on port 4131. Frames captured at the popup's true 300×600 metrics. Before-frames come from a clean worktree at `origin/main`, captured **in the same headless mode** — never mixed across modes.

### Measured heights (the numbers behind the pixels)

| State | Before | After |
|---|---|---|
| first painted frame | **259px** (`disconnected` — a false diagnosis) | **358px** (`pending` — neutral) |
| pairing form settled | 292px | 358px |
| pairing form + error | 358px | 358px |
| connected | 207px | 207px |

The pairing path now settles with **no window resize at all** (358 → 358 → 358). Before, the same path resized twice: 259 → 292 → 358.

The connected card is still shorter (207px), so an already-paired user sees the card settle downwards once. That is accepted deliberately: pinning the placeholder to the tallest state would leave a permanent band of empty card under the connected state that every user sees on every open, to spare one resize that only happens while the daemon is slow.

### Frames (before | after)

Rendered frames are on disk at `/tmp/pairjit/` on the capture host, as before|after strips
(before on the left, after on the right), 300x600 at 2x:

| Frame | File |
|---|---|
| First paint on open — the reported flash | `evidence-j1-first-paint.png` |
| Pairing form settled | `evidence-pairing-settled.png` |
| Wrong code (J7 — the error line) | `evidence-j7-wrong-code.png` |
| Connected (unchanged — regression check) | `evidence-connected.png` |

> **Note on attachment:** GitHub has no API for uploading images to a PR body — it requires
> a native OS file picker, which cannot be driven headlessly and would steal the operator's
> window focus, so I did not force it. The frames are reproducible from scratch with the rig
> described under "Reproducing this locally" below; whoever reviews from a session that can
> drag-and-drop should attach them to this thread.

### Reproducing this locally

The capture rig is not committed (AGENTS.md forbids evidence artifacts in the tree). To rebuild it:
run a bridge daemon on an isolated `HOME` and a non-default port, load `extension/dist` into
headless Chrome via CDP `Extensions.loadUnpacked`, pin that port into `chrome.storage.local`,
then open `popup/popup.html` at 300x600 and sample `#card`'s `getBoundingClientRect().height`
per animation frame. Delay the first `/health` to hold the first painted frame long enough to
screenshot it. Compare against a worktree at `origin/main` built the same way.

### Tests

New: `extension/tests/popup-pairing-jitter.integration.test.mjs` (6 tests) and `extension/tests/worker-pairing-eviction.integration.test.mjs` (3 tests). Both drive the real modules with esbuild, the way `popup-render.integration.test.mjs` established — a previous round proved pure-predicate tests structurally cannot catch defects in `render()`'s wiring, and mutation-tested that conclusion.

**Every new test was confirmed RED against the pre-fix bundle and green after** — that check found and fixed two tests that were silently guarding nothing (an `await`ed import meant only one render was ever in flight, and a positional fetch counter was consumed by an earlier render):

```
pre-fix  (worktree at origin/main): 5 of 6 popup tests FAIL, 1 of 3 worker tests FAIL
post-fix (this branch):             126 of 126 pass
```

`release.test.mjs` asserted a hardcoded `"0.1.8"` inside a test named for `tabGroups`; it now asserts that `manifest.json` and `package.json` **agree**, which is the actual invariant (the store zip is built from one and every release script reads the other) and does not need editing every release.

### Gates

| Gate | Result |
|---|---|
| `pnpm --dir extension typecheck` | clean |
| `pnpm --dir extension test` | 126 passed, 0 failed |
| `pnpm --dir extension build:zip` | `validated Chrome Web Store package v0.1.9 (12 files, no source maps)` |
| `flake8 .` | clean |
| `black --check .` (26.1.0) | 1034 files unchanged |
| `isort --check .` (5.13.2) | clean |
| `pyright` | 0 errors, 0 warnings |
| browser_bridge unit tests | 287 passed |

## Not addressed

- **J8's `maxlength` insert-block** — confirmed real, out of slice (see above).
- **`browser_bridge/install.py` is not isolated by `HOME`.** Found while building the rig: `LABEL` is a global constant and `plist_path()` derives only the file location from `Path.home()`, so `bootstrap` registers the same launchd label into the same `gui/<uid>` domain and **evicts the operator's running daemon** regardless of `HOME`. It briefly took down the real bridge on this machine during setup (restored immediately; pairing state untouched). Reported to the manager for the in-flight Linux-install PR, which is already touching that file. Not fixed here — different subsystem, and it needs a decision between refusing a non-default `HOME` and deriving the label from the config root.
- **A daemon-side comment pinning the meaning of close code 4000** (currently emitted only at `daemon.py:663`). A future daemon reusing that code would make a real disconnect silent. Architect's risk note; a follow-up, not this PR.

Release: patch — the browser extension's pairing popup no longer flashes "Not connected.", steals focus while you type, bounces between states, or resizes as you enter a code.
