### PR TITLE
fix(goal): submit goal text as an ordinary user message

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,8 @@ with its title and age:
 | `/resume` | Pick a past conversation and continue it |
 | `/new`, `/clear`, `/reload` | Fresh conversation · wipe the screen · relaunch this conversation on the current install |
 | `/update` | Install the latest version from PyPI and relaunch |
-| `/goal`, `/loop` | Set an objective, then iterate autonomously toward it |
+| `/goal <text>` | Set the session objective and send the same text to start work; bare `/goal` shows it and `/goal clear` clears it without starting a turn |
+| `/loop` | Iterate autonomously toward the session objective |
 | `/btw` | Ask a side question off the record; it never joins the conversation |
 | `/compact` | Compact the context now (it also happens automatically) |
 | `/usage`, `/context` | Provider quota and account spend · what's occupying the context window |

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -3989,7 +3989,12 @@ class RemoteSession:
     def set_goal(self, text: str) -> str:
         client = self._client
         if client is not None:
-            asyncio.create_task(client.slash("goal", text))
+            # This protocol setter is metadata-only, unlike a user's /goal.
+            # RemoteSession declares goal_set as consumed at attachment, so a
+            # typed receipt leaves admission here; deliberately not rendering
+            # it prevents a compatibility setter plus prompt from double-sending.
+            # Bare /goal now means status on every owner, so clearing is explicit.
+            asyncio.create_task(client.slash_result("goal", text.strip() or "clear"))
         return text.strip()
 
     @property

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -1645,8 +1645,7 @@ class OwnedSessionHandle(SessionHandle):
         TUI chrome (/help tables, /usage panels) is the phone UI's own job."""
         self._check_loop_thread()
         if command == "goal":
-            stored = self._session.set_goal(args)
-            return "goal updated" if stored else "goal cleared"
+            return await self.slash_images(command, args)
         if command == "compact":
             asyncio.ensure_future(self._session.compact_now())
             return "compacting context"
@@ -2123,16 +2122,13 @@ class OwnedSessionHandle(SessionHandle):
         dispatcher `run_slash_authoritative` uses and renders its notice as
         the receipt, rather than failing the request outright.
 
-        Images are accepted and ignored for the routed set (none of
-        `/goal`, `/rename`, `/approvals`, `/compact` consumes an attachment);
-        that is stated here so a future image-consuming routed command is
-        added deliberately rather than silently dropping its payload.
+        Legacy/mobile callers cannot consume action receipts themselves, so
+        the owner completes them through normal admission, including images.
+        This must share the authoritative path or `/goal` would set metadata
+        without starting work only when invoked from the phone.
         """
-        from local_operator.session.frontend_state import SlashResult
-
-        result = await self._slash_result(command, args, SlashResult)
-        text = getattr(result, "text", "") or f"ran /{command}"
-        return str(text)
+        result = await self.run_slash_authoritative(command, args, images)
+        return str(result.get("text") or f"ran /{command}")
 
     def credential_op(self, action: str, key: str, value: str) -> dict[str, Any]:
         """Run one ``/credential`` verb against the OWNER's variable store.
@@ -2518,6 +2514,7 @@ class OwnedSessionHandle(SessionHandle):
         )
 
     def _goal_slash(self, session: Any, arg: str, SlashResult: Any) -> Any:
+        arg = arg.strip()
         if not hasattr(session, "set_goal"):
             return SlashResult(kind="notice", text="session is still starting…", style="warning")
         if not arg:
@@ -2536,17 +2533,17 @@ class OwnedSessionHandle(SessionHandle):
             return SlashResult(
                 kind="notice",
                 text=(
-                    f"goal set — shortened to the {MAX_GOAL_CHARS}-character cap, "
-                    "applies from the next turn"
+                    f"goal set: shortened to the {MAX_GOAL_CHARS}-character cap. "
+                    "Sending the full request."
                 ),
                 style="warning",
-                data={"stored": stored},
+                data={"type": "goal_set", "stored": stored, "request": arg.strip()},
             )
         return SlashResult(
             kind="notice",
-            text="goal set — applies from the next step",
+            text="goal set",
             style="info",
-            data={"stored": stored},
+            data={"type": "goal_set", "stored": stored, "request": arg.strip()},
         )
 
     def _rename_slash(self, session: Any, arg: str, SlashResult: Any) -> Any:

--- a/local_operator/session/runtime/types.py
+++ b/local_operator/session/runtime/types.py
@@ -108,7 +108,9 @@ ATTACH_MAX_CLIENTS = 4
 #: The list is the single source of truth for both sides of that seam, and
 #: ``tests/unit/tui/test_noop_consumers.py`` fails CI if a producer emits a
 #: ``request``-carrying receipt whose type is missing here.
-SLASH_ACTION_RECEIPTS: tuple[str, ...] = ("team_attached", "agent_attached")
+# Goal submissions follow the same ownership rule: old/mobile clients leave
+# admission to the owner; current terminals consume the receipt exactly once.
+SLASH_ACTION_RECEIPTS: tuple[str, ...] = ("team_attached", "agent_attached", "goal_set")
 
 
 def runtime_must_complete(receipt_type: Any, consumers: Any) -> bool:

--- a/local_operator/slash_commands.py
+++ b/local_operator/slash_commands.py
@@ -364,16 +364,11 @@ SLASH_COMMANDS: list[SlashCommand] = [
         arguments=ArgumentMode.OPTIONAL,
         desktop_destination="analytics",
     ),
