### PR TITLE
fix(wakes): display local times with configurable clock format

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,13 @@ Work keeps moving after you walk away.
   execution. A session that was asleep past a due time fires the wake late
   and reports how many occurrences it skipped, rather than replaying six
   hourly checks at once. `lop wake status` and `lop wake list` show what is
-  installed and what fires next.
+  installed and what fires next. Human-readable wake times use the machine's
+  local timezone, labelled explicitly, with a 12-hour AM/PM clock by default.
+  Other dates include the month/day (and year when different). Choose **Wake
+  time format** in `/settings` → Appearance, or run
+  `lop config edit display.time_format 24h` for a 24-hour clock (`12h` restores
+  the default). This changes display only; stored timestamps and JSON output
+  remain epoch milliseconds, and existing transcript confirmations are not rewritten.
 - **Background jobs that report back on their own.** `task` always runs in
   the background and `bash` can (`background=true`); a long command
   interrupted by a steer detaches instead of dying; and every settled job

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -2214,7 +2214,12 @@ def _wake_create(args: argparse.Namespace) -> int:
             )
         )
         return 0
-    print(f"{schedule.id}  {_format_due((due_at - now_ms) / 1000.0)}  {schedule.message}")
+    from local_operator.wakes.display import format_wake_time
+
+    print(
+        f"{schedule.id}  {format_wake_time(due_at)} "
+        f"({_format_due((due_at - now_ms) / 1000.0)})  {schedule.message}"
+    )
     if installed_reason:
         print(f"supervisor: {installed_reason}")
     return 0
@@ -2313,9 +2318,10 @@ def wake_command(args: argparse.Namespace) -> int:
             print("no scheduled wakes")
             return 0
         from local_operator.harness.wake import format_duration
+        from local_operator.wakes.display import format_wake_time
 
         for row in rows:
-            when = _format_due(row["due_in_s"])
+            when = f'{format_wake_time(row["next_due_at"])} ({_format_due(row["due_in_s"])})'
             mark = " (dormant — session stopped)" if row["dormant"] else ""
             name = row["session_id"]
             # `every …` reuses the same renderer the tool listing and the wake

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -53,7 +53,7 @@ from collections.abc import (
     Sequence,
 )
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TypeGuard
 
