### PR TITLE
fix(tui): allow /reload and /update while a detached runtime keeps working

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,15 @@ with its title and age:
 | `/skills`, `/mcp` | List loaded skills · MCP servers |
 | `/theme`, `/rename` | Pick from 20+ built-in themes (arrows preview live) · rename the session |
 
+`/reload` and `/update` can replace the terminal while its detached session
+runtime keeps working. The new terminal reattaches to the same saved conversation,
+including streamed output and unanswered approval or ask prompts. The runtime
+adopts installed code only when all work is safely idle: active turns, tools,
+compaction, gates, loops, child agents, background jobs, and imminent wakes defer
+that refresh. Reloading an unchanged build does not restart the runtime. Local
+in-process work and terminal-owned `!` shell commands must finish first. A failed
+update leaves the current terminal and runtime running.
+
 ### Keys worth knowing
 
 - `$<skill>`: run a named skill on the rest of the line

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -3095,6 +3095,7 @@ class RemoteSession:
                 return
             if not self._gate_reply_is_current(pending, client):
                 return
+            self.preserve_viewer_gate_reply()
             await client.approval_answer(pending.request_id, approved)
             self._gate_answered_key = self._gate_identity(pending)
         except (asyncio.CancelledError, RuntimeError, ConnectionError):
@@ -3149,6 +3150,7 @@ class RemoteSession:
                 return
             values = answer.get(pending.request_id) or []
             if values:
