### PR TITLE
fix(tunnels): pin harness ports to the local record and close the websocket replay gap

### DIFF
--- a/docs/tunnels.md
+++ b/docs/tunnels.md
@@ -84,16 +84,19 @@ record the last local `create`, `connect`, or `configure` stored, so changing a
 harness port in the console alone stops the connector until you re-approve it
 locally. That keeps a console session from silently repointing a harness at an
 unrelated loopback service and handing it this device's relay credentials. The
-connector writes the reason and the remedy to `service.log` in the tunnel
-configuration directory:
+connector writes the reason and the remedy to
+`~/.local-operator/tunnel/service.log`:
 
 ```
 Tunnel connector stopped: Harness port for local-operator changed in the console. Run lop tunnel connect again.
 Tunnel connector stopped: Harness opencode is not approved on this device. Run lop tunnel connect again.
 ```
 
-Run `lop tunnel connect` to accept the console's current ports on this device;
-the connector restarts on its own once the record matches. Harnesses run
+`lop tunnel status` reports the cloud's own view and does not show harness
+ports, so it still reads `Status: active` while the connector is refusing to
+start — that log is where this state is visible. Run `lop tunnel connect` to
+accept the console's current ports on this device; the connector restarts on
+its own once the record matches. Harnesses run
 separately; the tunnel does not install OpenCode or change its server's bind
 address.
 

--- a/docs/tunnels.md
+++ b/docs/tunnels.md
@@ -77,9 +77,16 @@ default, leaving 4099 for the browser bridge and 4098 for the mobile relay.
 `--gateway-port` selects it at creation. It must differ from every
 harness port and remains fixed for that tunnel. Revoke and recreate to change
 it, so a running connector never targets a port before the proof gateway owns
-its listener. Ports below 1024 and arbitrary upstream URLs are
-rejected. Harnesses run separately; the tunnel does not install OpenCode or
-change its server's bind address.
+its listener. Ports below 1024 and arbitrary upstream URLs are rejected: a
+harness is always dialed on loopback at a numeric port, never at a URL the
+cloud supplies. Harness ports are additionally pinned on this device to the
+record the last local `create`, `connect`, or `configure` stored, so changing a
+harness port in the console alone stops the connector with
+`Harness port for <id> changed in the console. Run lop tunnel connect again.`
+until you re-approve it locally. That keeps a console session from silently
+repointing a harness at an unrelated loopback service and handing it this
+device's relay credentials. Harnesses run separately; the tunnel does not
+install OpenCode or change its server's bind address.
 
 For an OpenCode server that requires Basic authentication, create a private
 file outside any repository containing `{"username":"...","password":"..."}`,

--- a/docs/tunnels.md
+++ b/docs/tunnels.md
@@ -81,12 +81,21 @@ its listener. Ports below 1024 and arbitrary upstream URLs are rejected: a
 harness is always dialed on loopback at a numeric port, never at a URL the
 cloud supplies. Harness ports are additionally pinned on this device to the
 record the last local `create`, `connect`, or `configure` stored, so changing a
-harness port in the console alone stops the connector with
-`Harness port for <id> changed in the console. Run lop tunnel connect again.`
-until you re-approve it locally. That keeps a console session from silently
-repointing a harness at an unrelated loopback service and handing it this
-device's relay credentials. Harnesses run separately; the tunnel does not
-install OpenCode or change its server's bind address.
+harness port in the console alone stops the connector until you re-approve it
+locally. That keeps a console session from silently repointing a harness at an
+unrelated loopback service and handing it this device's relay credentials. The
+connector writes the reason and the remedy to `service.log` in the tunnel
+configuration directory:
+
+```
+Tunnel connector stopped: Harness port for local-operator changed in the console. Run lop tunnel connect again.
+Tunnel connector stopped: Harness opencode is not approved on this device. Run lop tunnel connect again.
+```
+
+Run `lop tunnel connect` to accept the console's current ports on this device;
+the connector restarts on its own once the record matches. Harnesses run
+separately; the tunnel does not install OpenCode or change its server's bind
+address.
 
 For an OpenCode server that requires Basic authentication, create a private
 file outside any repository containing `{"username":"...","password":"..."}`,

--- a/local_operator/tunnels/gateway.py
+++ b/local_operator/tunnels/gateway.py
@@ -70,9 +70,17 @@ class OriginVerifier:
     def __init__(self, access: dict[str, Any], client: httpx.AsyncClient) -> None:
         self.access = access
         self.client = client
-        self.keys: dict[str, Any] = {
-            row["kid"]: jwt.PyJWK.from_dict(row).key for row in access["jwks"]["keys"]
-        }
+        self.keys: dict[str, Any] = {}
+        for row in access["jwks"]["keys"]:
+            # A repeated kid makes key selection ambiguous, and a dict
+            # comprehension resolves that ambiguity silently by position: the
+            # last row wins. A JWKS carrying both the real key and a second key
+            # under the same kid would then be accepted, with which one
+            # verifies tokens decided by serialization order rather than by
+            # policy. Refuse the whole set instead of picking a winner.
+            if row["kid"] in self.keys:
+                raise ValueError("Duplicate key identifier in pinned origin keys.")
+            self.keys[row["kid"]] = jwt.PyJWK.from_dict(row).key
         if any(key.key_size < 2048 for key in self.keys.values()):
             raise ValueError("Origin proof requires RSA keys of at least 2048 bits.")
         self.used: dict[str, float] = {}
@@ -86,6 +94,7 @@ class OriginVerifier:
         method: str,
         target: str,
         body: bytes,
