### PR TITLE
fix(browser): make tab allocation exception-safe and ownership durable

### DIFF
--- a/.github/workflows/extension.yml
+++ b/.github/workflows/extension.yml
@@ -13,6 +13,14 @@ on:
       - 'extension/**'
       - 'local_operator/browser_bridge/protocol.py'
       - 'local_operator/browser_bridge/gen_ts.py'
+      - 'local_operator/browser_bridge/resources.py'
+      - 'local_operator/browser_bridge/backend.py'
+      - 'local_operator/harness/types.py'
+      - 'local_operator/harness/subagent.py'
+      - 'local_operator/session/session.py'
+      - 'local_operator/tools/builtin.py'
+      - 'tests/e2e/test_browser_ownership.py'
+      - '.github/workflows/extension.yml'
       # The store workflows are gated here because `release.test.mjs` asserts
       # their job topology (preflight has no `environment:`, the deploying job
       # `needs:` it). That guard is the primary boundary for an unattended
@@ -25,6 +33,14 @@ on:
       - 'extension/**'
       - 'local_operator/browser_bridge/protocol.py'
       - 'local_operator/browser_bridge/gen_ts.py'
+      - 'local_operator/browser_bridge/resources.py'
+      - 'local_operator/browser_bridge/backend.py'
+      - 'local_operator/harness/types.py'
+      - 'local_operator/harness/subagent.py'
+      - 'local_operator/session/session.py'
+      - 'local_operator/tools/builtin.py'
+      - 'tests/e2e/test_browser_ownership.py'
+      - '.github/workflows/extension.yml'
       - '.github/workflows/chrome-web-store.yml'
       - '.github/workflows/chrome-web-store-promote.yml'
   workflow_dispatch:
@@ -53,8 +69,8 @@ jobs:
           node-version: '24'
           cache: pnpm
           cache-dependency-path: extension/pnpm-lock.yaml
-      - name: Install protocol dependencies
-        run: python -m pip install pydantic
+      - name: Install host protocol and end-to-end dependencies
+        run: python -m pip install -e ".[dev]"
       - name: Install extension dependencies
         working-directory: extension
         run: pnpm install --frozen-lockfile
@@ -64,6 +80,10 @@ jobs:
       - name: Run extension tests
         working-directory: extension
         run: pnpm test
+      - name: Exercise session ownership through disposable protocol peer
+        # No Chromium: Node runs the actual extension modules against isolated
+        # Chrome API fixtures; Python drives its real Session and HTTP client.
+        run: python -m pytest tests/e2e/test_browser_ownership.py -m e2e -n0 -q
       - name: Build extension
         working-directory: extension
         run: pnpm build

--- a/extension/src/commands/nav.ts
+++ b/extension/src/commands/nav.ts
@@ -295,7 +295,7 @@ export async function close(params: Record<string, unknown>): Promise<Record<str
     const surface = await requireSurface(params.tab);
     const token = surfaceToken(surface);
     if (surface.allocationId && !params.owner_proof) {
-      throw new BridgeCommandError("internal", "owner-aware client required");
+      throw new BridgeCommandError("owner_refused", "owner-aware client required");
     }
     await closeSurface(token, surface);
     return { closed: token };
@@ -321,7 +321,7 @@ export async function close(params: Record<string, unknown>): Promise<Record<str
   // Legacy close inferred its sole target AFTER dispatch authorization. Check
   // the resolved target too, or close({}) bypasses the explicit-handle fence.
   if (surface.allocationId && !params.owner_proof) {
-    throw new BridgeCommandError("internal", "owner-aware client required");
+    throw new BridgeCommandError("owner_refused", "owner-aware client required");
   }
   await closeSurface(token, surface);
   return { closed: token };

--- a/extension/src/commands/nav.ts
+++ b/extension/src/commands/nav.ts
@@ -9,6 +9,7 @@ import {
 } from "../origins";
 import { settle } from "../settle";
 import { reconcileTabGroup } from "../tab-groups";
+import { recordAllocation } from "../ownership";
 import {
   atSurfaceCap,
   getSurfaces,
@@ -150,20 +151,39 @@ export async function open(params: Record<string, unknown>, requestId: string): 
     tabId: tab.id,
     nonce: crypto.randomUUID().replaceAll("-", ""),
     epoch: 1,
+    allocationId: typeof params.allocation_id === "string" ? params.allocation_id : undefined,
     createdAt: now,
     lastUsedAt: now,
   };
-  await putSurface(surface);
-  await attach(tab.id);
-  // Start buffering console/runtime logs immediately after attach and BEFORE
-  // navigating, so the `logs` command captures output from the destination
-  // page's very first script (finding: logs must be "since the surface opened").
-  await startLogCapture(tab.id, cdp);
-  // Security-sensitive ordering stays intact: blank tab persisted, debugger
-  // attached, and log capture armed before presentation, then navigation.
-  await reconcileTabGroup(surface, params, true);
-  const live = await navigate(tab.id, url, requestId, admission);
-  return { tab: surfaceToken(surface), ...live };
+  try {
+    await putSurface(surface);
+    await recordAllocation(params, surfaceToken(surface), "allocated");
+    await attach(tab.id);
+    // Arm capture and the origin gate before navigation; opening directly at
+    // the destination would let a redirect escape permission admission.
+    await startLogCapture(tab.id, cdp);
+    await reconcileTabGroup(surface, params, true);
+    const live = await navigate(tab.id, url, requestId, admission);
+    await recordAllocation(params, surfaceToken(surface), "owned");
+    return { tab: surfaceToken(surface), ...live };
+  } catch (error) {
+    // Only THIS fresh allocation is rollback-owned. A failed resume/goto must
+    // preserve the pre-existing tab (including a login the user is finishing).
+    try {
+      await closeSurface(surfaceToken(surface), surface);
+      await recordAllocation(params, "", "closed");
+    } catch {
+      // Do not hide the original navigation failure, but retain a capability
+      // when removal failed: otherwise neither close nor teardown can retry.
+      surface.cleanupPending = true;
+      await putSurface(surface);
+      await recordAllocation(params, surfaceToken(surface), "cleanup_pending");
+      const code = error instanceof BridgeCommandError ? error.code : "internal";
+      const message = error instanceof Error ? error.message : String(error);
+      throw new BridgeCommandError(code, message, { tab: surfaceToken(surface), cleanup_pending: true });
+    }
+    throw error;
+  }
 }
 
 export async function goto(params: Record<string, unknown>, requestId: string): Promise<Record<string, unknown>> {
@@ -237,7 +257,22 @@ export async function tabs(_params: Record<string, unknown>): Promise<Record<str
 async function closeSurface(token: string, surface: StoredSurface): Promise<void> {
   dropLogCapture(surface.tabId);
   await detach(surface.tabId);
-  try { await chrome.tabs.remove(surface.tabId); } catch { /* already gone is success */ }
+  try {
+    await chrome.tabs.remove(surface.tabId);
+  } catch (error) {
+    // Only a confirmed missing tab is idempotent success. Policy/debugger or
+    // transient failures must leave the capability available for retry.
+    try { await chrome.tabs.get(surface.tabId); } catch (missing) {
+      if (missing instanceof Error && /No tab with id|Invalid tab ID/i.test(missing.message)) {
+        await removeSurface(token);
+        return;
+      }
+      throw error;
+    }
+    surface.cleanupPending = true;
+    await putSurface(surface);
+    throw error;
+  }
   await removeSurface(token);
 }
 
@@ -259,6 +294,9 @@ export async function close(params: Record<string, unknown>): Promise<Record<str
   if (params.tab !== undefined && params.tab !== null && params.tab !== "") {
     const surface = await requireSurface(params.tab);
     const token = surfaceToken(surface);
+    if (surface.allocationId && !params.owner_proof) {
+      throw new BridgeCommandError("internal", "owner-aware client required");
+    }
     await closeSurface(token, surface);
     return { closed: token };
   }
@@ -280,6 +318,11 @@ export async function close(params: Record<string, unknown>): Promise<Record<str
     );
   }
   const [token, surface] = entries[0]!;
+  // Legacy close inferred its sole target AFTER dispatch authorization. Check
+  // the resolved target too, or close({}) bypasses the explicit-handle fence.
+  if (surface.allocationId && !params.owner_proof) {
+    throw new BridgeCommandError("internal", "owner-aware client required");
+  }
   await closeSurface(token, surface);
   return { closed: token };
 }

--- a/extension/src/ownership.ts
+++ b/extension/src/ownership.ts
@@ -1,0 +1,186 @@
+import { BridgeCommandError } from "./cdp";
+import { getSurfaces, withSessionMutation } from "./state";
+
+/** A private proof is intentionally separate from ownerKey (tab-group copy).
+ * Records live with surfaces in storage.session: worker churn preserves them;
+ * a full browser restart clears both, so a reused numeric tab id is never proof.
+ */
+export interface Scope {
+  session: string;
+  generation: string;
+  terminal?: string;
+  retention?: string;
+  allocations: Record<string, { tab?: string | undefined; state: string }>;
+  /** Tabs Chrome may have created for this owner whose handle never reached
+   * the journal (worker death between create and persist). Reported by
+   * diagnostics and counted against the pool; NEVER closed by inference. */
+  unknownReservations?: number;
+}
+type Params = Record<string, unknown>;
+const queues = new Map<string, Promise<unknown>>();
+let allocations: Promise<unknown> = Promise.resolve();
+
+async function scopes(): Promise<Record<string, Scope>> {
+  return (await chrome.storage.session.get(["ownerScopes"])).ownerScopes ?? {};
+}
+function identity(params: Params): [string, string, string] {
+  const proof = String(params.owner_proof ?? "");
+  const session = String(params.requester ?? "");
+  const generation = String(params.owner_generation ?? "");
+  if (!/^[a-zA-Z0-9_-]{32,}$/.test(proof) || !session.startsWith("session:") || !generation) {
+    throw new BridgeCommandError("internal", "missing private browser ownership proof");
+  }
+  return [proof, session, generation];
+}
+async function mutate<T>(params: Params, fn: (scope: Scope) => T, create = false): Promise<T> {
+  return withSessionMutation(async () => {
+    const [proof, session, generation] = identity(params);
+    const all = await scopes();
+    let scope = all[proof];
+    if (!scope && create) scope = all[proof] = { session, generation, allocations: {} };
+    if (!scope || scope.session !== session || scope.generation !== generation) {
+      throw new BridgeCommandError("internal", "browser owner generation is stale or unresolved");
+    }
+    const result = fn(scope);
+    await chrome.storage.session.set({ ownerScopes: all });
+    return result;
+  });
+}
+
+export async function recordAllocation(params: Params, tab: string, state: string): Promise<void> {
+  if (!params.owner_proof) return; // legacy clients retain capability-only behavior
+  await mutate(params, scope => {
+    const allocation = String(params.allocation_id ?? "");
+    if (!allocation || scope.terminal) throw new BridgeCommandError("internal", "browser scope ended");
+    scope.allocations[allocation] = { tab: tab || undefined, state };
+  });
+}
+
+/** Outstanding allocations survive worker crashes and count against the pool.
+ * Only a confirmed close/removal retires them; owner age/PID never does. */
+export async function outstandingReservations(): Promise<number> {
+  const surfaces = await getSurfaces();
+  const all = await scopes();
+  return Object.values(all).flatMap(scope => Object.values(scope.allocations)).filter(
+    allocation => ["allocating", "allocated", "cleanup_pending"].includes(allocation.state)
+      && (!allocation.tab || !surfaces[allocation.tab])
+  ).length;
+}
+
+/** Serialize owner commands through the entire side effect, not just the map
+ * write. A finish cannot overtake an in-flight allocation and then let its late
+ * navigation resurrect the tab. The daemon's deadlines remain bounded; a lost
+ * response is replayed by allocation id rather than creating a second tab.
+ */
+export function withOwnership(
+  method: string, params: Params, handler: () => Promise<Record<string, unknown>>,
+  close: (params: Params) => Promise<Record<string, unknown>>,
+): Promise<Record<string, unknown>> {
+  const key = String(params.owner_proof ?? "legacy");
+  const previous = queues.get(key) ?? Promise.resolve();
+  const operate = async (): Promise<Record<string, unknown>> => {
+    if (!params.owner_proof) {
+      // A legacy capability cannot bypass fencing for a modern allocation.
+      if (params.tab) {
+        const surface = (await getSurfaces())[String(params.tab)];
+        if (surface?.allocationId) throw new BridgeCommandError("internal", "owner-aware client required");
+      }
+      return handler();
+    }
+    const [proof, session, generation] = identity(params);
+    if (method === "owner_recover") {
+      return withSessionMutation(async () => {
+        const all = await scopes();
+        const scope = all[proof];
+        if (!scope) return { ownership_version: 1, state: "unresolved" };
+        const predecessors = Array.isArray(params.previous_generations) ? params.previous_generations : [];
+        if (scope.session !== session || (scope.generation !== generation && scope.generation !== params.previous_generation && !predecessors.includes(scope.generation))) {
+          throw new BridgeCommandError("internal", "browser owner generation is stale");
+        }
+        if (scope.generation !== generation) delete scope.terminal;
+        scope.generation = generation;
+        await chrome.storage.session.set({ ownerScopes: all });
+        const allocation = scope.allocations[String(params.allocation_id ?? "")];
+        const live = allocation?.tab && (await getSurfaces())[allocation.tab];
+        const unresolved = allocation && ["allocating", "allocated", "cleanup_pending"].includes(allocation.state);
+        return { ownership_version: 1, state: live ? (live.cleanupPending ? "cleanup_pending" : allocation.state) : unresolved ? "allocating" : "closed", tab: live ? allocation.tab : "", retention: scope.retention ?? "", terminal: scope.terminal ?? "", unknown_reservations: scope.unknownReservations ?? 0 };
+      });
+    }
+    if (method === "open") {
+      const existing = await mutate(params, scope => {
+        if (scope.terminal) throw new BridgeCommandError("internal", "browser scope ended; resume a new generation first");
+        const id = String(params.allocation_id ?? "");
+        if (!id) throw new BridgeCommandError("internal", "missing browser allocation id");
+        return scope.allocations[id];
+      }, true);
+      if (params.tab) {
+        if (existing?.tab !== params.tab) throw new BridgeCommandError("internal", "tab does not belong to allocation");
+        return handler();
+      }
+      if (existing?.tab && (await getSurfaces())[existing.tab]) {
+        // A response may have been lost after successful navigation. Return
+        // the recorded capability without navigating/submitting a second time.
+        const surface = (await getSurfaces())[existing.tab];
+        if (!surface) throw new BridgeCommandError("tab_closed", "browser tab disappeared");
+        const tab = await chrome.tabs.get(surface.tabId);
+        return { tab: existing.tab, url: tab.url ?? "", title: tab.title ?? "", state: existing.state };
+      }
+      if (existing && existing.state !== "closed") {
+        // The journal says this allocation began but no live tab carries it:
+        // the worker died between chrome.tabs.create and the handle write.
+        // That tab is UNKNOWN — counted and reported, never closed by
+        // inference — but it must not lock the owner out of browsing, so the
+        // allocation is retried under a fresh intent.
+        await mutate(params, scope => {
+          scope.unknownReservations = (scope.unknownReservations ?? 0) + 1;
+        });
+      }
+      await recordAllocation(params, "", "allocating");
+      return handler();
+    }
+    const scope = await mutate(params, value => value,
+      ["tabs", "status", "request_access", "await_access", "cancel_access", "owner_retain", "owner_finish"].includes(method));
+    if (method === "owner_retain") {
+      const reason = String(params.reason ?? "").trim();
+      if (!reason || reason.length > 500) throw new BridgeCommandError("internal", "retention requires a bounded reason");
+      await mutate(params, value => { value.retention = reason; });
+      return { state: "retained" };
+    }
+    if (method === "owner_release") {
+      await mutate(params, value => { delete value.retention; });
+      return { state: "released", terminal: scope.terminal ?? "" };
+    }
+    if (method === "owner_finish") {
+      await mutate(params, value => { value.terminal = String(params.outcome ?? "completed"); });
+      if (scope.retention) return { state: "retained" };
+      let pending = false;
+      for (const allocation of Object.values(scope.allocations)) {
+        if (!allocation.tab || !(await getSurfaces())[allocation.tab]) {
+          // A worker may die after Chrome creates a tab but before its id is
+          // journaled. That reservation is unknown, not invented free capacity.
+          if (["allocating", "allocated", "cleanup_pending"].includes(allocation.state)) pending = true;
+          continue;
+        }
+        try { await close({ ...params, tab: allocation.tab }); }
+        catch { pending = true; }
+      }
+      return { state: pending ? "pending" : "closed" };
+    }
+    if (scope.terminal && method !== "close" && method !== "tabs") throw new BridgeCommandError("internal", "browser scope ended");
+    if (params.tab && !Object.values(scope.allocations).some(a => a.tab === params.tab)) {
+      throw new BridgeCommandError("internal", "tab does not belong to this browser owner");
+    }
+    return handler();
+  };
+  const run = previous.catch(() => {}).then(() => {
+    if (method !== "open") return operate();
+    // Pool admission spans create+persist, including legacy callers. Sharing
+    // the allocation lane avoids two owners both observing the last free slot.
+    const allocation = allocations.catch(() => {}).then(operate);
+    allocations = allocation;
+    return allocation;
+  });
+  queues.set(key, run);
+  void run.finally(() => { if (queues.get(key) === run) queues.delete(key); }).catch(() => {});
+  return run;
+}

--- a/extension/src/ownership.ts
+++ b/extension/src/ownership.ts
@@ -28,7 +28,7 @@ function identity(params: Params): [string, string, string] {
   const session = String(params.requester ?? "");
   const generation = String(params.owner_generation ?? "");
   if (!/^[a-zA-Z0-9_-]{32,}$/.test(proof) || !session.startsWith("session:") || !generation) {
-    throw new BridgeCommandError("internal", "missing private browser ownership proof");
+    throw new BridgeCommandError("owner_refused", "missing private browser ownership proof");
   }
   return [proof, session, generation];
 }
