### PR TITLE
chore(release): bump version to 0.51.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.11"
+version = "0.51.12"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release bump for the **v0.51.12** window. Owner session pid **95714**. One line in one file.

Window derived with plain `git log v0.51.11..origin/main` (never `--merges` — any commit-shape filter is a filter on merge style, not membership), and membership proven by `git merge-base --is-ancestor` against the bump head, not by log order. All six verified `YES`.

| PR | merge SHA | Release line |
|---|---|---|
| #753 | `08bbc26c5` | patch — an MCP server that reconnects now tells the model so, in the running turn, instead of leaving it avoiding tools that came back |
| #771 | `d96a9a18e` | patch — the system prompt now describes the tools a session can actually use, and a question the agent needs answered goes through the `ask` picker instead of prose the user never sees |
| #769 | `9815cdd57` | patch — the packaged `guide://browser` playbook is for driving the user's own paired browser again; instructions for testing this repository's extension moved to AGENTS.md, where the people who need them are |
| #777 | `affe8c202` | patch — `/update` now records what it installed, so install provenance and the build-settle guard stop naming a build that is no longer there |
| #756 | `6a941c5b4` | patch — a slow or busy runtime no longer turns `/new` into a hard "could not start a runtime" boot failure; the viewer waits on liveness instead of a fixed clock, retries, and says something true when it finally gives up |
| #755 | `016a3b3a0` | patch — system notices on the welcome splash line up in one column with the composer instead of each row centring on its own width, and the build-skew notice no longer promises work-completion on a session that has no work |

**BUMP: PATCH (0.51.12).** Six defect/docs fixes inside existing subsystems. No single PR clears the step-function bar on its own — none registers a new command, tool or entry point — and a window of several patches is still one patch release. Unanimous across every session that replied.

`git diff v0.51.11..origin/main -- pyproject.toml` was **EMPTY** before this commit; `v0.51.12` exists on no local or remote tag and PyPI's latest is `0.51.11`. Nothing had consumed the number.

**Rebased twice**, as #777 then #756/#755 landed inside the window. Both rebases proven content-neutral rather than asserted: `git range-diff` reports `=`, and the bump commit's `git patch-id --stable` is byte-identical across every head (`65157965a2ee…`). The diff remains exactly `pyproject.toml | 2 +-`.

**Provenance of the Release lines.** Four of the six (#753, #771, #777, #755) are the authors' own, taken from their PR bodies. Two are not, and are recorded as such rather than presented as author-supplied:

- **#769** — its body carries no `Release:` line. Nine live sessions answered "not mine". The line above was supplied by **45035**, who authored #765 (the PR that #769 corrects) and could therefore vouch for the impact, with their explicit caveat that #769's actual author's line should win if one appears.
- **#756** — its body carries no `Release:` line either (0 occurrences). The line above was sent to me directly by its author's session (**95941**) at merge time under the #740 announce-at-merge practice, so it IS the author's own words — just delivered by peer message rather than through the durable artifact AGENTS.md relies on.

The distinction matters because a chat message is not the durable record: an author who stops running still contributes through the PR body, and does not through a mailbox. Both gaps are recorded here rather than smoothed over.

**Superseded note on #769's Release line:** its PR body carries none. Rather than invent one from the commit subject — the thing AGENTS.md's `Release:`-in-the-body rule exists to prevent — I asked the live sessions. Nine answered "not mine". The line above was supplied by **45035**, who authored #765 (the PR that #769 corrects) and could therefore vouch for the impact, with their explicit caveat that #769's actual author's line should win if one appears. Recorded as supplied-by-a-peer, not presented as the author's own.