+        websocket: bool = False,
     ) -> dict[str, Any]:
         if not token or len(token) > 16384:
             raise ValueError("Missing origin assertion.")
@@ -127,7 +136,16 @@ class OriginVerifier:
             or not 0 < expires - issued <= 30
         ):
             raise ValueError("Origin assertion lifetime exceeds thirty seconds.")
-        if method not in {"GET", "HEAD", "OPTIONS"}:
+        # A replayed idempotent read yields the same bytes the captor already
+        # holds, so GET/HEAD/OPTIONS are exempt to keep the nonce cache small.
+        # A WebSocket upgrade is signed as method="GET" but is NOT idempotent:
+        # replaying it opens an ADDITIONAL live bidirectional channel to the
+        # harness, which the captor can then drive. It therefore consumes the
+        # nonce like a mutation. The edge mints a fresh jti per request
+        # (Worker setJti(crypto.randomUUID()) on the single forward path that
+        # upgrades take), so legitimate rapid reconnects each carry their own
+        # nonce and are unaffected.
+        if websocket or method not in {"GET", "HEAD", "OPTIONS"}:
             # No await between check and insertion: concurrent replays on this
             # event loop cannot both pass. Refuse a full cache rather than
             # evict a still-live nonce and reopen its replay window.
@@ -355,6 +373,7 @@ class Gateway:
                 method="GET",
                 target=target,
                 body=b"",
+                websocket=True,
             )
             headers = self.headers(socket.headers, host, harness)
             headers.pop("host", None)

--- a/local_operator/tunnels/service.py
+++ b/local_operator/tunnels/service.py
@@ -48,6 +48,69 @@ def tunnel_path(value: dict[str, Any]) -> str:
     return "/" + quote(identifier, safe="")
 
 
