### PR TITLE
fix(failover): skip identical primary effort during quota preflight

### DIFF
--- a/local_operator/guides/failover/GUIDE.md
+++ b/local_operator/guides/failover/GUIDE.md
@@ -186,6 +186,11 @@ failing model's id.
 A target is either a legacy `provider/model` string or a mapping with
 `provider`, `model`, and optional `effort`. The mapping form is what lets a
 chain re-list the *current* model at a different effort as a real route.
+An entry without an effort that names the primary is skipped, so a shared
+`default` chain can safely contain models you also select as primary. When the
+primary effort is known, quota preflight and the stream also skip an explicitly
+identical effort; a genuinely different effort stays a separate route. Account
+rotation still happens within each route before descending the chain.
 
 `enabled: false` or `modelFallback: false` switches the cascade off entirely —
 `/failovers` names whichever of the two did it.

--- a/local_operator/model/configure.py
+++ b/local_operator/model/configure.py
@@ -2987,7 +2987,7 @@ class SessionStreamFn:
             return []
         selector = f"{model.provider}/{model.model_id}"
         chain = resolve_chain(selector, retry.fallback_chains)
-        return expand_fallback_targets(selector, chain or [])
+        return expand_fallback_targets(selector, chain or [], primary_effort=model.reasoning_effort)
 
     async def _target_has_auth(self, target: Any) -> bool:
         from local_operator.providers.failover import parse_selector

--- a/local_operator/providers/failover.py
+++ b/local_operator/providers/failover.py
@@ -1343,12 +1343,16 @@ def _fallback_target(entry: Any) -> FallbackTarget | None:
     return FallbackTarget(selector=selector, effort=effort)
 
 
-def expand_fallback_targets(selector: str, chain: Sequence[Any]) -> list[FallbackTarget]:
+def expand_fallback_targets(
+    selector: str, chain: Sequence[Any], *, primary_effort: str | None = None
+) -> list[FallbackTarget]:
     """Materialize configured entries into unique provider/model/effort targets.
 
     ``provider/*`` keeps the failing model id. A mapping may explicitly repeat
     the current selector with a different effort; that is a real fallback
-    route, while an unchanged legacy string is still suppressed.
+    route, while an unchanged legacy string is still suppressed. Callers that
+    know the selected effort pass it so quota preflight and the stream agree:
+    an explicitly identical effort is not another route to spend or pin.
     """
     _, _, bare_id = selector.partition("/")
     targets: list[FallbackTarget] = []
