### PR TITLE
fix(session): retain each conversation's model when shared defaults change

### DIFF
--- a/local_operator/bootstrap.py
+++ b/local_operator/bootstrap.py
@@ -110,6 +110,8 @@ def resolve_model_configuration(
     request_hosting: Optional[str] = None,
     request_model: Optional[str] = None,
     current_agent: Optional[AgentData] = None,
+    persist_conversation: bool = False,
+    model_selection_override: bool = True,
 ) -> tuple[ModelConfiguration, str, str]:
     """Resolve hosting/model and build the ``ModelConfiguration``.
 
@@ -121,9 +123,25 @@ def resolve_model_configuration(
         ValueError: when hosting/model config is missing or the provider is
             unknown.
     """
-    hosting, model_name = resolve_hosting_model(
-        config_manager, request_hosting, request_model, current_agent
-    )
+    if persist_conversation:
+        from local_operator.session_factory import (
+            resolve_hosting_model as resolve_session_model,
+        )
+
+        hosting, model_name = resolve_session_model(
+            current_agent,
+            argparse.Namespace(
+                hosting=request_hosting,
+                model=request_model,
+                train=True,
+                model_selection_override=model_selection_override,
+            ),
+            config_manager,
+        )
+    else:
+        hosting, model_name = resolve_hosting_model(
+            config_manager, request_hosting, request_model, current_agent
+        )
 
     chat_args: dict[str, Any] = {}
     if current_agent is not None:
@@ -193,6 +211,7 @@ async def initialize_operator(
     auto_save_conversation: bool = False,
     job_id: Optional[str] = None,
     verbosity_level: VerbosityLevel = VerbosityLevel.VERBOSE,
+    model_selection_override: bool | None = None,
 ) -> "SessionProtocol":
     """Build a fully wired harness session for a server or scheduled run.
 
@@ -213,6 +232,11 @@ async def initialize_operator(
     """
     from local_operator import session_factory
 
