### PR TITLE
perf(session): reuse bounded display pages and skip unused projection payloads

### DIFF
--- a/local_operator/session/history_window.py
+++ b/local_operator/session/history_window.py
@@ -200,6 +200,11 @@ def display_window(
         max_wire_bytes=max_wire_bytes,
         durable_seed_tools=durable_seed_tools,
     )
+    # Replay creates fresh models, but nested JSON-ish tool/provider payloads
+    # may still share children with journal dictionaries. The mutable display
+    # response must own those children even on a cold or non-admitted request.
+    # Copy only the selected page, never the whole canonical history.
+    page = page.model_copy(deep=True)
     if page.status != "reset":
         cache.put(key, page)
     return page

--- a/local_operator/session/history_window.py
+++ b/local_operator/session/history_window.py
@@ -12,6 +12,8 @@ import base64
 import hashlib
 import hmac
 import json
+import sys
+from collections import OrderedDict
 from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -24,6 +26,13 @@ if TYPE_CHECKING:
 DISPLAY_HISTORY_CAPABILITY = "display-history-window-v1"
 DISPLAY_HISTORY_MESSAGES = 120
 DISPLAY_HISTORY_BYTES = 512 * 1024
+
+# Per OWNER, not per viewer: a fleet of sessions must not retain a full replay
+# per speculative attach. Admission examines only the already bounded page,
+# never walks the whole canonical history merely to decide whether to cache it.
+DISPLAY_PAGE_CACHE_ENTRIES = 4
+DISPLAY_PAGE_CACHE_BYTES = 2 * 1024 * 1024
+_CACHE_CONTAINER_ALLOWANCE = 4096
 
 
 class DisplayHistoryWindow(BaseModel):
@@ -70,6 +79,79 @@ def _verify(token: str, key: bytes) -> dict[str, Any]:
         raise ValueError("invalid history token") from exc
 
 