@@ -1358,7 +1362,7 @@ def expand_fallback_targets(selector: str, chain: Sequence[Any]) -> list[Fallbac
             continue
         if target.selector.endswith("/*"):
             target = dataclasses.replace(target, selector=f"{target.selector[:-1]}{bare_id}")
-        if target.selector == selector and target.effort is None:
+        if target.selector == selector and target.effort in (None, primary_effort):
             continue
         if target not in targets:
             targets.append(target)
@@ -2338,7 +2342,9 @@ async def stream_with_failover(
     if retry.enabled and retry.model_fallback:
         chain = resolve_chain(primary_selector, retry.fallback_chains)
         if chain:
-            for candidate in expand_fallback_targets(primary_selector, chain):
+            for candidate in expand_fallback_targets(
+                primary_selector, chain, primary_effort=request.model.reasoning_effort
+            ):
                 if candidate not in targets:
                     targets.append(candidate)
     # The list as CONFIGURED, kept before the route-state trim below: the

--- a/tests/unit/providers/test_primary_in_cascade.py
+++ b/tests/unit/providers/test_primary_in_cascade.py
@@ -1,0 +1,227 @@
+"""A shared cascade can include the selected model without inventing a hop."""
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from local_operator.harness.types import (
+    ChatRequest,
+    ModelSpec,
+    StreamEndEvent,
+    StreamTextDelta,
+)
+from local_operator.model.configure import build_model_spec, create_stream_fn
+from local_operator.providers.auth_store import AuthStore
+from local_operator.providers.clients import AnthropicClient, OpenAICompatClient
+from local_operator.providers.failover import (
+    FailoverRouteState,
+    FallbackTarget,
+    ProviderError,
+    stream_with_failover,
+)
+from tests.unit.providers.test_failover import FakeAuth, ScriptedClient
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("effort", ["low", "high", "max"])
+async def test_preflight_skips_explicit_primary_effort(tmp_path, effort) -> None:
+    """Quota reserve must buy another route, not re-pin the route it just left."""
+    store = AuthStore(tmp_path / "auth.db")
+    selector = "anthropic/claude-opus-5"
+    stream = create_stream_fn(
+        store,
+        {
+            "retry": {
+                "fallbackChains": {
+                    "default": [
+                        selector,
+                        {"provider": "anthropic", "model": "claude-opus-5"},
+                        {"provider": "anthropic", "model": "*", "effort": effort},
+                        {"provider": "anthropic", "model": "claude-opus-5", "effort": effort},
+                        {"provider": "anthropic", "model": "claude-opus-5", "effort": "medium"},
+                        "openai/gpt-6-astra",
+                    ]
+                }
+            }
+        },
+        session_id="synthetic-primary-cascade",
+    )
+    model = ModelSpec(provider="anthropic", model_id="claude-opus-5", reasoning_effort=effort)
+    try:
+        with (
+            patch.object(stream, "_target_has_auth", AsyncMock(return_value=True)),
+            patch.object(stream, "_provider_quota_availability", AsyncMock(return_value="usable")),
+        ):
+            target = await stream._first_available_fallback(model, reserve_percent=10)
+        assert target == FallbackTarget(selector, "medium")
+        assert stream._fallback_targets(model) == [
+            FallbackTarget(selector, "medium"),
+            FallbackTarget("openai/gpt-6-astra"),
+        ]
+    finally:
+        await stream.close()
+        store.close()
+
+
+@pytest.mark.asyncio
+async def test_different_effort_remains_a_pinned_stream_route() -> None:
+    seen: list[str | None] = []
+
+    async def client_for(spec):
+        seen.append(spec.reasoning_effort)
+        if spec.reasoning_effort == "high":
+            return ScriptedClient(ProviderError(None, "route unavailable"))
+        return ScriptedClient(
+            [StreamTextDelta(delta="lower effort"), StreamEndEvent(stop_reason="stop")]
+        )
+
+    model = build_model_spec("anthropic", "claude-opus-5").model_copy(
+        update={"reasoning_effort": "high"}
+    )
+    settings = {
+        "retry": {
+            "fallbackChains": {
+                "default": [
+                    "anthropic/claude-opus-5",
+                    {"provider": "anthropic", "model": "claude-opus-5", "effort": "high"},
+                    {"provider": "anthropic", "model": "claude-opus-5", "effort": "low"},
+                    {"provider": "anthropic", "model": "claude-opus-5", "effort": "low"},
+                ]
+            }
+        }
+    }
+    route = FailoverRouteState()
+    for _ in range(2):
+        events = [
+            event
+            async for event in stream_with_failover(
+                ChatRequest(model=model),
+                FakeAuth({"anthropic": ["synthetic"]}),
+                settings,
+                client_for,
+                route_state=route,
+            )
+        ]
+        assert any(
+            isinstance(event, StreamTextDelta) and event.delta == "lower effort" for event in events
+        )
+    assert seen == ["high", "low", "low"]
+    assert route.active == FallbackTarget("anthropic/claude-opus-5", "low")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("primary", ["openai/gpt-6-astra", "anthropic/claude-opus-5"])
+async def test_shared_cascade_over_real_http(primary) -> None:
+    """Exercise both wire adapters and sibling rotation without paid provider calls.
+
+    The server refuses every account on the primary. Re-listing that primary in
+    either config syntax must not spend another request or obscure the next hop.
+    Only synthetic credentials cross this loopback socket.
+    """
+    requests: list[tuple[str, str]] = []
+    primary_provider, primary_model = primary.split("/", 1)
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, format: str, *args) -> None:
+            pass
+
+        def do_POST(self) -> None:
+            payload = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            model = payload["model"]
+            account = self.headers.get("x-api-key") or self.headers.get("Authorization", "")
+            requests.append((model, account))
+            if model == primary_model:
+                status = 403
+                body = json.dumps({"error": {"message": "account denied"}}).encode()
+            else:
+                status = 200
+                if model == "claude-opus-5":
+                    events = [
+                        ("message_start", {"message": {"usage": {"input_tokens": 1}}}),
+                        (
+                            "content_block_delta",
+                            {"index": 0, "delta": {"type": "text_delta", "text": "served"}},
+                        ),
+                        (
+                            "message_delta",
+                            {"delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 1}},
+                        ),
+                        ("message_stop", {}),
+                    ]
+                    body = "".join(
+                        f"event: {kind}\ndata: {json.dumps({'type': kind, **data})}\n\n"
+                        for kind, data in events
+                    ).encode()
+                else:
+                    body = (
+                        b'data: {"choices":[{"delta":{"content":"served"},'
+                        b'"finish_reason":null}]}\n\ndata: [DONE]\n\n'
+                    )
+            self.send_response(status)
+            self.send_header(
+                "Content-Type", "text/event-stream" if status == 200 else "application/json"
+            )
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    url = f"http://127.0.0.1:{server.server_port}"
+    chain = [
+        {"provider": "anthropic", "model": "claude-opus-5"},
+        "anthropic/claude-opus-5",
+        {"provider": primary_provider, "model": primary_model, "effort": "high"},
+        {"provider": "zai", "model": "glm-5.3"},
+        primary,
+    ]
+    keys = {
+        "openai": ["synthetic-openai"],
+        "anthropic": ["synthetic-anthropic"],
+        "zai": ["synthetic-zai"],
+    }
+    keys[primary_provider] = ["synthetic-first", "synthetic-second"]
+    auth = FakeAuth(keys)
+    try:
+        async with httpx.AsyncClient() as http:
+
+            async def client_for(spec):
+                if spec.provider == "anthropic":
+                    return AnthropicClient(url, http_client=http)
+                return OpenAICompatClient(url, http_client=http)
+
+            model = build_model_spec(primary_provider, primary_model).model_copy(
+                update={"reasoning_effort": "high"}
+            )
+            events = [
+                event
+                async for event in stream_with_failover(
+                    ChatRequest(model=model),
+                    auth,
+                    {"retry": {"maxRetries": 0, "fallbackChains": {"default": chain}}},
+                    client_for,
+                )
+            ]
+        assert any(
+            isinstance(event, StreamTextDelta) and event.delta == "served" for event in events
+        )
+        next_model = "claude-opus-5" if primary_provider == "openai" else "glm-5.3"
+        assert [model for model, _ in requests] == [primary_model, primary_model, next_model]
+        assert requests[0][1] != requests[1][1]
+        assert auth.rotations == [
+            (primary_provider, "synthetic-first"),
+            (primary_provider, "synthetic-second"),
+        ]
+        print(
+            f"{primary}: wire models={[model for model, _ in requests]}; "
+            "accounts rotated=2; output=served"
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()


### PR DESCRIPTION
## Outcome

A shared failover cascade may contain the currently selected model without treating an identical effort as another quota-preflight route. Selecting Opus 5 later must not turn the Opus-first cascade into a self hop.

**C2 — standard/pre-authorized.** This PR is the record; no tracker was requested.

Release: patch — quota preflight skips a cascade entry that repeats the selected model at its current effort, while retaining genuinely different-effort routes and account rotation.

## Diagnosis and change

The installed runtime already suppresses unqualified self entries, and the stream already deduplicates the exact primary `(selector, effort)` pair. Quota preflight did not know the primary effort when expanding the chain: an explicit same-effort entry could be selected instead of the next real route.

- Extend the shared target expander with optional `primary_effort` context.
- Pass the selected model's effort from quota preflight and the stream.
- Preserve legacy two-argument expansion, wildcard substitution, intentional different-effort entries, ordering, and within-provider account rotation.
- Document the self-entry contract in the failover guide.

**Acceptance:** an Astra primary walks to Opus after its accounts are exhausted; an Opus primary skips redundant Opus entries and reaches the next provider; explicit identical-effort entries do not capture quota preflight; genuinely different effort remains routable and pinned for subsequent calls in the same message.

**Non-goals:** changing the selected/default model, provider transports, retry/rotation policy, session model journaling, any UI layout/copy/interaction, or version/release mechanics. No version bump.

## Safe local configuration (not part of the git diff)

The operator-authorized effective config edit prepended only the unqualified `anthropic/claude-opus-5` route. The installed model registry confirmed the canonical selector. Full parsed-document equality before/after verified every other value was preserved; selected/default remains `openai/gpt-6-astra`.

Installed-runtime expansion after the edit:

```text
Astra -> Opus 5 -> GLM 5.3 -> Kimi K3 -> Qwen 3.8 Max -> Grok 4.6 -> Sol
Opus 5 primary -> GLM 5.3 -> Kimi K3 -> Qwen 3.8 Max -> Grok 4.6 -> Sol
```

This unqualified configuration is safe on the currently installed runtime; it does not depend on this patch shipping. No paid provider request or credential value was printed. No installation was changed.

## Verification

All TUI/fork-capable test invocations use a fresh `HOME` and `LOCAL_OPERATOR_CONFIG_DIR`, remove every inherited `CMUX_*` variable, unset `NO_COLOR`, and set `TERM=xterm-256color`. Tests use synthetic session IDs and credentials.

### Reproduction

Before the fix, `test_preflight_skips_explicit_primary_effort[low/high/max]` failed 3/3: quota preflight returned the identical effort instead of the intended `medium` route. With the fix, all three pass.

### Real local wire path

`tests/unit/providers/test_primary_in_cascade.py` starts a real loopback HTTP server and drives `stream_with_failover` through `OpenAICompatClient` and `AnthropicClient`. The primary returns HTTP 403 for both synthetic accounts; the next provider returns protocol-correct SSE. Requests actually cross a socket (not `MockTransport`).

```text
openai/gpt-6-astra: wire models=['gpt-6-astra', 'gpt-6-astra', 'claude-opus-5']; accounts rotated=2; output=served
anthropic/claude-opus-5: wire models=['claude-opus-5', 'claude-opus-5', 'glm-5.3']; accounts rotated=2; output=served
6 passed
```

The other stream case verifies an intentional high→low same-model hop, duplicate low-entry removal, and low remaining pinned for the next call (`high, low, low`). This case uses scripted clients to induce a route-specific failure without invalidating the shared account.

These are controlled local provider responses, **not** a claim of live Anthropic/OpenAI availability or quota. Tenant scoping is not part of this routing contract. Existing account/quota and assembled application tests supply adjacent regression coverage.

### Required gates

| Command | Actual result |
| --- | --- |
| `.venv/bin/python -m flake8 .` | PASS, no findings |
| `uvx --from black==26.1.0 black --check .` | PASS, 1,076 files unchanged |
| `uvx isort==5.13.2 --check .` | PASS |
| `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | PASS, 0 errors / 0 warnings |
| `.venv/bin/python -m pytest tests/unit/providers/test_primary_in_cascade.py -n0 -q -s` | 6 passed |
| `.venv/bin/python -m pytest tests/unit -q` | **1 failed, 16,226 passed, 18 skipped** in 2,156s |
| `.venv/bin/python -m pytest tests/unit/tui/test_welcome.py::test_a_fresh_view_opens_on_the_first_tip_and_only_then_varies -n0 -q` | Isolated rerun: **1 passed** in 7.73s |
| `.venv/bin/python -m pytest tests/e2e -m e2e -n0 -q` | **49 passed** in 77.83s |

The full suite was **not green**: its one failure was the unchanged welcome animation test expecting tip 0 but observing the next tip under heavy concurrent-suite contention. The test and welcome implementation have no diff from the base. An isolated rerun passed; that does not erase the original failure or establish that the flake is fixed. No unrelated UI change was made. The initial lint/type feedback in the new test file was corrected before these final static-gate results; one typing rerun exceeded its external 120s limit under contention and the completed rerun above passed.

## Rollout and review

No migration and no default change. Roll back the code by reverting this commit; the separately authorized unqualified Opus-first configuration remains safe without it. Backend routing only: no renderer, text, interaction, or visual artifact changed.

Draft pending independent agent review and independent QA. Manager owns those rounds and disposition. **Do not merge or release from this implementation handoff.**
