### PR TITLE
perf(tui): avoid rebuilding unchanged sidebar frames

### DIFF
--- a/local_operator/tui/widgets/session_sidebar.py
+++ b/local_operator/tui/widgets/session_sidebar.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 import time
 from collections.abc import Sequence
+from typing import Self
 
+from rich.segment import Segment
 from rich.style import Style
 from rich.text import Text
 from textual import events
@@ -17,6 +19,7 @@ from textual.binding import Binding
 from textual.geometry import Region
 from textual.message import Message
 from textual.reactive import Reactive
+from textual.strip import Strip
 from textual.timer import Timer
 from textual.widget import Widget
 
@@ -201,6 +204,10 @@ class SessionSidebar(Widget, can_focus=True):
         self._catalog_loading = True
         self._offset = 0
         self._frame = 0
+        self._painted_state: tuple[object, ...] | None = None
+        self._painted_lines: dict[int, Strip] = {}
+        self._painted_lines_valid = False
+        self._spinner_paint = False
         self._timer: Timer | None = None
         self._spinner_rate = SIDEBAR_SPINNER_INTERVAL_S
         self._pressed_id: str | None = None
@@ -339,7 +346,11 @@ class SessionSidebar(Widget, can_focus=True):
         # jiggled the mouse.
         self._set_hover(self._hover_y)
         self._sync_animation()
-        self.refresh()
+        # Polling must still adopt fresh summaries (including tooltip-only
+        # status), but an unchanged frame must not invalidate Rich's content
+        # and Textual's compositor every two seconds in every open terminal.
+        if self._paint_state() != self._painted_state:
+            self.refresh()
 
     def show_error(self, message: str) -> None:
         # A refresh error does not erase the last usable catalog.
@@ -403,9 +414,101 @@ class SessionSidebar(Widget, can_focus=True):
         else:
             self._timer.pause()
 
+    def _age(self, entry: CatalogEntry) -> str:
+        age = (
+            format_age(max(0, time.time() - entry.row.mtime)).replace(" ago", "")
+            if self.size.width >= 28
+            else ""
+        )
+        return age if len(age) <= 4 else ""
+
+    def _paint_state(self) -> tuple[object, ...]:
+        # Keep the complete immutable entries, not a partial fingerprint of
+        # their titles/status. New fields must never silently evade invalidation.
+        # Age is time-derived, so equal catalog bytes alone are insufficient.
+        return (
+            self.entries,
+            self.current_id,
+            self.cursor_id,
+            self._requested_id,
+            self._requested_spinning(),
+            self._offset,
+            self.has_focus,
+            self._hover_id,
+            self.error,
+            self._catalog_loading,
+            self.size,
+            tuple(self._age(entry) for entry in self.visible_entries),
+        )
+
+    def refresh(
+        self,
+        *regions: Region,
+        repaint: bool = True,
+        layout: bool = False,
+        recompose: bool = False,
+    ) -> Self:
+        # Any ordinary invalidation owns the next render: hover, theme, resize,
+        # focus and new summaries must never reuse a spinner-only projection.
+        # Textual may call refresh during Widget construction, before our init.
+        if repaint or layout or recompose:
+            self._spinner_paint = False
+            self._painted_lines_valid = False
+        return super().refresh(*regions, repaint=repaint, layout=layout, recompose=recompose)
+
+    def render_line(self, y: int) -> Strip:
+        # Widget's default render_line rebuilds the WHOLE Rich Text for even a
+        # one-cell dirty region. Reuse public content strips only for a known
+        # spinner-only paint; normal rendering and style application stay with
+        # Textual, and no private render/compositor cache is modified.
+        if self._spinner_paint and y in self._painted_lines:
+            return self._painted_lines[y]
+        line = super().render_line(y)
+        self._painted_lines[y] = line
+        return line
+
     def _advance_spinner(self) -> None:
         self._frame += 1