+                self.preserve_viewer_gate_reply()
                 await client.ask_answer(
                     pending.request_id,
                     values[0],
@@ -4144,7 +4146,17 @@ class RemoteSession:
         """
         return self._takeover_target is None
 
-    async def detach_viewer_gates(self) -> None:
+    def preserve_viewer_gate_reply(self) -> None:
+        """Latch a user's committed answer before its bridge gets scheduled.
+
+        The UI calls this synchronously when settling its future. Waiting until
+        the wire send starts loses answers when reload arrives on the same tick.
+        Detached unanswered bridges must never be revived by widget cleanup.
+        """
+        if not self._gates_detached and self._gate_task is not None:
+            self._keep_gate_reply = True
+
+    async def detach_viewer_gates(self, *, preserve_answers: bool = False) -> None:
         """Withdraw this UI's waiters without answering the owner's questions.
 
         A fork switch must stop the answer bridge BEFORE the app clears its
@@ -4155,7 +4167,11 @@ class RemoteSession:
         # A sibling frontend may settle Q1 while detach awaits cancellation.
         # Suppress the ensuing Q2 bridge as well, until this viewer is disposed.
         self._background_approval = False
-        self._keep_gate_reply = False
+        if not preserve_answers:
+            self._keep_gate_reply = False
+        # Relaunch drains answers already committed by the user before closing
+        # the socket. Unanswered gates are cancelled, and detached presentation
+        # prevents a successor question from starting during that drain.
         task = self.suspend_viewer_gates()
         if task is not None:
             await asyncio.gather(task, return_exceptions=True)

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -4135,6 +4135,15 @@ class RemoteSession:
                 if self._disposed or self._client is not client:
                     client.close()
 
+    @property
+    def can_detach_runtime(self) -> bool:
+        """Whether replacing this viewer leaves execution in another process.
+
+        Legacy owner recovery can install an in-process takeover target behind
+        this facade, so ``is_remote`` alone is not a survival guarantee.
+        """
+        return self._takeover_target is None
+
     async def detach_viewer_gates(self) -> None:
         """Withdraw this UI's waiters without answering the owner's questions.
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3313,6 +3313,10 @@ class OperatorApp(App[None]):
         self._interaction.draft.approve_all = value
 
     async def _on_message(self, message: TextualMessage) -> None:
+        # The owner keeps publishing while this viewer exits. Already queued
+        # messages outlive subscription disposal and must not paint a pruned DOM.
+        if self._restart_plan is not None and isinstance(message, SessionEvent):
+            return
         if isinstance(message, SessionEvent) and message.origin is not None:
             source = self._event_sources.get(message.origin)
             if source is not None:
@@ -5576,6 +5580,8 @@ class OperatorApp(App[None]):
         self.call_later(self._apply_pending_frontend_state, generation)
 
     def _apply_pending_frontend_state(self, generation: int) -> None:
+        if self._restart_plan is not None:
+            return
         if generation != getattr(self, "_frontend_session_generation", 0):
             return
         self._frontend_apply_scheduled = False
@@ -8150,12 +8156,10 @@ class OperatorApp(App[None]):
         self._request_relaunch()
 
     def _turn_is_live(self) -> bool:
-        """A mid-turn exec would drop work the user can still abort with esc.
+        """Include lock-held compaction and loops, not only streamed tokens.
 
-        Compaction holds the session lock with ``is_streaming`` False (see
-        the hold in :meth:`on_editor_submitted`), so it has to count here
-        too: ``/update`` and ``/reload`` would otherwise tear the process
-        down while history is being rewritten.
+        Local execution cannot survive a terminal exec; a detached owner can.
+        ``_relaunch_refusal`` makes that ownership distinction separately.
         """
         session = self._session
         streaming = session is not None and bool(getattr(session, "is_streaming", False))
@@ -8173,16 +8177,47 @@ class OperatorApp(App[None]):
             return "esc first — a loop is still running"
         return "esc first — a turn is still running"
 
+    def _relaunch_refusal(self) -> str:
+        """Only out-of-process work survives replacing the terminal image."""
+        from local_operator.session.remote import RemoteSession
+
+        for source in self._interactions.values():
+            worker = source.shell.worker
+            if worker is not None and not worker.is_finished:
+                return "wait for the local shell command to finish before relaunching"
+            session = source.session
+            if (
+                session is not None
+                and session is not self._session
+                and (not isinstance(session, RemoteSession) or not session.can_detach_runtime)
+                and (
+                    getattr(session, "is_streaming", False)
+                    or source.loop.running
+                    or source.compaction.active
+                )
+            ):
+                return "wait for local session work to finish before relaunching"
+        if not self._turn_is_live():
+            return ""
+        session = self._session
+        if not isinstance(session, RemoteSession) or not session.can_detach_runtime:
+            return self._live_turn_refuse_copy()
+        if not self._resumable_session_id():
+            return "wait for this conversation to be saved before relaunching"
+        return ""
+
     def _request_relaunch(self, *, force: bool = False) -> None:
         """Stash a :class:`RestartPlan` and exit 75 so ``cli.main`` re-execs.
 
-        ``force`` is the completed-upgrade path: the wheel is already on
-        disk, so a turn that started during the installer must not cancel
-        the relaunch. The composer is locked for that window; this is the
-        belt if something still looks live.
+        ``force`` identifies the completed-upgrade path so a refusal releases
+        the installer mutex. Recheck ownership even then: an in-process legacy
+        takeover during installation must not have its work killed by exec.
         """
-        if not force and self._turn_is_live():
-            self._system_notice(self._live_turn_refuse_copy(), "warning")
+        refusal = self._relaunch_refusal()
+        if refusal:
+            self._system_notice(refusal, "warning")
+            if force:
+                self._finish_update()
             return
         from local_operator.reexec import REEXEC_CODE, make_plan, stash_plan
 
@@ -8195,7 +8230,14 @@ class OperatorApp(App[None]):
         # carries no ``--resume`` and comes back as a cold launch. The
         # completed-upgrade path already painted ``restarting…`` on the
         # same tick, so it does not get a second line.
-        if not force:
+        from local_operator.session.remote import RemoteSession
+
+        if isinstance(self._session, RemoteSession) and self._session.can_detach_runtime:
+            self._system_notice(
+                "relaunching terminal; runtime work continues. "
+                "New runtime code waits until all work is safely idle."
+            )
+        elif not force:
             if resume_id is None:
                 self._system_notice("relaunching… this will open a new session")
             else:
@@ -8224,8 +8266,9 @@ class OperatorApp(App[None]):
         if self._update_in_progress:
             self._system_notice("an update is already running", "warning")
             return
-        if self._turn_is_live():
-            self._system_notice(self._live_turn_refuse_copy(), "warning")
+        refusal = self._relaunch_refusal()
+        if refusal:
+            self._system_notice(refusal, "warning")
             return
         # Armed BEFORE the worker so a second ``/update`` typed while the
         # first is still scheduling cannot start a second installer. The
@@ -8334,7 +8377,10 @@ class OperatorApp(App[None]):
                     "the foreground lop mobile serve process to pick up the new UI",
                     "warning",
                 )
-            self._system_notice(f"updated to v{installed} — restarting…")
+            if self._relaunch_refusal():
+                self._system_notice(f"updated to v{installed}; relaunch when local work is idle")
+            else:
+                self._system_notice(f"updated to v{installed} — restarting…")
             self._request_relaunch(force=True)
 
         self.call_from_thread(_relaunch_after_upgrade)
@@ -14699,6 +14745,8 @@ class OperatorApp(App[None]):
         # Unlike paint-only workers, bang-mode owns a subprocess and a durable
         # receipt. Abort and join it BEFORE the blanket cancellation: cancelling
         # execute_bash directly can bypass its normal result/persistence path.
+        if self._restart_plan is not None:
+            await self._detach_relaunch_gates()
         await self._settle_shell_command()
         self.workers.cancel_all()
         await super()._shutdown()
@@ -16030,8 +16078,35 @@ class OperatorApp(App[None]):
             logger.info("terminal front end closed; session is quiescent — exiting cleanly")
             self.exit()
 
