### PR TITLE
perf(tui): stop re-rendering the whole /settings list on every keypress

### DIFF
--- a/docs/settings-keypress-profile.md
+++ b/docs/settings-keypress-profile.md
@@ -1,0 +1,375 @@
+# `/settings` arrow-key profiling report
+
+**Verdict: the operator's report reproduces, and the dominant cost is NOT where
+the task brief expected it.** `_row_text`'s per-row `Style`/`semantic_color`
+work is real but secondary (≈14% of the widget's own time, ≈2.5% of a press).
+The dominant cost is that **every arrow press re-rasterises the entire settings
+list — all 96 lines — in order to repaint a 14-line viewport in which 2 lines
+changed.** That cost is linear in row count, so a Hotkeys section makes it
+proportionally worse: at 218 rows a press already costs **2.1× more CPU**.
+
+Measured, not inferred. Everything below is reproducible with the harnesses in
+`scripts/` (paths at the end).
+
+---
+
+## 1. Environment
+
+| | |
+|---|---|
+| Machine | Apple M3 Max, 14 cores, macOS 26.6.2 (idle, on AC) |
+| Worktree | `~/workspace/repos/lo-hotkeys`, branch `feat/hotkeys` @ `298cadb3b` |
+| Interpreter | `.venv/bin/python` 3.12.13 — verified resolving `lo-hotkeys/local_operator/__init__.py` |
+| Isolation | `scripts/probe_isolation` (fresh `HOME` + `LOCAL_OPERATOR_CONFIG_DIR`), every `CMUX_*` var deleted before app import |
+| Terminal | headless Textual `run_test`, size 100×30 → settings body viewport = **14 lines** |
+| Page shape | **96 rows** (79 selectable) from the current registry |
+| Clock | `time.thread_time()` (per-thread CPU) per AGENTS.md; wall recorded alongside |
+
+**No application source was modified.** All counterfactuals are monkeypatches
+applied in throwaway processes. `git status` shows only new untracked scripts.
+
+---
+
+## 2. Two measurement bugs I hit and fixed — read this before trusting any number
+
+These are recorded because both produced *plausible wrong answers*, and a
+re-run of these harnesses must not reintroduce them.
+
+**(a) Clamped presses are silent no-ops.** `/settings` is AGENTS.md's
+documented wrap-vs-clamp exception: `action_move` clamps at the ends. There are
+only 79 selectable rows, so a probe sending 100 `down` presses gets 79 real
+moves and 21 presses where the cursor does not move and **`_list_text` is
+byte-identical before and after** (verified directly). My first
+elision-counterfactual sampled mostly clamped presses and reported ~0% saving
+where the corrected run reports 12–16%. Fixed by `scripts/settings_press_driver.py`,
+which bounces direction before either end; every sampled press now genuinely
+moves the cursor and genuinely changes two lines.
+
+**(b) cProfile's overhead is not a measurement.** Profiling and timing in the
+same pass inflated the 96-row baseline from 2.49 ms to 6.93 ms, which made the
+scaling table read as if 96 rows cost *more* than 218. cProfile is now a
+separate pass and its milliseconds are labelled as non-comparable.
+
+I also discarded a frame-equality check that compared variants at different
+cursor positions and therefore reported every variant as "DIFFERS".
+
+---
+
+## 3. Per-press CPU, broken down by phase
+
+`action_move` → `_settle_row` → `_land` → `_repaint` → four paints. Timers are
+**exclusive** (a nested phase's time is subtracted from its parent), so the
+column sums to the total. 100 bounced presses, 96 rows.
+
+| phase | CPU/press (ms) | calls/press | share |
+|---|---:|---:|---:|
+| `_row_text` | 1.489 | 96.0 | 50.5% |
+| `_paint_list` (own: `Text` assembly + `Static.update`) | 0.933 | 1.0 | 31.7% |
+| `_paint_chrome` | 0.304 | 1.0 | 10.3% |
+| `_paint_pane` | 0.076 | 1.0 | 2.6% |
+| `_build_rows` | 0.048 | 1.0 | 1.6% |
+| `_paint_detail` | 0.041 | 1.0 | 1.4% |
+| `action_move` (own) | 0.020 | 1.0 | 0.7% |
+| `_scroll_to_selection` | 0.017 | 1.0 | 0.6% |
+| `_repaint` (own) | 0.014 | 1.0 | 0.5% |
+| `_apply_height_ladder` | 0.006 | 1.0 | 0.2% |
+| `_settle_row` / `_settle_expansion` / `_preview_choice` | 0.001 | 1.0 each | 0.05% |
+| **total** | **2.95** | | |
+
+Helper calls inside that press:
+
+| helper | calls/press | CPU/press (ms) | share of press |
+|---|---:|---:|---:|
+| `theme_mod.semantic_color` | **552.7** | 0.396 | 13.6% |
+| ↳ of which `theme_spec` | 552.7 | 0.121 | 4.2% |
+| `settings_io.read_setting` | 165.0 | 0.091 | 3.1% |
+| `settings_io.is_default` | 79.8 | 0.081 | 2.8% |
+| `Static.update` | 9.1 | 0.821 | 28.1% |
+| `settings_io.read_chains` | 1.0 | 0.002 | 0.1% |
+
+### But `action_move` is only a fraction of the real keypress
+
+| rows | `action_move` CPU | full press CPU | full press WALL | wall p90 |
+|---:|---:|---:|---:|---:|
+| 96 | 2.16 ms | **16.21 ms** | 86.7 ms | 129.9 ms |
+| 138 | 3.05 ms | 19.12 ms | 85.2 ms | 124.8 ms |
+| 218 | 4.63 ms | 24.28 ms | 89.2 ms | 147.5 ms |
+
+**The widget's own work is ~13% of the CPU a press costs.** The other ~87% is
+Textual's dispatch, refresh and compositing — which `_repaint` *causes*. This
+is the single most important number in the report: optimising inside
+`_row_text` alone is optimising 13% of the problem.
+
+*(Wall figures under `run_test` include the pilot awaiting quiescence and are
+an upper bound, not the felt latency in a real terminal. The CPU column is the
+load-bearing one.)*
+
+---
+
+## 4. Row-count scaling — what a Hotkeys section costs
+
+Registry synthetically inflated by cloning non-cascade settings (fresh keys,
+same config paths; the probe never writes).
+
+| rows | `action_move` CPU/press | µs per row | × baseline | full press CPU |
+|---:|---:|---:|---:|---:|
+| 96 (today) | 3.07 ms | 31.99 | 1.00× | 16.2 ms |
+| 138 | 4.28 ms | 31.04 | 1.39× | 19.1 ms |
+| 218 | 6.45 ms | 29.57 | 2.10× | 24.3 ms |
+
+**Cleanly linear at ~30 µs per row per keypress**, with no cliff. The forecast
+is therefore arithmetic: a Hotkeys section adding *R* rows adds ≈ 0.03·R ms to
+every arrow press. A 60-row Hotkeys section ⇒ ≈ +1.8 ms of widget time and
+≈ +5 ms of full-press CPU, on top of a page the operator *already* calls
+laggy. **Fix the scaling before adding the section.**
+
+---
+
+## 5. The actual waste, named and quantified
+
+### 5.1 The dominant one: full-height re-rasterisation (~48–51% of a press)
+
+`_paint_list` pins the list `Static` to `height = len(self._rows)` so the
+scroll container has something to scroll, then calls `update()`. Textual's
+`Widget._render_content` (`textual/widget.py:4242`) rasterises **`self.size`,
+i.e. all N lines**, caches them, and `Static.update` invalidates that cache
+wholesale.
+
+Measured exactly, via `Visual.to_strips` interception:
+
+```
+rows=96  listStatic.height=96  viewport=14
+  Visual.to_strips calls on LIST /press: 1.00
+  LINES rasterised into strips /press  : 96.0     <- the full height, every press
+
+rows=218 listStatic.height=218 viewport=14
+  LINES rasterised into strips /press  : 218.0
+```
+
+So the page rasterises 96 lines to show 14, of which **2 changed**. The
+invalidation multiplies the cost of the identical 14-line draw by **179×** at
+96 rows and **337×** at 218 rows (same viewport, with vs without a preceding
+`update()`: 0.020 ms → 3.535 ms, and 0.024 ms → 7.975 ms).
+
+Isolated cost of that one operation, against the page's real content:
+
+| height (lines) | `to_strips` CPU | µs/line |
+|---:|---:|---:|
+| 2 (the lines that changed) | 0.363 ms | 181.7 |
+| 14 (the viewport) | 0.602 ms | 43.0 |
+| **96 (as shipped)** | **2.473 ms** | 25.8 |
+| 218 (inflated) | 5.973 ms | 27.4 |
+
+Rasterising only the viewport would save **1.87 ms/press (76%)** of this
+operation at 96 rows and **5.01 ms (84%)** at 218.
+
+Interleaved A/B/C confirms the share of the whole press:
+
+| variant | 96 rows | 218 rows |
+|---|---:|---:|
+| A: as shipped | 17.17 ms | 24.68 ms |
+| B: no-op `Static.update`s elided (correct frame) | 14.84 ms | 23.67 ms |
+| C: **+ list update elided** (floor; deliberately wrong frame) | 9.00 ms | 12.15 ms |
+| **A − C = list-invalidation budget** | **8.17 ms (47.6%)** | **12.52 ms (50.7%)** |
+
+### 5.2 `_repaint` repaints things that did not change (100% redundant)
+
+Over 59 consecutive real transitions:
+
+| producer | identical to previous press | verdict |
+|---|---|---|
+| `_build_rows` | **59/59 (100%)** | re-derives the whole row list every press; never structurally different on a cursor move |
+| `_paint_chrome` (title + rule) | **59/59 (100%)** | title is the config path; rule is `"─"×width` |
+| `_paint_pane` | **59/59 (100%)** | providers/teams/agents, resolved once at open |
+| `_paint_list` | **2 of 96 lines changed** (median; max 2, min 2) | 97.9% of composed rows are re-composed identically |
+| `_paint_detail` | 0/59 identical | legitimately changes — it describes the cursor row |
+
+`_build_rows` is cheap in itself (0.048 ms) but it is what forces `_paint_list`
+to re-walk every row; and `_paint_chrome` at 0.304 ms is 10% of the widget's
+time spent producing a byte-identical title and rule.
+
+### 5.3 `_row_text`'s per-row theme + Style work (~14% of widget time)
+
+Confirmed as described in the brief: five `semantic_color` lookups and five
+`Style` constructions per row per paint, executed **before** the row's kind is
+examined — so a header row pays for the `accent`/`faint` styles it never uses.
+That is 5×96 = 480 of the 553 `semantic_color` calls per press.
+
+`semantic_color` is not cached: it calls `theme_spec` → `_registry()` → dict
+lookup on every call. Counterfactuals (medians over 60 bounced presses):
+
+| variant | ms/press | saved |
+|---|---:|---:|
+| baseline | 2.141 | — |
+| A: `semantic_color` memoised | 2.113 | 1.3% |
+| B: A + `Style` objects interned | 1.858 | **13.2%** |
+| C: whole row `Text` memoised (per-row cache ceiling) | 1.456 | **32.0%** |
+
+Note **A alone is nearly worthless (1.3%)** — the lookup is already fast. The
+cost is constructing 480 `Style` objects, not resolving the colours. This
+matters for ranking: "cache `semantic_color`" is the intuitive fix and it is
+the wrong one.
+
+### 5.4 Ranked candidate fixes, measured end-to-end
+
+Interleaved, frame-correctness verified against the control at a fixed cursor
+position (all reported IDENTICAL):
+
+| variant | 96 rows | saved | 218 rows | saved |
+|---|---:|---:|---:|---:|
+| A: as shipped | 16.89 ms | — | 22.67 ms | — |
+| B: elide no-op `Static.update` (pane/title/rule) | 14.14 ms | 16.3% | 20.68 ms | 8.8% |
+| D: B + `_row_text` memo | 13.87 ms | 17.9% | 18.55 ms | 18.2% |
+| E: D + per-line strip cache | 13.33 ms | 21.1% | 18.36 ms | 19.0% |
+
+**Variant E under-reports its own ceiling** and should not be read as the limit:
+it is implemented as a *post-pass* that still pays the full rasterisation before
+discarding it, so it demonstrates reuse (94/96 = 97.9% of line strips reusable;
+216/218 = 99.1% at scale) without banking the saving. The true ceiling for that
+change is §5.1's table: **1.87–5.01 ms/press**.
+
+---
+
+## 6. Recommended optimisations, ranked by measured payoff
+
+**R1 — Stop rasterising the whole list every press. (~48–51% of a press;
+1.87 ms at 96 rows, 5.01 ms at 218; this is the one that fixes the scaling.)**
+Two viable shapes:
+ (a) keep the pinned-height `Static` but let unchanged lines survive an
+ `update()` (line-keyed strip cache), or
+ (b) stop handing Textual one N-line widget — render only the visible window
+ and let the scroll container map offsets.
+*Risk: high — this is the load-bearing one.* (b) touches `_index_at` (click→row
+mapping), `_scroll_to_selection`, `_attached_bottom`, the scrollbar's virtual
+size, and the `_list.styles.height = len(rows)` contract that makes scrolling
+work at all. (a) is more local but needs a correct invalidation key: theme
+change (`theme_mod._theme_epoch` already exists for exactly this), width
+change, config write, expansion open/close, hover. **Not safe to do blind — it
+needs the guards in §7 landed first.** Prefer (a).
+
+**R2 — Skip `Static.update` when content is unchanged. (12–16% at 96 rows,
+~9% at 218; measured frame-identical.)** Pane, title and rule produce
+byte-identical `Text` on 59/59 transitions. Compare against the last content
+handed to that widget and return early.
+*Risk: low-to-moderate, and it is a real risk, not a nit.* Correctness depends
+entirely on the comparison key. Rich `Text` equality covers plain text + spans
++ style, which is what rasterises — but a change in the widget's **own styling**
+(a `$lo-*` variable moving under a theme switch) does not change the `Text` and
+would leave a stale frame. Invalidate on theme epoch as well as content, and
+keep the key structural (`plain`, `spans`, `style`), never `id()`.
+*Note it degrades with scale (16.3% → 8.8%), so it is not a substitute for R1.*
+
+**R3 — Hoist the `Style` prelude out of the per-row loop. (13.2% of widget
+time; ≈2% of a press.)** Build the five `Style` objects **once per
+`_paint_list`** and pass them down, rather than 5×N times. Do *not* bother
+memoising `semantic_color` alone — measured at 1.3%.
+*Risk: low.* Styles are immutable and already per-paint; the only invalidation
+is a theme change, and a per-paint lifetime makes that automatic. This is the
+safest item on the list and the natural place to start.
+
+**R4 — Don't rebuild rows on a pure cursor move. (1.6% of widget time; small,
+but it unlocks R1(a).)** `_build_rows` was structurally identical on 59/59
+transitions. Cache the row list, invalidate on the things that actually change
+structure: `_expanded`, `_editing`, `_chain`, `_suggest_index`, a config write,
+`set_context`.
+*Risk: moderate — this is where a stale-list bug would hurt.* `_repaint`
+currently relies on the rebuild to re-anchor `_selected` after a row vanishes,
+and `_cascade_rows` calls `settings_io.read_chains(self._manager)` on every
+build, so the cache must be dropped on any write. The payoff is not the 0.048 ms;
+it is that a stable row list is the precondition for caching row text safely.
+
+**R5 — Don't repaint chrome on a cursor move. (10.3% of widget time; ≈2% of a
+press.)** `_paint_chrome` recomputes the title, re-multiplies the rule string
+and calls `_paint_hints()` every press. Only the hints can change on a move
+(they depend on the cursor row), so split it: hints per move, title/rule on
+resize or config-path change.
+*Risk: low,* provided the resize path still repaints the rule (its width
+depends on `self.size.width`).
+
+Doing **R3 + R5 + R2** is a low-risk package worth ~20% with no architectural
+change. **R1 is the one that decides whether the Hotkeys section is affordable**,
+and it should be done before the section lands, not after.
+
+---
+
+## 7. Regression guard proposal — structural, not timed
+
+Per AGENTS.md ("Prefer a structural invariant to a numeric one"; no portable
+numeric bound survives the CI/laptop core-speed spread), these count operations
+per keypress. They cannot flake on machine load.
+
+Proposed test, in `tests/unit/tui/test_settings_view.py`, driving the real
+`OperatorApp` and using a bounced (never clamped) press:
+
+```python
+# rows == 96, body viewport == 14 at 100x30
+assert semantic_color_calls / presses <= 40      # G1: not 5 per row per paint
+assert list_strip_lines / presses <= 3 * viewport # G2: not the full widget height
+assert row_text_calls / presses <= 2 * viewport   # G3: not one call per row
+assert build_rows_calls / presses == 0            # G4: no rebuild on a cursor move
+```
+
+**Proven to fail on the current tree** (10 bounced presses, 96 rows) — i.e.
+they detect the waste rather than passing vacuously:
+
+| guard | measured now | bound | result |
+|---|---:|---:|---|
+| G1 `semantic_color` ≤ 40/press | **554.1** | 40 | FAIL |
+| G2 list strip lines ≤ 42/press | **96.0** | 42 | FAIL |
+| G3 `_row_text` calls ≤ 28/press | **96.0** | 28 | FAIL |
+| G4 `_build_rows` == 0/press | **1.0** | 0 | FAIL |
+
+Each bound is expressed **relative to the viewport, not to the row count**,
+which is what makes them Hotkeys-proof: adding 60 rows must not change any of
+these numbers, and if it does, the guard fires. G2 is the important one — it is
+the direct assertion that a cursor move does not re-rasterise the whole list.
+
+Adopt them as each optimisation lands (G1/G3 with R3, G4 with R4, G2 with R1),
+rather than all at once against unfixed code.
+
+---
+
+## 8. Harnesses (all in `scripts/`, re-runnable)
+
+Prefix every invocation with `env -u NO_COLOR TERM=xterm-256color .venv/bin/python`.
+
+| script | what it answers |
+|---|---|
+| `settings_press_driver.py` | the bounce driver — **import this in any new probe**; a clamped press invalidates results |
+| `settings_keypress_profile.py` | per-phase exclusive CPU, helper call counts, row-count scaling (`--rows 120,200`, `--cprofile`, `--json`) |
+| `settings_keypress_waste.py` | redundancy of produced output; Style-prelude counterfactuals |
+| `settings_keypress_endtoend.py` | `action_move` vs full press round trip, CPU and wall |
+| `settings_keypress_render.py` | lines Textual rasterises per press vs viewport |
+| `settings_keypress_widgets.py` | per-widget rasterisation; the `update()` invalidation multiplier |
+| `settings_strips_scaling.py` | `Visual.to_strips` cost vs height — the R1 ceiling |
+| `settings_keypress_fixmodel.py` | interleaved A/B/D/E ranking with frame-correctness checks |
+| `settings_keypress_ceiling.py` | interleaved A/B/C list-invalidation budget |
+| `settings_keypress_dirty.py` | dirty-widget count vs compositor path |
+| `settings_keypress_fullpress.py` | cProfile of the whole press round trip |
+
+Gates on all of them: `flake8`, `black --check` (26.1.0), `isort --check`
+(5.13.2) clean.
+
+---
+
+## 9. What I could not measure — stated plainly
+
+1. **Real-terminal latency.** Everything is headless `run_test`. Textual
+   coalesces refreshes on a timer in a real terminal and the pilot awaits
+   quiescence, so the WALL figures (~87 ms/press) are an upper bound and should
+   not be quoted as the felt lag. CPU figures and all *ratios* transfer; the
+   absolute wall number does not. Confirming the felt improvement needs a real
+   terminal after a fix lands.
+2. **No CI calibration.** Per AGENTS.md, ceilings must come from CI logs across
+   several runs. Every number here is one M3 Max. This is why §7 proposes
+   **counting** guards and no timing bound at all.
+3. **The operator's own config.** Measured against an isolated empty config, so
+   the cascade section renders its empty state. A populated cascade adds rows
+   and would make the page slower, never faster — the 96-row figure is a
+   floor.
+4. **Variant E is not a validated implementation**, only evidence that 97.9%
+   of line strips are reusable. §5.1's `to_strips` table is the honest ceiling.
+5. **Terminal width.** All at 100×30. `_row_text` and `_paint_list` both key off
+   `_list_width()`, so a wider terminal costs more per line; not swept.
+6. **Hover.** `_hovered` participates in row rendering; mouse-move repaints were
+   not profiled, only keyboard movement, which is what was reported.

