### PR TITLE
chore(release): bump version to 0.51.20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.19"
+version = "0.51.20"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Bumps the package version to **0.51.20** for the release window owned by session pid 55675.

## Scope

One line in one file: `pyproject.toml` `version = "0.51.19"` → `version = "0.51.20"`. No code, no dependency and no metadata changes.

## Window

- #791 — `fix(tui): align welcome notices with sidebar main lane`, merge SHA `20fb341267ec3adc68735a530b7c158448676b2a`.
  `Release: patch — welcome-screen version notices align with the composer when the session sidebar is open, while the closed-sidebar layout stays unchanged.`

`git log v0.51.19..origin/main --oneline` returns that one commit and nothing else, and `git diff v0.51.19..origin/main -- pyproject.toml` is empty, so no merged PR consumed this number.

## Bump class

**Patch.** The single PR in the window is a layout alignment fix; nothing in it clears the minor step-function bar.

## Validation

The version line is the whole diff; correctness is that `0.51.19 + patch = 0.51.20` matches the newest tag `v0.51.19`. Verified in the worktree before pushing:

```
$ git diff --numstat
1	1	pyproject.toml
```

Release: patch — release bump only, no user-visible behaviour change of its own.