### PR TITLE
chore(release): bump version to 0.51.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.12"
+version = "0.51.13"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
One-file release bump for the v0.51.13 window. C0 scope: `pyproject.toml` only, no product change.

**Window contents** (v0.51.12..main), derived with plain `git log` per #740 — never `--merges`, since a commit-shape filter is a filter on merge style rather than membership:

- #750 `85ba5aca4` — **Release: patch — clicking a background-completion notification now switches the session in the terminal you are already looking at, instead of opening a second window.**

**Bump class: PATCH.** The notification already existed and already carried a click action; it landed in the wrong place. No new command, no new surface, no API change. Applying the AGENTS.md test, there is no step-function capability to name in a release title.

**Pre-check:** `git diff v0.51.12..origin/main -- pyproject.toml` was EMPTY before this commit — nothing consumed 0.51.13.

Owner session pid **95768**. Announced to 17 peer sessions; no competing claim. I will re-derive the window immediately before `gh release create`, and build the tag rather than `main`.