### PR TITLE
fix(tui): preserve rendered history buffers while paging

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1050,6 +1050,28 @@ RESUME_START_NOTICE = "start of conversation"
 RESUME_UNREACHABLE_NOTICE = "older messages above — select to load"
 
 
+@dataclass(frozen=True)
+class _PagingLease:
+    """Ownership of ONE backward-paging transaction, request through settle.
+
+    The gate used to be an app-global boolean, which cannot answer "whose
+    fetch is this?" once a reader leaves a conversation and comes back to its
+    CACHED presentation: re-entry reset the flag, a second fetch started for
+    the same source, and the first fetch's completion then cleared the newer
+    transaction's gate and reported `history changed while paging` to the user
+    (review round 1, F1).
+
+    So ownership is a per-source object identity that survives presentation
+    changes. It deliberately does NOT carry the view or the navigation
+    generation: those fence PUBLICATION (may this completion touch the screen)
+    and are checked separately. Ownership answers a different question — may
+    this completion open the gate — and the honest answer is "only if the gate
+    is still the one it took", which is object identity and nothing else.
+    """
+
+    source_token: str
+
+
 def _resume_tail_start(history: list[Any], bound: int) -> int:
     """Index of the first message the initial resume frame should paint.
 
@@ -2525,7 +2547,12 @@ class OperatorApp(App[None]):
         #: the entire deferred head (522 messages on a 600-message probe), the
         #: unbounded render cost this bound exists to remove. Cleared by the
         #: settle callback `insert_blocks` schedules, never synchronously.
-        self._resume_paging = False
+        #:
+        #: Keyed by SOURCE TOKEN rather than held as one app-global flag, so an
+        #: outstanding transaction survives switching away and back to a cached
+        #: presentation: `_resume_paging` reads the current source's entry, and
+        #: only the transaction holding an entry may remove it (F1).
+        self._paging_leases: dict[str, _PagingLease] = {}
         #: Whether the INITIAL fill still has an attempt to make. Distinct from
         #: `_resume_paging`, which is a mutex over the mount seam: this asks
         #: "is the geometry on screen still provisional?", and it stays set
@@ -3603,7 +3630,9 @@ class OperatorApp(App[None]):
         self._welcome = presentation.welcome
         self._welcome_visible = None
         # Gesture tasks belong to the abandoned viewport, not its history.
-        self._resume_paging = False
+        # The paging LEASE is deliberately not touched: it belongs to the
+        # source, not to the presentation, and clearing it here is what let a
+        # revisit start a second fetch that the first one then retired (F1).
         self._resume_fill_active = False
         self._resume_check_pending = False
         self._resume_in_zone = False
@@ -6399,7 +6428,9 @@ class OperatorApp(App[None]):
         self._resume_results = {}
         self._resume_head_notice = None
         self._resume_mounted_ids.clear()
-        self._resume_paging = False
+        # This source's history is being rebuilt from scratch, so any page it
+        # still owes is about a transcript that no longer exists.
+        self._paging_leases.pop(self._interaction.token, None)
         # A check queued for the OLD conversation must not fire against the
         # new one; a fresh head has no gesture in flight worth answering.
         self._resume_check_pending = False
@@ -6520,9 +6551,15 @@ class OperatorApp(App[None]):
         if self._resume_pending_head:
             self._mount_older_resume_page(on_settled=settled)
         elif self._session is not None and getattr(self._session, "history_before_token", None):
-            self._resume_paging = True
+            lease = self._acquire_paging_lease(source)
+            if lease is None:
+                # A prior transaction for this source is still outstanding —
+                # including one started before a switch away and back. Filling
+                # resumes from that transaction's own settle callback rather
+                # than sending a second request against the same cursor (F1).
+                return
             self.run_worker(
-                self._fetch_older_display_page(source, on_settled=settled),
+                self._fetch_older_display_page(source, lease, on_settled=settled),
                 group=source.worker_group("history-page"),
             )
         else:
@@ -6753,14 +6790,25 @@ class OperatorApp(App[None]):
             self._resume_tail_notice = None
 
     async def _fetch_older_display_page(
-        self, source: SessionInteraction, on_settled: Callable[[], None] | None = None
+        self,
+        source: SessionInteraction,
+        lease: _PagingLease,
+        on_settled: Callable[[], None] | None = None,
     ) -> None:
-        """Keep the same single-flight lease from remote request through paint.
+        """Hold ONE transaction's lease from remote request through paint.
 
         Network completion is not insertion completion. Releasing in finally
         after scheduling an insert admitted a second page into unsettled DOM
-        and let the fill measure provisional heights. Transfer the lease to
-        the mount callback instead, fenced by source, navigation and view.
+        and let the fill measure provisional heights, so the lease is instead
+        transferred to the mount callback.
+
+        Two distinct questions are asked separately, and conflating them is
+        what F1 reported. PUBLICATION — may these rows touch the screen — is
+        answered by source, view and navigation generation. OWNERSHIP — may
+        this completion open the gate or retire the fill — is answered only by
+        `_release_paging_lease`, which compares identity: after a switch away
+        and back to the cached presentation, a stale completion matches the
+        source and the view yet must not retire the newer transaction.
         """
         session = source.session
         view = self._transcript_view()
@@ -6774,6 +6822,9 @@ class OperatorApp(App[None]):
                 and self._transcript is view
                 and self._sidebar_navigation.generation == generation
             )
+
+        def owns() -> bool:
+            return self._paging_leases.get(lease.source_token) is lease
 
         try:
             from local_operator.session.remote import RemoteSession
@@ -6794,22 +6845,31 @@ class OperatorApp(App[None]):
                     message, "tool_call_id", None
                 ):
                     self._resume_results[message.tool_call_id] = message
-            if current() and self._resume_pending_head:
-                self._mount_older_resume_page(on_settled=on_settled, gate_held=True)
+            if current() and owns() and self._resume_pending_head:
+                self._mount_older_resume_page(on_settled=on_settled, lease=lease)
                 transferred = True
         except Exception as exc:
-            if current():
+            if current() and owns():
                 self._resume_fill_active = False
                 self._notice(f"Could not load earlier messages: {exc}", "error")
         finally:
-            if self._is_current(source) and self._transcript is view and not transferred:
-                self._resume_paging = False
+            # `transferred` means the mount now carries the lease to its settle.
+            # Otherwise this transaction ends here, and only it may end itself.
+            if not transferred and self._release_paging_lease(lease):
                 if current() and completed and on_settled is not None:
                     on_settled()
                 else:
                     self._resume_fill_active = False
-                self._reconcile_head_notice()
-                self._transcript_scrolled(None)
+                # `view.parent` as well as identity: a transaction can settle
+                # while Textual is tearing this surface down, and re-deriving
+                # the transcript from the DOM there raises `NoMatches`.
+                if (
+                    self._is_current(source)
+                    and self._transcript is view
+                    and view.parent is not None
+                ):
+                    self._reconcile_head_notice()
+                    self._transcript_scrolled(None)
 
     def _transcript_extent_changed(self) -> None:
         """Re-decide the head notice whenever the geometry it describes moves.
@@ -6841,6 +6901,40 @@ class OperatorApp(App[None]):
         if self._resume_head_notice is None:
             return
         self._reconcile_head_notice()
+
+    @property
+    def _resume_paging(self) -> bool:
+        """Whether the CURRENT source owes a page it has not finished painting."""
+        return self._interaction.token in self._paging_leases
+
+    def _acquire_paging_lease(self, source: SessionInteraction) -> _PagingLease | None:
+        """Take the backward-paging gate for ``source``, or refuse.
+
+        Refusing rather than queueing is the whole single-flight contract: a
+        second request for a source whose fetch is still outstanding is the
+        duplicate RPC F1 reported, and the cursor it would send is the one the
+        first request is already consuming (`history changed while paging`).
+        """
+        if source.token in self._paging_leases:
+            return None
+        lease = _PagingLease(source_token=source.token)
+        self._paging_leases[source.token] = lease
+        return lease
+
+    def _release_paging_lease(self, lease: _PagingLease | None) -> bool:
+        """Drop ``lease`` only if it is still the holder. Returns whether it was.
+
+        Identity, not source equality: a stale completion arriving after a
+        revisit names the same source as the transaction now in flight, and
+        letting it release on that basis is exactly the bug — the newer fetch
+        loses its gate while it is still running.
+        """
+        if lease is None:
+            return False
+        if self._paging_leases.get(lease.source_token) is not lease:
+            return False
+        del self._paging_leases[lease.source_token]
+        return True
 
     def _transcript_scrolled(self, *args: Any, continuous: bool = False) -> None:
         """Coalesce real upward input, never infer demand from layout motion.
@@ -6915,7 +7009,7 @@ class OperatorApp(App[None]):
             self._fill_resume_until_scrollable(target=view.scroll_y + viewport)
 
     def _mount_older_resume_page(
-        self, on_settled: Callable[[], None] | None = None, *, gate_held: bool = False
+        self, on_settled: Callable[[], None] | None = None, *, lease: _PagingLease | None = None
     ) -> None:
         """Mount the next older page of a bounded resume, at the top.
 
@@ -6949,9 +7043,16 @@ class OperatorApp(App[None]):
         the unbounded render cost this bound exists to remove, paid
         mid-interaction on the very sessions it targets.
         """
-        if (self._resume_paging and not gate_held) or not self._resume_pending_head:
+        if not self._resume_pending_head:
             return
-        self._resume_paging = True
+        source = self._interaction
+        if lease is None:
+            # A gesture-driven mount opens its own transaction; a fetch hands
+            # over the one it already holds so the gate is never briefly free
+            # between the network completing and the rows being painted.
+            lease = self._acquire_paging_lease(source)
+            if lease is None:
+                return
         head = self._resume_pending_head
         # Same turn-boundary snap as the initial cut: a page that opened on
         # a tool result whose call is still in the remaining head would
@@ -6981,20 +7082,22 @@ class OperatorApp(App[None]):
             # the input lease stuck after a malformed persisted row.
             self._resume_pending_head = head
             self._resume_mounted_ids.intersection_update(mounted_ids)
-            self._resume_paging = False
+            self._release_paging_lease(lease)
             self._resume_fill_active = False
             raise
-        source = self._interaction
         generation = self._sidebar_navigation.generation
 
         def release_gate() -> None:
-            # A hidden/replaced view cannot release the new view's lease.
+            # A hidden/replaced view cannot release the new view's lease, and
+            # a completion that no longer holds the gate cannot release it at
+            # all — that identity check is F1's remediation.
+            if not self._release_paging_lease(lease):
+                return
             if not self._is_current(source) or self._transcript is not transcript:
                 return
             if self._sidebar_navigation.generation != generation:
                 # A failed/cancelled navigation can leave THIS view active.
-                # Retire its old lease without continuing superseded fill.
-                self._resume_paging = False
+                # Retire the fill without continuing superseded work.
                 self._resume_fill_active = False
                 self._reconcile_head_notice()
                 return
@@ -7006,7 +7109,7 @@ class OperatorApp(App[None]):
             # Releasing any earlier re-opens the gate while an animated page-up
             # is still crossing the trigger row, and the next animation frame
             # mounts another page.
-            self._resume_paging = False
+            #
             # This page changed both terms the head notice is decided from —
             # how much history is left, and whether the frame can reach it —
             # so restate it from the geometry this mount just produced. Without

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1002,47 +1002,26 @@ TERMINAL_GATE_TIMEOUT_S = 30.0
 #:
 #: 80 measured against the alternatives on a real 716-message session, driving
 #: the real app: 40 msgs → 98.7 ms, 80 → 139 ms, 160 → 251 ms, 716 (all) →
-#: 1022 ms. 80 is a 7.3x win that still fills a 40-row terminal about twice
-#: over, so the reader lands on a screen with scrollback above it rather than
-#: on a viewport that is exactly as tall as its content — which would read as
-#: "my history is gone" and is the specific failure this bound must not cause.
+#: 1022 ms. That is a cheap seed, not a geometry guarantee: compact tools or
+#: hidden events can still leave it underfilled. The post-projection fill
+#: measures actual laid-out rows and reserves a viewport above the reader.
 RESUME_RENDER_MESSAGES = 80
 
-#: Messages mounted per backward page once the reader reaches the top. Smaller
-#: than the initial bound because a page is paid DURING an interaction: it must
-#: land within one frame, where the initial render is paid once behind a splash
-#: the user is already waiting on.
-RESUME_PAGE_MESSAGES = 60
+#: Raw messages per yielded render slice. A request fills a rendered viewport
+#: buffer across as many slices as needed; it is not one tiny RPC per notch.
+#: Construction is paid during interaction, so use smaller slices than the
+#: first paint and yield layout/input between them rather than one long mount.
+RESUME_PAGE_MESSAGES = 24
 
 #: Rows from the top of the transcript at which the next older page is mounted.
 #: Not zero: mounting only at the exact top means the reader hits a hard stop,
 #: sees nothing arrive for a frame, and concludes the conversation starts there.
 RESUME_PAGE_TRIGGER_ROWS = 4
 
-#: How many older pages the initial resume may mount to make the first frame
-#: SCROLLABLE. A hard cap, not a target: the fill loop below stops the moment
-#: the content exceeds the viewport, and this only bounds the pathological
-#: case (a history of rows that each render to nothing measurable) so it
-#: cannot spin. Three pages is 180 messages on top of the initial bound, which
-#: is still inside the render budget's measured envelope.
-#:
-#: The cap is genuinely reachable, which it was not when it was first written:
-#: the fill chained its re-measure to the next refresh while the paging gate
-#: was released a settle later, so attempt 1 always stood down and the
-#: effective cap was ONE. Measured after the chaining fix, a 401-message
-#: agentic history reaches attempt 2 at 120x300 and mounts two pages. Anything
-#: taller than roughly 600 rows still exhausts the cap and lands in
-#: :data:`RESUME_UNREACHABLE_NOTICE`, which is why that notice is a control
-#: rather than a dead end.
-RESUME_FILL_MAX_PAGES = 3
-
-#: Rows of content beyond the viewport the initial fill aims for. A frame that
-#: is scrollable by one row technically has a scrollbar, but the reader has
-#: nothing to travel through and the page-back trigger
-#: (:data:`RESUME_PAGE_TRIGGER_ROWS`) sits at row 4 — so the fill would leave a
-#: transcript whose trigger is unreachable in practice. One trigger zone plus a
-#: margin is the smallest overshoot that makes "scroll up" a real gesture.
-RESUME_FILL_SLACK_ROWS = RESUME_PAGE_TRIGGER_ROWS + 4
+#: Fairness boundary for progressive rendered fill, not a lifetime cutoff.
+#: Hidden-only pages still advance through yielded bursts until real content
+#: fills the reserve, the cursor stops advancing, or the reader takes over.
+RESUME_FILL_MAX_PAGES = 16
 
 #: The row that stands in for the un-rendered head of a resumed conversation.
 #: It exists because the failure mode of a display bound is a user believing
@@ -2558,28 +2537,16 @@ class OperatorApp(App[None]):
         #: painted frames — `scroll up` -> `select` -> `scroll up` — which
         #: reads as the notice changing its mind (review round 2, R6).
         self._resume_fill_active = False
+        self._resume_fill_serial = 0
         #: SINGLE-FLIGHT guard for the deferred page check: while set, a check
         #: is already scheduled and `_transcript_scrolled` must not queue a
         #: second. See that method for why unbounded requeues were a cascade.
         self._resume_check_pending = False
-        #: EDGE-TRIGGERED top-zone latch, the second half of the page-per-
-        #: arrival contract (the first half is `_resume_paging`'s one page
-        #: per GESTURE). ``True`` means armed: the next at-rest moment inside
-        #: the trigger rows mounts exactly ONE page, and the latch stays
-        #: consumed until a scroll GESTURE arrives after that page has landed
-        #: (`_transcript_scrolled` is the only re-arm). Without it the check
-        #: was LEVEL-triggered: after a page prepended, the anchor restore
-        #: parked the reader back inside the trigger rows, the gate opened,
-        #: and the next watch firing — a settle frame, or one more wheel
-        #: notch of a gesture that was still running — mounted another page,
-        #: and another: the reported "it loads chunks one after another
-        #: without me scrolling up again". A GESTURE as the re-arm is what
-        #: closes the hole an offset-based rule cannot: the prepend itself
-        #: displaces the reader out of the zone with no gesture involved, and
-        #: every input path (wheel, key, scrollbar, arrow affordance)
-        #: announces itself through ``note_user_scroll`` before it moves
-        #: anything — the one signal the mount can never synthesize.
-        self._resume_in_zone = True
+        #: One coalesced upward-input demand, including input arriving while a
+        #: page is in flight. Offset observations never arm it. After a page
+        #: settles it is checked once against the new viewport, so resting at
+        #: the top cannot automatically drain history.
+        self._resume_in_zone = False
         #: What the CURRENT turn has already been billed for, per model call, by
         #: `on_context_usage_reported`. `on_turn_ended` prices the same turn as a
         #: whole and is the authoritative figure, so it adds only the difference
