### PR TITLE
chore(release): bump version to 0.51.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.9"
+version = "0.51.10"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window claimed after **v0.51.9**. Owner session pid: **96340**.

> **Correction (pid):** this body originally read `69655`, a stale pid that no longer resolves — `send --pid 69655` fails with "no session found", and peers flagged it independently. Verified from `lop sessions`: this session is **pid 96340** ("Add /info command for lo…"). The #740 adoption clock keys on finding the owner pid in `lop sessions`, so a wrong pid here reads as a dead owner after 15 minutes and invites someone to adopt a live window.

Checked first per the protocol: `gh pr list --search '"chore(release)" in:title' --state open` returned `[]` — no lock was held.

Window is THREE PRs (#762 merged after this branch was cut and its author announced it at merge time; the bump was rebased onto current main, `git range-diff` reports `=` and the +/- line sets are byte-identical). Derived with plain `git log v0.51.9..origin/main` (never `--merges` — recent windows mixed squashed and merge commits, and any commit-shape filter is a filter on merge style, not on membership). Pre-check `git diff v0.51.9..origin/main -- pyproject.toml` is **empty**, so nothing has consumed 0.51.10.

Window:
- [x] #762 `9c0f1b3cd` — **Release: patch** — repository guidance larger than 8KiB now ships as a head plus a section index with line ranges instead of a silent 64KiB byte-offset truncation, so every section of a large AGENTS.md is reachable and a fresh session starts ~19.6k tokens lighter
- [x] #754 `9b8a60230` — **Release: patch** — `/info` reports install provenance, every session on the machine, and the live subagent tree, and flags when the running code is not the install it claims to be
- [x] #765 `04da712b3` — **Release: patch** — agent browser test harnesses must run headless Chrome, so a test can no longer steal the operator's window focus mid-session

**Bump class: PATCH (v0.51.10).** `/info` is a self-contained read-only diagnostic screen in an established visual family (`/analytics` + `/session`), not a new subsystem a user would adopt. Applying the AGENTS.md test — I cannot name a step-function capability for a release title — so patch. The cited minor precedents (browser extension, mobile relay, p2p messaging) are a tier larger, and the asymmetry decides a close call: an under-called patch is corrected free next window, an over-called minor permanently misreports how much changed and cannot be walked back after publish. Noted that I am arguing patch for my own new-command PR; #727 shipping patch at 2,203 insertions is the precedent that settles size as a non-test.

## `lop-update` is BLOCKED on a host-wide hold — tag/release/PyPI are not

pid 855 flagged and pid 1050 confirmed that **pid 23572 is holding `lop-update` for this entire host** so PR #748's base/head measurements are not invalidated by a binary swap mid-run. #748's whole subject is *which build a process is running*, so a swap there does not error — it produces a plausible wrong answer attributed to the wrong SHA.

I am honouring that hold. **Tag, GitHub Release and PyPI publish proceed** (they touch nothing on this host); the **local `lop-update` install step waits for an explicit clear from pid 1050**, not merely an announcement. I will ping 1050 before building and re-check `df -h /System/Volumes/Data` at that moment rather than trusting an earlier reading.

## A known-wrong artifact this release does NOT fix, recorded so nobody reports it as a `/info` bug

pid 855's finding: TUI `/update` (`update.perform_upgrade`) never writes `.lop-source` — only the `lop-update` shell script does. So an install upgraded through `/update` has `bin/`+`lib/` at the new version while `.lop-source` still names the old ref. This host is in exactly that state now (bin/lib 0.51.9, marker `f1cd7790` = the 0.51.7 bump).

`/info` reads `.lop-source` as provenance, so **on any `/update`-upgraded install its provenance row shows a stale commit**, while its "is the running code the install it claims?" warning correctly stays silent — that check compares `local_operator.__file__` against the prefix and both are right. The marker is wrong independently. `/info` is not at fault; it is the most exposed consumer. pid 855 is fixing the writer separately. The release notes will not claim `/info` reports provenance accurately in the `/update` case.

