### PR TITLE
fix(extension): surface the store's rejection reason instead of curl's exit 22

### DIFF
--- a/extension/scripts/chrome-web-store.sh
+++ b/extension/scripts/chrome-web-store.sh
@@ -42,6 +42,12 @@ trap 'rm -rf "$tmp_dir"' EXIT
 # sed so the secret never reaches another process's argv, where `ps` would show
 # it. Do not extend this to dump headers, the curl command line, or the
 # environment.
+# A broken gateway or a hostile intermediary must not be able to flood the run
+# log: an unbounded echo works against the readability this script exists to
+# deliver (a single 400 was measured at 3,000,626 bytes of step output). The
+# sibling verify-release-environment.sh bounds its body the same way.
+BODY_PRINT_LIMIT=4000
+
 report_api_error() {
   local label=$1
   local status=$2
@@ -51,23 +57,39 @@ report_api_error() {
   # HTML, which is still worth showing verbatim rather than discarding.
   body=$(jq . "$output" 2>/dev/null) || body=$(cat "$output" 2>/dev/null) || body=""
   body=${body//"$CWS_ACCESS_TOKEN"/<redacted CWS_ACCESS_TOKEN>}
+  # Truncate AFTER redacting, so a token near the cut cannot survive by landing
+  # on the boundary. Bash parameter expansion rather than `head -c`: this body
+  # is a variable, not a file, and `printf ... | head -c` makes head exit early
+  # and SIGPIPE the producer, which under `set -o pipefail` aborts this function
+  # with 141 before the remedy below is ever printed (measured). The sibling can
+  # use `head -c` safely only because it reads a file.
+  local truncated=""
+  if [[ ${#body} -gt $BODY_PRINT_LIMIT ]]; then
+    truncated=" (truncated to $BODY_PRINT_LIMIT of ${#body} characters)"
+    body=${body:0:$BODY_PRINT_LIMIT}
+  fi
   printf 'Chrome Web Store %s call returned HTTP %s for extension %s v%s.\n' \
     "$label" "$status" "$CWS_EXTENSION_ID" "${EXPECTED_VERSION:-<unknown>}" >&2
   if [[ -n "$body" ]]; then
-    printf 'Response body (verbatim, from the store):\n%s\n' "$body" >&2
+    # The truncation is announced in the same line that introduces the body, so
+    # a cut-off payload cannot be misread as the store's complete answer.
+    printf 'Response body (verbatim, from the store)%s:\n%s\n' "$truncated" "$body" >&2
+    # No error-reason translation table on purpose. The v2 discovery document
+    # (revision 20260906) publishes response schemas but no enum of error
+    # reasons, so any mapping from a reason string to a remedy would be invented
+    # rather than sourced -- and a confident wrong diagnosis is worse than the
+    # body above, which is Google's own words. The pointers below are limited to
+    # operations the REST reference documents. This paragraph interprets the
+    # body, so it stays inside this branch: with no body there is nothing for it
+    # to refer to.
+    printf 'That body is the store speaking, not this script. If it reports that a\n' >&2
+    printf 'submission is already under review, the documented remedies are to wait for\n' >&2
+    printf 'that review to finish, or to withdraw it (the cancelSubmission method, or\n' >&2
+    printf 'Cancel in the Developer Dashboard) before submitting again.\n' >&2
   else
-    printf 'Response body was empty.\n' >&2
+    printf 'The store returned no response body to explain this.\n' >&2
   fi
-  # No error-reason translation table on purpose. The v2 discovery document
-  # (revision 20260906) publishes response schemas but no enum of error reasons,
-  # so any mapping from a reason string to a remedy would be invented rather
-  # than sourced -- and a confident wrong diagnosis is worse than the body
-  # above, which is Google's own words. The pointers below are limited to
-  # operations the REST reference documents.
-  printf 'That body is the store speaking, not this script. If it reports that a\n' >&2
-  printf 'submission is already under review, the documented remedies are to wait for\n' >&2
-  printf 'that review to finish, or to withdraw it (the cancelSubmission method, or\n' >&2
-  printf 'Cancel in the Developer Dashboard) before submitting again.\n' >&2
+  # Always useful, body or not: where to read the item's current state.
   printf 'Current state: GET %s/v2/%s:fetchStatus\n' "$API_ROOT" "$item" >&2
   exit 1
 }

--- a/extension/scripts/chrome-web-store.sh
+++ b/extension/scripts/chrome-web-store.sh
@@ -29,22 +29,78 @@ publish_url="$API_ROOT/v2/$item:publish"
 tmp_dir=$(mktemp -d)
 trap 'rm -rf "$tmp_dir"' EXIT
 
+# Print the store's own explanation of a rejected request, then fail.
+#
+# REDACTION — deliberately narrow, do not widen. Only the RESPONSE BODY is
+# echoed. GitHub Actions masks secrets it injected into the job environment, but
+# it does NOT mask arbitrary text a script prints, so anything echoed here is
+# public in the run log. Request headers therefore never appear (they carry the
+# bearer token), $CWS_ACCESS_TOKEN is never interpolated into a message, and any
+# exact occurrence of the token inside the body is replaced before printing so
+# that an API which echoed request context back cannot turn this diagnostic into
+# a credential leak. The substitution uses bash parameter expansion rather than
+# sed so the secret never reaches another process's argv, where `ps` would show
+# it. Do not extend this to dump headers, the curl command line, or the
+# environment.
+report_api_error() {
+  local label=$1
+  local status=$2
+  local output=$3
+  local body
+  # Pretty-print when the payload is JSON; a proxy or gateway can answer with
+  # HTML, which is still worth showing verbatim rather than discarding.
+  body=$(jq . "$output" 2>/dev/null) || body=$(cat "$output" 2>/dev/null) || body=""
+  body=${body//"$CWS_ACCESS_TOKEN"/<redacted CWS_ACCESS_TOKEN>}
+  printf 'Chrome Web Store %s call returned HTTP %s for extension %s v%s.\n' \
+    "$label" "$status" "$CWS_EXTENSION_ID" "${EXPECTED_VERSION:-<unknown>}" >&2
+  if [[ -n "$body" ]]; then
+    printf 'Response body (verbatim, from the store):\n%s\n' "$body" >&2
+  else
+    printf 'Response body was empty.\n' >&2
+  fi
+  # No error-reason translation table on purpose. The v2 discovery document
+  # (revision 20260906) publishes response schemas but no enum of error reasons,
+  # so any mapping from a reason string to a remedy would be invented rather
+  # than sourced -- and a confident wrong diagnosis is worse than the body
+  # above, which is Google's own words. The pointers below are limited to
+  # operations the REST reference documents.
+  printf 'That body is the store speaking, not this script. If it reports that a\n' >&2
+  printf 'submission is already under review, the documented remedies are to wait for\n' >&2
+  printf 'that review to finish, or to withdraw it (the cancelSubmission method, or\n' >&2
+  printf 'Cancel in the Developer Dashboard) before submitting again.\n' >&2
+  printf 'Current state: GET %s/v2/%s:fetchStatus\n' "$API_ROOT" "$item" >&2
+  exit 1
+}
+
 request() {
   local method=$1
   local url=$2
   local output=$3
-  shift 3
-  curl --fail-with-body --silent --show-error \
+  local label=$4
+  shift 4
+  local status
+  local rc=0
+  # `--write-out %{http_code}` decides the outcome here instead of
+  # `--fail-with-body`. That flag downloads the body and STILL exits 22, so
+  # `set -e` killed the script before anything read the file: run 34178951112
+  # reported nothing but `curl: (22) The requested URL returned error: 400`
+  # while the explanation sat unread in $tmp_dir/upload.json. Judging the status
+  # in the shell keeps the body in hand long enough to print it.
+  status=$(curl --silent --show-error \
+    --write-out '%{http_code}' \
     -X "$method" \
     -H "Authorization: Bearer $CWS_ACCESS_TOKEN" \
     "$@" \
     -o "$output" \
-    "$url"
-  jq -e . "$output" >/dev/null || fail "API returned a non-JSON response from $url"
+    "$url") || rc=$?
+  [[ $rc -eq 0 ]] \
+    || fail "$label call could not reach the Chrome Web Store (curl exit $rc)"
+  [[ "$status" == 2[0-9][0-9] ]] || report_api_error "$label" "$status" "$output"
+  jq -e . "$output" >/dev/null || fail "$label call returned a non-JSON response"
 }
 
 fetch_status() {
-  request GET "$status_url" "$1"
+  request GET "$status_url" "$1" fetchStatus
   [[ $(jq -r '.itemId // empty' "$1") == "$CWS_EXTENSION_ID" ]] \
     || fail "status response identified a different extension"
 }
@@ -64,7 +120,7 @@ publish_staged() {
   # Reusing STAGED_PUBLISH is intentional: the first call requests review with
   # deferred release; on an approved STAGED revision the same API operation is
   # Google's explicit promotion path and does not create another submission.
-  request POST "$publish_url" "$output" \
+  request POST "$publish_url" "$output" publish \
     -H 'Content-Type: application/json' \
     --data '{"publishType":"STAGED_PUBLISH","deployInfos":[{"deployPercentage":100}],"blockOnWarnings":true}'
 }
@@ -76,7 +132,7 @@ if [[ "$MODE" == "stage" ]]; then
   "$(dirname "$0")/validate-store-zip.sh" "$ZIP_PATH" "$EXPECTED_VERSION"
 
   upload_url="$API_ROOT/upload/v2/$item:upload"
-  request POST "$upload_url" "$tmp_dir/upload.json" \
+  request POST "$upload_url" "$tmp_dir/upload.json" upload \
     -H 'Content-Type: application/zip' \
     --upload-file "$ZIP_PATH"
 

--- a/extension/tests/release.test.mjs
+++ b/extension/tests/release.test.mjs
@@ -198,6 +198,11 @@ test("a transport failure is named as one, not reported as an HTTP status", asyn
   assert.doesNotMatch(output, /returned HTTP/);
 });
 
+// Mirrors BODY_PRINT_LIMIT in chrome-web-store.sh. The straddle test below has
+// to know where the cut falls, which is the one thing about the bound a test
+// cannot discover from the outside.
+const BODY_PRINT_LIMIT = 4000;
+
 test("an oversized error body is bounded and its truncation is disclosed", async () => {
   // An unbounded echo floods the run log -- a single 400 was measured at
   // 3,000,626 bytes of step output -- which works against the readability this
@@ -216,6 +221,54 @@ test("an oversized error body is bounded and its truncation is disclosed", async
   assert.match(output, /INVALID_ARGUMENT/);
   // Truncating the body must not cost the remedy that follows it.
   assert.match(output, /cancelSubmission/);
+});
+
+test("a token straddling the truncation boundary is redacted, not cut in half", async () => {
+  // Pins the ORDER of the redact and truncate blocks, which a comment argues
+  // for and nothing enforced: reversing them left the suite 30/30 green while
+  // leaking up to 28 characters of the token. Truncating first cuts the token
+  // in half, and the surviving prefix no longer matches the substitution
+  // pattern, so it prints verbatim -- a partial credential is still a leak.
+  const token = "ya29.a0AfB_STRADDLE-SECRET-TOKEN-VALUE";
+  const body = (pad) => ({
+    error: { code: 400, status: "INVALID_ARGUMENT", message: "P".repeat(pad) + token + "Q".repeat(400) },
+  });
+  // DERIVE the padding that puts the cut inside the token rather than hardcode
+  // it: jq's pretty-printing decides the offset, so a hardcoded pad would stop
+  // straddling the moment the envelope changed and the test would keep passing
+  // while measuring nothing. Half the token either side of the limit gives the
+  // reversed order its longest surviving prefix.
+  const envelope = JSON.stringify(body(0), null, 2).indexOf(token);
+  const pad = BODY_PRINT_LIMIT - envelope - Math.floor(token.length / 2);
+  const rendered = JSON.stringify(body(pad), null, 2);
+  const start = rendered.indexOf(token);
+  assert.ok(
+    start < BODY_PRINT_LIMIT && start + token.length > BODY_PRINT_LIMIT,
+    `the token must straddle the cut to measure anything (start ${start}, limit ${BODY_PRINT_LIMIT})`,
+  );
+
+  const error = await runRelease(
+    ["stage", "local-operator-extension.zip", VERSION],
+    [() => rejectWith(400, body(pad))],
+    { token, expectFailure: true },
+  );
+  const output = error.stdout + error.stderr;
+  // No prefix of the credential may survive -- not the whole token, and not the
+  // leading fragment the cut would otherwise leave behind. Report the surviving
+  // prefix itself on failure: the length is the finding, and a slice of the
+  // output at a fixed offset would show padding rather than the leak. Safe to
+  // print because this token is synthetic and local to the test.
+  assert.ok(!output.includes(token), "the whole token must never reach the log");
+  let survived = "";
+  for (let n = token.length; n >= 1; n -= 1) {
+    if (output.includes(token.slice(0, n))) { survived = token.slice(0, n); break; }
+  }
+  assert.ok(
+    !output.includes(token.slice(0, 8)),
+    `${survived.length} characters of the token survived truncation: ${JSON.stringify(survived)}`,
+  );
+  // The body really was cut here; otherwise the assertions above are vacuous.
+  assert.match(output, /\(truncated to \d+ of \d+ characters\)/);
 });
 
 test("a rejected call does not echo the access token, even if the body carries it", async () => {

--- a/extension/tests/release.test.mjs
+++ b/extension/tests/release.test.mjs
@@ -16,18 +16,25 @@ const VERSION = JSON.parse(
 const extensionId = "omibaecbjdhgbbcedbnnnmjpmopfheof";
 const itemPath = `/v2/publishers/test-publisher/items/${extensionId}`;
 
-async function runRelease(args, handlers) {
+// A handler normally returns the JSON payload of a 200. Wrapping it in
+// `rejectWith` makes the stub answer with a non-2xx and that body instead,
+// which is how the store reports a refused upload or publish.
+const rejectWith = (status, body) => ({ __rejectStatus: status, body });
+
+async function runRelease(args, handlers, options = {}) {
+  const { token = "test-token", expectFailure = false } = options;
   let requestIndex = 0;
   const server = createServer(async (request, response) => {
     const chunks = [];
     for await (const chunk of request) chunks.push(chunk);
     try {
-      assert.equal(request.headers.authorization, "Bearer test-token");
+      assert.equal(request.headers.authorization, `Bearer ${token}`);
       const handler = handlers[requestIndex++];
       assert.ok(handler, `unexpected request ${request.method} ${request.url}`);
       const payload = handler(request, Buffer.concat(chunks));
-      response.writeHead(200, { "Content-Type": "application/json" });
-      response.end(JSON.stringify(payload));
+      const rejected = payload && payload.__rejectStatus;
+      response.writeHead(rejected ?? 200, { "Content-Type": "application/json" });
+      response.end(JSON.stringify(rejected ? payload.body : payload));
     } catch (error) {
       response.writeHead(500, { "Content-Type": "application/json" });
       response.end(JSON.stringify({ error: String(error) }));
@@ -35,18 +42,28 @@ async function runRelease(args, handlers) {
   });
   await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
   const { port } = server.address();
+  const options_ = {
+    cwd: import.meta.dirname + "/..",
+    env: {
+      ...process.env,
+      CWS_API_ROOT: `http://127.0.0.1:${port}`,
+      CWS_ACCESS_TOKEN: token,
+      CWS_PUBLISHER_ID: "test-publisher",
+      CWS_EXTENSION_ID: extensionId,
+      CWS_POLL_INTERVAL_SECONDS: "0",
+    },
+  };
   try {
-    const result = await run("bash", ["scripts/chrome-web-store.sh", ...args], {
-      cwd: import.meta.dirname + "/..",
-      env: {
-        ...process.env,
-        CWS_API_ROOT: `http://127.0.0.1:${port}`,
-        CWS_ACCESS_TOKEN: "test-token",
-        CWS_PUBLISHER_ID: "test-publisher",
-        CWS_EXTENSION_ID: extensionId,
-        CWS_POLL_INTERVAL_SECONDS: "0",
-      },
-    });
+    let result;
+    if (expectFailure) {
+      // The script must exit non-zero here; a run that SUCCEEDS is itself the
+      // failure, so it is reported rather than silently accepted.
+      result = await run("bash", ["scripts/chrome-web-store.sh", ...args], options_)
+        .then((ok) => { throw new Error(`expected a non-zero exit, got:\n${ok.stdout}`); },
+          (error) => error);
+    } else {
+      result = await run("bash", ["scripts/chrome-web-store.sh", ...args], options_);
+    }
     assert.equal(requestIndex, handlers.length);
     return result;
   } finally {
@@ -93,6 +110,82 @@ test("publisher refuses any item except the permanent extension ID", async () =>
     }),
     /must be the permanent Local Operator ID/,
   );
+});
+
+// Run 34178951112 failed with nothing but `curl: (22) The requested URL
+// returned error: 400`. The store's explanation HAD been downloaded -- curl's
+// --fail-with-body writes the body and still exits 22, so `set -e` killed the
+// script before anything read the file. These tests pin that the body reaches
+// the release owner, because the log line alone left no way to tell whether to
+// wait, retry, or open the dashboard.
+const IN_REVIEW_BODY = {
+  error: {
+    code: 400,
+    message: "Item is currently in review and cannot be updated.",
+    status: "FAILED_PRECONDITION",
+  },
+};
+
+for (const { name, args, handlers, label } of [
+  {
+    name: "upload",
+    label: "upload",
+    args: ["stage", "local-operator-extension.zip", VERSION],
+    handlers: [() => rejectWith(400, IN_REVIEW_BODY)],
+  },
+  {
+    name: "publish",
+    label: "publish",
+    args: ["stage", "local-operator-extension.zip", VERSION],
+    handlers: [
+      () => ({ itemId: extensionId, uploadState: "SUCCEEDED", crxVersion: VERSION }),
+      () => rejectWith(400, IN_REVIEW_BODY),
+    ],
+  },
+  {
+    name: "fetchStatus",
+    label: "fetchStatus",
+    args: ["promote", VERSION],
+    handlers: [() => rejectWith(400, IN_REVIEW_BODY)],
+  },
+]) {
+  test(`a rejected ${name} call surfaces the store's explanation`, async () => {
+    const error = await runRelease(args, handlers, { expectFailure: true });
+    const output = error.stdout + error.stderr;
+    // The body itself -- the one thing the incident threw away.
+    assert.match(output, /Item is currently in review and cannot be updated\./);
+    assert.match(output, /FAILED_PRECONDITION/);
+    // Which call failed, at what status, for which version.
+    assert.match(output, new RegExp(`${label} call returned HTTP 400`));
+    assert.match(output, new RegExp(`v${VERSION.replaceAll(".", "\\.")}`));
+    // The remedy a release owner acts on.
+    assert.match(output, /cancelSubmission/);
+    // curl's bare exit 22 must no longer be the whole story.
+    assert.notEqual(error.code, 22);
+  });
+}
+
+test("a rejected call does not echo the access token, even if the body carries it", async () => {
+  // A response body is NOT masked by Actions, and an API that echoed request
+  // context could hand the token straight back. Nothing in this output may
+  // carry it: not the body, and not any message the script composes.
+  const token = "ya29.a0AfB_bearer-token-shaped-secret-value";
+  const error = await runRelease(
+    ["stage", "local-operator-extension.zip", VERSION],
+    [() => rejectWith(400, {
+      error: {
+        code: 400,
+        status: "INVALID_ARGUMENT",
+        message: `rejected request authorized by ${token}`,
+      },
+    })],
+    { token, expectFailure: true },
+  );
+  const output = error.stdout + error.stderr;
+  assert.ok(!output.includes(token), "the access token must never reach the log");
+  assert.match(output, /<redacted CWS_ACCESS_TOKEN>/);
+  // Redaction must not cost the diagnosis: the rest of the body still shows.
+  assert.match(output, /INVALID_ARGUMENT/);
 });
 
 test("stage uploads the validated zip and requests deferred publication", async () => {

--- a/extension/tests/release.test.mjs
+++ b/extension/tests/release.test.mjs
@@ -165,6 +165,59 @@ for (const { name, args, handlers, label } of [
   });
 }
 
+test("a transport failure is named as one, not reported as an HTTP status", async () => {
+  // Pins the `rc` guard, which a mutation proved load-bearing but unpinned:
+  // deleting it left the whole suite green. It is not redundant with the
+  // status check, because curl reports `http_code=200` alongside `rc=18` on a
+  // transfer truncated against its Content-Length -- a body that parses as
+  // valid JSON while the transfer was in fact broken. Only `rc` catches that.
+  // A closed port is the cheap, deterministic form of the same guard.
+  const server = createServer(() => {});
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  // Release the port before pointing the script at it, so nothing is listening
+  // and the socket cannot collide with an unrelated local service.
+  await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+
+  const error = await run("bash", ["scripts/chrome-web-store.sh", "promote", VERSION], {
+    cwd: import.meta.dirname + "/..",
+    env: {
+      ...process.env,
+      CWS_API_ROOT: `http://127.0.0.1:${port}`,
+      CWS_ACCESS_TOKEN: "test-token",
+      CWS_PUBLISHER_ID: "test-publisher",
+      CWS_EXTENSION_ID: extensionId,
+      CWS_POLL_INTERVAL_SECONDS: "0",
+    },
+  }).then((ok) => { throw new Error(`expected a non-zero exit, got:\n${ok.stdout}`); }, (e) => e);
+
+  const output = error.stdout + error.stderr;
+  // Named as unreachable, carrying curl's own exit code -- NOT dressed up as an
+  // HTTP status, which is what a missing `rc` guard would produce (`HTTP 000`).
+  assert.match(output, /fetchStatus call could not reach the Chrome Web Store \(curl exit \d+\)/);
+  assert.doesNotMatch(output, /returned HTTP/);
+});
+
+test("an oversized error body is bounded and its truncation is disclosed", async () => {
+  // An unbounded echo floods the run log -- a single 400 was measured at
+  // 3,000,626 bytes of step output -- which works against the readability this
+  // script exists to deliver. The cut must be visible, so a partial body is
+  // never mistaken for the store's complete answer.
+  const filler = "F".repeat(200_000);
+  const error = await runRelease(
+    ["stage", "local-operator-extension.zip", VERSION],
+    [() => rejectWith(400, { error: { code: 400, status: "INVALID_ARGUMENT", message: filler } })],
+    { expectFailure: true },
+  );
+  const output = error.stdout + error.stderr;
+  assert.match(output, /\(truncated to \d+ of \d+ characters\)/);
+  // Bounded well below what the stub sent, while still showing the beginning.
+  assert.ok(output.length < 20_000, `expected a bounded log, got ${output.length} characters`);
+  assert.match(output, /INVALID_ARGUMENT/);
+  // Truncating the body must not cost the remedy that follows it.
+  assert.match(output, /cancelSubmission/);
+});
+
 test("a rejected call does not echo the access token, even if the body carries it", async () => {
   // A response body is NOT masked by Actions, and an API that echoed request
   // context could hand the token straight back. Nothing in this output may


### PR DESCRIPTION
## What and why

The Chrome Web Store release workflow for extension v0.1.9 ([run 34178951112](https://github.com/damianvtran/local-operator/actions/runs/34178951112)) failed, and the **entire** diagnostic output was:

```
validated Chrome Web Store package v0.1.9 (13 files, no source maps)
curl: (22) The requested URL returned error: 400
##[error]Process completed with exit code 22.
```

The Chrome Web Store API returns a JSON body explaining exactly why it rejected the request. `extension/scripts/chrome-web-store.sh` asked for that body with `--fail-with-body`, so it **was** downloaded — into `$tmp_dir/upload.json` — and then `set -e` killed the script on curl's exit 22 before anything read or printed it. The one piece of information that would have told the release owner what to do was fetched, written to disk, and thrown away. The owner is left guessing between "wait", "retry", and "go to the dashboard".

**Change class: C1.** This is the same defect class as #768 (Linux daemon logs going to the journal while three surfaces point at a file that is never created): *a diagnostic path that discards the diagnosis*. The failure is not that something broke — it is that the breakage was made unreadable.

## What I reproduced first

I did not fix from the description. Two measurements, both against the unmodified script at `origin/main`:

**1. Does `--fail-with-body` behave as assumed?** Yes, and this is the crux — it writes the body *and* still exits 22:

```
curl exit=22
body bytes=75
body={"error":{"code":400,"status":"FAILED_PRECONDITION","message":"in review"}}
```

**2. Which call sites have the hole?** I drove the real script against a stub returning a 400 with a JSON body, at every call site. **All four** — the hypothesis that only `upload` was affected was wrong:

| call site | exit | output | body surfaced? |
|---|---|---|---|
| upload (the incident) | 22 | `curl: (22) The requested URL returned error: 400` | **NO** |
| publish (after good upload) | 22 | `curl: (22) ...error: 400` | **NO** |
| fetchStatus (promote) | 22 | `curl: (22) ...error: 400` | **NO** |
| publish (promote path) | 22 | `curl: (22) ...error: 400` | **NO** |

They share one `request()` helper, so one fix covers all four; none differs. The upload row is byte-identical to the production log above.

## After the fix

Same four scenarios, same stub:

```
Chrome Web Store upload call returned HTTP 400 for extension omibaecbjdhgbbcedbnnnmjpmopfheof v0.1.9.
Response body (verbatim, from the store):
{
  "error": {
    "code": 400,
    "status": "FAILED_PRECONDITION",
    "message": "Item is in review. context=<redacted CWS_ACCESS_TOKEN>"
  }
}
That body is the store speaking, not this script. If it reports that a
submission is already under review, the documented remedies are to wait for
that review to finish, or to withdraw it (the cancelSubmission method, or
Cancel in the Developer Dashboard) before submitting again.
Current state: GET https://chromewebstore.googleapis.com/v2/publishers/.../items/...:fetchStatus
```

`request()` now judges the outcome on `--write-out %{http_code}` rather than `--fail-with-body`, which keeps the body in hand past the point where `set -e` used to fire. A transport failure (connection refused) is now named too, instead of surfacing as a bare curl exit:

```
Chrome Web Store publish failed: fetchStatus call could not reach the Chrome Web Store (curl exit 7)
```

## Redaction argument, with evidence

A response body is **not** masked by Actions. The job's env dump shows `CWS_ACCESS_TOKEN: ***` because Actions masks secrets *it injected into the environment*; it does not mask arbitrary text a script prints. A sibling session measured this exact hazard today on a different PR, where blanket-printing exception text put a real bearer token into a log (`httpx` echoes the request URL with its query string; `OSError` echoes filesystem paths).

So the print site is deliberately narrow, and there is a comment at that site saying so and saying not to widen it:

- Only the **response body** is echoed — never request headers (they carry the bearer token), never the curl command line, never the environment.
- `$CWS_ACCESS_TOKEN` is never interpolated into any message.
- Any exact occurrence of the token *inside the body* is replaced before printing, so an API echoing request context back cannot turn this diagnostic into a leak.
- The substitution uses bash parameter expansion rather than `sed`, so the secret never reaches another process's argv where `ps` would show it.

**Verified by construction**, not by inspection: a test sets `CWS_ACCESS_TOKEN` to a token-shaped value and has the stub echo it inside the 400 body. The token does not appear in output; `<redacted CWS_ACCESS_TOKEN>` does; and the rest of the body (`INVALID_ARGUMENT`) still shows, so redaction does not cost the diagnosis.

## On translating "already in review"

I did **not** add an error-reason translation table. I fetched the API docs and the live v2 discovery document (revision `20260906`) and confirmed the `google.rpc.Status` envelope against the real endpoint:

```
$ curl -s -o body.json -w 'http=%{http_code}\n' 'https://chromewebstore.googleapis.com/v2/publishers/.../items/...:fetchStatus'
http=401
{"error":{"code":401,"message":"Request is missing required authentication credential...",
  "status":"UNAUTHENTICATED",
  "details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"CREDENTIALS_MISSING",...}]}}
```

The envelope carries a `details[].reason`, but Google publishes **no enum of error reasons** for this service — the [discovery document](https://chromewebstore.googleapis.com/$discovery/rest?version=v2) documents response schemas only. Inventing a string I have not observed is exactly the "confident wrong translation" the brief warned against, so the script prints the raw body and points at the remedies that *are* documented: [`cancelSubmission`](https://developer.chrome.com/docs/webstore/api/reference/rest/v2/publishers.items/cancelSubmission) ("cancel the review of a pending submission") or Cancel in the dashboard. A comment records why the table is absent, so nobody adds a fabricated one later.

This also means the operator's hypothesis about v0.1.8 being stuck in `PENDING_REVIEW` remains **unconfirmed** — but the next dispatch will print the store's own answer instead of exit 22, which is the point of the fix.

## Tests, each proven RED on the current script

Added to `extension/tests/release.test.mjs`, following the existing `runRelease` stub-server pattern used for `validate-store-zip.sh` and the stage/promote paths.

**Red check 1 — new tests against the pre-fix script** (restored from `origin/main`):

```
✖ a rejected upload call surfaces the store's explanation
✖ a rejected publish call surfaces the store's explanation
✖ a rejected fetchStatus call surfaces the store's explanation
✖ a rejected call does not echo the access token, even if the body carries it
ℹ pass 0   ℹ fail 4
```

**Red check 2 — the redaction guard measures redaction, not just failure.** Deleting *only* the one redaction line leaves the three body tests green and fails the token test alone, with the assertion that names the real cause:

```
✔ a rejected upload call surfaces the store's explanation
✔ a rejected publish call surfaces the store's explanation
✔ a rejected fetchStatus call surfaces the store's explanation
✖ a rejected call does not echo the access token, even if the body carries it
ℹ pass 3   ℹ fail 1

AssertionError [ERR_ASSERTION]: the access token must never reach the log
```

Both lines restored; full suite green: **140 pass, 0 fail**.

## Gates

| gate | result |
|---|---|
| `pnpm --dir extension test` | 140 pass, 0 fail |
| `pnpm --dir extension typecheck` | clean |
| `shellcheck` (both store scripts) | clean — *note: not a repo CI gate; run because the diff is bash* |
| `bash -n` | clean |
| `flake8 .` | clean |
| `black --check .` (26.1.0) | 1071 files unchanged |
| `isort --check .` (5.13.2) | clean |
| `pyright` (whole tree) | 0 errors, 0 warnings |
| `gen_ts --check` | clean |

The Python suite is not affected by this diff (bash + JS only), and the gates above are run over the whole tree exactly as CI runs them.

## Deliberately not done

- No change to success behaviour, upload/publish semantics, or retry behaviour.
- No retry added.
- `pyproject.toml` and `extension/manifest.json` untouched — the extension is at 0.1.9 and that is correct. No version bump, per the combined-release protocol.
- `extension/scripts/verify-release-environment.sh` is left alone, and it does **not** have a milder version of this defect. It already prints its response body (`verify-release-environment.sh:131-132`, bounded with `head -c 2000`) alongside the status and the `x-accepted-github-permissions` header. The real asymmetry is that it does not *redact* — but it authenticates with `GITHUB_TOKEN`, which Actions auto-masks because Actions injected it, unlike the WIF-minted `CWS_ACCESS_TOKEN` that is a step **output** in this workflow. So it is out of scope for a different reason than "it does not print the body". (An earlier version of this note said it printed only the status; that was wrong, and it is corrected here so nobody goes hunting for a fix that already exists. Round 1 finding A3.)

Release: patch — a rejected Chrome Web Store release now prints the store's own reason and the HTTP status instead of a bare `curl: (22)`, so a release owner can tell whether to wait, retry, or open the dashboard.

