### PR TITLE
chore(release): bump version to 0.51.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.16"
+version = "0.51.17"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Release window claim

**Owner session pid: 54107** (confirmed present in `lop sessions`). Coordinated by the parent release manager; release-owner task `d44cf660dad5`.

Latest published tag checked: **v0.51.16**. Provisional next version: **0.51.17**.

Window currently contains:
- [x] #772 — merge `dea525c92fc67c0da42145037bd4c428537eee3b`
  - Release: patch — /new and /resume get remappable hotkeys (ctrl+n / ctrl+s), configurable under /settings → Hotkeys and applied live to every running session.

The release manager must re-derive the reachable window before tagging so concurrently merged PRs are not omitted from the notes.

## Scope and protocol deviation

C0 release metadata only: **one commit, one changed line in `pyproject.toml`, `0.51.16` → `0.51.17`**. No dependency, code, lockfile or feature changes.

At the manager's explicit instruction, this draft lock starts with the provisional version bump rather than an empty claim commit. This avoids the standard empty-claim amendment requiring an unapproved force-push. The claim title retains the `chore(release):` lock prefix, and the same PR can be retitled after the independent scope review without rewriting history. The branch and worktree are unique rather than reusing an existing `release-next` branch.

No force-push, deletion, merge, tag, publish or installation has been performed by the implementing coder. The root checkout and feature working tree are untouched.

## Verification and handoff

- Fetched `origin/main`; base `dea525c92fc67c0da42145037bd4c428537eee3b` contains #772.
- `git log v0.51.16..origin/main` identifies #772 and its feature commits as the current window; `git diff v0.51.16..origin/main -- pyproject.toml` is empty.
- Parsed the edited file with `tomllib`: project version is exactly `0.51.17`.
- Compared the entire file against the base with only the requested replacement applied: exact match.
- `git diff --check` passed; `git diff --numstat` is `1 1 pyproject.toml`.
- No behavioral code changed, so no new application test suite was run for this metadata-only commit. Independent scope review and CI remain pending.

Implementer: coder subagent — `openai/gpt-6-astra`. Parent assigns an independent reviewer; release manager owns subsequent merge/publish/install steps.