@@ -39,7 +39,7 @@ async function mutate<T>(params: Params, fn: (scope: Scope) => T, create = false
     let scope = all[proof];
     if (!scope && create) scope = all[proof] = { session, generation, allocations: {} };
     if (!scope || scope.session !== session || scope.generation !== generation) {
-      throw new BridgeCommandError("internal", "browser owner generation is stale or unresolved");
+      throw new BridgeCommandError("owner_refused", "browser owner generation is stale or unresolved");
     }
     const result = fn(scope);
     await chrome.storage.session.set({ ownerScopes: all });
@@ -51,20 +51,9 @@ export async function recordAllocation(params: Params, tab: string, state: strin
   if (!params.owner_proof) return; // legacy clients retain capability-only behavior
   await mutate(params, scope => {
     const allocation = String(params.allocation_id ?? "");
-    if (!allocation || scope.terminal) throw new BridgeCommandError("internal", "browser scope ended");
+    if (!allocation || scope.terminal) throw new BridgeCommandError("owner_refused", "browser scope ended");
     scope.allocations[allocation] = { tab: tab || undefined, state };
   });
-}
-
-/** Outstanding allocations survive worker crashes and count against the pool.
- * Only a confirmed close/removal retires them; owner age/PID never does. */
-export async function outstandingReservations(): Promise<number> {
-  const surfaces = await getSurfaces();
-  const all = await scopes();
-  return Object.values(all).flatMap(scope => Object.values(scope.allocations)).filter(
-    allocation => ["allocating", "allocated", "cleanup_pending"].includes(allocation.state)
-      && (!allocation.tab || !surfaces[allocation.tab])
-  ).length;
 }
 
 /** Serialize owner commands through the entire side effect, not just the map
@@ -83,7 +72,7 @@ export function withOwnership(
       // A legacy capability cannot bypass fencing for a modern allocation.
       if (params.tab) {
         const surface = (await getSurfaces())[String(params.tab)];
-        if (surface?.allocationId) throw new BridgeCommandError("internal", "owner-aware client required");
+        if (surface?.allocationId) throw new BridgeCommandError("owner_refused", "owner-aware client required");
       }
       return handler();
     }
@@ -95,7 +84,7 @@ export function withOwnership(
         if (!scope) return { ownership_version: 1, state: "unresolved" };
         const predecessors = Array.isArray(params.previous_generations) ? params.previous_generations : [];
         if (scope.session !== session || (scope.generation !== generation && scope.generation !== params.previous_generation && !predecessors.includes(scope.generation))) {
-          throw new BridgeCommandError("internal", "browser owner generation is stale");
+          throw new BridgeCommandError("owner_refused", "browser owner generation is stale");
         }
         if (scope.generation !== generation) delete scope.terminal;
         scope.generation = generation;
@@ -108,13 +97,13 @@ export function withOwnership(
     }
     if (method === "open") {
       const existing = await mutate(params, scope => {
-        if (scope.terminal) throw new BridgeCommandError("internal", "browser scope ended; resume a new generation first");
+        if (scope.terminal) throw new BridgeCommandError("owner_refused", "browser scope ended; resume a new generation first");
         const id = String(params.allocation_id ?? "");
-        if (!id) throw new BridgeCommandError("internal", "missing browser allocation id");
+        if (!id) throw new BridgeCommandError("owner_refused", "missing browser allocation id");
         return scope.allocations[id];
       }, true);
       if (params.tab) {
-        if (existing?.tab !== params.tab) throw new BridgeCommandError("internal", "tab does not belong to allocation");
+        if (existing?.tab !== params.tab) throw new BridgeCommandError("owner_refused", "tab does not belong to allocation");
         return handler();
       }
       if (existing?.tab && (await getSurfaces())[existing.tab]) {
@@ -142,7 +131,7 @@ export function withOwnership(
       ["tabs", "status", "request_access", "await_access", "cancel_access", "owner_retain", "owner_finish"].includes(method));
     if (method === "owner_retain") {
       const reason = String(params.reason ?? "").trim();
-      if (!reason || reason.length > 500) throw new BridgeCommandError("internal", "retention requires a bounded reason");
+      if (!reason || reason.length > 500) throw new BridgeCommandError("owner_refused", "retention requires a bounded reason");
       await mutate(params, value => { value.retention = reason; });
       return { state: "retained" };
     }
@@ -166,9 +155,9 @@ export function withOwnership(
       }
       return { state: pending ? "pending" : "closed" };
     }
-    if (scope.terminal && method !== "close" && method !== "tabs") throw new BridgeCommandError("internal", "browser scope ended");
+    if (scope.terminal && method !== "close" && method !== "tabs") throw new BridgeCommandError("owner_refused", "browser scope ended");
     if (params.tab && !Object.values(scope.allocations).some(a => a.tab === params.tab)) {
-      throw new BridgeCommandError("internal", "tab does not belong to this browser owner");
+      throw new BridgeCommandError("owner_refused", "tab does not belong to this browser owner");
     }
     return handler();
   };

--- a/extension/src/ownership.ts
+++ b/extension/src/ownership.ts
@@ -86,7 +86,16 @@ export function withOwnership(
         if (scope.session !== session || (scope.generation !== generation && scope.generation !== params.previous_generation && !predecessors.includes(scope.generation))) {
           throw new BridgeCommandError("owner_refused", "browser owner generation is stale");
         }
-        if (scope.generation !== generation) delete scope.terminal;
+        // A resume retires the ended scope. Keying this on the generation
+        // CHANGING was unreachable for an in-process child: that path
+        // deliberately reuses one generation per session (so a second live
+        // instance can never fence the incumbent), so the clear never fired
+        // and `open` below refused forever — the owner was told to resume and
+        // then refused for not having resumed. `resumed_scope` is the owner's
+        // own statement that this is a later run over a settled scope, and it
+        // is only reachable here past the proof/session/generation check
+        // above, so a foreign caller cannot use it to clear someone else's.
+        if (scope.generation !== generation || params.resumed_scope === true) delete scope.terminal;
         scope.generation = generation;
         await chrome.storage.session.set({ ownerScopes: all });
         const allocation = scope.allocations[String(params.allocation_id ?? "")];

--- a/extension/src/protocol.gen.ts
+++ b/extension/src/protocol.gen.ts
@@ -21,6 +21,7 @@ export enum ErrorCode {
   TAB_AMBIGUOUS = 'tab_ambiguous',
   BUSY = 'busy',
   PROTO_MISMATCH = 'proto_mismatch',
+  OWNER_REFUSED = 'owner_refused',
   INTERNAL = 'internal',
 }
 

--- a/extension/src/protocol.gen.ts
+++ b/extension/src/protocol.gen.ts
@@ -24,7 +24,7 @@ export enum ErrorCode {
   INTERNAL = 'internal',
 }
 
-export type Method = 'open' | 'goto' | 'read' | 'snapshot' | 'screenshot' | 'click' | 'type' | 'close' | 'status' | 'tabs' | 'scroll' | 'logs' | 'request_access' | 'await_access' | 'cancel_access' | 'retitle';
+export type Method = 'open' | 'goto' | 'read' | 'snapshot' | 'screenshot' | 'click' | 'type' | 'close' | 'status' | 'tabs' | 'scroll' | 'logs' | 'request_access' | 'await_access' | 'cancel_access' | 'retitle' | 'owner_recover' | 'owner_finish' | 'owner_retain' | 'owner_release';
 // One buffered console/runtime log line, as `logs` returns it (newest last).
 // `level` is normalized to the error/warning/info/log vocabulary the tool
 // filters on; `source` distinguishes a page console call from an uncaught

--- a/extension/src/state.ts
+++ b/extension/src/state.ts
@@ -21,6 +21,9 @@ export interface StoredSurface {
   // Optional for seamless upgrade from 0.1.3 session storage. Identity and the
   // stable collision ordinal persist; native group ids do not survive Chrome.
   ownerKey?: string;
+  // Failed removal is a retryable obligation, never proof the tab disappeared.
+  cleanupPending?: boolean;
+  allocationId?: string | undefined;
   groupBaseLabel?: string;
   groupOrdinal?: number;
   groupAppliedLabel?: string;

--- a/extension/src/worker.ts
+++ b/extension/src/worker.ts
@@ -13,6 +13,7 @@ import { expireAccessRequest, resolveOrigin, restoreAccessQueue, setPendingObser
 import { DEFAULT_PORT, getLocal, isRedactedToken } from "./state";
 import { reconcileCommandTab, retitle } from "./tab-groups";
 import { reclaimRemovedTab } from "./tab-lifecycle";
+import { withOwnership } from "./ownership";
 import {
   RECONNECT_ALARM_NAME,
   RECONNECT_ALARM_PERIOD_MINUTES,
@@ -51,6 +52,10 @@ const HANDLERS: Record<
   // title that arrived after the tab was created. It drives no tab and reads
   // no page, so unlike every other handler it needs no surface admission.
   retitle,
+  owner_recover: async () => ({}),
+  owner_finish: async () => ({}),
+  owner_retain: async () => ({}),
+  owner_release: async () => ({}),
 };
 
 // How long a dial may sit unresolved before we force it closed and retry. A
@@ -186,7 +191,8 @@ async function dispatch(request: { id: string; method: string; params: Record<st
     if (request.method !== "open" && request.method !== "retitle") {
       await reconcileCommandTab(request.params);
     }
-    const result = await handler(request.params, request.id);
+    const result = await withOwnership(request.method, request.params,
+      () => handler(request.params, request.id), close);
     // Push the driven page so the daemon (and the Connected popup) can show
     // the human what the agent is on (finding U3).
     if (typeof result.url === "string" && result.url) {

--- a/extension/tests/fixtures/ownership-server.mjs
+++ b/extension/tests/fixtures/ownership-server.mjs
@@ -1,0 +1,32 @@
+import http from "node:http";
+import { fixture } from "./ownership.mjs";
+
+// Test-only HTTP peer for the REAL Python BridgeClient. It dispatches through
+// the bundled extension ownership/nav modules, but every Chrome API is in-memory.
+const f = await fixture();
+let oldExtension = false;
+const server = http.createServer(async (request, response) => {
+  if (request.headers["x-bridge-key"] !== process.env.BROWSER_FIXTURE_KEY) {
+    response.writeHead(401).end("unauthorized"); return;
+  }
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  const body = chunks.length ? JSON.parse(Buffer.concat(chunks).toString()) : {};
+  response.setHeader("content-type", "application/json");
+  if (request.url === "/fixture") {
+    Object.assign(f.faults, body.faults ?? {});
+    if (typeof body.oldExtension === "boolean") oldExtension = body.oldExtension;
+    if (body.restartWorker) await f.restart();
+    if (body.resetBrowser) f.resetStorage();
+    response.end(JSON.stringify({tabs:f.tabs.size,removed:f.removed.length})); return;
+  }
+  try {
+    if (oldExtension && body.method.startsWith("owner_")) throw {code:"internal",message:`unknown method ${body.method}`};
+    const result = await f.call(body.method, body.params);
+    response.end(JSON.stringify({id:body.id,ok:true,result}));
+  } catch (error) {
+    response.end(JSON.stringify({id:body.id,ok:false,error:{code:error.code ?? "internal",message:error.message ?? String(error),data:error.data ?? {}}}));
+  }
+});
+server.listen(0,"127.0.0.1",()=>console.log(JSON.stringify({port:server.address().port})));
+process.on("SIGTERM",()=>server.close(async()=>{await f.close();process.exit(0);}));

--- a/extension/tests/fixtures/ownership.mjs
+++ b/extension/tests/fixtures/ownership.mjs
@@ -1,0 +1,49 @@
+import { build } from "esbuild";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+// Actual navigation/state/ownership modules, disposable Chrome/CDP transport.
+// No browser process, live bridge, install, config, or operator tab is touched.
+export async function fixture() {
+  const dir = await mkdtemp(join(tmpdir(), "lop-ownership-"));
+  let store = {}; let next = 100;
+  const tabs = new Map(); const removed = [];
+  const faults = { navigation: false, remove: false, attach: false, capture: false };
+  globalThis.ownershipFaults = faults;
+  globalThis.chrome = {
+    storage: { session: {
+      get: async () => structuredClone(store),
+      set: async value => { Object.assign(store, structuredClone(value)); },
+    } },
+    tabs: {
+      create: async options => { const tab = { id: next++, ...options }; tabs.set(tab.id, tab); return tab; },
+      get: async id => { if (!tabs.has(id)) throw Error(`No tab with id: ${id}`); return tabs.get(id); },
+      update: async (id, options) => { if (faults.navigation) throw Error("net::ERR_CONNECTION_REFUSED"); Object.assign(tabs.get(id), options); return tabs.get(id); },
+      remove: async id => { if (faults.remove) throw Error("policy denied removal"); removed.push(id); tabs.delete(id); },
+    },
+  };
+  const entry = join(dir, "entry.mjs");
+  await writeFile(entry, `export * from ${JSON.stringify(resolve("src/commands/nav.ts"))}; export * from ${JSON.stringify(resolve("src/ownership.ts"))};`);
+  const mocks = {
+    cdp: `import {getSurfaces,removeSurface} from ${JSON.stringify(resolve("src/state.ts"))};
+      export class BridgeCommandError extends Error {constructor(code,message,data={}){super(message);this.code=code;this.data=data}}
+      export const attach=async()=>{if(globalThis.ownershipFaults.attach)throw Error('attach failed')},detach=async()=>{},cdp=async()=>({result:{value:JSON.stringify({url:'https://example.test/',title:'fixture'})}}),pruneSurface=async(t)=>removeSurface(t),requireSurface=async(t)=>{const s=(await getSurfaces())[t];if(!s)throw new BridgeCommandError('tab_closed','gone');await chrome.tabs.get(s.tabId);return s};`,
+    "log-capture": `export const dropLogCapture=()=>{},startLogCapture=async()=>{if(globalThis.ownershipFaults.capture)throw Error('capture failed')};`,
+    origins: `export const safeHttpUrl=v=>new URL(v),ensureTopLevelAccess=async()=>({allowed:true}),askOrigin=async()=>true,withOriginGate=async(t,r,fn)=>fn();`,
+    settle: `export const settle=async()=>{};`,
+    "tab-groups": `export const reconcileTabGroup=async()=>{};`,
+  };
+  const outfile = join(dir, "bundle.mjs");
+  await build({entryPoints:[entry],bundle:true,platform:"node",format:"esm",outfile,plugins:[{name:"isolated-transport",setup(b){
+    b.onResolve({filter:/^\.\.?\/(cdp|log-capture|origins|settle|tab-groups)$/},a=>({path:a.path.split('/').at(-1),namespace:"fixture"}));
+    b.onLoad({filter:/.*/,namespace:"fixture"},a=>({contents:mocks[a.path],loader:"js",resolveDir:resolve(".")}));
+  }}]});
+  let loaded = await import(pathToFileURL(outfile));
+  const owner = {owner_proof:"a".repeat(40),requester:"session:synthetic",owner_generation:"g1",allocation_id:"allocation-1",url:"https://example.test/"};
+  const call = (method, params=owner) => loaded.withOwnership(method,params,()=>loaded[method]?.(params,"synthetic-request") ?? Promise.resolve({}),loaded.close);
+  return {call,loaded,owner,tabs,removed,faults,store:()=>store,
+    restart:async()=>{loaded=await import(pathToFileURL(outfile)+`?restart=${Date.now()}`);},
+    resetStorage:()=>{store={};},close:()=>rm(dir,{recursive:true,force:true})};
+}

--- a/extension/tests/ownership-resume.integration.test.mjs
+++ b/extension/tests/ownership-resume.integration.test.mjs
@@ -1,0 +1,113 @@
+/* Retiring an ended scope is a TWO-SIDED fence, and this side was the one left up.
+ *
+ * The session's durable record and the extension's `scope.terminal` both have
+ * to be retired for a resumed owner to browse again. The extension used to
+ * clear its half only when the generation string CHANGED, which an in-process
+ * child never does — that path deliberately reuses one generation per session
+ * so a second live instance cannot fence the incumbent — so `open` was refused
+ * forever while `owner_recover` reported the scope settled and ready.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+import { build } from "esbuild";
+import { pathToFileURL } from "node:url";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+async function loadModule() {
+  const session = new Map();
+  globalThis.chrome = {
+    storage: { session: {
+      get: async (keys) => {
+        const out = {};
+        for (const key of Array.isArray(keys) ? keys : [keys]) {
+          if (session.has(key)) out[key] = session.get(key);
+        }
+        return out;
+      },
+      set: async (obj) => { for (const [k, v] of Object.entries(obj)) session.set(k, v); },
+    } },
+    tabs: {
+      get: async (id) => ({ id, url: "https://example.com/", title: "T" }),
+      onRemoved: { addListener: () => {} }, onReplaced: { addListener: () => {} },
+      onUpdated: { addListener: () => {} },
+    },
+    debugger: {
+      attach: async () => {}, detach: async () => {}, sendCommand: async () => ({}),
+      onEvent: { addListener: () => {} }, onDetach: { addListener: () => {} },
+    },
+    runtime: { getURL: (p) => p, getManifest: () => ({ version: "0.1.9" }), onMessage: { addListener: () => {} } },
+  };
+  const dir = await mkdtemp(join(tmpdir(), "lop-ownership-resume-"));
+  const outfile = join(dir, "module.mjs");
+  await build({ entryPoints: ["src/ownership.ts"], bundle: true, platform: "node", format: "esm", outfile });
+  return {
+    loaded: await import(pathToFileURL(outfile) + `?${Date.now()}`),
+    close: () => rm(dir, { recursive: true, force: true }),
+  };
+}
+
+const GEN = "reused-generation-0123456789abcdefgh";
+const OWNER = {
+  owner_proof: "proof-abcdefghijklmnopqrstuvwxyz0123456789",
+  requester: "session:child",
+  owner_generation: GEN,
+  previous_generation: "",
+  previous_generations: [GEN],
+  allocation_id: "alloc-1",
+};
+
+/** Run one owner command against the real dispatcher. */
+const run = (mod, method, params) =>
+  mod.withOwnership(method, params,
+    async () => ({ tab: "bridge:7:nonce", url: "", title: "", state: "owned" }),
+    async () => ({ state: "closed" }));
+
+async function settle(mod) {
+  await run(mod, "open", OWNER);
+  await run(mod, "owner_finish", { ...OWNER, outcome: "completed" });
+}
+
+test("a resumed owner may open again on the SAME generation", async (t) => {
+  const { loaded, close } = await loadModule();
+  t.after(close);
+  await settle(loaded);
+
+  const recovered = await run(loaded, "owner_recover", { ...OWNER, resumed_scope: true });
+  assert.equal(recovered.terminal, "", "recover must retire the ended scope");
+  const reopened = await run(loaded, "open", OWNER);
+  assert.equal(reopened.tab, "bridge:7:nonce");
+});
+
+test("an owner that is NOT resuming keeps its terminal intent", async (t) => {
+  const { loaded, close } = await loadModule();
+  t.after(close);
+  await settle(loaded);
+
+  const recovered = await run(loaded, "owner_recover", { ...OWNER });
+  assert.equal(recovered.terminal, "completed");
+  await assert.rejects(() => run(loaded, "open", OWNER), /browser scope ended/);
+});
+
+test("a foreign session cannot clear someone else's terminal by claiming a resume", async (t) => {
+  const { loaded, close } = await loadModule();
+  t.after(close);
+  await settle(loaded);
+
+  // The flag is only reachable PAST the proof/session/generation check, so it
+  // grants a stranger nothing: this is refused before the clear is considered.
+  await assert.rejects(
+    () => run(loaded, "owner_recover", { ...OWNER, requester: "session:attacker", resumed_scope: true }),
+    /stale/,
+  );
+  const stale = "stale-generation-0123456789abcdefgh";
+  await assert.rejects(
+    () => run(loaded, "owner_recover", {
+      ...OWNER, owner_generation: stale, previous_generations: [stale], resumed_scope: true,
+    }),
+    /stale/,
+  );
+  const recovered = await run(loaded, "owner_recover", { ...OWNER });
+  assert.equal(recovered.terminal, "completed", "the real owner's intent survived");
+});