@@ -10254,8 +10254,11 @@ class Session:
         schedule contributes its verbatim message exactly once."""
 
         def _due_label(schedule: WakeSchedule) -> str:
-            due = datetime.fromtimestamp(schedule.next_due_at / 1000).astimezone()
-            return due.strftime("%Y-%m-%d %H:%M")
+            from local_operator.wakes.display import format_wake_time
+
+            return format_wake_time(
+                schedule.next_due_at, now=datetime.fromtimestamp(now_ms / 1000, tz=UTC)
+            )
 
         lines = []
         for entry in missed:

--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -838,6 +838,19 @@ SETTINGS: tuple[Setting, ...] = (
         # four `session.cleanup.*` rows already use (design round 1, D4).
     ),
     Setting(
+        key="display.time_format",
+        path=("display.time_format",),
+        section="appearance",
+        label="Wake time format",
+        kind=Kind.ENUM,
+        default="12h",
+        help="Scheduled wake times use your local timezone. Choose a 12- or 24-hour clock.",
+        choices=(
+            Choice("12h", "12-hour", "7:52 PM PDT"),
+            Choice("24h", "24-hour", "19:52 PDT"),
+        ),
+    ),
+    Setting(
         # The session's INITIAL dock density, not a hard override: `ctrl+g`
         # cycles freely from it and never writes it back (the same split as
         # `tool_approval_mode` vs `/approvals`). A hard override would make

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -4827,10 +4827,12 @@ class WakeParams(BaseModel):
 
 
 def _wake_due_label(schedule: WakeSchedule) -> str:
-    due = datetime.fromtimestamp(schedule.next_due_at / 1000, tz=UTC)
+    from local_operator.wakes.display import format_wake_time
+
+    due = format_wake_time(schedule.next_due_at)
     every = f" every {format_duration(schedule.every_ms)}" if schedule.every_ms else ""
     fired = f" (fired {schedule.fired_count}x)" if schedule.fired_count else ""
-    return f"next at {due.isoformat()}{every}{fired}"
+    return f"next at {due}{every}{fired}"
 
 
 async def _wake_list(tool_call_id: str, scheduler: WakeSchedulerProtocol) -> ToolResult:
@@ -4865,11 +4867,13 @@ async def _wake_create(
     schedule = outcome["schedule"]
     updated = [s for s in existing if s.id != schedule.id] + [schedule]
     await scheduler.update(updated)
-    due = datetime.fromtimestamp(schedule.next_due_at / 1000, tz=UTC)
+    from local_operator.wakes.display import format_wake_time
+
+    due = format_wake_time(schedule.next_due_at)
     return _text(
         tool_call_id,
         "wake",
-        f"Scheduled wake '{schedule.id}' at {due.isoformat()}: \"{schedule.message}\"",
+        f"Scheduled wake '{schedule.id}' at {due}: \"{schedule.message}\"",
     )
 
 

--- a/local_operator/tui/settings.py
+++ b/local_operator/tui/settings.py
@@ -102,6 +102,7 @@ _DEFAULT_NOTES: dict[str, Any] = {
     # roster and on a live edit (applied only if the user has not cycled it
     # this session). Unknown strings read as full.
     "display.dock": "full",
+    "display.time_format": "12h",
 }
 
 _cache: dict[str, Any] | None = None

--- a/local_operator/tui/widgets/wake_panel.py
+++ b/local_operator/tui/widgets/wake_panel.py
@@ -20,7 +20,6 @@ from textual.widgets import Static
 
 from local_operator.harness.wake import format_duration
 from local_operator.tui import theme as theme_mod
-from local_operator.tui.widgets.tool_card import truncate_cells
 from local_operator.wakes.display import format_wake_time
 
 #: The most wake rows the band will spend. ``MAX_WAKE_SCHEDULES`` is 16, far
@@ -56,11 +55,11 @@ class WakePanel(Container):
     def __init__(self) -> None:
         super().__init__(id="wake-panel", classes="band-slot")
         self._body = Static(classes="band-body", id="wake-body")
-        #: What is painted: the per-schedule fingerprint AND the row budget it
+        #: What is painted: the per-schedule fingerprint AND the row/width budgets it
         #: was rendered against, so the 1 Hz poll repaints only when either
         #: moved (``TodoPanel``'s discipline — same contents, different space
         #: is a different paint).
-        self._shown: tuple[tuple[tuple[str, ...], ...], int] | None = None
+        self._shown: tuple[tuple[tuple[str, ...], ...], int, int] | None = None
         # Hidden until the first schedule exists: an empty panel is not content.
         self.display = False
 
@@ -82,9 +81,9 @@ class WakePanel(Container):
             schedules = list(scheduler.schedules) if scheduler is not None else []
             fingerprint = tuple(self._fingerprint(schedule) for schedule in schedules)
             budget = self._body_rows()
-            state = (fingerprint, budget)
+            state = (fingerprint, budget, self._row_cells())
             if state == self._shown:
-                return  # equality guard — identical list and budget = no work
+                return  # equality guard — identical list and budgets = no work
             self._shown = state
             if not fingerprint:
                 self.display = False
@@ -140,14 +139,17 @@ class WakePanel(Container):
             row.append(wake_id, style=muted)
             row.append(f" {due_label} · {every}", style=dim)
             if message:
-                snippet = truncate_cells(message, max(cells - cell_len_of(row) - 3, 0))
-                if snippet:
-                    row.append(f" — {snippet}", style=dim)
+                row.append(f" — {message}", style=dim)
             lines.append(row)
         if marker:
             overflow = Text(no_wrap=True, overflow="ellipsis")
             overflow.append(f"… {len(rows) - len(visible)} more wakes", style=dim)
             lines.append(overflow)
+        # The band is content-sized: Rich overflow alone cannot constrain its
+        # natural width. Clamp every row, including a long id/date/recurrence,
+        # against the screen just as TodoPanel does, before it is measured.
+        for line in lines:
+            line.truncate(cells, overflow="ellipsis")
         return Text("\n").join(lines)
 
     # -- geometry (the TodoPanel budget discipline) ----------------------------
@@ -212,16 +214,14 @@ class WakePanel(Container):
         return sum(slot_rows(slot) for slot in parent.children if slot is not self and slot.display)
 
     def _row_cells(self) -> int:
-        """Cells one row may occupy, or a safe default before layout."""
+        """Screen cells minus the body rail, never the content-sized band width.
+
+        Longer local clock labels can otherwise grow the band beyond a narrow
+        terminal. Include this width in the paint fingerprint so a resize also
+        recomputes truncation without waiting for the schedule to change.
+        """
         try:
-            width = self.size.width
+            width = self.screen.size.width
         except Exception:
             width = 0
-        return max(width - 2, 24) if width else 80
-
-
-def cell_len_of(text: Text) -> int:
-    """Display cells a ``Text`` occupies (no style), for snippet budgeting."""
-    from local_operator.tui.widgets.transcript import cell_len
-
-    return cell_len(text.plain)
+        return max(width - 2, 1) if width else 80

--- a/local_operator/tui/widgets/wake_panel.py
+++ b/local_operator/tui/widgets/wake_panel.py
@@ -11,7 +11,6 @@ will wake at 09:00 is to catch the delivery line as it scrolls past.
 
 from __future__ import annotations
 
-from datetime import datetime
 from typing import Any
 
 from rich.style import Style
@@ -22,6 +21,7 @@ from textual.widgets import Static
 from local_operator.harness.wake import format_duration
 from local_operator.tui import theme as theme_mod
 from local_operator.tui.widgets.tool_card import truncate_cells
+from local_operator.wakes.display import format_wake_time
 
 #: The most wake rows the band will spend. ``MAX_WAKE_SCHEDULES`` is 16, far
 #: more than the band can afford; the cap plus an overflow marker keeps a
@@ -102,8 +102,7 @@ class WakePanel(Container):
         clock must not count as a change, or the once-a-second poll would
         repaint a panel whose visible text did not move.
         """
