### PR TITLE
docs: return the browser guide to its users, keep harness flags in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1230,6 +1230,24 @@ on this host (Chrome 152.0.7977.76, `--headless=new`), the built
 `Page.captureScreenshot` returned a 34 KB PNG showing the real pairing form;
 `Input.dispatchMouseEvent` dispatched. Nothing appeared on screen.
 
+The launch itself, with the flags this section requires:
+
+```sh
+# Throwaway profile, headless, no keychain prompts, and a port Chrome picks.
+profile=$(mktemp -d /tmp/lo-harness.XXXXXX)
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  --headless=new --user-data-dir="$profile" \
+  --remote-debugging-port=0 \
+  --use-mock-keychain --password-store=basic \
+  --no-first-run --no-default-browser-check about:blank &
+
+# Chrome writes DevToolsActivePort asynchronously, so WAIT for it rather than
+# reading it straight after launch: an immediate read gets a missing or empty
+# file and the connect fails intermittently, which reads like a flaky harness.
+until [ -s "$profile/DevToolsActivePort" ]; do sleep 0.2; done
+port=$(head -1 "$profile/DevToolsActivePort")
+```
+
 **Load the extension over CDP, not `--load-extension`.** Branded Chrome removed
 that switch in 137 (`PSA: Removing --load-extension flag in Chrome branded
 builds`, chromium-extensions), and the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1253,11 +1253,13 @@ Drive it over CDP on `$port` per the steps below, then tear it down — by PID,
 because this snippet's Chrome is in your own process group:
 
 ```sh
-# SIGTERM to the browser PID alone is NOT enough and its shortfall is timing
-# dependent, which is why it looks fine in a quick test: measured on Chrome 152,
-# killing it left 1 survivor when torn down immediately and 5 once the browser
-# had settled for a second or more. Sweep your OWN profile afterwards -- the
-# pattern is what scopes it to your Chrome and never the operator's.
+# SIGTERM to the browser PID alone is NOT enough, and what it misses varies run
+# to run -- measured on Chrome 152 across 11 runs it left anywhere from 0 to 5
+# helpers behind, with no stable pattern by timing. That is exactly why a quick
+# test "passes": some runs really do come back clean. Never conclude from one.
+# Sweep your OWN profile afterwards, and assert the count rather than trusting
+# it. The unique mktemp pattern is what scopes the sweep to your Chrome and
+# never the operator's.
 kill "$chrome_pid" 2>/dev/null
 sleep 2
 pkill -f "$profile" 2>/dev/null

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1240,13 +1240,28 @@ profile=$(mktemp -d /tmp/lo-harness.XXXXXX)
   --remote-debugging-port=0 \
   --use-mock-keychain --password-store=basic \
   --no-first-run --no-default-browser-check about:blank &
+chrome_pid=$!
 
 # Chrome writes DevToolsActivePort asynchronously, so WAIT for it rather than
 # reading it straight after launch: an immediate read gets a missing or empty
 # file and the connect fails intermittently, which reads like a flaky harness.
 until [ -s "$profile/DevToolsActivePort" ]; do sleep 0.2; done
 port=$(head -1 "$profile/DevToolsActivePort")
+
+# Tear THIS one down by PID, not by process group: `&` leaves Chrome in the
+# caller's group, so `kill -TERM -$pgid` from a plain shell kills the shell too.
+kill "$chrome_pid"
 ```
