### PR TITLE
fix(tui): align welcome notices with sidebar main lane

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -4840,6 +4840,7 @@ class OperatorApp(App[None]):
             self._sidebar_focus_restore = ref(self.focused) if self.focused is not None else None
         sidebar.set_open(opened)
         self._sync_sidebar_layout(self.size)
+        self._sync_boot_layout()
         if self._sidebar_timer is not None:
             if opened:
                 self._sidebar_timer.resume()
@@ -11271,7 +11272,24 @@ class OperatorApp(App[None]):
         transcript = self._transcript_view()
         card = boot_card_width(box)
         card_up = self.screen.has_class(BOOT_CARD_CLASS) and box - card >= BOOT_CARD_MIN_INSET
-        # The card is centred by the stylesheet in `box` — the screen's own
+        # A docked sidebar has already displaced the transcript AND reduced the
+        # composer's containing box. Reusing the screen width here spends that
+        # space twice: at 190 columns the notice started 23 cells right of the
+        # composer. Use the sidebar's resolved layout inputs, not last frame's
+        # widget regions, so toggles and resizes land on the same painted frame.
+        sidebar = self._session_sidebar
+        sidebar_width = sidebar.styles.width
+        if (
+            sidebar.display
+            and not self.query_one("#session-workspace").has_class("sidebar-overlay")
+            and sidebar_width is not None
+        ):
+            box = max(0, box - int(sidebar_width.value))
+            # The existing card class keeps the stylesheet's 75-cell floor even
+            # when a docked sidebar leaves less room; match that composer rather
+            # than changing its layout as a side effect of moving a notice.
+            card = max(BOOT_CARD_MIN_WIDTH, boot_card_width(box))
+        # The card is centred by the stylesheet in `box` — the main lane's
         # content box — so the offset that lands a notice on the card's column
         # has to be computed against THAT box, then rebased into the transcript's
         # coordinate space. The block cannot be centred BY the stylesheet:
@@ -11300,7 +11318,8 @@ class OperatorApp(App[None]):
         # (`box=83`, `card=75`, `d=8 == BOOT_CARD_MIN_INSET`) and 84 (`d=7`) the
         # last uncarded one; 86 is merely the lowest carded width that drifts,
         # since 85's `d` is even.