+    async def _detach_relaunch_gates(self) -> None:
+        """Withdraw every viewer bridge before widget cleanup resolves futures.
+
+        Approval/ask widget teardown normally answers its local future. On a
+        relaunch that must not become a denial sent to the still-running owner;
+        the next viewer receives the unanswered gate from canonical state.
+        Sidebar sources can hold gates too, not just the visible conversation.
+        """
+        from local_operator.session.remote import RemoteSession
+
+        sessions = [source.session for source in self._interactions.values()]
+        sessions.append(self._session)
+        seen: set[int] = set()
+        for session in sessions:
+            if (
+                isinstance(session, RemoteSession)
+                and session.can_detach_runtime
+                and id(session) not in seen
+            ):
+                seen.add(id(session))
+                await session.detach_viewer_gates()
+
     async def on_unmount(self) -> None:
         from textual.worker import WorkerCancelled, WorkerFailed
+
+        # Keep direct hook callers safe too; normal shutdown already withdrew
+        # these bridges before Textual pruned the widgets or cancelled workers.
+        if self._restart_plan is not None:
+            await self._detach_relaunch_gates()
 
         if self._sidebar_prefetch is not None:
             self._sidebar_prefetch.cancel()

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -13403,6 +13403,8 @@ class OperatorApp(App[None]):
             # otherwise raise InvalidStateError out of Textual's callback.
             if not future.done() and view_generation == source.gate_view_generation:
                 source.gate_draft = None
+                if result:
+                    self._preserve_source_gate_reply(source)
                 future.set_result(result)
 
         # The subagent page hides the transcript and the aside floats over it,
@@ -13814,7 +13816,15 @@ class OperatorApp(App[None]):
             and (key is None or key == self._sidebar_gate_identity(source))
         ):
             source.gate_draft = None
+            self._preserve_source_gate_reply(source)
             self._latch_approval_answer(answer)
