### PR TITLE
fix(browser-bridge): make the Linux install path diagnosable and durable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,25 +292,37 @@ the two therefore agreed, which is precisely why nothing caught it. When you
 isolate a run, verify where its writes actually go, not merely that its reads
 are redirected.
 
-**`lop browser install` is not isolated by `HOME` at all — never run it from a
-test.** Same shape as the two hazards above: an isolated run reaching outside
-its sandbox, but here `HOME` does not even slow it down. `browser_bridge/
-install.py` hardcodes `LABEL = "com.local-operator.browser"` and derives only
+**`lop browser install` used not to be isolated by `HOME` at all, and the
+reason is worth keeping even though the hazard is now fixed.** `browser_bridge/
+install.py` hardcoded `LABEL = "com.local-operator.browser"` and derived only
 the plist *path* from `Path.home()`, while the launchd domain is `gui/<uid>`
-from `os.getuid()`. So a redirected `HOME` writes the plist somewhere harmless
-and then `bootstrap`s the *same global label* into the *same* domain — and the
-`bootout` that precedes it evicts whatever holds that label, which is the
-operator's live bridge daemon. It happened today: a sibling agent's test took
-the operator's daemon down on 4099 for ~90s, and the only symptom he saw was
-his browser tool going dead. Linux has the identical exposure through the fixed
-systemd unit name.
+from `os.getuid()`. A redirected `HOME` therefore wrote the plist somewhere
+harmless and then `bootstrap`ed the *same global label* into the *same*
+domain — and launchd resolves a plist to the `Label` INSIDE it, so the
+`bootout` that precedes it evicted whatever held that label: the operator's
+live bridge daemon. It happened: a sibling agent's test took the operator's
+daemon down on 4099 for ~90s, and the only symptom he saw was his browser tool
+going dead. Linux had the identical exposure through the fixed systemd unit
+name.
 
-So a bridge test runs the daemon as a **plain subprocess on a non-default
-port** (`python -m local_operator.browser_bridge.daemon --port <port>`, as
-`docs/design/browser-extension-evidence.md` does) and never calls `install`.
-Deriving the label per root would remove the hazard, but nothing has changed
-it yet: while `LABEL` is a module constant, `HOME` redirection is no protection
-here. Check that line rather than assuming a fix has landed.
+The supervisor name is now derived per config root — `label()` and
+`systemd_unit()` append a digest of the resolved root, so an isolated run
+registers its own daemon instead of evicting the default one. Two constraints
+that fix rests on, and that anything touching it must preserve: the DEFAULT
+root's names stay byte-identical (a rename orphans every installed daemon,
+leaving a live process the CLI can no longer stop), and "is this the default
+root?" is answered against the **uid's passwd home**, not `Path.home()` —
+`Path.home()` reads `$HOME`, so an isolated run would compare its root against
+its own redirected home, conclude it is the default, and reuse the real label.
+
+The advice below is therefore no longer load-bearing for safety, but it is
+still the cheaper way to test: run the daemon as a **plain subprocess on a
+non-default port** (`python -m local_operator.browser_bridge.daemon --port
+<port>`, as `docs/design/browser-extension-evidence.md` does) rather than
+calling `install` at all. If you do call `install` under a redirected `HOME`,
+confirm it reported a suffixed supervisor name (`lop browser status` prints
+`supervisor:` and `config root:` whenever it is not the default install)
+before trusting that it left the operator's daemon alone.
 
 ### Read the committed ref, not the working tree
 

--- a/README.md
+++ b/README.md
@@ -693,7 +693,7 @@ Then install the extension from the
 load `extension/dist` unpacked at `chrome://extensions` with Developer mode
 on), click its toolbar icon, and enter the pairing code. Once paired, `browser`
 tool calls drive a dedicated tab in your real browser. The first time the
-agent wants a new site, the published store build (v0.1.7) asks **Allow
+agent wants a new site, the published store build asks **Allow
 once**, **Always allow**, or **Deny**; you stay in control of which sites it
 can reach, and can revoke the whole browser any time from the extension's
 Settings or with `lop browser pair --reset`.

--- a/local_operator/browser_bridge/install.py
+++ b/local_operator/browser_bridge/install.py
@@ -157,6 +157,14 @@ def render_plist(port: int = DEFAULT_PORT) -> dict[str, object]:
 MIN_SYSTEMD_APPEND_VERSION = 240
 
 
+class _Detect:
+    """Sentinel type: "detect the version" as distinct from "it is unknown"."""
+
+
+#: Default for ``render_systemd(version=...)``. See the note at its use site.
+_DETECT = _Detect()
+
+
 def systemd_version() -> int | None:
     """Major version of the running systemd, or ``None`` if it cannot be read.
 
@@ -176,7 +184,7 @@ def systemd_version() -> int | None:
     return int(match.group(1)) if match else None
 
 
-def render_systemd(port: int = DEFAULT_PORT, *, version: int | None = None) -> str:
+def render_systemd(port: int = DEFAULT_PORT, *, version: int | None | _Detect = _DETECT) -> str:
     """The user unit.
 
     ``StandardOutput``/``StandardError`` are the reason this takes a version.
@@ -190,7 +198,13 @@ def render_systemd(port: int = DEFAULT_PORT, *, version: int | None = None) -> s
     ``No such file or directory`` while the output sat in the journal.
     """
     command = f"{sys.executable} -m local_operator.browser_bridge.daemon --port {port}"
-    resolved = systemd_version() if version is None else version
+    # ``_DETECT`` and not ``None`` as the default: ``None`` is a MEANINGFUL
+    # version value here ("systemd is present but its version could not be
+    # read"), so overloading it to also mean "caller did not pass one" would
+    # make that branch unreachable — and untestable — on any machine where
+    # detection happens to succeed. Caught by CI, whose Linux runners detect a
+    # modern systemd and so silently took the redirect path.
+    resolved = systemd_version() if isinstance(version, _Detect) else version
     redirect = ""
     if resolved is not None and resolved >= MIN_SYSTEMD_APPEND_VERSION:
         redirect = f"StandardOutput=append:{log_path()}\nStandardError=append:{log_path()}\n"

--- a/local_operator/browser_bridge/install.py
+++ b/local_operator/browser_bridge/install.py
@@ -42,6 +42,22 @@ SYSTEMD_UNIT = "local-operator-browser.service"
 _DEFAULT_CONFIG_DIRNAME = ".local-operator"
 
 
+def _passwd_home() -> Path:
+    """The uid's home from the passwd database, ignoring ``$HOME``.
+
+    The supervisor namespace is keyed by UID (launchd's ``gui/<uid>``, systemd's
+    ``--user`` instance) and does not move when ``$HOME`` is redirected, so
+    anything reasoning about "the default install" has to anchor here rather
+    than on :meth:`Path.home`, which reads ``$HOME``.
+    """
+    try:
+        import pwd
+
+        return Path(pwd.getpwuid(os.getuid()).pw_dir)
+    except (ImportError, KeyError, OSError):  # pragma: no cover - no pwd on win32
+        return Path.home()
+
+
 def _default_config_root() -> Path:
     """The config root that owns the DEFAULT supervisor name.
 
@@ -55,13 +71,7 @@ def _default_config_root() -> Path:
     default, and reuse the real daemon's label — which is the collision this
     exists to prevent.
     """
-    try:
-        import pwd
-
-        home = Path(pwd.getpwuid(os.getuid()).pw_dir)
-    except (ImportError, KeyError, OSError):  # pragma: no cover - no pwd on win32
-        home = Path.home()
-    return home / _DEFAULT_CONFIG_DIRNAME
+    return _passwd_home() / _DEFAULT_CONFIG_DIRNAME
 
 
 def _root_suffix() -> str:
@@ -538,26 +548,62 @@ def install(port: int = DEFAULT_PORT, *, dry_run: bool = False) -> dict[str, obj
     }
 
 
+def _own_registration_exists() -> bool:
+    """Whether this config root has a supervisor file under its OWN name."""
+    if sys.platform == "darwin":
+        return plist_path().exists()
+    if sys.platform.startswith("linux"):
+        return systemd_path().exists()
+    return False
+
+
+def _legacy_paths() -> list[Path]:
+    """Every place a pre-per-root build could have written this user's registration.
+
+    BOTH homes, and that is the correction this needed. ``Path.home()`` reads
+    ``$HOME``, but the released build ran under whatever ``$HOME`` was at the
+    time — normally the passwd home. An agent or a service running with a
+    redirected ``$HOME`` therefore looked in a directory the legacy install was
+    never written to, found nothing, and reported the orphan as absent. The two
+    coincide in the common case, so the list is de-duplicated rather than
+    assumed distinct.
+    """
+    homes: list[Path] = []
+    for home in (Path.home(), _passwd_home()):
+        if home not in homes:
+            homes.append(home)
+    if sys.platform == "darwin":
+        return [home / "Library" / "LaunchAgents" / f"{LABEL}.plist" for home in homes]
+    if sys.platform.startswith("linux"):
+        return [home / ".config" / "systemd" / "user" / SYSTEMD_UNIT for home in homes]
+    return []
+
+
 def legacy_registration() -> Path | None:
     """A registration written by a pre-per-root build that this root now orphans.
 