-    # THE exception. `/goal <text>` is the one command whose argument reaches
-    # the model: the goal rides the system prompt's volatile tail on every later
-    # turn (`Session.set_goal`). Words the model is given are the transcript's
-    # subject matter, and they belong to the user, so they get a user row rather
-    # than being paraphrased into a system notice. `_cmd_goal` writes that row
-    # itself, only on the branch that actually stored something — the flag is
-    # the permission, not the trigger.
+    # The argument becomes both a standing objective and an ordinary user
+    # message. Submission owns its user row; status/clear never start a turn.
     SlashCommand(
         "goal",
-        "Show, set, or clear the session goal",
+        "Set the goal and start work; show or clear it",
         echo=True,
         consumes_prompt=True,
         desktop_destination="session.goal",

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -9618,9 +9618,9 @@ class OperatorApp(App[None]):
     ) -> None:
         """Send a prompt-carrying slash command's argument as a real user turn.
 
-        The shared tail of ``/team <name> <request>`` and ``/agent <name>
-        <message>``: both attach something to the session and then hand the
-        argument to the model. The images the argument cites are resolved from
+        The shared tail of ``/goal <request>``, ``/team <name> <request>`` and
+        ``/agent <name> <message>``: each changes session context before handing
+        the argument to the model. The images the argument cites are resolved from
         the text itself (``resolve_markers``) — the same authority the composer
         uses, so a marker the request no longer cites drops its image and order
         follows the text — and both the resolved list and the raw index→image
@@ -20103,8 +20103,8 @@ class OperatorApp(App[None]):
             if style == "error":
                 notice_kind = "error"
             self._notice(text, notice_kind)
-        # The attach happened on the OWNER (that is where the roster and briefs
-        # are stamped); the request is sent from HERE so it carries this
+        # The goal/attach mutation happened on the OWNER (that is where session
+        # context lives); the request is sent from HERE so it carries this
         # terminal's own images and paste expansion, and so the transcript row
         # is written by the one path that writes user rows. Order matters: the
         # receipt prints first, then the turn starts beneath it.
@@ -20116,17 +20116,26 @@ class OperatorApp(App[None]):
         # wire but not consumed here is a request the runtime deferred to this
         # terminal and this terminal then dropped, which is the original
         # defect wearing a new hat.
-        if data.get("type") in ("team_attached", "agent_attached"):
+        # Older owners returned only `stored` for /goal and never admitted a
+        # turn. That positive typed receipt is safe to complete; opaque legacy
+        # strings and show/clear results are not proof that a goal was set.
+        legacy_goal = command == "/goal" and not data.get("type") and bool(data.get("stored"))
+        if data.get("type") in ("team_attached", "agent_attached", "goal_set") or legacy_goal:
             # Each receipt syncs ITS OWN segment (review round 1, N1): the
             # post-op push repaints both from ``frontend_state`` a tick later
             # anyway, but the explicit call is what a test reads, and syncing
             # the team band for an agent attach was simply the wrong one.
             if data.get("type") == "team_attached":
                 self._sync_team_band()
-            else:
+            elif data.get("type") == "agent_attached":
                 self._sync_agent_band()
-            request = str(data.get("request") or "")
+            request = arg if legacy_goal else str(data.get("request") or "")
             if request:
+                # Goal receipts carry the expanded text for old/mobile clients.
+                # This terminal still has the chip line: resolve its images
+                # BEFORE expanding pastes, just as ordinary submission does.
+                if data.get("type") == "goal_set":
+                    request = arg
                 self._submit_command_prompt(request, attachments)
 
     def _team_listing_block(self, items: list[Any]) -> RichBlock:
@@ -20385,7 +20394,10 @@ class OperatorApp(App[None]):
                         Callable[[str, str, Sequence[ImageContent]], Awaitable[Any]], remote_route
                     )
                     images = resolve_markers(arg, attachments or {})
-                    outcome = await typed_route(command.removeprefix("/"), arg, images)
+                    # The owner stores the standing goal, so its copy must
+                    # contain paste payloads, not this terminal's private chips.
+                    routed_arg = prompt_arg if command == "/goal" else arg
+                    outcome = await typed_route(command.removeprefix("/"), routed_arg, images)
                 except Exception as error:
                     if (
                         self._session is route_session
@@ -20500,7 +20512,7 @@ class OperatorApp(App[None]):
             else:
                 notice("context breakdown unavailable.")
         elif command == "/goal":
-            self._cmd_goal(prompt_arg, notice)
+            self._cmd_goal(arg, notice, attachments)
         elif command == "/loop":
             self._cmd_loop(prompt_arg, notice)
         elif command == "/btw":
@@ -23372,8 +23384,10 @@ class OperatorApp(App[None]):
         self._run_slash_command(f"/model {row.selector}")
 
     # -- goal / loop --------------------------------------------------------
-    def _cmd_goal(self, arg: str, notice: NoticeFn) -> None:
-        """``/goal`` — show; ``/goal <text>`` — set; ``/goal clear`` — unset.
+    def _cmd_goal(
+        self, arg: str, notice: NoticeFn, attachments: Mapping[int, Marked] | None = None
+    ) -> None:
+        """``/goal`` — show; ``/goal <text>`` — set and send; ``/goal clear`` — unset.
 
         The goal is a standing objective carried in the prompt's volatile
         tail, so it survives every turn (and compaction) without being
@@ -23386,47 +23400,30 @@ class OperatorApp(App[None]):
             # `notice` would collapse it for a typo.
             self._system_notice("session is still starting…", "warning")
             return
-        if not arg:
+        request = expand_pastes(arg, attachments or {}).strip()
+        if not request:
             current = session.goal
             notice(f"goal: {current}" if current else "no goal set — /goal <text> to set one")
             return
-        if arg.lower() in ("clear", "none", "reset"):
+        if request.lower() in ("clear", "none", "reset"):
             session.set_goal("")
             notice("goal cleared")
             return
-        stored = session.set_goal(arg)
-        # The ONE user row a slash command writes, and it is written here
-        # because this is the line that knows the words were taken: from the
-        # next turn on they ride the system prompt's volatile tail, so they are
-        # transcript subject matter and they belong to the user who typed them.
-        #
-        # ``stored``, not ``arg``: ``set_goal`` trims and length-caps, and the
-        # row's whole claim is "this is what the model is being told".
-        #
-        # The notice below therefore reports STATUS only. It used to repeat the
-        # goal text, which with the row above it would be the same duplication
-        # this change removed everywhere else.
-        self._echo_user_command(f"/goal {stored}")
+        stored = session.set_goal(request)
+        # Only the standing objective is capped. The ordinary user message
+        # retains the full request, and the normal submit path owns its ONE
+        # transcript row, busy steering, compaction hold and attachment order.
         from local_operator.session.goal import MAX_GOAL_CHARS
 
-        if len(stored) == MAX_GOAL_CHARS and len(arg.strip()) > MAX_GOAL_CHARS:
-            # Gated on the CAP, not on "the result came back shorter". `set_goal`
-            # is reached through a duck-typed `hasattr`, so an implementation
-            # that normalised further — collapsing newlines in a pasted goal —
-            # would make a length comparison announce a cap that never applied.
-            #
-            # Said out loud at all because the row above now carries the text and
-            # is attributed to the USER: a silent cut leaves the ledger claiming
-            # they typed something ending mid-word. The receipt this replaced
-            # printed the stored text and was equally silent about the cut, but
-            # it was at least system-attributed while doing it.
+        if len(stored) == MAX_GOAL_CHARS and len(request) > MAX_GOAL_CHARS:
             notice(
-                f"goal set — shortened to the {MAX_GOAL_CHARS}-character cap, "
-                "applies from the next step",
+                f"goal set: shortened to the {MAX_GOAL_CHARS}-character cap. "
+                "Sending the full request.",
                 "warning",
             )
-            return
-        notice("goal set — applies from the next step")
+        else:
+            notice("goal set")
+        self._submit_command_prompt(arg, attachments)
 
     def _cmd_loop(self, arg: str, notice: NoticeFn) -> None:
         """``/loop [n]`` — iterate toward the goal; ``/loop stop`` cancels.
