### PR TITLE
chore(release): bump version to 0.51.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.13"
+version = "0.51.14"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window after v0.51.13. Owner session pid: **33627**.

Window (all three merged, each `Release:` line taken from its own PR body):
- [x] #775 — `4bd261116` — Release: patch — a compromised Radient console session can no longer repoint your tunnel at another local service and hand it a live relay credential.
- [x] #770 — `263eb7f39` — Release: patch — a tool call whose arguments take a while to dictate no longer drops the terminal that is watching it, so a resumed session stops showing calls frozen at `composing…`.
- [x] #766 — `e3cb1ebc8` — Release: patch — the browser extension's pairing popup no longer flashes "Not connected.", steals focus while you type, bounces between states, or resizes as you enter a code.

Bump: **PATCH → 0.51.14**. Three defect fixes in existing subsystems. No single PR clears the step-function bar, and several patches in one window are still one patch release.

Scope: `pyproject.toml` only, one line. C0.