### PR TITLE
fix(runtime): supersede a placeholder compose key so a joiner never strands a finished call

### DIFF
--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -1428,30 +1428,41 @@ class AgentLoop:
                             # ONE frame that carried it to be the one lost,
                             # which would strand the row this exists to rescue.
                             #
+                            # This is load-bearing against the sibling compose
+                            # fold (PR #770), which keeps only the NEWEST frame
+                            # per ``tool_call_id``: a single announcement is
+                            # precisely what that fold would discard, so the
+                            # repeat is what lets the two changes coexist.
+                            #
                             # The immediate emission is also the ordering
                             # guarantee: the hand-off reaches the seed before
                             # the ``tool_execution_start`` that follows on the
                             # real id.
                             #
-                            # Only announced when a row was actually published
-                            # under the placeholder (``announced`` is still 0.0
-                            # before the first frame): with nothing on screen
-                            # and nothing in the seed there is no row to
-                            # supersede, so the key is corrected in place and
-                            # consumers are told nothing.
-                            if state["announced"] != 0.0:
-                                state["supersedes"] = state["key"]
+                            # No guard on ``announced`` here: the key is only
+                            # ever latched inside ``if state["name"]``, and the
+                            # block immediately below stamps ``announced`` on
+                            # that same first pass. So a placeholder that exists
+                            # at all has already been published, and a
+                            # "nothing announced yet" case cannot occur —
+                            # verified with a raising probe over the suite.
+                            state["supersedes"] = state["key"]
                             state["key"] = state["id"]
                             state["placeholder"] = False
-                            if state["supersedes"]:
-                                state["reported"] = state["bytes"]
-                                yield ToolCallComposeEvent(
-                                    tool_call_id=state["key"],
-                                    tool_name=state["name"],
-                                    argument_bytes=state["bytes"],
-                                    intent=state["intent"],
-                                    supersedes_tool_call_id=state["supersedes"],
-                                )
+                            state["reported"] = state["bytes"]
+                            yield ToolCallComposeEvent(
+                                tool_call_id=state["key"],
+                                tool_name=state["name"],
+                                argument_bytes=state["bytes"],
+                                intent=state["intent"],
+                                supersedes_tool_call_id=state["supersedes"],
+                            )
+                            # Stamp the throttle too: the promotion IS this
+                            # window's frame. Without it the block below fires
+                            # again in the same iteration and emits a second,
+                            # identical frame — harmless, but wasted at exactly
+                            # the moment the queue is under pressure.
+                            state["announced"] = time.monotonic()
                         now = time.monotonic()
                         first = state["announced"] == 0.0
                         if first or now - state["announced"] >= COMPOSE_NOTICE_INTERVAL_S:
@@ -1474,7 +1485,48 @@ class AgentLoop:
                     # display a size at all. It matters most on an aborted turn,
                     # where the frozen row is what the user is left reading.
                     for state in tool_states.values():
-                        if state["name"] and state["bytes"] != state["reported"]:
+                        if not state["name"]:
+                            continue
+                        if state["placeholder"] and not state["id"]:
+                            # The call's id NEVER arrived — the stream is over
+                            # and the row is still keyed by its placeholder.
+                            # This is the shape the OpenAI Responses API
+                            # actually produces: ``clients.py`` yields the id
+                            # and name in ONE delta with ``call_id`` defaulting
+                            # to the empty string, and the argument deltas that
+                            # follow carry no id at all. So the id does not
+                            # arrive LATE on that path, it never arrives, and
+                            # the late-arrival hand-off above cannot fire.
+                            #
+                            # Left alone, ``_assemble_tool_call`` mints a fresh
+                            # uuid for the ToolCall and execution proceeds under
+                            # an id the composing row has never seen — stranding
+                            # it exactly as a late id would.
+                            #
+                            # So mint the identity HERE, once, and announce it,
+                            # rather than letting the ToolCall mint a different
+                            # one silently. Same factory and same shape the
+                            # ToolCall would have used, deliberately: this id
+                            # goes back to the provider as Anthropic's
+                            # ``tool_use.id`` and Responses' ``call_id``, so it
+                            # must be an ordinary opaque token. Promoting the
+                            # PLACEHOLDER onto the wire instead would put
+                            # ``compose:{index}`` in that field — a value no
+                            # provider has agreed to accept, for no gain, since
+                            # nothing keys off the prefix.
+                            state["id"] = uuid.uuid4().hex[:12]
+                            # Unguarded for the same reason as the late-arrival
+                            # hand-off above: reaching here means a placeholder
+                            # was latched, which only happens on a pass that
+                            # also publishes the row.
+                            state["supersedes"] = state["key"]
+                            state["key"] = state["id"]
+                            state["placeholder"] = False
+                            # Force the announcement below: the identity change
+                            # must reach consumers even when the size has not
+                            # moved since the last frame.
+                            state["reported"] = -1
+                        if state["bytes"] != state["reported"]:
                             state["reported"] = state["bytes"]
                             yield ToolCallComposeEvent(
                                 tool_call_id=state["key"] or "compose:0",

--- a/local_operator/harness/loop.py
+++ b/local_operator/harness/loop.py
@@ -1333,6 +1333,16 @@ class AgentLoop:
                             "bytes": 0,
                             "announced": 0.0,
                             "key": "",
+                            # Whether ``key`` is the index-derived placeholder
+                            # rather than the provider's id. Tracked as a flag
+                            # instead of sniffing a ``compose:`` prefix off the
+                            # key, because a provider id is opaque and may
+                            # legally look like anything.
+                            "placeholder": False,
+                            # The placeholder this call was announced under,
+                            # once its real id has replaced it. Retained for
+                            # the rest of the stream — see the emission below.
+                            "supersedes": None,
                             "reported": -1,
                             # Bounded copy of the head of the argument stream,
                             # kept only until the intent scrape resolves. `None`
@@ -1380,6 +1390,68 @@ class AgentLoop:
                         # interrupted.
                         if not state["key"]:
                             state["key"] = state["id"] or f"compose:{event.index}"
+                            state["placeholder"] = not state["id"]
+                        elif state["placeholder"] and state["id"]:
+                            # The real id has arrived for a row announced under
+                            # a placeholder. The identity moves ONCE, here, and
+                            # is ANNOUNCED — the placeholder key is otherwise
+                            # kept for the rest of the stream while
+                            # ``tool_execution_start``/``_end`` carry the real
+                            # id, so every consumer that keys rows by
+                            # ``tool_call_id`` (the in-flight seed, the TUI's
+                            # composing cards, the mobile projection) ends up
+                            # holding TWO records for one call. A viewer joining
+                            # mid-turn then gets a composing row nothing can
+                            # adopt, and turn-end retirement paints it
+                            # ``⊘ interrupted`` on a call that SUCCEEDED.
+                            #
+                            # Announced rather than silently recomputed: silent
+                            # recomputation is the bug the latch above exists to
+                            # prevent (two rows for one call). Consumers rekey
+                            # the row they already have because this frame names
+                            # both ids.
+                            #
+                            # Announced immediately and UNTHROTTLED, then
+                            # REPEATED on every later compose frame for this
+                            # call. The throttle may swallow an ordinary compose
+                            # frame with no loss — a later one carries the same
+                            # cumulative size — but a frame carrying the
+                            # identity change is not interchangeable, so the
+                            # announcement must survive a lossy path. Anything
+                            # between here and a viewer may legitimately drop
+                            # frames: the per-connection queue compacts and
+                            # overflows, and a viewer that was away sees only
+                            # what the seed retained. Naming the placeholder on
+                            # every subsequent frame makes the hand-off
+                            # idempotent — a consumer that already rekeyed finds
+                            # nothing to drop — and makes it impossible for the
+                            # ONE frame that carried it to be the one lost,
+                            # which would strand the row this exists to rescue.
+                            #
+                            # The immediate emission is also the ordering
+                            # guarantee: the hand-off reaches the seed before
+                            # the ``tool_execution_start`` that follows on the
+                            # real id.
+                            #
+                            # Only announced when a row was actually published
+                            # under the placeholder (``announced`` is still 0.0
+                            # before the first frame): with nothing on screen
+                            # and nothing in the seed there is no row to
+                            # supersede, so the key is corrected in place and
+                            # consumers are told nothing.
+                            if state["announced"] != 0.0:
+                                state["supersedes"] = state["key"]
+                            state["key"] = state["id"]
+                            state["placeholder"] = False
+                            if state["supersedes"]:
+                                state["reported"] = state["bytes"]
+                                yield ToolCallComposeEvent(
+                                    tool_call_id=state["key"],
+                                    tool_name=state["name"],
+                                    argument_bytes=state["bytes"],
+                                    intent=state["intent"],
+                                    supersedes_tool_call_id=state["supersedes"],
+                                )
                         now = time.monotonic()
                         first = state["announced"] == 0.0
                         if first or now - state["announced"] >= COMPOSE_NOTICE_INTERVAL_S:
@@ -1390,6 +1462,7 @@ class AgentLoop:
                                 tool_name=state["name"],
                                 argument_bytes=state["bytes"],
                                 intent=state["intent"],
+                                supersedes_tool_call_id=state["supersedes"],
                             )
                 elif isinstance(event, StreamUsageEvent):
                     usage = event.usage
@@ -1408,6 +1481,7 @@ class AgentLoop:
                                 tool_name=state["name"],
                                 argument_bytes=state["bytes"],
                                 intent=state["intent"],
+                                supersedes_tool_call_id=state["supersedes"],
                             )
                     stop_reason = event.stop_reason
                     if event.usage is not None:

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -1186,6 +1186,36 @@ class ToolCallComposeEvent(AgentEvent[Literal["tool_call_compose"]]):
     row reads worse than no label. This is the highest-value place the field
     appears: ``argument_bytes`` says the agent is alive, and only the intent
     says what for, across the longest silence of the turn.