-        self.refresh()
+        if not self._painted_lines_valid or self._paint_state() != self._painted_state:
+            # A pending catalog/focus/age change needs its whole frame; never
+            # let a tick turn that invalidation into only a spinner-cell paint.
+            self.refresh()
+            return
+        if not self.entries and self._catalog_loading:
+            self.refresh(Region(0, 1, 1, 1))
+            return
+        rows = self._display_rows()
+        title = 0 if self._draws_section_headers(rows) else 1
+        regions = []
+        replacements: dict[int, Strip] = {}
+        for y, (_kind, entry) in enumerate(rows, title):
+            if entry is None:
+                continue
+            requested = entry.id == self._requested_id and entry.id != self.current_id
+            if (requested and self._requested_spinning()) or (
+                entry.row.live_state == "busy"
+                and not entry.row.pending
+                and not entry.shows_completion_mark
+            ):
+                line = self._painted_lines.get(y)
+                if line is None:
+                    self.refresh()
+                    return
+                # The old cell carries its exact resolved foreground/background
+                # (including cursor/hover selection). Only its glyph changes.
+                cell = line.crop(2, 3)
+                glyph = SPINNER_FRAMES[self._frame % len(SPINNER_FRAMES)]
+                mark = Strip([Segment(glyph, next(iter(cell)).style)], 1)
+                replacements[y] = Strip.join([line.crop(0, 2), mark, line.crop(3)])
+                regions.append(Region(2, y, 1, 1))
+        # refresh() with no regions means the ENTIRE widget, not no work.
+        # Only glyphs move at this cadence; titles, chrome and empty space do
+        # not need recompositing. The existing timer rate is unchanged.
+        if regions:
+            self.refresh(*regions)
+            self._painted_lines.update(replacements)
+            self._painted_lines_valid = True
+            self._spinner_paint = True
 
     def _cursor_index(self) -> int:
         return next((i for i, row in enumerate(self.entries) if row.id == self.cursor_id), 0)
@@ -639,6 +742,10 @@ class SessionSidebar(Widget, can_focus=True):
         self._sync_animation()
 
     def render(self) -> Text:
+        self._spinner_paint = False
+        self._painted_lines.clear()
+        self._painted_lines_valid = True
+        self._painted_state = self._paint_state()
         width = max(1, self.size.width)
         result = Text(no_wrap=True, overflow="crop")
         rows = self._display_rows()
@@ -744,13 +851,7 @@ class SessionSidebar(Widget, can_focus=True):
                     entry.completion_kind, COMPLETION_MARKERS["complete"]
                 )
             line.append(f"{mark or ' '} ", style=theme_mod.semantic_color(ink))
-            age = (
-                format_age(max(0, time.time() - entry.row.mtime)).replace(" ago", "")
-                if width >= 28
-                else ""
-            )
-            if len(age) > 4:
-                age = ""
+            age = self._age(entry)
             title_width = max(1, width - 4 - (len(age) + 1 if age else 0))
             title = truncate_cells(entry.row.name or "Untitled conversation", title_width)
             line.append(title)