@@ -27405,6 +27402,7 @@ class OperatorApp(App[None]):
         )
 
     def _goal_slash_result(self, arg: str, SlashResult: Any) -> Any:
+        arg = arg.strip()
         session = self._session
         if session is None or not hasattr(session, "set_goal"):
             return SlashResult(kind="notice", text="session is still starting…", style="warning")
@@ -27422,17 +27420,17 @@ class OperatorApp(App[None]):
             return SlashResult(
                 kind="notice",
                 text=(
-                    f"goal set — shortened to the {MAX_GOAL_CHARS}-character cap, "
-                    "applies from the next turn"
+                    f"goal set: shortened to the {MAX_GOAL_CHARS}-character cap. "
+                    "Sending the full request."
                 ),
                 style="warning",
-                data={"stored": stored},
+                data={"type": "goal_set", "stored": stored, "request": arg.strip()},
             )
         return SlashResult(
             kind="notice",
-            text="goal set — applies from the next turn",
+            text="goal set",
             style="info",
-            data={"stored": stored},
+            data={"type": "goal_set", "stored": stored, "request": arg.strip()},
         )
 
     def _rename_slash_result(self, arg: str, SlashResult: Any) -> Any:

--- a/scripts/goal_submit_shot.py
+++ b/scripts/goal_submit_shot.py
@@ -1,0 +1,64 @@
+"""Capture /goal's real composer-to-turn behavior before and after the fix."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+import scripts.probe_isolation  # noqa: F401 — isolate before application imports
+from local_operator.tui.app import OperatorApp
+from scripts.visual_capture import save_capture
+from tests.e2e.harness import (
+    ScriptedStream,
+    build_session,
+    dispose_quietly,
+    drain,
+    text_turn,
+    transcript_text,
+    wait_for_adoption,
+)
+
+
+async def main() -> None:
+    # A headless app must not inherit identities that can rename a live workspace.
+    for key in tuple(os.environ):
+        if key.startswith("CMUX_"):
+            os.environ.pop(key)
+    output = Path(sys.argv[1]).resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    root = Path(os.environ["LOCAL_OPERATOR_CONFIG_DIR"])
+    stream = ScriptedStream([text_turn("Working on the release checklist.")])
+    session = build_session(root / "sessions" / "goal-probe", stream, cwd=root)
+    session.set_conversation_name("Goal submission", user_set=True)
+
+    async def factory():
+        return session
+
+    app = OperatorApp(factory)
+    try:
+        async with app.run_test(size=(100, 30)) as pilot:
+            await wait_for_adoption(app, pilot)
+            await drain(pilot)
+            app._editor().load_text("/goal Prepare the release checklist")
+            await pilot.press("enter")
+            await drain(pilot, cycles=10)
+            save_capture(app, str(output / "first.svg"))
+            await app.workers.wait_for_complete()
+            await drain(pilot, cycles=20)
+            save_capture(app, str(output / "settled.svg"))
+            result = {
+                "goal": session.goal,
+                "transcript": transcript_text(app),
+                "requests": [r.model_dump(mode="json") for r in stream.requests],
+            }
+            (output / "result.json").write_text(json.dumps(result, indent=2))
+            print(json.dumps(result, indent=2))
+    finally:
+        await dispose_quietly(session)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/e2e/test_goal_submission.py
+++ b/tests/e2e/test_goal_submission.py
@@ -1,0 +1,78 @@
+"""A single /goal Enter must reach the real engine and execute a real tool."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from local_operator.harness.types import Message, TextContent
+from local_operator.tools.builtin import build_write_tool
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.transcript import UserBlock
+from tests.e2e.harness import (
+    ScriptedStream,
+    build_session,
+    dispose_quietly,
+    drain,
+    text_turn,
+    tool_call_turn,
+    transcript_text,
+    wait_for_adoption,
+)
+from tests.e2e.test_tui_e2e import _has_tool_call, _has_tool_result, _transcript_records
+from tests.e2e.watchdog import bounded
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.mark.asyncio
+async def test_one_goal_command_executes_and_persists_a_real_tool(headless_tui_env: Path):
+    target = headless_tui_env / "goal-artifact.txt"
+    request = "Write the goal artifact"
+    stream = ScriptedStream(
+        [
+            tool_call_turn(
+                text="Writing the goal artifact.",
+                tool_name="write",
+                tool_call_id="goal-write-1",
+                arguments={"path": str(target), "content": "goal command started this turn"},
+            ),
+            text_turn("The goal artifact is ready."),
+        ]
+    )
+    directory = headless_tui_env / "sessions" / "goal-submit"
+    session = build_session(directory, stream, tools=[build_write_tool()], cwd=headless_tui_env)
+    # Naming is another provider request, not part of the turn under test.
+    session.set_conversation_name("Goal regression", user_set=True)
+
+    async def factory():
+        return session
+
+    app = OperatorApp(factory)
+    try:
+        with bounded(60, "goal composer submission"):
+            async with app.run_test(size=(100, 30)) as pilot:
+                await wait_for_adoption(app, pilot)
+                await drain(pilot)
+                app._editor().load_text(f"/goal {request}")
+                await pilot.press("enter")
+                await app.workers.wait_for_complete()
+                await drain(pilot, cycles=20)
+                assert session.goal == request
+                assert target.read_text() == "goal command started this turn"
+                assert len(stream.requests) == 2
+                assert [row.text() for row in app.query(UserBlock)] == [request]
+                assert "The goal artifact is ready." in transcript_text(app)
+                history = [item for item in session.history() if isinstance(item, Message)]
+                users = [message for message in history if message.role == "user"]
+                assert len(users) == 1
+                content = users[0].content[0]
+                assert isinstance(content, TextContent)
+                assert content.text == request
+                assert any(message.role == "tool" for message in history)
+                records = _transcript_records(directory)
+                assert _has_tool_call(records, "write")
+                assert _has_tool_result(records, "write")
+    finally:
+        await dispose_quietly(session)

