### PR TITLE
feat(tui): collapse inbound peer receipts into an expandable ledger card

### DIFF
--- a/local_operator/tui/glyphs.py
+++ b/local_operator/tui/glyphs.py
@@ -101,6 +101,14 @@ NERD_TOOL_ICONS: dict[str, str] = {
     "task": "\uf0c0",  # nf-fa-users — work handed to another agent
     "agent": "\uf0c0",
     "send": "\uf1d8",  # nf-fa-paper_plane — a note handed to a peer session
+    # nf-fa-inbox. Not a tool at all: the `peer` row is the RECEIPT for a note
+    # another session handed to US, and it is in this table because the ledger
+    # resolves every card's icon through `tool_icon`, so a receipt that wants
+    # the ledger's spine has to be a key here like any other row. An inbox is
+    # the noun for "something arrived and is waiting to be read", which is what
+    # the collapsed row says; the paper plane above is the same event seen from
+    # the sending side.
+    "peer": "\uf01c",
 }
 
 #: Nerd Font glyph for any ``mcp__*`` tool: a plug, because what the row is
@@ -133,6 +141,11 @@ PLAIN_TOOL_ICONS: dict[str, str] = {
     "task": "»",  # work passed onward
     "agent": "»",
     "send": "\u2192",  # a rightward arrow: a message handed across to a peer
+    # The INBOUND counterpart to `send`'s `→`, and deliberately the same glyph
+    # mirrored rather than a second metaphor: the two rows are one
+    # conversation seen from its two ends, so a reader scanning a ledger full
+    # of cross-session traffic reads direction off the arrow alone.
+    "peer": "\u2190",
 }
 
 #: Plain fallback for ``mcp__*`` — a discrete module docked onto the harness.

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -341,8 +341,8 @@ ToolCard, WakeBlock, PeerMessageBlock {
     height: 1;
     background: $lo-surface;
     /* The hand pointer, not just the hover tint: the whole row is the click
-     * target for expand/collapse (ExpandableActionBlock.on_click, shared by
-     * all three),
+     * target for expand/collapse (ExpandableActionBlock.on_click is shared by
+     * all three widgets),
      * so the cursor is the affordance that says so BEFORE the click. Textual
      * walks this rule on every mouse event and emits OSC 22, which ghostty
      * implements and a terminal that does not simply ignores. */

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -239,7 +239,8 @@ TranscriptView {
 /* Blocks: zero outer margin, zero padding — no declarations here by design
  * (the minimalism defense asserts their absence; anything uniform here would
  * be the "blank row between everything" regression). */
-TranscriptBlock, UserBlock, NoticeBlock, RichBlock, AssistantBlock, ToolCard, WakeBlock {
+TranscriptBlock, UserBlock, NoticeBlock, RichBlock, AssistantBlock, ToolCard, WakeBlock,
+PeerMessageBlock {
     width: 1fr;
     height: auto;
 }
@@ -336,11 +337,12 @@ Screen > .screen--selection {
  * even after the resize rebuilds the row to fit — a ledger of one-line
  * traces silently doubles in height. Pinning makes the worst case a clipped
  * cell for one frame, which is the right failure. */
-ToolCard, WakeBlock {
+ToolCard, WakeBlock, PeerMessageBlock {
     height: 1;
     background: $lo-surface;
     /* The hand pointer, not just the hover tint: the whole row is the click
-     * target for expand/collapse (see ToolCard.on_click / WakeBlock.on_click),
+     * target for expand/collapse (ExpandableActionBlock.on_click, shared by
+     * all three),
      * so the cursor is the affordance that says so BEFORE the click. Textual
      * walks this rule on every mouse event and emits OSC 22, which ghostty
      * implements and a terminal that does not simply ignores. */
@@ -349,10 +351,10 @@ ToolCard, WakeBlock {
 
 /* Expanded is the ONE case that is content-sized: the summary row plus one
  * row per line of revealed output (each already truncated to width, so
- * nothing reflows). The class beats the type selector above. WakeBlock uses
- * its own class name because it is a different widget; the height contract
- * is the same. */
-ToolCard.tool-expanded, WakeBlock.wake-expanded {
+ * nothing reflows). The class beats the type selector above. WakeBlock and
+ * PeerMessageBlock use their own class names because they are different
+ * widgets; the height contract is the same. */
+ToolCard.tool-expanded, WakeBlock.wake-expanded, PeerMessageBlock.peer-expanded {
     height: auto;
 }
 
@@ -387,12 +389,13 @@ ToolCard.tool-expanded, WakeBlock.wake-expanded {
  *
  * Expanded rows are exempt: they are already `height: auto` and content-sized,
  * and the payload gives the pointer plenty to hit. */
-.comfortable-rows ToolCard, .comfortable-rows WakeBlock {
+.comfortable-rows ToolCard, .comfortable-rows WakeBlock, .comfortable-rows PeerMessageBlock {
     height: 2;
     padding: 1 0 0 0;
 }
 
-.comfortable-rows ToolCard.tool-expanded, .comfortable-rows WakeBlock.wake-expanded {
+.comfortable-rows ToolCard.tool-expanded, .comfortable-rows WakeBlock.wake-expanded,
+.comfortable-rows PeerMessageBlock.peer-expanded {
     height: auto;
     padding: 1 0 0 0;
 }
@@ -411,7 +414,7 @@ ToolCard.tool-error {
 /* Mouse affordance: the whole row is the click target for expand/collapse,
  * so the whole row lights on hover. Last rule wins over the state tints —
  * pointing at a row should always look the same. */
-ToolCard:hover, WakeBlock:hover, .interactive-notice:hover {
+ToolCard:hover, WakeBlock:hover, PeerMessageBlock:hover, .interactive-notice:hover {
     background: $lo-overlay;
 }
 
@@ -428,7 +431,7 @@ ToolCard:hover, WakeBlock:hover, .interactive-notice:hover {
  * Last rule in the block, so it wins over the state tints AND over :hover:
  * where the keyboard is, is the more load-bearing fact. Still no border —
  * elevation is a background step here as everywhere. */
-ToolCard:focus, WakeBlock:focus, .interactive-notice:focus {
+ToolCard:focus, WakeBlock:focus, PeerMessageBlock:focus, .interactive-notice:focus {
     background: $lo-tint-select;
 }
 

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -1770,67 +1770,77 @@ def _sanitize_sender_field(value: object) -> str:
     return text[:_SENDER_FIELD_MAX_CHARS]
 
 
-class PeerMessageBlock(TranscriptBlock):
-    """An inbound message from ANOTHER local lop session (`lop send`).
+class PeerMessageBlock(ExpandableActionBlock):
+    """An inbound message from ANOTHER local lop session (`lop send`), as a card.
 
-    This is deliberately NOT a :class:`UserBlock` and NOT a :class:`WakeBlock`.
-    It must read as *inbound cross-session* — a note the user did not type and
-    the schedule did not fire, but that another running session handed over —
-    so it carries its own affordances:
+    This is deliberately NOT a :class:`UserBlock`: it must read as *inbound
+    cross-session* — a note the user did not type and the schedule did not
+    fire, but that another running session handed over. It IS drawn as a
+    ledger card, the same shape :class:`WakeBlock` uses, and that is the fix
+    this class exists in its present form for.
 
-    - A ``↔`` glyph in the gutter rule marks the block as a two-way
-      cross-session hand-off, distinct from the user prompt's plain ``▌`` bar.
-      Using the same full-height rule discipline as :class:`UserBlock` keeps a
-      multi-paragraph peer message reading as ONE block rather than several.
-    - A muted header line names the sending session (conversation / pid /
-      model) so the reader can see WHO reached in, which is the whole point of
-      a cross-session indicator — the parent/wake paths have no slot for it.
+    **Why the card replaced the rule-and-header block.** The receipt used to
+    paint a full-height ``↔`` gutter rule, a wrapped sender header, and then
+    the WHOLE body at body weight. That is right for one message and wrong for
+    the traffic this harness actually carries: a single release-window
+    announcement from a peer measured **15 rows at 100 columns**, and two of
+    them pushed the conversation the user was reading off the top of the
+    screen. An inbound note is a RECEIPT — something arrived, from whom, about
+    what — and a receipt earns one line until the reader asks for more. So the
+    collapsed row names the sender and previews the message, and Enter / click
+    / Space reveals the full sender identity and the whole body, exactly the
+    contract every other action row in the ledger offers.
 
-    The header is app chrome (the app naming the sender), so it is excluded
-    from a copy the same way :class:`UserBlock`'s attachment receipt is; the
-    body copies verbatim.
+    It is a ledger row on purpose, for the reasons :class:`WakeBlock`'s
+    docstring gives: sharing :attr:`SPACING_KIND` with the tool card plus
+    :attr:`SPACING_AIRY` is what puts a blank row above and below it, and
+    ``LEDGER_ROW`` keeps its name column aligned with the tool rows a peer
+    message habitually lands between. A receipt sitting in a run of actions
+    with its own private layout is a second spine.
+
+    **The name leads the snippet.** ``_send_summary`` in ``tool_card.py``
+    learned this the expensive way: the row builder truncates the composed
+    summary from the right as ONE string, so whatever sits rightmost dies
+    first. WHO reached in is what the reader acts on — it is the address they
+    would answer at — and free text is the thing that can be shed without the
+    row becoming unidentifiable, so the sender leads and the snippet trails.
+
+    The summary row is app chrome (the app naming the sender), so it is
+    excluded from a copy the same way :class:`UserBlock`'s attachment receipt
+    is; :meth:`text` and the expanded body stay the peer's verbatim message.
     """
 
-    #: A cross-session message arrives unbidden — always give it air so it does
-    #: not fuse with whatever row preceded it.
-    SPACING_KIND = "peer"
-    SPACING_LEAD = True
+    EXPANDED_CLASS = "peer-expanded"
 
-    #: ``↔`` (LEFT RIGHT ARROW): a two-way link between sessions. One cell of
-    #: glyph plus a trailing space fills the same gutter width the user rule
-    #: uses, so the body lands in the shared text column and no other block
-    #: moves.
-    RULE = "↔"
-    RULE_COLS = SPINE_INDENT
-    #: The rule and header wear the accent-free ``muted`` ink: loud enough to
-    #: register as "something reached in", quiet enough not to compete with the
-    #: live-turn accent. The body is full ``fg`` so the message itself reads at
-    #: body weight.
-    RULE_TOKEN = "muted"
-    HEADER_TOKEN = "muted"
-    TEXT_TOKEN = "fg"
+    #: The name column says ``peer``. Not "receive" (which implies the agent
+    #: acted) and not "inbox" (a place, not an event): the row reports that a
+    #: peer session reached in. The icon carries the direction.
+    tool_name = "peer"
+
+    #: Kept for the expansion's identity line, which is the one place the old
+    #: header's information still belongs. The wrapping there is the card's,
+    #: so this is only the floor for the fit test in :meth:`_header`.
     MIN_BODY = 8
-    #: The model label is attached only when the WHOLE header still fits on one
-    #: row with it (see ``_header``). A fixed column threshold cannot express
-    #: that: it was calibrated against a 14-cell name, and at 22-26 cells — the
-    #: ordinary length here — crossing it re-attached a ~23-cell label that
-    #: cost more than the columns just gained, so widening a pane from 70 to 80
-    #: made the card TALLER. The rule is now about fit rather than width, which
-    #: is what makes wrapping monotonic: more columns never yields more rows.
 
     def __init__(self, body: str, sender: dict[str, object] | None = None) -> None:
         super().__init__()
         self.add_class("peer-message-block")
         self._text = body
         self._sender = sender or {}
-        #: How many rendered rows the header occupies. The header is ONE
-        #: paragraph but wraps to several rows at narrow widths and with a long
-        #: sender name, so a single index cannot describe it: set by ``_build``
-        #: at the width it actually wrapped at, so ``copy_row_is_chrome`` never
-        #: re-derives it and cannot disagree with the frame (the discipline
-        #: ``UserBlock._receipt_row`` already follows).
-        self._header_rows: int = 0
-        self.set_content(self._build())
+        self._expanded = False
+        self._hovered = False
+        self._focused = False
+        #: How many rendered rows are the card's OWN furniture — the summary
+        #: plus, when open, the sender identity and the rule beneath it. Set by
+        #: the build at the width it actually wrapped at, so
+        #: :meth:`copy_row_is_chrome` never re-derives it and cannot disagree
+        #: with the frame (the discipline the old header row count followed,
+        #: and ``UserBlock._receipt_row`` before it).
+        self._chrome_rows: int = 1
+        self._row_count = 1
+        self._applied_rows = -1
+        self._built_width = -1
+        self._refresh_row()
         self.finalize()
 
     def text(self) -> str:
@@ -1838,39 +1848,57 @@ class PeerMessageBlock(TranscriptBlock):
         their own row (parallel to :meth:`UserBlock.text`)."""
         return self._text
 
-    def _header(self) -> str:
-        """The sender label: 'peer message from "<name>" (pid N, <model>)'.
+    def can_expand(self) -> bool:
+        """Always: the collapsed line is a preview of a message behind it.
 
-        Every field is advisory — a leaner sender omits some — so the label is
-        assembled from whatever is present and never assumes a key exists.
+        Unconditional even for a one-word note, because the expansion also
+        carries the sender's pid and model — the fields a reader needs in
+        order to address the peer back, which no snippet can hold.
+        """
+        return True
 
-        When the conversation name is genuinely absent even after the receive
-        side's registry enrichment, the label falls back to the sender's cwd
-        basename and then to a short session id rather than showing a bare pid.
-        A row reading `peer message from (pid 1)` names nothing a reader can act
-        on — the whole point of the indicator is to say WHICH session reached
-        in, and a working directory or an id prefix answers that where a pid
-        assigned by the kernel does not."""
+    def _sender_name(self) -> tuple[str, bool]:
+        """``(name, quoted)`` for the sending session, or ``("", False)``.
+
+        The ladder — conversation name, then cwd basename, then a short session
+        id — is why a peer receipt never degrades to a bare pid: a row naming
+        `pid 1` names nothing a reader can act on, and the whole point of the
+        indicator is to say WHICH session reached in.
+
+        ``quoted`` is False for the two fallbacks. A name the peer CHOSE is
+        quoted; a directory basename and an id prefix are the app guessing, and
+        rendering them identically told the reader nothing about which they
+        were looking at — two sessions in sibling checkouts would both read as
+        "user-dashboard".
+        """
         name = _sanitize_sender_field(self._sender.get("conversation_name"))
+        if name:
+            return name, True
+        cwd = _sanitize_sender_field(self._sender.get("cwd")).rstrip("/")
+        if cwd:
+            return os.path.basename(cwd) + "/", False  # trailing slash: a directory
+        session_id = _sanitize_sender_field(self._sender.get("session_id"))
+        if session_id:
+            # A short prefix: a full ULID is 26 cells of entropy that pushes the
+            # message preview off the row without helping the eye.
+            return session_id[:8], False
+        return "", False
+
+    def _header(self, width: int | None = None) -> str:
+        """The full sender label: 'peer message from "<name>" (pid N, <model>)'.
+
+        This is the EXPANSION's identity line — the information the collapsed
+        row cannot hold and the operator asked to see on expand. Every field is
+        advisory (a leaner sender omits some), so the label is assembled from
+        whatever is present and never assumes a key exists.
+
+        ``width`` is the body width the caller will wrap this at; it defaults
+        to the block's own, which is what the pre-card call sites and the
+        degradation tests pass.
+        """
+        name, quoted = self._sender_name()
         pid = self._sender.get("pid")
         model = _sanitize_sender_field(self._sender.get("model_label"))
-        # Quoted only for a name the peer CHOSE. A directory basename and an id
-        # prefix are the app guessing, and rendering them identically to a real
-        # title told the reader nothing about which they were looking at — two
-        # sessions in sibling checkouts would both read as "user-dashboard".
-        quoted = True
-        if not name:
-            cwd = _sanitize_sender_field(self._sender.get("cwd")).rstrip("/")
-            if cwd:
-                name = os.path.basename(cwd) + "/"  # trailing slash: a directory
-                quoted = False
-        if not name:
-            session_id = _sanitize_sender_field(self._sender.get("session_id"))
-            if session_id:
-                # A short prefix: a full ULID is 26 cells of entropy that pushes
-                # the pid and model out of the header without helping the eye.
-                name = session_id[:8]
-                quoted = False
         bits: list[str] = []
         if pid is not None:
             bits.append(f"pid {pid}")
@@ -1892,49 +1920,169 @@ class PeerMessageBlock(TranscriptBlock):
         # "which session reached in, so I can go and talk to it", so it is the
         # first thing to give way (the information order name -> pid -> model is
         # also the shed order). It is attached only when the result still fits
-        # on ONE row, measured against the same body width ``_build`` wraps at.
+        # on ONE row, measured against the width it will be wrapped at.
         # Testing the terminal width instead made the behaviour non-monotonic:
         # a wider pane could re-attach a label that cost more than the extra
-        # columns and push the header onto a second row.
-        body = max((self.size.width or 80) - self.RULE_COLS, self.MIN_BODY)
+        # columns and push the identity line onto a second row.
+        body = width if width is not None else (self.size.width or 80)
+        body = max(body, self.MIN_BODY)
         with_model = _compose(bits + [model])
         return with_model if cell_len(with_model) <= body else header
 
+    def _summary(self) -> tuple[str, str]:
+        """``(identity, snippet)`` for the collapsed row — identity FIRST.
+
+        The identity is the sender's name alone, not the whole
+        ``peer message from …`` sentence: the ``peer`` name column and the
+        inbound icon already say what kind of row this is, and repeating it in
+        the summary is the caption-not-card problem :class:`WakeBlock` names
+        one column along. When even the fallback ladder finds nothing, the pid
+        is the last thing that identifies the sender at all, and it is better
+        on the row than an anonymous line.
+
+        The snippet carries NO cap of its own. The row's ``truncate_cells``
+        already sheds it to the available budget, and a second arbitrary bound
+        only left the line empty at wide widths while protecting nothing — the
+        identity survives either way because it leads.
+        """
+        name, quoted = self._sender_name()
+        if name:
+            identity = f'"{name}"' if quoted else name
+        else:
+            pid = self._sender.get("pid")
+            identity = f"pid {pid}" if pid is not None else "another session"
+        # Newlines collapse to spaces: the snippet is one row by construction,
+        # and an authored break inside it would be measured into a word's width
+        # and then printed literally mid-row.
+        snippet = " ".join(self._text.split())
+        return identity, snippet
+
+    def on_resize(self, event) -> None:  # type: ignore[no-untyped-def]
+        """Re-fit the card at the new width (same guard as the tool card)."""
+        size = getattr(event, "size", None)
+        if size is not None and size.width == self._built_width:
+            return
+        self._refresh_row()
+
     def copy_gutter(self, index: int) -> int:
-        """The rule occupies the gutter on every row (same as UserBlock)."""
-        return self.RULE_COLS
+        """The icon field on the summary row; the expansion's indent below it."""
+        from local_operator.tui.widgets.tool_card import OUTPUT_INDENT
+
+        return 2 if index == 0 else OUTPUT_INDENT
 
     def copy_row_is_chrome(self, index: int) -> bool:
-        """The sender header is the app talking, not the peer's message body.
+        """The summary and the sender identity are the app talking.
 
-        Every row the header wrapped to, not merely the first — the count comes
-        from the same build that produced the frame, so a resize cannot make
-        the two disagree.
+        Not the message: the peer's body copies verbatim, which is what makes a
+        drag over an expanded receipt paste the note rather than the app's own
+        label above it. The count comes from the same build that produced the
+        frame, so a resize cannot make the two disagree.
         """
-        return index < self._header_rows
+        return index < self._chrome_rows
 
-    def on_resize(self, event: object) -> None:
-        """Re-wrap at the new width and re-ask the spacing gap, matching the
-        UserBlock discipline: this block wraps itself, so a width change is a
-        content change and also a height change adaptive spacing depends on."""
+    def refresh_row(self) -> None:
+        """Repaint at the current width — the ledger's shared column moved."""
+        self._refresh_row()
+
+    def _refresh_row(self) -> None:
+        """Rebuild the card at its OWN width, matching :class:`WakeBlock`.
+
+        Finalization is bypassed deliberately: a resize, a hover, or an expand
+        must be able to re-fit a settled card, and the content it produces is a
+        pure function of the card's state, never new history.
+        """
+        from local_operator.tui.widgets.tool_card import FALLBACK_WIDTH
+
+        # Same ladder as `WakeBlock._refresh_row`, for the same reason: a row
+        # built before its first layout pass must fold at the width it is about
+        # to be given, not at the terminal's or at 80.
+        width = self.fold_width(0)
+        detached = False
+        if width <= 0:
+            try:
+                width = self.app.console.width
+            except Exception:
+                width = FALLBACK_WIDTH
+                detached = True
+        content = self._build_content(width)
+        self._row_count = max(1, len(content.plain.splitlines()))
+        if detached:
+            return
+        self._built_width = width
+        moved = self._row_count != self._applied_rows
+        self._applied_rows = self._row_count
         was_finalized = self._finalized
         self._finalized = False
         try:
-            self.set_content(self._build())
+            self.set_content(content, layout=moved)
         finally:
             self._finalized = was_finalized
+
+    def _name_col(self, width: int) -> int:
+        """The ledger's shared name column, in cells.
+
+        Read from the transcript rather than fixed here, because the column is
+        a spine: a peer receipt sitting between tool rows has to agree with
+        them or the ledger stops being a column.
+        """
+        from local_operator.tui.widgets.tool_card import NAME_COL, NAME_GROWTH_MIN_ROW
+
         parent = self.parent
-        if isinstance(parent, TranscriptView):
-            parent.refresh_gap_around(self)
+        if isinstance(parent, TranscriptView) and width >= NAME_GROWTH_MIN_ROW:
+            return parent.tool_name_col
+        return NAME_COL
 
-    def retheme(self) -> None:
-        """Re-ink rule, header and body from the current ramp."""
-        was_finalized = self._finalized
-        self._finalized = False
-        try:
-            self.set_content(self._build(), layout=False)
-        finally:
-            self._finalized = was_finalized
+    def _build_row(self, width: int) -> Text:
+        """The single summary row — the ONE-ROW guarantee lives here."""
+        from local_operator.tui.glyphs import display_name, tool_icon
+        from local_operator.tui.widgets.tool_card import (
+            _SUMMARY_FLOOR,
+            COLLAPSE_HINT,
+            EXPAND_HINT,
+            truncate_cells,
+        )
+
+        dim = Style(color=theme_mod.semantic_color("dim"))
+        muted = Style(color=theme_mod.semantic_color("muted"))
+        width = max(width - 2, 10)  # 1-cell inner padding each side (kit rule)
+
+        icon = tool_icon(self.tool_name)
+        label = display_name(self.tool_name)
+        name_budget = width - 4  # icon, its space, name's trailing space, 1 cell of summary
+        identity, snippet = self._summary()
+        if name_budget < 2:
+            row = Text(no_wrap=True, overflow="ellipsis")
+            row.append(icon + " ", style=dim)
+            return row
+
+        name_col = min(self._name_col(width), name_budget)
+        name = truncate_cells(label, name_col)
+        name = name + " " * max(0, name_col - cell_len(name))
+        prefix_cells = 2 + name_col + 1
+
+        slot = ""
+        remaining = max(0, width - prefix_cells)
+        if self._hovered or self._focused:
+            offer = COLLAPSE_HINT if self._expanded else EXPAND_HINT
+            if remaining - (cell_len(offer) + 1) >= _SUMMARY_FLOOR:
+                slot = offer
+        slot_cells = cell_len(slot) + 1 if slot else 0
+        budget = max(0, remaining - slot_cells)
+        # Identity first, snippet after the dash — one string, truncated from
+        # the right, so the free text is what sheds. See the class docstring.
+        composed = f"{identity} — {snippet}" if snippet else identity
+        summary = truncate_cells(composed, budget)
+
+        row = Text(no_wrap=True, overflow="ellipsis")
+        row.append(icon + " ", style=dim)
+        row.append(name + " ", style=muted)
+        row.append(summary, style=dim)
+        if slot:
+            used = cell_len(row.plain)
+            pad = max(1, width - used - cell_len(slot))
+            row.append(" " * pad, style=dim)
+            row.append(slot, style=dim)
+        return row
 
     def _body_rows(self, body: int) -> list[str]:
         """The message body wrapped to ``body`` cells, paragraphs preserved.
@@ -1954,39 +2102,54 @@ class PeerMessageBlock(TranscriptBlock):
             rows.pop()
         return rows
 
-    def _build(self) -> RenderableType:
-        """The sender header then the body, every row behind the ``↔`` gutter.
+    def _build_content(self, width: int) -> Text:
+        """The card: one summary row, plus sender identity and body when open.
 
-        Height is pinned to the row count for the same reason UserBlock pins
-        its own (an ``auto`` measurement caches the fallback-width build and
-        leaves a hole); this block authors its rows so it knows its height."""
-        rule_style = Style(color=theme_mod.semantic_color(self.RULE_TOKEN))
-        header_style = Style(color=theme_mod.semantic_color(self.HEADER_TOKEN))
-        text_style = Style(color=theme_mod.semantic_color(self.TEXT_TOKEN))
-        body = max((self.size.width or 80) - self.RULE_COLS, self.MIN_BODY)
-        gutter = self.RULE + " " * (self.RULE_COLS - cell_len(self.RULE))
+        The expansion answers the two questions the collapsed row cannot: WHO
+        exactly (name, pid, model — the fields the old always-on header
+        carried) and WHAT they said in full. The identity leads the body
+        because it is the shorter, fixed-shape fact; a blank row separates
+        them so a long message does not read as a continuation of the label.
+        """
+        from local_operator.tui.widgets.tool_card import OUTPUT_INDENT, truncate_cells
 
-        # The header is one wrapped paragraph; the body rows follow. EVERY
-        # header row is chrome, not just the first: an ordinary sender name
-        # wraps the header at 60-70 columns, and marking only row 0 meant
-        # dragging over a peer message copied app chrome above it ("…claude-
-        # opus-4)\ngates are green").
-        header_rows = wrap_cells(self._header(), body) or [""]
-        body_rows = self._body_rows(body)
-        self._header_rows = len(header_rows)
+        row = self._build_row(width)
+        if not self._expanded:
+            self._chrome_rows = 1
+            return row
 
-        rows: list[tuple[str, bool]] = [(row, True) for row in header_rows]
-        rows.extend((row, False) for row in body_rows)
-        self._set_authored_height(len(rows))
+        dim = Style(color=theme_mod.semantic_color("dim"))
+        text_style = Style(color=theme_mod.semantic_color("fg"))
+        line_width = max(1, width - 2 - OUTPUT_INDENT)
+        indent = " " * OUTPUT_INDENT
 
-        line = Text(no_wrap=True, overflow="ellipsis")
-        for index, (row, is_header) in enumerate(rows):
-            if index:
-                line.append("\n")
-            line.append(gutter, style=rule_style)
-            if row:
-                line.append(row, style=header_style if is_header else text_style)
-        return line
+        # Wrapped, not truncated: the identity is one paragraph, and at narrow
+        # widths a truncated pid is worse than a second row — it is the field a
+        # reader uses to address the peer back.
+        chrome = 1
+        for wrapped in wrap_cells(self._header(line_width), line_width) or [""]:
+            row.append("\n" + indent, style=dim)
+            row.append(truncate_cells(wrapped, line_width), style=dim)
+            chrome += 1
+        row.append("\n", style=dim)
+        chrome += 1
+        #: Everything above the body is the app's own furniture; the body is
+        #: the peer's words. `copy_row_is_chrome` reads this, so a drag over an
+        #: open receipt pastes the message and nothing else.
+        self._chrome_rows = chrome
+
+        for wrapped in self._body_rows(line_width):
+            row.append("\n" + indent, style=text_style)
+            row.append(truncate_cells(wrapped, line_width), style=text_style)
+        return row
+
+    def settled_rows(self) -> int:
+        """Rows settled now: one collapsed, the whole card when expanded."""
+        return self._row_count if self._finalized else 0
+
+    def spans_multiple_rows(self) -> bool:
+        """Exact: the card already tracks its own height, collapsed or not."""
+        return self._row_count > 1
 
 
 class RichBlock(TranscriptBlock):

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -58,6 +58,7 @@ from textual.selection import Selection
 from textual.widget import Widget
 from textual.widgets import Static
 
+from local_operator.ansi import strip_control_sequences
 from local_operator.harness.intent import ACTIVITY_THINKING
 from local_operator.tui import theme as theme_mod
 
@@ -1755,19 +1756,42 @@ def _sanitize_sender_field(value: object) -> str:
     Offending characters are dropped rather than escaped because the header is
     an identity label, not a place to display what an odd name contained.
     """
-    text = str(value or "")
     # Whitespace runs (newlines and tabs included) collapse to single spaces so
-    # the header stays exactly one paragraph.
-    text = " ".join(text.split())
-    # C0/C1 controls AND Unicode format characters. `unicodedata.category` is
-    # what makes the Cf class exhaustive — an explicit codepoint list would
-    # miss the next bidi control someone finds.
-    text = "".join(
+    # the header stays exactly one paragraph. AFTER the strip, because
+    # stripping can expose a newline that sat inside a sequence's payload.
+    return " ".join(_sanitize_line(value).split())[:_SENDER_FIELD_MAX_CHARS]
+
+
+def _sanitize_line(value: object) -> str:
+    """Drop control sequences and Cf from ``value``; keep every printable char.
+
+    The shared half of the two sanitizers on this spine, so the sender fields
+    and the message snippet cannot drift apart in what they consider unsafe —
+    which is how the block ended up stripping a hostile conversation name and
+    painting a hostile message body on the same row.
+
+    Control-sequence removal is :func:`local_operator.ansi.
+    strip_control_sequences`, the helper the tool ledger already uses
+    (``tool_card.py`` aliases the same function). It removes the WHOLE
+    sequence rather than only its ``ESC``, so an injected ``\\x1b[31m`` leaves
+    nothing rather than a literal ``[31m`` for the reader to puzzle over.
+
+    Cf is dropped on top of that, because a format character is not a control
+    sequence and survives the strip: ``U+202E`` and friends reorder the glyphs
+    AROUND them, which is how a bidi override visibly scrambled a pid — the
+    one field a reader uses to address the peer back.
+    ``unicodedata.category`` is what makes the class exhaustive; an explicit
+    codepoint list would miss the next bidi control someone finds.
+
+    Newlines and tabs deliberately SURVIVE here (``strip_control_sequences``
+    keeps them for multi-line tool output). Every caller on this spine renders
+    one row, so each collapses whitespace itself.
+    """
+    return "".join(
         char
-        for char in text
-        if ord(char) >= 32 and not 0x7F <= ord(char) <= 0x9F and unicodedata.category(char) != "Cf"
+        for char in strip_control_sequences(str(value or ""))
+        if unicodedata.category(char) != "Cf"
     )
-    return text[:_SENDER_FIELD_MAX_CHARS]
 
 
 class PeerMessageBlock(ExpandableActionBlock):
@@ -1817,9 +1841,13 @@ class PeerMessageBlock(ExpandableActionBlock):
     #: peer session reached in. The icon carries the direction.
     tool_name = "peer"
 
-    #: Kept for the expansion's identity line, which is the one place the old
-    #: header's information still belongs. The wrapping there is the card's,
-    #: so this is only the floor for the fit test in :meth:`_header`.
+    #: Floor for the width the expansion reasons about, in cells. Two uses,
+    #: which must agree or the card contradicts itself: :meth:`_header`'s
+    #: model-fit test (does the model label still leave the identity on one
+    #: row?) and :meth:`_build_content`'s wrap width. Without the second, a
+    #: pane a few cells wide wrapped a short body to 40 rows while the
+    #: collapsed row stayed correctly clamped at 1 — a floor on the fit test
+    #: alone is a floor on half the arithmetic.
     MIN_BODY = 8
 
     def __init__(self, body: str, sender: dict[str, object] | None = None) -> None:
@@ -1884,33 +1912,78 @@ class PeerMessageBlock(ExpandableActionBlock):
             return session_id[:8], False
         return "", False
 
-    def _header(self, width: int | None = None) -> str:
-        """The full sender label: 'peer message from "<name>" (pid N, <model>)'.
+    def _sender_pid(self) -> str:
+        """The sending session's pid as bounded, single-line text, or ``""``.
 
-        This is the EXPANSION's identity line — the information the collapsed
-        row cannot hold and the operator asked to see on expand. Every field is
-        advisory (a leaner sender omits some), so the label is assembled from
-        whatever is present and never assumes a key exists.
+        ``pid`` reads like the one field that could not be hostile — it is a
+        number — but nothing on the wire ever makes it one. It arrives as
+        ``dict[str, Any]`` (``harness/types.py``), the inbox validates the
+        sender's dict SHAPE and not its values
+        (``session/runtime/inbox.py``), and ``resolve_sender_identity``
+        returns early on a non-int pid rather than repairing it, so a peer's
+        ``{"pid": "42\\nROW-A\\nROW-B"}`` reaches this widget verbatim.
+
+        That made it the only advisory field skipping
+        :func:`_sanitize_sender_field`, on BOTH render paths — and it is the
+        field the pre-existing hostile-input test happened to pass a clean
+        value for, which is exactly why it survived. Newlines in it produced
+        a card whose ``_row_count``/:meth:`settled_rows` reported 3 against a
+        CSS-pinned 1-row widget, and pushed two rows of the app's own label
+        past :meth:`copy_row_is_chrome` into the clipboard.
+
+        Sanitized like every sibling rather than coerced to ``int``: a
+        rejected pid would silently erase an address the reader could
+        otherwise still act on, and this widget's job is to render what
+        arrived, safely. Falsy result means "no usable pid", which is why the
+        callers test truthiness rather than ``is not None`` — an empty string
+        is what a pid of pure control characters sanitizes down to.
+        """
+        pid = self._sender.get("pid")
+        return "" if pid is None else _sanitize_sender_field(pid)
+
+    def _header(self, width: int | None = None) -> str:
+        """The expansion's identity line: '"<name>" · pid N · <model>'.
+
+        This is the information the collapsed row cannot hold and the operator
+        asked to see on expand. Every field is advisory (a leaner sender omits
+        some), so the label is assembled from whatever is present and never
+        assumes a key exists.
+
+        **No ``peer message from`` prose.** The line used to open with it, and
+        at the seam that made three consecutive lines all restate the same
+        thing — the summary row says the name, the identity line repeated the
+        name inside a sentence, and the body below repeated the summary's
+        opening words. What the expansion actually ADDS is the pid and the
+        model, and those were the two facts buried mid-sentence. The icon, the
+        ``peer`` name column and the card the reader just opened all already
+        say this is an inbound peer message; spending the line's first 18
+        cells saying it a fourth time pushed the new information right.
+
+        The separator is `·`, the same structural glyph the summary row and
+        the neighbouring ``send`` row use, so one card does not carry two
+        punctuation vocabularies.
 
         ``width`` is the body width the caller will wrap this at; it defaults
-        to the block's own, which is what the pre-card call sites and the
-        degradation tests pass.
+        to the block's own, which is what the degradation tests pass.
         """
         name, quoted = self._sender_name()
-        pid = self._sender.get("pid")
+        pid = self._sender_pid()
         model = _sanitize_sender_field(self._sender.get("model_label"))
         bits: list[str] = []
-        if pid is not None:
+        if pid:
             bits.append(f"pid {pid}")
 
         def _compose(parts: list[str]) -> str:
-            detail = f" ({', '.join(parts)})" if parts else ""
             if name:
                 label = f'"{name}"' if quoted else name
-                return f"peer message from {label}{detail}"
+                return " · ".join([label, *parts])
             if parts:
-                return f"peer message from{detail}"
-            return "peer message from another session"
+                return " · ".join(parts)
+            # Nothing identifying at all. The one case that still needs prose,
+            # because a bare `·`-joined empty list says nothing — and it shares
+            # the wording `_summary` falls back to, and `harness/comms.py`
+            # before it, so the three do not drift.
+            return "another session"
 
         header = _compose(bits)
         if not model:
@@ -1949,12 +2022,37 @@ class PeerMessageBlock(ExpandableActionBlock):
         if name:
             identity = f'"{name}"' if quoted else name
         else:
-            pid = self._sender.get("pid")
-            identity = f"pid {pid}" if pid is not None else "another session"
-        # Newlines collapse to spaces: the snippet is one row by construction,
-        # and an authored break inside it would be measured into a word's width
-        # and then printed literally mid-row.
-        snippet = " ".join(self._text.split())
+            pid = self._sender_pid()
+            # "another session" is the same fallback vocabulary
+            # `harness/comms.py` uses when it cannot name a peer either; keep
+            # the two spellings identical so a reader meeting one in a
+            # transcript and one in a tool result does not think they are
+            # different states.
+            identity = f"pid {pid}" if pid else "another session"
+        # The SNIPPET is stripped of control sequences and Cf; the body is not.
+        #
+        # `text()` and the expansion must stay byte-verbatim or `/copy` stops
+        # returning what the peer actually wrote, which is the whole point of
+        # the block. But the snippet is a summary the app composes onto a
+        # `height: 1` pinned row on the shared ledger spine, and that is a
+        # different contract: `ESC[2K` + `ESC[1A` (erase-line, cursor-up) is
+        # how a row escapes its pinned box and repaints the receipts above it
+        # — `ansi.py` names that pair the highest-value forgery target the app
+        # has. Rich also mis-measures an escape (`cell_len` reported 16 for a
+        # 17-character string), so the arithmetic the one-row guarantee rests
+        # on is computed against a wrong count.
+        #
+        # `ToolCard` already strips exactly this on exactly this row, for the
+        # reason its own comment gives: a name rendered on every row can clear
+        # the terminal without the tool having run. Two summaries on one spine
+        # treating one trust boundary two opposite ways is the drift; this is
+        # the shared helper, not a second implementation.
+        #
+        # Order matters: strip FIRST, then collapse whitespace. Stripping can
+        # expose a newline that was inside an escape's payload, and collapsing
+        # first would leave it to be measured into a word's width and printed
+        # literally mid-row.
+        snippet = " ".join(_sanitize_line(self._text).split())
         return identity, snippet
 
     def on_resize(self, event) -> None:  # type: ignore[no-untyped-def]
@@ -2051,6 +2149,20 @@ class PeerMessageBlock(ExpandableActionBlock):
         name_budget = width - 4  # icon, its space, name's trailing space, 1 cell of summary
         identity, snippet = self._summary()
         if name_budget < 2:
+            # UNREACHABLE as the arithmetic stands, and kept deliberately.
+            # `width` is clamped to >= 10 two lines above, so `name_budget` is
+            # floored at 6 and this branch cannot be entered from any pane
+            # size — verified by sweeping `_build_row` from 1 to 8 cells, every
+            # one of which renders the normal degraded row (`<icon> peer …`)
+            # rather than this one.
+            #
+            # It is a structural guard on the arithmetic BELOW it, not a width
+            # case: `truncate_cells(label, name_col)` and the `prefix_cells`
+            # sum assume a name column of at least a cell or two, and a future
+            # change to the clamp or to the padding rule would reach them with
+            # a negative budget. `WakeBlock` carries the identical guard for
+            # the identical reason; removing it here alone would make the two
+            # rows disagree about their own floor.
             row = Text(no_wrap=True, overflow="ellipsis")
             row.append(icon + " ", style=dim)
             return row
@@ -2068,9 +2180,21 @@ class PeerMessageBlock(ExpandableActionBlock):
                 slot = offer
         slot_cells = cell_len(slot) + 1 if slot else 0
         budget = max(0, remaining - slot_cells)
-        # Identity first, snippet after the dash — one string, truncated from
+        # Identity first, snippet after the seam — one string, truncated from
         # the right, so the free text is what sheds. See the class docstring.
-        composed = f"{identity} — {snippet}" if snippet else identity
+        #
+        # The seam is `·`, NOT an em-dash, and that is about the content this
+        # row actually carries. Agent-to-agent prose in this project is full
+        # of em-dashes (every peer broadcast in the capture frames contains
+        # one), so an em-dash seam put the same glyph in a structural role and
+        # a prose role on one line with nothing to tell the eye which was
+        # which: `"lo-usage-panel" — my PR #744 merged — Release: patch`.
+        # `·` is the separator the neighbouring `send` row already reserves
+        # for structure (`_send_summary`'s `" · ".join`), and prose does not
+        # contain it — so the two halves of one cross-session conversation
+        # gain a shared punctuation vocabulary to go with their mirrored
+        # icons, and the seam survives its own content.
+        composed = f"{identity} · {snippet}" if snippet else identity
         summary = truncate_cells(composed, budget)
 
         row = Text(no_wrap=True, overflow="ellipsis")
@@ -2119,8 +2243,18 @@ class PeerMessageBlock(ExpandableActionBlock):
             return row
 
         dim = Style(color=theme_mod.semantic_color("dim"))
+        # The identity line is a HEADER, so it takes the middle step of the
+        # ramp: summary `dim` -> identity `muted` -> body `fg`. Rendered at
+        # `dim` it was the same ink as the summary row above it, so it read as
+        # a dimmer continuation of the headline rather than as the header of
+        # the block below, leaving the blank row to do all the structural work
+        # on its own.
+        header_style = Style(color=theme_mod.semantic_color("muted"))
         text_style = Style(color=theme_mod.semantic_color("fg"))
-        line_width = max(1, width - 2 - OUTPUT_INDENT)
+        # Floored at MIN_BODY so the wrap width and `_header`'s fit test
+        # reason about the same minimum: unfloored this reached 1 cell and
+        # turned a two-line note into 40 rows of one-character columns.
+        line_width = max(width - 2 - OUTPUT_INDENT, self.MIN_BODY)
         indent = " " * OUTPUT_INDENT
 
         # Wrapped, not truncated: the identity is one paragraph, and at narrow
@@ -2128,8 +2262,8 @@ class PeerMessageBlock(ExpandableActionBlock):
         # reader uses to address the peer back.
         chrome = 1
         for wrapped in wrap_cells(self._header(line_width), line_width) or [""]:
-            row.append("\n" + indent, style=dim)
-            row.append(truncate_cells(wrapped, line_width), style=dim)
+            row.append("\n" + indent, style=header_style)
+            row.append(truncate_cells(wrapped, line_width), style=header_style)
             chrome += 1
         row.append("\n", style=dim)
         chrome += 1
@@ -2138,7 +2272,22 @@ class PeerMessageBlock(ExpandableActionBlock):
         #: open receipt pastes the message and nothing else.
         self._chrome_rows = chrome
 
-        for wrapped in self._body_rows(line_width):
+        # A peer that sent nothing (or only whitespace) has no body worth
+        # painting: `_body_rows` always returns at least one entry, so an empty
+        # message rendered as a blank indented line under the blank separator —
+        # an expand affordance that promised detail and delivered two rows of
+        # whitespace. The identity line still justifies the expansion, since
+        # the pid and model are exactly what the collapsed row cannot carry.
+        #
+        # Only TRAILING blanks are dropped, never interior ones: a blank row
+        # between two paragraphs is the break the peer typed, and filtering
+        # every empty row would silently reflow their message into one block.
+        body_rows = self._body_rows(line_width)
+        while body_rows and not body_rows[-1].strip():
+            body_rows.pop()
+        if not body_rows:
+            return row
+        for wrapped in body_rows:
             row.append("\n" + indent, style=text_style)
             row.append(truncate_cells(wrapped, line_width), style=text_style)
         return row

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -1733,6 +1733,18 @@ class WakeBlock(ExpandableActionBlock):
 #: own the viewport.
 _SENDER_FIELD_MAX_CHARS = 120
 
+#: How much of a peer's message body is fed to the collapsed row's preview.
+#:
+#: NOT a display cap — the row truncates itself to the width it is given, and a
+#: second truncation rule beside that one would be a defect. This bounds the
+#: WORK: both the sanitize and `truncate_cells` walk the string handed to them,
+#: and a peer body is capped on the wire at `PEER_MESSAGE_MAX_BYTES` (256 KiB),
+#: which is four orders of magnitude more text than a single row can show.
+#: Chosen far above any reachable row (the widest terminal times the widest
+#: name column is still a few hundred cells) so it can never be the thing that
+#: decides what a reader sees, while keeping the per-repaint cost flat.
+_SNIPPET_SOURCE_MAX_CHARS = 4096
+
 
 def _sanitize_sender_field(value: object) -> str:
     """One line of bounded, plain text from an advisory sender field.
@@ -1784,8 +1796,10 @@ def _sanitize_line(value: object) -> str:
     codepoint list would miss the next bidi control someone finds.
 
     Newlines and tabs deliberately SURVIVE here (``strip_control_sequences``
-    keeps them for multi-line tool output). Every caller on this spine renders
-    one row, so each collapses whitespace itself.
+    keeps them for multi-line tool output) — this function is not what makes a
+    string single-line. Every caller on this spine renders ONE row and collapses
+    whitespace itself immediately after, so no newline reaches a row; a future
+    caller that skips the collapse would need its own.
     """
     return "".join(
         char
@@ -1865,6 +1879,42 @@ class PeerMessageBlock(ExpandableActionBlock):
         #: with the frame (the discipline the old header row count followed,
         #: and ``UserBlock._receipt_row`` before it).
         self._chrome_rows: int = 1
+        #: The collapsed row's preview of the body, sanitized and flattened
+        #: ONCE here rather than on every repaint.
+        #:
+        #: `_refresh_row` runs on hover, focus, expand/collapse, `retheme`,
+        #: `on_resize` AND `_invalidate_name_col` — and that last one repaints
+        #: every ledger block when the shared name column moves, so one peer
+        #: card's cost is paid by the whole ledger. The strip is a regex plus a
+        #: per-character `unicodedata.category` scan, and it runs over the
+        #: WHOLE body while all but one row of the result is discarded. The
+        #: body is not small by contract: `PEER_MESSAGE_MAX_BYTES` is 256 KiB,
+        #: which measured 23.9 ms of loop-thread CPU per repaint — real CPU on
+        #: the event loop, not scheduling noise (`time.thread_time`, the
+        #: measure AGENTS.md's timing section calls the honest one here).
+        #:
+        #: This mirrors `ToolCard`, which strips once at construction rather
+        #: than per paint — the precedent the snippet strip was modelled on,
+        #: and the half of it this class had not copied. Safe to cache because
+        #: `_text` is assigned once and never mutated; a block whose body
+        #: changed would need a new block, as every other transcript receipt
+        #: does.
+        #:
+        #: Order matters: strip FIRST, then collapse whitespace. Stripping can
+        #: expose a newline that was inside an escape's payload, and collapsing
+        #: first would leave it to be measured into a word's width and printed
+        #: literally mid-row.
+        #:
+        #: Sliced before sanitizing, and the slice is deliberately far larger
+        #: than any row: `truncate_cells` walks the string it is given, so a
+        #: 256 KiB snippet cost 0.89 ms per repaint even once the strip was
+        #: cached. `_SNIPPET_SOURCE_MAX_CHARS` cells cannot be reached by a row
+        #: (`TOOL_NAME_COL_MAX` plus a terminal's width is orders of magnitude
+        #: below it), so this bounds the work without being a second truncation
+        #: rule that could disagree with the row's own. Only the PREVIEW is
+        #: bounded \u2014 `text()` and the expansion read `_text` directly, so
+        #: `/copy` and the opened card stay byte-verbatim.
+        self._snippet = " ".join(_sanitize_line(body[:_SNIPPET_SOURCE_MAX_CHARS]).split())
         self._row_count = 1
         self._applied_rows = -1
         self._built_width = -1
@@ -2048,12 +2098,10 @@ class PeerMessageBlock(ExpandableActionBlock):
         # treating one trust boundary two opposite ways is the drift; this is
         # the shared helper, not a second implementation.
         #
-        # Order matters: strip FIRST, then collapse whitespace. Stripping can
-        # expose a newline that was inside an escape's payload, and collapsing
-        # first would leave it to be measured into a word's width and printed
-        # literally mid-row.
-        snippet = " ".join(_sanitize_line(self._text).split())
-        return identity, snippet
+        # Computed ONCE in `__init__` (see :attr:`_snippet`), not here: this
+        # method runs on every repaint, and the strip is ~20x the cost of the
+        # whitespace collapse it replaced.
+        return identity, self._snippet
 
     def on_resize(self, event) -> None:  # type: ignore[no-untyped-def]
         """Re-fit the card at the new width (same guard as the tool card)."""
@@ -2191,9 +2239,24 @@ class PeerMessageBlock(ExpandableActionBlock):
         # which: `"lo-usage-panel" — my PR #744 merged — Release: patch`.
         # `·` is the separator the neighbouring `send` row already reserves
         # for structure (`_send_summary`'s `" · ".join`), and prose does not
-        # contain it — so the two halves of one cross-session conversation
-        # gain a shared punctuation vocabulary to go with their mirrored
-        # icons, and the seam survives its own content.
+        # contain it — measured at 1921 em-dashes against 89 interpuncts
+        # (21.6:1) across this tree's markdown — so the two halves of one
+        # cross-session conversation gain a shared punctuation vocabulary to go
+        # with their mirrored icons, and the seam survives its own content.
+        #
+        # Two known residual collisions, both looked at in a rendered frame and
+        # both judged safe, recorded so the next reader does not re-derive them:
+        #
+        # - A peer QUOTING a ledger row relays `·`-joined text, so a structural
+        #   and a quoted separator can share a line. This is the em-dash problem
+        #   at 21.6x lower frequency, and the quoted name still delimits the
+        #   seam; it is not worth a third glyph.
+        # - `·` is also `NOTICE_GLYPHS["info"]`, and `_SPINNER`'s docstring in
+        #   this file records a real defect from that collision — a `"· "` head
+        #   painted in the same dim ink at the same column as an info notice.
+        #   This use does not repeat it: the notice's glyph LEADS its row in the
+        #   icon column, while this one sits mid-row inside a card band the
+        #   notice does not have, so the two never align.
         composed = f"{identity} · {snippet}" if snippet else identity
         summary = truncate_cells(composed, budget)
 
@@ -2265,12 +2328,6 @@ class PeerMessageBlock(ExpandableActionBlock):
             row.append("\n" + indent, style=header_style)
             row.append(truncate_cells(wrapped, line_width), style=header_style)
             chrome += 1
-        row.append("\n", style=dim)
-        chrome += 1
-        #: Everything above the body is the app's own furniture; the body is
-        #: the peer's words. `copy_row_is_chrome` reads this, so a drag over an
-        #: open receipt pastes the message and nothing else.
-        self._chrome_rows = chrome
 
         # A peer that sent nothing (or only whitespace) has no body worth
         # painting: `_body_rows` always returns at least one entry, so an empty
@@ -2285,15 +2342,41 @@ class PeerMessageBlock(ExpandableActionBlock):
         body_rows = self._body_rows(line_width)
         while body_rows and not body_rows[-1].strip():
             body_rows.pop()
-        if not body_rows:
-            return row
+
+        # The separator is appended ONLY once a body is known to follow, and
+        # that ordering is the whole finding. Appending it first left an empty
+        # card ending on a dangling "\n": Rich paints a row for it and
+        # `str.splitlines()` does not count one, so the card painted 3 rows
+        # while `_row_count`/`settled_rows()` reported 2 and `_chrome_rows`
+        # (3) exceeded the row count it is supposed to index into. That is the
+        # same self-contradiction about its own height that this class's
+        # hostile-pid fix closed one commit earlier — a separator with nothing
+        # under it is furniture for a body that does not exist.
+        if body_rows:
+            row.append("\n", style=dim)
+            chrome += 1
+        #: Everything above the body is the app's own furniture; the body is
+        #: the peer's words. `copy_row_is_chrome` reads this, so a drag over an
+        #: open receipt pastes the message and nothing else.
+        self._chrome_rows = chrome
+
         for wrapped in body_rows:
             row.append("\n" + indent, style=text_style)
             row.append(truncate_cells(wrapped, line_width), style=text_style)
         return row
 
     def settled_rows(self) -> int:
-        """Rows settled now: one collapsed, the whole card when expanded."""
+        """Rows settled now: one collapsed, the whole card when expanded.
+
+        The ``_finalized`` gate is defensive and cannot be observed False:
+        ``__init__`` calls :meth:`finalize` unconditionally, so the block is
+        finalized before any caller can hold a reference to it. Mutating the
+        gate away therefore leaves the suite green — that is an EQUIVALENT
+        mutant rather than a missing guard, so do not go hunting for a test to
+        write for it. The gate stays because it is :class:`WakeBlock`'s
+        contract for this method and the two ledger cards are read side by
+        side; the count itself IS guarded, and a constant return goes red.
+        """
         return self._row_count if self._finalized else 0
 
     def spans_multiple_rows(self) -> bool:

--- a/scripts/peer_message_shot.py
+++ b/scripts/peer_message_shot.py
@@ -1,0 +1,193 @@
+"""Capture an inbound peer-message receipt in a realistic transcript.
+
+Run from the worktree root:
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/peer_message_shot.py OUT.svg [COLSxROWS] [SHAPE] [ICONS]
+
+``SHAPE`` selects what the peer receipt is doing, because the two states are
+what the card has to be judged on together — a collapsed row that reads well
+but hides the message, or an expansion that buries the ledger, are each a
+failure the other frame does not show:
+
+    collapsed  (default)  every receipt closed: the ONE-ROW guarantee
+    expanded              the long receipt opened: sender detail + full body
+
+``ICONS`` is ``nerd`` (default) or ``plain``. The gate reads the environment at
+row-build time and this capture runs under an isolated HOME, so a marker has to
+be seeded here or every frame silently shows the ASCII fallback — which is not
+the frame the operator sees in cmux (it embeds ghostty).
+
+The seeded tree deliberately puts TOOL rows on both sides of the peer receipt.
+The card claims to share the ledger spine — same name column, same air above
+and below — and a frame with nothing to align against cannot show whether it
+does.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.visual_capture import isolate_capture, save_capture  # noqa: E402
+
+isolate_capture()
+
+
+def _seed_env(mode: str) -> None:
+    """Force the icon gate into ``mode`` BEFORE the app is imported.
+
+    Same technique (and the same marker list) as ``nerd_glyph_shot.py``: the
+    gate has no interactive probe, it reads exactly these variables, and the
+    first glyph lookup caches nothing but is resolved against whatever the env
+    says at that moment.
+    """
+    for var in (
+        "GHOSTTY_RESOURCES_DIR",
+        "GHOSTTY_BIN",
+        "KITTY_WINDOW_ID",
+        "WEZTERM_PANE",
+        "WEZTERM_EXECUTABLE",
+        "TERM_PROGRAM",
+        "LOCAL_OPERATOR_NO_NERD_ICONS",
+    ):
+        os.environ.pop(var, None)
+    if mode == "nerd":
+        os.environ["GHOSTTY_BIN"] = "/usr/local/bin/ghostty"
+    else:
+        os.environ["TERM_PROGRAM"] = "Apple_Terminal"
+
+
+_seed_env(sys.argv[4] if len(sys.argv) > 4 else "nerd")
+
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.widgets.assistant import AssistantBlock  # noqa: E402
+from local_operator.tui.widgets.tool_card import ToolCard  # noqa: E402
+from local_operator.tui.widgets.transcript import (  # noqa: E402
+    PeerMessageBlock,
+    UserBlock,
+)
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+#: The shape the operator reported: a multi-paragraph release-window
+#: announcement from a peer session. Verbatim-length prose, because the whole
+#: complaint is how many rows one of these costs at body weight.
+LONG_PEER_BODY = """I am claiming the current release window as owner (pid 48213).
+
+Window contents so far: #744 (fix: retainable cost estimate), #751 (fix: \
+tombstone dead OAuth grants instead of re-spending them), and #747 once its \
+QA round lands. If your PR merged since v0.50.3 and is not on that list, send \
+me the PR number, the merge SHA and your Release: line and I will fold it in.
+
+I am arguing patch for the whole window: none of the three clears the \
+step-function bar on its own, and three patches merged in the same hour are \
+still one patch release. Say so now if you disagree — once the bump PR is \
+open the number is decided.
+
+Do not start a second release. If you were about to cut one, close your bump \
+PR, delete its branch, and hand me the contents."""
+
+SHORT_PEER_BODY = "gates are green on #751 — merging now"
+
+LONG_SENDER = {
+    "pid": 48213,
+    "conversation_name": "lo-release-window",
+    "model_label": "anthropic/claude-opus-5",
+}
+SHORT_SENDER = {
+    "pid": 1174,
+    "conversation_name": "lo-mcp-oauth-tombstone",
+    "model_label": "anthropic/claude-opus-5",
+}
+
+
+def _answer(text: str) -> AssistantBlock:
+    """A SETTLED answer — `finalize_text` is what the stream does at message
+    end, and an unsettled block keeps its live-turn ink."""
+    block = AssistantBlock()
+    block.update_text(text)
+    block.finalize_text()
+    return block
+
+
+def _tool(app: OperatorApp, call_id: str, name: str, args: dict[str, object], result: str) -> None:
+    """Append a FINISHED tool row, so the ledger around the receipt is settled
+    ink rather than the live-turn accent. ``mark_done`` runs after the mount
+    because a card settles in place (the pattern ``theme_preview.py`` uses)."""
+    card = ToolCard(call_id, name, args)
+    app._append_block(card)
+    card.mark_done(result)
+
+
+def _seed(app: OperatorApp) -> list[PeerMessageBlock]:
+    app._append_block(UserBlock("what is left before we can cut the release?"))
+    app._append_block(
+        _answer("Two PRs are still in review. Checking what has merged since the tag.")
+    )
+    _tool(
+        app,
+        "t1",
+        "bash",
+        {"command": "git log --oneline v0.50.3..origin/main"},
+        "2 commits",
+    )
+
+    long_block = PeerMessageBlock(LONG_PEER_BODY, LONG_SENDER)
+    app._append_block(long_block)
+
+    _tool(
+        app,
+        "t2",
+        "send",
+        {"target": "lo-release-window", "message": "ack — folding #751 into your window"},
+        "delivered",
+    )
+
+    short_block = PeerMessageBlock(SHORT_PEER_BODY, SHORT_SENDER)
+    app._append_block(short_block)
+
+    app._append_block(_answer("A peer already owns the window, so I have handed it our PR."))
+    return [long_block, short_block]
+
+
+async def main() -> None:
+    out = sys.argv[1]
+    size = (100, 30)
+    if len(sys.argv) > 2:
+        cols, rows = sys.argv[2].split("x")
+        size = (int(cols), int(rows))
+    shape = sys.argv[3] if len(sys.argv) > 3 else "collapsed"
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=size) as pilot:
+        await pilot.pause()
+        blocks = _seed(app)
+        await pilot.pause()
+
+        if shape == "expanded":
+            # `toggle_expanded` exists only once the receipt is a ledger card.
+            # Tolerating its absence is what lets the SAME script take the
+            # before-frame from a checkout that predates the card.
+            toggle = getattr(blocks[0], "toggle_expanded", None)
+            if callable(toggle):
+                toggle()
+            await pilot.pause()
+
+        # A second settled frame: a first paint that differs from this one is a
+        # reflow the user sees as motion (AGENTS.md, "Animation and multi-frame
+        # changes").
+        await pilot.pause()
+        screen = app.screen
+        print(
+            f"size={screen.size} virtual={screen.virtual_size} "
+            f"vscroll={screen.show_vertical_scrollbar}",
+            file=sys.stderr,
+        )
+        save_capture(app, out)
+
+
+asyncio.run(main())

--- a/scripts/peer_message_shot.py
+++ b/scripts/peer_message_shot.py
@@ -12,6 +12,13 @@ failure the other frame does not show:
 
     collapsed  (default)  every receipt closed: the ONE-ROW guarantee
     expanded              the long receipt opened: sender detail + full body
+    empty                 an EMPTY-body receipt, opened — the degenerate case
+
+The ``empty`` shape exists because that branch is the one an ordinary body
+never takes, and it has now carried two defects in a row: first a dangling
+blank row the expansion promised detail and delivered whitespace for, then a
+separator with nothing under it that made the card paint one more row than it
+reported. A frame is the only instrument that shows either.
 
 ``ICONS`` is ``nerd`` (default) or ``plain``. The gate reads the environment at
 row-build time and this capture runs under an isolated HOME, so a marker has to
@@ -154,6 +161,36 @@ def _seed(app: OperatorApp) -> list[PeerMessageBlock]:
     return [long_block, short_block]
 
 
+def _seed_empty(app: OperatorApp) -> list[PeerMessageBlock]:
+    """Three degenerate bodies between ordinary ledger rows.
+
+    Empty, whitespace-only and a body that is nothing but blank lines all reach
+    the same branch by different routes, and the frame has to show that each
+    ends on its identity line rather than on painted whitespace.
+    """
+    app._append_block(UserBlock("did anything come in while I was away?"))
+    _tool(app, "t1", "bash", {"command": "lop sessions"}, "3 live")
+    blocks = [
+        PeerMessageBlock(body, sender)
+        for body, sender in (
+            (
+                "",
+                {
+                    "pid": 9,
+                    "conversation_name": "lo-empty",
+                    "model_label": "anthropic/claude-opus-5",
+                },
+            ),
+            ("   \n\n  ", {"pid": 11, "conversation_name": "lo-whitespace"}),
+            ("\n\n\n", {"pid": 13, "cwd": "/Users/x/lo-newlines"}),
+        )
+    ]
+    for block in blocks:
+        app._append_block(block)
+    app._append_block(_answer("Three peers reached in with nothing to say."))
+    return blocks
+
+
 async def main() -> None:
     out = sys.argv[1]
     size = (100, 30)
@@ -165,10 +202,18 @@ async def main() -> None:
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=size) as pilot:
         await pilot.pause()
-        blocks = _seed(app)
+        blocks = _seed_empty(app) if shape == "empty" else _seed(app)
         await pilot.pause()
 
-        if shape == "expanded":
+        if shape == "empty":
+            # Every degenerate card opened at once: the point of the frame is
+            # that none of them ends on a painted blank row.
+            for block in blocks:
+                toggle = getattr(block, "toggle_expanded", None)
+                if callable(toggle):
+                    toggle()
+            await pilot.pause()
+        elif shape == "expanded":
             # `toggle_expanded` exists only once the receipt is a ledger card.
             # Tolerating its absence is what lets the SAME script take the
             # before-frame from a checkout that predates the card.

--- a/tests/unit/tui/test_minimalism.py
+++ b/tests/unit/tui/test_minimalism.py
@@ -48,13 +48,17 @@ def test_tcss_pins_card_and_band_heights_rather_than_leaving_them_auto() -> None
     to be taller than one row.
     """
     text = TCSS.read_text()
-    # ToolCard and WakeBlock share the pin: a wake receipt is a ledger row,
-    # and leaving it on `auto` would be the same first-measurement-sticks-at-
-    # two-rows failure the ToolCard pin exists to stop. Combined selectors
-    # so the two cannot drift.
-    tool_block = re.search(r"^ToolCard,\s*WakeBlock\s*\{([^}]*)\}", text, re.MULTILINE)
+    # ToolCard, WakeBlock and PeerMessageBlock share the pin: a wake receipt
+    # and an inbound peer receipt are both ledger rows, and leaving either on
+    # `auto` would be the same first-measurement-sticks-at-two-rows failure the
+    # ToolCard pin exists to stop. Combined selectors so the three cannot
+    # drift.
+    tool_block = re.search(
+        r"^ToolCard,\s*WakeBlock,\s*PeerMessageBlock\s*\{([^}]*)\}", text, re.MULTILINE
+    )
     expanded = re.search(
-        r"^ToolCard\.tool-expanded,\s*WakeBlock\.wake-expanded\s*\{([^}]*)\}",
+        r"^ToolCard\.tool-expanded,\s*WakeBlock\.wake-expanded,\s*"
+        r"PeerMessageBlock\.peer-expanded\s*\{([^}]*)\}",
         text,
         re.MULTILINE,
     )
@@ -76,7 +80,7 @@ def test_block_selectors_declare_no_margin_or_padding() -> None:
     text = TCSS.read_text()
     match = re.search(
         r"^TranscriptBlock,\s*UserBlock,\s*NoticeBlock,\s*RichBlock,\s*"
-        r"AssistantBlock,\s*ToolCard,\s*WakeBlock\s*\{([^}]*)\}",
+        r"AssistantBlock,\s*ToolCard,\s*WakeBlock,\s*PeerMessageBlock\s*\{([^}]*)\}",
         text,
         re.MULTILINE,
     )

--- a/tests/unit/tui/test_peer_message.py
+++ b/tests/unit/tui/test_peer_message.py
@@ -1,9 +1,18 @@
 """TUI rendering of inbound peer messages (`lop send`).
 
-Two paths, mirroring the wake receipt: a LIVE delivery paints a
+Two delivery paths, mirroring the wake receipt: a LIVE delivery paints a
 ``PeerMessageBlock`` the instant the event lands, and a resumed conversation
 REPLAYS a persisted ``peer_message`` custom row as the same block — without
 double-painting one already shown live this session.
+
+The block itself is a ledger CARD (``ExpandableActionBlock``), not the
+rule-and-header block it started as. Cross-session traffic became routine
+enough that a receipt printing its whole body cost 15 rows for one realistic
+release-window announcement, and two of those pushed the conversation off
+screen. ``TestPeerCard`` onward pins the card's contract: one row closed, the
+sender named on it, full identity and full body on expand — and the sender
+fields, which cross the wire from another process, still hardened exactly as
+they were.
 """
 
 from __future__ import annotations
@@ -11,12 +20,41 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
+from rich.cells import cell_len
 
 from local_operator.harness.types import PeerMessageDeliveredEvent
 from local_operator.session.peer import PEER_MESSAGE_MESSAGE_TYPE
 from local_operator.tui.app import OperatorApp
-from local_operator.tui.widgets.transcript import PeerMessageBlock, TranscriptView
+from local_operator.tui.glyphs import tool_icon
+from local_operator.tui.widgets.tool_card import (
+    COLLAPSE_HINT,
+    EXPAND_HINT,
+    OUTPUT_INDENT,
+)
+from local_operator.tui.widgets.transcript import (
+    ExpandableActionBlock,
+    NoticeBlock,
+    PeerMessageBlock,
+    TranscriptView,
+    wrap_cells,
+)
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+#: The shape the operator reported: a multi-paragraph release announcement.
+#: Long enough that the old block's row cost is what these tests are about.
+LONG_BODY = (
+    "I am claiming the current release window as owner (pid 48213).\n\n"
+    "Window contents so far: #744, #751, and #747 once its QA round lands. If your PR "
+    "merged since v0.50.3 and is not on that list, send me the PR number, the merge "
+    "SHA and your Release: line and I will fold it in.\n\n"
+    "I am arguing patch for the whole window: none of the three clears the "
+    "step-function bar on its own."
+)
+LONG_SENDER = {
+    "pid": 48213,
+    "conversation_name": "lo-release-window",
+    "model_label": "anthropic/claude-opus-5",
+}
 
 
 def _peer_blocks(app) -> list[PeerMessageBlock]:
@@ -241,190 +279,406 @@ async def test_live_receipt_suppresses_its_replay() -> None:
         assert bodies.count("dup note") == 1
 
 
-def test_the_header_falls_back_to_cwd_then_session_id_not_a_bare_pid() -> None:
-    """A row reading `peer message from (pid 1)` names nothing a reader can act
-    on. The receive side resolves the name from the registry first; when even
-    that finds nothing, the cwd basename and then a short session id are still
-    better than a kernel-assigned number."""
-    by_cwd = PeerMessageBlock("body", {"pid": 1, "cwd": "/Users/x/minerva-core"})
-    assert "minerva-core" in by_cwd._header()
+class TestPeerCard:
+    """The receipt is a ledger card, not a rule-and-header block.
 
-    by_id = PeerMessageBlock("body", {"pid": 1, "session_id": "01JQ9ZK4W7X2M8N3PVQ6TYRB5H"})
-    header = by_id._header()
-    assert "01JQ9ZK4" in header
-    # Only a short prefix: a full ULID is 26 cells of entropy that would push
-    # the pid and model out of the header.
-    assert "01JQ9ZK4W7X2M8N3PVQ6TYRB5H" not in header
+    Why it changed: the old shape painted a full-height ``↔`` gutter, a
+    wrapped sender header and the WHOLE body at body weight — 15 rows at 100
+    columns for one realistic release-window announcement, and two of them
+    pushed the conversation off screen. These pin the card's contract: one row
+    closed, the sender named on it, full identity and full body on expand.
+    """
 
-    # A real name still wins over both fallbacks.
-    named = PeerMessageBlock(
-        "body", {"pid": 1, "cwd": "/Users/x/minerva-core", "conversation_name": "release cutter"}
-    )
-    assert "release cutter" in named._header()
+    def test_the_collapsed_row_is_exactly_one_row(self) -> None:
+        """The whole point of the change. A multi-paragraph note costs ONE row
+        until the reader asks for it."""
+        block = PeerMessageBlock(LONG_BODY, LONG_SENDER)
+        assert block._row_count == 1
+        assert len(block._build_row(100).plain.splitlines()) == 1
+        assert block.spans_multiple_rows() is False
 
-    # Nothing at all: the old bare-pid shape is still the last resort.
-    assert "pid 1" in PeerMessageBlock("body", {"pid": 1})._header()
+    def test_the_collapsed_row_names_the_sender_before_the_snippet(self) -> None:
+        """Identity leads: the row builder truncates the composed summary from
+        the RIGHT as one string, so free text is what sheds. `_send_summary`
+        in tool_card.py learned this the expensive way — with the identity
+        after the free text, rows that differ in who sent them paint
+        byte-identical at ordinary widths."""
+        row = PeerMessageBlock(LONG_BODY, LONG_SENDER)._build_row(100).plain
+        assert "peer" in row  # the name column
+        assert '"lo-release-window"' in row
+        assert row.index('"lo-release-window"') < row.index("I am claiming")
+
+    def test_the_snippet_sheds_before_the_sender_at_narrow_widths(self) -> None:
+        """Monotonic degradation, in the order that keeps the row useful: the
+        message preview gives way, the address does not."""
+        block = PeerMessageBlock(LONG_BODY, LONG_SENDER)
+        wide = block._build_row(120).plain
+        narrow = block._build_row(56).plain
+        assert "lo-release-window" in narrow
+        assert len(narrow.splitlines()) == 1
+        assert cell_len(narrow) < cell_len(wide)
+
+    def test_the_snippet_carries_no_cap_of_its_own(self) -> None:
+        """A second arbitrary bound only left the line empty at wide widths
+        while protecting nothing — the row's own truncate_cells is the budget
+        (the same finding `_send_summary` records)."""
+        block = PeerMessageBlock(LONG_BODY, LONG_SENDER)
+        rows = [block._build_row(width).plain for width in (80, 100, 140, 200)]
+        lengths = [cell_len(row.rstrip()) for row in rows]
+        assert lengths == sorted(lengths), lengths
+        # At 200 cells the row is genuinely using the room it was given.
+        assert lengths[-1] > lengths[0] + 40
+
+    def test_a_multiline_body_becomes_a_one_line_snippet(self) -> None:
+        """An authored newline inside the snippet would be measured into a
+        word's width and then printed literally mid-row."""
+        row = PeerMessageBlock("first line\n\nsecond line", {"pid": 3})._build_row(100).plain
+        assert "\n" not in row
+        assert "first line second line" in row
+
+    def test_expanding_reveals_the_full_sender_identity_and_the_full_body(self) -> None:
+        """The operator's ask: 'details of the recipient should be shown on
+        expand'. The identity line carries what the old always-on header did —
+        name, pid and model — and the body is complete, not a preview."""
+        block = PeerMessageBlock(LONG_BODY, LONG_SENDER)
+        assert block.can_expand() is True
+        assert block.toggle_expanded() is True
+        rendered = block._build_content(100).plain
+        assert 'peer message from "lo-release-window"' in rendered
+        assert "pid 48213" in rendered
+        assert "anthropic/claude-opus-5" in rendered
+        # Every paragraph of the body, not just the snippet's first sentence.
+        for paragraph in LONG_BODY.split("\n\n"):
+            first_words = " ".join(paragraph.split()[:5])
+            assert first_words in " ".join(rendered.split()), first_words
+        assert block.spans_multiple_rows() is True
+
+    def test_activate_toggles_like_the_rest_of_the_ledger(self) -> None:
+        block = PeerMessageBlock("note", {"pid": 3, "conversation_name": "peer"})
+        assert block.expanded is False
+        assert block.activate() is True
+        assert block.expanded is True
+        assert block.has_class(PeerMessageBlock.EXPANDED_CLASS)
+        block.activate()
+        assert block.expanded is False
+        assert not block.has_class(PeerMessageBlock.EXPANDED_CLASS)
+
+    def test_the_hint_appears_only_when_pointed_at_or_focused(self) -> None:
+        """Same affordance contract as the tool and wake rows."""
+        block = PeerMessageBlock("note", {"pid": 3, "conversation_name": "peer"})
+        assert EXPAND_HINT not in block._build_row(100).plain
+        block._set_hovered(True)
+        assert EXPAND_HINT in block._build_row(100).plain
+        block._set_hovered(False)
+        block._set_focused(True)
+        assert EXPAND_HINT in block._build_row(100).plain
+        block.toggle_expanded()
+        assert COLLAPSE_HINT in block._build_row(100).plain
+
+    def test_retheme_is_the_shared_finalized_re_entry_point(self) -> None:
+        """A theme switch repaints settled ledger rows through the ONE hook on
+        the base, not a per-subclass override."""
+        assert PeerMessageBlock.retheme is ExpandableActionBlock.retheme
+
+    def test_a_height_only_resize_rebuilds_nothing(self) -> None:
+        """WakeBlock's `_built_width` guard: an expansion raises a Resize back
+        into on_resize, and rebuilding an identical row was a third of all
+        builds on a measured replay."""
+        block = PeerMessageBlock(LONG_BODY, LONG_SENDER)
+        width = block._built_width
+        builds = {"n": 0}
+        original = PeerMessageBlock._refresh_row
+        block._refresh_row = (  # type: ignore[assignment]
+            lambda: (builds.__setitem__("n", builds["n"] + 1), original(block))[1]
+        )
+        block.on_resize(SimpleNamespace(size=SimpleNamespace(width=width)))
+        assert builds["n"] == 0
+        block.on_resize(SimpleNamespace(size=SimpleNamespace(width=width - 20)))
+        assert builds["n"] == 1
+
+
+class TestPeerCardDegradation:
+    """A receipt that cannot name its sender must still say something a reader
+    can act on. This is the principle the old header ladder pinned, carried
+    onto the collapsed row where it now matters most: at one row there is no
+    second line to recover on."""
+
+    def test_the_row_falls_back_to_cwd_then_session_id_not_a_bare_pid(self) -> None:
+        by_cwd = PeerMessageBlock("body", {"pid": 1, "cwd": "/Users/x/minerva-core"})
+        assert "minerva-core" in by_cwd._build_row(100).plain
+
+        by_id = PeerMessageBlock("body", {"pid": 1, "session_id": "01JQ9ZK4W7X2M8N3PVQ6TYRB5H"})
+        row = by_id._build_row(100).plain
+        assert "01JQ9ZK4" in row
+        # Only a short prefix: a full ULID is 26 cells of entropy that would
+        # push the message preview off the row.
+        assert "01JQ9ZK4W7X2M8N3PVQ6TYRB5H" not in row
+
+        # A real name still wins over both fallbacks, and is QUOTED — the
+        # fallbacks are the app guessing and must not look like a chosen title.
+        named = PeerMessageBlock(
+            "body",
+            {"pid": 1, "cwd": "/Users/x/minerva-core", "conversation_name": "release cutter"},
+        )
+        assert '"release cutter"' in named._build_row(100).plain
+        assert '"minerva-core' not in by_cwd._build_row(100).plain
+
+    def test_a_sender_with_nothing_but_a_pid_still_identifies_itself(self) -> None:
+        """The last resort. A pid is a poor address but it is an address; a row
+        that named nothing at all would be unactionable."""
+        assert "pid 1" in PeerMessageBlock("body", {"pid": 1})._build_row(100).plain
+
+    def test_a_sender_with_no_fields_at_all_still_says_what_it_is(self) -> None:
+        row = PeerMessageBlock("body", {})._build_row(100).plain
+        assert "peer" in row
+        assert "another session" in row
+
+
+class TestPeerCardHardening:
+    """The sender fields cross the wire from another process, so they are the
+    least trusted strings this widget paints. The card changed shape; the
+    hardening did not."""
+
+    def test_a_control_character_in_a_sender_name_cannot_break_the_row(self) -> None:
+        """A newline split the label into rows the block never counted — its
+        height is PINNED to that count, so the extra row painted outside the
+        reserved space — and an escape sequence would re-ink the transcript
+        from inside a label."""
+        block = PeerMessageBlock(
+            "body",
+            {"pid": 7, "conversation_name": "line1\nline2\nline3", "model_label": "m\x1b[31m"},
+        )
+        row = block._build_row(100).plain
+        assert "\n" not in row
+        assert "\x1b" not in row
+        assert block._row_count == 1
+        # The identity line in the EXPANSION is bounded the same way.
+        assert "\x1b" not in block._header(100)
+        assert "\n" not in block._header(100)
+
+    def test_a_giant_sender_name_cannot_own_the_viewport(self) -> None:
+        """Sanitization fixed the SHAPE of an advisory field; this bounds its
+        SIZE. Uncapped, a 50,000-character name wrapped to a block hundreds of
+        rows tall that pushed the whole conversation off screen.
+
+        The card makes this stronger than the old block could: collapsed, a
+        hostile name cannot cost more than the one row every receipt costs."""
+        block = PeerMessageBlock("body", {"pid": 7, "conversation_name": "x" * 50_000})
+        assert block._row_count == 1
+        assert len(block._build_row(100).plain.splitlines()) == 1
+        assert len(block._header(100)) < 200
+
+        # Expanded, the identity line is bounded too: a handful of rows, not
+        # hundreds, and the card's own count matches what it painted.
+        block.toggle_expanded()
+        rendered = block._build_content(100).plain
+        assert len(rendered.splitlines()) == block._row_count
+        assert block._row_count < 10, block._row_count
+
+        # Every advisory field is bounded, not just the name.
+        wide = PeerMessageBlock(
+            "body",
+            {
+                "pid": 7,
+                "conversation_name": "y" * 9000,
+                "model_label": "m" * 9000,
+                "cwd": "/" + "d" * 9000,
+                "session_id": "s" * 9000,
+            },
+        )
+        assert len(wide._header(100)) < 400
+        assert wide._row_count == 1
+
+    def test_a_bidi_override_cannot_scramble_the_pid(self) -> None:
+        """Unicode format characters (category Cf) reorder the glyphs AROUND
+        them. An unterminated U+202E visibly scrambled the pid — the one field
+        a reader uses to address the peer back — so the label misreported the
+        address. C0/C1 stripping did not touch these."""
+        import unicodedata
+
+        payloads = {
+            "rtl-override": "evil\u202ename",
+            "rtl-embedding": "evil\u202bname",
+            "zwsp": "a\u200bb",
+            "zwj": "a\u200db",
+            "bom": "\ufeffname",
+            "lro": "\u202dname",
+            "isolate": "a\u2066b",
+        }
+        for label, name in payloads.items():
+            block = PeerMessageBlock("body", {"pid": 48213, "conversation_name": name})
+            row = block._build_row(100).plain
+            header = block._header(100)
+            assert not [c for c in row if unicodedata.category(c) == "Cf"], label
+            assert not [c for c in header if unicodedata.category(c) == "Cf"], label
+            # The addressing field survives intact and in order.
+            assert "(pid 48213)" in header, label
+
+    def test_a_wider_pane_never_makes_the_identity_line_taller(self) -> None:
+        """Wrapping must be monotonic in the right direction. The model label
+        used to attach at a fixed column threshold calibrated on a 14-cell
+        name; for real 22-57 cell names, crossing it re-attached a ~23-cell
+        label that cost more than the columns just gained, so dragging a pane
+        from 70 to 80 columns made the card TALLER."""
+        names = [
+            "release cutter",  # 14
+            "minerva-user-dashboard",  # 22
+            "01JQ9ZK4W7X2M8N3PVQ6TYRB5H",  # 26 (a session id)
+            "minerva-user-dashboard-release-cutter",  # 37
+            "minerva-user-dashboard-release-cutter-standby",  # 45
+            "minerva-user-dashboard-release-cutter-standby-secondary",  # 57
+        ]
+        widths = (60, 70, 80, 100, 120)
+        for name in names:
+            rows = [
+                len(
+                    wrap_cells(
+                        PeerMessageBlock(
+                            "body",
+                            {
+                                "pid": 48213,
+                                "conversation_name": name,
+                                "model_label": "anthropic/claude-opus-5",
+                            },
+                        )._header(width),
+                        width,
+                    )
+                )
+                for width in widths
+            ]
+            assert all(
+                rows[i] >= rows[i + 1] for i in range(len(rows) - 1)
+            ), f"{len(name)}-cell name wraps non-monotonically across {widths}: {rows}"
 
 
 @pytest.mark.asyncio
 async def test_dragging_over_a_peer_message_copies_no_app_chrome() -> None:
-    """Every row the header WRAPPED to is chrome, not just the first.
+    """The card is a ledger row for selection too: the summary and the sender
+    identity are the app talking, and only the peer's body reaches the
+    clipboard — text the user can paste into what they were quoting into.
 
-    The header is one paragraph, but an ordinary sender name wraps it at
-    half-screen widths. Marking only row 0 meant a drag over the message copied
-    the tail of the app's own label into the user's clipboard — text they never
-    wrote, landing in whatever they were quoting into.
+    The old block had the same contract over a wrapped header; the card moves
+    the boundary to `_chrome_rows`, set by the same build that painted the
+    frame so a resize cannot make the two disagree.
     """
     from textual.selection import Selection as ScreenSelection
 
     app = OperatorApp(lambda: _factory(FakeSession()))
     async with app.run_test(size=(62, 14)) as pilot:
         await _settle_for_session(pilot, app)
-        block = PeerMessageBlock(
-            "gates are green",
-            {
-                "pid": 48213,
-                "conversation_name": "minerva-user-dashboard-release-cutter",
-                "model_label": "anthropic/claude-opus-5",
-            },
-        )
+        block = PeerMessageBlock("gates are green\n\non the second line", LONG_SENDER)
         app._append_block(block)
         await pilot.pause()
+        block.toggle_expanded()
+        await pilot.pause()
 
-        # The case only bites when the header actually wraps.
-        assert block._header_rows > 1, "widen the case: the header did not wrap"
+        assert block.copy_gutter(0) == 2  # the icon field, like ToolCard
+        assert block.copy_gutter(1) == OUTPUT_INDENT
+        assert block._chrome_rows > 1, "the identity line is chrome too"
 
         copied = block.get_selection(ScreenSelection(None, None))
         assert copied is not None
         text = copied[0]
         assert "gates are green" in text
-        # No fragment of the app's label may ride along.
+        assert "on the second line" in text
+        # No fragment of the app's own label may ride along.
         assert "peer message from" not in text
-        assert "minerva-user-dashboard" not in text
+        assert "lo-release-window" not in text
         assert "claude-opus" not in text
         assert "pid 48213" not in text
+        assert tool_icon("peer") not in text
 
 
 @pytest.mark.asyncio
-async def test_a_control_character_in_a_sender_name_cannot_break_the_row() -> None:
-    """The sender name crosses the wire from another process, so it is the
-    least trusted string this widget paints.
+async def test_the_card_shares_the_ledger_spine_with_the_tool_rows() -> None:
+    """A receipt sitting in a run of actions must be a column, not a second
+    layout: same SPACING_KIND, same name column, same air above and below.
 
-    A newline split the header into rows the block never counted — its height is
-    PINNED to that count, so the extra row paints outside the reserved space —
-    and an escape sequence would re-ink the transcript from inside a label.
+    This is why the block is an ExpandableActionBlock rather than a bespoke
+    shape — the old `SPACING_KIND = "peer"` gave it its own spacing class and
+    its own left edge, so it interrupted the ledger it landed in.
     """
+    from local_operator.tui.widgets.tool_card import ToolCard
+
+    assert PeerMessageBlock.SPACING_KIND == ToolCard.SPACING_KIND
+    assert PeerMessageBlock.LEDGER_ROW is True
+    assert PeerMessageBlock.SPACING_AIRY is True
+
     app = OperatorApp(lambda: _factory(FakeSession()))
-    async with app.run_test(size=(100, 14)) as pilot:
+    async with app.run_test(size=(100, 24)) as pilot:
+        await _settle_for_session(pilot, app)
+        card = ToolCard("t1", "read", {"path": "a.py"})
+        app._append_block(card)
+        peer = PeerMessageBlock("note", LONG_SENDER)
+        app._append_block(peer)
+        await pilot.pause()
+        await pilot.pause()
+
+        # Same name column, so the two summaries start at the same cell.
+        assert peer._name_col(98) == card._name_col(98)
+        assert peer.size.height == 1
+        # One blank row between them: the AIRY rule, not a bespoke lead.
+        assert peer.region.y - card.region.y == 2
+
+
+@pytest.mark.asyncio
+async def test_real_pointer_hover_and_click_use_the_ledger_contract() -> None:
+    """Exercise the actual Textual event path under the production sheet: the
+    terminal receives a hand pointer, the real hover event reveals the hint,
+    and a click grows and collapses the card without losing the row of air
+    below it."""
+    from tests.unit.tui.conftest import StyledTranscriptApp
+
+    app = StyledTranscriptApp()
+    async with app.run_test(size=(100, 24)) as pilot:
+        view = app.query_one(TranscriptView)
+        peer = PeerMessageBlock(LONG_BODY, LONG_SENDER)
+        below = NoticeBlock("trying another account", "warning")
+        view.append_block(peer)
+        view.append_block(below)
+        await pilot.pause()
+        await pilot.pause()
+
+        assert peer.size.height == 1
+        assert below.region.y - peer.region.y == 2
+
+        landed = await pilot.hover(peer)
+        assert landed, "hover missed the peer card"
+        await pilot.pause()
+        assert app.screen._pointer_shape == "pointer"
+
+        await pilot.click(peer)
+        await pilot.pause()
+        assert peer.expanded is True
+        assert peer.size.height > 1
+        # The card grew by exactly what it painted — a height that disagrees
+        # with the frame laps the block below.
+        assert peer.size.height == peer._row_count
+
+        await pilot.click(peer)
+        await pilot.pause()
+        assert peer.expanded is False
+        assert peer.size.height == 1
+        assert below.region.y - peer.region.y == 2
+
+
+@pytest.mark.asyncio
+async def test_a_narrow_pane_keeps_the_one_row_guarantee() -> None:
+    """The guarantee has to hold where it is hardest: a long name and a long
+    body at a width that cannot hold either."""
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(48, 20)) as pilot:
         await _settle_for_session(pilot, app)
         block = PeerMessageBlock(
-            "body",
-            {"pid": 7, "conversation_name": "line1\nline2\nline3", "model_label": "m\x1b[31m"},
+            LONG_BODY,
+            {
+                "pid": 48213,
+                "conversation_name": "minerva-user-dashboard-release-cutter-standby",
+                "model_label": "anthropic/claude-opus-5",
+            },
         )
         app._append_block(block)
         await pilot.pause()
-
-        header = block._header()
-        assert "\n" not in header
-        assert "\x1b" not in header
-        # The pinned height matches what the block actually painted.
-        assert block.styles.height is not None
-        assert block.styles.height.value == block._header_rows + 1
-
-
-def test_a_giant_sender_name_cannot_own_the_viewport() -> None:
-    """Sanitization fixed the SHAPE of an advisory field; this bounds its SIZE.
-
-    The name crosses the wire, so its length is the peer's choice. Uncapped, a
-    50,000-character name wrapped to a block hundreds of rows tall that pushed
-    the whole conversation off screen (round 3, MINOR-9).
-    """
-    block = PeerMessageBlock("body", {"pid": 7, "conversation_name": "x" * 50_000})
-    header = block._header()
-    assert len(header) < 200, len(header)
-    # Geometry holds: a handful of rows, and the pin still matches the build.
-    assert block._header_rows <= 4
-    assert block.styles.height is not None
-    assert block.styles.height.value == block._header_rows + 1
-
-    # Every advisory field is bounded, not just the name.
-    wide = PeerMessageBlock(
-        "body",
-        {
-            "pid": 7,
-            "conversation_name": "y" * 9000,
-            "model_label": "m" * 9000,
-            "cwd": "/" + "d" * 9000,
-            "session_id": "s" * 9000,
-        },
-    )
-    assert len(wide._header()) < 400
-
-
-def test_a_bidi_override_cannot_scramble_the_pid() -> None:
-    """Unicode format characters (category Cf) reorder the glyphs AROUND them.
-
-    An unterminated U+202E visibly scrambled the pid — the one field a reader
-    uses to address the peer back — so the label misreported the address. C0/C1
-    stripping did not touch these (round 3, D15).
-    """
-    import unicodedata
-
-    payloads = {
-        "rtl-override": "evil\u202ename",
-        "rtl-embedding": "evil\u202bname",
-        "zwsp": "a\u200bb",
-        "zwj": "a\u200db",
-        "bom": "\ufeffname",
-        "lro": "\u202dname",
-        "isolate": "a\u2066b",
-    }
-    for label, name in payloads.items():
-        header = PeerMessageBlock("body", {"pid": 48213, "conversation_name": name})._header()
-        assert not [c for c in header if unicodedata.category(c) == "Cf"], label
-        # The addressing field survives intact and in order.
-        assert "(pid 48213)" in header, label
-
-
-@pytest.mark.asyncio
-async def test_a_wider_pane_never_makes_the_peer_header_taller() -> None:
-    """Wrapping must be monotonic in the right direction (round 3, D14).
-
-    The model label used to attach at a fixed column threshold calibrated on a
-    14-cell name. Real conversation names here run 22-57 cells, and for those,
-    crossing the threshold re-attached a ~23-cell label that cost more than the
-    columns just gained — so dragging a pane from 70 to 80 columns made the
-    card TALLER. Attaching the label only when the whole header still fits on
-    one row is what makes "more columns never means more rows" true.
-    """
-    names = [
-        "release cutter",  # 14
-        "minerva-user-dashboard",  # 22
-        "01JQ9ZK4W7X2M8N3PVQ6TYRB5H",  # 26 (a session id)
-        "minerva-user-dashboard-release-cutter",  # 37
-        "minerva-user-dashboard-release-cutter-standby",  # 45
-        "minerva-user-dashboard-release-cutter-standby-secondary",  # 57
-    ]
-    widths = (60, 70, 80, 100, 120)
-
-    for name in names:
-        rows: list[int] = []
-        for width in widths:
-            app = OperatorApp(lambda: _factory(FakeSession()))
-            async with app.run_test(size=(width, 14)) as pilot:
-                await pilot.pause()
-                block = PeerMessageBlock(
-                    "body",
-                    {
-                        "pid": 48213,
-                        "conversation_name": name,
-                        "model_label": "anthropic/claude-opus-5",
-                    },
-                )
-                app._append_block(block)
-                await pilot.pause()
-                rows.append(block._header_rows)
-
-        assert all(
-            rows[i] >= rows[i + 1] for i in range(len(rows) - 1)
-        ), f"{len(name)}-cell name wraps non-monotonically across {widths}: {rows}"
+        await pilot.pause()
+        assert block.size.height == 1
+        assert block._row_count == 1

--- a/tests/unit/tui/test_peer_message.py
+++ b/tests/unit/tui/test_peer_message.py
@@ -21,6 +21,7 @@ from types import SimpleNamespace
 
 import pytest
 from rich.cells import cell_len
+from rich.text import Text
 
 from local_operator.harness.types import PeerMessageDeliveredEvent
 from local_operator.session.peer import PEER_MESSAGE_MESSAGE_TYPE
@@ -296,6 +297,12 @@ class TestPeerCard:
         assert block._row_count == 1
         assert len(block._build_row(100).plain.splitlines()) == 1
         assert block.spans_multiple_rows() is False
+        # `settled_rows()` feeds `project_settled_rows`, which decides how much
+        # history fits; a value that disagrees with the painted frame spends
+        # another block's budget. It is finalized by `__init__`, so it reports
+        # rather than returning the not-yet-settled 0.
+        assert block.is_finalized() is True
+        assert block.settled_rows() == block._row_count == 1
 
     def test_the_collapsed_row_names_the_sender_before_the_snippet(self) -> None:
         """Identity leads: the row builder truncates the composed summary from
@@ -344,7 +351,7 @@ class TestPeerCard:
         assert block.can_expand() is True
         assert block.toggle_expanded() is True
         rendered = block._build_content(100).plain
-        assert 'peer message from "lo-release-window"' in rendered
+        assert '"lo-release-window" · pid 48213' in rendered
         assert "pid 48213" in rendered
         assert "anthropic/claude-opus-5" in rendered
         # Every paragraph of the body, not just the snippet's first sentence.
@@ -352,6 +359,11 @@ class TestPeerCard:
             first_words = " ".join(paragraph.split()[:5])
             assert first_words in " ".join(rendered.split()), first_words
         assert block.spans_multiple_rows() is True
+        # The same accounting control as collapsed, on the branch where the
+        # count actually varies: expanded, `settled_rows()` must still be the
+        # rows the card painted.
+        assert block.settled_rows() == block._row_count
+        assert block._row_count == len(rendered.splitlines())
 
     def test_activate_toggles_like_the_rest_of_the_ledger(self) -> None:
         block = PeerMessageBlock("note", {"pid": 3, "conversation_name": "peer"})
@@ -443,18 +455,113 @@ class TestPeerCardHardening:
         """A newline split the label into rows the block never counted — its
         height is PINNED to that count, so the extra row painted outside the
         reserved space — and an escape sequence would re-ink the transcript
-        from inside a label."""
-        block = PeerMessageBlock(
-            "body",
-            {"pid": 7, "conversation_name": "line1\nline2\nline3", "model_label": "m\x1b[31m"},
-        )
+        from inside a label.
+
+        **`pid` is attacked here too, and it is the reason this test was
+        extended.** The original version passed a clean `pid: 7` and put the
+        payload only in the sibling fields — so the one field that skipped
+        `_sanitize_sender_field` was the one field the hostile-input guard did
+        not touch. Every advisory field the card renders is hostile in this
+        test now; a new one must be added here as well as to the ladder.
+        """
+        hostile_name: dict[str, object] = {
+            "pid": 7,
+            "conversation_name": "line1\nline2\nline3",
+            "model_label": "m\x1b[31m",
+        }
+        # Both paths, for every field: `pid` is rendered on the collapsed row
+        # AND on the expanded identity line, so a guard on one is half a guard.
+        # A str pid is the realistic hostile shape — nothing on the wire ever
+        # coerces it to int (see `_sender_pid`).
+        hostile_pid: dict[str, object] = {
+            "pid": "42\nROW-A\nROW-B",
+            "conversation_name": "",
+            "model_label": "",
+        }
+        hostile_pid_escape: dict[str, object] = {"pid": "1\x1b[31mRED", "conversation_name": ""}
+        for label, sender in (
+            ("name", hostile_name),
+            ("pid-newlines", hostile_pid),
+            ("pid-escape", hostile_pid_escape),
+        ):
+            block = PeerMessageBlock("body", sender)
+            row = block._build_row(100).plain
+            assert "\n" not in row, label
+            assert "\x1b" not in row, label
+            # The pinned height and every count derived from it must agree
+            # with the single row actually painted. A newline in an unbounded
+            # field made `_row_count`/`settled_rows()` report 3 against a
+            # CSS-pinned 1-row widget.
+            assert block._row_count == 1, label
+            assert block.settled_rows() == 1, label
+            assert block.spans_multiple_rows() is False, label
+            # The identity line in the EXPANSION is bounded the same way.
+            assert "\x1b" not in block._header(100), label
+            assert "\n" not in block._header(100), label
+
+    def test_a_hostile_pid_cannot_smuggle_chrome_into_a_copy(self) -> None:
+        """The other half of the unsanitized-pid defect: `copy_row_is_chrome`.
+
+        With the collapsed card reporting `_chrome_rows = 1`, newlines injected
+        through `pid` pushed rows 1 and 2 of the app's own label past the chrome
+        boundary and into the clipboard — `'W-A\\nW-B — ping'`, which is neither
+        chrome the user wanted nor the peer's message. The card is entirely
+        chrome while collapsed, so a drag over it must yield nothing at all.
+        """
+        block = PeerMessageBlock("ping", {"pid": "42\nROW-A\nROW-B"})
+        rendered: Text = block._build_content(100)
+        assert len(rendered.plain.splitlines()) == 1
+        # Collapsed, EVERY painted row is the app's own label, so a drag over
+        # the card must find no body rows to hand to the clipboard.
+        assert block._chrome_rows == 1
+        assert all(block.copy_row_is_chrome(index) for index in range(block._row_count))
+        # And the pid still identifies the sender rather than being dropped:
+        # a rejected pid would erase an address the reader could act on.
+        assert "42" in block._build_row(100).plain
+
+    def test_a_control_sequence_in_the_message_body_never_reaches_the_row(self) -> None:
+        """The peer's BODY is peer-controlled text on a `height: 1` pinned row.
+
+        `ESC[2K` + `ESC[1A` is erase-line plus cursor-up — the pair `ansi.py`
+        names as the highest-value forgery target the app has, and the exact
+        way a row escapes the box the CSS pins it to and repaints the receipts
+        above it. Rich also mis-measures an escape, so the width arithmetic
+        the one-row guarantee rests on is computed against a wrong cell count.
+
+        Every sibling on this spine already strips: `ToolCard` given the same
+        payload paints no escape. Two summaries on one ledger treating one
+        trust boundary two opposite ways is the drift this pins shut.
+        """
+        hostile = "benign note\x1b[2K\x1b[1A\x1b[2KFORGED: gates are green\x1b[0m"
+        block = PeerMessageBlock(hostile, {"pid": 7, "conversation_name": "attacker"})
         row = block._build_row(100).plain
-        assert "\n" not in row
         assert "\x1b" not in row
+        assert "[2K" not in row  # the whole sequence goes, not just its ESC
+        assert "[1A" not in row
         assert block._row_count == 1
-        # The identity line in the EXPANSION is bounded the same way.
-        assert "\x1b" not in block._header(100)
-        assert "\n" not in block._header(100)
+        # A Cf character is not a control sequence and survives the strip, so
+        # it is dropped separately — a bidi override in the body would reorder
+        # the glyphs around it, including the sender name beside it.
+        import unicodedata
+
+        bidi = PeerMessageBlock("a\u202eb\u200dc", {"pid": 7, "conversation_name": "p"})
+        assert not [c for c in bidi._build_row(100).plain if unicodedata.category(c) == "Cf"]
+
+    def test_the_body_and_copy_stay_byte_verbatim_despite_the_snippet_strip(self) -> None:
+        """The strip is the SNIPPET's, not the body's.
+
+        `text()` feeds `/copy`, and the expansion is what the reader opened the
+        card to read: both must return exactly what the peer sent, or the block
+        stops being a faithful record of another session's words. This is the
+        constraint that makes the fix snippet-only rather than a body sanitize.
+        """
+        body = "first para with \x1b[31mescape\x1b[0m inside\n\nsecond para — kept"
+        block = PeerMessageBlock(body, {"pid": 7, "conversation_name": "peer-a"})
+        assert block.text() == body  # byte-identical, escapes and all
+        assert "\x1b" not in block._build_row(100).plain
+        block.toggle_expanded()
+        rendered = block._build_content(100).plain
+        assert "first para" in rendered and "second para" in rendered
 
     def test_a_giant_sender_name_cannot_own_the_viewport(self) -> None:
         """Sanitization fixed the SHAPE of an advisory field; this bounds its
@@ -512,7 +619,7 @@ class TestPeerCardHardening:
             assert not [c for c in row if unicodedata.category(c) == "Cf"], label
             assert not [c for c in header if unicodedata.category(c) == "Cf"], label
             # The addressing field survives intact and in order.
-            assert "(pid 48213)" in header, label
+            assert "pid 48213" in header, label
 
     def test_a_wider_pane_never_makes_the_identity_line_taller(self) -> None:
         """Wrapping must be monotonic in the right direction. The model label
@@ -682,3 +789,123 @@ async def test_a_narrow_pane_keeps_the_one_row_guarantee() -> None:
         await pilot.pause()
         assert block.size.height == 1
         assert block._row_count == 1
+
+
+class TestPeerCardSeamAndExpansionHeader:
+    """The two design-round findings: the seam glyph and the identity line.
+
+    Both are about a card whose own content competes with its structure —
+    the kind of defect that only shows up against real traffic, which is why
+    the frames that found them were seeded with actual peer broadcasts.
+    """
+
+    def test_the_seam_is_not_a_glyph_the_prose_also_uses(self) -> None:
+        """Agent-to-agent prose here is full of em-dashes, so an em-dash seam
+        put the same glyph in a structural and a prose role on one line with
+        nothing to tell them apart. `·` is what the neighbouring `send` row
+        already reserves for structure."""
+        body = "my PR #744 merged at 9f2ac13 — Release: patch, retainable cost estimate"
+        row = PeerMessageBlock(body, {"pid": 3, "conversation_name": "lo-usage-panel"})
+        rendered = row._build_row(120).plain
+        assert '"lo-usage-panel" · my PR #744' in rendered
+        # Exactly one structural separator, and the prose em-dash survives
+        # untouched — the point is that the two are now distinguishable.
+        head, seam, tail = rendered.partition(" · ")
+        assert seam and "·" not in tail
+        assert "—" in tail
+
+    def test_the_expansion_header_leads_with_what_the_expansion_adds(self) -> None:
+        """The identity line used to open `peer message from "<name>"`, which
+        restated the summary row's own opening; the pid and model — the only
+        facts the expansion actually adds — were buried mid-sentence."""
+        header = PeerMessageBlock(LONG_BODY, LONG_SENDER)._header(96)
+        assert header == '"lo-release-window" · pid 48213 · anthropic/claude-opus-5'
+        assert "peer message from" not in header
+
+    def test_the_expansion_header_is_a_step_brighter_than_the_summary(self) -> None:
+        """Hierarchy is headline -> header -> body. Painted at the summary's
+        own `dim` the identity line read as a dimmer continuation of the
+        headline, leaving the blank row to do the structural work alone."""
+        from local_operator.tui import theme as theme_mod
+
+        block = PeerMessageBlock(LONG_BODY, LONG_SENDER)
+        block.toggle_expanded()
+        content = block._build_content(96)
+        inks = {}
+        for span in content.spans:
+            row = content.plain[: span.start].count("\n")
+            colour = getattr(span.style, "color", None)
+            if colour is not None and row not in inks:
+                inks[row] = colour.triplet.hex if colour.triplet else str(colour)
+        summary, identity, body = inks[0], inks[1], inks[3]
+        assert summary == theme_mod.semantic_color("dim")
+        assert identity == theme_mod.semantic_color("muted")
+        assert body == theme_mod.semantic_color("fg")
+        assert len({summary, identity, body}) == 3
+
+    def test_an_absurdly_narrow_pane_still_paints_one_honest_row(self) -> None:
+        """What a sub-six-cell card looks like — the question the review asked.
+
+        Not the `name_budget < 2` branch: `width` is clamped to >= 10 before
+        the budget is computed, so that branch is unreachable from any pane
+        size and is documented in the source as a structural guard rather than
+        a width case. What actually happens is the normal row, truncated to a
+        real `…`, still exactly one row, still carrying the ledger's left edge.
+        """
+        from local_operator.tui.glyphs import tool_icon
+
+        block = PeerMessageBlock(LONG_BODY, LONG_SENDER)
+        for width in (1, 3, 5, 6, 8):
+            row = block._build_row(width).plain
+            assert len(row.splitlines()) == 1, width
+            assert row.startswith(tool_icon("peer")), (width, row)
+            # Honest about what it dropped rather than silently cutting.
+            assert row.endswith("…"), (width, row)
+        # And it comes back: the degradation is a function of width, not a
+        # latched state.
+        assert "lo-release-window" in block._build_row(100).plain
+
+    def test_a_narrow_expansion_wraps_at_the_same_floor_the_fit_test_uses(self) -> None:
+        """`MIN_BODY` floored `_header`'s fit test but not `_build_content`'s
+        wrap width, so a pane a few cells wide turned a two-line note into 40
+        rows of one-character columns while the collapsed row stayed correctly
+        clamped at 1. Both halves of the arithmetic now share one floor."""
+        block = PeerMessageBlock("hello there peer", LONG_SENDER)
+        block.toggle_expanded()
+        counts = [len(block._build_content(w).plain.splitlines()) for w in (1, 3, 5, 8, 12)]
+        assert max(counts) <= 12, counts
+        # Monotonic in the right direction: narrower never yields fewer rows,
+        # and no width explodes relative to its neighbour.
+        assert counts == sorted(counts, reverse=True), counts
+
+    def test_an_empty_body_expands_to_its_identity_and_no_whitespace(self) -> None:
+        """The expand affordance must not promise detail and deliver blanks.
+
+        `_body_rows` always yields at least one entry, so a peer that sent
+        nothing rendered a blank separator followed by a blank indented line.
+        The identity line still earns the expansion — pid and model are exactly
+        what the collapsed row has no budget for.
+        """
+        for body in ("", "   ", "\n\n"):
+            block = PeerMessageBlock(body, {"pid": 9, "conversation_name": "lo-empty"})
+            block.toggle_expanded()
+            rows = block._build_content(96).plain.splitlines()
+            assert rows[-1].strip(), (body, rows)
+            assert "pid 9" in rows[-1]
+            assert block._row_count == len(rows)
+            # No dangling seam on the collapsed row either, when there is no
+            # snippet to put after it.
+            assert not block._build_row(96).plain.rstrip().endswith("·"), body
+
+    def test_an_interior_paragraph_break_is_not_trimmed_with_the_trailing_ones(self) -> None:
+        """The blank row BETWEEN paragraphs is the break the peer typed.
+
+        Trimming every empty row (rather than only trailing ones) would reflow
+        their message into a single block — a quiet corruption of the one thing
+        the expansion exists to show faithfully.
+        """
+        block = PeerMessageBlock("para one here.\n\npara two here.", {"pid": 9})
+        block.toggle_expanded()
+        rows = block._build_content(96).plain.splitlines()
+        body = rows[block._chrome_rows :]
+        assert [row.strip() for row in body] == ["para one here.", "", "para two here."]

--- a/tests/unit/tui/test_peer_message.py
+++ b/tests/unit/tui/test_peer_message.py
@@ -855,12 +855,21 @@ class TestPeerCardSeamAndExpansionHeader:
         from local_operator.tui.glyphs import tool_icon
 
         block = PeerMessageBlock(LONG_BODY, LONG_SENDER)
-        for width in (1, 3, 5, 6, 8):
+        icon = tool_icon("peer")
+        for width in range(1, 12):
             row = block._build_row(width).plain
             assert len(row.splitlines()) == 1, width
-            assert row.startswith(tool_icon("peer")), (width, row)
+            assert row.startswith(icon), (width, row)
             # Honest about what it dropped rather than silently cutting.
             assert row.endswith("…"), (width, row)
+            # PINS the source comment's unreachability claim rather than
+            # restating it in prose: the degenerate branch emits the icon and
+            # nothing else, so a row carrying the name column proves the branch
+            # was not taken. If the `max(width - 2, 10)` clamp above the budget
+            # ever moves, this fails instead of the comment quietly becoming a
+            # lie.
+            assert row.strip() != icon, (width, row)
+            assert "peer" in row, (width, row)
         # And it comes back: the degradation is a function of width, not a
         # latched state.
         assert "lo-release-window" in block._build_row(100).plain
@@ -874,9 +883,23 @@ class TestPeerCardSeamAndExpansionHeader:
         block.toggle_expanded()
         counts = [len(block._build_content(w).plain.splitlines()) for w in (1, 3, 5, 8, 12)]
         assert max(counts) <= 12, counts
-        # Monotonic in the right direction: narrower never yields fewer rows,
-        # and no width explodes relative to its neighbour.
-        assert counts == sorted(counts, reverse=True), counts
+
+        # The PROPERTY, swept rather than sampled: widening a pane must never
+        # make the card taller. This file's history is about exactly that —
+        # the model-label fit test was once keyed on a fixed column threshold,
+        # so dragging a pane from 70 to 80 columns re-attached a label that
+        # cost more than the columns it gained and the card GREW. A handful of
+        # sampled widths cannot see a single non-monotonic step between them.
+        heights = [len(block._build_content(w).plain.split("\n")) for w in range(1, 201)]
+        regressions = [
+            (width, heights[width - 1], heights[width])
+            for width in range(1, len(heights))
+            if heights[width] > heights[width - 1]
+        ]
+        assert regressions == [], f"widening made the card taller: {regressions}"
+        # And the collapsed row is exactly one at every one of those widths.
+        collapsed = PeerMessageBlock(LONG_BODY, LONG_SENDER)
+        assert {len(collapsed._build_row(w).plain.split("\n")) for w in range(1, 201)} == {1}
 
     def test_an_empty_body_expands_to_its_identity_and_no_whitespace(self) -> None:
         """The expand affordance must not promise detail and deliver blanks.
@@ -889,10 +912,20 @@ class TestPeerCardSeamAndExpansionHeader:
         for body in ("", "   ", "\n\n"):
             block = PeerMessageBlock(body, {"pid": 9, "conversation_name": "lo-empty"})
             block.toggle_expanded()
-            rows = block._build_content(96).plain.splitlines()
+            plain = block._build_content(96).plain
+            rows = plain.splitlines()
             assert rows[-1].strip(), (body, rows)
             assert "pid 9" in rows[-1]
-            assert block._row_count == len(rows)
+            # `split("\n")`, NOT `splitlines()`. `_row_count` is itself
+            # `len(plain.splitlines())`, so asserting against a second
+            # `splitlines()` compares the measurement to itself and is true for
+            # every possible content — including content ending in a dangling
+            # newline, which is exactly the row Rich paints and `splitlines()`
+            # cannot see. This assertion was satisfiable without the property
+            # being true, and it shipped green over a card that painted 3 rows
+            # while reporting 2.
+            assert not plain.endswith("\n"), (body, repr(plain))
+            assert block._row_count == len(plain.split("\n")), (body, repr(plain))
             # No dangling seam on the collapsed row either, when there is no
             # snippet to put after it.
             assert not block._build_row(96).plain.rstrip().endswith("·"), body
@@ -909,3 +942,124 @@ class TestPeerCardSeamAndExpansionHeader:
         rows = block._build_content(96).plain.splitlines()
         body = rows[block._chrome_rows :]
         assert [row.strip() for row in body] == ["para one here.", "", "para two here."]
+
+
+@pytest.mark.asyncio
+async def test_the_card_paints_exactly_as_many_rows_as_it_reports() -> None:
+    """The property the empty-body guard could not see: painted == reported.
+
+    `_row_count` is derived from `splitlines()`, so any assertion written in
+    terms of `splitlines()` compares the measurement to itself and is true for
+    all content. Textual lays the widget out from the RENDERED content, which
+    counts a trailing newline that `splitlines()` discards — so the only honest
+    instrument is the painted frame under a real pilot.
+
+    That gap shipped once: a separator appended before the empty-body early
+    return left a dangling `\\n`, and the card painted 3 rows while reporting
+    2, with `_chrome_rows` (3) exceeding `_row_count` (2). Every consumer of
+    `settled_rows()` (`project_settled_rows`, the resume/reconnect replay)
+    reasons about that number, and `copy_row_is_chrome` indexes rows the count
+    said did not exist.
+
+    Every payload class the card renders is swept, because the defect lived in
+    exactly the one branch the ordinary body never takes.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _settle_for_session(pilot, app)
+        cases = {
+            "empty": "",
+            "whitespace": "   \n\n  ",
+            "one-line": "alpha.",
+            "paragraphs": "first para.\n\nsecond para.",
+            "trailing-newlines": "text\n\n\n\n",
+            "long": LONG_BODY,
+        }
+        for label, body in cases.items():
+            block = PeerMessageBlock(body, LONG_SENDER)
+            app._append_block(block)
+            await pilot.pause()
+            await pilot.pause()
+            assert block.size.height == block._row_count == block.settled_rows(), label
+
+            block.toggle_expanded()
+            await pilot.pause()
+            await pilot.pause()
+            # The painted height is the ground truth; the reported count and
+            # the settled count must both equal it.
+            assert block.size.height == block._row_count, (label, "expanded")
+            assert block.settled_rows() == block.size.height, (label, "settled")
+            # The furniture count indexes into the rows that exist, so it can
+            # never exceed them — `_chrome_rows > _row_count` is the incoherent
+            # state that made `copy_row_is_chrome` answer about a phantom row.
+            assert block._chrome_rows <= block._row_count, (label, "chrome")
+
+            block.toggle_expanded()
+            await pilot.pause()
+            await pilot.pause()
+            assert block.size.height == block._row_count == 1, (label, "recollapse")
+
+
+@pytest.mark.asyncio
+async def test_a_repaint_does_not_rescan_the_whole_body() -> None:
+    """The snippet is sanitized once at construction, not per repaint.
+
+    `_refresh_row` runs on hover, focus, expand, retheme, resize and — through
+    `_invalidate_name_col` — on every ledger block when the shared name column
+    moves. The strip is a regex plus a per-character `unicodedata.category`
+    scan; run over a body at the 256 KiB wire cap it measured 23.9 ms of
+    loop-thread CPU *per repaint*, so one card taxed the whole ledger.
+
+    Asserted structurally rather than with a time bound, per AGENTS.md: a
+    threshold calibrated on this machine is not a threshold on CI, and the
+    property is "the scan happens once", which is a fact about call counts
+    rather than about duration.
+    """
+    import local_operator.tui.widgets.transcript as transcript_mod
+
+    calls: list[int] = []
+    original = transcript_mod._sanitize_line
+
+    def counting(value: object) -> str:
+        calls.append(len(str(value or "")))
+        return original(value)
+
+    body = "word " * 4000
+    transcript_mod._sanitize_line = counting  # type: ignore[assignment]
+    try:
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=(100, 30)) as pilot:
+            await _settle_for_session(pilot, app)
+            block = PeerMessageBlock(body, LONG_SENDER)
+            app._append_block(block)
+            await pilot.pause()
+            await pilot.pause()
+            after_construction = len(calls)
+
+            # Every repaint path, none of which may re-scan the body.
+            block._set_hovered(True)
+            block._set_hovered(False)
+            block._set_focused(True)
+            block.toggle_expanded()
+            block.toggle_expanded()
+            block.retheme()
+            for width in range(60, 120, 10):
+                block._build_content(width)
+            await pilot.pause()
+
+            body_scans = [n for n in calls[after_construction:] if n > 100]
+            assert body_scans == [], f"body re-scanned on repaint: {body_scans}"
+    finally:
+        transcript_mod._sanitize_line = original  # type: ignore[assignment]
+
+    # And the work is bounded even on the one pass that does run, so a body at
+    # the wire cap cannot make construction the expensive thing instead.
+    huge = "word " * 60_000
+    calls.clear()
+    transcript_mod._sanitize_line = counting  # type: ignore[assignment]
+    try:
+        PeerMessageBlock(huge, LONG_SENDER)
+    finally:
+        transcript_mod._sanitize_line = original  # type: ignore[assignment]
+    assert calls, "construction did not sanitize at all"
+    assert max(calls) <= transcript_mod._SNIPPET_SOURCE_MAX_CHARS, calls


### PR DESCRIPTION
The operator's ask, verbatim:

> "Now that we have a lot more cross-session communication happening, [peer messages] can end up taking up a lot of space, so we should collapse peer message receipts into an expandable tool card line with a suitable icon, similar to how send is collapsed as a tool line... In the condensed tool line, we can show the name of the session that the message was received from and a very short synopsis/snippet and click to expand and show the full details if needed."

Release: patch — an inbound peer message is now a one-line ledger card naming the sender, expandable to its full identity and body, instead of a receipt that spent 11–16 rows of transcript on every note.

## Change authorization

C2 — standard/pre-authorized. Bounded TUI feature iteration and hardening within the existing transcript/ledger architecture; the PR is the change record. No launch or foundational trust-model change, and no separate RFC approval is required. This classification does not waive the agent-review, QA, or design gates.


## The problem

`PeerMessageBlock` painted a full-height `↔` gutter rule, a wrapped sender header, and then the **whole body** at body weight. That is right for one message and wrong for the traffic this harness actually carries. Measured on a realistic release-window announcement from a peer session:

| width | before (always) | after, collapsed | after, expanded |
|---|---|---|---|
| 72 cols | 16 rows | **1** | 19 |
| 100 cols | 14 rows | **1** | 16 |
| 140 cols | 11 rows | **1** | 13 |

At 100x30 a single peer message plus its neighbours filled the frame; the user's own question and the agent's answer were off the top of the screen. Two of them buried the conversation entirely.

## What changed and why

`PeerMessageBlock` becomes an `ExpandableActionBlock` — the same ledger card `WakeBlock` already is, mirrored closely rather than invented a second time.

**Collapsed, one row:** `<icon> peer  "<session name>" — <snippet>`.

The **identity leads the snippet**, and that ordering is load-bearing rather than taste. The row builder truncates the composed summary from the right as one string, so whatever sits rightmost dies first — the lesson `_send_summary` records in `tool_card.py` after three cards with the same peer and different delivery promises painted byte-identical rows. WHO reached in is what the reader acts on; the free text is what can be shed. The snippet carries **no cap of its own**: the row's own `truncate_cells` is the budget, and an extra bound only left the line empty at wide widths while protecting nothing.

**Expanded (Enter / click / Space):** the full sender identity the old always-on header carried — name, pid, model — then a blank row, then the complete body, wrapped with paragraphs preserved.

**Icon:** `peer` registered in both glyph tables as its own key, so it resolves through the normal `tool_icon` path. Nerd `\uf01c` (nf-fa-inbox — a note that arrived), plain `←` — deliberately `send`'s `→` mirrored rather than a second metaphor, since the two rows are one conversation seen from its two ends. Both measure exactly one cell (`cell_len` verified; `\uf01c` is in the PUA as `test_every_nerd_glyph_is_one_cell_and_lives_in_the_private_use_area` requires, `←` correctly is not).

**Spacing:** `SPACING_KIND` moves from a bespoke `"peer"` to the ledger's `"tool"` + `LEDGER_ROW` + `SPACING_AIRY`. That is what puts a blank row above and below the card and aligns its name column with the tool rows a peer message habitually lands between — the old private spacing class gave the receipt its own left edge, so it interrupted the ledger it landed in. The `"peer"` kind was referenced by nothing else in the codebase or the tcss (grepped) and is removed.

**Hardening is unchanged.** `_sanitize_sender_field` and `_SENDER_FIELD_MAX_CHARS` are untouched: the sender fields still cross the wire from another process and are still bounded in shape, rendering and size. The card makes the size guarantee *stronger* — the 50,000-character name that once wrapped to a block 865 rows tall now cannot cost more than the one row every receipt costs.

**`/copy` follows `WakeBlock`:** `copy_gutter` is 2 on the summary row and `OUTPUT_INDENT` below; the summary and identity rows are chrome, the body is not. `text()` still returns the verbatim body, and the block still lacks `is_truncated`, which is what `copy_targets.py` discriminates on.

## Before / after

Rendered with `scripts/peer_message_shot.py` (new, added here) through the **real `OperatorApp`** so the production stylesheet applies, `isolate_capture()` before app imports, seeded with tool rows on both sides of the receipt so the shared ledger spine is checkable. Every frame was viewed, not just exported.

**Before — 100x30.** One peer message owns the screen; the user's question is gone.

![before 100x30](https://gist.githubusercontent.com/damianvtran/c2120ea82ab51653a83baa8d24a1ab3a/raw/38260f094da3c2302d6fa5e42bbf3922fa273dd1/before-collapsed-100x30.svg)

**After, collapsed — 100x30.** The whole exchange fits, and both peer rows sit on the spine with `bash` and `send`.

![after collapsed 100x30](https://gist.githubusercontent.com/damianvtran/c2120ea82ab51653a83baa8d24a1ab3a/raw/4cf855e7b8130b9fb277a86c2890bd021b979478/after-collapsed-100x30.svg)

**After, expanded — 100x30.** Sender identity, then the full body.

![after expanded 100x30](https://gist.githubusercontent.com/damianvtran/c2120ea82ab51653a83baa8d24a1ab3a/raw/9e6279f7f6689fbbe9d2de77d9f242776b9ad182/after-expanded-100x30.svg)

**After, collapsed — 72 cols.** The one-row guarantee where it is hardest; the snippet sheds, the sender name does not.

![after collapsed 72](https://gist.githubusercontent.com/damianvtran/c2120ea82ab51653a83baa8d24a1ab3a/raw/550204a2415da10c5b8287a2b0c9c33a62f2ca01/after-collapsed-72x30.svg)

**After, expanded — 72 cols** ([link](https://gist.githubusercontent.com/damianvtran/c2120ea82ab51653a83baa8d24a1ab3a/raw/74334cb103b4c2859fb2202def70c14b3bf37707/after-expanded-72x30.svg)) and **before at 72 cols** ([link](https://gist.githubusercontent.com/damianvtran/c2120ea82ab51653a83baa8d24a1ab3a/raw/b0248f4162e974b61383f4ea8ba88431de45a465/before-collapsed-72x30.svg)).

**Plain-icon fallback — 100x30.** `← peer` against `→ send`, the direction pair, on a terminal without a patched font.

![plain icons](https://gist.githubusercontent.com/damianvtran/c2120ea82ab51653a83baa8d24a1ab3a/raw/97a8d4eaa0ba9dd76a49d110744aecfed7a59ea0/after-collapsed-plain-100x30.svg)

### Geometry behind the pixels

Per AGENTS.md, the stills show the symptom and the numbers show the cause. Every capture printed its screen geometry; no frame introduced a scrollbar or a virtual size past the actual — the tall-overlay regression class the usage-card round caught this way:

```
100x30 collapsed : size=98x28  virtual=98x28  vscroll=False
100x30 expanded  : size=98x28  virtual=98x28  vscroll=False
 72x30 collapsed : size=70x28  virtual=70x28  vscroll=False
 72x30 expanded  : size=70x28  virtual=70x28  vscroll=False
```

And the card's pinned height agrees with what it painted at every width (a count that disagrees laps the block below):

```
  72 cols: collapsed= 1 rows   expanded=19 rows   height==rowcount:True
 100 cols: collapsed= 1 rows   expanded=16 rows   height==rowcount:True
 140 cols: collapsed= 1 rows   expanded=13 rows   height==rowcount:True
```

## Testing evidence

### The real path, driven end to end

Not a constructed widget: a `PeerMessageDeliveredEvent` emitted into the live app, through the two-hop delivery the TUI actually uses, then the real key path.

```
LIVE mounted: PeerMessageBlock height: 1 rows: 1
row: '\uf01c peer     "peer-send design" — release window claimed second paragraph with detail'
dedupe id recorded: True
after Enter expanded: True height: 6 == rows: True
after Enter again: False height: 1
typing passthrough ok: True
```

The last line matters: a printable key on a focused card still reaches the composer rather than being eaten by the row.

`/copy` over an expanded receipt, driven through the real screen selection:

```
copied: 'I am claiming the release window.\n\nWindow contents: #744, #751.\n\nDo not start a second release.'
```

No `peer message from`, no session name, no pid, no icon — only the peer's words.

### Every new guard proven able to go red

Per AGENTS.md ("Prove the test can still fail"), each guard class was mutated on a scratch copy and the tests re-run, then the tree restored:

| mutation | result |
|---|---|
| M1 put the snippet ahead of the identity (the `_send_summary` defect) | 2 failed — ordering + narrow-width shed |
| M2 drop `_sanitize_sender_field` from the collapsed row's identity | 3 failed — control chars, 50k name, bidi override |
| M3 give `PeerMessageBlock` a `margin-top` / un-pin its height in the tcss | 2 failed — minimalism height pin + single-gap-source |

### Tests

`tests/unit/tui/test_peer_message.py` rewritten for the new shape (25 tests): the collapsed row is exactly one row and names the sender before the snippet; the snippet sheds first at narrow widths and carries no cap of its own; a multi-line body becomes a one-line snippet; expansion reveals full identity **and** every paragraph of the body; activate/Enter/click toggles; the hint appears only on hover or focus; `retheme` is the shared base hook; a height-only resize rebuilds nothing (`_built_width` guard); the degradation ladder (cwd → session-id prefix → pid, never a bare unactionable row); the hardening set including the 50k-character name, C0/C1 controls and seven Cf/bidi payloads; monotonic wrapping of the identity line across six name lengths × five widths; a chrome-free copy; the shared ledger spine (same `SPACING_KIND`, same name column, one row of air); the real pointer hover/click path under the production sheet; and the one-row guarantee at 48 columns. The replay double-paint guard and the busy-steer regression test are unchanged.

`tests/unit/tui/test_minimalism.py`: the two tcss matchers that pin the collapsed-height and no-margin contracts by exact selector text now include `PeerMessageBlock`, so the card is held to the same pins rather than silently exempt.

### Gates — whole tree, exactly as CI

```
.venv/bin/python -m flake8 .                                 clean
uvx --from black==26.1.0 black --check .                     1035 files would be left unchanged
uvx isort==5.13.2 --check .                                  clean (skipped 2)
.venv/bin/python -m pyright --pythonpath .venv/bin/python .  0 errors, 0 warnings, 0 informations
.venv/bin/python -m pytest tests/unit                        1 failed, 15633 passed, 18 skipped (41:14)
env -u NO_COLOR TERM=xterm-256color pytest tests/unit/tui    2 failed, 5811 passed, 12 skipped (48:29)
```

**Disclosed:** the two TUI-suite failures are contention flakes in files this diff does not touch — `test_app_pilot.py::test_an_unreadable_credential_store_says_that_instead` (`assert 'unreadable' in ''`) and `test_word_caret.py::test_real_teardown_settles_a_held_escape_and_leaks_no_callback` (`KeyError: "No 'text-area--gutter' key in COMPONENT_CLASSES"`). Both pass serially on this branch (`2 passed`), and both passed in the full `tests/unit` run. That run happened at **load average 101–130** with sibling worktrees running their own suites.

The single `tests/unit` failure is contention, established by re-running the whole suite: **a different unrelated test failed each time, and every one passes serially.**

| full-suite run | failure | serial re-run on this branch |
|---|---|---|
| run A | a process-scan test whose assertion diff is a list of live pids (`'96789'`, `'99706'`, `'99708'` …) — it observed this machine's sibling worktree processes | `tests/unit/session/runtime`: **315 passed** |
| run B | `test_band_panels.py::test_the_inset_is_never_what_tips_a_long_subagent_list_over[20-10]` — `NoMatches: No nodes match '#band'`, i.e. the app had not finished mounting its band | **5 passed** |

Neither file is in this diff, and a regression would fail the *same* test twice. Both runs happened at **load average 74–130** with sibling worktrees running their own suites — the condition AGENTS.md describes as the reason a wall-clock budget stretches while the assertion does not.

An **earlier** full `tests/unit` run surfaced **2 genuine failures** — the `test_minimalism.py` selector matchers, which pin the tcss contracts by exact selector text and did not know about the new `PeerMessageBlock` selector. Those are fixed in this branch rather than worked around: the pins now cover the card, so it is held to the same collapsed-height and no-margin contracts as `ToolCard` and `WakeBlock` instead of being silently exempt.

## Scope

`local_operator/tui/widgets/transcript.py`, `local_operator/tui/glyphs.py`, `local_operator/tui/local_operator.tcss`, `tests/unit/tui/test_peer_message.py`, `tests/unit/tui/test_minimalism.py`, and the new `scripts/peer_message_shot.py`. **`pyproject.toml` untouched** — no version bump on this branch.

Deliberately **not** in scope:

- **The mobile web surface.** `local_operator/mobile/web/src/components/transcript.tsx` case `peer_message` renders the same event in the phone portal and is unchanged. It has its own layout constraints and a different reader posture, and folding it in here would make one review cover two surfaces.
- **The two call sites.** `app.py`'s `on_peer_message_delivered` and `session_presentation.py`'s `/resume` replay branch both keep working untouched: the constructor signature is preserved, which is what let the replay double-paint guard stay as it was.
- **`scripts/visual_inventory.json`.** The gallery census is a frozen artifact pinned to a base SHA with counted variants (`documented_variants: 111`, `frozen_scope`); adding a row would edit a freeze this PR is not the right place to re-cut. The shot script runs standalone with the documented CLI.

## Not addressed

`tests/unit/mobile/test_peer_send.py`, `tests/unit/test_cli_send.py` and `tests/unit/session/test_session_peer.py` mention the old `peer message from (pid 1)` label — but only in **docstrings**, as prose describing the defect each test guards against. No assertion in any of them reads the rendered label, so they pass unchanged and were left alone; the phrase still describes the failure accurately, since `_header()` produces exactly that string in the expansion.