+
+    ``supersedes_tool_call_id`` announces that THIS frame and the frames that
+    carried ``supersedes_tool_call_id`` as their id are the SAME call, whose
+    real id has arrived. It is set only when the row was first announced under
+    an index-derived placeholder, and then on EVERY later frame for that call:
+    the identity moves once, but the announcement is repeated so a compacted or
+    overflowing queue cannot drop the only copy of it. Applying it twice is
+    defined to be the same as applying it once — the second time there is no
+    placeholder left to retire.
+
+    It exists because the two id spaces otherwise never meet. A provider that
+    sends a call's ``name`` before its ``id`` makes the loop announce the row as
+    ``compose:{index}``, while ``tool_execution_start``/``_end`` carry the
+    provider's real id. Anything that keys rows by ``tool_call_id`` — the
+    in-flight seed in ``_fold_live_event``, the TUI's composing cards, the
+    mobile projection's rows — then holds TWO records for one call, and a
+    viewer joining mid-turn is handed a composing row nothing can ever adopt or
+    settle: at turn end it is painted ``⊘ interrupted`` on a call that
+    SUCCEEDED. The promotion frame is what lets each of those consumers rekey
+    the row it already has instead of opening a second one.
+
+    Why an explicit announcement rather than silently re-deriving the key each
+    frame: re-deriving is what this code used to do, and it changed the key
+    mid-stream with nobody told, so the UI mounted a second row for one call and
+    then marked the abandoned one interrupted (see the latch comment in
+    ``harness/loop.py``). The identity moves exactly once, and it says so.
+
+    Additive on purpose. An older runtime never sets it and every consumer
+    keeps today's behaviour; an older viewer receiving it ignores it, because
+    ``AgentEvent`` allows extra fields.
     """
 
     type: Literal["tool_call_compose"] = "tool_call_compose"
@@ -1193,6 +1223,7 @@ class ToolCallComposeEvent(AgentEvent[Literal["tool_call_compose"]]):
     tool_name: str
     argument_bytes: int = 0
     intent: str | None = None
+    supersedes_tool_call_id: str | None = None
 
 
 class ToolExecutionStartEvent(AgentEvent[Literal["tool_execution_start"]]):

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -931,7 +931,15 @@ class ProjectionFold:
             # The entry's own ``id`` is deliberately left alone: clients diff
             # the transcript by row id, so re-identifying a row mid-turn would
             # read as the row being replaced. Only the correlation key moves.
-            superseded = getattr(event, "supersedes_tool_call_id", None)
+            # Plain attribute read is safe HERE, unlike in the TUI: this branch
+            # sits behind ``isinstance(event, ToolCallComposeEvent)``, so the
+            # field is guaranteed to exist with its ``None`` default. The TUI's
+            # equivalent keeps ``getattr`` because its dispatch routes on
+            # ``event.type`` without re-validating, so a legacy relayed frame
+            # reaches it as a bare ``AgentEvent`` (see the comment there).
+            # An older owner that omits the field arrives as ``None`` and takes
+            # the falsy no-op path below.
+            superseded = event.supersedes_tool_call_id
             if superseded:
                 entry_id = self._tool_rows.pop(str(superseded), None)
                 if entry_id is not None:

--- a/local_operator/mobile/projection.py
+++ b/local_operator/mobile/projection.py
@@ -921,6 +921,24 @@ class ProjectionFold:
                 row.final = True
             self._open_message_id = None
         elif isinstance(event, ToolCallComposeEvent):
+            # Same rekey the TUI does: the call's real id has arrived for a row
+            # opened under an index-derived placeholder, so move the existing
+            # row's correlation onto the real id. Without it ``_tool_row``
+            # misses and appends a SECOND row for one call, and the placeholder
+            # row is left composing forever because every later start/end
+            # carries the real id.
+            #
+            # The entry's own ``id`` is deliberately left alone: clients diff
+            # the transcript by row id, so re-identifying a row mid-turn would
+            # read as the row being replaced. Only the correlation key moves.
+            superseded = getattr(event, "supersedes_tool_call_id", None)
+            if superseded:
+                entry_id = self._tool_rows.pop(str(superseded), None)
+                if entry_id is not None:
+                    self._tool_rows[event.tool_call_id] = entry_id
+                    promoted = self._find(entry_id)
+                    if promoted is not None:
+                        promoted.tool_call_id = event.tool_call_id
             row = self._tool_row(event.tool_call_id, event.tool_name)
             row.tool_state = "composing"
             row.summary = event.intent or f"dictating {event.tool_name}"

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -3332,7 +3332,25 @@ class FrontendStateStore:
             ]
         elif kind in {"tool_call_compose", "tool_execution_start"}:
             call_id = str(data.get("tool_call_id") or "")
-            live = [item for item in live if str(item.get("tool_call_id") or "") != call_id]
+            # A compose frame may announce that the call's real id has just
+            # arrived and that the row previously seeded under an index-derived
+            # placeholder is the SAME call. Drop the superseded entry with it,
+            # or the seed keeps BOTH id spaces: a joiner is then handed a
+            # composing row keyed by the placeholder that no later
+            # ``tool_execution_start``/``_end`` can ever match, and turn-end
+            # retirement paints it ``⊘ interrupted`` on a call that SUCCEEDED.
+            #
+            # Keyed on the announcement rather than on a rule like *any start
+            # clears the composing entries*: with several calls in flight
+            # nothing else can tell WHICH composing entry a start belongs to,
+            # so the broad rule would drop rows for calls still being dictated.
+            #
+            # The falsy guard keeps an OLDER runtime working: it never sets the
+            # field, so ``superseded`` is empty and this is exactly today's
+            # behaviour.
+            superseded = str(data.get("supersedes_tool_call_id") or "")
+            drop = {call_id, superseded} if superseded else {call_id}
+            live = [item for item in live if str(item.get("tool_call_id") or "") not in drop]
             live.append(data)
         elif kind == "tool_execution_end":
             call_id = str(data.get("tool_call_id") or "")

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -29304,6 +29304,19 @@ class OperatorApp(App[None]):
         # promotion frame reads as a brand-new call, so the screen carries two
         # rows for one call and the abandoned one is marked ``⊘ interrupted`` at
         # turn end — precisely the failure the compose key is latched to avoid.
+        # ``getattr`` with a default, NOT a plain attribute read, and that is
+        # load-bearing rather than defensive habit. ``EventController._on_event``
+        # dispatches on ``event.type`` alone and never re-validates to the
+        # declared class, so an event relayed from an owner whose build predates
+        # this field arrives here as a bare ``AgentEvent`` — which allows extra
+        # fields but declares none of them. A plain read raises
+        # ``AttributeError: 'AgentEvent' object has no attribute
+        # 'supersedes_tool_call_id'`` and takes the turn down.
+        #
+        # Reviewer round 1 (R5) suggested the plain read on the grounds that the
+        # field is always defaulted. That holds for the pydantic model but not
+        # for the object that actually reaches this method; the compat test
+        # below fails outright on the plain read. Pinned there deliberately.
         superseded = getattr(event, "supersedes_tool_call_id", None)
         if superseded:
             promoted = self._composing_cards.pop(str(superseded), None)

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -29298,6 +29298,21 @@ class OperatorApp(App[None]):
         reasonable reading of that frame was that the agent had hung.
         """
         event = message.event
+        # The call's real id has just arrived for a row this surface mounted
+        # under an index-derived placeholder: REKEY the row rather than letting
+        # the lookup below miss and mount a second one. Without this the
+        # promotion frame reads as a brand-new call, so the screen carries two
+        # rows for one call and the abandoned one is marked ``⊘ interrupted`` at
+        # turn end — precisely the failure the compose key is latched to avoid.
+        superseded = getattr(event, "supersedes_tool_call_id", None)
+        if superseded:
+            promoted = self._composing_cards.pop(str(superseded), None)
+            if promoted is not None:
+                promoted.tool_call_id = event.tool_call_id
+                # The anchor is the row's scroll identity; leaving it on the
+                # placeholder would strand a restored scroll position.
+                promoted.navigation_anchor_id = f"tool:{event.tool_call_id}"
+                self._composing_cards[event.tool_call_id] = promoted
         card = self._composing_cards.get(event.tool_call_id)
         if card is None:
             card = ToolCard(event.tool_call_id, event.tool_name)

--- a/tests/e2e/test_viewer_attach_e2e.py
+++ b/tests/e2e/test_viewer_attach_e2e.py
@@ -1077,9 +1077,45 @@ def _late_id_tool_turn(count: int) -> list[Any]:
     return events
 
 