--- a/extension/tests/ownership.integration.test.mjs
+++ b/extension/tests/ownership.integration.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { fixture } from "./fixtures/ownership.mjs";
+
+for (const fault of ["navigation", "attach", "capture"]) {
+  test(`new allocation rolls back ${fault} failure`, async () => {
+    const f = await fixture();
+    try { f.faults[fault]=true; await assert.rejects(f.call("open")); assert.equal(f.tabs.size,0); assert.equal(Object.keys(f.store().surfaces).length,0); assert.equal(f.removed.length,1); }
+    finally { await f.close(); }
+  });
+}
+
+test("failed rollback remains recoverable and cleanup retries exactly one owner", async () => {
+  const f = await fixture();
+  try {
+    f.faults.navigation=true; f.faults.remove=true;
+    await assert.rejects(f.call("open"),e=>e.data.cleanup_pending===true);
+    const recovered=await f.call("owner_recover"); assert.ok(recovered.tab); assert.equal(recovered.state,"cleanup_pending");
+    assert.equal((await f.call("owner_finish",{...f.owner,outcome:"failed"})).state,"pending");
+    assert.equal(f.tabs.size,1); f.faults.remove=false;
+    assert.equal((await f.call("owner_finish",{...f.owner,outcome:"failed"})).state,"closed"); assert.equal(f.tabs.size,0);
+  } finally { await f.close(); }
+});
+
+test("lost response replays allocation and failed existing navigation never closes", async () => {
+  const f=await fixture();
+  try {
+    const first=await f.call("open"); const replay=await f.call("open"); assert.equal(first.tab,replay.tab); assert.equal(f.tabs.size,1);
+    f.faults.navigation=true; await assert.rejects(f.call("open",{...f.owner,tab:first.tab})); assert.equal(f.tabs.size,1); assert.equal(f.removed.length,0);
+  } finally { await f.close(); }
+});
+
+test("new generation fences stale finalizers and foreign proof", async () => {
+  const f=await fixture();
+  try {
+    const first=await f.call("open");
+    const resumed={...f.owner,owner_generation:"g2",previous_generation:"g1"};
+    assert.equal((await f.call("owner_recover",resumed)).tab,first.tab);
+    await assert.rejects(f.call("owner_finish"),/generation is stale/);
+    await assert.rejects(f.call("close",{...resumed,owner_proof:"b".repeat(40),tab:first.tab}));
+    await assert.rejects(f.call("close",{tab:first.tab}),/owner-aware client required/);
+    await assert.rejects(f.call("close",{}),/owner-aware client required/);
+    assert.equal(f.tabs.size,1);
+  } finally { await f.close(); }
+});
+
+test("legacy clients still close their own sole legacy allocation", async () => {
+  const f=await fixture();
+  try {
+    await f.call("open",{url:"https://example.test/"});
+    await f.call("close",{});
+    assert.equal(f.tabs.size,0);
+  } finally { await f.close(); }
+});
+
+test("retention survives completion and release enables exact cleanup", async () => {
+  const f=await fixture();
+  try {
+    await f.call("open"); await f.call("owner_retain",{...f.owner,reason:"pending login"});
+    assert.equal((await f.call("owner_finish",{...f.owner,outcome:"completed"})).state,"retained"); assert.equal(f.tabs.size,1);
+    await f.call("owner_release"); assert.equal((await f.call("owner_finish")).state,"closed"); assert.equal(f.tabs.size,0);
+  } finally { await f.close(); }
+});
+
+test("concurrent owners honor eight-tab capacity without hijacking live owners", async () => {
+  const f=await fixture();
+  try {
+    const results=await Promise.allSettled(Array.from({length:10},(_,i)=>f.call("open",{...f.owner,owner_proof:String(i).repeat(40),requester:`session:synthetic-${i}`})));
+    assert.equal(results.filter(r=>r.status==="fulfilled").length,8); assert.equal(f.tabs.size,8); assert.equal(f.removed.length,0);
+  } finally { await f.close(); }
+});
+
+test("worker restart recovers exact allocation; browser restart never adopts numeric IDs", async () => {
+  const f=await fixture();
+  try {
+    const first=await f.call("open"); await f.restart();
+    assert.equal((await f.call("owner_recover")).tab,first.tab);
+    f.resetStorage(); await f.restart();
+    assert.equal((await f.call("owner_recover")).state,"unresolved");
+    assert.equal(f.tabs.size,1); assert.equal(f.removed.length,0);
+  } finally { await f.close(); }
+});
+
+test("normal close and user-closed stale pool release only confirmed missing tabs", async () => {
+  const f=await fixture();
+  try {
+    const first=await f.call("open"); await f.call("close",{...f.owner,tab:first.tab});
+    assert.equal(f.tabs.size,0);
+    for(let i=0;i<8;i++) await f.call("open",{...f.owner,owner_proof:String(i).repeat(40),requester:`session:synthetic-${i}`});
+    f.tabs.delete(101); // user closes one owned tab; listing performs stale reconciliation
+    await f.call("tabs",f.owner);
+    await f.call("open",{...f.owner,allocation_id:"replacement"});
+    assert.equal(f.tabs.size,8);
+  } finally { await f.close(); }
+});
+
+test("completion queued during allocation leaves no late tab", async () => {
+  const f=await fixture();
+  try { const opening=f.call("open"); const finishing=f.call("owner_finish",{...f.owner,outcome:"completed"}); await opening; assert.equal((await finishing).state,"closed"); assert.equal(f.tabs.size,0); }
+  finally { await f.close(); }
+});

--- a/local_operator/browser_bridge/protocol.py
+++ b/local_operator/browser_bridge/protocol.py
@@ -171,6 +171,13 @@ class ErrorCode(StrEnum):
     TAB_AMBIGUOUS = "tab_ambiguous"
     BUSY = "busy"
     PROTO_MISMATCH = "proto_mismatch"
+    # An ownership-aware refusal: stale generation, foreign proof, ended scope,
+    # a tab belonging to another owner. Typed so the session can tell it from a
+    # bridge fault WITHOUT substring-matching a human message. That distinction
+    # is what makes an `internal` reply to an `owner_*` method mean "this
+    # extension predates ownership" — an already-released extension's wording
+    # cannot be retrofitted, so the NEW side is what has to be unambiguous.
+    OWNER_REFUSED = "owner_refused"
     INTERNAL = "internal"
 
 

--- a/local_operator/browser_bridge/protocol.py
+++ b/local_operator/browser_bridge/protocol.py
@@ -65,6 +65,10 @@ METHODS = (
     # issues no later command and so never self-healed. Presentation only: it
     # drives no tab, reads no page, and returns nothing but the applied label.
     "retitle",
+    "owner_recover",
+    "owner_finish",
+    "owner_retain",
+    "owner_release",
 )
 
 
@@ -90,6 +94,10 @@ ORIGIN_PROMPT_TIMEOUT_MS = 60_000
 #: HTTP timeout from them (backend.py) so the daemon's typed timeout always
 #: arrives before the client gives up.
 COMMAND_TIMEOUTS = {
+    "owner_recover": 20.0,
+    "owner_finish": 20.0,
+    "owner_retain": 20.0,
+    "owner_release": 20.0,
     "open": 30.0,
     "goto": 30.0,
     "click": 25.0,

--- a/local_operator/browser_bridge/resources.py
+++ b/local_operator/browser_bridge/resources.py
@@ -117,14 +117,47 @@ class BrowserResource:
             allocation_id=self.record.get("allocation_id") or secrets.token_urlsafe(24),
             state=self.record.get("state", "closed"),
         )
-        if self._lease_at_creation and self.previous_generation != self.generation:
-            # Only a real lease change is a resume. Gating this on "generation
-            # differs" alone would retire a live owner's terminal intent on the
-            # unleased path, where the generation is now deliberately reused.
+        if self._is_new_execution_over_settled_scope():
             self.record.pop("terminal", None)
             if self.record.get("retention") == "paused scope":
                 self.record["release_pause"] = True
         self._save()
+
+    def _is_new_execution_over_settled_scope(self) -> bool:
+        """May this owner retire the terminal intent the record already carries?
+
+        The question a resume has to answer is "is this a NEW RUN of the
+        session", and the honest evidence for that is the record itself, never
+        a pid and never a lease.
+
+        Keying this on holding a lease was wrong in both directions, and the
+        wrong one shipped: in-process children use ``claim_session``, not
+        ``acquire_session_lease``, so for every subagent the branch was dead
+        and ``terminal`` became permanent. ``allocate`` refuses on terminal, so
+        a finalized child could never browse again on any later run — and
+        ``hub op='resume'`` relaunches children on their own directory, which
+        made that an ordinary flow, not a corner. Worse, a scope that ended
+        holding a tab for a pending approval could no longer be finished, so
+        the tab was stranded: the leak class this module exists to remove.
+
+        Two facts make the record sufficient. ``terminal`` is written only by
+        ``finish``, so its presence means the previous scope SETTLED and has no
+        live owner left to fence. And ``initialize`` runs only on a
+        freshly-constructed resource — the instance that called ``finish``
+        returns early from it — so reaching here over a settled record IS a
+        later execution. That keeps B1 intact: a live incumbent has no terminal
+        recorded, so a concurrent second instance still cannot retire anything.
+
+        A STRANDED scope (the close failed, so the tab is still out there) is
+        retired too, and that is deliberate rather than an oversight: the
+        resumed owner is alive again and is the party responsible for that tab,
+        which is precisely the route out that the crash-shape refusal names
+        — resume the session and let the owner close it. It costs the operator
+        no evidence, because ``cleanup_exact`` reaches a record through
+        ``adopt``, never through this method, and a row only stops being a
+        cleanup candidate while a live owner is actually holding it.
+        """
+        return bool(self.record.get("terminal"))
 
     def adopt(self, generation: str) -> None:
         """Take on an EXISTING record's identity without minting a new one.
@@ -277,7 +310,10 @@ class BrowserResource:
                 self._save()
                 return BrowserCleanupResult(state)
         except Exception as exc:
-            return BrowserCleanupResult("pending", type(exc).__name__)
+            # The bridge's own message names the command that diagnoses the
+            # failure; the class name is the fallback for a type that carries
+            # no message, matching how the CLI renders its outer handler.
+            return BrowserCleanupResult("pending", str(exc) or type(exc).__name__)
 
 
 #: States in which a tab is stranded and an operator may recover it. Both are

--- a/local_operator/browser_bridge/resources.py
+++ b/local_operator/browser_bridge/resources.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any
 
 from local_operator.browser_bridge.backend import BridgeClient, BridgeError
+from local_operator.browser_bridge.protocol import ErrorCode
 
 RESOURCE_NAME = ".browser-resource.json"
 
@@ -42,12 +43,27 @@ class BrowserResource:
         self.previous_generation = ""
         self.recovered = False
         self._lease_at_creation = self._lease_generation()
-        self._host_generation = self._lease_at_creation or secrets.token_urlsafe(24)
+        # Whether the execution lease DEFINES this owner's identity. Only then
+        # is a lease change a resume that must fence us; an owner whose identity
+        # came from the record is authorized by the record plus, for the CLI
+        # path, the lease it holds for exclusivity rather than for naming.
+        self._identity_from_lease = False
 
     @property
     def execution_generation(self) -> str:
-        """A pure identity lookup; stale owners are rejected INSIDE finalization."""
-        return self.generation or self._host_generation
+        """A pure identity lookup; stale owners are rejected INSIDE finalization.
+
+        Never mints: an identity read must not become a write, or merely asking
+        who owns the tab would rotate the answer.
+        """
+        if self.generation:
+            return self.generation
+        if self._lease_at_creation:
+            return self._lease_at_creation
+        try:
+            return str(self._load().get("generation", ""))
+        except (BrowserOwnershipError, OSError, ValueError):
+            return ""
 
     def _load(self) -> dict[str, Any]:
         try:
@@ -70,12 +86,25 @@ class BrowserResource:
             return
         self.record = self._load()
         self.previous_generation = str(self.record.get("generation", ""))
-        # Factory-created sessions use the existing exclusive execution lease.
-        # In-process children have unique transcript directories and no lease;
-        # their private generation still fences a stale finalizer after resume.
         if self._lease_at_creation and self._lease_generation() != self._lease_at_creation:
             raise BrowserOwnershipError("browser host execution lease changed; no action taken")
-        self.generation = self._host_generation
+        # Identity is DURABLE PER SESSION, never per BrowserResource instance.
+        #
+        # Factory-built sessions inherit the exclusive execution lease's
+        # generation, so a resume is a genuinely new execution and the old one
+        # is correctly fenced. In-process children take neither path: they use
+        # `claim_session`, not `acquire_session_lease`, so there is no lease to
+        # read. Minting a per-instance token there made a SECOND Session over
+        # the same directory revoke the FIRST one's authority over a tab it was
+        # still holding — the incumbent's finalizer returned `unresolved` while
+        # the newcomer inherited its surface_id, stranding a tab in the pool
+        # that nobody could close. That is the exact leak this module exists to
+        # remove, so the unleased case ADOPTS the stored identity instead: one
+        # session id means one owner, whichever object is asking.
+        self.generation = (
+            self._lease_at_creation or self.previous_generation or secrets.token_urlsafe(24)
+        )
+        self._identity_from_lease = bool(self._lease_at_creation)
         generations = list(self.record.get("bridge_generations", []))
         for candidate in (self.previous_generation, self.generation):
             if candidate and candidate not in generations:
@@ -88,17 +117,32 @@ class BrowserResource:
             allocation_id=self.record.get("allocation_id") or secrets.token_urlsafe(24),
             state=self.record.get("state", "closed"),
         )
-        if self.previous_generation and self.previous_generation != self.generation:
-            # A resume is a new execution of the SAME conversation, authorized
-            # by the lease. Preserve its tab/retention but retire old run intent.
+        if self._lease_at_creation and self.previous_generation != self.generation:
+            # Only a real lease change is a resume. Gating this on "generation
+            # differs" alone would retire a live owner's terminal intent on the
+            # unleased path, where the generation is now deliberately reused.
             self.record.pop("terminal", None)
             if self.record.get("retention") == "paused scope":
                 self.record["release_pause"] = True
         self._save()
 
+    def adopt(self, generation: str) -> None:
+        """Take on an EXISTING record's identity without minting a new one.
+
+        Operator recovery acts on the row the operator selected, so it must not
+        renumber it: the CLI holds the lease for exclusivity, and the lease's
+        own freshly-minted generation is not this owner's name.
+        """
+        self.record = self._load()
+        if self.record.get("generation") != generation:
+            raise BrowserOwnershipError("browser owner generation is stale; no action taken")
+        self.generation = generation
+        self.previous_generation = generation
+        self._identity_from_lease = False
+
     def assert_current(self) -> None:
-        lease = self._lease_generation()
         current = self._load()
+        lease = self._lease_generation() if self._identity_from_lease else ""
         if (lease and lease != self.generation) or current.get("generation") != self.generation:
             raise BrowserOwnershipError("browser owner generation is stale; no action taken")
 
@@ -130,7 +174,12 @@ class BrowserResource:
         try:
             result = await BridgeClient().call("owner_recover", self.params())
         except BridgeError as exc:
-            if "unknown method" in exc.message or "protocol" in exc.message.lower():
+            # An ownership-AWARE extension refuses with the typed OWNER_REFUSED;
+            # anything else from an `owner_*` method means the extension does
+            # not implement ownership at all. Keying on the typed code rather
+            # than on the old side's wording is what stops a reworded message
+            # from silently degrading this into a raw internal error.
+            if exc.code in (ErrorCode.INTERNAL, ErrorCode.PROTO_MISMATCH):
                 raise BrowserOwnershipError(
                     "Browser ownership recovery requires an updated Local Operator extension. "
                     "Update the extension, reconnect it, then retry; no new tab was allocated."
@@ -231,12 +280,47 @@ class BrowserResource:
             return BrowserCleanupResult("pending", type(exc).__name__)
 
 
+#: States in which a tab is stranded and an operator may recover it. Both are
+#: reachable: ``finish`` writes ``cleanup_pending`` as its durable intent, then
+#: OVERWRITES it with the bridge's own reply, so a failed ``chrome.tabs.remove``
+#: persists ``pending``. Listing one and accepting the other made the single
+#: genuinely-stranded state render as "not a candidate" while cleanup would have
+#: taken it. One tuple, read by both, so they cannot drift apart again.
+_RECOVERABLE_STATES = ("cleanup_pending", "pending")
+
+
+def cleanup_disposition(value: dict[str, Any]) -> tuple[bool, str]:
+    """``(eligible, reason)`` for one record — the ONE eligibility rule.
+
+    The reason names what would make the row actionable, because "you copied
+    the wrong generation" and "a human is finishing a login in that tab" are
+    opposite situations and the operator cannot otherwise tell which they are
+    in. Guessing wrong pushes them to retry against a protected tab, which is
+    the behaviour the fence exists to discourage.
+    """
+    if value.get("retention"):
+        return False, f"retained: {value['retention']} — the owning session must release it"
+    if not value.get("terminal"):
+        # The crash shape: killed before finish_browser_scope, so no terminal
+        # intent exists and none may be inferred from the process being gone.
+        # Refusing is correct, but refusing SILENTLY dead-ends the operator, so
+        # name the route that actually works: the owner closes its own tab.
+        return False, (
+            "no terminal intent recorded (owner did not finish) — "
+            "resume it with 'lop --resume <session>' and let it close the tab"
+        )
+    if value.get("state") not in _RECOVERABLE_STATES:
+        return False, f"state is '{value.get('state', 'unresolved')}'; nothing is stranded"
+    return True, ""
+
+
 def read_inventory(directory: Path) -> list[dict[str, Any]]:
     """Redacted local evidence; unknown/live/retained never becomes eligible."""
     rows: list[dict[str, Any]] = []
     for path in sorted(directory.glob(f"*/{RESOURCE_NAME}")):
         try:
             value = json.loads(path.read_text())
+            eligible, reason = cleanup_disposition(value)
             rows.append(
                 {
                     "session_id": path.parent.name,
@@ -244,14 +328,18 @@ def read_inventory(directory: Path) -> list[dict[str, Any]]:
                     "state": value.get("state", "unresolved"),
                     "terminal": value.get("terminal", ""),
                     "retention": value.get("retention", ""),
-                    "cleanup_candidate": bool(value.get("terminal"))
-                    and not value.get("retention")
-                    and value.get("state") == "cleanup_pending",
+                    "cleanup_candidate": eligible,
+                    "blocked_reason": reason,
                 }
             )
         except (OSError, ValueError, TypeError):
             rows.append(
-                {"session_id": path.parent.name, "state": "unresolved", "cleanup_candidate": False}
+                {
+                    "session_id": path.parent.name,
+                    "state": "unresolved",
+                    "cleanup_candidate": False,
+                    "blocked_reason": "record is unreadable",
+                }
             )
     return rows
 
@@ -265,15 +353,29 @@ async def cleanup_exact(directory: Path, generation: str) -> BrowserCleanupResul
     from local_operator.session_lease import acquire_session_lease
 
     value = BrowserResource(directory, directory.name)._load()
-    if value.get("generation") != generation or not value.get("terminal") or value.get("retention"):
-        return BrowserCleanupResult("unresolved", "selection stale, nonterminal, or retained")
+    if not value:
+        return BrowserCleanupResult("unresolved", "no ownership record for that session")
+    if value.get("generation") != generation:
+        return BrowserCleanupResult(
+            "unresolved",
+            "generation does not match the current record — "
+            "re-run 'lop browser tabs' and copy the current generation",
+        )
+    eligible, reason = cleanup_disposition(value)
+    if not eligible:
+        return BrowserCleanupResult("unresolved", reason)
     lease = acquire_session_lease(directory)
     try:
+        # Constructed INSIDE the lease so it reads the generation the lease just
+        # established. Building it outside made a CLI-path resource mint its own
+        # token and persist it, rotating the very identifier the listing had
+        # just told the operator to copy: their retry then failed as "stale"
+        # through no fault of theirs, on every attempt.
         resource = BrowserResource(directory, directory.name)
         current = resource._load()
         if current != value:
             return BrowserCleanupResult("unresolved", "ownership changed; no action taken")
-        resource.initialize()
+        resource.adopt(str(value["generation"]))
         return await asyncio.wait_for(
             resource.finish(resource.generation, str(value["terminal"])), 5.0
         )

--- a/local_operator/browser_bridge/resources.py
+++ b/local_operator/browser_bridge/resources.py
@@ -1,0 +1,283 @@
+"""Private session browser obligations, never a PID/age-based orphan registry.
+
+The transcript's execution lease owns writes. A process disappearing proves
+nothing about task completion: only finish() records terminal intent. Capabilities
+stay in a mode-0600 sidecar, and public inventories deliberately omit them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import secrets
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from local_operator.browser_bridge.backend import BridgeClient, BridgeError
+
+RESOURCE_NAME = ".browser-resource.json"
+
+
+class BrowserOwnershipError(RuntimeError):
+    """An expected ownership/compatibility refusal, safe to show without a stack."""
+
+
+@dataclass(frozen=True)
+class BrowserCleanupResult:
+    state: str
+    detail: str = ""
+
+
+class BrowserResource:
+    def __init__(self, directory: Path, session_id: str) -> None:
+        self.directory = directory
+        self.session_id = session_id
+        self.path = directory / RESOURCE_NAME
+        self.lock = asyncio.Lock()
+        self.record: dict[str, Any] = {}
+        self.generation = ""
+        self.previous_generation = ""
+        self.recovered = False
+        self._lease_at_creation = self._lease_generation()
+        self._host_generation = self._lease_at_creation or secrets.token_urlsafe(24)
+
+    @property
+    def execution_generation(self) -> str:
+        """A pure identity lookup; stale owners are rejected INSIDE finalization."""
+        return self.generation or self._host_generation
+
+    def _load(self) -> dict[str, Any]:
+        try:
+            value = json.loads(self.path.read_text())
+        except FileNotFoundError:
+            return {}
+        if not isinstance(value, dict) or value.get("session_id") != self.session_id:
+            raise BrowserOwnershipError("browser resource ownership is unresolved")
+        return value
+
+    def _lease_generation(self) -> str:
+        from local_operator.session_lease import _read_claim
+
+        generation, _pid = _read_claim(self.directory / ".execution-lease")
+        return generation or ""
+
+    def initialize(self) -> None:
+        if self.generation:
+            self.assert_current()
+            return
+        self.record = self._load()
+        self.previous_generation = str(self.record.get("generation", ""))
+        # Factory-created sessions use the existing exclusive execution lease.
+        # In-process children have unique transcript directories and no lease;
+        # their private generation still fences a stale finalizer after resume.
+        if self._lease_at_creation and self._lease_generation() != self._lease_at_creation:
+            raise BrowserOwnershipError("browser host execution lease changed; no action taken")
+        self.generation = self._host_generation
+        generations = list(self.record.get("bridge_generations", []))
+        for candidate in (self.previous_generation, self.generation):
+            if candidate and candidate not in generations:
+                generations.append(candidate)
+        self.record.update(
+            bridge_generations=generations,
+            session_id=self.session_id,
+            generation=self.generation,
+            proof=self.record.get("proof") or secrets.token_urlsafe(32),
+            allocation_id=self.record.get("allocation_id") or secrets.token_urlsafe(24),
+            state=self.record.get("state", "closed"),
+        )
+        if self.previous_generation and self.previous_generation != self.generation:
+            # A resume is a new execution of the SAME conversation, authorized
+            # by the lease. Preserve its tab/retention but retire old run intent.
+            self.record.pop("terminal", None)
+            if self.record.get("retention") == "paused scope":
+                self.record["release_pause"] = True
+        self._save()
+
+    def assert_current(self) -> None:
+        lease = self._lease_generation()
+        current = self._load()
+        if (lease and lease != self.generation) or current.get("generation") != self.generation:
+            raise BrowserOwnershipError("browser owner generation is stale; no action taken")
+
+    def _save(self) -> None:
+        self.directory.mkdir(parents=True, exist_ok=True)
+        fd, name = tempfile.mkstemp(prefix=".browser-resource-", dir=self.directory)
+        try:
+            with os.fdopen(fd, "w") as stream:
+                json.dump(self.record, stream)
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(name, self.path)
+        finally:
+            if os.path.exists(name):
+                os.unlink(name)
+
+    def params(self) -> dict[str, Any]:
+        self.initialize()
+        return {
+            "requester": f"session:{self.session_id}",
+            "owner_proof": str(self.record["proof"]),
+            "owner_generation": self.generation,
+            "previous_generation": self.previous_generation,
+            "previous_generations": self.record["bridge_generations"],
+            "allocation_id": str(self.record["allocation_id"]),
+        }
+
+    async def recover(self) -> dict[str, Any]:
+        try:
+            result = await BridgeClient().call("owner_recover", self.params())
+        except BridgeError as exc:
+            if "unknown method" in exc.message or "protocol" in exc.message.lower():
+                raise BrowserOwnershipError(
+                    "Browser ownership recovery requires an updated Local Operator extension. "
+                    "Update the extension, reconnect it, then retry; no new tab was allocated."
+                ) from exc
+            raise
+        if result.get("ownership_version") != 1:
+            raise BrowserOwnershipError(
+                "browser extension needs ownership-recovery support; update it first"
+            )
+        self.assert_current()
+        if self.record.get("release_pause") and result.get("state") != "unresolved":
+            await BridgeClient().call("owner_release", self.params())
+            self.assert_current()
+            self.record.pop("release_pause", None)
+            self.record["retention"] = ""
+        if result.get("state") == "unresolved" and self.record.get("surface_id"):
+            # A full browser restart destroys session-storage authority. Keep
+            # the old capability only as private evidence, never adopt by tab ID.
+            self.record["unresolved_surface_id"] = self.record["surface_id"]
+        self.record["surface_id"] = str(result.get("tab", ""))
+        self.record["state"] = (
+            "cleanup_pending"
+            if self.record.get("terminal")
+            else str(result.get("state", "unresolved"))
+        )
+        if result.get("state") != "unresolved":
+            # Acknowledged CAS collapses the crash-replay chain. Before this
+            # receipt every attempted generation remains a possible peer state.
+            self.record["bridge_generations"] = [self.generation]
+        self.recovered = True
+        self._save()
+        return result
+
+    def remember(self, surface_id: str, *, state: str | None = None) -> None:
+        self.assert_current()
+        self.record["surface_id"] = surface_id
+        self.record["state"] = (
+            "cleanup_pending"
+            if self.record.get("terminal")
+            else state or ("owned" if surface_id else "closed")
+        )
+        self._save()
+
+    def allocate(self) -> None:
+        self.assert_current()
+        if self.record.get("terminal"):
+            raise BrowserOwnershipError("browser scope has ended; resume it before allocating")
+        if self.record.get("state") in ("closed", "unresolved"):
+            self.record["allocation_id"] = secrets.token_urlsafe(24)
+        self.record["state"] = "allocating"
+        self._save()
+
+    async def finish(self, generation: str, outcome: str) -> BrowserCleanupResult:
+        try:
+            self.initialize()
+        except (RuntimeError, OSError, ValueError):
+            # A stale child still owes its terminal event. Refusal must be a
+            # result, not an exception that bypasses the runner's publication.
+            return BrowserCleanupResult(
+                "unresolved", "owner changed or unreadable; no action taken"
+            )
+        if generation != self.generation:
+            return BrowserCleanupResult("unresolved", "stale generation; no action taken")
+        # Persist intent BEFORE waiting for a possibly in-flight tool. A crash
+        # or timeout leaves an exact obligation, not guessed terminal evidence.
+        self.assert_current()
+        outcome = str(self.record.get("terminal") or outcome)
+        self.record["terminal"] = outcome
+        self.record["state"] = "cleanup_pending"
+        self._save()
+        try:
+            async with self.lock:
+                self.assert_current()
+                if not self.recovered:
+                    await self.recover()
+                if self.record.get("unresolved_surface_id") and not self.record.get("surface_id"):
+                    return BrowserCleanupResult(
+                        "unresolved",
+                        "browser ownership could not be proven after restart; no tab adopted",
+                    )
+                if self.record.get("retention"):
+                    await BridgeClient().call(
+                        "owner_retain", {**self.params(), "reason": self.record["retention"]}
+                    )
+                result = await BridgeClient().call(
+                    "owner_finish", {**self.params(), "outcome": outcome}
+                )
+                self.assert_current()
+                state = str(result.get("state", "unresolved"))
+                self.record["state"] = state
+                if state == "closed":
+                    self.record["surface_id"] = ""
+                    if self.record.get("unresolved_surface_id"):
+                        state = self.record["state"] = "unresolved"
+                self._save()
+                return BrowserCleanupResult(state)
+        except Exception as exc:
+            return BrowserCleanupResult("pending", type(exc).__name__)
+
+
+def read_inventory(directory: Path) -> list[dict[str, Any]]:
+    """Redacted local evidence; unknown/live/retained never becomes eligible."""
+    rows: list[dict[str, Any]] = []
+    for path in sorted(directory.glob(f"*/{RESOURCE_NAME}")):
+        try:
+            value = json.loads(path.read_text())
+            rows.append(
+                {
+                    "session_id": path.parent.name,
+                    "generation": value.get("generation", ""),
+                    "state": value.get("state", "unresolved"),
+                    "terminal": value.get("terminal", ""),
+                    "retention": value.get("retention", ""),
+                    "cleanup_candidate": bool(value.get("terminal"))
+                    and not value.get("retention")
+                    and value.get("state") == "cleanup_pending",
+                }
+            )
+        except (OSError, ValueError, TypeError):
+            rows.append(
+                {"session_id": path.parent.name, "state": "unresolved", "cleanup_candidate": False}
+            )
+    return rows
+
+
+async def cleanup_exact(directory: Path, generation: str) -> BrowserCleanupResult:
+    """Explicit operator recovery of ONE terminal generation, never a sweep.
+
+    The execution lease rejects live/uncertain owners. A dead PID only permits
+    acquiring that lease; matching durable terminal intent is still mandatory.
+    """
+    from local_operator.session_lease import acquire_session_lease
+
+    value = BrowserResource(directory, directory.name)._load()
+    if value.get("generation") != generation or not value.get("terminal") or value.get("retention"):
+        return BrowserCleanupResult("unresolved", "selection stale, nonterminal, or retained")
+    lease = acquire_session_lease(directory)
+    try:
+        resource = BrowserResource(directory, directory.name)
+        current = resource._load()
+        if current != value:
+            return BrowserCleanupResult("unresolved", "ownership changed; no action taken")
+        resource.initialize()
+        return await asyncio.wait_for(
+            resource.finish(resource.generation, str(value["terminal"])), 5.0
+        )
+    except TimeoutError:
+        return BrowserCleanupResult("pending", "browser cleanup deadline exceeded")
+    finally:
+        lease.release()