-    Only ever non-``None`` for a NON-default config root: the default root's
-    name is unchanged, so an existing install stays exactly where it was and
-    is adopted, not orphaned. An isolated root, though, may find a plist or
-    unit that an older build wrote under the shared default name while running
-    under this same root — that file is no longer addressable by the CLI, so
-    the honest move is to name it rather than leave a running daemon nobody
-    can stop.
+    Only ever non-``None`` when this root's supervisor name is SUFFIXED: the
+    default root's name is unchanged, so an existing install stays exactly
+    where it was and is adopted, not orphaned. Two things produce a suffix and
+    both are ordinary user situations rather than just test isolation — a
+    ``LOCAL_OPERATOR_CONFIG_DIR`` (a documented setting), and a ``$HOME`` that
+    differs from the passwd home.
+
+    Such a user upgrading from a released build has a registration under the
+    SHARED default name that this build no longer addresses. Left unresolved
+    that produced a false success: ``uninstall`` reported "no LaunchAgent was
+    installed" and exited 0 while the daemon kept running — the same "claimed
+    success it did not achieve" shape :func:`uninstall` was fixed to remove,
+    reintroduced on a different path. So every entry point that manages a
+    supervisor — install, uninstall, start/stop/restart, status — resolves it
+    the same way, on both platforms.
     """
     if not _root_suffix():
         return None
-    if sys.platform == "darwin":
-        legacy = Path.home() / "Library" / "LaunchAgents" / f"{LABEL}.plist"
-    elif sys.platform.startswith("linux"):
-        legacy = Path.home() / ".config" / "systemd" / "user" / SYSTEMD_UNIT
-    else:
-        return None
-    return legacy if legacy.exists() else None
+    for legacy in _legacy_paths():
+        if legacy.exists():
+            return legacy
+    return None
 
 
 def uninstall(*, purge: bool = False, dry_run: bool = False) -> dict[str, object]:
@@ -572,12 +618,29 @@ def uninstall(*, purge: bool = False, dry_run: bool = False) -> dict[str, object
     steps: list[str] = []
     ok = True
     supervisor = _supervisor()
+    # A registration this root inherits from a pre-per-root build is part of
+    # what "uninstall" means to the user: leaving it behind while reporting
+    # success is the false-success shape this function exists to avoid. It is
+    # removed under the LEGACY name, which is the name it was registered with.
+    orphan = legacy_registration()
     if supervisor == "launchctl":
         if not dry_run:
             existed = plist_path().exists()
             _launchctl("bootout", _domain(), str(plist_path()))
             plist_path().unlink(missing_ok=True)
-            steps.append("removed the LaunchAgent" if existed else "no LaunchAgent was installed")
+            if orphan is not None:
+                _launchctl("bootout", _domain(), str(orphan))
+                orphan.unlink(missing_ok=True)
+                steps.append(f"removed the LaunchAgent an older build left at {orphan}")
+            steps.append(
+                "removed the LaunchAgent"
+                if existed
+                else (
+                    "no LaunchAgent was installed under this config root's name"
+                    if orphan is not None
+                    else "no LaunchAgent was installed"
+                )
+            )
         else:
             steps.append("removed the LaunchAgent")
     elif supervisor == "systemctl":
@@ -585,6 +648,12 @@ def uninstall(*, purge: bool = False, dry_run: bool = False) -> dict[str, object
             existed = systemd_path().exists()
             disabled = _systemctl_user("disable", "--now", systemd_unit())
             systemd_path().unlink(missing_ok=True)
+            if orphan is not None:
+                # Disable by UNIT NAME: systemd addresses units by name, and the
+                # legacy unit is the one an older build enabled.
+                _systemctl_user("disable", "--now", SYSTEMD_UNIT)
+                orphan.unlink(missing_ok=True)
+                steps.append(f"removed the systemd unit an older build left at {orphan}")
             _systemctl_user("daemon-reload")
             if disabled.returncode and existed:
                 ok = False
@@ -596,7 +665,11 @@ def uninstall(*, purge: bool = False, dry_run: bool = False) -> dict[str, object
                 steps.append(
                     "removed the systemd user service"
                     if existed
-                    else "no systemd user service was installed"
+                    else (
+                        "no systemd user service was installed under this config " "root's name"
+                        if orphan is not None
+                        else "no systemd user service was installed"
+                    )
                 )
         else:
             steps.append("removed the systemd user service")
@@ -622,11 +695,19 @@ def service_action(action: str) -> dict[str, object]:
         # restart raised FileNotFoundError out of the CLI on a systemd-less
         # Linux and on win32, which fell into the same branch.
         return {"ok": False, "error": NO_SUPERVISOR_ERROR}
+    # A root whose own registration does not exist but which INHERITS one from a
+    # pre-per-root build must act on the inherited name, or start/stop/restart
+    # address a service that was never registered: launchctl answers "no such
+    # service" while the real daemon keeps running. Only when this root has no
+    # install of its own — an existing per-root install always wins.
+    orphan = legacy_registration()
+    adopted = orphan is not None and not _own_registration_exists()
     if supervisor == "launchctl":
-        target = f"{_domain()}/{label()}"
-        if action in ("start", "restart") and plist_path().exists():
+        target = f"{_domain()}/{LABEL if adopted else label()}"
+        plist = orphan if adopted and orphan is not None else plist_path()
+        if action in ("start", "restart") and plist.exists():
             if _launchctl("print", target).returncode:
-                loaded = _launchctl("bootstrap", _domain(), str(plist_path()))
+                loaded = _launchctl("bootstrap", _domain(), str(plist))
                 if loaded.returncode:
                     return {"ok": False, "error": loaded.stderr.strip()[:300]}
         args = {
@@ -641,10 +722,11 @@ def service_action(action: str) -> dict[str, object]:
     # before the manager started) fails start/restart with "not found" until
     # something reloads it. Reload once, then retry, rather than making the
     # user discover `systemctl --user daemon-reload` themselves.
-    result = _systemctl_user(action, systemd_unit())
+    unit = SYSTEMD_UNIT if adopted else systemd_unit()
+    result = _systemctl_user(action, unit)
     if result.returncode and action in ("start", "restart") and systemd_path().exists():
         _systemctl_user("daemon-reload")
-        result = _systemctl_user(action, systemd_unit())
+        result = _systemctl_user(action, unit)
     return {"ok": result.returncode == 0, "error": _translate_systemctl_error(result.stderr)}
 
 
@@ -653,8 +735,13 @@ def status(port: int | None = None) -> dict[str, object]:
     resolved_port = port or (current.port if current else DEFAULT_PORT)
     probe = health(resolved_port)
     pairing = pairing_status()
+    # An inherited registration counts as installed: reporting "installed: no"
+    # while a pre-per-root build's daemon is running is the same false answer
+    # `uninstall` was fixed for, and it is what sends a user to reinstall on
+    # top of a daemon they already have.
+    orphan = legacy_registration()
     return {
-        "installed": plist_path().exists() if sys.platform == "darwin" else systemd_path().exists(),
+        "installed": _own_registration_exists() or orphan is not None,
         "healthy": probe is not None,
         "health": probe,
         "port": resolved_port,
@@ -671,4 +758,8 @@ def status(port: int | None = None) -> dict[str, object]:
         # there is no way to tell which instance you are talking to.
         "supervisor": label() if sys.platform == "darwin" else systemd_unit(),
         "config_root": str(config_dir()),
+        # Named, not merely folded into `installed`: this is the one thing that
+        # explains why a daemon is running under a name the CLI would not
+        # otherwise mention, and it tells the user which file to act on.
+        "legacy_registration": str(orphan) if orphan is not None else None,
     }

--- a/local_operator/browser_bridge/install.py
+++ b/local_operator/browser_bridge/install.py
@@ -7,9 +7,11 @@ its next restart without rewriting supervisor configuration.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import plistlib
+import re
 import shutil
 import subprocess
 import sys
@@ -26,18 +28,94 @@ from local_operator.browser_bridge.daemon import (
     pairing_status,
     reset_pairing,
 )
-from local_operator.paths import log_dir
+from local_operator.paths import config_dir, log_dir
 
+#: The supervisor name for the DEFAULT config root. Every already-installed
+#: user's daemon is registered under exactly this label, so it must never
+#: change: a rename would orphan those daemons, leaving a running process the
+#: CLI can no longer stop, start or uninstall.
 LABEL = "com.local-operator.browser"
 SYSTEMD_UNIT = "local-operator-browser.service"
 
+#: The config root the default label belongs to. Compared against the resolved
+#: root to decide whether this run is the default install or an isolated one.
+_DEFAULT_CONFIG_DIRNAME = ".local-operator"
+
+
+def _default_config_root() -> Path:
+    """The config root that owns the DEFAULT supervisor name.
+
+    Anchored on the uid's passwd home rather than on ``Path.home()``, which
+    reads ``$HOME``. That distinction is the entire fix: the launchd domain is
+    ``gui/<uid>`` and the systemd ``--user`` instance is likewise per-uid, so
+    the namespace a label collides in is keyed by UID and does NOT move when
+    ``$HOME`` is redirected. Deriving the "is this the default install?" test
+    from ``Path.home()`` would make an isolated ``HOME=/tmp/... lop browser
+    install`` compare its own root against its own home, conclude it IS the
+    default, and reuse the real daemon's label — which is the collision this
+    exists to prevent.
+    """
+    try:
+        import pwd
+
+        home = Path(pwd.getpwuid(os.getuid()).pw_dir)
+    except (ImportError, KeyError, OSError):  # pragma: no cover - no pwd on win32
+        home = Path.home()
+    return home / _DEFAULT_CONFIG_DIRNAME
+
+
+def _root_suffix() -> str:
+    """``""`` for the default config root, else ``.<8-hex-of-root>``.
+
+    Why the supervisor name has to depend on the config root: the label is a
+    GLOBAL name in the user's launchd domain (``gui/<uid>``) and in the systemd
+    ``--user`` instance. ``plist_path()`` varies with ``$HOME``, but launchd
+    resolves a plist to the ``Label`` INSIDE it — so ``bootout`` with a plist
+    at a different path evicts the incumbent registered under the same label.
+    Verified directly with a throwaway service: bootstrapping from one path and
+    booting out via a second path carrying the same ``Label`` removed it.
+
+    The consequence was that an isolated run — the exact isolation AGENTS.md
+    tells agents to use, ``HOME=/tmp/... lop browser install`` — evicted the
+    operator's live daemon and replaced it with its own. That happened on this
+    machine.
+
+    Deriving the suffix from the config root rather than refusing a non-default
+    root keeps that isolation working (concurrent isolated daemons no longer
+    collide) instead of blocking it. The digest is of the RESOLVED, symlink-free
+    path so two spellings of one root produce one label.
+    """
+    try:
+        root = config_dir().expanduser().resolve()
+        default_root = _default_config_root().expanduser().resolve()
+    except OSError:  # pragma: no cover - resolve() on an unreadable parent
+        root = config_dir().expanduser()
+        default_root = _default_config_root().expanduser()
+    if root == default_root:
+        return ""
+    digest = hashlib.sha256(str(root).encode("utf-8")).hexdigest()[:8]
+    return f".{digest}"
+
+
+def label() -> str:
+    """Launchd label for this config root; byte-identical to :data:`LABEL` by default."""
+    return f"{LABEL}{_root_suffix()}"
+
+
+def systemd_unit() -> str:
+    """systemd unit name for this config root; the default root keeps the plain name."""
+    suffix = _root_suffix()
+    if not suffix:
+        return SYSTEMD_UNIT
+    return f"local-operator-browser{suffix}.service"
+
 
 def plist_path() -> Path:
-    return Path.home() / "Library" / "LaunchAgents" / f"{LABEL}.plist"
+    return Path.home() / "Library" / "LaunchAgents" / f"{label()}.plist"
 
 
 def systemd_path() -> Path:
-    return Path.home() / ".config" / "systemd" / "user" / SYSTEMD_UNIT
+    return Path.home() / ".config" / "systemd" / "user" / systemd_unit()
 
 
 def log_path() -> Path:
@@ -46,7 +124,10 @@ def log_path() -> Path:
 
 def render_plist(port: int = DEFAULT_PORT) -> dict[str, object]:
     return {
-        "Label": LABEL,
+        # Per-config-root label (this PR) over #752's branded interpreter
+        # image: the two are orthogonal — one decides WHICH daemon launchd is
+        # told about, the other decides what the user sees it called.
+        "Label": label(),
         # Branded interpreter image when one can be planted: macOS names this
         # background item by the basename of ProgramArguments[0], so a bare
         # `sys.executable` is what made installing the bridge notify that
@@ -64,8 +145,55 @@ def render_plist(port: int = DEFAULT_PORT) -> dict[str, object]:
     }
 
 
-def render_systemd(port: int = DEFAULT_PORT) -> str:
+#: ``StandardOutput=append:`` landed in systemd 240 (upstream NEWS; confirmed
+#: by the maintainer on systemd-devel). An older systemd does NOT refuse the
+#: unit — measured on 255 against a deliberately invalid specifier, it logs
+#: "Failed to parse output specifier, ignoring" and starts anyway — so the
+#: real cost of emitting it blindly is subtler than a hard failure: the
+#: directive is silently dropped, the output goes to the journal, and the
+#: product would still be pointing users at a file nothing writes. That is the
+#: exact defect being fixed, so the version gate is what keeps the emitted unit
+#: and :func:`log_location` telling the same story on every systemd.
+MIN_SYSTEMD_APPEND_VERSION = 240
+
+
+def systemd_version() -> int | None:
+    """Major version of the running systemd, or ``None`` if it cannot be read.
+
+    ``systemctl --version`` prints e.g. ``systemd 255 (255.4-1ubuntu8.17)``.
+    Unknown degrades to "assume old", which is the safe direction: the unit
+    stays loadable and the output goes to the journal.
+    """
+    if not shutil.which("systemctl"):
+        return None
+    try:
+        result = subprocess.run(
+            ["systemctl", "--version"], capture_output=True, text=True, timeout=10
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    match = re.search(r"systemd\s+(\d+)", result.stdout or "")
+    return int(match.group(1)) if match else None
+
+
+def render_systemd(port: int = DEFAULT_PORT, *, version: int | None = None) -> str:
+    """The user unit.
+
+    ``StandardOutput``/``StandardError`` are the reason this takes a version.
+    systemd's default sends daemon output to the JOURNAL, while three product
+    surfaces — the install failure message, ``lop browser logs`` and the ``log:``
+    line in ``lop browser status`` — all pointed at :func:`log_path`, a file
+    nothing ever wrote. ``install()`` creates that file's parent directory, so
+    a Linux user following those instructions found an empty directory, which
+    reads as "the daemon produced no output" rather than "look somewhere else".
+    Reproduced on real systemd 255: ``tail`` of that path reported
+    ``No such file or directory`` while the output sat in the journal.
+    """
     command = f"{sys.executable} -m local_operator.browser_bridge.daemon --port {port}"
+    resolved = systemd_version() if version is None else version
+    redirect = ""
+    if resolved is not None and resolved >= MIN_SYSTEMD_APPEND_VERSION:
+        redirect = f"StandardOutput=append:{log_path()}\nStandardError=append:{log_path()}\n"
     return f"""[Unit]
 Description=Local Operator browser bridge
 
@@ -73,10 +201,46 @@ Description=Local Operator browser bridge
 ExecStart={command}
 Restart=on-failure
 RestartSec=5
-
+{redirect}
 [Install]
 WantedBy=default.target
 """
+
+
+def logs_command(lines: int = 100, *, follow: bool = False) -> list[str]:
+    """The command that actually shows this platform's daemon output.
+
+    Keeping this in one place is what stops the three surfaces disagreeing:
+    on a systemd too old for ``append:`` the log file genuinely does not exist,
+    and the honest answer is ``journalctl``, not a ``tail`` that cannot open it.
+    """
+    if _supervisor() == "systemctl" and not _log_file_is_written():
+        command = ["journalctl", "--user", "-u", systemd_unit(), "-n", str(lines)]
+        if follow:
+            command.append("-f")
+        return command
+    command = ["tail", "-n", str(lines)]
+    if follow:
+        command.append("-f")
+    command.append(str(log_path()))
+    return command
+
+
+def _log_file_is_written() -> bool:
+    """Whether this platform's supervisor redirects the daemon's output to a file."""
+    if sys.platform == "darwin":
+        return True
+    version = systemd_version()
+    return version is not None and version >= MIN_SYSTEMD_APPEND_VERSION
+
+
+def log_location() -> str:
+    """Human-readable location of the daemon's output, for status and errors."""
+    if _log_file_is_written():
+        return str(log_path())
+    if _supervisor() == "systemctl":
+        return f"journalctl --user -u {systemd_unit()}"
+    return str(log_path())
 
 
 def _domain() -> str:
@@ -85,6 +249,99 @@ def _domain() -> str:
 
 def _launchctl(*args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(["launchctl", *args], capture_output=True, text=True, timeout=15)
+
+
+#: What to tell a user whose platform has no user-level service supervisor.
+#: One string shared by install/uninstall/start/stop/restart so the entry
+#: points cannot drift into describing the same machine differently.
+NO_SUPERVISOR_ERROR = (
+    "no supported user service supervisor found (launchctl on macOS, "
+    "systemctl --user on Linux); run `lop browser serve` in the foreground"
+)
+
+
+def _supervisor() -> str | None:
+    """``"launchctl"``, ``"systemctl"``, or ``None`` when neither is usable.
+
+    Guarding on the BINARY rather than on ``sys.platform`` is the whole point.
+    ``subprocess.run(..., check=False)`` suppresses a non-zero exit status but
+    NOT ``FileNotFoundError`` when the executable is absent, so every caller
+    that skipped this check raised an uncaught traceback out of the CLI on a
+    Linux without systemd (Devuan, Alpine, Void, OpenRC, many containers, WSL2
+    without systemd) and on win32, which fell into the same branch. Reproduced
+    before this fix: ``start``, ``stop``, ``restart`` and ``uninstall`` all
+    raised ``FileNotFoundError: 'systemctl'``.
+    """
+    if sys.platform == "darwin" and shutil.which("launchctl"):
+        return "launchctl"
+    if sys.platform.startswith("linux") and shutil.which("systemctl"):
+        return "systemctl"
+    return None
+
+
+def _systemctl_user(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["systemctl", "--user", *args], capture_output=True, text=True, timeout=30
+    )
+
+
+#: systemd's message when there is no user D-Bus to talk to — the normal state
+#: over plain SSH without lingering.
+_NO_BUS_MARKERS = ("Failed to connect to bus", "No medium found", "XDG_RUNTIME_DIR")
+
+
+def linger_remedy() -> str:
+    user = os.environ.get("USER") or "$USER"
+    return (
+        "systemd has no user session bus for this login (normal over plain "
+        "SSH). Enable lingering so the user manager starts at boot and "
+        f"survives logout:\n    loginctl enable-linger {user}\n"
+        "then re-run `lop browser install`."
+    )
+
+
+def _translate_systemctl_error(stderr: str) -> str:
+    """Name the remedy for the one systemctl failure users actually hit.
+
+    The raw stderr was surfaced verbatim — truthful, but it left the user to
+    discover ``loginctl enable-linger`` on their own, and nothing in the
+    product named it.
+    """
+    text = (stderr or "").strip()
+    if any(marker in text for marker in _NO_BUS_MARKERS):
+        return f"{text[:200]}\n\n{linger_remedy()}" if text else linger_remedy()
+    return text[:300]
+
+
+def enable_linger() -> bool:
+    """Best-effort ``loginctl enable-linger``; never fatal to an install.
+
+    Per ``loginctl(1)``, without lingering no user manager is spawned at boot
+    and it is torn down when the last session ends — so ``WantedBy=default.target``
+    plus ``enable --now`` does NOT deliver "survives restarts" the way macOS's
+    ``RunAtLoad`` does. Confirmed on systemd 255: with lingering disabled,
+    ``systemctl --user`` cannot reach the user manager at all ("User ID is not
+    logged in or lingering"). A graphical desktop login is close enough in
+    practice; SSH and headless hosts are where the daemon dies and stays dead.
+
+    Non-fatal because it can legitimately be refused (no polkit agent, a locked
+    down host), and an install that otherwise succeeded must not be reported as
+    failed over it.
+    """
+    binary = shutil.which("loginctl")
+    if not binary:
+        return False
+    user = os.environ.get("USER")
+    try:
+        result = subprocess.run(
+            [binary, "enable-linger", *([user] if user else [])],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
 
 
 def health(port: int = DEFAULT_PORT, timeout: float = 3.0) -> dict[str, Any] | None:
@@ -203,7 +460,17 @@ def repair(port: int | None = None, root: Path | None = None) -> dict[str, Any]:
 def install(port: int = DEFAULT_PORT, *, dry_run: bool = False) -> dict[str, object]:
     steps: list[str] = []
     log_path().parent.mkdir(parents=True, exist_ok=True)
-    if sys.platform == "darwin" and shutil.which("launchctl"):
+    # An isolated root that finds an older build's shared-name registration in
+    # its own HOME would otherwise leave it running and unaddressable.
+    orphan = legacy_registration()
+    if orphan is not None:
+        steps.append(
+            f"note: {orphan} was written by an older build under the shared "
+            "supervisor name and is no longer managed by this config root; "
+            "remove it by hand if it is still running"
+        )
+    supervisor = _supervisor()
+    if supervisor == "launchctl":
         plist_path().parent.mkdir(parents=True, exist_ok=True)
         if not dry_run:
             plist_path().write_bytes(plistlib.dumps(render_plist(port)))
@@ -213,28 +480,34 @@ def install(port: int = DEFAULT_PORT, *, dry_run: bool = False) -> dict[str, obj
             loaded = _launchctl("bootstrap", _domain(), str(plist_path()))
             if loaded.returncode:
                 return {"ok": False, "steps": steps, "error": loaded.stderr.strip()[:300]}
-            steps.append("loaded the LaunchAgent")
-    elif sys.platform.startswith("linux") and shutil.which("systemctl"):
+            steps.append(f"loaded the LaunchAgent ({label()})")
+    elif supervisor == "systemctl":
         systemd_path().parent.mkdir(parents=True, exist_ok=True)
         if not dry_run:
             systemd_path().write_text(render_systemd(port), encoding="utf-8")
         steps.append(f"wrote {systemd_path()}")
         if not dry_run:
-            subprocess.run(["systemctl", "--user", "daemon-reload"], check=False)
-            loaded = subprocess.run(
-                ["systemctl", "--user", "enable", "--now", SYSTEMD_UNIT],
-                capture_output=True,
-                text=True,
-            )
+            # Lingering BEFORE enable --now: without a user manager the enable
+            # itself fails with the bus error, and enabling linger is what
+            # spawns one. Best-effort, so a refusal does not fail the install.
+            if enable_linger():
+                steps.append("enabled lingering so the daemon survives logout and reboot")
+            else:
+                steps.append(
+                    "could not enable lingering; the daemon may not survive logout "
+                    f"(run: loginctl enable-linger {os.environ.get('USER', '$USER')})"
+                )
+            _systemctl_user("daemon-reload")
+            loaded = _systemctl_user("enable", "--now", systemd_unit())
             if loaded.returncode:
-                return {"ok": False, "steps": steps, "error": loaded.stderr.strip()[:300]}
-            steps.append("enabled the systemd user service")
+                return {
+                    "ok": False,
+                    "steps": steps,
+                    "error": _translate_systemctl_error(loaded.stderr),
+                }
+            steps.append(f"enabled the systemd user service ({systemd_unit()})")
     else:
-        return {
-            "ok": False,
-            "steps": steps,
-            "error": "no supported user supervisor; run `lop browser serve` in the foreground",
-        }
+        return {"ok": False, "steps": steps, "error": NO_SUPERVISOR_ERROR}
     if dry_run:
         return {"ok": True, "steps": [*steps, "dry run: skipped load and verification"]}
     deadline = time.time() + 20
@@ -245,49 +518,120 @@ def install(port: int = DEFAULT_PORT, *, dry_run: bool = False) -> dict[str, obj
     return {
         "ok": False,
         "steps": steps,
-        "error": f"daemon did not become healthy; see {log_path()}",
+        # Naming the journal where that is where the output actually went: the
+        # old message sent Linux users to a file nothing writes.
+        "error": f"daemon did not become healthy; see {log_location()}",
     }
 
 
-def uninstall(*, purge: bool = False, dry_run: bool = False) -> dict[str, object]:
-    steps: list[str] = []
+def legacy_registration() -> Path | None:
+    """A registration written by a pre-per-root build that this root now orphans.
+
+    Only ever non-``None`` for a NON-default config root: the default root's
+    name is unchanged, so an existing install stays exactly where it was and
+    is adopted, not orphaned. An isolated root, though, may find a plist or
+    unit that an older build wrote under the shared default name while running
+    under this same root — that file is no longer addressable by the CLI, so
+    the honest move is to name it rather than leave a running daemon nobody
+    can stop.
+    """
+    if not _root_suffix():
+        return None
     if sys.platform == "darwin":
+        legacy = Path.home() / "Library" / "LaunchAgents" / f"{LABEL}.plist"
+    elif sys.platform.startswith("linux"):
+        legacy = Path.home() / ".config" / "systemd" / "user" / SYSTEMD_UNIT
+    else:
+        return None
+    return legacy if legacy.exists() else None
+
+
+def uninstall(*, purge: bool = False, dry_run: bool = False) -> dict[str, object]:
+    """Remove this config root's supervisor registration.
+
+    Reports what it actually achieved. It used to append "removed the systemd
+    user service" and return ``ok: True`` unconditionally, so the CLI printed
+    success and exited 0 even when ``systemctl`` was absent or the disable
+    failed — reproduced with a stub ``systemctl`` exiting 1, which still
+    yielded ``{'ok': True}``.
+    """
+    steps: list[str] = []
+    ok = True
+    supervisor = _supervisor()
+    if supervisor == "launchctl":
         if not dry_run:
+            existed = plist_path().exists()
             _launchctl("bootout", _domain(), str(plist_path()))
             plist_path().unlink(missing_ok=True)
-        steps.append("removed the LaunchAgent")
-    elif sys.platform.startswith("linux"):
+            steps.append("removed the LaunchAgent" if existed else "no LaunchAgent was installed")
+        else:
+            steps.append("removed the LaunchAgent")
+    elif supervisor == "systemctl":
         if not dry_run:
-            subprocess.run(["systemctl", "--user", "disable", "--now", SYSTEMD_UNIT], check=False)
+            existed = systemd_path().exists()
+            disabled = _systemctl_user("disable", "--now", systemd_unit())
             systemd_path().unlink(missing_ok=True)
-            subprocess.run(["systemctl", "--user", "daemon-reload"], check=False)
-        steps.append("removed the systemd user service")
+            _systemctl_user("daemon-reload")
+            if disabled.returncode and existed:
+                ok = False
+                steps.append(
+                    f"unit file removed, but `systemctl --user disable` failed: "
+                    f"{_translate_systemctl_error(disabled.stderr)}"
+                )
+            else:
+                steps.append(
+                    "removed the systemd user service"
+                    if existed
+                    else "no systemd user service was installed"
+                )
+        else:
+            steps.append("removed the systemd user service")
+    elif not purge:
+        # Nothing to unregister and nothing else asked for: say so rather than
+        # claiming a removal that never happened.
+        return {"ok": False, "steps": steps, "error": NO_SUPERVISOR_ERROR}
     if purge:
         if not dry_run:
             reset_pairing()
             state_store.remove()
         steps.append("deleted pairing and bridge state")
-    return {"ok": True, "steps": steps}
+    # `ok` and not a literal: the disable branch above sets it False, and
+    # returning True there is exactly the "claimed success it did not achieve"
+    # bug this function was fixed for.
+    return {"ok": ok, "steps": steps}
 
 
 def service_action(action: str) -> dict[str, object]:
-    if sys.platform == "darwin":
+    supervisor = _supervisor()
+    if supervisor is None:
+        # Returned, never raised. Without this guard all three of start/stop/
+        # restart raised FileNotFoundError out of the CLI on a systemd-less
+        # Linux and on win32, which fell into the same branch.
+        return {"ok": False, "error": NO_SUPERVISOR_ERROR}
+    if supervisor == "launchctl":
+        target = f"{_domain()}/{label()}"
         if action in ("start", "restart") and plist_path().exists():
-            if _launchctl("print", f"{_domain()}/{LABEL}").returncode:
+            if _launchctl("print", target).returncode:
                 loaded = _launchctl("bootstrap", _domain(), str(plist_path()))
                 if loaded.returncode:
                     return {"ok": False, "error": loaded.stderr.strip()[:300]}
         args = {
-            "start": ("kickstart", f"{_domain()}/{LABEL}"),
-            "stop": ("kill", "SIGTERM", f"{_domain()}/{LABEL}"),
-            "restart": ("kickstart", "-k", f"{_domain()}/{LABEL}"),
+            "start": ("kickstart", target),
+            "stop": ("kill", "SIGTERM", target),
+            "restart": ("kickstart", "-k", target),
         }[action]
         result = _launchctl(*args)
-    else:
-        result = subprocess.run(
-            ["systemctl", "--user", action, SYSTEMD_UNIT], capture_output=True, text=True
-        )
-    return {"ok": result.returncode == 0, "error": result.stderr.strip()[:300]}
+        return {"ok": result.returncode == 0, "error": result.stderr.strip()[:300]}
+    # Linux gains the recovery macOS already had: a unit file on disk that the
+    # user manager has not read yet (installed by an older run, or written
+    # before the manager started) fails start/restart with "not found" until
+    # something reloads it. Reload once, then retry, rather than making the
+    # user discover `systemctl --user daemon-reload` themselves.
+    result = _systemctl_user(action, systemd_unit())
+    if result.returncode and action in ("start", "restart") and systemd_path().exists():
+        _systemctl_user("daemon-reload")
+        result = _systemctl_user(action, systemd_unit())
+    return {"ok": result.returncode == 0, "error": _translate_systemctl_error(result.stderr)}
 
 
 def status(port: int | None = None) -> dict[str, object]:
@@ -305,5 +649,12 @@ def status(port: int | None = None) -> dict[str, object]:
         "extension_id": pairing["extension_id"],
         "pending_code": pairing["pending_code"],
         "pending_expires_at": pairing["pending_expires_at"],
-        "log": str(log_path()),
+        # The location the output is ACTUALLY readable from, which on a systemd
+        # too old for `append:` is the journal, not a file that never exists.
+        "log": log_location(),
+        # Which config root's supervisor registration this is reporting on.
+        # Without it two isolated daemons produce identical status output and
+        # there is no way to tell which instance you are talking to.
+        "supervisor": label() if sys.platform == "darwin" else systemd_unit(),
+        "config_root": str(config_dir()),
     }

--- a/local_operator/browser_bridge/install.py
+++ b/local_operator/browser_bridge/install.py
@@ -557,26 +557,37 @@ def _own_registration_exists() -> bool:
     return False
 
 
-def _legacy_paths() -> list[Path]:
-    """Every place a pre-per-root build could have written this user's registration.
+def _legacy_path() -> Path | None:
+    """Where a pre-per-root build running under THIS ``$HOME`` wrote its registration.
 
-    BOTH homes, and that is the correction this needed. ``Path.home()`` reads
-    ``$HOME``, but the released build ran under whatever ``$HOME`` was at the
-    time — normally the passwd home. An agent or a service running with a
-    redirected ``$HOME`` therefore looked in a directory the legacy install was
-    never written to, found nothing, and reported the orphan as absent. The two
-    coincide in the common case, so the list is de-duplicated rather than
-    assumed distinct.
+    ``Path.home()`` only, and the distinction from :func:`_default_config_root`
+    is the whole point rather than an inconsistency:
+
+    * :func:`_default_config_root` asks a UID-keyed question — "does this root
+      own the default supervisor NAME?" The namespace it guards is launchd's
+      ``gui/<uid>`` and systemd's ``--user`` instance, neither of which moves
+      when ``$HOME`` does, so it must anchor on the passwd home.
+    * This asks a HOME-keyed question — "did MY predecessor write this file?"
+      A registration under a *different* ``$HOME`` belongs to a different run,
+      and adopting it is not an upgrade path; it is one root claiming another
+      root's supervisor.
+
+    Searching the passwd home here as well looked like it served a second
+    upgrade trigger, and instead recreated the incident this module exists to
+    prevent: under the isolation AGENTS.md prescribes
+    (``HOME=/tmp/... LOCAL_OPERATOR_CONFIG_DIR=...``) the lookup resolved the
+    OPERATOR's live plist, and because such a root has no install of its own it
+    would be adopted — then booted out, unlinked, and SIGTERM'd. It fanned out
+    without bound, since every isolated root resolved that same one file, and
+    ownership cannot be recovered from the plist body: nothing in it names a
+    config root.
     """
-    homes: list[Path] = []
-    for home in (Path.home(), _passwd_home()):
-        if home not in homes:
-            homes.append(home)
+    home = Path.home()
     if sys.platform == "darwin":
-        return [home / "Library" / "LaunchAgents" / f"{LABEL}.plist" for home in homes]
+        return home / "Library" / "LaunchAgents" / f"{LABEL}.plist"
     if sys.platform.startswith("linux"):
-        return [home / ".config" / "systemd" / "user" / SYSTEMD_UNIT for home in homes]
-    return []
+        return home / ".config" / "systemd" / "user" / SYSTEMD_UNIT
+    return None
 
 
 def legacy_registration() -> Path | None:
@@ -585,9 +596,8 @@ def legacy_registration() -> Path | None:
     Only ever non-``None`` when this root's supervisor name is SUFFIXED: the
     default root's name is unchanged, so an existing install stays exactly
     where it was and is adopted, not orphaned. Two things produce a suffix and
-    both are ordinary user situations rather than just test isolation — a
-    ``LOCAL_OPERATOR_CONFIG_DIR`` (a documented setting), and a ``$HOME`` that
-    differs from the passwd home.
+    the usual cause being a ``LOCAL_OPERATOR_CONFIG_DIR``, which is a
+    documented setting.
 
     Such a user upgrading from a released build has a registration under the
     SHARED default name that this build no longer addresses. Left unresolved
@@ -597,13 +607,14 @@ def legacy_registration() -> Path | None:
     reintroduced on a different path. So every entry point that manages a
     supervisor — install, uninstall, start/stop/restart, status — resolves it
     the same way, on both platforms.
+
+    Scoped to this ``$HOME`` by :func:`_legacy_path`; see there for why a
+    registration under another ``$HOME`` is deliberately NOT adopted.
     """
     if not _root_suffix():
         return None
-    for legacy in _legacy_paths():
-        if legacy.exists():
-            return legacy
-    return None
+    legacy = _legacy_path()
+    return legacy if legacy is not None and legacy.exists() else None
 
 
 def uninstall(*, purge: bool = False, dry_run: bool = False) -> dict[str, object]:

--- a/local_operator/browser_bridge/install.py
+++ b/local_operator/browser_bridge/install.py
@@ -577,16 +577,130 @@ def _legacy_path() -> Path | None:
     prevent: under the isolation AGENTS.md prescribes
     (``HOME=/tmp/... LOCAL_OPERATOR_CONFIG_DIR=...``) the lookup resolved the
     OPERATOR's live plist, and because such a root has no install of its own it
-    would be adopted — then booted out, unlinked, and SIGTERM'd. It fanned out
-    without bound, since every isolated root resolved that same one file, and
-    ownership cannot be recovered from the plist body: nothing in it names a
-    config root.
+    would be adopted — then booted out, unlinked, and SIGTERM'd.
+
+    Location alone is NOT ownership, which is why this is only the first of
+    three tests; see :func:`legacy_registration`.
     """
     home = Path.home()
     if sys.platform == "darwin":
         return home / "Library" / "LaunchAgents" / f"{LABEL}.plist"
     if sys.platform.startswith("linux"):
         return home / ".config" / "systemd" / "user" / SYSTEMD_UNIT
+    return None
+
+
+def _canonical(path: str | Path) -> str:
+    """A path in the one spelling ownership comparisons can use.
+
+    Ownership is decided by comparing two recorded paths, so the comparison has
+    to survive symlinks (``/tmp`` → ``/private/tmp`` on macOS) and ``..``/``.``
+    segments. ``resolve()`` without ``strict`` also canonicalises a path whose
+    final component no longer exists, which is the normal case for a log file
+    that was never written.
+    """
+    try:
+        return str(Path(path).expanduser().resolve())
+    except OSError:  # pragma: no cover - unreadable parent
+        return str(Path(path).expanduser())
+
+
+def _recorded_log_path(registration: Path) -> str | None:
+    """The log destination a supervisor file records, or ``None`` when it records none.
+
+    This is the ownership evidence, and it exists because every build derives
+    the daemon's stdout/stderr destination from :func:`log_path`, which honours
+    ``LOCAL_OPERATOR_CONFIG_DIR`` unconditionally. A registration written under
+    ``LOCAL_OPERATOR_CONFIG_DIR=/x`` therefore records ``/x/logs/...`` while the
+    default root records the platform log dir — verified against the RELEASED
+    writer at ``v0.51.14``, not merely against current code.
+
+    ``None`` means the file carries no evidence, and callers must read that as
+    "not provably mine" rather than "mine". That case is real and common on
+    Linux: the released ``render_systemd`` emits ``ExecStart`` only, with no
+    ``StandardOutput=``, so a legacy unit from any build before this one is
+    journal-only and unattributable. Such a unit is never auto-adopted.
+    """
+    if sys.platform == "darwin":
+        try:
+            with registration.open("rb") as handle:
+                parsed = plistlib.load(handle)
+        except Exception:  # noqa: BLE001 - a corrupt plist is "no evidence", not a crash
+            return None
+        value = parsed.get("StandardOutPath") if isinstance(parsed, dict) else None
+        return value if isinstance(value, str) and value else None
+    try:
+        text = registration.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    # `StandardOutput=append:<path>` is the only place a unit records this, and
+    # this build emits it only on systemd >= 240; older systemd logs to the
+    # journal, so the absence of this line is expected rather than anomalous.
+    match = re.search(r"^StandardOutput=append:(.+)$", text, re.MULTILINE)
+    return match.group(1).strip() if match else None
+
+
+def _default_root_dir_exists() -> bool:
+    """HEURISTIC: does the default config root's DIRECTORY exist?
+
+    Deliberately named for what it measures. Directory existence proves neither
+    that a default-root daemon is running nor that the default root wrote the
+    registration under scrutiny — it is a conservative refusal signal, not
+    ownership. It is kept because the cost of the two errors is wildly
+    asymmetric: wrongly refusing leaves a stale file for the user to delete by
+    hand, while wrongly claiming deletes a live LaunchAgent along with its
+    ``RunAtLoad``/``KeepAlive``, so the bridge never returns after a reboot.
+
+    What it legitimately blocks, and this is a real cost rather than a
+    theoretical one: a user who has BOTH a populated ``~/.local-operator`` and a
+    ``LOCAL_OPERATOR_CONFIG_DIR`` root whose own legacy registration is the one
+    on disk cannot have it auto-removed, even when the evidence says it is
+    theirs. They get :func:`legacy_ambiguity`'s message naming the file instead
+    of a silent no-op. Positive evidence alone would serve that user; this
+    refusal is the price of not trusting evidence that a pre-``append:`` Linux
+    unit cannot supply at all.
+    """
+    return _default_config_root().exists()
+
+
+def legacy_ambiguity() -> str | None:
+    """Why a legacy registration that IS present was not claimed by this root.
+
+    Ambiguity must reach the user as an actionable statement naming the file,
+    never as a silent ``None`` that the caller then reports as "no service
+    installed" — that is the false-success shape this module keeps re-learning.
+    ``None`` here means there is genuinely nothing to report.
+    """
+    if not _root_suffix():
+        return None
+    candidate = _legacy_path()
+    if candidate is None or not candidate.exists():
+        return None
+    if _own_registration_exists():
+        return (
+            f"{candidate} was left by an older build, but this config root has its "
+            "own registration, which takes precedence. Left untouched."
+        )
+    recorded = _recorded_log_path(candidate)
+    if recorded is None:
+        noun = "unit" if sys.platform.startswith("linux") else "plist"
+        return (
+            f"{candidate} records no log destination, so nothing proves it belongs "
+            f"to this config root (a pre-0.51 systemd {noun} logs to the journal and "
+            "carries no such evidence). Left untouched — remove it by hand if it is "
+            "yours."
+        )
+    if _canonical(recorded) != _canonical(log_path()):
+        return (
+            f"{candidate} was written by a different config root: its logs go to "
+            f"{recorded}, this root's to {log_path()}. Left untouched."
+        )
+    if _default_root_dir_exists():
+        return (
+            f"{candidate} looks like this root's, but the default config root "
+            f"{_default_config_root()} still exists and may own it. Left untouched "
+            "— remove it by hand, or remove that config root first."
+        )
     return None
 
 
@@ -608,13 +722,35 @@ def legacy_registration() -> Path | None:
     supervisor — install, uninstall, start/stop/restart, status — resolves it
     the same way, on both platforms.
 
-    Scoped to this ``$HOME`` by :func:`_legacy_path`; see there for why a
-    registration under another ``$HOME`` is deliberately NOT adopted.
+    Claiming one requires POSITIVE, canonicalised evidence that it is this
+    root's, never mere presence at the expected location. All of:
+
+    1. discovery is scoped to this ``$HOME`` (:func:`_legacy_path`);
+    2. this root has no registration of its own, which always takes precedence;
+    3. the file records a log destination equal to this root's, and the default
+       root's directory is absent (:func:`_default_root_dir_exists`, a labelled
+       heuristic — see its docstring for the upgrade it legitimately blocks).
+
+    Anything else returns ``None`` and is reported through
+    :func:`legacy_ambiguity`, because the alternative is deleting a supervisor
+    belonging to another root. Presence alone let ``uninstall`` from any
+    non-default root remove the DEFAULT root's live LaunchAgent while reporting
+    success — data loss behind a success message, which is the shape this
+    module exists to prevent.
     """
     if not _root_suffix():
         return None
     legacy = _legacy_path()
-    return legacy if legacy is not None and legacy.exists() else None
+    if legacy is None or not legacy.exists():
+        return None
+    if _own_registration_exists():
+        return None
+    recorded = _recorded_log_path(legacy)
+    if recorded is None or _canonical(recorded) != _canonical(log_path()):
+        return None
+    if _default_root_dir_exists():
+        return None
+    return legacy
 
 
 def uninstall(*, purge: bool = False, dry_run: bool = False) -> dict[str, object]:
@@ -634,6 +770,10 @@ def uninstall(*, purge: bool = False, dry_run: bool = False) -> dict[str, object
     # success is the false-success shape this function exists to avoid. It is
     # removed under the LEGACY name, which is the name it was registered with.
     orphan = legacy_registration()
+    # Unclaimable-but-present must not be reported as "nothing was installed".
+    # The user asked this root to manage a supervisor and it declined; saying so
+    # is the difference between an answer and a false success.
+    ambiguity = legacy_ambiguity()
     if supervisor == "launchctl":
         if not dry_run:
             existed = plist_path().exists()
@@ -696,7 +836,13 @@ def uninstall(*, purge: bool = False, dry_run: bool = False) -> dict[str, object
     # `ok` and not a literal: the disable branch above sets it False, and
     # returning True there is exactly the "claimed success it did not achieve"
     # bug this function was fixed for.
-    return {"ok": ok, "steps": steps}
+    result: dict[str, object] = {"ok": ok, "steps": steps}
+    if ambiguity is not None:
+        # Not an error — the removal this root COULD do succeeded — but the user
+        # must be told what was found and left, with the path, so "uninstalled"
+        # never silently means "and something of yours is still registered".
+        result["warning"] = ambiguity
+    return result
 
 
 def service_action(action: str) -> dict[str, object]:
@@ -773,4 +919,7 @@ def status(port: int | None = None) -> dict[str, object]:
         # explains why a daemon is running under a name the CLI would not
         # otherwise mention, and it tells the user which file to act on.
         "legacy_registration": str(orphan) if orphan is not None else None,
+        # A present-but-unclaimable registration is the case a user most needs
+        # named: it explains a daemon this root can neither see nor manage.
+        "legacy_ambiguity": legacy_ambiguity(),
     }

--- a/local_operator/browser_bridge/install.py
+++ b/local_operator/browser_bridge/install.py
@@ -698,8 +698,9 @@ def legacy_ambiguity() -> str | None:
     if _default_root_dir_exists():
         return (
             f"{candidate} looks like this root's, but the default config root "
-            f"{_default_config_root()} still exists and may own it. Left untouched "
-            "— remove it by hand, or remove that config root first."
+            f"{_default_config_root()} still exists and may own it. Left untouched. "
+            "Inspect the named supervisor registration and confirm ownership before "
+            "stopping or removing it. Keep all configuration and session data."
         )
     return None
 

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -1377,6 +1377,14 @@ def browser_command(args: argparse.Namespace) -> int:
             print("                     run 'lop browser status --repair' to reconcile.")
         print(f"port:                {result['port']}")
         print(f"log:                 {result['log']}")
+        # Only when this is NOT the default install: the common case should not
+        # grow a line, but an isolated run (a redirected HOME or
+        # LOCAL_OPERATOR_CONFIG_DIR) is otherwise indistinguishable from the
+        # real one in this output.
+        supervisor = result.get("supervisor")
+        if supervisor not in (browser_install.LABEL, browser_install.SYSTEMD_UNIT):
+            print(f"supervisor:          {supervisor}")
+            print(f"config root:         {result.get('config_root')}")
         return 0 if result["healthy"] else 1
     if command == "pair":
         if args.reset:
@@ -1419,17 +1427,43 @@ def browser_command(args: argparse.Namespace) -> int:
     if command == "logs":
         import subprocess
 
-        command_line = ["tail", "-n", str(args.lines)]
-        if args.follow:
-            command_line.append("-f")
-        command_line.append(str(browser_install.log_path()))
-        return subprocess.call(command_line)
+        # Through logs_command() so this matches where the daemon's output
+        # actually goes: systemd's default is the journal, and tailing the
+        # log file there reports "cannot open" on a path nothing writes.
+        command_line = browser_install.logs_command(args.lines, follow=args.follow)
+        # A log file that was never created means the daemon has not run under
+        # a supervisor here, which is a different thing from "it ran and said
+        # nothing". Say which, instead of leaving the user with `tail`'s
+        # "No such file or directory" on a path they never chose.
+        if command_line[0] == "tail" and not browser_install.log_path().exists():
+            print(
+                f"no daemon log at {browser_install.log_path()}.\n"
+                "The bridge has not run under a service supervisor on this machine. "
+                "Run `lop browser install`, or `lop browser serve` to run it in the "
+                "foreground."
+            )
+            return 1
+        try:
+            return subprocess.call(command_line)
+        except FileNotFoundError:
+            print(
+                f"\033[1;31mcannot run `{command_line[0]}`: not installed on this "
+                f"system.\033[0m\nThe daemon's output is at "
+                f"{browser_install.log_location()}."
+            )
+            return 1
     if command == "uninstall":
         result = browser_install.uninstall(purge=args.purge)
         steps = result.get("steps", [])
         assert isinstance(steps, list)
         for step in steps:
             print(f"  {step}")
+        # Print the reason too. Without this a failed uninstall exits 1 having
+        # said nothing at all — the no-supervisor case produces no steps, so
+        # the user got a bare non-zero exit with no explanation.
+        error = result.get("error")
+        if not result.get("ok") and error:
+            print(f"\033[1;31m{error}\033[0m")
         return 0 if result.get("ok") else 1
     print("usage: lop browser {install|status|start|stop|restart|pair|logs|uninstall|serve}")
     return 1

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -1385,6 +1385,13 @@ def browser_command(args: argparse.Namespace) -> int:
         if supervisor not in (browser_install.LABEL, browser_install.SYSTEMD_UNIT):
             print(f"supervisor:          {supervisor}")
             print(f"config root:         {result.get('config_root')}")
+        # An inherited registration explains a daemon running under a name this
+        # build would not otherwise mention, so name the file to act on.
+        legacy = result.get("legacy_registration")
+        if legacy:
+            print(f"legacy install:      {legacy}")
+            print("                     (written by an older build under the shared name;")
+            print("                      'lop browser uninstall' removes it)")
         return 0 if result["healthy"] else 1
     if command == "pair":
         if args.reset:

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -1392,6 +1392,12 @@ def browser_command(args: argparse.Namespace) -> int:
             print(f"legacy install:      {legacy}")
             print("                     (written by an older build under the shared name;")
             print("                      'lop browser uninstall' removes it)")
+        # A registration this root found but may not manage. Named explicitly,
+        # because otherwise a user sees "installed: no" beside a daemon that is
+        # plainly running and has nothing to act on.
+        ambiguous = result.get("legacy_ambiguity")
+        if ambiguous:
+            print(f"\n\033[1;33munclaimed registration:\033[0m {ambiguous}")
         return 0 if result["healthy"] else 1
     if command == "pair":
         if args.reset:
@@ -1471,6 +1477,11 @@ def browser_command(args: argparse.Namespace) -> int:
         error = result.get("error")
         if not result.get("ok") and error:
             print(f"\033[1;31m{error}\033[0m")
+        # What was found and deliberately left behind, so "uninstalled" never
+        # silently means "and something of yours is still registered".
+        warning = result.get("warning")
+        if warning:
+            print(f"\033[1;33mnote:\033[0m {warning}")
         return 0 if result.get("ok") else 1
     print("usage: lop browser {install|status|start|stop|restart|pair|logs|uninstall|serve}")
     return 1

--- a/local_operator/guides/browser/GUIDE.md
+++ b/local_operator/guides/browser/GUIDE.md
@@ -93,7 +93,10 @@ running — especially when it is not the user's daily browser (they live in
 Arc, the extension is in Chrome). Check first, silently:
 
 ```sh
+# macOS
 pgrep -x "Google Chrome"
+# Linux — the process is named for the binary, and varies by browser/distro
+pgrep -x chrome || pgrep -x chromium || pgrep -x chromium-browser || pgrep -x brave
 ```
 
 If it is not running, ask the user before starting it the FIRST time (a
@@ -101,12 +104,18 @@ standing "yes, launch Chrome when you need it" is enough forever after),
 then launch it backgrounded:
 
 ```sh
+# macOS
 open -g -a "Google Chrome"
+# Linux — `open` is absent (or unrelated); xdg-open takes no -a/-g, so run
+# the binary directly and detach it so it does not die with the shell.
+setsid google-chrome >/dev/null 2>&1 < /dev/null &
 ```
 
 `open -g` launches it in the background without stealing focus or raising a
 window — the extension connects to the daemon within seconds of the browser
-starting. Never launch with
+starting. On Linux `setsid ... &` is the equivalent detach; the window may
+take focus depending on the window manager, so prefer asking the user to
+open it themselves if focus matters. Never launch with
 `--remote-debugging-port` or developer flags: the extension is the debugger,
 and a debug-port browser on a real logged-in profile is an open door for any
 local process.
@@ -135,7 +144,15 @@ lop browser install
 ```
 
 This installs and starts the loopback daemon (a LaunchAgent on macOS /
-systemd user unit on Linux, so it survives restarts). The daemon binds
+systemd user unit on Linux). On macOS `RunAtLoad` starts it at login. On
+Linux it survives logout and reboot **only if user lingering is enabled** —
+`install` now runs `loginctl enable-linger` best-effort and says so in its
+steps, but if that was refused the daemon is torn down when the user's last
+session ends and does not come back at boot. On a headless or SSH host that
+is the difference between working and silently dead; the remedy is
+`loginctl enable-linger $USER`. `systemctl --user` over plain SSH without
+lingering also fails outright with `Failed to connect to bus: No medium
+found`, which `install` translates to that same remedy. The daemon binds
 **127.0.0.1 only** — never widen it. Once the extension is loaded and connected
 you pair it (step 4); until then `install` just gets the daemon healthy.
 
@@ -364,12 +381,17 @@ Every failure is one actionable string; act on it rather than retrying blindly:
   and don't silently churn — after the first failed check, tell the user
   what's wrong and what you're doing about it:
   1. **Is the paired browser even running?** Check before asking the user
-     anything: `pgrep -x "Google Chrome"` (or the browser they paired). This
+     anything: `pgrep -x "Google Chrome"` on macOS, or
+     `pgrep -x chrome || pgrep -x chromium || pgrep -x brave` on Linux (or
+     whichever browser they paired). This
      matters especially when the paired browser is NOT the user's primary one
      — a user who lives in Arc but paired Chrome will forget Chrome exists.
      If it isn't running, ask the user for permission to start it, then
      launch it BACKGROUNDED so it never steals focus:
-     `open -g -a "Google Chrome"` (macOS). Never add `--remote-debugging-port`
+     `open -g -a "Google Chrome"` (macOS) or
+     `setsid google-chrome >/dev/null 2>&1 </dev/null &` (Linux — there is no
+     `open -a`, and `xdg-open` takes neither `-a` nor `-g`).
+     Never add `--remote-debugging-port`
      or other debug flags — the extension IS the debugger; a debug-port
      browser on a real profile is a security hole. Not headless either: this
      is the user's own browser and they need to be able to see it. `-g` is
@@ -413,6 +435,16 @@ Every failure is one actionable string; act on it rather than retrying blindly:
   automate the Web Store (install other extensions, fill the developer console,
   etc.) through the extension. Drive the user there and have them click, or use
   a separate tab for the rest of the task.
+
+**Reading the daemon's own output**, which several of the above tell you to do.
+`lop browser logs` picks the right source per platform: the log file on macOS,
+and on Linux the log file only when systemd is new enough for
+`StandardOutput=append:` (>= 240) — otherwise the output is in the journal and
+`logs` runs `journalctl --user -u local-operator-browser.service` instead.
+`lop browser status` prints the location it actually reads under `log:`, so
+quote that rather than assuming a path. A daemon that cannot bind its port
+restarts every 5s under `Restart=on-failure`, which is invisible unless you
+read that output.
 
 ## Pages the extension cannot drive
 

--- a/tests/unit/browser_bridge/test_install.py
+++ b/tests/unit/browser_bridge/test_install.py
@@ -1,0 +1,464 @@
+"""Supervisor-layer guards for the browser bridge installer.
+
+There was no coverage for ``browser_bridge/install.py`` at all before this
+file, which is how four separate defects survived in the Linux path: a log
+destination the product could not read, an uncaught ``FileNotFoundError`` on
+every systemd-less machine, an uninstall that reported success it had not
+achieved, and a supervisor label that collided across config roots.
+
+The systemd branch is exercised on macOS by monkeypatching ``sys.platform``
+and ``shutil.which`` — the same technique ``tests/unit/mcp/test_manager.py``
+already uses — because the code under test dispatches on exactly those two
+things. Where a claim can only be settled by a real service manager (whether
+``append:`` actually redirects, whether a non-lingering user has a manager at
+all) it was verified by hand against systemd 255 in a container and is cited
+in the docstrings; those are deliberately NOT asserted here, since a test that
+mocks systemd cannot prove what systemd does.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from local_operator.browser_bridge import install
+
+
+@pytest.fixture
+def linux(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Present as Linux WITH systemd available."""
+    monkeypatch.setattr(install.sys, "platform", "linux")
+    monkeypatch.setattr(install.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+
+@pytest.fixture
+def linux_without_systemd(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Devuan/Alpine/Void/OpenRC/WSL2-without-systemd, and every container."""
+    monkeypatch.setattr(install.sys, "platform", "linux")
+    monkeypatch.setattr(install.shutil, "which", lambda name: None)
+
+
+@pytest.fixture
+def isolated_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """A config root that is NOT the uid's default — i.e. an isolated run."""
+    root = tmp_path / "isolated-config"
+    root.mkdir()
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(root))
+    return root
+
+
+# --------------------------------------------------------------------------
+# L1 — the generated unit has to send output somewhere the product reads.
+# --------------------------------------------------------------------------
+
+
+def test_systemd_unit_redirects_output_to_the_log_file_on_modern_systemd() -> None:
+    """Without this, output goes to the journal while three surfaces cite a file.
+
+    Reproduced on real systemd 255 before the fix: the unit produced output,
+    ``tail`` of ``log_path()`` reported "No such file or directory", and the
+    lines were in ``journalctl`` instead.
+    """
+    unit = install.render_systemd(4099, version=255)
+    assert f"StandardOutput=append:{install.log_path()}" in unit
+    assert f"StandardError=append:{install.log_path()}" in unit
+
+
+def test_systemd_unit_omits_append_on_systemd_too_old_for_it() -> None:
+    """``append:`` is a 240+ value, and an older systemd drops it SILENTLY.
+
+    Measured on systemd 255 with a deliberately invalid specifier: the unit
+    still starts and logs "Failed to parse output specifier, ignoring". So
+    emitting it blindly would not break the daemon — it would leave the output
+    in the journal while the product kept citing a file nothing writes, which
+    is the defect being fixed. The gate is what keeps the unit and
+    ``log_location()`` agreeing on every systemd.
+    """
+    unit = install.render_systemd(4099, version=239)
+    assert "append:" not in unit
+    # Still a well-formed unit that would start.
+    assert "ExecStart=" in unit
+    assert "WantedBy=default.target" in unit
+
+
+def test_systemd_unit_omits_append_when_the_version_cannot_be_read() -> None:
+    """Unknown degrades to "assume old": keep the unit loadable."""
+    assert "append:" not in install.render_systemd(4099, version=None)
+
+
+def test_logs_command_reads_the_journal_when_the_log_file_is_not_written(
+    linux: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``lop browser logs`` must not tail a path nothing writes."""
+    monkeypatch.setattr(install, "systemd_version", lambda: 239)
+    command = install.logs_command(50)
+    assert command[:2] == ["journalctl", "--user"]
+    assert install.systemd_unit() in command
+    assert "-f" not in command
+
+
+def test_logs_command_follows_the_journal_when_asked(
+    linux: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(install, "systemd_version", lambda: 239)
+    assert install.logs_command(50, follow=True)[-1] == "-f"
+
+
+def test_logs_command_tails_the_file_when_systemd_does_redirect(
+    linux: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(install, "systemd_version", lambda: 255)
+    command = install.logs_command(50)
+    assert command[0] == "tail"
+    assert command[-1] == str(install.log_path())
+
+
+def test_status_reports_the_journal_as_the_log_location_on_old_systemd(
+    linux: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The ``log:`` line users are told to look at must be true.
+
+    This is the surface that made the empty directory read as "the daemon
+    produced no output".
+    """
+    monkeypatch.setattr(install, "systemd_version", lambda: 239)
+    assert install.log_location() == f"journalctl --user -u {install.systemd_unit()}"
+
+
+# --------------------------------------------------------------------------
+# L2 — no entry point may raise on a machine without a supervisor.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("action", ["start", "stop", "restart"])
+def test_service_action_returns_an_error_instead_of_raising(
+    action: str, linux_without_systemd: None
+) -> None:
+    """Pre-fix this raised ``FileNotFoundError: 'systemctl'`` out of the CLI.
+
+    ``check=False`` suppresses a non-zero exit status, not a missing binary —
+    the distinction the original code was relying on and did not have.
+    """
+    result = install.service_action(action)
+    assert result["ok"] is False
+    assert "no supported user service supervisor" in str(result["error"])
+
+
+def test_uninstall_returns_an_error_instead_of_raising(linux_without_systemd: None) -> None:
+    result = install.uninstall()
+    assert result["ok"] is False
+    assert "no supported user service supervisor" in str(result["error"])
+
+
+def test_install_refuses_without_a_supervisor_using_the_same_message(
+    linux_without_systemd: None,
+) -> None:
+    """One shared string: the entry points cannot describe one machine differently."""
+    result = install.install()
+    assert result["ok"] is False
+    assert result["error"] == install.NO_SUPERVISOR_ERROR
+
+
+def test_service_action_never_shells_out_when_there_is_no_supervisor(
+    linux_without_systemd: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The guard must come BEFORE the subprocess call, not wrap it."""
+
+    def explode(*args: object, **kwargs: object) -> None:
+        raise AssertionError("must not invoke a subprocess without a supervisor")
+
+    monkeypatch.setattr(install.subprocess, "run", explode)
+    assert install.service_action("start")["ok"] is False
+
+
+# --------------------------------------------------------------------------
+# L2 (recovery) — Linux gains the reload-and-retry macOS already had.
+# --------------------------------------------------------------------------
+
+
+def test_start_reloads_and_retries_when_the_unit_is_not_yet_known(
+    linux: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A unit on disk the manager has not read fails until something reloads it."""
+    monkeypatch.setattr(install, "systemd_path", lambda: tmp_path / "unit.service")
+    (tmp_path / "unit.service").write_text("[Service]\n", encoding="utf-8")
+    calls: list[tuple[str, ...]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(tuple(cmd[2:]))
+        failed = cmd[2] == "start" and ("daemon-reload",) not in calls
+        return subprocess.CompletedProcess(
+            cmd, 1 if failed else 0, "", "Unit not found." if failed else ""
+        )
+
+    monkeypatch.setattr(install.subprocess, "run", fake_run)
+    result = install.service_action("start")
+    assert result["ok"] is True, "a reload-then-retry should recover this"
+    assert ("daemon-reload",) in calls
+
+
+def test_stop_does_not_reload_and_retry(
+    linux: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Recovery is for start/restart; a failed stop is not fixed by a reload."""
+    monkeypatch.setattr(install, "systemd_path", lambda: tmp_path / "unit.service")
+    (tmp_path / "unit.service").write_text("[Service]\n", encoding="utf-8")
+    calls: list[tuple[str, ...]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(tuple(cmd[2:]))
+        return subprocess.CompletedProcess(cmd, 1, "", "boom")
+
+    monkeypatch.setattr(install.subprocess, "run", fake_run)
+    assert install.service_action("stop")["ok"] is False
+    assert ("daemon-reload",) not in calls
+
+
+# --------------------------------------------------------------------------
+# L3 — uninstall must not claim a removal it did not perform.
+# --------------------------------------------------------------------------
+
+
+def test_uninstall_reports_failure_when_disable_fails(
+    linux: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Pre-fix this returned ``ok: True`` and the CLI exited 0.
+
+    Reproduced with a real ``systemctl`` stub exiting 1: the result was
+    ``{'ok': True, 'steps': ['removed the systemd user service']}``.
+    """
+    unit = tmp_path / "unit.service"
+    unit.write_text("[Service]\n", encoding="utf-8")
+    monkeypatch.setattr(install, "systemd_path", lambda: unit)
+    monkeypatch.setattr(
+        install.subprocess,
+        "run",
+        lambda cmd, **kw: subprocess.CompletedProcess(cmd, 1, "", "Failed to disable"),
+    )
+    result = install.uninstall()
+    assert result["ok"] is False
+    steps = result["steps"]
+    assert isinstance(steps, list)
+    assert any("failed" in str(step) for step in steps)
+
+
+def test_uninstall_says_nothing_was_installed_rather_than_claiming_removal(
+    linux: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(install, "systemd_path", lambda: tmp_path / "absent.service")
+    monkeypatch.setattr(
+        install.subprocess,
+        "run",
+        lambda cmd, **kw: subprocess.CompletedProcess(cmd, 1, "", "Unit not loaded"),
+    )
+    result = install.uninstall()
+    assert result["ok"] is True
+    steps = result["steps"]
+    assert isinstance(steps, list)
+    assert any("no systemd user service" in str(step) for step in steps)
+
+
+# --------------------------------------------------------------------------
+# L4 — lingering, and the bus error that names its remedy.
+# --------------------------------------------------------------------------
+
+
+def test_install_enables_lingering_before_enabling_the_unit(
+    linux: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Order matters: without a user manager the enable itself fails."""
+    monkeypatch.setattr(install, "systemd_path", lambda: tmp_path / "unit.service")
+    monkeypatch.setattr(install, "log_path", lambda: tmp_path / "bridge.log")
+    monkeypatch.setattr(install, "health", lambda *a, **k: {"ok": True})
+    order: list[str] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        order.append("linger" if "enable-linger" in cmd else " ".join(cmd[2:3]))
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(install.subprocess, "run", fake_run)
+    result = install.install(4099)
+    assert result["ok"] is True
+    assert "linger" in order, "install must attempt loginctl enable-linger"
+    assert order.index("linger") < order.index("enable")
+
+
+def test_a_refused_linger_does_not_fail_the_install(
+    linux: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """It can legitimately be refused; the install otherwise succeeded."""
+    monkeypatch.setattr(install, "systemd_path", lambda: tmp_path / "unit.service")
+    monkeypatch.setattr(install, "log_path", lambda: tmp_path / "bridge.log")
+    monkeypatch.setattr(install, "health", lambda *a, **k: {"ok": True})
+    monkeypatch.setattr(install, "enable_linger", lambda: False)
+    monkeypatch.setattr(
+        install.subprocess,
+        "run",
+        lambda cmd, **kw: subprocess.CompletedProcess(cmd, 0, "", ""),
+    )
+    result = install.install(4099)
+    assert result["ok"] is True
+    steps = result["steps"]
+    assert isinstance(steps, list)
+    assert any("lingering" in str(step) for step in steps)
+
+
+def test_the_bus_error_is_translated_into_the_linger_remedy() -> None:
+    """Surfacing systemd's stderr verbatim was truthful but not actionable.
+
+    Nothing in the product named ``loginctl enable-linger`` before this.
+    """
+    translated = install._translate_systemctl_error("Failed to connect to bus: No medium found")
+    assert "loginctl enable-linger" in translated
+    assert "No medium found" in translated, "keep the original cause too"
+
+
+def test_an_unrelated_systemctl_error_is_passed_through_unchanged() -> None:
+    """Do not attach the linger advice to failures it does not explain."""
+    translated = install._translate_systemctl_error("Job for x.service failed")
+    assert "loginctl enable-linger" not in translated
+
+
+def test_enable_linger_is_absent_rather_than_raising_without_loginctl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(install.shutil, "which", lambda name: None)
+    assert install.enable_linger() is False
+
+
+# --------------------------------------------------------------------------
+# L11 — the supervisor name is global per-uid, so it must follow the root.
+# --------------------------------------------------------------------------
+
+
+def test_the_default_config_root_keeps_the_historical_label_byte_for_byte(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BACKWARD COMPATIBILITY, and the sharp edge of this change.
+
+    Every already-installed user's daemon is registered under exactly these
+    names. If they moved, that daemon becomes an orphan: a running process the
+    CLI can no longer stop, start or uninstall, with no way back short of
+    hand-editing launchd/systemd. The default root must therefore be
+    indistinguishable from the pre-change build.
+    """
+    monkeypatch.delenv("LOCAL_OPERATOR_CONFIG_DIR", raising=False)
+    # Point the config root at the uid's REAL default location. The suite's
+    # autouse isolation redirects HOME to a tmp dir, which is itself a
+    # non-default root — so without this the fixture, not the code, is what
+    # makes the label differ, and the compatibility claim goes untested.
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(install._default_config_root()))
+    assert install.label() == "com.local-operator.browser"
+    assert install.systemd_unit() == "local-operator-browser.service"
+
+
+def test_the_default_label_is_anchored_on_the_uid_not_on_HOME(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The collision namespace is ``gui/<uid>``, which does not move with $HOME.
+
+    Deriving "is this the default install?" from ``Path.home()`` would let an
+    isolated ``HOME=/tmp/... lop browser install`` compare its root against its
+    own home, conclude it IS the default, and reuse the real daemon's label —
+    the exact collision this fixes.
+    """
+    monkeypatch.delenv("LOCAL_OPERATOR_CONFIG_DIR", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    assert install.label() != "com.local-operator.browser"
+
+
+def test_an_isolated_config_root_gets_its_own_label(isolated_root: Path) -> None:
+    """Verified against launchd: bootout resolves a plist to the Label INSIDE it,
+    so a same-label plist at another path evicts the incumbent. An isolated run
+    killed the operator's live daemon on this machine before this fix."""
+    assert install.label().startswith("com.local-operator.browser.")
+    assert install.label() != "com.local-operator.browser"
+    assert install.systemd_unit() != "local-operator-browser.service"
+    assert install.systemd_unit().endswith(".service")
+
+
+def test_two_different_isolated_roots_do_not_collide(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "a"))
+    (tmp_path / "a").mkdir()
+    first = install.label()
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "b"))
+    (tmp_path / "b").mkdir()
+    assert install.label() != first
+
+
+def test_the_label_is_stable_across_equivalent_spellings_of_one_root(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Otherwise ``/tmp/x`` and ``/tmp/./x`` would manage two different daemons."""
+    root = tmp_path / "root"
+    root.mkdir()
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(root))
+    plain = install.label()
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(root) + "/./")
+    assert install.label() == plain
+
+
+def test_the_plist_and_unit_paths_follow_the_label(isolated_root: Path) -> None:
+    assert install.plist_path().name == f"{install.label()}.plist"
+    assert install.systemd_path().name == install.systemd_unit()
+
+
+def test_the_rendered_plist_carries_this_roots_label(isolated_root: Path) -> None:
+    """The Label INSIDE the plist is what launchd registers, so it is the one
+    that must be per-root — the filename alone is not enough."""
+    assert install.render_plist(4099)["Label"] == install.label()
+
+
+def test_a_default_install_reports_no_orphan(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The default root's name did not change, so its install is adopted, not orphaned."""
+    monkeypatch.delenv("LOCAL_OPERATOR_CONFIG_DIR", raising=False)
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(install._default_config_root()))
+    assert install.legacy_registration() is None
+
+
+def test_an_isolated_root_names_an_older_builds_shared_registration(
+    isolated_root: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """MIGRATION: a pre-change build under this root wrote the shared name.
+
+    That file is no longer addressable by the CLI, so it is named rather than
+    left as a running daemon nobody can stop.
+    """
+    home = tmp_path / "home"
+    (home / "Library" / "LaunchAgents").mkdir(parents=True)
+    (home / "Library" / "LaunchAgents" / f"{install.LABEL}.plist").write_text("x")
+    monkeypatch.setattr(install.sys, "platform", "darwin")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    assert install.legacy_registration() is not None
+
+
+def test_status_names_the_supervisor_and_root_it_reports_on(
+    isolated_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two isolated daemons otherwise produce identical status output."""
+    monkeypatch.setattr(install, "health", lambda *a, **k: None)
+    result = install.status()
+    assert result["supervisor"] == install.label() or result["supervisor"] == (
+        install.systemd_unit()
+    )
+    assert result["config_root"] == str(isolated_root)
+
+
+# --------------------------------------------------------------------------
+# CLI edges: a non-zero exit must never be silent.
+# --------------------------------------------------------------------------
+
+
+def test_uninstall_carries_an_error_string_for_the_cli_to_print(
+    linux_without_systemd: None,
+) -> None:
+    """The no-supervisor case produces no steps, so without this the CLI
+    exited 1 having printed nothing at all."""
+    result = install.uninstall()
+    assert result["ok"] is False
+    assert str(result.get("error", "")).strip(), "a failed uninstall must say why"

--- a/tests/unit/browser_bridge/test_install.py
+++ b/tests/unit/browser_bridge/test_install.py
@@ -18,7 +18,9 @@ mocks systemd cannot prove what systemd does.
 
 from __future__ import annotations
 
+import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -394,13 +396,65 @@ def test_two_different_isolated_roots_do_not_collide(
 def test_the_label_is_stable_across_equivalent_spellings_of_one_root(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Otherwise ``/tmp/x`` and ``/tmp/./x`` would manage two different daemons."""
+    """Two paths naming ONE directory must produce one daemon, not two.
+
+    Through a real SYMLINK, which is what makes this a test of ``.resolve()``.
+    An earlier version compared ``/tmp/x`` against ``/tmp/x/./`` and passed with
+    ``.resolve()`` deleted, because ``pathlib`` collapses ``./`` in its own
+    constructor (``str(Path("/tmp/x/./")) == "/tmp/x"``) — it named symlink
+    canonicalisation and measured string normalisation ``Path`` did for free.
+    A symlink survives that constructor, so only a real ``resolve()`` collapses
+    it.
+    """
     root = tmp_path / "root"
     root.mkdir()
+    link = tmp_path / "link-to-root"
+    link.symlink_to(root, target_is_directory=True)
+    # Guard the guard: if these were already equal as strings the assertion
+    # below would hold with no canonicalisation at all.
+    assert str(link) != str(root)
+
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(root))
-    plain = install.label()
-    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(root) + "/./")
-    assert install.label() == plain
+    through_real_path = install.label()
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(link))
+    assert install.label() == through_real_path
+
+
+def test_the_digest_is_stable_across_processes(tmp_path: Path) -> None:
+    """The label must survive a restart, so its digest cannot be salted.
+
+    ``hash()`` is randomised per process by ``PYTHONHASHSEED``, so swapping
+    sha256 for it would give the SAME process one stable label — passing every
+    in-process assertion — while the next ``lop`` invocation computed a
+    different one and lost track of the daemon it installed. Nothing else in
+    the suite would catch that, so this pins the value across a real
+    interpreter boundary rather than within one.
+    """
+    root = tmp_path / "stable-root"
+    root.mkdir()
+    program = (
+        "import os, sys;"
+        "sys.path.insert(0, os.environ['LO_REPO']);"
+        "from local_operator.browser_bridge import install;"
+        "print(install.label())"
+    )
+    env = {
+        **os.environ,
+        "LOCAL_OPERATOR_CONFIG_DIR": str(root),
+        "LO_REPO": str(Path(install.__file__).resolve().parents[2]),
+    }
+    seen = set()
+    for seed in ("0", "1", "12345"):
+        result = subprocess.run(
+            [sys.executable, "-c", program],
+            capture_output=True,
+            text=True,
+            env={**env, "PYTHONHASHSEED": seed},
+        )
+        assert result.returncode == 0, result.stderr
+        seen.add(result.stdout.strip())
+    assert len(seen) == 1, f"label changed across PYTHONHASHSEED values: {seen}"
+    assert seen.pop().startswith("com.local-operator.browser.")
 
 
 def test_the_plist_and_unit_paths_follow_the_label(isolated_root: Path) -> None:
@@ -462,3 +516,163 @@ def test_uninstall_carries_an_error_string_for_the_cli_to_print(
     result = install.uninstall()
     assert result["ok"] is False
     assert str(result.get("error", "")).strip(), "a failed uninstall must say why"
+
+
+# --------------------------------------------------------------------------
+# A1 — a config root that INHERITS a pre-per-root build's registration.
+#
+# `LOCAL_OPERATOR_CONFIG_DIR` is a documented setting, and a `$HOME` that
+# differs from the passwd home suffixes the label too. For those users the
+# released build registered the DEFAULT name while this build looks for a
+# suffixed one, so every entry point has to resolve the inherited one or it
+# reports a success it did not achieve.
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def inherited_darwin(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, isolated_root: Path) -> Path:
+    """A legacy plist exactly as the released build wrote it, under a suffixed root."""
+    home = tmp_path / "home"
+    (home / "Library" / "LaunchAgents").mkdir(parents=True)
+    monkeypatch.setattr(install.sys, "platform", "darwin")
+    monkeypatch.setattr(install.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    legacy = home / "Library" / "LaunchAgents" / f"{install.LABEL}.plist"
+    legacy.write_text("<plist>released build</plist>", encoding="utf-8")
+    return legacy
+
+
+def test_uninstall_removes_the_registration_an_older_build_left(
+    inherited_darwin: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reproduced before this fix: ``{'ok': True, 'steps': ['no LaunchAgent was
+    installed']}`` while the plist stayed on disk and its daemon kept running —
+    the same false success ``uninstall`` exists to prevent."""
+    calls: list[tuple[str, ...]] = []
+    monkeypatch.setattr(
+        install,
+        "_launchctl",
+        lambda *a: calls.append(a) or subprocess.CompletedProcess(list(a), 0, "", ""),
+    )
+    result = install.uninstall()
+    assert result["ok"] is True
+    assert not inherited_darwin.exists(), "the inherited plist must actually be removed"
+    assert any(a[0] == "bootout" and str(inherited_darwin) in a[-1] for a in calls)
+    steps = result["steps"]
+    assert isinstance(steps, list)
+    assert any("older build" in str(step) for step in steps)
+
+
+def test_uninstall_does_not_claim_a_removal_it_did_not_make(
+    isolated_root: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No own install and nothing inherited: still says so plainly."""
+    home = tmp_path / "empty-home"
+    (home / "Library" / "LaunchAgents").mkdir(parents=True)
+    monkeypatch.setattr(install.sys, "platform", "darwin")
+    monkeypatch.setattr(install.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(install, "_passwd_home", lambda: home)
+    monkeypatch.setattr(
+        install, "_launchctl", lambda *a: subprocess.CompletedProcess(list(a), 0, "", "")
+    )
+    result = install.uninstall()
+    steps = result["steps"]
+    assert isinstance(steps, list)
+    assert any("no LaunchAgent was installed" in str(step) for step in steps)
+    assert not any("older build" in str(step) for step in steps)
+
+
+def test_status_counts_an_inherited_registration_as_installed(
+    inherited_darwin: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ "installed: no" beside a running daemon sends the user to reinstall on
+    top of what they already have."""
+    monkeypatch.setattr(install, "health", lambda *a, **k: None)
+    result = install.status()
+    assert result["installed"] is True
+    assert result["legacy_registration"] == str(inherited_darwin)
+
+
+def test_status_reports_no_legacy_registration_for_a_default_install(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The default root is adopted, never orphaned, so nothing to report."""
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(install._default_config_root()))
+    monkeypatch.setattr(install, "health", lambda *a, **k: None)
+    assert install.status()["legacy_registration"] is None
+
+
+@pytest.mark.parametrize("action", ["start", "stop", "restart"])
+def test_service_action_targets_the_inherited_label(
+    action: str, inherited_darwin: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Otherwise start/stop/restart address a service that was never registered
+    while the real daemon keeps running."""
+    calls: list[tuple[str, ...]] = []
+    monkeypatch.setattr(
+        install,
+        "_launchctl",
+        lambda *a: calls.append(a) or subprocess.CompletedProcess(list(a), 0, "", ""),
+    )
+    install.service_action(action)
+    targets = [a[-1] for a in calls]
+    assert any(t.endswith(f"/{install.LABEL}") or t == str(inherited_darwin) for t in targets)
+    assert not any(install.label() in t for t in targets), "must not use the suffixed name"
+
+
+def test_an_own_registration_wins_over_an_inherited_one(
+    inherited_darwin: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Adoption is only for a root with no install of its own."""
+    install.plist_path().write_bytes(b"<plist>this root</plist>")
+    calls: list[tuple[str, ...]] = []
+    monkeypatch.setattr(
+        install,
+        "_launchctl",
+        lambda *a: calls.append(a) or subprocess.CompletedProcess(list(a), 0, "", ""),
+    )
+    install.service_action("start")
+    assert any(install.label() in a[-1] for a in calls)
+
+
+def test_the_legacy_lookup_searches_the_passwd_home_too(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, isolated_root: Path
+) -> None:
+    """A redirected ``$HOME`` must not hide a registration written under the
+    passwd home — the released build ran with ``$HOME`` at its normal value."""
+    passwd_home = tmp_path / "passwd-home"
+    (passwd_home / "Library" / "LaunchAgents").mkdir(parents=True)
+    legacy = passwd_home / "Library" / "LaunchAgents" / f"{install.LABEL}.plist"
+    legacy.write_text("<plist/>", encoding="utf-8")
+    redirected = tmp_path / "redirected-home"
+    (redirected / "Library" / "LaunchAgents").mkdir(parents=True)
+    monkeypatch.setattr(install.sys, "platform", "darwin")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: redirected))
+    monkeypatch.setattr(install, "_passwd_home", lambda: passwd_home)
+    assert install.legacy_registration() == legacy
+
+
+def test_the_legacy_unit_is_resolved_on_linux_too(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, isolated_root: Path
+) -> None:
+    """Same exposure through the fixed systemd unit name."""
+    home = tmp_path / "linux-home"
+    unit_dir = home / ".config" / "systemd" / "user"
+    unit_dir.mkdir(parents=True)
+    legacy = unit_dir / install.SYSTEMD_UNIT
+    legacy.write_text("[Service]\n", encoding="utf-8")
+    monkeypatch.setattr(install.sys, "platform", "linux")
+    monkeypatch.setattr(install.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(install, "_passwd_home", lambda: home)
+    assert install.legacy_registration() == legacy
+    calls: list[tuple[str, ...]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(tuple(cmd))
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(install.subprocess, "run", fake_run)
+    install.service_action("start")
+    assert any(install.SYSTEMD_UNIT in c and install.systemd_unit() not in c for c in calls)

--- a/tests/unit/browser_bridge/test_install.py
+++ b/tests/unit/browser_bridge/test_install.py
@@ -19,6 +19,7 @@ mocks systemd cannot prove what systemd does.
 from __future__ import annotations
 
 import os
+import plistlib
 import subprocess
 import sys
 from pathlib import Path
@@ -480,15 +481,20 @@ def test_an_isolated_root_names_an_older_builds_shared_registration(
 ) -> None:
     """MIGRATION: a pre-change build under this root wrote the shared name.
 
-    That file is no longer addressable by the CLI, so it is named rather than
-    left as a running daemon nobody can stop.
+    An evidence-free file is NAMED, never claimed. It is not addressable by this
+    build, so leaving it silent would present a running daemon nobody can stop
+    as "nothing installed" — but claiming it on location alone is how a
+    non-default root came to delete the default root's live LaunchAgent.
     """
     home = tmp_path / "home"
     (home / "Library" / "LaunchAgents").mkdir(parents=True)
     (home / "Library" / "LaunchAgents" / f"{install.LABEL}.plist").write_text("x")
     monkeypatch.setattr(install.sys, "platform", "darwin")
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
-    assert install.legacy_registration() is not None
+    monkeypatch.setattr(install, "_passwd_home", lambda: home)
+    assert install.legacy_registration() is None, "no evidence means not ours to claim"
+    reported = install.legacy_ambiguity()
+    assert reported is not None and str(install.LABEL) in reported
 
 
 def test_status_names_the_supervisor_and_root_it_reports_on(
@@ -531,14 +537,27 @@ def test_uninstall_carries_an_error_string_for_the_cli_to_print(
 
 @pytest.fixture
 def inherited_darwin(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, isolated_root: Path) -> Path:
-    """A legacy plist exactly as the released build wrote it, under a suffixed root."""
+    """A CLAIMABLE legacy plist: written as a released build writes it, carrying
+    the evidence that makes it provably this root's.
+
+    ``StandardOutPath`` is what the released ``render_plist`` records
+    (``str(log_path())`` — verified against v0.51.14) and it is the ownership
+    evidence, because it derives from the CONFIG ROOT: a plist written under a
+    different root records a different path. The default root's directory is
+    deliberately absent, since while it exists the shared-name registration may
+    be the default install's and is refused. Both conditions have their own
+    negative tests below.
+    """
     home = tmp_path / "home"
     (home / "Library" / "LaunchAgents").mkdir(parents=True)
     monkeypatch.setattr(install.sys, "platform", "darwin")
     monkeypatch.setattr(install.shutil, "which", lambda name: f"/usr/bin/{name}")
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(install, "_passwd_home", lambda: home)
     legacy = home / "Library" / "LaunchAgents" / f"{install.LABEL}.plist"
-    legacy.write_text("<plist>released build</plist>", encoding="utf-8")
+    legacy.write_bytes(
+        plistlib.dumps({"Label": install.LABEL, "StandardOutPath": str(install.log_path())})
+    )
     return legacy
 
 
@@ -689,17 +708,35 @@ def test_a_redirected_home_never_adopts_the_passwd_homes_registration(
 def test_the_legacy_unit_is_resolved_on_linux_too(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, isolated_root: Path
 ) -> None:
-    """Same exposure through the fixed systemd unit name."""
+    """A JOURNAL-ONLY legacy unit is never auto-adopted, on name alone.
+
+    This is the Linux case that has no macOS twin. The released
+    ``render_systemd`` emitted ``ExecStart`` only — no ``StandardOutput=`` —
+    so every unit written before this build carries NO ownership evidence at
+    all, and its output went to the journal. Adopting one because its NAME
+    matches is precisely the reasoning that let a root claim another root's
+    supervisor, so it is refused and reported instead.
+    """
     home = tmp_path / "linux-home"
     unit_dir = home / ".config" / "systemd" / "user"
     unit_dir.mkdir(parents=True)
     legacy = unit_dir / install.SYSTEMD_UNIT
-    legacy.write_text("[Service]\n", encoding="utf-8")
+    # Exactly what v0.51.14's render_systemd produced.
+    legacy.write_text(
+        "[Unit]\nDescription=Local Operator browser bridge\n\n"
+        "[Service]\nExecStart=/usr/bin/python -m local_operator.browser_bridge.daemon\n"
+        "Restart=on-failure\nRestartSec=5\n\n[Install]\nWantedBy=default.target\n",
+        encoding="utf-8",
+    )
     monkeypatch.setattr(install.sys, "platform", "linux")
     monkeypatch.setattr(install.shutil, "which", lambda name: f"/usr/bin/{name}")
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
     monkeypatch.setattr(install, "_passwd_home", lambda: home)
-    assert install.legacy_registration() == legacy
+
+    assert install.legacy_registration() is None, "journal-only unit carries no evidence"
+    reported = install.legacy_ambiguity()
+    assert reported is not None and "journal" in reported
+
     calls: list[tuple[str, ...]] = []
 
     def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
@@ -708,7 +745,10 @@ def test_the_legacy_unit_is_resolved_on_linux_too(
 
     monkeypatch.setattr(install.subprocess, "run", fake_run)
     install.service_action("start")
-    assert any(install.SYSTEMD_UNIT in c and install.systemd_unit() not in c for c in calls)
+    # Never addresses the legacy unit name it cannot prove is its own.
+    assert not any(install.SYSTEMD_UNIT in c and install.systemd_unit() not in c for c in calls)
+    install.uninstall()
+    assert legacy.exists(), "an unattributable unit must not be deleted"
 
 
 # --------------------------------------------------------------------------
@@ -722,14 +762,27 @@ def test_the_legacy_unit_is_resolved_on_linux_too(
 
 @pytest.fixture
 def inherited_linux(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, isolated_root: Path) -> Path:
-    """A legacy unit exactly as a pre-per-root build wrote it, under a suffixed root."""
+    """A CLAIMABLE legacy unit: carrying the ``StandardOutput=append:`` line that
+    is the only ownership evidence a unit can hold.
+
+    Note what this fixture implies about the Linux upgrade path, which is
+    covered by its own test below: the RELEASED ``render_systemd`` emitted
+    ``ExecStart`` only, so a unit from any build before this one is journal-only
+    and carries NO evidence. Those are never auto-adopted; this fixture
+    represents a unit written by a build new enough to record the destination
+    (systemd >= 240).
+    """
     home = tmp_path / "linux-home"
     (home / ".config" / "systemd" / "user").mkdir(parents=True)
     monkeypatch.setattr(install.sys, "platform", "linux")
     monkeypatch.setattr(install.shutil, "which", lambda name: f"/usr/bin/{name}")
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(install, "_passwd_home", lambda: home)
     legacy = home / ".config" / "systemd" / "user" / install.SYSTEMD_UNIT
-    legacy.write_text("[Service]\nExecStart=/bin/true\n", encoding="utf-8")
+    legacy.write_text(
+        "[Service]\nExecStart=/bin/true\n" f"StandardOutput=append:{install.log_path()}\n",
+        encoding="utf-8",
+    )
     return legacy
 
 
@@ -785,3 +838,131 @@ def test_uninstall_leaves_no_systemd_unit_untouched_when_nothing_was_inherited(
     calls = _systemctl_spy(monkeypatch)
     install.uninstall()
     assert not any(install.SYSTEMD_UNIT in c and install.systemd_unit() not in c for c in calls)
+
+
+# --------------------------------------------------------------------------
+# Q1/Q2 — ownership must be PROVEN before a legacy registration is claimed.
+#
+# QA hit Q1 for real: from a non-default config root, `uninstall` deleted the
+# operator's live default-root LaunchAgent (restored byte-for-byte). On a user's
+# machine that takes RunAtLoad/KeepAlive with it, so the bridge never returns
+# after a reboot — while `uninstall` reports success.
+# --------------------------------------------------------------------------
+
+
+def _plant(home: Path, *, log_path: str | None) -> Path:
+    """A default-named plist, optionally carrying ownership evidence."""
+    (home / "Library" / "LaunchAgents").mkdir(parents=True, exist_ok=True)
+    body: dict[str, object] = {"Label": install.LABEL}
+    if log_path is not None:
+        body["StandardOutPath"] = log_path
+    target = home / "Library" / "LaunchAgents" / f"{install.LABEL}.plist"
+    target.write_bytes(plistlib.dumps(body))
+    return target
+
+
+def test_a_non_default_root_never_claims_the_default_roots_registration(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, isolated_root: Path
+) -> None:
+    """Q1. While the default root exists, the shared-name file may be its live
+    install, so no other root may claim — or delete — it."""
+    home = tmp_path / "home"
+    (home / ".local-operator").mkdir(parents=True)  # the default root, present
+    monkeypatch.setattr(install.sys, "platform", "darwin")
+    monkeypatch.setattr(install.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(install, "_passwd_home", lambda: home)
+    # Evidence that would otherwise satisfy ownership: still refused.
+    live = _plant(home, log_path=str(install.log_path()))
+    monkeypatch.setattr(
+        install, "_launchctl", lambda *a: subprocess.CompletedProcess(list(a), 0, "", "")
+    )
+
+    assert install.legacy_registration() is None
+    result = install.uninstall()
+    assert live.exists(), "must never delete the default root's registration"
+    assert result.get("warning"), "and must say what it found and left"
+
+
+def test_a_registration_written_by_another_root_is_refused(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, isolated_root: Path
+) -> None:
+    """Ownership is decided by recorded evidence, not by location."""
+    home = tmp_path / "home"
+    monkeypatch.setattr(install.sys, "platform", "darwin")
+    monkeypatch.setattr(install.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(install, "_passwd_home", lambda: home)
+    other = _plant(home, log_path="/some/other/root/logs/browser-bridge.log")
+    monkeypatch.setattr(
+        install, "_launchctl", lambda *a: subprocess.CompletedProcess(list(a), 0, "", "")
+    )
+
+    assert install.legacy_registration() is None
+    install.uninstall()
+    assert other.exists()
+    reported = install.legacy_ambiguity()
+    assert reported is not None and "different config root" in reported
+
+
+def test_ownership_evidence_is_compared_canonically(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, isolated_root: Path
+) -> None:
+    """A symlinked or dot-segmented spelling of ONE path is the same path.
+
+    Without canonicalisation a genuine owner is refused on macOS, where
+    ``/tmp`` is a symlink to ``/private/tmp`` — the recorded string and the
+    computed one then differ while naming one file.
+    """
+    home = tmp_path / "home"
+    monkeypatch.setattr(install.sys, "platform", "darwin")
+    monkeypatch.setattr(install.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(install, "_passwd_home", lambda: home)
+    # A real symlink, since `Path` collapses `./` in its own constructor and
+    # would make this pass without any canonicalisation at all.
+    real_logs = install.log_path().parent
+    real_logs.mkdir(parents=True, exist_ok=True)
+    link = tmp_path / "logs-via-symlink"
+    link.symlink_to(real_logs, target_is_directory=True)
+    through_link = str(link / install.log_path().name)
+    assert through_link != str(install.log_path())
+    _plant(home, log_path=through_link)
+    assert install.legacy_registration() is not None
+
+
+def test_this_roots_own_registration_takes_precedence(
+    inherited_darwin: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Q2. With an own install present, uninstall removes ITS registration and
+    leaves the other one alone — uninstalling root A must not take down root B."""
+    install.plist_path().write_bytes(plistlib.dumps({"Label": install.label()}))
+    monkeypatch.setattr(
+        install, "_launchctl", lambda *a: subprocess.CompletedProcess(list(a), 0, "", "")
+    )
+    result = install.uninstall()
+    assert inherited_darwin.exists(), "must not remove a registration it does not own"
+    assert not install.plist_path().exists(), "must remove its own"
+    assert result.get("warning"), "and must name what it left"
+
+
+def test_an_unclaimable_registration_is_reported_not_silently_ignored(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, isolated_root: Path
+) -> None:
+    """Unknown ownership must reach the user, never collapse into the
+    'no LaunchAgent was installed' success that hides it."""
+    home = tmp_path / "home"
+    (home / ".local-operator").mkdir(parents=True)
+    monkeypatch.setattr(install.sys, "platform", "darwin")
+    monkeypatch.setattr(install.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setattr(install, "_passwd_home", lambda: home)
+    _plant(home, log_path=str(install.log_path()))
+    monkeypatch.setattr(
+        install, "_launchctl", lambda *a: subprocess.CompletedProcess(list(a), 0, "", "")
+    )
+    monkeypatch.setattr(install, "health", lambda *a, **k: None)
+
+    warning = install.uninstall().get("warning")
+    assert warning is not None and str(install.LABEL) in str(warning)
+    assert install.status()["legacy_ambiguity"] is not None

--- a/tests/unit/browser_bridge/test_install.py
+++ b/tests/unit/browser_bridge/test_install.py
@@ -664,9 +664,10 @@ def test_a_redirected_home_never_adopts_the_passwd_homes_registration(
     prescribes for any bridge work. An earlier version of this fix also searched
     the passwd home, so that pattern resolved the OPERATOR's live plist; the
     isolated root has no install of its own, so it was ADOPTED and would then be
-    booted out, unlinked and SIGTERM'd. It fanned out without bound — every
-    isolated root resolves that same one file — and ownership is unrecoverable
-    from the plist, which names no config root.
+    booted out, unlinked and SIGTERM'd. The fake passwd-home plist must satisfy
+    the other ownership checks: valid matching-log evidence and no default-root
+    directory. A malformed or no-log fixture is rejected by the evidence guard
+    even if HOME discovery widens, so it cannot test this boundary.
 
     The lookup is HOME-keyed on purpose ("did MY predecessor write this?"),
     unlike ``_default_config_root``, which is UID-keyed ("does this root own the
@@ -678,7 +679,10 @@ def test_a_redirected_home_never_adopts_the_passwd_homes_registration(
     passwd_home = tmp_path / "passwd-home"
     (passwd_home / "Library" / "LaunchAgents").mkdir(parents=True)
     other_root_plist = passwd_home / "Library" / "LaunchAgents" / f"{install.LABEL}.plist"
-    other_root_plist.write_text("<plist>another root's daemon</plist>", encoding="utf-8")
+    other_root_plist.write_bytes(
+        plistlib.dumps({"Label": install.LABEL, "StandardOutPath": str(install.log_path())})
+    )
+    original_plist = other_root_plist.read_bytes()
     redirected = tmp_path / "redirected-home"
     (redirected / "Library" / "LaunchAgents").mkdir(parents=True)
     monkeypatch.setattr(install.sys, "platform", "darwin")
@@ -686,6 +690,13 @@ def test_a_redirected_home_never_adopts_the_passwd_homes_registration(
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: redirected))
     monkeypatch.setattr(install, "_passwd_home", lambda: passwd_home)
 
+    # Isolate the discovery boundary: none of the later checks may reject this
+    # candidate and conceal a passwd-home fallback regression.
+    assert not install._default_config_root().exists()
+    assert not install._own_registration_exists()
+    recorded = install._recorded_log_path(other_root_plist)
+    assert recorded is not None
+    assert install._canonical(recorded) == install._canonical(install.log_path())
     assert install.legacy_registration() is None, "must not resolve another HOME's plist"
 
     # And the consequences, not merely the lookup: nothing may target or delete
@@ -697,7 +708,9 @@ def test_a_redirected_home_never_adopts_the_passwd_homes_registration(
         lambda *a: calls.append(a) or subprocess.CompletedProcess(list(a), 0, "", ""),
     )
     install.uninstall()
-    assert other_root_plist.exists(), "uninstall must not delete another root's plist"
+    assert (
+        other_root_plist.read_bytes() == original_plist
+    ), "uninstall must preserve another root's plist byte-for-byte"
     install.service_action("stop")
     assert not any(str(other_root_plist) in c[-1] for c in calls)
     assert not any(
@@ -966,3 +979,40 @@ def test_an_unclaimable_registration_is_reported_not_silently_ignored(
     warning = install.uninstall().get("warning")
     assert warning is not None and str(install.LABEL) in str(warning)
     assert install.status()["legacy_ambiguity"] is not None
+
+
+def test_ambiguous_uninstall_advice_preserves_configuration_and_sessions(
+    inherited_darwin: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A5: removing persistent user data is not a remedy for an ambiguous job.
+
+    Exercise the printed CLI warning, not only the helper's return value. The
+    ownership heuristic must still refuse, but its advice must concern only the
+    named supervisor registration, never the retained config/session root.
+    """
+    from argparse import Namespace
+
+    from local_operator.cli import browser_command
+
+    default_root = install._default_config_root()
+    default_root.mkdir()
+    transcript = default_root / "sessions" / "synthetic" / "transcript.jsonl"
+    transcript.parent.mkdir(parents=True)
+    transcript.write_text('{"synthetic": true}\n', encoding="utf-8")
+    original = inherited_darwin.read_bytes()
+    monkeypatch.setattr(
+        install, "_launchctl", lambda *a: subprocess.CompletedProcess(list(a), 0, "", "")
+    )
+
+    # Preserve the previously approved return contract; this change is advice
+    # only, not a redesign of ambiguity handling.
+    assert browser_command(Namespace(browser_command="uninstall", purge=False)) == 0
+    output = capsys.readouterr().out
+    assert str(inherited_darwin) in output
+    assert "remove that config root" not in output
+    assert "confirm ownership" in output
+    assert "Keep all configuration and session data" in output
+    assert inherited_darwin.read_bytes() == original
+    assert transcript.read_text(encoding="utf-8") == '{"synthetic": true}\n'

--- a/tests/unit/browser_bridge/test_install.py
+++ b/tests/unit/browser_bridge/test_install.py
@@ -636,21 +636,54 @@ def test_an_own_registration_wins_over_an_inherited_one(
     assert any(install.label() in a[-1] for a in calls)
 
 
-def test_the_legacy_lookup_searches_the_passwd_home_too(
+def test_a_redirected_home_never_adopts_the_passwd_homes_registration(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, isolated_root: Path
 ) -> None:
-    """A redirected ``$HOME`` must not hide a registration written under the
-    passwd home — the released build ran with ``$HOME`` at its normal value."""
+    """THE A3 GUARD. An isolated root must not claim another root's supervisor.
+
+    ``HOME=/tmp/... LOCAL_OPERATOR_CONFIG_DIR=...`` is the isolation AGENTS.md
+    prescribes for any bridge work. An earlier version of this fix also searched
+    the passwd home, so that pattern resolved the OPERATOR's live plist; the
+    isolated root has no install of its own, so it was ADOPTED and would then be
+    booted out, unlinked and SIGTERM'd. It fanned out without bound — every
+    isolated root resolves that same one file — and ownership is unrecoverable
+    from the plist, which names no config root.
+
+    The lookup is HOME-keyed on purpose ("did MY predecessor write this?"),
+    unlike ``_default_config_root``, which is UID-keyed ("does this root own the
+    default NAME?"). A registration under a different ``$HOME`` belongs to a
+    different run.
+
+    Uses a FAKE passwd home: this must never depend on, or touch, the real one.
+    """
     passwd_home = tmp_path / "passwd-home"
     (passwd_home / "Library" / "LaunchAgents").mkdir(parents=True)
-    legacy = passwd_home / "Library" / "LaunchAgents" / f"{install.LABEL}.plist"
-    legacy.write_text("<plist/>", encoding="utf-8")
+    other_root_plist = passwd_home / "Library" / "LaunchAgents" / f"{install.LABEL}.plist"
+    other_root_plist.write_text("<plist>another root's daemon</plist>", encoding="utf-8")
     redirected = tmp_path / "redirected-home"
     (redirected / "Library" / "LaunchAgents").mkdir(parents=True)
     monkeypatch.setattr(install.sys, "platform", "darwin")
+    monkeypatch.setattr(install.shutil, "which", lambda name: f"/usr/bin/{name}")
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: redirected))
     monkeypatch.setattr(install, "_passwd_home", lambda: passwd_home)
-    assert install.legacy_registration() == legacy
+
+    assert install.legacy_registration() is None, "must not resolve another HOME's plist"
+
+    # And the consequences, not merely the lookup: nothing may target or delete
+    # a registration this root does not own.
+    calls: list[tuple[str, ...]] = []
+    monkeypatch.setattr(
+        install,
+        "_launchctl",
+        lambda *a: calls.append(a) or subprocess.CompletedProcess(list(a), 0, "", ""),
+    )
+    install.uninstall()
+    assert other_root_plist.exists(), "uninstall must not delete another root's plist"
+    install.service_action("stop")
+    assert not any(str(other_root_plist) in c[-1] for c in calls)
+    assert not any(
+        c[-1].endswith(f"/{install.LABEL}") for c in calls
+    ), "must not address the default label it does not own"
 
 
 def test_the_legacy_unit_is_resolved_on_linux_too(
@@ -676,3 +709,79 @@ def test_the_legacy_unit_is_resolved_on_linux_too(
     monkeypatch.setattr(install.subprocess, "run", fake_run)
     install.service_action("start")
     assert any(install.SYSTEMD_UNIT in c and install.systemd_unit() not in c for c in calls)
+
+
+# --------------------------------------------------------------------------
+# A4 — the systemd half of the inherited-registration handling.
+#
+# On a PR whose whole purpose is the Linux path, this branch was unguarded:
+# deleting it entirely, and separately swapping its by-unit-name disable for
+# the suffixed name, both left 187 tests green.
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def inherited_linux(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, isolated_root: Path) -> Path:
+    """A legacy unit exactly as a pre-per-root build wrote it, under a suffixed root."""
+    home = tmp_path / "linux-home"
+    (home / ".config" / "systemd" / "user").mkdir(parents=True)
+    monkeypatch.setattr(install.sys, "platform", "linux")
+    monkeypatch.setattr(install.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    legacy = home / ".config" / "systemd" / "user" / install.SYSTEMD_UNIT
+    legacy.write_text("[Service]\nExecStart=/bin/true\n", encoding="utf-8")
+    return legacy
+
+
+def _systemctl_spy(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, ...]]:
+    """Record every ``systemctl`` argv without running one."""
+    calls: list[tuple[str, ...]] = []
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(tuple(cmd))
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(install.subprocess, "run", fake_run)
+    return calls
+
+
+def test_uninstall_removes_the_systemd_unit_an_older_build_left(
+    inherited_linux: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The Linux twin of the launchd case: the file must actually go, and the
+    step must say so, or `uninstall` reports a success it did not achieve."""
+    _systemctl_spy(monkeypatch)
+    result = install.uninstall()
+    assert not inherited_linux.exists(), "the inherited unit file must be removed"
+    steps = result["steps"]
+    assert isinstance(steps, list)
+    assert any("older build" in str(step) for step in steps)
+
+
+def test_uninstall_disables_the_legacy_unit_by_its_own_name(
+    inherited_linux: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """systemd addresses units by NAME, so disabling the suffixed name leaves the
+    legacy unit enabled and its daemon running — deleting the file alone does not
+    stop it. Swapping this for ``systemd_unit()`` previously passed every test."""
+    calls = _systemctl_spy(monkeypatch)
+    install.uninstall()
+    disables = [c for c in calls if "disable" in c]
+    assert any(
+        install.SYSTEMD_UNIT in c for c in disables
+    ), f"no disable targeted the legacy unit name; saw {disables}"
+
+
+def test_uninstall_leaves_no_systemd_unit_untouched_when_nothing_was_inherited(
+    isolated_root: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The mirror of the above: with nothing inherited, the legacy name is never
+    disabled — otherwise this would disable a unit belonging to someone else."""
+    home = tmp_path / "bare-home"
+    (home / ".config" / "systemd" / "user").mkdir(parents=True)
+    monkeypatch.setattr(install.sys, "platform", "linux")
+    monkeypatch.setattr(install.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    calls = _systemctl_spy(monkeypatch)
+    install.uninstall()
+    assert not any(install.SYSTEMD_UNIT in c and install.systemd_unit() not in c for c in calls)

--- a/tests/unit/session/test_no_session_deletion.py
+++ b/tests/unit/session/test_no_session_deletion.py
@@ -381,8 +381,14 @@ _ALLOWED_ROWS: tuple[tuple[str | int, ...], ...] = (
     (
         "local_operator/browser_bridge/install.py::uninstall",
         "<path>.unlink",
-        "plist/unit FILEs; state_store.remove()",
-        2,
+        # 4, not 2: this root's own plist/unit, PLUS the registration a
+        # pre-per-root build left under the shared default name. A config root
+        # with a suffixed supervisor name inherits that file, and leaving it
+        # behind made `uninstall` report success while the daemon kept running.
+        # Both are supervisor config FILEs the user asked to remove — never a
+        # session, transcript or state directory.
+        "plist/unit FILEs (own + one inherited from a pre-per-root build)",
+        4,
     ),
     (
         "local_operator/browser_bridge/install.py::uninstall",


### PR DESCRIPTION
## Summary

The Linux browser-bridge install path had four defects that made it hard to
diagnose and, in one case, hazardous to a concurrently-running daemon. This
fixes them in the supervisor layer (`browser_bridge/install.py`), the CLI
surfaces that report on it, and the docs that describe it.

**Change class: C2** — bug fixes plus one behaviour change (per-config-root
supervisor names) confined to one module and its two CLI callers. No schema,
no API, no user-data migration. `pyproject.toml` is untouched; `extension/` is
untouched (a sibling PR owns it).

**Every finding arrived as an UNREPRODUCED source-reading hypothesis.** The
first thing done with each was to reproduce it by execution. One did not hold
up and is reported as such.

## Findings, and what was actually verified

| ID | Status | How it was settled |
|---|---|---|
| L1 | **Reproduced, fixed** | Real systemd 255 in a container |
| L2 | **Reproduced, fixed** | Executed on this box (`systemctl` genuinely absent) |
| L3 | **Reproduced, fixed** | Real failing `systemctl` stub on `PATH` |
| L4 | **Reproduced, fixed** | Real systemd 255, lingering toggled |
| L5 | Confirmed by inspection, fixed | `grep` over the guide |
| L6 | **DOES NOT REPRODUCE** | See below — partially actioned |
| L11 | **Reproduced, fixed** | launchd, using a throwaway service |

### L1 (high) — daemon logs went where the product could not read them

`render_systemd()` emitted no `StandardOutput=`/`StandardError=`, so systemd's
default sent output to the journal, while three surfaces cited `log_path()`:
the install failure message, `lop browser logs` (`tail`), and the `log:` line
in `lop browser status`. Because `install()` creates that file's *parent
directory*, the user found an empty directory — which reads as "the daemon
produced no output", not "look somewhere else".

Reproduced on real systemd 255, with the unit exactly as the pre-fix code
emits it:

```
=== does the log file the product points at exist? ===
total 8
drwxr-xr-x 2 lopuser root 4096 Sep  7 19:45 .        <- empty
=== tail of that path (what 'lop browser logs' runs) ===
tail: cannot open '/home/lopuser/.local/state/local-operator/logs/browser-bridge.log'
      for reading: No such file or directory
=== where the output ACTUALLY went ===
Sep 07 19:46:00 3806e15f72f7 sh[159]: BRIDGE_STDOUT_LINE
Sep 07 19:46:00 3806e15f72f7 sh[159]: BRIDGE_STDERR_LINE
```

**Fix:** both directions at once, kept consistent by construction. The unit
emits `append:` when systemd is >= 240; `log_location()` and `logs_command()`
are the single source of truth for every surface, and on an older systemd they
name `journalctl --user -u <unit>` because that is where the output genuinely
is.

Verified with the fixed generator against the same live systemd:

```
StandardOutput=append:/home/lopuser/.local/state/local-operator/logs/browser-bridge.log
StandardError=append:/home/lopuser/.local/state/local-operator/logs/browser-bridge.log
=== log file the product points at ===
REAL_CODE_STDOUT
REAL_CODE_STDERR
```

**The `>= 240` claim was checked, and the failure mode is not what the finding
assumed.** `append:` did land in 240 (upstream NEWS, confirmed by the
maintainer on systemd-devel). But an older systemd does **not** refuse the
unit — measured against a deliberately invalid specifier on 255:

```
lo-badvalue.service:4: Failed to parse output specifier, ignoring: totally-not-a-valid-value
```

It logs and starts anyway. So emitting `append:` blindly would not break the
daemon; it would silently drop the redirect and leave the product citing a file
nothing writes — i.e. exactly the bug being fixed. The version gate is what
keeps the emitted unit and `log_location()` telling the same story. The code
comment and test docstring were corrected to say this rather than the
"fails to load" claim I first wrote.

### L2 (high) — traceback instead of a message without systemd

`install()` guarded on `shutil.which("systemctl")`; `service_action()` and
`uninstall()` did not. `check=False` suppresses a non-zero exit, **not**
`FileNotFoundError`. Reproduced on this box, where `systemctl` is genuinely
absent, with `sys.platform` patched to `linux`:

```
systemctl on PATH here: None
service_action('start')   -> RAISED FileNotFoundError: [Errno 2] ... 'systemctl'
service_action('stop')    -> RAISED FileNotFoundError: [Errno 2] ... 'systemctl'
service_action('restart') -> RAISED FileNotFoundError: [Errno 2] ... 'systemctl'
uninstall()               -> RAISED FileNotFoundError: [Errno 2] ... 'systemctl'
```

**Fix:** one `_supervisor()` helper guarding on the binary, used by all three
entry points with one shared message. Linux also gains the reload-and-retry
recovery macOS already had (a unit on disk the user manager has not read yet).

After, through the **real CLI**:

```
######## lop browser start   (Linux, no systemd) ########
no supported user service supervisor found (launchctl on macOS,
systemctl --user on Linux); run `lop browser serve` in the foreground
   [exit=1]
```

…identically for `stop`, `restart` and `uninstall`. Two CLI-side gaps surfaced
while exercising this and are fixed here too: a failed `uninstall` exited 1
having printed *nothing* (no steps in that branch), and `logs` leaked a raw
`tail: No such file or directory` instead of explaining that the bridge has
never run under a supervisor.

### L3 (minor) — uninstall claimed success it did not achieve

Reproduced with a real `systemctl` stub on `PATH` exiting 1:

```
real systemctl stub exits 1; uninstall() says:
    {'ok': True, 'steps': ['removed the systemd user service']}
```

**Fix:** it reports what it actually did. A second, smaller instance of the
same bug was caught by the new test and fixed: the failure branch set
`ok = False`, but the function returned a hardcoded `{"ok": True}` that
discarded it.

### L4 (high) — "survives restarts" was false as written

`WantedBy=default.target` + `enable --now`, with no `loginctl enable-linger`.
Confirmed on systemd 255 — with lingering disabled there is no user manager
at all:

```
$ loginctl show-user lopuser -p Linger
Failed to get user: User ID 1001 is not logged in or lingering
$ systemctl --user enable --now local-operator-browser.service   # no session bus
Failed to connect to bus: No medium found
```

**Fix:** best-effort `enable_linger()` during install (non-fatal — it can
legitimately be refused by a locked-down host, and an otherwise-successful
install must not be reported as failed over it), ordered *before* `enable
--now` because without a user manager the enable itself fails. The bus error
is translated into the named remedy; verified the translator matches the exact
string real systemd emits, and the `$DBUS_SESSION_BUS_ADDRESS` variant.

The guide's "so it survives restarts" sentence now states the Linux condition
instead of implying parity with macOS's `RunAtLoad`.

### L5 (medium, docs) — troubleshooting was macOS-only

`pgrep -x "Google Chrome"` and `open -g -a` in `local_operator/guides/browser/GUIDE.md`.
Linux equivalents added inline (`pgrep -x chrome || chromium || brave`,
`setsid google-chrome ... &`, noting `xdg-open` takes neither `-a` nor `-g`),
plus a new note on reading the daemon's output per platform.

### L6 (minor, docs) — DOES NOT REPRODUCE

The finding says `README.md` still claims the extension "is not yet on the
Chrome Web Store" and tells users to build from source. **It does not.** The
README already links the live store listing and offers building from source
only as a parenthetical alternative. There is no "not yet" claim anywhere in
the file:

```
$ grep -n "not yet\|isn't yet\|is not yet\|not published" README.md
(no matches)
```

What *was* stale is adjacent: the prose pinned `(v0.1.7)` while the extension
is at 0.1.8. Rather than bump a number that goes stale every release — and
that PR A owns — the version reference is removed. Flagging this as a scout
finding that did not survive contact.

### L11 (high) — supervisor name collided across config roots

Added mid-task. The launchd `Label` and systemd unit name are **global
per-uid**, but were module constants. `plist_path()` varies with `$HOME`, so
this looks safe — but launchd resolves a plist to the `Label` *inside* it.

Reproduced without touching the operator's daemon, using a throwaway service I
owned: bootstrapped from path A, then `bootout` via a **different path B**
carrying the same `Label`:

```
--- incumbent bootstrapped from PATH A ---   state = running, pid = 90275
--- now bootout using the DIFFERENT path B (same Label) ---   bootout rc=0
EVICTED: a different path with the same Label removed it
```

That is the mechanism by which `HOME=/tmp/... lop browser install` — the
isolation AGENTS.md prescribes — killed the operator's live daemon.

**Fix:** the name carries an 8-hex digest of the resolved config root.

**The backward-compatibility constraint is the sharp edge, and it is
covered by a test.** Every installed user's daemon is registered under the
current names; if they moved, that daemon becomes an orphan the CLI can no
longer stop, start or uninstall. So the default root's names must be
byte-identical, and are:

```
DEFAULT root label     : com.local-operator.browser
DEFAULT unit           : local-operator-browser.service
byte-identical to LABEL: True
ISOLATED label         : com.local-operator.browser.f1e244c6
OTHER isolated label   : com.local-operator.browser.397510f3
```

One subtlety worth calling out for review: `_default_config_root()` is anchored
on the **uid's passwd home**, not `Path.home()`. `Path.home()` reads `$HOME`,
so an isolated run would compare its root against its *own* redirected home,
conclude it is the default, and reuse the real label — reintroducing the
collision. The collision namespace is `gui/<uid>`, which does not move with
`$HOME`. There is a dedicated test for this.

**Migration/orphan case — rewritten after review rounds 1 and 2; this is the
current contract.** The default root is *adopted*, not orphaned, since its name
is unchanged. For a root whose name IS suffixed (a `LOCAL_OPERATOR_CONFIG_DIR`
user, or a `$HOME` differing from the passwd home), a registration left under
the shared default name is claimed **only on proven ownership**, and claiming it
means `uninstall` REMOVES it, `service_action` adopts it for start/stop/restart,
and `status` counts it installed and names the file.

All of these must hold before anything is claimed or deleted:

1. **HOME-scoped discovery.** `Path.home()` only. (Round 2 A3: also searching
   the passwd home made the isolation AGENTS.md prescribes resolve the
   operator's live plist, which was then adopted and would have been booted
   out, unlinked and SIGTERM'd.)
2. **Own-install precedence.** A root with its own registration never touches
   another's; uninstalling root A must not take down root B.
3. **Canonicalised positive evidence.** The registration must record a log
   destination equal to this root's. Every build derives that from the config
   root — verified against the RELEASED writer at `v0.51.14`, not just current
   code — so it is a measurement rather than an assumption. Compared through
   `resolve()`, so a symlinked or dot-segmented spelling of one path is one
   path.
4. **A conservative refusal while the default root's directory exists**, which
   is labelled a heuristic in the code because directory existence proves
   neither a live service nor ownership. (Round 2 Q1: without it, `uninstall`
   from any non-default root deleted the DEFAULT root's live LaunchAgent,
   taking `RunAtLoad`/`KeepAlive` with it — the bridge never returns after a
   reboot, and `uninstall` reports success. QA reproduced this against the real
   machine and restored the plist byte-for-byte.) The cost is documented: a
   user with both a populated `~/.local-operator` and an override root must
   remove their legacy registration by hand.

**Unknown ownership is never silence.** `legacy_ambiguity()` says what was
found and why it was left, surfaced by `status` and as a `warning` on
`uninstall`, so "no LaunchAgent was installed" can no longer conceal another
root's live daemon.

**Linux is weaker than macOS here and is treated as such.** The released
`render_systemd` emitted `ExecStart` only — no `StandardOutput=` — so every unit
written by a prior build is journal-only and carries no ownership evidence at
all. Those are never auto-adopted on name alone; they are reported instead.

`status()` now reports the supervisor and config root, printed by the CLI only
when it is *not* the default install so the common case gains no line.

End-to-end through the real CLI under an isolated HOME, with the operator's
daemon live throughout:

```
port:                4099
log:                 /tmp/lo-cli-iso.byzkgN/.local-operator/logs/browser-bridge.log
supervisor:          com.local-operator.browser.75915906
config root:         /tmp/lo-cli-iso.byzkgN/.local-operator
```

```
$ ps -p 87461   -> still running
OPERATOR LAUNCHD REGISTRATION: INTACT
```

## Testing

**There was no coverage for `browser_bridge/install.py` at all.** Verified —
`grep` for `render_systemd`/`service_action` across `tests/` matched only the
unrelated mobile installer. Adds `tests/unit/browser_bridge/test_install.py`,
33 tests, exercising the systemd branch on macOS by monkeypatching
`sys.platform` and `shutil.which` (the pattern `tests/unit/mcp/test_manager.py`
already uses).

**Each guard was proven able to go red.** Applied the new file to a detached
worktree at `origin/main` and ran it against the pre-fix code: **31 failed, 1
passed** — and the failures name the defect itself, not a missing import:

```
FAILED ...test_service_action_returns_an_error_instead_of_raising[start]
  - FileNotFoundError: [Errno 2] No such file or directory: 'systemctl'
FAILED ...test_uninstall_reports_failure_when_disable_fails - assert True is False
FAILED ...test_start_reloads_and_retries_when_the_unit_is_not_yet_known
  - AssertionError: a reload-then-retry should recover this
FAILED ...test_install_enables_lingering_before_enabling_the_unit
  - AssertionError: install must attempt loginctl enable-linger
  assert 'linger' in ['daemon-reload', 'enable']
FAILED ...test_the_default_config_root_keeps_the_historical_label_byte_for_byte
FAILED ...test_service_action_never_shells_out_when_there_is_no_supervisor
  - AssertionError: must not invoke a subprocess without a supervisor
```

The one test that passed pre-fix is the "unrelated systemctl error passes
through unchanged" guard, which asserts a *non*-regression.

**A third bug was caught by CI**, and it was a real API defect rather than a
test artifact. `render_systemd(version=None)` conflated "caller did not pass
one, detect it" with "systemd is present but its version is unreadable" —
making the unknown-version branch unreachable on any machine where detection
succeeds, so its guard passed for the wrong reason locally (macOS: no
`systemctl`) and failed on CI's Linux runners, which detect a modern systemd.
A caller asking for the unknown-version rendering could not get it. Fixed with
a `_Detect` sentinel (`dad8d6cd9`), leaving `None` to mean only what it says.

Two further tests caught real bugs in my own first draft: the discarded
`ok` in `uninstall()`, and a compatibility test that was passing for the wrong
reason (the suite's autouse isolation redirects `HOME`, which is itself a
non-default root — so the fixture, not the code, was making the label differ).

Post-fix on this branch: **33 passed**.

### Gates

| Gate | Result |
|---|---|
| `flake8 .` | clean |
| `black --check .` (26.1.0) | 1035 files unchanged |
| `isort --check .` (5.13.2) | clean |
| `pyright .` | 0 errors, 0 warnings |
| Affected surfaces (`browser_bridge`, `mobile`, `no_session_deletion`, `ambient_env_isolation`) | **648 passed** |
| Full `tests/unit` | see comment below |

### Linux coverage: what is settled, what is stubbed

**This PR must not be read as carrying Linux coverage.** Stated plainly,
because QA's round-1 report and my own evidence differ on one point and a
reader should not have to reconcile them:

**Settled on macOS, for real (no stubs):** every systemd-ABSENT path. The
`FileNotFoundError` reproductions and the fixes are exercised through the real
CLI entry point on this box, where `systemctl` genuinely does not exist — QA
independently reproduced 4 uncaught tracebacks at the base commit and 0 on this
head. L11's default-root compatibility and the A1 inherited-registration paths
are likewise real (launchd, live registration, `_launchctl` spied so nothing is
booted out).

**Stubbed:** every systemd-PRESENT path. `_systemctl_user` and `subprocess.run`
are monkeypatched in the unit tests, so what is proven there is the argv we
build and the branching, not systemd's response to it.

**The Docker evidence is disputed and should be treated as unreproduced.** My
earlier run booted `systemd 255` in a privileged `--cgroupns=host` container
built locally from `ubuntu:24.04` (no registry pull for the systemd image
itself, which is likely the difference) and produced the `append:`,
journal-vs-file, lingering and bus-error transcripts quoted above. On QA's run
the same host hung past 300s on registry pulls and even on `hello-world`. I
cannot reproduce QA's hang and QA could not reproduce my run, so: **do not
count the container transcripts as verification.** They are consistent with the
documented systemd behaviour they assert, and nothing in the fix depends on
them being accepted — the version gate degrades to "assume old" when detection
fails, which is the safe direction.

**One smoke on a real Linux host closes Q-B1/Q-B3/Q-B4** — install, confirm the
unit's `StandardOutput=append:` (or the journal fallback on systemd < 240),
`lop browser logs`, and `loginctl enable-linger`. That is the only outstanding
gap, and it is a gap in *evidence*, not a known defect: the base commit is
broken on these paths in ways the reproductions above do demonstrate.

**Not run on Linux at all:** the full `lop browser install` → healthy-daemon
round trip, and L11's unit-name collision on systemd (the launchd half is
demonstrated; the systemd half is the same global-name shape, fixed
identically).

## Not in scope

L7 (killed by the scout), L8/L9 (audited clean), L10 (no telemetry to
implement against). No `extension/` files and no `pyproject.toml` change.

Release: patch — Linux browser-bridge installs now log where the product says
they do, fail with actionable messages instead of tracebacks, and no longer
collide with another config root's daemon.


