### PR TITLE
chore(release): bump version to 0.51.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.18"
+version = "0.51.19"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## Release window v0.51.19

Owner session pid: 43422 (delegated release coordinator `788744d5`). Lock taken as the claim PR at `cde8b15b8`; the version commit was **added** on top rather than amended, at the parent manager's explicit direction, so nothing is force-pushed and the lock PR number never changes. The occupied shared `release-next` branch was left untouched.

**Change class: C0, standard/pre-authorized.** Version metadata only.

`Release: patch — keep sidebar updates realtime while reusing unchanged rows and repainting only busy glyphs, eliminating full-sidebar Rich rebuilds.`

## Window contents

Everything on `origin/main` since `v0.51.18`, derived with the plain log (not `--merges`):

- [x] #787 — merge SHA `65ce1e5dacf9741572f0c9adf3d963366636b4e1`
  - `Release: patch` — keep sidebar updates realtime while reusing unchanged rows and repainting only busy glyphs, eliminating full-sidebar Rich rebuilds (QA measured 42 -> 0 renders over 6s; poll count unchanged at 3 -> 3).

`git log v0.51.18..origin/main` lists exactly that one PR. `git diff v0.51.18..origin/main -- pyproject.toml` is empty, so no merged PR consumed `0.51.19`. Patch is correct for the whole window: a single rendering-performance fix, with no step-function capability to name in a release title.

The window will be re-derived immediately before `gh release create`, since anything merged above this bump commit still ships in the tag.

## Delivery contract

Acceptance: the PR diff is exactly one changed line in exactly one file, `pyproject.toml` `0.51.18` -> `0.51.19`; all other parsed metadata is byte-identical; the built wheel reports `0.51.19`.

Non-goals: application code, dependencies, entry points, lockfiles, release notes, tagging, publication, and installation. Those belong to the release step after this merges, or to their own reviewed PRs.

## Testing evidence

- `git diff origin/main..HEAD` is the two version lines and nothing else; `--stat` reports `1 file changed, 1 insertion(+), 1 deletion(-)`.
- `tomllib` parse of both sides with `version` popped compares **equal**: no dependency pin, script, or entry point moved beside the bump.
- Wheel build evidence is recorded by the independent QA round below rather than self-asserted here.

## Review disclosure

This PR is agent-authored, so it carries the standing review gate: an **independent** reviewer subagent and an **independent** QA round, neither of them this coordinator. The coordinator is prohibited from self-reviewing it.

The coordinating session started this window on `openai/gpt-6-astra` and was moved mid-window to `anthropic/claude-opus-5` by a provider fallback. Disclosed here because a mid-round model change is disclosable under the standing rules.