+
+    @staticmethod
+    def _preserve_source_gate_reply(source: SessionInteraction) -> None:
+        from local_operator.session.remote import RemoteSession
+
+        if isinstance(source.session, RemoteSession):
+            source.session.preserve_viewer_gate_reply()
 
     def _latch_approval_answer(self, answer: str) -> None:
         """What an answer means beyond the one call. Runs BEFORE the future.
@@ -16091,6 +16101,7 @@ class OperatorApp(App[None]):
         sessions = [source.session for source in self._interactions.values()]
         sessions.append(self._session)
         seen: set[int] = set()
+        pending = []
         for session in sessions:
             if (
                 isinstance(session, RemoteSession)
@@ -16098,7 +16109,10 @@ class OperatorApp(App[None]):
                 and id(session) not in seen
             ):
                 seen.add(id(session))
-                await session.detach_viewer_gates()
+                pending.append(session.detach_viewer_gates(preserve_answers=True))
+        # Suspend every source before waiting on any one reply, so a background
+        # source cannot create a successor gate while another socket drains.
+        await asyncio.gather(*pending)
 
     async def on_unmount(self) -> None:
         from textual.worker import WorkerCancelled, WorkerFailed

--- a/tests/e2e/test_reload_gate_delivery_e2e.py
+++ b/tests/e2e/test_reload_gate_delivery_e2e.py
@@ -1,0 +1,174 @@
+"""Committed answers drain; unanswered successor questions survive relaunch."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from local_operator.harness.types import AskOption, AskQuestion
+from local_operator.reexec import REEXEC_CODE, take_plan
+from local_operator.session.remote import RemoteSession
+from local_operator.session.runtime.owned import OwnedSessionHandle
+from local_operator.session.runtime.server import RuntimeServer
+from local_operator.tui.app import OperatorApp
+from tests.e2e.harness import (
+    ScriptedStream,
+    build_session,
+    seed_transcript,
+    user_message,
+    wait_for_adoption,
+)
+from tests.e2e.test_fork_e2e import _never_take_over, _pump
+from tests.e2e.watchdog import bounded
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["approval", "ask"])
+@pytest.mark.parametrize("timing", ["same-tick", "sending", "sidebar"])
+async def test_committed_gate_drains_before_viewer_disposal(
+    headless_tui_env: Path, workspace: Path, monkeypatch, kind: str, timing: str
+) -> None:
+    config = headless_tui_env
+    directory = config / "sessions" / "replyowner01"
+    await seed_transcript(directory, [user_message("Preserve my answer")])
+    owner = build_session(directory, ScriptedStream([]), cwd=workspace)
+    handle = OwnedSessionHandle(owner, asyncio.get_running_loop(), cwd=str(workspace))
+    server = RuntimeServer(handle, kind="daemon")
+    await server.start_in_process()
+    viewer = await RemoteSession.connect(
+        server._record, owner.session_id, config_dir=config, takeover_factory=_never_take_over
+    )
+    client = viewer._client
+    assert client is not None
+    send_entered, release_send, detach_entered = asyncio.Event(), asyncio.Event(), asyncio.Event()
+    cancelled = []
+    attempts = []
+    original = getattr(client, f"{kind}_answer")
+
+    async def delayed_answer(*args, **kwargs):
+        attempts.append(args)
+        send_entered.set()
+        try:
+            await release_send.wait()
+            return await original(*args, **kwargs)
+        except asyncio.CancelledError:
+            # Owner state may retire a delivered gate before the wire ACK comes
+            # back. Cancellation BEFORE release is the data-loss window here.
+            if not release_send.is_set():
+                cancelled.append(True)
+            raise
+
+    monkeypatch.setattr(client, f"{kind}_answer", delayed_answer)
+    detach = viewer.detach_viewer_gates
+
+    async def observed_detach(**kwargs):
+        detach_entered.set()
+        await detach(**kwargs)
+
+    monkeypatch.setattr(viewer, "detach_viewer_gates", observed_detach)
+
+    async def factory():
+        return viewer
+
+    async def deliver_during_shutdown():
+        await detach_entered.wait()
+        await send_entered.wait()
+        assert not cancelled
+        release_send.set()
+
+    answer_task = None
+    delivery = None
+    try:
+        with bounded(60, "committed gate delivery through relaunch"):
+            app = OperatorApp(factory)
+            async with app.run_test(size=(120, 36)) as pilot:
+                await wait_for_adoption(app, pilot)
+                app._set_approve_all(False)
+                if kind == "approval":
+                    handle._auto_approve = False
+                    answer_task = asyncio.create_task(
+                        handle._approval_gate("write", "Save one record")
+                    )
+                    await _pump(pilot, lambda: app._approval is not None)
+                    app._answer_live_approval_as_allowed()
+                else:
+                    questions = [
+                        AskQuestion(
+                            id="choice",
+                            question="Choose a destination",
+                            options=[AskOption(label="Here"), AskOption(label="There")],
+                        ),
+                        AskQuestion(
+                            id="next",
+                            question="Confirm the next step",
+                            options=[AskOption(label="Proceed"), AskOption(label="Wait")],
+                        ),
+                    ]
+                    answer_task = asyncio.create_task(handle._ask_gate(questions))
+                    await _pump(pilot, lambda: app._ask_screen is not None)
+                    assert app._ask_screen is not None
+                    assert viewer.pending_gate is not None
+                    app._ask_screen.settle({viewer.pending_gate.request_id: ["Here"]})
+                if timing != "same-tick":
+                    await send_entered.wait()
+                if timing == "sidebar":
+                    app._suspend_sidebar_gates(app._interaction)
+                    assert viewer.has_pending_gate_reply
+                delivery = asyncio.create_task(deliver_during_shutdown())
+                app._run_slash_command("/reload")
+                assert app.return_code == REEXEC_CODE
+            await delivery
+            assert answer_task is not None
+            if kind == "ask":
+                # Draining Q1 must not auto-answer/cancel Q2 while the old DOM
+                # disappears. A fresh viewer receives the still-pending question.
+                assert not answer_task.done()
+                successor = await RemoteSession.connect(
+                    server._record,
+                    owner.session_id,
+                    config_dir=config,
+                    takeover_factory=_never_take_over,
+                )
+
+                async def replacement_factory():
+                    return successor
+
+                replacement = OperatorApp(replacement_factory)
+                async with replacement.run_test(size=(120, 36)) as pilot:
+                    await wait_for_adoption(replacement, pilot)
+                    await _pump(pilot, lambda: replacement._ask_screen is not None)
+                    assert successor.pending_gate is not None
+                    assert successor.pending_gate.question_index == 1
+                    assert replacement._ask_screen is not None
+                    replacement._ask_screen.settle({successor.pending_gate.request_id: ["Proceed"]})
+                    await _pump(pilot, answer_task.done)
+                await successor.dispose()
+            result = await answer_task
+            assert result == (
+                True if kind == "approval" else {"choice": ["Here"], "next": ["Proceed"]}
+            )
+            assert len(attempts) == 1
+            assert not cancelled
+            assert not owner._disposed
+            print(
+                {
+                    "kind": kind,
+                    "timing": timing,
+                    "attempts": len(attempts),
+                    "answer": result,
+                    "cancelled_before_delivery": cancelled,
+                }
+            )
+    finally:
+        release_send.set()
+        take_plan()
+        if delivery is not None:
+            await asyncio.gather(delivery, return_exceptions=True)
+        if answer_task is not None and not answer_task.done():
+            answer_task.cancel()
+            await asyncio.gather(answer_task, return_exceptions=True)
+        await viewer.dispose()
+        await server.aclose()
+        await owner.dispose()

