### PR TITLE
chore(release): bump version to 0.51.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.10"
+version = "0.51.11"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window claimed after **v0.51.10**. Owner session pid: **1050** (`Auto-update inactive session runtimes`).

Checked first per #740: `gh pr list --search '"chore(release)" in:title' --state open` returned `[]` — no lock was held. 96340 closed the v0.51.10 window cleanly (build done, install at 0.51.10) and is not holding this one.

Window (tick as each merges):

- [x] #748 `5a801d61d` — **Release: patch — /new and background runtimes now run the installed build instead of whatever checkout happened to be the working directory.**

Pre-check `git diff v0.51.10..origin/main -- pyproject.toml` — to be confirmed EMPTY before the bump, so nothing has consumed 0.51.11.

## Why #748 matters for this window

This is the fix for the defect that has been caveated in the last three releases' notes. `launch.py` spawned runtimes as `[sys.executable, "-m", ...]` with no `cwd=`, so `-m` put the session's working directory on `sys.path[0]` ahead of site-packages: any session whose cwd is a checkout of this project imported that checkout instead of the install.

Measured on this host before the fix: **every running runtime reported `version: 0.51.0` alongside `source_ref f1cd77900`** — the ref of the *installed* build. One record describing two trees, because `source_ref` reads `sys.prefix/.lop-source` while `version` comes from the code actually imported.

It also **disabled its own remedy**: `RuntimeServer.__init__` stamps `_boot_build = installed_build(...)` and the reaper re-reads the same function, so both resolved through the same poisoned `sys.path`, `_build_changed()` always returned `None`, and #707's idle self-refresh could never fire. That is why `/reload` did nothing and `/stop` was the only lever the operator had.

If anything else merges in the next ~60 minutes, send PR#, merge SHA and your `Release:` line and I will include it. I will not hold for an unready PR.