-        offset = max(0, (box - card) // 2 - transcript.styles.gutter.left)
+        # A flush card still needs the gutter rebased out of its local origin.
+        offset = max(0, (box - card) // 2) - transcript.styles.gutter.left
         for block in transcript.query(".notice-block"):
             block.set_class(card_up, BOOT_COLUMN_CLASS)
             if card_up:

--- a/tests/unit/tui/test_boot_layout.py
+++ b/tests/unit/tui/test_boot_layout.py
@@ -629,9 +629,11 @@ BOOT_NOTICE_WIDTHS = (86, 90, 100, 110, 120, 160)
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("terminal_width", BOOT_NOTICE_WIDTHS)
+@pytest.mark.parametrize("terminal_width", (*BOOT_NOTICE_WIDTHS, 190, 240))
+@pytest.mark.parametrize("sidebar_open", (False, True))
 async def test_a_notice_under_the_splash_sits_on_the_card_not_the_spine(
     terminal_width: int,
+    sidebar_open: bool,
 ) -> None:
     """A boot notice shares the card's COLUMN, and keeps one left edge in it.
 
@@ -654,14 +656,20 @@ async def test_a_notice_under_the_splash_sits_on_the_card_not_the_spine(
     async with app.run_test(size=(terminal_width, 36)) as pilot:
         await pilot.pause()
         await _settle(pilot)
+        app._set_sidebar_open(sidebar_open)
         app._system_notice("MCP cloudflare failed: needs authorization", "error")
         await _settle(pilot)
         card = app.query_one("#input-shell").region
         notice = app.query_one(NoticeBlock).region
-        assert card.width == _expected_card_width(terminal_width)
+        if not sidebar_open:
+            assert card.width == _expected_card_width(terminal_width)
         assert notice.width == card.width, (notice.width, card.width)
         # The BLOCK shares the card's column, not only its width.
         assert notice.x == card.x, (terminal_width, notice.x, card.x)
+        # The narrow drawer intentionally covers the transcript, not the dock.
+        # Assert its geometry above, but do not mistake occlusion for alignment.
+        if app.query_one("#session-workspace").has_class("sidebar-overlay"):
+            return
         # And its text starts on ONE column: the glyph field's width in from the
         # block's own left edge, exactly as a spine notice does.
         line = _rows(app)[notice.y]
@@ -671,9 +679,11 @@ async def test_a_notice_under_the_splash_sits_on_the_card_not_the_spine(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("terminal_width", BOOT_NOTICE_WIDTHS)
+@pytest.mark.parametrize("terminal_width", (*BOOT_NOTICE_WIDTHS, 190, 240))
+@pytest.mark.parametrize("sidebar_open", (False, True))
 async def test_a_boot_notice_starts_on_the_composers_own_text_column(
     terminal_width: int,
+    sidebar_open: bool,
 ) -> None:
     """The notice's sentence begins where the user's typing begins.
 
@@ -691,6 +701,7 @@ async def test_a_boot_notice_starts_on_the_composers_own_text_column(
     async with app.run_test(size=(terminal_width, 36)) as pilot:
         await pilot.pause()
         await _settle(pilot)
+        app._set_sidebar_open(sidebar_open)
         app._system_notice(
             "this session is running 0.51.0@ad6db35 \u2192 0.51.5@ad6db35 \u2014 it will "
             "switch to the new version when it is next idle.",
@@ -705,6 +716,8 @@ async def test_a_boot_notice_starts_on_the_composers_own_text_column(
             sentence_x,
             composer_text_x,
         )
+        if app.query_one("#session-workspace").has_class("sidebar-overlay"):
+            return
         # Every wrapped continuation lands on that same column — the property a
         # per-row centre destroyed, where a 4-word orphan floated 34 cells right
         # of its own first row at 160 columns.
@@ -714,6 +727,54 @@ async def test_a_boot_notice_starts_on_the_composers_own_text_column(
             if not span.strip():
                 continue
             assert notice.x + (len(span) - len(span.lstrip())) == sentence_x, span
+
+
+@pytest.mark.asyncio
+async def test_boot_notice_tracks_sidebar_toggles_and_resizes(
+    monkeypatch,
+) -> None:
+    """Sidebar toggles do not paint a stale column; resizing keeps the same lane.
+
+    Sample every compositor frame on drawer toggles, rather than accepting a
+    fix that only converges after paint. Resize checks cover the settled layout
+    across the overlay boundary and the existing composer's width floor.
+    """
+    app = _make_app()
+    async with app.run_test(size=(190, 36)) as pilot:
+        await _settle(pilot)
+        app._system_notice("this session is running an older version", "note")
+        await _settle(pilot)
+        block = app.query_one(NoticeBlock)
+        frames: list[tuple[int, int, int, int]] = []
+        painted = Screen._compositor_refresh
+
+        def record(screen: "Screen[object]") -> None:
+            painted(screen)
+            notice = block.region
+            card = app.query_one("#input-shell").region
+            frames.append((notice.x, notice.width, card.x, card.width))
+
+        monkeypatch.setattr(Screen, "_compositor_refresh", record)
+        previous_width = 190
+        for width, sidebar_open in (
+            (190, True),
+            (190, False),
+            (190, True),
+            (240, True),
+            (100, True),
+            (90, True),
+            (120, True),
+            (120, False),
+            (190, False),
+        ):
+            frames.clear()
+            app._set_sidebar_open(sidebar_open)
+            await pilot.resize_terminal(width, 36)
+            await _settle(pilot)
+            assert frames, "premise: the changed layout painted"
+            checked = frames if width == previous_width else frames[-2:]
+            assert all(nx == cx and nw == cw for nx, nw, cx, cw in checked), frames
+            previous_width = width
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What and why

**C1 — standard/pre-authorized UI defect fix.** With the session sidebar docked open, the welcome-screen runtime-version notice used the whole terminal's width to calculate its centered column, even though its transcript parent and the composer were already in the narrower main lane. That counted the sidebar displacement twice. Closing the sidebar was already correct.

Use the sidebar's resolved layout inputs to size and position the notice inside the same main lane as the composer. Reconcile that column during sidebar toggles, not only following a welcome resize. Keep the existing composer floor and overlay behavior; when the composer is flush to its lane, subtract the transcript gutter even if that requires a negative local offset.

### Delivery contract
- The runtime-version notice's block matches the composer's x and width with the docked sidebar open; its sentence and wrapped continuations begin on the editor's text column.
- Sidebar closed retains the existing layout. Overlay drawers retain their intentional transcript occlusion.
- An existing notice follows open/close toggles and terminal resizing; sidebar toggles do not paint a stale column first.
- No changed copy, version bump, runtime refresh behavior, persistence, or interaction flow. No redesign of the composer or welcome splash.
- Blast radius: boot-only system notices sharing this column (including MCP authorization failures); active transcript notices retain their existing spine behavior.

## Reproduced before editing, then exercised after

Real `OperatorApp.run_test`, loading `local_operator.tcss`, at **190×48** with the actual runtime-version notice text. The session factory is a deterministic test fixture; the app, layout, compositor, and widgets are real. All `CMUX_*` variables scrubbed before app imports, HOME/config/cache isolated, and session runtime records consequently isolated under config/run. No live operator sessions or runtime processes were touched.

Geometry in terminal cells (`x / width`):

| State | Before notice | Before composer | After notice | After composer |
|---|---:|---:|---:|---:|
| Sidebar closed | 45 / 100 | 45 / 100 | 45 / 100 | 45 / 100 |
| Sidebar open | 92 / 100 | 69 / 98 | 69 / 98 | 69 / 98 |
| Reclosed | 45 / 100 | 45 / 100 | 45 / 100 | 45 / 100 |

Notice y=32, height=2 and composer y=35, height=5 are unchanged. Two consecutive captures per state have identical geometry and byte-identical rasterized PNGs (all six before/after state pairs checked with `cmp`). Screen size and virtual size both remain 188×46, with neither scrollbar present. Before/after closed PNGs are **byte-identical** (`cmp` exit 0).

Captured with `scripts.visual_capture.save_capture` (native 8×17px cells, Menlo; 1520×816 output), rasterized with `rsvg-convert`, and **visually inspected** before and after. The open notice now aligns with the composer instead of overflowing off to the right.

### Rendered evidence

Retained on the capture host for the independent review streams, outside the repository:
- `/tmp/lo-welcome-evidence/before-open.png` / `after-open.png`
- `/tmp/lo-welcome-evidence/before-closed.png` / `after-closed.png`
- All six before/after state pairs as `*-{closed,open,reclosed}-{0,1}.svg`, each with `.geometry.json`.
- Capture command: `.venv/bin/python /tmp/lo-welcome-capture.py before` (before editing), then the identical command with `after` after the fix.
- Reusable local capture script: `/tmp/lo-welcome-capture.py`; isolated command wrapper: `/tmp/lo-welcome-run.py`.

Images are not yet uploaded as GitHub attachments; these are actual local artifact paths, not pretend attachment URLs. No evidence artifacts are committed. The independent local design reviewer has access to these exact files.

## Regression and validation evidence

Expanded the existing geometry and painted-text tests over open/closed states at 86, 90, 100, 110, 120, 160, 190, and 240 columns. Added a held-notice test that samples every painted frame during sidebar toggles and settled frames across narrow-overlay/docked/wide resize transitions.

Restoring only `_sync_boot_column_width` from committed base `be2546ec069dde12d6b0a06aa9c2498178bb3d72` in memory with a test plugin makes all four wide-sidebar regression cases fail:
```
4 failed, 80 deselected in 3.38s
190 cols: notice width 100 != composer 98; sentence x 96 != editor x 73
240 cols: notice x 117 != composer x 93; sentence x 121 != editor x 97
```
No source rollback or shared-checkout mutation was needed.

| Gate | Actual result |
|---|---|
| `.venv/bin/python -m flake8 .` | clean, exit 0 |
| `uvx --from black==26.1.0 black --check .` | 1072 files unchanged, exit 0 |
| `uvx isort==5.13.2 --check .` | clean, exit 0 |
| `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | 0 errors, 0 warnings |
| Complete `tests/unit` (corrected environment) | **Exit 1: 3 failed, 16234 passed, 18 skipped**, 680 warnings in 2289.23s |
| Exact three failures, serial rerun on unchanged head | **3 passed**, 2 warnings in 11.99s, exit 0 |
| Full boot layout regression file | 84 passed, 4 warnings in 50.94s |
| Sidebar neighbor file | 61 passed, 4 warnings in 54.97s |
| `tests/e2e -m e2e -n0 -q` | 49 passed, 6 warnings in 72.68s |

Raw logs: `/tmp/lo-welcome-evidence/logs/{flake8,black,isort,pyright,unit-final,full-failures-recheck,boot-layout,sidebar,e2e,baseline-regression}.log`. Explicit exit artifacts: `unit-final.exit` = 1; `full-failures-recheck.exit` = 0. Tests run through the isolated wrapper with `NO_COLOR` unset and `TERM=xterm-256color`.

### Full-suite failures: disclosed, not called green

The full local suite is **not clean**. Three intermittent failures occurred on unchanged surfaces under heavy host contention (observed load averages above 130). Each passed in the earlier full run and all three pass together on the exact same head when rerun serially:

| Test | Full-run failure | Unchanged surface |
|---|---|---|
| `tests/unit/session/test_attach_frame_size.py::test_attach_succeeds_against_an_owner_offering_thousands_of_models` | `RuntimeUnresponsiveError` waiting for the owner snapshot | Real-socket attach/serialization; no boot UI code |
| `tests/unit/test_computer_input.py::test_failure_is_bounded_redacted_and_does_not_retry[hang]` | Fake subprocess `owner.pid` absent | Clipboard subprocess timeout/cleanup; no TUI code |
| `tests/unit/tui/test_band_panels.py::test_the_inset_is_never_what_tips_a_long_subagent_list_over[15-5]` | Test's `without_inset` monkeypatch queried `#band` during teardown after removal | Band-inset A/B fixture, not sidebar positioning |

The earlier full run had a different, diagnosed runner mistake: a capture-only `LOCAL_OPERATOR_NO_TERMINAL_TITLE=1` flag caused three title tests to fail. That flag was removed from the gate wrapper; those exact tests passed (3 passed in 5.03s) and pass in the corrected full run. No production or test source was changed to hide any of these failures.

The coordinating manager explicitly authorized opening this PR with the full failure record and exact passing recheck rather than running a third full 40-minute local suite. **CI's complete suite remains the required final green gate before merge.** Independent code, design, and QA streams have reviewed this pinned head; their formal rounds will be posted on this PR.

## Not addressed

The pre-existing **terminal resize**, distinct from a sidebar toggle, can briefly report a mixed compositor frame while changing from 120 to 190 columns with the sidebar closed. Both the committed baseline method and this fix produce the identical sequence `(notice x45/w100, composer x19/w82)` followed by `(45/100, 45/100)`. This patch preserves that closed-layout behavior rather than redesigning the resize lifecycle. Evidence: `/tmp/lo-welcome-evidence/logs/resize-neighbor.log`. Sidebar toggles themselves are asserted on every painted frame.

## Rollout / rollback

Ordinary package release after independent code, QA and design rounds; no migration or configuration change. Revert this commit to restore prior positioning. **Not merged or released by the implementing agent.**

Release: patch — welcome-screen version notices align with the composer when the session sidebar is open, while the closed-sidebar layout stays unchanged.
