### PR TITLE
chore(release): bump version to 0.51.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.14"
+version = "0.51.15"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window claimed after v0.51.14. Owner session pid: **88595** (lo-session-sidebar).

Checked first per #740: `gh pr list --search '"chore(release)" in:title' --state open` returned no open lock.

Window (tick as each merges):
- [x] #774 `3ed633a65` — Release: patch — a viewer that joins a session mid-turn no longer paints completed tool calls as `⊘ interrupted`.

Bump class argued: **PATCH (v0.51.15)**. A defect fix inside an existing subsystem — no new command, no new surface, no API change. Cannot name a step-function capability for a release title, which is AGENTS.md's own test.

Related and ALREADY RELEASED in v0.51.14: #770 `263eb7f39` (the sibling fix from the same audit). Not in this window.

If you merge in the next ~60 minutes, send PR#, merge SHA and your `Release:` line and I will include it. I will not hold for an unready PR.

Will build the **TAG, not `main`** (`lop-update v0.51.15`) and announce before running it.