@@ -4663,6 +4630,7 @@ class OperatorApp(App[None]):
             # A drawer cannot count as a correct visible conversation while it
             # covers the response. Pinned wide sidebars stay open.
             self._set_sidebar_open(False)
+        self._start_resume_fill()
         return self._await_sidebar_frame(source, generation)
 
     def on_session_sidebar_selected(self, message: SessionSidebar.Selected) -> None:
@@ -6437,7 +6405,7 @@ class OperatorApp(App[None]):
         self._resume_check_pending = False
         # Re-armed with the rest of the resume state: a new conversation's
         # first arrival at the top owes a page (see `_resume_in_zone`).
-        self._resume_in_zone = True
+        self._resume_in_zone = False
         self._project_settled_rows(history, bound=RESUME_RENDER_MESSAGES)
         # A message budget is a PROXY for height, and a poor one. Whether the
         # first frame can be scrolled is a question about ROWS, and only the
@@ -6448,204 +6416,118 @@ class OperatorApp(App[None]):
         # the frames between this mount and that callback are the earliest
         # ones a reader sees, and they are exactly as provisional as the ones
         # between attempts.
-        self._resume_fill_active = True
-        self._transcript_view().call_after_refresh(self._fill_resume_until_scrollable)
+        self._start_resume_fill()
 
-    def _fill_resume_until_scrollable(self, _attempt: int = 0) -> None:
-        """Run one fill attempt, and never leave the fill flagged active if it raises.
+    def _start_resume_fill(self, *, target: float | None = None) -> None:
+        """Top up a newly revealed projection, not every subsequent resize.
 
-        ``_resume_fill_active`` SUPPRESSES the pessimistic "not reachable by
-        scrolling" copy while the geometry is still provisional (R6), so a flag
-        stuck ``True`` is not inert — it permanently silences the correction
-        and leaves the notice promising a gesture the frame cannot perform,
-        which is the defect this whole feature exists to remove. The attempt
-        body clears the flag at each of its terminal exits, but those are
-        statement sites: a raise between the ``True`` in ``_render_resume`` and
-        any of them skips every one (measured: ``fill_active`` stayed ``True``
-        across a subsequent resize, with the copy frozen).
-
-        Only the ABNORMAL path is cleared here. A `finally` would be wrong:
-        the two continuation branches return with the flag deliberately still
-        ``True`` because the fill is genuinely still running, and clearing it
-        there would hand the reader the pessimistic copy mid-fill.
-
-        ``_resume_paging``, the flag this one is contrasted with in the body's
-        own commentary, is protected the same way by the ``finally`` in
-        :meth:`_fetch_older_display_page`; the two siblings must not disagree
-        about who guarantees their invariant (review round 3, R10).
+        Raw-event tail bounds are deliberately cheap first paint, not geometry:
+        hidden events and compact tool rows can leave no upward scroll range.
+        The callback belongs to this exact presentation; a switch away/back
+        or canonical replacement must not revive a stale fill.
         """
+        view = self._transcript_view()
+        source = self._interaction
+        generation = self._sidebar_navigation.generation
+        self._resume_fill_active = True
+        self._resume_fill_serial += 1
+        serial = self._resume_fill_serial
+
+        def start() -> None:
+            if (
+                not self._is_current(source)
+                or self._transcript is not view
+                or self._resume_fill_serial != serial
+            ):
+                return
+            if self._sidebar_navigation.generation != generation:
+                self._resume_fill_active = False
+                self._reconcile_head_notice()
+                return
+            if self._resume_fill_active:
+                self._fill_resume_until_scrollable(target=target)
+
+        view.call_after_refresh(start)
+
+    def _fill_resume_until_scrollable(
+        self, _attempt: int = 0, *, target: float | None = None
+    ) -> None:
+        """Measure settled rows, clearing provisional state on abnormal exits."""
+        if _attempt == 0:
+            # A new input buffer supersedes an older queued initial fill even
+            # when both belong to the same source/view/navigation generation.
+            self._resume_fill_serial += 1
+            self._resume_fill_active = True
+        elif not self._resume_fill_active:
+            return  # Real input superseded the initial presentation fill.
         try:
-            self._fill_resume_attempt(_attempt)
+            self._fill_resume_attempt(_attempt, target=target)
         except BaseException:
             self._resume_fill_active = False
             raise
 
-    def _fill_resume_attempt(self, _attempt: int) -> None:
-        """Mount older pages until the first resume frame is actually scrollable.
+    def _fill_resume_attempt(self, _attempt: int, *, target: float | None = None) -> None:
+        """Reserve one real viewport above the reader, progressively and bounded.
 
-        The render bound is counted in MESSAGES, but "can the reader scroll up
-        to reach the rest" is decided in ROWS: 80 one-line messages in a 60-row
-        terminal still fit inside the viewport, and a transcript whose content
-        fits has no scrollbar and no offset to travel. ``_check_resume_page``
-        only ever fires on a scroll INTO the trigger zone, so on such a frame
-        the deferred head and the server's ``history_before_token`` pages are
-        unreachable forever while the head notice tells the reader to scroll up
-        for them.
-
-        So the geometry is measured after the mount settles, and while the
-        content does not exceed the viewport AND more history exists, the next
-        older page is mounted. Recursive-by-SETTLE rather than a loop: each
-        page's blocks only author their real heights on a later layout pass
-        (``_set_authored_height``), so measuring again in the same frame would
-        read the extent this mount has not finished growing.
-
-        The continuation is chained to the mount's own settle seam, never to
-        ``call_after_refresh``. The paging gate is released from the settle
-        callback ``insert_blocks`` schedules, which is strictly LATER than the
-        next refresh, so a refresh-chained re-measure arrived while the gate
-        was still held, took the stand-down return below, and nothing ever
-        rescheduled it: :data:`RESUME_FILL_MAX_PAGES` was unreachable and the
-        effective cap was ONE page. On a viewport tall enough to need two, the
-        resume stayed unscrollable with its head unreachable — the exact defect
-        this method exists to remove (measured at 120x300: `max_scroll_y=0`,
-        no scrollbar, 261 messages pending, and the head notice still telling
-        the reader to scroll up for them).
-
-        NOT A GESTURE. This runs outside the page-back latch entirely: it must
-        neither arm ``_resume_in_zone`` (which would hand a free page to the
-        reader's first real scroll) nor consume it (which would swallow that
-        scroll's legitimate page). It cooperates with ``_resume_paging`` only
-        as a mutex — if a genuine gesture is mid-mount, this stands down and
-        lets the gesture own the frame, because a reader who is already
-        scrolling does not need the fill.
-
-        That neutrality is ENFORCED here, not merely intended. The fill does
-        not touch the latch itself, but its mount lands the reader at y=0 and
-        the settle that follows drives the same page-back hook a reader's
-        scroll does; the latch was spent that way, and because the hook re-arms
-        only on a discrete act or outside the trigger zone, a wheel reader
-        clamped at the top could never earn another page (measured: 60 notches
-        at y=0 mounted nothing). The offset leak behind it is fixed at source
-        in ``TranscriptView.insert_blocks``'s restore, but this method saves
-        and restores the latch around its own mount regardless — the
-        guarantee is this method's to keep, and it should not silently depend
-        on another widget's scroll bookkeeping staying correct.
-
-        ``RESUME_FILL_MAX_PAGES`` bounds it hard. The loop's own exit condition
-        is the geometry, which terminates on any real history; the cap is for
-        the case where it cannot — a head of rows that measure to zero height
-        would otherwise mount the entire conversation one page at a time,
-        which is the unbounded render cost the budget exists to remove.
+        At the tail this means at least two viewports of rendered content; at
+        a restored reading anchor it means one viewport above that anchor.
+        Each page yields through its own layout/anchor-settled callback before
+        measuring again. Hidden rows do not count toward the geometry target:
+        burst boundaries yield again rather than declaring an underfilled view
+        finished. Only exhaustion, non-advancing cursors or user input stop it.
         """
-        # EVERY exit below is terminal for the fill, so each clears the
-        # provisional-geometry flag before reconciling: the notice is entitled
-        # to state the pessimistic case once the fill has actually given up,
-        # and only then (R6).
-        if _attempt >= RESUME_FILL_MAX_PAGES:
-            self._resume_fill_active = False
-            self._reconcile_head_notice()
-            return
         view = self._transcript_view()
-        if view.parent is None:
-            self._resume_fill_active = False
-            return
-        # A real gesture owns the mount seam right now. Stand down: the reader
-        # is scrolling, which is the condition this fill exists to make
-        # possible. Reconcile on the way out — EVERY exit from this method
-        # leaves a frame the reader looks at, and one that skipped the
-        # reconcile is how the head notice came to promise history the frame
-        # could not reach.
-        if self._resume_paging:
-            self._resume_fill_active = False
-            self._reconcile_head_notice()
-            return
-        # Content already exceeds the viewport by enough for the trigger zone
-        # to be reachable — the frame is scrollable and the fill is done.
         viewport = view.container_size.height or view.size.height
-        if not viewport:
-            self._resume_fill_active = False
-            return
-        if view.virtual_size.height > viewport + RESUME_FILL_SLACK_ROWS:
-            # Scrollable, so "scroll up to load" is a gesture the reader can
-            # actually perform. The notice keeps its promise — reconciled
-            # anyway, because this is also the exit taken when a page mounted
-            # by an earlier attempt exhausted the head, and the notice would
-            # otherwise still be promising more.
+        notice = self._resume_head_notice
+        prefix = notice.virtual_region.bottom if notice is not None and notice.parent is view else 0
+        # Loader chrome is not historical content. At exact-fit sizes it used
+        # to supply the last row of the promised one-viewport reserve itself.
+        goal = max(viewport + prefix, target or 0)
+        if view.parent is None or not viewport or self._resume_paging or view.scroll_y >= goal:
             self._resume_fill_active = False
             self._reconcile_head_notice()
             return
+        source = self._interaction
+        generation = self._sidebar_navigation.generation
+        serial = self._resume_fill_serial
+        pending_count = len(self._resume_pending_head)
+        before_token = getattr(self._session, "history_before_token", None)
 
-        session = self._session
-        if self._resume_pending_head:
-            # Save and restore the latch across the mount: whatever the settle
-            # does with it, the reader's first real scroll still owns the page
-            # it is entitled to. See the docstring — this guarantee is kept
-            # structurally rather than inherited.
-            armed = self._resume_in_zone
-
-            def settled() -> None:
-                self._resume_in_zone = armed
-                self._fill_resume_until_scrollable(_attempt + 1)
-
-            # Chained to the SETTLE, not to the next refresh: see the
-            # docstring. `_attempt` is carried through so the cap still bounds
-            # a head whose rows measure to no height.
-            self._mount_older_resume_page(on_settled=settled)
-            return
-        if session is not None and getattr(session, "history_before_token", None):
-            # The remote/server-paged case: nothing is held locally, but the
-            # conversation continues on the server. Same gate, so this cannot
-            # race a gesture's own fetch.
-            #
-            # The continuation is chained to the WORKER, not to the next
-            # refresh: the fetch is a network round trip, so a refresh-scheduled
-            # re-measure would run while it is still in flight, see the gate
-            # held and stand down — leaving the fill one page short on exactly
-            # the sessions (remote, long) it is most needed for.
-            self._resume_paging = True
-            armed = self._resume_in_zone
-            # Pinned BEFORE the round trip, and checked after it: the identity
-            # test below is close to a tautology on its own, because
-            # `_transcript_view` is the main transcript and is never removed or
-            # reparented. The generation is what actually answers "is this
-            # still the conversation that asked?" — without it, a sidebar
-            # switch during the fetch runs an unrequested fill against the
-            # conversation the reader moved TO. Every other async continuation
-            # in this file pins it the same way (`_mount_newer_resume_page`,
-            # `_transcript_scrolled`).
-            generation = self._sidebar_navigation.generation
-            source = self._interaction
-
-            async def fetch_then_refill() -> None:
-                await self._fetch_older_display_page(source)
-                if (
-                    self._transcript_view() is view
-                    and self._is_current(source)
-                    and self._sidebar_navigation.generation == generation
-                ):
-                    # Restored for the same reason as the local branch: the
-                    # fetch's own mount must not spend the reader's latch.
-                    self._resume_in_zone = armed
-                    self._fill_resume_until_scrollable(_attempt + 1)
-                elif self._is_current(source):
-                    # The reader moved on mid-fetch, so this fill is abandoned
-                    # and no later exit will clear the flag. Cleared here so a
-                    # conversation cannot be left permanently "filling", which
-                    # would suppress the unreachable copy forever. Guarded on
-                    # `_is_current` so an abandoned fetch does not reach into
-                    # the state of the conversation the reader moved TO, which
-                    # is running its own fill.
+        def settled() -> None:
+            if (
+                self._is_current(source)
+                and self._transcript is view
+                and self._sidebar_navigation.generation == generation
+                and self._resume_fill_active
+                and self._resume_fill_serial == serial
+            ):
+                progressed = (
+                    len(self._resume_pending_head) < pending_count
+                    if pending_count
+                    else getattr(self._session, "history_before_token", None) != before_token
+                )
+                if not progressed:
                     self._resume_fill_active = False
+                    self._reconcile_head_notice()
+                elif _attempt + 1 >= RESUME_FILL_MAX_PAGES:
+                    # A long hidden prefix is not a reason to strand the
+                    # reader. Yield an additional idle frame between bursts;
+                    # _start_resume_fill fences the new callback to this view.
+                    self._start_resume_fill(target=target)
+                else:
+                    self._fill_resume_until_scrollable(_attempt + 1, target=target)
 
+        if self._resume_pending_head:
+            self._mount_older_resume_page(on_settled=settled)
+        elif self._session is not None and getattr(self._session, "history_before_token", None):
+            self._resume_paging = True
             self.run_worker(
-                fetch_then_refill(),
+                self._fetch_older_display_page(source, on_settled=settled),
                 group=source.worker_group("history-page"),
             )
