### PR TITLE
fix(tui): condense model confirmations and coalesce keeping notices

### DIFF
--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -1845,6 +1845,11 @@ class Session:
         #: EDIT order rather than in whichever-thread-finished-first order
         #: (review round 1, R2).
         self._configured_model_generation = 0
+        # A provider/model save notifies once per key. Defer pinned-session
+        # receipts to the final pair, and remember semantic state rather than
+        # file fingerprints so repeated refreshes cannot repeat the notice.
+        self._configured_model_notice_generation = 0
+        self._configured_model_notice_key: tuple[str, str, str, str] | None = None
         #: Set by :meth:`_apply_config_change` when ``web_search.enabled`` /
         #: ``web_fetch.enabled`` moved; consumed at the next TURN boundary by
         #: :meth:`_reconcile_web_tools`. Deferred rather than applied on the
@@ -11185,33 +11190,66 @@ class Session:
         if self._job_id is not None:
             return
         if self._model_source != "config" or self._explicit_model_choice:
-            label = self.model_label
-            if self._explicit_model_choice:
-                reason = "chosen with /model"
-            elif self._model_source == "agent":
-                reason = "chosen by an agent profile"
-            else:
-                reason = "chosen by a flag"
+            self._configured_model_notice_generation += 1
             self._spawn_background(
-                self._emit(
-                    NoticeEvent(
-                        text=(
-                            f"keeping {label} — {reason}; config.yml default changed, "
-                            "/model saved adopts it"
-                        ),
-                        kind="info",
-                        # A glance for the boot toast, so it does not fall
-                        # through to a blind cut landing mid-phrase (design
-                        # round 1, D3). See ``NoticeEvent.headline``.
-                        headline="Model unchanged",
-                    )
-                )
+                self._notice_configured_model_kept(values, self._configured_model_notice_generation)
             )
             return
         # Bumped BEFORE the spawn so an adopt already parked on its thread hop
         # sees a generation newer than the one it captured and stands down.
         self._configured_model_generation += 1
         self._spawn_background(self._adopt_configured_model(values))
+
+    async def _notice_configured_model_kept(
+        self, values: Mapping[str, Any], generation: int
+    ) -> None:
+        """Report a divergent default once, never the intermediate half of a save.
+
+        The settings facade writes hosting and model_name synchronously, each
+        with its own watcher notification. By the time this task runs, only
+        the newest pair owns a receipt. This does not debounce model adoption
+        or delay a user's switch; it only coalesces explanatory notices.
+        """
+        if self._disposed or generation != self._configured_model_notice_generation:
+            return
+        hosting = str(values.get("hosting") or "").strip().lower()
+        model_name = str(values.get("model_name") or "").strip()
+        if hosting and not model_name:
+            from local_operator.model.defaults import default_model_for
+
+            model_name = default_model_for(hosting) or ""
+        current = self.effective_model
+        if (
+            not hosting
+            or not model_name
+            or (hosting, model_name)
+            == (
+                current.provider,
+                current.model_id,
+            )
+        ):
+            # Saving the pinned model changes no decision for this session.
+            # Clear the latch so a later return to a divergent default is NEW.
+            self._configured_model_notice_key = None
+            return
+        label = self.effective_model_label
+        if self._explicit_model_choice:
+            reason = "chosen with /model"
+        elif self._model_source == "agent":
+            reason = "chosen by an agent profile"
+        else:
+            reason = "chosen by a flag"
+        key = (hosting, model_name, label, reason)
+        if key == self._configured_model_notice_key:
+            return
+        self._configured_model_notice_key = key
+        await self._emit(
+            NoticeEvent(
+                text=f"keeping {label} — {reason}; /model saved adopts {hosting}/{model_name}",
+                kind="info",
+                headline="Model unchanged",
+            )
+        )
 
     async def _adopt_configured_model(self, values: Mapping[str, Any]) -> None:
         """Switch onto the ``hosting``/``model_name`` pair in ``values``.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -21299,17 +21299,13 @@ class OperatorApp(App[None]):
         "which models can I switch to", which they had no way to ask. The label is
         still reported, as the picker's current-row marker.
 
-        Every route out of here names ``/model default``, because a switch is
-        SESSION-scoped and does not look it. The user who picks a model has just
-        answered "which model do I want", the app confirms the switch, and nothing
-        on screen says the next launch comes back on the old one — so the command
-        that fixes that was reachable only by already knowing it existed.
+        The explicit bare command shows scope guidance. Merely entering the
+        picker (including while typing the next /model default command) must
+        not append help to the conversation after a successful switch.
         """
         session = self._session
         if not arg:
-            # The persist-hint notice is NOT printed here: reopening the list
-            # posts ``ModelQueryOpened`` and ``on_model_query_opened`` prints it,
-            # on this route and on the keystroke route alike.
+            self._system_notice(self._persist_hint_notice())
             self._open_model_picker()
             return
         # ``/model default [<provider>/<id>]`` PERSISTS the choice as the boot
@@ -21609,7 +21605,6 @@ class OperatorApp(App[None]):
             # gate makes this a no-op when the row is already warm.
             self._warm_usage_background()
         persist_result: str | None = None
-        saved_to = ""
         if persist_default:
             # Persist as the boot default. Written independently of the live
             # switch above so the two stay composable (``/model default p/m``
@@ -21645,7 +21640,6 @@ class OperatorApp(App[None]):
                     if setting is None:  # pragma: no cover - both keys are registered
                         raise KeyError(f"{key} is not a registered setting")
                     settings_io.write_setting(manager, setting, value)
-                saved_to = _home_relative(str(manager.config_file))
             except Exception as error:  # config write failure
                 # The write-only form switched nothing, so its failure receipt
                 # must not claim it did (QA round 1, Q1b).
@@ -21668,44 +21662,17 @@ class OperatorApp(App[None]):
                 fast=_fast_label(session),
                 context_window=_context_window(session),
             )
-        # The access note answers "can I use the model I just switched to". On
-        # the write-only form nothing was switched to, so the note is filler on
-        # a row that is already three lines at 50 columns (UX review U7) and
-        # the login warning would be about a provider already serving the
-        # session.
-        suffix, warning = ("", None) if write_only else self._model_access_note(provider)
+        # Successful credential checks need no receipt; actionable access
+        # failures still get their own warning. Saving the current default
+        # changes no access decision at all.
+        _, warning = ("", None) if write_only else self._model_access_note(provider)
         if persist_result is not None:
             notice(persist_result, "warning")
         elif persist_default:
-            # Names both halves, the file and the keys. "saved" alone is a claim
-            # the user cannot check without quitting and relaunching, and the
-            # PROVIDER is the half that rides along silently — it is written from
-            # the selector's left side, never typed as its own setting.
-            #
-            # "used by new sessions", the noun PERSIST_HINT already uses, not
-            # "from the next launch" (design review D3): a user who ran this
-            # after reading the footer met three phrasings of "when" within two
-            # rows. "New sessions" is also the fuller claim — `/new` reloads
-            # `hosting`/`model_name` before it builds, so the default applies
-            # there as well as at relaunch. The settings page keeps its own
-            # "new launch" vocabulary; it is a different surface.
-            notice(
-                f"boot default saved to {saved_to}: hosting {provider}, "
-                f"model_name {model_id} (used by new sessions){suffix}"
-            )
+            scope = "new sessions" if write_only else "this session + new sessions"
+            notice(f"boot default saved: {provider}/{model_id} ({scope})")
         else:
-            # "(next turn)" alone read as permanent — the complaint behind this
-            # wording. The scope and the one command that widens it belong on the
-            # line that announces the switch, not in documentation the user would
-            # have to already suspect exists.
-            #
-            # TWO clauses and no more. This carried four separators — a
-            # parenthetical with a comma in it, the access note's ` · `, then a
-            # ` — ` onto a sentence of its own — and wrapped at 80 columns into a
-            # run-on. "(this session)" is the half that answers "for how long";
-            # "from the next turn" answered "starting when", which nothing had
-            # asked and which the very next receipt demonstrates anyway.
-            notice(f"model: {old_label} → {new_label} (this session){suffix} — {PERSIST_HINT}")
+            notice(f"model: {old_label} → {new_label} (this session)")
         # MID-TURN is the one moment "starting when" is a live question, and the
         # next receipt cannot answer it because the answer is visible before
         # then: the agent goes on working on the old model until the step in
@@ -22932,50 +22899,11 @@ class OperatorApp(App[None]):
         completed into it by the command picker, or dispatching `/model` all end up
         here. Before this, only the dispatched route had rows.
 