--- a/local_operator/browser_bridge/resources.py
+++ b/local_operator/browser_bridge/resources.py
@@ -119,6 +119,14 @@ class BrowserResource:
         )
         if self._is_new_execution_over_settled_scope():
             self.record.pop("terminal", None)
+            # The extension keeps its OWN copy of the terminal intent and used
+            # to clear it only when the generation string changed — which the
+            # unleased path deliberately never does, so retiring the record
+            # alone moved the refusal one layer down instead of removing it.
+            # DURABLE, and cleared only by an acknowledged recover: a run that
+            # dies between here and the bridge would otherwise leave the
+            # extension holding a terminal no later run could ever retire.
+            self.record["resumed_scope"] = True
             if self.record.get("retention") == "paused scope":
                 self.record["release_pause"] = True
         self._save()
@@ -201,6 +209,11 @@ class BrowserResource:
             "previous_generation": self.previous_generation,
             "previous_generations": self.record["bridge_generations"],
             "allocation_id": str(self.record["allocation_id"]),
+            # This owner is a NEW RUN over a scope that already settled. The
+            # generation is reused (B1), so it is the only evidence the
+            # extension has that a resume happened; without it the two sides
+            # disagree about what a resume is and `open` is refused forever.
+            "resumed_scope": bool(self.record.get("resumed_scope")),
         }
 
     async def recover(self) -> dict[str, Any]:
@@ -242,6 +255,12 @@ class BrowserResource:
             # Acknowledged CAS collapses the crash-replay chain. Before this
             # receipt every attempted generation remains a possible peer state.
             self.record["bridge_generations"] = [self.generation]
+        # The extension has now retired its copy, so the obligation is
+        # discharged. Held until the ACK rather than cleared when it was
+        # written: an unacknowledged resume must be replayed, and leaving it
+        # set would make a LATER finish's terminal clearable by a recover that
+        # is no longer a resume at all.
+        self.record.pop("resumed_scope", None)
         self.recovered = True
         self._save()
         return result

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -1370,14 +1370,21 @@ def browser_command(args: argparse.Namespace) -> int:
         # script as an empty browser. Unowned tabs are listed, never selectable.
         live_tabs: list[dict[str, Any]] = []
         current = browser_state.read()
-        if current is not None:
-            # Read-only, and never fatal: an absent or unreachable bridge just
-            # means the live half is unknown, which must not break the listing
-            # of the durable half.
-            probe = browser_install.health(current.port)
-            driven = (probe or {}).get("driven_tabs")
-            if isinstance(driven, list):
-                live_tabs = [entry for entry in driven if isinstance(entry, dict)]
+        # Resolve the port exactly as the sibling `status` does. `state.read()`
+        # returns None for a MISSING OR CORRUPT discovery file as much as for
+        # an absent daemon, so skipping the probe on None made a healthy bridge
+        # driving five tabs render as an empty browser — `status` found them at
+        # the default port in the same state, which is the divergence this
+        # command was added to remove.
+        probe = browser_install.health(current.port if current else browser_install.DEFAULT_PORT)
+        driven = (probe or {}).get("driven_tabs")
+        # Read-only and never fatal, but UNKNOWN IS NOT ZERO: a probe that did
+        # not answer means the live half is unknowable, and reporting that as
+        # "no tabs" tells the operator the opposite of the truth in exactly the
+        # wedged-bridge state that sent them here.
+        live_known = isinstance(driven, list)
+        if live_known:
+            live_tabs = [entry for entry in driven if isinstance(entry, dict)]
         # Every durable record is redacted (no capability, no tab handle), so a
         # record cannot be matched to a live URL here. The honest framing is a
         # count of records against a count of live tabs, with the live ones
@@ -1388,11 +1395,18 @@ def browser_command(args: argparse.Namespace) -> int:
                 json.dumps(
                     {
                         "resources": rows,
-                        "unowned_tabs": [
+                        "live_tabs": [
                             {"url": str(tab.get("url", "")), "title": str(tab.get("title", ""))}
                             for tab in unowned
                         ],
-                        "live_tab_count": len(live_tabs),
+                        # Null, not 0, when the bridge did not answer: a script
+                        # must not be able to read an unreachable bridge as an
+                        # empty browser. The key is `live_tabs` to match the
+                        # rendered heading — records are redacted, so a listed
+                        # tab can only be described as live, never proven
+                        # unowned.
+                        "live_tabs_known": live_known,
+                        "live_tab_count": len(live_tabs) if live_known else None,
                         "mode": "read-only",
                     },
                     indent=2,
@@ -1400,7 +1414,16 @@ def browser_command(args: argparse.Namespace) -> int:
             )
             return 0
         if not rows and not live_tabs:
-            print("No browser tabs and no ownership records.")
+            print(
+                "No browser tabs and no ownership records."
+                if live_known
+                else textwrap.fill(
+                    "No ownership records. The bridge did not answer, so open "
+                    "tabs are unknown — run 'lop browser status' to check the "
+                    "daemon.",
+                    width=78,
+                )
+            )
             return 0
         if rows:
             # Pad the state so the third column starts at one offset: at real
@@ -1415,10 +1438,19 @@ def browser_command(args: argparse.Namespace) -> int:
                 # rstrip so an unmarked row carries no trailing padding.
                 print(f"{row['session_id']}  {str(row.get('state', '')):<{width}}{mark}".rstrip())
                 print(f"  generation={row.get('generation', '')}")
-                print(
-                    f"  terminal={row.get('terminal') or 'not established'}; "
-                    f"retention={row.get('retention') or 'none recorded'}"
-                )
+                # Wrapped on the same discipline as the reason below it: a
+                # retention reason is free text (it can quote a whole approval
+                # URL), so an unwrapped line here ran to 141 columns beside
+                # neighbours that wrap at 76.
+                for line in textwrap.wrap(
+                    f"terminal={row.get('terminal') or 'not established'}; "
+                    f"retention={row.get('retention') or 'none recorded'}",
+                    width=76,
+                    initial_indent="  ",
+                    subsequent_indent="    ",
+                    break_long_words=False,
+                ):
+                    print(line)
                 if not row.get("cleanup_candidate") and row.get("blocked_reason"):
                     # Wrapped: the reasons name a recovery command, and a line
                     # running past the terminal width is where that command
@@ -1446,6 +1478,18 @@ def browser_command(args: argparse.Namespace) -> int:
             print(
                 "  Handles are redacted, so these cannot be attributed to a record above."
                 "\n  Close an unwanted tab by hand; provenance is unproven."
+            )
+        elif not live_known and rows:
+            # The records rendered above are only half the answer, and silence
+            # here would read as "the browser is empty" beside them.
+            print()
+            print(
+                textwrap.fill(
+                    "Live tabs: unknown — the bridge did not answer, so tabs open "
+                    "outside these records could not be listed. Run 'lop browser "
+                    "status' to check the daemon.",
+                    width=78,
+                )
             )
         print("\nRead-only. PID absence, age, and localhost URLs never authorize cleanup.")
         if any(row.get("cleanup_candidate") for row in rows):

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -446,6 +446,17 @@ def build_cli_parser() -> argparse.ArgumentParser:
         help="Reconcile advertised state against reality: drop tabs that no longer "
         "exist and republish a fresh heartbeat. Safe while sessions are live.",
     )
+    for action in ("tabs", "reconcile"):
+        inventory_browser = browser_subparsers.add_parser(
+            action, help="Inspect redacted browser ownership; never close tabs"
+        )
+        inventory_browser.add_argument("--json", action="store_true")
+    cleanup_browser = browser_subparsers.add_parser(
+        "cleanup", help="Close one proven-terminal browser owner after revalidation"
+    )
+    cleanup_browser.add_argument("session_id")
+    cleanup_browser.add_argument("--generation", required=True)
+    cleanup_browser.add_argument("--yes", action="store_true", help="Approve this exact cleanup")
     for action in ("start", "stop", "restart"):
         browser_subparsers.add_parser(action, help=f"{action.capitalize()} the daemon")
     pair_browser = browser_subparsers.add_parser("pair", help="Show the extension pairing code")
@@ -1302,6 +1313,47 @@ def config_list_command() -> int:
 def browser_command(args: argparse.Namespace) -> int:
     """Dispatch ``lop browser …`` without importing the daemon at CLI startup."""
     command = getattr(args, "browser_command", None)
+    if command in ("tabs", "reconcile", "cleanup"):
+        import asyncio
+        import json
+
+        from local_operator.browser_bridge.resources import (
+            cleanup_exact,
+            read_inventory,
+        )
+
+        sessions = config_dir() / "sessions"
+        if command == "cleanup":
+            if not args.yes:
+                print("No changes. Repeat with --yes to approve this exact session and generation.")
+                return 1
+            if Path(args.session_id).name != args.session_id or args.session_id in (".", ".."):
+                print("Invalid session id; no action taken.")
+                return 1
+            try:
+                result = asyncio.run(cleanup_exact(sessions / args.session_id, args.generation))
+            except Exception as exc:
+                print(f"Cleanup blocked: {type(exc).__name__}; no unproven tab was selected.")
+                return 1
+            print(f"Browser cleanup: {result.state}. {result.detail}")
+            return 0 if result.state in ("closed", "retained") else 1
+        rows = read_inventory(sessions)
+        if args.json:
+            print(json.dumps({"resources": rows, "mode": "read-only"}))
+        elif not rows:
+            print("No durable browser ownership records. Legacy tabs remain unknown and untouched.")
+        else:
+            for row in rows:
+                print(
+                    f"{row['session_id']}  {row['state']}  generation={row.get('generation', '')}"
+                )
+                print(
+                    f"  terminal={row.get('terminal') or 'not established'}; "
+                    f"retention={row.get('retention') or 'none recorded'}"
+                )
+            print("Read-only. PID absence, age, and localhost URLs never authorize cleanup.")
+            print("Exact cleanup: lop browser cleanup SESSION --generation GENERATION --yes")
+        return 0
     if command == "serve":
         from local_operator.browser_bridge.daemon import main as serve_main
 

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -446,11 +446,14 @@ def build_cli_parser() -> argparse.ArgumentParser:
         help="Reconcile advertised state against reality: drop tabs that no longer "
         "exist and republish a fresh heartbeat. Safe while sessions are live.",
     )