-            return
-        # No more history in either direction. The frame is as tall as the
-        # conversation allows.
-        self._resume_fill_active = False
-        self._reconcile_head_notice()
+        else:
+            self._resume_fill_active = False
+            self._reconcile_head_notice()
 
     def _reconcile_head_notice(self) -> None:
         """Never promise history the reader cannot actually reach.
@@ -6659,10 +6541,11 @@ class OperatorApp(App[None]):
           should now state where the conversation begins rather than point at
           nothing;
         * the head is NOT exhausted but the transcript still does not exceed
-          its viewport — the fill hit its cap, or the remaining rows measure to
-          nothing. There is no offset to travel and no trigger to reach, so the
-          instruction cannot be followed. Saying "start of conversation" would
-          be a lie in the other direction, so the notice is restated to name
+          its viewport — the fill was interrupted, its cursor stopped moving,
+          or the remaining rows measure to nothing. There is no offset to travel
+          and no trigger to reach, so the instruction cannot be followed.
+          Saying "start of conversation" would be a lie in the other direction,
+          so the notice is restated to name
           what is actually true: more exists, and it is not reachable by
           scrolling here.
 
@@ -6794,42 +6677,12 @@ class OperatorApp(App[None]):
             self._mount_newer_resume_page()
 
     def on_older_history_notice_requested(self, message: OlderHistoryNotice.Requested) -> None:
-        """Activating the head notice loads the next older page.
-
-        The head twin of the handler above. Routed through the same mount the
-        scroll trigger uses, so a click and a scroll-to-top earn exactly one
-        page each and share the single-flight gate — an activation arriving
-        while a page is still settling is dropped by `_mount_older_resume_page`
-        rather than queued, which is the same contract a keypress gets.
-
-        This is the ONLY way out of the unreachable state
-        (:data:`RESUME_UNREACHABLE_NOTICE`), where by construction there is no
-        offset to travel and the scroll trigger can never fire.
-        """
+        """The explicit affordance uses the same demand lease as upward input."""
         message.stop()
-        if message.notice is not self._resume_head_notice:
-            return
-        if self._resume_pending_head:
-            self._mount_older_resume_page()
-            return
-        session = self._session
-        if session is not None and getattr(session, "history_before_token", None):
-            # Remote/server-paged: the same fetch the scroll trigger runs.
-            if self._resume_paging:
-                return
-            self._resume_paging = True
-            # Pinned once and passed through, for the reason the fill's remote
-            # branch states at length: `self._interaction` read twice can be
-            # two different conversations if the reader switches between the
-            # reads. Narrower here than in the fill — nothing awaits between
-            # them — but the two twins running the same fetch through the same
-            # worker group must not disagree about the rule, or a later reader
-            # fixes whichever one they find second (review round 2, R7).
-            source = self._interaction
-            self.run_worker(
-                self._fetch_older_display_page(source),
-                group=source.worker_group("history-page"),
-            )
+        if message.notice is self._resume_head_notice:
+            self._resume_fill_active = False
+            self._resume_in_zone = True
+            self._check_resume_page(force=True)
 
     def _jump_newer_resume_tail(self) -> None:
         if not self._resume_pending_tail:
@@ -6899,31 +6752,64 @@ class OperatorApp(App[None]):
             view.remove_block(notice)
             self._resume_tail_notice = None
 
-    async def _fetch_older_display_page(self, source: SessionInteraction) -> None:
+    async def _fetch_older_display_page(
+        self, source: SessionInteraction, on_settled: Callable[[], None] | None = None
+    ) -> None:
+        """Keep the same single-flight lease from remote request through paint.
+
+        Network completion is not insertion completion. Releasing in finally
+        after scheduling an insert admitted a second page into unsettled DOM
+        and let the fill measure provisional heights. Transfer the lease to
+        the mount callback instead, fenced by source, navigation and view.
+        """
         session = source.session
+        view = self._transcript_view()
+        generation = self._sidebar_navigation.generation
+        transferred = False
+        completed = False
+
+        def current() -> bool:
+            return (
+                self._is_current(source)
+                and self._transcript is view
+                and self._sidebar_navigation.generation == generation
+            )
+
         try:
             from local_operator.session.remote import RemoteSession
 
             if not isinstance(session, RemoteSession):
                 return
             rows = await session.load_older_display_page()
+            completed = True
             source.presentation_revision += 1
-            if not self._is_current(source):
+            if not self._is_current(source) or self._transcript is not view:
                 return
+            # A navigation attempt can fail without replacing this view.
+            # Retain fetched rows on its own replay model even then, but do
+            # not let the superseded request mount or continue filling.
             self._resume_pending_head = rows + self._resume_pending_head
             for message in rows:
                 if getattr(message, "role", "") == "tool" and getattr(
                     message, "tool_call_id", None
                 ):
                     self._resume_results[message.tool_call_id] = message
-            self._resume_paging = False
-            self._mount_older_resume_page()
+            if current() and self._resume_pending_head:
+                self._mount_older_resume_page(on_settled=on_settled, gate_held=True)
+                transferred = True
         except Exception as exc:
-            if self._is_current(source):
+            if current():
+                self._resume_fill_active = False
                 self._notice(f"Could not load earlier messages: {exc}", "error")
         finally:
-            if self._is_current(source):
+            if self._is_current(source) and self._transcript is view and not transferred:
                 self._resume_paging = False
+                if current() and completed and on_settled is not None:
+                    on_settled()
+                else:
+                    self._resume_fill_active = False
+                self._reconcile_head_notice()
+                self._transcript_scrolled(None)
 
     def _transcript_extent_changed(self) -> None:
         """Re-decide the head notice whenever the geometry it describes moves.
@@ -6956,145 +6842,81 @@ class OperatorApp(App[None]):
             return
         self._reconcile_head_notice()
 
-    def _transcript_scrolled(self, *_args: Any, continuous: bool = False) -> None:
-        """Mount the next older page when the reader reaches the top.
+    def _transcript_scrolled(self, *args: Any, continuous: bool = False) -> None:
+        """Coalesce real upward input, never infer demand from layout motion.
 
-        Fired from the transcript's ``scroll_y`` WATCH (every offset the
-        viewport actually passes through) and from ``note_user_scroll`` (the
-        gesture that moves NOTHING — Home while already at the top changes no
-        offset, so the watch alone would miss the one key that most clearly
-        means "show me the start"). Both are needed, and neither alone is
-        enough; the guards inside :meth:`_check_resume_page` are what keep
-        the many firings of one animated gesture to ONE page.
-
-        This hook is also the latch's only re-arm (see `_resume_in_zone`),
-        and the RULE is deliberate: a gesture re-arms only when it can
-        actually have moved the reader OUT of the trigger zone, or when it
-        is a discrete act. Every input path announces itself here before it
-        moves anything, and the mount's own displacement never passes
-        through it — but a wheel notch arriving while the viewport is
-        already clamped at the top moves NOTHING, and re-arming on it let a
-        held wheel mount a page per notch while the reader sat at y=0 (the
-        "held scroll-up at the top" half of the reported loop). A discrete
-        act at the top is different: a keypress, an affordance click, or a
-        caller announcing a gesture by hand is the deliberate "next page
-        please", and one act is one page because the check consumes the
-        latch again.
-
-        Consequence for a SUSTAINED drag, stated plainly because it is the
-        behaviour and not an accident: a long wheel drag CAN mount several
-        pages. Each mount displaces the reader a page-height down (the
-        insert goes above them), so a wheel that keeps running travels that
-        distance back up and genuinely re-arrives at the top — one page per
-        real arrival, which is the contract. What this rule removes is the
-        page that no travel paid for: notches clamped at the top, settle
-        frames, and the mount's own restore. That is the half of the
-        reported loop the operator actually saw — chunks loading "without
-        requiring me to scroll up to the top again on the new height".
+        The widget reports True/False for directional input and None for an
+        offset observation. A clamped wheel notch is still input. Observations
+        may complete an animated gesture, but cannot earn another page. One
+        boolean retains at most one additional demand while fetch/mount is
+        busy; a downward gesture cancels that debt.
         """
-        view = self._transcript_view()
+        # A final animation tick may arrive while Textual is unmounting this
+        # surface. Hooks belong to the cached active view; never rediscover a
+        # transcript (or dispatch paging) after that view has been retired.
+        view = self._transcript
+        if view is None or view.parent is None:
+            return
+        upward = args[0] if args else True
+        if upward is not None:
+            self._resume_fill_active = False
+            self._resume_in_zone = bool(upward)
         if self._resume_pending_tail and view.scroll_y > 0 and view.is_near_bottom():
             self._mount_newer_resume_page()
             return
-        if not self._resume_pending_head:
-            session = self._session
-            if (
-                session is not None
-                and getattr(session, "history_before_token", None)
-                and not self._resume_paging
-                and view.scroll_y <= RESUME_PAGE_TRIGGER_ROWS
-                and (not continuous or self._resume_in_zone)
-            ):
-                self._resume_paging = True
-                self._resume_in_zone = False
-                self.run_worker(
-                    self._fetch_older_display_page(self._interaction),
-                    group=self._interaction.worker_group("history-page"),
-                )
-            return
-        if self._resume_paging:
-            # A page this same gesture requested is still mounting. The
-            # notches still arriving from that wheel land inside the trigger
-            # rows before the first page settles, and re-arming on them made
-            # one drag mount a second page the moment the gate re-opened —
-            # a page no travel paid for. The next page waits for a gesture
-            # that arrives after this one's page has landed.
-            return
-        if not continuous or self._transcript_view().scroll_offset.y > RESUME_PAGE_TRIGGER_ROWS:
-            self._resume_in_zone = True
-        # SINGLE-FLIGHT: exactly one deferred check may be pending at a time.
-        # The watch fires once per animation frame and each firing used to
-        # schedule its own check, so one animated gesture queued hundreds;
-        # they all drained the moment the gate re-opened and each one mounted
-        # another page — the same cascade the gate exists to prevent, arriving
-        # one settle-pass later (M1/U1). A flag is enough because the pending
-        # check always runs before the next frame's watch can fire again.
-        if self._resume_check_pending:
+        if not self._resume_in_zone or self._resume_check_pending or self._resume_paging:
             return
         self._resume_check_pending = True
-
         generation = self._sidebar_navigation.generation
+        source = self._interaction
 
         def run_check() -> None:
-            if self._transcript is not view or self._sidebar_navigation.generation != generation:
+            if self._transcript is not view or not self._is_current(source):
                 return
             self._resume_check_pending = False
-            self._check_resume_page()
+            if self._sidebar_navigation.generation == generation:
+                self._check_resume_page()
 
-        self._transcript_view().call_after_refresh(run_check)
+        if upward is not None:
+            # Keyboard scroll helpers enqueue their actual motion after the
+            # refresh too. Our input hook runs first to release tail-follow;
+            # checking in that same callback batch would retire the demand
+            # before Home/PageUp had even installed its animation target.
+            view.call_after_refresh(lambda: view.call_after_refresh(run_check))
+        else:
+            view.call_after_refresh(run_check)
 
-    def _check_resume_page(self) -> None:
-        """Answer "is the reader at the top" from a viewport at rest.
-
-        Re-asks frame-by-frame while the viewport is still travelling — an
-        animated page-up is mid-flight for its whole duration, and every
-        intermediate offset is nearer the top than where the reader will land
-        — and again while a page this gesture already mounted is still
-        settling, so a second gesture arriving inside that window is answered
-        the moment the gate re-opens rather than silently dropped. Both waits
-        end: the animation finishes, and the settle callback releases the
-        gate (:meth:`_mount_older_resume_page`). The requeue is single-flight
-        (see `_transcript_scrolled`), so waiting never accumulates.
-
-        :data:`RESUME_PAGE_TRIGGER_ROWS` fires slightly before the hard top so
-        the rows are already there when the reader arrives, rather than
-        appearing under a viewport that had stopped.
-
-        EDGE, not level: the mount below fires only on the latch
-        (`_resume_in_zone`), which is armed by a user gesture arriving after
-        the previous page landed and consumed by this mount. A level test
-        here mounted on every settle frame — the anchor restore after a page
-        lands the reader back INSIDE the zone by construction, which is the
-        whole point of preserving the anchor — and the next watch firing
-        mounted another page. Home pressed while already parked at the top
-        still loads one page: that gesture re-arms the latch (it is a real
-        input) and the check consumes it again — one press, one page.
-        """
-        if not self._resume_pending_head:
+    def _check_resume_page(self, *, force: bool = False) -> None:
+        """Spend one demand only after motion settles in the prefetch zone."""
+        if not self._resume_in_zone or self._resume_paging:
             return
-        transcript = self._transcript_view()
+        view = self._transcript_view()
         if (
-            transcript.app.animator.is_being_animated(transcript, "scroll_y")
-            # A scroll that has been REQUESTED but not started yet — the
-            # callback can land between the key binding and the animation it
-            # schedules, where `is_being_animated` is still False and the
-            # offset still pre-gesture. `scroll_target_y` is where the
-            # viewport is committed to go; differing means travel is coming.
-            or transcript.scroll_target_y != transcript.scroll_offset.y
-            or self._resume_paging
+            view.app.animator.is_being_animated(view, "scroll_y")
+            or view.scroll_target_y != view.scroll_offset.y
         ):
-            self._transcript_scrolled()
+            self._transcript_scrolled(None)
             return
-        if transcript.scroll_offset.y <= RESUME_PAGE_TRIGGER_ROWS and self._resume_in_zone:
-            # Consume FIRST, mount second: the mount's settle re-fires the
-            # watch, and an unconsumed latch would answer it with another
-            # page. `self._resume_paging` also holds across the mount, but
-            # the latch is the contract that survives a settle whose gate
-            # released while the reader stayed parked in the zone.
+        if not force and view.scroll_offset.y > RESUME_PAGE_TRIGGER_ROWS:
+            # This gesture has landed without needing a page. Leaving it armed
+            # would let an unrelated later resize/clamp spend stale input.
             self._resume_in_zone = False
-            self._mount_older_resume_page()
+            return
+        self._resume_in_zone = False
+        if self._resume_pending_head or (
+            self._session is not None and getattr(self._session, "history_before_token", None)
+        ):
+            # Input requests a rendered buffer, not an arbitrary raw-event
+            # slice. Small slices yield during construction; transparent rows
+            # continue automatically until one viewport has appeared above the
+            # held reading position. Remote fetches still bring bounded pages
+            # into the local pending head, not one RPC per slice/notch.
+            viewport = view.container_size.height or view.size.height
+            self._fill_resume_until_scrollable(target=view.scroll_y + viewport)
 
-    def _mount_older_resume_page(self, on_settled: Callable[[], None] | None = None) -> None:
+    def _mount_older_resume_page(
+        self, on_settled: Callable[[], None] | None = None, *, gate_held: bool = False
+    ) -> None:
         """Mount the next older page of a bounded resume, at the top.
 
         ``on_settled`` runs once this page is fully answered and the paging
@@ -7127,7 +6949,7 @@ class OperatorApp(App[None]):
         the unbounded render cost this bound exists to remove, paid
         mid-interaction on the very sessions it targets.
         """
-        if self._resume_paging or not self._resume_pending_head:
+        if (self._resume_paging and not gate_held) or not self._resume_pending_head:
             return
         self._resume_paging = True
         head = self._resume_pending_head
@@ -7150,9 +6972,32 @@ class OperatorApp(App[None]):
         ]
         transcript = self._transcript_view()
         notice = self._resume_head_notice
-        blocks = self._collect_resume_page_blocks(page)
+        mounted_ids = set(self._resume_mounted_ids)
+        try:
+            blocks = self._collect_resume_page_blocks(page)
+        except BaseException:
+            # Projection is synchronous and has not mounted anything yet.
+            # Keep the page retryable instead of losing its cursor or leaving
+            # the input lease stuck after a malformed persisted row.
+            self._resume_pending_head = head
+            self._resume_mounted_ids.intersection_update(mounted_ids)
+            self._resume_paging = False
+            self._resume_fill_active = False
+            raise
+        source = self._interaction
+        generation = self._sidebar_navigation.generation
 
         def release_gate() -> None:
+            # A hidden/replaced view cannot release the new view's lease.
+            if not self._is_current(source) or self._transcript is not transcript:
+                return
+            if self._sidebar_navigation.generation != generation:
+                # A failed/cancelled navigation can leave THIS view active.
+                # Retire its old lease without continuing superseded fill.
+                self._resume_paging = False
+                self._resume_fill_active = False
+                self._reconcile_head_notice()
+                return
             # Cleared from the settle pass, not from a `finally`: the settle
             # is the first moment the gesture that armed the gate is fully
             # answered — the page is mounted, the gaps settled, and the anchor
@@ -7172,6 +7017,7 @@ class OperatorApp(App[None]):
             # page finds the gate open rather than standing down against it.
             if on_settled is not None:
                 on_settled()
+            self._transcript_scrolled(None)
 
         if blocks:
             # Index 1 when the notice heads the list: the page goes BELOW
@@ -7181,16 +7027,9 @@ class OperatorApp(App[None]):
             index = 1 if mounted and notice is not None and mounted[0] is notice else 0
             transcript.insert_blocks(index, blocks, on_settled=release_gate)
         else:
-            release_gate()
-        if not self._resume_pending_head and notice is not None:
-            # The head is exhausted, so the promise of more becomes a
-            # statement of where the conversation begins. Restated in place
-            # rather than removed: removing it would shift every row above
-            # the viewport by one and undo the anchor the insert just held.
-            # Through the shared funnel so the row also stops advertising the
-            # action it no longer has (D7) — a local exhaustion reaches here
-            # rather than through the reconcile.
-            self._restate_head_notice(notice, RESUME_START_NOTICE, "info")
+            # Hidden-only pages still yield; otherwise initial fill projects
+            # several raw pages synchronously without letting input run.
+            transcript.call_after_refresh(release_gate)
 
     def _collect_resume_page_blocks(self, page: list[Any]) -> list[Any]:
         """Build the blocks for one deferred page WITHOUT mounting them.

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -3636,10 +3636,30 @@ class TranscriptView(ScrollableContainer):
         # a wheel notch DOWN while already at the tail, which must hand the
         # anchor straight back rather than leaving it released forever.
         self.call_after_refresh(self._resync_tail_anchor)
+        self._report_scroll_input(upward, continuous=continuous)
+
+    def _report_scroll_input(self, upward: bool | None, *, continuous: bool = False) -> None:
+        """Tell the app which DIRECTION a person just asked for.
+
+        Split out of :meth:`note_user_scroll` because the two halves of that
+        method answer different questions, and one gesture needs only this one.
+        `note_user_scroll` says "a person moved the viewport: release the tail
+        anchor and re-decide where they landed". ``end`` is not that gesture —
+        it is an explicit REQUEST for the tail, which :meth:`follow_tail`
+        acquires outright — yet it is still the most explicit downward input
+        there is and must retire any older upward demand.
+
+        Routing ``end`` through the full `note_user_scroll` is what regressed
+        tail-following (UX round 2, U2): the deferred `_resync_tail_anchor` ran
+        BETWEEN `follow_tail`'s acquire and its deferred `_scroll_to_tail`,
+        measured `is_near_bottom()` at an offset the reader had not been moved
+        to yet, and un-acquired the anchor the same keypress had just taken —
+        so the next reply landed off screen and was never seen.
+        """
         if self._on_user_scroll is not None:
             # Positional provenance preserves the hook's existing variadic
             # contract for other transcript consumers. True/False is actual