--- a/tests/unit/session/runtime/test_goal_submission.py
+++ b/tests/unit/session/runtime/test_goal_submission.py
@@ -1,0 +1,89 @@
+"""Every owner-side /goal entry point submits once, or only changes status.
+
+Legacy/mobile clients cannot consume receipts. Current terminals explicitly
+claim goal_set and own the ordinary submit, so the owner must not also send.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from local_operator.session.goal import MAX_GOAL_CHARS, GoalState
+from local_operator.session.runtime.owned import OwnedSessionHandle
+from tests.unit.session.runtime.test_owned import FakeSession
+
+
+class GoalSession(FakeSession):
+    def __init__(self) -> None:
+        super().__init__()
+        self.goal_state = GoalState()
+        self.prompt_release.set()
+
+    @property
+    def goal(self) -> str:
+        return self.goal_state.text
+
+    def set_goal(self, text: str) -> str:
+        return self.goal_state.set(text)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("entry", ["slash", "slash_images", "authoritative"])
+@pytest.mark.parametrize("busy", [False, True])
+async def test_goal_starts_or_steers_once(entry, busy):
+    session = GoalSession()
+    session.is_streaming = busy
+    handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd="/tmp")
+    try:
+        if entry == "authoritative":
+            result = await handle.run_slash_authoritative("goal", "ship it", None)
+            assert result["data"]["type"] == "goal_set"
+        else:
+            result = await getattr(handle, entry)("goal", "ship it")
+            assert result == "goal set"
+        await asyncio.sleep(0.05)
+        assert session.goal == "ship it"
+        assert session.prompt_calls == ([] if busy else ["ship it"])
+        assert session.steer_calls == (["ship it"] if busy else [])
+    finally:
+        await handle.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("consumers", [None, [], ["team_attached"], ["goal_set"]])
+async def test_goal_receipt_honors_exact_declared_consumer_and_keeps_full_request(consumers):
+    session = GoalSession()
+    handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd="/tmp")
+    text = "x" * (MAX_GOAL_CHARS + 100)
+    try:
+        result = await handle.run_slash_authoritative("goal", text, None, consumers=consumers)
+        await asyncio.sleep(0.05)
+        assert session.goal == text[:MAX_GOAL_CHARS]
+        assert result["data"] == {"type": "goal_set", "stored": session.goal, "request": text}
+        assert result["style"] == "warning"
+        assert session.prompt_calls == ([] if consumers == ["goal_set"] else [text])
+    finally:
+        await handle.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("entry", ["slash", "slash_images", "authoritative"])
+@pytest.mark.parametrize("arg", ["", "clear", "none", "reset", "CLEAR"])
+async def test_goal_status_and_clear_never_submit(entry, arg):
+    session = GoalSession()
+    session.set_goal("existing goal")
+    handle = OwnedSessionHandle(session, asyncio.get_running_loop(), cwd="/tmp")
+    try:
+        if entry == "authoritative":
+            result = await handle.run_slash_authoritative("goal", arg, None)
+            assert not result.get("data")
+        else:
+            await getattr(handle, entry)("goal", arg)
+        await asyncio.sleep(0)
+        assert session.goal == ("existing goal" if not arg else "")
+        assert session.prompt_calls == []
+        assert session.steer_calls == []
+    finally:
+        await handle.dispose()

--- a/tests/unit/session/test_remote_goal.py
+++ b/tests/unit/session/test_remote_goal.py
@@ -1,0 +1,31 @@
+"""The compatibility goal setter must not invoke the new submit-and-goal RPC."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, cast
+
+import pytest
+
+from local_operator.session.remote import RemoteSession
+
+
+@pytest.mark.asyncio
+async def test_remote_goal_setter_uses_consumed_receipt_and_explicit_clear():
+    calls = []
+
+    class Client:
+        async def slash_result(self, command, text):
+            calls.append((command, text))
+            return {"kind": "notice", "data": {"type": "goal_set", "request": text}}
+
+        async def slash(self, command, text):
+            raise AssertionError("the legacy slash RPC would also submit a turn")
+
+    remote = object.__new__(RemoteSession)
+    remote._client = cast(Any, Client())
+    assert remote.set_goal(" ship it ") == "ship it"
+    await asyncio.sleep(0)
+    assert remote.set_goal("") == ""
+    await asyncio.sleep(0)
+    assert calls == [("goal", "ship it"), ("goal", "clear")]

