### PR TITLE
chore(release): bump version to 0.51.23

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.22"
+version = "0.51.23"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Combined release for the window since v0.51.22. Bump class: **patch**.

Scope check: this PR changes exactly one line — the version string in `pyproject.toml`. Nothing else, no dependency pin, no script, no entry point.

Window contents:
- #797 — `5f3a63ee210aba31993737eb9d405f1585ad622b` — `Release: patch — each conversation keeps the model it started on when the global default changes; the default now applies to new conversations and /new only`
- #794 — `103bc07deff89520b2ce53a8a796e1df05310fb7` — `Release: patch — a busy session's control loop stops re-parsing whole transcripts for repeated page reads, and stops building viewer payloads nobody is subscribed to`

Owner session pid 52384. Patch rather than minor: both PRs correct behaviour or performance without adding a user-facing capability or changing the config schema.