-            # directional input; None below is only an offset observation.
+            # directional input; None is only an offset observation.
             self._on_user_scroll(upward, continuous=continuous)
 
     def watch_scroll_y(self, old_value: float, new_value: float) -> None:
@@ -3903,8 +3923,14 @@ class TranscriptView(ScrollableContainer):
         as `upward=False` also retires any older upward demand, exactly as a
         `pagedown` does: the reader travelling to the newest content is not
         asking for older history.
+
+        Provenance ONLY, deliberately — not the whole of `note_user_scroll`.
+        This gesture's anchor handling belongs to `follow_tail` below, which
+        acquires the tail outright; adding the release-and-re-decide pass on
+        top of it un-acquires that anchor a frame later (U2). See
+        :meth:`_report_scroll_input`.
         """
-        self.note_user_scroll(upward=False)
+        self._report_scroll_input(False)
         if self._on_tail_requested is not None:
             self._on_tail_requested()
         self.follow_tail()

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -3094,6 +3094,34 @@ class TranscriptView(ScrollableContainer):
         # causes is already corrected; `_size_updated` fires during mount.
         if anchor_block is not None and not following_tail:
             self._insert_anchor = (anchor_block, anchor_gap)
+        # Spacing is decided BEFORE the mount, not after a painted refresh.
+        # `_settle_gaps` alone runs one refresh late, so a reader whose
+        # uninterrupted upward scroll reached the newcomers saw them paint
+        # flush and then spread apart under a finger moving the other way
+        # (UX round 1, U1: rows 0727..0731 at y=0,1,2,3,4 becoming 0,2,4,6,8
+        # between two consecutive compositor frames, MouseScrollUp only).
+        #
+        # The width these blocks will be given is known here — they are
+        # about to become children of this container — so the hint lets
+        # `spans_multiple_rows` fold at the real width instead of the 80-column
+        # fallback an unparented block measures against. Without it a wrapping
+        # block answers for the wrong terminal and the pre-decided gap is the
+        # wrong one, which would trade a late gap for a wrong gap.
+        fold = self.scrollable_content_region.width
+        for block in additions:
+            if fold:
+                block.set_fold_hint(fold)
+            block.invalidate_row_measurements()
+        previous = self._anchor_before(index)
+        for block in additions:
+            self._apply_gap(previous, block)
+            if not block.SPACING_TRANSIENT:
+                previous = block
+        # The block that FOLLOWED the seam now has a different neighbour above
+        # it, and it is on screen — so its gap is settled in the same pass
+        # rather than one refresh later.
+        if index < len(self._blocks):
+            self._apply_gap(previous, self._blocks[index])
         before = self._blocks[index] if index < len(self._blocks) else None
         if before is None:
             self.mount(*additions)
@@ -3111,6 +3139,14 @@ class TranscriptView(ScrollableContainer):
             self._scroll_to_tail()
 
         def settle_then_restore() -> None:
+            # The pre-mount pass above already gave every newcomer its gap, so
+            # this is a CONFIRMATION against real laid-out widths rather than
+            # the first decision: `spans_multiple_rows` is re-answered now that
+            # each block has its own size, and `_settle_gaps` is idempotent
+            # (it re-applies the same class and nothing repaints) whenever the
+            # hinted width and the assigned width agree, which is the common
+            # case. Keeping it is what makes an unhinted or re-wrapped block
+            # converge instead of keeping a guess.
             self._settle_gaps(additions)
             self._remeasure_empty_state()
 
@@ -3859,7 +3895,16 @@ class TranscriptView(ScrollableContainer):
         was pressed, and a stream that grows during the glide lands the reader
         short of the new end — where ``watch_scroll_y`` correctly concludes they
         are not at the bottom and releases the anchor they had just asked for.
+
+        Announced as DOWNWARD input, through the same provenance every other
+        key uses. `end` is the most explicit downward gesture there is, and a
+        tail request that stayed silent left a delayed anchor restore free to
+        pull the reader back off the end they had just asked for. Reporting it
+        as `upward=False` also retires any older upward demand, exactly as a
+        `pagedown` does: the reader travelling to the newest content is not
+        asking for older history.
         """
+        self.note_user_scroll(upward=False)
         if self._on_tail_requested is not None:
             self._on_tail_requested()
         self.follow_tail()

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -3155,7 +3155,18 @@ class TranscriptView(ScrollableContainer):
                 # changed its gap. A closed-over pre-insert gap would undo the
                 # reader's newer movement in this last callback.
                 held, self._insert_anchor = self._insert_anchor, None
-                if self._tail_anchor.following:
+                # An EXPLICIT `anchor_offset` outranks the tail state. The
+                # caller measured the offset it wants held before requesting
+                # the page, and its scroll may not have landed yet when the
+                # rows arrive — a subagent Home whose page returns before the
+                # jump applies is still following the tail at arming time, so
+                # no anchor is armed and the tail branch below would strand
+                # the reader on the newest row instead of the page they asked
+                # for. Falling back to the anchor computed above restores the
+                # pre-change behaviour for exactly that race.
+                if held is None and anchor_offset is not None and anchor_block is not None:
+                    held = (anchor_block, anchor_gap)
+                if held is None and self._tail_anchor.following:
                     self._scroll_to_tail()
                 elif held is not None:
                     block, gap = held

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -41,6 +41,7 @@ from typing import (
     Literal,
     Protocol,
     Sequence,
+    cast,
 )
 
 from rich.cells import cell_len
@@ -48,12 +49,14 @@ from rich.console import Console, RenderableType
 from rich.style import Style
 from rich.text import Text
 from textual import events
+from textual._arrange import DockArrangeResult
 from textual.binding import Binding
 from textual.containers import ScrollableContainer
 from textual.content import Content
 from textual.events import Key
 from textual.geometry import Size
-from textual.scrollbar import ScrollDown, ScrollTo, ScrollUp
+from textual.reactive import Reactive
+from textual.scrollbar import ScrollBar, ScrollDown, ScrollTo, ScrollUp
 from textual.selection import Selection
 from textual.widget import Widget
 from textual.widgets import Static
@@ -3054,12 +3057,20 @@ class TranscriptView(ScrollableContainer):
         """
         additions = list(blocks)
         if not additions:
+            if on_settled is not None:
+                on_settled()
             return
         index = max(0, min(index, len(self._blocks)))
         old_scroll = self.scroll_y if anchor_offset is None else anchor_offset
+        # A fixed prefix (the older-history notice or delegation header) does
+        # not move when rows are inserted below it. Anchoring that prefix at
+        # y=0 therefore replaced the reader's content with the incoming page.
+        # Hold retained CONTENT at/after the insertion seam, including its gap
+        # below the viewport top when the prefix was visible.
+        candidates = self._blocks[index:]
         anchor_block = next(
-            (block for block in self._blocks if block.virtual_region.bottom > old_scroll),
-            self._blocks[-1] if self._blocks else None,
+            (block for block in candidates if block.virtual_region.bottom > old_scroll),
+            candidates[-1] if candidates else None,
         )
         anchor_gap = anchor_block.virtual_region.y - old_scroll if anchor_block is not None else 0.0
         # A reader who is FOLLOWING THE TAIL is not holding a position for this
@@ -3104,70 +3115,22 @@ class TranscriptView(ScrollableContainer):
             self._remeasure_empty_state()
 
             def restore_anchor() -> None:
-                # Release the held anchor whatever happens next: the settle is
-                # over, and leaving it armed would have `_size_updated` pin the
-                # reader against ordinary later growth (a streaming message, a
-                # card unfolding) that has nothing to do with this insert.
-                self._insert_anchor = None
-                if anchor_block is None or anchor_block.parent is not self:
-                    if on_settled is not None:
-                        on_settled()
-                    return
+                # Read the CURRENT transaction: input during layout may have
+                # changed its gap. A closed-over pre-insert gap would undo the
+                # reader's newer movement in this last callback.
+                held, self._insert_anchor = self._insert_anchor, None
                 if self._tail_anchor.following:
-                    # The reader is on the tail (see the arming guard above):
-                    # restoring a held offset here would drag them off the end
-                    # they never left. Land them on it instead, and only then
-                    # hand the gate back.
                     self._scroll_to_tail()
-                    if on_settled is not None:
-                        on_settled()
-                    return
-                # Inside the programmatic guard: this scroll is the insert's
-                # own, not a reader's, so it must not release the tail anchor
-                # (`watch_scroll_y` skips the resync) — and, for the resume
-                # page-back path, must not be read as a reader arriving at the
-                # top. The restored offset can be inside the page trigger
-                # zone by construction: the rows above were just inserted, so
-                # the anchor lands where it was, which was the top.
+                elif held is not None:
+                    block, gap = held
+                    if block.parent is self:
+                        target = max(0.0, block.virtual_region.y - gap)
+                        if abs(self.scroll_y - target) >= 0.5:
+                            with self._tail_anchor.programmatic_scroll():
+                                self.scroll_to(y=target, animate=False, immediate=True)
+                # Do not stop a newer animation merely to restore an offset
+                # arrange() already held exactly on every painted frame.
                 with self._tail_anchor.programmatic_scroll():
-                    # `immediate=True` for the SAME reason `_reanchor_insert`
-                    # needs it, and its omission here was the deeper half of
-                    # that defect. Textual's `scroll_to` defers the offset
-                    # change with `call_after_refresh` unless `immediate`, so
-                    # the deferred `_scroll_to` runs AFTER this `with` block
-                    # has exited — outside the very guard that marks the
-                    # scroll as this widget's own. `watch_scroll_y` then reads
-                    # `programmatic == False` and treats the insert's own
-                    # restore as a READER's scroll, with two measured
-                    # consequences: it resyncs the tail anchor to
-                    # `at_end=False` (so a resume whose fill inserted at y=0
-                    # stops following the tail and lands the reader on the
-                    # OLDEST row instead of the newest), and it drives the
-                    # resume page-back hook, which spends `_resume_in_zone` on
-                    # a scroll no human made and leaves a wheel reader parked
-                    # at the top unable to earn another page.
-                    #
-                    # Traced on a 401-message resume at 120x200:
-                    #   scroll_to y=0 programmatic=True   <- inside the guard
-                    #   APPLY     y=0 programmatic=False  <- deferred, outside
-                    #
-                    # Applying inside the guard makes that window not exist
-                    # rather than not matter — the same trade the `on_settled`
-                    # placement below already documents.
-                    self.scroll_to(
-                        y=max(0, anchor_block.virtual_region.y - anchor_gap),
-                        animate=False,
-                        immediate=True,
-                    )
-                    # INSIDE the guard, not after it: `on_settled` re-opens the
-                    # caller's page gate, and the guard is what keeps THIS
-                    # widget's own restore scroll from being reported to that
-                    # caller as a reader's scroll. Releasing outside the guard
-                    # left a frame where the gate was open and the offset sat
-                    # inside the trigger zone — harmless only while every
-                    # consumer ALSO edge-triggers on zone entry, which is a
-                    # contract too easy to regress silently. Releasing inside
-                    # makes the window not exist rather than not matter.
                     if on_settled is not None:
                         on_settled()
 
@@ -3617,7 +3580,7 @@ class TranscriptView(ScrollableContainer):
         self._tail_anchor.acquire()
         self.call_after_refresh(self._scroll_to_tail)
 
-    def note_user_scroll(self, *, continuous: bool = False) -> None:
+    def note_user_scroll(self, *, continuous: bool = False, upward: bool = True) -> None:
         """A person moved the viewport: release, then re-decide where they land.
 
         Public because a scroll gesture does not always arrive as an event on
@@ -3625,14 +3588,10 @@ class TranscriptView(ScrollableContainer):
         outside it, and a click on an affordance is as much a user scroll as
         the wheel is.
 
-        ``continuous`` marks a free-running gesture (wheel, scrollbar drag)
-        rather than a discrete act (keystroke, click on an affordance, or a
-        caller announcing a gesture by hand). The distinction matters to the
-        page-back latch: a wheel notch arriving while the viewport is already
-        clamped at the top moves NOTHING, so it is not evidence the reader
-        left and came back — re-arming on it let a held wheel mount a page per
-        notch while the reader sat at y=0. A discrete act at the top IS an
-        ask ("show me the next older page"), so it re-arms.
+        ``continuous`` retains the free-running/discrete distinction for
+        consumers such as the subagent view. ``upward`` supplies actual input
+        direction: even a notch clamped at zero can request older history,
+        whereas a downward notch and a passive layout correction cannot.
         """
         self._tail_anchor.note_user_scroll()
         # After the refresh, not now: the scroll this call is reporting has not
@@ -3642,7 +3601,10 @@ class TranscriptView(ScrollableContainer):
         # anchor straight back rather than leaving it released forever.
         self.call_after_refresh(self._resync_tail_anchor)
         if self._on_user_scroll is not None:
-            self._on_user_scroll(continuous=continuous)
+            # Positional provenance preserves the hook's existing variadic
+            # contract for other transcript consumers. True/False is actual
+            # directional input; None below is only an offset observation.
+            self._on_user_scroll(upward, continuous=continuous)
 
     def watch_scroll_y(self, old_value: float, new_value: float) -> None:
         """Re-decide following from every offset the viewport actually rests at.
@@ -3660,6 +3622,12 @@ class TranscriptView(ScrollableContainer):
         """
         super().watch_scroll_y(old_value, new_value)
         if not self._tail_anchor.programmatic:
+            if self._insert_anchor is not None:
+                block, gap = self._insert_anchor
+                # New user travel changes the transaction's reading position.
+                # Internal compensation uses set_reactive/programmatic_scroll
+                # and never comes through this observation path.
+                self._insert_anchor = (block, gap - (new_value - old_value))
             self._tail_anchor.resync(at_end=self.is_near_bottom())
             # The page-back trigger rides the same watch, scheduled for after
             # the refresh rather than answered here. `note_user_scroll` fires
@@ -3671,13 +3639,9 @@ class TranscriptView(ScrollableContainer):
             # gate open — see `OperatorApp._check_resume_page`), so the many
             # firings of one animated gesture collapse into ONE page (M1/U1).
             if self._on_user_scroll is not None:
-                # NOT the re-arm: the watch reports OFFSET MOTION, which is
-                # travel evidence rather than a gesture, and it fires for the
-                # clamped 1->0 step of a wheel already pinned at the top.
-                # Passing continuous=True keeps the page-back latch's re-arm
-                # rule intact (a clamped notch earns nothing) while still
-                # scheduling the at-rest check that lands the gesture.
-                self._on_user_scroll(continuous=True)
+                # Observation can complete motion already requested by input,
+                # but must never arm demand by itself (including layout clamps).
+                self._on_user_scroll(None, continuous=True)
 
     def _resync_tail_anchor(self) -> None:
         # Not while the viewport is still travelling: an animated page-up is
@@ -3698,6 +3662,55 @@ class TranscriptView(ScrollableContainer):
         """
         with self._tail_anchor.programmatic_scroll():
             self.scroll_to(y=self.max_scroll_y, animate=False, immediate=True, force=True)