--- a/tests/e2e/test_reload_runtime_e2e.py
+++ b/tests/e2e/test_reload_runtime_e2e.py
@@ -1,0 +1,162 @@
+"""Replace real viewers while a real socket owner retains its turn and gates."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from local_operator.reexec import REEXEC_CODE, take_plan
+from local_operator.session.remote import RemoteSession
+from local_operator.session.runtime.owned import OwnedSessionHandle
+from local_operator.session.runtime.server import RuntimeServer
+from local_operator.tools.builtin import build_write_tool
+from local_operator.tui.app import OperatorApp
+from local_operator.update import MobileRefresh, VersionCheck
+from tests.e2e.harness import (
+    ScriptedStream,
+    build_session,
+    seed_transcript,
+    text_turn,
+    tool_call_turn,
+    transcript_text,
+    user_message,
+    wait_for_adoption,
+)
+from tests.e2e.test_fork_e2e import _capture, _never_take_over, _pump
+from tests.e2e.watchdog import bounded
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("command", ["/reload", "/update"])
+@pytest.mark.parametrize("approval", [False, True, "answered"])
+async def test_relaunch_preserves_owner_turn_and_gate(
+    headless_tui_env: Path, workspace: Path, monkeypatch, command: str, approval: bool | str
+) -> None:
+    config = headless_tui_env
+    monkeypatch.setattr(OwnedSessionHandle, "_maybe_name_conversation", lambda *_: None)
+    monkeypatch.setattr(
+        "local_operator.update.check_latest",
+        lambda **_: VersionCheck(installed="0.1.0", latest="0.2.0", behind=True),
+    )
+    monkeypatch.setattr("local_operator.update.perform_upgrade", lambda **_: "0.2.0")
+    monkeypatch.setattr(
+        "local_operator.update.refresh_mobile_after_upgrade",
+        lambda **_: MobileRefresh(kind="skipped"),
+    )
+    directory = config / "sessions" / "reloadowner01"
+    await seed_transcript(directory, [user_message("Saved original context")])
+    entered, release = asyncio.Event(), asyncio.Event()
+    cancelled = []
+    writes = []
+    target = workspace / "result.txt"
+    tool = build_write_tool()
+    execute = tool.execute
+
+    async def held_write(*args, **kwargs):
+        entered.set()
+        try:
+            await release.wait()
+            result = await execute(*args, **kwargs)
+            writes.append(target.read_text())
+            return result
+        except asyncio.CancelledError:
+            cancelled.append(True)
+            raise
+
+    tool.execute = held_write
+    stream = ScriptedStream(
+        [
+            tool_call_turn(
+                text="Writing while the terminal reloads",
+                tool_name="write",
+                tool_call_id="reload-write",
+                arguments={"path": str(target), "content": "completed once"},
+            ),
+            text_turn("The original turn completed"),
+        ]
+    )
+    owner = build_session(directory, stream, tools=[tool], cwd=workspace)
+    owner._yolo = not approval
+    handle = OwnedSessionHandle(owner, asyncio.get_running_loop(), cwd=str(workspace))
+    server = RuntimeServer(handle, kind="daemon")
+    await server.start_in_process()
+    viewers = []
+
+    async def factory():
+        viewer = await RemoteSession.connect(
+            server._record,
+            owner.session_id,
+            config_dir=config,
+            takeover_factory=_never_take_over,
+        )
+        viewers.append(viewer)
+        return viewer
+
+    pending = ()
+    try:
+        with bounded(90, "reload preserves owner and unanswered approval"):
+            app = OperatorApp(factory)
+            async with app.run_test(size=(120, 36)) as pilot:
+                await wait_for_adoption(app, pilot)
+                app._set_approve_all(not approval)
+                await app._session.prompt("Continue original work")
+                if approval:
+                    await _pump(pilot, lambda: app._approval is not None)
+                    pending = tuple(handle._pending_futures.values())
+                    assert len(pending) == 1
+                    if approval == "answered":
+                        app._answer_live_approval_as_allowed()
+                        await entered.wait()
+                        pending = ()
+                else:
+                    await entered.wait()
+                pid = viewers[0]._runtime_pid
+                await _capture(app, pilot, f"reload-before-{command[1:]}-{approval}")
+                app._run_slash_command(command)
+                await _pump(pilot, lambda: app.return_code == REEXEC_CODE)
+                assert app._restart_plan.resume_id == owner.session_id
+            assert not owner._disposed
+            assert not cancelled
+            assert all(not future.done() for future in pending)
+            assert not target.exists()
+            replacement = OperatorApp(factory)
+            async with replacement.run_test(size=(120, 36)) as pilot:
+                await wait_for_adoption(replacement, pilot)
+                replacement._set_approve_all(not approval)
+                assert viewers[-1]._runtime_pid == pid
+                assert replacement._session.session_id == owner.session_id
+                assert "Saved original context" in transcript_text(replacement)
+                if approval is True:
+                    await _pump(pilot, lambda: replacement._approval is not None)
+                await _capture(replacement, pilot, f"reload-after-{command[1:]}-{approval}")
+                if approval is True:
+                    replacement._answer_live_approval_as_allowed()
+                    await entered.wait()
+                release.set()
+                await _pump(pilot, lambda: not owner.is_streaming and bool(writes))
+                await _pump(
+                    pilot,
+                    lambda: "The original turn completed" in transcript_text(replacement),
+                )
+                assert writes == ["completed once"]
+                assert not cancelled
+                await _capture(replacement, pilot, f"reload-settled-{command[1:]}-{approval}")
+                print(
+                    {
+                        "command": command,
+                        "approval": approval,
+                        "owner_pid": pid,
+                        "writes": writes,
+                        "cancelled": cancelled,
+                        "pending_survived": len(pending),
+                    }
+                )
+    finally:
+        release.set()
+        take_plan()
+        for viewer in viewers:
+            await viewer.dispose()
+        await server.aclose()
+        await owner.dispose()

--- a/tests/e2e/test_reload_runtime_e2e.py
+++ b/tests/e2e/test_reload_runtime_e2e.py
@@ -101,6 +101,7 @@ async def test_relaunch_preserves_owner_turn_and_gate(
             async with app.run_test(size=(120, 36)) as pilot:
                 await wait_for_adoption(app, pilot)
                 app._set_approve_all(not approval)
+                assert app._session is not None
                 await app._session.prompt("Continue original work")
                 if approval:
                     await _pump(pilot, lambda: app._approval is not None)
@@ -116,6 +117,7 @@ async def test_relaunch_preserves_owner_turn_and_gate(
                 await _capture(app, pilot, f"reload-before-{command[1:]}-{approval}")
                 app._run_slash_command(command)
                 await _pump(pilot, lambda: app.return_code == REEXEC_CODE)
+                assert app._restart_plan is not None
                 assert app._restart_plan.resume_id == owner.session_id
             assert not owner._disposed
             assert not cancelled
@@ -126,6 +128,7 @@ async def test_relaunch_preserves_owner_turn_and_gate(
                 await wait_for_adoption(replacement, pilot)
                 replacement._set_approve_all(not approval)
                 assert viewers[-1]._runtime_pid == pid
+                assert replacement._session is not None
                 assert replacement._session.session_id == owner.session_id
                 assert "Saved original context" in transcript_text(replacement)
                 if approval is True:

--- a/tests/unit/tui/test_reload_runtime.py
+++ b/tests/unit/tui/test_reload_runtime.py
@@ -1,0 +1,66 @@
+"""Ownership and teardown boundaries for terminal-only replacement."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from local_operator.session.remote import RemoteSession
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.session_interaction import SessionInteraction
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+def remote(tmp_path):
+    return RemoteSession(config_dir=tmp_path, session_id="reload001", takeover_factory=AsyncMock())
+
+
+@pytest.mark.parametrize("state", ["streaming", "compacting", "loop"])
+@pytest.mark.parametrize("ownership", ["remote", "local", "takeover", "unsaved"])
+def test_relaunch_admission(tmp_path, monkeypatch, state, ownership):
+    session = remote(tmp_path) if ownership != "local" else FakeSession()
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    app._session = session
+    if state == "streaming":
+        if isinstance(session, RemoteSession):
+            session._streaming = True
+        else:
+            session.streaming = True
+    elif state == "compacting":
+        app._compacting = True
+    else:
+        app._loop_running = True
+    if ownership == "takeover":
+        session._takeover_target = FakeSession()
+    monkeypatch.setattr(
+        app, "_resumable_session_id", lambda: "" if ownership == "unsaved" else "reload001"
+    )
+    refusal = app._relaunch_refusal()
+    assert bool(refusal) == (ownership != "remote")
+    if ownership == "unsaved":
+        assert "saved" in refusal
+
+
+def test_background_shell_blocks_relaunch(tmp_path):
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    source = SessionInteraction(remote(tmp_path))
+    source.shell.worker = SimpleNamespace(is_finished=False)
+    app._interactions[id(source.session)] = source
+    assert "local shell" in app._relaunch_refusal()
+    source.shell.worker.is_finished = True
+    assert app._relaunch_refusal() == ""
+
+
+@pytest.mark.asyncio
+async def test_detach_covers_background_sources_once(tmp_path):
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    visible, background, takeover = [remote(tmp_path) for _ in range(3)]
+    takeover._takeover_target = FakeSession()
+    for session in (visible, background, takeover):
+        session.detach_viewer_gates = AsyncMock()
+        app._interactions[id(session)] = SessionInteraction(session)
+    app._session = visible
+    await app._detach_relaunch_gates()
+    visible.detach_viewer_gates.assert_awaited_once()
+    background.detach_viewer_gates.assert_awaited_once()
+    takeover.detach_viewer_gates.assert_not_awaited()