+    explicit = (
+        bool(request_hosting or request_model)
+        if model_selection_override is None
+        else model_selection_override
+    )
     _, hosting, model_name = resolve_model_configuration(
         config_manager,
         credential_manager,
@@ -220,6 +244,8 @@ async def initialize_operator(
         request_hosting=request_hosting,
         request_model=request_model,
         current_agent=current_agent,
+        persist_conversation=persist_conversation,
+        model_selection_override=explicit,
     )
     logger.debug(
         f"Initializing session (Type: {operator_type.name}) with Hosting: {hosting}, "
@@ -232,6 +258,9 @@ async def initialize_operator(
         current_agent=current_agent,
         persist_conversation=persist_conversation,
     )
+    # This pair may be a synthesized default; only the original caller's
+    # intent can supersede the saved selection on a persisted conversation.
+    session_args.model_selection_override = explicit
     session = await session_factory.create_session(
         session_args,
         config_manager,

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -4390,6 +4390,8 @@ def main() -> int:
             tui_config = config_manager.get_config_value("tui", None)
             theme_name = tui_config.get("theme", "dark") if isinstance(tui_config, dict) else "dark"
 
+            viewer_started = False
+
             async def viewer_factory(resume_id: "str | None"):
                 """Build the TUI's session facade: a VIEWER, never an owner.
 
@@ -4414,15 +4416,35 @@ def main() -> int:
                 runtime materialises the directory for it on the first real
                 write — an engaged-but-unused session leaves nothing behind.
                 """
+                nonlocal viewer_started
                 import uuid as _uuid
 
+                from local_operator.harness.types import ModelSpec
                 from local_operator.mobile.attach_client import find_owner_record
                 from local_operator.session.remote import RemoteSession
+                from local_operator.session_factory import resolve_hosting_model
 
                 config_directory = config_manager.config_dir
                 # Same expression session_factory uses for a new session's
                 # directory name, so ids minted by either path are one shape.
                 session_id = resume_id or _uuid.uuid4().hex[:12]
+                # The CLI flags belong to startup, not every /new or picker
+                # resume in this viewer. Refresh the file only at this boundary.
+                birth_args = argparse.Namespace(**vars(args))
+                birth_args.resume = resume_id
+                if viewer_started:
+                    birth_args.hosting = None
+                    birth_args.model = None
+                viewer_started = True
+                initial_model = None
+                try:
+                    provider, model_id = resolve_hosting_model(
+                        current_agent, birth_args, ConfigManager(config_directory)
+                    )
+                    initial_model = ModelSpec(provider=provider, model_id=model_id)
+                except ValueError:
+                    # Setup mode must still open without a configured model.
+                    pass
 
                 async def take_over():
                     # A viewer must never win the transcript lease — the
@@ -4455,12 +4477,22 @@ def main() -> int:
                 degraded_reason = ""
                 if record is not None:
                     try:
-                        return await RemoteSession.connect(
+                        attached = await RemoteSession.connect(
                             record,
                             session_id,
                             config_dir=config_directory,
                             takeover_factory=take_over,
                         )
+                        if initial_model is not None and (birth_args.hosting or birth_args.model):
+                            # A live resume needs the same deliberate override
+                            # as a cold one; send it to the existing owner,
+                            # never replace its journal from the viewer.
+                            receipt = await attached.route_shared_slash(
+                                "model", f"{initial_model.provider}/{initial_model.model_id}"
+                            )
+                            if isinstance(receipt, dict) and receipt.get("style") == "error":
+                                attached.degraded_reason = str(receipt.get("text") or "")
+                        return attached
                     except (ConnectionError, OSError, TimeoutError) as error:
                         # The runtime died between the scan and the dial, or is
                         # too old to attach to. Cold is the honest fallback:
@@ -4491,6 +4523,8 @@ def main() -> int:
                     config_dir=config_directory,
                     cwd=os.getcwd(),
                     takeover_factory=take_over,
+                    initial_model=initial_model,
+                    model_selection_override=bool(birth_args.hosting or birth_args.model),
                 )
                 if degraded_reason:
                     viewer.degraded_reason = degraded_reason

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -4532,7 +4532,13 @@ def main() -> int:
                     cwd=os.getcwd(),
                     takeover_factory=take_over,
                     initial_model=initial_model,
-                    model_selection_override=bool(birth_args.hosting or birth_args.model),
+                    # Only a RESOLVED spec can be a deliberate override. Setup
+                    # mode leaves `initial_model` None when the machine has no
+                    # usable configuration yet, and claiming an override there
+                    # would assert an intent with nothing to apply.
+                    model_selection_override=(
+                        initial_model is not None and bool(birth_args.hosting or birth_args.model)
+                    ),
                 )
                 if degraded_reason:
                     viewer.degraded_reason = degraded_reason

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -4437,10 +4437,18 @@ def main() -> int:
                     birth_args.model = None
                 viewer_started = True
                 initial_model = None
-                try:
-                    provider, model_id = resolve_hosting_model(
-                        current_agent, birth_args, ConfigManager(config_directory)
+                birth_agent = current_agent
+
+                def resolve_birth():
+                    # Both the config and saved selection can require disk I/O.
+                    # The captured arguments above fix WHICH conversation this
+                    # read belongs to before yielding to the worker.
+                    return resolve_hosting_model(
+                        birth_agent, birth_args, ConfigManager(config_directory)
                     )
+
+                try:
+                    provider, model_id = await asyncio.to_thread(resolve_birth)
                     initial_model = ModelSpec(provider=provider, model_id=model_id)
                 except ValueError:
                     # Setup mode must still open without a configured model.

--- a/local_operator/guides/configuration/GUIDE.md
+++ b/local_operator/guides/configuration/GUIDE.md
@@ -83,7 +83,11 @@ local-operator --hosting anthropic --model claude-sonnet-4
 local-operator --hosting openrouter --model openai/gpt-4.1 exec "summarize this repository"
 ```
 
-Resolution precedence is agent profile, then CLI flags, then `config.yml`. An agent with its own `hosting` or `model` therefore overrides both the session flags and global defaults.
+For a **new conversation**, resolution precedence is agent profile, then CLI flags, then `config.yml`. The concrete provider/model pair is sampled at startup or `/new`; editing shared defaults never switches existing conversations. `/model <provider>/<id>` switches only the current conversation, and `/model saved` explicitly adopts the latest default there. `/model default` still saves the launch default and switches its owning conversation, not siblings.
+
+Resume and fork retain the conversation's saved selection, even after defaults or the previously bound agent profile change. A deliberate `--hosting`/`--model` on resume overrides that selection: `--model` alone retains the saved provider; `--hosting` alone uses that provider's default model. Subagents inherit their launching conversation's selection unless an explicit role/tier selection overrides it. Provider failover remains a separate effective route, not a replacement global default.
+
+Older transcripts recover the latest usable primary-model observation from their selection journal or frontend checkpoint. If none exists, the owner samples the current default once and announces that recovery; it cannot reconstruct an unrecorded historical model. Selections become durable when the owner admits real work, so merely opening and abandoning an empty draft does not create a conversation on disk.
 
 Manage secrets separately; never place API keys in `config.yml`:
 

--- a/local_operator/mobile/daemon.py
+++ b/local_operator/mobile/daemon.py
@@ -1721,6 +1721,12 @@ class MobileDaemon:
         else:
             env.pop("LOP_MOBILE_CHILD_MODEL", None)
         env["LOP_MOBILE_CHILD_RESUME"] = session_id
+        # Unlike a viewer's synthesized birth seed these optional fields came
+        # from the Start request itself, so they are deliberate overrides.
+        if provider or model_id:
+            env["LOP_MODEL_SELECTION_OVERRIDE"] = "1"
+        else:
+            env.pop("LOP_MODEL_SELECTION_OVERRIDE", None)
         # A deliberate Start is not speculative prewarming inherited from an
         # enclosing process. The child's existing adopt path mints this exact ID.
         env.pop("LOP_RUNTIME_DEFER_MATERIALISE", None)

--- a/local_operator/server/utils/operator.py
+++ b/local_operator/server/utils/operator.py
@@ -628,7 +628,9 @@ class ServerOperator:
         persist_conversation: bool = False,
         job_id: Optional[str] = None,
         status_queue: StatusQueue | None = None,
+        model_selection_override: bool = True,
     ) -> None:
+        self.model_selection_override = model_selection_override
         self.executor = executor
         self.config_manager = config_manager
         self.credential_manager = credential_manager
@@ -708,6 +710,7 @@ class ServerOperator:
             },
             request_hosting=self.hosting,
             request_model=self.model,
+            model_selection_override=self.model_selection_override,
             current_agent=self.current_agent,
             persist_conversation=self.persist_agent_conversation,
             job_id=self.job_id,
@@ -861,6 +864,8 @@ def create_operator(
         request_hosting=request_hosting,
         request_model=request_model,
         current_agent=current_agent,
+        persist_conversation=persist_conversation,
+        model_selection_override=bool(request_hosting or request_model),
     )
 
     executor = ServerExecutor(
@@ -882,6 +887,7 @@ def create_operator(
         env_config=env_config,
         hosting=hosting,
         model=model_name,
+        model_selection_override=bool(request_hosting or request_model),
         current_agent=current_agent,
         persist_conversation=persist_conversation,
         job_id=job_id,

--- a/local_operator/session/model_selection.py
+++ b/local_operator/session/model_selection.py
@@ -1,0 +1,108 @@
+"""Conversation model identity, shared by owners and runtime-less viewers.
+
+The journal is authoritative, not config.yml and not the effective fallback
+route. Version 2 rows own the initial selection as well as explicit switches.
+Legacy writers only journalled switches; their later frontend checkpoints can
+therefore be newer evidence of the primary they actually selected on resume.
+Reading never creates a directory or migrates a transcript: only its leased
+owner may append the upgraded selection when it admits real work.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Iterable
+
+SELECTED_MODEL_CUSTOM_TYPE = "selected_model"
+SELECTION_VERSION = 2
+
+
+@dataclass(frozen=True)
+class StoredModelSelection:
+    provider: str
+    model_id: str
+    effort: str | None = None
+    authoritative: bool = False
+    recovered: bool = False
+
+    @property
+    def selector(self) -> str:
+        return f"{self.provider}/{self.model_id}"
+
+
+def _selection(selector: Any, effort: Any, *, authoritative: bool = False):
+    if not isinstance(selector, str) or "/" not in selector:
+        return None
+    provider, model_id = selector.split("/", 1)
+    if not provider or not model_id:
+        return None
+    from local_operator.providers.registry import get_provider_definition
+
+    if get_provider_definition(provider) is None:
+        return None
+    return StoredModelSelection(
+        provider, model_id, effort if isinstance(effort, str) and effort else None, authoritative
+    )
+
+
+def selection_from_payloads(payloads: Iterable[dict[str, Any]]) -> StoredModelSelection | None:
+    authoritative = None
+    legacy = None
+    unusable = False
+    for payload in payloads:
+        kind = payload.get("custom_type")
+        details = payload.get("details")
+        if not isinstance(details, dict):
+            continue
+        if kind == SELECTED_MODEL_CUSTOM_TYPE:
+            version = details.get("version")
+            selected = _selection(
+                details.get("selector"),
+                details.get("effort"),
+                authoritative=version == SELECTION_VERSION,
+            )
+            if selected is not None:
+                if selected.authoritative:
+                    authoritative = selected
+                    unusable = False
+                elif version is None:
+                    legacy = selected
+            elif version == SELECTION_VERSION or (version is None and authoritative is None):
+                unusable = True
+        elif kind == "frontend_state_checkpoint_v1":
+            state = details.get("state")
+            model = state.get("selected_model") if isinstance(state, dict) else None
+            if isinstance(model, dict):
+                selected = _selection(
+                    f"{model.get('provider', '')}/{model.get('model_id', '')}",
+                    model.get("reasoning_effort"),
+                )
+                if selected is not None:
+                    legacy = selected
+    selected = authoritative or legacy
+    return replace(selected, recovered=unusable) if selected is not None else None
+
+
+def read_model_selection(directory: Path) -> StoredModelSelection | None:
+    """Read only identity rows without loading message attachments or history."""
+
+    def payloads():
+        try:
+            with (directory / "transcript.jsonl").open(encoding="utf-8") as handle:
+                for line in handle:
+                    # Large transcripts mostly contain messages. Do not parse
+                    # their payloads just to recover a two-field selector.
+                    if '"custom_type"' not in line:
+                        continue
+                    try:
+                        row = json.loads(line)
+                    except (ValueError, TypeError):
+                        continue
+                    if isinstance(row, dict) and isinstance(row.get("payload"), dict):
+                        yield row["payload"]
+        except (OSError, UnicodeError):
+            return
+
+    return selection_from_payloads(payloads())

--- a/local_operator/session/model_selection.py
+++ b/local_operator/session/model_selection.py
@@ -26,13 +26,16 @@ class StoredModelSelection:
     effort: str | None = None
     authoritative: bool = False
     recovered: bool = False
+    # This is the conversation's birth selector, not the pair configured while
+    # constructing a resumed owner. Existing /effort journalling depends on it.
+    boot_selector: str | None = None
 
     @property
     def selector(self) -> str:
         return f"{self.provider}/{self.model_id}"
 
 
-def _selection(selector: Any, effort: Any, *, authoritative: bool = False):
+def _selection(selector: Any, effort: Any, *, authoritative: bool = False, boot: Any = None):
     if not isinstance(selector, str) or "/" not in selector:
         return None
     provider, model_id = selector.split("/", 1)
@@ -43,11 +46,18 @@ def _selection(selector: Any, effort: Any, *, authoritative: bool = False):
     if get_provider_definition(provider) is None:
         return None
     return StoredModelSelection(
-        provider, model_id, effort if isinstance(effort, str) and effort else None, authoritative
+        provider,
+        model_id,
+        effort if isinstance(effort, str) and effort else None,
+        authoritative,
+        boot_selector=(
+            boot if isinstance(boot, str) and "/" in boot and all(boot.split("/", 1)) else None
+        ),
     )
 
 
 def selection_from_payloads(payloads: Iterable[dict[str, Any]]) -> StoredModelSelection | None:
+    """Resolve CUSTOM-entry payloads; both callers enforce the envelope first."""
     authoritative = None
     legacy = None
     unusable = False
@@ -62,6 +72,7 @@ def selection_from_payloads(payloads: Iterable[dict[str, Any]]) -> StoredModelSe
                 details.get("selector"),
                 details.get("effort"),
                 authoritative=version == SELECTION_VERSION,
+                boot=details.get("boot"),
             )
             if selected is not None:
                 if selected.authoritative:
@@ -80,6 +91,11 @@ def selection_from_payloads(payloads: Iterable[dict[str, Any]]) -> StoredModelSe
                     model.get("reasoning_effort"),
                 )
                 if selected is not None:
+                    # A checkpoint refreshes the observed primary, not its
+                    # birth. Retain known provenance only for the SAME primary;
+                    # an abandoned old switch cannot lend its birth to a new one.
+                    if legacy is not None and legacy.selector == selected.selector:
+                        selected = replace(selected, boot_selector=legacy.boot_selector)
                     legacy = selected
     selected = authoritative or legacy
     return replace(selected, recovered=unusable) if selected is not None else None
@@ -100,7 +116,11 @@ def read_model_selection(directory: Path) -> StoredModelSelection | None:
                         row = json.loads(line)
                     except (ValueError, TypeError):
                         continue
-                    if isinstance(row, dict) and isinstance(row.get("payload"), dict):
+                    if (
+                        isinstance(row, dict)
+                        and row.get("type") == "custom"
+                        and isinstance(row.get("payload"), dict)
+                    ):
                         yield row["payload"]
         except (OSError, UnicodeError):
             return

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -256,6 +256,15 @@ _BACKGROUND_BIND_BUDGET_S = FRONTEND_SYNC_BACKSTOP_S
 #: moment before it would have succeeded.
 _BACKGROUND_YIELD_BUDGET_S = 1.0
 
+#: Shown to the USER verbatim: the TUI relays a refused bind's text straight
+#: into a notice, so this is product copy rather than an internal diagnostic.
+#: It therefore names no runtime vocabulary ("owner"), and ends in the same
+#: next step every sibling refusal on this seam offers, because a refusal the
+#: reader cannot act on reads as a dead end (design D1, UX U1).
+_MODEL_INTENT_PENDING = (
+    "still starting this conversation on the model you asked for; " "try that again in a moment"
+)
+
 #: Bounded retry of the INITIAL bind. A first attempt that loses its race with
 #: a retiring runtime, or that hits an owner whose loop is momentarily busy, is
 #: a transient — the owner is typically answering seconds later, and before
@@ -1707,8 +1716,8 @@ class RemoteSession:
         if not self._can_go_cold or self._disposed:
             return
         if self._recovering:
-            if self._model_selection_override:
-                raise ConnectionError("explicit model selection is waiting for its owner")
+            if self._model_selection_override and self._birth_model is not None:
+                raise ConnectionError(_MODEL_INTENT_PENDING)
             return
         if not self.is_cold and not self._model_selection_override:
             return
@@ -1946,6 +1955,10 @@ class RemoteSession:
     async def _consume_model_override(self) -> None:
         """A warm engagement proves ownership exists, not that intent landed.
 
+        A missing spec is "nothing to consume" rather than an error: only a
+        RESOLVED selection can be sent, and treating its absence as a pending
+        intent makes the state unrecoverable from every caller.
+
         Another cold viewer may have started the winning owner with a different
         selection. Only the existing model RPC's success acknowledgement means
         this viewer's deliberate override was consumed. Keep it across failed
@@ -1954,8 +1967,16 @@ class RemoteSession:
         if not self._model_selection_override:
             return
         client, requested = self._client, self._birth_model
-        if client is None or requested is None or self._recovering or self.is_cold:
-            raise ConnectionError("explicit model selection is waiting for its owner")
+        if requested is None:
+            # Nothing to consume. The CLI pairs a raw ``--model`` flag with no
+            # resolved spec whenever the machine has no usable configuration
+            # yet, and a pending intent that can never be satisfied would
+            # refuse every later call — including the ``/model`` the refusal
+            # invites. Clearing it restores the ordinary unconfigured path.
+            self._model_selection_override = False
+            return
+        if client is None or self._recovering or self.is_cold:
+            raise ConnectionError(_MODEL_INTENT_PENDING)
         await client.set_model(requested.provider, requested.model_id)
         self._model_selection_override = False
 

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -416,6 +416,8 @@ class RemoteSession:
     ) -> None:
         self._config_dir = config_dir
         self._session_id = session_id
+        self._birth_model: ModelSpec | None = None
+        self._model_selection_override = False
         self._takeover_factory = takeover_factory
         self._surface = surface
         self._desktop_visible = False
@@ -781,6 +783,8 @@ class RemoteSession:
         cwd: str,
         takeover_factory: Callable[[], Any],
         surface: str = "terminal",
+        initial_model: ModelSpec | None = None,
+        model_selection_override: bool = False,
     ) -> "RemoteSession":
         """A viewer bound to NOTHING: durable history and a spool, no runtime.
 
@@ -806,6 +810,8 @@ class RemoteSession:
         )
         self._cwd = cwd
         self._can_go_cold = True
+        self._birth_model = initial_model
+        self._model_selection_override = model_selection_override
         state = await self._synthesise_cold_state(cwd)
         # A session that has never run has no transcript to read; one being
         # reopened has its whole history here, off the loop as always.
@@ -850,7 +856,7 @@ class RemoteSession:
         The checkpoint is authoritative for what it carries and the synthesised
         state is authoritative for the rest, so the two are merged rather than
         one replacing the other: ``cwd`` and the model come from THIS process
-        (the config may have changed since; the checkpoint's copy is history),
+        (using the shared conversation-selection reader, not mutable defaults),
         while the roster, todos, title and costs come from disk. ``jobs`` are
         stamped ``restored`` for the same reason the session's own restore does
         — a restored row has no in-process trajectory, and the panel says so
@@ -1168,7 +1174,25 @@ class RemoteSession:
                 config = ConfigManager(config_dir=self._config_dir)
                 provider = str(config.get_config_value("hosting", "") or "")
                 model_id = str(config.get_config_value("model_name", "") or "")
-                model = FrontendModelSpec(provider=provider, model_id=model_id)
+                from local_operator.session.model_selection import read_model_selection
+
+                saved = read_model_selection(self._config_dir / "sessions" / self._session_id)
+                if self._birth_model is not None and (
+                    saved is None or self._model_selection_override
+                ):
+                    model = FrontendModelSpec(**self._birth_model.model_dump())
+                elif saved is not None:
+                    model = FrontendModelSpec(
+                        provider=saved.provider,
+                        model_id=saved.model_id,
+                        reasoning_effort=saved.effort,
+                    )
+                else:
+                    if provider and not model_id:
+                        from local_operator.model.defaults import default_model_for
+
+                        model_id = default_model_for(provider) or ""
+                    model = FrontendModelSpec(provider=provider, model_id=model_id)
             except Exception:  # noqa: BLE001 — an unreadable config is not fatal
                 logger.debug("cold state could not read the configured model", exc_info=True)
             if model is None:
@@ -1756,7 +1780,10 @@ class RemoteSession:
             await engage_runtime(
                 self._session_id,
                 self._cwd,
-                WarmErrand(),
+                WarmErrand(
+                    initial_model=self._birth_model,
+                    model_selection_override=self._model_selection_override,
+                ),
                 config_dir=self._config_dir,
                 # The engage yields TIME, not the runtime: a candidate it
                 # spawned keeps constructing and the foreground caller's own
@@ -1765,6 +1792,9 @@ class RemoteSession:
                 preempt=preempt,
                 preempt_budget_s=_BACKGROUND_YIELD_BUDGET_S,
             )
+            # The owner has now consumed startup intent. A later recovery must
+            # prefer its journal, including explicit switches made after boot.
+            self._model_selection_override = False
         except TimeoutError as error:
             # The engage ran out of deadline — either its own 30 s or, when a
             # foreground caller arrived, the yield budget above. Both mean the
@@ -2931,6 +2961,24 @@ class RemoteSession:
         self._streaming = state.streaming
         self._generation = state.generation
         self._model = state.selected_model
+        # Keep the concrete primary seen at birth OR on an attached owner. A
+        # speculatively warmed owner can retire before its first durable row;
+        # a connected viewer must still seed its successor with that selection,
+        # not whatever global default happened to change while it was idle.
+        from local_operator.providers.registry import get_provider_definition
+
+        selected = state.selected_model
+        if (
+            selected is not None
+            and selected.model_id
+            and (
+                self._birth_model is None
+                or (self._birth_model.provider, self._birth_model.model_id)
+                != (selected.provider, selected.model_id)
+            )
+            and get_provider_definition(selected.provider) is not None
+        ):
+            self._birth_model = ModelSpec(provider=selected.provider, model_id=selected.model_id)
         self.jobs.replace(state.jobs)
         self._subagent_comms.replace(state.jobs)
         self.wake_scheduler.replace(state.wakes)

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -1704,10 +1704,20 @@ class RemoteSession:
         # Recovery already owns its dial/sync and signals _owner_ready. A
         # prompt or steer must wait on that promise, not start a competing
         # initial attachment merely because its connected socket is not ready.
-        if not self._can_go_cold or not self.is_cold or self._disposed or self._recovering:
+        if not self._can_go_cold or self._disposed:
+            return
+        if self._recovering:
+            if self._model_selection_override:
+                raise ConnectionError("explicit model selection is waiting for its owner")
+            return
+        if not self.is_cold and not self._model_selection_override:
             return
         async with self._bind_lock_for(foreground=foreground):
             await self._bind_under_lock(foreground=foreground)
+            # Cover every winning-owner path, including another attach/recovery
+            # completing during an await. A failed model RPC is not a failed
+            # socket bind and must remain a visible, retryable pending intent.
+            await self._consume_model_override()
 
     @asynccontextmanager
     async def _bind_lock_for(self, *, foreground: bool) -> AsyncIterator[None]:
@@ -1756,7 +1766,9 @@ class RemoteSession:
         statement and cannot drift from the `finally` that clears it. Not a
         public seam: the guards below assume the lock is held.
         """
-        if not self.is_cold or self._disposed or self._recovering:
+        if self._disposed or self._recovering:
+            return
+        if not self.is_cold:
             return
         from local_operator.mobile.attach_client import find_owner_record
         from local_operator.session.runtime.launch import (
@@ -1792,9 +1804,6 @@ class RemoteSession:
                 preempt=preempt,
                 preempt_budget_s=_BACKGROUND_YIELD_BUDGET_S,
             )
-            # The owner has now consumed startup intent. A later recovery must
-            # prefer its journal, including explicit switches made after boot.
-            self._model_selection_override = False
         except TimeoutError as error:
             # The engage ran out of deadline — either its own 30 s or, when a
             # foreground caller arrived, the yield budget above. Both mean the
@@ -1933,6 +1942,22 @@ class RemoteSession:
                 delay = min(delay * _BIND_RETRY_FACTOR, _BIND_RETRY_DELAY_CAP_S)
         if last_error is not None:
             raise last_error
+
+    async def _consume_model_override(self) -> None:
+        """A warm engagement proves ownership exists, not that intent landed.
+
+        Another cold viewer may have started the winning owner with a different
+        selection. Only the existing model RPC's success acknowledgement means
+        this viewer's deliberate override was consumed. Keep it across failed
+        acknowledgements, and never promote an ordinary birth seed to a switch.
+        """
+        if not self._model_selection_override:
+            return
+        client, requested = self._client, self._birth_model
+        if client is None or requested is None or self._recovering or self.is_cold:
+            raise ConnectionError("explicit model selection is waiting for its owner")
+        await client.set_model(requested.provider, requested.model_id)
+        self._model_selection_override = False
 
     async def _bind_to(
         self,
@@ -2971,6 +2996,9 @@ class RemoteSession:
         if (
             selected is not None
             and selected.model_id
+            # The first winning-owner snapshot may still name another model;
+            # it must not overwrite explicit intent before the RPC consumes it.
+            and not self._model_selection_override
             and (
                 self._birth_model is None
                 or (self._birth_model.provider, self._birth_model.model_id)

--- a/local_operator/session/runtime/launch.py
+++ b/local_operator/session/runtime/launch.py
@@ -187,6 +187,10 @@ class WarmErrand:
     """
 
     command_id: str = ""
+    # Memory-only birth sample; meaningful only if this engagement has to
+    # create an owner. An already-running owner retains its own selection.
+    initial_model: Any = None
+    model_selection_override: bool = False
 
 
 Errand = Union[PromptErrand, SteerErrand, PeerMessageErrand, WakeErrand, WarmErrand]
@@ -235,7 +239,12 @@ def _lease_holder(config_dir: Path, session_id: str) -> int | None:
 
 
 def _spawn_runtime(
-    session_id: str, cwd: str, *, defer_materialise: bool
+    session_id: str,
+    cwd: str,
+    *,
+    defer_materialise: bool,
+    initial_model: Any = None,
+    model_selection_override: bool = False,
 ) -> "subprocess.Popen[bytes]":
     """Start one detached runtime candidate for ``session_id``.
 
@@ -261,13 +270,26 @@ def _spawn_runtime(
 
     Only routing data enters the environment — prompt text, images and command
     identity travel over the authenticated loopback socket, never through
-    ``ps``-readable state. These are the two variables ``process.py`` already
-    reads, plus the deferred-materialisation flag; the spawn stays bare by
-    design (design §11.3 C1).
+    ``ps``-readable state. Alongside identity and deferred-materialisation,
+    the optional birth model is routing data: it seeds only a new owner,
+    never an already-running session or a saved selection on resume.
     """
     env = dict(os.environ)
     env["LOP_MOBILE_CHILD_CWD"] = cwd
     env["LOP_MOBILE_CHILD_RESUME"] = session_id
+    # A viewer's birth sample seeds only a new conversation. It is NOT a
+    # resume override, and inherited spawn flags must not leak into siblings.
+    for key in (
+        "LOP_MOBILE_CHILD_PROVIDER",
+        "LOP_MOBILE_CHILD_MODEL",
+        "LOP_MODEL_SELECTION_OVERRIDE",
+    ):
+        env.pop(key, None)
+    if initial_model is not None:
+        env["LOP_MOBILE_CHILD_PROVIDER"] = initial_model.provider
+        env["LOP_MOBILE_CHILD_MODEL"] = initial_model.model_id
+    if model_selection_override:
+        env["LOP_MODEL_SELECTION_OVERRIDE"] = "1"
     if defer_materialise:
         env["LOP_RUNTIME_DEFER_MATERIALISE"] = "1"
     else:
@@ -582,7 +604,14 @@ async def engage_runtime(
             elif not spawned:
                 logger.debug("engage: spawning a runtime for %s", session_id)
                 candidate = await asyncio.to_thread(
-                    _spawn_runtime, session_id, cwd, defer_materialise=defer
+                    _spawn_runtime,
+                    session_id,
+                    cwd,
+                    defer_materialise=defer,
+                    initial_model=work.initial_model if isinstance(work, WarmErrand) else None,
+                    model_selection_override=(
+                        work.model_selection_override if isinstance(work, WarmErrand) else False
+                    ),
                 )
                 capture = getattr(candidate, "lop_capture_path", None)
                 spawned = True
@@ -623,7 +652,14 @@ async def engage_runtime(
                     spawn_reason or "no output captured",
                 )
                 candidate = await asyncio.to_thread(
-                    _spawn_runtime, session_id, cwd, defer_materialise=defer
+                    _spawn_runtime,
+                    session_id,
+                    cwd,
+                    defer_materialise=defer,
+                    initial_model=work.initial_model if isinstance(work, WarmErrand) else None,
+                    model_selection_override=(
+                        work.model_selection_override if isinstance(work, WarmErrand) else False
+                    ),
                 )
                 capture = getattr(candidate, "lop_capture_path", None)
                 spawns += 1

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -3634,6 +3634,7 @@ async def spawn_owned_session(
     provider: str | None = None,
     model_id: str | None = None,
     resume: str | None = None,
+    model_selection_override: bool = True,
 ) -> OwnedSessionHandle:
     """Build a session for the phone with the CLI's composition root.
 
@@ -3698,6 +3699,7 @@ async def spawn_owned_session(
         yolo=False,
         train=False,
         resume=resume,
+        model_selection_override=model_selection_override,
     )
     session = await create_session(
         args,

--- a/local_operator/session/runtime/process.py
+++ b/local_operator/session/runtime/process.py
@@ -487,7 +487,12 @@ async def amain() -> int:
     loop = asyncio.get_running_loop()
     try:
         handle: OwnedSessionHandle = await spawn_owned_session(
-            loop, cwd=cwd, provider=provider, model_id=model_id, resume=resume
+            loop,
+            cwd=cwd,
+            provider=provider,
+            model_id=model_id,
+            resume=resume,
+            model_selection_override=os.environ.get("LOP_MODEL_SELECTION_OVERRIDE") == "1",
         )
     except SessionLeaseHeldError as exc:
         # LOSING THE LEASE IS NOT AN ERROR. Under ``engage_runtime`` every

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -146,7 +146,7 @@ from local_operator.session.naming import (
 )
 from local_operator.session.peer import PEER_MESSAGE_MESSAGE_TYPE
 from local_operator.session.protocol import CompactionOutcome
-from local_operator.session.transcript import Transcript
+from local_operator.session.transcript import ENTRY_CUSTOM, Transcript
 from local_operator.tools.builtin import (
     TODO_REMINDER_MESSAGE_TYPE,
     open_todos,
@@ -1800,9 +1800,10 @@ class Session:
         #: is never tagged; ``_load_conversation_name`` sets it from the
         #: ``_is_unnamed_fork()`` verdict it already computes at construction.
         self._wears_inherited_title = False
-        # Birth provenance is diagnostic only. Shared defaults never own a
-        # running conversation; explicit resume flags are separately identified
-        # by the factory so synthesized bootstrap pairs cannot erase history.
+        # The birth selector also governs the existing effort-journalling
+        # policy. Restore its historical value on resume: the factory now
+        # configures the saved primary before construction, not today's default.
+        # Only deliberate flags, never synthesized pairs, may override history.
         self._boot_selector = f"{model.provider}/{model.model_id}"
         self._model_source = model_source
         self._explicit_model_choice = False
@@ -10707,13 +10708,17 @@ class Session:
         """Restore conversation identity independently of today's defaults."""
         from local_operator.session.model_selection import selection_from_payloads
 
-        saved = selection_from_payloads(row.payload for row in self._transcript.entries())
+        saved = selection_from_payloads(
+            row.payload for row in self._transcript.entries() if row.type == ENTRY_CUSTOM
+        )
         if self._model_source == "flag":
             return
         if saved is None:
             self._model_migration_notice = bool(self._transcript.entries())
             return
         selector, effort = saved.selector, saved.effort
+        if saved.boot_selector is not None:
+            self._boot_selector = saved.boot_selector
         self._selection_needs_initial_write = not saved.authoritative or saved.recovered
         self._model_migration_notice = saved.recovered
         if selector == self.model_label and effort == self._model.reasoning_effort:

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -138,6 +138,7 @@ from local_operator.prompts_api import (
 )
 from local_operator.session.goal import GoalState
 from local_operator.session.mcp_status import McpStartupOutcome
+from local_operator.session.model_selection import SELECTED_MODEL_CUSTOM_TYPE
 from local_operator.session.naming import (
     CONVERSATION_NAME_CUSTOM_TYPE,
     MAX_TITLE_CHARS,
@@ -176,24 +177,6 @@ logger = logging.getLogger(__name__)
 #: An entry with ``active: None`` records the recovery, which is what lets
 #: ``latest_custom``'s backward scan land on "no fallback pinned" after one.
 ACTIVE_ROUTE_CUSTOM_TYPE = "active_model_route"
-
-#: Transcript custom-entry type recording the model the user explicitly
-#: SELECTED mid-session (``/model <provider>/<id>``), so a resumed session
-#: comes back on it instead of silently reverting to the boot default. The
-#: sibling of :data:`ACTIVE_ROUTE_CUSTOM_TYPE`, which records where a
-#: provider FALLBACK routed requests; this one records where the USER did.
-#: Without it a ``/model`` switch survived exactly as long as the process:
-#: quit and ``--resume`` replayed the whole conversation onto the config
-#: default, which contradicts what the transcript itself shows the user
-#: choosing.
-#:
-#: Each row snapshots ``boot`` — the selector the session was CONSTRUCTED
-#: with — beside the selection, so the restore can tell a journalled switch
-#: that still applies from one stranded by a changed boot selection (a
-#: ``/model default`` write, an edited agent profile, an explicit
-#: ``--hosting``/``--model`` flag on the resume itself). A changed boot
-#: selection wins: it is the newer, more deliberate choice.
-SELECTED_MODEL_CUSTOM_TYPE = "selected_model"
 
 #: Transcript custom-entry type holding a snapshot of the subagents this
 #: session launched (see ``SubagentComms.snapshot``) plus their job rows (see
@@ -1686,13 +1669,10 @@ class Session:
         conversation_name: ConversationName | None = None,
         #: Where the BOOT model came from: ``"config"`` (the ``hosting`` /
         #: ``model_name`` keys), ``"agent"`` (a profile), ``"flag"``
-        #: (``--hosting``/``--model``) or ``"child"`` (a subagent, whose spec
-        #: was picked at spawn). Decides whether a later ``config.yml`` edit
-        #: to those keys SWITCHES this session: only a config-sourced session
-        #: follows the file, because for the others the file was never what
-        #: chose the model. Defaults to ``"config"`` because that is the
-        #: composition root's common case and what every caller predating
-        #: this kwarg meant.
+        #: (deliberate ``--hosting``/``--model``), ``"resume"`` (the journal),
+        #: or ``"child"`` (selected at spawn). Only a deliberate flag may
+        #: supersede journalled identity. Shared defaults never change any
+        #: existing session, regardless of where its birth selection came from.
         model_source: str = "config",
         # Called each turn with the session's live ``model_label`` so the env
         # block names the running model; accepts it positionally (``...``) and
@@ -1820,31 +1800,14 @@ class Session:
         #: is never tagged; ``_load_conversation_name`` sets it from the
         #: ``_is_unnamed_fork()`` verdict it already computes at construction.
         self._wears_inherited_title = False
-        #: The ``provider/model_id`` this session was CONSTRUCTED with — the
-        #: boot selection resolved from agent > CLI flag > config. Captured
-        #: before any restore or switch moves ``_model``, because it is the
-        #: reference every ``selected_model`` journal row carries: a resume
-        #: whose boot selection no longer matches a row's ``boot`` must NOT
-        #: adopt that row (the changed default/flag/profile is the newer
-        #: choice). See :data:`SELECTED_MODEL_CUSTOM_TYPE`.
+        # Birth provenance is diagnostic only. Shared defaults never own a
+        # running conversation; explicit resume flags are separately identified
+        # by the factory so synthesized bootstrap pairs cannot erase history.
         self._boot_selector = f"{model.provider}/{model.model_id}"
         self._model_source = model_source
-        #: True once the user has made a deliberate model CHOICE in this
-        #: session (``/model p/id``, the phone's switch, or a restored
-        #: ``selected_model`` row). A ``hosting``/``model_name`` edit on disk
-        #: then leaves this session alone and prints a keep notice instead —
-        #: the user's explicit pick outranks the default it replaced. Cleared
-        #: only by :meth:`_adopt_configured_model` itself, so a session that
-        #: is following config keeps following it across successive edits.
         self._explicit_model_choice = False
-        #: Bumped by :meth:`_on_configured_model_changed` on every dispatch, and
-        #: captured by :meth:`_adopt_configured_model` before its thread hop.
-        #: An adopt whose generation is stale when it returns has been
-        #: superseded by a newer ``hosting``/``model_name`` edit and abandons,
-        #: so two edits arriving inside one ``build_model_spec`` resolve in
-        #: EDIT order rather than in whichever-thread-finished-first order
-        #: (review round 1, R2).
-        self._configured_model_generation = 0
+        self._selection_needs_initial_write = True
+        self._model_migration_notice = False
         #: Set by :meth:`_apply_config_change` when ``web_search.enabled`` /
         #: ``web_fetch.enabled`` moved; consumed at the next TURN boundary by
         #: :meth:`_reconcile_web_tools`. Deferred rather than applied on the
@@ -3634,12 +3597,10 @@ class Session:
           rides ``set_model`` on the same pair too, and the journal stores no
           sampling — so re-journalling on those would append identical rows for
           a change the row cannot even express.
-        - **Only a non-boot selection.** The boot model deliberately persists
-          no effort (the ``/effort`` non-goal): ``_restore_selected_model``
-          skips a row whose selector equals the boot selector, so a boot-model
-          effort change has nothing to restore onto and journalling one would
-          both be inert and break the non-goal. A selection the user switched
-          to already has a row whose effort must stay truthful.
+        - **Only a non-birth selection.** This retains the existing /effort
+          policy: effort changes alone do not create model-switch records on
+          the birth model. Initial identity is now durable at admission, but
+          that is not an expansion of this effort-change journalling policy.
         """
         if previous.reasoning_effort == model.reasoning_effort:
             return
@@ -4848,6 +4809,7 @@ class Session:
         copy boundary; active history rewrites are refused explicitly.
         """
         busy = self._is_streaming or self._turn_lock.locked()
+        await self._ensure_selected_model()
         fork_id, omitted = await self._transcript.fork_snapshot(
             message=message, is_compacting=lambda: self._compacting
         )
@@ -4960,6 +4922,7 @@ class Session:
         from local_operator.fork import ForkError, fork_session
 
         try:
+            await self._ensure_selected_model()
             # On a worker thread: the copy is small in practice (the largest
             # transcript in a real store measured 216 KB) but its size is
             # user-controlled, and a turn boundary is not a place to hold the
@@ -6338,6 +6301,7 @@ class Session:
             # the fresh signal rather than running work the user just stopped.
             signal.abort("interrupted")
         try:
+            await self._ensure_selected_model()
             for message in initial:
                 await self._transcript.append_message(
                     message,
@@ -10692,11 +10656,13 @@ class Session:
         """
         model = self._model
         payload = {
+            "version": 2,
             "selector": f"{model.provider}/{model.model_id}",
             "effort": model.reasoning_effort,
             "boot": self._boot_selector,
         }
         await self._transcript.append_custom(SELECTED_MODEL_CUSTOM_TYPE, payload)
+        self._selection_needs_initial_write = False
         current = self._model
         if (f"{current.provider}/{current.model_id}", current.reasoning_effort) == (
             payload["selector"],
@@ -10713,61 +10679,44 @@ class Session:
             # done and create exactly one successor.
             asyncio.get_running_loop().call_soon(self._spawn_selected_model_write)
 
-    def _restore_selected_model(self) -> None:
-        """Re-adopt the model a ``/model`` switch selected before the quit.
+    async def _ensure_selected_model(self) -> None:
+        """Durably select before admitting work, never for an abandoned draft.
 
-        Guarded twice, each a real situation rather than paranoia:
-
-        - persisted ``boot`` differs from THIS construction's boot selection →
-          the journal belongs to a boot default the user has since changed (a
-          ``/model default`` write, an edited agent profile, an explicit
-          ``--hosting``/``--model`` flag on the resume command itself). The
-          changed selection is the newer choice and wins; adopting the row
-          would make the flag the user just typed silently not work.
-        - the journalled selector equals the boot selection → the user
-          switched and later switched back; nothing to do, and skipping the
-          no-op keeps a fresh session's construction byte-identical to one
-          that never switched.
-
-        Tolerant of a malformed or unresolvable entry, matching
-        :meth:`_load_conversation_name`: a resume must not be refused because
-        one bookkeeping row could not be read, and a selector whose provider
-        no longer resolves (an uninstalled registry entry) logs and falls
-        back to the boot model rather than constructing a session around a
-        spec that cannot serve requests.
-
-        Restores quietly (no event, no journal write): construction runs
-        before any front end subscribes, so hosts read ``model`` when they
-        build their chrome, and re-journalling the row it just read would
-        grow the transcript on every resume.
+        Initial selections and legacy migrations use the same row as /model.
+        Awaiting here also closes immediate-switch -> fork and missed-wake
+        races: a request or snapshot cannot outrun the background writer.
         """
-        details = self._transcript.latest_custom(SELECTED_MODEL_CUSTOM_TYPE)
-        if not details:
-            return
-        selector = str(details.get("selector") or "")
-        if "/" not in selector:
-            return
-        boot = str(details.get("boot") or "")
-        if boot != self._boot_selector:
-            return
-        if selector == self._boot_selector:
-            return
-        raw_effort = details.get("effort")
-        effort = str(raw_effort) if isinstance(raw_effort, str) and raw_effort else None
-        # Validate the PROVIDER before adopting the row, exactly as the TUI's
-        # `/model` does and for the same reason: `spec_for_target` does not
-        # raise on an unknown provider, it returns a spec with `base_url=None`.
-        # A provider that has since left the registry (a renamed id, a build
-        # without it) would therefore resume the session onto a spec that
-        # cannot serve requests, and the failure would surface on the first
-        # prompt as a network error rather than as the stale journal row it is.
-        from local_operator.providers.registry import get_provider_definition
-
-        provider = selector.split("/", 1)[0]
-        if get_provider_definition(provider) is None:
-            logger.warning(
-                "dropping persisted model selection naming an unknown provider: %r", selector
+        if self._selection_needs_initial_write:
+            await self._persist_selected_model()
+        await self._flush_selected_model()
+        if self._model_migration_notice:
+            self._model_migration_notice = False
+            await self._emit(
+                NoticeEvent(
+                    text=(
+                        "Saved model information is incomplete; "
+                        f"using {self.model_label}. "
+                        "This selection is now saved for future resumes."
+                    ),
+                    kind="warning",
+                    headline="Model selected",
+                )
             )
+
+    def _restore_selected_model(self) -> None:
+        """Restore conversation identity independently of today's defaults."""
+        from local_operator.session.model_selection import selection_from_payloads
+
+        saved = selection_from_payloads(row.payload for row in self._transcript.entries())
+        if self._model_source == "flag":
+            return
+        if saved is None:
+            self._model_migration_notice = bool(self._transcript.entries())
+            return
+        selector, effort = saved.selector, saved.effort
+        self._selection_needs_initial_write = not saved.authoritative or saved.recovered
+        self._model_migration_notice = saved.recovered
+        if selector == self.model_label and effort == self._model.reasoning_effort:
             return
         # The SAME derivation `/model` itself lands on: `spec_for_target`
         # builds the target model's own spec (its base_url, window,
@@ -10778,6 +10727,8 @@ class Session:
         spec = self._spec_for_route(selector, effort)
         if spec is None:
             logger.warning("dropping unresolvable persisted model selection: %r", selector)
+            self._selection_needs_initial_write = True
+            self._model_migration_notice = True
             return
         self._model = spec
         # A restored row IS the user's earlier explicit choice, so a config
@@ -11037,17 +10988,9 @@ class Session:
           the same validation the constructor applied; an unset or invalid
           value restores the manager's built-in default rather than freezing
           the last explicit one, so "reset to default" on the page means it.
-        * ``hosting`` / ``model_name`` — the running model FOLLOWS the file
-          iff it came from the file: ``_model_source == "config"`` and no
-          explicit ``/model`` choice since boot. Otherwise a keep notice says
-          so and names ``/model saved`` as the way to adopt the default. A
-          CHILD (``_job_id`` set) never follows: its spec was chosen at spawn
-          (tier or parent) and a review child losing its cache prefix
-          mid-task is pure cost. The switch itself is :meth:`set_model` — the
-          same operation ``/model`` performs, landing at the next provider
-          call and never splitting a response. Either key alone triggers it
-          (a bare ``model_name`` edit is the common case); the pair is
-          re-read from ``values`` as a whole.
+        * ``hosting`` / ``model_name`` — announce that NEW conversations use
+          the default; never mutate this conversation's selection. Explicit
+          /model commands select on their owning session, not through a watcher.
         * ``web_search.enabled`` / ``web_fetch.enabled`` — marked dirty here
           and reconciled into the inventory at the next TURN boundary
           (:meth:`_reconcile_web_tools`), top-level sessions only. The tools
@@ -11173,168 +11116,30 @@ class Session:
         self.refresh_tools([rebuilt.get(tool.name, tool) for tool in self._tools])
 
     def _on_configured_model_changed(self, values: Mapping[str, Any]) -> None:
-        """Decide whether a ``hosting``/``model_name`` edit moves THIS session.
+        """Defaults seed NEW conversations; reloading them never selects a model.
 
-        Sync and cheap: the decision is made here, the switch (which resolves
-        model metadata, possibly over the network) runs in the background.
-        The keep notice is emitted from here too, so a session that declines
-        still tells the user why the pane did not move — the TUI prints no
-        clause of its own for the ``model`` section precisely because only
-        this process knows the answer.
+        A watcher cannot identify which pane authored an edit. Local commands
+        that promise a switch call set_model explicitly on their own session.
+        Treating a config-sourced birth as a subscription moved every sibling
+        at the next provider call, invalidating its cache and conversation.
         """
         if self._job_id is not None:
             return
-        if self._model_source != "config" or self._explicit_model_choice:
-            label = self.model_label
-            if self._explicit_model_choice:
-                reason = "chosen with /model"
-            elif self._model_source == "agent":
-                reason = "chosen by an agent profile"
-            else:
-                reason = "chosen by a flag"
-            self._spawn_background(
-                self._emit(
-                    NoticeEvent(
-                        text=(
-                            f"keeping {label} — {reason}; config.yml default changed, "
-                            "/model saved adopts it"
-                        ),
-                        kind="info",
-                        # A glance for the boot toast, so it does not fall
-                        # through to a blind cut landing mid-phrase (design
-                        # round 1, D3). See ``NoticeEvent.headline``.
-                        headline="Model unchanged",
-                    )
-                )
-            )
+        if (values.get("hosting"), values.get("model_name")) == (
+            self.model.provider,
+            self.model.model_id,
+        ):
             return
-        # Bumped BEFORE the spawn so an adopt already parked on its thread hop
-        # sees a generation newer than the one it captured and stands down.
-        self._configured_model_generation += 1
-        self._spawn_background(self._adopt_configured_model(values))
-
-    async def _adopt_configured_model(self, values: Mapping[str, Any]) -> None:
-        """Switch onto the ``hosting``/``model_name`` pair in ``values``.
-
-        Mirrors ``resolve_hosting_model``'s config arm (an empty model falls
-        back to the provider's default) and ``_restore_selected_model``'s
-        validation (an unknown provider is a warning, never a switch onto a
-        spec that cannot serve). ``build_model_spec`` may fetch a provider
-        listing over a blocking client, so it runs on a thread exactly as the
-        runtime's ``/model`` op does. The chosen effort rides along when the
-        new model's ladder has it, as the TUI's ``/model`` carries it.
-
-        Goes through :meth:`set_model` with ``explicit=True`` so a pinned
-        fallback is withdrawn (the default the fallback was rescuing is gone),
-        then RESTORES ``_explicit_model_choice`` to what it was before the
-        call rather than assigning ``False``: adopting the file is not the user
-        choosing, so a session that was following config keeps following it —
-        but a session that had already recorded a real ``/model`` choice must
-        not have that record erased by an adopt (review round 1, R2, second
-        half). The boot selector is re-based too, so a ``selected_model``
-        journal row written for this switch is skipped on resume (the new
-        default IS the boot).
-
-        **The apply is guarded against the await.** ``build_model_spec`` may
-        fetch a provider listing, so the thread hop below is a real window in
-        which the user can type ``/model`` and a second config edit can land.
-        Reproduced in review: a ``/model`` choice made during a parked adopt
-        was silently undone AND its ``_explicit_model_choice`` reset, which
-        disabled the keep rule for every later edit. Two guards close it, both
-        re-checked AFTER the await:
-
-        * ``_explicit_model_choice`` — a user choice that landed while this was
-          in flight outranks the file, the same rule
-          :meth:`_on_configured_model_changed` applies before spawning; and
-        * ``_configured_model_generation`` — bumped by every dispatch, so a
-          NEWER adopt (a second edit while the first was resolving) wins and
-          the older task abandons rather than last-writer-wins between two
-          tasks with no ordering.
-
-        Both abandon silently: the newer decision emits its own receipt, and a
-        second line about a switch that did not happen is noise.
-
-        Reads ``values`` — the watcher's validated snapshot — never a fresh
-        ``ConfigManager`` (the module docstring of ``config_watch`` explains
-        why a listener must not construct one).
-        """
-        generation = self._configured_model_generation
-        explicit_before = self._explicit_model_choice
-        hosting = str(values.get("hosting") or "").strip().lower()
-        model_name = str(values.get("model_name") or "").strip()
-        if not hosting:
-            return
-        from local_operator.providers.registry import get_provider_definition
-
-        if get_provider_definition(hosting) is None:
-            await self._emit(
+        self._spawn_background(
+            self._emit(
                 NoticeEvent(
                     text=(
-                        f"config.yml names unknown provider {hosting!r}; "
-                        f"keeping {self.model_label}"
+                        f"keeping {self.model_label}; default changed for new sessions. "
+                        "/model saved adopts it here"
                     ),
-                    kind="warning",
+                    kind="info",
+                    headline="Model unchanged",
                 )
-            )
-            return
-        if not model_name:
-            from local_operator.model.defaults import default_model_for
-
-            model_name = default_model_for(hosting) or ""
-            if not model_name:
-                await self._emit(
-                    NoticeEvent(
-                        text=(
-                            f"config.yml sets hosting {hosting} with no model_name and "
-                            f"{hosting} has no default; keeping {self.model_label}"
-                        ),
-                        kind="warning",
-                    )
-                )
-                return
-        current = self._model
-        if (current.provider, current.model_id) == (hosting, model_name):
-            # The writer's own pane: `/model default` already switched it (or
-            # it was already there). Nothing to do, and no receipt owed.
-            return
-        from local_operator.model.configure import build_model_spec
-
-        try:
-            spec = await asyncio.to_thread(build_model_spec, hosting, model_name)
-        except Exception as error:  # noqa: BLE001 — reported, never a broken session
-            await self._emit(
-                NoticeEvent(
-                    text=f"could not resolve {hosting}/{model_name} from config.yml: {error}",
-                    kind="warning",
-                )
-            )
-            return
-        if self._disposed:
-            return
-        if self._explicit_model_choice and not explicit_before:
-            # The user chose while this adopt was resolving. Their pick is
-            # newer and explicit; applying the file's spec now would undo it.
-            return
-        if self._configured_model_generation != generation:
-            # A newer config edit has already been dispatched. It resolves
-            # against the newer values and owns the receipt.
-            return
-        chosen_effort = current.reasoning_effort
-        if chosen_effort and chosen_effort in tuple(spec.reasoning_efforts or ()):
-            spec = spec.model_copy(update={"reasoning_effort": chosen_effort})
-        previous_label = self.model_label
-        self.set_model(spec, explicit=True)
-        # RESTORED, not cleared: see the docstring. ``set_model(explicit=True)``
-        # sets the flag as a side effect of withdrawing a pinned fallback, and
-        # this call is the file's decision rather than the user's — so the flag
-        # goes back to whatever the user's own history had made it.
-        self._explicit_model_choice = explicit_before
-        self._boot_selector = f"{spec.provider}/{spec.model_id}"
-        await self._emit(
-            NoticeEvent(
-                text=f"model: {previous_label} → {self.model_label} — config.yml default changed",
-                kind="info",
-                headline=f"model: {self.model_label}",
             )
         )
 

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -55,7 +55,7 @@ from local_operator.paths import config_dir as app_config_dir
 
 # Pure path policy, no engine — see local_operator/resume.py for why it is
 # its own module rather than living here.
-from local_operator.resume import resume_dir
+from local_operator.resume import ResumeNotFound, resume_dir
 
 if TYPE_CHECKING:
     # Type-only imports: this module's whole discipline is that the heavy
@@ -426,8 +426,8 @@ def resolve_hosting_model(
     Raises ``ValueError`` with the legacy message shapes when either value is
     missing, so the CLI's red-banner handler reports it exactly like before.
     The pair-only shape every existing caller expects; the composition root
-    uses :func:`resolve_hosting_model_with_source` because the SOURCE decides
-    whether the session later follows a ``hosting``/``model_name`` edit.
+    uses :func:`resolve_hosting_model_with_source` to distinguish deliberate
+    resume overrides from synthesized bootstrap arguments.
     """
     hosting, model_name, _source = resolve_hosting_model_with_source(agent, args, config_manager)
     return hosting, model_name
@@ -436,34 +436,51 @@ def resolve_hosting_model(
 def resolve_hosting_model_with_source(
     agent: AgentData | None, args: argparse.Namespace, config_manager: ConfigManager
 ) -> tuple[str, str, str]:
-    """``resolve_hosting_model`` plus WHERE the model SELECTION came from.
+    """Resolve conversation identity, retaining the provenance of real overrides.
 
-    The third element is ``"agent"``, ``"flag"`` or ``"config"``. The session
-    stores it as ``model_source``: only a ``"config"``-sourced session switches
-    when the file's default changes, because for the other two the file never
-    chose the model (see ``Session._apply_config_change``).
-
-    Keyed on EITHER field of the pair, not on the hosting alone (review round
-    1, R3). Both directions have to classify as chosen: a model name from
-    config under a flagged hosting is a flag-chosen run, and — the harmful
-    direction — ``--model X`` with no ``--hosting`` is equally chosen, because
-    ``cli.py`` registers the two flags independently and ``lop exec --model
-    <pinned>`` is the spelling a user reaches for to pin a run. Keyed on
-    hosting only, that run classified ``"config"`` and another pane's ``/model
-    default`` moved it off the model the flag named — a file default silently
-    overriding an explicit flag, which is the converse of the rule this source
-    exists to enforce.
-
-    The HOSTING's own origin stays separate and narrower, because
-    :class:`HostingUnknownError` uses it to name the place the bad value came
-    from ("passed with --hosting", "on the agent record"). Widening that one
-    would have ``--model gpt-5`` under a config hosting report the config's
-    typo as having been passed on a flag the user never typed — a repair
-    instruction pointing at the wrong file.
+    New: agent > CLI > defaults. Resume: deliberate CLI override > durable
+    selection > birth precedence for legacy histories with no usable evidence.
+    Agent/profile edits and synthesized bootstrap arguments are not overrides.
     """
-    # The SOURCE is tracked alongside the value, not just the value: the repair
-    # offered when this turns out to be unusable writes the config file, which
-    # is only the last of these three. See HostingUnknownError.source.
+    # Resolve durable identity BEFORE validating global defaults or building a
+    # provider client. A removed/invalid default cannot make a valid saved
+    # conversation impossible to resume. Bootstrap callers pass resolved pairs
+    # too, so their values are not automatically deliberate resume overrides.
+    from local_operator.providers.registry import get_provider_definition
+    from local_operator.session.model_selection import read_model_selection
+
+    directory = None
+    resume = getattr(args, "resume", None)
+    if resume:
+        try:
+            directory = resume_dir(config_manager.config_dir, str(resume))
+        except (ResumeNotFound, ValueError, FileNotFoundError):
+            # A viewer may own only a freshly minted id, with no directory yet.
+            pass
+    elif getattr(args, "train", False):
+        # The legacy unnamed --train/server persistence path uses the registry's
+        # stable autosave id, not a new conversation on each request.
+        agent_id = str(agent.id) if agent is not None else "autosave"
+        directory = Path(config_manager.config_dir) / "agents" / agent_id
+    saved = read_model_selection(directory) if directory is not None else None
+    explicit = getattr(args, "model_selection_override", True)
+    flag_hosting = getattr(args, "hosting", None) if explicit else None
+    flag_model = getattr(args, "model", None) if explicit else None
+    if saved is not None:
+        if flag_hosting or flag_model:
+            from local_operator.model.defaults import default_model_for
+
+            provider = flag_hosting or saved.provider
+            model = flag_model or default_model_for(provider)
+            if get_provider_definition(provider) is None:
+                raise HostingUnknownError(
+                    _unknown_hosting_message(provider, "flag"), provider, "flag"
+                )
+            if not model:
+                raise ModelNotConfiguredError(_no_model_message(provider), provider)
+            return provider, model, "flag"
+        return saved.provider, saved.model_id, "resume"
+
     agent_hosting: str | None = getattr(agent, "hosting", None) if agent is not None else None
     flag_hosting: str | None = getattr(args, "hosting", None)
     hosting = agent_hosting or flag_hosting or config_manager.get_config_value("hosting")
@@ -478,7 +495,7 @@ def resolve_hosting_model_with_source(
     model_source = (
         "agent"
         if (agent_hosting or agent_model)
-        else "flag" if (flag_hosting or flag_model) else "config"
+        else "flag" if explicit and (flag_hosting or flag_model) else "config"
     )
     model_name: str | None = (
         agent_model or flag_model or config_manager.get_config_value("model_name")
@@ -499,8 +516,6 @@ def resolve_hosting_model_with_source(
     # working config into a setup prompt. It is also the exact lookup
     # `configure_model` performs, so this accepts precisely what the engine
     # accepts -- a preflight stricter than the engine is its own outage.
-    from local_operator.providers.registry import get_provider_definition
-
     if get_provider_definition(hosting) is None:
         # Before the default-model lookup below: an unknown provider has no
         # default model either, so checking the model first reported the missing
@@ -1857,8 +1872,8 @@ async def _prepare(
         variables=variable_store,
         agent_registry=agent_registry,
         team_registry=team_registry,
-        # Whether a later ``hosting``/``model_name`` edit switches this session
-        # (config-sourced) or only prints a keep notice (agent/flag).
+        # Provenance distinguishes deliberate resume flags from persisted
+        # identity; no provenance subscribes a session to mutable defaults.
         model_source=model_source,
     )
     return _SessionPlan(

--- a/local_operator/session_factory.py
+++ b/local_operator/session_factory.py
@@ -1609,10 +1609,17 @@ async def _prepare(
     provider; raises ``ValueError`` when hosting/model config is missing.
     ``cwd`` (default: process cwd) is the single working-directory source for
     the tool context, the session and MCP discovery."""
-    agent = resolve_agent(args, agent_registry)
-    hosting, model_name, model_source = resolve_hosting_model_with_source(
-        agent, args, config_manager
-    )
+    # Resolving a saved model now reads its journal, which can be large. Keep
+    # agent/profile I/O and identity resolution off the loop together, before
+    # the contiguous lease/claim critical section below. Snapshot the command
+    # first so /new or /resume cannot retarget an in-flight factory at the await.
+    args = argparse.Namespace(**vars(args))
+
+    def resolve_birth():
+        agent = resolve_agent(args, agent_registry)
+        return agent, resolve_hosting_model_with_source(agent, args, config_manager)
+
+    agent, (hosting, model_name, model_source) = await asyncio.to_thread(resolve_birth)
     yolo = bool(getattr(args, "yolo", False))
 
     transcript_dir, agent_id = _transcript_dir_and_agent_id(agent, args, agent_registry)

--- a/local_operator/settings_io.py
+++ b/local_operator/settings_io.py
@@ -254,22 +254,14 @@ class Section:
 # retired keys are last.
 
 SECTIONS: tuple[Section, ...] = (
-    # LIVE with a rule, not unconditionally: ``Session._apply_config_change``
-    # switches a running session onto the new pair iff its model CAME from
-    # config (not an agent profile, not ``--hosting``/``--model``) and no
-    # explicit ``/model`` choice has been made since boot. A session the user
-    # pointed somewhere deliberately keeps its choice and prints a keep
-    # notice — ``/model saved`` re-adopts the default on demand. Children
-    # (subagents) never follow; their spec was picked at spawn. Before this
-    # the section was NEW_LAUNCH and the operator's report was exactly the
-    # painted lie: `/model default` in one pane told every other pane
-    # "model_name needs a relaunch" while "all my agents" was the intent.
+    # Defaults are sampled at conversation birth. The watcher still announces
+    # edits, but only an explicit local /model action may select for an owner.
     Section(
         "model",
         "Model",
-        Scope.LIVE,
-        "The provider and model sessions run on. Sessions that chose a model "
-        "with /model keep it (/model saved adopts the default).",
+        Scope.NEW_SESSIONS,
+        "Provider and model for new conversations. Existing sessions keep their model; "
+        "/model saved adopts the default here.",
     ),
     # Split out of ``model`` (review round 1, M3). The design left this key in
     # ``model`` and proposed documenting the discrepancy, which was defensible
@@ -279,9 +271,8 @@ SECTIONS: tuple[Section, ...] = (
     # ``configure._openai_api_mode`` reads the rebound mapping when it builds
     # the next client. Scope is uniform within a section by construction, so
     # saying something true here means a section of its own, exactly as ``fork``
-    # and ``web_tools`` are. ``model`` has since gone LIVE too, but by a
-    # DIFFERENT mechanism (a guarded model switch rather than a mapping
-    # rebind), so the two stay separate sections with separate descriptions.
+    # and ``web_tools`` are. Transport policy stays live while the model
+    # identity belongs to its conversation, so these must remain separate.
     Section(
         "providers",
         # Titled for the WIRE FORMAT, not the word "provider" (design review
@@ -511,7 +502,7 @@ SETTINGS: tuple[Setting, ...] = (
         # key path (the thing a user maps a row to the file by) and then the
         # sentence itself is clipped mid-clause with no ellipsis (design round
         # 1, D2). Measure any edit to these four before landing it.
-        help="Provider sessions run on unless chosen with /model. Also /model default.",
+        help="Provider for new conversations. /model saved adopts it here.",
         empty_unsets=True,
     ),
     Setting(
@@ -522,7 +513,7 @@ SETTINGS: tuple[Setting, ...] = (
         kind=Kind.TEXT,
         default="",
         # 72 cells — see the note on `hosting` above.
-        help="Model id sessions run on unless chosen with /model. Also /model default.",
+        help="Model for new conversations. /model saved adopts it here.",
         empty_unsets=True,
     ),
     # -- providers ----------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,7 @@ _AMBIENT_VARS = (
     "LOP_MOBILE_CHILD_RESUME",
     "LOP_MOBILE_CHILD_PROVIDER",
     "LOP_MOBILE_CHILD_MODEL",
+    "LOP_MODEL_SELECTION_OVERRIDE",
     "LOP_MOBILE_CHILD_CWD",
     "LOP_MOBILE_PASSWORD",
     # The calling cmux workspace/surface. A headless fork e2e test inherited

--- a/tests/e2e/test_model_ownership_e2e.py
+++ b/tests/e2e/test_model_ownership_e2e.py
@@ -26,6 +26,122 @@ pytestmark = pytest.mark.e2e
 
 
 @pytest.mark.asyncio
+async def test_competing_cold_resumes_acknowledge_explicit_model_on_winning_owner(headless_tui_env):
+    import asyncio
+
+    from local_operator.harness.types import ModelSpec
+    from local_operator.session.remote import RemoteSession
+    from tests.e2e.watchdog import bounded
+    from tests.unit.session.test_model_ownership import session
+
+    config = headless_tui_env
+    ConfigManager(config).update_config({"hosting": "test", "model_name": "default-c"})
+    sid = "competingmodel01"
+    saved, _ = session(
+        config / "sessions" / sid, model=ModelSpec(provider="test", model_id="original-a")
+    )
+    await saved.prompt("seed saved conversation")
+    await saved.dispose()
+
+    async def no_takeover():
+        raise AssertionError("viewer must not become the owner")
+
+    first = await RemoteSession.cold(
+        sid, config_dir=config, cwd=str(config), takeover_factory=no_takeover
+    )
+    second = await RemoteSession.cold(
+        sid,
+        config_dir=config,
+        cwd=str(config),
+        takeover_factory=no_takeover,
+        initial_model=ModelSpec(provider="test", model_id="explicit-b"),
+        model_selection_override=True,
+    )
+    calls, ended = [], asyncio.Event()
+
+    def observe(event):
+        if event.type == "provider_turn_start":
+            calls.append((event.provider, event.model_id))
+        if event.type == "agent_end":
+            ended.set()
+
+    second.subscribe(observe)
+    try:
+        with bounded(60, "competing cold model override"):
+            await first._ensure_bound(foreground=True)
+            await second._ensure_bound(foreground=True)
+            await second.prompt("use the deliberately selected model")
+            await ended.wait()
+        assert calls == [("test", "explicit-b")]
+        assert first.model.model_id == second.model.model_id == "explicit-b"
+        assert second._model_selection_override is False
+    finally:
+        if second._client is not None:
+            await second._client.request_stop()
+        await second.dispose()
+        await first.dispose()
+
+
+@pytest.mark.asyncio
+async def test_factory_resume_preserves_effort_journalling_for_explicit_selection(
+    headless_tui_env,
+    monkeypatch,
+):
+    from local_operator.model.configure import build_model_spec
+
+    config = headless_tui_env
+    ConfigManager(config).update_config({"hosting": "test", "model_name": "initial-a"})
+    calls = []
+    original_stream = MockClient.stream
+
+    async def recording(self, request, api_key, oauth_access=None):
+        calls.append(request.model.reasoning_effort)
+        async for event in original_stream(self, request, api_key, oauth_access):
+            yield event
+
+    monkeypatch.setattr(MockClient, "stream", recording)
+
+    async def build(resume=None):
+        return await create_session(
+            argparse.Namespace(
+                hosting=None,
+                model=None,
+                agent_name=None,
+                agent_id=None,
+                yolo=True,
+                train=False,
+                resume=resume,
+            ),
+            ConfigManager(config),
+            CredentialManager(config),
+            AgentRegistry(config),
+            has_ui=False,
+            cwd=str(config),
+        )
+
+    first = await build()
+    sid = first.session_id
+    try:
+        await first.prompt("birth")
+        first.set_model(build_model_spec("test", "claude-opus-5"), explicit=True)
+        await first.prompt("explicit selection")
+    finally:
+        await first.dispose()
+    resumed = await build(sid)
+    try:
+        resumed.set_model(resumed.model.model_copy(update={"reasoning_effort": "low"}))
+        await resumed.prompt("use low effort")
+    finally:
+        await resumed.dispose()
+    again = await build(sid)
+    try:
+        await again.prompt("resume low effort")
+        assert calls == [None, "high", "low", "low"]
+    finally:
+        await again.dispose()
+
+
+@pytest.mark.asyncio
 async def test_persisted_server_adapters_do_not_treat_defaults_as_explicit_flags(
     headless_tui_env: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/e2e/test_model_ownership_e2e.py
+++ b/tests/e2e/test_model_ownership_e2e.py
@@ -26,6 +26,56 @@ pytestmark = pytest.mark.e2e
 
 
 @pytest.mark.asyncio
+async def test_an_unresolved_model_flag_does_not_wedge_the_conversation(headless_tui_env):
+    """Review round 2, F3: the pairing setup mode builds must still run.
+
+    A raw ``--model`` flag with no resolvable configuration reached the viewer
+    as ``initial_model=None`` plus ``model_selection_override=True``, and the
+    pending intent then refused every later call permanently. Driven through
+    the real prompt path on a working machine, so a refusal here can only be
+    that guard rather than a genuine configuration failure.
+    """
+    import asyncio
+
+    from local_operator.session.remote import RemoteSession
+    from tests.e2e.watchdog import bounded
+
+    config = headless_tui_env
+    ConfigManager(config).update_config({"hosting": "test", "model_name": "working-a"})
+
+    async def no_takeover():
+        raise AssertionError("viewer must not become the owner")
+
+    viewer = await RemoteSession.cold(
+        "firstrunflag001",
+        config_dir=config,
+        cwd=str(config),
+        takeover_factory=no_takeover,
+        initial_model=None,
+        model_selection_override=True,
+    )
+    calls, ended = [], asyncio.Event()
+
+    def observe(event):
+        if event.type == "provider_turn_start":
+            calls.append((event.provider, event.model_id))
+        if event.type == "agent_end":
+            ended.set()
+
+    viewer.subscribe(observe)
+    try:
+        with bounded(60, "first run with an unresolved model flag"):
+            await viewer.prompt("the first message on a fresh machine")
+            await ended.wait()
+        assert calls == [("test", "working-a")]
+        assert viewer._model_selection_override is False
+    finally:
+        if viewer._client is not None:
+            await viewer._client.request_stop()
+        await viewer.dispose()
+
+
+@pytest.mark.asyncio
 async def test_competing_cold_resumes_acknowledge_explicit_model_on_winning_owner(headless_tui_env):
     import asyncio
 

--- a/tests/e2e/test_model_ownership_e2e.py
+++ b/tests/e2e/test_model_ownership_e2e.py
@@ -1,0 +1,212 @@
+"""Assembled factory/owner/provider routing with no paid or external calls.
+
+Only the network transport is a local recorder: the real composition root,
+config watcher, SessionStreamFn, agent loop and journal stay in the path.
+This catches label-only fixes and clients configured before saved identity was
+resolved, neither of which a Session facade assertion can observe.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from local_operator.agents import AgentRegistry
+from local_operator.config import ConfigManager
+from local_operator.config_watch import process_watcher
+from local_operator.credentials import CredentialManager
+from local_operator.providers.clients import MockClient
+from local_operator.session_factory import create_session
+
+pytestmark = pytest.mark.e2e
+
+
+@pytest.mark.asyncio
+async def test_persisted_server_adapters_do_not_treat_defaults_as_explicit_flags(
+    headless_tui_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from local_operator.env import get_env_config
+    from local_operator.server.utils.operator import create_operator
+    from tests.unit.test_session_factory import _agent_fields
+
+    config = ConfigManager(headless_tui_env)
+    config.update_config({"hosting": "test", "model_name": "server-a"})
+    registry = AgentRegistry(headless_tui_env)
+    agent = registry.create_agent(
+        _agent_fields("stable-server").model_copy(update={"hosting": None, "model": None})
+    )
+    credentials = CredentialManager(headless_tui_env)
+    calls = []
+    original_stream = MockClient.stream
+
+    async def recording_stream(self, request, api_key, oauth_access=None):
+        calls.append((request.model.provider, request.model.model_id))
+        async for event in original_stream(self, request, api_key, oauth_access):
+            yield event
+
+    monkeypatch.setattr(MockClient, "stream", recording_stream)
+    for text in ("first persisted request", "second persisted request"):
+        operator = create_operator(
+            "",
+            "",
+            credentials,
+            config,
+            registry,
+            get_env_config(),
+            current_agent=agent,
+            persist_conversation=True,
+        )
+        await operator.handle_user_input(text)
+        config.update_config({"hosting": "invalid-default", "model_name": "server-b"})
+    assert calls == [("test", "server-a"), ("test", "server-a")]
+    print("persisted server provider requests:", calls)
+
+
+@pytest.mark.asyncio
+async def test_factory_routes_existing_and_resumed_conversations_to_saved_model(
+    headless_tui_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    config_dir = headless_tui_env
+    config = ConfigManager(config_dir)
+    config.set_config_value("hosting", "test")
+    config.set_config_value("model_name", "birth-a")
+    calls = []
+    original_stream = MockClient.stream
+
+    async def recording_stream(self, request, api_key, oauth_access=None):
+        calls.append((request.model.provider, request.model.model_id))
+        async for event in original_stream(self, request, api_key, oauth_access):
+            yield event
+
+    monkeypatch.setattr(MockClient, "stream", recording_stream)
+
+    async def build(resume=None, **extra):
+        return await create_session(
+            argparse.Namespace(
+                hosting=extra.get("hosting"),
+                model=extra.get("model"),
+                model_selection_override=extra.get("override", True),
+                agent_name=None,
+                agent_id=None,
+                yolo=True,
+                train=False,
+                resume=resume,
+            ),
+            ConfigManager(config_dir),
+            CredentialManager(config_dir),
+            AgentRegistry(config_dir),
+            has_ui=False,
+            cwd=str(config_dir),
+        )
+
+    first = await build()
+    sibling = await build()
+    session_id = first.session_id
+    try:
+        await first.prompt("before edit")
+        edited = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "local_operator.cli",
+                "config",
+                "edit",
+                "model_name",
+                "default-b",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert "Successfully updated model_name" in edited.stdout
+        process_watcher(config_dir).poll_now()
+        await first.prompt("after edit")
+        await sibling.prompt("sibling after edit")
+        assert calls == [("test", "birth-a")] * 3
+        newer = await build()
+        try:
+            await newer.prompt("new conversation")
+            assert calls[-1] == ("test", "default-b")
+        finally:
+            await newer.dispose()
+    finally:
+        await first.dispose()
+        await sibling.dispose()
+
+    config = ConfigManager(config_dir)
+    config.set_config_value("hosting", "invalid-default-provider")
+    resumed = await build(session_id)
+    try:
+        await resumed.prompt("resume with invalid global default")
+        assert calls[-1] == ("test", "birth-a")
+    finally:
+        await resumed.dispose()
+    overridden = await build(session_id, model="explicit-c")
+    try:
+        await overridden.prompt("deliberate resume override")
+        assert calls[-1] == ("test", "explicit-c")
+    finally:
+        await overridden.dispose()
+    # Detached owners and server adapters carry already-resolved argument
+    # pairs, not new user intent. The journal must win over those stale seeds.
+    synthetic = await build(session_id, hosting="test", model="stale-seed", override=False)
+    try:
+        await synthetic.prompt("resume from synthesized bootstrap")
+        assert calls[-1] == ("test", "explicit-c")
+    finally:
+        await synthetic.dispose()
+    print("provider-boundary requests:", calls)
+
+
+@pytest.mark.asyncio
+async def test_cold_viewer_carries_birth_model_into_real_detached_owner(
+    headless_tui_env: Path,
+):
+    import asyncio
+
+    from local_operator.session.remote import RemoteSession
+    from tests.e2e.watchdog import bounded
+
+    config = ConfigManager(headless_tui_env)
+    config.set_config_value("hosting", "test")
+    config.set_config_value("model_name", "cold-birth-a")
+
+    async def never_take_over():
+        raise AssertionError("viewer must remain a viewer")
+
+    viewer = await RemoteSession.cold(
+        "modelbirth0001",
+        config_dir=headless_tui_env,
+        cwd=str(headless_tui_env),
+        takeover_factory=never_take_over,
+    )
+    seen = []
+    ended = asyncio.Event()
+
+    def observe(event):
+        if event.type == "provider_turn_start":
+            seen.append((event.provider, event.model_id))
+        if event.type == "agent_end":
+            ended.set()
+
+    unsubscribe = viewer.subscribe(observe)
+    try:
+        # No owner exists yet. A sibling changes defaults between painting the
+        # initial band and engaging the detached runtime on the first request.
+        config.set_config_value("model_name", "cold-default-b")
+        with bounded(60, "cold model admission and provider request"):
+            await viewer.prompt("first detached request")
+            await ended.wait()
+        assert seen == [("test", "cold-birth-a")]
+        print("detached provider-turn-start:", seen)
+    finally:
+        unsubscribe()
+        if viewer._client is not None:
+            await viewer._client.request_stop()
+        await viewer.dispose()

--- a/tests/unit/session/runtime/test_eager_runtime.py
+++ b/tests/unit/session/runtime/test_eager_runtime.py
@@ -634,7 +634,11 @@ async def test_a_provider_without_a_model_name_still_engages(tmp_path: Path, mon
         "s1", config_dir=tmp_path, cwd=str(tmp_path), takeover_factory=_never
     )
     assert viewer.frontend_state.effective_model is not None
-    assert viewer.frontend_state.effective_model.model_id == ""
+    from local_operator.model.defaults import default_model_for
+
+    # The cold viewer now samples the same concrete default as its owner;
+    # first engagement must not defer this choice to a later config snapshot.
+    assert viewer.frontend_state.effective_model.model_id == default_model_for("anthropic")
 
     async def factory():
         return viewer

--- a/tests/unit/session/runtime/test_launch_arbitration.py
+++ b/tests/unit/session/runtime/test_launch_arbitration.py
@@ -81,7 +81,15 @@ class FakeRuntimeFleet:
 
     # -- the spawn contract -------------------------------------------------
 
-    def spawn(self, session_id: str, cwd: str, *, defer_materialise: bool) -> None:
+    def spawn(
+        self,
+        session_id: str,
+        cwd: str,
+        *,
+        defer_materialise: bool,
+        initial_model=None,
+        model_selection_override=False,
+    ) -> None:
         self.spawns += 1
         self.deferred.append(defer_materialise)
         directory = self.config_dir / "sessions" / session_id
@@ -183,7 +191,14 @@ def fleet(tmp_path: Path, monkeypatch):  # noqa: ANN201
     (tmp_path / "sessions").mkdir(parents=True, exist_ok=True)
     instance = FakeRuntimeFleet(tmp_path)
 
-    def _spawn(session_id: str, cwd: str, *, defer_materialise: bool) -> None:
+    def _spawn(
+        session_id: str,
+        cwd: str,
+        *,
+        defer_materialise: bool,
+        initial_model=None,
+        model_selection_override=False,
+    ) -> None:
         instance.spawn(session_id, cwd, defer_materialise=defer_materialise)
 
     monkeypatch.setattr("local_operator.session.runtime.launch._spawn_runtime", _spawn)
@@ -263,7 +278,7 @@ async def test_engaging_during_construction_waits_instead_of_spawning(
     instance.loop = asyncio.get_running_loop()
     monkeypatch.setattr(
         "local_operator.session.runtime.launch._spawn_runtime",
-        lambda session_id, cwd, *, defer_materialise: instance.spawn(
+        lambda session_id, cwd, *, defer_materialise, **seed: instance.spawn(
             session_id, cwd, defer_materialise=defer_materialise
         ),
     )
@@ -312,8 +327,10 @@ async def test_warm_errand_defers_materialisation_and_others_do_not(
     import local_operator.session.runtime.launch as launch_module
 
     original = launch_module._spawn_runtime
-    launch_module._spawn_runtime = lambda session_id, cwd, *, defer_materialise: other.spawn(
-        session_id, cwd, defer_materialise=defer_materialise
+    launch_module._spawn_runtime = (
+        lambda session_id, cwd, *, defer_materialise, **seed: other.spawn(
+            session_id, cwd, defer_materialise=defer_materialise
+        )
     )
     try:
         await engage_runtime(
@@ -366,7 +383,7 @@ async def test_engage_times_out_rather_than_spinning_forever(tmp_path: Path, mon
     (tmp_path / "sessions").mkdir(parents=True, exist_ok=True)
     monkeypatch.setattr(
         "local_operator.session.runtime.launch._spawn_runtime",
-        lambda session_id, cwd, *, defer_materialise: None,  # a spawn that never starts
+        lambda session_id, cwd, *, defer_materialise, **seed: None,  # a spawn that never starts
     )
     with pytest.raises(TimeoutError):
         await engage_runtime(
@@ -410,7 +427,12 @@ async def test_a_candidate_that_dies_during_construction_is_respawned(
             return self.returncode
 
     def dies_during_construction(
-        session_id: str, cwd: str, *, defer_materialise: bool
+        session_id: str,
+        cwd: str,
+        *,
+        defer_materialise: bool,
+        initial_model=None,
+        model_selection_override=False,
     ) -> _DeadPopen:
         """Take the lease, then vanish — publishing no record."""
         from local_operator.session_lease import acquire_session_lease
@@ -461,7 +483,14 @@ async def test_a_child_that_dies_reports_its_own_reason_not_a_generic_failure(
         def poll(self) -> int:
             return self.returncode
 
-    def dies_with_a_reason(session_id: str, cwd: str, *, defer_materialise: bool) -> _DeadPopen:
+    def dies_with_a_reason(
+        session_id: str,
+        cwd: str,
+        *,
+        defer_materialise: bool,
+        initial_model=None,
+        model_selection_override=False,
+    ) -> _DeadPopen:
         from local_operator.session_lease import acquire_session_lease
 
         acquire_session_lease(tmp_path / "sessions" / session_id).release()
@@ -754,7 +783,7 @@ async def test_engage_polls_densely_while_its_own_candidate_constructs(
 
     monkeypatch.setattr(
         "local_operator.session.runtime.launch._spawn_runtime",
-        lambda session_id, cwd, *, defer_materialise: _LiveCandidate(),
+        lambda session_id, cwd, *, defer_materialise, **seed: _LiveCandidate(),
     )
 
     slept: list[float] = []
@@ -802,7 +831,7 @@ async def test_engage_uses_the_coarse_grid_when_nothing_is_constructing(
     # so the loop can observe no construction in flight.
     monkeypatch.setattr(
         "local_operator.session.runtime.launch._spawn_runtime",
-        lambda session_id, cwd, *, defer_materialise: None,
+        lambda session_id, cwd, *, defer_materialise, **seed: None,
     )
 
     slept: list[float] = []
@@ -848,7 +877,7 @@ async def test_a_dense_window_does_not_outlive_its_welcome(tmp_path: Path, monke
 
     monkeypatch.setattr(
         "local_operator.session.runtime.launch._spawn_runtime",
-        lambda session_id, cwd, *, defer_materialise: _WedgedCandidate(),
+        lambda session_id, cwd, *, defer_materialise, **seed: _WedgedCandidate(),
     )
 
     slept: list[float] = []
@@ -932,7 +961,9 @@ async def test_a_published_record_that_refuses_the_dial_is_not_polled_densely(
     # retrying the dial. A spawn here would be a separate (arbitration) bug.
     monkeypatch.setattr(
         "local_operator.session.runtime.launch._spawn_runtime",
-        lambda session_id, cwd, *, defer_materialise: pytest.fail("spawned despite a live record"),
+        lambda session_id, cwd, *, defer_materialise, **seed: pytest.fail(
+            "spawned despite a live record"
+        ),
     )
 
     slept: list[float] = []

--- a/tests/unit/session/test_config_live.py
+++ b/tests/unit/session/test_config_live.py
@@ -191,26 +191,6 @@ def compaction_of(session: Session) -> CompactionSettings:
     return settings
 
 
-async def _settled_model(session: Session) -> ModelSpec:
-    """``session.model`` after the background model adopt has landed.
-
-    ``_apply_config_change`` spawns the switch (``build_model_spec`` may hit
-    the network for a real provider), so the observer AWAITS the session's
-    background tasks rather than the clock. The probe table's other observers
-    are sync; the live-apply test awaits whatever an observer returns.
-    """
-    import asyncio
-
-    pending = [task for task in session._background_tasks if not task.done()]
-    if pending:
-        await asyncio.gather(*pending, return_exceptions=True)
-    return session.model
-
-
-async def _settled_model_attr(session: Session, attr: str) -> Any:
-    return getattr(await _settled_model(session), attr)
-
-
 def _web_tool_offered(session: Session, name: str) -> bool:
     """Whether ``name`` is in the inventory after the next turn-boundary reconcile.
 
@@ -348,16 +328,6 @@ LIVE_KEY_PROBES: dict[str, tuple[Any, Any]] = {
     "web_fetch.render_backend": ("stdlib", lambda s, w: _fetch_settings(w).render_backend),
     "web_fetch.enrich": (False, lambda s, w: _fetch_settings(w).enrich),
     "bash.shell": ("/opt/probe/bash", lambda s, w: _bash_shell(w)),
-    # -- model: the session's OWN spec, after the background adopt settles -----
-    # Observed on ``session.model``, not the snapshot: what makes these keys
-    # live is that a config-sourced session SWITCHES. ``model_name`` probes
-    # against the ``test`` provider the session boots on; ``hosting`` moves to
-    # ``openai`` with no ``model_name`` set, which exercises the
-    # default-model fallback and resolves from the static registry (verified
-    # with sockets blocked: ~4 ms, no network). The observer awaits the
-    # background adopt so the switch has landed before it reads.
-    "hosting": ("openai", lambda s, w: _settled_model_attr(s, "provider")),
-    "model_name": ("probe-model", lambda s, w: _settled_model_attr(s, "model_id")),
     # -- web_tools: the inventory after the next turn boundary -----------------
     # Observed through the SAME reconcile the turn start runs, on a session
     # whose inventory starts with both tools, so a disable is seen as the tool
@@ -592,21 +562,15 @@ async def test_a_non_live_key_does_not_quietly_apply_to_a_running_session(tmp_pa
 
 
 def test_the_scope_of_every_reclassified_key_is_the_one_its_consumer_earns() -> None:
-    """The reversal of the original build-time design, pinned as a DECISION.
+    """Scope is a behavioral contract, not a side effect of section grouping.
 
-    ``tool_approval_mode``, ``hosting``/``model_name`` and ``web_*.enabled``
-    were kept out of LIVE on purpose and are now IN it on purpose: the gate,
-    the model and the web tools all follow the file in a running session. A
-    future relabel in either direction must be a decision, not a side effect
-    of a section split. ``auto_save_conversation`` and ``session.cleanup.*``
-    go the other way — nothing reads them after process start, so the honest
-    label is NEW_LAUNCH, not the "new sessions" the old section claimed.
+    Approvals and web inventory remain live. Provider/model defaults seed new
+    conversations only; store cleanup is applied at process startup.
     """
     scope_of = {s.name: s.scope for s in settings_io.SECTIONS}
+    assert scope_of["model"] is settings_io.Scope.NEW_SESSIONS
     for key, section in (
         ("tool_approval_mode", "approvals"),
-        ("hosting", "model"),
-        ("model_name", "model"),
         ("web_search.enabled", "web_tools"),
         ("web_fetch.enabled", "web_tools"),
     ):
@@ -842,37 +806,27 @@ async def _settle(session: Session) -> None:
 
 
 @pytest.mark.asyncio
-async def test_a_model_name_edit_alone_switches_a_config_sourced_session(
-    tmp_path, monkeypatch
-) -> None:
-    """The operator's exact report: ``/model default`` (or ``lop config edit
-    model_name``) in one pane printed "model_name needs a relaunch" in every
-    other. A bare ``model_name`` diff, ``hosting`` untouched, is the common
-    shape and must switch on its own — the pair is re-read as a whole."""
+async def test_a_model_name_edit_never_rebuilds_an_existing_selection(tmp_path, monkeypatch):
+    """Shared reloads cannot open an asynchronous model-adoption race at all."""
+    from local_operator.model import configure as configure_mod
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("a default reload must not configure a conversation model")
+
+    monkeypatch.setattr(configure_mod, "build_model_spec", forbidden)
     config_dir = tmp_path / "config"
-    config_dir.mkdir()
-    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
     ConfigManager(config_dir).set_config_value("hosting", MODEL.provider)
-    session = make_session(tmp_path, RebindableStream({}), compaction_settings=CompactionSettings())
+    session = make_session(tmp_path, RebindableStream({}))
     _capture_events(session)
     watcher = process_watcher(config_dir)
     subscribe(session, watcher)
     try:
-        write_from_another_process(config_dir, "model_name", "m-next")
-        change = watcher.poll_now()
-        assert change is not None and change.changed_keys == {"model_name"}
-        await _settle(session)
-        assert (session.model.provider, session.model.model_id) == ("test", "m-next")
-        # The receipt names both ends and the cause, and comes from the session.
-        assert any("test/m → test/m-next" in n and "config.yml" in n for n in _notices(session))
-        # Adopting the file is not the user choosing: a SECOND edit applies too.
-        write_from_another_process(config_dir, "model_name", "m-after")
-        watcher.poll_now()
-        await _settle(session)
-        assert session.model.model_id == "m-after"
-        # And the boot selector re-based, so the journal row for this switch is
-        # skipped on resume (the new default IS the boot).
-        assert session._boot_selector == "test/m-after"
+        for target in ("m-next", "m-after"):
+            write_from_another_process(config_dir, "model_name", target)
+            watcher.poll_now()
+            await _settle(session)
+            assert session.model.model_id == "m"
+        assert any("new sessions" in n for n in _notices(session))
     finally:
         await session.dispose()
 
@@ -898,9 +852,7 @@ async def test_an_explicit_model_choice_keeps_its_model_and_says_so(tmp_path, mo
         await _settle(session)
         assert session.model.model_id == "chosen"
         keep = [n for n in _notices(session) if "keeping test/chosen" in n]
-        assert keep and "chosen with /model" in keep[0] and "/model saved" in keep[0], _notices(
-            session
-        )
+        assert keep and "new sessions" in keep[0] and "/model saved" in keep[0], _notices(session)
     finally:
         await session.dispose()
 
@@ -928,9 +880,9 @@ async def test_an_agent_or_flag_sourced_session_gets_a_notice_only(
         watcher.poll_now()
         await _settle(session)
         assert session.model.model_id == "m"
-        assert any(phrase in n and "keeping test/m" in n for n in _notices(session)), _notices(
-            session
-        )
+        assert any(
+            "new sessions" in n and "keeping test/m" in n for n in _notices(session)
+        ), _notices(session)
     finally:
         await session.dispose()
 
@@ -983,9 +935,9 @@ async def test_an_unknown_provider_in_config_warns_and_does_not_switch(
         warnings = [
             e
             for e in _EVENTS[id(session)]
-            if e.type == "notice" and getattr(e, "kind", "") == "warning"
+            if e.type == "notice" and getattr(e, "kind", "") == "info"
         ]
-        assert warnings and "unknown provider 'no-such-provider'" in warnings[0].text
+        assert warnings and "keeping test/m" in warnings[0].text
     finally:
         await session.dispose()
 
@@ -1083,134 +1035,6 @@ async def test_a_child_keeps_its_spawn_inventory(tmp_path, monkeypatch) -> None:
         session._reconcile_web_tools()
         assert "web_search" in _offered(session)
     finally:
-        await session.dispose()
-
-
-@pytest.mark.asyncio
-async def test_a_model_choice_during_a_parked_adopt_is_not_undone(tmp_path, monkeypatch) -> None:
-    """Review round 1, R2 — the race, reproduced and closed.
-
-    ``_adopt_configured_model`` awaits ``build_model_spec`` on a thread (it may
-    fetch a provider listing), and on return re-checked only ``_disposed``. A
-    ``/model`` choice made inside that window was silently undone AND
-    ``_explicit_model_choice`` was reset to ``False``, which disabled the keep
-    rule for every LATER edit — so one race cost the user their pick and their
-    protection from the next edit too.
-
-    The spec build is held open here so the window is deterministic rather than
-    timing-dependent.
-    """
-    import asyncio
-
-    from local_operator.model import configure as configure_mod
-
-    config_dir = tmp_path / "config"
-    config_dir.mkdir()
-    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
-    ConfigManager(config_dir).set_config_value("hosting", MODEL.provider)
-    session = make_session(tmp_path, RebindableStream({}), compaction_settings=CompactionSettings())
-    _capture_events(session)
-    watcher = process_watcher(config_dir)
-    subscribe(session, watcher)
-
-    entered = asyncio.Event()
-    release = asyncio.Event()
-    loop = asyncio.get_running_loop()
-
-    def _slow_build(hosting: str, model_id: str, *a, **k):
-        # Runs on the thread `to_thread` put it on; hop back to signal.
-        loop.call_soon_threadsafe(entered.set)
-        asyncio.run_coroutine_threadsafe(_wait_release(), loop).result(timeout=5)
-        return MODEL.model_copy(update={"provider": hosting, "model_id": model_id})
-
-    async def _wait_release() -> None:
-        await release.wait()
-
-    monkeypatch.setattr(configure_mod, "build_model_spec", _slow_build)
-    try:
-        write_from_another_process(config_dir, "model_name", "m-from-config")
-        watcher.poll_now()
-        await asyncio.wait_for(entered.wait(), timeout=5)
-
-        # The user chooses WHILE the adopt is parked on its thread hop.
-        session.set_model(MODEL.model_copy(update={"model_id": "m-user-chose"}), explicit=True)
-        assert session._explicit_model_choice is True
-
-        release.set()
-        await _settle(session)
-
-        assert (
-            session.model.model_id == "m-user-chose"
-        ), "a parked adopt landed a stale spec over a newer explicit /model choice"
-        assert session._explicit_model_choice is True, (
-            "the adopt cleared _explicit_model_choice, disabling the keep rule "
-            "for every later config edit"
-        )
-        # The abandon is silent: no receipt for a switch that did not happen.
-        assert not [n for n in _notices(session) if "m-from-config" in n], _notices(session)
-
-        # And the keep rule really is still in force for the NEXT edit.
-        write_from_another_process(config_dir, "model_name", "m-later")
-        watcher.poll_now()
-        await _settle(session)
-        assert session.model.model_id == "m-user-chose"
-    finally:
-        release.set()
-        await session.dispose()
-
-
-@pytest.mark.asyncio
-async def test_a_newer_config_edit_wins_over_an_in_flight_adopt(tmp_path, monkeypatch) -> None:
-    """R2, second half. Two edits arriving inside one ``build_model_spec``
-    used to be two tasks with no ordering — last writer wins, which is
-    whichever thread happened to finish, not whichever edit the operator made
-    last. The generation guard makes the NEWER edit the one that lands."""
-    import asyncio
-
-    from local_operator.model import configure as configure_mod
-
-    config_dir = tmp_path / "config"
-    config_dir.mkdir()
-    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(config_dir))
-    ConfigManager(config_dir).set_config_value("hosting", MODEL.provider)
-    session = make_session(tmp_path, RebindableStream({}), compaction_settings=CompactionSettings())
-    _capture_events(session)
-    watcher = process_watcher(config_dir)
-    subscribe(session, watcher)
-
-    entered_first = asyncio.Event()
-    release = asyncio.Event()
-    loop = asyncio.get_running_loop()
-    seen: list[str] = []
-
-    def _build(hosting: str, model_id: str, *a, **k):
-        seen.append(model_id)
-        if model_id == "m-first":
-            loop.call_soon_threadsafe(entered_first.set)
-            asyncio.run_coroutine_threadsafe(_wait_release(), loop).result(timeout=5)
-        return MODEL.model_copy(update={"provider": hosting, "model_id": model_id})
-
-    async def _wait_release() -> None:
-        await release.wait()
-
-    monkeypatch.setattr(configure_mod, "build_model_spec", _build)
-    try:
-        write_from_another_process(config_dir, "model_name", "m-first")
-        watcher.poll_now()
-        await asyncio.wait_for(entered_first.wait(), timeout=5)
-
-        # A SECOND edit lands while the first is still resolving.
-        write_from_another_process(config_dir, "model_name", "m-second")
-        watcher.poll_now()
-        release.set()
-        await _settle(session)
-
-        assert "m-second" in seen, seen
-        assert (
-            session.model.model_id == "m-second"
-        ), "the older in-flight adopt overwrote the newer edit"
-    finally:
-        release.set()
         await session.dispose()
 
 

--- a/tests/unit/session/test_model_ownership.py
+++ b/tests/unit/session/test_model_ownership.py
@@ -1,0 +1,279 @@
+"""Model ownership is proved at the request boundary, not just in the band.
+
+All providers are local recording streams. Shared config is still live for
+other settings, but its provider/model pair is a birth default, not a lease on
+conversations that happened to start from it.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from local_operator.config import ConfigManager
+from local_operator.config_watch import ConfigWatcher
+from local_operator.harness.types import ModelSpec
+from local_operator.session.model_selection import read_model_selection
+from local_operator.session.remote import RemoteSession
+from local_operator.session.session import Session
+from local_operator.session.transcript import Transcript
+from local_operator.session_factory import resolve_hosting_model_with_source
+from tests.e2e.harness import ScriptedStream, text_turn
+
+
+@pytest.mark.asyncio
+async def test_child_inherits_launching_conversation_not_new_global_default(tmp_path, monkeypatch):
+    from local_operator.harness.subagent import _build_child_session, _dispose_child
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    config = ConfigManager(tmp_path)
+    config.update_config({"hosting": "test", "model_name": "global-b"})
+    parent, stream = session(tmp_path / "sessions" / "parent")
+    child = await _build_child_session(
+        label="child", prompt="inherit", parent_session=parent, model_spec=None, job_id="child-1"
+    )
+    try:
+        await child.prompt("which model")
+        assert stream.requests[-1].model.model_id == A.model_id
+    finally:
+        await _dispose_child(child)
+        await parent.dispose()
+
+
+@pytest.mark.asyncio
+async def test_unusable_legacy_selection_recovers_visibly_once(tmp_path):
+    directory = tmp_path / "sessions" / "legacy-invalid"
+    transcript = Transcript(directory)
+    await transcript.append_custom("selected_model", {"selector": "missing-provider/model"})
+    owner, stream = session(directory)
+    notices = []
+    owner.subscribe(lambda event: notices.append(event) if event.type == "notice" else None)
+    await owner.prompt("recover")
+    assert stream.requests[-1].model.model_id == A.model_id
+    assert any("Saved model information is incomplete" in event.text for event in notices)
+    await owner.dispose()
+    resumed, _ = session(directory, model=B)
+    try:
+        assert not resumed._model_migration_notice
+        assert resumed.model.model_id == A.model_id
+    finally:
+        await resumed.dispose()
+
+
+A = ModelSpec(provider="test", model_id="conversation-a", context_window=100_000)
+B = A.model_copy(update={"model_id": "default-b"})
+
+
+def session(directory: Path, *, model=A, source="config", defer=False):
+    stream = ScriptedStream([text_turn("ok") for _ in range(8)])
+    owner = Session(
+        model=model,
+        model_source=source,
+        stream_fn=stream,
+        tools=[],
+        transcript=Transcript(directory, defer_materialise=defer),
+        system_blocks_provider=lambda: [],
+        cwd=str(directory.parent),
+    )
+    return owner, stream
+
+
+@pytest.mark.asyncio
+async def test_sibling_default_changes_never_change_subsequent_requests(tmp_path):
+    config_dir = tmp_path / "config"
+    config = ConfigManager(config_dir)
+    config.set_config_value("hosting", "test")
+    config.set_config_value("model_name", A.model_id)
+    watcher = ConfigWatcher(config_dir)
+    owners = [session(config_dir / "sessions" / name) for name in ("a", "b")]
+    for owner, _ in owners:
+        owner.add_dispose_hook(watcher.subscribe(owner._apply_config_change))
+    try:
+        for owner, _ in owners:
+            await owner.prompt("before")
+        writer = ConfigManager(config_dir)
+        writer.set_config_value("model_name", B.model_id)
+        watcher.poll_now()
+        for owner, stream in owners:
+            await owner.prompt("after")
+            assert [r.model.model_id for r in stream.requests] == [A.model_id, A.model_id]
+        # A deliberate selection belongs to exactly its owner.
+        owners[0][0].set_model(B, explicit=True)
+        for owner, _ in owners:
+            await owner.prompt("explicit")
+        assert owners[0][1].requests[-1].model.model_id == B.model_id
+        assert owners[1][1].requests[-1].model.model_id == A.model_id
+    finally:
+        for owner, _ in owners:
+            await owner.dispose()
+
+
+@pytest.mark.asyncio
+async def test_birth_selection_is_durable_only_when_work_is_admitted(tmp_path):
+    directory = tmp_path / "sessions" / "birth"
+    owner, stream = session(directory, defer=True)
+    assert not directory.exists()
+    await owner.prompt("first")
+    saved = read_model_selection(directory)
+    assert saved is not None and saved.authoritative and saved.selector == "test/conversation-a"
+    await owner.dispose()
+    resumed, requests = session(directory, model=B)
+    try:
+        await resumed.prompt("resume after default changed")
+        assert requests.requests[-1].model.model_id == A.model_id
+        assert (
+            len(
+                [
+                    r
+                    for r in resumed.transcript.entries()
+                    if r.payload.get("custom_type") == "selected_model"
+                ]
+            )
+            == 1
+        )
+    finally:
+        await resumed.dispose()
+    unused, _ = session(tmp_path / "unused", defer=True)
+    await unused.dispose()
+    assert not (tmp_path / "unused").exists()
+
+
+@pytest.mark.asyncio
+async def test_explicit_switch_survives_changed_default_and_immediate_fork(tmp_path):
+    directory = tmp_path / "sessions" / "parent"
+    owner, _ = session(directory)
+    await owner.prompt("seed")
+    owner.set_model(B, explicit=True)
+    # Exercise the session's snapshot method, which must await the switch row.
+    result = await owner.fork_snapshot()
+    await owner.dispose()
+    resumed, stream = session(directory, model=A.model_copy(update={"model_id": "new-default"}))
+    try:
+        await resumed.prompt("resume")
+        assert stream.requests[-1].model.model_id == B.model_id
+    finally:
+        await resumed.dispose()
+    fork_id = result["fork_id"]
+    forked, fork_stream = session(tmp_path / "sessions" / fork_id, model=A)
+    try:
+        await forked.prompt("fork")
+        assert fork_stream.requests[-1].model.model_id == B.model_id
+    finally:
+        await forked.dispose()
+
+
+@pytest.mark.asyncio
+async def test_legacy_migration_prefers_latest_primary_observation(tmp_path):
+    directory = tmp_path / "sessions" / "legacy"
+    transcript = Transcript(directory)
+    await transcript.append_custom(
+        "selected_model", {"selector": "test/old-switch", "boot": "test/old-boot"}
+    )
+    await transcript.append_custom(
+        "frontend_state_checkpoint_v1",
+        {
+            "state": {
+                "selected_model": B.model_dump(),
+                "effective_model": A.model_dump(),
+            }
+        },
+    )
+    saved = read_model_selection(directory)
+    assert saved is not None and saved.selector == "test/default-b"
+    owner, stream = session(directory)
+    await owner.prompt("migrate")
+    assert stream.requests[-1].model.model_id == B.model_id
+    await owner.dispose()
+    # New authority wins even over a stale later checkpoint or old writer row.
+    transcript = Transcript(directory)
+    await transcript.append_custom(
+        "frontend_state_checkpoint_v1", {"state": {"selected_model": A.model_dump()}}
+    )
+    saved = read_model_selection(directory)
+    assert saved is not None and saved.selector == "test/default-b"
+    assert saved.authoritative
+
+
+@pytest.mark.asyncio
+async def test_model_resolution_before_invalid_defaults_and_profile_changes(tmp_path):
+    config = ConfigManager(tmp_path)
+    directory = tmp_path / "sessions" / "saved"
+    owner, _ = session(directory)
+    await owner.prompt("seed")
+    await owner.dispose()
+    config.set_config_value("hosting", "not-a-provider")
+    config.set_config_value("model_name", "")
+    agent: Any = SimpleNamespace(hosting="openai", model="gpt-6")
+    args = argparse.Namespace(resume="saved", hosting=None, model=None)
+    assert resolve_hosting_model_with_source(agent, args, config) == ("test", A.model_id, "resume")
+    args.model = "explicit-model"
+    assert resolve_hosting_model_with_source(agent, args, config) == (
+        "test",
+        "explicit-model",
+        "flag",
+    )
+    args.hosting = "openai"
+    args.model = None
+    provider, model_id, source = resolve_hosting_model_with_source(agent, args, config)
+    assert provider == "openai" and model_id and source == "flag"
+    # Same model id on another provider must not compare equal.
+    args.model = A.model_id
+    assert resolve_hosting_model_with_source(agent, args, config) == ("openai", A.model_id, "flag")
+    args.model_selection_override = False
+    assert resolve_hosting_model_with_source(agent, args, config) == ("test", A.model_id, "resume")
+
+
+@pytest.mark.asyncio
+async def test_cold_viewer_birth_and_resume_use_same_selection(tmp_path):
+    config = ConfigManager(tmp_path)
+    config.set_config_value("hosting", "test")
+    config.set_config_value("model_name", A.model_id)
+
+    async def takeover():
+        raise AssertionError("read-only viewer must not take ownership")
+
+    cold = await RemoteSession.cold(
+        "new", config_dir=tmp_path, cwd=str(tmp_path), takeover_factory=takeover
+    )
+    try:
+        config.set_config_value("model_name", B.model_id)
+        assert cold.model.model_id == A.model_id
+        assert cold._birth_model is not None
+        assert cold._birth_model.model_id == A.model_id
+        assert not (tmp_path / "sessions" / "new").exists()
+        # A viewer attaching to a warmed (not yet materialized) owner learns
+        # its primary too. Recovery must retain that observation in memory.
+        from local_operator.session.frontend_state import FrontendModelSpec
+
+        cold._install_frontend(
+            cold.frontend_state.model_copy(
+                update={
+                    "epoch": "owner-epoch",
+                    "selected_model": FrontendModelSpec(provider="test", model_id="owner-picked"),
+                }
+            )
+        )
+        assert cold._birth_model.model_id == "owner-picked"
+        newer = await RemoteSession.cold(
+            "newer", config_dir=tmp_path, cwd=str(tmp_path), takeover_factory=takeover
+        )
+        assert newer.model.model_id == B.model_id
+        await newer.dispose()
+    finally:
+        await cold.dispose()
+    owner, _ = session(tmp_path / "sessions" / "saved")
+    await owner.prompt("save")
+    await owner.dispose()
+    config.set_config_value("hosting", "invalid")
+    resumed = await RemoteSession.cold(
+        "saved", config_dir=tmp_path, cwd=str(tmp_path), takeover_factory=takeover
+    )
+    try:
+        assert resumed.model.provider == "test"
+        assert resumed.model.model_id == A.model_id
+    finally:
+        await resumed.dispose()

--- a/tests/unit/session/test_model_ownership.py
+++ b/tests/unit/session/test_model_ownership.py
@@ -214,6 +214,43 @@ async def test_factory_resolves_birth_off_loop_with_arguments_captured_before_ho
             await asyncio.gather(task, return_exceptions=True)
 
 
+@pytest.mark.asyncio
+async def test_an_override_with_no_resolved_model_is_nothing_to_consume(tmp_path):
+    """The pairing the CLI builds on an unconfigured first run.
+
+    ``resolve_hosting_model`` raises on a machine with no usable configuration,
+    so setup mode reaches the viewer with ``initial_model=None`` while a raw
+    ``--model`` flag is still present. Every other test supplies a concrete
+    spec alongside the override, so this pairing was uncovered — and it wedged
+    the session permanently, refusing the prompt, the bind, and the ``/model``
+    the refusal invited (review round 2, F3).
+    """
+    config = ConfigManager(tmp_path)
+    config.update_config({"hosting": "test", "model_name": "working-a"})
+
+    async def no_takeover():
+        raise AssertionError("viewer cannot take ownership")
+
+    viewer = await RemoteSession.cold(
+        "unresolved",
+        config_dir=tmp_path,
+        cwd=str(tmp_path),
+        takeover_factory=no_takeover,
+        initial_model=None,
+        model_selection_override=True,
+    )
+    try:
+        # Nothing to send, so nothing is pending: the guard clears rather than
+        # holding an intent no later call could ever satisfy.
+        await viewer._consume_model_override()
+        assert viewer._model_selection_override is False
+        # And the same call again is still not an error.
+        await viewer._consume_model_override()
+        assert viewer._model_selection_override is False
+    finally:
+        await viewer.dispose()
+
+
 A = ModelSpec(provider="test", model_id="conversation-a", context_window=100_000)
 B = A.model_copy(update={"model_id": "default-b"})
 

--- a/tests/unit/session/test_model_ownership.py
+++ b/tests/unit/session/test_model_ownership.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -62,6 +62,156 @@ async def test_unusable_legacy_selection_recovers_visibly_once(tmp_path):
         assert resumed.model.model_id == A.model_id
     finally:
         await resumed.dispose()
+
+
+@pytest.mark.asyncio
+async def test_only_bookkeeping_envelopes_can_select_a_model(tmp_path):
+    from local_operator.harness.types import CustomMessage
+
+    directory = tmp_path / "sessions" / "envelopes"
+    transcript = Transcript(directory)
+    await transcript.append_custom(
+        "selected_model",
+        {
+            "version": 2,
+            "selector": "test/legitimate-a",
+        },
+    )
+    # A context message is valid, but its similarly named payload is not a
+    # bookkeeping entry. Disk and in-memory readers must enforce that boundary.
+    await transcript.append_message(
+        CustomMessage(
+            custom_type="selected_model",
+            details={"version": 2, "selector": "test/not-bookkeeping-b"},
+        )
+    )
+    indexed = transcript.latest_custom("selected_model")
+    saved = read_model_selection(directory)
+    assert indexed is not None and saved is not None
+    assert indexed["selector"] == saved.selector == "test/legitimate-a"
+    owner, stream = session(directory)
+    try:
+        await owner.prompt("use the real selection")
+        assert stream.requests[-1].model.model_id == "legitimate-a"
+    finally:
+        await owner.dispose()
+
+
+@pytest.mark.asyncio
+async def test_explicit_resume_intent_survives_rpc_errors_and_owner_snapshots(tmp_path):
+    from unittest.mock import AsyncMock
+
+    from local_operator.session.frontend_state import FrontendModelSpec
+
+    async def no_takeover():
+        raise AssertionError("viewer cannot take ownership")
+
+    viewer = await RemoteSession.cold(
+        "intent",
+        config_dir=tmp_path,
+        cwd=str(tmp_path),
+        takeover_factory=no_takeover,
+        initial_model=B,
+        model_selection_override=True,
+    )
+    client = SimpleNamespace(
+        connected=True, set_model=AsyncMock(side_effect=[RuntimeError("refused"), "selected"])
+    )
+    viewer._client = cast(Any, client)
+    viewer._ready_for_events = True
+    viewer._install_frontend(
+        viewer.frontend_state.model_copy(
+            update={
+                "epoch": "winning-owner",
+                "selected_model": FrontendModelSpec(**A.model_dump()),
+            }
+        )
+    )
+    try:
+        with pytest.raises(RuntimeError, match="refused"):
+            await viewer._ensure_bound(foreground=True)
+        assert viewer._model_selection_override is True
+        assert viewer._birth_model is not None and viewer._birth_model.model_id == B.model_id
+        await viewer._ensure_bound(foreground=True)
+        assert viewer._model_selection_override is False
+        assert client.set_model.call_args_list[0].args == (B.provider, B.model_id)
+        assert client.set_model.call_args_list[1].args == (B.provider, B.model_id)
+    finally:
+        viewer._client = None
+        await viewer.dispose()
+
+
+@pytest.mark.asyncio
+async def test_factory_resolves_birth_off_loop_with_arguments_captured_before_hop(
+    tmp_path, monkeypatch
+):
+    import asyncio
+    import threading
+
+    from local_operator import session_factory
+    from local_operator.agents import AgentRegistry
+    from local_operator.credentials import CredentialManager
+
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path))
+    config = ConfigManager(tmp_path)
+    config.update_config({"hosting": "test", "model_name": "default"})
+    args = argparse.Namespace(
+        hosting="test",
+        model="captured-a",
+        agent_id=None,
+        agent_name=None,
+        train=False,
+        yolo=True,
+        resume=None,
+    )
+    loop = asyncio.get_running_loop()
+    loop_thread = threading.get_ident()
+    entered, release = asyncio.Event(), threading.Event()
+    observed = []
+    original_agent = session_factory.resolve_agent
+    original_model = session_factory.resolve_hosting_model_with_source
+
+    def resolve_agent(captured, registry):
+        loop.call_soon_threadsafe(entered.set)
+        assert threading.get_ident() != loop_thread, "agent I/O ran on the event loop"
+        observed.append(("agent", threading.get_ident()))
+        assert release.wait(20), "test did not release the resolver"
+        return original_agent(captured, registry)
+
+    def resolve_model(agent, captured, manager):
+        assert threading.get_ident() != loop_thread, "journal I/O ran on the event loop"
+        observed.append(("model", threading.get_ident()))
+        assert captured.model == "captured-a" and captured.resume is None
+        return original_model(agent, captured, manager)
+
+    monkeypatch.setattr(session_factory, "resolve_agent", resolve_agent)
+    monkeypatch.setattr(session_factory, "resolve_hosting_model_with_source", resolve_model)
+    task = asyncio.create_task(
+        session_factory.create_session(
+            args,
+            config,
+            CredentialManager(tmp_path),
+            AgentRegistry(tmp_path),
+            has_ui=False,
+            cwd=str(tmp_path),
+        )
+    )
+    try:
+        await asyncio.wait_for(entered.wait(), 20)
+        args.model, args.resume = "retargeted-b", "another-conversation"
+        release.set()
+        owner = await task
+        try:
+            assert owner.model.model_id == "captured-a"
+            assert [name for name, _ in observed] == ["agent", "model"]
+            assert len({thread for _, thread in observed}) == 1
+        finally:
+            await owner.dispose()
+    finally:
+        release.set()
+        if not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
 
 
 A = ModelSpec(provider="test", model_id="conversation-a", context_window=100_000)

--- a/tests/unit/session/test_remote_cold.py
+++ b/tests/unit/session/test_remote_cold.py
@@ -763,7 +763,12 @@ async def test_a_restored_reading_is_dropped_when_the_model_changed(
     )
 
     viewer = await RemoteSession.cold(
-        SESSION_ID, config_dir=tmp_path, cwd=str(tmp_path), takeover_factory=_never
+        SESSION_ID,
+        config_dir=tmp_path,
+        cwd=str(tmp_path),
+        takeover_factory=_never,
+        initial_model=FrontendModelSpec(provider="openai", model_id="gpt-5.6-sol"),
+        model_selection_override=True,
     )
     try:
         state = viewer.frontend_state

--- a/tests/unit/session/test_selected_model.py
+++ b/tests/unit/session/test_selected_model.py
@@ -10,10 +10,9 @@ The mechanism is a ``selected_model`` custom transcript entry, the sibling of
 requests, this one records where the USER did. Both are journalled on the edge
 and read back at construction.
 
-Each row carries the boot selector the session was constructed with, which is
-what lets the restore tell a switch that still applies from one stranded by a
-changed boot selection — a ``/model default`` write, an edited agent profile,
-or an explicit ``--hosting``/``--model`` flag on the resume itself.
+Versioned rows are conversation-owned, including the initial selection.
+Defaults and profile edits cannot invalidate them; only a deliberate resume
+flag overrides them. Legacy boot fields remain readable as historical evidence.
 """
 
 from __future__ import annotations
@@ -90,7 +89,7 @@ async def test_a_switch_is_journalled_with_the_boot_selector(tmp_path):
     await wait_for(lambda: bool(_selection_entries(session)))
 
     assert _selection_entries(session) == [
-        {"selector": "anthropic/claude-opus-5", "effort": None, "boot": "test/m"}
+        {"version": 2, "selector": "anthropic/claude-opus-5", "effort": None, "boot": "test/m"}
     ]
     await session.dispose()
 
@@ -174,13 +173,8 @@ async def test_switching_back_leaves_the_resume_on_the_boot_model(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_a_changed_boot_selection_outranks_the_journalled_switch(tmp_path):
-    """``/model default`` (or ``--model``) between runs wins over the journal.
-
-    The changed boot selection is the newer, more deliberate choice — and a
-    restore that overrode it would make the flag the user just typed silently
-    not work.
-    """
+async def test_an_explicit_resume_flag_outranks_the_journalled_switch(tmp_path):
+    """A deliberate resume flag wins; changing shared defaults never does."""
     stream = NotifyingStream()
     session = _session(tmp_path, stream)
     session.set_model(SWITCHED, explicit=True)
@@ -189,6 +183,7 @@ async def test_a_changed_boot_selection_outranks_the_journalled_switch(tmp_path)
     rebooted_stream = NotifyingStream()
     rebooted = Session(
         model=ModelSpec(provider="openai", model_id="gpt-6", context_window=400_000),
+        model_source="flag",
         stream_fn=rebooted_stream,
         tools=[],
         transcript=Transcript(tmp_path / "sess"),
@@ -353,7 +348,7 @@ async def test_an_unresolvable_selection_falls_back_to_the_boot_model(tmp_path):
         {"selector": ""},
         {"selector": "no-slash", "boot": "test/m"},
         {"selector": 17, "boot": "test/m"},
-        {"selector": "anthropic/claude-opus-5"},  # no boot recorded
+        {"selector": "missing-provider/model"},  # unavailable provider
     ],
 )
 async def test_a_malformed_row_is_tolerated(tmp_path, details):

--- a/tests/unit/test_cli_new.py
+++ b/tests/unit/test_cli_new.py
@@ -819,6 +819,57 @@ def test_main_exception_banner(tmp_home: Path, quiet_env: None, capsys) -> None:
     assert "Stack Trace" in err
 
 
+def test_viewer_birth_config_and_model_resolution_run_off_the_event_loop(
+    tmp_home: Path,
+    quiet_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Guard the real nested viewer factory, not a free-standing helper."""
+    import threading
+
+    from local_operator import session_factory as factory_module
+
+    seen: dict[str, Any] = {"active": False, "config_threads": [], "model_threads": []}
+    original_resolve = factory_module.resolve_hosting_model
+
+    def config_manager(*args, **kwargs):
+        if seen["active"]:
+            seen["config_threads"].append(threading.get_ident())
+        return _fake_config_manager(*args, **kwargs)
+
+    def resolve_model(*args, **kwargs):
+        if seen["active"]:
+            seen["model_threads"].append(threading.get_ident())
+        return original_resolve(*args, **kwargs)
+
+    async def fake_cold(*args, **kwargs):
+        return object()
+
+    async def run_tui(session_factory, session_registry=None, **kwargs):
+        seen["loop_thread"] = threading.get_ident()
+        seen["active"] = True
+        try:
+            await session_factory()
+        finally:
+            seen["active"] = False
+        return 0
+
+    fake_tui = _fake_tui_module()
+    setattr(fake_tui, "run_tui", run_tui)
+    monkeypatch.setitem(sys.modules, "local_operator.tui", fake_tui)
+    monkeypatch.setattr(factory_module, "resolve_hosting_model", resolve_model)
+    monkeypatch.setattr("local_operator.cli.ConfigManager", config_manager)
+    monkeypatch.setattr("local_operator.cli.CredentialManager", _bare_credential_manager)
+    monkeypatch.setattr("local_operator.agents.AgentRegistry", MagicMock())
+    monkeypatch.setattr("local_operator.session.remote.RemoteSession.cold", staticmethod(fake_cold))
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    with patch("sys.argv", ["program", "--hosting", "test", "--model", "captured-a"]):
+        assert main() == 0
+    for key in ("config_threads", "model_threads"):
+        assert seen[key], key
+        assert all(thread != seen["loop_thread"] for thread in seen[key]), key
+
+
 def test_main_interactive_tty_uses_tui(
     tmp_home: Path, quiet_env: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/test_cli_new.py
+++ b/tests/unit/test_cli_new.py
@@ -870,6 +870,54 @@ def test_viewer_birth_config_and_model_resolution_run_off_the_event_loop(
         assert all(thread != seen["loop_thread"] for thread in seen[key]), key
 
 
+def test_setup_mode_with_a_model_flag_claims_no_override_it_cannot_apply(
+    tmp_home: Path,
+    quiet_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`lop --model <id>` on an unconfigured machine (review round 2, F3).
+
+    The birth resolution raises, so setup mode reaches the viewer with no
+    resolved spec. Claiming an override there left a pending intent nothing
+    could satisfy, which refused every later call including the `/model` the
+    refusal invited. Asserted on what `main()` really passes to `cold`.
+    """
+    seen: dict[str, Any] = {}
+
+    async def fake_cold(*args, **kwargs):
+        seen["initial_model"] = kwargs.get("initial_model")
+        seen["override"] = kwargs.get("model_selection_override")
+        return object()
+
+    async def run_tui(session_factory, session_registry=None, **kwargs):
+        await session_factory()
+        return 0
+
+    def unconfigured(*args, **kwargs):
+        # The real error the factory raises, not a bare ValueError: only these
+        # subclasses route into setup mode, so a stand-in would exercise the
+        # fail-fast branch instead of the path under test.
+        from local_operator.session_factory import HostingNotConfiguredError
+
+        raise HostingNotConfiguredError("Hosting platform is not configured.")
+
+    fake_tui = _fake_tui_module()
+    setattr(fake_tui, "run_tui", run_tui)
+    monkeypatch.setitem(sys.modules, "local_operator.tui", fake_tui)
+    monkeypatch.setattr("local_operator.session_factory.resolve_hosting_model", unconfigured)
+    monkeypatch.setattr("local_operator.cli.ConfigManager", _fake_config_manager)
+    monkeypatch.setattr("local_operator.cli.CredentialManager", _bare_credential_manager)
+    monkeypatch.setattr("local_operator.agents.AgentRegistry", MagicMock())
+    monkeypatch.setattr("local_operator.session.remote.RemoteSession.cold", staticmethod(fake_cold))
+    monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+    with patch("sys.argv", ["program", "--model", "some-model"]):
+        assert main() == 0
+    assert seen["initial_model"] is None
+    assert (
+        seen["override"] is False
+    ), "an unresolved model must not be claimed as a deliberate override"
+
+
 def test_main_interactive_tty_uses_tui(
     tmp_home: Path, quiet_env: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Change authorization

C2 — standard/pre-authorized bug fix. This PR is the change record. No version bump, release, fallback-policy change, or new persistence store.

## Problem and intended contract

A conversation started from `config.yml` remained subscribed to its global provider/model defaults. A `/model default` or config edit in one pane silently moved sibling conversations onto the new model on their next provider request. Existing resume logic also discarded selected-model records when today's boot defaults differed, and a cold viewer could display model A but launch its owner later with default B.

**Acceptance criteria**
- New conversations sample a concrete provider/model at startup or `/new` (agent > explicit launch flags > defaults).
- Existing conversations retain their selection when shared settings reload; unrelated compaction, transport, tools, and approval settings retain their existing live behavior.
- An explicit model switch affects its owning conversation. Resume/fork retain saved identity; deliberate resume flags may override it. `--model` alone keeps the saved provider; `--hosting` alone selects the new provider's default model.
- Children inherit the launching conversation, not mutable global defaults. Selected identity remains distinct from an effective provider-fallback route.
- Cold viewers and detached owners agree, including startup-to-first-engage and idle-owner recovery. Abandoned drafts create no model journal.
- Actual provider requests, not only labels, satisfy these rules.

## What changed

- Reused `selected_model` custom journal rows, versioned to own initial selections as well as explicit switches. Durability happens before real work admission and before fork snapshots, not speculative construction.
- Added one read-only selection resolver shared by owners and cold viewers. Versioned authority wins; legacy switch rows and primary-model checkpoints are considered in append order. Effective fallback metadata is never mistaken for a primary selection. Missing/unusable historical evidence recovers visibly, once, without bulk rewriting the store.
- Resolved saved identity before validating mutable defaults or configuring provider clients. Previously bound profile edits cannot override a saved conversation.
- Carried in-memory birth samples through warm engagement, detached launch and owned-session construction. Preserved explicit override intent separately from synthesized bootstrap arguments in CLI, mobile, and persisted server adapters.
- Removed automatic model adoption from shared-config reload. Updated settings scope/help and the configuration guide to state that defaults apply to new conversations.

**Non-goals:** changing retry/fallback policy, adding model tiers, redesigning `/effort`, changing auth/tenant boundaries, mutating operator configuration, or reconstructing an unrecorded historical model.

## Real-path evidence

Every run redirects HOME and LOCAL_OPERATOR_CONFIG_DIR and removes **all** CMUX_* variables before app imports. Only local scripted/mock transports are used; no paid requests or operator session/config writes.

### Reproduction and corrected actual requests

Real `OperatorApp` + `Session` + recording provider:

```text
Before: test/e2e-model → test/sibling-default
After:  test/e2e-model → test/e2e-model
```

The same new assembled E2E tests were run against committed baseline `184560c14235add439db46de2a7d52a887576f1d` and fail on actual request identity:

```text
factory: [('test','birth-a'), ('test','default-b'), ('test','default-b')]
expected: [('test','birth-a'), ('test','birth-a'), ('test','birth-a')]

detached owner after cold viewer birth A / shared edit B:
actual provider_turn_start ('test','cold-default-b')
expected                  ('test','cold-birth-a')
```

Corrected assembled execution, through real composition roots, `SessionStreamFn`, the agent loop and its journal:

```text
provider-boundary requests:
  birth-a, birth-a, sibling birth-a, new default-b,
  resumed birth-a (global provider now invalid), explicit-c,
  synthesized-bootstrap resume explicit-c
persisted server provider requests: server-a, server-a
real detached process provider_turn_start: test/cold-birth-a
```

Commands:

```sh
.venv/bin/python /tmp/lo-stable-run-safe.py .venv/bin/python -m pytest \
  tests/e2e/test_model_ownership_e2e.py -m e2e -n0 -q -s
.venv/bin/python /tmp/lo-stable-run-safe.py .venv/bin/python -m pytest \
  tests/unit/session/test_model_ownership.py \
  tests/unit/session/runtime/test_launch_arbitration.py \
  tests/e2e/test_model_ownership_e2e.py -m '' -n0 -q
```

The expanded focused slice passed **28 tests**. The model/settings/launch-focused unit pass completed **605 passed**. Coverage includes legacy migration, malformed/unavailable selection recovery, initial durability/no abandoned-draft writes, sibling isolation, explicit switches, immediate switch→fork, child inheritance, same model id on different providers, partial resume overrides, changed profiles, cold identity and invalid shared defaults.

## Before / after frames

All frames were rendered with the real application stylesheet, rasterized and viewed. Evidence lives [on this gist](https://gist.github.com/damianvtran/eeeba59843015bffb9d29ed28f0ac534), not in the repository.

### Sibling default edit

Before:
![Before model leakage](https://gist.githubusercontent.com/damianvtran/eeeba59843015bffb9d29ed28f0ac534/raw/4f14224d7e0b9adfb3e6493a0d03bdad24bb1570/before-model-default-change.svg)

After:
![After stable conversation selection](https://gist.githubusercontent.com/damianvtran/eeeba59843015bffb9d29ed28f0ac534/raw/2bf7eff839c2a499b674acdf05dc73c6eab5a7cc/after-model-default-change.svg)

### Settings state the new-conversation scope

[Before](https://gist.githubusercontent.com/damianvtran/eeeba59843015bffb9d29ed28f0ac534/raw/609f582e0cd67538306a9e892ccbc1e64472cf58/before-settings-model-scope.svg)

![After settings scope](https://gist.githubusercontent.com/damianvtran/eeeba59843015bffb9d29ed28f0ac534/raw/c43a8bdbf13db4cb228a6f96e697a1b6d55d52f4/after-settings-model-scope.svg)

[80×24 narrow frame](https://gist.githubusercontent.com/damianvtran/eeeba59843015bffb9d29ed28f0ac534/raw/e1ce81d4ea315b8bd247c89eb3034b39ea114f86/after-settings-model-scope-narrow.svg)

Geometry: conversation screen/virtual **108×32 / 108×32**, settings **98×32 / 98×32**, narrow settings **78×22 / 78×22**; no screen scrollbar. Before/after geometry is unchanged. Consecutive settled conversation frames have identical PNG hashes. Only the settings list itself scrolls, as before.

## Review round 1 remediation (second commit)

The first commit was frozen so the code, QA, design and UX streams could run in parallel on one head. Their findings were batched into a single follow-up commit rather than cascading pushes.

**F1 (MAJOR) — a deliberate resume selection was dropped when another cold viewer won the race.** `_bind_under_lock` passed the override on a `WarmErrand`, which is a no-op against an owner that already exists, and then cleared the intent unconditionally. Two cold facades on one saved conversation therefore ran on the first one's model. The intent now stays pending until the owner's own `set_model` RPC returns, is applied on every winning-owner path (including a bind that finds the session already bound), survives a failed RPC as a visible retryable error, and is never promoted from an ordinary birth seed.

```text
before: requests [('test','original-a')]  first=original-a second=original-a
after:  requests [('test','explicit-b')]  first=explicit-b second=explicit-b  override_pending=False
```

**F2 (MINOR) — the selection readers accepted any row carrying a selector-shaped payload.** A context message whose `details` happened to look like bookkeeping outranked the real journal row. Both the disk reader and the in-memory restore now require the custom envelope, matching what `latest_custom` always indexed.

```text
before: latest_custom=test/legitimate-a  reader=test/not-bookkeeping-b  request=not-bookkeeping-b
after:  latest_custom=test/legitimate-a  reader=test/legitimate-a       request=legitimate-a
```

**Q25 (MAJOR) — resolving the saved model before construction suppressed effort journalling.** `_refresh_selected_effort` skips a write when the current selector equals the boot selector, and early resolution made the resumed model *be* the boot selector. Version-2 rows now carry the conversation's birth selector and restore it on resume, so the existing effort policy is unchanged rather than widened. QA's own probe:

```text
round-1 head (456506c70): provider efforts [null, high, low, high]   resumed effort high
head (remediated):        provider efforts [null, high, low, low]    resumed effort low
```

The regression was introduced by round 1's early saved-model resolution, so the row above is the round-1 head rather than the merge base. The merge base itself already reported `[null, high, low, low]`: this restores existing behaviour rather than adding new behaviour.

**Startup liveness (self-audited, architect-confirmed).** Reading a saved selection touches the journal, which is up to 103 MB. `create_session` now batches `resolve_agent` + `resolve_hosting_model_with_source` into one `to_thread` with the arguments snapshotted before the hop, and the CLI viewer factory batches its `ConfigManager` + resolver the same way. The public sync resolver is unchanged and the lease/claim critical section stays contiguous on the loop. The regressions assert thread identity and pre-hop argument capture — structural facts, no timing thresholds.

**Two suite contracts moved with the behaviour, deliberately:** `test_a_provider_without_a_model_name_still_engages` asserted a cold viewer shows an empty model id for a provider-only config; it now samples the same concrete provider default its owner will use, which is the point of the change. And `LOP_MODEL_SELECTION_OVERRIDE` was added to `tests/conftest.py` `_AMBIENT_VARS`, as the ambient-isolation guard requires of any new variable naming a real-machine resource.

Every remediation regression was run against the round-1 head and fails there, so none of them is a guard that cannot go red:

```text
FAILED test_only_bookkeeping_envelopes_can_select_a_model
FAILED test_explicit_resume_intent_survives_rpc_errors_and_owner_snapshots
FAILED test_viewer_birth_config_and_model_resolution_run_off_the_event_loop
FAILED test_competing_cold_resumes_acknowledge_explicit_model_on_winning_owner
FAILED test_factory_resume_preserves_effort_journalling_for_explicit_selection
5 failed
```

No visual surface changed in this round (the diff is session/CLI logic and tests), so the frames above remain current.

## Review round 2 remediation (third commit)

Round 2 returned a QA pass, a design approval with one non-gating `MINOR`, and one new `blocker` that round 1's remediation introduced. All three were fixed in one commit.

**F3 (BLOCKER) — a raw `--model` flag on an unconfigured machine wedged the session permanently.** Setup mode leaves `initial_model` as `None` when the birth resolution raises, but the override was still computed from the raw flags, so the viewer held a pending intent with nothing to apply. `_consume_model_override` raised on the missing spec, and because the check ran before binding, *every* later call was refused — the prompt, the bind, and the `/model` the refusal itself invited. All three factory configuration errors are `ValueError` subclasses, so this is the ordinary first-run path.

Both halves are fixed, and the second matters independently of the first: a missing spec is now **nothing to consume** rather than an error, because that state is reachable from any caller and was unrecoverable once entered.

Driven through the real prompt path on a **working** machine, so a refusal can only be the guard rather than a genuine configuration failure:

```text
round-1 head (456506c70): prompt ACCEPTED   requests [('test','working-a')]   override_pending False
head 6926fd7 (regressed): prompt REFUSED    requests []                       override_pending True
head cb9434a (fixed):     prompt ACCEPTED   requests [('test','working-a')]   override_pending False
```

And on a genuinely unconfigured machine the wedge is replaced by the ordinary actionable setup message: `No model provider is configured yet. Connect one in Settings > Providers, then send the message again.`

**Guard gap closed.** Every existing test that set `model_selection_override=True` also supplied a concrete `initial_model`, so the pairing the CLI actually builds was covered nowhere. Three regressions now sit exactly on it — the viewer-level guard, the real `main()` wiring, and the full prompt path — and all three fail on `6926fd7` with the wedge:

```text
FAILED test_an_override_with_no_resolved_model_is_nothing_to_consume - ConnectionError: explicit model selection is waiting for its owner
FAILED test_setup_mode_with_a_model_flag_claims_no_override_it_cannot_apply - AssertionError: an unresolved model must not be claimed as a deliberate override
FAILED test_an_unresolved_model_flag_does_not_wedge_the_conversation - ConnectionError: explicit model selection is waiting for its owner
3 failed
```

**D1 / U1 (MINOR, design + UX) — the new refusal string was internal vocabulary relayed verbatim to the user.** It said "waiting for its owner", contradicted its own relayed prefix ("Could not open conversation: … is waiting"), and named no next step, unlike every sibling refusal on that seam. It is now one shared constant carrying the UX wording, which matches the established house pattern:

```text
sidebar : Could not open conversation: still starting this conversation on the model you asked for; try that again in a moment
notice  : still starting this conversation on the model you asked for; try that again in a moment
```

**On the round-1 claim that the delta touched no rendered surface: that was wrong**, and the design round caught it. This round's claim was checked rather than asserted — the delta was searched for added string literals, which found exactly one user-visible string (the replacement above), and it was rendered through both real relay shapes to confirm it. No other rendered surface changed, so the existing frames remain current.

## Complete gates

Run over the whole tree exactly as CI, on head `cb9434a`, in an isolated `HOME` + `LOCAL_OPERATOR_CONFIG_DIR` with every `CMUX_*` variable removed.

```text
.venv/bin/python -m flake8 .                              -> 0
uvx --from black==26.1.0 black --check .                  -> 0   (1075 files unchanged)
uvx isort==5.13.2 --check .                               -> 0
.venv/bin/python -m pyright --pythonpath .venv/bin/python . -> 0  (0 errors, 0 warnings)
.venv/bin/python -m pytest tests/unit -q                  -> 0   16228 passed, 18 skipped (22:43)
.venv/bin/python -m pytest tests/e2e -m e2e -n0 -q        -> 0   55 passed (1:07)
```

Counts, not bare exit codes: an earlier full-unit attempt exhausted a 1200-second execution bound around 81% and produced no summary line, so it was not counted as a pass and was re-run to completion.

**Six `ERROR`s seen on one intermediate run were investigated, not waved off.** They were all `adapter_wheel` setup errors in `tests/unit/evaluation/adapters/osworld/test_spawn.py`, where `pip wheel` died with `SIGABRT` under a loaded xdist worker. `build_adapter_wheel` was then run directly against **both** the committed base and this branch, and built the wheel cleanly on both (exit 0); the final full run above is clean. Nothing in this diff reaches that fixture.

## Review and rollout

Draft while the review rounds are posted: round 1 against the frozen head, round 2 scoped to the remediation delta. No human reviewer added while remediation is in flight. Rollback is a revert of these two commits — no schema migration and no config rewrite, though reverting does restore the old default-following behaviour for conversations whose journal already carries a version-2 row (older runtimes ignore the unknown field and fall back to their existing legacy-row handling).