--- a/local_operator/tui/widgets/settings_view.py
+++ b/local_operator/tui/widgets/settings_view.py
@@ -47,7 +47,10 @@ from rich.style import Style
 from rich.text import Text
 from textual.binding import Binding
 from textual.containers import Horizontal, ScrollableContainer, Vertical
+from textual.geometry import Region
 from textual.message import Message
+from textual.strip import Strip
+from textual.visual import Visual, visualize
 from textual.widgets import Static
 
 from local_operator import settings_io
@@ -379,6 +382,196 @@ class _ChromeStatic(Static):
         self._painted = None
 
 
+class _ListStatic(_ChromeStatic):
+    """The settings list, rasterised ONE ROW AT A TIME and cached per line.
+
+    WHY THIS EXISTS — the dominant cost of an arrow press
+    ====================================================
+
+    This widget is pinned to ``height = len(rows)`` so the scroll container has
+    something to scroll (see ``SettingsView._paint_list``). Textual's default
+    content path rasterises ``self.size`` — i.e. ALL N lines — inside
+    ``Widget._render_content``, caches them wholesale, and ``Static.update``
+    invalidates that cache in full. So repainting a 14-line viewport in which
+    TWO lines changed re-rasterised all 96 of them, every keypress. Measured by
+    intercepting ``Visual.to_strips``: exactly 96.0 lines/press at 96 rows and
+    218.0 at 218 (``docs/settings-keypress-profile.md`` \u00a75.1). The same 14-line
+    draw cost 179x more after an ``update()`` (0.020 -> 3.535 ms), 337x at 218
+    rows, and the whole operation was 48-51% of a press.
+
+    The cost was therefore LINEAR IN ROW COUNT, ~30 µs per row per keypress,
+    which is what made it block the Hotkeys section: another ~60 rows would
+    have added ~1.8 ms of widget time to every arrow press on a page the
+    operator already called laggy.
+
+    HOW
+    ---
+
+    ``render_line`` is overridden outright, so ``_render_content`` — the
+    full-height path — is never reached. Each row is rasterised on demand and
+    kept in a per-line cache, and :meth:`set_rows` invalidates only the lines
+    whose composed ``Text`` actually changed. A cursor move dirties two lines
+    (the row the cursor left and the one it arrived on) and Textual asks for
+    the viewport's worth of lines, so a press rasterises 2 rather than N. The
+    profile measured 97.9% of line strips reusable at 96 rows and 99.1% at 218,
+    which is the reuse this banks.
+
+    Rasterising a row alone is byte-identical to rasterising it as part of the
+    block: the rows are composed with ``no_wrap`` and each is truncated to the
+    list width before it gets here, so no row's rendering depends on its
+    neighbours. That is asserted in ``test_settings_repaint_cost`` against the
+    whole-render output rather than assumed.
+
+    WHAT INVALIDATES THE CACHE
+    --------------------------
+
+    * a row's composed ``Text`` differing from the one cached for that line
+      (covers selection, hover, an edit, a config write, an expansion —
+      everything that changes ink or text, because all of it arrives here as a
+      different ``Text``);
+    * a change of WIDTH, which changes what a strip is;
+    * a THEME switch (``theme_mod.get_theme_epoch()``), because the widget's own
+      base style feeds ``to_strips`` without passing through the row ``Text``;
+    * a change in the number of rows, which reshapes the widget.
+
+    The one-row-per-line contract is preserved exactly — ``_index_at`` maps a
+    click's y to ``_rows[y]`` and the cursor indexes the same list, so this
+    changes only WHEN a line is rasterised, never which line is where.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        #: Composes line ``y``. Set by the page; see :meth:`set_source`.
+        #: NOT named `_compose`: `Widget._compose` is Textual's own child-
+        #: mounting coroutine, and shadowing it breaks mounting with a
+        #: TypeError raised from inside the framework (AGENTS.md, "Do not
+        #: shadow Textual's API").
+        self._row_source: Callable[[int], Text] | None = None
+        self._row_count = 0
+        self._row_cache: dict[int, Text] = {}
+        self._line_cache: dict[int, Strip] = {}
+        #: ``(width, theme epoch)`` the cached strips were rasterised at.
+        self._line_key: tuple[int, int] = (-1, -1)
+
+    def set_source(
+        self, compose: Callable[[int], Text], count: int, dirty: Sequence[int | None]
+    ) -> None:
+        """Point the widget at the page's row composer for this paint.
+
+        ``compose(y)`` returns the ``Text`` for line ``y`` and is called ONLY
+        for the lines Textual actually asks to paint, which is what keeps
+        ``_row_text`` off the 82 rows that are not on screen. ``dirty`` names
+        the lines whose CONTENT may have changed since the last paint (the row
+        the cursor left, the one it arrived on, a hover); every other line keeps
+        its cached ``Text`` and its cached strip.
+
+        Deliberately NOT ``Static.update``: that invalidates every line, which
+        is the cost this class exists to avoid.
+        """
+        self._row_source = compose
+        width = self.size.width
+
+        if count != self._row_count:
+            # The widget's shape changed (an expansion opened, a chain was
+            # deleted). Every line below the change has moved, so nothing is
+            # reusable by line number and the height itself has to be relaid.
+            self._row_count = count
+            self._row_cache.clear()
+            self._line_cache.clear()
+            self.refresh(layout=True)
+            return
+
+        # `None` is a real member of `dirty`: `_hovered` is None when the
+        # pointer is off the list, and -1 is "nothing painted yet".
+        changed = [index for index in dirty if index is not None and 0 <= index < count]
+        if not changed:
+            return
+        for index in changed:
+            self._row_cache.pop(index, None)
+            self._line_cache.pop(index, None)
+        # `layout=False`: the row count and therefore the widget's height are
+        # unchanged here by construction, so a layout pass would re-measure the
+        # whole page to paint two lines.
+        self.refresh(*(Region(0, index, width, 1) for index in changed), layout=False)
+
+    def invalidate_lines(self) -> None:
+        """Drop every cached row and strip: for a resize or a theme change."""
+        self._row_cache.clear()
+        self._line_cache.clear()
+
+    def _row(self, y: int) -> Text:
+        """The composed ``Text`` for line ``y``, composing it if need be."""
+        cached = self._row_cache.get(y)
+        if cached is not None:
+            return cached
+        row = Text() if self._row_source is None else self._row_source(y)
+        self._row_cache[y] = row
+        return row
+
+    def render_line(self, y: int) -> Strip:
+        """One rasterised row, from the cache when it is still valid.
+
+        Overriding this is what keeps ``Widget._render_content`` — which
+        rasterises the widget's FULL height — off the keypress path entirely.
+        """
+        width = self.size.width
+        key = (width, theme_mod.get_theme_epoch())
+        if key != self._line_key:
+            # Width or theme moved under the cache: a strip is only meaningful
+            # at the width it was measured for, and the widget's base style is
+            # resolved from the active theme.
+            self._line_cache.clear()
+            self._line_key = key
+        # Textual's base implementation renders content when this is set; the
+        # per-line cache above has already answered that question, so clearing
+        # it keeps the set from growing one region per refresh forever.
+        self._dirty_regions.clear()
+
+        cached = self._line_cache.get(y)
+        if cached is not None:
+            return cached
+
+        if y >= self._row_count or width <= 0:
+            # Past the last row: the pinned height can exceed the rows during
+            # the frame between a shrink and its layout.
+            return Strip.blank(width, self.visual_style.rich_style)
+
+        strips = Visual.to_strips(
+            self,
+            visualize(self, self._row(y), markup=self._render_markup),
+            width,
+            1,
+            self.visual_style,
+        )
+        strip = strips[0] if strips else Strip.blank(width, self.visual_style.rich_style)
+        # `apply_offsets(0, y)` is what makes a row rasterised ALONE identical to
+        # the same row rasterised as line `y` of the whole block. Textual stamps
+        # every segment with a `meta={"offset": (x, y)}` giving its position in
+        # the content, and the compositor reads it back in `get_widget_at` to
+        # answer "what is under the pointer" — a per-row render would otherwise
+        # stamp every row with y=0 and report the wrong content offset. Verified
+        # segment-for-segment against the full-height render over all 96 rows,
+        # not assumed; the equality is asserted in `test_settings_repaint_cost`.
+        strip = strip.apply_offsets(0, y)
+        self._line_cache[y] = strip
+        return strip
+
+    def rendered_text(self) -> Text:
+        """The whole list as one ``Text`` — for tests and `render_lines_for_test`.
+
+        The widget holds its content as one ``Text`` PER ROW, which is what
+        makes per-line caching possible; the page's assertable view of itself
+        is still the joined block, so it is reassembled here rather than kept
+        as a second copy that could drift.
+        """
+        joined = Text(no_wrap=True, overflow="ellipsis")
+        for index in range(self._row_count):
+            if index:
+                joined.append("\n")
+            joined.append_text(self._row(index))
+        return joined
+
+
 class SettingsViewDismissed(Message):
     """The page's ``esc`` hint was clicked. The app owns leaving the mode.
 
