### PR TITLE
chore(release): bump version to 0.51.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.17"
+version = "0.51.18"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Summary and release lock

Owner parent runtime pid: **95645**. Owner session: **9c0e372c878a**. Release execution is delegated to **release-manager**; the implementing coder does not merge, tag, publish, or install.

This draft PR is the release-window lock for **0.51.18**, following the latest tag **v0.51.17**. Change class: **C0, standard/pre-authorized**, release metadata only. The parent request covers the release; independent review and release-manager verification still gate it.

Release: patch — /session stops reporting healthy requests and excluded nested calls as failures, and shows an explicit model tool-call error rate

## Release window

- [x] #788 — merge SHA `8704040431fbc8a13a35a31332fc8ee461e224cd`
  - Release: patch — quota preflight skips a cascade entry that repeats the selected model at its current effort, while retaining genuinely different-effort routes and account rotation.

- [x] #768 — merge SHA `07bb350544699a692dc99854df94cf9d82a4f125`
  - Release: patch — Linux browser-bridge installs now log where the product says they do, fail with actionable messages instead of tracebacks, and no longer collide with another config root's daemon.
  - Coverage: macOS and simulated Linux CLI; native systemd/journald/persistence remain unverified. No live bridge lifecycle operations are part of this release smoke.

- [x] #763 — merge SHA `4fe92133686828fa6401355fc6db91fb1d05cd42`
  - Release: patch — /session stops reporting healthy requests and excluded nested calls as failures, and shows an explicit model tool-call error rate

Fresh `origin/main` was exactly `4fe92133686828fa6401355fc6db91fb1d05cd42`; plain `git log v0.51.17..origin/main` contained only #763. `git diff v0.51.17..origin/main -- pyproject.toml` was empty. Patch is appropriate because this corrects existing diagnostics rather than adding a step-function capability. The release manager must re-derive the reachable window immediately before tagging, including any concurrent merges.

## Delivery contract and explicit protocol departure

Acceptance: exactly one commit changes exactly one line in `pyproject.toml`, `0.51.17` → `0.51.18`; parsed metadata is otherwise identical and the wheel reports version `0.51.18`.

At the parent's explicit authorization, this PR starts directly with the one-line version commit instead of the usual empty-claim/amend sequence. This avoids force-pushing. A unique branch and clean worktree replace the shared `release-next` name. The `chore(release):` prefix makes this draft the same observable release lock. Locks were checked at task start and are rechecked immediately before push and immediately before opening.

Non-goals: production code, dependency or entry-point changes, lockfile updates, feature remediation, migrations, deployment, shared-main/index changes, force-push, deletion, merge, tag, and installation. The only changed contract is package version identity. Rollout/publishing and recovery remain with the release manager after independent review and CI; this PR itself changes no running installation.

## Testing evidence

Implementer: coder subagent (`openai/gpt-6-astra`). Base `4fe92133686828fa6401355fc6db91fb1d05cd42`; head `00b7dd1aa8726ceb52f896b1648c6748c3866ff2`.

- Python `tomllib` parsed both versions and compared the whole file against the exact single replacement: `PASS: TOML parses; exactly one version line changes; all other metadata is identical`.
- `git diff --check`: exit 0.
- `git diff HEAD^..HEAD`: only `-version = "0.51.17"` / `+version = "0.51.18"`; `git show --stat HEAD`: `1 file changed, 1 insertion(+), 1 deletion(-)`.
- Real packaging path: `uv build --wheel --out-dir /tmp/lop-release-0.51.18.M9MA3Y/dist` exited 0. Reading `.dist-info/METADATA` from the generated wheel yielded `PASS: local_operator-0.51.18-py3-none-any.whl: Name=local-operator; Version=0.51.18`.
- Post-build `git status --porcelain`: empty.

No application behavior or visual surface is changed by this metadata-only diff, so the broad application suite, full-tree lint/type gates, and UI captures were not repeated locally. #763 owns its behavioral and design evidence. This PR instead exercises the actual build and version metadata path; independent code/QA review and CI remain pending. No live installation smoke or publication is claimed.