+
+    def arrange(self, size: Size, optimal: bool = False) -> DockArrangeResult:
+        """Apply the insertion anchor before the compositor places child rows.
+
+        `_size_updated` runs AFTER reflow calculated screen coordinates. An
+        immediate scroll there still paints one displaced frame, then corrects
+        it on the next reflow. Fresh placements here already include authored
+        heights/gaps, and the compositor reads scroll_offset immediately after
+        arrange returns. This is the same pre-placement seam Textual uses for
+        its own anchored container; no second layout or historical-height
+        estimate is needed.
+        """
+        result = super().arrange(size, optimal)
+        held = self._insert_anchor
+        if held is not None and not self._tail_anchor.following:
+            block, gap = held
+            for placement in result.placements:
+                if placement.widget is block:
+                    target = max(0.0, placement.region.y - gap)
+                    # The previous max_scroll_y is stale until _size_updated.
+                    # Bypass that old clamp exactly as Textual's native anchor
+                    # does; the fresh content extent bounds the destination.
+                    target = min(target, max(0, result.total_region.bottom - size.height))
+                    if abs(target - self.scroll_y) >= 0.5 and self.app.animator.is_being_animated(
+                        self, "scroll_y"
+                    ):
+                        # A newer key gesture can start during insertion. Its
+                        # animation holds old absolute endpoints; finish its
+                        # remaining requested travel in the new coordinates
+                        # instead of letting the next tick undo compensation.
+                        remaining = self.scroll_target_y - self.scroll_y
+                        target = min(
+                            max(0.0, target + remaining),
+                            max(0, result.total_region.bottom - size.height),
+                        )
+                        self._insert_anchor = (block, placement.region.y - target)
+                        self.app.animator.force_stop_animation(self, "scroll_y")
+                    elif self.app.animator.is_being_animated(self, "scroll_y"):
+                        # No geometry compensation is needed on this frame.
+                        # Do not overwrite a newer animation's destination with
+                        # its intermediate offset: it would finish at y=0 with
+                        # target_y still midway, keeping page demand unsettled
+                        # forever despite the animation having completed.
+                        break
+                    self.set_reactive(Widget.scroll_y, target)
+                    self.set_reactive(cast(Reactive[float], Widget.scroll_target_y), target)
+                    self.vertical_scrollbar.set_reactive(ScrollBar.position, target)
+                    break
+        return result
 
     def _size_updated(
         self, size: Size, virtual_size: Size, container_size: Size, layout: bool = True
@@ -3780,23 +3793,42 @@ class TranscriptView(ScrollableContainer):
     # messages — and a scroll arriving through one of them came from a person.
 
     def _on_mouse_scroll_down(self, event: events.MouseScrollDown) -> None:
-        self.note_user_scroll(continuous=True)
+        # We invoke the native handler explicitly. Prevent Textual's MRO
+        # dispatch from invoking it a second time, and own a vertical notch
+        # even when clamped: bubbling it back through the screen can redispatch
+        # the same physical input after a page has already consumed its demand.
+        event.prevent_default()
+        if not (event.ctrl or event.shift):
+            self.note_user_scroll(continuous=True, upward=False)
+            event.stop()
         super()._on_mouse_scroll_down(event)
 
     def _on_mouse_scroll_up(self, event: events.MouseScrollUp) -> None:
-        self.note_user_scroll(continuous=True)
+        # We invoke the native handler explicitly. Prevent Textual's MRO
+        # dispatch from invoking it a second time, and own a vertical notch
+        # even when clamped: bubbling it back through the screen can redispatch
+        # the same physical input after a page has already consumed its demand.
+        event.prevent_default()
+        if not (event.ctrl or event.shift):
+            self.note_user_scroll(continuous=True, upward=True)
+            event.stop()
         super()._on_mouse_scroll_up(event)
 
     def _on_scroll_to(self, message: ScrollTo) -> None:
-        self.note_user_scroll(continuous=True)
+        message.prevent_default()
+        self.note_user_scroll(
+            continuous=True, upward=message.y is not None and message.y < self.scroll_y
+        )
         super()._on_scroll_to(message)
 
     def _on_scroll_up(self, event: ScrollUp) -> None:
+        event.prevent_default()
         self.note_user_scroll(continuous=True)
         super()._on_scroll_up(event)
 
     def _on_scroll_down(self, event: ScrollDown) -> None:
-        self.note_user_scroll(continuous=True)
+        event.prevent_default()
+        self.note_user_scroll(continuous=True, upward=False)
         super()._on_scroll_down(event)
 
     def action_scroll_up(self) -> None:
@@ -3804,7 +3836,7 @@ class TranscriptView(ScrollableContainer):
         super().action_scroll_up()
 
     def action_scroll_down(self) -> None:
-        self.note_user_scroll()
+        self.note_user_scroll(upward=False)
         super().action_scroll_down()
 
     def action_page_up(self) -> None:
@@ -3812,7 +3844,7 @@ class TranscriptView(ScrollableContainer):
         super().action_page_up()
 
     def action_page_down(self) -> None:
-        self.note_user_scroll()
+        self.note_user_scroll(upward=False)
         super().action_page_down()
 
     def action_scroll_home(self) -> None:

--- a/tests/unit/tui/test_page_back_latch.py
+++ b/tests/unit/tui/test_page_back_latch.py
@@ -175,7 +175,8 @@ async def test_resume_latch_ignores_watch_firings_while_parked_in_zone() -> None
         before = len(app._resume_pending_head)
         assert before
 
-        # Arrive at the top through the real watch path: one page.
+        # Input earns demand; the watch only observes where it lands.
+        view.note_user_scroll()
         view.scroll_to(y=0, animate=False)
         for _ in range(20):
             await pilot.pause()
@@ -193,6 +194,7 @@ async def test_resume_latch_ignores_watch_firings_while_parked_in_zone() -> None
         app._resume_in_zone = True  # what a real gesture does via the hook
         view.scroll_to(y=40, animate=False)
         await pilot.pause()
+        view.note_user_scroll()
         view.scroll_to(y=0, animate=False)
         for _ in range(20):
             await pilot.pause()

--- a/tests/unit/tui/test_rendered_history_paging.py
+++ b/tests/unit/tui/test_rendered_history_paging.py
@@ -20,6 +20,7 @@ from local_operator.session.runtime.server import RuntimeServer
 from local_operator.tui.app import OperatorApp, _PagingLease
 from local_operator.tui.session_interaction import SessionInteraction
 from local_operator.tui.session_presentation import OlderHistoryNotice
+from local_operator.tui.widgets.assistant import AssistantBlock
 from local_operator.tui.widgets.transcript import GAP_CLASS, NoticeBlock
 from tests.e2e.harness import ScriptedStream, build_session, seed_transcript, text_turn
 from tests.unit.session.test_remote import _never_take_over
@@ -777,3 +778,67 @@ async def test_end_holds_the_tail_and_still_retires_upward_demand() -> None:
         assert view.is_following_tail is True
         assert arrived.region.bottom <= view.content_region.bottom
         assert arrived.region.y >= view.content_region.y
+
+
+@pytest.mark.asyncio
+async def test_explicit_anchor_offset_outranks_a_tail_following_view() -> None:
+    """An `anchor_offset` the caller supplied wins over the view's tail state.
+
+    The subagent's Home path loads a page and jumps to the top, and those are
+    two different frames: the page can arrive while the jump is still pending,
+    so the view is STILL FOLLOWING THE TAIL at the moment `insert_blocks` arms
+    its anchor. Nothing is armed, and a restore that consults only the armed
+    transaction falls through to the tail branch — throwing the reader to the
+    end of the transcript instead of holding the offset the caller measured.
+
+    Driven at the seam rather than through the loader: reproducing it through
+    the real subagent worker means racing that pending jump, which is what
+    made `test_history_home_key_lands_on_newly_loaded_page` an intermittent
+    net (it caught this regression only 4 runs in 5, and the round-2 commit
+    that introduced the defect shipped past it). Calling `insert_blocks`
+    directly puts the view in the exact state the race produces — following
+    the tail, with an explicit anchor supplied — every single run.
+    """
+    session = FakeSession()
+    session._history = history(count=120)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(90, 28)) as pilot:
+        await settled(app, pilot)
+        view = app._transcript_view()
+
+        # The state the race leaves behind: the caller's scroll has not landed,
+        # so the view still holds the tail while the page is already arriving.
+        view.follow_tail()
+        for _ in range(4):
+            await pilot.pause()
+        assert view.is_following_tail is True
+
+        retained = view.blocks()
+        assert retained, "no retained content to hold"
+        # What the reader is looking at, named by identity: the assertion below
+        # is about THIS row still being where it was, not about a row index.
+        held = next(block for block in retained if block.virtual_region.bottom > 0)
+
+        page = []
+        for index in range(40):
+            block = AssistantBlock()
+            block.update_text(f"older page row {index:03}")
+            block.finalize_text()
+            page.append(block)
+
+        inserted_at = float(view.max_scroll_y)
+        view.insert_blocks(0, page, anchor_offset=0.0)
+        for _ in range(14):
+            await pilot.pause()
+
+        # The reader is NOT at the end: pre-fix this restored to the tail,
+        # deterministically, because the tail branch owned the decision.
+        assert view.scroll_y < view.max_scroll_y - 1, (
+            "an explicit anchor_offset was overridden by the view's tail state; "
+            "the reader was thrown to the end of the transcript"
+        )
+        # And the anchor did its actual job: the row the reader was on is
+        # still at the top of the viewport, with the page mounted above it.
+        assert abs(view.scroll_y - held.virtual_region.y) < 1.0
+        assert view.max_scroll_y > inserted_at, "the page did not mount above"
+        assert view.blocks()[:40] == page, "the page is not above the retained rows"

--- a/tests/unit/tui/test_rendered_history_paging.py
+++ b/tests/unit/tui/test_rendered_history_paging.py
@@ -17,9 +17,10 @@ from local_operator.harness.types import Message, TextContent
 from local_operator.session.remote import RemoteSession
 from local_operator.session.runtime.owned import OwnedSessionHandle
 from local_operator.session.runtime.server import RuntimeServer
-from local_operator.tui.app import OperatorApp
+from local_operator.tui.app import OperatorApp, _PagingLease
 from local_operator.tui.session_interaction import SessionInteraction
 from local_operator.tui.session_presentation import OlderHistoryNotice
+from local_operator.tui.widgets.transcript import GAP_CLASS
 from tests.e2e.harness import ScriptedStream, build_session, seed_transcript, text_turn
 from tests.unit.session.test_remote import _never_take_over
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
@@ -547,3 +548,186 @@ async def test_early_pageup_during_insert_keeps_native_animation_target() -> Non
         assert not app.animator.is_being_animated(view, "scroll_y")
         assert view.scroll_y == view.scroll_target_y
         assert not app._resume_paging and not app._resume_check_pending
+
+
+@pytest.mark.asyncio
+async def test_revisiting_a_cached_view_never_duplicates_or_retires_its_paging(tmp_path) -> None:
+    """A → B → cached A while a real RPC is held: one request, one owner.
+
+    The reviewer's F1: re-entry used to reset an app-global paging flag and
+    start a second fetch against the same cursor, and the FIRST completion
+    then cleared the newer transaction's gate and surfaced `history changed
+    while paging` to the reader.
+    """
+    async with (
+        remote_session(tmp_path, history()) as remote,
+        remote_session(tmp_path, history(count=1), name="target") as target,
+    ):
+
+        async def factory():
+            return remote
+
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settled(app, pilot)
+            while app._resume_pending_head:
+                app._mount_older_resume_page()
+                await settled(app, pilot)
+
+            requests = 0
+            fetched = asyncio.Event()
+            release = asyncio.Event()
+            returned = asyncio.Event()
+            real_fetch = remote.load_older_display_page
+
+            async def delayed_completion():
+                nonlocal requests
+                requests += 1
+                rows = await real_fetch()
+                fetched.set()
+                try:
+                    await release.wait()
+                except asyncio.CancelledError:
+                    # Owner-side completion may resist viewer cancellation.
+                    await release.wait()
+                returned.set()
+                return rows
+
+            remote.load_older_display_page = delayed_completion
+            notices: list[str] = []
+            app._notice = lambda text, kind="info": notices.append(str(text))  # type: ignore
+
+            home = app._interaction
+            assert isinstance(app._resume_head_notice, OlderHistoryNotice)
+            app._resume_head_notice.action_older()
+            await asyncio.wait_for(fetched.wait(), 5)
+            assert app._resume_paging
+
+            # Away to B, then BACK to the cached A presentation.
+            away = SessionInteraction(target)
+            app._sidebar_sources[target.session_id] = away
+            sources = {target.session_id: away, remote.session_id: home}
+
+            async def lease(session_id, *, speculative=False):
+                chosen = sources[session_id]
+                chosen.preparations += 1
+                return chosen
+
+            app._lease_sidebar_source = lease
+            for session_id in (target.session_id, remote.session_id):
+                prepared = await app._prepare_sidebar_session(session_id)
+                ready = app._commit_sidebar_session(
+                    session_id, prepared, app._sidebar_navigation.generation
+                )
+                # Not `settled()`: that waits for the paging gate to clear, and
+                # this test is deliberately holding it across the round trip.
+                for _ in range(12):
+                    await pilot.pause()
+                if ready is not None and not ready.done():
+                    ready.cancel()
+
+            assert app._interaction is home
+            # The transaction survived the round trip, so the revisit neither
+            # started a second request nor found an open gate to spend.
+            assert requests == 1
+            assert app._resume_paging
+            view = app._transcript_view()
+            view.scroll_to(y=0, animate=False, immediate=True)
+            app._transcript_scrolled(True)
+            for _ in range(6):
+                await pilot.pause()
+            assert requests == 1
+
+            # The held completion now lands: it owns the gate, so it releases
+            # it exactly once, with no error surfaced to the reader.
+            before = len(app._resume_pending_head)
+            release.set()
+            await asyncio.wait_for(returned.wait(), 5)
+            await settled(app, pilot)
+            for _ in range(6):
+                await pilot.pause()
+            assert requests == 1
+            assert not app._resume_paging
+            assert len(app._resume_pending_head) >= before
+            assert not any("history changed while paging" in text for text in notices)
+            assert not notices, notices
+
+            # And a stale completion from that retired transaction cannot
+            # retire whatever the reader started afterwards.
+            stale = _PagingLease(source_token=home.token)
+            fresh = app._acquire_paging_lease(home)
+            assert fresh is not None
+            assert not app._release_paging_lease(stale)
+            assert app._resume_paging
+            assert app._release_paging_lease(fresh)
+            assert not app._resume_paging
+
+
+@pytest.mark.asyncio
+async def test_inserted_rows_never_paint_with_provisional_spacing() -> None:
+    """U1: newcomers carry their final gap on the frame they first appear.
+
+    Spacing used to be decided in `_settle_gaps`, one painted refresh after
+    the mount, so a reader whose upward scroll reached the new rows saw them
+    paint flush and then spread apart under an upward-moving finger.
+
+    Asserted on the newcomers themselves, not only on the retained anchor: the
+    y offset of every inserted block is compared across each compositor frame
+    of the insertion, and the gap class each one carries on its first visible
+    frame must equal the one it settles with.
+    """
+    session = FakeSession()
+    session._history = history()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await settled(app, pilot)
+        view = app._transcript_view()
+        view.scroll_to(y=0, animate=False, immediate=True)
+        await pilot.pause()
+
+        known = set(view.blocks())
+        frames: list[dict[int, tuple[int, bool]]] = []
+        refresh = app.screen._compositor_refresh
+
+        def capture() -> None:
+            refresh()
+            # Only rows actually inside the viewport: a block parked off screen
+            # has no painted position for a reader to see move.
+            frames.append(
+                {
+                    id(block): (
+                        block.region.y - view.content_region.y,
+                        block.has_class(GAP_CLASS),
+                    )
+                    for block in view.blocks()
+                    if block not in known
+                    and block.region.bottom > view.content_region.y
+                    and block.region.y < view.content_region.bottom
+                }
+            )
+
+        app.screen._compositor_refresh = capture
+        try:
+            app._mount_older_resume_page()
+            await settled(app, pilot)
+        finally:
+            app.screen._compositor_refresh = refresh
+
+        newcomers = [block for block in view.blocks() if block not in known]
+        assert newcomers, "no rows were inserted"
+        final = {id(block): block.has_class(GAP_CLASS) for block in newcomers}
+
+        seen: dict[int, tuple[int, bool]] = {}
+        for frame in frames:
+            for key, (y, gap) in frame.items():
+                assert gap == final[key], (
+                    "a newly inserted row painted with provisional spacing "
+                    "before its gap settled (U1)"
+                )
+                if key in seen:
+                    assert seen[key][0] == y, (
+                        f"visible inserted row moved {seen[key][0]} -> {y} "
+                        "between painted frames"
+                    )
+                seen[key] = (y, gap)
+        assert seen, "no inserted row was ever visible during the insertion"

--- a/tests/unit/tui/test_rendered_history_paging.py
+++ b/tests/unit/tui/test_rendered_history_paging.py
@@ -20,7 +20,7 @@ from local_operator.session.runtime.server import RuntimeServer
 from local_operator.tui.app import OperatorApp, _PagingLease
 from local_operator.tui.session_interaction import SessionInteraction
 from local_operator.tui.session_presentation import OlderHistoryNotice
-from local_operator.tui.widgets.transcript import GAP_CLASS
+from local_operator.tui.widgets.transcript import GAP_CLASS, NoticeBlock
 from tests.e2e.harness import ScriptedStream, build_session, seed_transcript, text_turn
 from tests.unit.session.test_remote import _never_take_over
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
@@ -731,3 +731,49 @@ async def test_inserted_rows_never_paint_with_provisional_spacing() -> None:
                     )
                 seen[key] = (y, gap)
         assert seen, "no inserted row was ever visible during the insertion"
