### PR TITLE
fix(runtime): fold compose frames so a stalled viewer is not dropped mid-dictation

### DIFF
--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -2365,13 +2365,50 @@ class RuntimeServer:
             self._enqueue_client_frame(conn, frame)
 
     def _compact_event_queue(self, conn: _ClientConn) -> bool:
-        """Merge runs of same-message ``message_update`` frames in place.
+        """Fold the two compactible frame families in place.
 
-        Lossless by construction: the later event's ``message`` already
-        contains the earlier one's text, and concatenating ``delta`` preserves
-        the append contract UIs rely on. Returns whether any room was freed.
-        Runs synchronously on the runtime loop, so the drain task cannot
+        Merges runs of same-message ``message_update`` frames, and keeps only
+        the NEWEST ``tool_call_compose`` per ``tool_call_id``.
+
+        Both are lossless by construction. For ``message_update`` the later
+        event's ``message`` already contains the earlier one's text, and
+        concatenating ``delta`` preserves the append contract UIs rely on. For
+        ``tool_call_compose`` the argument is the one ``_fold_live_event``
+        (``frontend_state.py``) already relies on for the reconnect seed: a
+        compose frame is a SNAPSHOT of a call being dictated (``tool_name``,
+        CUMULATIVE ``argument_bytes``, ``intent``), never a delta, so an older
+        frame carries nothing the newer one lacks. Returns whether any room was
+        freed. Runs synchronously on the runtime loop, so the drain task cannot
         observe a half-compacted queue.
+
+        WHY THE COMPOSE FOLD EXISTS. Without it these frames are
+        incompressible — each carries a distinct ``tool_call_id`` and a growing
+        ``argument_bytes`` — so a viewer stalled during a tool-argument
+        dictation fills its whole FIFO with frames compaction cannot touch,
+        frees nothing, and is dropped with ``event queue overflow``. That is
+        not hypothetical: at three concurrent calls the measured compose rate
+        is 16.0 frames/s, which overflows ``_EVENT_QUEUE_MAX`` in ~4.0 s —
+        BEFORE ``_TUI_SEND_TIMEOUT_S`` (5.0 s) can be reached, so the timeout
+        raised from 1.0 s specifically to stop dropping stalled TUI viewers was
+        bypassed for exactly the multi-call case it was meant to protect. The
+        dropped viewer re-attaches, its seed re-mounts the composing rows, and
+        nothing ever adopts or retires them: the user sees several tool cards
+        frozen at one identical elapsed time on calls that in fact ran fine.
+        Folding bounds the queue at ONE entry per in-flight call regardless of
+        how long the dictation runs, which closes the class; raising
+        ``_EVENT_QUEUE_MAX`` would only buy a linear factor against an
+        unbounded dictation and re-open the memory question the bound exists
+        for.
+
+        THE COMPOSE FOLD REPLACES IN PLACE AND NEVER APPENDS. The newer frame
+        takes the retained slot's FIFO position, and the fold is abandoned for
+        a call as soon as any OTHER frame for that same ``tool_call_id`` goes
+        by (``tool_execution_start``/``_update``/``_end``). Both halves are
+        load-bearing: appending would let a compose frame arrive after the
+        start that ends composition, and folding across an intervening start
+        would move a compose frame BACK past it. Either way the viewer adopts
+        out of order and can re-mount a composing row for a call that is
+        already executing — the stranded row this fold exists to prevent.
 
         A MERGE THAT WOULD NOT FIT IS REFUSED, and that check cannot be
         skipped on the grounds that everything in this queue already passed
@@ -2403,7 +2440,40 @@ class RuntimeServer:
         # Tracked incrementally so a merge never re-measures the deltas already
         # folded in; see the size check below for why this is exact.
         merged_delta_bytes: list[int] = []
+        # ``tool_call_id`` -> index in ``compacted`` of the compose frame
+        # retained for that call. An INDEX, not a list position to append at:
+        # the newest snapshot overwrites the slot so the row's FIFO mount point
+        # is the call's FIRST compose frame, unchanged. Only the snapshot's
+        # contents refresh early, and they refresh an already-mounted row.
+        compose_slot: dict[str, int] = {}
         for frame in frames:
+            if frame.get("op") == "event":
+                event_data = frame.get("data") or {}
+                event_type = event_data.get("type")
+                call_id = str(event_data.get("tool_call_id") or "")
+                if event_type == "tool_call_compose" and call_id:
+                    slot = compose_slot.get(call_id)
+                    if slot is not None:
+                        # REPLACE IN PLACE. The frame already passed
+                        # ``relay_frame_or_degraded`` individually at enqueue,
+                        # and a replacement is not a concatenation, so unlike
+                        # the ``message_update`` merge below this cannot
+                        # assemble an oversized frame and needs no size check.
+                        compacted[slot] = frame
+                        continue
+                    compose_slot[call_id] = len(compacted)
+                elif call_id:
+                    # Any OTHER frame for this call ends its composition. Stop
+                    # folding it, so a later compose frame appends after this
+                    # one instead of moving back in front of it.
+                    compose_slot.pop(call_id, None)
+                elif event_type in {"agent_start", "agent_end"}:
+                    # Turn boundary. Placeholder compose keys are index-derived
+                    # (``compose:{index}``, ``harness/loop.py``), so they REPEAT
+                    # across turns: without this, a viewer stalled across a turn
+                    # boundary would fold the next turn's ``compose:0`` back
+                    # onto the previous turn's slot, ahead of this very frame.
+                    compose_slot.clear()
             previous = compacted[-1] if compacted else None
             if (
                 previous is not None

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -124,6 +124,36 @@ def _frame_size_without_delta(frame: dict[str, Any]) -> int:
     return len(json.dumps(probe).encode()) + 1 - 2
 
 
+def _compose_reuses_key(retained: dict[str, Any], incoming: dict[str, Any]) -> bool:
+    """Whether ``incoming`` is a DIFFERENT call that reused a compose key.
+
+    ``argument_bytes`` is the running size of the arguments dictated so far, so
+    within one call it only ever grows. A decrease therefore cannot happen on
+    the call that is already holding the slot — it proves the key was recycled
+    by a new call, and folding the two together would splice one call's
+    progress onto another's row.
+
+    This is the second half of the step-boundary defence, and it is deliberately
+    independent of the first: the boundary reset needs a ``turn_start`` to be
+    present in the SAME compaction batch, which holds for a viewer stalled
+    across a step but not for one whose queue happens to contain only compose
+    frames from either side of it. Monotonicity needs no boundary frame at all.
+    Both are cheap, and the failure they guard — a snapshot folded backwards
+    past an execution start — is the exact stranded row this fold exists to
+    remove.
+
+    Missing or non-integer counts are treated as NOT a reuse: the fold is the
+    safe default here (an equal or absent count is what an un-throttled repeat
+    of the same call looks like), and refusing on every malformed frame would
+    reopen the overflow this method exists to close.
+    """
+    previous = (retained.get("data") or {}).get("argument_bytes")
+    current = (incoming.get("data") or {}).get("argument_bytes")
+    if not isinstance(previous, int) or not isinstance(current, int):
+        return False
+    return current < previous
+
+
 def relay_frame_or_degraded(frame: dict[str, Any], cap_bytes: int) -> dict[str, Any]:
     """Return ``frame``, or a small stand-in when it cannot be read.
 
@@ -2410,6 +2440,18 @@ class RuntimeServer:
         out of order and can re-mount a composing row for a call that is
         already executing — the stranded row this fold exists to prevent.
 
+        A COMPOSE KEY IS ONLY UNIQUE WITHIN ONE MODEL STEP, so two further
+        guards keep a recycled key from folding across one. The id may be a
+        placeholder (``compose:{index}``) derived from ``tool_states``, which
+        ``harness/loop.py`` scopes to a single ``_model_turn`` — one STEP of a
+        turn, not the whole run — so ``compose:0`` recurs on every tool-calling
+        step. A step boundary (``turn_start``/``turn_end``) clears every slot,
+        and independently a fold is refused when ``argument_bytes`` goes
+        BACKWARDS, which cannot happen within a call and so proves the key was
+        reused. Only clearing on ``agent_start``/``agent_end`` guarded the run
+        boundary while leaving the step boundary — the common one — open
+        (review R1).
+
         A MERGE THAT WOULD NOT FIT IS REFUSED, and that check cannot be
         skipped on the grounds that everything in this queue already passed
         ``relay_frame_or_degraded``. It did — individually. Merging is the one
@@ -2445,6 +2487,15 @@ class RuntimeServer:
         # the newest snapshot overwrites the slot so the row's FIFO mount point
         # is the call's FIRST compose frame, unchanged. Only the snapshot's
         # contents refresh early, and they refresh an already-mounted row.
+        #
+        # INDEX-PARALLEL WITH ``merged_delta_bytes``, and a replacement here
+        # deliberately does NOT touch that list. Safe only because a compose
+        # frame carries no ``delta``: the outgoing and incoming frames both
+        # contribute 0, so the two lists stay aligned AND correctly valued. A
+        # future fold over any frame family that does carry a delta must update
+        # ``merged_delta_bytes[slot]`` too, or the ``message_update`` size
+        # accounting below silently under-counts and re-opens the oversize bug
+        # that accounting exists to prevent.
         compose_slot: dict[str, int] = {}
         for frame in frames:
             if frame.get("op") == "event":
@@ -2453,7 +2504,7 @@ class RuntimeServer:
                 call_id = str(event_data.get("tool_call_id") or "")
                 if event_type == "tool_call_compose" and call_id:
                     slot = compose_slot.get(call_id)
-                    if slot is not None:
+                    if slot is not None and not _compose_reuses_key(compacted[slot], frame):
                         # REPLACE IN PLACE. The frame already passed
                         # ``relay_frame_or_degraded`` individually at enqueue,
                         # and a replacement is not a concatenation, so unlike
@@ -2467,12 +2518,24 @@ class RuntimeServer:
                     # folding it, so a later compose frame appends after this
                     # one instead of moving back in front of it.
                     compose_slot.pop(call_id, None)
-                elif event_type in {"agent_start", "agent_end"}:
-                    # Turn boundary. Placeholder compose keys are index-derived
-                    # (``compose:{index}``, ``harness/loop.py``), so they REPEAT
-                    # across turns: without this, a viewer stalled across a turn
-                    # boundary would fold the next turn's ``compose:0`` back
-                    # onto the previous turn's slot, ahead of this very frame.
+                elif event_type in {"turn_start", "turn_end", "agent_start", "agent_end"}:
+                    # STEP boundary, not merely a turn boundary. Placeholder
+                    # compose keys are index-derived (``compose:{index}``,
+                    # ``harness/loop.py``) off ``tool_states``, which is local
+                    # to ``_model_turn`` — and ``_model_turn`` runs once PER
+                    # STEP, inside ``run()``'s ``while has_more_tool_calls``
+                    # loop. So ``compose:0`` recurs on every tool-calling step,
+                    # while ``agent_start``/``agent_end`` bracket the whole run.
+                    # Resetting only on those left the COMMON boundary open:
+                    # step 2's snapshot folded backwards past step 1's start
+                    # and end (review R1). ``turn_start`` is the exact frame
+                    # ``_model_turn`` emits after creating ``tool_states``, so
+                    # it is the boundary the key's lifetime is defined by.
+                    #
+                    # The ``elif call_id`` branch above does NOT cover this:
+                    # under the placeholder regime the compose frame is keyed
+                    # ``compose:0`` while start/end carry the provider's real
+                    # id, so the pop misses and the slot stays live.
                     compose_slot.clear()
             previous = compacted[-1] if compacted else None
             if (

--- a/tests/unit/session/runtime/test_server.py
+++ b/tests/unit/session/runtime/test_server.py
@@ -2134,3 +2134,224 @@ async def test_tui_send_timeout_is_five_seconds(monkeypatch: pytest.MonkeyPatch)
         if writer is not None:
             writer.close()
         runtime.close()
+
+
+# -- compose-frame folding ----------------------------------------------------
+#
+# ``_compact_event_queue`` is exercised here against a bare ``_ClientConn`` and
+# a bare ``RuntimeServer`` rather than a live socket: the property under test is
+# a pure function of the FIFO's contents, and the drop that motivates it is
+# already covered end-to-end over a real connection by
+# ``test_high_volume_event_relay_bounds_nonreader_and_preserves_healthy_order``.
+
+
+def _compose_frame(call_id: str, argument_bytes: int, intent: str | None = None) -> dict[str, Any]:
+    return {
+        "op": "event",
+        "data": {
+            "type": "tool_call_compose",
+            "tool_call_id": call_id,
+            "tool_name": "bash",
+            "argument_bytes": argument_bytes,
+            "intent": intent,
+        },
+    }
+
+
+def _stalled_conn() -> Any:
+    """A connection whose reader never drains, i.e. the case the bound is for."""
+    from local_operator.session.runtime.server import _EVENT_QUEUE_MAX, _ClientConn
+
+    conn = _ClientConn(writer=cast(Any, object()), kind=cast(Any, "attach"))
+    conn.event_queue = asyncio.Queue(maxsize=_EVENT_QUEUE_MAX)
+    conn.wants_events = True
+    conn.wants_frontend = True
+    conn.events_ready = True
+    return conn
+
+
+class _NeverDrains(RuntimeServer):
+    """Enqueue-path harness: records drops, never consumes the FIFO."""
+
+    def __init__(self) -> None:  # noqa: D107 — deliberately skips RuntimeServer.__init__
+        self._clients: dict[int, Any] = {}
+        self._event_sends: set[Any] = set()
+        self.dropped: list[str] = []
+
+    def _drop_client(  # type: ignore[override]
+        self, conn: Any, *, reason: str = "unspecified"
+    ) -> None:
+        self.dropped.append(reason)
+
+    async def _drain_event_queue(self, conn: Any) -> None:  # type: ignore[override]
+        await asyncio.sleep(3600)
+
+
+@pytest.mark.asyncio
+async def test_a_stalled_viewer_survives_a_long_multi_call_dictation() -> None:
+    """A dictation must not overflow the FIFO and drop the viewer.
+
+    Compose frames carry a distinct ``tool_call_id`` and a growing
+    ``argument_bytes``, so before the fold NOTHING in the queue was compactible
+    during a tool-argument dictation: 300 frames across 3 calls dropped the
+    client after 65 with ``event queue overflow (64 frames)``. That matters
+    because the measured compose rate at three concurrent calls is 16.0
+    frames/s — the 64-frame bound is reached in ~4.0 s, BEFORE the 5.0 s
+    ``_TUI_SEND_TIMEOUT_S`` raised specifically to protect stalled TUI viewers.
+    The dropped viewer re-attaches and its seed re-mounts composing rows that
+    nothing adopts, which is the operator-reported "tool cards frozen at an
+    identical elapsed time" on calls that in fact ran.
+
+    Frame counts, not seconds: this asserts a structural property of the
+    queue, so it cannot flake under host contention.
+    """
+    server = _NeverDrains()
+    conn = _stalled_conn()
+    server._clients[id(conn.writer)] = conn
+
+    for index in range(300):
+        server._enqueue_client_frame(conn, _compose_frame(f"call_{index % 3}", index * 10))
+
+    assert server.dropped == [], f"stalled viewer was dropped: {server.dropped}"
+
+    # Compaction runs only ON OVERFLOW, so between passes the queue legitimately
+    # refills with not-yet-folded frames. The invariant is therefore asserted
+    # where it is claimed — after a pass — rather than at an arbitrary depth.
+    server._compact_event_queue(cast(Any, conn))
+
+    # The fold's actual guarantee: at most one entry per in-flight call, each
+    # carrying that call's NEWEST byte count. Bounded by the number of calls in
+    # flight, never by the dictation's length.
+    queued = list(conn.event_queue._queue)
+    composes = [f for f in queued if (f.get("data") or {}).get("type") == "tool_call_compose"]
+    per_call: dict[str, list[int]] = {}
+    for frame in composes:
+        data = frame["data"]
+        per_call.setdefault(str(data["tool_call_id"]), []).append(int(data["argument_bytes"]))
+    for call_id, sizes in per_call.items():
+        assert len(sizes) == 1, f"{call_id} kept {len(sizes)} compose frames, expected 1"
+
+    # LOSSLESS in the only sense a snapshot can be: the retained frame is the
+    # newest the queue ever saw for that call, so the viewer's byte counter
+    # jumps forward rather than backward. Without this the test would pass
+    # against a fold that kept the OLDEST frame and discarded every update.
+    newest = {f"call_{call}": max(i * 10 for i in range(300) if i % 3 == call) for call in range(3)}
+    assert {k: v[0] for k, v in per_call.items()} == newest
+
+
+@pytest.mark.asyncio
+async def test_a_folded_compose_frame_never_overtakes_the_start_that_follows_it() -> None:
+    """Folding must not move a compose frame past its call's execution start.
+
+    The UI keys rows by ``tool_call_id`` and adopts a composing row when the
+    ``tool_execution_start`` arrives. If a later compose frame were folded onto
+    a slot AHEAD of that start, the viewer would apply "still composing" after
+    "now executing" and re-mount a composing row for a call already running —
+    reintroducing the stranded row this fold exists to remove. The fold
+    therefore stops for a call the moment any other frame for it goes by.
+    """
+    server = _NeverDrains()
+    conn = _stalled_conn()
+    server._clients[id(conn.writer)] = conn
+
+    start = {
+        "op": "event",
+        "data": {"type": "tool_execution_start", "tool_call_id": "c1", "tool_name": "bash"},
+    }
+    end = {
+        "op": "event",
+        "data": {"type": "tool_execution_end", "tool_call_id": "c1", "tool_name": "bash"},
+    }
+    # A frame for ANOTHER call sits between the two folded snapshots. That
+    # separation is what makes this test able to fail: with the two composes
+    # adjacent, replacing in place and deleting-then-appending produce the same
+    # order, so an append-based fold would pass unnoticed. Here it moves c1's
+    # row behind c2's and the assertion catches it.
+    other = _compose_frame("c2", 99)
+    for frame in (
+        _compose_frame("c1", 10),
+        other,
+        _compose_frame("c1", 20),
+        start,
+        _compose_frame("c1", 30),
+        end,
+    ):
+        server._enqueue_client_frame(conn, frame)
+
+    server._compact_event_queue(cast(Any, conn))
+
+    order = [
+        (f["data"]["type"], f["data"]["tool_call_id"], f["data"].get("argument_bytes"))
+        for f in conn.event_queue._queue
+    ]
+    # c1's two pre-start snapshots fold to the newest AND KEEP c1'S ORIGINAL
+    # SLOT, still ahead of c2. The trailing snapshot is kept separately behind
+    # the start rather than folded back in front of it.
+    assert order == [
+        ("tool_call_compose", "c1", 20),
+        ("tool_call_compose", "c2", 99),
+        ("tool_execution_start", "c1", None),
+        ("tool_call_compose", "c1", 30),
+        ("tool_execution_end", "c1", None),
+    ], order
+
+
+@pytest.mark.asyncio
+async def test_folding_does_not_carry_a_compose_slot_across_a_turn_boundary() -> None:
+    """Placeholder compose keys repeat per turn, so slots must not outlive one.
+
+    ``harness/loop.py`` latches an index-derived ``compose:{index}`` key when a
+    provider announces a call's name before its id, so the NEXT turn's first
+    call is ``compose:0`` again. Folding across the boundary would move that
+    frame back in front of the ``agent_end``/``agent_start`` between them.
+    """
+    server = _NeverDrains()
+    conn = _stalled_conn()
+    server._clients[id(conn.writer)] = conn
+
+    for frame in (
+        _compose_frame("compose:0", 10),
+        {"op": "event", "data": {"type": "agent_end"}},
+        {"op": "event", "data": {"type": "agent_start"}},
+        _compose_frame("compose:0", 5),
+    ):
+        server._enqueue_client_frame(conn, frame)
+
+    server._compact_event_queue(cast(Any, conn))
+
+    assert [f["data"]["type"] for f in conn.event_queue._queue] == [
+        "tool_call_compose",
+        "agent_end",
+        "agent_start",
+        "tool_call_compose",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_the_compose_fold_never_emits_an_unreadable_frame() -> None:
+    """The fold REPLACES, so it cannot assemble an oversized frame.
+
+    ``_compact_event_queue``'s size refusal exists because merging
+    ``message_update`` deltas is the one operation that makes a frame bigger
+    than anything the relay guard was shown. A compose fold discards the older
+    snapshot instead of concatenating, so the output is always a frame that
+    already passed the guard individually — asserted here rather than assumed,
+    because a future fold that started merging would silently defeat that
+    refusal.
+    """
+    from local_operator.session.runtime.server import _MAX_LINE_BYTES
+
+    server = _NeverDrains()
+    conn = _stalled_conn()
+    server._clients[id(conn.writer)] = conn
+
+    # Near-limit but individually legal, the shape that killed a real pump.
+    for index in range(200):
+        server._enqueue_client_frame(
+            conn, _compose_frame(f"call_{index % 3}", index, intent="i" * 300_000)
+        )
+
+    assert server.dropped == []
+    for frame in conn.event_queue._queue:
+        size = len(json.dumps(frame).encode()) + 1
+        assert size <= _MAX_LINE_BYTES, f"fold emitted an unreadable {size}-byte frame"

--- a/tests/unit/session/runtime/test_server.py
+++ b/tests/unit/session/runtime/test_server.py
@@ -2140,9 +2140,20 @@ async def test_tui_send_timeout_is_five_seconds(monkeypatch: pytest.MonkeyPatch)
 #
 # ``_compact_event_queue`` is exercised here against a bare ``_ClientConn`` and
 # a bare ``RuntimeServer`` rather than a live socket: the property under test is
-# a pure function of the FIFO's contents, and the drop that motivates it is
-# already covered end-to-end over a real connection by
-# ``test_high_volume_event_relay_bounds_nonreader_and_preserves_healthy_order``.
+# a pure function of the FIFO's contents.
+#
+# What the neighbouring coverage does and does NOT give. The GENERIC overflow
+# drop is driven over a real socket by
+# ``test_high_volume_event_relay_bounds_nonreader_and_preserves_healthy_order``,
+# but that test emits only ``NoticeEvent`` — it never puts a compose frame on
+# the wire, so it is not evidence for this path (review R2). The compose path
+# itself was driven end to end against a production ``RuntimeServer`` and a real
+# ``RemoteSession`` viewer in QA's round-1 cell, which reproduced the reported
+# frame on base (viewer dropped by overflow; three composing rows never adopted
+# or retired; the turn never completed) and showed this branch adopting and
+# retiring all three. That cell needs two processes and a real socket, so it
+# lives with the PR evidence; these tests are the fast structural guard for the
+# same property.
 
 
 def _compose_frame(call_id: str, argument_bytes: int, intent: str | None = None) -> dict[str, Any]:
@@ -2325,6 +2336,162 @@ async def test_folding_does_not_carry_a_compose_slot_across_a_turn_boundary() ->
         "agent_start",
         "tool_call_compose",
     ]
+
+
+@pytest.mark.asyncio
+async def test_a_compose_slot_does_not_survive_a_model_STEP_boundary() -> None:
+    """A recycled placeholder key must not fold backwards past a step's calls.
+
+    THE BOUNDARY THAT MATTERS IS THE STEP, NOT THE RUN. ``compose:{index}`` is
+    derived from ``tool_states``, which ``harness/loop.py`` scopes to a single
+    ``_model_turn`` — and ``_model_turn`` is called once per STEP from
+    ``run()``'s ``while has_more_tool_calls or pending:`` loop, while
+    ``agent_start``/``agent_end`` bracket the whole run. So ``compose:0``
+    recurs on every tool-calling step, and a reset keyed only on the run
+    boundary never fires between them (review R1).
+
+    Nor does the ``elif call_id`` abandon-branch save it: under the placeholder
+    regime the compose frame is keyed ``compose:0`` while the start and end
+    carry the provider's real id, so the pop misses and the slot stays live
+    straight through the execution.
+
+    This is the reviewer's reproduction: without the fix, step 2's snapshot
+    folds backwards past TWO execution starts and TWO ends, landing in front of
+    work that has already finished.
+    """
+    server = _NeverDrains()
+    conn = _stalled_conn()
+    server._clients[id(conn.writer)] = conn
+
+    def _exec(kind: str, call_id: str) -> dict[str, Any]:
+        return {"op": "event", "data": {"type": kind, "tool_call_id": call_id}}
+
+    for frame in (
+        {"op": "event", "data": {"type": "agent_start"}},
+        # --- step 1: dictate compose:0, then run it under its REAL id --------
+        {"op": "event", "data": {"type": "turn_start"}},
+        _compose_frame("compose:0", 10),
+        _compose_frame("compose:0", 20),
+        _compose_frame("compose:0", 30),
+        _exec("tool_execution_start", "real_0"),
+        _exec("tool_execution_end", "real_0"),
+        # --- step 2: the SAME placeholder key, a different call --------------
+        {"op": "event", "data": {"type": "turn_start"}},
+        _compose_frame("compose:0", 110),
+        _compose_frame("compose:0", 120),
+        _compose_frame("compose:0", 130),
+        _exec("tool_execution_start", "real_1"),
+        _exec("tool_execution_end", "real_1"),
+        {"op": "event", "data": {"type": "agent_end"}},
+    ):
+        server._enqueue_client_frame(conn, frame)
+
+    server._compact_event_queue(cast(Any, conn))
+
+    order = [(f["data"]["type"], f["data"].get("argument_bytes")) for f in conn.event_queue._queue]
+    # Each step keeps its OWN folded snapshot, behind its own boundary and
+    # ahead of its own execution. Step 1's snapshot is not overwritten by step
+    # 2's, and step 2's has not moved in front of step 1's start/end.
+    assert order == [
+        ("agent_start", None),
+        ("turn_start", None),
+        ("tool_call_compose", 30),
+        ("tool_execution_start", None),
+        ("tool_execution_end", None),
+        ("turn_start", None),
+        ("tool_call_compose", 130),
+        ("tool_execution_start", None),
+        ("tool_execution_end", None),
+        ("agent_end", None),
+    ], order
+
+
+@pytest.mark.asyncio
+async def test_a_compose_count_that_goes_backwards_starts_a_new_slot() -> None:
+    """A shrinking ``argument_bytes`` proves the key was reused, so do not fold.
+
+    ``argument_bytes`` is cumulative within one call, so it can only grow. A
+    DECREASE therefore cannot come from the call already holding the slot — it
+    is a different call that recycled the key, and folding the two together
+    would splice one call's dictation progress onto another's row.
+
+    This is the second, independent half of the step-boundary defence. The
+    boundary reset needs the boundary frame to be present in the SAME
+    compaction batch; this one needs no boundary frame at all, which covers a
+    queue holding only compose frames from either side of a step.
+    """
+    server = _NeverDrains()
+    conn = _stalled_conn()
+    server._clients[id(conn.writer)] = conn
+
+    # No boundary frame anywhere: only the byte count reveals the reuse.
+    for frame in (
+        _compose_frame("compose:0", 100),
+        _compose_frame("compose:0", 200),
+        _compose_frame("compose:0", 5),
+        _compose_frame("compose:0", 15),
+    ):
+        server._enqueue_client_frame(conn, frame)
+
+    server._compact_event_queue(cast(Any, conn))
+
+    # Two slots: the first call folded to its newest (200), then the reuse
+    # opened a fresh slot BEHIND it which folded to its own newest (15).
+    assert [f["data"]["argument_bytes"] for f in conn.event_queue._queue] == [200, 15]
+
+
+@pytest.mark.asyncio
+async def test_an_absent_or_malformed_byte_count_still_folds() -> None:
+    """The reuse check must not become a back door to the overflow drop.
+
+    Refusing to fold on every frame whose ``argument_bytes`` is missing or
+    non-integer would let a malformed producer reopen the very overflow this
+    method exists to close. An equal or absent count is what an un-throttled
+    repeat of the SAME call looks like, so folding is the safe default.
+    """
+    server = _NeverDrains()
+    conn = _stalled_conn()
+    server._clients[id(conn.writer)] = conn
+
+    for _ in range(200):
+        server._enqueue_client_frame(
+            conn,
+            {
+                "op": "event",
+                "data": {
+                    "type": "tool_call_compose",
+                    "tool_call_id": "c1",
+                    "tool_name": "bash",
+                    # No ``argument_bytes`` at all.
+                },
+            },
+        )
+
+    assert server.dropped == [], f"malformed frames reopened the drop: {server.dropped}"
+    server._compact_event_queue(cast(Any, conn))
+    assert len(conn.event_queue._queue) == 1
+
+
+@pytest.mark.asyncio
+async def test_an_unchanged_byte_count_still_folds() -> None:
+    """Only a DECREASE proves reuse; an equal count is the same call repeating.
+
+    The reuse check must be strictly ``<``. At ``<=`` every repeat of an
+    unchanged count would open a fresh slot, so a producer emitting equal
+    counts fills the FIFO one frame at a time and the overflow drop this method
+    exists to close is reopened — the guard turning into the bug. Caught by
+    mutation: ``<`` → ``<=`` passed every other test in this block.
+    """
+    server = _NeverDrains()
+    conn = _stalled_conn()
+    server._clients[id(conn.writer)] = conn
+
+    for _ in range(200):
+        server._enqueue_client_frame(conn, _compose_frame("c1", 500))
+
+    assert server.dropped == [], f"equal counts reopened the drop: {server.dropped}"
+    server._compact_event_queue(cast(Any, conn))
+    assert [f["data"]["argument_bytes"] for f in conn.event_queue._queue] == [500]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes finding **A1** of the stream/tool-call integrity audit: a viewer whose reader stalls during a tool-argument dictation is **dropped by the event FIFO**, and the re-attached viewer is left holding composing rows nothing ever adopts or retires.

This is the fix that plausibly explains the operator's screenshot — three tool cards and the working line all frozen at an **identical** `1m27s`. Each composing row stamps its own clock (`ToolCard.set_composing`, `tool_card.py:1168`), so three independently-hanging calls would show three *different* elapsed times. Four clocks agreeing on one value means one shared start instant and no updates since: **the rows were stranded, the tools were not hung.**

`Release: patch — a stalled viewer is no longer dropped mid tool-call dictation, so resumed sessions stop showing tool cards frozen at an identical elapsed time on calls that actually completed.`

## The bug

Every attach client has one 64-deep FIFO (`_EVENT_QUEUE_MAX = 64`). On overflow `_enqueue_client_frame` calls `_compact_event_queue`, which merged **only** runs of same-message `message_update` frames. `tool_call_compose` frames are incompressible — each carries a distinct `tool_call_id` and a growing `argument_bytes` — so during a dictation the queue fills with frames compaction cannot touch, nothing is freed, and the client is dropped with `event queue overflow (64 frames)`.

**The sting:** `_TUI_SEND_TIMEOUT_S` was raised 1.0s → 5.0s specifically to stop dropping stalled TUI viewers. But the audit measured the compose rate at **16.0 frames/s for three concurrent calls**, which overflows 64 frames in **~4.0s — before the 5s timeout can ever be reached**. For a multi-call dictation the FIFO, not the send timeout, is the binding constraint, so the protection is bypassed for exactly the case in the screenshot. The screenshot shows three calls.

## The fix

Fold `tool_call_compose` by `tool_call_id`, keeping the **newest** frame per call. Lossless by exactly the argument `_fold_live_event` (`frontend_state.py`) already relies on for the reconnect seed: a compose frame is a **snapshot** (`tool_name`, cumulative `argument_bytes`, `intent`), never a delta, so an older frame carries nothing the newer one lacks. The queue then holds at most one entry per in-flight call regardless of dictation length.

`_EVENT_QUEUE_MAX` is deliberately **not** raised: it buys a linear factor against an unbounded dictation and re-opens the memory question the bound exists for. The fold is O(1) in queue depth per call and closes the class.

Three properties are load-bearing, each covered by a test that provably fails without it:
1. **Replaces in place**, so a folded frame keeps the call's original FIFO position.
2. **Stops folding a call once any other frame for it goes by**, so a compose frame can never overtake the `tool_execution_start` that follows it.
3. **Resets at a turn boundary**, because placeholder `compose:{index}` keys (`harness/loop.py:1382`) repeat across turns.

The **oversize refusal is untouched**: a fold *replaces* rather than concatenates, so unlike the `message_update` merge it cannot assemble an oversized frame from individually-legal ones. Asserted rather than assumed.

## Testing evidence — real execution

### Reproduction: the audit's `probe5_queue.py`, run against this branch's venv

Drives the **real** `_enqueue_client_frame` / `_compact_event_queue` against a connection whose `drain()` never returns.

**BEFORE (base `9c0f1b3cd`) — reproduced myself, not quoted from the audit:**
```
_EVENT_QUEUE_MAX = 64
_SEND_TIMEOUT_S = 1.0  _TUI_SEND_TIMEOUT_S = 5.0

--- A: 300 message_update frames (compactible) ---
  survived 300 frames; queue depth=48

--- B: 300 tool_call_compose frames, 3 calls (incompressible) ---
  DROPPED after 65 frames enqueued: reason='event queue overflow (64 frames)'
  queue depth at drop: 64

--- C: 30 message_update then 300 compose (realistic dictation) ---
  DROPPED after 94 frames enqueued: reason='event queue overflow (64 frames)'
  queue depth at drop: 64
```

**AFTER (this branch):**
```
_EVENT_QUEUE_MAX = 64
_SEND_TIMEOUT_S = 1.0  _TUI_SEND_TIMEOUT_S = 5.0

--- A: 300 message_update frames (compactible) ---
  survived 300 frames; queue depth=48

--- B: 300 tool_call_compose frames, 3 calls (incompressible) ---
  survived 300 frames; queue depth=56

--- C: 30 message_update then 300 compose (realistic dictation) ---
  survived 330 frames; queue depth=30
```

Cell A is **byte-identical** before and after — `message_update` compaction is untouched. Cells B and C go from dropped to surviving.

### Mutation testing — proof the new guards can actually go red

A guard that cannot fail is worse than none, so each constraint was reintroduced as a bug and the suite re-run:

| mutant | constraint violated | result |
|---|---|---|
| baseline (unmutated) | — | **7 passed** |
| append instead of replace-in-place | FIFO position preserved | **1 failed**, 6 passed |
| keep oldest snapshot, not newest | fold is lossless | **2 failed**, 5 passed |
| fold across an intervening `tool_execution_start` | compose cannot overtake start | **1 failed**, 6 passed |
| no turn-boundary reset | placeholder keys collide across turns | **1 failed**, 6 passed |
| restored | — | **7 passed** |

This round found a real weakness: my first ordering test placed the two compose frames adjacently, where replace-in-place and delete-then-append produce the *same* order — so mutant 1 initially **survived**. The test now interleaves a second call's frame between them, which is what makes the position assertion meaningful.

### Regression surface
```
$ .venv/bin/python -m pytest tests/unit/session/runtime/test_server.py \
                            tests/unit/session/test_attach_frame_size.py -q
108 passed in 68.23s
```
This includes every pre-existing `message_update` compaction test and `test_compaction_never_assembles_an_unreadable_frame` (the oversize refusal) — both green and unmodified.

### Quality gates (whole tree, exactly as CI)
| gate | result |
|---|---|
| `python -m flake8 .` | clean |
| `black --check .` (26.1.0) | 1057 files unchanged |
| `isort --check .` (5.13.2) | clean |
| `pyright --pythonpath .venv/bin/python .` | **0 errors, 0 warnings** |
| `pytest tests/unit` | see comment below |

## Notes

- **No version bump** — `pyproject.toml` stays at `0.51.9` per the combined-release process. The window owner needs the `Release:` line above.
- **Scope:** `server.py` + its tests only. Finding **A2** (placeholder compose key adoption) is deliberately untouched — a sibling PR owns that seam.
- The tests assert **frame counts and ordering**, never wall-clock durations, so they cannot flake under host contention (AGENTS.md "Timing, flakes").
- Built and verified in a dedicated worktree with its own real (non-symlinked) venv, confirmed resolving to `lo-compose-fold/local_operator/__init__.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