--- a/scripts/sidebar_performance.py
+++ b/scripts/sidebar_performance.py
@@ -1,0 +1,212 @@
+"""Measure assembled sidebar rendering and the real off-loop catalog collector.
+
+Examples (no live configuration, sessions, providers or sockets are used)::
+
+    .venv/bin/python scripts/sidebar_performance.py --output /tmp/sidebar-after
+    .venv/bin/python scripts/sidebar_performance.py --mode frames --output /tmp/frames
+    .venv/bin/python scripts/sidebar_performance.py --mode catalog --output /tmp/catalog
+
+For an interleaved before/after comparison, --source-root points at a clean
+baseline worktree. The SAME harness drives both trees; source provenance is
+recorded in every result. Matrix cells use synthetic catalog summaries and
+suppress prewarm ONLY, separating render cost from session attach cost. Catalog
+cells separately exercise real transcript/registry/attention reads in a worker.
+Timings are evidence, not CI ceilings: regression tests assert work counts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import cProfile
+import json
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+PARSER = argparse.ArgumentParser(description=__doc__)
+PARSER.add_argument("--source-root", type=Path, default=Path(__file__).resolve().parent.parent)
+PARSER.add_argument("--output", type=Path, required=True)
+PARSER.add_argument("--mode", choices=("matrix", "frames", "catalog"), default="matrix")
+PARSER.add_argument("--samples", type=int, default=40)
+ARGS = PARSER.parse_args()
+if ARGS.samples < 1:
+    PARSER.error("--samples must be positive")
+ARGS.output.mkdir(parents=True, exist_ok=True)
+sys.path.insert(0, str(ARGS.source_root.resolve()))
+# Multiplexer variables are independent of HOME/config. Even headless pilots
+# must not inherit identifiers that could rename the operator's real workspace.
+for _key in tuple(os.environ):
+    if _key.startswith("CMUX_"):
+        del os.environ[_key]
+
+import scripts.probe_isolation as isolation  # noqa: E402
+
+# isort: split
+# Isolation must precede even the package root import.
+import local_operator  # noqa: E402
+from local_operator.harness.types import Message  # noqa: E402
+from local_operator.resume import SessionRow  # noqa: E402
+from local_operator.session.runtime.types import SessionRecord  # noqa: E402
+from local_operator.session.transcript import Transcript  # noqa: E402
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.session_catalog import CatalogEntry, load_catalog  # noqa: E402
+from local_operator.tui.widgets.assistant import AssistantBlock  # noqa: E402
+from local_operator.tui.widgets.transcript import UserBlock  # noqa: E402
+from scripts.visual_capture import save_capture  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+
+
+async def render_cell(count: int, opened: bool, streaming: bool) -> dict[str, Any]:
+    entries = [
+        CatalogEntry(
+            SessionRow(
+                f"{i + 1:012x}",
+                1788700000 - i * 60,
+                f"Background session {i}: investigate timeouts",
+                live_state="busy" if streaming else "idle",
+            )
+        )
+        for i in range(count)
+    ]
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    with (
+        patch("local_operator.tui.session_catalog.load_catalog", return_value=entries),
+        patch.object(app, "_prewarm_sidebar"),
+    ):
+        async with app.run_test(size=(150, 40)) as pilot:
+            await pilot.pause()
+            app._append_block(UserBlock("Investigate responsiveness with background sessions."))
+            block = AssistantBlock()
+            block.update_text("Profiling sidebar updates.")
+            app._append_block(block)
+            app._set_sidebar_open(opened)
+            await pilot.pause()
+            sidebar = app._session_sidebar
+            name = f"{count}-{int(opened)}-{int(streaming)}"
+            # Stable captures do not suppress animation during measurement.
+            if sidebar._timer is not None:
+                sidebar._timer.pause()
+            sidebar._frame = 0
+            sidebar.refresh()
+            await pilot.pause()
+            save_capture(app, str(ARGS.output / f"{name}-before.svg"))
+            if ARGS.mode == "frames":
+                # Fixed work, not fixed time: every tick must reach a painted
+                # frame before the next. This removes profiler/scheduler noise.
+                if app._sidebar_timer is not None:
+                    app._sidebar_timer.pause()
+                app._sidebar_refresh_generation += 1
+            else:
+                sidebar._sync_animation()
+            profiler = cProfile.Profile()
+            if ARGS.mode == "matrix":
+                profiler.enable()
+            with patch.object(sidebar, "render", wraps=sidebar.render) as renders:
+                cpu_start, wall_start = time.thread_time(), time.monotonic()
+                for i in range(ARGS.samples):
+                    if ARGS.mode == "frames":
+                        if streaming:
+                            sidebar._advance_spinner()
+                        else:
+                            sidebar.set_entries(entries)
+                        await pilot.pause()
+                    else:
+                        if streaming:
+                            block.update_text(
+                                "Profiling sidebar updates. "
+                                + "A live update remains visible. " * i
+                            )
+                        await asyncio.sleep(0.1)
+                cpu = time.thread_time() - cpu_start
+                wall = time.monotonic() - wall_start
+                render_count = renders.call_count
+            profiler.disable()
+            if ARGS.mode == "matrix":
+                profiler.dump_stats(str(ARGS.output / f"{name}.prof"))
+            if ARGS.mode == "frames" and streaming:
+                save_capture(app, str(ARGS.output / f"{name}-live.svg"))
+                sidebar._advance_spinner()
+                await pilot.pause()
+                save_capture(app, str(ARGS.output / f"{name}-next.svg"))
+            if sidebar._timer is not None:
+                sidebar._timer.pause()
+            sidebar._frame = 0
+            sidebar.refresh()
+            await pilot.pause()
+            save_capture(app, str(ARGS.output / f"{name}-after.svg"))
+            result = {
+                "mode": ARGS.mode,
+                "sessions": count,
+                "sidebar": opened,
+                "streaming": streaming,
+                "samples": ARGS.samples,
+                "loop_cpu_s": cpu,
+                "wall_s": wall,
+                "full_sidebar_renders": render_count,
+                "source": str(local_operator.__file__),
+            }
+            print(json.dumps(result), flush=True)
+            return result
+
+
+async def catalog_cell(count: int) -> dict[str, Any]:
+    root = isolation.SANDBOX / f"catalog-{count}"
+    run = root / "run/mobile"
+    run.mkdir(parents=True)
+    for i in range(count):
+        session_id = f"{i + 1:012x}"
+        transcript = Transcript(root / "sessions" / session_id)
+        await transcript.append_messages(
+            [
+                Message.user(f"Session {i} turn {j}: " + "representative history " * 20)
+                for j in range(1000)
+            ]
+        )
+        # All files reference THIS probe's pid, so registry.scan executes real
+        # liveness syscalls without probing unrelated processes. No control
+        # server is created; port zero cannot attach to an operator session.
+        record = SessionRecord(
+            os.getpid(), "tui", session_id, f"Fixture {i}", str(root), "synthetic", 0, "fixture"
+        )
+        (run / f"{i}.json").write_text(json.dumps(record.to_json()))
+    cpu_samples, wall_samples = [], []
+    for _ in range(ARGS.samples):
+        cpu, wall = time.thread_time(), time.monotonic()
+        rows = await asyncio.to_thread(load_catalog, root)
+        cpu_samples.append(time.thread_time() - cpu)
+        wall_samples.append(time.monotonic() - wall)
+        assert len(rows) == count
+    result = {
+        "mode": "catalog",
+        "sessions": count,
+        "messages_each": 1000,
+        "samples": ARGS.samples,
+        "median_wall_s": statistics.median(wall_samples),
+        "max_wall_s": max(wall_samples),
+        "median_loop_cpu_s": statistics.median(cpu_samples),
+        "max_loop_cpu_s": max(cpu_samples),
+        "source": str(local_operator.__file__),
+    }
+    print(json.dumps(result), flush=True)
+    return result
+
+
+async def main() -> None:
+    results = []
+    for count in (1, 10, 50):
+        if ARGS.mode == "catalog":
+            results.append(await catalog_cell(count))
+        else:
+            for streaming in (False, True):
+                for opened in ((True,) if ARGS.mode == "frames" else (False, True)):
+                    results.append(await render_cell(count, opened, streaming))
+    (ARGS.output / "results.json").write_text(json.dumps(results, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/unit/session/test_subagent_accounting.py
+++ b/tests/unit/session/test_subagent_accounting.py
@@ -23,7 +23,8 @@ from local_operator.tui.widgets.subagent_panel import job_stats
 #: Loop TURNS to allow the app's boot worker, not seconds. A turn count
 #: survives the contention a wall-clock budget does not (AGENTS.md, "Wait on
 #: the event, never on the clock"), and the only test here that drives a real
-#: ``OperatorApp`` needs the band mounted before it can assert on the ledger.
+#: ``OperatorApp`` needs its band mounted AND its session adopted before it
+#: can assert on that session's ledger.
 MAX_BOOT_TURNS = 200
 
 
@@ -203,21 +204,19 @@ async def test_rendered_footer_uses_whole_owner_ledger():
     from local_operator.tui.app import OperatorApp
     from tests.unit.tui.test_app_pilot import FakeSession, _factory
 
-    app = OperatorApp(lambda: _factory(FakeSession()))
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(120, 40)) as pilot:
-        # Wait for the BAND to exist, not for a fixed number of pauses.
-        # ``_apply_frontend_state`` returns early while ``_status`` is None, so
-        # a single pause asserts nothing about the ledger on a machine where
-        # boot has not finished within one loop turn — the total simply stays
-        # 0.0 and the failure names the cost rather than the race. Idle, one
-        # pause is enough (measured); under CI shard load it is not, which is
-        # how this went red on a branch that only ever ADDED unrelated test
-        # files: file-index sharding moved this test to a busier shard.
+        # The band mounts BEFORE the asynchronous factory finishes. Applying
+        # money at that point writes the placeholder interaction's ledger;
+        # adoption correctly replaces it with the new session's empty ledger
+        # on the next yield. Wait for the actual owner as well as the band,
+        # not a fixed delay or merely the existence of the rendered widget.
         for _ in range(MAX_BOOT_TURNS):
             await pilot.pause()
-            if app._status is not None:
+            if app._status is not None and app._session is session:
                 break
-        assert app._status is not None, "the band never mounted"
+        assert app._status is not None and app._session is session, "session never adopted"
         state = FrontendSessionState(
             epoch="money",
             session_id="money",

--- a/tests/unit/tui/test_sidebar_repaint.py
+++ b/tests/unit/tui/test_sidebar_repaint.py
@@ -1,0 +1,218 @@
+"""Steady-state paints are bounded by changed cells, not catalog poll count."""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import replace
+from unittest.mock import patch
+
+import pytest
+from textual.geometry import Region
+
+from local_operator.resume import SessionRow
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.session_catalog import CatalogEntry
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+@pytest.fixture(autouse=True)
+def isolated_sidebar(tmp_path, monkeypatch):
+    for key in tuple(os.environ):
+        if key.startswith("CMUX_"):
+            monkeypatch.delenv(key)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_NOTIFICATIONS", "1")
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_TERMINAL_TITLE", "1")
+    monkeypatch.setattr(OperatorApp, "_check_for_update", lambda self: None)
+    monkeypatch.setattr(OperatorApp, "_prewarm_sidebar", lambda self, entries: None)
+
+
+async def prepare(app, pilot, entries):
+    await pilot.pause()
+    app._set_sidebar_open(True)
+    # Retire both the immediate read and future timer reads before installing
+    # synthetic rows; a real empty catalog must not overwrite this fixture.
+    app._sidebar_timer.pause()
+    app._sidebar_refresh_generation += 1
+    sidebar = app._session_sidebar
+    sidebar.set_entries(entries)
+    sidebar._timer.stop()
+    sidebar._timer = None
+    await pilot.pause()
+    return sidebar
+
+
+@pytest.mark.asyncio
+async def test_identical_catalog_does_not_invalidate_rendered_frame():
+    entries = [CatalogEntry(SessionRow("aaaaaaaaaaa1", 940, "One", live_state="idle"))]
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    with patch("local_operator.tui.widgets.session_sidebar.time.time", return_value=1000):
+        async with app.run_test(size=(150, 40)) as pilot:
+            sidebar = await prepare(app, pilot, entries)
+            with patch.object(sidebar, "refresh", wraps=sidebar.refresh) as refresh:
+                for _ in range(50):
+                    # Fresh objects, not object identity, determine no-op polls.
+                    sidebar.set_entries(
+                        [replace(entry, row=entry.row._replace()) for entry in entries]
+                    )
+                refresh.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_changes_and_age_still_invalidate_immediately():
+    entry = CatalogEntry(SessionRow("aaaaaaaaaaa1", 940, "One", live_state="idle"))
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    with patch("local_operator.tui.widgets.session_sidebar.time.time", return_value=1000) as clock:
+        async with app.run_test(size=(150, 40)) as pilot:
+            sidebar = await prepare(app, pilot, [entry])
+            # Include tooltip-only metadata; a new field must not silently
+            # bypass invalidation because somebody listed only painted fields.
+            changed = [
+                replace(entry, row=entry.row._replace(name="Renamed")),
+                replace(entry, row=entry.row._replace(pending="ask")),
+                replace(entry, row=entry.row._replace(live_state="busy")),
+                replace(entry, row=entry.row._replace(wakes=2)),
+                replace(entry, unseen=True),
+                replace(entry, completion_kind="error"),
+                replace(entry, completion_token="new-token"),
+            ]
+            for fresh in changed:
+                sidebar.set_entries([entry])
+                await pilot.pause()
+                with patch.object(sidebar, "refresh", wraps=sidebar.refresh) as refresh:
+                    sidebar.set_entries([fresh])
+                    refresh.assert_called()
+                await pilot.pause()
+            sidebar.set_entries([entry])
+            await pilot.pause()
+            for attribute, value in (("current_id", entry.id), ("cursor_id", entry.id)):
+                setattr(sidebar, attribute, "")
+                sidebar.refresh()
+                await pilot.pause()
+                setattr(sidebar, attribute, value)
+                with patch.object(sidebar, "refresh", wraps=sidebar.refresh) as refresh:
+                    sidebar.set_entries([entry])
+                    refresh.assert_called()
+                await pilot.pause()
+            sidebar.show_error("Read failed")
+            await pilot.pause()
+            with patch.object(sidebar, "refresh", wraps=sidebar.refresh) as refresh:
+                sidebar.set_entries([entry])
+                refresh.assert_called()
+            await pilot.pause()
+            clock.return_value = 1060
+            with patch.object(sidebar, "refresh", wraps=sidebar.refresh) as refresh:
+                sidebar.set_entries([entry])
+                refresh.assert_called()
+            await pilot.pause()
+            assert "2m" in sidebar.render().plain
+            sidebar.set_entries([])
+            await pilot.pause()
+            assert "No conversations yet" in sidebar.render().plain
+
+
+@pytest.mark.asyncio
+async def test_spinner_repaints_only_visible_animated_cells_and_age_boundary():
+    entries = [
+        CatalogEntry(SessionRow("aaaaaaaaaaa1", 940, "Working", live_state="busy")),
+        CatalogEntry(SessionRow("aaaaaaaaaaa2", 939, "Idle", live_state="idle")),
+        CatalogEntry(SessionRow("aaaaaaaaaaa3", 938, "Question", live_state="busy", pending="ask")),
+    ]
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    with patch("local_operator.tui.widgets.session_sidebar.time.time", return_value=1000) as clock:
+        async with app.run_test(size=(150, 40)) as pilot:
+            sidebar = await prepare(app, pilot, entries)
+            rows = sidebar._display_rows()
+            title = 0 if sidebar._draws_section_headers(rows) else 1
+            busy_y = next(
+                y for y, (_, row) in enumerate(rows, title) if row and row.id == entries[0].id
+            )
+            before = sidebar._painted_lines[busy_y].text
+            with (
+                patch.object(sidebar, "refresh", wraps=sidebar.refresh) as refresh,
+                patch.object(sidebar, "render", wraps=sidebar.render) as render,
+            ):
+                sidebar._advance_spinner()
+                refresh.assert_called_once_with(Region(2, busy_y, 1, 1))
+                await pilot.pause()
+                render.assert_not_called()
+            after = sidebar._painted_lines[busy_y].text
+            assert before != after
+            assert before[:2] == after[:2] and before[3:] == after[3:]
+            assert "Working" in after
+            clock.return_value = 1060
+            with patch.object(sidebar, "refresh", wraps=sidebar.refresh) as refresh:
+                sidebar._advance_spinner()
+                refresh.assert_called_once_with()
+            await pilot.pause()
+            assert "2m" in sidebar.render().plain
+
+
+@pytest.mark.asyncio
+async def test_cached_strips_match_full_render_across_navigation_and_styles():
+    entries = [
+        CatalogEntry(SessionRow(f"{i + 1:012x}", 940 - i, f"Working {i}", live_state="busy"))
+        for i in range(50)
+    ]
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    with patch("local_operator.tui.widgets.session_sidebar.time.time", return_value=1000):
+        async with app.run_test(size=(150, 40)) as pilot:
+            sidebar = await prepare(app, pilot, entries)
+
+            async def assert_equivalent():
+                sidebar._advance_spinner()
+                await pilot.pause()
+                cached = {y: tuple(strip) for y, strip in sidebar._painted_lines.items()}
+                sidebar.refresh()
+                await pilot.pause()
+                full = {y: tuple(strip) for y, strip in sidebar._painted_lines.items()}
+
+                # Strip segmentation may differ after joining a replaced cell;
+                # compare each cell's glyph/style, not incidental segment runs.
+                def cells(lines):
+                    return {
+                        y: [(char, segment.style) for segment in segments for char in segment.text]
+                        for y, segments in lines.items()
+                    }
+
+                assert cells(cached) == cells(full)
+
+            await assert_equivalent()
+            sidebar.focus()
+            sidebar.current_id = entries[0].id
+            sidebar._set_hover(2)
+            sidebar.refresh()
+            await pilot.pause()
+            await assert_equivalent()
+            sidebar._scroll(1)
+            await pilot.pause()
+            await assert_equivalent()
+            idle = CatalogEntry(SessionRow("bbbbbbbbbbbb", 1000, "Idle request", live_state="idle"))
+            sidebar.set_entries([idle, *entries])
+            sidebar._offset = 0
+            sidebar.requested_id = idle.id
+            sidebar._requested_at = time.monotonic() + 1000
+            sidebar.refresh()
+            await pilot.pause()
+            # The delay expiring changes the glyph AND its ink. Reusing the
+            # previous cell's dim style would produce an incorrectly styled
+            # opening spinner even though its character advances correctly.
+            sidebar._requested_at = -1000
+            with patch.object(sidebar, "render", wraps=sidebar.render) as render:
+                sidebar._advance_spinner()
+                await pilot.pause()
+                assert render.call_count > 0
+            await assert_equivalent()
+            # A style invalidation queued immediately before a tick must win:
+            # equal catalog data is not proof that the old strips are reusable.
+            sidebar.styles.color = "red"
+            with patch.object(sidebar, "render", wraps=sidebar.render) as render:
+                sidebar._advance_spinner()
+                await pilot.pause()
+                assert render.call_count > 0
+            await assert_equivalent()
+            await pilot.resize_terminal(80, 24)
+            await pilot.pause()
+            await assert_equivalent()


### PR DESCRIPTION
## Summary of changes

Reduce repeated work while the session sidebar remains open, without lowering catalog freshness or animation cadence.

**Change class: C2, standard/pre-authorized.** No wire/API, configuration, dependency, authorization, or interaction changes. **Release: patch.** No version bump in this PR.

### Delivery contract

- Identical catalog snapshots do not repaint an unchanged frame; changed rows, count, current/cursor/hover, error recovery, request-spinner delay and time-derived ages remain immediately invalidated.
- An ordinary spinner tick replaces only the visible spinner cells. It does not reconstruct the whole Rich sidebar or repaint titles, footer, and empty space.
- An ordinary refresh (including pending theme/style, layout, resize and focus changes) always wins over cached spinner strips.
- The existing catalog poll interval and foreground/background spinner intervals are unchanged. No token/state updates are dropped, delayed, or coalesced differently.
- Cached rendered strips remain viewport-sized. Existing ordering, selection, hover styling, opening indicators and dock geometry are preserved.

**Non-goals:** session-switch preparation/leases/readiness; owner canonical-history reconstruction; daemon queues and projection broadcast; new executors; timeout increases; cosmetic redesign. Those are independently owned investigations. This PR does not claim to resolve every reported hang or to reproduce a multi-second freeze.

### Implementation

`SessionSidebar` records a complete immutable catalog/presentation key, including displayed age and the delayed-request-spinner phase. Equal polls still adopt fresh summaries and update tooltip state but do not invalidate content. On spinner-only ticks, its public `render_line` seam reuses content strips and replaces the glyph cell while retaining its resolved style. Every normal refresh invalidates this narrow fast path. No Textual private render/compositor cache is mutated.

Why not just smaller dirty rectangles? I measured that first: Textual's default `Widget.render_line` rebuilds the entire Rich content on any dirty cell. Narrow dirty regions alone did not materially improve the 50-busy-row case. Reusing unchanged strips removes that reconstruction as well.

## Reproduction and measured outcome

All application experiments scrub **every** `CMUX_*` variable, redirect **both HOME and LOCAL_OPERATOR_CONFIG_DIR**, and use synthetic session IDs. No requests to live owners, provider calls, or changes to operator configuration.

First profiled the assembled `OperatorApp`, real stylesheet and compositor, at 150×40: **1/10/50 sessions × sidebar open/closed × idle/10Hz assistant streaming**. List-render measurements use synthetic catalog summaries and suppress only speculative prewarm, explicitly separating list rendering from attach work. Catalog filesystem work is measured separately below.

For CPU attribution, three interleaved baseline/current runs used a fixed workload of **40 ticks or unchanged polls**, awaiting each rendered frame, with no profiler. These are CPU per equal work, not claims about seconds of production idle time:

| Sessions | Work | Before median loop CPU | After median loop CPU | Reduction |
|---:|---|---:|---:|---:|
| 1 | unchanged polls | 185.55 ms | 59.61 ms | 67.9% |
| 10 | unchanged polls | 178.54 ms | 56.94 ms | 68.1% |
| 50 | unchanged polls | 214.90 ms | 65.09 ms | 69.7% |
| 1 | spinner ticks | 174.75 ms | 87.44 ms | 50.0% |
| 10 | spinner ticks | 178.73 ms | 97.63 ms | 45.4% |
| 50 | spinner ticks | 229.77 ms | 140.89 ms | 38.7% |

**Structural result: 40 full sidebar Rich renders before → 0 after in every fixed-work cell.** This is the deterministic regression assertion; laptop CPU numbers are not CI thresholds. The before source is `4433b7e8b5eb714afc6efc4f40d5406529177020`.

The ordinary-cadence 12-cell matrix also completed. The final 50-row open/streaming cell spent 346.1 ms loop CPU over 4.09 s, with zero full sidebar renders. Do not attribute the entire difference between open/closed to sidebar painting: opening also narrows the transcript and changes wrapping.

### Real catalog reads, not an in-memory stand-in

The collector probe creates actual JSONL histories (1,000 messages each), registry records and attention storage. It calls the production `load_catalog` through `asyncio.to_thread`, including real liveness syscalls against the probe's own PID only. Thirty samples per cell:

| Sessions | Median wall | Maximum wall | Median event-loop CPU |
|---:|---:|---:|---:|
| 1 | 0.477 ms | 2.579 ms | 0.069 ms |
| 10 | 1.293 ms | 5.390 ms | 0.086 ms |
| 50 | 4.226 ms | 19.369 ms | 0.067 ms |

An earlier cold-import probe measured a 433 ms first read, also off-loop. Neither probe establishes a catalog-driven event-loop hang. This PR changes no collector or executor behavior.

### Reproduce

```sh
# Harness isolates HOME/config and removes all CMUX_* variables itself.
.venv/bin/python scripts/sidebar_performance.py --mode matrix --output /tmp/sidebar-matrix
.venv/bin/python scripts/sidebar_performance.py --mode catalog --samples 30 --output /tmp/sidebar-catalog
.venv/bin/python scripts/sidebar_performance.py --mode frames --samples 40 --output /tmp/sidebar-after
# The same harness against a separate clean baseline checkout:
.venv/bin/python scripts/sidebar_performance.py --source-root /path/to/baseline-worktree --mode frames --samples 40 --output /tmp/sidebar-before
```

Results carry the actual imported source path. Profile files, native SVGs, consecutive animation frames, and geometry JSON are written beside `results.json`; generated evidence is not committed.

## Correctness and visual evidence

- New deterministic tests cover 50 identical fresh-object snapshots, changed row metadata/count/status/attention, current/cursor changes, error recovery, age rollover, sparse animated-cell invalidation and no full Rich rendering.
- Cached glyph/style cells are compared against a forced full render after focus, hover, current/requested changes, scrolling, delayed request activation, pending style invalidation and resize.
- Mutation proof restored each original method **in memory only**. The no-op test fails with `refresh called 50 times`; the spinner test fails because baseline requests a full refresh rather than `Region(x=2, y=3, width=1, height=1)`.
- Rendered and inspected before/after PNGs: all six pairs (1/10/50 × idle/busy) are **pixel-identical**, with identical geometry. Native 1200×680 at 150×40; sidebar content 43×38 (47×38 including padding), conversation 101×38, no sidebar or screen scrollbars.
- Consecutive cached animation frames differ only in spinner pixels, bounding box `(32, 56, 35, 639)`; no reflow. Loading, empty and error states were also rendered and inspected.

**Image attachment limitation:** current browser tooling exposes no file-upload mechanism and no existing evidence host was available. Images are not remotely attached; no fake links or repository evidence artifacts. Independent design review receives local PNGs `/tmp/sidebar-review/{before,after}-{1,10,50}-{0,1}.png`, `after-50-{live,next}.png`, and `{loading,loading-next,empty,error}.png`. Geometry is under `/tmp/sidebar-fixed-3-{before,after}/*.geometry.json`. This limitation is explicit rather than presenting local paths as GitHub attachments.

## Validation gates

- Whole-tree flake8, pinned Black 26.1.0, isort 5.13.2, pyright: **PASS**.
- Targeted sidebar suite: **64 passed** before final delayed-request guard; final four focused regressions **4 passed** afterward. Independent reviewer reran the complete targeted suite: **65 passed**.
- Complete unit invocation: **16,189 passed, 18 skipped, 3 failed, 1 setup error** in 28m06s. This is **not** presented as a green full run. The three terminal-title tests were disabled by my overly broad `LOCAL_OPERATOR_NO_TERMINAL_TITLE=1` runner environment. All three exact failures reproduced on clean `4433b7e8` under that environment. Removing title/notification suppression while keeping HOME/config isolation and all CMUX variables scrubbed gives **4 passed** on baseline and **4 passed** on this head for the four affected cases. The fourth case initially failed while discovering a copied uv interpreter's libpython; its actual library probe subsequently returned rc=0 with valid paths on all three A/B runs. That setup failure did not reproduce and is **not** assigned a speculative cause. No test or product code was changed to bypass it. This draft PR requires a fresh green **whole CI unit/e2e invocation before merge**, not a skip or waiver.
- Assembled `tests/e2e -m e2e -n0`: **49 passed**, also independently repeated by QA.
- Independent [code review](https://github.com/damianvtran/local-operator/pull/787#issuecomment-5579210741), [QA report](https://github.com/damianvtran/local-operator/pull/787#issuecomment-5579209106), and [design review](https://github.com/damianvtran/local-operator/pull/787#issuecomment-5579210370) are **clean and TERMINAL** on `c5417e00a36b54caf04ae09f8c1acbad2492981d`. The author has posted all three no-findings remediation acknowledgments. Independent QA includes the actual **49 passed** assembled e2e run and 21 transition scenarios. The first CI run exposed a baseline-reproducible footer-test startup race, fixed in test-only commit `05675609186873524ffbe422e6180d089780fb39`: wait for the specific FakeSession to be adopted, not merely its band to mount. The identical controlled delayed-factory schedule now passes; affected accounting and sidebar suites total **94 passed**. [Code round 2](https://github.com/damianvtran/local-operator/pull/787#issuecomment-5579450726) and [QA round 2](https://github.com/damianvtran/local-operator/pull/787#issuecomment-5579454598) are clean and TERMINAL for `c5417e00..05675609`, with both author remediation acknowledgments posted. The design round remains fresh because production output is unchanged. Fresh whole CI must still finish green before merge.

## Risk, rollout and rollback

The reachable risk is a stale or incorrectly styled sidebar cell, not owner/session data. The fast path is restricted to a fully painted, unchanged presentation and normal refresh invalidates it before reuse. Revert this commit to restore the previous renderer. There are no migrations or persistent settings to roll back. No live runtime update or release is performed in this PR phase.