+def pinned_harness_ports(value: dict[str, Any]) -> dict[str, int] | None:
+    """The harness ports the operator last approved from this device.
+
+    `lop tunnel create/connect/configure` persist the whole cloud record
+    locally, so `record.harnesses` is the device's own copy of the port map an
+    operator ran a local command to accept. Returns None — meaning "no usable
+    pin" — for a record written before the field existed or hand-edited into a
+    shape we cannot trust, so callers can fall back rather than strand a device
+    whose config predates this check.
+    """
+    record = value.get("record")
+    harnesses = record.get("harnesses") if isinstance(record, dict) else None
+    if not isinstance(harnesses, list) or not harnesses:
+        return None
+    pinned: dict[str, int] = {}
+    for harness in harnesses:
+        if not isinstance(harness, dict) or not isinstance(harness.get("id"), str):
+            return None
+        try:
+            pinned[harness["id"]] = config.port(harness.get("port"))
+        except ValueError:
+            return None
+    return pinned
+
+
+def enforce_harness_ports(connection: dict[str, Any], value: dict[str, Any]) -> None:
+    """Refuse a /connect that repoints a harness at an unapproved local port.
+
+    The cloud validates a harness port only as 1024-65535 and != gateway_port,
+    and replaces the harness list wholesale on PATCH, so anyone holding the
+    owner's console session can aim a harness at any other loopback service.
+    The gateway then attaches this device's mobile-relay cookie or OpenCode
+    Basic credential to whatever answers there (gateway.headers), handing a
+    live relay credential to an unrelated local service. Pinning against the
+    locally stored record makes changing a harness port require an act on this
+    machine, exactly as the cloud already treats gateway_port.
+
+    Fail-closed but recoverable: the console PATCH that legitimately changes a
+    port bumps the tunnel version, the poller restarts, and this refusal then
+    names the local command that re-approves it. Refreshing the pin is left to
+    those commands (they are what write `record`); re-pinning from the polled
+    record here would restore exactly the silent repointing this prevents.
+    """
+    pinned = pinned_harness_ports(value)
+    if pinned is None:
+        print(
+            "Warning: this tunnel configuration predates harness port pinning, so console "
+            "port changes are not verified locally. Run lop tunnel connect to pin them.",
+            flush=True,
+        )
+        return
+    for harness in connection["tunnel"]["harnesses"]:
+        # A disabled harness is never dialed (Gateway.harness filters on it),
+        # so its port cannot carry a credential and is not worth an outage.
+        if not harness["enabled"]:
+            continue
+        if pinned.get(harness["id"]) != harness["port"]:
+            raise ValueError(
+                f"Harness port for {harness['id']} changed in the console. "
+                "Run lop tunnel connect again."
+            )
+
+
 def active(record: Any) -> bool:
     return (
         isinstance(record, dict)
@@ -106,6 +169,7 @@ async def run() -> int:
                 raise ValueError(
                     "Gateway port changed in the console. Run lop tunnel connect again."
                 )
+            enforce_harness_ports(connection, value)
             needs_mobile = any(
                 h["enabled"] and h["id"] == "local-operator"
                 for h in connection["tunnel"]["harnesses"]

--- a/local_operator/tunnels/service.py
+++ b/local_operator/tunnels/service.py
@@ -48,29 +48,42 @@ def tunnel_path(value: dict[str, Any]) -> str:
     return "/" + quote(identifier, safe="")
 
 
-def pinned_harness_ports(value: dict[str, Any]) -> dict[str, int] | None:
+def pinned_harness_ports(value: dict[str, Any]) -> tuple[dict[str, int] | None, str]:
     """The harness ports the operator last approved from this device.
 
     `lop tunnel create/connect/configure` persist the whole cloud record
     locally, so `record.harnesses` is the device's own copy of the port map an
-    operator ran a local command to accept. Returns None — meaning "no usable
-    pin" — for a record written before the field existed or hand-edited into a
-    shape we cannot trust, so callers can fall back rather than strand a device
-    whose config predates this check.
+    operator ran a local command to accept. Returns `(None, reason)` — meaning
+    "no usable pin" — for a record written before the field existed or
+    hand-edited into a shape we cannot trust, so callers can fall back rather
+    than strand a device whose config predates this check.
+
+    One unusable entry disables the pin for the whole record, so the reason
+    names that entry: without it an operator reading the fallback warning knows
+    the pin is off but not which line of config.json to repair.
     """
     record = value.get("record")
     harnesses = record.get("harnesses") if isinstance(record, dict) else None
     if not isinstance(harnesses, list) or not harnesses:
-        return None
+        return None, "this tunnel configuration predates it"
     pinned: dict[str, int] = {}
-    for harness in harnesses:
+    for position, harness in enumerate(harnesses, start=1):
         if not isinstance(harness, dict) or not isinstance(harness.get("id"), str):
-            return None
+            return None, f"stored harness entry {position} has no usable id"
+        if harness["id"] in pinned:
+            # The same silent last-wins ambiguity the JWKS loader refuses on a
+            # repeated kid (gateway.OriginVerifier): two entries claiming one
+            # id leave the approved port decided by serialization order rather
+            # than by the operator, and this file is hand-editable. Fall back
+            # and name it instead of picking a winner. Falling back rather than
+            # raising keeps the untrustworthy-shape contract above: a bad local
+            # record must never strand a device that the cloud still serves.
+            return None, f"stored harness {harness['id']} is listed twice"
         try:
             pinned[harness["id"]] = config.port(harness.get("port"))
         except ValueError:
-            return None
-    return pinned
+            return None, f"stored harness {harness['id']} has an unusable port"
+    return pinned, ""
 
 
 def enforce_harness_ports(connection: dict[str, Any], value: dict[str, Any]) -> None:
@@ -91,11 +104,11 @@ def enforce_harness_ports(connection: dict[str, Any], value: dict[str, Any]) -> 
     those commands (they are what write `record`); re-pinning from the polled
     record here would restore exactly the silent repointing this prevents.
     """
-    pinned = pinned_harness_ports(value)
+    pinned, unpinnable = pinned_harness_ports(value)
     if pinned is None:
         print(
-            "Warning: this tunnel configuration predates harness port pinning, so console "
-            "port changes are not verified locally. Run lop tunnel connect to pin them.",
+            f"Warning: harness port pinning is inactive ({unpinnable}), so console port "
+            "changes are not verified locally. Run lop tunnel connect to pin them.",
             flush=True,
         )
         return
@@ -104,7 +117,17 @@ def enforce_harness_ports(connection: dict[str, Any], value: dict[str, Any]) -> 
         # so its port cannot carry a credential and is not worth an outage.
         if not harness["enabled"]:
             continue
-        if pinned.get(harness["id"]) != harness["port"]:
+        approved = pinned.get(harness["id"])
+        if approved is None:
+            # A harness the console ADDED since the last local command. The
+            # remedy is the same, but reporting it as a port change describes
+            # an event that did not happen and sends the operator hunting for
+            # a port they never set.
+            raise ValueError(
+                f"Harness {harness['id']} is not approved on this device. "
+                "Run lop tunnel connect again."
+            )
+        if approved != harness["port"]:
             raise ValueError(
                 f"Harness port for {harness['id']} changed in the console. "
                 "Run lop tunnel connect again."
@@ -316,9 +339,25 @@ async def run() -> int:
 def main() -> int:
     try:
         return asyncio.run(run())
-    except (ValueError, OSError, httpx.HTTPError):
+    except ValueError as failure:
         # Service logs contain operational state, never upstream bodies,
-        # request URLs, or a traceback containing credential arguments.
+        # request URLs, or a traceback containing credential arguments, and
+        # printing a ValueError's text keeps that property: every ValueError
+        # this package raises is a fixed literal carrying at most a harness id,
+        # a tunnel status, or an HTTP status code (api.py deliberately refuses
+        # to echo provider bodies). The only ValueErrors run() does not author
+        # are json.JSONDecodeError on a corrupt config.json or /connect body,
+        # whose message is a byte offset and never the document, and int() on a
+        # hand-edited credential_id, which is a local row id and not a secret.
+        # This is the only place the remedy is written down: suppressing it is
+        # what left the harness-port refusal telling the operator to check a
+        # Radient login that is fine, with nothing naming lop tunnel connect.
+        print(f"Tunnel connector stopped: {failure}", flush=True)
+        return 1
+    except (OSError, httpx.HTTPError):
+        # These carry text this module did not author: httpx echoes the full
+        # request URL (query string included) and OSError echoes filesystem
+        # paths, so only the generic line is safe here.
         print(
             "Tunnel connector stopped; check lop tunnel status and your Radient login.", flush=True
         )

--- a/tests/unit/test_tunnels.py
+++ b/tests/unit/test_tunnels.py
@@ -6,10 +6,12 @@ import argparse
 import copy
 import hashlib
 import json
+import socket
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import closing
+from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 import httpx
@@ -773,3 +775,208 @@ async def test_agent_billing_json_is_fresh_owner_pinned_and_allowlisted(
     select.assert_called_once_with(19)
     assert factory.call_args.args[0] == 19
     api.request.assert_awaited_once_with("GET", "/billing")
+
+
+def _stored(connection: dict[str, Any], **overrides: Any) -> dict[str, Any]:
+    """Local config as `lop tunnel connect` writes it: the whole cloud record."""
+    value = {
+        "tunnel_id": connection["tunnel"]["id"],
+        "credential_id": 7,
+        "gateway_port": connection["gateway_port"],
+        "record": copy.deepcopy(connection["tunnel"]),
+    }
+    value.update(overrides)
+    return value
+
+
+def test_harness_port_change_in_the_console_alone_cannot_repoint_the_tunnel(connection):
+    """A3: the console may replace harness ports wholesale, and the gateway
+    attaches this device's relay credential to whatever answers on them. Only
+    a locally run command may move a harness port."""
+    from local_operator.tunnels import service
+
+    stored = _stored(connection)
+    moved = copy.deepcopy(connection)
+    # 4098 is the mobile relay; 4096 is any other loopback service the console
+    # session could aim this harness at to be handed a signed lop_mobile cookie.
+    moved["tunnel"]["harnesses"][0]["port"] = 4096
+    with pytest.raises(ValueError) as failure:
+        service.enforce_harness_ports(moved, stored)
+    # Fail-closed refusals must name the remedy: the console PATCH bumps the
+    # version, the poller restarts, and without this wording the operator has
+    # a permanently dark tunnel and no way to self-diagnose it.
+    assert "local-operator" in str(failure.value)
+    assert "lop tunnel connect" in str(failure.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("console_port", [4096, 4098])
+async def test_service_refuses_to_publish_a_connector_on_an_unpinned_harness_port(
+    tmp_path, monkeypatch, connection, console_port
+):
+    """The pin must be wired into the real supervisor, not merely callable.
+
+    service.run() is the only path a device takes to publish a connector, so
+    the guard is only worth anything if a mismatched /connect stops it before
+    cloudflared launches. 4098 is the matching (pinned) port and must still
+    start; 4096 is the repointed one and must not.
+    """
+    from local_operator.tunnels import service
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    with closing(socket.socket()) as probe:
+        probe.bind(("127.0.0.1", 0))
+        free = probe.getsockname()[1]
+    stored = _stored(connection, gateway_port=free)
+    stored["record"]["harnesses"][0]["port"] = 4098
+    config.save(stored)
+    served = copy.deepcopy(connection)
+    served["gateway_port"] = served["tunnel"]["gateway_port"] = free
+    served["tunnel"]["harnesses"][0]["port"] = console_port
+    api = AsyncMock()
+    api.request.return_value = served
+    monkeypatch.setattr(service, "RadientTunnels", lambda *args: api)
+    monkeypatch.setattr(service, "cloudflared_binary", lambda *_: "/trusted/cloudflared")
+    launched = AsyncMock(side_effect=AssertionError("connector launched on an unpinned port"))
+    monkeypatch.setattr(service.asyncio, "create_subprocess_exec", launched)
+    monkeypatch.setattr(service, "load_password", lambda: "private-local-password")
+    if console_port == 4098:
+        # The matching case must get all the way to launching the connector,
+        # which is where this stub deliberately stops it.
+        with pytest.raises(AssertionError):
+            await service.run()
+        return
+    with pytest.raises(ValueError, match="Run lop tunnel connect again"):
+        await service.run()
+    launched.assert_not_called()
+
+
+def test_matching_harness_ports_still_connect_after_pinning(connection):
+    """The §3.3 outage guard: over-refusal here strands every legitimate user,
+    including one whose harness the console merely disabled or renamed."""
+    from local_operator.tunnels import service
+
+    stored = _stored(connection)
+    service.enforce_harness_ports(copy.deepcopy(connection), stored)
+    # A harness the operator turned off is never dialed, so its port cannot
+    # carry a credential and must not cost the whole tunnel its connection.
+    disabled = copy.deepcopy(connection)
+    disabled["tunnel"]["harnesses"][0].update(enabled=False, port=4096)
+    service.enforce_harness_ports(disabled, stored)
+    # An added harness the local record predates is still pinned, not admitted.
+    added = copy.deepcopy(connection)
+    added["tunnel"]["harnesses"].append(
+        {"id": "opencode", "enabled": True, "port": 4096, "hostname": "abc123-oc.radienthq.com"}
+    )
+    with pytest.raises(ValueError):
+        service.enforce_harness_ports(added, stored)
+
+
+@pytest.mark.parametrize(
+    "record",
+    [None, {}, {"harnesses": []}, {"harnesses": "not-a-list"}, {"harnesses": [{"id": "x"}]}],
+)
+def test_absent_local_harness_record_warns_instead_of_stranding_the_device(
+    connection, capsys, record
+):
+    """Upgrade safety: hard-failing on config written before this field existed
+    would convert a security fix into a fleet outage nobody can fix remotely."""
+    from local_operator.tunnels import service
+
+    stored = _stored(connection)
+    if record is None:
+        stored.pop("record")
+    else:
+        stored["record"] = record
+    moved = copy.deepcopy(connection)
+    moved["tunnel"]["harnesses"][0]["port"] = 4096
+    service.enforce_harness_ports(moved, stored)
+    assert "harness port pinning" in capsys.readouterr().out
+
+
+@pytest.mark.asyncio
+async def test_replayed_websocket_upgrade_cannot_open_a_second_channel(connection):
+    """A4: a WS upgrade is signed as method="GET" but is not idempotent —
+    replaying it yields an extra live bidirectional channel to the harness."""
+    from starlette.applications import Starlette
+    from starlette.routing import WebSocketRoute
+    from websockets.asyncio.client import connect as ws_connect
+    from websockets.exceptions import WebSocketException
+    from websockets.typing import Origin
+
+    from tests.unit.test_tunnel_sockets import server
+
+    accepted = []
+
+    async def harness(socket):
+        accepted.append(True)
+        await socket.accept()
+        await socket.send_text("harness open")
+        await socket.close()
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public = json.loads(RSAAlgorithm.to_jwk(key.public_key()))
+    public.update(kid="origin-1", alg="RS256")
+    connection = copy.deepcopy(connection)
+    connection["origin_auth"]["jwks"]["keys"] = [public]
+
+    async with server(Starlette(routes=[WebSocketRoute("/ws", harness)])) as harness_port:
+        connection["tunnel"]["harnesses"][0]["port"] = harness_port
+        now = int(time.time())
+        # ONE assertion, presented twice inside its 30s window — exactly what a
+        # captor of a single upgrade holds. A fresh reconnect carries its own
+        # jti (the Worker mints crypto.randomUUID() per request) and is unaffected.
+        token = jwt.encode(
+            {
+                "iss": config.ORIGIN_ISSUER,
+                "aud": HOST,
+                "sub": "owner-1",
+                "tunnel_id": "tunnel-1",
+                "harness_id": "local-operator",
+                "version": 2,
+                "method": "GET",
+                "target": "/ws",
+                "body_sha256": hashlib.sha256(b"").hexdigest(),
+                "iat": now,
+                "exp": now + 30,
+                "jti": str(uuid.uuid4()),
+            },
+            key,
+            algorithm="RS256",
+            headers={"kid": "origin-1"},
+        )
+        async with httpx.AsyncClient(trust_env=False) as upstream:
+            gateway = Gateway(connection, upstream, mobile_password="pw")
+            async with server(gateway.app()) as gateway_port:
+
+                async def dial():
+                    async with ws_connect(
+                        "ws://" + HOST + "/ws",
+                        host="127.0.0.1",
+                        port=gateway_port,
+                        proxy=None,
+                        origin=Origin("https://" + HOST),
+                        additional_headers={PROOF_HEADER: token},
+                    ) as socket:
+                        return await socket.recv()
+
+                assert await dial() == "harness open"
+                with pytest.raises(WebSocketException):
+                    await dial()
+    assert accepted == [True]
+
+
+def test_duplicate_key_identifier_in_the_pinned_jwks_is_rejected(connection, signing_key):
+    """Two keys sharing a kid make verification order-dependent; a dict
+    comprehension silently lets the last row win. Refuse the whole set."""
+    from local_operator.tunnels.gateway import OriginVerifier
+
+    other = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    shadow = json.loads(RSAAlgorithm.to_jwk(other.public_key()))
+    shadow.update(kid="origin-1", alg="RS256")
+    connection["origin_auth"]["jwks"]["keys"].append(shadow)
+    # config.validate_connection admits it — duplicate kid is a trust-boundary
+    # ambiguity the verifier owns, not a schema violation.
+    config.validate_connection(connection)
+    with pytest.raises(ValueError, match="Duplicate key identifier"):
+        OriginVerifier(connection["origin_auth"], Mock())

--- a/tests/unit/test_tunnels.py
+++ b/tests/unit/test_tunnels.py
@@ -789,6 +789,28 @@ def _stored(connection: dict[str, Any], **overrides: Any) -> dict[str, Any]:
     return value
 
 
+def _pinned_service(tmp_path, monkeypatch, connection, console_port):
+    """Config and stubs for a service whose /connect serves `console_port`."""
+    from local_operator.tunnels import service
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    with closing(socket.socket()) as probe:
+        probe.bind(("127.0.0.1", 0))
+        free = probe.getsockname()[1]
+    stored = _stored(connection, gateway_port=free)
+    stored["record"]["harnesses"][0]["port"] = 4098
+    config.save(stored)
+    served = copy.deepcopy(connection)
+    served["gateway_port"] = served["tunnel"]["gateway_port"] = free
+    served["tunnel"]["harnesses"][0]["port"] = console_port
+    api = AsyncMock()
+    api.request.return_value = served
+    monkeypatch.setattr(service, "RadientTunnels", lambda *args: api)
+    monkeypatch.setattr(service, "cloudflared_binary", lambda *_: "/trusted/cloudflared")
+    monkeypatch.setattr(service, "load_password", lambda: "private-local-password")
+    return service
+
+
 def test_harness_port_change_in_the_console_alone_cannot_repoint_the_tunnel(connection):
     """A3: the console may replace harness ports wholesale, and the gateway
     attaches this device's relay credential to whatever answers on them. Only
@@ -821,25 +843,9 @@ async def test_service_refuses_to_publish_a_connector_on_an_unpinned_harness_por
     cloudflared launches. 4098 is the matching (pinned) port and must still
     start; 4096 is the repointed one and must not.
     """
-    from local_operator.tunnels import service
-
-    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
-    with closing(socket.socket()) as probe:
-        probe.bind(("127.0.0.1", 0))
-        free = probe.getsockname()[1]
-    stored = _stored(connection, gateway_port=free)
-    stored["record"]["harnesses"][0]["port"] = 4098
-    config.save(stored)
-    served = copy.deepcopy(connection)
-    served["gateway_port"] = served["tunnel"]["gateway_port"] = free
-    served["tunnel"]["harnesses"][0]["port"] = console_port
-    api = AsyncMock()
-    api.request.return_value = served
-    monkeypatch.setattr(service, "RadientTunnels", lambda *args: api)
-    monkeypatch.setattr(service, "cloudflared_binary", lambda *_: "/trusted/cloudflared")
+    service = _pinned_service(tmp_path, monkeypatch, connection, console_port)
     launched = AsyncMock(side_effect=AssertionError("connector launched on an unpinned port"))
     monkeypatch.setattr(service.asyncio, "create_subprocess_exec", launched)
-    monkeypatch.setattr(service, "load_password", lambda: "private-local-password")
     if console_port == 4098:
         # The matching case must get all the way to launching the connector,
         # which is where this stub deliberately stops it.
@@ -849,6 +855,55 @@ async def test_service_refuses_to_publish_a_connector_on_an_unpinned_harness_por
     with pytest.raises(ValueError, match="Run lop tunnel connect again"):
         await service.run()
     launched.assert_not_called()
+
+
+def test_the_refusal_reaches_the_operator_through_the_supervised_entry_point(
+    tmp_path, monkeypatch, connection, capsys
+):
+    """M1: run() raises the right words, but launchd executes main(), and
+    StandardOutPath/StandardErrorPath are service.log — so whatever main()
+    prints is the entirety of what the operator can read.
+
+    Asserting on the exception object proves nothing here: the previous round
+    did exactly that while main() swallowed the message and sent the operator
+    to a Radient login that was fine. This drives the real entry point and
+    reads the bytes, and it is the observable docs/tunnels.md promises.
+    """
+    service = _pinned_service(tmp_path, monkeypatch, connection, 4096)
+    launched = AsyncMock(side_effect=AssertionError("connector launched on an unpinned port"))
+    monkeypatch.setattr(service.asyncio, "create_subprocess_exec", launched)
+
+    assert service.main() == 1
+
+    logged = capsys.readouterr().out
+    assert "Harness port for local-operator changed in the console." in logged
+    assert "Run lop tunnel connect again." in logged
+    # The old generic line sent the operator to two places that are both fine.
+    assert "your Radient login" not in logged
+    launched.assert_not_called()
+
+
+def test_main_still_withholds_error_text_it_did_not_author(tmp_path, monkeypatch, capsys):
+    """The suppression exists so upstream bodies, request URLs and filesystem
+    paths stay out of a log the operator may paste into a support thread.
+    Surfacing this package's own refusals must not widen that."""
+    from local_operator.tunnels import service
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    leaky = httpx.HTTPStatusError(
+        "Server error '500' for url 'https://api.radienthq.com/v1/tunnels/t-1?k=SECRET'",
+        request=httpx.Request("POST", "https://api.radienthq.com/v1/tunnels/t-1?k=SECRET"),
+        response=httpx.Response(500),
+    )
+
+    async def fail():
+        raise leaky
+
+    monkeypatch.setattr(service, "run", fail)
+    assert service.main() == 1
+    logged = capsys.readouterr().out
+    assert "SECRET" not in logged
+    assert "check lop tunnel status and your Radient login" in logged
 
 
 def test_matching_harness_ports_still_connect_after_pinning(connection):
@@ -872,15 +927,65 @@ def test_matching_harness_ports_still_connect_after_pinning(connection):
         service.enforce_harness_ports(added, stored)
 
 
+def test_a_console_added_harness_is_refused_as_unapproved_not_as_a_port_change(connection):
+    """m2: refusing an added harness is right, but calling it a port change
+    describes an event that never happened and sends the operator hunting for
+    a port they never set. Both refusals name the same remedy."""
+    from local_operator.tunnels import service
+
+    stored = _stored(connection)
+    added = copy.deepcopy(connection)
+    added["tunnel"]["harnesses"].append(
+        {"id": "opencode", "enabled": True, "port": 4096, "hostname": "abc123-oc.radienthq.com"}
+    )
+    with pytest.raises(ValueError) as failure:
+        service.enforce_harness_ports(added, stored)
+    assert "opencode is not approved on this device" in str(failure.value)
+    assert "changed in the console" not in str(failure.value)
+    assert "lop tunnel connect" in str(failure.value)
+
+
+def test_a_harness_listed_twice_in_the_stored_record_disables_the_pin(connection, capsys):
+    """m1: two entries claiming one id leave the approved port decided by
+    serialization order rather than by the operator, exactly the last-wins
+    ambiguity the JWKS loader refuses on a repeated kid. Falling back keeps a
+    hand-edited local file from stranding a device the cloud still serves."""
+    from local_operator.tunnels import service
+
+    stored = _stored(connection)
+    stored["record"]["harnesses"] = [
+        {"id": "local-operator", "enabled": True, "port": 4096, "hostname": HOST},
+        {"id": "local-operator", "enabled": True, "port": 4098, "hostname": HOST},
+    ]
+    assert service.pinned_harness_ports(stored)[0] is None
+    # Without the guard the second entry wins and 4098 is silently approved.
+    served = copy.deepcopy(connection)
+    served["tunnel"]["harnesses"][0]["port"] = 4098
+    service.enforce_harness_ports(served, stored)
+    assert "listed twice" in capsys.readouterr().out
+
+
 @pytest.mark.parametrize(
-    "record",
-    [None, {}, {"harnesses": []}, {"harnesses": "not-a-list"}, {"harnesses": [{"id": "x"}]}],
+    "record,names",
+    [
+        (None, "predates"),
+        ({}, "predates"),
+        ({"harnesses": []}, "predates"),
+        ({"harnesses": "not-a-list"}, "predates"),
+        ({"harnesses": [{"id": "x"}]}, "harness x has an unusable port"),
+        ({"harnesses": [{"port": 4098}]}, "entry 1 has no usable id"),
+    ],
 )
 def test_absent_local_harness_record_warns_instead_of_stranding_the_device(
-    connection, capsys, record
+    connection, capsys, record, names
 ):
     """Upgrade safety: hard-failing on config written before this field existed
-    would convert a security fix into a fleet outage nobody can fix remotely."""
+    would convert a security fix into a fleet outage nobody can fix remotely.
+
+    n1: one bad entry disables the pin for the whole record, so the warning
+    names it — otherwise the operator knows the pin is off but not which line
+    of config.json to repair.
+    """
     from local_operator.tunnels import service
 
     stored = _stored(connection)
@@ -891,7 +996,9 @@ def test_absent_local_harness_record_warns_instead_of_stranding_the_device(
     moved = copy.deepcopy(connection)
     moved["tunnel"]["harnesses"][0]["port"] = 4096
     service.enforce_harness_ports(moved, stored)
-    assert "harness port pinning" in capsys.readouterr().out
+    warning = capsys.readouterr().out
+    assert "harness port pinning is inactive" in warning
+    assert names in warning
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
A Radient console session could silently repoint a personal tunnel's harness at **any other loopback service ≥1024** and be handed this device's relay credentials. The auth gate itself is sound — this is a defect *around* it.

The blast radius is real because three things line up: the cloud validates a harness port only as `1024-65535` and `!= gateway_port` and replaces the harness list **wholesale** on PATCH (`model.go:88-94`, `service.go:391-393`); the device validated **only** `gateway_port` (`service.py:105`) and dialed `harness["port"]` verbatim (`gateway.py:280,367`); and `headers()` (`gateway.py:194-199`) then attaches a signed `lop_mobile` cookie or the OpenCode Basic credential to whatever answered. The cloud already treats `gateway_port` as sensitive for exactly this reason — `service.go:383-390` returns 409 on any change, commented *"Switching ports could therefore expose an unrelated local service"*. `Harnesses` had no such guard on either side.

`Release: patch — a Radient console session can no longer repoint a tunnel harness at an unrelated loopback service and be handed this device's relay credentials.`

**Change class: C2 (standard / pre-authorized).** Device-side only. **No control-plane, protocol, or `/connect` contract change**, so it is independently deployable and backward-compatible in both directions: an old device ignores the new local pin, and a new device works against today's unchanged cloud and Worker.

## What changed

**A3 — harness ports pinned to the local record** (`service.py`). `lop tunnel create/connect/configure` already persist the whole cloud record locally (`cli.py:288`), so `record.harnesses` *is* the device's own copy of a port map an operator ran a local command to accept. `enforce_harness_ports()` compares `/connect`'s ports against it, mirroring the existing `gateway_port` check three lines above.

Three properties are load-bearing and each is commented in place, because the obvious "simplification" of any one of them re-opens the hole or causes an outage:

- **The pin is refreshed only by the local commands that write `record`** — never by the poller. Silent re-pinning from the polled record would restore precisely the repointing this prevents.
- **Fail-closed but recoverable.** A legitimate console port change bumps `version`, the poller restarts (`service.py:194`), and a naive pin would then leave the tunnel **permanently dark with nothing the operator could diagnose**. The refusal names the remedy, in the wording already used for `gateway_port`: `Harness port for <id> changed in the console. Run lop tunnel connect again.`
- **Absent local state warns and falls back**, never hard-fails. Hard-failing on a config written before this field existed would turn a security fix into a fleet outage on upgrade. I verified the real stored shape rather than assuming — `record.harnesses[].port` is present and `int` on this machine's live config — but the fallback costs three lines and removes the whole class.

A **disabled** harness is skipped: `Gateway.harness()` filters on `enabled`, so it is never dialed, cannot carry a credential, and is not worth an outage.

**A4 — the `jti` replay cache now covers WebSocket upgrades** (`gateway.py`). `:130` exempted `GET/HEAD/OPTIONS` and `:355` signs a WS upgrade as `method="GET"`, so upgrades were exempt. A replayed GET is idempotent; a replayed **upgrade is not** — it yields an *additional* live bidirectional channel the captor can drive.

**No edge change is needed, and I verified that against the deployed Worker rather than assuming it** (this was the one place a device-side tightening could reject traffic a live edge produces):

```
$ npx wrangler deployments list
Version(s):  (100%) af67d0bf-fcc9-44e8-9810-a3047d5c9a1c
Message:     Reviewed tunnel edge e10aac1; existing Free plan defaults for live QA

$ git diff e10aac1 origin/main -- edge/tunnel-worker/src/index.ts
(empty — deployed source is identical to agent-server main)
```

That source mints `setJti(crypto.randomUUID())` at `index.ts:181`, inside `forward()` — the single path a WS upgrade takes (`:73` classifies the upgrade, `:191` preserves `Connection` for it, and there is no second minting site). So every legitimate reconnect carries its own nonce. Proven end to end below: replay rejected, fresh reconnect still works.

**minor — duplicate `kid` in the pinned JWKS is rejected** (`gateway.py:73-75`). The dict comprehension resolved a repeated `kid` silently by position — last row wins — so a JWKS carrying the real key plus a shadow under the same `kid` was accepted, with the winner decided by serialization order rather than policy. Refuse the set instead of picking.

**docs — `docs/tunnels.md:80` corrected.** Its claim that "arbitrary upstream URLs are rejected" becomes true only with the pin in place; it now also states the refusal string and the remedy.

Not in this PR, deliberately (§3.2): **no device-side enforcement of the proof's `token_use`/`typ` discriminator.** PR-1 adds that claim at the Worker additively. A device that *required* it would fail every request closed if the Worker rolled back.

## Validation

Six regression tests in `tests/unit/test_tunnels.py`. **Every one is mutation-proven** — the fix hunk reverted in place (never `git stash`; peers hold uncommitted work in these checkouts), actual failure captured, restored.

### Mutation 1 — A3 guard removed from `service.run()`

The pure-function tests still pass with the call site deleted, which is why there is also a test driving the **real supervisor**. Only that one bites:

```
MUTATION 1: A3 guard removed from service.run()
E               AssertionError: connector launched on an unpinned port
FAILED tests/unit/test_tunnels.py::test_service_refuses_to_publish_a_connector_on_an_unpinned_harness_port[4096]
1 failed, 8 passed
```

### Mutation 2 — upgrade fallback replaced by hard-fail

```
MUTATION 2: fallback-and-warn replaced by hard-fail on absent local record
E   ValueError: Harness port for local-operator changed in the console. Run lop tunnel connect again.
FAILED ...test_absent_local_harness_record_warns_instead_of_stranding_the_device[None]
FAILED ...[record1]  FAILED ...[record2]  FAILED ...[record3]  FAILED ...[record4]
5 failed
```

### Mutation 3 — over-refusal (the §3.3 outage shape)

The mandatory "matching ports still connect" guard. Pinning a *disabled* harness is enough to trip it:

```
MUTATION 3: over-refusal — disabled harnesses also pinned
E   ValueError: Harness port for local-operator changed in the console. Run lop tunnel connect again.
FAILED tests/unit/test_tunnels.py::test_matching_harness_ports_still_connect_after_pinning
1 failed
```

### Mutation 4 — A4 reverted, WS exempt again

```
MUTATION 4: A4 reverted — WS upgrades exempt from the jti replay cache again
FAILED ...test_replayed_websocket_upgrade_cannot_open_a_second_channel - Failed: DID NOT RAISE WebSocketException
1 failed
```

`DID NOT RAISE` is the finding stated exactly: without the fix the replayed upgrade **opened a second live channel**.

### Mutation 5 — duplicate-`kid` rejection reverted to last-row-wins

```
MUTATION 5: duplicate-kid rejection reverted to the silent last-row-wins comprehension
FAILED ...test_duplicate_key_identifier_in_the_pinned_jwks_is_rejected - Failed: DID NOT RAISE ValueError
1 failed
```

### Real-path proof — the actual gateway against a stub control plane

Unit tests are the floor. This drives **`local_operator.tunnels.service.run()`** — the real supervisor — against a real loopback HTTP control plane serving a real `/connect`, with the real `Gateway` reached over a real TCP socket carrying a real RS256 origin proof. Nothing in the code under test is mocked; only `cloudflared` (not launched), the API base URL, and the OAuth row are substituted.

Isolated **`HOME` *and*** config dir per scenario — `LOCAL_OPERATOR_CONFIG_DIR` alone does not redirect the cache, and a stale cache has produced false QA results here twice. All inherited `CMUX_*` unset. The operator's live tunnel config and sessions were never touched.

```
########## scenario: mismatch ##########
[setup] locally approved harness port : 64164
[setup] port served by /connect        : 64165      <- console repointed it
[setup] gateway port                   : 64162
[REFUSED] ValueError: Harness port for local-operator changed in the console. Run lop tunnel connect again.
[ok] no gateway listener after refusal: ConnectError

########## scenario: match ##########
[setup] locally approved harness port : 64173
[setup] port served by /connect        : 64173      <- matches the local record
[CONNECTED] supervisor published the gateway
[http] 200 {"harness":"approved","path":"/api/sessions"}

########## scenario: ws-replay ##########
[CONNECTED] supervisor published the gateway
[http] 200 {"harness":"approved","path":"/api/sessions"}
[ws  ] first upgrade  : 'channel open'
[ok  ] replayed upgrade rejected: InvalidStatus: server rejected WebSocket connection: HTTP 403
[ok  ] fresh jti reconnect still works: 'channel open'
```

The mismatch case also proves **nothing was published**: after the refusal, nothing answers on the gateway port at all (`ConnectError`), so the repointed harness never received a credential. The ws-replay case proves both directions — the replay is refused **and** a fresh-`jti` reconnect still succeeds, which is the regression that would matter if the edge did not mint per-request nonces.

### Gates — whole tree, exactly as CI

Run via `python -m` / `uvx`, never the `.venv/bin/*` console scripts (those exit 126 after a sibling worktree is deleted, and a pipeline swallows it, so a gate that never ran looks green).

```
$ .venv/bin/python -m flake8 .                                    rc=0
$ uvx --from black==26.1.0 black --check .                        1063 files would be left unchanged.
$ uvx isort==5.13.2 --check .                                     Skipped 2 files
$ .venv/bin/python -m pyright --pythonpath .venv/bin/python .     0 errors, 0 warnings, 0 informations
$ .venv/bin/python -m pytest tests/unit -q
  15810 passed, 18 skipped, 680 warnings in 2724.18s (0:45:24)    PYTEST_RC=0
```

Worktree owns a real venv installed editable from itself (never a symlink, which would silently import `main` and make an interactive test prove nothing):

```
$ .venv/bin/python -c "import local_operator; print(local_operator.__file__)"
/Users/damian/workspace/repos/lo-tunnel-pin/local_operator/__init__.py
```

**No version bump** — `pyproject.toml` untouched; this rides a normal release window.

Rebased onto `5a801d61d` after the base moved mid-suite. No overlap: nothing upstream touched `tunnels/` or `test_tunnels.py`, and the diffstat is byte-identical across the rebase. Gates and all three real-path scenarios were re-run on the rebased head and are the transcripts shown above.