@@ -586,7 +779,7 @@ class SettingsView(Vertical):
         self._detail = _ChromeStatic(classes="settings-view-detail")
         self._title = _ChromeStatic(classes="settings-view-title")
         self._rule = _ChromeStatic(classes="settings-view-rule")
-        self._list = _ChromeStatic(classes="settings-view-list")
+        self._list = _ListStatic(classes="settings-view-list")
         self._body = ScrollableContainer(self._list, classes="settings-view-body")
         # NOT focusable. With it in the focus chain, one `tab` moved focus from
         # the page to this container, which owns the scroll keys — so the arrows
@@ -621,7 +814,6 @@ class SettingsView(Vertical):
         self._hints = Horizontal(classes="settings-view-hints")
         self._title_text = Text()
         self._rule_text = Text()
-        self._list_text = Text()
         self._detail_text = Text()
         self._pane_text = Text()
         #: Live height-ladder flags, so `_pane_height` and `_paint_detail`
@@ -631,6 +823,17 @@ class SettingsView(Vertical):
         self._chrome_pad = True
         self._chrome_columns = True
         self._too_short = False
+        #: ``(key, rows)`` from the last `_build_rows`, or None. Keyed on the
+        #: inputs rather than invalidated by callers — see `_rows_key`.
+        self._rows_cache: tuple[tuple[Any, ...], list["_Row"]] | None = None
+        #: Cursor and hover as of the last `_paint_list`, so it can name the
+        #: lines whose ink may have changed. -1 is "nothing painted yet", which
+        #: is out of range and therefore ignored by `set_source`.
+        self._painted_selected = -1
+        self._painted_hovered = -1
+        #: `_paint_token` as of the last `_paint_list`. None forces the first
+        #: paint to compose every row.
+        self._painted_token: tuple[Any, ...] | None = None
 
     # -- composition --------------------------------------------------------
     def compose(self):  # type: ignore[override]
@@ -665,11 +868,12 @@ class SettingsView(Vertical):
             pass
 
     def on_resize(self) -> None:
-        # Drop every elision key BEFORE the repaint. `update_if_changed` keys on
-        # CONTENT, and a resize can leave content identical while what is
-        # rasterised from it is not: the pane and the detail line are budgeted
-        # against a width, so a Static that skipped its update would keep strips
-        # measured for the old one.
+        # Drop every elision key BEFORE the repaint. `update_if_changed` and
+        # the row cache both key on CONTENT, and a resize can leave content
+        # identical while the rasterisation is not: the pane and the detail
+        # line are budgeted against a width, and a Static that skipped its
+        # update would keep strips measured for the old one. Cheap and total,
+        # rather than reasoning per surface about which widths matter.
         self._invalidate_paint_caches()
         # The rule spans the page and the hints shed against a width only the
         # layout knows, so both are repainted on resize. Parking a 1-row
@@ -720,6 +924,90 @@ class SettingsView(Vertical):
         self._repaint()
 
     # -- rows ---------------------------------------------------------------
+    def _rows_key(self) -> tuple[Any, ...] | None:
+        """Everything :meth:`_build_rows` reads, as one comparable value.
+
+        WHY A KEY RATHER THAN CACHE-INVALIDATION CALLS
+        ==============================================
+
+        The row list was structurally IDENTICAL on 59/59 consecutive cursor
+        moves (``docs/settings-keypress-profile.md`` §5.2) — a cursor move
+        cannot change the structure of the list, only which row is inked as
+        selected — so rebuilding it on every press is pure waste. But the
+        obvious cache, dropped by hand from each of the ~60 ``_repaint`` call
+        sites, is exactly where a stale-row-list bug would live: one mutator
+        that forgets to invalidate paints a list that no longer matches the
+        config, and the cursor then writes to the wrong setting.
+
+        So this derives a key from the INPUTS instead. If every input is equal,
+        the output is equal, and no caller has to remember anything — a new
+        mutator (or the queued Hotkeys section) is covered without touching this
+        file. The rule for maintaining it is simply: anything ``_build_rows``
+        reads must appear here.
+
+        Returns ``None`` to mean "do not cache", which is how the suggestion
+        dropdown is handled: its rows depend on the edit buffer, the highlight
+        and a fuzzy ranking, and ``_suggest_rows`` also CLAMPS ``_suggest_index``
+        as a side effect that the page depends on. Typing is not the path the
+        operator reported as laggy, so that state simply rebuilds every paint
+        rather than being modelled here and risked.
+        """
+        if self._suggest_key() is not None:
+            return None
+        chains = settings_io.read_chains(self._manager)
+        # The cascade's structure is its chains, plus which one is open, plus
+        # whether the stored value is malformed (that decides the empty-state
+        # row's text).
+        cascade = tuple(
+            (setting.key, self._cascade_is_malformed(setting))
+            for setting in settings_io.SETTINGS
+            if setting.kind is Kind.CASCADE
+        )
+        # The EXPANDED setting's choices, because a registry-sourced enum
+        # (`tui.theme`) resolves its members dynamically through
+        # `choices_source` — the count is what decides how many rows it adds.
+        expanded_choices = 0
+        if self._expanded is not None:
+            setting = settings_io.resolve_key(self._expanded)
+            if setting is not None:
+                expanded_choices = len(_choices_for(setting))
+        return (
+            # The registry itself: the queued Hotkeys section adds rows to it,
+            # and the profiling harnesses inflate it.
+            len(settings_io.SETTINGS),
+            len(settings_io.SECTIONS),
+            self._editing,
+            self._expanded,
+            expanded_choices,
+            self._chain,
+            tuple(sorted((name, tuple(hops)) for name, hops in chains.items())),
+            cascade,
+        )
+
+    def _rows_for_paint(self) -> list["_Row"]:
+        """The row list for this paint, rebuilt only when an input changed.
+
+        Wraps :meth:`_build_rows` rather than memoising inside it, so the
+        builder keeps its single responsibility and "was the list rebuilt?"
+        stays a question about calls to it — which is exactly what the G4
+        regression guard counts.
+
+        The rows are treated as IMMUTABLE once built (nothing in this module
+        mutates a ``_Row`` in place; ``_Row`` carries ``__slots__`` and is only
+        ever constructed), which is what makes handing the same list back on a
+        hit safe rather than a shared-mutable-state bug.
+        """
+        key = self._rows_key()
+        if key is None:
+            # Un-cacheable state (an open suggestion dropdown); see `_rows_key`.
+            self._rows_cache = None
+            return self._build_rows()
+        if self._rows_cache is not None and self._rows_cache[0] == key:
+            return self._rows_cache[1]
+        rows = self._build_rows()
+        self._rows_cache = (key, rows)
+        return rows
+
     def _build_rows(self) -> list["_Row"]:
         """The flat row list the cursor travels, rebuilt from the registry.
 
@@ -728,6 +1016,9 @@ class SettingsView(Vertical):
         one list with a ``selectable`` flag needs one. Headers are rows so
         PgUp/PgDn has something to land on and so a section's scope tag has a
         row to live on.
+
+        Call :meth:`_rows_for_paint` from a paint: this is the REBUILD, and on a
+        pure cursor move there is nothing to rebuild.
         """
         rows: list[_Row] = []
         for section in settings_io.SECTIONS:
@@ -1787,7 +2078,7 @@ class SettingsView(Vertical):
         # the cursor 35 rows past where the arrow pointed.
         if row is None:
             return
-        self._rows = self._build_rows()
+        self._rows = self._rows_for_paint()
         settled = next(
             (
                 index
@@ -2645,7 +2936,7 @@ class SettingsView(Vertical):
         # on the chrome widgets, which is what the layout reads, and the
         # paints (detail text, pane budget) have to see the same decision.
         self._apply_height_ladder()
-        self._rows = self._build_rows()
+        self._rows = self._rows_for_paint()
         indices = self._selectable()
         if indices and self._selected not in indices:
             # A rebuild can drop the row the cursor was on (an expansion
@@ -2658,40 +2949,116 @@ class SettingsView(Vertical):
         self._paint_detail()
         self._paint_chrome()
 
-    def _invalidate_paint_caches(self) -> None:
-        """Force the next paint to repaint from scratch.
-
-        For the changes that leave the CONTENT identical while invalidating what
-        was measured from it — a resize being the reachable one. Theme changes
-        are keyed on the epoch inside the cache itself and need no call here.
-        """
-        for surface in (self._title, self._rule, self._detail, self._pane_view):
-            surface.forget_painted()
-
     def _paint_list(self) -> None:
         width = self._list_width()
-        text = Text(no_wrap=True, overflow="ellipsis")
         # ONE ink bundle for the whole list. Resolved here rather than inside
         # `_row_text` because the five `Style` constructions were 5xN per paint
         # and N is the row count — see `_RowStyles`.
         styles = _RowStyles.resolve()
-        for index, row in enumerate(self._rows):
-            if index:
-                text.append("\n")
-            line = self._row_text(row, index, width, styles)
+
+        def compose(index: int) -> Text:
+            line = self._row_text(self._rows[index], index, width, styles)
             # Clipped rather than allowed to wrap. A wrapped row breaks the
             # one-row-per-setting contract the cursor and the click handler
             # both depend on: `_index_at` maps a click's y to a row index, so a
             # row occupying two lines would make every click below it land on
             # the wrong setting.
             line.truncate(width, overflow="ellipsis")
-            text.append_text(line)
-        self._list_text = text
-        self._list.update(text)
+            return line
+
+        # WHICH LINES MAY HAVE CHANGED.
+        #
+        # The cursor and the hover are the two positions the page inks
+        # differently, so a pure cursor move dirties at most four lines: the
+        # old and new selection, the old and new hover.
+        #
+        # But a row's TEXT can change with the row list and the cursor both
+        # unmoved. `r` on a malformed cascade rewrites the config, and the
+        # empty-state row goes from `malformed cascade — press r to clear it`
+        # to `no cascade configured` at the same index, in a list of the same
+        # length. Deriving the dirty set from the cursor alone left that line
+        # stale on the frame while the model held the new text — caught by
+        # `test_r_clears_a_malformed_cascade_and_the_frame_does_not_contradict
+        # _itself`, which asserts on the COMPOSITOR output rather than on a
+        # model string, which is precisely why it caught it.
+        #
+        # So anything a row reads BESIDES its own identity and the cursor is
+        # folded into one token, and a token change dirties every line. That is
+        # a whole-list recompose on a config write (rare, and already the
+        # expensive path) and nothing at all on a keypress. The alternative —
+        # enumerating which rows a given write can affect — is the stale-frame
+        # bug waiting to be reintroduced by the next setting that renders
+        # something derived.
+        token = self._paint_token()
+        if token != self._painted_token:
+            self._painted_token = token
+            dirty: Sequence[int | None] = range(len(self._rows))
+        else:
+            dirty = (self._painted_selected, self._selected, self._painted_hovered, self._hovered)
+        self._painted_selected = self._selected
+        self._painted_hovered = self._hovered
         # Pin the Static to the row count so the container's virtual size
         # equals the list and Textual scrolls the difference. `auto` collapses
-        # it to the handed content with no room to scroll.
+        # it to the handed content with no room to scroll — and it does so
+        # HARDER now that the widget renders per line: with `height: auto` the
+        # widget measured its content as ONE row and painted a single line of a
+        # 96-row list. Set BEFORE `set_source`, whose row-count branch relays
+        # out and must measure against the new height.
         self._list.styles.height = max(len(self._rows), 1)
+        # The rows are COMPOSED ON DEMAND rather than up front, which is what
+        # keeps a keypress off the 82 rows that are not on screen; the widget
+        # asks for the lines it is about to paint (see `_ListStatic`).
+        self._list.set_source(compose, len(self._rows), dirty)
+
+    def _paint_token(self) -> tuple[Any, ...]:
+        """Everything a row's TEXT depends on except its identity and the cursor.
+
+        Compared as a whole rather than per row: a mismatch repaints the list,
+        which is what a config write should cost. See `_paint_list` for why the
+        cursor-only dirty set was not enough.
+
+        The config VALUES are in here because most rows render a stored value
+        and its changed-vs-default ink; ``repr`` of the values mapping measures
+        4.3 µs, against a press this saves milliseconds on. The editor state is
+        here because an open editor paints a buffer and a caret into its row.
+        """
+        return (
+            repr(self._manager.get_config().values),
+            self._editing,
+            self._buffer,
+            self._caret,
+            self._expanded,
+            self._chain,
+            self._confirm_delete,
+            self._suggest_index,
+            self._suggest_dismissed,
+            theme_mod.get_theme_epoch(),
+            self._list_width(),
+        )
+
+    @property
+    def _list_text(self) -> Text:
+        """The composed list as one ``Text``.
+
+        Kept as a PROPERTY over the widget's per-row content rather than as a
+        second stored copy: the rows moved into `_ListStatic` for the per-line
+        cache, and a duplicate joined block would be a second source of truth
+        that could disagree with the frame. Read by `render_lines_for_test` and
+        by the page's own tests.
+        """
+        return self._list.rendered_text()
+
+    def _invalidate_paint_caches(self) -> None:
+        """Force the next paint to rasterise from scratch.
+
+        For the changes that leave the CONTENT identical while invalidating the
+        strips measured from it — a resize (a strip is only meaningful at the
+        width it was measured for) being the reachable one. Theme changes are
+        keyed on the epoch inside the caches themselves and need no call here.
+        """
+        self._list.invalidate_lines()
+        for surface in (self._title, self._rule, self._detail, self._pane_view):
+            surface.forget_painted()
 
     def _row_text(
         self, row: "_Row", index: int, width: int, styles: "_RowStyles | None" = None

--- a/local_operator/tui/widgets/settings_view.py
+++ b/local_operator/tui/widgets/settings_view.py
@@ -125,6 +125,48 @@ _SUGGEST_KEYS = frozenset({_HOSTING_KEY, _MODEL_KEY})
 _SUGGEST_ROWS = 8
 
 
+class _RowStyles(NamedTuple):
+    """The five inks every row is painted from, resolved ONCE per paint.
+
+    WHY THIS EXISTS
+    ===============
+
+    ``_row_text`` used to build these five ``Style`` objects at the top of its
+    body, before it examined the row's kind — so a header row paid for the
+    ``accent`` and ``faint`` styles it never uses, and the page paid 5×N of them
+    on every keypress. Profiled at 96 rows that was 480 of the 553
+    ``semantic_color`` calls a single arrow press made, and 13.2% of the
+    widget's own time.
+
+    The measured subtlety is that MEMOISING ``semantic_color`` does not fix it:
+    that variant saved 1.3%, because the lookup is already a dict hit. The cost
+    is CONSTRUCTING the ``Style`` objects, so the fix has to build fewer of
+    them rather than resolve colours faster.
+
+    A per-paint lifetime is what makes invalidation free: a theme switch
+    repaints the page, and the next paint resolves the new ramp because these
+    are rebuilt from scratch every time. Nothing caches them across paints, so
+    there is no epoch to track.
+    """
+
+    dim: Style
+    muted: Style
+    fg: Style
+    accent: Style
+    faint: Style
+
+    @classmethod
+    def resolve(cls) -> "_RowStyles":
+        """Build the bundle from the ACTIVE theme."""
+        return cls(
+            dim=Style(color=theme_mod.semantic_color("dim")),
+            muted=Style(color=theme_mod.semantic_color("muted")),
+            fg=Style(color=theme_mod.semantic_color("fg")),
+            accent=Style(color=theme_mod.semantic_color("accent")),
+            faint=Style(color=theme_mod.semantic_color("faint")),
+        )
+
+
 class _Suggestion(NamedTuple):
     """One row of the inline suggestion dropdown.
 
@@ -2555,10 +2597,14 @@ class SettingsView(Vertical):
     def _paint_list(self) -> None:
         width = self._list_width()
         text = Text(no_wrap=True, overflow="ellipsis")
+        # ONE ink bundle for the whole list. Resolved here rather than inside
+        # `_row_text` because the five `Style` constructions were 5xN per paint
+        # and N is the row count — see `_RowStyles`.
+        styles = _RowStyles.resolve()
         for index, row in enumerate(self._rows):
             if index:
                 text.append("\n")
-            line = self._row_text(row, index, width)
+            line = self._row_text(row, index, width, styles)
             # Clipped rather than allowed to wrap. A wrapped row breaks the
             # one-row-per-setting contract the cursor and the click handler
             # both depend on: `_index_at` maps a click's y to a row index, so a
@@ -2573,24 +2619,34 @@ class SettingsView(Vertical):
         # it to the handed content with no room to scroll.
         self._list.styles.height = max(len(self._rows), 1)
 
-    def _row_text(self, row: "_Row", index: int, width: int) -> Text:
+    def _row_text(
+        self, row: "_Row", index: int, width: int, styles: "_RowStyles | None" = None
+    ) -> Text:
+        """Compose one painted line.
+
+        ``styles`` is the per-paint ink bundle (:class:`_RowStyles`). It is
+        OPTIONAL so the many call sites that paint a single row — and any
+        caller outside this module — keep working unchanged; passing it is what
+        lets ``_paint_list`` resolve the five theme colours once for the whole
+        list instead of once per row (see :class:`_RowStyles`).
+        """
         selected = index == self._selected
         hovered = index == self._hovered
         line = Text(no_wrap=True, overflow="ellipsis")
-        dim = Style(color=theme_mod.semantic_color("dim"))
-        muted = Style(color=theme_mod.semantic_color("muted"))
-        fg = Style(color=theme_mod.semantic_color("fg"))
-        accent = Style(color=theme_mod.semantic_color("accent"))
-        faint = Style(color=theme_mod.semantic_color("faint"))
+        if styles is None:
+            styles = _RowStyles.resolve()
+        dim = styles.dim
+        muted = styles.muted
+        fg = styles.fg
+        accent = styles.accent
+        faint = styles.faint
 
         if row.kind == "header" and row.section is not None:
             # The scope tag rides the SECTION header, right-aligned and dim: it
             # answers "when does this take effect" once per group rather than
             # fifty times down the page. See the module docstring.
             head = Text(no_wrap=True)
-            head.append(
-                row.section.title, style=Style(color=theme_mod.semantic_color("fg"), bold=True)
-            )
+            head.append(row.section.title, style=fg + Style(bold=True))
             # The tag sheds its PREFIX before it sheds the scope itself: on a
             # narrow body "takes effect: new sessions" does not fit beside the
             # title, and the half that carries the meaning is the scope. Dropped

--- a/local_operator/tui/widgets/settings_view.py
+++ b/local_operator/tui/widgets/settings_view.py
@@ -320,6 +320,64 @@ class _ChromeStatic(Static):
 
     ALLOW_SELECT = False
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        #: The (content, theme epoch) last handed to `update_if_changed`, or
+        #: None before the first one. See that method for why the epoch is
+        #: half of the key.
+        self._painted: tuple[Text, int] | None = None
+
+    def update_if_changed(self, content: Text, *, layout: bool = True) -> bool:
+        """``update`` unless this surface already holds ``content``. True if painted.
+
+        WHY THIS EXISTS
+        ===============
+
+        ``Static.update`` invalidates the widget's whole render cache, and
+        ``Widget._render_content`` then rasterises ``self.size`` — every line of
+        it — on the next paint. On ``/settings`` that is the dominant cost of an
+        arrow press. Measured over 59 consecutive real cursor transitions, the
+        title, the rule and the side pane produced BYTE-IDENTICAL ``Text`` on
+        59/59 of them, so all of that work was thrown away and repainted
+        identically (``docs/settings-keypress-profile.md`` §5.2). Eliding those
+        no-op updates measured 12-16% of a press at 96 rows.
+
+        THE COMPARISON KEY IS THE WHOLE CORRECTNESS ARGUMENT, and it is why the
+        theme epoch is in it. Rich ``Text`` equality covers the plain string and
+        the spans, which is what rasterises — but a THEME SWITCH can change what
+        this widget paints without changing the ``Text`` at all, because the
+        surface's own ``$lo-*`` styling comes from the stylesheet rather than
+        from the content. Comparing content alone would leave a stale frame on
+        screen across a theme change. ``theme_mod.get_theme_epoch()`` exists for
+        exactly this and is bumped by every ``set_theme``.
+
+        Structural equality, never identity: the painters build a fresh ``Text``
+        every time, so an ``id()`` key would never match and this would elide
+        nothing. Kept here rather than in each painter so all five surfaces
+        answer the question the same way.
+        """
+        epoch = theme_mod.get_theme_epoch()
+        if self._painted is not None:
+            last_content, last_epoch = self._painted
+            if last_epoch == epoch and last_content == content:
+                return False
+        # The Text is stored as handed over. The painters treat a composed row
+        # as immutable once painted (none of them mutates a `Text` it has
+        # already given to a widget), so holding the reference is safe and
+        # copying it on every paint would pay back part of what this saves.
+        self._painted = (content, epoch)
+        self.update(content, layout=layout)
+        return True
+
+    def forget_painted(self) -> None:
+        """Drop the elision key, so the next update always paints.
+
+        For the cases where the CONTENT is unchanged but the rasterisation is
+        not — a resize, or anything that invalidates Textual's own caches
+        underneath this widget.
+        """
+        self._painted = None
+
 
 class SettingsViewDismissed(Message):
     """The page's ``esc`` hint was clicked. The app owns leaving the mode.
@@ -607,6 +665,12 @@ class SettingsView(Vertical):
             pass
 
     def on_resize(self) -> None:
+        # Drop every elision key BEFORE the repaint. `update_if_changed` keys on
+        # CONTENT, and a resize can leave content identical while what is
+        # rasterised from it is not: the pane and the detail line are budgeted
+        # against a width, so a Static that skipped its update would keep strips
+        # measured for the old one.
+        self._invalidate_paint_caches()
         # The rule spans the page and the hints shed against a width only the
         # layout knows, so both are repainted on resize. Parking a 1-row
         # body on the selected setting has to wait until AFTER this
@@ -2594,6 +2658,16 @@ class SettingsView(Vertical):
         self._paint_detail()
         self._paint_chrome()
 
+    def _invalidate_paint_caches(self) -> None:
+        """Force the next paint to repaint from scratch.
+
+        For the changes that leave the CONTENT identical while invalidating what
+        was measured from it — a resize being the reachable one. Theme changes
+        are keyed on the epoch inside the cache itself and need no call here.
+        """
+        for surface in (self._title, self._rule, self._detail, self._pane_view):
+            surface.forget_painted()
+
     def _paint_list(self) -> None:
         width = self._list_width()
         text = Text(no_wrap=True, overflow="ellipsis")
@@ -3323,7 +3397,11 @@ class SettingsView(Vertical):
                     text.append(truncate_cells(rendered.plain, width), style=rung[0][1])
                     break
         self._detail_text = text
-        self._detail.update(text)
+        # The one surface that legitimately changes on every move (it describes
+        # the cursor row), so this elides nothing in the common case — it is
+        # routed through the same helper so all five surfaces behave alike and
+        # a future state that DOES repeat a detail line is covered for free.
+        self._detail.update_if_changed(text)
 
     @staticmethod
     def _join_detail(parts: list[tuple[str, Style, bool]]) -> Text:
@@ -3634,7 +3712,10 @@ class SettingsView(Vertical):
             dim,
             roster_foldable=foldable,
         )
-        self._pane_view.update(self._pane_text)
+        # The pane is resolved once at open (providers, teams, agents) and was
+        # byte-identical on 59/59 consecutive cursor moves, so this repaints on
+        # a pane SWITCH and on nothing else.
+        self._pane_view.update_if_changed(self._pane_text)
 
     def _fit_pane(
         self,
@@ -4017,11 +4098,15 @@ class SettingsView(Vertical):
         path = self._config_path()
         title.append(truncate_cells(path, max(self._title_room(), 12)), style=dim)
         self._title_text = title
-        self._title.update(title)
+        # The title is the config path: identical on every cursor move, and
+        # changed only by a resize (the truncation budget) or a config-path
+        # change.
+        self._title.update_if_changed(title)
 
         width = max(self.size.width - 2, 1)
         self._rule_text = Text("─" * width, style=dim)
-        self._rule.update(self._rule_text)
+        # `"─" * width` — changed only by a resize.
+        self._rule.update_if_changed(self._rule_text)
         self._paint_hints()
 
     def _current_is_readonly(self) -> bool:

--- a/local_operator/tui/widgets/settings_view.py
+++ b/local_operator/tui/widgets/settings_view.py
@@ -450,8 +450,12 @@ class _ListStatic(_ChromeStatic):
         self._row_count = 0
         self._row_cache: dict[int, Text] = {}
         self._line_cache: dict[int, Strip] = {}
-        #: ``(width, theme epoch)`` the cached strips were rasterised at.
-        self._line_key: tuple[int, int] = (-1, -1)
+        #: ``(width, theme epoch, base style)`` the cached strips were
+        #: rasterised at. The base style is in here rather than only the epoch
+        #: because this widget discards Textual's own invalidation signal —
+        #: see :meth:`render_line`. ``None`` is the "nothing cached yet" style,
+        #: which no resolved style equals.
+        self._line_key: tuple[int, int, Style | None] = (-1, -1, None)
 
     def set_source(
         self, compose: Callable[[int], Text], count: int, dirty: Sequence[int | None]
@@ -515,16 +519,54 @@ class _ListStatic(_ChromeStatic):
         rasterises the widget's FULL height — off the keypress path entirely.
         """
         width = self.size.width
-        key = (width, theme_mod.get_theme_epoch())
+        # THE RESOLVED BASE STYLE IS PART OF THE KEY, not just the theme epoch.
+        #
+        # This override throws away `_dirty_regions` below, which is Textual's
+        # own "your styles changed, re-render" signal (`Widget._set_dirty`
+        # populates it on ANY style invalidation: a class add/remove, a
+        # pseudo-class like `:focus` or `:hover`, an inline `styles.*`
+        # assignment, a stylesheet reparse). A key of (width, epoch) covers only
+        # two of those causes, so every other one was silently swallowed and the
+        # stale strip returned.
+        #
+        # Keying on `visual_style.rich_style` — the style the strips are
+        # actually measured against — closes that gap at the point it matters:
+        # whatever the CAUSE of the invalidation, if it changed what a strip
+        # would look like, the key moves. That keeps this widget honest about
+        # the framework's invalidation protocol rather than opting out of it,
+        # which is what makes it safe for the next person to add a `:focus`
+        # rule to `.settings-view-list` and simply have it work.
+        #
+        # `rich_style` is hashable and Textual memoises it against
+        # `styles._cache_key`, so this is a cache-key comparison and not a
+        # restyle per line; measured at zero cost (61.0/2.0/2.0/0.0 per press,
+        # byte-identical to the narrower key).
+        key = (width, theme_mod.get_theme_epoch(), self.visual_style.rich_style)
         if key != self._line_key:
-            # Width or theme moved under the cache: a strip is only meaningful
-            # at the width it was measured for, and the widget's base style is
-            # resolved from the active theme.
+            # Width, theme or base style moved under the cache, so BOTH caches
+            # are dropped — a strip is only meaningful at the width it was
+            # measured for, and a composed row carries the theme's inks, so
+            # re-rasterising a kept `Text` would put the old colours in a new
+            # frame. Clearing only `_line_cache` (as this did) left that half
+            # inert: it re-rasterised from exactly the `Text` it already had.
+            #
+            # WHAT THIS BRANCH DOES AND DOES NOT DO, since the distinction is
+            # easy to misread: dropping the row cache lets the rows be RE-COMPOSED,
+            # but the recomposition runs the `compose` closure `_paint_list`
+            # last installed, which captured its `_RowStyles` bundle. So an
+            # epoch bump on its own does not re-ink — measured. The re-inking
+            # comes from the repaint the theme change triggers, which builds a
+            # fresh bundle. This branch's job is narrower and still necessary:
+            # to guarantee no strip measured under the OLD style survives into
+            # the new frame. `invalidate_lines` clears the same pair for the
+            # same reason.
+            self._row_cache.clear()
             self._line_cache.clear()
             self._line_key = key
         # Textual's base implementation renders content when this is set; the
         # per-line cache above has already answered that question, so clearing
-        # it keeps the set from growing one region per refresh forever.
+        # it keeps the set from growing one region per refresh forever. Safe
+        # only because the key above now tracks the style those regions signal.
         self._dirty_regions.clear()
 
         cached = self._line_cache.get(y)
@@ -3017,6 +3059,27 @@ class SettingsView(Vertical):
         which is what a config write should cost. See `_paint_list` for why the
         cursor-only dirty set was not enough.
 
+        HOW TO KEEP THIS TRUE, because the docstring above is a promise the next
+        author will build on rather than re-derive. Anything ``_row_text`` reads
+        TRANSITIVELY must appear here, and "transitively" is the whole trap: the
+        catalogues below are not touched by ``_row_text`` itself, they are four
+        calls down (``_row_text`` -> ``_editor_text`` -> ``_suggest_ghost`` ->
+        ``_highlighted_suggestion`` -> ``_suggestions``). They were missing, and
+        a same-length catalogue swap through ``load()`` painted a stale
+        suggestion dropdown while the model held the new one — the failure is
+        silent by construction, because a paint cache that returns the wrong
+        answer looks exactly like one that returns the right answer.
+
+        Derive this list by walking that call graph, not from memory. An AST
+        walk from ``_row_text`` over this class's own methods, differenced
+        against the attributes named here, takes a minute and is what found the
+        omission; the only reads it turns up that are deliberately absent are
+        ``_selected`` and ``_hovered`` (the cursor and hover, which the dirty
+        set in `_paint_list` handles per line precisely so a cursor move does
+        NOT invalidate the list) and ``_TWO_COLUMN_MIN_WIDTH`` (a class
+        constant, and the width it feeds is already covered by
+        ``_list_width()``).
+
         The config VALUES are in here because most rows render a stored value
         and its changed-vs-default ink; ``repr`` of the values mapping measures
         4.3 µs, against a press this saves milliseconds on. The editor state is
@@ -3034,6 +3097,20 @@ class SettingsView(Vertical):
             self._suggest_dismissed,
             theme_mod.get_theme_epoch(),
             self._list_width(),
+            # The two suggestion catalogues, by CONTENT rather than by length.
+            # `load()` replaces both lists wholesale, and a same-length swap
+            # (two providers exchanged for two others) leaves every other
+            # member of this token unchanged — which is precisely the case that
+            # painted a stale dropdown, because `_suggest_index` normally moves
+            # and masks the omission.
+            #
+            # The whole `ModelRow` rather than its selector: a suggestion row
+            # renders the model id, the selector AND `_suggestion_detail`'s
+            # provider/price note, so keying on the selector alone would miss a
+            # re-priced catalogue. `ModelRow` is a frozen dataclass and hashable,
+            # so it is a valid tuple member and compares by value.
+            tuple(self._provider_catalogue),
+            tuple(self._model_catalogue),
         )
 
     @property

--- a/scripts/settings_press_driver.py
+++ b/scripts/settings_press_driver.py
@@ -1,0 +1,78 @@
+"""A keypress driver that never measures a CLAMPED (no-op) press.
+
+WHY THIS EXISTS — a measurement bug this investigation hit and had to correct.
+
+``/settings`` is the documented exception to the repo's wrap-vs-clamp rule
+(AGENTS.md, "Wrapping vs clamping"): ``action_move`` CLAMPS at the ends of the
+list. The page has 96 rows but only 79 SELECTABLE ones, so a probe that sends
+100 ``down`` presses gets 79 real moves followed by 21 presses on which the
+cursor does not move at all.
+
+A clamped press is not a cheap press — it is a DIFFERENT press. Verified
+directly: after clamping, ``_list_text`` is byte-identical before and after the
+press, so a probe that elides updates on equal content elides EVERY update on
+those presses, including the list. That made an elision counterfactual look
+~3x faster than it is, purely because most of its samples were presses with
+nothing to repaint.
+
+So the driver below reverses direction one press before an end. Every sample is
+a press that genuinely moves the cursor and genuinely changes two row lines,
+which is the operation the operator's report is about. Direction reversal is
+itself never sampled.
+
+Use ``bounce_presses`` for pilot-driven runs and ``bounce_moves`` for direct
+``action_move`` calls.
+"""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, Iterator
+
+
+class Bouncer:
+    """Yields +1/-1 steps that stay strictly inside the selectable range.
+
+    ``view`` is a ``SettingsView``. The turn is decided from the CURRENT cursor
+    position against the live selectable list, so it stays correct when the row
+    count changes underneath it (an inflated registry, an expansion opening).
+    """
+
+    def __init__(self, view: Any, margin: int = 2) -> None:
+        self._view = view
+        # Turn `margin` rows before the true end, so no sampled press is the one
+        # that lands exactly on the boundary either — that press moves, but the
+        # NEXT one would not, and keeping a margin makes the sampled population
+        # uniform rather than mostly-moving-with-occasional-stalls.
+        self._margin = max(1, margin)
+        self._delta = 1
+
+    def step(self) -> int:
+        indices = self._view._selectable()
+        if not indices:
+            return self._delta
+        try:
+            position = indices.index(self._view._selected)
+        except ValueError:
+            position = 0
+        if position >= len(indices) - self._margin:
+            self._delta = -1
+        elif position <= self._margin - 1:
+            self._delta = 1
+        return self._delta
+
+    def key(self) -> str:
+        return "down" if self.step() == 1 else "up"
+
+
+def bounce_moves(view: Any, count: int) -> Iterator[int]:
+    """Yield ``count`` deltas, calling nothing — the caller times each move."""
+    bouncer = Bouncer(view)
+    for _ in range(count):
+        yield bouncer.step()
+
+
+async def bounce_presses(pilot: Any, view: Any, count: int) -> AsyncIterator[str]:
+    """Yield the key to press for each of ``count`` guaranteed-moving presses."""
+    bouncer = Bouncer(view)
+    for _ in range(count):
+        yield bouncer.key()

--- a/scripts/settings_repaint_probe.py
+++ b/scripts/settings_repaint_probe.py
@@ -1,0 +1,245 @@
+"""Count the per-keypress repaint work on ``/settings`` — the guard's engine.
+
+WHY THIS EXISTS
+===============
+
+``docs/settings-keypress-profile.md`` measured that an arrow press on
+``/settings`` re-rasterises the ENTIRE settings list (96 lines at 96 rows, 218
+at 218) in order to repaint a 14-line viewport in which two lines changed, and
+that the cost is linear in row count at ~30 µs/row/press. A ~60-row Hotkeys
+section is queued behind that finding, so the waste has to be measured as a
+COUNT rather than as a duration: AGENTS.md ("Prefer a structural invariant to a
+numeric one", "Calibrate ceilings from CI, never from your laptop") is explicit
+that no portable wall-clock bound survives the CI/laptop core-speed spread, and
+the profiler declined to propose one for exactly that reason.
+
+So this module counts four operations per press and nothing else. It is shared
+by the regression test (``tests/unit/tui/test_settings_repaint_cost.py``) and by
+ad-hoc runs of this file, so the guard and the evidence in the PR cannot drift
+apart by being two different probes.
+
+WHAT IS COUNTED, AND WHY EACH ONE
+---------------------------------
+
+``semantic_color``   theme lookups. Five ``Style`` objects were constructed per
+                     ROW per paint, before the row's kind was even examined, so
+                     a header row paid for the accent/faint styles it never
+                     uses. Linear in row count.
+``row_text``         calls to ``SettingsView._row_text``. One per row per paint
+                     means every off-screen row is composed to repaint a
+                     viewport.
+``strip_lines``      LINES handed back by ``Visual.to_strips`` for the list
+                     widget. This is the direct measurement of the dominant
+                     cost: ``Static.update`` invalidates the whole render cache
+                     and ``Widget._render_content`` rasterises ``self.size``,
+                     i.e. all N lines. Counted at ``Visual.to_strips`` because
+                     that is the ONE boundary both the pre-fix (whole-widget)
+                     and post-fix (per-line) render paths cross, so the same
+                     number means the same thing on both trees.
+``build_rows``       calls to ``SettingsView._build_rows``, which re-derives the
+                     whole row list on a pure cursor move.
+
+EVERY PRESS SAMPLED MUST ACTUALLY MOVE THE CURSOR — see
+``scripts/settings_press_driver``. ``/settings`` is AGENTS.md's documented
+wrap-vs-clamp exception, and a clamped press repaints nothing, so a naive
+``down``-press loop silently dilutes the sample with no-ops. That bug made the
+first counterfactual in the profile read ~0% saving where the truth was 12-16%.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.settings_press_driver import Bouncer  # noqa: E402
+
+
+@dataclass
+class PressCounts:
+    """Operations counted while ``presses`` guaranteed-moving presses ran."""
+
+    presses: int
+    rows: int
+    viewport: int
+    semantic_color: int
+    row_text: int
+    strip_lines: int
+    build_rows: int
+
+    def per_press(self, field: str) -> float:
+        """A counted total divided by the presses that produced it."""
+        return getattr(self, field) / self.presses if self.presses else 0.0
+
+    def summary(self) -> str:
+        return (
+            f"rows={self.rows} viewport={self.viewport} presses={self.presses} | "
+            f"semantic_color={self.per_press('semantic_color'):.1f}/press "
+            f"row_text={self.per_press('row_text'):.1f}/press "
+            f"strip_lines={self.per_press('strip_lines'):.1f}/press "
+            f"build_rows={self.per_press('build_rows'):.1f}/press"
+        )
+
+
+class _Counter:
+    """A call tally plus the ``wrap`` that produces a countable stand-in.
+
+    ``wrap`` returns a plain FUNCTION, never this object. A callable instance
+    assigned to a class attribute is not a descriptor, so ``view._row_text(...)``
+    would hand the instance back unbound and the call would lose ``self`` —
+    which is exactly the ``TypeError`` a first version of this probe raised.
+    """
+
+    def __init__(self) -> None:
+        self.count = 0
+        self.armed = False
+
+    def wrap(self, target: Callable[..., Any]) -> Callable[..., Any]:
+        def counted(*args: Any, **kwargs: Any) -> Any:
+            result = target(*args, **kwargs)
+            if self.armed:
+                self.count += 1
+            return result
+
+        return counted
+
+
+async def count_presses(
+    pilot: Any,
+    view: Any,
+    presses: int,
+    monkeypatch: Any,
+) -> PressCounts:
+    """Drive ``presses`` bounced presses and return what they cost, counted.
+
+    ``monkeypatch`` is pytest's fixture (or anything exposing ``setattr``), so
+    every patch is undone by the caller's teardown rather than by a ``finally``
+    this function would have to get right. Counting is ARMED only for the
+    sampled presses: opening the page and the pilot's first settle legitimately
+    rasterise everything once, and folding that into the average would report a
+    fixed start-up cost as a per-press cost.
+    """
+    from textual.visual import Visual
+
+    from local_operator.tui import theme as theme_mod
+    from local_operator.tui.widgets.settings_view import SettingsView
+
+    list_widget = view._list
+
+    semantic = _Counter()
+    row_text = _Counter()
+    build_rows = _Counter()
+    strips = _Counter()
+
+    inner_to_strips = Visual.to_strips.__func__  # type: ignore[attr-defined]
+
+    # `cls` FIRST, then `widget`. `to_strips` is a classmethod, so a wrapper
+    # written as `(widget, *args)` silently binds `widget` to the Visual CLASS
+    # and every `widget is list_widget` test is False — which is a guard that
+    # passes at 0.0 lines/press against code that rasterises 96 of them.
+    def to_strips(cls: Any, widget: Any, *args: Any, **kwargs: Any) -> Any:
+        # Attributed to the LIST widget only, and counted in LINES rather than
+        # in calls: the title, rule, detail and pane rasterise on the same press
+        # and would otherwise be charged to the cost this guard is about.
+        result = inner_to_strips(cls, widget, *args, **kwargs)
+        if strips.armed and widget is list_widget:
+            strips.count += len(result)
+        return result
+
+    # `semantic_color` is patched on the MODULE the widget resolves through:
+    # `settings_view` does `from ... import theme as theme_mod`, so it shares
+    # the module object and one patch covers the list, detail, pane and chrome
+    # painters alike — which is what makes the count a per-PRESS figure.
+    monkeypatch.setattr(theme_mod, "semantic_color", semantic.wrap(theme_mod.semantic_color))
+    monkeypatch.setattr(SettingsView, "_row_text", row_text.wrap(SettingsView._row_text))
+    monkeypatch.setattr(SettingsView, "_build_rows", build_rows.wrap(SettingsView._build_rows))
+    monkeypatch.setattr(Visual, "to_strips", classmethod(to_strips))
+
+    bouncer = Bouncer(view)
+    # One un-armed warm-up press so the sample never includes the first paint
+    # after the patches went in.
+    await pilot.press(bouncer.key())
+    await pilot.pause()
+
+    for counter in (semantic, row_text, build_rows, strips):
+        counter.armed = True
+
+    for _ in range(presses):
+        await pilot.press(bouncer.key())
+        await pilot.pause()
+
+    for counter in (semantic, row_text, build_rows, strips):
+        counter.armed = False
+
+    return PressCounts(
+        presses=presses,
+        rows=len(view._rows),
+        viewport=view._body.size.height,
+        semantic_color=semantic.count,
+        row_text=row_text.count,
+        strip_lines=strips.count,
+        build_rows=build_rows.count,
+    )
+
+
+async def open_settings(app: Any, pilot: Any) -> Any:
+    """Open ``/settings`` on a booted app and hand back the view."""
+    from local_operator.tui.widgets.settings_view import SettingsView
+
+    app._open_settings_view()
+    await pilot.pause()
+    view = app.query_one(SettingsView)
+    await pilot.pause()
+    return view
+
+
+def main() -> None:
+    """Run the probe standalone and print the counts (PR evidence)."""
+    import asyncio
+
+    from scripts.visual_capture import isolate_capture
+
+    isolate_capture()
+    os.environ.setdefault("LOCAL_OPERATOR_CONFIG_DIR", os.environ["LOCAL_OPERATOR_CONFIG_DIR"])
+
+    from local_operator.tui.app import OperatorApp
+    from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+    class _Patch:
+        """The two-line `monkeypatch` this file needs outside pytest."""
+
+        def __init__(self) -> None:
+            self._undo: list[tuple[Any, str, Any]] = []
+
+        def setattr(self, target: Any, name: str, value: Any) -> None:
+            self._undo.append((target, name, getattr(target, name)))
+            setattr(target, name, value)
+
+        def undo(self) -> None:
+            for target, name, old in reversed(self._undo):
+                setattr(target, name, old)
+
+    size = (100, 30)
+    presses = int(sys.argv[1]) if len(sys.argv) > 1 else 10
+
+    async def run() -> None:
+        app = OperatorApp(lambda: _factory(FakeSession()))
+        async with app.run_test(size=size) as pilot:
+            await pilot.pause()
+            view = await open_settings(app, pilot)
+            patch = _Patch()
+            try:
+                counts = await count_presses(pilot, view, presses, patch)
+            finally:
+                patch.undo()
+            print(counts.summary())
+
+    asyncio.run(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/tui/test_settings_repaint_cost.py
+++ b/tests/unit/tui/test_settings_repaint_cost.py
@@ -147,30 +147,40 @@ async def test_a_cursor_move_does_not_resolve_a_theme_colour_per_row(
 
     The bound is an ABSOLUTE number rather than a multiple of the viewport,
     because after the fix the count is a property of the PAINTERS and no longer
-    of the list at all. Measured post-fix, it does not move with either the
-    rows or the window:
+    of the list at all. Measured post-fix at ``_SIZE``, and flat under a
+    Hotkeys-sized registry, which is the property that matters here:
 
         rows  96 -> 216 (registry inflated) : 61.0/press both
-        size  100x30, 140x40, 200x50        : 61.0/press
-        size  80x24, 70x20 (footer sheds)   : 44.0/press
+        size  100x30, 120x32, 140x40, 200x50: 61.0/press
+        size  80x24, 70x20, 60x20 (footer sheds): 44.0/press
 
-    WHY 80 AND NOT THE PROFILE'S PROPOSED 40. The profile's figure assumed the
-    residual would be the settings painters alone. It is not: 44 of the 61 come
-    from ``HintButton._build``, the FOOTER, which resolves two-to-four colours
-    per hint on every paint and is shared with ``OrgChartView`` and
-    ``SubagentView``. Fixing it means changing a widget three views depend on,
-    which is outside this change and would collide with the concurrent hotkeys
-    work; 40 is not reachable without it, and a bound the code cannot meet is
-    a red suite rather than a guard.
+    THE BOUND IS 65, AND IT IS DELIBERATELY TIGHT ENOUGH TO FAIL ALONE.
+    It was 80, and at 80 this guard did not do its job: reverting the
+    ``_RowStyles`` hoist — the exact optimisation it names — took the count to
+    only 71.0 and the test stayed GREEN, so it was really re-detecting the lazy
+    compose that G3 already covers. A guard that cannot go red for the thing it
+    guards is a decoration.
 
-    So this holds the line where this change actually left it — the per-ROW
-    cost is gone (552 -> 61, and flat in row count, which is the property the
-    Hotkeys section needs) — with headroom for the footer's own shedding
-    ladder rather than pretending the footer was fixed here.
+    65 is chosen against the measured pair, not by taste: 61.0 for the correct
+    code and 71.0 for the hoist reverted, both stable to the count across every
+    geometry above and under an inflated registry. It sits inside that 10-count
+    gap with 4 counts of headroom below and 6 above, and this suite pins the
+    terminal size, so the 44.0 of the shed footer ladder is not in play. The
+    mutation is re-run in the PR's remediation round rather than asserted here.
+
+    WHY NOT THE PROFILE'S PROPOSED 40. That figure assumed the residual would
+    be the settings painters alone. It is not: 44 of the 61 come from
+    ``HintButton._build``, the FOOTER, which resolves two-to-four colours per
+    hint on every paint and is shared with ``OrgChartView`` and
+    ``SubagentView`` — independently confirmed by a caller-attributing spy at
+    exactly 44.0/press. Reaching 40 means changing a widget three views depend
+    on, which is outside this change; a bound the code cannot meet is a red
+    suite rather than a guard. What this change owns is the per-ROW cost, and
+    that is gone (552 -> 61, flat in row count).
     """
     counts = await _measure(monkeypatch)
 
-    assert counts.per_press("semantic_color") <= 80, counts.summary()
+    assert counts.per_press("semantic_color") <= 65, counts.summary()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_settings_repaint_cost.py
+++ b/tests/unit/tui/test_settings_repaint_cost.py
@@ -1,0 +1,235 @@
+"""Structural guards on what ONE arrow press costs on ``/settings``.
+
+WHY THESE ARE COUNTS AND NOT TIMINGS
+====================================
+
+The operator reported perceptible lag arrow-keying through ``/settings``, and
+``docs/settings-keypress-profile.md`` measured why: a press re-rasterised the
+ENTIRE list (96 lines at 96 rows, 218 at 218) to repaint a 14-line viewport in
+which two lines had changed, plus one ``_row_text`` call and five
+``semantic_color`` lookups per row per paint. The cost was cleanly linear at
+~30 µs per row per press, which is what made it urgent: a ~60-row Hotkeys
+section is queued behind this work and would have inherited the scaling.
+
+Nothing here measures a duration. AGENTS.md is emphatic on the point
+("Prefer a structural invariant to a numeric one"; "Calibrate ceilings from CI,
+never from your laptop"), and the profiler explicitly declined to propose a
+wall-clock bound because every number it had came from one M3 Max. A count of
+operations per press is a fact about what the code DID, not about how fast the
+machine was, so these cannot flake under load — which is the property that lets
+them sit in the default suite alongside 2,700 other tests.
+
+WHY THE BOUNDS ARE VIEWPORT-RELATIVE
+------------------------------------
+
+Every bound below is expressed against the BODY VIEWPORT (how many rows are on
+screen), never against ``len(view._rows)``. That is the whole point: adding the
+Hotkeys section must not move any of these numbers, and if it does, the guard
+has done its job. A bound of "≤ 3 × rows" would pass vacuously on any list
+length and would have passed on the code this test was written against.
+
+PROVEN TO FAIL BEFORE THE FIX (AGENTS.md, "Prove the test can still fail").
+Measured on the pre-fix tree at 100x30, 96 rows, viewport 14, 10 bounced
+presses — each guard's failing value, against the bound it now holds:
+
+    G1  semantic_color   552.0/press   bound  80   FAIL
+    G2  list strip lines  96.0/press   bound  42   FAIL
+    G3  _row_text calls   96.0/press   bound  28   FAIL
+    G4  _build_rows        1.0/press   bound   0   FAIL
+
+EVERY SAMPLED PRESS MUST MOVE THE CURSOR. ``/settings`` is AGENTS.md's
+documented wrap-vs-clamp exception, so a press at the end of the list is a
+silent no-op that repaints nothing; a naive ``down`` loop dilutes the sample
+with those and under-reports the waste (the profile records this as one of two
+measurement bugs it had to correct). ``scripts/settings_repaint_probe`` drives
+the presses through ``scripts.settings_press_driver.Bouncer``, which reverses
+direction before either end.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from local_operator.tui.app import OperatorApp
+from scripts.settings_repaint_probe import PressCounts, count_presses, open_settings
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+#: Terminal the guards are stated at. 100x30 resolves to a 14-row body
+#: viewport and 96 list rows on the shipped registry — the exact shape the
+#: profile measured, so its numbers and these bounds describe one page.
+_SIZE = (100, 30)
+
+#: Enough presses that a one-off (a lazily-built cache filling on the first
+#: press, a scroll that happened to fire) is averaged down rather than
+#: dominating, and few enough that the test stays inside a second or two.
+_PRESSES = 10
+
+
+@pytest.fixture(autouse=True)
+def _scratch_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Read and write an empty scratch config, never the developer's own.
+
+    The page writes on Enter and reads on every paint; a test on the real
+    config dir would both edit the developer's settings and count a row list
+    that differs per machine.
+    """
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    from local_operator.tui.settings import settings_reload
+
+    settings_reload()
+    return tmp_path
+
+
+async def _measure(monkeypatch: pytest.MonkeyPatch) -> PressCounts:
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=_SIZE) as pilot:
+        await pilot.pause()
+        view = await open_settings(app, pilot)
+        counts = await count_presses(pilot, view, _PRESSES, monkeypatch)
+    return counts
+
+
+@pytest.mark.asyncio
+async def test_a_cursor_move_does_not_rasterise_the_whole_settings_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """G2 — the load-bearing one: lines rasterised scale with the VIEWPORT.
+
+    This is the direct assertion that a press repaints what is on screen rather
+    than the whole widget. Pre-fix it measured 96.0 lines/press at 96 rows and
+    218.0 at 218 — i.e. exactly ``len(rows)``, the signature of
+    ``Static.update`` invalidating the render cache and
+    ``Widget._render_content`` rasterising ``self.size``.
+
+    The bound is ``3 × viewport`` rather than ``1 × viewport`` because a press
+    legitimately dirties more than one band: the cursor's old row and its new
+    row are in different places, a scroll can shift the window, and Textual
+    renders a line on demand per compositor pass. Three screenfuls is
+    comfortably above that and still an order of magnitude below the 96 the
+    pre-fix code produced, so the guard has real headroom without being
+    vacuous.
+    """
+    counts = await _measure(monkeypatch)
+
+    assert counts.rows > 3 * counts.viewport, (
+        "the guard is only meaningful while the list is much longer than the "
+        f"viewport; got {counts.rows} rows against {counts.viewport} visible"
+    )
+    assert counts.per_press("strip_lines") <= 3 * counts.viewport, counts.summary()
+
+
+@pytest.mark.asyncio
+async def test_a_cursor_move_composes_only_the_rows_it_needs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """G3 — ``_row_text`` is called for a screenful, not for every row.
+
+    Pre-fix: 96.0 calls/press, one per row, so 82 of 96 rows were composed to
+    repaint 14. Bounded at ``2 × viewport`` to leave room for the row cache
+    filling around the edges of a scroll.
+    """
+    counts = await _measure(monkeypatch)
+
+    assert counts.per_press("row_text") <= 2 * counts.viewport, counts.summary()
+
+
+@pytest.mark.asyncio
+async def test_a_cursor_move_does_not_resolve_a_theme_colour_per_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """G1 — theme lookups are per PAINT, not per row per paint.
+
+    Pre-fix: 554.1 lookups/press, of which 480 were the five-``Style`` prelude
+    ``_row_text`` built before it examined the row's kind — so a header row paid
+    for the accent and faint styles it never used.
+
+    The bound is an ABSOLUTE number rather than a multiple of the viewport,
+    because after the fix the count is a property of the PAINTERS and no longer
+    of the list at all. Measured post-fix, it does not move with either the
+    rows or the window:
+
+        rows  96 -> 216 (registry inflated) : 61.0/press both
+        size  100x30, 140x40, 200x50        : 61.0/press
+        size  80x24, 70x20 (footer sheds)   : 44.0/press
+
+    WHY 80 AND NOT THE PROFILE'S PROPOSED 40. The profile's figure assumed the
+    residual would be the settings painters alone. It is not: 44 of the 61 come
+    from ``HintButton._build``, the FOOTER, which resolves two-to-four colours
+    per hint on every paint and is shared with ``OrgChartView`` and
+    ``SubagentView``. Fixing it means changing a widget three views depend on,
+    which is outside this change and would collide with the concurrent hotkeys
+    work; 40 is not reachable without it, and a bound the code cannot meet is
+    a red suite rather than a guard.
+
+    So this holds the line where this change actually left it — the per-ROW
+    cost is gone (552 -> 61, and flat in row count, which is the property the
+    Hotkeys section needs) — with headroom for the footer's own shedding
+    ladder rather than pretending the footer was fixed here.
+    """
+    counts = await _measure(monkeypatch)
+
+    assert counts.per_press("semantic_color") <= 80, counts.summary()
+
+
+@pytest.mark.asyncio
+async def test_a_cursor_move_does_not_rebuild_the_row_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """G4 — moving the cursor re-derives no rows at all.
+
+    ``_build_rows`` was structurally identical on 59/59 consecutive transitions
+    in the profile: a cursor move cannot change the STRUCTURE of the list, only
+    which row is inked as selected. Exactly zero, not "few": a rebuild on a pure
+    move means the cache's invalidation has stopped tracking what actually
+    changes structure, and any nonzero count is that bug.
+    """
+    counts = await _measure(monkeypatch)
+
+    assert counts.build_rows == 0, counts.summary()
+
+
+@pytest.mark.asyncio
+async def test_a_row_rendered_alone_is_identical_to_the_whole_block() -> None:
+    """The correctness premise under the per-line render, asserted not assumed.
+
+    ``_ListStatic.render_line`` rasterises ONE row at a time, where Textual's
+    default path rasterises the widget's full height in a single pass. That is
+    only sound if a row rendered alone is byte-identical to the same row
+    rendered as line ``y`` of the whole block — which holds because the rows are
+    composed ``no_wrap`` and each is truncated to the list width before it
+    reaches the renderer, so no row's rendering depends on its neighbours.
+
+    The one thing that does NOT survive the split by itself is the segment
+    metadata: Textual stamps each segment with ``meta={"offset": (x, y)}``
+    naming its position in the content, and the compositor reads it back in
+    ``get_widget_at``. A row rendered alone is at y=0, so ``render_line``
+    re-stamps it with ``apply_offsets(0, y)``. Written without that call, this
+    test fails on 95 of 96 rows — which is what makes it a real assertion about
+    the mechanism rather than a restatement of it.
+    """
+    from textual.visual import Visual, visualize
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=_SIZE) as pilot:
+        await pilot.pause()
+        view = await open_settings(app, pilot)
+        widget = view._list
+
+        # The whole list in ONE pass — the pre-fix rendering, as the control.
+        whole = Visual.to_strips(
+            widget,
+            visualize(widget, view._list_text),
+            widget.size.width,
+            widget.size.height,
+            widget.visual_style,
+        )
+        assert len(whole) == len(view._rows) > 3 * view._body.size.height
+
+        mismatched = [y for y in range(len(whole)) if list(widget.render_line(y)) != list(whole[y])]
+
+    assert not mismatched, (
+        "a row rendered on its own differs from the same row rendered as part "
+        f"of the whole block, at line(s) {mismatched[:5]}"
+    )


### PR DESCRIPTION
## Summary

The operator reports perceptible lag arrow-keying through `/settings`. `docs/settings-keypress-profile.md` (included here) measured why, and the dominant cost is not where you would guess: **every arrow press re-rasterised the entire settings list — all 96 lines — to repaint a 14-line viewport in which 2 lines had changed.**

That cost is **linear in row count** (~30 µs/row/press), which is why this lands before the ~60-row Hotkeys section rather than after it: that section would have inherited the scaling and added ~1.8 ms of widget time to every arrow press on a page already called laggy.

Release: patch — arrow-keying through `/settings` no longer re-renders the whole page on every press, so the list stays responsive as it grows.

Patch and not minor per AGENTS.md materiality: a performance fix inside an existing surface, no new capability to name in a release title.

## Change class

C2 — three internal changes to one widget's paint path. **The rendered frame is unchanged, and that is the correctness bar** (23 before/after captures, below). `pyproject.toml` is untouched; no version bump.

## The three fixes, each its own commit

| | fix | measured payoff |
|---|---|---|
| **R3** `2ec45944b` | hoist the `Style` prelude out of the per-row loop | `semantic_color` **552 → 61** calls/press |
| **R2** `0b6942c1f` | elide `Static.update` when content is byte-identical | 12–16% of a press (title/rule/pane were identical on 59/59 transitions) |
| **R1**+R4 `b10fe7ed8` | render the list **per line** instead of at full height | strip lines **96 → 2**/press; `_row_text` **96 → 2**; `_build_rows` **1 → 0** |

### R3 — the counterintuitive one

The profile measured that **memoising `semantic_color` saves only 1.3%**. The lookup is already a dict hit; the cost is *constructing* 480 `Style` objects per paint, five per row, built before the row's kind was examined — so a header row paid for the `accent`/`faint` styles it never uses. Fixed by resolving them once per paint into a `_RowStyles` bundle, whose per-paint lifetime makes theme invalidation automatic.

### R2 — the comparison key is the whole correctness argument

Rich `Text` equality covers the plain string and spans, which is what rasterises. But a **theme switch changes what the widget paints without changing the `Text`**, because the surface's own `$lo-*` styling comes from the stylesheet. So the key is `(content, theme epoch)` — and it is structural, never `id()`: the painters build a fresh `Text` every paint, so an identity key would elide nothing at all.

### R1 — the one that fixes the scaling

`_ListStatic` overrides `render_line`, so Textual's `_render_content` (which rasterises `self.size`, i.e. all N lines) is never reached. Rows are rasterised on demand and cached per line. Two things were load-bearing:

- **`apply_offsets(0, y)`.** Textual stamps every segment with `meta={"offset": (x, y)}` and the compositor reads it back in `get_widget_at` to answer "what is under the pointer". A row rendered alone is at y=0, so without the re-stamp every row reports the wrong content offset. Verified segment-for-segment against the full-height render over all 96 rows — and there is a test that **fails on 95 of 96 rows** if the call is removed.
- **The height pin must precede `set_source`.** With `height: auto` the widget measures its own content, which is now *one* row, and painted a single line of a 96-row list. Caught by driving the real page, not by a test.

### R4 rides with R1, and its invalidation is derived rather than remembered

`_build_rows` was structurally identical on 59/59 transitions. `_rows_for_paint` memoises it on a key **derived from its inputs** rather than invalidated at each of the ~60 `_repaint` call sites — one mutator that forgot would paint a list that no longer matches the config, and the cursor would then write to the wrong setting. A new mutator (or the Hotkeys section) is covered without touching this file.

**The dirty-line set is keyed the same way, and this caught a real bug I introduced.** Deriving it from the cursor alone left a stale line on the frame when `r` clears a malformed cascade: same row count, same cursor position, different text. It was caught by an *existing* test that asserts on the **compositor output** rather than on a model string — which is exactly why it caught it.

## Measured results

Interleaved A/B, three passes, median of 60 **bounced** presses (100x30, `time.thread_time`):

| rows | before | after | |
|---:|---:|---:|---|
| 96 | 19.4 – 20.8 ms | 12.4 – 13.4 ms | ~−38% |
| 216 | 27.1 – 29.0 ms | 11.7 – 13.7 ms | ~−55% |

**The point is the second column, not the percentage: 216 rows now cost the same as 96, where before they cost 1.4× more.** That is the property the Hotkeys section needs.

> Every sampled press must actually *move the cursor*. `/settings` is AGENTS.md's documented wrap-vs-clamp exception, so a press at either end is a silent no-op that repaints nothing; a naive `down` loop dilutes the sample and under-reports the saving. All measurement goes through `scripts/settings_press_driver.py`, which bounces before the ends — the profile records this as one of two measurement bugs it had to correct.

## Regression guards — counts, not timings

Five structural assertions in `tests/unit/tui/test_settings_repaint_cost.py`. Nothing here measures a duration: AGENTS.md is explicit that no portable wall-clock bound survives the CI/laptop core-speed spread, and the profiler declined to propose one because every number it had came from one M3 Max. **A count of operations cannot flake on machine load.**

**Proof they fail on the pre-fix tree** (AGENTS.md, "Prove the test can still fail") — run in a throwaway worktree at the base commit with only the test and probe copied in:

```
E  assert 552.0 <= 80          G1 semantic_color
E  assert 96.0 <= (3 * 14)     G2 list strip lines
E  assert 96.0 <= (2 * 14)     G3 _row_text calls
E  assert 10 == 0              G4 _build_rows
4 failed
```

| guard | pre-fix | bound | post-fix |
|---|---:|---:|---:|
| G1 `semantic_color`/press | 552.0 | 80 | 61.0 |
| G2 list strip lines/press | 96.0 | 3 × viewport | 2.0 |
| G3 `_row_text` calls/press | 96.0 | 2 × viewport | 2.0 |
| G4 `_build_rows`/press | 1.0 | 0 | 0.0 |

Plus a fifth: a row rendered alone is byte-identical to the same row in the whole block (fails on 95/96 rows without `apply_offsets`).

**Bounds are stated against the VIEWPORT, never the row count** — that is what keeps them meaningful once Hotkeys lands. A bound of "≤ 3 × rows" would pass vacuously on any list length.

**G1 is 80, not the profile's proposed 40 — stated plainly because it is a gap.** 44 of the residual 61 come from `HintButton._build`, the footer shared with `OrgChartView` and `SubagentView`; reaching 40 means changing a widget three views depend on, which is outside this change and would collide with the concurrent hotkeys work. What this change owns is gone: the per-**row** cost, 552 → 61, **flat in row count** (61.0/press at both 96 and 216 rows) and flat across widths (61.0 at 100/140/200 cols; 44.0 at 80/70 where the footer sheds).

## Frames — the correctness bar

The frame must be **identical** before and after. Captured with `scripts/settings_shot.py` through `visual_capture.save_capture` on the real `OperatorApp` (the only host that loads the stylesheet), `isolate_capture()` before app imports.

**23 before/after pairs, all identical**, at 100x30 and 80x24: overview, enum expansion, cascade, cascade-row (+ activated), teams pane, agents pane, retired section, top-of-list, delete confirm, reset-offered (+ at-default), validation error, bool expansion (+ activated), and consecutive frames.

<details><summary>Verification method, and the one honest caveat</summary>

The capture is byte-deterministic across runs, so `diff` is the comparison. One row is excluded: the **status band** below the page shows `connecting…` vs `test/model` depending on a session-boot race. Proven pre-existing rather than assumed — the **unmodified base** flips it too (1 of 6 runs), as does this branch (1 of 5). It is below the settings page and unrelated to the diff.

</details>

Narrow width (80x24) confirms the height/width ladders still shed correctly — side pane hidden, cursor and scrollbar intact.

## Testing evidence

Beyond the suites, I drove the **real page** and read the actual frames, because a green test proves the code does what I expected rather than that the feature works:

| check | result |
|---|---|
| 40× `down`, exactly one cursor on every frame | PASS |
| selected row's label present on the frame | PASS |
| enum expands and its choices paint (96 → 98 rows) | PASS |
| `pagedown`/`pageup` keep one cursor | PASS |
| wheel scrolls the viewport, list still paints | PASS |
| pane switch (`←→`) repaints | PASS |
| resize 100x30 → 80x24 repaints the list | PASS |
| commit a number edit — new value in the value column | PASS |
| `space` toggles a bool — `on ▸` → `off ▸`, stored `True` → `False` | PASS |
| reject `99999` — `must be at most 100` on the detail line | PASS |
| `r` on a malformed cascade — row becomes `no cascade configured` | PASS (this is the bug the token key fixed) |

**Suites** (rebased head, run exactly as CI):

- `tests/unit` — **16034 passed**, 18 skipped. 2 failures in `tests/unit/test_computer_input.py`, an xdist temp-dir flake under load (ten sibling worktrees were running suites concurrently); **13/13 pass serially, and identically on the unmodified base**, and this diff touches no subprocess or pid code.
- `tests/unit/tui` — **6017 passed**, 12 skipped, 0 failed.
- `tests/e2e -m e2e -n0` — **47 passed**.
- `flake8` / `black --check` (26.1.0) / `isort --check` (5.13.2) / `pyright` — all clean over the whole tree.

## Rebase note for the concurrent hotkeys branch

Kept deliberately narrow to keep that rebase cheap. `_row_text`'s signature gains **one optional trailing keyword** (`styles`), so every existing call site works unchanged; `_build_rows` is untouched in body and signature (the memo wraps it in a new `_rows_for_paint`). The diff is confined to the paint/rasterisation path.

## Not addressed

- **`HintButton._build`'s per-paint colour resolution** (44 of the 61 residual `semantic_color` calls). Shared by three views; out of scope here, and it is why G1 is 80 rather than 40.
- **R5** (splitting `_paint_chrome` so only the hints repaint on a move). Not needed once R2 elides the identical title and rule, and it would add a second invalidation path for ~2% of a press.
- A pre-existing literal `\u2014` escape in a `settings_view.py` docstring (present in `main`, unrelated to this change) — left alone rather than folded into a perf PR.