-    for action in ("tabs", "reconcile"):
-        inventory_browser = browser_subparsers.add_parser(
-            action, help="Inspect redacted browser ownership; never close tabs"
+    for action, blurb in (
+        ("tabs", "List durable ownership records and live tabs (read-only)"),
+        ("reconcile", "Alias for 'tabs': inspect ownership without closing anything"),
+    ):
+        inventory_browser = browser_subparsers.add_parser(action, help=blurb)
+        inventory_browser.add_argument(
+            "--json", action="store_true", help="machine-readable output"
         )
-        inventory_browser.add_argument("--json", action="store_true")
     cleanup_browser = browser_subparsers.add_parser(
         "cleanup", help="Close one proven-terminal browser owner after revalidation"
     )
@@ -1316,7 +1319,10 @@ def browser_command(args: argparse.Namespace) -> int:
     if command in ("tabs", "reconcile", "cleanup"):
         import asyncio
         import json
+        import textwrap
 
+        from local_operator.browser_bridge import install as browser_install
+        from local_operator.browser_bridge import state as browser_state
         from local_operator.browser_bridge.resources import (
             cleanup_exact,
             read_inventory,
@@ -1333,25 +1339,116 @@ def browser_command(args: argparse.Namespace) -> int:
             try:
                 result = asyncio.run(cleanup_exact(sessions / args.session_id, args.generation))
             except Exception as exc:
-                print(f"Cleanup blocked: {type(exc).__name__}; no unproven tab was selected.")
+                # The bridge and lease errors already carry operator-grade
+                # sentences naming the command that fixes them; printing the
+                # class name instead threw that away and read as a truncated
+                # message. Keep the class name only for genuinely unexpected types.
+                detail = str(exc) or type(exc).__name__
+                print(f"Cleanup blocked: {detail} Nothing was closed.")
                 return 1
-            print(f"Browser cleanup: {result.state}. {result.detail}")
+            if result.state == "closed":
+                message = "Browser cleanup: closed. The tab was closed and its record settled."
+            elif result.state == "retained":
+                message = f"Browser cleanup: retained — {result.detail or 'the tab is held open'}."
+            elif result.state == "pending":
+                # The generation is deliberately NOT rotated by a failed attempt
+                # any more, so the value they already copied stays correct.
+                message = (
+                    f"Browser cleanup: pending — nothing was closed ({result.detail}). "
+                    "Retry the same command once the bridge answers; "
+                    "the generation you copied is still current."
+                )
+            else:
+                message = f"Browser cleanup: no action taken — {result.detail}."
+            print(textwrap.fill(message, width=78, subsequent_indent="  "))
             return 0 if result.state in ("closed", "retained") else 1
         rows = read_inventory(sessions)
+        # A command called `tabs` must reconcile with the browser and with
+        # `status`: reporting "no records" while the bridge drives seven tabs
+        # renders as its own opposite in EXACTLY the pool-exhausted state an
+        # operator reaches for it in, and `{"resources": []}` reads to any
+        # script as an empty browser. Unowned tabs are listed, never selectable.
+        live_tabs: list[dict[str, Any]] = []
+        current = browser_state.read()
+        if current is not None:
+            # Read-only, and never fatal: an absent or unreachable bridge just
+            # means the live half is unknown, which must not break the listing
+            # of the durable half.
+            probe = browser_install.health(current.port)
+            driven = (probe or {}).get("driven_tabs")
+            if isinstance(driven, list):
+                live_tabs = [entry for entry in driven if isinstance(entry, dict)]
+        # Every durable record is redacted (no capability, no tab handle), so a
+        # record cannot be matched to a live URL here. The honest framing is a
+        # count of records against a count of live tabs, with the live ones
+        # listed as unattributed rather than falsely claimed by a session.
+        unowned = live_tabs
         if args.json:
-            print(json.dumps({"resources": rows, "mode": "read-only"}))
-        elif not rows:
-            print("No durable browser ownership records. Legacy tabs remain unknown and untouched.")
-        else:
-            for row in rows:
-                print(
-                    f"{row['session_id']}  {row['state']}  generation={row.get('generation', '')}"
+            print(
+                json.dumps(
+                    {
+                        "resources": rows,
+                        "unowned_tabs": [
+                            {"url": str(tab.get("url", "")), "title": str(tab.get("title", ""))}
+                            for tab in unowned
+                        ],
+                        "live_tab_count": len(live_tabs),
+                        "mode": "read-only",
+                    },
+                    indent=2,
                 )
+            )
+            return 0
+        if not rows and not live_tabs:
+            print("No browser tabs and no ownership records.")
+            return 0
+        if rows:
+            # Pad the state so the third column starts at one offset: at real
+            # id and token widths an unpadded row loses its columns entirely,
+            # and the generation is moved to its own indented line so an
+            # 80-column terminal cannot wrap it mid-token — a wrapped token's
+            # continuation sits in column 1, looks like a new record, and is
+            # unsafe to copy, which is exactly what cleanup asks you to do.
+            width = max(len(str(row.get("state", ""))) for row in rows)
+            for row in rows:
+                mark = "  <- cleanup candidate" if row.get("cleanup_candidate") else ""
+                # rstrip so an unmarked row carries no trailing padding.
+                print(f"{row['session_id']}  {str(row.get('state', '')):<{width}}{mark}".rstrip())
+                print(f"  generation={row.get('generation', '')}")
                 print(
                     f"  terminal={row.get('terminal') or 'not established'}; "
                     f"retention={row.get('retention') or 'none recorded'}"
                 )
-            print("Read-only. PID absence, age, and localhost URLs never authorize cleanup.")
+                if not row.get("cleanup_candidate") and row.get("blocked_reason"):
+                    # Wrapped: the reasons name a recovery command, and a line
+                    # running past the terminal width is where that command
+                    # would be broken across a wrap and mis-copied.
+                    for line in textwrap.wrap(
+                        f"not cleanable: {row['blocked_reason']}",
+                        width=76,
+                        initial_indent="  ",
+                        subsequent_indent="    ",
+                        break_long_words=False,
+                    ):
+                        print(line)
+        if unowned:
+            if not rows:
+                print(
+                    textwrap.fill(
+                        f"No durable ownership records. {len(unowned)} tab(s) are open with "
+                        "no proven owner — listed below; Local Operator will not close them.",
+                        width=78,
+                    )
+                )
+            print(f"\nlive tabs ({len(unowned)}, not selectable for cleanup):")
+            for tab in unowned:
+                print(f"  - {tab.get('url', '')}")
+            print(
+                "  Handles are redacted, so these cannot be attributed to a record above."
+                "\n  Close an unwanted tab by hand; provenance is unproven."
+            )
+        print("\nRead-only. PID absence, age, and localhost URLs never authorize cleanup.")
+        if any(row.get("cleanup_candidate") for row in rows):
             print("Exact cleanup: lop browser cleanup SESSION --generation GENERATION --yes")
         return 0
     if command == "serve":

--- a/local_operator/guides/browser/GUIDE.md
+++ b/local_operator/guides/browser/GUIDE.md
@@ -81,6 +81,48 @@ Chrome, never a window"), carries the launch recipe, the required flags,
 teardown, and the measured reasons for each. If you are not changing the
 extension's own code, this does not apply to you.
 
+## Recovering ownership without touching another session's tab
+
+A failed first navigation now rolls back only its new allocation. If removal
+fails too, ownership remains recoverable rather than disappearing behind the
+eight-tab cap. Use `browser action=recover` in the same durable session after
+an interrupted operation or resume; it cannot adopt a listed foreign handle.
+Then retry `close` or continue the owned interaction.
+
+Use `browser action=retain text="pending login"` (or another specific reason)
+when the user must finish an interaction in that exact tab, or explicitly asks
+to keep it. `release` clears that hold and completes any pending terminal
+cleanup. Ordinary assistant final messages and idle sessions are not terminal
+lifecycle evidence. Running jobs, paused work, and pending approvals are not
+orphans.
+
+Operator diagnostics are conservative:
+
+```sh
+lop browser tabs --json       # redacted durable ownership records
+lop browser reconcile         # read-only explanation; never a sweep
+lop browser cleanup SESSION --generation GENERATION --yes
+```
+
+The cleanup command is for an **explicitly selected, durably terminal owner**.
+Copy its exact session and generation from diagnostics after inspecting the
+state; the command rechecks terminal intent, retention, and the execution
+lease immediately before acting. A live or uncertain lease blocks it.
+`--yes` approves that exact operation, not unknown tabs or other user tabs.
+Legacy records with no proven owner remain unknown: ask the operator to close
+an explicitly identified unwanted tab by hand instead of guessing from its URL.
+Neither PID absence, age, an expired localhost server, nor absent runtime
+publication proves that a tab is safe to close. `status --repair` repairs bridge
+discovery; it is not an ownership takeover command.
+
+Worker/bridge restarts preserve owner recovery. A full browser restart may
+remove the extension's authority records; diagnostics then say **unresolved**.
+No restored tab is adopted merely because its numeric ID or URL matches.
+New runtimes require the ownership-capable extension and fail before allocation
+with an update instruction when an older extension is connected. Older runtimes
+continue their capability-only legacy path; their tabs are never automatically
+claimed by the new owner protocol.
+
 ## When the `browser` tool is missing: set the extension up
 
 Treat the tool's absence as a one-minute setup step, not a dead end. Do the

--- a/local_operator/guides/browser/GUIDE.md
+++ b/local_operator/guides/browser/GUIDE.md
@@ -99,10 +99,24 @@ orphans.
 Operator diagnostics are conservative:
 
 ```sh
-lop browser tabs --json       # redacted durable ownership records
-lop browser reconcile         # read-only explanation; never a sweep
+lop browser tabs              # durable ownership records + live unowned tabs
+lop browser tabs --json       # the same, machine-readable
 lop browser cleanup SESSION --generation GENERATION --yes
 ```
+
+`reconcile` is an alias for `tabs`, not a second step.
+
+The listing marks the rows cleanup will accept (`<- cleanup candidate`) and
+states why each of the others is refused, so eligibility never has to be
+inferred. Live tabs the bridge is driving are listed separately: handles are
+redacted, so they cannot be attributed to a record, and Local Operator will not
+close them.
+
+**A session killed before it finished has no terminal intent, and cleanup will
+refuse it forever — correctly, because a live owner must not be closed behind
+its back.** The route out is not `cleanup`: resume that session
+(`lop --resume <session_id>`) and let the owner `close` the tab or finalize its
+scope. The listing says this on the row itself.
 
 The cleanup command is for an **explicitly selected, durably terminal owner**.
 Copy its exact session and generation from diagnostics after inspecting the

--- a/local_operator/guides/browser/GUIDE.md
+++ b/local_operator/guides/browser/GUIDE.md
@@ -99,7 +99,7 @@ orphans.
 Operator diagnostics are conservative:
 
 ```sh
-lop browser tabs              # durable ownership records + live unowned tabs
+lop browser tabs              # durable ownership records + live bridge tabs
 lop browser tabs --json       # the same, machine-readable
 lop browser cleanup SESSION --generation GENERATION --yes
 ```
@@ -111,6 +111,12 @@ states why each of the others is refused, so eligibility never has to be
 inferred. Live tabs the bridge is driving are listed separately: handles are
 redacted, so they cannot be attributed to a record, and Local Operator will not
 close them.
+
+An unreachable bridge makes the live half **unknown, never zero** — the listing
+says so and points at `lop browser status`, and `--json` reports
+`live_tabs_known: false` with a null `live_tab_count`. Do not read that as an
+empty browser: a wedged bridge is often why tabs are stranded in the first
+place.
 
 **A session killed before it finished has no terminal intent, and cleanup will
 refuse it forever — correctly, because a live owner must not be closed behind

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -763,6 +763,7 @@ def _make_runner(
             # records outlive them so a child stays resumable, and without
             # this the roster (``hub op='list'``) could not say whether a
             # swept child finished or crashed.
+            await _finish_child_browser(child, comms, job_id, "completed")
             await _publish_terminal_outcome(
                 comms,
                 emit,
@@ -786,6 +787,9 @@ def _make_runner(
             # the record's ``paused`` flag alone precisely so the roster can
             # still tell the two apart.
             with contextlib.suppress(BaseException):
+                await _settle_child_cleanup(
+                    asyncio.create_task(_finish_child_browser(child, comms, job_id, "cancelled"))
+                )
                 await _publish_terminal_outcome(
                     comms,
                     emit,
@@ -800,6 +804,7 @@ def _make_runner(
             # is what the roster shows for a failed child once the row is
             # swept, which is the state an operator is most likely to be
             # looking at when they ask what went wrong.
+            await _finish_child_browser(child, comms, job_id, "failed")
             await _publish_terminal_outcome(
                 comms,
                 emit,
@@ -934,6 +939,36 @@ def _answered_prefix(messages: list[Any]) -> list[Any]:
             break
         cut = index
     return messages[:cut]
+
+
+async def _finish_child_browser(
+    child: "Session | None", comms: Any, job_id: str, outcome: str
+) -> None:
+    """Resource settlement precedes authoritative outcome publication.
+
+    Pausing cancels the runner too, but is not task completion. Preserve that
+    explicit lifecycle hold through dispose rather than classifying cancellation
+    (or a dead process) as authority to close a suspended interaction.
+    """
+    if child is None:
+        return
+    record = comms._record(job_id) if comms is not None else None
+    resource = getattr(getattr(child, "_browser", None), "resource", None)
+    if record is not None and record.paused and resource is not None:
+        if resource.generation or resource.path.exists():
+            try:
+                resource.initialize()
+                resource.record["retention"] = "paused scope"
+                resource.remember(child._browser.surface_id, state="retained")
+            except (RuntimeError, OSError, ValueError):
+                logger.warning("paused browser ownership changed; retained successor untouched")
+        return
+    if callable(getattr(child, "finish_browser_scope", None)):
+        result = await child.finish_browser_scope(
+            scope_id=child.session_id, generation=child.browser_generation, outcome=outcome
+        )
+        if result.state not in ("closed", "retained"):
+            logger.warning("child browser cleanup %s: %s", result.state, result.detail)
 
 
 async def _dispose_child(child: "Session") -> None:

--- a/local_operator/harness/subagent.py
+++ b/local_operator/harness/subagent.py
@@ -963,12 +963,20 @@ async def _finish_child_browser(
             except (RuntimeError, OSError, ValueError):
                 logger.warning("paused browser ownership changed; retained successor untouched")
         return
-    if callable(getattr(child, "finish_browser_scope", None)):
-        result = await child.finish_browser_scope(
-            scope_id=child.session_id, generation=child.browser_generation, outcome=outcome
-        )
-        if result.state not in ("closed", "retained"):
-            logger.warning("child browser cleanup %s: %s", result.state, result.detail)
+    if resource is None or not callable(getattr(child, "finish_browser_scope", None)):
+        # A host that built a BrowserSurface without a resource has no durable
+        # ownership to settle. Reading the generation anyway raised straight
+        # through the completed/failed paths, replacing the child's real outcome.
+        return
+    result = await child.finish_browser_scope(
+        scope_id=child.session_id,
+        # Off the resource the branch has already proven non-None, not the
+        # Session property, so this cannot fault on an unwired host.
+        generation=resource.execution_generation,
+        outcome=outcome,
+    )
+    if result.state not in ("closed", "retained"):
+        logger.warning("child browser cleanup %s: %s", result.state, result.detail)
 
 
 async def _dispose_child(child: "Session") -> None:

--- a/local_operator/harness/types.py
+++ b/local_operator/harness/types.py
@@ -508,10 +508,12 @@ class BrowserSurface:
     own one without importing the tool layer.
     """
 
-    __slots__ = ("surface_id",)
+    __slots__ = ("surface_id", "resource")
 
-    def __init__(self) -> None:
+    def __init__(self, resource: Any = None) -> None:
         self.surface_id = ""
+        # Host-owned persistence stays outside the harness import graph.
+        self.resource = resource
 
 
 @runtime_checkable

--- a/local_operator/session/session.py
+++ b/local_operator/session/session.py
@@ -2380,7 +2380,9 @@ class Session:
         # all ("open X", then next message "click Y" → "no browser surface
         # open") and that every turn which opened a browser stranded a cmux tab
         # the agent could never close. dispose() closes whatever is still open.
-        self._browser = BrowserSurface()
+        from local_operator.browser_bridge.resources import BrowserResource
+
+        self._browser = BrowserSurface(BrowserResource(transcript.directory, self._session_id))
         # Connections and overlapping read requests have a conversation owner.
         # This avoids rebuilding pools for every tool call without allowing one
         # child's disposal to close a sibling's active transport.
@@ -11447,6 +11449,44 @@ class Session:
         """
         self._dispose_hooks.append(hook)
 
+    @property
+    def browser_generation(self) -> str:
+        """The browser resource's execution-lease generation, never its PID."""
+        return self._browser.resource.execution_generation
+
+    async def finish_browser_scope(self, *, scope_id: str, generation: str, outcome: str) -> Any:
+        """Fence authoritative completion before publishing the child outcome.
+
+        Ordinary assistant finals and idle turns do not call this: they may be
+        waiting for a login or user approval in the exact owned tab.
+        """
+        from local_operator.browser_bridge.resources import BrowserCleanupResult
+
+        resource = self._browser.resource
+        if scope_id != self.session_id:
+            return BrowserCleanupResult("unresolved", "scope mismatch; no action taken")
+        if not resource.generation and not resource.path.exists():
+            if self._browser.surface_id:
+                from local_operator.tools.builtin import close_browser_surface
+
+                try:
+                    problem = await asyncio.wait_for(close_browser_surface(self._browser), 5.0)
+                    return BrowserCleanupResult("pending" if problem else "closed", problem)
+                except TimeoutError:
+                    return BrowserCleanupResult("pending", "cmux cleanup deadline exceeded")
+            return BrowserCleanupResult("closed")
+        try:
+            result = await asyncio.wait_for(resource.finish(generation, outcome), timeout=5.0)
+            if result.state == "closed":
+                self._browser.surface_id = ""
+            return result
+        except TimeoutError:
+            return BrowserCleanupResult("pending", "browser cleanup deadline exceeded")
+        except Exception:
+            # Teardown cannot suppress the authoritative child outcome because
+            # ownership advanced or the private sidecar became unreadable.
+            return BrowserCleanupResult("unresolved", "ownership changed; no action taken")
+
     async def _close_browser_surface(self) -> None:
         """Close a browser surface the agent left open as a teardown fallback.
 
@@ -11469,6 +11509,14 @@ class Session:
         ``CancelledError``), so the timeout does not trade a stranded tab for an
         orphaned process.
         """
+        resource = self._browser.resource
+        if resource.generation or resource.path.exists():
+            # Disposal is a fallback for process exit, not a claim that an idle
+            # assistant turn ended. Structured retention survives this boundary.
+            await self.finish_browser_scope(
+                scope_id=self.session_id, generation=self.browser_generation, outcome="disposed"
+            )
+            return
         if not self._browser.surface_id:
             return
         try:

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -5491,6 +5491,9 @@ BROWSER_ACTIONS = (
     "request_access",
     "await_access",
     "cancel_access",
+    "recover",
+    "retain",
+    "release",
 )
 
 #: ``retitle`` is a wire METHOD but deliberately NOT an action: the SESSION
@@ -5601,7 +5604,9 @@ class BrowserParams(BaseModel):
         "sessions' included) | request_access (raise the site-approval prompt "
         "for a not-yet-allowed origin; returns pending/allowed/denied immediately) "
         "| await_access (wait for the user's decision on that prompt) | "
-        "cancel_access (cancel YOUR pending exact-origin request) | close (end "
+        "cancel_access (cancel YOUR pending exact-origin request) | "
+        "recover (recover YOUR tab after an interrupted action) | "
+        "retain (hold it, reason in text) | release (end that hold) | close (end "
         "YOUR tab when done with it)."
     )
     url: str = Field(
@@ -5617,7 +5622,7 @@ class BrowserParams(BaseModel):
         "scopes the text for 'read' (default: body); for 'scroll', the element "
         "to bring into view.",
     )
-    text: str = Field(default="", description="Text to enter for 'type'.")
+    text: str = Field(default="", description="Text to enter for 'type'; the reason for 'retain'.")
     # scroll params. All optional: with none set, 'scroll' pages one viewport
     # down. Precedence is selector > x/y > direction > default (mirrors
     # extension/src/commands/scroll.ts).
@@ -6795,12 +6800,16 @@ def _browser_cwd_label(cwd: str) -> str:
     return "" if path.name in ("", path.anchor) else path.name
 
 
-def _browser_identity_params(context: ToolContext | None, tool_call_id: str) -> dict[str, str]:
+def _browser_identity_params(context: ToolContext | None, tool_call_id: str) -> dict[str, Any]:
     """Trusted wire metadata; model/browser arguments cannot override it."""
-    return {
+    identity = {
         "requester": _browser_requester(context, tool_call_id),
         "session_label": _browser_session_label(context),
     }
+    resource = getattr(getattr(context, "browser", None), "resource", None)
+    if resource is not None and resource.generation:
+        identity.update(resource.params())
+    return identity
 
 
 async def _bridge_call(
@@ -6829,6 +6838,10 @@ async def _bridge_call(
         # recovery, handle-drop) instead of substring-matching the human
         # diagnostic, which broke silently on any rewording (finding m4).
         problem.details = {"error_code": exc.code.value}
+        # A failed new allocation may also fail rollback. Keep its private
+        # capability on the host, not in model-visible diagnostics.
+        if exc.data.get("cleanup_pending") and isinstance(exc.data.get("tab"), str):
+            problem.details["cleanup_surface"] = exc.data["tab"]
         return None, problem
     except BridgeUnreachable as exc:
         return None, _error(tool_call_id, "browser", str(exc))
@@ -6870,6 +6883,9 @@ async def _bridge_open(
             {"url": raw_url.strip(), **_browser_identity_params(context, tool_call_id)},
         )
     if problem is not None:
+        pending = (problem.details or {}).pop("cleanup_surface", "")
+        if isinstance(pending, str) and re.fullmatch(r"bridge:\d+:[A-Za-z0-9_-]+", pending):
+            state.surface_id = pending
         return problem
     assert result is not None
     surface = str(result.get("tab", ""))
@@ -7408,13 +7424,15 @@ async def close_browser_surface(state: BrowserSurfaceProtocol) -> str:
     if not surface:
         return ""
     if surface.startswith("bridge:"):
+        resource = getattr(state, "resource", None)
+        identity = resource.params() if resource is not None and resource.generation else {}
         _result, problem = await _bridge_call(
-            "teardown", "close", {"tab": surface}, surface=surface
+            "teardown", "close", {"tab": surface, **identity}, surface=surface
         )
-        state.surface_id = ""
-        if problem is None:
+        if problem is None or (problem.details or {}).get("error_code") == "tab_closed":
+            state.surface_id = ""
             return ""
-        return "browser extension could not close the tab"
+        return "browser extension could not close the tab; ownership retained for retry"
     code, out = await _run_cmux(["close-surface", "--surface", surface])
     state.surface_id = ""
     return "" if code == 0 else out or f"cmux exited {code}"
@@ -7426,16 +7444,110 @@ async def _browser_close(tool_call_id: str, state: BrowserSurfaceProtocol) -> To
     surface = state.surface_id
     problem = await close_browser_surface(state)
     if problem:
-        return _text(
+        disposition = "ownership retained" if state.surface_id else "dropped the handle"
+        return _error(
             tool_call_id,
             "browser",
-            f"Browser surface {surface} could not be closed ({problem}); dropped the handle.",
+            f"Browser surface {surface} could not be closed ({problem}); {disposition}.",
         )
     return _text(tool_call_id, "browser", f"Closed browser surface {surface}.")
 
 
 @_guard("browser")
 async def execute_browser(
+    tool_call_id: str,
+    args: dict[str, Any],
+    signal: AbortSignal | None = None,
+    on_update: Callable[[AgentToolUpdate], None] | None = None,
+    context: ToolContext | None = None,
+) -> ToolResult:
+    """Serialize and persist browser side effects at the host-owned boundary."""
+    state = _browser_state(context)
+    resource = getattr(state, "resource", None)
+    if resource is None or state.surface_id.startswith("surface:"):
+        return await _execute_browser(tool_call_id, args, signal, on_update, context)
+    if not resource.generation and not await bridge_browser_reachable():
+        return await _execute_browser(tool_call_id, args, signal, on_update, context)
+    try:
+        validated = BrowserParams(**args)
+    except ValidationError as exc:
+        return _error(tool_call_id, "browser", str(exc))
+    action = validated.action.strip().lower()
+    if action not in BROWSER_ACTIONS:
+        return _error(
+            tool_call_id,
+            "browser",
+            f"unknown action: {action} (expected one of {', '.join(BROWSER_ACTIONS)})",
+        )
+    invalid = _validate_browser_args(action, validated)
+    if invalid:
+        return _error(tool_call_id, "browser", invalid)
+    from local_operator.browser_bridge.backend import BridgeError, BridgeUnreachable
+    from local_operator.browser_bridge.resources import BrowserOwnershipError
+
+    async with resource.lock:
+        try:
+            resource.initialize()
+            if not resource.recovered:
+                await resource.recover()
+                state.surface_id = str(resource.record.get("surface_id", ""))
+        except (BrowserOwnershipError, BridgeError, BridgeUnreachable) as exc:
+            return _error(tool_call_id, "browser", str(exc))
+        action = str(args.get("action", "")).strip().lower()
+        if action == "recover":
+            result = await resource.recover()
+            state.surface_id = str(result.get("tab", ""))
+            return _text(tool_call_id, "browser", f"Browser ownership: {result.get('state')}.")
+        if action in ("retain", "release"):
+            from local_operator.browser_bridge.backend import BridgeClient
+
+            reason = str(args.get("text", "")).strip()
+            result = await BridgeClient().call(
+                f"owner_{action}", {**resource.params(), "reason": reason}
+            )
+            resource.record["retention"] = reason if action == "retain" else ""
+            if action == "release" and resource.record.get("terminal"):
+                result = await BridgeClient().call(
+                    "owner_finish", {**resource.params(), "outcome": resource.record["terminal"]}
+                )
+                if result.get("state") == "closed":
+                    state.surface_id = ""
+            resource.record["surface_id"] = state.surface_id
+            resource.record["state"] = str(result.get("state", "unresolved"))
+            resource.assert_current()
+            resource._save()
+            return _text(tool_call_id, "browser", f"Browser ownership: {result.get('state')}.")
+        if resource.record.get("terminal"):
+            return _error(tool_call_id, "browser", "Browser scope ended; resume before browsing.")
+        if action == "open" and not state.surface_id:
+            resource.allocate()
+        failed_close = False
+        try:
+            result = await _execute_browser(tool_call_id, args, signal, on_update, context)
+            failed_close = action == "close" and result.is_error and bool(state.surface_id)
+            if action in ("request_access", "await_access", "cancel_access"):
+                access_state = (result.details or {}).get("state")
+                if access_state == "pending":
+                    resource.record["retention"] = "pending site approval"
+                elif access_state and resource.record.get("retention") == "pending site approval":
+                    from local_operator.browser_bridge.backend import BridgeClient
+
+                    await BridgeClient().call("owner_release", resource.params())
+                    resource.record["retention"] = ""
+            return result
+        finally:
+            # Lost responses retain the allocation intent. A retry/recover asks
+            # the extension for that exact allocation instead of opening twice.
+            pending = resource.record.get("state") == "allocating" and not state.surface_id
+            resource.remember(
+                state.surface_id,
+                state="cleanup_pending" if failed_close else "allocating" if pending else None,
+            )
+            if pending:
+                resource.recovered = False
+
+
+async def _execute_browser(
     tool_call_id: str,
     args: dict[str, Any],
     signal: AbortSignal | None = None,
@@ -7786,6 +7898,8 @@ def build_browser_tool(context: ToolContext | None) -> AgentTool | None:
             "'tabs' lists every extension-driven tab including other sessions' "
             "(handles are redacted: the listing is awareness-only and cannot "
             "drive or close anything), and 'close' ends only your own tab. "
+            "After an interrupted operation, 'recover' recovers YOUR tab only. Keep a tab past "
+            "your turn with 'retain' (reason in text) and end that hold with 'release'. "
             "'scroll', 'logs' and "
             "'tabs' need the extension backend (cmux says so). On the extension, "
             "'open'/'goto' to a site the user has not approved fails with "

--- a/local_operator/tools/builtin.py
+++ b/local_operator/tools/builtin.py
@@ -6800,6 +6800,29 @@ def _browser_cwd_label(cwd: str) -> str:
     return "" if path.name in ("", path.anchor) else path.name
 
 
+def _browser_ownership_text(state: str, has_surface: bool) -> str:
+    """Protocol state -> what the agent should do next.
+
+    ``allocating``/``unresolved`` are wire vocabulary: returned verbatim they
+    read as a success while no tab exists, which sent an agent round a loop of
+    three non-error answers and no tab. Say what is true and what to do.
+    """
+    if state in ("owned", "cleanup_pending") and has_surface:
+        return f"Browser ownership recovered ({state}); your tab is available again."
+    if state == "retained":
+        return "Browser tab retained; it stays open past this turn until you 'release' it."
+    if state == "released":
+        return "Browser retention cleared; the tab closes at the end of this scope."
+    if state == "closed":
+        return "Browser ownership settled; no tab is open. Use 'open' to start one."
+    if state == "allocating":
+        return (
+            "Nothing to recover: an allocation was started but no tab exists. If 'open' "
+            "reported the 8-tab limit, none can be allocated until a tab is released."
+        )
+    return "Nothing to recover: this session has no browser tab. Use 'open' to start one."
+
+
 def _browser_identity_params(context: ToolContext | None, tool_call_id: str) -> dict[str, Any]:
     """Trusted wire metadata; model/browser arguments cannot override it."""
     identity = {
@@ -7494,29 +7517,55 @@ async def execute_browser(
         except (BrowserOwnershipError, BridgeError, BridgeUnreachable) as exc:
             return _error(tool_call_id, "browser", str(exc))
         action = str(args.get("action", "")).strip().lower()
-        if action == "recover":
-            result = await resource.recover()
-            state.surface_id = str(result.get("tab", ""))
-            return _text(tool_call_id, "browser", f"Browser ownership: {result.get('state')}.")
-        if action in ("retain", "release"):
-            from local_operator.browser_bridge.backend import BridgeClient
-
-            reason = str(args.get("text", "")).strip()
-            result = await BridgeClient().call(
-                f"owner_{action}", {**resource.params(), "reason": reason}
-            )
-            resource.record["retention"] = reason if action == "retain" else ""
-            if action == "release" and resource.record.get("terminal"):
-                result = await BridgeClient().call(
-                    "owner_finish", {**resource.params(), "outcome": resource.record["terminal"]}
+        try:
+            if action == "recover":
+                result = await resource.recover()
+                state.surface_id = str(result.get("tab", ""))
+                return _text(
+                    tool_call_id,
+                    "browser",
+                    _browser_ownership_text(str(result.get("state", "")), bool(state.surface_id)),
                 )
-                if result.get("state") == "closed":
-                    state.surface_id = ""
-            resource.record["surface_id"] = state.surface_id
-            resource.record["state"] = str(result.get("state", "unresolved"))
-            resource.assert_current()
-            resource._save()
-            return _text(tool_call_id, "browser", f"Browser ownership: {result.get('state')}.")
+            if action in ("retain", "release"):
+                from local_operator.browser_bridge.backend import BridgeClient
+
+                reason = str(args.get("text", "")).strip()
+                if action == "retain" and not reason:
+                    # Caught HERE because `text` defaults to "", so omitting it
+                    # is a well-formed call a model will make; the extension's
+                    # refusal would otherwise arrive as a raw traceback in the
+                    # context of the one action that protects a pending login.
+                    return _error(
+                        tool_call_id,
+                        "browser",
+                        "'retain' needs a reason: pass text='pending login' (or similar) "
+                        "describing why this tab must stay open past your turn.",
+                    )
+                result = await BridgeClient().call(
+                    f"owner_{action}", {**resource.params(), "reason": reason}
+                )
+                resource.record["retention"] = reason if action == "retain" else ""
+                if action == "release" and resource.record.get("terminal"):
+                    result = await BridgeClient().call(
+                        "owner_finish",
+                        {**resource.params(), "outcome": resource.record["terminal"]},
+                    )
+                    if result.get("state") == "closed":
+                        state.surface_id = ""
+                resource.record["surface_id"] = state.surface_id
+                resource.record["state"] = str(result.get("state", "unresolved"))
+                resource.assert_current()
+                resource._save()
+                return _text(
+                    tool_call_id,
+                    "browser",
+                    _browser_ownership_text(str(result.get("state", "")), bool(state.surface_id)),
+                )
+        except (BrowserOwnershipError, BridgeError, BridgeUnreachable) as exc:
+            # Same containment the initialize/recover block above already has:
+            # an expected ownership or bridge refusal is a sentence, never a
+            # stack trace spent in the model's context.
+            return _error(tool_call_id, "browser", str(exc))
         if resource.record.get("terminal"):
             return _error(tool_call_id, "browser", "Browser scope ended; resume before browsing.")
         if action == "open" and not state.surface_id:
@@ -7538,11 +7587,21 @@ async def execute_browser(
         finally:
             # Lost responses retain the allocation intent. A retry/recover asks
             # the extension for that exact allocation instead of opening twice.
+            #
+            # Swallowing is load-bearing, not defensive habit: a raising
+            # `finally:` DISCARDS the value the `try:` already produced, so an
+            # ownership advance racing a successful open would replace a real
+            # ToolResult (naming a tab that exists) with a traceback telling the
+            # model the action failed. Persistence is best-effort here; the next
+            # command's own `assert_current` is what refuses a stale owner.
             pending = resource.record.get("state") == "allocating" and not state.surface_id
-            resource.remember(
-                state.surface_id,
-                state="cleanup_pending" if failed_close else "allocating" if pending else None,
-            )
+            try:
+                resource.remember(
+                    state.surface_id,
+                    state="cleanup_pending" if failed_close else "allocating" if pending else None,
+                )
+            except (BrowserOwnershipError, OSError, ValueError):
+                logger.warning("browser ownership record not updated", exc_info=True)
             if pending:
                 resource.recovered = False
 

--- a/tests/e2e/test_browser_ownership.py
+++ b/tests/e2e/test_browser_ownership.py
@@ -338,3 +338,86 @@ async def test_old_extension_is_actionable_before_any_allocation(
         assert _control(protocol_peer)["tabs"] == 0
     finally:
         await session.dispose()
+
+
+def _unleased_session(root: Path) -> Session:
+    """A child as ``_build_child_session`` builds one: claimed, never leased.
+
+    The distinction is the whole point of this guard. Round 2 established that
+    an in-process child reuses ONE generation per session so a second live
+    instance cannot fence the incumbent; the leased ``_session`` above rotates
+    its generation on resume and therefore cannot observe anything that depends
+    on the generation staying the same.
+    """
+    from local_operator.session.retention import claim_session
+
+    directory = root / "sessions" / "synthetic-child"
+    claim_session(directory)
+
+    def stream(_request: Any, _signal: Any) -> Any:
+        async def events() -> Any:
+            if False:
+                yield None
+
+        return events()
+
+    return Session(
+        model=ModelSpec(provider="test", model_id="synthetic", context_window=1000),
+        stream_fn=stream,
+        tools=[],
+        transcript=Transcript(directory),
+        system_blocks_provider=lambda: [],
+    )
+
+
+@pytest.mark.asyncio
+async def test_resumed_unleased_child_can_open_again_across_the_bridge(
+    protocol_peer: tuple[int, str], headless_tui_env: Path
+) -> None:
+    """A finalized subagent must be able to browse on a later run.
+
+    This crosses the WIRE deliberately. The unit guard for the same invariant
+    stops at ``allocate()``, which is a local sidecar write, so it could not
+    observe that the extension keeps its own copy of the terminal intent and
+    used to clear it only when the generation string changed — which the
+    unleased path never does. Both halves of the fence have to be retired, and
+    only a real ``open`` through the fixture proves it: the tab count is the
+    assertion, because a refusal here still returns a well-formed error.
+    """
+    first = _unleased_session(headless_tui_env)
+    try:
+        opened = await execute_browser(
+            "child-run1-open",
+            {"action": "open", "url": "https://example.test/"},
+            None,
+            None,
+            first._build_tool_context(),
+        )
+        assert not opened.is_error, opened.text
+        assert _control(protocol_peer)["tabs"] == 1
+        finished = await first.finish_browser_scope(
+            scope_id=first.session_id,
+            generation=first.browser_generation,
+            outcome="completed",
+        )
+        assert finished.state == "closed"
+        assert _control(protocol_peer)["tabs"] == 0
+    finally:
+        await first.dispose()
+
+    # `hub op='resume'` relaunches the child over its own transcript directory.
+    resumed = _unleased_session(headless_tui_env)
+    try:
+        assert resumed.browser_generation == first.browser_generation, "B1 reuses the generation"
+        reopened = await execute_browser(
+            "child-run2-open",
+            {"action": "open", "url": "https://example.test/"},
+            None,
+            None,
+            resumed._build_tool_context(),
+        )
+        assert not reopened.is_error, reopened.text
+        # Run 2 allocated a REAL tab; the round-2 head reported 0 here.
+        assert _control(protocol_peer)["tabs"] == 1
+    finally:
+        await resumed.dispose()

--- a/tests/e2e/test_browser_ownership.py
+++ b/tests/e2e/test_browser_ownership.py
@@ -1,0 +1,340 @@
+"""Real Session → authenticated HTTP → bundled extension; Chrome is disposable.
+
+The extension CI installs the Node fixture dependencies and runs this module.
+Python-only TUI jobs skip it rather than downloading any browser engine.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import secrets
+import shutil
+import subprocess
+from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from local_operator.browser_bridge import state
+from local_operator.browser_bridge.protocol import PROTO_VERSION
+from local_operator.harness.types import (
+    ModelSpec,
+    StreamEndEvent,
+    StreamTextDelta,
+    StreamToolCallDelta,
+)
+from local_operator.session.session import Session
+from local_operator.session.transcript import Transcript
+from local_operator.session_lease import acquire_session_lease
+from local_operator.tools.builtin import execute_browser
+from tests.e2e.watchdog import bounded
+
+EXTENSION = Path(__file__).resolve().parents[2] / "extension"
+
+
+@pytest.fixture(autouse=True)
+def bound_protocol_run() -> Iterator[None]:
+    with bounded(60, "browser ownership protocol fixture"):
+        yield
+
+
+@pytest.fixture
+def protocol_peer(
+    headless_tui_env: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[tuple[int, str]]:
+    for key in tuple(os.environ):
+        if key.startswith("CMUX_"):
+            monkeypatch.delenv(key)
+    node = shutil.which("node")
+    if not node or not (EXTENSION / "node_modules" / "esbuild").exists():
+        pytest.skip(
+            "run pnpm install in extension/ for disposable protocol E2E (no browser needed)"
+        )
+    key = secrets.token_urlsafe(32)
+    env = {**os.environ, "BROWSER_FIXTURE_KEY": key}
+    process = subprocess.Popen(
+        [node, "tests/fixtures/ownership-server.mjs"],
+        cwd=EXTENSION,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    assert process.stdout is not None
+    try:
+        greeting = process.stdout.readline()
+        assert greeting, "disposable extension fixture failed to start"
+        port = json.loads(greeting)["port"]
+        state.publish(
+            state.BridgeState(
+                pid=process.pid,
+                port=port,
+                session_key=key,
+                proto=PROTO_VERSION,
+                extension_connected=True,
+                paired=True,
+            ),
+            headless_tui_env,
+        )
+        yield port, key
+    finally:
+        process.terminate()
+        process.wait(timeout=10)
+
+
+def _control(peer: tuple[int, str], **changes: Any) -> dict[str, Any]:
+    port, key = peer
+    response = httpx.post(
+        f"http://127.0.0.1:{port}/fixture",
+        headers={"X-Bridge-Key": key},
+        json=changes,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def _session(root: Path) -> Session:
+    directory = root / "sessions" / "synthetic-browser"
+    lease = acquire_session_lease(directory)
+
+    def stream(_request: Any, _signal: Any) -> Any:
+        async def events() -> Any:
+            if False:
+                yield None
+
+        return events()
+
+    session = Session(
+        model=ModelSpec(provider="test", model_id="synthetic", context_window=1000),
+        stream_fn=stream,
+        tools=[],
+        transcript=Transcript(directory),
+        system_blocks_provider=lambda: [],
+    )
+    session.add_dispose_hook(lease.release)
+    return session
+
+
+@pytest.mark.asyncio
+async def test_failed_navigation_then_completion_uses_real_protocol(
+    protocol_peer: tuple[int, str], headless_tui_env: Path
+) -> None:
+    session = _session(headless_tui_env)
+    try:
+        port, _key = protocol_peer
+        denied = httpx.post(f"http://127.0.0.1:{port}/rpc", json={})
+        assert denied.status_code == 401
+        _control(protocol_peer, faults={"navigation": True})
+        failed = await execute_browser(
+            "synthetic-fail",
+            {"action": "open", "url": "https://example.test/"},
+            None,
+            None,
+            session._build_tool_context(),
+        )
+        assert failed.is_error
+        assert _control(protocol_peer)["tabs"] == 0
+        _control(protocol_peer, faults={"navigation": False})
+        opened = await execute_browser(
+            "synthetic-open",
+            {"action": "open", "url": "https://example.test/"},
+            None,
+            None,
+            session._build_tool_context(),
+        )
+        assert not opened.is_error, opened.text
+        assert _control(protocol_peer)["tabs"] == 1
+        finished = await session.finish_browser_scope(
+            scope_id=session.session_id, generation=session.browser_generation, outcome="completed"
+        )
+        assert finished.state == "closed"
+        assert _control(protocol_peer)["tabs"] == 0
+        assert session._browser.resource.record["terminal"] == "completed"
+    finally:
+        await session.dispose()
+
+
+@pytest.mark.asyncio
+async def test_failed_close_retention_resume_and_release(
+    protocol_peer: tuple[int, str], headless_tui_env: Path
+) -> None:
+    session = _session(headless_tui_env)
+    try:
+        opened = await execute_browser(
+            "synthetic-open",
+            {"action": "open", "url": "https://example.test/"},
+            None,
+            None,
+            session._build_tool_context(),
+        )
+        assert not opened.is_error, opened.text
+        _control(protocol_peer, faults={"remove": True})
+        closed = await execute_browser(
+            "synthetic-close",
+            {"action": "close"},
+            None,
+            None,
+            session._build_tool_context(),
+        )
+        assert closed.is_error and "retained" in closed.text
+        assert session._browser.surface_id
+        retained = await execute_browser(
+            "synthetic-retain",
+            {"action": "retain", "text": "pending login"},
+            None,
+            None,
+            session._build_tool_context(),
+        )
+        assert not retained.is_error, retained.text
+    finally:
+        await session.dispose()
+    assert _control(protocol_peer)["tabs"] == 1
+    _control(protocol_peer, faults={"remove": False}, restartWorker=True)
+    resumed = _session(headless_tui_env)
+    try:
+        recovered = await execute_browser(
+            "synthetic-recover",
+            {"action": "recover"},
+            None,
+            None,
+            resumed._build_tool_context(),
+        )
+        assert not recovered.is_error, recovered.text
+        assert resumed._browser.surface_id
+        assert _control(protocol_peer)["tabs"] == 1
+        # A stale child must still publish its outcome: generation lookup is
+        # pure and the finalizer returns unresolved without touching its successor.
+        stale = await session.finish_browser_scope(
+            scope_id=session.session_id,
+            generation=session.browser_generation,
+            outcome="failed",
+        )
+        assert stale.state == "unresolved"
+        assert _control(protocol_peer)["tabs"] == 1
+        assert not resumed._browser.resource.record.get("terminal")
+        released = await execute_browser(
+            "synthetic-release",
+            {"action": "release"},
+            None,
+            None,
+            resumed._build_tool_context(),
+        )
+        assert not released.is_error, released.text
+        assert (
+            await resumed.finish_browser_scope(
+                scope_id=resumed.session_id,
+                generation=resumed.browser_generation,
+                outcome="completed",
+            )
+        ).state == "closed"
+        assert _control(protocol_peer)["tabs"] == 0
+    finally:
+        await resumed.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("outcome", ["completed", "failed", "cancelled"])
+async def test_child_finalizes_before_terminal_handoff(
+    protocol_peer: tuple[int, str],
+    headless_tui_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    outcome: str,
+) -> None:
+    from local_operator.harness import subagent
+
+    calls = 0
+    opened = asyncio.Event()
+    terminal_tab_counts: list[int] = []
+    allocated_tab_counts: list[int] = []
+    publish = subagent._publish_terminal_outcome
+
+    async def observed_publish(*args: Any, **kwargs: Any) -> Any:
+        terminal_tab_counts.append(_control(protocol_peer)["tabs"])
+        return await publish(*args, **kwargs)
+
+    monkeypatch.setattr(subagent, "_publish_terminal_outcome", observed_publish)
+
+    async def stream(request: Any, signal: Any = None) -> AsyncIterator[Any]:
+        nonlocal calls
+        if not any("BROWSER_CHILD" in getattr(message, "text", "") for message in request.messages):
+            yield StreamTextDelta(delta="Acknowledged")
+            yield StreamEndEvent(stop_reason="stop")
+            return
+        calls += 1
+        if calls == 1:
+            yield StreamToolCallDelta(
+                index=0,
+                id="synthetic-child-open",
+                name="browser",
+                argument_delta=json.dumps(
+                    {
+                        "action": "open",
+                        "url": "https://example.test/",
+                        "i": "Opening isolated fixture",
+                    }
+                ),
+            )
+            yield StreamEndEvent(stop_reason="toolUse")
+            return
+        allocated_tab_counts.append(_control(protocol_peer)["tabs"])
+        opened.set()
+        if outcome == "failed":
+            raise RuntimeError("controlled child failure after browser allocation")
+        if outcome == "cancelled":
+            await asyncio.Event().wait()
+        yield StreamTextDelta(delta="Completed child")
+        yield StreamEndEvent(stop_reason="stop")
+
+    async def approve(*_args: Any, **_kwargs: Any) -> bool:
+        return True
+
+    owner = Session(
+        model=ModelSpec(provider="test", model_id="synthetic", context_window=100000),
+        stream_fn=stream,
+        tools=[],
+        transcript=Transcript(headless_tui_env / "sessions" / "synthetic-parent"),
+        system_blocks_provider=lambda *_: [],
+        yolo=True,
+        cwd=str(headless_tui_env),
+        request_approval=approve,
+    )
+    try:
+        job_id = owner._launch_subagent("browser-child", "BROWSER_CHILD")
+        if outcome == "cancelled":
+            await asyncio.wait_for(opened.wait(), 20)
+            assert _control(protocol_peer)["tabs"] == 1
+            await owner.jobs.cancel(job_id)
+        await asyncio.wait_for(owner.jobs.settled_event(job_id).wait(), 25)
+        row = owner.jobs.get(job_id)
+        assert row is not None and row.status == outcome
+        assert calls >= 2, "child must actually execute the browser tool"
+        assert allocated_tab_counts == [1]
+        assert terminal_tab_counts == [0]
+        assert _control(protocol_peer)["tabs"] == 0
+    finally:
+        await owner.dispose()
+
+
+@pytest.mark.asyncio
+async def test_old_extension_is_actionable_before_any_allocation(
+    protocol_peer: tuple[int, str], headless_tui_env: Path
+) -> None:
+    session = _session(headless_tui_env)
+    try:
+        _control(protocol_peer, oldExtension=True)
+        result = await execute_browser(
+            "synthetic-old",
+            {"action": "open", "url": "https://example.test/"},
+            None,
+            None,
+            session._build_tool_context(),
+        )
+        assert result.is_error
+        assert "Update the extension" in result.text
+        assert _control(protocol_peer)["tabs"] == 0
+    finally:
+        await session.dispose()

--- a/tests/unit/browser_bridge/test_resources.py
+++ b/tests/unit/browser_bridge/test_resources.py
@@ -9,6 +9,7 @@ import pytest
 
 from local_operator.browser_bridge import resources
 from local_operator.browser_bridge.resources import (
+    RESOURCE_NAME,
     BrowserResource,
     cleanup_exact,
     read_inventory,
@@ -23,6 +24,10 @@ class BridgeFixture:
         self.calls: list[tuple[str, dict[str, Any]]] = []
         self.fail_close = False
         self.retained = False
+        #: Override the state ``owner_finish`` replies with, so the "extension
+        #: could not remove the tab" answer can be exercised as itself rather
+        #: than as a transport failure.
+        self.finish_state = ""
 
     async def call(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
         self.calls.append((method, params))
@@ -34,6 +39,8 @@ class BridgeFixture:
         if method == "owner_finish":
             if self.fail_close:
                 raise ConnectionError("disposable fixture unavailable")
+            if self.finish_state:
+                return {"state": self.finish_state}
             return {"state": "retained" if self.retained else "closed"}
         raise AssertionError(method)
 
@@ -84,18 +91,20 @@ async def test_failed_cleanup_survives_reconstruction(
     record = json.loads(resource.path.read_text())
     assert record["terminal"] == "failed"
     assert record["surface_id"] == "bridge:100:private"
-    # Reconstruction models a restarted host. The stable proof and allocation
-    # survive; a new generation is presented with the previous CAS token.
+    # Reconstruction models a restarted host. The proof, the allocation AND the
+    # generation all survive: on an unleased directory identity belongs to the
+    # SESSION, not to the BrowserResource object, so a second instance adopts
+    # the stored owner instead of minting a token that would fence out an
+    # incumbent still holding a live tab (review round 1, B1).
     resumed = BrowserResource(tmp_path, tmp_path.name)
     resumed.initialize()
     assert resumed.params()["owner_proof"] == resource.record["proof"]
-    assert resumed.params()["previous_generation"] == resource.generation
-    assert resumed.generation != resource.generation
+    assert resumed.generation == resource.generation
     bridge.fail_close = False
     await resumed.recover()
     assert resumed.record["surface_id"] == "bridge:100:private"
-    with pytest.raises(RuntimeError, match="stale"):
-        resource.remember("")
+    # The incumbent is NOT fenced out by the reconstruction: same identity.
+    resource.remember("bridge:100:private")
 
 
 @pytest.mark.asyncio
@@ -154,3 +163,116 @@ async def test_dead_process_alone_never_authorizes_cleanup(
     resource.remember("bridge:100:private")
     assert (await cleanup_exact(tmp_path, resource.generation)).state == "unresolved"
     assert not bridge.calls
+
+
+def test_unleased_second_instance_never_fences_out_the_live_owner(tmp_path: Path) -> None:
+    """B1: identity is durable per SESSION, not per BrowserResource instance.
+
+    In-process children take this path — they use ``claim_session``, not
+    ``acquire_session_lease`` — so a per-instance token meant every subagent
+    could have its live tab silently transferred to a newcomer, stranding a
+    tab in the pool that nobody could close.
+    """
+    assert not (tmp_path / ".execution-lease").exists()
+    incumbent = BrowserResource(tmp_path, tmp_path.name)
+    incumbent.initialize()
+    incumbent.remember("bridge:2:live")
+
+    newcomer = BrowserResource(tmp_path, tmp_path.name)
+    newcomer.initialize()
+
+    assert newcomer.generation == incumbent.generation
+    incumbent.remember("bridge:2:live")  # still authoritative over its own tab
+    assert incumbent.record["surface_id"] == "bridge:2:live"
+
+
+def test_identity_read_never_mints_or_rotates(tmp_path: Path) -> None:
+    """execution_generation is a lookup; asking who owns must not renumber."""
+    fresh = BrowserResource(tmp_path, tmp_path.name)
+    assert fresh.execution_generation == ""
+    fresh.initialize()
+    stored = fresh.generation
+    for _ in range(3):
+        assert BrowserResource(tmp_path, tmp_path.name).execution_generation == stored
+    assert json.loads((tmp_path / RESOURCE_NAME).read_text())["generation"] == stored
+
+
+@pytest.mark.asyncio
+async def test_failed_cleanup_does_not_rotate_the_copied_generation(
+    tmp_path: Path, bridge: BridgeFixture
+) -> None:
+    """D3/U2: the identifier the listing told the operator to copy stays valid."""
+    resource = BrowserResource(tmp_path, tmp_path.name)
+    resource.initialize()
+    resource.record["terminal"] = "failed"
+    resource.remember("bridge:5:tok", state="cleanup_pending")
+    copied = resource.generation
+    bridge.fail_close = True
+
+    for _ in range(3):
+        result = await cleanup_exact(tmp_path, copied)
+        assert result.state == "pending"
+        assert json.loads((tmp_path / RESOURCE_NAME).read_text())["generation"] == copied
+
+    bridge.fail_close = False
+    assert (await cleanup_exact(tmp_path, copied)).state == "closed"
+
+
+@pytest.mark.asyncio
+async def test_listing_and_cleanup_agree_on_the_stranded_state(
+    tmp_path: Path, bridge: BridgeFixture
+) -> None:
+    """M1: a failed removal persists 'pending'; both surfaces must accept it."""
+    # Own sessions root: tmp_path.parent is pytest's shared directory and would
+    # scan sibling tests' records.
+    sessions = tmp_path / "sessions"
+    directory = sessions / "stranded"
+    resource = BrowserResource(directory, "stranded")
+    resource.initialize()
+    resource.record["terminal"] = "completed"
+    resource.remember("bridge:100:private")
+    # The extension REPORTS pending when chrome.tabs.remove threw: the reply
+    # overwrites the durable 'cleanup_pending' intent, which is how the two
+    # surfaces came to disagree about the one genuinely stranded state.
+    bridge.finish_state = "pending"
+    assert (await resource.finish(resource.generation, "completed")).state == "pending"
+
+    row = read_inventory(sessions)[0]
+    assert row["state"] == "pending"
+    assert row["cleanup_candidate"] is True, "the one stranded state must be listed as cleanable"
+
+    bridge.finish_state = ""
+    assert (await cleanup_exact(directory, resource.generation)).state == "closed"
+
+
+@pytest.mark.asyncio
+async def test_refusals_name_the_specific_cause_and_the_route_out(
+    tmp_path: Path, bridge: BridgeFixture
+) -> None:
+    """U1/U4: the crash shape must name resume, not read as a mistyped id."""
+    crashed = tmp_path / "crashed"
+    resource = BrowserResource(crashed, "crashed")
+    resource.initialize()
+    resource.remember("bridge:9:stranded")  # killed before finish: no terminal
+
+    row = read_inventory(tmp_path)[0]
+    assert row["cleanup_candidate"] is False
+    assert "resume" in row["blocked_reason"] and "lop --resume" in row["blocked_reason"]
+
+    refused = await cleanup_exact(crashed, resource.generation)
+    assert refused.state == "unresolved"
+    assert "lop --resume" in refused.detail
+    assert "stale" not in refused.detail, "a live owner is not a stale selection"
+
+    wrong = await cleanup_exact(crashed, "not-the-generation")
+    assert "generation does not match" in wrong.detail
+    missing = await cleanup_exact(tmp_path / "no-such-session", "any")
+    assert "no ownership record" in missing.detail
+
+    retained = tmp_path / "held"
+    held = BrowserResource(retained, "held")
+    held.initialize()
+    held.record.update(terminal="completed", retention="pending login")
+    held.remember("bridge:9:held")
+    assert "pending login" in (await cleanup_exact(retained, held.generation)).detail
+    assert bridge.calls == [], "no refusal may reach the bridge"

--- a/tests/unit/browser_bridge/test_resources.py
+++ b/tests/unit/browser_bridge/test_resources.py
@@ -8,9 +8,11 @@ from typing import Any
 import pytest
 
 from local_operator.browser_bridge import resources
+from local_operator.browser_bridge.backend import BridgeUnreachable
 from local_operator.browser_bridge.resources import (
     RESOURCE_NAME,
     BrowserResource,
+    cleanup_disposition,
     cleanup_exact,
     read_inventory,
 )
@@ -28,6 +30,9 @@ class BridgeFixture:
         #: could not remove the tab" answer can be exercised as itself rather
         #: than as a transport failure.
         self.finish_state = ""
+        #: Raise the real transport error, whose message names the diagnosing
+        #: command — the detail the operator is supposed to receive.
+        self.unreachable = False
 
     async def call(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
         self.calls.append((method, params))
@@ -37,6 +42,10 @@ class BridgeFixture:
             self.retained = True
             return {"state": "retained"}
         if method == "owner_finish":
+            if self.unreachable:
+                raise BridgeUnreachable(
+                    "browser bridge unreachable: no live daemon state. " "Run 'lop browser status'."
+                )
             if self.fail_close:
                 raise ConnectionError("disposable fixture unavailable")
             if self.finish_state:
@@ -276,3 +285,99 @@ async def test_refusals_name_the_specific_cause_and_the_route_out(
     held.remember("bridge:9:held")
     assert "pending login" in (await cleanup_exact(retained, held.generation)).detail
     assert bridge.calls == [], "no refusal may reach the bridge"
+
+
+def test_finalized_unleased_child_can_browse_on_a_later_run(tmp_path: Path) -> None:
+    """M3/Q2: a settled scope must not lock a resumed child out of the browser.
+
+    In-process children use ``claim_session``, not ``acquire_session_lease``,
+    so gating the retire branch on holding a lease made ``terminal`` permanent
+    for EVERY subagent: ``allocate`` refuses on terminal, and ``hub
+    op='resume'`` relaunches children on their own directory, so an ordinary
+    finish-then-resume left a child that could never browse again. No round-1
+    guard set ``terminal`` on an UNLEASED record, which is why the regression
+    passed 15/15.
+    """
+    directory = tmp_path / "sessions" / "child"
+    first = BrowserResource(directory, "child")
+    first.initialize()
+    first.record.update(state="retained", surface_id="bridge:9:tok", terminal="cancelled")
+    first._save()
+    assert not (directory / ".execution-lease").exists()
+
+    resumed = BrowserResource(directory, "child")
+    resumed.initialize()
+    assert resumed.record.get("terminal") is None
+    resumed.allocate()
+
+
+def test_paused_unleased_child_consumes_its_release_on_resume(tmp_path: Path) -> None:
+    """A pause routes through cancellation, so the unleased path must release it."""
+    directory = tmp_path / "sessions" / "paused"
+    first = BrowserResource(directory, "paused")
+    first.initialize()
+    first.record.update(state="retained", terminal="cancelled", retention="paused scope")
+    first._save()
+
+    resumed = BrowserResource(directory, "paused")
+    resumed.initialize()
+    assert resumed.record.get("release_pause") is True
+
+
+def test_operator_cleanup_of_a_stranded_scope_is_never_blocked_by_a_resume(
+    tmp_path: Path,
+) -> None:
+    """Retiring a stranded scope must not cost the operator their recovery route.
+
+    A failed close leaves the tab out there, and the resumed owner is the party
+    responsible for it — the route the crash-shape refusal names. That is safe
+    for the operator's own path because ``cleanup_exact`` reaches a record
+    through ``adopt``, never through ``initialize``, so an untouched stranded
+    record stays a cleanup candidate with its terminal intact.
+    """
+    directory = tmp_path / "sessions" / "stranded"
+    first = BrowserResource(directory, "stranded")
+    first.initialize()
+    first.record.update(state="cleanup_pending", surface_id="bridge:4:tok", terminal="completed")
+    first._save()
+
+    # Untouched by any new run, the row remains the operator's to clean up.
+    assert cleanup_disposition(read_inventory(tmp_path / "sessions")[0])[0] is True
+
+    # A resume takes responsibility for the tab and may browse again.
+    resumed = BrowserResource(directory, "stranded")
+    resumed.initialize()
+    assert resumed.record.get("terminal") is None
+    resumed.allocate()
+
+
+def test_a_live_incumbent_is_never_retired_by_a_concurrent_instance(tmp_path: Path) -> None:
+    """B1 must survive the M3 fix: no terminal means no retire, so no fencing."""
+    directory = tmp_path / "sessions" / "live"
+    incumbent = BrowserResource(directory, "live")
+    incumbent.initialize()
+    incumbent.remember("bridge:2:live")
+
+    newcomer = BrowserResource(directory, "live")
+    newcomer.initialize()
+    assert newcomer.generation == incumbent.generation
+    # The incumbent still owns its tab; the newcomer adopted, not seized.
+    incumbent.remember("bridge:2:live")
+
+
+@pytest.mark.asyncio
+async def test_pending_cleanup_names_the_command_not_the_class(
+    tmp_path: Path, bridge: BridgeFixture
+) -> None:
+    """D10/U10: the bridge's own message names the fix; the class name does not."""
+    directory = tmp_path / "sessions" / "unreachable"
+    resource = BrowserResource(directory, "unreachable")
+    resource.initialize()
+    resource.record["terminal"] = "completed"
+    resource.remember("bridge:100:private")
+    bridge.unreachable = True
+
+    result = await resource.finish(resource.generation, "completed")
+    assert result.state == "pending"
+    assert "BridgeUnreachable" != result.detail
+    assert "lop browser status" in result.detail

--- a/tests/unit/browser_bridge/test_resources.py
+++ b/tests/unit/browser_bridge/test_resources.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.browser_bridge import resources
+from local_operator.browser_bridge.resources import (
+    BrowserResource,
+    cleanup_exact,
+    read_inventory,
+)
+from local_operator.session_lease import SessionLeaseHeldError, acquire_session_lease
+
+
+class BridgeFixture:
+    """Disposable protocol peer; never discovers the operator's bridge."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.fail_close = False
+        self.retained = False
+
+    async def call(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append((method, params))
+        if method == "owner_recover":
+            return {"ownership_version": 1, "state": "owned", "tab": "bridge:100:private"}
+        if method == "owner_retain":
+            self.retained = True
+            return {"state": "retained"}
+        if method == "owner_finish":
+            if self.fail_close:
+                raise ConnectionError("disposable fixture unavailable")
+            return {"state": "retained" if self.retained else "closed"}
+        raise AssertionError(method)
+
+
+@pytest.fixture
+def bridge(monkeypatch: pytest.MonkeyPatch) -> BridgeFixture:
+    fixture = BridgeFixture()
+    monkeypatch.setattr(resources, "BridgeClient", lambda: fixture)
+    return fixture
+
+
+def test_private_sidecar_and_redacted_inventory(tmp_path: Path) -> None:
+    directory = tmp_path / "synthetic"
+    resource = BrowserResource(directory, directory.name)
+    resource.initialize()
+    resource.remember("bridge:100:secret-capability")
+    assert os.stat(resource.path).st_mode & 0o777 == 0o600
+    raw = json.dumps(read_inventory(tmp_path))
+    assert resource.record["proof"] not in raw
+    assert "secret-capability" not in raw
+    assert read_inventory(tmp_path)[0]["cleanup_candidate"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("outcome", ["completed", "cancelled", "failed", "disposed"])
+async def test_terminal_cleanup_is_durable_and_idempotent(
+    tmp_path: Path, bridge: BridgeFixture, outcome: str
+) -> None:
+    resource = BrowserResource(tmp_path, tmp_path.name)
+    resource.initialize()
+    resource.remember("bridge:100:private")
+    result = await resource.finish(resource.generation, outcome)
+    assert result.state == "closed"
+    assert json.loads(resource.path.read_text())["terminal"] == outcome
+    assert json.loads(resource.path.read_text())["surface_id"] == ""
+    assert (await resource.finish(resource.generation, outcome)).state == "closed"
+
+
+@pytest.mark.asyncio
+async def test_failed_cleanup_survives_reconstruction(
+    tmp_path: Path, bridge: BridgeFixture
+) -> None:
+    resource = BrowserResource(tmp_path, tmp_path.name)
+    resource.initialize()
+    resource.remember("bridge:100:private")
+    bridge.fail_close = True
+    assert (await resource.finish(resource.generation, "failed")).state == "pending"
+    record = json.loads(resource.path.read_text())
+    assert record["terminal"] == "failed"
+    assert record["surface_id"] == "bridge:100:private"
+    # Reconstruction models a restarted host. The stable proof and allocation
+    # survive; a new generation is presented with the previous CAS token.
+    resumed = BrowserResource(tmp_path, tmp_path.name)
+    resumed.initialize()
+    assert resumed.params()["owner_proof"] == resource.record["proof"]
+    assert resumed.params()["previous_generation"] == resource.generation
+    assert resumed.generation != resource.generation
+    bridge.fail_close = False
+    await resumed.recover()
+    assert resumed.record["surface_id"] == "bridge:100:private"
+    with pytest.raises(RuntimeError, match="stale"):
+        resource.remember("")
+
+
+@pytest.mark.asyncio
+async def test_pending_login_and_paused_retention_protect_terminal_scope(
+    tmp_path: Path, bridge: BridgeFixture
+) -> None:
+    resource = BrowserResource(tmp_path, tmp_path.name)
+    resource.initialize()
+    resource.record["retention"] = "pending login"
+    resource.remember("bridge:100:private")
+    assert (await resource.finish(resource.generation, "completed")).state == "retained"
+    assert resource.record["surface_id"] == "bridge:100:private"
+    assert [call[0] for call in bridge.calls] == ["owner_recover", "owner_retain", "owner_finish"]
+
+
+def test_execution_lease_fences_even_lazy_old_host(tmp_path: Path) -> None:
+    lease = acquire_session_lease(tmp_path)
+    old = BrowserResource(tmp_path, tmp_path.name)
+    lease.release()
+    successor = acquire_session_lease(tmp_path)
+    try:
+        with pytest.raises(RuntimeError, match="lease changed"):
+            old.initialize()
+        current = BrowserResource(tmp_path, tmp_path.name)
+        current.initialize()
+        assert current.generation == successor.generation
+    finally:
+        successor.release()
+
+
+@pytest.mark.asyncio
+async def test_exact_cleanup_rejects_live_lease_and_stale_selection(
+    tmp_path: Path, bridge: BridgeFixture
+) -> None:
+    lease = acquire_session_lease(tmp_path)
+    try:
+        resource = BrowserResource(tmp_path, tmp_path.name)
+        resource.initialize()
+        resource.record["terminal"] = "failed"
+        resource.remember("bridge:100:private")
+        with pytest.raises(SessionLeaseHeldError):
+            await cleanup_exact(tmp_path, resource.generation)
+        assert (await cleanup_exact(tmp_path, "wrong-generation")).state == "unresolved"
+        assert not bridge.calls
+    finally:
+        lease.release()
+    assert (await cleanup_exact(tmp_path, resource.generation)).state == "closed"
+
+
+@pytest.mark.asyncio
+async def test_dead_process_alone_never_authorizes_cleanup(
+    tmp_path: Path, bridge: BridgeFixture
+) -> None:
+    resource = BrowserResource(tmp_path, tmp_path.name)
+    resource.initialize()
+    resource.remember("bridge:100:private")
+    assert (await cleanup_exact(tmp_path, resource.generation)).state == "unresolved"
+    assert not bridge.calls

--- a/tests/unit/browser_bridge/test_tabs_rendering.py
+++ b/tests/unit/browser_bridge/test_tabs_rendering.py
@@ -1,0 +1,106 @@
+"""`lop browser tabs` must never render an UNKNOWN browser as an empty one.
+
+The live-tab merge answered a blocker (a command called `tabs` reporting no
+tabs while `status` drove seven), and shipped with no guard at all: nothing in
+the tree exercised this rendering, so a one-line divergence from `status`
+passed CI. These tests pin the distinction that divergence erased.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator import cli
+from local_operator.browser_bridge import install as browser_install
+from local_operator.browser_bridge import state as browser_state
+
+
+def _run(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    *,
+    health: dict[str, Any] | None,
+    discovery: object | None = None,
+    json_mode: bool = False,
+) -> str:
+    monkeypatch.setattr(cli, "config_dir", lambda: tmp_path)
+    monkeypatch.setattr(browser_state, "read", lambda: discovery)
+    monkeypatch.setattr(browser_install, "health", lambda port, **kw: health)
+    argv = ["lop", "browser", "tabs"] + (["--json"] if json_mode else [])
+    monkeypatch.setattr("sys.argv", argv)
+    cli.main()
+    return capsys.readouterr().out
+
+
+def test_a_missing_discovery_file_still_finds_the_daemons_tabs(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    """D9/U9: `state.read()` returns None for a CORRUPT file as much as no daemon.
+
+    Skipping the probe on None made a healthy bridge driving five tabs render
+    as an empty browser, while `status` found them at the default port in the
+    same state.
+    """
+    tabs = [{"url": "http://127.0.0.1:4199/", "title": ""}]
+    out = _run(
+        monkeypatch,
+        capsys,
+        tmp_path,
+        health={"extension_connected": True, "driven_tabs": tabs},
+        discovery=None,
+    )
+    assert "http://127.0.0.1:4199/" in out
+    assert "No browser tabs" not in out
+
+
+def test_an_unreachable_bridge_is_not_reported_as_zero_tabs(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    """A probe that did not answer must read as unknown, and name the diagnosis."""
+    out = _run(monkeypatch, capsys, tmp_path, health=None, discovery=None)
+    assert "No browser tabs" not in out
+    assert "unknown" in out
+    assert "lop browser status" in out
+
+
+def test_a_live_bridge_with_no_tabs_still_says_so(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    """The honest zero must stay distinguishable from the unknown."""
+    out = _run(
+        monkeypatch,
+        capsys,
+        tmp_path,
+        health={"extension_connected": True, "driven_tabs": []},
+        discovery=None,
+    )
+    assert "No browser tabs and no ownership records." in out
+
+
+def test_json_reports_unknown_as_null_never_zero(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    """A script must not be able to read an unreachable bridge as an empty one."""
+    unknown = json.loads(
+        _run(monkeypatch, capsys, tmp_path, health=None, discovery=None, json_mode=True)
+    )
+    assert unknown["live_tabs_known"] is False
+    assert unknown["live_tab_count"] is None
+
+    live = json.loads(
+        _run(
+            monkeypatch,
+            capsys,
+            tmp_path,
+            health={"extension_connected": True, "driven_tabs": []},
+            discovery=None,
+            json_mode=True,
+        )
+    )
+    assert live["live_tabs_known"] is True
+    assert live["live_tab_count"] == 0

--- a/tests/unit/session/test_no_session_deletion.py
+++ b/tests/unit/session/test_no_session_deletion.py
@@ -115,6 +115,23 @@ _ALLOWED_ROWS: tuple[tuple[str | int, ...], ...] = (
         "<path>.remove",
         "Textual TranscriptView.remove unmounts failed preparation; no filesystem path",
     ),
+    # The browser resource sidecar. Both paths are the FILE
+    # `<session_dir>/.browser-resource.json` and a `mkstemp` sibling of it, so
+    # neither call can name the directory itself: `os.replace` over a regular
+    # file never removes or renames its parent, and the unlink targets only the
+    # temporary file this same call created. The session directory is written
+    # INTO here, never removed — the module holds no directory-removal call at
+    # all, which is what this invariant is protecting.
+    (
+        "local_operator/browser_bridge/resources.py::BrowserResource._save",
+        "os.replace",
+        "Atomic write of the .browser-resource.json FILE; the parent directory is never named",
+    ),
+    (
+        "local_operator/browser_bridge/resources.py::BrowserResource._save",
+        "os.unlink",
+        "Removes only this call's own mkstemp sidecar temp file after a failed replace",
+    ),
     (
         "local_operator/tui/session_drafts.py::SessionDraftStore._write",
         "os.replace",


### PR DESCRIPTION
## Summary

A failed **first** navigation created a real browser tab, persisted it, and then
threw before the handle ever reached the session. The tab counted against the
eight-tab cap while `goto` answered *"no browser surface open"*, `close`
answered *"No browser surface open."*, and `tabs` listed it without `(yours)` —
so nothing in the supported surface could ever reclaim it. Three sessions hit
this in one window and the pool filled up.

This makes allocation a **transaction**, ownership **durable**, and terminal
cleanup **authoritative** — without ever inferring that an unknown tab is safe
to close.

No version bump: `pyproject.toml` stays at the last released version.

## The defect, reproduced before it was fixed

Against the real bundled `nav.ts`/`state.ts` with disposable Chrome fixtures
(`/tmp/browser-ownership-repro.log`), on the **pre-fix** tree:

```json
{"navigationFailures":8,"allocatedTabs":8,"storedSurfaces":8,
 "removedTabs":0,"ninthOpen":"tab_limit","liveBrowserTouched":false}
```

Eight refused navigations produced eight persisted tabs and zero removals, then
the ninth open was refused with `tab_limit`. `nav.ts:146-166` created and
persisted the tab, then awaited attach/log-capture/grouping/navigation with no
rollback; `builtin.py` recorded ownership only on success.

**Established vs. unproven.** The allocation leak is an established code defect
with a captured incident. The provenance of the seven older tabs on the
operator's machine is **unproven** — their URL, age and appearance cannot
establish ownership history, and nothing here treats them as reclaimable.

## What changed

**1. Exception-safe allocation.** A new allocation that fails at attach, log
capture, grouping or navigation removes only **its own** tab. A resumed `open`
or a failed `goto` never closes a pre-existing tab — that tab may hold a login
the user is finishing. When removal itself fails, the capability is retained as
`cleanup_pending` rather than forgotten: only a **confirmed missing** tab counts
as a successful close, on both sides of the wire. The security-sensitive
ordering (blank inactive tab → debugger/origin gate → navigate) and the
eight-tab cap are unchanged; leakage is not "solved" by raising the cap.

**2. Durable ownership.** A private `0600` sidecar per session holds the
allocation id, capability, terminal intent and retention, fenced by the
**existing execution lease generation** — never a PID, launcher or team name. A
retry of the same allocation returns the tab it already created instead of
opening a second one; a stale generation can neither drive nor finalize a
resumed owner. Capabilities never reach transcripts, listings or CLI output
(asserted by test).

**3. One authoritative finalizer.** `Session.finish_browser_scope(scope_id,
generation, outcome)` is called by the subagent runner **before** the terminal
outcome is published, with `dispose()` remaining an idempotent fallback. It
records terminal intent **before** acting, so a timeout leaves a retryable
obligation rather than a false "closed". Ordinary assistant finals and idle
turns finalize nothing. Protected: running/long jobs, paused children, pending
login in the exact owned tab, pending site approvals, explicit retention.

**4. Conservative recovery.** `browser recover` recovers only this owner's own
allocation; `retain`/`release` carry a structured reason.

```
lop browser tabs --json   # redacted inventory, read-only
lop browser reconcile     # read-only explanation, never a sweep
lop browser cleanup <session> --generation <gen> --yes
```

Cleanup acts on **one explicitly named terminal owner** and revalidates terminal
intent, retention and the execution lease immediately before closing. A missing
owner, dead PID, old heartbeat, localhost URL, stopped fixture server or absent
runtime registry means **UNKNOWN**, not safe to close. A full browser restart is
reported `unresolved` rather than adopting a tab by matching numeric id or URL.

## Testing evidence

Every run used a scrubbed `HOME`/config with all `CMUX_*` removed. **No browser
engine was installed or scripted, no live tab, bridge install or global config
was touched** — Node runs the actual bundled extension modules against in-memory
Chrome fixtures while Python drives its real `Session` and real HTTP client.

**Transaction matrix — 12/12 pass** (`extension/tests/ownership.integration.test.mjs`):
rollback on navigation/attach/capture failure · failed-rollback stays recoverable
and retries exactly one owner · lost response replays one allocation · failed
existing-tab navigation never closes · stale generation and foreign capability
rejected · legacy client still closes its own legacy tab · retention survives
completion, release enables cleanup · 10 concurrent owners capped at 8 with no
hijack · worker restart recovers, browser restart never adopts numeric ids ·
normal close and user-closed stale pool release only confirmed-missing tabs ·
completion racing allocation leaves no late tab.

**Assembled session E2E — 6/6 pass** (`tests/e2e/test_browser_ownership.py`),
real `Session` → authenticated HTTP → bundled extension:

| Case | Actual result |
|---|---|
| Failed nav, then success, then completion | `tabs=0` after failure; `tabs=1` open; finish `closed`, `tabs=0` |
| Wrong bridge key | `401` |
| Failed close → retention → resume → release | handle retained, resumed owner recovers same surface, release closes |
| Stale owner finalizing after resume | `unresolved`, successor untouched (`tabs=1`, no terminal) |
| Child completed / failed / cancelled | tab allocated `=1`, then `=0` **before** the terminal handoff |
| New runtime, old extension | actionable update message, **zero tabs allocated** |

**Quality gates on this head** (`53579bc7d`, base `20fb34126`): flake8 `0` ·
black `--check` `0` · isort `--check` `0` · pyright **`0 errors`, whole tree,
re-captured at this head**
(`/tmp/browser-ownership-evidence/round1/pyright-at-head.log`) ·
context-budget PASS · extension `pnpm typecheck` + `155` tests ·
`tests/e2e -m e2e -n0` `55 passed` · resource units `15 passed`.

Whole-tree unit suite: `16487 passed, 1 failed`. **That one failure is
pre-existing and unrelated** — `test_procname::test_unreadable_libpython_parent_does_not_raise`
fails identically at base `20fb34126`, reproduced independently by both the
reviewer and QA. The TUI anchor test **passes**: it is an order-dependent
flake, not a regression, and this diff touches no TUI code. (An earlier
revision of this body claimed two failures and linked a pyright log that
predated the head by 32 minutes; both are corrected here.)

**Rendered CLI frames** re-captured after the round-1 visual fixes, at REAL
identifier widths (UUID session dirs, `token_urlsafe(24)` generations) and
viewed as images: `/tmp/browser-ownership-evidence/round1/` — `populated`,
`unowned-tabs`, `refusal-crashed`, `refusal-retained`, `empty`,
`approval-required`, `help`. Max line width 76, zero lines over 80, no
mid-token wrapping. Frames assert no capability material is rendered.

## Round 1 review: all gating findings remediated

Code, design and UX each requested changes (1 blocker + 2 major apiece); QA
passed 37/39 with no findings owed. All are fixed in `53579bc7d` and
dispositioned in three remediation comments on this PR.

The blocker worth naming: **the lease invariant I asked to have reviewed was
broken on its fallback path.** An unleased directory minted a generation per
`BrowserResource` *instance*, and in-process children take that path (they use
`claim_session`, not `acquire_session_lease`), so a second `Session` over one
directory fenced the live owner out of a tab it was still holding — a pool slot
nobody could close, reached through the contract's own safe default. Identity
is now durable per session. Reproduced before and after; pinned by regression
tests.

**PID independence — the operator's hardest requirement — is met, confirmed
independently by both the reviewer and QA.** `resources.py` never reads
`.execution-lease.recovery`; its single lease read discards the pid
(`generation, _pid = _read_claim(...)`); identity is the lease *generation
token*, never a process id. `_pid_state` is unreachable from
`finish_browser_scope`, `cleanup_exact`, `recover` and the inventory. PID
liveness exists only inside `acquire_session_lease`, where it can only ever
*refuse*: a lease naming a live unrelated pid makes `cleanup_exact` raise
`SessionLeaseHeldError` and close nothing. **Liveness can never authorize a
cleanup, only decline one.** No age, heartbeat, localhost-URL or empty-registry
test participates in any decision.

## Reviewer notes

- The two `test_no_session_deletion.py` allow-list rows were reviewed and
  recorded as a positive: the guard is keyed by `path::function::call-shape`
  **with a live-count equality check**, so they cannot mask a regression — any
  additional same-shape call fails until a reviewer bumps the count.
- **Disclosed, distinct, out of scope:** a pre-existing `attention.publish`
  `ValueError: completion token belongs to another outcome` surfaces when two
  real `Session` objects run concurrently over one transcript. Both the
  reviewer and QA independently confirmed it is pre-existing and **not
  worsened** by this diff, which touches no attention file.
- The new wire methods require the updated extension. A new runtime against an
  old one fails with an update instruction **before allocating anything**, now
  keyed on a typed `OWNER_REFUSED` code rather than a substring match. Old
  runtimes keep their legacy capability-only path and their tabs are never
  auto-claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