--- a/tests/unit/tui/test_reload_runtime.py
+++ b/tests/unit/tui/test_reload_runtime.py
@@ -31,6 +31,7 @@ def test_relaunch_admission(tmp_path, monkeypatch, state, ownership):
     else:
         app._loop_running = True
     if ownership == "takeover":
+        assert isinstance(session, RemoteSession)
         session._takeover_target = FakeSession()
     monkeypatch.setattr(
         app, "_resumable_session_id", lambda: "" if ownership == "unsaved" else "reload001"
@@ -56,11 +57,12 @@ async def test_detach_covers_background_sources_once(tmp_path):
     app = OperatorApp(lambda: _factory(FakeSession()))
     visible, background, takeover = [remote(tmp_path) for _ in range(3)]
     takeover._takeover_target = FakeSession()
-    for session in (visible, background, takeover):
-        session.detach_viewer_gates = AsyncMock()
+    mocks = [AsyncMock() for _ in range(3)]
+    for session, mock in zip((visible, background, takeover), mocks):
+        session.detach_viewer_gates = mock
         app._interactions[id(session)] = SessionInteraction(session)
     app._session = visible
     await app._detach_relaunch_gates()
-    visible.detach_viewer_gates.assert_awaited_once()
-    background.detach_viewer_gates.assert_awaited_once()
-    takeover.detach_viewer_gates.assert_not_awaited()
+    mocks[0].assert_awaited_once_with(preserve_answers=True)
+    mocks[1].assert_awaited_once_with(preserve_answers=True)
+    mocks[2].assert_not_awaited()

--- a/tests/unit/tui/test_update_command.py
+++ b/tests/unit/tui/test_update_command.py
@@ -318,7 +318,7 @@ async def test_composer_is_not_submittable_during_upgrade() -> None:
 
 
 @pytest.mark.asyncio
-async def test_successful_upgrade_exits_75_even_if_something_looks_live() -> None:
+async def test_successful_upgrade_preserves_new_local_work_and_unlocks_composer() -> None:
     app = OperatorApp(lambda: _factory(FakeSession()))
     check = VersionCheck(installed="0.27.0", latest="0.28.0", behind=True)
 
@@ -348,8 +348,10 @@ async def test_successful_upgrade_exits_75_even_if_something_looks_live() -> Non
                 await pilot.pause()
                 if app.return_code == REEXEC_CODE:
                     break
-            assert app.return_code == REEXEC_CODE
-            assert any("restarting" in text for text in _notices(app))
+            assert app.return_code is None
+            assert any("esc first" in text for text in _notices(app))
+            assert not app._update_in_progress
+            assert not editor.read_only
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Allow `/reload` and `/update` to replace the terminal while a detached session runtime continues its current work, then resume the same durable conversation. Local in-process execution, legacy local takeover, unsaved active sessions, and terminal-owned bang commands remain protected from relaunch.

Change class: **C2, standard/pre-authorized**. No version bump. No new supervisor, owner migration, forced runtime restart, or changes to the existing runtime-wide safe-refresh predicate.

Release: patch — reload or update the terminal during detached runtime work without stopping its turn, tools, or pending questions.

## Delivery contract

- Preserve owner execution, streamed transcript and durable session identity across viewer replacement.
- Withdraw all visible/background approval and ask bridges before worker cancellation or widget pruning; unanswered gates reappear on reattach.
- Adopt installed runtime code only at existing runtime-wide safe quiescence (turn, tools, compaction, gates, loops, children, jobs and imminent wakes defer refresh).
- Installer failure leaves current runtime/viewer intact; duplicate update remains serialized.
- Do not replace a process that owns active local work. Do not add new runtime lifecycle machinery.

## Reproduction and execution evidence

Before: real `OperatorApp.run_test` submitted both commands with its synthetic session fixture marked streaming. Both printed `esc first — a turn is still running`; exit code remained unset and streaming remained true.

After: six real `OperatorApp` + production socket-owner/client cells cover `/reload` and `/update` during a held real write, pending approval, and already-owner-acknowledged approval. The replacement viewer retains the same owner PID/session, replays saved context, and the original write completes **once**, without cancellation. Installer calls are simulated to avoid modifying the operator's installation.

```
python -m pytest tests/e2e/test_reload_runtime_e2e.py -m e2e -n0 -q -s
6 passed, 2 warnings in 8.44s
```

Independent QA additionally exercised actual detached subprocess owners; its report will be posted below. All test/boot environments remove inherited `CMUX_*`, isolate HOME/config, and never use live sessions.

### Initial review and unified remediation

Initial review of `50d6b7f7` found one shared major: committed-but-not-delivered gate replies could be cancelled during viewer teardown (R1/Q1/U1). Unified remediation `829a937f` adds synchronous UI answer commitment plus a reply drain before socket disposal, suppressing successor gates on all sources before awaiting any one drain.

The new matrix holds the actual client answer operation before delivery and exercises approval and ask at same-tick, actively-sending, and sidebar-suspended timings. Each answer reaches its owner exactly once with no pre-delivery cancellation. Ask Q2 remains pending and reappears on a fresh viewer. This specifically covers the gap that the initial already-acknowledged-approval matrix did not.

```
python -m pytest tests/unit/tui/test_reload_runtime.py tests/unit/tui/test_update_command.py tests/unit/session/test_remote.py tests/unit/session/runtime -q
369 passed, 8 warnings in 17.90s

python -m pytest tests/e2e/test_reload_gate_delivery_e2e.py tests/e2e/test_reload_runtime_e2e.py tests/e2e/test_runtime_refresh_e2e.py -m e2e -n0 -q -s
15 passed, 2 warnings in 43.86s

python -m pytest tests/e2e -m e2e -n0 -q
61 passed, 6 warnings in 201.13s
```

### Visual evidence

Rendered and inspected real-app before/after captures are [published in this review evidence gist](https://gist.github.com/damianvtran/464f1ff94f19ad5f69fab7dc3a70011d). It contains baseline refusal, restored running tool/approval, settled original turn, and narrow installing/failure/relaunch states. The synthetic home username is redacted with an equal-length replacement; cell geometry is unchanged. Raw consecutive captures and geometry are also retained locally at `/tmp/lo-reload-evidence/` for the reviewing agents (local paths are not forge attachments). Main frame: 120×36 terminal cells; resolved screen 118×34, virtual size 118×34, no vertical scrollbar; editor 112×1. Restored approval remains actionable; held write and final completion retain the original transcript. Additional 60×24 and 120×36 captures show installing, failure/unlocked composer, and relaunch feedback at `command-states/`. The installer and held exit are simulated only for these copy/state captures, not the owner-survival matrix. Designer has independently inspected the rendered PNGs. After remediation, the six-cell matrix was recaptured on `829a937f` (6 passed in 17.52s); the [current-head approval SVG](https://gist.githubusercontent.com/damianvtran/464f1ff94f19ad5f69fab7dc3a70011d/raw/remediation-approval.svg) was rendered and inspected again. Screen/virtual dimensions and prompt layout are unchanged; only synthetic temporary directory names differ.

<details><summary>Rendered before/after and narrow command states</summary>

![Before: live-turn refusal](https://gist.githubusercontent.com/damianvtran/464f1ff94f19ad5f69fab7dc3a70011d/raw/before-refusal.svg)

![After: original approval restored](https://gist.githubusercontent.com/damianvtran/464f1ff94f19ad5f69fab7dc3a70011d/raw/after-approval.svg)

![After: original turn completed once](https://gist.githubusercontent.com/damianvtran/464f1ff94f19ad5f69fab7dc3a70011d/raw/after-settled.svg)

![Narrow: installer failed safely](https://gist.githubusercontent.com/damianvtran/464f1ff94f19ad5f69fab7dc3a70011d/raw/failed-narrow.svg)

Raw SVG links and the remaining states are also available in the gist above if the forge image proxy does not render SVGs.

</details>

## Quality gates / readiness

Whole-tree flake8, pinned Black 26.1.0 and isort 5.13.2 are clean. Final pyright on this head: 0 errors, 0 warnings.

**Full unit suite: two samples of this same commit, each with a small disjoint set of host-contention flakes. Not reported as green.**

| Sample | Result | Failures |
| --- | --- | --- |
| 1 (33:19) | 3 failed, 16232 passed, 18 skipped | `test_computer_input.py` x3 |
| 2 (16:17) | 2 failed, 16233 passed, 18 skipped | `test_procname.py::test_reload_roundtrip_rebrands`, `test_logger_silence.py` |

Disjoint failures across two runs of one unchanged commit cannot both be caused by that commit. Each is also structurally unreachable from this diff:

- `test_computer_input`: the guest source `paste_text_source()` generates has zero `local_operator` imports and no reference to `remote`/`tui`/`RemoteSession`, verified by generating and parsing it, so nothing here can execute inside the failing subprocess. The failure is the fixture's own fake `xclip` racing its writer under a 12s timeout; one failure is literally `FileNotFoundError` on `owner.pid`.
- `test_procname`: imports stdlib only, and its failure references `/private/tmp/link.bak`, a machine-global path this repository never writes, shared with 15 concurrent sibling unit suites on the host.
- `test_logger_silence`: a `dyld: Library not loaded: libpython3.12.dylib` from a spawned MCP server resolving against that same shared artifact.

All five pass together in isolation on this head (`66 passed in 16.92s`). The host carried load average 180 with ~63 MiB free during sample 1. This is disclosed rather than retried away; a reviewer should weigh it. Seven initial new-test pyright narrowing/mock-typing errors are fixed in the unified remediation. Full unit and final type-check results will be recorded before this PR is opened. Independent code/QA/UX convergence on `50d6b7f7..829a937f` and the clean initial design round will be posted in the thread. No merge or human-reviewer request is authorized at this stage.

## Rollout / rollback

Normal reviewed patch release; terminal relaunch reuses the existing `RestartPlan` and `--resume` path. Runtime safe-refresh implementation is unchanged. Revert this PR to restore busy-command refusal. No storage migration or irreversible action.