-        due = datetime.fromtimestamp(schedule.next_due_at / 1000).astimezone()
-        due_label = due.strftime("%H:%M" if due.date() == datetime.now().date() else "%b %d %H:%M")
+        due_label = format_wake_time(schedule.next_due_at)
         every = f"every {format_duration(schedule.every_ms)}" if schedule.every_ms else "once"
         message = " ".join(str(schedule.message).split())
         return (str(schedule.id), due_label, every, message)

--- a/local_operator/wakes/display.py
+++ b/local_operator/wakes/display.py
@@ -1,0 +1,30 @@
+"""Human-facing wake timestamps; scheduling and JSON retain epoch milliseconds."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+DEFAULT_TIME_FORMAT = "12h"
+
+
+def format_wake_time(epoch_ms: int, *, now: datetime | None = None) -> str:
+    """Render in the OS local zone at the due instant, including its DST offset.
+
+    Convert the instant itself rather than attaching today's local tzinfo: the
+    latter is a fixed offset and gives the wrong clock across a DST transition.
+    A date is necessary off today's local date; the year disambiguates distant
+    reminders. The zone stays visible even today so UTC is never implied.
+    """
+    from local_operator.tui.settings import settings_get
+
+    due = datetime.fromtimestamp(epoch_ms / 1000, tz=UTC).astimezone()
+    today = (now or datetime.now(UTC)).astimezone().date()
+    if settings_get("display.time_format", DEFAULT_TIME_FORMAT) == "24h":
+        clock = f"{due.hour:02d}:{due.minute:02d}"
+    else:
+        # Explicit AM/PM, not locale-dependent %p (which can be empty).
+        clock = f"{due.hour % 12 or 12}:{due.minute:02d} {'AM' if due.hour < 12 else 'PM'}"
+    date = ""
+    if due.date() != today:
+        date = due.strftime("%b %d %Y " if due.year != today.year else "%b %d ")
+    return f"{date}{clock} {due.tzname() or due.strftime('%z')}"

--- a/tests/unit/test_settings_io.py
+++ b/tests/unit/test_settings_io.py
@@ -68,6 +68,7 @@ def _consumer_defaults() -> dict[str, object]:
         DEFAULT_SIDEBAR_VISIBLE,
     )
     from local_operator.tui.theme import DEFAULT_THEME
+    from local_operator.wakes.display import DEFAULT_TIME_FORMAT
     from local_operator.web_fetch.models import DEFAULT_WEB_FETCH_CONFIG
     from local_operator.web_search.models import DEFAULT_WEB_SEARCH_CONFIG
 
@@ -80,6 +81,7 @@ def _consumer_defaults() -> dict[str, object]:
         # registry said `""` while the app used `dark`, so the page reported a
         # user explicitly on `dark` as having changed the setting (round 1, M1).
         "tui.theme": DEFAULT_THEME,
+        "display.time_format": DEFAULT_TIME_FORMAT,
         "tui.sidebar_visible": DEFAULT_SIDEBAR_VISIBLE,
         "tui.sidebar_position": DEFAULT_SIDEBAR_POSITION,
         "retry.enabled": retry.enabled,

--- a/tests/unit/tui/test_settings_view.py
+++ b/tests/unit/tui/test_settings_view.py
@@ -473,7 +473,15 @@ async def test_arriving_at_the_top_shows_the_section_header_that_owns_the_row() 
 
         view.action_jump(1)
         await pilot.pause()
-        for _ in range(80):
+        # One press per selectable row, DERIVED rather than a hardcoded count.
+        # Travelling from the last row to the first needs len - 1 presses, so
+        # any fixed number is a bet that the registry never grows: at 80 rows
+        # the old literal 80 had one spare press, and adding one setting left
+        # the cursor one row short of the top while the clamp itself was fine
+        # (CI shard 0 on a config carrying fallback chains, which contribute
+        # rows of their own). The clamp under test makes surplus presses free,
+        # so spending one per row is always enough and never too many.
+        for _ in range(len(view._selectable())):
             view.action_move(-1)
         await pilot.pause()
         assert view._selected == view._selectable()[0]
@@ -485,6 +493,43 @@ async def test_arriving_at_the_top_shows_the_section_header_that_owns_the_row() 
         view.action_jump(0)
         await pilot.pause()
         assert view._body.scroll_offset.y == 0
+
+
+@pytest.mark.asyncio
+async def test_arriving_at_the_top_holds_with_cascade_rows(tmp_path: Path) -> None:
+    """The same arrival contract on a config whose cascade ADDS rows.
+
+    The page's row count is not fixed: a configured chain contributes rows the
+    empty default never renders, so a developer machine with no chains and a
+    runner with two disagree about how long the list is. The test above ran
+    only the empty shape, which is why a registry addition that shortened its
+    margin failed on CI and passed locally. Pinning the arrival at a LONGER
+    list keeps that gap covered rather than relying on the shorter one.
+    """
+    from local_operator import settings_io
+    from local_operator.config import ConfigManager
+
+    settings_io.write_chains(
+        ConfigManager(tmp_path), {"alpha": ["anthropic/a"], "beta": ["openrouter/b"]}
+    )
+
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._open_settings_view()
+        view = app.query_one(SettingsView)
+        await pilot.pause()
+        await pilot.pause()
+
+        assert len(view._selectable()) > 80, "the cascade rows did not lengthen the page"
+
+        view.action_jump(1)
+        await pilot.pause()
+        for _ in range(len(view._selectable())):
+            view.action_move(-1)
+        await pilot.pause()
+        assert view._selected == view._selectable()[0]
+        assert view._body.scroll_offset.y == 0, "the owning section header is scrolled off"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tui/test_settings_view.py
+++ b/tests/unit/tui/test_settings_view.py
@@ -475,12 +475,20 @@ async def test_arriving_at_the_top_shows_the_section_header_that_owns_the_row() 
         await pilot.pause()
         # One press per selectable row, DERIVED rather than a hardcoded count.
         # Travelling from the last row to the first needs len - 1 presses, so
-        # any fixed number is a bet that the registry never grows: at 80 rows
-        # the old literal 80 had one spare press, and adding one setting left
-        # the cursor one row short of the top while the clamp itself was fine
-        # (CI shard 0 on a config carrying fallback chains, which contribute
-        # rows of their own). The clamp under test makes surplus presses free,
-        # so spending one per row is always enough and never too many.
+        # any fixed number is a bet on how long the page is. The old literal 80
+        # covered up to 81 rows and first fell short at 82, leaving the cursor
+        # one row below the top while the clamp itself was correct.
+        #
+        # CI shard 0 hit that: its page was longer than this machine's, and the
+        # reason for the extra rows was NOT established — a page carrying
+        # configured cascade chains is one shape that reaches 82, but it was
+        # not reproduced through the fixtures, so treat the length as an
+        # observation rather than a known cause. That is also why the count is
+        # derived instead of raised: the arrival contract was verified directly
+        # against production across 79-84 rows, so the test now passes at
+        # whatever length the runner produces and the reason stops mattering.
+        # The clamp makes surplus presses free, so one per row is always enough
+        # and never too many.
         for _ in range(len(view._selectable())):
             view.action_move(-1)
         await pilot.pause()
@@ -499,12 +507,12 @@ async def test_arriving_at_the_top_shows_the_section_header_that_owns_the_row() 
 async def test_arriving_at_the_top_holds_with_cascade_rows(tmp_path: Path) -> None:
     """The same arrival contract on a config whose cascade ADDS rows.
 