+
+
+@pytest.mark.asyncio
+async def test_end_holds_the_tail_and_still_retires_upward_demand() -> None:
+    """`end` must acquire the tail AND cancel older upward demand (U2).
+
+    Reporting the gesture through the full `note_user_scroll` scheduled a
+    resync that ran between `follow_tail`'s acquire and its deferred scroll,
+    measured the not-yet-moved offset, and released the anchor the keypress
+    had just taken — so a reply arriving afterwards landed off screen.
+    """
+    session = FakeSession()
+    session._history = history()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await settled(app, pilot)
+        view = app._transcript_view()
+        view.focus()
+
+        # Read upward first, so there is genuine upward demand to retire and
+        # the reader is demonstrably away from the tail.
+        view.scroll_to(y=0, animate=False, immediate=True)
+        app._transcript_scrolled(True)
+        await settled(app, pilot)
+        assert view.is_following_tail is False
+
+        pending_before = len(app._resume_pending_head)
+        await pilot.press("end")
+        await settled(app, pilot)
+
+        # The anchor the keypress asked for is still held.
+        assert view.is_following_tail is True
+        # And the demand it retired stays retired: no page is drawn by
+        # travelling to the newest content.
+        assert not app._resume_in_zone
+        assert len(app._resume_pending_head) == pending_before
+
+        # The user-visible half: a reply arriving after `end` is on screen.
+        app._append_block(NoticeBlock("a reply that arrives after end", "info"))
+        await settled(app, pilot)
+        for _ in range(6):
+            await pilot.pause()
+        arrived = view.blocks()[-1]
+        assert view.is_following_tail is True
+        assert arrived.region.bottom <= view.content_region.bottom
+        assert arrived.region.y >= view.content_region.y

--- a/tests/unit/tui/test_rendered_history_paging.py
+++ b/tests/unit/tui/test_rendered_history_paging.py
@@ -1,0 +1,549 @@
+"""Rendered history contracts, including real owner RPC and every painted frame.
+
+These tests use synthetic sessions only. The suite launcher isolates HOME/config
+and removes all CMUX_* before imports, as required for any OperatorApp pilot.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+from textual.events import MouseScrollUp
+
+from local_operator.harness.types import Message, TextContent
+from local_operator.session.remote import RemoteSession
+from local_operator.session.runtime.owned import OwnedSessionHandle
+from local_operator.session.runtime.server import RuntimeServer
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.session_interaction import SessionInteraction
+from local_operator.tui.session_presentation import OlderHistoryNotice
+from tests.e2e.harness import ScriptedStream, build_session, seed_transcript, text_turn
+from tests.unit.session.test_remote import _never_take_over
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+def history(count: int = 600, hidden: int = 0) -> list[Message]:
+    return [
+        Message(
+            id=f"synthetic-row-{i:04}",
+            role="assistant",
+            content=(
+                [TextContent(text=f"Saved row {i:04}")] if i < count or i == count + hidden else []
+            ),
+            stop_reason="stop",
+        )
+        for i in range(count + hidden + 1)
+    ]
+
+
+async def settled(app, pilot) -> None:
+    for _ in range(200):
+        await pilot.pause()
+        if (
+            app._session is not None
+            and app._transcript_view().blocks()
+            and not app._resume_paging
+            and not app._resume_fill_active
+            and not app._resume_check_pending
+        ):
+            await pilot.pause()
+            return
+    raise AssertionError("history presentation never settled")
+
+
+@asynccontextmanager
+async def remote_session(tmp_path: Path, rows: list[Message], name: str = "paging"):
+    config = tmp_path / "config"
+    config.mkdir(exist_ok=True)
+    (config / "config.yml").write_text(
+        "version: 0.0.0\nvalues:\n  hosting: test\n  model_name: mock\n"
+    )
+    directory = config / "sessions" / f"synthetic-{name}"
+    await seed_transcript(directory, rows)
+    session = build_session(directory, ScriptedStream([text_turn("unused")]), cwd=tmp_path)
+    handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd=str(tmp_path))
+    server = RuntimeServer(handle, kind="daemon")
+    await server.start_in_process()
+    remote = await RemoteSession.connect(
+        server._record,
+        directory.name,
+        config_dir=config,
+        takeover_factory=_never_take_over,
+        display_window=True,
+    )
+    try:
+        yield remote
+    finally:
+        await remote.dispose()
+        server.close()
+        await handle.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "height,hidden", [(40, 0), (50, 0), (100, 0), (40, 500), (100, 500), (100, 1400)]
+)
+async def test_resume_reserves_rendered_viewport_not_raw_messages(height, hidden) -> None:
+    session = FakeSession()
+    session._history = history(hidden=hidden)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, height)) as pilot:
+        await settled(app, pilot)
+        view = app._transcript_view()
+        notice = app._resume_head_notice
+        assert notice is not None
+        assert view.scroll_y - notice.virtual_region.bottom >= view.container_size.height
+        assert view.virtual_size.height >= 2 * view.container_size.height
+        assert app._resume_pending_head  # reserve is not eager whole-history replay
+        assert not app._resume_in_zone  # initial geometry does not invent input
+        before = len(app._resume_pending_head)
+        for _ in range(8):
+            app._transcript_scrolled(None)
+            await pilot.pause()
+        assert len(app._resume_pending_head) == before
+
+
+@pytest.mark.asyncio
+async def test_top_prefix_does_not_anchor_insert_and_every_paint_stays_still() -> None:
+    session = FakeSession()
+    session._history = history()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await settled(app, pilot)
+        view = app._transcript_view()
+        view.scroll_to(y=0, animate=False, immediate=True)
+        await pilot.pause()
+        retained = view.blocks()[1]
+        gap = retained.region.y - view.content_region.y
+        frames = []
+        refresh = app.screen._compositor_refresh
+
+        def capture() -> None:
+            refresh()
+            frames.append(retained.region.y - view.content_region.y)
+
+        app.screen._compositor_refresh = capture
+        before = len(app._resume_pending_head)
+        try:
+            view.post_message(MouseScrollUp(view, 1, 1, 0, -1, 0, False, False, False))
+            await settled(app, pilot)
+        finally:
+            app.screen._compositor_refresh = refresh
+        assert frames and set(frames) == {gap}
+        assert len(app._resume_pending_head) < before
+        ids = [block.navigation_anchor_id for block in view.blocks() if block.navigation_anchor_id]
+        assert ids == sorted(set(ids))
+
+
+@pytest.mark.asyncio
+async def test_clamped_input_rearms_but_observation_and_downward_input_do_not() -> None:
+    session = FakeSession()
+    session._history = history()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await settled(app, pilot)
+        view = app._transcript_view()
+        for _ in range(3):
+            view.scroll_to(y=0, animate=False, immediate=True)
+            await pilot.pause()
+            before = len(app._resume_pending_head)
+            view.note_user_scroll(continuous=True, upward=False)
+            for _ in range(3):
+                app._transcript_scrolled(None)
+                await pilot.pause()
+            assert len(app._resume_pending_head) == before
+            view.post_message(MouseScrollUp(view, 1, 1, 0, -1, 0, False, False, False))
+            await settled(app, pilot)
+            assert len(app._resume_pending_head) < before, (
+                view.scroll_y,
+                view.scroll_target_y,
+                app._resume_in_zone,
+                app._resume_check_pending,
+                app._resume_paging,
+            )
+            rested = len(app._resume_pending_head)
+            for _ in range(5):
+                app._transcript_scrolled(None)
+                await pilot.pause()
+            assert len(app._resume_pending_head) == rested
+
+
+@pytest.mark.asyncio
+async def test_newer_user_travel_survives_final_anchor_callback() -> None:
+    session = FakeSession()
+    session._history = history()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await settled(app, pilot)
+        view = app._transcript_view()
+        view.scroll_to(y=4, animate=False, immediate=True)
+        await pilot.pause()
+        moved = []
+        original = view._settle_gaps
+
+        def move_during_settle(blocks) -> None:
+            original(blocks)
+            # An actual downward request between gap settlement and the final
+            # callback must change the mutable anchor, not be undone by it.
+            if view._insert_anchor is not None:
+                view.note_user_scroll(upward=False)
+                view.scroll_to(y=view.scroll_y + 3, animate=False, immediate=True)
+                moved.append(view.scroll_y)
+
+        view._settle_gaps = move_during_settle
+        app._mount_older_resume_page()
+        await settled(app, pilot)
+        assert moved and view.scroll_y == moved[-1]
+
+
+@pytest.mark.asyncio
+async def test_remote_fetch_lease_extends_through_painted_settlement(tmp_path) -> None:
+    async with remote_session(tmp_path, history(hidden=500)) as remote:
+
+        async def factory():
+            return remote
+
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settled(app, pilot)
+            view = app._transcript_view()
+            assert view.scroll_y >= view.container_size.height
+            # Consume only already-local rows so the next real control action
+            # must cross the production RemoteSession / runtime RPC boundary.
+            while app._resume_pending_head:
+                app._mount_older_resume_page()
+                await settled(app, pilot)
+            assert remote.history_before_token
+            active = 0
+            maximum = 0
+            calls = 0
+            real_fetch = remote.load_older_display_page
+            cursor = remote.history_before_token
+
+            async def measured_fetch():
+                nonlocal active, maximum, calls
+                calls += 1
+                active += 1
+                maximum = max(maximum, active)
+                try:
+                    return await real_fetch()
+                finally:
+                    active -= 1
+
+            remote.load_older_display_page = measured_fetch
+            refresh = app.screen._compositor_refresh
+            leases = []
+
+            def capture() -> None:
+                refresh()
+                if view._insert_anchor is not None:
+                    leases.append(app._resume_paging)
+
+            app.screen._compositor_refresh = capture
+            view.scroll_to(y=0, animate=False, immediate=True)
+            await pilot.pause()
+            assert isinstance(app._resume_head_notice, OlderHistoryNotice)
+            app._resume_head_notice.action_older()
+            await settled(app, pilot)
+            app.screen._compositor_refresh = refresh
+            assert calls == maximum == 1
+            assert leases and all(leases)
+            assert remote.history_before_token != cursor
+            assert not app._resume_paging
+            assert app._resume_head_notice.text() != "start of conversation"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("hidden", [0, 500])
+async def test_real_sidebar_projection_runs_rendered_fill(tmp_path, hidden) -> None:
+    async with (
+        remote_session(tmp_path, history(hidden=hidden)) as remote,
+        remote_session(tmp_path, history(count=1), name="initial") as initial,
+    ):
+
+        async def factory():
+            return initial
+
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 100)) as pilot:
+            for _ in range(100):
+                await pilot.pause()
+                if app._session is initial:
+                    break
+            source = SessionInteraction(remote)
+            app._sidebar_sources[remote.session_id] = source
+
+            async def lease(session_id, *, speculative=False):
+                assert session_id == remote.session_id
+                source.preparations += 1
+                return source
+
+            # Only external discovery is redirected. Prepare, commit, remote
+            # display paging, projection and layout are all production paths.
+            app._lease_sidebar_source = lease
+            prepared = await app._prepare_sidebar_session(remote.session_id)
+            ready = app._commit_sidebar_session(
+                remote.session_id, prepared, app._sidebar_navigation.generation
+            )
+            await settled(app, pilot)
+            view = app._transcript_view()
+            assert app._session is remote
+            assert view.scroll_y >= view.container_size.height
+            assert view.virtual_size.height >= 2 * view.container_size.height
+            if ready is not None and not ready.done():
+                ready.cancel()  # readiness scheduling is a separate peer's scope
+
+
+@pytest.mark.asyncio
+async def test_remote_no_progress_stops_fill_and_preserves_retry(tmp_path) -> None:
+    async with remote_session(tmp_path, history()) as remote:
+
+        async def factory():
+            return remote
+
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settled(app, pilot)
+            while app._resume_pending_head:
+                app._mount_older_resume_page()
+                await settled(app, pilot)
+            view = app._transcript_view()
+            view.scroll_to(y=0, animate=False, immediate=True)
+            calls = 0
+
+            async def no_progress():
+                nonlocal calls
+                calls += 1
+                return []
+
+            remote.load_older_display_page = no_progress
+            app._start_resume_fill()
+            await settled(app, pilot)
+            for _ in range(5):
+                await pilot.pause()
+            assert calls == 1
+            assert not app._resume_paging and not app._resume_fill_active
+            assert isinstance(app._resume_head_notice, OlderHistoryNotice)
+            assert app._resume_head_notice.can_focus
+            app._resume_head_notice.action_older()
+            await settled(app, pilot)
+            assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_cancel_resistant_remote_completion_cannot_append_after_switch(tmp_path) -> None:
+    async with (
+        remote_session(tmp_path, history()) as remote,
+        remote_session(tmp_path, history(count=1), name="target") as target,
+    ):
+
+        async def factory():
+            return remote
+
+        app = OperatorApp(factory)
+        async with app.run_test(size=(100, 40)) as pilot:
+            await settled(app, pilot)
+            while app._resume_pending_head:
+                app._mount_older_resume_page()
+                await settled(app, pilot)
+            fetched = asyncio.Event()
+            release = asyncio.Event()
+            returned = asyncio.Event()
+            real_fetch = remote.load_older_display_page
+
+            async def delayed_completion():
+                rows = await real_fetch()
+                fetched.set()
+                try:
+                    await release.wait()
+                except asyncio.CancelledError:
+                    # Socket/cleanup completion is allowed to resist viewer
+                    # cancellation; publication still belongs to its old view.
+                    await release.wait()
+                returned.set()
+                return rows
+
+            remote.load_older_display_page = delayed_completion
+            assert isinstance(app._resume_head_notice, OlderHistoryNotice)
+            app._resume_head_notice.action_older()
+            await asyncio.wait_for(fetched.wait(), 5)
+            source = SessionInteraction(target)
+            app._sidebar_sources[target.session_id] = source
+
+            async def lease(session_id, *, speculative=False):
+                assert session_id == target.session_id
+                source.preparations += 1
+                return source
+
+            app._lease_sidebar_source = lease
+            prepared = await app._prepare_sidebar_session(target.session_id)
+            ready = app._commit_sidebar_session(
+                target.session_id, prepared, app._sidebar_navigation.generation
+            )
+            await settled(app, pilot)
+            before = list(app._transcript_view().blocks())
+            release.set()
+            await asyncio.wait_for(returned.wait(), 5)
+            for _ in range(4):
+                await pilot.pause()
+            assert app._session is target
+            assert app._transcript_view().blocks() == before
+            assert not app._resume_paging
+            if ready is not None and not ready.done():
+                ready.cancel()
+
+
+@pytest.mark.asyncio
+async def test_projection_failure_releases_gate_without_losing_pending_page(monkeypatch) -> None:
+    session = FakeSession()
+    session._history = history()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await settled(app, pilot)
+        pending = list(app._resume_pending_head)
+        mounted = set(app._resume_mounted_ids)
+
+        def fail(page):
+            app._resume_mounted_ids.add("synthetic-partial-projection")
+            raise ValueError("synthetic malformed row")
+
+        monkeypatch.setattr(app, "_collect_resume_page_blocks", fail)
+        with pytest.raises(ValueError, match="malformed row"):
+            app._mount_older_resume_page()
+        assert app._resume_pending_head == pending
+        assert app._resume_mounted_ids == mounted
+        assert not app._resume_paging
+
+
+@pytest.mark.asyncio
+async def test_live_append_during_insert_does_not_enter_older_page_or_move_anchor() -> None:
+    from local_operator.tui.widgets.transcript import NoticeBlock
+
+    session = FakeSession()
+    session._history = history()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await settled(app, pilot)
+        view = app._transcript_view()
+        view.scroll_to(y=0, animate=False, immediate=True)
+        await pilot.pause()
+        retained = view.blocks()[1]
+        gap = retained.region.y - view.content_region.y
+        app._mount_older_resume_page()
+        tail = NoticeBlock("Synthetic live tail event", "info")
+        view.append_block(tail)
+        await settled(app, pilot)
+        assert view.blocks()[-1] is tail
+        assert retained.region.y - view.content_region.y == gap
+        view.action_scroll_end()
+        await pilot.pause()
+        assert view.is_near_bottom()
+
+
+@pytest.mark.asyncio
+async def test_navigation_generation_change_retires_same_view_callbacks() -> None:
+    session = FakeSession()
+    session._history = history()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await settled(app, pilot)
+        view = app._transcript_view()
+        view.scroll_to(y=0, animate=False, immediate=True)
+        app._transcript_scrolled(True)
+        assert app._resume_check_pending
+        # A navigation that is cancelled before commit leaves this exact
+        # transcript on screen. Its stale check must still retire its lease.
+        app._sidebar_navigation.generation += 1
+        await pilot.pause()
+        assert not app._resume_check_pending
+        app._mount_older_resume_page()
+        assert app._resume_paging
+        app._sidebar_navigation.generation += 1
+        await settled(app, pilot)
+        assert not app._resume_paging
+        before = len(app._resume_pending_head)
+        view.scroll_to(y=0, animate=False, immediate=True)
+        view.note_user_scroll()
+        await settled(app, pilot)
+        assert len(app._resume_pending_head) < before
+
+
+@pytest.mark.asyncio
+async def test_busy_upward_burst_earns_only_one_pending_page(monkeypatch) -> None:
+    original_start = OperatorApp._start_resume_fill
+    monkeypatch.setattr(
+        OperatorApp,
+        "_start_resume_fill",
+        lambda self, *, target=None: (
+            original_start(self, target=target) if target is not None else None
+        ),
+    )
+    session = FakeSession()
+    session._history = history(hidden=500)
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await settled(app, pilot)
+        view = app._transcript_view()
+        before = len(app._resume_pending_head)
+        app._mount_older_resume_page()
+        assert app._resume_paging
+        for _ in range(20):
+            # One event-loop burst, before the active hidden page can settle.
+            view._on_mouse_scroll_up(MouseScrollUp(view, 1, 1, 0, -1, 0, False, False, False))
+        await settled(app, pilot)
+        # The one pending request is a rendered buffer: hidden-only slices
+        # must keep yielding until actual rows exist, not stop after 24 events.
+        assert before - len(app._resume_pending_head) > 120
+        assert view.scroll_y >= view.container_size.height
+        rest = len(app._resume_pending_head)
+        for _ in range(8):
+            app._transcript_scrolled(None)
+            await pilot.pause()
+        assert len(app._resume_pending_head) == rest
+
+
+@pytest.mark.asyncio
+async def test_one_physical_wheel_notch_moves_once_and_horizontal_is_not_history() -> None:
+    session = FakeSession()
+    session._history = history()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await settled(app, pilot)
+        view = app._transcript_view()
+        view.scroll_to(y=20, animate=False, immediate=True)
+        await pilot.pause()
+        before = len(app._resume_pending_head)
+        view.post_message(MouseScrollUp(view, 1, 1, 0, -1, 0, False, False, False))
+        await settled(app, pilot)
+        assert view.scroll_y == 20 - app.scroll_sensitivity_y
+        assert len(app._resume_pending_head) == before
+        assert not app._resume_in_zone
+        view.scroll_to(y=0, animate=False, immediate=True)
+        view.post_message(MouseScrollUp(view, 1, 1, 0, -1, 0, True, False, False))
+        await settled(app, pilot)
+        assert len(app._resume_pending_head) == before
+        assert not app._resume_in_zone
+
+
+@pytest.mark.asyncio
+async def test_early_pageup_during_insert_keeps_native_animation_target() -> None:
+    session = FakeSession()
+    session._history = history()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 40)) as pilot:
+        await settled(app, pilot)
+        view = app._transcript_view()
+        view.scroll_to(y=10, animate=False, immediate=True)
+        await pilot.pause()
+        app._mount_older_resume_page()
+        # Earlier than the late-settle movement case: the native animation
+        # starts while insert anchoring still participates in fresh arrange.
+        # A no-op arrangement must not replace target_y with its interim y.
+        view.action_page_up()
+        await settled(app, pilot)
+        assert not app.animator.is_being_animated(view, "scroll_y")
+        assert view.scroll_y == view.scroll_target_y
+        assert not app._resume_paging and not app._resume_check_pending

--- a/tests/unit/tui/test_resume_render.py
+++ b/tests/unit/tui/test_resume_render.py
@@ -219,20 +219,16 @@ async def test_an_animated_page_up_mounts_exactly_one_page() -> None:
         await _press_and_settle(pilot, view, "pageup")
         assert len(app._resume_pending_head) == before_pending - RESUME_PAGE_MESSAGES
         assert len(view.blocks()) > before_blocks
-        assert view.scroll_offset.y <= RESUME_PAGE_TRIGGER_ROWS
+        assert view.scroll_offset.y > RESUME_PAGE_TRIGGER_ROWS
 
 
 @pytest.mark.asyncio
 async def test_an_animated_home_mounts_one_page_and_lands_at_the_top() -> None:
-    """One animated Home mounts ONE page and lands at the TOP of it.
+    """Home requests one older rendered buffer without replacing the reading row.
 
-    The cascade this guards against was worst for Home: the whole remaining
-    conversation mounted in one keypress and the viewport landed
-    mid-conversation (y=146 of 270 on a 150-message session), because the Home
-    animation and the mount's anchor restore fought for the offset. The
-    gesture must be fast, mount one page, and leave the reader at the start
-    of what is rendered — not in the middle, and not needing a second press.
-    """
+    The retained content moves down the virtual canvas, and the scroll offset
+    must move with it. Pinning the fixed notice at zero was the old jitter bug.
+    A second Home is fresh input, not an automatic history-exhaustion loop."""
     session = FakeSession()
     session._history = _history(50)  # 150 messages; ~70 deferred
     app = OperatorApp(lambda: _factory(session))
@@ -247,7 +243,7 @@ async def test_an_animated_home_mounts_one_page_and_lands_at_the_top() -> None:
         # Exactly one page: the head shrank by one page, not to zero.
         assert len(app._resume_pending_head) == before_pending - RESUME_PAGE_MESSAGES
         # The reader landed AT THE TOP of what is rendered, not mid-page.
-        assert view.scroll_offset.y <= RESUME_PAGE_TRIGGER_ROWS
+        assert view.scroll_offset.y > RESUME_PAGE_TRIGGER_ROWS
         first_users = [t for t in _user_texts(app)][:1]
         assert first_users, "a page mounted"
         # A second Home mounts the NEXT page (the gesture re-arms), and still
@@ -262,7 +258,7 @@ async def test_an_animated_home_mounts_one_page_and_lands_at_the_top() -> None:
             <= len(app._resume_pending_head)
             < (before_pending - RESUME_PAGE_MESSAGES)
         )
-        assert view.scroll_offset.y <= RESUME_PAGE_TRIGGER_ROWS
+        assert view.scroll_offset.y > RESUME_PAGE_TRIGGER_ROWS
 
 
 @pytest.mark.asyncio
@@ -287,7 +283,7 @@ async def test_the_composer_pages_the_transcript_by_keyboard() -> None:
         assert composer_focused is not view
         await _press_and_settle(pilot, view, "ctrl+home")
         assert len(app._resume_pending_head) == before_pending - RESUME_PAGE_MESSAGES
-        assert view.scroll_offset.y <= RESUME_PAGE_TRIGGER_ROWS
+        assert view.scroll_offset.y > RESUME_PAGE_TRIGGER_ROWS
         # Focus never left the composer — the reader can type immediately.
         assert app.focused is composer_focused
         await _press_and_settle(pilot, view, "ctrl+end")
@@ -388,32 +384,12 @@ async def test_scrolling_up_a_long_resume_reveals_older_rows_in_order() -> None:
 
 
 @pytest.mark.asyncio
-async def test_arriving_at_the_top_mounts_one_page_then_stops() -> None:
-    """Arriving at the top loads ONE page — and nothing more until the reader
-    actually travels away from the top rows and comes back.
+async def test_arriving_at_the_top_mounts_one_page_then_stops(monkeypatch) -> None:
+    """A held wheel can request more buffers, but resting never drains history.
 
-    The pre-fix trigger was LEVEL-triggered: after a page prepended, the
-    anchor restore parked the viewport back inside the trigger rows, the gate
-    released while the reader was still at the top, and the next watch firing
-    — the settle frames of the mount itself, or a wheel notch clamped against
-    the top — mounted another page, and another. To the reader that is "I
-    scroll to the top and it loads chunks one after another without me
-    scrolling up again". The trigger must be an EDGE, and the property that
-    makes it one is that NO page mounts without the reader having travelled
-    out of the trigger zone since the previous one.
-
-    Driven with real wheel events as a CONTINUED drag that does not stop at
-    the first mount (review round 1, M1: stopping there ends the gesture
-    exactly where a cascade would begin, so that shape passed pre-fix). The
-    drag runs in the rhythm a trackpad delivers — several notches per frame —
-    and then holds the wheel against the clamped top, where the offset cannot
-    move at all. On this view the violation is deterministic: a 40-row
-    viewport against a ~120-row page means the reader reaches the clamped top
-    long before the head is anywhere near exhausted, so pre-fix every mount
-    after the first happened with no travel at all (8 of 9 on a 600-message
-    session, 3/3 runs). Every mount is audited against the offset's peak
-    since the previous one.
-    """
+    Clamped upward notches are real input; no artificial down/up re-arm is
+    required. Once input stops, passive offset/layout callbacks cannot earn
+    another buffer."""
     session = FakeSession()
     session._history = _history(200)  # 600 messages; many pages available
     app = OperatorApp(lambda: _factory(session))
@@ -427,15 +403,15 @@ async def test_arriving_at_the_top_mounts_one_page_then_stops() -> None:
         mounts = {"n": 0, "no_travel": 0, "first": True, "peak": 0.0}
         real_mount = OperatorApp._mount_older_resume_page
 
-        def auditing_mount(self: OperatorApp) -> None:
+        def auditing_mount(self: OperatorApp, *args: Any, **kwargs: Any) -> None:
             if not mounts["first"] and mounts["peak"] <= RESUME_PAGE_TRIGGER_ROWS:
                 mounts["no_travel"] += 1
             mounts["first"] = False
             mounts["n"] += 1
             mounts["peak"] = 0.0
-            real_mount(self)
+            real_mount(self, *args, **kwargs)
 
-        OperatorApp._mount_older_resume_page = auditing_mount  # type: ignore[method-assign]
+        monkeypatch.setattr(OperatorApp, "_mount_older_resume_page", auditing_mount)
 
         def notch() -> None:
             view.post_message(
@@ -471,13 +447,8 @@ async def test_arriving_at_the_top_mounts_one_page_then_stops() -> None:
             await pilot.pause()
         OperatorApp._mount_older_resume_page = real_mount  # type: ignore[method-assign]
 
-        # The contract: a long drag may mount several pages (each genuine
-        # re-arrival at the top earns one), but NEVER without travel away
-        # from the zone since the previous page.
-        assert mounts["no_travel"] == 0, (
-            f"{mounts['no_travel']} of {mounts['n']} pages mounted with no "
-            "travel away from the trigger zone — the level-trigger cascade"
-        )
+        # Real upward notches may earn another page even when clamped.
+        # The invariant is that observations alone cannot continue loading.
         assert mounts["n"] >= 1, "the drag reached the top and mounted a page"
         # And once the gesture is over, parked wherever it left them, no
         # further page mounts however long the view idles.
@@ -495,7 +466,7 @@ async def test_arriving_at_the_top_mounts_one_page_then_stops() -> None:
             before = len(app._resume_pending_head)
             await _press_and_settle(pilot, view, "home")
             assert len(app._resume_pending_head) < before
-            assert view.scroll_offset.y <= RESUME_PAGE_TRIGGER_ROWS
+            assert view.scroll_offset.y > RESUME_PAGE_TRIGGER_ROWS
             for _ in range(60):
                 await pilot.pause()
             assert len(app._resume_pending_head) == before - RESUME_PAGE_MESSAGES
@@ -596,7 +567,7 @@ def test_resume_page_size_is_smaller_than_the_initial_bound() -> None:
     first-frame budget. The constants are the contract the measurements
     justified; drifting them silently would undo the 7× render win."""
     assert RESUME_RENDER_MESSAGES == 80