+def _never_id_tool_turn(count: int) -> list[Any]:
+    """The shape `clients.py` ACTUALLY produces on the OpenAI Responses API.
+
+    `:2568` yields the id and name in ONE delta with `call_id` defaulting to
+    the empty string, and the argument deltas at `:2578` carry no id at all —
+    so the real id never arrives. This is the only ordering a shipping provider
+    is known to emit, which makes it the reachable half of the defect: the loop
+    must settle the identity itself, or execution runs under a fresh uuid the
+    composing row has never seen.
+    """
+    from local_operator.harness.types import (
+        StreamEndEvent,
+        StreamTextDelta,
+        StreamToolCallDelta,
+    )
+
+    events: list[Any] = [StreamTextDelta(delta="working")]
+    events += [StreamToolCallDelta(index=i, id="", name="probe") for i in range(count)]
+    events += [
+        StreamToolCallDelta(index=i, id="", name="", argument_delta="{}") for i in range(count)
+    ]
+    events.append(StreamEndEvent(stop_reason="toolUse"))
+    return events
+
+
+@pytest.mark.parametrize(
+    ("shape", "expected_ids"),
+    [
+        # The ordering this mechanism was first written for.
+        ("late_id", {"real_0", "real_1", "real_2"}),
+        # The ordering `clients.py` actually produces (Responses API): the id
+        # never arrives, so the loop settles one itself. The ids are minted, so
+        # the assertion is on their COUNT and on nothing being left composing.
+        ("never_id", None),
+    ],
+)
 @pytest.mark.asyncio
 async def test_a_joiner_after_the_tools_end_paints_no_interrupted_card(
-    headless_tui_env: Path, workspace: Path
+    headless_tui_env: Path, workspace: Path, shape: str, expected_ids: set[str] | None
 ) -> None:
     """Three succeeded calls must not be painted as interrupted.
 
@@ -1134,7 +1170,8 @@ async def test_a_joiner_after_the_tools_end_paints_no_interrupted_card(
 
             async def gen():
                 if is_tool_turn:
-                    for event in _late_id_tool_turn(3):
+                    turn = _late_id_tool_turn(3) if shape == "late_id" else _never_id_tool_turn(3)
+                    for event in turn:
                         yield event
                     return
                 if has_result:
@@ -1145,7 +1182,7 @@ async def test_a_joiner_after_the_tools_end_paints_no_interrupted_card(
 
             return gen()
 
-    directory = headless_tui_env / "sessions" / "latejoin0001"
+    directory = headless_tui_env / "sessions" / f"join{shape[:8]}"
     directory.mkdir(parents=True)
     session = build_session(directory, _Stream(), tools=[probe], cwd=workspace)
     handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd=str(workspace))
@@ -1187,7 +1224,13 @@ async def test_a_joiner_after_the_tools_end_paints_no_interrupted_card(
         # carry — and it must carry NOTHING that claims they are still being
         # composed. Before the fix this held three `compose:N` rows beside
         # these ends, and every one of them became a false `⊘ interrupted`.
-        assert ended == {"real_0", "real_1", "real_2"}, seed
+        if expected_ids is not None:
+            assert ended == expected_ids, seed
+        else:
+            # Minted ids: assert the shape rather than the values, and that
+            # none of them is the placeholder that would reach the provider.
+            assert len(ended) == 3, seed
+            assert not any(call_id.startswith("compose:") for call_id in ended), seed
         assert composing == [], (
             "the seed handed the joiner a composing row for a call that had "
             f"already finished; those rows are painted interrupted: {composing}"

--- a/tests/e2e/test_viewer_attach_e2e.py
+++ b/tests/e2e/test_viewer_attach_e2e.py
@@ -29,6 +29,7 @@ asyncio components against each other, which is the e2e stage's job.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from pathlib import Path
 from typing import Any, cast
 
@@ -1029,3 +1030,175 @@ async def test_a_tool_started_during_the_gap_paints_and_completes_after_rebind(
             await viewer.dispose()
         server.close()
         await handle.dispose()
+
+
+# ---------------------------------------------------------------------------
+# A viewer joining AFTER the tools finished, against a provider that sends each
+# call's name before its id.
+#
+# The dangerous window is after the calls END but before ``agent_end`` clears
+# ``live_events``. Under the unfixed code the seed held the placeholder-keyed
+# compose rows BESIDE the real ends, so the joiner mounted three composing
+# cards nothing could adopt, discarded three ends it had no card for, and
+# painted `⊘ interrupted` on three calls that SUCCEEDED.
+#
+# Driven against the production handle, the production server, a real socket
+# and the production ``RemoteSession`` for the reason this module's docstring
+# gives: a stub that declares the capability is what hid the last outage.
+# ---------------------------------------------------------------------------
+
+
+def _late_id_tool_turn(count: int) -> list[Any]:
+    """A provider stream that announces each call's NAME before its ID.
+
+    This is the ordering `providers/clients.py` tolerates on the Responses API,
+    where ``call_id`` falls back to the empty string. Scripted here rather than
+    waiting for a provider to start doing it, because the branch is reachable
+    by contract and had no coverage at all.
+    """
+    from local_operator.harness.types import (
+        StreamEndEvent,
+        StreamTextDelta,
+        StreamToolCallDelta,
+    )
+
+    events: list[Any] = [StreamTextDelta(delta="working")]
+    # Names first, with NO id: this is what latches the `compose:{index}` key.
+    events += [StreamToolCallDelta(index=i, id="", name="probe") for i in range(count)]
+    events += [
+        StreamToolCallDelta(index=i, id="", name="", argument_delta="{}") for i in range(count)
+    ]
+    # The real ids arrive only now, and every execution event carries them.
+    events += [
+        StreamToolCallDelta(index=i, id=f"real_{i}", name="", argument_delta="")
+        for i in range(count)
+    ]
+    events.append(StreamEndEvent(stop_reason="toolUse"))
+    return events
+
+
+@pytest.mark.asyncio
+async def test_a_joiner_after_the_tools_end_paints_no_interrupted_card(
+    headless_tui_env: Path, workspace: Path
+) -> None:
+    """Three succeeded calls must not be painted as interrupted.
+
+    Asserted on the SEED the viewer is actually handed: it must carry one entry
+    per call, keyed by the id the executions used, and no compose row whose
+    call has already started. That is the property `_retire_live_tool_cards`
+    depends on — its docstring says so, and says the fix belongs in the seed,
+    which is where it is.
+    """
+    import os
+
+    from local_operator.harness.types import AgentTool, TextContent, ToolResult
+    from local_operator.session.remote import RemoteSession
+    from tests.e2e.harness import text_turn
+
+    tools_done = asyncio.Event()
+    hold_summary = asyncio.Event()
+
+    async def execute(  # noqa: ANN001
+        tool_call_id, args, signal=None, on_update=None, context=None
+    ):
+        return ToolResult(
+            tool_call_id=tool_call_id, tool_name="probe", content=[TextContent(text="ok")]
+        )
+
+    probe = AgentTool(
+        name="probe",
+        parameters={"type": "object", "properties": {}},
+        execute=execute,
+        interruptible=True,
+    )
+
+    class _Stream:
+        """Turn 1 dictates 3 late-id calls; turn 2 is held open.
+
+        Holding turn 2 keeps the turn alive after the tools have ended, which
+        is the exact window ``live_events`` still describes and the window a
+        `/resume` lands in.
+        """
+
+        def __init__(self) -> None:
+            self.requests: list[Any] = []
+            self.fired = False
+
+        def __call__(self, request, signal=None):  # noqa: ANN001
+            self.requests.append(request)
+            roles = [getattr(m, "role", "") for m in getattr(request, "messages", [])]
+            has_result = "tool" in roles
+            is_tool_turn = bool(getattr(request, "tools", None)) and not has_result
+            if is_tool_turn:
+                self.fired = True
+
+            async def gen():
+                if is_tool_turn:
+                    for event in _late_id_tool_turn(3):
+                        yield event
+                    return
+                if has_result:
+                    tools_done.set()
+                    await hold_summary.wait()
+                for event in text_turn("summarised"):
+                    yield event
+
+            return gen()
+
+    directory = headless_tui_env / "sessions" / "latejoin0001"
+    directory.mkdir(parents=True)
+    session = build_session(directory, _Stream(), tools=[probe], cwd=workspace)
+    handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd=str(workspace))
+    server = RuntimeServer(handle, kind="daemon")
+    await server.start_in_process()
+    # A real runtime process writes this; without it `find_owner_record` cannot
+    # see a perfectly healthy runtime and the viewer goes cold, faking an abort.
+    (directory / ".session.pid").write_text(str(os.getpid()), encoding="utf-8")
+
+    viewer = None
+    owner_turn = asyncio.create_task(session.prompt("run three probes"))
+    try:
+        await asyncio.wait_for(tools_done.wait(), timeout=30)
+
+        record = await _wait_for_record(headless_tui_env, session.session_id)
+        viewer = await RemoteSession.connect(
+            record,
+            session.session_id,
+            config_dir=headless_tui_env,
+            takeover_factory=_never_take_over,
+        )
+        assert viewer.frontend_state is not None
+        seed = list(viewer.frontend_state.live_events)
+
+        tool_rows = [
+            row
+            for row in seed
+            if str(row.get("type", "")).startswith("tool_")
+            or row.get("type") == "tool_call_compose"
+        ]
+        composing = [row for row in tool_rows if row.get("type") == "tool_call_compose"]
+        ended = {
+            str(row.get("tool_call_id"))
+            for row in tool_rows
+            if row.get("type") == "tool_execution_end"
+        }
+
+        # The three calls succeeded, so their ends are what the seed must
+        # carry — and it must carry NOTHING that claims they are still being
+        # composed. Before the fix this held three `compose:N` rows beside
+        # these ends, and every one of them became a false `⊘ interrupted`.
+        assert ended == {"real_0", "real_1", "real_2"}, seed
+        assert composing == [], (
+            "the seed handed the joiner a composing row for a call that had "
+            f"already finished; those rows are painted interrupted: {composing}"
+        )
+        # No id space other than the executions' own reaches the joiner.
+        assert {str(row.get("tool_call_id")) for row in tool_rows} == ended
+    finally:
+        hold_summary.set()
+        with contextlib.suppress(Exception):
+            await asyncio.wait_for(owner_turn, timeout=30)
+        if viewer is not None:
+            await viewer.dispose()
+        server.close()
+        await session.dispose()

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -3578,12 +3578,18 @@ async def test_concurrent_late_id_calls_each_supersede_their_own_placeholder():
 
 
 @pytest.mark.asyncio
-async def test_a_call_whose_id_never_arrives_keeps_its_placeholder():
-    """No id at all: the placeholder must stay latched for the whole stream.
+async def test_a_call_whose_id_never_arrives_keeps_its_placeholder_while_streaming():
+    """No id at all: the placeholder stays latched for the whole STREAM.
 
-    Re-deriving the key is what mounted a second row for one call, so a call
-    that never learns its provider id keeps the identity it was announced
-    under rather than acquiring one late.
+    Re-deriving the key mid-stream is what mounted a second row for one call,
+    so a call that never learns its provider id keeps the identity it was
+    announced under for as long as arguments are arriving.
+
+    Scoped to the streaming phase deliberately. At stream END the identity must
+    be settled, because ``_assemble_tool_call`` would otherwise mint a fresh
+    uuid and execute under an id this row has never seen — see
+    ``test_a_call_whose_id_never_arrives_is_promoted_at_stream_end``. The
+    invariant is "never re-keyed silently mid-stream", not "never re-keyed".
     """
     executed: list[str] = []
     stream = ScriptedStream(
@@ -3602,8 +3608,11 @@ async def test_a_call_whose_id_never_arrives_keeps_its_placeholder():
         events.append(event)
 
     composes = [e for e in events if isinstance(e, ToolCallComposeEvent)]
-    assert {c.tool_call_id for c in composes} == {"compose:0"}
-    assert all(c.supersedes_tool_call_id is None for c in composes)
+    # Every frame emitted WHILE the arguments stream keeps the placeholder and
+    # announces no hand-off: the row a viewer is watching does not move under
+    # it. Only the stream-end settle promotes, and it announces when it does.
+    streaming = [c for c in composes if c.supersedes_tool_call_id is None]
+    assert {c.tool_call_id for c in streaming} == {"compose:0"}
     assert executed == ["echo"]
 
 
@@ -3643,3 +3652,99 @@ async def test_the_supersession_is_repeated_so_a_dropped_frame_cannot_strand_the
     # is enough to rekey the row.
     assert all(c.supersedes_tool_call_id == "compose:0" for c in after)
     assert executed == ["echo"]
+
+
+@pytest.mark.asyncio
+async def test_a_call_whose_id_never_arrives_is_promoted_at_stream_end():
+    """THE SHAPE THE RESPONSES API ACTUALLY PRODUCES (review round 1, R1).
+
+    ``clients.py`` yields the Responses API's id and name in ONE delta, with
+    ``call_id`` falling back to the empty string, and the argument deltas that
+    follow carry no id at all. So on that path the real id does not arrive
+    LATE — it never arrives, and the late-arrival hand-off cannot fire.
+
+    Left alone, ``_assemble_tool_call`` mints a fresh uuid for the ToolCall, so
+    execution proceeds under an id the composing row has never seen and strands
+    it exactly as a late id would. The identity is therefore minted once at
+    stream end and ANNOUNCED, so the row and the execution agree.
+
+    This is the only ordering a shipping provider is known to produce, which is
+    why the PR that added the late-id hand-off had to cover it too.
+    """
+    executed: list[str] = []
+    stream = ScriptedStream(
+        [
+            [
+                # id and name together, id EMPTY — verbatim `clients.py:2568`.
+                tool_call_delta(0, id="", name="echo"),
+                # Argument deltas carry no id — verbatim `clients.py:2578`.
+                tool_call_delta(0, args='{"text":"hi"}'),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            [StreamTextDelta(delta="done"), StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    context = LoopContext(system_blocks=["sys"], tools=[echo_tool(executed)])
+    events = []
+    async for event in AgentLoop().run([Message.user("go")], context, make_config(stream), None):
+        events.append(event)
+
+    composes = [e for e in events if isinstance(e, ToolCallComposeEvent)]
+    # The row is announced under the placeholder, because that is all there is.
+    assert composes[0].tool_call_id == "compose:0"
+
+    promotions = [c for c in composes if c.supersedes_tool_call_id]
+    assert promotions, "the id never arrived and no identity was ever announced"
+    assert {c.supersedes_tool_call_id for c in promotions} == {"compose:0"}
+
+    # THE EQUALITY THAT MATTERS: the announced id is the one execution uses.
+    # Its absence is the whole defect — a stranded row and an unrenderable end.
+    start = next(e for e in events if isinstance(e, ToolExecutionStartEvent))
+    assert start.tool_call_id == promotions[-1].tool_call_id
+    assert executed == ["echo"]
+
+    # The minted id goes back to the provider as Anthropic's ``tool_use.id``
+    # and Responses' ``call_id``, so it must be an ordinary opaque token —
+    # never the ``compose:{index}`` placeholder, which contains a colon and
+    # which no provider has agreed to accept.
+    assert start.tool_call_id != "compose:0"
+    assert start.tool_call_id.isalnum()
+
+    # And the assistant message carries that same id, so the tool_use/
+    # tool_result pairing the next request depends on stays legal.
+    end = events[-1]
+    assert isinstance(end, AgentEndEvent)
+    assistant = next(
+        m for m in end.messages if isinstance(m, Message) and m.role == "assistant" and m.tool_calls
+    )
+    assert [c.id for c in assistant.tool_calls] == [start.tool_call_id]
+
+
+@pytest.mark.asyncio
+async def test_a_never_id_call_is_promoted_once_not_per_state():
+    """Three never-id calls each mint their OWN identity, announced per call."""
+    executed: list[str] = []
+    deltas: list[StreamEvent] = [tool_call_delta(i, id="", name="echo") for i in range(3)]
+    deltas += [tool_call_delta(i, args='{"text":"hi"}') for i in range(3)]
+    deltas.append(StreamEndEvent(stop_reason="toolUse"))
+    stream = ScriptedStream(
+        [deltas, [StreamTextDelta(delta="done"), StreamEndEvent(stop_reason="stop")]]
+    )
+    context = LoopContext(system_blocks=["sys"], tools=[echo_tool(executed)])
+    events = []
+    async for event in AgentLoop().run([Message.user("go")], context, make_config(stream), None):
+        events.append(event)
+
+    promotions = {
+        c.supersedes_tool_call_id: c.tool_call_id
+        for c in events
+        if isinstance(c, ToolCallComposeEvent) and c.supersedes_tool_call_id
+    }
+    assert sorted(promotions) == ["compose:0", "compose:1", "compose:2"]
+    # Distinct identities: one shared id would collapse three rows into one and
+    # break tool_use/tool_result pairing on the next request.
+    assert len(set(promotions.values())) == 3
+
+    starts = [e.tool_call_id for e in events if isinstance(e, ToolExecutionStartEvent)]
+    assert sorted(starts) == sorted(promotions.values())
+    assert executed == ["echo", "echo", "echo"]

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -1138,13 +1138,27 @@ async def test_a_composing_call_reports_its_final_size():
 
 
 @pytest.mark.asyncio
-async def test_a_late_call_id_does_not_change_the_compose_key():
-    """The key is latched on the first announcement.
+async def test_a_late_call_id_never_changes_the_compose_key_unannounced():
+    """The key never moves SILENTLY. It may move, but only by announcement.
 
     An OpenAI-compatible endpoint may send the tool NAME before the call id.
     Recomputing the key each time changed it mid-stream, and the UI — which keys
     its rows by it — mounted a second row and then marked the abandoned one
     interrupted, for a call that had in fact succeeded.
+
+    This test originally asserted the proxy for that: one distinct id across the
+    whole stream. The proxy stopped describing the invariant once the key
+    acquired a way to move that consumers can FOLLOW — a frame naming both the
+    old and the new id, which is how a row announced under a placeholder is
+    reconciled with the real id every ``tool_execution_start``/``_end`` carries
+    (without it a mid-turn joiner is left holding a composing row nothing can
+    adopt, painted ``⊘ interrupted`` on a call that SUCCEEDED).
+
+    So the assertion is now the invariant itself rather than its proxy: an id
+    the stream introduces without saying what it replaces is the original bug,
+    and a second unannounced id is exactly what mounted the second row. The
+    proof that no second row results is in ``tests/unit/tui``, driven against
+    the real app.
     """
     stream = ScriptedStream(
         [
@@ -1167,7 +1181,22 @@ async def test_a_late_call_id_does_not_change_the_compose_key():
         async for event in loop.run([Message.user("go")], context, make_config(stream), None)
         if isinstance(event, ToolCallComposeEvent)
     ]
-    assert len({event.tool_call_id for event in composes}) == 1
+
+    # Walk the stream the way a consumer does and retire each superseded key.
+    # Anything still standing at the end is a row that consumer would be
+    # holding; more than one of those is the two-rows-for-one-call bug.
+    outstanding: list[str] = []
+    for event in composes:
+        superseded = event.supersedes_tool_call_id
+        if superseded and superseded in outstanding:
+            outstanding.remove(superseded)
+        if event.tool_call_id not in outstanding:
+            outstanding.append(event.tool_call_id)
+    assert outstanding == ["call_late"]
+
+    # And the surviving key is the one execution uses, which is the equality
+    # whose absence stranded the row in the first place.
+    assert executed == ["echo"]
 
 
 class TestSystemBlocksAreReadAtEveryCall:

--- a/tests/unit/harness/test_loop.py
+++ b/tests/unit/harness/test_loop.py
@@ -3378,3 +3378,239 @@ async def test_connectivity_continuation_request_is_wire_legal_for_anthropic() -
     # the transcript can stay byte-identical to what was displayed.
     assistant_text = body["messages"][1]["content"][0]["text"]
     assert assistant_text == "The answer is "
+
+
+# ---------------------------------------------------------------------------
+# The placeholder compose key and its supersession.
+#
+# A provider that announces a call's NAME before its ID makes the loop announce
+# the row under `compose:{index}`, because that is the only identity available
+# at the moment the UI needs a row. The real id arrives later and every
+# `tool_execution_start`/`_end` carries it, so without an explicit hand-off the
+# two id spaces never meet: anything keying rows by `tool_call_id` holds two
+# records for one call, and a viewer joining mid-turn is left with a composing
+# row nothing can adopt, painted `⊘ interrupted` at turn end on a call that
+# SUCCEEDED.
+#
+# This branch had NO coverage before these tests, which is why a provider
+# ordering change could start exercising it silently.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_late_id_announces_under_a_placeholder_then_supersedes_it():
+    """Name-before-id: the row is announced as `compose:N`, then promoted ONCE.
+
+    The promotion frame is the only carrier of the identity change, so it must
+    name both ids and must not be swallowed by the compose throttle.
+    """
+    executed: list[str] = []
+    stream = ScriptedStream(
+        [
+            [
+                # Name with no id — the shape `providers/clients.py` tolerates
+                # on the Responses API, where `call_id` defaults to "".
+                tool_call_delta(0, name="echo"),
+                tool_call_delta(0, args='{"text":"hi"}'),
+                # The id lands only now.
+                tool_call_delta(0, id="real_0"),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            [StreamTextDelta(delta="done"), StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    context = LoopContext(system_blocks=["sys"], tools=[echo_tool(executed)])
+    events = []
+    async for event in AgentLoop().run([Message.user("go")], context, make_config(stream), None):
+        events.append(event)
+
+    composes = [e for e in events if isinstance(e, ToolCallComposeEvent)]
+    # The row is announced before the id exists — that is the whole point of
+    # the event, and the placeholder is the only key available then.
+    assert composes[0].tool_call_id == "compose:0"
+    assert composes[0].supersedes_tool_call_id is None
+
+    promotions = [c for c in composes if c.supersedes_tool_call_id]
+    assert promotions, "the real id arrived but no hand-off was announced"
+    # The identity moves ONCE and always names the same pair. The announcement
+    # is then REPEATED on later frames so a lossy path cannot drop the only
+    # copy of it, which is safe precisely because it is idempotent: a consumer
+    # that already rekeyed finds no placeholder left to drop. What must never
+    # happen is a SECOND distinct promotion, which would mean the key was being
+    # re-derived per frame — the latch bug that mounted two rows for one call.
+    assert {(c.supersedes_tool_call_id, c.tool_call_id) for c in promotions} == {
+        ("compose:0", "real_0")
+    }
+
+    # Every compose frame after the first promotion uses the real id, so
+    # nothing downstream is left keyed on a placeholder.
+    tail = composes[composes.index(promotions[0]) :]
+    assert {c.tool_call_id for c in tail} == {"real_0"}
+
+    # And the promoted key is the one execution actually uses: this is the
+    # equality that was missing before, and its absence is what stranded rows.
+    start = next(e for e in events if isinstance(e, ToolExecutionStartEvent))
+    assert start.tool_call_id == "real_0"
+    assert executed == ["echo"]
+
+
+@pytest.mark.asyncio
+async def test_id_before_name_never_supersedes():
+    """The common ordering (OpenAI-compat, Anthropic, Gemini) is unchanged.
+
+    The id is already latched when the row is announced, so there is no
+    placeholder and no promotion frame — the wire for these providers must be
+    byte-identical to before this field existed.
+    """
+    executed: list[str] = []
+    stream = ScriptedStream(
+        [
+            [
+                tool_call_delta(0, id="call_1"),
+                tool_call_delta(0, name="echo"),
+                tool_call_delta(0, args='{"text":"hi"}'),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            [StreamTextDelta(delta="done"), StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    context = LoopContext(system_blocks=["sys"], tools=[echo_tool(executed)])
+    events = []
+    async for event in AgentLoop().run([Message.user("go")], context, make_config(stream), None):
+        events.append(event)
+
+    composes = [e for e in events if isinstance(e, ToolCallComposeEvent)]
+    assert composes
+    assert {c.tool_call_id for c in composes} == {"call_1"}
+    assert all(c.supersedes_tool_call_id is None for c in composes)
+    assert executed == ["echo"]
+
+
+@pytest.mark.asyncio
+async def test_id_arriving_before_the_first_announcement_needs_no_promotion():
+    """A name+id pair split across deltas with no compose frame in between.
+
+    Nothing has been announced yet, so there is no row to supersede: the key is
+    corrected in place and no promotion frame is emitted. Emitting one anyway
+    would tell every consumer to rekey a row that does not exist.
+    """
+    executed: list[str] = []
+    stream = ScriptedStream(
+        [
+            [
+                # Name and id in the same delta: the key latches straight to the
+                # real id, exactly as `:3380` (Anthropic) and `:3696` (Gemini) send it.
+                tool_call_delta(0, id="real_0", name="echo"),
+                tool_call_delta(0, args='{"text":"hi"}'),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            [StreamTextDelta(delta="done"), StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    context = LoopContext(system_blocks=["sys"], tools=[echo_tool(executed)])
+    events = []
+    async for event in AgentLoop().run([Message.user("go")], context, make_config(stream), None):
+        events.append(event)
+
+    composes = [e for e in events if isinstance(e, ToolCallComposeEvent)]
+    assert {c.tool_call_id for c in composes} == {"real_0"}
+    assert all(c.supersedes_tool_call_id is None for c in composes)
+    assert executed == ["echo"]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_late_id_calls_each_supersede_their_own_placeholder():
+    """Three calls in flight, each promoted to its OWN id.
+
+    This is the screenshot's shape, and it is why the promotion is announced
+    per call rather than inferred: with several rows composing at once nothing
+    downstream could otherwise tell which placeholder a real id belongs to.
+    """
+    executed: list[str] = []
+    deltas: list[StreamEvent] = [tool_call_delta(i, name="echo") for i in range(3)]
+    deltas += [tool_call_delta(i, args='{"text":"hi"}') for i in range(3)]
+    deltas += [tool_call_delta(i, id=f"real_{i}") for i in range(3)]
+    deltas.append(StreamEndEvent(stop_reason="toolUse"))
+    stream = ScriptedStream(
+        [deltas, [StreamTextDelta(delta="done"), StreamEndEvent(stop_reason="stop")]]
+    )
+    context = LoopContext(system_blocks=["sys"], tools=[echo_tool(executed)])
+    events = []
+    async for event in AgentLoop().run([Message.user("go")], context, make_config(stream), None):
+        events.append(event)
+
+    promotions = {
+        c.supersedes_tool_call_id: c.tool_call_id
+        for c in events
+        if isinstance(c, ToolCallComposeEvent) and c.supersedes_tool_call_id
+    }
+    assert promotions == {"compose:0": "real_0", "compose:1": "real_1", "compose:2": "real_2"}
+    assert executed == ["echo", "echo", "echo"]
+
+
+@pytest.mark.asyncio
+async def test_a_call_whose_id_never_arrives_keeps_its_placeholder():
+    """No id at all: the placeholder must stay latched for the whole stream.
+
+    Re-deriving the key is what mounted a second row for one call, so a call
+    that never learns its provider id keeps the identity it was announced
+    under rather than acquiring one late.
+    """
+    executed: list[str] = []
+    stream = ScriptedStream(
+        [
+            [
+                tool_call_delta(0, name="echo"),
+                tool_call_delta(0, args='{"text":"hi"}'),
+                StreamEndEvent(stop_reason="toolUse"),
+            ],
+            [StreamTextDelta(delta="done"), StreamEndEvent(stop_reason="stop")],
+        ]
+    )
+    context = LoopContext(system_blocks=["sys"], tools=[echo_tool(executed)])
+    events = []
+    async for event in AgentLoop().run([Message.user("go")], context, make_config(stream), None):
+        events.append(event)
+
+    composes = [e for e in events if isinstance(e, ToolCallComposeEvent)]
+    assert {c.tool_call_id for c in composes} == {"compose:0"}
+    assert all(c.supersedes_tool_call_id is None for c in composes)
+    assert executed == ["echo"]
+
+
+@pytest.mark.asyncio
+async def test_the_supersession_is_repeated_so_a_dropped_frame_cannot_strand_the_row():
+    """The hand-off survives a lossy path, and stays idempotent.
+
+    A single announcement is a single point of failure: the per-connection
+    queue compacts and can overflow, and a viewer that was away sees only what
+    the seed retained, so the one frame carrying the identity change is exactly
+    the one that may be lost — and losing it strands the row this mechanism
+    exists to rescue. Every compose frame after the promotion therefore repeats
+    the placeholder it replaced. Safe because it is idempotent: a consumer that
+    already rekeyed has no placeholder left to drop.
+    """
+    executed: list[str] = []
+    payload = '{"text":"' + "z" * 200 + '"}'
+    deltas: list[StreamEvent] = [tool_call_delta(0, name="echo")]
+    deltas.append(tool_call_delta(0, args=payload[:10]))
+    deltas.append(tool_call_delta(0, id="real_0"))
+    # Enough argument frames after the promotion to outlast the compose
+    # throttle, so later announcements really are emitted.
+    deltas += [tool_call_delta(0, args=ch) for ch in payload[10:]]
+    deltas.append(StreamEndEvent(stop_reason="toolUse"))
+    stream = ScriptedStream(
+        [deltas, [StreamTextDelta(delta="done"), StreamEndEvent(stop_reason="stop")]]
+    )
+    context = LoopContext(system_blocks=["sys"], tools=[echo_tool(executed)])
+    events = []
+    async for event in AgentLoop().run([Message.user("go")], context, make_config(stream), None):
+        events.append(event)
+
+    composes = [e for e in events if isinstance(e, ToolCallComposeEvent)]
+    after = [c for c in composes if c.tool_call_id == "real_0"]
+    assert len(after) > 1, "not enough post-promotion frames to prove the repeat"
+    # EVERY frame under the real id carries the hand-off, so whichever survives
+    # is enough to rekey the row.
+    assert all(c.supersedes_tool_call_id == "compose:0" for c in after)
+    assert executed == ["echo"]

--- a/tests/unit/mobile/test_projection.py
+++ b/tests/unit/mobile/test_projection.py
@@ -1144,3 +1144,92 @@ def test_a_history_fold_clears_pending_echoes() -> None:
     assert fold._pending_user_echoes
     fold.fold_history([Message.user("something else entirely")])
     assert fold._pending_user_echoes == {}
+
+
+def test_a_promoted_compose_key_rekeys_the_phone_row_instead_of_appending() -> None:
+    """The phone must show ONE row for a call whose id arrived late.
+
+    ``_tool_row`` correlates by ``tool_call_id``. A provider that sends the
+    name before the id makes the loop announce the row under ``compose:0`` and
+    then promote it to the real id on one frame naming both. Without honouring
+    that hand-off the lookup misses, a SECOND row is appended, and the
+    placeholder row is left composing forever because every later start and end
+    carries the real id.
+
+    The entry's own ``id`` deliberately does not move: clients diff the
+    transcript by row id, so re-identifying a row mid-turn would read as the
+    row being replaced rather than updated.
+    """
+    fold = make_fold()
+    fold.fold_event(AgentStartEvent(generation=1))
+    fold.fold_event(
+        ToolCallComposeEvent(tool_call_id="compose:0", tool_name="bash", argument_bytes=8)
+    )
+    tool_rows = [row for row in fold.projection.transcript if row.kind == "tool"]
+    assert len(tool_rows) == 1
+    original_row_id = tool_rows[0].id
+
+    fold.fold_event(
+        ToolCallComposeEvent(
+            tool_call_id="real_0",
+            tool_name="bash",
+            argument_bytes=64,
+            supersedes_tool_call_id="compose:0",
+        )
+    )
+    tool_rows = [row for row in fold.projection.transcript if row.kind == "tool"]
+    assert len(tool_rows) == 1
+    assert tool_rows[0].id == original_row_id
+    assert tool_rows[0].tool_call_id == "real_0"
+
+    # The real start and end settle THAT row rather than opening another.
+    fold.fold_event(ToolExecutionStartEvent(tool_call_id="real_0", tool_name="bash", args={}))
+    fold.fold_event(
+        ToolExecutionEndEvent(
+            tool_call_id="real_0",
+            tool_name="bash",
+            result=ToolResult(
+                tool_call_id="real_0", content=[TextContent(text="ok")], is_error=False
+            ),
+        )
+    )
+    tool_rows = [row for row in fold.projection.transcript if row.kind == "tool"]
+    assert len(tool_rows) == 1
+    assert tool_rows[0].tool_state == "done"
+
+
+def test_a_compose_event_without_the_supersedes_field_is_unchanged() -> None:
+    """An older runtime omits the field; the phone must behave as before."""
+    fold = make_fold()
+    fold.fold_event(AgentStartEvent(generation=1))
+    fold.fold_event(ToolCallComposeEvent(tool_call_id="c1", tool_name="bash", argument_bytes=8))
+    fold.fold_event(ToolCallComposeEvent(tool_call_id="c2", tool_name="bash", argument_bytes=8))
+    tool_rows = [row for row in fold.projection.transcript if row.kind == "tool"]
+    assert [row.tool_call_id for row in tool_rows] == ["c1", "c2"]
+
+
+def test_a_repeated_supersession_does_not_disturb_an_already_rekeyed_row() -> None:
+    """The hand-off is repeated on every later frame and must stay idempotent.
+
+    The second and third promotions find no placeholder to move, so they take
+    the ordinary path and update the row already keyed by the real id rather
+    than appending another.
+    """
+    fold = make_fold()
+    fold.fold_event(AgentStartEvent(generation=1))
+    fold.fold_event(
+        ToolCallComposeEvent(tool_call_id="compose:0", tool_name="bash", argument_bytes=5)
+    )
+    for size in (10, 20, 30):
+        fold.fold_event(
+            ToolCallComposeEvent(
+                tool_call_id="real_0",
+                tool_name="bash",
+                argument_bytes=size,
+                supersedes_tool_call_id="compose:0",
+            )
+        )
+    tool_rows = [row for row in fold.projection.transcript if row.kind == "tool"]
+    assert len(tool_rows) == 1
+    assert tool_rows[0].tool_call_id == "real_0"
+    assert tool_rows[0].details["argument_bytes"] == 30

--- a/tests/unit/session/test_frontend_state.py
+++ b/tests/unit/session/test_frontend_state.py
@@ -15,10 +15,13 @@ import pytest
 from local_operator.harness.jobs import AsyncJob
 from local_operator.harness.types import (
     AgentEndEvent,
+    AgentEvent,
     AgentStartEvent,
     Message,
     ModelSpec,
     SubagentProgressEvent,
+    ToolCallComposeEvent,
+    ToolExecutionStartEvent,
     Usage,
 )
 from local_operator.session.frontend_state import (
@@ -1027,3 +1030,183 @@ def test_agent_end_records_last_turn_outcome() -> None:
     store.observe_event(session, AgentStartEvent(generation=5))
     store.observe_event(session, AgentEndEvent(error="boom"))
     assert store.state.last_turn_outcome == "error"
+
+
+# ---------------------------------------------------------------------------
+# The in-flight seed and the placeholder compose key.
+#
+# `_fold_live_event` keys the seed by `tool_call_id`. A provider that announces
+# a call's name before its id makes the loop announce the row under
+# `compose:{index}` while every `tool_execution_start`/`_end` carries the real
+# id, so without the supersession hand-off the seed keeps BOTH id spaces. A
+# viewer joining mid-turn then receives a composing row that no start or end
+# can ever match, and turn-end retirement paints it `⊘ interrupted` on a call
+# that SUCCEEDED (the round-1 Q2 bug, reached by a new route).
+# ---------------------------------------------------------------------------
+
+
+def _fold(store: FrontendStateStore, *events) -> list[dict[str, Any]]:  # noqa: ANN002
+    session = SimpleNamespace(effective_model=_spec())
+    for event in events:
+        store.observe_event(session, event)
+    return list(store.state.live_events)
+
+
+def test_seed_drops_the_placeholder_row_when_the_real_id_is_announced() -> None:
+    """One call, one seed entry — keyed by the id execution will actually use."""
+    store = FrontendStateStore(_state())
+    live = _fold(
+        store,
+        AgentStartEvent(generation=1),
+        ToolCallComposeEvent(tool_call_id="compose:0", tool_name="bash", argument_bytes=10),
+        ToolCallComposeEvent(
+            tool_call_id="real_0",
+            tool_name="bash",
+            argument_bytes=20,
+            supersedes_tool_call_id="compose:0",
+        ),
+    )
+    tool_rows = [row for row in live if row.get("type") == "tool_call_compose"]
+    assert [row["tool_call_id"] for row in tool_rows] == ["real_0"]
+
+
+def test_seed_supersession_is_per_call_with_several_in_flight() -> None:
+    """Three concurrent calls: each promotion drops ONLY its own placeholder.
+
+    This is why the promotion is announced rather than inferred from a start.
+    A rule like "any tool_execution_start clears the composing entries" cannot
+    tell which placeholder a real id belongs to, so it would drop the rows of
+    calls still being dictated.
+    """
+    store = FrontendStateStore(_state())
+    events = [AgentStartEvent(generation=1)]
+    events += [
+        ToolCallComposeEvent(tool_call_id=f"compose:{i}", tool_name="bash", argument_bytes=5)
+        for i in range(3)
+    ]
+    # Only the middle call learns its id.
+    events.append(
+        ToolCallComposeEvent(
+            tool_call_id="real_1",
+            tool_name="bash",
+            argument_bytes=9,
+            supersedes_tool_call_id="compose:1",
+        )
+    )
+    live = _fold(store, *events)
+
+    ids = [row["tool_call_id"] for row in live if row.get("type") == "tool_call_compose"]
+    # The other two rows are still being dictated and must survive.
+    assert sorted(ids) == ["compose:0", "compose:2", "real_1"]
+
+
+def test_seed_carries_one_row_per_call_through_start_and_end() -> None:
+    """End to end: the joiner's seed never holds a row it cannot settle.
+
+    Without the hand-off this seed held six entries — three unadoptable
+    `compose:N` rows beside the three real ones.
+    """
+    store = FrontendStateStore(_state())
+    events = [AgentStartEvent(generation=1)]
+    events += [
+        ToolCallComposeEvent(tool_call_id=f"compose:{i}", tool_name="bash", argument_bytes=5)
+        for i in range(3)
+    ]
+    events += [
+        ToolCallComposeEvent(
+            tool_call_id=f"real_{i}",
+            tool_name="bash",
+            argument_bytes=9,
+            supersedes_tool_call_id=f"compose:{i}",
+        )
+        for i in range(3)
+    ]
+    events += [
+        ToolExecutionStartEvent(tool_call_id=f"real_{i}", tool_name="bash", args={})
+        for i in range(3)
+    ]
+    live = _fold(store, *events)
+
+    assert len(live) == 3
+    assert [row["type"] for row in live] == ["tool_execution_start"] * 3
+    assert [row["tool_call_id"] for row in live] == ["real_0", "real_1", "real_2"]
+
+
+def test_seed_fold_is_unchanged_when_an_older_runtime_omits_the_field() -> None:
+    """BACKWARD COMPATIBILITY, pinned.
+
+    `supersedes_tool_call_id` is additive: an older runtime relaying through a
+    newer viewer simply never sets it. The fold must then behave exactly as it
+    did before the field existed — replace by `tool_call_id`, drop nothing
+    else — so a viewer cannot break on a payload that omits it.
+
+    Asserted on a RAW wire payload with the key genuinely absent, not merely
+    set to None, because that is the shape an older owner actually sends.
+    Built through ``model_validate`` on the base ``AgentEvent``, which is
+    exactly how ``deserialize_event`` rehydrates a frame whose type an older
+    peer relayed: extras are allowed and the absent field stays absent, so the
+    dump is the old payload byte for byte rather than a null-valued imitation.
+    """
+    store = FrontendStateStore(_state())
+    session = SimpleNamespace(effective_model=_spec())
+    store.observe_event(session, AgentStartEvent(generation=1))
+
+    for call_id in ("compose:0", "compose:1"):
+        legacy = AgentEvent.model_validate(
+            {
+                "type": "tool_call_compose",
+                "tool_call_id": call_id,
+                "tool_name": "bash",
+                "argument_bytes": 7,
+            }
+        )
+        assert "supersedes_tool_call_id" not in legacy.model_dump(mode="json")
+        store.observe_event(session, legacy)
+
+    live = list(store.state.live_events)
+    rows = [row for row in live if row.get("type") == "tool_call_compose"]
+    # Today's behaviour: both rows kept, keyed by their own ids, and no
+    # `supersedes_tool_call_id` key anywhere in the payload.
+    assert [row["tool_call_id"] for row in rows] == ["compose:0", "compose:1"]
+    assert all("supersedes_tool_call_id" not in row for row in rows)
+
+
+def test_compose_event_tolerates_a_payload_without_the_field() -> None:
+    """A viewer deserializing an older owner's frame must not raise.
+
+    The field is optional with a None default precisely so this validates.
+    """
+    event = ToolCallComposeEvent.model_validate(
+        {"type": "tool_call_compose", "tool_call_id": "c1", "tool_name": "bash"}
+    )
+    assert event.supersedes_tool_call_id is None
+
+
+def test_a_repeated_supersession_is_idempotent_in_the_seed() -> None:
+    """The hand-off is repeated on every later frame; replaying it changes nothing.
+
+    The repeat exists so a lossy path cannot drop the only copy of the identity
+    change. That is only safe if applying it twice is the same as applying it
+    once — the second time there is no placeholder left to drop, and the fold
+    must simply replace the real id's own row as it always does.
+    """
+    store = FrontendStateStore(_state())
+    events = [
+        AgentStartEvent(generation=1),
+        ToolCallComposeEvent(tool_call_id="compose:0", tool_name="bash", argument_bytes=5),
+    ]
+    events += [
+        ToolCallComposeEvent(
+            tool_call_id="real_0",
+            tool_name="bash",
+            argument_bytes=size,
+            supersedes_tool_call_id="compose:0",
+        )
+        for size in (10, 20, 30)
+    ]
+    live = _fold(store, *events)
+
+    assert len(live) == 1
+    assert live[0]["tool_call_id"] == "real_0"
+    # The newest frame wins, so the size the viewer reads is the current one.
+    assert live[0]["argument_bytes"] == 30

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -3198,3 +3198,126 @@ async def test_moving_the_caret_after_a_copy_gives_ctrl_c_back_to_the_draft() ->
         await pilot.press("ctrl+c")
         await pilot.pause()
         assert app.is_running, "the second tap quit with the draft lost"
+
+
+@pytest.mark.asyncio
+async def test_a_promoted_compose_key_rekeys_its_row_instead_of_mounting_a_second() -> None:
+    """A provider that sends the name before the id must still paint ONE row.
+
+    The row is announced under `compose:0` because that is the only identity
+    available before the id arrives; the loop then announces the promotion by
+    naming both ids on one frame. Keyed purely by `tool_call_id`, that frame
+    reads as a brand-new call, so the screen would carry two rows for one call
+    and turn-end retirement would mark the abandoned one `⊘ interrupted` —
+    which is the exact failure the compose key is latched to avoid, reached
+    through the fix for it.
+
+    Drives the REAL app so the adoption path, not a re-implementation of it, is
+    what gets exercised.
+    """
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        app.post_message(
+            ToolComposing(
+                ToolCallComposeEvent(tool_call_id="compose:0", tool_name="write", argument_bytes=8)
+            )
+        )
+        await pilot.pause()
+        assert set(app._composing_cards) == {"compose:0"}
+
+        app.post_message(
+            ToolComposing(
+                ToolCallComposeEvent(
+                    tool_call_id="real_0",
+                    tool_name="write",
+                    argument_bytes=14079,
+                    supersedes_tool_call_id="compose:0",
+                )
+            )
+        )
+        await pilot.pause()
+        # The SAME row, rekeyed — not a second one beside it.
+        assert set(app._composing_cards) == {"real_0"}
+        painted = [strip.text for strip in app.screen._compositor.render_strips()]
+        assert len([row for row in painted if "composing" in row]) == 1
+        assert [row for row in painted if "13.7 KB" in row]
+
+        # And the real start adopts it by id, with no fallback needed.
+        app.post_message(
+            ToolStarted(
+                ToolExecutionStartEvent(
+                    tool_call_id="real_0", tool_name="write", args={"path": "/tmp/x"}
+                )
+            )
+        )
+        await pilot.pause()
+        assert not app._composing_cards
+        painted = [strip.text for strip in app.screen._compositor.render_strips()]
+        assert len([row for row in painted if "write" in row]) == 1
+        assert not [row for row in painted if "composing" in row]
+
+
+@pytest.mark.asyncio
+async def test_a_promotion_for_an_unknown_row_still_mounts_exactly_one_card() -> None:
+    """A promotion whose placeholder this surface never saw is not special.
+
+    A viewer attaching mid-dictation can receive the promotion without ever
+    having seen the frame it supersedes. There is no row to rekey, so the
+    normal mount runs and the call gets its one card under the real id.
+    """
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        app.post_message(
+            ToolComposing(
+                ToolCallComposeEvent(
+                    tool_call_id="real_0",
+                    tool_name="write",
+                    argument_bytes=14079,
+                    supersedes_tool_call_id="compose:0",
+                )
+            )
+        )
+        await pilot.pause()
+        assert set(app._composing_cards) == {"real_0"}
+        painted = [strip.text for strip in app.screen._compositor.render_strips()]
+        assert len([row for row in painted if "composing" in row]) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_repeated_supersession_keeps_exactly_one_row_on_screen() -> None:
+    """The hand-off repeats on every later frame; the screen must not react.
+
+    Once the row has been rekeyed there is no placeholder left to pop, so each
+    repeat takes the ordinary path and updates the row already keyed by the
+    real id. A second card here would be the two-rows-for-one-call failure
+    arriving through the mechanism meant to prevent it.
+    """
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        app.post_message(
+            ToolComposing(
+                ToolCallComposeEvent(tool_call_id="compose:0", tool_name="write", argument_bytes=8)
+            )
+        )
+        for size in (4096, 8192, 14079):
+            app.post_message(
+                ToolComposing(
+                    ToolCallComposeEvent(
+                        tool_call_id="real_0",
+                        tool_name="write",
+                        argument_bytes=size,
+                        supersedes_tool_call_id="compose:0",
+                    )
+                )
+            )
+        await pilot.pause()
+        assert set(app._composing_cards) == {"real_0"}
+        painted = [strip.text for strip in app.screen._compositor.render_strips()]
+        assert len([row for row in painted if "composing" in row]) == 1
+        assert [row for row in painted if "13.7 KB" in row]

--- a/tests/unit/tui/test_steering_approval.py
+++ b/tests/unit/tui/test_steering_approval.py
@@ -3321,3 +3321,39 @@ async def test_a_repeated_supersession_keeps_exactly_one_row_on_screen() -> None
         painted = [strip.text for strip in app.screen._compositor.render_strips()]
         assert len([row for row in painted if "composing" in row]) == 1
         assert [row for row in painted if "13.7 KB" in row]
+
+
+@pytest.mark.asyncio
+async def test_a_compose_frame_without_the_supersedes_field_mounts_one_card() -> None:
+    """BACKWARD COMPATIBILITY at the third consumer (review round 1, R3).
+
+    The seed fold and the mobile projection each pin the field-absent path; the
+    TUI did not. An older owner never sets the field, and its frames must mount
+    exactly one card and pop nothing — the assertion that would fail if the
+    plain attribute read here ever became something that assumed a value.
+
+    Built through ``AgentEvent.model_validate``, which is how
+    ``deserialize_event`` rehydrates a relayed frame, so the payload genuinely
+    lacks the key rather than carrying a null.
+    """
+    from local_operator.harness.types import AgentEvent
+
+    legacy = AgentEvent.model_validate(
+        {
+            "type": "tool_call_compose",
+            "tool_call_id": "c1",
+            "tool_name": "write",
+            "argument_bytes": 8,
+        }
+    )
+    assert "supersedes_tool_call_id" not in legacy.model_dump(mode="json")
+
+    session = SteerableSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _boot(pilot, app)
+        app.post_message(ToolComposing(cast(Any, legacy)))
+        await pilot.pause()
+        assert set(app._composing_cards) == {"c1"}
+        painted = [strip.text for strip in app.screen._compositor.render_strips()]
+        assert len([row for row in painted if "composing" in row]) == 1


### PR DESCRIPTION
## Summary

When a provider announces a tool call's `name` before its `id`, `harness/loop.py` latches the compose key as `compose:{index}` — that placeholder is the only identity available at the moment the UI needs a row. Every later `tool_call_compose` keeps it, while `tool_execution_start` / `tool_execution_end` carry the provider's **real** id. **The two id spaces never meet.**

Everything that keys rows by `tool_call_id` therefore holds **two records for one call**: the in-flight seed in `_fold_live_event`, the TUI's composing cards, and the mobile projection's rows. A viewer joining mid-turn is handed a composing row that no start or end can ever match, and `_retire_live_tool_cards` — correctly unconditional — paints it `⊘ interrupted` **on a call that succeeded**.

That method's docstring already predicted this exact failure and named where to fix it:

> If a future change lets the seed drop an end again, this method will mark a succeeded call `⊘ interrupted` — that was the round-1 Q2 bug, and **the fix belongs in the seed rather than in an outcome test here**.

The seed does retain the end — but under a key no card on screen carries, which defeats the guarantee just as effectively. So the fix is in the seed, at the seam where identity becomes known. `_retire_live_tool_cards` is untouched.

**Release: patch — a viewer that resumes or attaches mid-turn no longer paints succeeded tool calls as `⊘ interrupted`, and the runtime hands every surface one row per call instead of two.**

Patch and not minor per AGENTS.md materiality: no new surface or subsystem, and there is no step-function capability to name in a release title. It is a correctness fix to an existing rendering path.

## Reachability — CORRECTED in round 1: two orderings, and the reachable one is now covered

**My original table was wrong about `:2568`, and that mattered.** It named the Responses API as "the gap" on the theory that its id arrives *late*. Round-1 review showed the id does not arrive late there — it never arrives at all — so the hand-off this PR originally shipped could not fire on the one path a shipping provider actually produces. I verified that at source and reproduced it before changing anything.

There are **two** distinct shapes, and the PR now covers both:

| site | what it actually emits | shape | status |
|---|---|---|---|
| `:2417-2419` OpenAI-compat | `id` **then** `name`, separate deltas | id present at latch | safe by ordering only — no assertion, no test pinning it |
| `:3380-3382` Anthropic, `:3696` Gemini | `id` and `name` together | id present at latch | safe |
| `:2568` OpenAI **Responses API** | `call_id = item.get("call_id") or item.get("id") or ""` — the **empty string** — yielded with `name` in ONE delta; the argument deltas at `:2578` carry **no id at all** | **never-id** | **the reachable gap — now fixed by the stream-end settle** |
| *(no shipping provider)* | `name` first, real `id` in a later delta | **late-id** | fixed by the supersession hand-off |

Reproduced on the previous head, through the real `AgentLoop` and the real `_fold_live_event`:

```
[A late-id  (what this PR originally fixed)]  STRANDED: []
[B never-id (the :2568 shape)]                STRANDED: ['compose:0']   <- still broken
   compose keys : ['compose:0']
   promotions   : []
   start ids    : ['df5663a6510e']   <- uuid4, unrelated to the compose key
```

On the never-id path `_assemble_tool_call` mints a fresh uuid, so execution runs under an id the composing row has never seen — stranding it exactly as a late id would. Fixed on the current head: `STRANDED: []`, with the start id equal to the announced one.

**Why I did not take the reviewer's sketch.** It proposed promoting the placeholder onto the `ToolCall` (`call.id = state["key"]`), and flagged an unresolved wire-legality question. I resolved that question rather than inheriting it: that id travels back to the provider as Anthropic's `tool_use.id` (`clients.py:3137`) and Responses' `call_id` (`:1727`), so the sketch puts `compose:{index}` — **containing a colon** — into a wire field no provider has agreed to accept, and does so on the *common* path. Minting the same `uuid4().hex[:12]` the `ToolCall` would have minted anyway keeps the wire byte-identical to today and makes the legality question **moot rather than answered**. Nothing anywhere keys off the `compose:` prefix (`grep` confirms: four hits, all comments or the format string itself), so there is no benefit to weigh against the risk.

So the honest status: the **never-id** shape is contract-reachable today and is now covered end to end. The **late-id** shape remains latent — no shipping provider emits it — but the mechanism is shared, and the branch that had no direct coverage now has it.

## What changed

Fixed at the seam where the identity becomes known, **not** in the UI.

- **`harness/types.py`** — additive `supersedes_tool_call_id` on `ToolCallComposeEvent`.
- **`harness/loop.py`** — when the real id arrives for a row announced under a placeholder, emit one `tool_call_compose` naming **both** ids. **The key is never un-latched.** Re-deriving it per frame is the documented worse bug (two rows for one call, the abandoned one marked interrupted), so the hand-off is announced explicitly.
- **`session/frontend_state.py`** — `_fold_live_event` retires the superseded entry, so the seed never contains a compose row whose call has already started.
- **`tui/app.py`** and **`mobile/projection.py`** — rekey the row they already hold. **This is mandatory, not incidental:** the promotion frame reaches *live* viewers too, and without the rekey it reads as a brand-new call and mounts a second row — reintroducing the bug through its own fix. Proven below.

### The announcement repeats, and that is deliberate

A single promotion frame is a single point of failure on a path that legitimately drops frames — the per-connection queue compacts and overflows (see #770), and a viewer that was away sees only what the seed retained. Losing that one frame strands the row this mechanism exists to rescue. So every later compose frame for the call repeats the placeholder it replaced.

Safe because it is **idempotent by construction**: the second time there is no placeholder left to retire. Pinned at all three consumers (seed, TUI, projection).

### Explicitly rejected

- **Un-latching the compose key** — `loop.py:1377-1380` documents that re-evaluating it mounted two rows for one call.
- **An outcome test inside `_retire_live_tool_cards`** — its docstring says the fix belongs in the seed. Untouched.
- **Dropping compose entries on any `tool_execution_start` regardless of id** — with several calls in flight it cannot tell which compose entry a start belongs to, so it would drop rows for calls still being dictated. `test_seed_supersession_is_per_call_with_several_in_flight` pins that this is per-call.

## Backward compatibility

Additive. An older runtime never sets the field and every consumer keeps today's behaviour; an older viewer ignores it, because `AgentEvent` allows extra fields. Pinned by `test_seed_fold_is_unchanged_when_an_older_runtime_omits_the_field`, which folds a **raw wire payload with the key genuinely absent** (built through `AgentEvent.model_validate`, the same path `deserialize_event` uses) rather than a null-valued imitation.

## Evidence — real execution, before and after

The architect's probes stand up a **real** `Session`, the production `OwnedSessionHandle`, the production `RuntimeServer` over a real unix socket, and the production `RemoteSession` viewer. Run isolated (`env -i`, own `HOME` + `LOCAL_OPERATOR_CONFIG_DIR`, no `CMUX_*` inherited, synthetic session ids). No operator process was touched.

### probe7 — a viewer joining AFTER the tools finished, before turn end

This is the decisive cell: `live_events` is cleared only at `agent_end`, so this window is exactly what a `/resume` lands in.

**BEFORE (`9b8a60230`):**
```
=== A: control (id up front) ===
>>> APP RESULT: stranded/interrupted cards = []

=== B: late id (placeholder compose keys) ===
[p7late000001] SEED after tools ended, turn still open (8 entries):
[p7late000001]    tool_call_compose id='compose:0'
[p7late000001]    tool_call_compose id='compose:1'
[p7late000001]    tool_call_compose id='compose:2'
[p7late000001]    tool_execution_end id='real_0'
[p7late000001]    tool_execution_end id='real_1'
[p7late000001]    tool_execution_end id='real_2'
>>> APP RESULT: stranded/interrupted cards = [<compose:0:bash:INTERRUPTED>, <compose:1:bash:INTERRUPTED>, <compose:2:bash:INTERRUPTED>]
>>> APP RESULT: ends dropped unrendered   = ['real_0', 'real_1', 'real_2']
```
**Three calls that succeeded, painted as interrupted.**

**AFTER (this branch):**
```
=== B: late id (placeholder compose keys) ===
[p7late000001] SEED after tools ended, turn still open (5 entries):
[p7late000001]    tool_execution_end id='real_0'
[p7late000001]    tool_execution_end id='real_1'
[p7late000001]    tool_execution_end id='real_2'
[p7late000001]    message_start id=''
[p7late000001]    message_update id=''
>>> APP RESULT: stranded/interrupted cards = []
>>> APP RESULT: ends dropped unrendered   = ['real_0', 'real_1', 'real_2']
```
Cell B is now **identical to the control**.

### probe6 — the seed must not carry both id spaces

**BEFORE:**
```
[p6late000001] SEED while tools RUN (6 entries):
   tool_call_compose id='compose:0' / 'compose:1' / 'compose:2'
   tool_execution_start id='real_0' / 'real_1' / 'real_2'
[p6late000001] JOINER STRANDED composing rows: ['compose:0', 'compose:1', 'compose:2']
```
**AFTER:**
```
[p6late000001] SEED while tools RUN (3 entries):
   tool_execution_start id='real_0' / 'real_1' / 'real_2'
[p6late000001] JOINER STRANDED composing rows: []
```
Six entries → three, matching the control exactly.

### Every new guard was proven able to fail

A guard that cannot go red is worse than none, because it is believed. Each was run against the reverted fix:

- **e2e joiner test**, promotion block removed:
  ```
  AssertionError: the seed handed the joiner a composing row for a call that had already
  finished; those rows are painted interrupted: [{'type': 'tool_call_compose',
  'tool_call_id': 'compose:0', ...}, {'tool_call_id': 'compose:1', ...},
  {'tool_call_id': 'compose:2', ...}]
  1 failed
  ```
- **loop unit tests**, promotion block removed: `2 failed, 3 passed`
- **TUI rekey test**, app-side rekey removed — the two-rows-for-one-call failure, exactly as predicted:
  ```
  AssertionError: assert {'compose:0', 'real_0'} == {'real_0'}
  ```

### No size is lost by the promotion

The promotion sets `reported`, so I verified a later flush still reports the final size:
```
compose id='compose:0' bytes=0  supersedes=None
compose id='real_0'    bytes=9  supersedes='compose:0'
compose id='real_0'    bytes=21 supersedes=None      <- post-promotion bytes still reported
final call args: [('real_0', {'text': 'abcdefghij'})]
```

## Tests

First **direct** coverage of the `compose:N` branch, and the first coverage of any kind for what a mid-turn joiner receives.

- `tests/unit/harness/test_loop.py` — 6 tests: placeholder latch + promotion; id-before-name unchanged; id arriving before the first announcement needs no promotion; three concurrent calls each promoted to their own id (the screenshot's shape); a call whose id never arrives keeps its placeholder; the repeat survives a dropped frame.
- `tests/unit/session/test_frontend_state.py` — seed drops the placeholder; supersession is per-call with several in flight; one row per call through start and end; **old-runtime field-absent compat**; repeat is idempotent; event validates without the field.
- `tests/unit/tui/test_steering_approval.py` — 3 tests driving the **real `OperatorApp`**: rekey instead of a second row; a promotion for a row this surface never saw; repeat keeps exactly one row.
- `tests/unit/mobile/test_projection.py` — phone rekeys rather than appending (entry `id` deliberately stable, since clients diff by row id); no-field unchanged; repeat idempotent.
- `tests/e2e/test_viewer_attach_e2e.py` — probe7 promoted: real runtime, real socket, production `RemoteSession`, asserting on the seed the viewer is actually handed.

## Gates

```
.venv/bin/python -m flake8 .                              -> clean
uvx --from black==26.1.0 black --check .                  -> 1057 files unchanged
uvx isort==5.13.2 --check .                               -> clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python . -> 0 errors, 0 warnings
tests/e2e/test_viewer_attach_e2e.py -m e2e -n0            -> 13 passed
```

Own worktree, own real venv (never symlinked), verified resolving to this tree:
```
/Users/damian/workspace/repos/lo-supersede-key/local_operator/__init__.py
```

## Scope

`loop.py`, `types.py`, `frontend_state.py`, the two row-keyed consumers, and tests. **`_compact_event_queue` in `session/runtime/server.py` is untouched** — that is #770's. The two are complementary and do not overlap: the seed fold runs upstream of the per-client queue, so #770's compaction cannot drop a hand-off from the seed. No version bump.

