### PR TITLE
chore(release): bump version to 0.51.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.21"
+version = "0.51.22"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window bump. Owner session pid: **80475**.

Last tag: `v0.51.21` (`db2cc7e4d102baf8925ef7b10bba4521fcae5481`). New version: **0.51.22** (patch).

## Window

- [x] #801 — `b80b8a0e271f7423cb15381d281743087abef58b` — Release: patch — reload or update the terminal during detached runtime work without stopping its turn, tools, or pending questions.

No peer reported an additional merge after ownership was announced to all 11 live sessions. The window will be re-derived immediately before `gh release create`.

## Bump class: patch

#801 is a single bug-class fix to command admission — `/reload` and `/update` stop refusing while a detached runtime is mid-turn. It adds no new surface or subsystem a user would notice and adopt, so it does not clear the step-function bar for a minor. Per AGENTS.md "Versioning: choose the bump by materiality": when in doubt, patch.

## Scope

One line in one file:

```
-version = "0.51.21"
+version = "0.51.22"
```

`git diff v0.51.21..origin/main -- pyproject.toml` was **empty** before this commit, so no merged PR in the window consumed this number.

This is the same single commit that opened as `chore(release): claim release window`, amended in place — the PR number, and so the lock, never changed.

Awaiting the C0 one-file scope-check round from an independent reviewer agent before admin merge.