### PR TITLE
chore(release): bump version to 0.51.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.15"
+version = "0.51.16"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window claimed. Owner session pid: 78576. Managed by its delegated release manager.

C0 standard/pre-authorized release coordination. No feature changes. Window collection begins after this lock is opened; merged PR #776 is required. The final window is reconciled against bump-merge ancestry.

Window:
- [ ] Collect every merged PR since the last ancestor release tag and its Release: line.
- [ ] Independent bump code review and QA, implementer remediation replies, green CI.
- [ ] Tag/publish, PyPI verification, tagged stable install, isolated installed-runtime smoke.

No force-push is authorized; use an additive bump commit and squash merge to retain a one-line release commit. Install the exact tag; do not move the shared main pointer.

## Bump scope and acceptance

C0 standard/pre-authorized: change only `pyproject.toml` project version from `0.51.15` to `0.51.16` (one line in one file). No feature, dependency, entry-point, or UI changes. Preserve the empty claim and one additive conventional bump commit; the manager will squash merge.

Release: patch — an inbound peer message is now a one-line ledger card naming the sender, expandable to its full identity and body, instead of a receipt that spent 11–16 rows of transcript on every note.

Current collected window: #776, merge `184560c14235add439db46de2a7d52a887576f1d`; last verified tag `v0.51.15`. The release manager owns final ancestry reconciliation.

## Validation

This metadata-only bump has no new feature runtime path. Validation covers the one-line full diff, an owned editable installation and CLI version output, plus whole-tree flake8, pinned Black/isort, pyright, and CI. Per the release manager’s C0 scope instruction, no full local unit-suite rerun is being launched for this metadata-only bump. Results will be recorded in a follow-up comment. Feature behavior and visual evidence remain on #776. Independent review and QA are pending.


### Window update
- [x] #782 — `be2546ec069dde12d6b0a06aa9c2498178bb3d72` — Release: patch — a rejected Chrome Web Store release now prints the store's own reason and the HTTP status instead of a bare `curl: (22)`, so a release owner can tell whether to wait, retry, or open the dashboard.

The window will be reconciled once more against the exact bump merge before tagging. This ships release-script diagnostics, not Chrome Web Store approval/publication; extension 0.1.9 store rollout remains independent.


### Final ancestry / publication

Bump merge: `c26aa83142ea752431e1446384fed85a79135b2b`. The exact tagged ancestry after `v0.51.15` contains **#776, #782, #779 and this release bump**; no other merged PR is reachable. Release: https://github.com/damianvtran/local-operator/releases/tag/v0.51.16 . Publish workflow: https://github.com/damianvtran/local-operator/actions/runs/34185737315 .

Independent scope/QA rounds are terminal and answered. CI is **not all green**: one pre-existing, explicitly accepted accounting-test assertion repeated after a bounded retry; 12 checks passed and 3 downstream checks were skipped. Exact evidence and owner authorization are in the thread and release notes. No force-push, rebase, feature change or shared-main-pointer update. Installed-runtime verification remains pending and will be posted separately.