-    assert RESUME_PAGE_MESSAGES == 60
+    assert RESUME_PAGE_MESSAGES == 24
     assert RESUME_PAGE_MESSAGES < RESUME_RENDER_MESSAGES
 
 
@@ -732,21 +703,10 @@ async def test_a_resumed_long_single_turn_transcript_is_scrollable() -> None:
 
 @pytest.mark.asyncio
 async def test_the_fill_does_not_arm_or_consume_the_page_back_latch() -> None:
-    """The scrollability fill is not a gesture and must not spend one.
+    """Automatic rendered fill creates no user demand.
 
-    It runs outside the page-back latch by construction. If it armed
-    ``_resume_in_zone`` the reader's first scroll would collect a free extra
-    page; if it consumed one, that scroll's legitimate page would be swallowed.
-    Either way the hard-won "ONE page per user gesture" contract breaks, so it
-    is pinned rather than trusted.
-
-    PINNED AT 120x170, NOT 120x40, and that is the whole value of this test.
-    At 40 rows the frame is already scrollable, the fill returns at its
-    scrollable-exit having mounted NOTHING, and the assertion below reads back
-    a value no code touched — it passed while the latch was in fact being
-    consumed on every taller frame. A guard that cannot go red is worse than
-    no guard, so the size is chosen to be one where the fill really mounts.
-    """
+    The fill is independent of the input latch; a subsequent actual wheel
+    notch can arm demand even at a clamped top."""
     session = FakeSession()
     session._history = _agentic_history(200, followups=1)
     app = OperatorApp(lambda: _factory(session))
@@ -776,34 +736,29 @@ async def test_the_fill_does_not_arm_or_consume_the_page_back_latch() -> None:
             "the fill mounted no pages at this size, so the latch assertion "
             "below would pin a value nothing touched"
         )
-        # The latch is still armed: the fill is not a gesture, so the reader's
-        # first arrival at the top is still owed a page.
-        assert app._resume_in_zone is True
+        # Automatic fill creates no demand; the next real input earns one.
+        assert app._resume_in_zone is False
         assert app._resume_paging is False
 
-        # And that first gesture mounts exactly ONE page, not the cascade.
+        # One requested rendered buffer may need several small raw slices.
         before = len(app._resume_pending_head)
         assert before
         await _press_and_settle(pilot, view, "ctrl+home")
-        assert len(app._resume_pending_head) == before - RESUME_PAGE_MESSAGES
+        remaining = len(app._resume_pending_head)
+        assert 0 < remaining < before
+        assert view.scroll_y >= view.container_size.height
+        for _ in range(8):
+            app._transcript_scrolled(None)
+            await pilot.pause()
+        assert len(app._resume_pending_head) == remaining
 
 
 @pytest.mark.asyncio
 async def test_a_wheel_reader_at_the_top_can_still_page_after_the_fill() -> None:
-    """The latch guarantee, from the READER's side rather than the flag's.
+    """A clamped wheel notch after fill is fresh upward demand.
 
-    The flag assertion above says the fill left the latch armed. This says what
-    that is FOR, through the only input that cannot re-arm it: a wheel notch
-    arriving while the viewport is already clamped at the top moves nothing, so
-    it is not evidence the reader left and came back, so it never re-arms. If
-    the fill spends the latch, such a reader is stuck forever — measured before
-    the fix as 60 settled notches at y=0 mounting exactly nothing, while the
-    first row of that transcript told them to scroll up.
-
-    A wheel gesture rather than a keypress on purpose: `pageup`, `home` and
-    `ctrl+home` are discrete acts and re-arm unconditionally, so they cannot
-    observe this defect at all.
-    """
+    It must not require an artificial downward movement before history can
+    continue loading."""
     session = FakeSession()
     session._history = _agentic_history(200, followups=1)
     app = OperatorApp(lambda: _factory(session))
@@ -814,6 +769,8 @@ async def test_a_wheel_reader_at_the_top_can_still_page_after_the_fill() -> None
             await pilot.pause()
         before = len(app._resume_pending_head)
         assert before, "no deferred head to page"
+        # Start clamped: the amount of initial reserve is geometry-dependent.
+        view.scroll_to(y=0, animate=False, immediate=True)
 
         # Real wheel events through the widget's own input surface, which is
         # what routes through `note_user_scroll` and the latch. Enough notches
@@ -913,7 +870,7 @@ async def test_mounting_an_older_page_never_moves_the_rows_under_the_reader() ->
 
 
 @pytest.mark.asyncio
-async def test_an_unreachable_head_never_says_scroll_up_to_load() -> None:
+async def test_an_unreachable_head_never_says_scroll_up_to_load(monkeypatch) -> None:
     """The head notice is an instruction; it must only appear when it works.
 
     "older messages above — scroll up to load" is what the operator's frame
@@ -929,6 +886,15 @@ async def test_an_unreachable_head_never_says_scroll_up_to_load() -> None:
     still fit inside the viewport, so this reaches the state the same way a
     reader on a large display at a small font does.
     """
+    # Exercise notice fallback without the automatic post-projection fill.
+    original_start = OperatorApp._start_resume_fill
+    monkeypatch.setattr(
+        OperatorApp,
+        "_start_resume_fill",
+        lambda self, *, target=None: (
+            original_start(self, target=target) if target is not None else None
+        ),
+    )
     session = FakeSession()
     session._history = _agentic_history(200, followups=1)
     app = OperatorApp(lambda: _factory(session))
@@ -969,7 +935,7 @@ async def test_an_unreachable_head_never_says_scroll_up_to_load() -> None:
 
 
 @pytest.mark.asyncio
-async def test_the_head_notice_stops_saying_unreachable_once_it_is_reachable() -> None:
+async def test_the_head_notice_stops_saying_unreachable_once_it_is_reachable(monkeypatch) -> None:
     """The notice must restate BOTH ways, not latch on its darkest state.
 
     ``_reconcile_head_notice`` only ever demoted: there was no path from
@@ -979,8 +945,17 @@ async def test_the_head_notice_stops_saying_unreachable_once_it_is_reachable() -
     the stale-copy failure `NoticeBlock.restate` exists to prevent, one state
     over from the one this file fixes.
     """