-    The page's row count is not fixed: a configured chain contributes rows the
-    empty default never renders, so a developer machine with no chains and a
-    runner with two disagree about how long the list is. The test above ran
-    only the empty shape, which is why a registry addition that shortened its
-    margin failed on CI and passed locally. Pinning the arrival at a LONGER
-    list keeps that gap covered rather than relying on the shorter one.
+    The page's row count is not fixed: writing chains here lengthens it past
+    the shape the test above sees, and that shorter shape is the only one the
+    suite covered when a press budget sized for it fell short on CI. What the
+    extra rows on that runner actually were is not established, so this pins
+    the arrival at a LONGER page by construction rather than asserting why any
+    particular page is long.
     """
     from local_operator import settings_io
     from local_operator.config import ConfigManager

--- a/tests/unit/wakes/test_display.py
+++ b/tests/unit/wakes/test_display.py
@@ -1,0 +1,191 @@
+"""Local clock rendering never changes a wake's absolute scheduled instant."""
+
+from __future__ import annotations
+
+import os
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.config import ConfigManager
+from local_operator.settings_io import BY_KEY, write_setting
+from local_operator.tui.settings import settings_reload
+from local_operator.wakes.display import format_wake_time
+
+
+@pytest.fixture(autouse=True)
+def local_clock(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    if not hasattr(time, "tzset"):
+        pytest.skip("Changing the process timezone requires tzset")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    for key in list(os.environ):
+        if key.startswith("CMUX_"):
+            monkeypatch.delenv(key)
+    monkeypatch.setenv("TZ", "America/Los_Angeles")
+    time.tzset()
+    settings_reload()
+    yield
+    monkeypatch.undo()
+    time.tzset()
+    settings_reload()
+
+
+def ms(iso: str) -> int:
+    return int(datetime.fromisoformat(iso).timestamp() * 1000)
+
+
+@pytest.mark.parametrize(
+    ("due", "expected"),
+    [
+        ("2026-09-09T02:52:00+00:00", "7:52 PM PDT"),
+        ("2026-09-08T07:00:00+00:00", "12:00 AM PDT"),
+        ("2026-09-08T19:00:00+00:00", "12:00 PM PDT"),
+        ("2026-09-09T07:00:00+00:00", "Sep 09 12:00 AM PDT"),
+        ("2027-01-01T08:00:00+00:00", "Jan 01 2027 12:00 AM PST"),
+        ("2026-11-01T08:30:00+00:00", "Nov 01 1:30 AM PDT"),
+        ("2026-11-01T09:30:00+00:00", "Nov 01 1:30 AM PST"),
+    ],
+)
+def test_local_clock_dates_and_dst(due: str, expected: str) -> None:
+    # UTC is already Sep 09, but the viewer's local date is still Sep 08.
+    now = datetime(2026, 9, 9, 1, tzinfo=UTC)
+    assert format_wake_time(ms(due), now=now) == expected
+
+
+@pytest.mark.parametrize("value,expected", [("24h", "00:00 PDT"), ("12h", "12:00 AM PDT")])
+def test_persisted_preference(value: str, expected: str, tmp_path: Path) -> None:
+    manager = ConfigManager(tmp_path / "config")
+    write_setting(manager, BY_KEY["display.time_format"], value)
+    settings_reload()
+    assert (
+        format_wake_time(ms("2026-09-08T07:00:00+00:00"), now=datetime(2026, 9, 8, 20, tzinfo=UTC))
+        == expected
+    )
+    assert ConfigManager(tmp_path / "config").get_config_value("display.time_format") == value
+
+
+@pytest.mark.asyncio
+async def test_settings_choice_persists_and_refreshes_panel(tmp_path: Path) -> None:
+    from types import SimpleNamespace
+
+    from local_operator.harness.wake import WakeSchedule
+    from local_operator.tui.app import OperatorApp
+    from local_operator.tui.widgets.settings_view import SettingsView
+    from tests.unit.tui.test_app_pilot import FakeSession, _factory
+    from tests.unit.tui.test_settings_view import _select
+
+    session: Any = FakeSession()
+    schedule = WakeSchedule(
+        id="w1", message="build", next_due_at=ms("2026-09-09T02:52:00+00:00"), created_at=1
+    )
+    session.wake_scheduler = SimpleNamespace(schedules=[schedule])
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        assert app._wake_panel is not None
+        app._wake_panel.sync(session)
+        assert app._wake_panel._shown is not None
+        assert "7:52 PM PDT" in app._wake_panel._shown[0][0][1]
+        app._run_slash_command("/settings")
+        await pilot.pause()
+        view = app.query_one(SettingsView)
+        _select(view, "display.time_format")
+        await pilot.press("enter", "down", "enter")
+        await pilot.pause()
+        # Opening the enum starts on the current 12h choice; Down selects 24h.
+        assert ConfigManager(tmp_path / "config").get_config_value("display.time_format") == "24h"
+        await pilot.press("escape")
+        app._wake_panel.sync(session)
+        await pilot.pause()
+        assert app._wake_panel._shown is not None
+        assert "19:52 PDT" in app._wake_panel._shown[0][0][1]
+        assert schedule.next_due_at == ms("2026-09-09T02:52:00+00:00")
+        assert not app.screen.show_vertical_scrollbar
+
+
+def test_cli_create_list_and_json_preserve_instant(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import argparse
+    import json
+    from types import SimpleNamespace
+
+    from local_operator.cli import _wake_create, wake_command
+    from local_operator.wakes.store import read_entry
+    from tests.unit.wakes.test_wake_create_cli import _args, _session
+
+    root = tmp_path / "config"
+    _session(root, "wakecreate01")
+    due = ms("2026-09-09T02:52:00+00:00")
+    monkeypatch.setattr(time, "time", lambda: due / 1000 - 120)
+    # A CLI display test must never install or restart the machine's daemon.
+    monkeypatch.setattr(
+        "local_operator.wakes.install.ensure_supervisor_installed",
+        lambda _: SimpleNamespace(reason="test: supervisor not installed"),
+    )
+    assert _wake_create(_args(json=False)) == 0
+    assert "7:52 PM PDT" in capsys.readouterr().out
+    entry = read_entry(root, "wakecreate01")
+    assert entry is not None and entry["schedules"][0]["next_due_at"] == due
+    args = argparse.Namespace(wake_command="list", json=False)
+    assert wake_command(args) == 0
+    assert "7:52 PM PDT" in capsys.readouterr().out
+    args.json = True
+    assert wake_command(args) == 0
+    rows = json.loads(capsys.readouterr().out)
+    assert rows[0]["next_due_at"] == due
+    write_setting(ConfigManager(root), BY_KEY["display.time_format"], "24h")
+    args.json = False
+    assert wake_command(args) == 0
+    assert "19:52 PDT" in capsys.readouterr().out
+
+
+def test_missed_wake_receipt_uses_local_clock() -> None:
+    from local_operator.harness.wake import WakeSchedule
+    from local_operator.session.session import Session
+
+    due = ms("2026-09-09T02:52:00+00:00")
+    schedule = WakeSchedule(id="w1", message="build", next_due_at=due, created_at=1)
+    text = Session._format_missed_wake_catchup(
+        [{"schedule": schedule, "occurrences": 1, "due": 1}], due + 60_000
+    )
+    assert "7:52 PM PDT" in text
+    assert schedule.next_due_at == due
+
+
+def test_unknown_preference_falls_back_to_am_pm(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("local_operator.tui.settings.settings_get", lambda *_: "bogus")
+    assert "12:00 PM PDT" in format_wake_time(ms("2026-09-08T19:00:00+00:00"))
+
+
+@pytest.mark.asyncio
+async def test_tool_create_list_and_panel_share_clock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from local_operator.harness.types import ToolContext
+    from local_operator.tools.builtin import execute_wake
+    from local_operator.tui.widgets.wake_panel import WakePanel
+    from tests.unit.tools.test_builtin_tools import _FakeScheduler
+
+    due = ms("2026-09-09T02:52:00+00:00")
+    monkeypatch.setattr("local_operator.tools.builtin.time.time", lambda: due / 1000 - 60)
+    scheduler = _FakeScheduler()
+    context = ToolContext(cwd=str(tmp_path), session_id="clock-test", wake_scheduler=scheduler)
+    created = await execute_wake(
+        "c", {"op": "create", "message": "check build", "in": "1m"}, None, None, context
+    )
+    assert not created.is_error
+    assert "7:52 PM PDT" in created.text
+    assert scheduler.schedules[0].next_due_at == due
+    listed = await execute_wake("l", {"op": "list"}, None, None, context)
+    assert "7:52 PM PDT" in listed.text
+    assert "7:52 PM PDT" in WakePanel._fingerprint(scheduler.schedules[0])[1]
+    write_setting(ConfigManager(tmp_path / "config"), BY_KEY["display.time_format"], "24h")
+    listed = await execute_wake("l", {"op": "list"}, None, None, context)
+    assert "19:52 PDT" in listed.text
+    assert "19:52 PDT" in WakePanel._fingerprint(scheduler.schedules[0])[1]
+    assert scheduler.schedules[0].next_due_at == due

--- a/tests/unit/wakes/test_display.py
+++ b/tests/unit/wakes/test_display.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import time
 from datetime import UTC, datetime
@@ -85,9 +86,11 @@ async def test_settings_choice_persists_and_refreshes_panel(tmp_path: Path) -> N
     session.wake_scheduler = SimpleNamespace(schedules=[schedule])
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
+        async with asyncio.timeout(5):
+            while app._session is None:
+                await pilot.pause()
         assert app._wake_panel is not None
-        app._wake_panel.sync(session)
+        app._refresh_band()
         assert app._wake_panel._shown is not None
         assert "7:52 PM PDT" in app._wake_panel._shown[0][0][1]
         app._run_slash_command("/settings")
@@ -99,9 +102,10 @@ async def test_settings_choice_persists_and_refreshes_panel(tmp_path: Path) -> N
         # Opening the enum starts on the current 12h choice; Down selects 24h.
         assert ConfigManager(tmp_path / "config").get_config_value("display.time_format") == "24h"
         await pilot.press("escape")
-        app._wake_panel.sync(session)
-        await pilot.pause()
-        assert app._wake_panel._shown is not None
+        # Let the production timer perform the repaint, not a test-only sync.
+        async with asyncio.timeout(5):
+            while "19:52 PDT" not in app._wake_panel._shown[0][0][1]:
+                await pilot.pause()
         assert "19:52 PDT" in app._wake_panel._shown[0][0][1]
         assert schedule.next_due_at == ms("2026-09-09T02:52:00+00:00")
         assert not app.screen.show_vertical_scrollbar

--- a/tests/unit/wakes/test_display.py
+++ b/tests/unit/wakes/test_display.py
@@ -70,7 +70,8 @@ def test_persisted_preference(value: str, expected: str, tmp_path: Path) -> None
 
 
 @pytest.mark.asyncio
-async def test_settings_choice_persists_and_refreshes_panel(tmp_path: Path) -> None:
+@pytest.mark.parametrize("columns", [100, 60])
+async def test_settings_choice_persists_and_refreshes_panel(tmp_path: Path, columns: int) -> None:
     from types import SimpleNamespace
 
     from local_operator.harness.wake import WakeSchedule
@@ -81,11 +82,14 @@ async def test_settings_choice_persists_and_refreshes_panel(tmp_path: Path) -> N
 
     session: Any = FakeSession()
     schedule = WakeSchedule(
-        id="w1", message="build", next_due_at=ms("2026-09-09T02:52:00+00:00"), created_at=1
+        id="w1",
+        message="Check the build and report every failing stage",
+        next_due_at=ms("2026-09-09T02:52:00+00:00"),
+        created_at=1,
     )
     session.wake_scheduler = SimpleNamespace(schedules=[schedule])
     app = OperatorApp(lambda: _factory(session))
-    async with app.run_test(size=(100, 30)) as pilot:
+    async with app.run_test(size=(columns, 30)) as pilot:
         async with asyncio.timeout(5):
             while app._session is None:
                 await pilot.pause()
@@ -93,6 +97,8 @@ async def test_settings_choice_persists_and_refreshes_panel(tmp_path: Path) -> N
         app._refresh_band()
         assert app._wake_panel._shown is not None
         assert "7:52 PM PDT" in app._wake_panel._shown[0][0][1]
+        await pilot.pause()
+        assert app._wake_panel.size.width <= app.screen.size.width
         app._run_slash_command("/settings")
         await pilot.pause()
         view = app.query_one(SettingsView)
@@ -109,6 +115,17 @@ async def test_settings_choice_persists_and_refreshes_panel(tmp_path: Path) -> N
         assert "19:52 PDT" in app._wake_panel._shown[0][0][1]
         assert schedule.next_due_at == ms("2026-09-09T02:52:00+00:00")
         assert not app.screen.show_vertical_scrollbar
+        await pilot.resize_terminal(40, 30)
+        async with asyncio.timeout(5):
+            while app._wake_panel._shown[2] != app.screen.size.width - 2:
+                await pilot.pause()
+        await pilot.pause()
+        assert app._wake_panel.size.width <= app.screen.size.width
+        from rich.cells import cell_len
+
+        lines = app._wake_panel._build(app._wake_panel._shown[0]).plain.splitlines()
+        assert all(cell_len(line) <= app.screen.size.width - 2 for line in lines)
+        assert any(line.endswith("…") for line in lines)
 
 
 def test_cli_create_list_and_json_preserve_instant(


### PR DESCRIPTION
## Summary

**C1 — standard, pre-authorized bug fix.** Scheduled wake times should be readable in the operator's local timezone, with AM/PM by default and a 24-hour opt-in.

The dock already converted its timestamp to local time, but rendered an unlabelled 24-hour clock. The wake tool's create/list text instead exposed UTC ISO timestamps. This makes the human-facing surfaces consistent without changing any scheduled instant.

- Shared local-time formatter for the Wakes dock, wake tool create/list, CLI create/list, and missed-wake resume receipts.
- Default `12h` clock with explicit AM/PM and local timezone abbreviation; non-today dates include month/day, and a different year is included.
- `display.time_format: 24h` opt-in, registered as **Wake time format** in `/settings` → Appearance and through `lop config edit display.time_format 24h`. Live panel refresh uses the existing display-settings cache invalidation and timer.
- Width-aware wake row truncation follows TodoPanel's existing screen-bound pattern so longer timezone-labelled timestamps cannot widen a narrow dock; width participates in the repaint fingerprint.
- UTC epoch-millisecond storage, scheduling arithmetic, time parsing, and JSON output remain unchanged. No version bump.

### Acceptance criteria / non-goals

- A UTC instant such as `2026-09-09T02:52Z` displays as `7:52 PM PDT` in America/Los_Angeles, never bare `02:52` or unlabelled `19:52`.
- Midnight/noon, local day rollover, year changes, and daylight-saving transitions remain unambiguous.
- Choosing 24-hour time persists and refreshes the mounted wake panel without restarting.
- Wake recurrence, limits, cancellation, supervisor lifecycle, timestamp parsing, JSON contracts, and non-wake timestamps are not changed. Existing transcript confirmations are historical text and are not rewritten.

## Execution evidence

All app/subprocess runs use isolated HOME/config directories, synthetic sessions, and remove **every `CMUX_*` variable** before importing or booting the app. No operator sessions/config or installed runtime were used. The isolated CLI persistence probe disables only supervisor installation so it cannot restart a host daemon; scheduling/index/transcript writes and CLI/tool formatting execute normally.

[Portable synthetic evidence: before/after SVGs, settings walkthrough, reproduction scripts, and actual CLI/tool output](https://gist.github.com/damianvtran/d9b3092a38654ff9525067174eb227dc)

Actual probe output (full output in `smoke.log`):

```text
wake create: w1  Sep 08 7:52 PM PDT (in 2m)  check the build
wake list:   Sep 08 7:52 PM PDT (in 2m)  wakecreate01  check the build
stored epoch: 1788922320000
lop config edit display.time_format 24h
Successfully updated display.time_format to 24h
lop config edit display.time_format bad
Error: display.time_format: expected one of: 12-hour, 24-hour
exit: 1
wake list (24h): Sep 08 19:52 PDT ...
wake tool create: Scheduled wake 'w1' at Sep 08 19:52 PDT: "check build"
wake tool list: - w1: "check build" next at Sep 08 19:52 PDT
invalid duration 'garbage'; use e.g. 45s, 30m, 2h, 7d, 1w.
```

`wake list --json` retains `next_due_at: 1788922320000`, the exact value read back from the stored schedule. Tests separately exercise default 12-hour tool confirmation/list and the 24-hour listing. Authorization/wrong-tenant cases are not applicable to this local formatting change; invalid enum/duration paths are exercised.

### Rendered UI verification

Captured the **real OperatorApp** loading production CSS, rendered SVGs to PNG, and looked at the resulting frames. Before uses committed base `c26aa8314`; after uses this branch. No screenshot/evidence artifacts are committed.

| Artifact | What it demonstrates |
|---|---|
| `before.svg` | Bare local `Sep 08 19:52` in the existing dock |
| `after.svg` | Explicit `Sep 08 7:52 PM PDT` with unchanged row height |
| `settings-choices.svg` | Existing settings enum interaction exposes 12-hour/24-hour choices |
| `after-24h.svg` | Enter → Down → Enter persists 24h; Escape returns to the dock, whose production timer paints `19:52 PDT` |

At 100×30, both captures have screen content **98×28**, virtual size **98×28**, **no screen scrollbar**, wake panel **98×3**, and body **96×3**. Consecutive captured frames verify settling. At 60 columns, the screen/panel are both **58 cells**, body **56 cells**: time, zone, and recurrence remain readable and shortened messages have an ellipsis. The longer labels initially exposed an intrinsic-width overflow (62-cell panel inside a 58-cell screen); fixed using the same screen-bound truncation as TodoPanel, with 100→40 and 60→40 resize regressions. The empty state stays hidden; a populated overflow fixture retains the count/overflow marker. There is no separate wake-panel loading/error state; invalid create inputs are covered in the CLI/tool probe.

Local PNGs, SVGs, geometry JSON, and scripts for independent reviewers: `/tmp/wake-clock-evidence/`. Re-run with the worktree's interpreter: `.venv/bin/python /tmp/wake-clock-evidence/capture.py /tmp/wake-clock-evidence/after.svg`.

## Validation

| Gate | Result |
|---|---|
| `flake8 .` (7.3.0) | Clean |
| `black --check .` (26.1.0) | Clean |
| `isort --check-only .` (5.13.2) | Clean |
| `python -m pyright --pythonpath .venv/bin/python .` | 0 errors, 0 warnings |
| Final-head touched-surface matrix | **594 passed** (44.31s): wakes, built-in tools, settings registry, session, wake UI, spacing; delta pyright clean |
| Entire unit suite | **16,235 passed, 18 skipped, 1 timing failure** in 1832.87s; details below |
| Process-reaper timing follow-up | Entire unchanged module: **20 passed** serially on this branch and **20 passed** on base `c26aa8314` |
| `tests/e2e -m e2e -n0 -q` | 49 passed (90.04s); followed by the final narrow-display delta above |

The sole whole-suite failure was unchanged `tests/unit/session/runtime/test_process_reaper.py::test_phone_watchers_do_not_change_idle_timing`: three wall-clock durations were 93ms / 108ms / 182ms, exceeding its 40ms spread bound while multiple suites were running on this host. Neither that test nor `local_operator/session/runtime/process.py` changes here. The entire module passes on both this branch (3.58s) and the base (3.50s) in isolated serial follow-ups. The bound was **not widened**, no failure was suppressed, and no unrelated reaper rewrite is bundled. CI must be green on the final head before merge; the original local whole-suite run is **not claimed green**.

**Run provenance:** the full local unit process began on the initial implementation, before the missed-wake receipt and narrow-width additions. The final head subsequently passed a **594-test matrix over every touched surface** (wakes, built-in tools, settings registry, session, wake UI, spacing), including the final receipt/width changes. Static gates ran over the whole tree, with the last width-only refinement also typechecked explicitly. CI's full suite must complete on the final immutable PR head before merge; no claim is made that the initial local process loaded subsequently edited code.

Regression matrix covers timezone conversion, midnight/noon, local-vs-UTC date rollover, non-today/year labels, both sides of DST fallback, persistence, invalid preference fallback, live enum selection/automatic repaint, wake tool create/list, CLI create/list/JSON, and missed-wake receipts. Whole-tree settings default-consumer enforcement also passes.

## Rollout / rollback

Patch-level user-facing fix, no migration. Default clock display changes immediately for newly rendered wake text. `display.time_format=24h` retains a 24-hour clock while still making the local zone explicit. Revert this PR to roll back. Merge/release belongs to the manager after independent code, QA, design, and UX rounds; this implementation handoff does not merge or release.