-        The persist-hint notice is printed HERE for the same reason (UX review
-        U5). It used to be printed by ``_cmd_model`` before it reopened the
-        list, so only a dispatched `/model` (Esc past the command picker, then
-        Enter, or the `/models` alias) ever named `/model saved` and `/settings`
-        — the primary keystroke path, where the command picker completes
-        `/model ` and the list opens without a dispatch, printed nothing. The
-        message fires once per closed→open transition, so this is one row per
-        opening on every route, exactly what the dispatched route already did.
-        ``_system_notice`` rather than ``_notice``: opening the picker is the
-        user configuring the app, not starting a conversation, and a plain
-        notice ends the empty state — which collapses the boot composition and
-        makes the centred prompt unreachable.
-
-        The notice is skipped when the ledger's last ROW ALREADY SAYS IT. The
-        message is meant to fire once per visible opening, and the editor now
-        keeps that true across an Esc (``ModelPicker.dismiss`` — UX review
-        round 2, U8, where each Esc-then-edit cycle stacked another copy). This
-        is the second line of defence for the same property: no sequence of
-        opens that produces nothing between them can print the hint twice,
-        whatever the editor's resync does in future. Compared on the text, so
-        a hint that changed (a switch landed between two opens) still prints.
-
-        THE SCAN SKIPS THE PINNED WORKING LINE (code review round 2, R12). A
-        turn in flight pins its working line to the bottom of the transcript
-        (``TranscriptView.pin_tail``) and every later append is inserted BEFORE
-        it, so mid-turn the hint never lands last and a guard reading only
-        ``blocks()[-1]`` could not match it — the deduplication silently
-        stopped applying in exactly the state where a user re-opening the list
-        while the agent works would stack copies. Walking back over the pinned
-        tail costs one comparison and makes the guard mean what its name says
-        in both states. Only the tail is skipped, not an arbitrary run: two
-        notices with a real block between them are two separate openings and
-        must both print.
+        Opening a picker is transient UI state, not a transcript event. The
+        footer keeps the save shortcut discoverable; explicit /model and /help
+        retain full guidance without repeating it as the user types a command.
         """
         message.stop()
-        hint = self._persist_hint_notice()
-        transcript = self._transcript_view()
-        blocks = transcript.blocks()
-        pinned = transcript.pinned_tail()
-        # The last block that is not the pinned working line — which is where a
-        # mid-turn append actually lands.
-        last = next((b for b in reversed(blocks) if b is not pinned), None)
-        if not (isinstance(last, NoticeBlock) and last.text() == hint):
-            self._system_notice(hint)
         self._populate_model_picker()
 
     def _open_model_picker(self) -> None:
@@ -27888,12 +27816,12 @@ class OperatorApp(App[None]):
         self._probe_quota_after_switch(session)
         self._effort_refusal_shown = None
         self._warm_usage_background()
-        suffix, warning = self._model_access_note(provider)
+        _, warning = self._model_access_note(provider)
         # The switch lands on the SHARED session, so every terminal's band
         # repaints from the canonical update — the receipt below only has to
         # reach the invoker. Mid-turn timing is stated by the owner-side
         # notice path (the streamed turn's own events carry it).
-        text = f"model: {old_label} → {new_label} (this session){suffix} — {PERSIST_HINT}"
+        text = f"model: {old_label} → {new_label} (this session)"
         if warning:
             text = f"{text}\n{warning}"
         return SlashResult(kind="notice", text=text, style="info")

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -21669,7 +21669,11 @@ class OperatorApp(App[None]):
         if persist_result is not None:
             notice(persist_result, "warning")
         elif persist_default:
-            scope = "new sessions" if write_only else "this session + new sessions"
+            # A cold viewer can save the next runtime's default, but its
+            # disconnected set_model is a no-op. Do not claim a live switch
+            # merely because the requested pair differs from its stale label.
+            switches_session = not write_only and not bool(getattr(session, "is_cold", False))
+            scope = "this session + new sessions" if switches_session else "new sessions"
             notice(f"boot default saved: {provider}/{model_id} ({scope})")
         else:
             notice(f"model: {old_label} → {new_label} (this session)")

--- a/tests/unit/session/test_config_live.py
+++ b/tests/unit/session/test_config_live.py
@@ -906,6 +906,58 @@ async def test_an_explicit_model_choice_keeps_its_model_and_says_so(tmp_path, mo
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("source", ["config", "agent", "flag"])
+@pytest.mark.parametrize("saved_model, expected_notices", [("chosen", 0), ("other", 1)])
+async def test_model_default_pair_save_coalesces_pinned_notices(
+    tmp_path, monkeypatch, source, saved_model, expected_notices
+) -> None:
+    """The real facade emits twice, but its intermediate provider/model pair
+    is not a second user decision. Saving the pin itself needs no keep row.
+    """
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+    manager = ConfigManager(config_dir)
+    manager.set_config_value("hosting", "anthropic")
+    manager.set_config_value("model_name", "old")
+    session = make_session(tmp_path, RebindableStream({}), model_source=source)
+    session.set_model(ModelSpec(provider="openai", model_id="chosen"), explicit=source == "config")
+    _capture_events(session)
+    watcher = process_watcher(config_dir)
+    subscribe(session, watcher)
+    changes = []
+    watcher.subscribe(changes.append)
+    try:
+        for key, value in (("hosting", "openai"), ("model_name", saved_model)):
+            setting = settings_io.resolve_key(key)
+            assert setting is not None
+            settings_io.write_setting(manager, setting, value)
+        assert len(changes) == 2  # Exercises the reported duplicate's real cause.
+        await _settle(session)
+        assert len(_notices(session)) == expected_notices, _notices(session)
+        assert session.model_label == "openai/chosen"
+        assert session._explicit_model_choice is (source == "config")
+        assert watcher.poll_now() is None
+        if expected_notices:
+            assert "/model saved adopts openai/other" in _notices(session)[0]
+            # Redelivery and spelling-only disk edits are the same decision.
+            session._apply_config_change(changes[-1])
+            await _settle(session)
+            manager.set_config_value("hosting", " OpenAI ")
+            watcher.poll_now()
+            await _settle(session)
+            assert len(_notices(session)) == 1
+            # A genuinely different default earns one new receipt, including
+            # returning to a previous divergence after a matching default.
+            for name, count in (("another", 2), ("chosen", 2), ("other", 3)):
+                write_from_another_process(config_dir, "model_name", name)
+                watcher.poll_now()
+                await _settle(session)
+                assert len(_notices(session)) == count, _notices(session)
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("source, phrase", [("agent", "an agent profile"), ("flag", "a flag")])
 async def test_an_agent_or_flag_sourced_session_gets_a_notice_only(
     tmp_path, monkeypatch, source: str, phrase: str

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -2309,16 +2309,8 @@ async def test_model_opens_the_picker_instead_of_reporting_a_label() -> None:
         await pilot.pause()
         assert editor.text == "/model ", editor.text
         assert editor.model_picker.is_open()
-        # NOTHING was submitted: completing a command whose argument drives its
-        # own list is not running it, so there is no echoed UserBlock. The one
-        # block is the persist-hint notice, which rides the list's OPEN
-        # transition rather than the dispatch (UX review U5) so this keystroke
-        # route — the primary one — names `/model saved` and `/settings` just
-        # as the dispatched `/model` does. A system notice, so the empty state
-        # is intact and the composition has not collapsed.
-        blocks = app.query_one(TranscriptView).blocks()
-        assert [type(b).__name__ for b in blocks] == ["NoticeBlock"], blocks
-        assert _unwrapped(PERSIST_HINT) in _unwrapped(_transcript_text(app))
+        # Completion opens transient UI; guidance belongs to explicit help.
+        assert app.query_one(TranscriptView).blocks() == []
         assert app._welcome_visible is True
     assert session.prompts == []
 
@@ -2326,18 +2318,7 @@ async def test_model_opens_the_picker_instead_of_reporting_a_label() -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("size", [(100, 30), (80, 24)])
 async def test_the_picker_notice_is_exactly_its_rows_tall(size: tuple[int, int]) -> None:
-    """A notice appended from a message handler must not keep a stale height.
-
-    Found the moment the persist-hint notice moved onto ``ModelQueryOpened``:
-    built before layout at the 80-column fallback, measured at the 75-cell
-    boot column where each fallback row folded once more, and then re-authored
-    at the right width — but the second measurement never replaced the first
-    in the box-model cache, so a three-row notice held five rows and put a
-    scrollbar on a two-block transcript at 80-100 columns. ``NoticeBlock``
-    now pins its authored height like ``UserBlock`` does. Asserted as the
-    invariant (block height equals authored rows; no scrollbar) rather than
-    as a number, so a longer hint does not turn this into a golden.
-    """
+    """Explicit model guidance still has content-sized geometry, without empty rows."""
     session = FakeSession()
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=size) as pilot:
@@ -2345,7 +2326,7 @@ async def test_the_picker_notice_is_exactly_its_rows_tall(size: tuple[int, int])
         editor = app.query_one(Editor)
         editor.focus()
         await pilot.pause()
-        await pilot.press("slash", "m", "o", "d", "e", "l", "space")
+        app._run_slash_command("/model")
         for _ in range(6):
             await pilot.pause()
         transcript = app.query_one(TranscriptView)
@@ -2363,24 +2344,10 @@ async def test_the_picker_notice_is_exactly_its_rows_tall(size: tuple[int, int])
 
 @pytest.mark.asyncio
 async def test_escaping_the_model_list_then_editing_prints_no_second_notice() -> None:
-    """Esc-dismissing the list and clearing the line leaves one notice, not a
-    stack (UX review round 2, U8).
-
-    The editor re-derives every list from the buffer on EVERY key before
-    routing, so a bare ``close()`` on Esc was undone by the next keystroke's
-    pre-sync: the list reopened on the unchanged `/model `, posted
-    ``ModelQueryOpened``, and the key's own edit closed it again in the same
-    tick — nothing showed, but the app printed the hint once per cycle. Five
-    cycles left ten identical notices and a transcript scrollbar. Esc is now a
-    ``dismiss`` the picker holds until the query changes. Driven through the
-    exact reported gesture, three times, and asserted on both the count and
-    the scrollbar the stack produced.
-    """
+    """Esc dismissal survives edits; repeated openings never add transcript help."""
     session = FakeSession()
     app = OperatorApp(lambda: _factory(session))
-    # Counted separately from the notices so the ROOT fix is pinned on its own:
-    # the dedupe guard in `on_model_query_opened` would hide a resync that
-    # still announced a phantom opening, and this is the handler's other call.
+    # Count openings too: silent notices must not hide phantom picker resyncs.
     opens: list[int] = []
     populate = app._populate_model_picker
 
@@ -2415,7 +2382,7 @@ async def test_escaping_the_model_list_then_editing_prints_no_second_notice() ->
             await pilot.pause()
         transcript = app.query_one(TranscriptView)
         notices = [b for b in transcript.blocks() if isinstance(b, NoticeBlock)]
-        assert len(notices) == 1, [n.text() for n in notices]
+        assert notices == [], [n.text() for n in notices]
         assert transcript.virtual_size.height <= transcript.size.height, (
             transcript.virtual_size,
             transcript.size,
@@ -2424,11 +2391,8 @@ async def test_escaping_the_model_list_then_editing_prints_no_second_notice() ->
 
 
 @pytest.mark.asyncio
-async def test_escaping_then_retyping_the_model_query_reopens_and_reprints() -> None:
-    """The control for the U8 fix: Esc then a CHANGED query is a real new
-    opening and prints again. Two openings that show a list are two notices;
-    the dismissal expires the moment the query text moves, so a user who
-    pressed Esc still gets the list back by typing."""
+async def test_escaping_then_retyping_the_model_query_reopens_without_transcript_noise() -> None:
+    """The Esc latch still expires when query text changes; neither opening prints help."""
     session = _SwitchableSession()
     ctrl = _AccessController(stored=("openrouter", "anthropic"))
     app = OperatorApp(lambda: _factory(session), provider_controller=ctrl)
@@ -2444,8 +2408,7 @@ async def test_escaping_then_retyping_the_model_query_reopens_and_reprints() -> 
         for _ in range(3):
             await pilot.pause()
         assert not editor.model_picker.is_open()
-        # A typed character changes the query: the list is back, and so is the
-        # hint — but only this once, not once per keystroke after it.
+        # A changed query brings the list back, without adding transcript help.
         await pilot.press("o")
         for _ in range(4):
             await pilot.pause()
@@ -2456,13 +2419,8 @@ async def test_escaping_then_retyping_the_model_query_reopens_and_reprints() -> 
             await pilot.pause()
         transcript = app.query_one(TranscriptView)
         notices = [b for b in transcript.blocks() if isinstance(b, NoticeBlock)]
-        # ONE, not two: the second open showed the same list under the same
-        # hint, and the ledger's last row already says it (the belt-and-braces
-        # guard in `on_model_query_opened`). The picker's rows were refilled
-        # either way — that is what `is_open` above proves.
-        assert len(notices) == 1, [n.text() for n in notices]
-        # The guard compares TEXT, not "a notice was printed": once a switch
-        # has changed the hint's subject, the next opening prints the new one.
+        assert notices == []
+        # Switching changes the subject, but still must not reprint help.
         editor.clear_content()
         await pilot.pause()
         app._run_slash_command("/model anthropic/claude-opus-5")
@@ -2472,11 +2430,10 @@ async def test_escaping_then_retyping_the_model_query_reopens_and_reprints() -> 
         for _ in range(4):
             await pilot.pause()
         hints = [b.text() or "" for b in app.query(NoticeBlock) if PERSIST_HINT in (b.text() or "")]
-        # The first hint, the switch receipt (it carries PERSIST_HINT too), and
-        # the second hint naming the new model.
-        assert len(hints) == 3, hints
-        assert hints[0].startswith("model: openrouter/"), hints[0]
-        assert hints[-1].startswith("model: anthropic/claude-opus-5"), hints[-1]
+        assert hints == []
+        notices = [b.text() for b in app.query(NoticeBlock)]
+        assert len(notices) == 1, notices
+        assert "→ anthropic/claude-opus-5 (this session)" in (notices[0] or "")
 
 
 @pytest.mark.asyncio
@@ -2527,7 +2484,7 @@ async def test_a_caret_move_does_not_expire_an_escaped_model_list() -> None:
         assert editor.text == "/model ", editor.text
         transcript = app.query_one(TranscriptView)
         notices = [b for b in transcript.blocks() if isinstance(b, NoticeBlock)]
-        assert len(notices) == 1, [n.text() for n in notices]
+        assert notices == [], [n.text() for n in notices]
         # Typing still expires the dismissal — the latch holds an Esc, it does
         # not disable the list.
         await pilot.press("o")
@@ -2719,15 +2676,8 @@ async def test_a_held_model_latch_does_not_swallow_tab_elsewhere_in_the_buffer()
 
 
 @pytest.mark.asyncio
-async def test_the_hint_dedupe_guard_sees_past_a_pinned_working_line() -> None:
-    """R12: the guard reads the last block a caller appended, not the pin.
-
-    A turn in flight pins its working line to the bottom of the transcript and
-    every later append lands BEFORE it, so a guard reading ``blocks()[-1]``
-    matched the working line and never the hint — the deduplication silently
-    stopped applying in exactly the state where re-opening the list mid-turn
-    would stack copies.
-    """
+async def test_model_picker_openings_do_not_disturb_a_pinned_working_line() -> None:
+    """Opening and dismissing a picker while working must not grow the ledger."""
     session = _SwitchableSession()
     ctrl = _AccessController(stored=("openrouter", "anthropic"))
     app = OperatorApp(lambda: _factory(session), provider_controller=ctrl)
@@ -2757,29 +2707,16 @@ async def test_the_hint_dedupe_guard_sees_past_a_pinned_working_line() -> None:
         hints = [
             b for b in blocks if isinstance(b, NoticeBlock) and PERSIST_HINT in (b.text() or "")
         ]
-        assert len(hints) == 1, [h.text() for h in hints]
-        # The pin really was in the way: the hint is not the last block, which
-        # is the condition the old guard could not see past.
+        assert hints == []
         assert blocks[-1] is working
-        assert blocks[-1] is not hints[0]
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("route", ["typed", "pasted"])
-async def test_a_fully_typed_selector_prints_the_hint_once_above_its_receipt(
+async def test_a_fully_typed_selector_prints_only_its_receipt(
     route: str,
 ) -> None:
-    """A selector typed in full (or pasted whole) still gets ONE hint, above the
-    receipt — recorded, not fixed (UX review round 2, U10).
-
-    The list opens on the space after `/model`, before any id exists, so the
-    hint has to decide before it can know the user will type a full selector;
-    the space is the same moment a bare `/model ` opens on, which printed this
-    notice before this PR. What this pins is the bound: one hint for the
-    opening and none for the keystrokes after it, on both routes. The paste
-    goes through the app like a real clipboard drop, since the editor's paste
-    handler re-inserts a payload posted straight to it.
-    """
+    """Typed and pasted switches owe exactly one confirmation, not automatic help."""
     from textual import events
 
     session = _SwitchableSession()
@@ -2804,9 +2741,8 @@ async def test_a_fully_typed_selector_prints_the_hint_once_above_its_receipt(
         for _ in range(6):
             await pilot.pause()
         notices = [b.text() or "" for b in app.query(NoticeBlock)]
-    assert len(notices) == 2, notices
-    assert notices[0].startswith("model: openrouter/deepseek/deepseek-chat — "), notices[0]
-    assert "→ anthropic/claude-opus-5 (this session)" in notices[1], notices[1]
+    assert len(notices) == 1, notices
+    assert "→ anthropic/claude-opus-5 (this session)" in notices[0], notices[0]
     assert session.model_label == "anthropic/claude-opus-5"
 
 
@@ -7731,9 +7667,8 @@ class _SwitchableSession(FakeSession):
 
 
 @pytest.mark.asyncio
-async def test_switching_confirms_access_instead_of_warning_about_it() -> None:
-    """The old line told the user to go and check something the app knew, on every
-    provider change including the ones that were fine."""
+async def test_switching_omits_ordinary_access_confirmation() -> None:
+    """A usable provider needs neither a redundant access confirmation nor a warning."""
     session = _SwitchableSession()
     ctrl = _AccessController(stored=("openrouter", "anthropic"))
     app = OperatorApp(lambda: _factory(session), provider_controller=ctrl)
@@ -7743,7 +7678,7 @@ async def test_switching_confirms_access_instead_of_warning_about_it() -> None:
         await pilot.pause()
         text = _transcript_text(app)
     assert "anthropic/claude-opus-5" in text, text
-    assert "anthropic logged in" in text, text
+    assert "anthropic logged in" not in text, text
     assert "make sure you are logged in" not in text, text
 
 
@@ -8702,10 +8637,8 @@ async def test_the_paste_key_rows_do_not_wrap_at_eighty_columns() -> None:
 
 
 @pytest.mark.asyncio
-async def test_a_switch_admits_it_is_session_only_and_names_the_persist_command() -> None:
-    """A switch that looks permanent and is not is the actual bug: the old
-    "(next turn)" said WHEN it applied and never said for how long, so the next
-    launch coming back on the old model read as the switch having been lost."""
+async def test_a_switch_confirms_session_scope_without_repeating_help() -> None:
+    """The confirmation states what changed and its scope; full help remains explicit."""
     session = _SwitchableSession()
     ctrl = _AccessController(stored=("openrouter", "anthropic"))
     app = OperatorApp(lambda: _factory(session), provider_controller=ctrl)
@@ -8715,20 +8648,15 @@ async def test_a_switch_admits_it_is_session_only_and_names_the_persist_command(
         await pilot.pause()
         text = _transcript_text(app)
     assert _unwrapped("this session") in _unwrapped(text), text
-    # The persist breadcrumb names `/model default` again: the `d` affordance
-    # #369 briefly introduced is gone, and the bare command writes.
-    assert _unwrapped(PERSIST_HINT) in _unwrapped(text), text
-    # The access clause is unchanged by the new one sharing the line.
-    assert _unwrapped("anthropic logged in") in _unwrapped(text), text
+    assert _unwrapped(PERSIST_HINT) not in _unwrapped(text), text
+    assert _unwrapped("anthropic logged in") not in _unwrapped(text), text
 
 
 @pytest.mark.asyncio
-async def test_model_default_confirms_both_keys_and_the_file_it_wrote(
+async def test_model_default_confirms_the_pair_and_scope(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A bare "saved" is a claim the user cannot check without relaunching.
-    The provider is the half that rides along silently — it is written from the
-    selector's left side and never typed as a setting of its own."""
+    """A concise receipt names the saved pair and both scopes; verify the disk write too."""
     import yaml
 
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
@@ -8746,10 +8674,8 @@ async def test_model_default_confirms_both_keys_and_the_file_it_wrote(
     written = yaml.safe_load((tmp_path / "config.yml").read_text())["values"]
     assert written["hosting"] == "anthropic", written
     assert written["model_name"] == "claude-opus-5", written
-    # What it wrote, under the names the config file uses…
-    assert _unwrapped("hosting anthropic, model_name claude-opus-5") in _unwrapped(text), text
-    # …and where, so the user can go and read or undo it.
-    assert str(tmp_path / "config.yml") in _unwrapped(text), text
+    assert _unwrapped("boot default saved: anthropic/claude-opus-5") in _unwrapped(text)
+    assert _unwrapped("this session + new sessions") in _unwrapped(text)
 
 
 @pytest.mark.asyncio
@@ -8800,8 +8726,8 @@ async def test_model_default_alone_saves_the_model_the_session_is_on(
     # the persist path's own `set_model` is a no-op re-selection.
     assert label_after == "anthropic/claude-opus-5", label_after
     # Same receipt vocabulary as the explicit spelling — one outcome, one wording.
-    assert _unwrapped("hosting anthropic, model_name claude-opus-5") in _unwrapped(text), text
-    assert str(tmp_path / "config.yml") in _unwrapped(text), text
+    assert _unwrapped("boot default saved: anthropic/claude-opus-5") in _unwrapped(text), text
+    assert _unwrapped("(new sessions)") in _unwrapped(text), text
 
 
 @pytest.mark.asyncio
@@ -9016,7 +8942,7 @@ async def test_model_default_alone_is_write_only(
         await pilot.pause()
     written = yaml.safe_load((tmp_path / "config.yml").read_text())["values"]
     # The bare form WROTE (its receipt names the pair) without the access note…
-    assert _unwrapped("hosting openrouter, model_name deepseek/deepseek-chat") in bare_receipt
+    assert _unwrapped("boot default saved: openrouter/deepseek/deepseek-chat") in bare_receipt
     assert _unwrapped("openrouter logged in") not in bare_receipt, bare_receipt
     # …and the explicit form with a different model took the switch tail once.
     assert session.set_model_calls == [("anthropic/claude-opus-5", True)], session.set_model_calls
@@ -9496,24 +9422,8 @@ async def test_the_bare_model_notice_does_not_orphan_a_route_token() -> None:
 
 @pytest.mark.asyncio
 async def test_every_model_default_surface_says_it_the_same_way() -> None:
-    """D14. One instruction had four wordings on four surfaces a user meets
-    within two keystrokes. The canonical sentence now names the consequence —
-    future sessions — rather than merely saying an unspecified pair is saved.
-
-    The defect is the divergence, so all four surfaces are checked together.
-    The footer is checked unwrapped and whole because it is the tightest site:
-    an instruction that is consistent only after truncation is not consistent.
-
-    THE `/help` ROW IS THE ONE DOCUMENTED EXCEPTION (design review round 3,
-    D7). It carries the same COMMAND and the same consequence, but not the
-    same sentence: reusing ``PERSIST_HINT`` verbatim there needed a ≤12-cell
-    lead to stay inside the 55-cell description column, and every such lead was
-    a fragment (`Switch;`, `Pick one;`). ``PERSIST_HINT``'s exact length is set
-    by the picker footer's 43-cell budget, which is not a constraint `/help`
-    shares, so the row gets its own carrier and this test asserts the invariant
-    that actually matters — one command, one consequence, no second paraphrase
-    of what is being saved.
-    """
+    """Explicit model/help and the picker footer retain the save command and scope;
+    successful switches do not repeat that guidance."""
     session = _SwitchableSession()
     ctrl = _AccessController(stored=("openrouter", "anthropic"))
     app = OperatorApp(lambda: _factory(session), provider_controller=ctrl)
@@ -9532,10 +9442,10 @@ async def test_every_model_default_surface_says_it_the_same_way() -> None:
         await pilot.pause()
         help_text = _transcript_text(app)
 
-    # 1. the notice a bare `/model` prints above the list, 2. the switch receipt,
-    # 3. the picker's own footer, 4. the `/help` row.
+    # Full guidance is explicit; the picker footer retains the save shortcut.
+    # The subsequent switch must not add another copy to the transcript.
     assert _unwrapped(PERSIST_HINT) in _unwrapped(bare_notice), bare_notice
-    assert _unwrapped(PERSIST_HINT) in _unwrapped(receipt), receipt
+    assert _unwrapped(receipt).count(_unwrapped(PERSIST_HINT)) == 1, receipt
     assert PERSIST_HINT in footer, footer
     model_row = next(c for c in SLASH_COMMANDS if c.name == "model")
     # `/help` names the same command and the same consequence in its own words
@@ -9557,13 +9467,11 @@ async def test_every_model_default_surface_says_it_the_same_way() -> None:
     ):
         assert _unwrapped(stale) not in everything, stale
 
-    # The receipt is two clauses now, not a run-on of four separators — and it
-    # still says the two things that made it necessary: the scope, and the access
-    # state of the provider it just switched to.
+    # The receipt confirms scope, not ordinary credential state or repeated help.
     switch_line = next(line for line in _unwrapped(receipt).split("·") if _unwrapped("→") in line)
     assert _unwrapped("(this session)") in switch_line, switch_line
     assert _unwrapped("from the next turn") not in _unwrapped(receipt), receipt
-    assert _unwrapped("anthropic logged in") in _unwrapped(receipt), receipt
+    assert _unwrapped("anthropic logged in") not in _unwrapped(receipt), receipt
 
 
 @pytest.mark.asyncio
@@ -9592,8 +9500,7 @@ async def test_a_mid_turn_switch_says_when_it_starts_applying() -> None:
     # keeps it to two wrapped lines at the widths this app supports. Folding the
     # timing into the scope parenthetical measured three.
     assert _unwrapped("(this session)") in text, text
-    # The persist breadcrumb is PERSIST_HINT, which names `/model default`.
-    assert _unwrapped(PERSIST_HINT) in text, text
+    assert _unwrapped(PERSIST_HINT) not in text, text
     # SAME INK as the receipt it qualifies (design review D3). At `note` the
     # subordinate row measured 8.62:1 against the receipt's 4.55:1 and the eye
     # landed on the qualifier first; the token is asserted rather than the
@@ -9940,7 +9847,7 @@ async def test_model_default_on_a_cold_viewer_still_saves(
         app._run_slash_command("/model default anthropic/claude-fable-5-1")
         await pilot.pause()
         text = _unwrapped(_transcript_text(app))
-    assert _unwrapped("boot default saved to") in text, text
+    assert _unwrapped("boot default saved:") in text, text
     assert _unwrapped("no runtime is running") not in text, text
     assert "model_name: claude-fable-5-1" in (tmp_path / "config.yml").read_text()
 
@@ -9989,7 +9896,7 @@ async def test_model_default_mid_turn_also_says_when_it_applies(
     assert _unwrapped(MODEL_SWITCH_MID_TURN_NOTICE) in text, text
     # Still the persistence receipt, not the session one: this asserts the row
     # was ADDED to that branch rather than the branch being changed.
-    assert _unwrapped("used by new sessions") in text, text
+    assert _unwrapped("this session + new sessions") in text, text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -9840,15 +9840,16 @@ async def test_model_default_on_a_cold_viewer_still_saves(
     monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
     (tmp_path / "config.yml").write_text("version: 0.0.0\nvalues:\n  hosting: openrouter\n")
     session = _ColdAsyncLabelSession()
+    before_label = session.model_label
     ctrl = _AccessController(stored=("openrouter", "anthropic"))
     app = OperatorApp(lambda: _factory(session), provider_controller=ctrl)
     async with app.run_test(size=(110, 24)) as pilot:
         await _await_session(app, pilot)
         app._run_slash_command("/model default anthropic/claude-fable-5-1")
         await pilot.pause()
-        text = _unwrapped(_transcript_text(app))
-    assert _unwrapped("boot default saved:") in text, text
-    assert _unwrapped("no runtime is running") not in text, text
+        notices = [block.text() for block in app.query(NoticeBlock)]
+    assert session.model_label == before_label
+    assert notices == ["boot default saved: anthropic/claude-fable-5-1 (new sessions)"], notices
     assert "model_name: claude-fable-5-1" in (tmp_path / "config.yml").read_text()
 
 

--- a/tests/unit/tui/test_model_notice_flow.py
+++ b/tests/unit/tui/test_model_notice_flow.py
@@ -1,0 +1,82 @@
+"""Model receipts through the real app, session and per-key config watcher.
+
+The older default-save pilot used a switchable fake without a session watcher:
+it could assert one app receipt while production appended two keeping notices.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from local_operator.config import ConfigManager
+from local_operator.config_watch import _reset_for_tests, process_watcher
+from local_operator.harness.types import ModelSpec
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.transcript import NoticeBlock
+from tests.unit.session.test_config_live import (
+    RebindableStream,
+    make_session,
+    subscribe,
+)
+from tests.unit.tui.test_app_pilot import _AccessController, _await_session
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("width", [60, 100])
+async def test_switch_then_save_prints_one_confirmation_per_action(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, width: int
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    config_dir = tmp_path / "config"
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
+    _reset_for_tests()
+    manager = ConfigManager(config_dir)
+    manager.set_config_value("hosting", "anthropic")
+    manager.set_config_value("model_name", "old")
+    session = make_session(tmp_path, RebindableStream({}), model_source="config")
+    watcher = process_watcher(config_dir)
+    subscribe(session, watcher)
+    ctrl = _AccessController(stored=("openrouter", "anthropic"))
+    monkeypatch.setattr(
+        ctrl,
+        "resolve_model",
+        lambda provider, model: ModelSpec(provider=provider, model_id=model),
+    )
+
+    async def factory():
+        return session
+
+    app = OperatorApp(factory, provider_controller=ctrl)
+    try:
+        async with app.run_test(size=(width, 32)) as pilot:
+            await _await_session(app, pilot)
+            app._run_slash_command("/model openrouter/chosen")
+            await pilot.pause()
+            # The next command starts by opening the same picker. It must not
+            # append full help after the switch just because the buffer resyncs.
+            app._editor().begin_model_query()
+            await pilot.pause()
+            app._editor().clear_content()
+            app._run_slash_command("/model default")
+            await pilot.pause()
+            assert watcher.poll_now() is None
+            await pilot.pause()
+            notices = [block.text() for block in app.query(NoticeBlock)]
+            assert len(notices) == 2, notices
+            assert notices[0] == "model: test/m → openrouter/chosen (this session)"
+            assert notices[1] == "boot default saved: openrouter/chosen (new sessions)"
+            assert session.model_label == "openrouter/chosen"
+            assert session._explicit_model_choice
+            saved = ConfigManager(config_dir)
+            assert saved.get_config_value("hosting") == "openrouter"
+            assert saved.get_config_value("model_name") == "chosen"
+            # The hidden-from-transcript help remains reachable intentionally.
+            app._run_slash_command("/model")
+            await pilot.pause()
+            guidance = [block.text() or "" for block in app.query(NoticeBlock)][-1]
+            for route in ("/model default", "/model saved", "/settings"):
+                assert route in guidance
+    finally:
+        await session.dispose()
+        await watcher.stop()
+        _reset_for_tests()


### PR DESCRIPTION
## Change authorization

**C1 — standard/pre-authorized bug fix.** This PR is the change record. The request is to condense redundant model-switch transcript output and eliminate duplicate `keeping` messages, without changing model-selection semantics. **Hold: work requested only; do not merge or release.** No version bump.

## Root cause, reproduced

There were two independent sources of noise:

1. Every `ModelQueryOpened` appended full model/default/settings help to the transcript. Typing the next `/model default` command therefore repeated the help immediately after a switch confirmation.
2. Saving the default writes `hosting`, then `model_name`, through `settings_io.write_setting`. Each synchronously notifies the config watcher. A real pinned `Session` unconditionally emitted `keeping ...` for both notifications, including the final pair that now matched its model. The existing default-save pilot used a switchable fake without the session watcher, so it could pass while production printed both duplicates.

The reproduction below uses the **real `OperatorApp`, `Session`, config manager, per-key facade writes and process watcher**, with a deterministic provider stream/catalogue boundary. It does not make paid provider requests. It strips **all** inherited `CMUX_*` variables and isolates HOME/config before app imports.

## Behavior and acceptance criteria

- A successful switch prints one old → new confirmation with `(this session)`. Ordinary successful credential checks no longer add noise; actionable credential warnings remain.
- Saving the current model prints `boot default saved: <provider>/<model> (new sessions)`. The connected explicit switch-and-save form says `(this session + new sessions)`; a cold/disconnected viewer correctly says `(new sessions)` because no runtime is switched.
- Merely opening/filtering/reopening the model picker appends no transcript help. Its footer still names the save shortcut. Explicit bare `/model` and `/help` retain the full guidance.
- Pinned-session config receipts coalesce synchronous per-key callbacks to the final pair. Matching effective models are silent; semantic duplicates are silent; a genuinely changed divergent default produces one notice identifying the target `/model saved` would adopt.
- Model selection, explicit pinning, config-following sessions, `/model saved`, write failures, mid-turn timing, model-switch state injection and runtime routing remain intact.

**Non-goals:** unrelated runtime-version notices, config schema changes, model/provider resolution redesign, deployment/release. No auth, tenant, API, database or migration contracts change.

## Real execution evidence

[Reproduction script, raw outputs, before/after SVGs and geometry](https://gist.github.com/damianvtran/bb2ae25cb712fbaed4be8dd400a70d4b)

```sh
# Run from the worktree, using its own editable .venv.
.venv/bin/python reproduce.py /tmp/model-before 100
.venv/bin/python reproduce.py /tmp/model-before 60
# Same commands after implementation, outputting to /tmp/model-after.
```

Actual before (both widths): **5 notices**, including the repeated full help and two identical `keeping openai/gpt-6-astra` notices.

Actual after (both widths):
```text
model: anthropic/claude-opus-5 → openai/gpt-6-astra (this session)
boot default saved: openai/gpt-6-astra (new sessions)
```

Read-back in both runs: effective/selected model `openai/gpt-6-astra`, explicit pin `true`, saved pair `hosting=openai`, `model_name=gpt-6-astra`.

The same real-app probe also exercised these paths ([raw output and edge probe in the evidence gist](https://gist.github.com/damianvtran/bb2ae25cb712fbaed4be8dd400a70d4b)):

| Action | Actual result |
|---|---|
| `/model invalid-selector` | Usage warning; model/pin unchanged |
| `/model unknown-provider/model` | Unknown-provider warning; model/pin unchanged |
| Switch with synthetic missing credentials | Concise confirmation **plus** `anthropic needs login — /login anthropic` |
| `/model saved` | Reads disk and switches back in one receipt; explicit pin remains |
| Inject write failure at the settings boundary | `could not save default: synthetic read-only config`; model/pin unchanged |
| External `ConfigManager` model edit, then real watcher poll | Exactly one `keeping ...; /model saved adopts openai/external-model` |
| Repeat poll unchanged | No notice |
| `/model saved` after external edit | One receipt, adopts `openai/external-model` |
| Next real Session prompt with deterministic stream | Provider request contains `[model switch]` and `openai/external-model` |

Credential state and write failure are deterministic injected boundaries, not claims of live-provider authentication or a real filesystem outage. No remote authentication/tenant surface was changed.

### Before / after, inspected at native scale

| Width | Before | After |
|---|---|---|
| 100×32 | ![Before normal](https://gist.githubusercontent.com/damianvtran/bb2ae25cb712fbaed4be8dd400a70d4b/raw/699360a2273a2aa9b0dfedeafbb3c875a42f4946/before-100.svg) | ![After normal](https://gist.githubusercontent.com/damianvtran/bb2ae25cb712fbaed4be8dd400a70d4b/raw/2ed795d51819574bbf3caeb509d669056d511de7/after-100.svg) |
| 60×32 | ![Before narrow](https://gist.githubusercontent.com/damianvtran/bb2ae25cb712fbaed4be8dd400a70d4b/raw/469697c7aa18b6d2cff3c5c1b262e3246602fc65/before-60.svg) | ![After narrow](https://gist.githubusercontent.com/damianvtran/bb2ae25cb712fbaed4be8dd400a70d4b/raw/dfa0478eda9f00ae73cb9bbc71fb5ffafa0ec781/after-60.svg) |

Captured through `scripts.visual_capture.save_capture`, production stylesheet, 8×17 px cells; rasterized with `rsvg-convert` and actually viewed. Consecutive settled frames are pixel-identical at each width before and after. Notice-body rows: **10 → 2 at 100 columns; 14 → 4 at 60 columns** (excluding inter-block margins). Screen size equals virtual size (98×30 / 58×30); editor remains one row; no new scrollbar or reflow.

## Verification

All required full-tree gates passed on `6f20b45b07ed154db896ca30d9aaee2d3e2b9285`:

| Command | Actual result |
|---|---|
| `.venv/bin/python -m flake8 .` | PASS, exit 0 (no output) |
| `uvx --from black==26.1.0 black --check .` | PASS, 1072 files unchanged |
| `uvx isort==5.13.2 --check .` | PASS, exit 0 |
| `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | PASS, 0 errors / 0 warnings |
| `.venv/bin/python -m pytest tests/unit -q` | **16197 passed, 18 skipped**, 685 warnings, 1502.63s |
| `.venv/bin/python -m pytest tests/e2e -m e2e -n0 -q` | **49 passed**, 6 warnings, 71.99s |

Both pytest commands ran via an isolation wrapper setting fresh `HOME` and `LOCAL_OPERATOR_CONFIG_DIR`, stripping every `CMUX_*` variable, unsetting `NO_COLOR`, and setting `TERM=xterm-256color`. The full suite reached 100% with its final accounting (not an early exit). Gate logs are attached to the evidence gist. The editable venv resolves to this worktree even from `/tmp`; its isolated console entry point reports `v0.51.15` (unchanged).

New regression coverage includes the actual command + real session watcher at 60/100 columns, per-key matching/divergent default saves for explicit, agent and flag selections, repeated callback delivery, spelling-only provider changes, and subsequent meaningful default changes. Existing typed/pasted picker flows, pinning, save-only/switch-and-save, missing credentials, invalid selectors, write errors, mid-turn timing and model-visible switch injection remain in the suite.

### Unified round-one remediation

Code-review R1 (cold-viewer receipt scope) is fixed in `e77a70e4f59fedd95b77a5a4e002995433807695`. A disconnected viewer still saves the next runtime's default without changing its current model, and its receipt now truthfully says `(new sessions)`.

- Extended the cold-save regression to assert **unchanged session label and exact receipt**, plus the existing disk write assertion. Ran that test against the original implementation first: **1 failed** with the false `(this session + new sessions)` receipt. After the fix, the focused cold/saved/default/async-label/mid-turn matrix is **24 passed** (11.08s).
- All four full-tree static gates pass again on the remediation. The complete unit/e2e results above belong to the original head; the tiny remediation uses the required delta-focused verification rather than another 25-minute full suite.
- Re-ran the real cold-viewer `OperatorApp` probe at 100/60 columns. Both runs keep `anthropic/claude-opus-5` unchanged and emit exactly `boot default saved: anthropic/claude-fable-5-1 (new sessions)`.
- Re-rendered and viewed both cold-after frames. Every cold first/settled SVG pair is byte-identical. Normal connected-session after-frames remain **byte-identical** to the original approved captures at both widths.

| Cold viewer | Before R1 | After R1 |
|---|---|---|
| 100×32 | [Incorrect scope](https://gist.githubusercontent.com/damianvtran/bb2ae25cb712fbaed4be8dd400a70d4b/raw/54781f49f5cb7e41040824ddcbc963923e78182e/cold-before-100.svg) | ![Correct cold scope](https://gist.githubusercontent.com/damianvtran/bb2ae25cb712fbaed4be8dd400a70d4b/raw/276029a821d9945cfc67cf72411ed519d902313f/cold-after-100.svg) |
| 60×32 | [Incorrect scope narrow](https://gist.githubusercontent.com/damianvtran/bb2ae25cb712fbaed4be8dd400a70d4b/raw/64fdd76597648dbbbe768d5648045eced73d9986/cold-before-60.svg) | ![Correct cold scope narrow](https://gist.githubusercontent.com/damianvtran/bb2ae25cb712fbaed4be8dd400a70d4b/raw/367e3b75bceccc569670b452661bf5460e2f5389/cold-after-60.svg) |

### Review status on current head

Current head: `e77a70e4f59fedd95b77a5a4e002995433807695`. All required agent review streams are clean and author replies are posted:

| Stream | Current approval | Author response |
|---|---|---|
| Code | [Round 2: TERMINAL, R1 fixed, no blocker/major](https://github.com/damianvtran/local-operator/pull/785#issuecomment-5579083773) | [Round 2 remediation](https://github.com/damianvtran/local-operator/pull/785#issuecomment-5579145620) |
| QA | [Round 2: PASS, TERMINAL; 18 assertions using real cold RemoteSession and live Session](https://github.com/damianvtran/local-operator/pull/785#issuecomment-5579118707) | [Round 2 remediation](https://github.com/damianvtran/local-operator/pull/785#issuecomment-5579145781) |
| Design | [Round 2: APPROVE, TERMINAL; cold before/after actually viewed and independently re-rendered](https://github.com/damianvtran/local-operator/pull/785#issuecomment-5579079746) | [Round 2 remediation](https://github.com/damianvtran/local-operator/pull/785#issuecomment-5579145952) |
| UX | [Round 1: TERMINAL; unchanged interaction flow](https://github.com/damianvtran/local-operator/pull/785#issuecomment-5579003826) | [Round 1 remediation; final delta only changes cold receipt scope](https://github.com/damianvtran/local-operator/pull/785#issuecomment-5579062826) |

**All 16 current-head CI checks are green**, including all five unit shards, static checks, coverage, CLI/server sanity, and both macOS/Linux E2E jobs ([successful run, attempt 2](https://github.com/damianvtran/local-operator/actions/runs/34185982463)). The first CLI-sanity attempt exited 1 during the JSON streaming command; its workflow redirects diagnostic output without uploading it, so the underlying cause was not exposed. Rerunning that single job on the unchanged head passed; no code or CI changes were made. The PR is ready for review, with the normal code owner requested field-only for awareness. **Hold unmerged; no release requested.** Existing picker-on-resize redraw behavior, independently reproduced on the base too, is explicitly **not addressed** by this notification cleanup; no issue was created.

## Rollout / rollback

No migration or config rewrite. A future reviewed release can include this change; rollback is reverting this PR and rebuilding the runtime in the usual release window. This task deliberately does **not** merge, tag, publish or update the installed `lop`.