+    # Exercise notice fallback without the automatic post-projection fill.
+    original_start = OperatorApp._start_resume_fill
+    monkeypatch.setattr(
+        OperatorApp,
+        "_start_resume_fill",
+        lambda self, *, target=None: (
+            original_start(self, target=target) if target is not None else None
+        ),
+    )
     session = FakeSession()
-    session._history = _agentic_history(200, followups=1)
+    session._history = _agentic_history(600, followups=1)
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(120, 600)) as pilot:
         await _wait_for_resume(pilot, app)
@@ -1097,7 +1072,7 @@ async def test_the_fill_pages_a_remote_session_through_its_fetch_worker() -> Non
     app = OperatorApp(lambda: _factory(session))
     fetches = 0
 
-    async def fake_fetch(source: Any) -> None:
+    async def fake_fetch(source: Any, on_settled=None) -> None:
         # Stands in for the round trip: prepend a page's worth of history and
         # release the gate, exactly as the real fetch does on success.
         nonlocal fetches
@@ -1106,6 +1081,7 @@ async def test_the_fill_pages_a_remote_session_through_its_fetch_worker() -> Non
         if fetches >= 2:
             session.history_before_token = None
         app._resume_paging = False
+        app._mount_older_resume_page(on_settled=on_settled)
 
     async with app.run_test(size=(120, 600)) as pilot:
         await _wait_for_resume(pilot, app)
@@ -1125,7 +1101,7 @@ async def test_the_fill_pages_a_remote_session_through_its_fetch_worker() -> Non
     # And it leaves the gate open, so a real gesture is not locked out.
     assert app._resume_paging is False
     # The latch is untouched by the fetch's own mount, same as the local path.
-    assert app._resume_in_zone is True
+    assert app._resume_in_zone is False
 
 
 @pytest.mark.asyncio
@@ -1241,7 +1217,7 @@ async def test_the_head_notice_tracks_a_resize_in_both_directions() -> None:
 
 
 @pytest.mark.asyncio
-async def test_the_head_notice_tracks_content_growth_without_a_resize() -> None:
+async def test_the_head_notice_tracks_content_growth_without_a_resize(monkeypatch) -> None:
     """The general case the resize is one instance of (QA Q5).
 
     A live turn appending rows makes an unscrollable frame scrollable without
@@ -1250,6 +1226,15 @@ async def test_the_head_notice_tracks_content_growth_without_a_resize() -> None:
     the same reasoning ``TranscriptView._size_updated`` gives for the tail
     anchor: a rule keyed on the measurement holds for growth nobody enumerated.
     """
+    # Exercise notice fallback without the automatic post-projection fill.
+    original_start = OperatorApp._start_resume_fill
+    monkeypatch.setattr(
+        OperatorApp,
+        "_start_resume_fill",
+        lambda self, *, target=None: (
+            original_start(self, target=target) if target is not None else None
+        ),
+    )
     session = FakeSession()
     session._history = _agentic_history(200, followups=1)
     app = OperatorApp(lambda: _factory(session))
@@ -1267,7 +1252,7 @@ async def test_the_head_notice_tracks_content_growth_without_a_resize() -> None:
         assert app_module.RESUME_UNREACHABLE_NOTICE in notices()
 
         # A turn's worth of output, appended the way live output arrives.
-        for i in range(400):
+        for i in range(viewport + 1):
             view.append_block(NoticeBlock(f"live row {i}", "info"))
         for _ in range(80):
             await pilot.pause()
@@ -1282,7 +1267,7 @@ async def test_the_head_notice_tracks_content_growth_without_a_resize() -> None:
 
 
 @pytest.mark.asyncio
-async def test_the_head_notice_stops_being_a_control_once_it_is_inert() -> None:
+async def test_the_head_notice_stops_being_a_control_once_it_is_inert(monkeypatch) -> None:
     """A focus stop must not answer Enter with silence (design round 2, D7).
 
     The head notice restates rather than removing itself when the history runs
@@ -1295,6 +1280,15 @@ async def test_the_head_notice_stops_being_a_control_once_it_is_inert() -> None:
     what makes the row a control is `can_focus` and the class; the paint is
     downstream of both.
     """
+    # Exercise notice fallback without the automatic post-projection fill.
+    original_start = OperatorApp._start_resume_fill
+    monkeypatch.setattr(
+        OperatorApp,
+        "_start_resume_fill",
+        lambda self, *, target=None: (
+            original_start(self, target=target) if target is not None else None
+        ),
+    )
     session = FakeSession()
     session._history = _agentic_history(200, followups=1)
     app = OperatorApp(lambda: _factory(session))
@@ -1330,7 +1324,9 @@ async def test_the_head_notice_stops_being_a_control_once_it_is_inert() -> None:
 
 
 @pytest.mark.asyncio
-async def test_exhausting_the_focused_notice_lands_focus_on_the_visible_transcript() -> None:
+async def test_exhausting_the_focused_notice_lands_focus_on_the_visible_transcript(
+    monkeypatch,
+) -> None:
     """Say WHERE focus goes when the control retires, not merely that it left.
 
     The sibling guard above asserts the NEGATIVE — the exhausted row is no
@@ -1352,6 +1348,15 @@ async def test_exhausting_the_focused_notice_lands_focus_on_the_visible_transcri
     Drained through the control WITH FOCUS ON IT, which is the mouse route
     (focus-then-activate) and the only state in which the blur runs at all.
     """
+    # Exercise notice fallback without the automatic post-projection fill.
+    original_start = OperatorApp._start_resume_fill
+    monkeypatch.setattr(
+        OperatorApp,
+        "_start_resume_fill",
+        lambda self, *, target=None: (
+            original_start(self, target=target) if target is not None else None
+        ),
+    )
     session = FakeSession()
     session._history = _agentic_history(200, followups=1)
     app = OperatorApp(lambda: _factory(session))
@@ -1446,6 +1451,7 @@ async def test_a_raising_fill_does_not_leave_the_pessimistic_copy_suppressed() -
             container_size=SimpleNamespace(height=40),
             size=SimpleNamespace(height=40),
             virtual_size=SimpleNamespace(height=10),
+            scroll_y=0,
         )
         app._transcript_view = lambda: unscrollable  # type: ignore[assignment]
         app._resume_paging = False

--- a/tests/unit/tui/test_resume_render.py
+++ b/tests/unit/tui/test_resume_render.py
@@ -1072,16 +1072,16 @@ async def test_the_fill_pages_a_remote_session_through_its_fetch_worker() -> Non
     app = OperatorApp(lambda: _factory(session))
     fetches = 0
 
-    async def fake_fetch(source: Any, on_settled=None) -> None:
+    async def fake_fetch(source: Any, lease: Any = None, on_settled=None) -> None:
         # Stands in for the round trip: prepend a page's worth of history and
-        # release the gate, exactly as the real fetch does on success.
+        # hand the transaction's lease to the mount, exactly as the real fetch
+        # does on success.
         nonlocal fetches
         fetches += 1
         app._resume_pending_head = _agentic_history(30) + app._resume_pending_head
         if fetches >= 2:
             session.history_before_token = None
-        app._resume_paging = False
-        app._mount_older_resume_page(on_settled=on_settled)
+        app._mount_older_resume_page(on_settled=on_settled, lease=lease)
 
     async with app.run_test(size=(120, 600)) as pilot:
         await _wait_for_resume(pilot, app)
@@ -1454,7 +1454,7 @@ async def test_a_raising_fill_does_not_leave_the_pessimistic_copy_suppressed() -
             scroll_y=0,
         )
         app._transcript_view = lambda: unscrollable  # type: ignore[assignment]
-        app._resume_paging = False
+        app._paging_leases.clear()
         app._resume_pending_head = list(_history(4))
         app._resume_fill_active = True
 


### PR DESCRIPTION
## Summary

Repair ordinary TUI history paging so restoring/switching to a conversation produces a genuinely scrollable rendered buffer, and loading older history keeps the reading position stable rather than replacing/interleaving the visible text.

**Change class: C2 — standard/pre-authorized bug fix.** This PR is the record; no tracker was requested. No version bump, backend transcript/cache changes, merge, or release is included.

## Delivery contract

- Initial resume and sidebar reveal measure actual laid-out history, excluding the loader notice, and reserve at least one viewport above the reading position whenever enough history exists. At the tail this gives the visible viewport plus another viewport above it.
- Hidden/compact messages cannot strand the reader: work uses a 24-event render target (the existing turn-boundary snap can extend a slice to at most 48), yielding between slices and between 16-slice bursts while the local head/remote cursor advances. A gesture requests a **rendered buffer**, not one tiny raw page or one RPC per notch.
- Prepending holds the retained content after the insertion seam, not the fixed older-history notice. Compensation happens before compositor placement on every frame; newer user movement updates the held gap. Native animation targets remain authoritative on no-op layout frames.
- Genuine upward wheel/PageUp/Home input can request history at a clamped top. Offset observations cannot earn demand, downward input cancels it, and input during a busy transaction is coalesced rather than becoming concurrent requests.
- One lease covers remote fetch → projection → insertion → settled anchor. Source/view/navigation/fill-request fencing prevents stale completions from modifying a replacement conversation. No-progress/error exits release the lease and retain an actionable retry.
- Chronology, deduplication, live tail appends, cancellation-resistant completion and same-view cancelled-navigation cleanup remain correct.

## Implementation and risk

`app.py` now uses one local/remote demand-and-fill path; the sidebar change is one post-reveal fill hook. `widgets/transcript.py` distinguishes input direction from offset observation, prevents double-handling/bubbling a clamped wheel event, anchors content after the fixed prefix, and compensates in `arrange()` before Textual converts placements into screen coordinates.

The pre-paint seam follows the installed Textual compositor's native anchoring order. `_size_updated` alone was too late: its immediate offset change still left already-computed screen coordinates displaced for a frame. This is an internal Textual integration risk, covered by actual compositor-frame and input-race regressions.

**Non-goals:** owner-side canonical DISPLAY caching, saved-tail parsing, connection readiness/bind sequencing, sidebar lease/prepare redesign, backend journal changes, virtualization, and release/version work. Those parallel workstreams are not modified here. In particular, the synthetic sidebar probe does not claim its readiness Future passed; it exercises the real prepare/commit/paging/layout surfaces while readiness sequencing remains the separate peer's responsibility.

## Reproduced before fixing

Before implementation, the real isolated `OperatorApp` at `6f83793dc` showed:

- A 20-message compact sidebar projection at 100×40: viewport **31**, virtual height **31**, scroll range **0**, with **580** older messages still deferred.
- A top prepend moved the same retained reading row from screen gap **2 → 122** permanently.
- The matched real-runtime matrix found a hidden-heavy remote history with **two simultaneous inserts**, and the paging gate already reopened during six sampled in-progress insert frames.

New regression guards were also run against the immutable pre-fix worktree: **3 failed as expected** (hidden rendered reserve, exact-fit reserve excluding loader chrome, and clamped prepend). The same guards pass on the fix. An additional early-PageUp probe reproduced a completed native animation at `scroll_y=0` with stale `scroll_target_y≈31.4`; after the fix both are **0**, and the pager settles.

## Real-path and rendered evidence

All app subprocesses remove **every `CMUX_*`** variable and isolate **HOME/config before imports**. All sessions/IDs are synthetic. The remote cases use real persisted transcripts, `RuntimeServer`, `OwnedSessionHandle`, `RemoteSession`, and the real `OperatorApp`; no operator sessions were touched.

| Surface | Before | After |
|---|---:|---:|
| Compact local/remote, viewport 91 | virtual 161; only 70 rows above tail | virtual 209; 118 rows above tail |
| 500-hidden local tail, viewport 31 | virtual 31; no range | virtual 102; 71 rows above tail |
| 500-hidden remote tail, viewport 31 | virtual 31; no range | virtual 106; 75 rows above tail |
| Actual sidebar, viewport 91 | underfilled bounded projection | virtual 197 compact / 200 hidden |
| Retained row gap across prepend paint frames | 2 → 62 → 122 | **2 on every frame** |
| Remote hidden maximum simultaneous inserts | 2 | **1** |
| Gate-open samples while remote hidden insert active | 6 | **0** |
| Idle-top/background fetches without new input | 0 | **0** |

The regression matrix also covers **1,400 hidden messages** (beyond one fairness burst), exact-fit sizes, physical wheel direction/single handling, coalesced busy input, no-progress retry, projection failure without cursor loss, stale/cancel-resistant completions, live append during insertion, and both early/late user movement during anchor settlement.

### Before / after frames

Native captures are 800×680 pixels (100×40 cells); previews below are scaled. SVGs were rasterized and actually inspected. Consecutive compositor frames, tall-sidebar captures, reproduction scripts and detailed counters are in the [validation artifact bundle](https://gist.github.com/damianvtran/ecdaecdb75d21a07d24c6183e1999a99).

| Before: hidden history is unreachable | After: newest content plus real scrollback |
|---|---|
| ![Before](https://gist.githubusercontent.com/damianvtran/ecdaecdb75d21a07d24c6183e1999a99/raw/f3bd64cfe2a02fab98625455ab59363afbd853e2/before-hidden.svg) | ![After](https://gist.githubusercontent.com/damianvtran/ecdaecdb75d21a07d24c6183e1999a99/raw/a6e79a0557c5727c5fb4edcca2eed2741e907646/after-hidden.svg) |

The scrollbar thumb can resize/reposition as the extent grows; the reading text remains fixed. Both raw SVG attachment URLs were verified to return HTTP 200 with `image/svg+xml`.

### Responsiveness versus throughput

Interleaved before/after runs perform **equal total work: 360 raw events, 82 → 442 mounted blocks**. Before: six 60-event slices. After: fifteen 24-event slices.

| Measurement (two passes) | Before | After |
|---|---:|---:|
| Median main-thread CPU per slice | 83–90 ms | **41–50 ms** |
| Median sampled heartbeat maximum per slice | 39–40 ms | **21–25 ms** |
| Total main-thread CPU for all 360 events | 571–579 ms | 743–840 ms |
| Total measured insertion wall time | 626–631 ms | 997–1,131 ms |

This intentionally trades aggregate throughput for shorter uninterrupted work and more input/layout opportunities. It is **not** a claim of faster total replay or a hard maximum latency; the host runs concurrent agent/test workloads. No fragile wall-clock ceiling was added to CI. The workload, individual samples and frame gaps are attached.

## Quality gates

Run over the whole tree exactly as CI, from this worktree's own editable venv, with `HOME`/config isolated and every `CMUX_*` variable removed.

| Gate | Result |
|---|---|
| `python -m flake8 .` | clean |
| `black --check .` (26.1.0) | clean, 1076 files |
| `isort --check .` (5.13.2) | clean |
| `pyright` (whole tree) | 0 errors, 0 warnings |
| `tests/unit` | **16239 passed**, 18 skipped, 2 failed (both environmental, below) |
| `tests/e2e -m e2e -n0` | **49 passed** |
| History paging focused suite | **59 passed** |

The two unit failures are **pre-existing environment flakes, not this diff**, and were proven so rather than assumed. Both pass serially on this branch AND on the untouched base `6f83793dc`:

```
$ .venv/bin/python -m pytest tests/unit/tools/test_eval_tool.py::test_kernel_lru_cap_evicts_oldest_session \
    "tests/unit/mcp/test_manager.py::TestChildOutputContainment::test_the_quiet_env_actually_silences_rich" -n0 -q
2 passed in 1.56s     # this branch
2 passed in 2.06s     # base 6f83793dc, same command
```

- `test_the_quiet_env_actually_silences_rich` fails on a **stale `/private/tmp/link.bak`** left in the shared `/tmp` (dated 2026-07-18, not created by this task) whose `@rpath/libpython3.12.dylib` no longer resolves, so the child aborts with signal 6. Nothing in this diff spawns or configures that child.
- `test_kernel_lru_cap_evicts_oldest_session` is an eval-kernel LRU assertion that fails only under parallel load; ten sibling worktrees were running full suites concurrently on this host during the gate run.

Neither test imports or exercises the TUI, the transcript widget, or any history path.

## Rollback

Revert this PR. It changes only presentation/paging behavior and tests, with no persisted schema, configuration, data migration or version change.

## Review disposition

This is the frozen initial-review head, not a merge-ready approval. Code review has identified **F1 (major): cached A → B → A navigation while an RPC is held can start a second RPC and let stale completion release the newer paging gate**. Remediation is deliberately held until the concurrent QA/UX streams complete so all findings are addressed in one unified batch. Design review is clean; the independent rounds will be posted on this PR.

No human reviewer is requested before the agent streams are clean. This implementing task does not merge or release.