+class _DisplayWindowCache:
+    """Private detached page templates; no model/context consumer sees them."""
+
+    def __init__(self) -> None:
+        self.entries: OrderedDict[tuple[object, ...], tuple[DisplayHistoryWindow, int]] = (
+            OrderedDict()
+        )
+        self.retained_bytes = 0
+
+    def get(self, key: tuple[object, ...]) -> DisplayHistoryWindow | None:
+        cached = self.entries.get(key)
+        if cached is None:
+            return None
+        self.entries.move_to_end(key)
+        # Rendering and seed annotation mutate returned models. A shared cached
+        # Message would poison later attaches and violate replay's ownership.
+        return cached[0].model_copy(deep=True)
+
+    def put(self, key: tuple[object, ...], page: DisplayHistoryWindow) -> None:
+        size = _retained_size((key, page), DISPLAY_PAGE_CACHE_BYTES - _CACHE_CONTAINER_ALLOWANCE)
+        if size is None:
+            return
+        previous = self.entries.pop(key, None)
+        if previous is not None:
+            self.retained_bytes -= previous[1]
+        while self.entries and (
+            len(self.entries) >= DISPLAY_PAGE_CACHE_ENTRIES
+            or self.retained_bytes + size > DISPLAY_PAGE_CACHE_BYTES - _CACHE_CONTAINER_ALLOWANCE
+        ):
+            _, (_, removed) = self.entries.popitem(last=False)
+            self.retained_bytes -= removed
+        self.entries[key] = (page.model_copy(deep=True), size)
+        self.retained_bytes += size
+
+
+def _retained_size(value: object, limit: int) -> int | None:
+    """Bound the page's reachable data, including keys, tool metadata and media.
+
+    This is a small page walk, not a full-history admission pass (the latter
+    doubled cold 20k-row replay CPU in the measured prototype). Shared immutable
+    values count once within a page and conservatively again across cache entries.
+    The fixed allowance covers the four LRU nodes and bookkeeping. Framework
+    class/schema objects are process-global, not retained by this cache.
+    """
+    pending = [value]
+    seen: set[int] = set()
+    total = 0
+    while pending:
+        item = pending.pop()
+        identity = id(item)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        total += sys.getsizeof(item)
+        if total > limit:
+            return None
+        if isinstance(item, BaseModel):
+            pending.extend(
+                (
+                    item.__dict__,
+                    item.__pydantic_fields_set__,
+                    item.__pydantic_extra__,
+                    item.__pydantic_private__,
+                )
+            )
+        elif isinstance(item, dict):
+            pending.extend(item)
+            pending.extend(item.values())
+        elif isinstance(item, (list, tuple, set, frozenset)):
+            pending.extend(item)
+    return total
+
+
 def display_window(
     transcript: Transcript,
     *,
@@ -80,6 +162,60 @@ def display_window(
     anchor: str = "",
     max_messages: int = DISPLAY_HISTORY_MESSAGES,
     max_wire_bytes: int = DISPLAY_HISTORY_BYTES,
+    durable_seed_tools: frozenset[str] = frozenset(),
+) -> DisplayHistoryWindow:
+    """Reuse exact bounded display requests, never the mutable public replay.
+
+    A signed ``before`` token owns its cut, irrespective of the newer cursor
+    the caller passes beside it. The token itself is part of the key, so no
+    validation is bypassed: only the exact request already validated at this
+    generation/epoch can hit. Invalid/reset requests are never retained.
+    """
+    cache = transcript._display_window_cache
+    if cache is None:
+        cache = transcript._display_window_cache = _DisplayWindowCache()
+    key = (
+        conversation_id,
+        owner_epoch,
+        transcript._history_generation,
+        transcript._history_page_key,
+        None if before is not None else through_id,
+        before,
+        anchor,
+        max_messages,
+        max_wire_bytes,
+        durable_seed_tools,
+    )
+    cached = cache.get(key)
+    if cached is not None:
+        return cached
+    page = _capture_display_window(
+        transcript,
+        conversation_id=conversation_id,
+        owner_epoch=owner_epoch,
+        through_id=through_id,
+        before=before,
+        anchor=anchor,
+        max_messages=max_messages,
+        max_wire_bytes=max_wire_bytes,
+        durable_seed_tools=durable_seed_tools,
+    )
+    if page.status != "reset":
+        cache.put(key, page)
+    return page
+
+
+def _capture_display_window(
+    transcript: Transcript,
+    *,
+    conversation_id: str,
+    owner_epoch: str,
+    through_id: str | None,
+    before: str | None = None,
+    anchor: str = "",
+    max_messages: int = DISPLAY_HISTORY_MESSAGES,
+    max_wire_bytes: int = DISPLAY_HISTORY_BYTES,
+    durable_seed_tools: frozenset[str] = frozenset(),
 ) -> DisplayHistoryWindow:
     """Return complete replay rows, with tool call/result groups kept together.
 
@@ -110,6 +246,20 @@ def display_window(
         history = transcript.build_llm_history(through_id=through_id) if through_id else []
     except ValueError:
         return DisplayHistoryWindow(status="reset", **envelope)
+    # These identities belong to the SAME durable cut as the page. Derive
+    # them before discarding the full replay, including on an oversized page;
+    # a subscribing session must not reconstruct history a second time.
+    seed_tool_ids = (
+        [
+            str(message.tool_call_id)
+            for message in history
+            if isinstance(message, Message)
+            and message.role == "tool"
+            and message.tool_call_id in durable_seed_tools
+        ]
+        if durable_seed_tools
+        else []
+    )
     total = len(history)
     end = int(claims["position"]) if claims is not None else total
     if end < 0 or end > total:
@@ -162,7 +312,9 @@ def display_window(
                     for m in selected
                 )
             ):
-                return DisplayHistoryWindow(status="full_required", **envelope)
+                return DisplayHistoryWindow(
+                    status="full_required", durable_seed_tool_ids=seed_tool_ids, **envelope
+                )
             break
         selected[0:0] = group
         used += cost
@@ -177,6 +329,7 @@ def display_window(
     return DisplayHistoryWindow(
         **envelope,
         messages=selected,
+        durable_seed_tool_ids=seed_tool_ids,
         before_token=before_token,
         snapshot_token=snapshot_token,
         has_more=start > 0,

--- a/local_operator/session/history_window.py
+++ b/local_operator/session/history_window.py
@@ -120,10 +120,20 @@ def _retained_size(value: object, limit: int) -> int | None:
     This is a small page walk, not a full-history admission pass (the latter
     doubled cold 20k-row replay CPU in the measured prototype). Shared immutable
     values count once within a page and conservatively again across cache entries.
+
+    Deliberately an OVER-estimate: ``sys.getsizeof`` charges per-object CPython
+    overhead (measured ~7.5x a pickled page — 91,960 accounted against 12,172
+    serialized), so the effective retention ceiling is well under the nominal
+    2 MiB. That direction is the safe one for a per-owner budget multiplied
+    across a fleet, but anyone re-tuning the constant should size it against
+    ACCOUNTED bytes rather than expecting a wire-sized figure.
     The fixed allowance covers the four LRU nodes and bookkeeping. Framework
     class/schema objects are process-global, not retained by this cache.
     """
     pending = [value]
+    # Identity-keyed, and safe only because nothing here is freed mid-walk: the
+    # page and its key are held by `pending`/the caller for the whole traversal,
+    # so no id() can be recycled into a false "already counted".
     seen: set[int] = set()
     total = 0
     while pending:

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -2680,12 +2680,15 @@ class RuntimeServer:
         Full-TUI attach clients are skipped (see ``_projection_recipients``).
         Phone daemon frames stay byte-identical.
         """
+        recipients = self._projection_recipients()
+        if not recipients:
+            # Detached owners and full-TUI-only viewers have nobody consuming
+            # repaints. Avoid building a large payload at every coalesced tick;
+            # welcome frames and all subscribed update cadences are unchanged.
+            return
         ordinary = self._projection_payload()
         await asyncio.gather(
-            *(
-                self._send_to(conn, self._projection_frame(conn, ordinary))
-                for conn in self._projection_recipients()
-            )
+            *(self._send_to(conn, self._projection_frame(conn, ordinary)) for conn in recipients)
         )
 
     def _projection_payload(self) -> dict[str, Any]:

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -2685,6 +2685,12 @@ class RuntimeServer:
             # Detached owners and full-TUI-only viewers have nobody consuming
             # repaints. Avoid building a large payload at every coalesced tick;
             # welcome frames and all subscribed update cadences are unchanged.
+            #
+            # The warning latch still has to be released: no frame was emitted,
+            # so nothing degraded, and leaving it set would swallow the log line
+            # for the NEXT genuine degradation after a quiet period — exactly
+            # what the once-per-episode latch exists to preserve.
+            self._frame_cap_warned = False
             return
         ordinary = self._projection_payload()
         await asyncio.gather(

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -5755,6 +5755,11 @@ class Session:
                     conversation_id=sync.snapshot.session_id,
                     owner_epoch=sync.epoch,
                     through_id=sync.live_cursor,
+                    durable_seed_tools=frozenset(
+                        str(event.get("tool_call_id", ""))
+                        for event in sync.snapshot.live_events
+                        if event.get("type") == "tool_execution_end"
+                    ),
                 )
                 window.durable_seed_ids = [
                     str(event["message"]["id"])
@@ -5762,21 +5767,6 @@ class Session:
                     if isinstance(event.get("message"), dict)
                     and self._transcript.has_entry(str(event["message"].get("id", "")))
                 ]
-                seed_tools = {
-                    str(event.get("tool_call_id", ""))
-                    for event in sync.snapshot.live_events
-                    if event.get("type") == "tool_execution_end"
-                }
-                if seed_tools:
-                    window.durable_seed_tool_ids = [
-                        str(message.tool_call_id)
-                        for message in self._transcript.build_llm_history(
-                            through_id=sync.live_cursor
-                        )
-                        if isinstance(message, Message)
-                        and message.role == "tool"
-                        and message.tool_call_id in seed_tools
-                    ]
                 sync.display_history = window
             except BaseException:
                 subscription.unsubscribe()

--- a/local_operator/session/transcript.py
+++ b/local_operator/session/transcript.py
@@ -43,7 +43,7 @@ import uuid
 from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Sequence
 
 from local_operator.harness.types import (
     AgentMessage,
@@ -52,6 +52,9 @@ from local_operator.harness.types import (
     TextContent,
 )
 from local_operator.session.attachments import AttachmentStore
+
+if TYPE_CHECKING:
+    from local_operator.session.history_window import _DisplayWindowCache
 
 logger = logging.getLogger(__name__)
 
@@ -522,6 +525,7 @@ class Transcript:
         # a new owner. The signing key never leaves this resident transcript.
         self._history_generation = 0
         self._history_page_key = os.urandom(32)
+        self._display_window_cache: _DisplayWindowCache | None = None
         # Derived indexes only describe durable rows. They are updated after
         # fsync, rebuilt after a file fold, and never published from a worker.
         self._entry_ids: set[str] = set()
@@ -818,6 +822,7 @@ class Transcript:
     def _index_entry(self, entry: TranscriptEntry) -> None:
         if entry.type in (ENTRY_COMPACTION, ENTRY_PRUNE):
             self._history_generation += 1
+            self._display_window_cache = None
         self._entry_ids.add(entry.id)
         self._latest_by_type[entry.type] = entry
         if entry.type == ENTRY_CUSTOM:
@@ -1164,6 +1169,7 @@ class Transcript:
                         break
             self._entries = folded
             self._history_generation += 1
+            self._display_window_cache = None
             self._entry_ids.clear()
             self._latest_by_type.clear()
             self._latest_custom_entries.clear()

--- a/scripts/display_cache_performance.py
+++ b/scripts/display_cache_performance.py
@@ -1,0 +1,258 @@
+"""Measure cold/warm canonical display requests and real owner socket latency.
+
+    .venv/bin/python scripts/display_cache_performance.py --output /tmp/owner-cache
+    .venv/bin/python scripts/display_cache_performance.py --source-root BASE --output OUT
+
+Both trees run the same harness, with synthetic data and isolated HOME/config.
+The optional --fleet measures cache retention for 50 transcript owners, not the
+entire memory footprint of 50 running agent processes. No timing is a CI limit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable
+from unittest.mock import patch
+
+PARSER = argparse.ArgumentParser(description=__doc__)
+PARSER.add_argument("--source-root", type=Path, default=Path(__file__).resolve().parent.parent)
+PARSER.add_argument("--output", type=Path, required=True)
+PARSER.add_argument("--messages", type=int, default=20_000)
+PARSER.add_argument("--samples", type=int, default=5)
+PARSER.add_argument("--fleet", action="store_true")
+ARGS = PARSER.parse_args()
+if ARGS.messages < 140 or ARGS.samples < 1:
+    PARSER.error("--messages must be at least 140; --samples must be positive")
+ARGS.output.mkdir(parents=True, exist_ok=True)
+sys.path.insert(0, str(ARGS.source_root.resolve()))
+for _key in tuple(os.environ):
+    if _key.startswith("CMUX_"):
+        del os.environ[_key]
+
+import scripts.probe_isolation as isolation  # noqa: E402
+
+# isort: split
+import local_operator  # noqa: E402
+from local_operator.harness.types import Message  # noqa: E402
+from local_operator.mobile.attach_client import AttachClient  # noqa: E402
+from local_operator.session.history_window import display_window  # noqa: E402
+from local_operator.session.runtime.owned import OwnedSessionHandle  # noqa: E402
+from local_operator.session.runtime.server import RuntimeServer  # noqa: E402
+from local_operator.session.transcript import Transcript  # noqa: E402
+from tests.e2e.harness import ScriptedStream, build_session  # noqa: E402
+
+ROOT = isolation.SANDBOX / "config"
+RESULTS: list[dict[str, Any]] = []
+
+
+def record(case: str, **values: Any) -> None:
+    row = {"case": case, "source": str(local_operator.__file__), **values}
+    RESULTS.append(row)
+    print(json.dumps(row), flush=True)
+
+
+def measure(call: Callable[[], Any]) -> tuple[Any, dict[str, float]]:
+    cpu, wall = [], []
+    result = None
+    for _ in range(ARGS.samples):
+        c, w = time.thread_time(), time.monotonic()
+        result = call()
+        cpu.append((time.thread_time() - c) * 1000)
+        wall.append((time.monotonic() - w) * 1000)
+    return result, {
+        "median_cpu_ms": statistics.median(cpu),
+        "max_cpu_ms": max(cpu),
+        "median_wall_ms": statistics.median(wall),
+        "max_wall_ms": max(wall),
+    }
+
+
+def cache_bytes(transcript: Transcript) -> int:
+    return int(getattr(getattr(transcript, "_display_window_cache", None), "retained_bytes", 0))
+
+
+async def main() -> None:
+    directory = ROOT / "sessions/000000000001"
+    transcript = Transcript(directory)
+    await transcript.append_messages(
+        [
+            (
+                Message.user(f"synthetic content {i}" + " x" * 500)
+                if i % 2 == 0
+                else Message.assistant(f"synthetic answer {i}" + " x" * 500)
+            )
+            for i in range(ARGS.messages)
+        ]
+    )
+    cut = transcript.entries()[-1].id
+
+    def capture():
+        return display_window(
+            transcript,
+            conversation_id=directory.name,
+            owner_epoch="synthetic-epoch",
+            through_id=cut,
+        )
+
+    def cold():
+        # Baseline has no cache attribute. Resetting only the new private cache
+        # measures admission separately from warm reuse, not filesystem startup.
+        if hasattr(transcript, "_display_window_cache"):
+            transcript._display_window_cache = None
+        return capture()
+
+    first, cold_cost = measure(cold)
+    _, warm_cost = measure(capture)
+
+    def previous():
+        return display_window(
+            transcript,
+            conversation_id=directory.name,
+            owner_epoch="synthetic-epoch",
+            through_id=cut,
+            before=first.before_token,
+        )
+
+    previous()
+    _, older_cost = measure(previous)
+    record(
+        "display",
+        messages=ARGS.messages,
+        durable_bytes=transcript.path.stat().st_size,
+        returned=len(first.messages),
+        wire_bytes=len(first.model_dump_json()),
+        cold=cold_cost,
+        warm=warm_cost,
+        warm_older=older_cost,
+        retained_bytes=cache_bytes(transcript),
+    )
+    session = build_session(directory, ScriptedStream([]), cwd=isolation.SANDBOX)
+    server = None
+    established = None
+    writers = []
+    try:
+
+        def subscribe():
+            subscription = session.subscribe_frontend(lambda _: None, display_window=True)
+            subscription.unsubscribe()
+            return subscription
+
+        subscribe()
+        _, subscription_cost = measure(subscribe)
+        record("actual_warm_subscribe", **subscription_cost)
+        handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd=str(isolation.SANDBOX))
+        server = RuntimeServer(handle, kind="daemon")
+        await server.start_in_process()
+        established = AttachClient(lambda _: None, lambda _: None)
+        await established.connect(server.record, directory.name)
+        gaps = []
+        done = False
+
+        async def ticker() -> None:
+            previous_time = time.monotonic()
+            while not done:
+                await asyncio.sleep(0.005)
+                now = time.monotonic()
+                gaps.append((now - previous_time) * 1000)
+                previous_time = now
+
+        tick = asyncio.create_task(ticker())
+        await asyncio.sleep(0.03)
+        readers = []
+        for _ in range(3):
+            reader, writer = await asyncio.open_connection(
+                "127.0.0.1", server.record.control_port, limit=2 * 1024 * 1024
+            )
+            writer.write(
+                (
+                    json.dumps(
+                        {
+                            "key": server.record.control_key,
+                            "client": "attach",
+                            "frontend_state": True,
+                            "events": True,
+                            "display_window": True,
+                        }
+                    )
+                    + "\n"
+                ).encode()
+            )
+            await writer.drain()
+            readers.append(reader)
+            writers.append(writer)
+        start = time.monotonic()
+        answer = await established._request("ping")
+        rtt = (time.monotonic() - start) * 1000
+        for reader in readers:
+            assert json.loads(await reader.readline())["op"] == "projection"
+            assert json.loads(await reader.readline())["op"] == "frontend_sync"
+        done = True
+        await tick
+        record(
+            "three_full_attaches", control_result=answer, ping_ms=rtt, max_5ms_tick_gap_ms=max(gaps)
+        )
+        for writer in writers:
+            writer.close()
+            await writer.wait_closed()
+        writers.clear()
+        await established.detach()
+        established = None
+        for _ in range(1000):
+            if not server._clients:
+                break
+            await asyncio.sleep(0)
+        assert not server._clients
+        with patch.object(
+            server, "_projection_payload", wraps=server._projection_payload
+        ) as payload:
+            start = time.thread_time()
+            for _ in range(100):
+                await server._push()
+            record(
+                "no_recipient_push",
+                pushes=100,
+                payload_calls=payload.call_count,
+                cpu_ms=(time.thread_time() - start) * 1000,
+            )
+    finally:
+        for writer in writers:
+            writer.close()
+            await writer.wait_closed()
+        if established is not None:
+            await established.detach()
+        if server is not None:
+            await server.aclose()
+        await session.dispose()
+    if ARGS.fleet:
+        owners = []
+        for index in range(50):
+            owner = Transcript(ROOT / "sessions" / f"{index + 2:012x}")
+            await owner.append_messages(
+                [Message.user(f"row {i} " + "x" * 1000) for i in range(1000)]
+            )
+            display_window(
+                owner,
+                conversation_id=owner.directory.name,
+                owner_epoch="fleet",
+                through_id=owner.entries()[-1].id,
+            )
+            owners.append(owner)
+        record(
+            "fifty_owner_cache",
+            owners=50,
+            messages_each=1000,
+            retained_bytes=sum(cache_bytes(owner) for owner in owners),
+            max_owner_bytes=max(cache_bytes(owner) for owner in owners),
+        )
+    (ARGS.output / "results.json").write_text(json.dumps(RESULTS, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/unit/evaluation/copied_interpreter.py
+++ b/tests/unit/evaluation/copied_interpreter.py
@@ -125,11 +125,19 @@ def copied_interpreter(venv: Path) -> Path:
         # cannot start: a shared libpython the copy resolves relative to
         # itself. Carry it across and try once more; anything else is a real
         # failure and is reported as one.
-        library = _shared_libpython(base)
+        try:
+            library = _shared_libpython(base)
+        except AssertionError as error:
+            # Keep BOTH stages: the copy's loader failure triggered discovery,
+            # but a failed metadata probe is not evidence that no library exists.
+            raise AssertionError(
+                f"{error}; copied interpreter {executable} (from {base}) did not start: "
+                f"{_probe_context(started)}"
+            ) from error
         if library is None:
             raise AssertionError(
-                f"copied interpreter {executable} (from {base}) did not start and the "
-                f"base reports no shared libpython to carry across: {started.stderr[-800:]}"
+                f"copied interpreter {executable} (from {base}) did not start and "
+                f"no shared libpython repair is supported: {started.stderr[-800:]}"
             )
         target = venv / "lib" / library.name
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -169,6 +177,14 @@ def _probe(executable: Path, code: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _probe_context(answer: subprocess.CompletedProcess[str]) -> str:
+    """Bound diagnostic output without discarding which subprocess failed."""
+    return (
+        f"rc={answer.returncode}; stdout={(answer.stdout or '')[-800:]!r}; "
+        f"stderr={(answer.stderr or '')[-800:]!r}"
+    )
+
+
 def _shared_libpython(base: Path) -> Path | None:
     """The shared library ``base`` links, if it is built ``--enable-shared``.
 
@@ -186,13 +202,36 @@ def _shared_libpython(base: Path) -> Path | None:
     )
     answer = _probe(base, query)
     if answer.returncode != 0:
+        raise AssertionError(
+            f"shared-libpython metadata query failed for {base}: {_probe_context(answer)}"
+        )
+    # Preserve empty fields: a non-shared build legitimately prints 0 plus two
+    # empty metadata lines. A truncated/malformed answer is a different outcome.
+    lines = (answer.stdout or "").splitlines()
+    if len(lines) != 3 or lines[0].strip() not in {"0", "1"}:
+        raise AssertionError(
+            f"malformed shared-libpython metadata from {base}: {_probe_context(answer)}"
+        )
+    if lines[0].strip() == "0":
         return None
-    lines = answer.stdout.strip().splitlines()
-    if len(lines) != 3 or lines[0].strip() != "1" or not lines[1] or not lines[2]:
-        return None
+    if not lines[1] or not lines[2]:
+        raise AssertionError(
+            f"incomplete shared-libpython metadata from {base}: {_probe_context(answer)}"
+        )
+    if "/" in lines[2]:
+        return None  # Positively unsupported framework/path-style soname.
     library = Path(lines[1]) / lines[2]
     # A framework build's INSTSONAME is ``Python.framework/Versions/X/Python``;
     # its executable resolves it through the framework, not ``@rpath``, so a
     # copy of it started fine and never reaches here. A plain file is the
     # uv/manylinux shape this repair exists for.
-    return library if library.is_file() and "/" not in lines[2] else None
+    context = f"candidate={str(library)[-800:]!r}; {_probe_context(answer)}"
+    try:
+        exists = library.is_file()
+    except OSError as error:
+        raise AssertionError(
+            f"cannot inspect shared libpython advertised by {base}: {context}"
+        ) from error
+    if not exists:
+        raise AssertionError(f"shared libpython advertised by {base} is missing: {context}")
+    return library

--- a/tests/unit/evaluation/test_copied_interpreter.py
+++ b/tests/unit/evaluation/test_copied_interpreter.py
@@ -11,6 +11,7 @@ of the cause. See ``copied_interpreter.py`` for the full account.
 
 from __future__ import annotations
 
+import subprocess
 import sys
 from pathlib import Path
 
@@ -74,3 +75,86 @@ def test_import_mismatch_names_the_pth_rather_than_falling_through(
     assert "cannot import pydantic_core" in message
     assert helper.REPO_PTH_NAME in message
     assert "ModuleNotFoundError" in message
+
+
+def test_failed_base_query_reports_its_exit_and_bounded_output(tmp_path, monkeypatch) -> None:
+    answer = subprocess.CompletedProcess(
+        [],
+        73,
+        stdout="x" * 2000 + "STDOUT_TAIL",
+        stderr="y" * 2000 + "SYNTHETIC_BASE_QUERY_FAILURE",
+    )
+    monkeypatch.setattr(helper, "_probe", lambda *_: answer)
+    with pytest.raises(AssertionError, match="metadata query failed") as raised:
+        helper._shared_libpython(tmp_path / "python")
+    message = str(raised.value)
+    assert "rc=73" in message
+    assert "STDOUT_TAIL" in message and "SYNTHETIC_BASE_QUERY_FAILURE" in message
+    assert len(message) < 2500
+    assert "no shared libpython" not in message
+
+
+@pytest.mark.parametrize(
+    "stdout",
+    [
+        "truncated\n",
+        "1\nmissing-line\n",
+        "invalid\n/lib\nlibpython.so\n",
+        "1\n\nlibpython.so\n",
+        "1\n/lib\n\n",
+    ],
+)
+def test_malformed_shared_metadata_is_not_reported_as_no_library(
+    tmp_path, monkeypatch, stdout
+) -> None:
+    monkeypatch.setattr(helper, "_probe", lambda *_: subprocess.CompletedProcess([], 0, stdout, ""))
+    with pytest.raises(AssertionError, match="metadata") as raised:
+        helper._shared_libpython(tmp_path / "python")
+    assert "stdout=" in str(raised.value) and "rc=0" in str(raised.value)
+
+
+@pytest.mark.parametrize("stdout", ["0\n\n\n", "1\n/lib\nPython.framework/Versions/3/Python\n"])
+def test_only_positive_nonshared_or_unsupported_metadata_returns_none(
+    tmp_path, monkeypatch, stdout
+) -> None:
+    monkeypatch.setattr(helper, "_probe", lambda *_: subprocess.CompletedProcess([], 0, stdout, ""))
+    assert helper._shared_libpython(tmp_path / "python") is None
+
+
+def test_advertised_missing_library_names_the_candidate(tmp_path, monkeypatch) -> None:
+    candidate = tmp_path / "libpython-test.dylib"
+    stdout = f"1\n{tmp_path}\n{candidate.name}\n"
+    monkeypatch.setattr(
+        helper, "_probe", lambda *_: subprocess.CompletedProcess([], 0, stdout, "query-note")
+    )
+    with pytest.raises(AssertionError, match="is missing") as raised:
+        helper._shared_libpython(tmp_path / "python")
+    message = str(raised.value)
+    assert str(candidate) in message and "query-note" in message and "rc=0" in message
+
+
+def test_query_failure_preserves_the_copied_interpreters_start_context(
+    tmp_path, monkeypatch
+) -> None:
+    real_probe = helper._probe
+    queries = []
+
+    def injected(executable, code):
+        if code == "print('ok')":
+            return subprocess.CompletedProcess([], 134, "FIRST_START_STDOUT", "ORIGINAL_DYLD_ERROR")
+        if "Py_ENABLE_SHARED" in code:
+            queries.append(executable)
+            return subprocess.CompletedProcess(
+                [], 73, "BASE_QUERY_STDOUT", "SYNTHETIC_BASE_QUERY_FAILURE"
+            )
+        return real_probe(executable, code)
+
+    monkeypatch.setattr(helper, "_probe", injected)
+    with pytest.raises(AssertionError, match="metadata query failed") as raised:
+        helper.copied_interpreter(tmp_path / "venv")
+    message = str(raised.value)
+    assert "rc=73" in message and "SYNTHETIC_BASE_QUERY_FAILURE" in message
+    assert "rc=134" in message and "ORIGINAL_DYLD_ERROR" in message
+    assert "FIRST_START_STDOUT" in message and "BASE_QUERY_STDOUT" in message
+    assert isinstance(raised.value.__cause__, AssertionError)
+    assert len(queries) == 1  # Never retry or cache the failed probe.

--- a/tests/unit/evaluation/test_copied_interpreter.py
+++ b/tests/unit/evaluation/test_copied_interpreter.py
@@ -133,6 +133,34 @@ def test_advertised_missing_library_names_the_candidate(tmp_path, monkeypatch) -
     assert str(candidate) in message and "query-note" in message and "rc=0" in message
 
 
+def test_unreadable_advertised_library_names_the_candidate_and_keeps_the_cause(
+    tmp_path, monkeypatch
+) -> None:
+    """An unreadable path is not evidence that no library exists.
+
+    The stat itself can fail (a permission-denied mount, a stale automount),
+    and reporting that as "no shared libpython" is the exact
+    misclassification this module exists to prevent.
+    """
+    stdout = f"1\n{tmp_path}\nlibpython-unreadable.dylib\n"
+    monkeypatch.setattr(
+        helper, "_probe", lambda *_: subprocess.CompletedProcess([], 0, stdout, "query-note")
+    )
+    failure = PermissionError(13, "Permission denied")
+
+    def refuse(self):  # noqa: ANN001, ANN202
+        raise failure
+
+    monkeypatch.setattr(Path, "is_file", refuse)
+    with pytest.raises(AssertionError, match="cannot inspect shared libpython") as raised:
+        helper._shared_libpython(tmp_path / "python")
+    message = str(raised.value)
+    assert "libpython-unreadable.dylib" in message
+    assert "rc=0" in message and "query-note" in message
+    assert "no shared libpython" not in message
+    assert raised.value.__cause__ is failure
+
+
 def test_query_failure_preserves_the_copied_interpreters_start_context(
     tmp_path, monkeypatch
 ) -> None:

--- a/tests/unit/session/runtime/test_server.py
+++ b/tests/unit/session/runtime/test_server.py
@@ -1961,6 +1961,57 @@ async def test_a_credential_frame_with_a_non_string_value_is_refused() -> None:
 
 
 @pytest.mark.asyncio
+async def test_push_builds_no_payload_without_projection_recipients() -> None:
+    from unittest.mock import patch
+
+    runtime = RuntimeServer(FakeHandle(), kind="tui")
+    await runtime.start_in_process()
+    writer = daemon_writer = None
+    try:
+        with patch.object(
+            runtime, "_projection_payload", wraps=runtime._projection_payload
+        ) as payload:
+            for _ in range(20):
+                await runtime._push()
+            payload.assert_not_called()
+            record = runtime.record
+            reader, writer = await asyncio.open_connection(
+                "127.0.0.1", record.control_port, limit=1 << 20
+            )
+            writer.write(
+                json.dumps(
+                    {
+                        "key": record.control_key,
+                        "client": "attach",
+                        "events": True,
+                        "frontend_state": True,
+                    }
+                ).encode()
+                + b"\n"
+            )
+            await writer.drain()
+            assert json.loads(await reader.readline())["op"] == "projection"
+            assert json.loads(await reader.readline())["op"] == "frontend_sync"
+            payload.assert_called_once()  # Identity welcome is never suppressed.
+            payload.reset_mock()
+            for _ in range(20):
+                await runtime._push()
+            payload.assert_not_called()
+            daemon_reader, daemon_writer = await _dial(record)
+            payload.assert_called_once()
+            payload.reset_mock()
+            await runtime._push()
+            assert json.loads(await daemon_reader.readline())["op"] == "projection"
+            payload.assert_called_once()
+    finally:
+        for connection in (writer, daemon_writer):
+            if connection is not None:
+                connection.close()
+                await connection.wait_closed()
+        await runtime.aclose()
+
+
+@pytest.mark.asyncio
 async def test_push_skips_full_tui_clients_but_keeps_welcome_and_daemon() -> None:
     """Test 20: ``_push`` skips events+frontend clients; welcome still delivered.
 

--- a/tests/unit/session/test_display_page_cache.py
+++ b/tests/unit/session/test_display_page_cache.py
@@ -91,6 +91,34 @@ async def test_repeated_tail_older_anchor_and_limits_do_not_replay(tmp_path: Pat
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("retain", [True, False])
+async def test_cold_nested_display_payload_cannot_mutate_journal(
+    tmp_path: Path, monkeypatch, retain
+):
+    if not retain:
+        monkeypatch.setattr("local_operator.session.history_window.DISPLAY_PAGE_CACHE_BYTES", 1)
+    transcript = Transcript(tmp_path / "session")
+    await transcript.append_message(
+        Message.assistant(
+            "call",
+            tool_calls=[ToolCall(name="bash", arguments={"nested": {"values": [1]}})],
+            provider_payload={"details": {"tags": ["original"]}},
+        )
+    )
+    first = page(transcript).messages[0]
+    assert isinstance(first, Message)
+    first.tool_calls[0].arguments["nested"]["values"].append(2)
+    assert first.provider_payload is not None
+    first.provider_payload["details"]["tags"].append("changed")
+    for fresh in (transcript.build_llm_history()[0], page(transcript).messages[0]):
+        assert isinstance(fresh, Message)
+        assert fresh.tool_calls[0].arguments["nested"]["values"] == [1]
+        assert fresh.provider_payload == {"details": {"tags": ["original"]}}
+    assert transcript._display_window_cache is not None
+    assert bool(transcript._display_window_cache.entries) is retain
+
+
+@pytest.mark.asyncio
 async def test_old_cut_hits_after_append_and_regenerates_after_eviction(tmp_path: Path) -> None:
     transcript = Transcript(tmp_path / "session")
     await transcript.append_messages([Message.user(str(i)) for i in range(140)])

--- a/tests/unit/session/test_display_page_cache.py
+++ b/tests/unit/session/test_display_page_cache.py
@@ -1,0 +1,263 @@
+"""Exact display requests are detached and bounded; misses keep canonical replay."""
+
+from __future__ import annotations
+
+import base64
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from local_operator.harness.types import (
+    ImageContent,
+    Message,
+    TextContent,
+    ToolCall,
+    ToolExecutionEndEvent,
+    ToolResult,
+)
+from local_operator.session.history_window import (
+    DISPLAY_PAGE_CACHE_BYTES,
+    DISPLAY_PAGE_CACHE_ENTRIES,
+    display_window,
+)
+from local_operator.session.transcript import Transcript
+from tests.e2e.harness import ScriptedStream, build_session
+
+
+@pytest.fixture(autouse=True)
+def isolated_owner(tmp_path, monkeypatch):
+    for key in tuple(os.environ):
+        if key.startswith("CMUX_"):
+            monkeypatch.delenv(key)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+
+
+def page(transcript: Transcript, **kwargs):
+    return display_window(
+        transcript,
+        conversation_id="synthetic-cache",
+        owner_epoch="synthetic-epoch",
+        through_id=transcript.entries()[-1].id if transcript.entries() else None,
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_repeated_tail_older_anchor_and_limits_do_not_replay(tmp_path: Path) -> None:
+    transcript = Transcript(tmp_path / "session")
+    messages = [Message.user(f"row {index}") for index in range(270)]
+    await transcript.append_messages(messages)
+    first = page(transcript)
+    variants = [
+        {},
+        {"before": first.before_token},
+        {"before": first.snapshot_token, "anchor": messages[0].id},
+        {"max_messages": 4},
+    ]
+    for kwargs in variants:
+        expected = page(transcript, **kwargs).model_dump()
+        with patch.object(
+            transcript, "build_llm_history", wraps=transcript.build_llm_history
+        ) as replay:
+            actual = page(transcript, **kwargs)
+            assert actual.model_dump() == expected
+            replay.assert_not_called()
+        message = actual.messages[0]
+        assert isinstance(message, Message)
+        content = message.content[0]
+        assert isinstance(content, TextContent)
+        content.text = "caller mutation"
+        actual.messages.clear()
+        actual.durable_seed_ids.append("caller seed")
+        assert page(transcript, **kwargs).model_dump() == expected
+    # Model/context consumers still own independent replay objects.
+    message = transcript.build_llm_history()[0]
+    assert isinstance(message, Message)
+    content = message.content[0]
+    assert isinstance(content, TextContent)
+    content.text = "model mutation"
+    fresh = transcript.build_llm_history()[0]
+    assert isinstance(fresh, Message)
+    assert fresh.text == "row 0"
+    # A cached valid token must not outlive its signing authority, even when
+    # conversation/epoch/cut are unchanged.
+    page(transcript, before=first.snapshot_token)
+    transcript._history_page_key = b"replacement-test-signing-key"
+    with pytest.raises(ValueError, match="invalid history token"):
+        page(transcript, before=first.snapshot_token)
+
+
+@pytest.mark.asyncio
+async def test_old_cut_hits_after_append_and_regenerates_after_eviction(tmp_path: Path) -> None:
+    transcript = Transcript(tmp_path / "session")
+    await transcript.append_messages([Message.user(str(i)) for i in range(140)])
+    first = page(transcript)
+    previous = page(transcript, before=first.before_token)
+    await transcript.append_message(Message.assistant("after old cut"))
+    with patch.object(
+        transcript, "build_llm_history", wraps=transcript.build_llm_history
+    ) as replay:
+        assert page(transcript, before=first.before_token).model_dump() == previous.model_dump()
+        replay.assert_not_called()
+    for i in range(200):
+        await transcript.append_message(Message.user(f"new cut {i}"))
+        page(transcript)
+        cache = transcript._display_window_cache
+        assert cache is not None
+        assert len(cache.entries) <= DISPLAY_PAGE_CACHE_ENTRIES
+        assert cache.retained_bytes + 4096 <= DISPLAY_PAGE_CACHE_BYTES
+    with patch.object(
+        transcript, "build_llm_history", wraps=transcript.build_llm_history
+    ) as replay:
+        regenerated = page(transcript, before=first.before_token)
+        assert regenerated.model_dump() == previous.model_dump()
+        replay.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_seed_tools_share_replay_cut_and_are_part_of_request_key(tmp_path: Path) -> None:
+    transcript = Transcript(tmp_path / "session")
+    call = Message.assistant(
+        "call", tool_calls=[ToolCall(id="tool-one", name="bash", arguments={})]
+    )
+    result = Message.tool_result(
+        ToolResult(tool_call_id="tool-one", content=[TextContent(text="done")])
+    )
+    await transcript.append_messages([Message.user("start"), call, result])
+    with patch.object(
+        transcript, "build_llm_history", wraps=transcript.build_llm_history
+    ) as replay:
+        seeded = page(transcript, durable_seed_tools=frozenset({"tool-one", "not-durable"}))
+        assert seeded.durable_seed_tool_ids == ["tool-one"]
+        replay.assert_called_once()
+    with patch.object(
+        transcript, "build_llm_history", wraps=transcript.build_llm_history
+    ) as replay:
+        assert (
+            page(transcript, durable_seed_tools=frozenset({"not-durable", "tool-one"})).model_dump()
+            == seeded.model_dump()
+        )
+        replay.assert_not_called()
+    assert page(transcript).durable_seed_tool_ids == []
+    # Full-required fallback must still get its seed from that same replay.
+    with patch.object(
+        transcript, "build_llm_history", wraps=transcript.build_llm_history
+    ) as replay:
+        too_small = page(transcript, durable_seed_tools=frozenset({"tool-one"}), max_messages=1)
+        assert too_small.status == "full_required"
+        assert too_small.durable_seed_tool_ids == ["tool-one"]
+        replay.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_actual_session_subscribe_replays_once_then_reuses_tool_seed_cut(
+    tmp_path: Path,
+) -> None:
+    directory = tmp_path / "config/sessions/aaaaaaaaaaaa"
+    transcript = Transcript(directory)
+    result = ToolResult(
+        tool_call_id="durable-tool", tool_name="bash", content=[TextContent(text="done")]
+    )
+    await transcript.append_messages(
+        [
+            Message.user("start"),
+            Message.assistant(
+                "calling", tool_calls=[ToolCall(id="durable-tool", name="bash", arguments={})]
+            ),
+            Message.tool_result(result),
+        ]
+    )
+    session = build_session(directory, ScriptedStream([]), cwd=tmp_path)
+    try:
+        for tool_result in (result, ToolResult(tool_call_id="not-durable", tool_name="bash")):
+            session._frontend_state_store._fold_live_event(
+                ToolExecutionEndEvent(
+                    tool_call_id=tool_result.tool_call_id, tool_name="bash", result=tool_result
+                )
+            )
+        with patch.object(
+            session._transcript, "build_llm_history", wraps=session._transcript.build_llm_history
+        ) as replay:
+            subscription = session.subscribe_frontend(lambda _: None, display_window=True)
+            try:
+                window = subscription.sync.display_history
+                assert window is not None
+                assert window.through_id == subscription.sync.live_cursor
+                assert window.durable_seed_tool_ids == ["durable-tool"]
+                replay.assert_called_once()
+            finally:
+                subscription.unsubscribe()
+        with patch.object(
+            session._transcript, "build_llm_history", wraps=session._transcript.build_llm_history
+        ) as replay:
+            subscription = session.subscribe_frontend(lambda _: None, display_window=True)
+            try:
+                assert subscription.sync.display_history == window
+                replay.assert_not_called()
+            finally:
+                subscription.unsubscribe()
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_prune_compaction_and_fold_discard_cache_and_preserve_token_rules(
+    tmp_path: Path,
+) -> None:
+    transcript = Transcript(tmp_path / "session")
+    first = Message.user("preserved opener")
+    tool = Message.tool_result(
+        ToolResult(tool_call_id="one", content=[TextContent(text="large " * 500)])
+    )
+    last = Message.user("last")
+    await transcript.append_messages([first, tool, last])
+    old = page(transcript, max_messages=1)
+    await transcript.append_prune(tool.id, "pruned")
+    assert transcript._display_window_cache is None
+    assert page(transcript, before=old.before_token).status == "reset"
+    after = page(transcript)
+    assert [m.model_dump() for m in after.messages] == [
+        m.model_dump() for m in transcript.build_llm_history()
+    ]
+    await transcript.append_compaction(
+        "summary", last.id, 200, preserved_user_turns=[{"id": first.id, "text": first.text}]
+    )
+    assert transcript._display_window_cache is None
+    compacted = page(transcript)
+    assert [m.model_dump() for m in compacted.messages] == [
+        m.model_dump() for m in transcript.build_llm_history()
+    ]
+    await transcript.compact_file(min_reclaim_bytes=0)
+    assert transcript._display_window_cache is None
+    assert [m.model_dump() for m in page(transcript).messages] == [
+        m.model_dump() for m in transcript.build_llm_history()
+    ]
+    assert page(transcript, before=compacted.snapshot_token).status == "reset"
+
+
+@pytest.mark.asyncio
+async def test_media_and_metadata_admission_stay_within_owner_budget(tmp_path: Path) -> None:
+    transcript = Transcript(tmp_path / "session")
+    image = ImageContent(data=base64.b64encode(b"synthetic" * 60_000).decode())
+    for i in range(8):
+        await transcript.append_message(Message.user(str(i), images=[image]))
+        result = page(transcript, max_messages=1, max_wire_bytes=2 * 1024 * 1024)
+        assert result.status == "ok"
+        message = result.messages[0]
+        assert isinstance(message, Message)
+        content = message.content[1]
+        assert isinstance(content, ImageContent)
+        assert content.data == image.data
+        cache = transcript._display_window_cache
+        assert cache is not None
+        assert cache.retained_bytes + 4096 <= DISPLAY_PAGE_CACHE_BYTES
+        assert len(cache.entries) < DISPLAY_PAGE_CACHE_ENTRIES
+    # A request key can itself be huge even when the resulting page is tiny.
+    # Include seed identities in admission, not merely message body bytes.
+    empty = Transcript(tmp_path / "empty")
+    page(empty, durable_seed_tools=frozenset({"x" * DISPLAY_PAGE_CACHE_BYTES}))
+    assert empty._display_window_cache is not None
+    assert not empty._display_window_cache.entries


### PR DESCRIPTION
# PR Description

## Summary of Changes

Steady-state owner cost when several background sessions and viewers are attached. Two runtime changes plus one test-infrastructure diagnostic, all inside the session runtime — no wire, page-token, or public API change.

1. **Bounded per-owner display-page cache** (`local_operator/session/history_window.py`, `transcript.py`). An attach that asks for the same display page twice used to replay the whole canonical history each time. Exact requests — same conversation, epoch, history generation, signing key, cut/`before` token, anchor, limits and durable tool seeds — now reuse a private detached page. At most **4 pages / 2 MiB accounted per owner**, LRU-evicted.
2. **Same-cut durable tool seeds** (`session.py`). `subscribe_frontend(display_window=True)` ran `build_llm_history` a **second** time purely to resolve tool-result identities. Those identities are now derived inside the same capture that already holds that replay, including on the oversized `full_required` path.
3. **No-recipient projection skip** (`runtime/server.py`). `_push` built and sized a 100–900 KB projection payload on every coalesced tick even when nobody consumes projections (a detached owner, or only full-TUI viewers). It now returns before building the payload when the recipient list is empty. Welcome frames, daemon bytes and every subscribed cadence are byte-for-byte unchanged.
4. **Diagnostic honesty in `tests/unit/evaluation/copied_interpreter.py`** (test infrastructure only, at the architect's recommendation). A failed shared-libpython metadata query was silently converted into "the base reports no shared libpython", which is how **two** real spawn-test failures reported a cause that was never established. Each stage now raises with its own bounded `rc`/stdout/stderr and candidate path, and `None` is returned only for a positively non-shared or unsupported build. No retries, no cached probe answers, no interpreter substitution.

**Change class: C2, standard/pre-authorized. Release: patch. No version bump in this PR** (`pyproject.toml` untouched).

### Scope, stated honestly

This speeds up **repeated identical display requests** and **pushes with zero projection consumers**. It does **not** make first/new pages faster, does not make an active session's cost independent of history length, and is not a general fix for every reported hang. Cold pages measurably cost **+1.68 ms** more than before (admission accounting plus the defensive copy), which is the deliberate price of the two properties below.

An earlier full-history resident-index design was **rejected on measurement**: exact reachable-graph accounting added 101–108 ms to a 96 ms cold replay (45.9 MB retained per owner), and even a cheaper non-deduplicating walk added 44–47 ms. That cost is not worth paying on every cold attach across dozens of owners.

### Delivery contract

- Canonical replay is untouched: `Transcript.build_llm_history` still returns fresh, detached, mutable messages to model/context consumers.
- **Display responses own their data on every path** — warm, cold, and cache-refused. Replay creates fresh models, but nested JSON-ish tool arguments and `provider_payload` children could still alias journal dictionaries, so the selected page is deep-copied. Only the already-bounded page is copied, never the whole history.
- A compaction, prune or file fold discards the cache; old signed tokens still validate or `reset` exactly as before, and regenerate correctly after eviction.
- **One behaviour genuinely changes, and it is not a no-op** (reviewer MINOR-1). Because seed-tool derivation moved *inside* `display_window`, a subscription whose live cursor is no longer retained now degrades to `status="reset"` instead of raising. Verified independently on this branch: the base path's second, unguarded `build_llm_history(through_id=...)` raises `ValueError: history cursor is no longer retained`, which propagated out of `subscribe_frontend` (its `except BaseException` unsubscribed and re-raised); the same input on this head returns a `reset` window. This is accepted deliberately — an unretained cursor is precisely the condition `reset` exists to express, the client already handles `reset` by refetching, and a joining viewer getting a recoverable reset is strictly better than an exception that tears down its subscription. It is called out here because the earlier blanket "no cursor-contract change" claim was wrong.
- The cache key includes the transcript's signing key, so a cached page cannot outlive its signing authority.
- Admission counts keys, metadata, seed identities and media — a tiny page with a huge request key is refused rather than admitted. Accounting deliberately **over-estimates** (measured ~7.5x a pickled page: 91,960 accounted against 12,172 serialized), so the real ceiling sits well under the nominal 2 MiB; anyone re-tuning the constant should size it against accounted bytes, not wire bytes (reviewer MINOR-2).
- Reset/invalid requests are never retained.

## Related Issue(s)

- Related: steady-state hangs/timeouts with multiple background sessions (sibling: #787, sidebar rendering).

## Impact

No breaking changes, no dependency changes, no security implications. Frontend/daemon wire shapes, page tokens, cadences and authorization are unchanged; `_projection_recipients` membership is unchanged — only the work done when it is empty.

## Testing Details

All runs use an isolated `HOME`/`LOCAL_OPERATOR_CONFIG_DIR`, remove **every** inherited `CMUX_*` variable before imports, and use synthetic transcripts. No live session, live config, provider or network access.

### Measured, same 20k-row transcript (23.5 MB durable)

Interleaved in one process, 12 rounds, thread CPU medians:

| Path | Before | After |
|---|---|---|
| Canonical capture (no cache) | 96.35 ms | — |
| Cold display request | 96.35 ms | **~2–3 ms slower under load** (see below) |
| Repeated tail page | 98.22 ms | **0.788 ms** |
| Repeated older page | 97.19 ms | **0.800 ms** |
| Real `Session.subscribe_frontend(display_window=True)` | 173.86 ms | **1.59 ms** |
| 100 `_push` calls, zero recipients | 100 payload builds, 46.15 ms | **0 builds, 0.022 ms** |

Real socket, 3 concurrent full attaches plus an established control client, under heavy shared-host load: control `ping` 942.6 → 78.2 ms wall, worst 5 ms heartbeat gap 942.4 → 56.5 ms. Wall figures on a loaded shared machine are directional, not a guarantee.

Cold cost is stated as a band rather than a point: three independent measurements of the same path disagree by more than the effect — mine +1.68 ms, QA's +2.84 ms, and the reviewer's **−0.56 ms** (i.e. faster). On a loaded shared host this is scheduling noise around a small real cost; **~2–3 ms is the honest characterisation**, and no single figure should be read as a bound.

Memory: 50 synthetic owners × 1000 messages retain **13,920,300 B total, 278,406 B max per owner**. That figure warms **one page per owner**; QA independently warmed **two** pages per owner — the realistic viewer shape — and measured **18.81 MB total / 394,521 B max**. Both are far inside the 4-page, 2 MiB-per-owner bound, and both are against ~45.9 MB *per owner* for the rejected index.

Harness: `scripts/display_cache_performance.py` (`--fleet` for the 50-owner figure), runnable against any source root for before/after.

### Deterministic regression tests

`tests/unit/session/test_display_page_cache.py` (new): repeated tail/older/anchor/limit reuse with no replay and no caller-visible mutation; cold and cache-refused nested-payload ownership; old-cut reuse after append and correct regeneration after 200 distinct cuts with the bound asserted every iteration; seed-tool cut sharing including `full_required`; prune/compaction/file-fold invalidation and token `reset`; media/metadata admission bounds; signing-key rotation. Plus `test_push_builds_no_payload_without_projection_recipients` on the real socket, and new negative/positive coverage in `tests/unit/evaluation/test_copied_interpreter.py`.

### Mutation proofs (each new guard fails against the original code)

Each run restores the **original** function from git into the live module and runs the new test:

| Restored original | Result |
|---|---|
| `display_window` before the ownership fix | `assert [1, 2] == [1]` (both parametrizations) |
| `_capture_display_window` as `display_window` (no cache) | `Expected 'build_llm_history' to not have been called. Called 1 times.` |
| `_push` from `6f83793dc` | `Expected '_projection_payload' to not have been called. Called 20 times.` |
| `_shared_libpython` from `6f83793dc` | `DID NOT RAISE AssertionError` |

Logs: `/tmp/owner-cache-mutation-{cold,warm,push,diagnostic}.log`.

### Gates

- `flake8`, `black --check` (26.1.0), `isort --check` (5.13.2), `pyright` over the whole tree: **clean** (0 errors).
- Focused suite (`test_display_page_cache`, `test_history_window`, `test_transcript`, `runtime/test_server`, `test_copied_interpreter`): **123 passed**.
- Whole `tests/unit` (`-n 2`): **16,237 passed, 18 skipped, 3 failed in 54m09s**. The three failures are all `tests/unit/test_computer_input.py::test_generated_source_transfers_exact_utf8_and_only_explicit_chord[whitespace|injection|100k-unicode]`, failing inside a spawned subprocess with `RuntimeError: clipboard paste failed`. That file is untouched by this diff (which is confined to `session/` plus two test files), and the whole module passes **13 passed in 17.48s** standalone on this exact head. They contend for the single shared system pasteboard under `-n 2`. Not waived: a fresh green whole CI run is required before merge, and CI runs this file in its own shard.
- `tests/e2e -m e2e -n0`: **49 passed**, independently reproduced by QA.
- Independent QA measured **81 cells, 0 FAIL**, repeat page 131.6 → 0.8 ms CPU, worst tick gap 393.7 → 33.8 ms, zero-recipient 100 builds → 0.

### Review findings addressed in the remediation commit

MINOR-3 (missing `OSError`-from-`is_file()` coverage) and MINOR-4 (zero-recipient return skipped the `_frame_cap_warned` reset) are fixed in code; MINOR-1, MINOR-2 and QA's Q1/Q2 are corrected in this description above. Of the two NITs: the `id()`-based `seen` set now carries the comment explaining why identity keying is safe here (nothing is freed mid-walk); the suggestion to drop `scripts/display_cache_performance.py` as unreferenced is **rejected** — it is the reproducer for every before/after number above and AGENTS.md explicitly keeps capture/measurement scripts under `scripts/` rather than in a PR comment. No follow-up issues were opened.

No UI surface changes, so no design round applies.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required.
- [x] Security considerations are addressed (especially for code execution features).
- [x] I have linked all related issues.
