### PR TITLE
fix(update): record what /update installed, so the marker stops naming the displaced build

### DIFF
--- a/docs/design-build-skew.md
+++ b/docs/design-build-skew.md
@@ -117,6 +117,14 @@ can: `lop-update` records `<git-sha> <tag>` there (live example:
 **pair**: `(version, source_ref)`, with `version` the fallback when
 `.lop-source` is absent (PyPI/pipx installs, editable checkouts).
 
+> **Amended after the stale-marker fix.** `lop-update` is no longer the only
+> writer: a PyPI upgrade through `perform_upgrade` (`lop update` and the TUI's
+> `/update`) now records `pypi <version>` at the same path, because leaving the
+> marker alone made it describe the build the upgrade had *displaced*. The file
+> therefore no longer implies "git snapshot" by its mere existence — the first
+> token does, and `source_ref` returns `""` for the `pypi` sentinel so a wheel
+> still compares on version alone exactly as described above.
+
 ## 4. The change, file by file
 
 ### 4.0 New shared helper — `local_operator/update.py`

--- a/docs/design-runtime-autorefresh.md
+++ b/docs/design-runtime-autorefresh.md
@@ -291,6 +291,14 @@ for the settle check. Editable checkouts have no `.lop-source` and a
 constant version: they never trip this, by design (matches
 `design-build-skew.md` §6.5).
 
+> **Amended after the stale-marker fix.** The settle check takes the **most
+> recent** of the marker and dist-info mtimes rather than preferring the
+> marker and falling back to dist-info. "Marker first" assumed the marker is
+> rewritten whenever the payload is; it was not, so a marker older than the
+> payload reported a minutes-old install as ~19000 s old and disarmed this
+> guard exactly when it was needed. Taking the newest can only shrink the
+> reported age, and a smaller age makes the guard wait longer.
+
 **Policy.** Not a fourth term inside `_should_exit` — that predicate answers
 "may I exit *quietly*", and a refresh must *announce*. Add beside it:
 

--- a/local_operator/update.py
+++ b/local_operator/update.py
@@ -554,29 +554,66 @@ def install_kind(
     return InstallKind.UNKNOWN
 
 
-def is_git_snapshot(prefix: str | Path | None = None) -> bool:
-    """``.lop-source`` marks a ``lop-update`` uv-tool snapshot, not a PyPI wheel.
+#: First token written into ``.lop-source`` for an install that came from a
+#: PyPI wheel rather than from a git snapshot. A sentinel rather than a fake
+#: commit: a PyPI upgrade genuinely HAS no git ref, and copying the previous
+#: install's sha forward is exactly the lie this module exists to stop.
+PYPI_SOURCE_TOKEN = "pypi"
 
-    Default is still PyPI: the caller prints one line and upgrades. We do
-    not invoke ``lop-update`` — developers who want git ``main`` keep using
-    that script.
+
+def _looks_like_git_sha(token: str) -> bool:
+    """Is this ``.lop-source`` token a commit, as opposed to a sentinel?
+
+    The marker's first token is either an abbreviated-or-full git sha (what
+    ``lop-update`` writes) or :data:`PYPI_SOURCE_TOKEN`. Discriminating on
+    SHAPE rather than on an allow-list keeps the two writers — this module and
+    the out-of-tree ``lop-update`` shell script — from having to agree on
+    anything but the format, and means an unrecognised future sentinel degrades
+    to "no ref" instead of being rendered as a bogus commit.
+
+    A PyPI version can never collide: it carries dots, which are not hex.
     """
-    root = Path(prefix) if prefix is not None else Path(sys.prefix)
-    return (root / ".lop-source").is_file()
+    if not (7 <= len(token) <= 40):
+        return False
+    return all(char in "0123456789abcdefABCDEF" for char in token)
+
+
+def is_git_snapshot(prefix: str | Path | None = None) -> bool:
+    """Was this install built from a git ref, as opposed to a PyPI wheel?
+
+    Presence of ``.lop-source`` used to be the whole test, which was true only
+    while ``lop-update`` was the sole writer. It is not any more: a PyPI
+    ``/update`` now records ``pypi <version>`` at the same path (see
+    :func:`write_source_marker`), so the marker survives the transition from a
+    git snapshot to a wheel and the FIRST TOKEN — not the file's existence —
+    is what says which one is installed.
+
+    Reading existence alone here is what made ``lop update`` keep printing
+    "this runtime was built from git" on a host whose git snapshot had already
+    been replaced by a wheel, and made ``/info`` label that wheel a snapshot.
+
+    Default is still PyPI: the caller prints one line and upgrades. We do not
+    invoke ``lop-update`` — developers who want git ``main`` keep using that
+    script.
+    """
+    return bool(source_ref(prefix))
 
 
 def source_ref(prefix: str | Path | None = None) -> str:
-    """The git ref ``lop-update`` recorded for this install, or ``""``.
+    """The git commit this install was built from, or ``""``.
 
-    ``lop-update`` writes ``<git-sha> <tag>`` into ``.lop-source`` at the same
-    root :func:`is_git_snapshot` probes, so the FIRST whitespace-separated
-    token is the commit the install was built from. Only that token is kept:
-    the tag half is a label that repeats across rebuilds of one release and
-    therefore cannot distinguish two builds, which is the whole job here.
+    ``.lop-source`` holds two whitespace-separated tokens at the root
+    :func:`is_git_snapshot` probes, in one of two shapes:
 
-    Absent (a PyPI wheel, a pipx install, an editable checkout) is ``""``
-    rather than an error — those installs have no second token and fall back
-    to the distribution version alone.
+    * ``<git-sha> <ref>`` — a ``lop-update`` snapshot. The sha is the commit;
+      the ref half is a label that repeats across rebuilds of one release and
+      therefore cannot distinguish two builds, which is the whole job here.
+    * ``pypi <version>`` — a PyPI wheel installed by :func:`perform_upgrade`.
+      There is no commit, so this returns ``""`` and the caller falls back to
+      the distribution version alone.
+
+    Absent (never upgraded through either writer, an editable checkout) is
+    ``""`` too, for the same reason.
     """
     root = Path(prefix) if prefix is not None else Path(sys.prefix)
     try:
@@ -592,7 +629,91 @@ def source_ref(prefix: str | Path | None = None) -> str:
         # diagnostic path (review round 1, R1-2).
         return ""
     parts = raw.split()
-    return parts[0] if parts else ""
+    if not parts:
+        return ""
+    return parts[0] if _looks_like_git_sha(parts[0]) else ""
+
+
+def write_source_marker(
+    root: str | Path,
+    *,
+    version: str,
+    commit: str = "",
+    ref: str = "",
+) -> bool:
+    """Record what is installed at ``root`` in ``.lop-source``. Never raises.
+
+    WHY THIS EXISTS
+    ---------------
+    ``perform_upgrade`` replaced the payload under ``root`` and nothing wrote
+    the marker back, so the file kept describing the build it had DISPLACED.
+    On the reporting host that left ``.lop-source`` naming the 0.51.7 bump
+    commit while site-packages carried 0.51.9 — every ``version@ref`` label,
+    every :class:`BuildStamp` comparison and the settle clock below all read
+    from a file about a build that was no longer there.
+
+    THE FORMAT IS A CONTRACT WITH A SECOND WRITER
+    ---------------------------------------------
+    ``~/.local/bin/lop-update`` (a shell script, out of this tree) writes
+    ``printf '%s %s\\n' "$COMMIT" "$REF"``. That shape is preserved exactly, so
+    the two writers stay interchangeable and neither has to know about the
+    other; :func:`source_ref` discriminates on token shape, not on which writer
+    produced the line. A PyPI upgrade has no commit, so it writes
+    ``pypi <version>`` — honest about having no ref rather than carrying the
+    previous install's sha forward.
+
+    ORDERING IS LOAD-BEARING
+    ------------------------
+    Callers must write this only AFTER the installer has exited successfully.
+    :func:`build_marker_age_s` uses this file's mtime as the moment the install
+    became whole, and a runtime that acted on a marker written mid-install
+    could spawn a successor that imports a torn tree.
+
+    ATOMIC, AND BEST-EFFORT
+    -----------------------
+    Temp-and-rename within the destination directory, mirroring
+    :func:`_write_cache`: a torn or interrupted write cannot leave a partial
+    marker behind, which matters because ``RuntimeServer.__init__`` reads this
+    file and a corrupt one would otherwise reach every runtime on the host
+    (review round 1, R1-2). A failure to write returns ``False`` rather than
+    raising — a missing marker degrades to "compare on version alone", while a
+    failed upgrade report would be a worse outcome than an unrecorded one.
+    """
+    first = commit if commit else PYPI_SOURCE_TOKEN
+    second = ref if commit else version
+    line = f"{first} {second}\n"
+
+    path = Path(root) / ".lop-source"
+    fd: int | None = None
+    tmp: Path | None = None
+    try:
+        handle, name = tempfile.mkstemp(dir=str(path.parent), prefix=f"{path.name}.", suffix=".tmp")
+        fd, tmp = handle, Path(name)
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            fd = None
+            stream.write(line)
+            # fsync before the rename: the marker's whole value is that it is
+            # true about the tree beside it, and an unflushed write that
+            # survives as an empty file after a crash reads as "no ref".
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.chmod(tmp, 0o644 & ~_umask())
+        tmp.replace(path)
+        tmp = None
+        return True
+    except OSError:
+        return False
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        if tmp is not None:
+            try:
+                tmp.unlink(missing_ok=True)
+            except OSError:
+                pass
 
 
 def installed_build(prefix: str | Path | None = None) -> BuildStamp:
@@ -613,33 +734,54 @@ def build_marker_age_s(prefix: str | Path | None = None) -> float | None:
     """Seconds since the install on disk was last written, or ``None``.
 
     The settle input for a runtime's self-refresh (``process._build_changed``):
-    ``lop-update`` runs ``uv tool install --force`` — which rewrites
-    site-packages over several seconds — and only THEN writes ``.lop-source``,
-    so the marker's mtime is the moment the install became whole. A runtime
-    that acted on a marker younger than ``BUILD_SETTLE_S`` could spawn a
-    successor that imports a torn tree. When there is no marker (a PyPI or
-    pipx install) the ``dist-info`` directory's mtime plays the same role; it
-    is written last by every installer. ``None`` when neither can be read —
-    an editable checkout has no dist-info of its own and no marker, and the
-    caller treats "unknown" as "not settled", which is the safe side.
+    an installer rewrites site-packages over several seconds, and a runtime
+    that acted inside that window could spawn a successor importing a torn
+    tree. Two files record when the install was last touched: ``.lop-source``,
+    written last by both writers (``lop-update`` and
+    :func:`write_source_marker`) precisely so it marks the moment the install
+    became whole, and the ``dist-info`` directory, written last by the
+    installer itself.
+
+    WHY THE NEWEST OF THE TWO, NOT THE MARKER FIRST
+    -----------------------------------------------
+    Reading the marker first and the dist-info only as a fallback assumed the
+    marker is rewritten whenever the payload is — which was not true before
+    :func:`write_source_marker` existed, and still is not for an install
+    upgraded by some path that writes neither (a hand-run ``uv tool install
+    --force``). A marker older than the payload then reported a minutes-old
+    install as hours old: on the reporting host, ~19000 s for a tree written
+    minutes earlier, which is the settle guard reading the wrong clock and
+    disarming itself exactly when it was needed.
+
+    Taking the MOST RECENT of the two mtimes cannot have that failure: any
+    write to either file only makes the reported age smaller, and a smaller
+    age means the guard waits longer. Erring toward "not settled yet" is the
+    safe direction — the cost is one more refresh check, against the cost of
+    spawning from a half-written tree.
+
+    ``None`` when neither can be read — an editable checkout has no dist-info
+    of its own and no marker, and the caller treats "unknown" as "not
+    settled", which is the same safe side.
     """
     root = Path(prefix) if prefix is not None else Path(sys.prefix)
-    marker = root / ".lop-source"
+    mtimes: list[float] = []
+
     try:
-        mtime = marker.stat().st_mtime
+        mtimes.append((root / ".lop-source").stat().st_mtime)
     except OSError:
-        try:
-            dist = distribution("local-operator")
-        except PackageNotFoundError:
-            return None
+        pass
+
+    try:
+        dist = distribution("local-operator")
         located = getattr(dist, "_path", None)
-        if located is None:
-            return None
-        try:
-            mtime = Path(located).stat().st_mtime
-        except OSError:
-            return None
-    return max(0.0, time.time() - mtime)
+        if located is not None:
+            mtimes.append(Path(located).stat().st_mtime)
+    except (PackageNotFoundError, OSError):
+        pass
+
+    if not mtimes:
+        return None
+    return max(0.0, time.time() - max(mtimes))
 
 
 def installer_argv(
@@ -740,6 +882,19 @@ def perform_upgrade(
 
     The new wheel is not imported into this interpreter; callers print
     ``target`` rather than asking :func:`installed_version` again.
+
+    On success the ``.lop-source`` marker is rewritten to describe what was
+    just installed — see :func:`write_source_marker`. Without that step the
+    marker kept naming the DISPLACED build: it is written only by the
+    ``lop-update`` shell script, so an upgrade driven from here (``lop
+    update`` and the TUI's ``/update``, which share this function) moved
+    site-packages and left the marker behind, and every ``version@ref`` label
+    and settle-clock reading on the host went on describing a build that was
+    no longer installed.
+
+    Ordering is deliberate and load-bearing: the marker is written only after
+    the installer has exited 0, because its mtime is the signal a runtime uses
+    to decide the install has settled.
     """
     detected = kind if kind is not None else install_kind(prefix=prefix, executable=executable)
     if detected is InstallKind.EDITABLE:
@@ -753,6 +908,17 @@ def perform_upgrade(
     code = runner(argv)
     if code != 0:
         raise UpdateError(f"installer exited {code}")
+
+    # Only the uv-tool layout has a ``.lop-source`` root to record into, and
+    # it is the layout ``lop-update`` shares. pipx and pip installs never had
+    # a marker and gain nothing from one: they compare on version alone.
+    if detected is InstallKind.UV_TOOL:
+        root = Path(prefix) if prefix is not None else Path(sys.prefix)
+        # ``target`` is the PyPI version just installed, and this path is
+        # always a PyPI wheel: ``installer_argv`` runs `uv tool install
+        # --force local-operator` with no --from, so no git ref exists to
+        # record. Passing no commit is what makes the marker say so.
+        write_source_marker(root, version=target)
     return target
 
 

--- a/local_operator/update.py
+++ b/local_operator/update.py
@@ -30,6 +30,7 @@ still rewrite the cache so the next splash is free.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sys
 import tempfile
@@ -39,6 +40,8 @@ from enum import Enum
 from importlib.metadata import PackageNotFoundError, distribution, version
 from pathlib import Path
 from typing import Any, Callable, Literal
+
+logger = logging.getLogger(__name__)
 
 #: Same cache root the model catalogue uses, so there is one place to clear.
 _CACHE_DIR = Path("~/.local-operator/cache")
@@ -558,6 +561,14 @@ def install_kind(
 #: PyPI wheel rather than from a git snapshot. A sentinel rather than a fake
 #: commit: a PyPI upgrade genuinely HAS no git ref, and copying the previous
 #: install's sha forward is exactly the lie this module exists to stop.
+#:
+#: Expect one cosmetic artefact in the upgrade window that introduces this
+#: token: a runtime still on PRE-SENTINEL code reads the whole first token as
+#: a ref and renders ``/info`` as ``source git snapshot @ pypi``. It is
+#: self-clearing rather than sticky — the marker's mtime still CHANGES, so
+#: those runtimes see a new build and retire on their own (measured at ~1.5 s,
+#: QA round 1, Q2) — and it is unavoidable for a format change that must keep
+#: the marker a single file shared with ``lop-update``.
 PYPI_SOURCE_TOKEN = "pypi"
 
 
@@ -572,6 +583,14 @@ def _looks_like_git_sha(token: str) -> bool:
     to "no ref" instead of being rendered as a bogus commit.
 
     A PyPI version can never collide: it carries dots, which are not hex.
+
+    The shape test is deliberately loose: it admits any 7-40 hex token, so a
+    hex-looking BRANCH name (``deadbeef``) in the second writer's ref position
+    would read as a commit. It cannot fire today — ``lop-update`` only ever
+    writes ``git rev-parse --verify`` output into the first token — but it is
+    the constraint on anyone adding a sentinel later: A FUTURE SENTINEL MUST
+    NOT BE HEX, or it will render as a bogus commit instead of degrading to
+    "no ref" (review round 1, R1-3).
     """
     if not (7 <= len(token) <= 40):
         return False
@@ -762,6 +781,25 @@ def build_marker_age_s(prefix: str | Path | None = None) -> float | None:
     ``None`` when neither can be read — an editable checkout has no dist-info
     of its own and no marker, and the caller treats "unknown" as "not
     settled", which is the same safe side.
+
+    THE TWO TERMS ARE NOT SCOPED THE SAME WAY, ON PURPOSE
+    -----------------------------------------------------
+    The marker is read from ``prefix``; the dist-info is always the RUNNING
+    INTERPRETER's, because :func:`distribution` resolves through ``sys.path``
+    and takes no prefix. In production the two are the same tree — a
+    runtime's ``prefix`` IS its own install — so the distinction is invisible.
+    It shows only through the ``LOP_BUILD_PREFIX`` test seam, where a caller
+    passing a foreign prefix gets an age mixing that prefix's marker with this
+    interpreter's dist-info (review round 1, R1-2).
+
+    That is deliberate rather than merely tolerated. Scoping the dist-info to
+    ``prefix`` means globbing ``<prefix>/lib/*/site-packages/*.dist-info``,
+    and a layout that glob does not match degrades this back to reading the
+    MARKER ALONE — which is precisely the stale-marker failure the max-of-two
+    was introduced to fix, reintroduced on the production path to sharpen a
+    seam only the e2e stage uses. The mixed answer is also safe in the one
+    direction that matters: an extra mtime can only make the age SMALLER, so
+    the settle guard waits longer, never less.
     """
     root = Path(prefix) if prefix is not None else Path(sys.prefix)
     mtimes: list[float] = []
@@ -918,7 +956,19 @@ def perform_upgrade(
         # always a PyPI wheel: ``installer_argv`` runs `uv tool install
         # --force local-operator` with no --from, so no git ref exists to
         # record. Passing no commit is what makes the marker say so.
-        write_source_marker(root, version=target)
+        if not write_source_marker(root, version=target):
+            # Deliberately not fatal: the upgrade itself SUCCEEDED, and a
+            # failed marker only costs accuracy in the labels. But without a
+            # line here the host silently reverts to the pre-fix behaviour —
+            # a marker naming the displaced build — with nothing to find
+            # afterwards, so log it rather than discarding the result
+            # (review round 1, R1-4).
+            logger.warning(
+                "Upgraded to %s but could not record it in %s/.lop-source; "
+                "version labels will keep naming the previous build.",
+                target,
+                root,
+            )
     return target
 
 

--- a/tests/unit/session/test_no_session_deletion.py
+++ b/tests/unit/session/test_no_session_deletion.py
@@ -534,6 +534,22 @@ _ALLOWED_ROWS: tuple[tuple[str | int, ...], ...] = (
     ("local_operator/tunnels/service.py::run", "<path>.unlink", "tunnel pid/state FILEs", 3),
     ("local_operator/update.py::_write_cache", "<path>.replace", "temp FILE -> update cache FILE"),
     ("local_operator/update.py::_write_cache", "<path>.unlink", "temp FILE -> update cache FILE"),
+    # The install-provenance marker, written atomically after an upgrade. Both
+    # calls are confined to the temp file this function itself created with
+    # ``mkstemp`` inside the INSTALL prefix (a uv tool root), and the rename
+    # target is the single FILE ``<prefix>/.lop-source``. Neither name is ever
+    # derived from a session path, and the install prefix is not under the
+    # session store.
+    (
+        "local_operator/update.py::write_source_marker",
+        "<path>.replace",
+        "temp FILE -> .lop-source FILE in the install prefix",
+    ),
+    (
+        "local_operator/update.py::write_source_marker",
+        "<path>.unlink",
+        "cleanup of this function's own mkstemp temp FILE",
+    ),
     ("local_operator/wakes/install.py::uninstall", "<path>.unlink", "plist FILE"),
     ("local_operator/wakes/store.py::remove_entry", "<path>.unlink", "wakes/<id>.json FILE"),
     ("local_operator/web_fetch/service.py::_prune_cache", "<path>.unlink", "fetch cache FILEs"),

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -918,9 +918,66 @@ def test_write_source_marker_leaves_no_temp_file_behind(tmp_path: Path) -> None:
 
     ``RuntimeServer.__init__`` reads this file, so a torn write would reach
     every runtime on the host (review round 1, R1-2).
+
+    NOT SUFFICIENT ON ITS OWN. A plain ``path.write_text`` leaves no temp file
+    either, so this assertion is satisfied by the very implementation it reads
+    as rejecting; it passed against both non-atomic mutants in review round 1.
+    The two tests below are the ones that discriminate — this one only pins
+    that the temp file is cleaned up.
     """
     update_mod.write_source_marker(tmp_path, version="0.51.9")
     assert sorted(p.name for p in tmp_path.iterdir()) == [".lop-source"]
+
+
+def test_write_source_marker_installs_by_rename_not_by_writing_in_place(
+    tmp_path: Path,
+) -> None:
+    """The destination is only ever reached by a rename, never opened for write.
+
+    THIS IS THE ATOMICITY GUARD, and it is structural rather than timed: a
+    rename REPLACES the destination, so the inode a reader would open changes;
+    truncating the destination in place (``path.write_text``, or a
+    ``shutil.copyfile`` over it) keeps the same inode and exposes a window in
+    which a concurrent ``RuntimeServer.__init__`` reads a half-written marker.
+    Inode identity is a fact about how the file got there, so this cannot flake
+    the way a race-the-writer test would.
+
+    Verified to discriminate (review round 1, R1-1): both the ``write_text``
+    and ``copyfile`` mutants keep the inode and fail here.
+    """
+    marker = tmp_path / ".lop-source"
+    marker.write_text("f1cd77900182 main\n", encoding="utf-8")
+    before = marker.stat().st_ino
+
+    assert update_mod.write_source_marker(tmp_path, version="0.51.9") is True
+
+    after = marker.stat().st_ino
+    assert after != before, (
+        "the marker must be installed by renaming a fully-written temp file over it; "
+        f"the inode was unchanged ({before}), so the destination was written in place"
+    )
+
+
+def test_a_failed_marker_write_leaves_the_previous_marker_byte_intact(
+    tmp_path: Path,
+) -> None:
+    """A write that cannot start must not damage what is already there.
+
+    The companion to the rename guard above, covering the failure path: with
+    the temp file unavailable there is nothing to rename, so the function has
+    to report ``False`` and leave the existing marker exactly as it found it.
+    An implementation that writes the destination directly reports success and
+    overwrites a marker it never managed to replace — which is worse than not
+    writing at all, because every runtime on the host then reads it.
+    """
+    marker = tmp_path / ".lop-source"
+    stale = "f1cd77900182 main\n"
+    marker.write_text(stale, encoding="utf-8")
+
+    with patch.object(update_mod.tempfile, "mkstemp", side_effect=OSError("no temp")):
+        assert update_mod.write_source_marker(tmp_path, version="0.51.9") is False
+
+    assert marker.read_text(encoding="utf-8") == stale
 
 
 def test_upgrading_a_uv_tool_records_what_it_just_installed(tmp_path: Path) -> None:

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import time
 from contextlib import contextmanager
+from importlib.metadata import PackageNotFoundError
 from pathlib import Path
 from unittest.mock import patch
 
@@ -346,23 +348,32 @@ def test_install_kind_editable_outranks_pip_installer(tmp_path: Path) -> None:
         assert install_kind(prefix=tmp_path) is InstallKind.EDITABLE
 
 
-def test_perform_upgrade_runs_detected_argv() -> None:
+def test_perform_upgrade_runs_detected_argv(tmp_path: Path) -> None:
     seen: list[list[str]] = []
 
     def run(argv: list[str]) -> int:
         seen.append(argv)
         return 0
 
-    out = perform_upgrade(target="0.28.0", kind=InstallKind.UV_TOOL, run=run)
+    # ``prefix`` is passed on every call because a successful UV_TOOL upgrade
+    # now writes ``.lop-source`` at the prefix; without it this test would
+    # drop a marker into the developer's own ``sys.prefix``.
+    out = perform_upgrade(target="0.28.0", kind=InstallKind.UV_TOOL, run=run, prefix=tmp_path)
     assert out == "0.28.0"
     assert seen == [["uv", "tool", "install", "--force", "local-operator"]]
 
     seen.clear()
-    perform_upgrade(target="0.28.0", kind=InstallKind.PIPX, run=run)
+    perform_upgrade(target="0.28.0", kind=InstallKind.PIPX, run=run, prefix=tmp_path)
     assert seen == [["pipx", "upgrade", "local-operator"]]
 
     seen.clear()
-    perform_upgrade(target="0.28.0", kind=InstallKind.PIP, run=run, executable="/venv/bin/python")
+    perform_upgrade(
+        target="0.28.0",
+        kind=InstallKind.PIP,
+        run=run,
+        executable="/venv/bin/python",
+        prefix=tmp_path,
+    )
     assert seen == [["/venv/bin/python", "-m", "pip", "install", "-U", "local-operator"]]
 
 
@@ -373,9 +384,9 @@ def test_perform_upgrade_refuses_editable_and_unknown() -> None:
         perform_upgrade(target="0.28.0", kind=InstallKind.UNKNOWN, run=lambda _: 0)
 
 
-def test_perform_upgrade_nonzero_installer() -> None:
+def test_perform_upgrade_nonzero_installer(tmp_path: Path) -> None:
     with pytest.raises(UpdateError, match="exited 9"):
-        perform_upgrade(target="0.28.0", kind=InstallKind.UV_TOOL, run=lambda _: 9)
+        perform_upgrade(target="0.28.0", kind=InstallKind.UV_TOOL, run=lambda _: 9, prefix=tmp_path)
 
 
 def test_installer_argv_matches_kind() -> None:
@@ -704,12 +715,14 @@ def test_update_command_unsupervised_warns(capsys: pytest.CaptureFixture[str]) -
     assert "lop mobile restart" not in captured.err
 
 
-def test_perform_upgrade_does_not_refresh() -> None:
+def test_perform_upgrade_does_not_refresh(tmp_path: Path) -> None:
     with (
         patch.object(update_mod, "refresh_mobile_after_upgrade") as refresh,
         patch("subprocess.run") as run,
     ):
-        out = perform_upgrade(target="0.28.0", kind=InstallKind.UV_TOOL, run=lambda _: 0)
+        out = perform_upgrade(
+            target="0.28.0", kind=InstallKind.UV_TOOL, run=lambda _: 0, prefix=tmp_path
+        )
     assert out == "0.28.0"
     refresh.assert_not_called()
     run.assert_not_called()
@@ -831,6 +844,147 @@ def test_same_version_rebuilds_are_different_builds() -> None:
     after = update_mod.BuildStamp(version="0.49.0", source_ref="bbbbbbb2222")
     assert before != after
     assert before.version == after.version, "the version alone cannot tell them apart"
+
+
+def test_source_ref_ignores_the_pypi_sentinel(tmp_path: Path) -> None:
+    """``pypi <version>`` is an honest "no commit", not a ref to render.
+
+    A PyPI upgrade has no git commit at all. The marker still records what is
+    installed, so the file exists — but ``source_ref`` must not hand a caller
+    the word ``pypi`` to print as ``0.51.9@pypi``.
+    """
+    (tmp_path / ".lop-source").write_text("pypi 0.51.9\n", encoding="utf-8")
+    assert update_mod.source_ref(tmp_path) == ""
+    assert update_mod.installed_build(tmp_path).source_ref == ""
+
+
+def test_is_git_snapshot_follows_the_token_not_the_files_existence(tmp_path: Path) -> None:
+    """The regression this whole change is about, stated as a predicate.
+
+    Before ``/update`` wrote the marker, existence WAS the test — correct only
+    while ``lop-update`` was the sole writer. Now a wheel installed over a git
+    snapshot leaves a marker behind, and calling that host a git snapshot
+    would keep printing "this runtime was built from git" about a wheel.
+    """
+    marker = tmp_path / ".lop-source"
+
+    marker.write_text("4d3ce1d1a48f4f3b799efdfabb014979e70e0630 main\n", encoding="utf-8")
+    assert update_mod.is_git_snapshot(tmp_path) is True
+
+    marker.write_text("pypi 0.51.9\n", encoding="utf-8")
+    assert update_mod.is_git_snapshot(tmp_path) is False
+
+
+def test_write_source_marker_records_a_pypi_install(tmp_path: Path) -> None:
+    assert update_mod.write_source_marker(tmp_path, version="0.51.9") is True
+    assert (tmp_path / ".lop-source").read_text(encoding="utf-8") == "pypi 0.51.9\n"
+    assert update_mod.source_ref(tmp_path) == ""
+    assert update_mod.is_git_snapshot(tmp_path) is False
+
+
+def test_write_source_marker_keeps_lop_updates_two_token_shape(tmp_path: Path) -> None:
+    """``lop-update`` is a second writer, out of this tree; the format is the contract.
+
+    It writes ``printf '%s %s\\n' "$COMMIT" "$REF"``. Writing the same shape
+    here is what keeps the two interchangeable — a marker written by either
+    reads identically through ``source_ref``.
+    """
+    sha = "4d3ce1d1a48f4f3b799efdfabb014979e70e0630"
+    assert update_mod.write_source_marker(tmp_path, version="0.51.9", commit=sha, ref="main")
+    assert (tmp_path / ".lop-source").read_text(encoding="utf-8") == f"{sha} main\n"
+    assert update_mod.source_ref(tmp_path) == sha
+    assert update_mod.is_git_snapshot(tmp_path) is True
+
+
+def test_write_source_marker_replaces_a_stale_marker(tmp_path: Path) -> None:
+    """The reported state: a marker naming the build the upgrade DISPLACED."""
+    stale = "f1cd77900182616a683c4e7e58f0b0e01be580b3"
+    (tmp_path / ".lop-source").write_text(f"{stale} main\n", encoding="utf-8")
+    assert update_mod.source_ref(tmp_path) == stale
+
+    update_mod.write_source_marker(tmp_path, version="0.51.9")
+    assert update_mod.source_ref(tmp_path) == ""
+    assert (tmp_path / ".lop-source").read_text(encoding="utf-8") == "pypi 0.51.9\n"
+
+
+def test_write_source_marker_never_raises_on_an_unwritable_root(tmp_path: Path) -> None:
+    """A failed marker write must not turn a SUCCESSFUL upgrade into an error."""
+    missing = tmp_path / "does-not-exist"
+    assert update_mod.write_source_marker(missing, version="0.51.9") is False
+
+
+def test_write_source_marker_leaves_no_temp_file_behind(tmp_path: Path) -> None:
+    """Temp-and-rename: a reader must never see a partial marker.
+
+    ``RuntimeServer.__init__`` reads this file, so a torn write would reach
+    every runtime on the host (review round 1, R1-2).
+    """
+    update_mod.write_source_marker(tmp_path, version="0.51.9")
+    assert sorted(p.name for p in tmp_path.iterdir()) == [".lop-source"]
+
+
+def test_upgrading_a_uv_tool_records_what_it_just_installed(tmp_path: Path) -> None:
+    """End to end over ``perform_upgrade``: the marker follows the payload.
+
+    Nothing in Python wrote ``.lop-source`` before this, so an upgrade driven
+    from ``lop update`` or the TUI's ``/update`` left it naming the displaced
+    build for as long as the host lived.
+    """
+    stale = "f1cd77900182616a683c4e7e58f0b0e01be580b3"
+    (tmp_path / ".lop-source").write_text(f"{stale} main\n", encoding="utf-8")
+
+    perform_upgrade(target="0.51.9", kind=InstallKind.UV_TOOL, run=lambda _: 0, prefix=tmp_path)
+
+    assert (tmp_path / ".lop-source").read_text(encoding="utf-8") == "pypi 0.51.9\n"
+    assert update_mod.source_ref(tmp_path) == "", "no commit may be invented for a wheel"
+
+
+def test_a_failed_upgrade_leaves_the_marker_alone(tmp_path: Path) -> None:
+    """The marker describes what is INSTALLED, and a failed install changed nothing."""
+    stale = "f1cd77900182616a683c4e7e58f0b0e01be580b3"
+    (tmp_path / ".lop-source").write_text(f"{stale} main\n", encoding="utf-8")
+
+    with pytest.raises(UpdateError):
+        perform_upgrade(target="0.51.9", kind=InstallKind.UV_TOOL, run=lambda _: 1, prefix=tmp_path)
+
+    assert update_mod.source_ref(tmp_path) == stale
+
+
+def test_only_the_uv_tool_layout_gets_a_marker(tmp_path: Path) -> None:
+    """pipx and pip installs never had a marker and gain nothing from one."""
+    perform_upgrade(target="0.51.9", kind=InstallKind.PIPX, run=lambda _: 0, prefix=tmp_path)
+    assert not (tmp_path / ".lop-source").exists()
+
+
+def test_build_marker_age_reads_the_newest_write_not_the_marker(tmp_path: Path) -> None:
+    """The settle guard must not be disarmed by a marker older than the payload.
+
+    A stale marker reported a minutes-old install as ~19000 s old on the
+    reporting host. Taking the most recent of marker and dist-info can only
+    make the age smaller, and a smaller age makes the guard wait longer —
+    the safe direction.
+    """
+    marker = tmp_path / ".lop-source"
+    marker.write_text("pypi 0.51.9\n", encoding="utf-8")
+    old = time.time() - 19_000
+    os.utime(marker, (old, old))
+
+    dist_dir = tmp_path / "local_operator-0.51.9.dist-info"
+    dist_dir.mkdir()
+
+    class _Located:
+        _path = dist_dir
+
+    with patch.object(update_mod, "distribution", return_value=_Located()):
+        age = update_mod.build_marker_age_s(tmp_path)
+
+    assert age is not None
+    assert age < 60, f"the fresh dist-info must win over the stale marker, got {age}"
+
+
+def test_build_marker_age_is_none_without_either_signal(tmp_path: Path) -> None:
+    with patch.object(update_mod, "distribution", side_effect=PackageNotFoundError()):
+        assert update_mod.build_marker_age_s(tmp_path) is None
 
 
 def test_a_build_label_names_the_ref_only_when_there_is_one() -> None:


### PR DESCRIPTION
## Summary

The TUI's `/update` (and `lop update` — they share one function) upgrades the installation but never updates `.lop-source`, so the marker goes on describing the build the upgrade **displaced**.

`perform_upgrade()` shells `uv tool install --force local-operator` and returns. Nothing in Python has ever written that file; only the out-of-tree `~/.local/bin/lop-update` shell script does (`printf '%s %s\n' "$COMMIT" "$REF"`). So any upgrade driven from inside the app moves site-packages and leaves the marker where it was.

On the reporting host right now: `bin/` and `lib/` are 0.51.9 (dist-info mtime 17:11, `INSTALLER=uv`) while `.lop-source` still reads `f1cd77900182616a683c4e7e58f0b0e01be580b3 main` with mtime 11:58 — the 0.51.7 bump commit.

**Release: patch — `/update` now records what it installed, so `version@ref` labels, the build-settle clock and the git-snapshot notice stop describing a build that is no longer on disk.**

Patch and not minor per AGENTS.md materiality: a correctness fix inside an existing mechanism, no new surface to name in a release title.

## Change class

C1 — a bug fix in `update.py` plus its two readers' semantics. No user-visible layout change; the only rendering difference is that `/info` now tells the truth about a wheel installed over a snapshot.

## The three consequences, and what each required

### (a) `source_ref()` returned a commit that was not installed

Every `version@ref` label and every `BuildStamp` comparison on the host read from it. The operator's banner literally reads `0.51.0@f1cd779 → 0.51.9@f1cd779` — **the same ref on both sides of an arrow that exists to show a change**. (The version half of that banner is PR #748's defect; this PR fixes the ref half. They are independent — see "Interaction with #748" below.)

### (b) `build_marker_age_s()` was reading the wrong clock

It uses the marker's mtime as the settle signal that stops a runtime acting on a half-written install. A stale marker made a minutes-old install look ~19000 s old.

**I changed the fallback ordering, and this was the judgement call the task flagged.** It was "marker first, dist-info second". That ordering assumes the marker is rewritten whenever the payload is — which was not true before this PR, and *still* is not true for an install upgraded by some path that writes neither (a hand-run `uv tool install --force`). It now takes the **most recent of the two**. That cannot have the failure mode: any write to either file only makes the reported age *smaller*, and a smaller age makes the guard wait *longer*. Erring toward "not settled yet" costs one more refresh check; erring the other way spawns from a torn tree.

### (c) A PyPI `/update` has no git commit — so the marker must be able to say so

I did **not** invent or copy a commit. The marker keeps `lop-update`'s exact two-token shape and writes `pypi <version>` when there is no commit:

- `<git-sha> <ref>` — a `lop-update` snapshot (unchanged, still written by the shell script)
- `pypi <version>` — a wheel installed by `perform_upgrade`

`source_ref()` discriminates on **token shape** (hex, 7–40 chars) rather than an allow-list, so the two writers only have to agree on the format and an unrecognised future sentinel degrades to "no ref" instead of rendering as a bogus commit. A PyPI version can never collide: it contains dots, which are not hex.

This forced a third change. `is_git_snapshot()` treated the file's **mere existence** as "git snapshot" — correct only while `lop-update` was the sole writer. Now that a wheel also leaves a marker, it reads the first token. Without this, a host whose snapshot had been replaced by a wheel would keep printing *"this runtime was built from git"* and `/info` would label that wheel a snapshot.

### Atomicity (the R1-2 blast radius)

`RuntimeServer.__init__` reads this file, so a corrupt marker stops **every runtime on the host** from being constructed. The write is mkstemp + fsync + rename inside the destination directory, mirroring `_write_cache`, and returns `False` rather than raising — a failed marker write must not turn a *successful* upgrade into an error.

### One writer or two?

I kept two writers and made the **format** the contract rather than converging them. Converging would mean either shelling out to `lop-update` from the app (it is a release tool that archives git `main` — the opposite audience, and it refuses without a repo) or reimplementing its remote-sync and downgrade gates in Python. The format is two tokens; both writers emit it; `source_ref` reads either without knowing which produced it. A test pins the shell script's exact shape.

## Reproduction, on real isolated uv tool installs

`HOME` and `LOCAL_OPERATOR_CONFIG_DIR` redirected together (config dir alone does not redirect the cache), plus `UV_TOOL_DIR`/`UV_TOOL_BIN_DIR`.

### Before — the reported state, reproduced

```
$ uv tool install --force local-operator==0.51.7      # then a prior lop-update marker
$ uv tool install --force local-operator==0.51.9      # what perform_upgrade shells

BEFORE upgrade:
  marker: f1cd77900182616a683c4e7e58f0b0e01be580b3 main (mtime 11:58:00)
  dist-info: local_operator-0.51.7.dist-info
AFTER upgrade:
  marker: f1cd77900182616a683c4e7e58f0b0e01be580b3 main (mtime 11:58:00)
  dist-info: local_operator-0.51.9.dist-info
```

The payload moved; the marker did not. Read back through the real functions:

```
installed_build():  BuildStamp(version='0.51.9', source_ref='f1cd7790...')  -> 0.51.9@f1cd779
source_ref():       f1cd77900182616a683c4e7e58f0b0e01be580b3
is_git_snapshot():  True          <- but a PyPI wheel is installed
build_marker_age_s(): 19825 s     <- the install is minutes old
```

### After — a real 0.51.7 → 0.51.9 upgrade through the real `perform_upgrade`

```
$ python -c "from local_operator import update as u; \
    u.perform_upgrade(target='0.51.9', kind=u.InstallKind.UV_TOOL, prefix=TD)"
 - local-operator==0.51.7
 + local-operator==0.51.9
perform_upgrade returned: 0.51.9

  marker file          : pypi 0.51.9
  dist-info            : local_operator-0.51.9.dist-info
  installed_build()    : 0.51.9      <- no fake @ref
  source_ref()         : ''          <- honestly empty: a wheel has no commit
  is_git_snapshot()    : False       <- was True, and a wheel is installed
  build_marker_age_s() : 7 s         <- sane; install is seconds old
```

### The git-ref case, separately: a real `lop-update main`

Run against an isolated clone at `origin/main` (the operator's own checkout was never touched). The remote-sync gate was exercised and correctly refused a stale local `main` first.

```
lop-update: installed local-operator 0.51.9 from main (9b8a6023)
lop-update: remote check: in sync with origin/main

  marker file          : 9b8a60230bfb87eb0f20b78bc5f2efee7390bffc main
  installed_build()    : 0.51.9@9b8a602   <- version@ref, exactly as before
  source_ref()         : 9b8a60230bfb87eb0f20b78bc5f2efee7390bffc
  is_git_snapshot()    : True             <- a real git snapshot
  build_marker_age_s() : 7 s
```

The shell script's writes are unchanged and read correctly by the new code.

### The transition case — `/update` on top of a real git snapshot

This is the operator's actual situation:

```
  before: 9b8a60230bfb87eb0f20b78bc5f2efee7390bffc main  (0.51.9 built from main)
  after : pypi 0.51.9                                    (the wheel replaced the snapshot)

  is_git_snapshot()    : False    <- correctly no longer a snapshot
  installed_build()    : 0.51.9   <- no stale @9b8a602 carried forward
```

## Effect on autorefresh

`_build_changed()` refuses unless the on-disk stamp **differs** from the boot stamp and the marker has settled. Same-version upgrades are this host's common case, so the ref is what has to carry the change:

```
WITHOUT the marker fix: on_disk == boot -> True  -> _build_changed() returns None -> never refreshes
WITH the marker fix   : on_disk == boot -> False -> differs, so the refresh path is reachable
  boot   : 0.51.9@9b8a602
  on disk: 0.51.9
  settle : build_marker_age_s() = 14 s (BUILD_SETTLE_S = 10.0)
```

**This is necessary but not sufficient, and I deliberately did not expand the slice.** Defect A (PR #748) is the other half: `RuntimeServer.__init__` and the reaper both resolve `installed_build()` through a sys.path poisoned by the session cwd, so on a checkout host both sides of the comparison still come from the checkout. The two fixes compose but neither alone completes it — measured, with cwd set to a checkout:

```
sys.path[0]        : (cwd)
installed_version(): 0.51.9   <- Defect A: read via importlib from the CHECKOUT
source_ref()       : ''       <- read from sys.prefix, NOT poisoned by cwd
```

The marker half is filesystem-rooted and so is independent of #748. Full autorefresh on a checkout host needs both.

## Interaction with #748

No file overlap in the functions changed: #748 fixes the child spawn's `sys.path`; this fixes what is written to and read from `.lop-source`. Both touch `update.py`, so whichever lands second rebases.

## Tests

- `source_ref` ignores the `pypi` sentinel; `installed_build` carries no ref for a wheel
- `is_git_snapshot` follows the token, not the file's existence (both directions)
- the writer records a PyPI install, keeps `lop-update`'s two-token shape, replaces a stale marker, never raises on an unwritable root, leaves no temp file behind
- `perform_upgrade` records what it installed; a **failed** upgrade leaves the marker alone; pipx/pip get no marker
- `build_marker_age_s` prefers a fresh dist-info over a 19000 s-old marker; `None` without either signal

Two existing tests were passing `perform_upgrade` no `prefix`, which now writes a marker into the developer's own `sys.prefix` — I caught one in this worktree's `.venv` and scoped them to `tmp_path`.

`tests/unit/session/test_no_session_deletion.py` failed on the new `rename`/`unlink` call sites, exactly as designed. Both are allow-listed with reasons rather than the guard being loosened: both are confined to a temp file this function created with `mkstemp` inside the install prefix, and the rename target is the single file `<prefix>/.lop-source`.

## Gates

All run over the whole tree, exactly as CI:

```
.venv/bin/python -m flake8 .                              -> clean
uvx --from black==26.1.0 black --check .                  -> 1057 files unchanged
uvx isort==5.13.2 --check .                               -> clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python . -> 0 errors, 0 warnings
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
                                                          -> 15982 passed, 18 skipped
```

The suite run reported 3 failures, all investigated:

- `test_no_session_deletion` — **genuinely mine**, fixed as described above.
- `test_resume_subagents_todos` (a byte-size assertion) and `test_stream_anchor` (a scroll-offset assertion) — **not mine**. The host was at load average 164 with many sibling worktrees running suites. Both files pass in full on this branch *and* on a clean `origin/main` worktree on the same host (39 passed, both times), and this diff touches neither subsystem.

`pyproject.toml` is untouched — no version bump, per the combined-release protocol.

## Not addressed (deliberate)

- **Defect A / PR #748** — the other half of the update stall, in flight separately. Out of scope here.
- **Converging the two writers.** Reasoned above; the format is the contract instead.
- **Backfilling a marker for pipx/pip installs.** They never had one and compare on version alone; adding one would be new behaviour, not a fix.
- **Correcting an already-stale marker on an existing host.** The next `/update` or `lop-update` writes it correctly; a repair-on-read would have to guess what is installed, which is the class of lie this PR removes.