+
+**The process-group teardown below applies to a harness that owns its own
+group, not to this shell snippet.** A backgrounded `&` puts Chrome in the
+*caller's* process group, so signalling that group signals whatever is running
+the script — verified here: the child inherited the caller's pgid and
+`kill -TERM -$pgid` terminated the calling shell with `-15`. Kill the captured
+PID from a shell; use the pgid form only from a harness that started Chrome
+with `start_new_session=True` (Python) or an equivalent, which is what puts it
+in a group of its own. `setsid` is not the escape hatch on macOS — it does not
+exist there.
 
 **Load the extension over CDP, not `--load-extension`.** Branded Chrome removed
 that switch in 137 (`PSA: Removing --load-extension flag in Chrome branded

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1247,10 +1247,22 @@ chrome_pid=$!
 # file and the connect fails intermittently, which reads like a flaky harness.
 until [ -s "$profile/DevToolsActivePort" ]; do sleep 0.2; done
 port=$(head -1 "$profile/DevToolsActivePort")
+```
 
-# Tear THIS one down by PID, not by process group: `&` leaves Chrome in the
-# caller's group, so `kill -TERM -$pgid` from a plain shell kills the shell too.
-kill "$chrome_pid"
+Drive it over CDP on `$port` per the steps below, then tear it down — by PID,
+because this snippet's Chrome is in your own process group:
+
+```sh
+# SIGTERM to the browser PID alone is NOT enough and its shortfall is timing
+# dependent, which is why it looks fine in a quick test: measured on Chrome 152,
+# killing it left 1 survivor when torn down immediately and 5 once the browser
+# had settled for a second or more. Sweep your OWN profile afterwards -- the
+# pattern is what scopes it to your Chrome and never the operator's.
+kill "$chrome_pid" 2>/dev/null
+sleep 2
+pkill -f "$profile" 2>/dev/null
+pgrep -f "$profile" | wc -l   # assert 0, every run
+rm -rf "$profile"
 ```
 
 **The process-group teardown below applies to a harness that owns its own

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1202,6 +1202,15 @@ extension's popup and options page are the other user-visible surface here, and
 they are captured out of a real Chrome rather than out of a pilot. **Any Chrome
 an agent launches for testing, capture, or CDP work runs `--headless=new`.**
 
+**This section is for people and agents developing the extension itself**, where
+the artifact under test is `extension/dist` and it has to be loaded into a
+browser that does not have it yet. It is not how anyone *uses* the browser tool:
+a user — or an agent doing ordinary browser work in any repository — drives the
+browser that is already paired, per `guide://browser`, and never starts a second
+one. Keep the two apart in both directions. Do not send contributors to the user
+guide for harness flags, and do not let this recipe leak into the guide and read
+as advice to spin up Chrome for everyday browsing.
+
 This is not a preference. On 2026-09-07 agent test harnesses driving the
 extension launched *headful* Chrome, and the windows took focus from the
 operator repeatedly while he was working in another application. The whole
@@ -1210,7 +1219,9 @@ creates its tab with `active: false`, every cmux command passes `--focus false`,
 and `guide://browser` carries a "Focus safety — never steal the user's focus"
 section. A harness that pops a window on screen violates the same principle the
 product spends real effort upholding, and "it is only a quick check" is exactly
-the reasoning that produced the incident.
+the reasoning that produced the incident. **Never stealing focus is the general
+rule for every browser this project starts, in any context**; headless is simply
+how a harness satisfies it, and `open -g` is how a real-browser launch does.
 
 New headless is not the old one: it is the same browser binary with no window,
 so extensions, DevTools/CDP, screenshots and synthetic input all work. Measured
@@ -1292,6 +1303,12 @@ already background-launched by `-g`. It is correct as written; do not
 "headless" it. The distinction is the profile: the operator's logged-in browser
 is woken in the background and never given debug flags, while a harness browser
 is a throwaway profile that is headless, debug-ported and torn down.
+
+And it does not cover verifying a change *through* the extension once it is
+loaded — a rendered page, a flow, a screenshot for a PR. That is ordinary
+browser work: use the `browser` tool against the paired browser like any other
+session. Reach for a harness only when you need a browser that does not yet
+have the build you are testing.
 
 ### 7. Evidence goes on the PR, never into the repository
 

--- a/local_operator/guides/browser/GUIDE.md
+++ b/local_operator/guides/browser/GUIDE.md
@@ -45,10 +45,11 @@ window. The extension is built to respect that and you must keep it that way:
   actions to work. If you ever find yourself wanting to activate a tab, don't —
   the whole point is that the user keeps doing their own thing.
 - **Anything you start yourself is bound by the same rule.** If a step needs a
-  browser that is not already running, it gets launched in the background
-  (`open -g -a "Google Chrome"` on macOS) — never in a way that raises a window
-  or pulls the user out of what they are doing. A window appearing on screen
-  because the agent was working is the failure this whole design prevents.
+  browser that is not already running, ask the user before starting it the
+  first time, then launch it in the background (`open -g -a "Google Chrome"` on
+  macOS) — never in a way that raises a window or pulls the user out of what
+  they are doing. A window appearing on screen because the agent was working is
+  the failure this whole design prevents. Step 0 below has the full sequence.
 
 Chrome shows a small "Local Operator is debugging this browser" banner on the
 tab the agent controls. That is intentional and good: it is how the user can
@@ -75,7 +76,8 @@ The one case where a separate browser is legitimate is **developing Local
 Operator's own extension**, where the thing under test is the extension build
 rather than a website. That is a contributor workflow, not a user one, and it
 runs headless with a throwaway profile: `AGENTS.md` in the local-operator
-repository ("Capturing a browser surface") carries the required flags,
+repository, §6 of "Visual validation" ("Capturing a browser surface: headless
+Chrome, never a window"), carries the launch recipe, the required flags,
 teardown, and the measured reasons for each. If you are not changing the
 extension's own code, this does not apply to you.
 

--- a/local_operator/guides/browser/GUIDE.md
+++ b/local_operator/guides/browser/GUIDE.md
@@ -44,102 +44,40 @@ window. The extension is built to respect that and you must keep it that way:
 - Do **not** ask the user to switch to the browser or leave a tab focused for
   actions to work. If you ever find yourself wanting to activate a tab, don't —
   the whole point is that the user keeps doing their own thing.
+- **Anything you start yourself is bound by the same rule.** If a step needs a
+  browser that is not already running, it gets launched in the background
+  (`open -g -a "Google Chrome"` on macOS) — never in a way that raises a window
+  or pulls the user out of what they are doing. A window appearing on screen
+  because the agent was working is the failure this whole design prevents.
 
 Chrome shows a small "Local Operator is debugging this browser" banner on the
 tab the agent controls. That is intentional and good: it is how the user can
 always see which tab the agent has. Tell them it is expected, not a warning.
 
-### Testing the extension: any Chrome YOU launch is headless
+### Verifying a change: use the browser that is already paired
 
-The rules above govern the browser the user already has open. A test harness
-launches its own Chrome, and the same principle binds it: **a Chrome an agent
-starts for testing, capture, or CDP work runs `--headless=new`, always.**
+When a task needs you to check that something renders or behaves correctly —
+a page you changed, a flow you automated, a screenshot for a review — do it in
+the browser the user already has open with the extension in it. That is the
+whole point of the design: it holds their logins, it is already running, and
+`screenshot` works on the background tab without disturbing them. Do not stand
+up a second browser to verify something the paired one can show you.
 
-On 2026-09-07 agent harnesses driving this extension launched headful Chrome
-and its windows took focus from the operator mid-session, repeatedly. Everything
-else here is engineered so that cannot happen; a harness is not exempt because
-the check is quick.
+**Never launch a separate browser as a workaround.** A downloaded Chromium, a
+`playwright install`, or a hand-started Chrome with debug flags is not a
+shortcut around a permission prompt, a login wall, or a `browser` tool that is
+not connected — each of those has a real fix in this guide: the approval dance,
+asking the user to sign in, and the setup and troubleshooting steps below. A
+second browser cannot see the user's session and, if it opens with a window,
+it takes their focus.
 
-New headless is the same browser without a window, so nothing is given up.
-Measured on Chrome 152.0.7977.76: the built `extension/dist` loaded, its popup
-rendered at an explicit 300x600 viewport, `Page.captureScreenshot` returned a
-real PNG of the pairing form, and `Input.dispatchMouseEvent` dispatched — with
-no window on screen.
-
-```sh
-# Throwaway profile, headless, no keychain prompts, and a port Chrome picks.
-profile=$(mktemp -d /tmp/lo-harness.XXXXXX)
-"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
-  --headless=new --user-data-dir="$profile" \
-  --remote-debugging-port=0 \
-  --use-mock-keychain --password-store=basic \
-  --no-first-run --no-default-browser-check about:blank &
-
-# Chrome writes the port it actually bound; never assume one.
-until [ -s "$profile/DevToolsActivePort" ]; do sleep 0.2; done
-port=$(head -1 "$profile/DevToolsActivePort")
-```
-
-- **Load the extension over CDP `Extensions.loadUnpacked`, not
-  `--load-extension`.** Branded Chrome removed that switch in 137 and it is
-  now **silently ignored** — no error, just a Chrome with no extension, which
-  reads as "headless does not support extensions" and is not what happened.
-  Verified on 152: `--load-extension` produced no matching target;
-  `Extensions.loadUnpacked` returned the id and the popup drove normally.
-- **Set the viewport with `Emulation.setDeviceMetricsOverride`, not
-  `--window-size`.** Headless inherits no window, so it defaults to whatever
-  the platform picks (measured 756x469, `dpr=1`, with no flag) — and a frame
-  whose size you did not set is not evidence. `--window-size` looks like the
-  remedy and is not: on Chrome 152 the width clamps at a 500px floor and the
-  height loses 87px to chrome, so `--window-size=300,600` yields **500x513**,
-  silently. Measured, same flags, fresh profile each run:
-
-  | flag | resulting viewport |
-  |---|---|
-  | `--window-size=300,600` | `500x513 dpr=1` |
-  | `--window-size=400,600` | `500x513 dpr=1` |
-  | `--window-size=500,600` | `500x513 dpr=1` |
-  | `--window-size=1000,800` | `1000x713 dpr=1` |
-  | `Emulation.setDeviceMetricsOverride 300x600` | `300x600 dpr=2` ✓ |
-
-  The CDP override is exact, controls `deviceScaleFactor` (which the flag
-  cannot), and wins regardless of how Chrome was started — verified giving a
-  true `300x600 dpr=2` even on a browser launched with the clamped flag. Use it
-  for the extension popup's 300x600 metrics and for every other capture size.
-- **Let Chrome choose the debug port: `--remote-debugging-port=0`, then read
-  `"$profile/DevToolsActivePort"`.** A hardcoded port is a shared path in the
-  same sense as a shared profile dir, and this machine runs many agent sessions
-  at once. Measured: two harnesses on distinct profiles both asking for 39222 —
-  the second starts fine, writes **no** `DevToolsActivePort`, reports **no**
-  error, and the port answers as the *first* harness's browser. A harness that
-  then connects believes it drives its own Chrome while every CDP call,
-  screenshot and `Target.closeTarget` lands on another session's. With port `0`
-  the same pair got 57827 and 57829 and each drove its own browser. Chrome only
-  writes `DevToolsActivePort` when it picked the port itself (under an explicit
-  port the file is absent entirely), so reading that file is both the fix and
-  its own proof.
-- **Never compare a headful before-frame with a headless after-frame.** Device
-  pixel ratio and scrollbar presence differ across the modes, so the pair shows
-  differences your change did not cause. Recapture both sides in one mode.
-- **Unique `--user-data-dir` per launch, under `/tmp`** — never the operator's
-  profile, never a shared path.
-- **`--use-mock-keychain --password-store=basic`** — without them real Chrome
-  on macOS reaches for the login keychain and raises modal "Keychain not found"
-  dialogs on the operator's screen (reported from a run of ~37 concurrent
-  instances). On-screen dialogs defeat headless on their own.
-- **`start_new_session=True`, teardown by process group** (SIGTERM to the pgid,
-  then SIGKILL), **plus an `atexit` handler**. The hazard is the harness dying
-  before its cleanup runs: measured here, `SIGKILL` to the harness left the
-  whole Chrome tree alive with the browser reparented to `PPID 1`, still
-  holding the profile dir. A previous session reportedly leaked 47 that way.
-  Helper counts vary per run, so assert **zero** afterwards with
-  `pgrep -f <your profile prefix>` rather than against a remembered count.
-- **Never touch the operator's own Chrome.** Match your own profile prefix;
-  never `pkill -f "Google Chrome"`.
-
-This does not change how you wake the user's *real* paired browser — see the
-next section, where `open -g` is correct precisely because it is a different
-activity.
+The one case where a separate browser is legitimate is **developing Local
+Operator's own extension**, where the thing under test is the extension build
+rather than a website. That is a contributor workflow, not a user one, and it
+runs headless with a throwaway profile: `AGENTS.md` in the local-operator
+repository ("Capturing a browser surface") carries the required flags,
+teardown, and the measured reasons for each. If you are not changing the
+extension's own code, this does not apply to you.
 
 ## When the `browser` tool is missing: set the extension up
 
@@ -171,12 +109,12 @@ starting. Never launch with
 and a debug-port browser on a real logged-in profile is an open door for any
 local process.
 
-This is the operator's real logged-in browser, not a harness, so it is **not**
-headless and must not be made so: the user has to be able to see and use it,
-and headless would defeat the point of pairing to the browser they already
-have. `-g` is what keeps it focus-safe. The headless rule above governs a
-throwaway Chrome an agent starts for testing; conflating the two ends with
-someone "fixing" this line and breaking reconnection.
+This is the user's real logged-in browser, so it is **not** headless and must
+not be made so: they have to be able to see and use it, and headless would
+defeat the point of pairing to the browser they already have. `-g` is what
+keeps it focus-safe — it starts the browser without raising a window or taking
+focus, which is the rule for anything the agent launches. Do not "fix" this
+line into a headless launch; that breaks reconnection.
 
 ### 1. Check status
 
@@ -432,8 +370,8 @@ Every failure is one actionable string; act on it rather than retrying blindly:
      `open -g -a "Google Chrome"` (macOS). Never add `--remote-debugging-port`
      or other debug flags — the extension IS the debugger; a debug-port
      browser on a real profile is a security hole. Not headless either: this
-     is the user's own browser, and the headless rule in "Testing the
-     extension" covers only a throwaway Chrome an agent launches itself.
+     is the user's own browser and they need to be able to see it. `-g` is
+     what keeps the launch from stealing their focus.
   2. **Browser running but still disconnected?** The service worker may be
      idle-suspended. A periodic reconnect alarm rewakes and reconnects it on
      its own — up to ~1 minute in a packed/released build (Chrome clamps


### PR DESCRIPTION
## What and why

Follow-up to #765. That PR fixed a real incident — agent harnesses launching
headful Chrome and stealing the operator's focus — and wrote the remedy into two
documents. One of them was the wrong audience.

`local_operator/guides/browser/GUIDE.md` is **packaged and shipped**:
`pyproject.toml` includes `guides/*/*.md`, and it is served as `guide://browser`
to every user's agent on every machine that installs lop. It is the operational
playbook for driving the browser the **user** has paired. #765 added 92 lines to
it about building `extension/dist`, `Extensions.loadUnpacked`,
`DevToolsActivePort`, `--use-mock-keychain`, process-group teardown, and
`pgrep`-ing for leaked helpers.

None of that is reachable for a reader who is not modifying this repository's own
extension. Worse is where it sat: immediately under "Focus safety", **before** the
setup section, so an agent reading the guide top-down for browser guidance met a
Chrome-launching recipe before it met the paired browser it was supposed to use.
That is a good way to reintroduce exactly the second browser stack the guide's
opening section forbids.

The guidance itself is right and it stays — in `AGENTS.md`, where the reader is by
definition working on lop. That section already carried the fuller measured
version (viewport clamps, the 39222 port collision, the `PPID 1` survivors), so
removing the guide's copy loses nothing. The two copies were also a divergence
risk: a later correction to one would silently not reach the other.

## Changes

- **`GUIDE.md`** — the harness recipe is replaced by
  `### Verifying a change: use the browser that is already paired`, which answers
  the question a user actually has. Verify in the paired browser; a separately
  launched browser is refused as a workaround for a permission prompt or a login
  wall (each of which has a real fix in the guide); contributors are pointed to
  `AGENTS.md` for the one legitimate case.
- **`GUIDE.md`** — focus safety is generalized to cover **anything the agent
  starts**, not only the extension's own tab. This is the durable rule behind the
  incident, and it now lives in the section named for it rather than inside a
  harness recipe where only harness authors would find it.
- **`AGENTS.md`** — the section is scoped to extension development explicitly, in
  both directions ("do not send contributors to the user guide for harness flags,
  and do not let this recipe leak into the guide"). Focus-safety is stated as the
  general principle that headless and `open -g` are two satisfactions of, and a
  closing note says verifying a change *through* the loaded extension is ordinary
  browser work, not a reason to start a harness.
- Two now-dangling cross-references to the removed guide heading, fixed.

Net: guide **-99/+37** (28.5k → 23.9k chars), `AGENTS.md` **+18**.

## Change class

**C0 — documentation only.** No code, no `pyproject.toml`, no `extension/`.
`git diff --stat` is exactly two `.md` files (+55/-100).

## Validation

Documentation has no runtime path to exercise end-to-end, so the meaningful
checks are that the shipped guide still resolves through the code that serves it,
and that the restored contributor recipe actually runs.

**The guide resolves through the real loader** (`discover_guides` →
`make_guide_resolver`), not by reading the file: 19 headings intact, frontmatter
parses, section order unchanged apart from the replaced subsection.

**The restored §6 harness recipe was executed as written**, launch through
teardown:

```
port=65067  caller_pgid=71411  chrome_pgid=71411
CDP responded: Chrome/152.0.7977.83
SHELL SURVIVED the documented teardown
leaked: 0
```

Identical caller/Chrome pgids are the F4 hazard reproduced; the shell surviving
with zero leaks is the documented fix working.

**Teardown reliability was measured rather than assumed.** A bare
`kill "$chrome_pid"` leaves 0–5 helpers behind across runs with no stable timing
pattern (n=11, Chrome 152, independently reproduced by the reviewer); the
documented TERM → settle → profile-scoped sweep reached 0 survivors on every run
at three settle times. Two of my own measured claims did not survive the
reviewer's replication and were corrected on the PR — noted here because this PR
is about documents that instruct agents to measure rather than assume.

`bash -n` passes on both §6 blocks, fences balanced, `pytest -k guide` → 24
passed, and no `lo-harness.*` profiles or Chrome processes were left on the
machine.

**CI: all 16 checks green on `dc2a2df12`.**

An earlier head had `test (3.12, 3)` red on
`test_subagent_accounting.py::test_rendered_footer_uses_whole_owner_ledger`. That
was not this PR — it was failing on `main` too — but the cause is worth recording:
the branch was based before #758, so it ran the old sort-position sharding that
packed a Textual timing test into a busier shard. Rebasing onto current `main`
(duration-balanced shards) turned it green along with the three checks that had
been skipped behind it. See the round-5 re-pin note.

No browser harness was launched to produce evidence for the *guide* change
itself — there was nothing rendered to capture, and starting one would have been
the exact behaviour these documents now discourage.

## Review

Five agent review rounds, all recorded on this PR: F1 (major, deleted content
restored), F2/F3 (minor, cross-references), F4 (major, process-group teardown
would kill the contributor's shell), F5/F6 (minor, recipe ergonomics and an
over-precise measurement). Rounds 3, 4 and 5 each returned Approve/TERMINAL, the
last on the current content. Reviewer was a separate agent from the author on
every round.