--- a/tests/unit/tui/test_app_pilot.py
+++ b/tests/unit/tui/test_app_pilot.py
@@ -1630,7 +1630,8 @@ async def test_owner_slash_result_producers_match_local_handler_vocabulary() -> 
                 break
         goal = await app.run_slash_authoritative("goal", "ship it")
         assert goal["kind"] == "notice"
-        assert "goal set — applies from the next turn" in goal["text"]
+        assert goal["text"] == "goal set"
+        assert goal["data"]["request"] == "ship it"
         assert session.goal == "ship it"
 
         bare_goal = await app.run_slash_authoritative("goal", "")

--- a/tests/unit/tui/test_goal_submission.py
+++ b/tests/unit/tui/test_goal_submission.py
@@ -1,0 +1,177 @@
+"""Goal submission shares ordinary prompt echo, steering and owner routing."""
+
+from __future__ import annotations
+
+import pytest
+
+from local_operator.harness.types import ImageContent
+from local_operator.session.frontend_state import (
+    CommandScope,
+    FrontendSessionState,
+    SlashCapability,
+    SlashResult,
+)
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.events import CompactionEnded
+from local_operator.tui.widgets.editor import Attachment, PastedText
+from local_operator.tui.widgets.transcript import UserBlock
+from tests.unit.tui.test_app_pilot import FakeSession, GoalSession, _factory
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("busy", [False, True])
+async def test_composer_goal_submits_or_steers_one_plain_user_message(busy):
+    session = GoalSession()
+    session.streaming = busy
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._editor().load_text("/goal ship the checklist")
+        await pilot.press("enter")
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert session.goal == "ship the checklist"
+        assert [row.text() for row in app.query(UserBlock)] == ["ship the checklist"]
+        if busy:
+            assert session.prompts == []
+            assert [message.content[0].text for message in session.queued_steering()] == [
+                "ship the checklist"
+            ]
+        else:
+            assert session.prompts == ["ship the checklist"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("arg", ["", "clear", "none", "reset", "CLEAR"])
+async def test_goal_metadata_forms_do_not_start_work(arg):
+    session = GoalSession()
+    session.set_goal("existing")
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._run_slash_command(f"/goal {arg}".rstrip())
+        await pilot.pause()
+        assert session.goal == ("existing" if not arg else "")
+        assert session.prompts == []
+        assert not list(app.query(UserBlock))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("consumers", [None, [], ["team_attached"], ["goal_set"]])
+async def test_tui_owner_completes_only_unclaimed_goal_receipts(consumers):
+    session = GoalSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        result = await app.run_slash_authoritative("goal", "ship it", None, consumers=consumers)
+        await app.workers.wait_for_complete()
+        assert session.goal == "ship it"
+        assert result["data"]["type"] == "goal_set"
+        assert session.prompts == ([] if consumers == ["goal_set"] else ["ship it"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("legacy_owner", [False, True])
+async def test_current_viewer_consumes_goal_receipt_through_plain_submission(legacy_owner):
+    session = GoalSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        result = app._goal_slash_result("ship it", SlashResult)
+        assert session.prompts == []
+        outcome = result.model_dump()
+        if legacy_owner:
+            # The pre-fix owner stores metadata only and returns precisely
+            # this shape on success; no other legacy result proves admission.
+            outcome["data"] = {"stored": "ship it"}
+        app._render_authoritative_slash("/goal", "ship it", outcome)
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert session.prompts == ["ship it"]
+        assert [row.text() for row in app.query(UserBlock)] == ["ship it"]
+
+
+@pytest.mark.asyncio
+async def test_goal_paste_is_held_during_compaction_and_submitted_once_afterwards():
+    session = GoalSession()
+    app = OperatorApp(lambda: _factory(session))
+    marker = "[Paste #1, 40 lines]"
+    payload = "\n".join(f"task {index}" for index in range(40))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._compacting = True
+        app._run_slash_command(f"/goal {marker}", {1: PastedText(payload, marker)})
+        await pilot.pause()
+        assert session.goal == payload
+        assert session.prompts == []
+        assert app._prompt_held_for_compaction == payload
+        assert app._typed_held_for_compaction == marker
+        app._compacting = False
+        app.on_compaction_ended(CompactionEnded(reason="manual", success=True))
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert session.prompts == [payload]
+        assert [row.text() for row in app.query(UserBlock)] == [payload]
+
+
+@pytest.mark.asyncio
+async def test_routed_goal_stores_and_submits_paste_payload_not_private_chip():
+    routed = []
+
+    class RoutedSession(GoalSession):
+        frontend_state: FrontendSessionState
+
+        async def route_shared_slash(self, command, args, images=()):
+            routed.append((command, args))
+            self.set_goal(args)
+            return {
+                "kind": "notice",
+                "text": "goal set",
+                "style": "info",
+                "data": {"type": "goal_set", "stored": args, "request": args},
+            }
+
+    session = RoutedSession()
+    session.frontend_state = FrontendSessionState(
+        session_id=session.session_id,
+        epoch="goal-owner",
+        slash_capabilities=[
+            SlashCapability(command="goal", scope=CommandScope.AUTHORITATIVE_SESSION)
+        ],
+    )
+    app = OperatorApp(lambda: _factory(session))
+    marker = "[Paste #1, 40 lines]"
+    payload = "\n".join(f"task {index}" for index in range(40))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._run_slash_command(f"/goal {marker}", {1: PastedText(payload, marker)})
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert routed == [("goal", payload)]
+        assert session.goal == payload
+        assert session.prompts == [payload]
+        assert [row.text() for row in app.query(UserBlock)] == [payload]
+
+
+@pytest.mark.asyncio
+async def test_goal_submits_cited_image_and_keeps_pasted_lookalikes_out_of_resolution():
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    image = ImageContent(data="aGk=", mime_type="image/png")
+    marker = "[Image #2, 1x1]"
+    paste_marker = "[Paste #1, 40 lines]"
+    # A quoted citation inside pasted prose must not reorder the real image.
+    payload = "a previous log quoted [Image #3, 1x1]"
+    attachments = {
+        1: PastedText(payload, paste_marker),
+        2: Attachment(image, marker),
+        3: Attachment(ImageContent(data="b2xk", mime_type="image/png"), "[Image #3, 1x1]"),
+    }
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._run_slash_command(f"/goal Check {paste_marker} against {marker}", attachments)
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert session.goal == f"Check {payload} against {marker}"
+        assert session.prompts == [session.goal]
+        assert session.prompt_images == [[image]]

--- a/tests/unit/tui/test_slash_echo.py
+++ b/tests/unit/tui/test_slash_echo.py
@@ -1281,15 +1281,10 @@ async def test_repeated_panel_commands_do_not_accumulate_a_ledger() -> None:
 
 @pytest.mark.asyncio
 async def test_setting_the_goal_writes_the_users_words_to_the_ledger() -> None:
-    """`/goal <text>` is the one argument that reaches the model, on every later
-    turn. The ledger shows what the model was told, attributed to whoever said
-    it, so this row is content rather than a keystroke.
+    """The goal argument is one ordinary user message, not a slash ledger row.
 
-    The notice beside the row reports status ONLY — repeating the goal there
-    would be the duplicate row this change removed everywhere else. That the
-    row carries the STORED text rather than the typed one is not visible here
-    (the editor strips too, so only the length cap separates them): it is
-    ``test_a_goal_cut_by_the_cap_says_so`` that pins it.
+    The notice reports status only; submission owns the echo and sends the same
+    text immediately as well as storing the standing objective.
     """
     session = FakeSession()
     app = OperatorApp(lambda: _factory(session))
@@ -1298,17 +1293,15 @@ async def test_setting_the_goal_writes_the_users_words_to_the_ledger() -> None:
         await _submit(pilot, app, "/goal   land the OAuth refresh fix  ")
         rows = _user_rows(app)
         painted = _painted(app)
-    assert rows == ["/goal land the OAuth refresh fix"], rows
+    assert rows == ["land the OAuth refresh fix"], rows
     assert session.goal == "land the OAuth refresh fix"
-    assert "goal set — applies from the next step" in painted, painted
+    assert session.prompts == ["land the OAuth refresh fix"]
+    assert "goal set" in painted, painted
 
 
 @pytest.mark.asyncio
 async def test_a_goal_cut_by_the_cap_says_so() -> None:
-    """`GoalState.set` caps at 2000 characters silently. That was survivable
-    while the receipt was a system notice; now the text sits in a row
-    ATTRIBUTED TO THE USER, so a silent cut leaves the ledger claiming they
-    typed something ending mid-word."""
+    """Cap the standing objective, not the ordinary user message or its echo."""
 
     class _CappingSession(FakeSession):
         """`FakeSession.set_goal` only strips — this applies the real cap."""
@@ -1331,7 +1324,9 @@ async def test_a_goal_cut_by_the_cap_says_so() -> None:
         await _submit(pilot, app, "/goal " + "x" * (MAX_GOAL_CHARS + 100))
         rows = _user_rows(app)
         notices = _notice_texts(app)
-    assert rows == ["/goal " + "x" * MAX_GOAL_CHARS], len(rows[0]) if rows else rows
+    assert rows == ["x" * (MAX_GOAL_CHARS + 100)], len(rows[0]) if rows else rows
+    assert session.prompts == rows
+    assert session.goal == "x" * MAX_GOAL_CHARS
     assert any(f"shortened to the {MAX_GOAL_CHARS}-character cap" in n for n in notices), notices
 
 
@@ -1534,17 +1529,17 @@ async def test_a_real_command_still_wins_over_the_prose_fallback() -> None:
     assert session.prompts == [], session.prompts
     assert rows == [], rows
 
-    # An ARGUMENT-carrying command still dispatches too: `/goal` is the one
-    # echoing command, so its row proves the handler ran rather than the line
-    # having been sent as prose.
+    # Goal dispatch stores the objective and submits only its argument, not
+    # the slash command itself as prose.
     argued = FakeSession()
     app = OperatorApp(lambda: _factory(argued))
     async with app.run_test(size=(120, 40)) as pilot:
         await _boot(pilot, app)
         await _submit(pilot, app, "/goal ship it")
         rows = _user_rows(app)
-    assert argued.prompts == [], argued.prompts
-    assert rows == ["/goal ship it"], rows
+    assert argued.prompts == ["ship it"], argued.prompts
+    assert argued.goal == "ship it"
+    assert rows == ["ship it"], rows
 
     # An ALIAS resolves through the same entry, so the branch that now asks the
     # resolver must accept it exactly as it accepts the primary name.


### PR DESCRIPTION
## Summary of Changes

`/goal <text>` now stores the standing objective **and submits the same text as an ordinary user message**, so one Enter starts work. The command no longer needs a second message and no longer writes a separate `/goal …` echo row.

C1 standard/pre-authorized bug fix. This PR is the change record; no tracker or RFC was requested.

Release: patch — setting a goal now starts work immediately, using the usual prompt, steering and compaction-queue behavior instead of waiting for another message.

## Related Issue(s)

None requested; this PR is the C1 change record.

## Delivery contract

- Local composer, TUI-hosted authoritative owner, detached owner, and legacy/mobile `slash`/`slash_images` paths all submit exactly once.
- Busy sessions use existing steering. Compaction holds and releases the message through the ordinary submission path.
- Bare `/goal` reports status; `clear`, `none`, and `reset` (case-insensitive) clear it without a user message or model call. Starting/unavailable sessions retain their existing refusal behavior.
- The standing objective keeps its 2,000-character cap; the submitted message retains the **full** request. The cap warning says so.
- Cited images and collapsed pastes follow existing normal submission resolution. A routed owner stores the expanded paste, not a private terminal chip.
- New `goal_set` action receipts use the established consumer declaration contract: current terminals admit their own request, older/mobile clients leave admission to the owner. A current terminal can also complete the exact pre-fix typed goal receipt (`data.stored`, no action type), which the old owner only produced after metadata mutation and never submitted. Opaque legacy strings are not guessed at.

Non-goals: no new loop mode, scheduling policy, model/provider behavior, layout or theme changes; no version bump or release in this PR. `Session.set_goal` itself remains a metadata setter.

## Reproduction and actual execution

The before and after probes run the **real `OperatorApp`, real `Session`, real transcript and real engine**, with only the model provider scripted. The conversation title is pinned during the after probe so background auto-naming is not mistaken for a second agent turn.

Before, one composer Enter on `/goal Prepare the release checklist` produced:

```text
▌ /goal Prepare the release checklist
  · goal set — applies from the next step
```

The objective was stored but the agent did not start.

After, the same command produced **one provider request** with the plain user message and:

```text
  · goal set
▌ Prepare the release checklist
Working on the release checklist.
```

`tests/e2e/test_goal_submission.py` additionally drives that Enter through a real `write` tool: it writes `goal-artifact.txt` containing `goal command started this turn`, asserts exactly one user message, the two expected provider steps (tool call + final answer), and both the tool call and result in the on-disk transcript.

A held-provider probe also exercised a busy turn: `/goal` queued one steering message, then delivered it once. There were two total requests (the original task and the goal message); bare status and clear left that count at two. A synthetic provider error produced one user row and the normal visible error/stop state, with the goal still stored.

## Testing Details

| Check | Actual result |
| --- | --- |
| Whole-tree unit suite | **16,261 passed, 18 skipped, 1 failed, 1 error** in 2,299.75s (38m19s) — both non-passes classified below as host-contention flakes |
| Final bounded goal/compatibility regression pass | **85 passed**, 8 warnings, 23.60s |
| Final assembled `tests/e2e -m e2e -n0` | **50 passed**, 6 warnings, 74.83s |
| Whole-tree flake8 | exit 0 |
| Pinned Black 26.1.0 | 1,080 files unchanged |
| Pinned isort 5.13.2 | exit 0 |
| Whole-tree pyright | **0 errors, 0 warnings, 0 informations** |

All final validation is against committed head `925b27c78ac1e0712bdd0a687e1dcff754efd16f`. An earlier full unit attempt hit its 30-minute command bound at 98%; it had no test failures but **is not counted as a pass**. The completed run above used the repository's existing capped parallelism.

**The two non-passes are not this diff, and that is shown rather than asserted.** This machine is shared with roughly twenty concurrent agent worktrees; load average was 124 when the run started and 293 near the end.

| Non-pass | Why it is not this change |
| --- | --- |
| `tests/unit/harness/test_efficiency.py::test_daemon_thread_cannot_inherit_next_eval_cells_bridge` | A `threading.Event` timing assertion in the eval kernel. Passes on this head both alone and as a whole module. |
| `tests/unit/evaluation/runner/test_episode_subprocess.py::test_worker_cannot_deliver_frames_from_outside_the_root[fifo-…]` | Errored while copying an interpreter into a temp venv: `Library not loaded: @rpath/libpython3.12.dylib`. An environment failure inside the fixture, with no assertion reached. |

Evidence for that classification:

```sh
# Neither module references any module this PR touches.
$ grep -cE 'tui\.app|runtime\.owned|runtime\.types|session\.remote|slash_commands' \
    tests/unit/harness/test_efficiency.py tests/unit/evaluation/runner/test_episode_subprocess.py
tests/unit/harness/test_efficiency.py:0
tests/unit/evaluation/runner/test_episode_subprocess.py:0

# Both whole modules, on this head:
$ .venv/bin/python -m pytest tests/unit/harness/test_efficiency.py \
    tests/unit/evaluation/runner/test_episode_subprocess.py -q
43 passed in 72.25s (0:01:12)

# The same two modules on the unmodified base c26aa8314, for comparison:
43 passed in 72.18s (0:01:12)
```

CI runs the whole tree on a dedicated runner and is the authority on this head; I am not claiming a green local full suite. Logs live under `/tmp/goal-submit-evidence/`: `unit.log`, `unit-timeout.log` (the abandoned incomplete attempt), `final-delta.log`, `e2e-final.log`, and `{flake8,black,isort,pyright}-final.log`.

Commands use the worktree's own editable `.venv`; import resolution was verified as `~/local-operator-goal-submit/local_operator/__init__.py`. Before every TUI/fork run, **all `CMUX_*` environment variables were removed**, `NO_COLOR` was unset, `TERM=xterm-256color` was set, and a fresh config directory was used. Captures also isolate HOME/config before app imports.

```sh
for key in $(env | cut -d= -f1 | grep '^CMUX_'); do unset "$key"; done
export LOCAL_OPERATOR_CONFIG_DIR=$(mktemp -d)
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/e2e -m e2e -n0 -q
.venv/bin/python -m flake8 .
uvx --from black==26.1.0 black --check .
uvx isort==5.13.2 --check .
.venv/bin/python -m pyright --pythonpath .venv/bin/python .
```

## Visual evidence

**These screenshots are local review artifacts, not attached to GitHub.** They are deliberately not committed, per `AGENTS.md`.

- `/tmp/goal-submit-evidence/before/{first,settled}.{svg,png,geometry.json}`
- `/tmp/goal-submit-evidence/after/{first,settled}.{svg,png,geometry.json}`
- `/tmp/goal-submit-evidence/states/queued.png`, `busy-settled.png`, `status.png`, `clear.png`, `error-settled.png` (with adjacent SVG and geometry files)
- Exact transcript/provider evidence: `/tmp/goal-submit-evidence/after/result.json`, `states.log`
- Geometry digest: `/tmp/goal-submit-evidence/geometry-summary.txt`

The rendered PNGs were actually viewed. At 100×30 cells (800×510 native pixels), both before/after and consecutive first/settled frames retain:

| Surface | Region | Content / virtual size | Scrollbars |
| --- | --- | --- | --- |
| Transcript | `(1,1,98,23)` | `97×21` / `96×21` | none |
| Input dock | `(1,24,98,5)` | `98×5` / `98×5` | none |
| Input shell | `(1,24,98,5)` | `96×3` / `96×3` | none |
| Editor | `(4,25,94,1)` | `92×1` / `0×1` | none |

Within each phase, first/settled PNGs are byte-identical. The change adds the expected assistant output rather than moving or resizing the composer.

Reproduce the main after capture:

```sh
env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m scripts.goal_submit_shot /tmp/goal-after
rsvg-convert /tmp/goal-after/settled.svg -o /tmp/goal-after/settled.png
```

## Impact and rollback

The intentional behavior change is that setting a goal now consumes a normal model turn instead of only setting metadata. There are no dependency updates, new execution privileges, or incompatible wire-schema changes.

The blast radius is prompt-carrying goal commands and shared action-receipt completion. Existing normal prompt/steer/hold and image/paste machinery is reused, not reimplemented. No schema migration or configuration change. Revert this PR to restore metadata-only goal commands. Agent, independent QA, design and UX rounds are pending; no human reviewers have been added and this PR will not be merged by the implementing agent.

## Checklist

- [x] Project style, formatting, linting and type checks pass.
- [x] Self-reviewed the bounded diff and actual rendered frames.
- [x] Regression tests and real assembled execution evidence included.
- [x] README and command help describe the new behavior.
- [x] Security/ownership implications checked; normal admission and existing authenticated routing retained.
- [x] No issue was requested; the PR is the change record.
- [ ] Independent agent, QA, design and UX rounds completed and answered.
- [ ] CI whole-tree validation on the final head is green.
