### PR TITLE
chore(release): bump version to 0.51.21

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.20"
+version = "0.51.21"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window claimed. Owner session pid: 96607.

Window (tick as each merges):
- [x] #796 9223b7c4b51ad545d626ebe718bb19dd71455958 — Release: patch — `/goal <text>` now sets the objective AND submits that text as an ordinary user message, so one Enter starts the work.

Provisional version: v0.51.21 (patch).