### PR TITLE
feat(exec): run saved teams and goal loops in persisted headless sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,15 +589,25 @@ project-supplied servers.
 
 ## ⚙️ Headless & Server Modes
 
-**One-shot execution** for scripts and automation:
+**Headless sessions** for scripts, saved teams and goal loops:
 
 ```bash
 lop exec "summarize the failures in ./test.log"
 lop exec "long migration" --background   # detach with a log file
 lop exec "audit deps" --json             # one JSON line per event
+lop exec "review the change" --team release --background
+lop exec --goal "Finish the checklist" --loop 3
+lop exec --status JOB_ID                 # durable outcome and session ID
+lop --resume SESSION_ID                  # live TUI attachment or cold resume
 ```
 
-Exit code 0 on success, so `lop exec` composes in a pipeline.
+Foreground exit code 0 means success, so `lop exec` composes in a pipeline.
+Background launch prints a readiness receipt; use `--status` for the eventual
+outcome. Saved teams, reusable profiles, goals and conversation names persist
+with the ordinary session. Non-TTY approvals still deny unless explicitly
+changed; `--control` opts into supervisor gates, not automatic approval.
+See [the full exec guide](./docs/EXEC.md) for option combinations, stdin,
+resume precedence, loop counting, approvals and lifecycle semantics.
 
 **Server mode** exposes the agent as a FastAPI service (used by the optional
 [desktop UI](https://github.com/damianvtran/local-operator-ui)):

--- a/docs/EXEC.md
+++ b/docs/EXEC.md
@@ -1,0 +1,97 @@
+# Headless sessions (`lop exec`)
+
+`lop exec --help` is the complete command reference. Exec runs an ordinary
+persisted conversation without starting a terminal UI. A saved team is a real
+attachment: the current session becomes its manager, with the saved roster,
+manager instructions, collaboration and project briefs. Delegated work uses
+that same team; the prompt is never rewritten into a simulated slash command.
+
+```sh
+lop exec 'Review the implementation' --team release --background
+printf 'Summarize this report' | lop exec --profile reviewer
+lop exec --goal 'Finish the acceptance checklist' --loop 3 --name 'Night audit'
+lop exec --resume SESSION_ID --loop-goal 'All acceptance checks are verified'
+lop exec --status JOB_ID
+lop --resume SESSION_ID
+```
+
+## Startup options and precedence
+
+| Option | Contract |
+| --- | --- |
+| `command` | Literal initial prompt. `-`, or omitted with piped stdin, reads stdin (surrounding whitespace is trimmed). An omitted prompt is allowed for a valid loop. Slash-looking text stays literal. |
+| `--team NAME` | Resolve a saved team and attach it. Unknown names fail before model construction or a detached spawn, and are checked again by the worker. |
+| `--profile NAME` | Attach a registered role, specialist or packaged starter, exactly like `/agent`. Unknown names fail preflight. |
+| `--agent NAME`, `--agent-name NAME` | Existing legacy named-agent selection; creates a missing agent. Not the `/agent` role attachment. |
+| `--agent-id ID` | Select an exact existing legacy agent; mutually exclusive with `--agent`. |
+| `--goal TEXT` | Set the literal standing goal (`clear` is text, not a command). A goal alone does not start a model, and it is not sent as a message — see [Divergence from `/goal`](#divergence-from-goal). |
+| `--clear-goal` | Explicitly clear a resumed standing goal; mutually exclusive with `--goal`. |
+| `--loop N` | Run 1–25 continuation iterations **after** an optional initial prompt. Requires a new or resumed standing goal. |
+| `--loop-goal TEXT` | Run continuation/judge iterations until achieved. No fixed iteration cap; repeated undecidable judge results fail safely. Mutually exclusive with `--loop`. |
+| `--name TEXT` | Set the persisted conversation title. |
+| `--effort LEVEL` | Set reasoning effort using the selected model's existing validation. Unsupported levels fail before a turn. |
+| `--resume [ID]` | Reopen the same transcript; omit the ID to select the most recent session. A live headless owner is refused rather than raced; `lop --resume ID` attaches the TUI to that owner instead. |
+| `--background` | Detach a worker. The launcher prints a bounded readiness receipt, not a claim that the work completed. |
+| `--status JOB_ID` | Print the durable job record as JSON, including terminal outcome and canonical session ID. Does not run a model; cannot combine with a prompt or run options. |
+| `--control` | Install supervisor approval/question gates. These may wait for an attached user. Runtime discovery and live TUI attachment work without this flag too. |
+| `--yolo` | Explicit approval override; never implied by teams, loops, attachment or background execution. |
+| `--json` | Emit one JSON object per agent event on stdout, carrying the session ID. Notices and receipts use stderr. |
+| `--hosting`, `--model` | Existing provider/model selection; ordinary model-resolution precedence is unchanged. |
+| `--run-in DIRECTORY` | Change the working directory before executing or spawning the worker. |
+| `--debug` | Enable verbose CLI logging (launcher/foreground process). |
+| `-h`, `--help` | Show every exec flag and startup examples without executing a task. |
+| `--train` | Existing legacy agent-directory history mode (or an autosave agent when unnamed), not needed for normal session persistence. `--resume` wins over its directory selection. |
+
+This is deliberately a bounded startup interface, not an
+arbitrary slash-command interpreter: UI commands and configuration-mutating
+commands are not startup flags.
+
+Resume restores the conversation, team, profile, goal and title first. Explicit
+startup options override only their own slots. Team and profile can coexist;
+a profile does not remove the team's roster. Stored loop progress remains
+visible, but restarting or resuming never automatically replays iterations.
+Pass a new loop option explicitly to start another loop.
+
+## Divergence from `/goal`
+
+The TUI's `/goal <text>` sets the objective **and** submits that text as an
+ordinary user message, so a single Enter both records the goal and starts the
+work. `--goal TEXT` deliberately does not: it only sets the standing goal.
+
+The reason is that exec already has a message channel — the positional prompt,
+`-`, or piped stdin. If `--goal` also submitted its text, then
+`lop exec 'Do the thing' --goal 'Ship safely'` would send two messages for one
+invocation, and there would be no way to set a goal without spending a turn.
+So the goal is the objective, the prompt is the message, and a run with a goal
+but no prompt and no loop is refused rather than silently starting a turn.
+
+To get the `/goal` behaviour in one command, pass the same text both ways:
+
+```sh
+lop exec 'Finish the checklist' --goal 'Finish the checklist'
+```
+
+## Approvals and lifetime
+
+Without `--control`, non-TTY approval requests remain denied under the existing
+headless gate. Publishing a discovery record does not replace that gate with
+an interactive one. With `--control`, work may park for a supervisor. Choose
+`--yolo` only when you intend that override; it is not required for an
+unattended run. Viewer attach/detach does not end the worker's work.
+
+A foreground run exits 0 on success and nonzero on failure/cancellation. A
+background launcher exits after readiness (or reports `starting` after a
+bounded wait); its exit code is **not** the eventual execution result. Follow
+`lop exec --status JOB_ID` for `starting`, `running`, `succeeded`, `failed`,
+`cancelled` or `interrupted`, and inspect its log. Worker termination disposes
+the session before writing the terminal result. Abrupt death cannot truthfully
+report success: status reconciliation compares the PID's process-start identity
+and marks a proven-dead owner interrupted. It never restarts a loop or cleans
+up a successor's resources.
+
+The job ID identifies the execution receipt; the session ID identifies the
+conversation. They are distinct. Receipts include the log path and, once ready,
+`lop --resume SESSION_ID`. The append-only job ledger lives under the same
+configuration root's `logs/exec_jobs.jsonl`; the ordinary transcript and
+attachment stay in the normal session storage. Runtime discovery records are
+ephemeral; completed outcomes remain in the ledger after their record is gone.

--- a/docs/EXEC.md
+++ b/docs/EXEC.md
@@ -79,6 +79,12 @@ an interactive one. With `--control`, work may park for a supervisor. Choose
 `--yolo` only when you intend that override; it is not required for an
 unattended run. Viewer attach/detach does not end the worker's work.
 
+A parked run stays `running` for as long as nobody answers it, so the status
+names what it is waiting on: `--status` reports `"pending": "approval"`
+alongside `"status": "running"`, and `lop sessions` shows the same thing in its
+`NEEDS` column. That field is live state read from the run's runtime record,
+not a durable ledger row, so it disappears once the gate is answered.
+
 A foreground run exits 0 on success and nonzero on failure/cancellation. A
 background launcher exits after readiness (or reports `starting` after a
 bounded wait); its exit code is **not** the eventual execution result. Follow
@@ -92,6 +98,6 @@ up a successor's resources.
 The job ID identifies the execution receipt; the session ID identifies the
 conversation. They are distinct. Receipts include the log path and, once ready,
 `lop --resume SESSION_ID`. The append-only job ledger lives under the same
-configuration root's `logs/exec_jobs.jsonl`; the ordinary transcript and
+configuration root's `logs/exec-jobs.jsonl`; the ordinary transcript and
 attachment stay in the normal session storage. Runtime discovery records are
 ephemeral; completed outcomes remain in the ledger after their record is gone.

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -4248,7 +4248,18 @@ def main() -> int:
                     return 1
                 state = job_status(args.status)
                 if not state:
-                    print(f"No exec job {args.status!r}", file=sys.stderr)
+                    # Every other refusal in this feature names a recovery
+                    # command; this one had none to name (there is no `lop
+                    # exec --list`), so it names where the answer actually
+                    # lives. Also carries the `exec failed: ` prefix its
+                    # siblings all use, which it was alone in omitting.
+                    from local_operator.exec_mode import JOBS_FILE, logs_dir
+
+                    print(
+                        f"exec failed: No exec job {args.status!r}; job IDs are printed "
+                        f"by --background and recorded in {logs_dir() / JOBS_FILE}",
+                        file=sys.stderr,
+                    )
                     return 1
                 print(json.dumps(state, ensure_ascii=False))
                 return 0

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -100,17 +100,16 @@ def build_cli_parser() -> argparse.ArgumentParser:
         "--agent",
         "--agent-name",
         type=str,
-        help="Name of the agent to use for this session.  If not provided, the default"
-        " agent will be used which does not persist its session.",
+        help="Select a legacy named agent (creates it if missing). Without --train, "
+        "use a separate persisted session; exec --profile attaches a reusable role instead.",
         dest="agent_name",
     )
     parent_parser.add_argument(
         "--train",
         action="store_true",
-        help="Enable training mode for the operator.  The agent's conversation history will be"
-        " saved to the agent's directory after each completed task.  This allows the agent to"
-        " learn from its experiences and improve its performance over time.  Omit this flag to"
-        " have the agent not store the conversation history, thus resetting it after each session.",
+        help="Use the legacy agent history directory (or an autosave agent) instead "
+        "of a separate session. Ordinary sessions are also persisted and resumable; "
+        "--resume takes precedence over this directory selection.",
     )
 
     # Main parser
@@ -759,13 +758,45 @@ def build_cli_parser() -> argparse.ArgumentParser:
 
     exec_parser = subparsers.add_parser(
         "exec",
-        help="Execute a single command without starting interactive mode",
+        help="Execute a task or goal loop in a persisted session without starting the TUI",
         parents=[parent_parser],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  lop exec 'Review the change' --team release --background\n"
+            "  printf 'Inspect this report' | lop exec --profile reviewer\n"
+            "  lop exec --goal 'Finish the checklist' --loop 3 --name 'Night audit'\n"
+            "  lop exec --resume SESSION_ID --loop-goal 'Verify every acceptance criterion'\n"
+            "  lop exec --status JOB_ID\n\n"
+            "Resume restores the transcript, team, profile, goal and name first; explicit\n"
+            "startup flags override their own slots. Team and profile may coexist. A loop\n"
+            "runs after the optional initial prompt; --loop N counts continuations only.\n"
+            "Saved loop progress is visible on resume, but iterations never replay automatically.\n"
+            "A goal alone does not run a model. Prompts are literal, not slash commands.\n"
+            "--goal only SETS the objective; unlike the TUI's /goal it does not also\n"
+            "send that text as a message, because the prompt is exec's message channel.\n"
+            "--agent/--agent-id select legacy agent data and are mutually exclusive.\n"
+            "Default non-TTY approvals deny. --control may wait for a supervisor; --yolo\n"
+            "is an explicit override, never implied by --background or --team.\n"
+            "Foreground events/text use stdout; receipts use stderr. Detached runs log\n"
+            "both streams and print distinct job/session IDs. Use lop --resume SESSION_ID\n"
+            "to view a live run or resume a finished one; exec refuses a live owner."
+        ),
     )
     exec_parser.add_argument(
         "command",
         type=str,
-        help="The command to execute",
+        nargs="?",
+        default=None,
+        help="Literal prompt; '-' or omitted with piped stdin reads stdin; optional for a loop",
+    )
+    from local_operator.exec_startup import add_startup_arguments
+
+    add_startup_arguments(exec_parser)
+    exec_parser.add_argument(
+        "--status",
+        metavar="JOB_ID",
+        help="Read a durable background-job status as JSON; does not start a session",
     )
     # --- Additive exec flags (rewrite) ------------------------------------
     exec_parser.add_argument(
@@ -789,12 +820,9 @@ def build_cli_parser() -> argparse.ArgumentParser:
         "--control",
         action="store_true",
         help=(
-            "Publish a session record and serve the control socket for this run, "
-            "so an external supervisor can steer, cancel and answer gates "
-            "mid-run. Prints the endpoint on stderr. Off by default. "
-            "Note: this routes tool approvals to the supervisor, so a run "
-            "WITHOUT --yolo parks on each gate until one answers (then denies). "
-            "An unattended run wants --control --yolo."
+            "Route approvals and questions to an attached supervisor (may wait). "
+            "Without this flag non-TTY approvals deny; discovery and live attachment "
+            "are available either way. --yolo remains an explicit approval override."
         ),
     )
 
@@ -4196,11 +4224,45 @@ def main() -> int:
                         file=sys.stderr,
                     )
                     return 1
-            from local_operator.exec_mode import ExecArgs, run_exec
+            from local_operator.exec_mode import ExecArgs, job_status, run_exec
 
+            if args.status:
+                import json
+
+                from local_operator.exec_startup import STARTUP_FIELDS
+
+                run_options = (
+                    *STARTUP_FIELDS,
+                    "background",
+                    "control",
+                    "resume",
+                    "agent_name",
+                    "agent_id",
+                    "yolo",
+                    "train",
+                )
+                if args.command is not None or any(getattr(args, key, None) for key in run_options):
+                    print(
+                        "--status cannot be combined with a prompt or run options", file=sys.stderr
+                    )
+                    return 1
+                state = job_status(args.status)
+                if not state:
+                    print(f"No exec job {args.status!r}", file=sys.stderr)
+                    return 1
+                print(json.dumps(state, ensure_ascii=False))
+                return 0
             exec_args = ExecArgs(
                 background=args.background,
                 json_mode=args.json_mode,
+                team=args.team,
+                profile=args.profile,
+                goal=args.goal,
+                clear_goal=args.clear_goal,
+                loop=args.loop,
+                loop_goal=args.loop_goal,
+                name=args.name,
+                effort=args.effort,
                 agent_name=args.agent_name,
                 agent_id=getattr(args, "agent_id", None),
                 yolo=args.yolo,

--- a/local_operator/exec_mode.py
+++ b/local_operator/exec_mode.py
@@ -109,6 +109,14 @@ class ExecArgs:
     #: mechanism. Carried through to the worker so `--background --control` is
     #: the same request run elsewhere, exactly like ``resume``.
     control: bool = False
+    team: str | None = None
+    profile: str | None = None
+    goal: str | None = None
+    clear_goal: bool = False
+    loop: int | None = None
+    loop_goal: str | None = None
+    name: str | None = None
+    effort: str | None = None
 
 
 def slugify(command: str, max_length: int = 40) -> str:
@@ -134,6 +142,14 @@ def build_worker_argv(command: str, exec_args: ExecArgs) -> list[str]:
     # silently answering with different code than `lop --version` reports.
     # Same defect as the runtime spawn; see :mod:`local_operator.interpreter`.
     argv = python_argv("-m", "local_operator.exec_worker", "--prompt", command)
+    from local_operator.exec_startup import STARTUP_FIELDS
+
+    for field in STARTUP_FIELDS:
+        value = getattr(exec_args, field)
+        if value is not None and value is not False:
+            argv.append("--" + field.replace("_", "-"))
+            if value is not True:
+                argv.append(str(value))
     if exec_args.json_mode:
         argv.append("--json")
     if exec_args.yolo:
@@ -187,7 +203,14 @@ def _open_log_file(log_path: Path) -> Any:
     return os.fdopen(os.open(str(log_path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600), "ab")
 
 
-def _append_job_record(log_path: Path, prompt: str, pid: int, job_id: str | None = None) -> str:
+def _append_job_record(
+    log_path: Path,
+    prompt: str,
+    pid: int,
+    job_id: str | None = None,
+    *,
+    requested_team: str | None = None,
+) -> str:
     """Append the detached run as one JSONL record and return the job id.
 
     O_APPEND single-write (CL-11): POSIX guarantees atomicity for small
@@ -205,6 +228,9 @@ def _append_job_record(log_path: Path, prompt: str, pid: int, job_id: str | None
         "prompt": prompt,
         "log": str(log_path),
         "pid": pid,
+        "process_generation": _process_generation(pid),
+        "status": "starting",
+        "requested_team": requested_team,
         "finished_at": None,
         "exit_code": None,
     }
@@ -256,6 +282,11 @@ def update_job_exit(job_id: str, exit_code: int) -> None:
         "id": job_id,
         "finished_at": datetime.now().astimezone().isoformat(),
         "exit_code": exit_code,
+        "pid": os.getpid(),
+        "process_generation": _process_generation(os.getpid()),
+        "status": (
+            "succeeded" if exit_code == 0 else "cancelled" if exit_code in (130, 143) else "failed"
+        ),
     }
     try:
         fd = os.open(str(jobs_path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
@@ -265,6 +296,80 @@ def update_job_exit(job_id: str, exit_code: int) -> None:
             os.close(fd)
     except OSError:
         pass
+
+
+def _process_generation(pid: int) -> str | None:
+    # Reuse the resource reaper's locale-stable start token; bare PID liveness
+    # must never credit a recycled process with keeping this job alive.
+    from local_operator.tools.group_reaper import _owner_start_token
+
+    return _owner_start_token(pid)
+
+
+def update_job_running(job_id: str, session: Any, control: Any) -> None:
+    from local_operator.session.runtime.registry import record_path
+
+    update = {
+        "id": job_id,
+        "session_id": session.session_id,
+        "pid": os.getpid(),
+        "process_generation": _process_generation(os.getpid()),
+        "status": "running",
+        "team": session.active_team_name,
+        "session_directory": str(session._transcript.directory),
+        "runtime_path": str(record_path(os.getpid())),
+    }
+    _append_job_update(update)
+
+
+def _append_job_update(update: dict[str, Any]) -> None:
+    path = _ensure_logs_dir() / JOBS_FILE
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    try:
+        os.write(fd, (json.dumps(update, ensure_ascii=False) + "\n").encode())
+    finally:
+        os.close(fd)
+
+
+def job_status(job_id: str, *, reconcile: bool = True) -> dict[str, Any]:
+    """Fold the existing append-only ledger without allowing late spawn rows
+    to regress a worker's ready/terminal record. Dead owners are interrupted,
+    never successful, and reconciliation never acts on their resources.
+    """
+    result: dict[str, Any] = {}
+    rank = {
+        "starting": 0,
+        "running": 1,
+        "succeeded": 2,
+        "failed": 2,
+        "cancelled": 2,
+        "interrupted": 2,
+    }
+    current = -1
+    for row in read_job_records():
+        if row.get("id") != job_id:
+            continue
+        level = rank.get(row.get("status", "starting"), 0)
+        if level < current:
+            for key, value in row.items():
+                result.setdefault(key, value)
+            continue
+        result.update(row)
+        current = level
+    if reconcile and result.get("status") in ("starting", "running"):
+        from local_operator.tools.group_reaper import _owner_is_dead
+
+        generation = result.get("process_generation")
+        pid = result.get("pid")
+        if pid and generation and _owner_is_dead(pid, generation) is True:
+            update = {
+                "id": job_id,
+                "status": "interrupted",
+                "finished_at": datetime.now().astimezone().isoformat(),
+            }
+            _append_job_update(update)
+            result.update(update)
+    return result
 
 
 def resolve_hosting_model_dry(exec_args: ExecArgs) -> tuple[str, str]:
@@ -325,9 +430,8 @@ def _spawn_background(command: str, exec_args: ExecArgs) -> int:
 
     logs_root = _ensure_logs_dir()
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    log_path = logs_root / f"exec-{timestamp}-{slugify(command)}.log"
-
     job_id = uuid4().hex[:12]
+    log_path = logs_root / f"exec-{timestamp}-{slugify(command)}-{job_id}.log"
     argv = build_worker_argv(command, exec_args)
     argv.extend(["--job-id", job_id])
     popen_kwargs: dict[str, Any] = dict(
@@ -357,13 +461,30 @@ def _spawn_background(command: str, exec_args: ExecArgs) -> int:
         log_handle.flush()
         process = subprocess.Popen(argv, stdout=log_handle, **popen_kwargs)
 
-    _append_job_record(log_path, command, process.pid, job_id=job_id)
+    _append_job_record(log_path, command, process.pid, job_id=job_id, requested_team=exec_args.team)
     # --json and --background are independent flags, so these notices must not
     # land on stdout: a consumer parsing the event stream would hit two
     # unparseable lines before any event.
-    print(f"Started background job {job_id}", file=sys.stderr)
+    import time
+
+    # Readiness is not completion: bound the launcher's wait and report an
+    # honest 'starting' receipt when provider/session initialization is slow.
+    deadline = time.monotonic() + 5.0
+    state = job_status(job_id, reconcile=False)
+    while state.get("status") == "starting" and time.monotonic() < deadline:
+        if process.poll() is not None:
+            break
+        time.sleep(0.05)
+        state = job_status(job_id, reconcile=False)
+    state = job_status(job_id)
+    print(f"Background job {job_id}: {state.get('status', 'starting')}", file=sys.stderr)
+    if state.get("session_id"):
+        print(
+            f"Session: {state['session_id']} (lop --resume {state['session_id']})", file=sys.stderr
+        )
+    print(f"Status: lop exec --status {job_id}", file=sys.stderr)
     print(f"Log: {log_path}", file=sys.stderr)
-    return 0
+    return 1 if state.get("status") in ("failed", "cancelled", "interrupted") else 0
 
 
 def _make_default_session_factory(exec_args: ExecArgs) -> SessionFactory:
@@ -415,7 +536,7 @@ def _make_default_session_factory(exec_args: ExecArgs) -> SessionFactory:
 STDIN_PROMPT_SENTINEL = "-"
 
 
-def resolve_prompt(command: str, *, stdin_text: str | None = None) -> str:
+def resolve_prompt(command: str | None, *, stdin_text: str | None = None) -> str:
     """Return the prompt to run, reading stdin when ``command`` is ``-``.
 
     Resolved BEFORE the ``--background`` branch on purpose: the background
@@ -427,13 +548,16 @@ def resolve_prompt(command: str, *, stdin_text: str | None = None) -> str:
     ``stdin_text`` is injectable so the behaviour is testable without a real
     pipe on the process.
     """
-    if command != STDIN_PROMPT_SENTINEL:
+    if command is None:
+        if stdin_text is None and sys.stdin.isatty():
+            return ""
+    elif command != STDIN_PROMPT_SENTINEL:
         return command
     text = sys.stdin.read() if stdin_text is None else stdin_text
     return text.strip()
 
 
-def run_exec(command: str, args: ExecArgs) -> int:
+def run_exec(command: str | None, args: ExecArgs) -> int:
     """Entry point for the ``exec`` subcommand (README contract: exit 0 on
     success, non-zero on error).
 
@@ -451,16 +575,31 @@ def run_exec(command: str, args: ExecArgs) -> int:
     control socket) so a supervisor can steer and cancel it; the endpoint goes
     to STDERR because stdout is the payload stream.
     """
-    command = resolve_prompt(command)
-    if not command:
-        print("exec failed: empty prompt", file=sys.stderr)
+    from local_operator.exec_startup import resolve_startup
+
+    try:
+        team = resolve_startup(args)
+        command = resolve_prompt(command)
+    except (ValueError, OSError) as exc:
+        print(f"exec failed: {exc}", file=sys.stderr)
+        return 1
+    # The positional is optional so a loop-only or piped run can omit it
+    # (argparse cannot express "required unless --loop/--loop-goal/stdin"), so
+    # the requirement is enforced here — naming the ways to supply one rather
+    # than reporting a bare "empty prompt".
+    if not command.strip() and args.loop is None and args.loop_goal is None:
+        print(
+            "exec failed: no prompt. Pass one as an argument, pipe it on stdin "
+            "(or '-'), or run a loop with --loop/--loop-goal",
+            file=sys.stderr,
+        )
         return 1
     if args.background:
         return _spawn_background(command, args)
 
     import asyncio
 
-    from local_operator.headless_print import run_print_mode
+    from local_operator.exec_session import run_session
 
     factory = default_session_factory or _make_default_session_factory(args)
 
@@ -468,41 +607,11 @@ def run_exec(command: str, args: ExecArgs) -> int:
         session = factory()
         if asyncio.iscoroutine(session):
             session = await session
-        # Function-local by contract: the runtime pulls asyncio and the owned
-        # handle's composition root, and ``tests/unit/test_import_graph.py``
-        # pins what ``import local_operator.cli`` may load. Imported even when
-        # the flag is off is still too early — this module is imported by the
-        # CLI dispatch — so the import sits inside the run, not at module scope.
-        from local_operator.session.runtime.exec_control import maybe_start_exec_control
-
-        control = await maybe_start_exec_control(
-            session,
-            enabled=args.control,
-            cwd=os.getcwd(),
-            yolo=args.yolo,
-        )
-        if control is not None:
-            # STDERR: stdout carries the NDJSON event stream (or the final
-            # assistant text), and a supervisor parsing it line-by-line would
-            # choke on a chrome line. Same rule headless_print states for every
-            # other progress line.
-            print(control.endpoint_line, file=sys.stderr, flush=True)
-        # The surface must close BEFORE run_print_mode disposes the session, and
-        # that dispose is inside run_print_mode's own ``finally`` — so the
-        # ordering cannot be expressed from out here and is handed in as the
-        # ``before_dispose`` hook instead. A short run that finishes before the
-        # first 15 s heartbeat therefore still announces its stop and unpublishes
-        # its record; nothing is left for a scanner to reap.
-        return await run_print_mode(
-            session,
-            [command],
-            json_mode=args.json_mode,
-            before_dispose=(control.aclose if control is not None else None),
-        )
+        return await run_session(session, command, args, team)
 
     try:
         return asyncio.run(runner())
-    except KeyboardInterrupt:
+    except (KeyboardInterrupt, asyncio.CancelledError):
         return 130
     except Exception as exc:  # noqa: BLE001 — CL-19: raising prompt = exit 1
         print(f"exec failed: {exc}", file=sys.stderr)

--- a/local_operator/exec_mode.py
+++ b/local_operator/exec_mode.py
@@ -141,15 +141,23 @@ def build_worker_argv(command: str, exec_args: ExecArgs) -> list[str]:
     # this project would execute that checkout rather than the installed build,
     # silently answering with different code than `lop --version` reports.
     # Same defect as the runtime spawn; see :mod:`local_operator.interpreter`.
-    argv = python_argv("-m", "local_operator.exec_worker", "--prompt", command)
+    # EVERY value-carrying option uses the `--opt=value` form, never two argv
+    # items. argparse reads a following token that starts with `-` as the next
+    # OPTION, so `--name -nightly` (or a prompt phrased `-- verify everything`)
+    # dies at the worker's parse_args — before `--job-id` is honoured, so no
+    # terminal ledger row is ever written and reconciliation reports the run as
+    # `interrupted`: the vocabulary reserved for a worker killed mid-flight,
+    # for a run that never started. The `=` form is unambiguous for any value.
+    argv = python_argv("-m", "local_operator.exec_worker", f"--prompt={command}")
     from local_operator.exec_startup import STARTUP_FIELDS
 
     for field in STARTUP_FIELDS:
         value = getattr(exec_args, field)
-        if value is not None and value is not False:
-            argv.append("--" + field.replace("_", "-"))
-            if value is not True:
-                argv.append(str(value))
+        if value is None or value is False:
+            continue
+        option = "--" + field.replace("_", "-")
+        # `True` is a store_true flag, which carries no value to attach.
+        argv.append(option if value is True else f"{option}={value}")
     if exec_args.json_mode:
         argv.append("--json")
     if exec_args.yolo:
@@ -157,13 +165,13 @@ def build_worker_argv(command: str, exec_args: ExecArgs) -> list[str]:
     if exec_args.train:
         argv.append("--train")
     if exec_args.agent_name:
-        argv.extend(["--agent", exec_args.agent_name])
+        argv.append(f"--agent={exec_args.agent_name}")
     if exec_args.agent_id:
-        argv.extend(["--agent-id", exec_args.agent_id])
+        argv.append(f"--agent-id={exec_args.agent_id}")
     if exec_args.hosting:
-        argv.extend(["--hosting", exec_args.hosting])
+        argv.append(f"--hosting={exec_args.hosting}")
     if exec_args.model:
-        argv.extend(["--model", exec_args.model])
+        argv.append(f"--model={exec_args.model}")
     if exec_args.control:
         # A detached run is the one that most needs steering — nobody is
         # watching its log — so the flag has to survive the process boundary.
@@ -176,7 +184,7 @@ def build_worker_argv(command: str, exec_args: ExecArgs) -> list[str]:
         # silently started a FRESH session in the worker and reported success
         # against the wrong history — the failure `ExecArgs.resume` exists to
         # prevent, one process boundary further out.
-        argv.extend(["--resume", exec_args.resume])
+        argv.append(f"--resume={exec_args.resume}")
     return argv
 
 
@@ -306,7 +314,7 @@ def _process_generation(pid: int) -> str | None:
     return _owner_start_token(pid)
 
 
-def update_job_running(job_id: str, session: Any, control: Any) -> None:
+def update_job_running(job_id: str, session: Any) -> None:
     from local_operator.session.runtime.registry import record_path
 
     update = {
@@ -369,7 +377,33 @@ def job_status(job_id: str, *, reconcile: bool = True) -> dict[str, Any]:
             }
             _append_job_update(update)
             result.update(update)
+    if result.get("status") == "running":
+        # "Waiting for you" and "working" are the two states a detached run can
+        # be in, and they are the ones a user must tell apart — a supervised run
+        # parked on a gate reports `running` forever, and neither --status nor
+        # the log said so. `lop sessions` already computes this from the live
+        # runtime record; read the same field rather than inventing a second
+        # source of truth. NOT persisted to the ledger: it is live state that
+        # goes stale the moment the gate is answered, whereas every ledger row
+        # is a durable fact about the run.
+        result["pending"] = _live_pending(result.get("runtime_path"))
     return result
+
+
+def _live_pending(runtime_path: str | None) -> str | None:
+    """What the live runtime says this run is blocked on, or ``None``.
+
+    Reads the record the run already publishes. Absent/unreadable/older-runtime
+    records answer ``None`` — an unknown answer must never be reported as a
+    parked gate, and a status read must not fail because a worker just exited.
+    """
+    if not runtime_path:
+        return None
+    try:
+        with open(runtime_path, encoding="utf-8") as handle:
+            return json.load(handle).get("pending") or None
+    except (OSError, ValueError):
+        return None
 
 
 def resolve_hosting_model_dry(exec_args: ExecArgs) -> tuple[str, str]:
@@ -433,7 +467,7 @@ def _spawn_background(command: str, exec_args: ExecArgs) -> int:
     job_id = uuid4().hex[:12]
     log_path = logs_root / f"exec-{timestamp}-{slugify(command)}-{job_id}.log"
     argv = build_worker_argv(command, exec_args)
-    argv.extend(["--job-id", job_id])
+    argv.append(f"--job-id={job_id}")
     popen_kwargs: dict[str, Any] = dict(
         stderr=subprocess.STDOUT,
         stdin=subprocess.DEVNULL,
@@ -477,14 +511,51 @@ def _spawn_background(command: str, exec_args: ExecArgs) -> int:
         time.sleep(0.05)
         state = job_status(job_id, reconcile=False)
     state = job_status(job_id)
-    print(f"Background job {job_id}: {state.get('status', 'starting')}", file=sys.stderr)
+    status = state.get("status", "starting")
+    # The job/session split is the receipt's whole reason for existing, but two
+    # twelve-hex ids in the same shape do not carry it on their own: say which
+    # is the execution receipt and which is the conversation, and give each an
+    # imperative rather than leaving `Session:` a bare parenthetical.
+    failure = _worker_failure(log_path) if status == "failed" else ""
+    # The reason is already written to a file whose path we hold, and the
+    # launcher is still in the foreground: making the user open a log to read a
+    # one-line validation error is a gap we can close for free.
+    print(
+        f"Background job {job_id}: {status} (execution receipt)"
+        + (f" \u2014 {failure}" if failure else ""),
+        file=sys.stderr,
+    )
     if state.get("session_id"):
         print(
-            f"Session: {state['session_id']} (lop --resume {state['session_id']})", file=sys.stderr
+            f"Session: {state['session_id']} (the conversation) \u2014 attach or resume: "
+            f"lop --resume {state['session_id']}",
+            file=sys.stderr,
         )
     print(f"Status: lop exec --status {job_id}", file=sys.stderr)
     print(f"Log: {log_path}", file=sys.stderr)
-    return 1 if state.get("status") in ("failed", "cancelled", "interrupted") else 0
+    if getattr(exec_args, "control", False):
+        # A supervised run can park on a gate and sit at `running` indefinitely.
+        # `lop sessions` is the one command that shows what a run NEEDS, and it
+        # was the one command this receipt never mentioned.
+        print("Waiting on you? lop sessions shows what a run needs", file=sys.stderr)
+    return 1 if status in ("failed", "cancelled", "interrupted") else 0
+
+
+def _worker_failure(log_path: Path) -> str:
+    """The worker's own last error line, for a launch that already failed.
+
+    Best-effort by contract: the receipt is strictly better with the reason and
+    must never be lost to a race on the log file, so any read problem yields an
+    empty string and the caller prints the plain status it already had.
+    """
+    try:
+        lines = [line.strip() for line in log_path.read_text(errors="replace").splitlines()]
+    except OSError:
+        return ""
+    for line in reversed(lines):
+        if line and not line.startswith("#"):
+            return line[:200]
+    return ""
 
 
 def _make_default_session_factory(exec_args: ExecArgs) -> SessionFactory:
@@ -536,7 +607,9 @@ def _make_default_session_factory(exec_args: ExecArgs) -> SessionFactory:
 STDIN_PROMPT_SENTINEL = "-"
 
 
-def resolve_prompt(command: str | None, *, stdin_text: str | None = None) -> str:
+def resolve_prompt(
+    command: str | None, *, stdin_text: str | None = None, has_loop: bool = False
+) -> str:
     """Return the prompt to run, reading stdin when ``command`` is ``-``.
 
     Resolved BEFORE the ``--background`` branch on purpose: the background
@@ -545,11 +618,20 @@ def resolve_prompt(command: str | None, *, stdin_text: str | None = None) -> str
     literal ``-`` — the same class of silent-wrong-input bug the ``resume``
     field documents having already been fixed once, one process boundary out.
 
+    ``has_loop`` reports that ``--loop``/``--loop-goal`` was given, which is a
+    DECLARATION that this run has no prompt. Without it an omitted positional
+    fell through to an unbounded ``sys.stdin.read()`` on any non-TTY stdin, and
+    a pipe whose writer stays open never sends EOF — so the documented
+    ``lop exec --goal X --loop 3`` hung forever, with no output, under every
+    supervisor that hands its child an inherited pipe (a CI runner, a cmux
+    surface, ``Popen(stdin=PIPE)``). An explicit ``-`` still reads, because
+    that is the user asking for stdin rather than merely inheriting one.
+
     ``stdin_text`` is injectable so the behaviour is testable without a real
     pipe on the process.
     """
     if command is None:
-        if stdin_text is None and sys.stdin.isatty():
+        if stdin_text is None and (has_loop or sys.stdin.isatty()):
             return ""
     elif command != STDIN_PROMPT_SENTINEL:
         return command
@@ -577,22 +659,39 @@ def run_exec(command: str | None, args: ExecArgs) -> int:
     """
     from local_operator.exec_startup import resolve_startup
 
+    has_loop = args.loop is not None or args.loop_goal is not None
     try:
         team = resolve_startup(args)
-        command = resolve_prompt(command)
+        command = resolve_prompt(command, has_loop=has_loop)
     except (ValueError, OSError) as exc:
         print(f"exec failed: {exc}", file=sys.stderr)
         return 1
     # The positional is optional so a loop-only or piped run can omit it
     # (argparse cannot express "required unless --loop/--loop-goal/stdin"), so
     # the requirement is enforced here — naming the ways to supply one rather
-    # than reporting a bare "empty prompt".
-    if not command.strip() and args.loop is None and args.loop_goal is None:
-        print(
-            "exec failed: no prompt. Pass one as an argument, pipe it on stdin "
-            "(or '-'), or run a loop with --loop/--loop-goal",
-            file=sys.stderr,
-        )
+    # than reporting a bare "empty prompt". Each refusal below answers the
+    # BELIEF that produced it, not merely the missing argument: a user who
+    # typed --goal expected the TUI's /goal, which also sends the text.
+    if not command.strip() and not has_loop:
+        if args.clear_goal:
+            print(
+                "exec failed: --clear-goal adjusts a run, it does not start one. "
+                "Pair it with --resume SESSION_ID plus a prompt or --loop.",
+                file=sys.stderr,
+            )
+        elif args.goal:
+            print(
+                "exec failed: --goal sets the objective but does not start work "
+                "(unlike the TUI's /goal). Add a prompt, pipe one on stdin (or "
+                "'-'), or run a loop with --loop N.",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                "exec failed: no prompt. Pass one as an argument, pipe it on stdin "
+                "(or '-'), or run a loop with --loop/--loop-goal",
+                file=sys.stderr,
+            )
         return 1
     if args.background:
         return _spawn_background(command, args)

--- a/local_operator/exec_session.py
+++ b/local_operator/exec_session.py
@@ -88,7 +88,7 @@ async def run_session(session: Any, prompt: str, args: Any, team: Any) -> int:
         if job_id:
             from local_operator.exec_mode import update_job_running
 
-            update_job_running(job_id, session, control)
+            update_job_running(job_id, session)
         print(control.endpoint_line, file=sys.stderr, flush=True)
     except BaseException:
         if control is not None:

--- a/local_operator/exec_session.py
+++ b/local_operator/exec_session.py
@@ -1,0 +1,144 @@
+"""One ordinary session lifetime for foreground and detached exec.
+
+The runtime owns the prompt queue and loop scheduler; the renderer observes
+that lifetime once. Publishing discovery never implicitly installs gates.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+from typing import Any
+
+from local_operator.exec_startup import apply_startup
+
+logger = logging.getLogger(__name__)
+
+
+async def _finish_browser_scope(session: Any, outcome: str) -> None:
+    """Release the run's browser scope, if this build has that seam yet.
+
+    Deliberately INERT until the browser owner's ``finish_browser_scope`` lands
+    (PR #798): resolved by name so this file carries no speculative import of an
+    API that does not exist, and simply does nothing on a build without it.
+
+    Two properties are structural rather than incidental, because getting them
+    wrong is how a cleanup helper starts corrupting outcomes:
+
+    * **It can never alter the run's verdict.** The caller ignores the result
+      and this function returns ``None``, so ``closed``, ``pending`` (a session
+      with no lease/sidecar, or a bounded timeout) and ``unresolved`` (a stale
+      generation or a scope mismatch) are all non-fatal by construction. The
+      terminal ledger row is written by the worker afterwards regardless.
+    * **No exception escapes.** A cleanup failure must not convert a succeeded
+      run into a crashed one, so everything is swallowed to a debug log.
+
+    The generation is the browser resource's execution-LEASE generation, read
+    off the live session and passed verbatim. Exec's own ``process_generation``
+    (a PID start-token) is deliberately NOT used here: it proves a recycled PID
+    is not our worker in the exec ledger, which is a different question from
+    which continuous run owns a browser scope.
+    """
+    finish = getattr(session, "finish_browser_scope", None)
+    if finish is None:
+        return
+    try:
+        generation = getattr(session, "browser_generation", None)
+        if not generation:
+            return
+        # Awaited BEFORE the terminal outcome is published, per the contract.
+        result = await finish(
+            scope_id=session.session_id,
+            generation=generation,
+            outcome=outcome,
+        )
+        logger.debug("exec browser scope finish: %s", result)
+    except Exception:  # noqa: BLE001 — cleanup must never fail a finished run
+        logger.debug("exec browser scope finish failed", exc_info=True)
+
+
+async def run_session(session: Any, prompt: str, args: Any, team: Any) -> int:
+    from local_operator.headless_print import run_print_mode
+    from local_operator.session.runtime.exec_control import start_exec_control
+
+    control = None
+    try:
+        apply_startup(session, args, team)
+        control = await start_exec_control(
+            session,
+            cwd=os.getcwd(),
+            yolo=bool(args.yolo),
+            supervised=bool(getattr(args, "control", False)),
+        )
+        lifetime = asyncio.current_task()
+
+        def stop() -> None:
+            session.abort("stopped by supervisor")
+            if lifetime is not None:
+                # Stop the lifetime, not merely the active turn: a loop may be
+                # between turns or judging when the supervisor ends the run.
+                asyncio.get_running_loop().call_soon(lifetime.cancel)
+
+        control.handle.on_stop_requested = stop
+        if getattr(args, "effort", None):
+            await control.handle.set_effort(args.effort)
+        job_id = getattr(args, "job_id", None)
+        if job_id:
+            from local_operator.exec_mode import update_job_running
+
+            update_job_running(job_id, session, control)
+        print(control.endpoint_line, file=sys.stderr, flush=True)
+    except BaseException:
+        if control is not None:
+            await control.aclose()
+        await session.dispose()
+        raise
+
+    count = getattr(args, "loop", None)
+    goal = getattr(args, "loop_goal", None)
+
+    # Settled as the run proceeds so the browser scope is finalized with the
+    # SAME terminal string the ledger records, rather than a second guess at it.
+    # `cancelled` is recorded here because only this frame sees the
+    # CancelledError; `failed` is read back from the renderer at teardown,
+    # because a provider error arrives as an EVENT the renderer folds into its
+    # verdict and never reaches this frame at all.
+    outcome: dict[str, str] = {"terminal": "succeeded"}
+
+    async def submit(text: str) -> bool:
+        completed = await control.handle.run_headless_prompt(text)
+        if not completed:
+            # A raising turn emits no error event, so the renderer has nothing
+            # to print. Report the queue's recorded reason on stderr, where the
+            # rest of exec's diagnostics go.
+            reason = control.handle.last_prompt_failure or "the turn did not complete"
+            print(f"exec failed: {reason}", file=sys.stderr, flush=True)
+        return completed
+
+    async def continuation() -> bool:
+        try:
+            return await control.handle.run_headless_loop(count=count, goal=goal)
+        except asyncio.CancelledError:
+            outcome["terminal"] = "cancelled"
+            raise
+
+    async def close(failed: bool = False) -> None:
+        await control.handle.cancel_headless_loop()
+        if failed and outcome["terminal"] == "succeeded":
+            outcome["terminal"] = "failed"
+        # The ledger's own vocabulary, so one run cannot describe its end two
+        # different ways to two consumers. Settled by now: the renderer runs
+        # this teardown after every turn and the loop have finished.
+        await _finish_browser_scope(session, outcome["terminal"])
+        await control.aclose()
+
+    return await run_print_mode(
+        session,
+        [prompt] if prompt.strip() else [],
+        json_mode=bool(args.json_mode),
+        before_dispose=close,
+        prompt_handler=submit,
+        continuation=continuation if count is not None or goal is not None else None,
+    )

--- a/local_operator/exec_startup.py
+++ b/local_operator/exec_startup.py
@@ -72,6 +72,16 @@ def resolve_startup(args: Any) -> Any:
             raise ValueError(f"--loop must be between 1 and {MAX_LOOP_ITERATIONS}")
     if goal is not None and not goal.strip():
         raise ValueError("--loop-goal must not be empty")
+    # Decidable WITHOUT constructing anything: --loop needs a standing goal, and
+    # only a resumed session can supply one this run did not pass. Refusing in
+    # apply_startup instead left an empty session directory behind on every
+    # typo, which the goal-alone path (refused at preflight) never does.
+    if (
+        count is not None
+        and getattr(args, "goal", None) is None
+        and not getattr(args, "resume", None)
+    ):
+        raise ValueError("--loop requires --goal, or --resume a session that has one")
     team = None
     if getattr(args, "team", None):
         from local_operator.paths import config_dir
@@ -89,7 +99,19 @@ def resolve_startup(args: Any) -> Any:
             resolve_profile_or_specialist(args.profile, registry=AgentRegistry(config_dir()))[0]
             is None
         ):
-            raise ValueError(f"No role or specialist named {args.profile!r}; use 'lop agents list'")
+            # NOT 'lop agents list': that lists legacy AgentData records, which
+            # is the --agent/--agent-id world this flag is distinct from. On a
+            # fresh config it prints "No agents found." while --profile reviewer
+            # resolves a packaged seed perfectly well, so the one message whose
+            # job is "here is how to find the right name" pointed at the surface
+            # that structurally cannot contain it. Name the seeds instead.
+            from local_operator.agent_profiles import list_seeds
+
+            available = ", ".join(sorted(list_seeds()))
+            raise ValueError(
+                f"No role or specialist named {args.profile!r}. "
+                f"Available roles: {available}. Add your own with 'lop agents create'"
+            )
     return team
 
 
@@ -105,5 +127,10 @@ def apply_startup(session: Any, args: Any, team: Any) -> None:
         session.set_goal(args.goal)
     if getattr(args, "name", None) is not None:
         session.set_conversation_name(args.name)
+    # The second half of the check resolve_startup starts: only here, with the
+    # session built, can a RESUMED standing goal be consulted. resolve_startup
+    # already rejected the decidable case (no --goal and no --resume) before
+    # anything was constructed, so reaching this raise means the resumed session
+    # genuinely has no goal to continue.
     if getattr(args, "loop", None) is not None and not session.goal:
         raise ValueError("--loop requires --goal or a resumed standing goal")

--- a/local_operator/exec_startup.py
+++ b/local_operator/exec_startup.py
@@ -1,0 +1,109 @@
+"""Bounded exec counterparts of owner-side startup commands.
+
+Resolve before provider construction AND again in a detached worker: a saved
+registry may change between preflight and spawn. Never interpret prompt text as
+slash commands, and never reinterpret the legacy --agent selector as a role.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+STARTUP_FIELDS = ("team", "profile", "goal", "clear_goal", "loop", "loop_goal", "name", "effort")
+
+
+def add_startup_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--team", metavar="NAME", help="Attach a saved team with its manager, roster and briefs"
+    )
+    parser.add_argument(
+        "--profile",
+        metavar="NAME",
+        help="Attach a reusable role/specialist (/agent counterpart; not legacy --agent)",
+    )
+    goals = parser.add_mutually_exclusive_group()
+    # Deliberately NOT the TUI's /goal, which also submits the text as a message
+    # so one Enter starts the work. Here the positional prompt IS the message
+    # channel, so auto-submitting would double-send whenever both are given.
+    goals.add_argument(
+        "--goal",
+        metavar="TEXT",
+        help=(
+            "Set a literal standing goal. Unlike the TUI's /goal this does NOT also "
+            "send the text as a message: pair it with a prompt or --loop"
+        ),
+    )
+    goals.add_argument("--clear-goal", action="store_true", help="Clear the resumed standing goal")
+    loops = parser.add_mutually_exclusive_group()
+    loops.add_argument(
+        "--loop",
+        type=int,
+        metavar="N",
+        help="Run N continuation iterations after the optional prompt; needs a standing goal",
+    )
+    loops.add_argument(
+        "--loop-goal",
+        metavar="TEXT",
+        help="Continue and judge this goal until achieved (no fixed iteration count)",
+    )
+    parser.add_argument("--name", metavar="TEXT", help="Set the persisted conversation name")
+    parser.add_argument(
+        "--effort",
+        metavar="LEVEL",
+        help="Set reasoning effort; validated against the selected model",
+    )
+
+
+def resolve_startup(args: Any) -> Any:
+    """Validate independent inputs without constructing a session or model."""
+    if getattr(args, "agent_name", None) and getattr(args, "agent_id", None):
+        raise ValueError("--agent and --agent-id are mutually exclusive")
+    if getattr(args, "goal", None) is not None and getattr(args, "clear_goal", False):
+        raise ValueError("--goal and --clear-goal are mutually exclusive")
+    count = getattr(args, "loop", None)
+    goal = getattr(args, "loop_goal", None)
+    if count is not None:
+        from local_operator.session.goal_loop import MAX_LOOP_ITERATIONS
+
+        if goal is not None:
+            raise ValueError("--loop and --loop-goal are mutually exclusive")
+        if not 1 <= count <= MAX_LOOP_ITERATIONS:
+            raise ValueError(f"--loop must be between 1 and {MAX_LOOP_ITERATIONS}")
+    if goal is not None and not goal.strip():
+        raise ValueError("--loop-goal must not be empty")
+    team = None
+    if getattr(args, "team", None):
+        from local_operator.paths import config_dir
+        from local_operator.teams import TeamRegistry
+
+        team = TeamRegistry(config_dir()).get_team_by_name(args.team)
+        if team is None:
+            raise ValueError(f"No team named {args.team!r}; use 'lop teams list'")
+    if getattr(args, "profile", None):
+        from local_operator.agent_profiles import resolve_profile_or_specialist
+        from local_operator.agents import AgentRegistry
+        from local_operator.paths import config_dir
+
+        if (
+            resolve_profile_or_specialist(args.profile, registry=AgentRegistry(config_dir()))[0]
+            is None
+        ):
+            raise ValueError(f"No role or specialist named {args.profile!r}; use 'lop agents list'")
+    return team
+
+
+def apply_startup(session: Any, args: Any, team: Any) -> None:
+    """Apply explicit overrides after ordinary resume restored its attachment."""
+    if team is not None:
+        session.attach_team(team)
+    if getattr(args, "profile", None) and not session.attach_agent_profile(args.profile):
+        raise ValueError(f"Could not attach profile {args.profile!r}")
+    if getattr(args, "clear_goal", False):
+        session.set_goal("")
+    elif getattr(args, "goal", None) is not None:
+        session.set_goal(args.goal)
+    if getattr(args, "name", None) is not None:
+        session.set_conversation_name(args.name)
+    if getattr(args, "loop", None) is not None and not session.goal:
+        raise ValueError("--loop requires --goal or a resumed standing goal")

--- a/local_operator/exec_worker.py
+++ b/local_operator/exec_worker.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import argparse
 import asyncio
 import inspect
-import os
 import signal
 import sys
 from typing import TYPE_CHECKING, Awaitable, Callable
@@ -79,6 +78,9 @@ def build_parser() -> argparse.ArgumentParser:
         # session while reporting success.
         help="Resume a previous session by id (or '@latest')",
     )
+    from local_operator.exec_startup import add_startup_arguments
+
+    add_startup_arguments(parser)
     return parser
 
 
@@ -167,8 +169,13 @@ def run(
     ``session_factory`` is injectable for tests; the default wires the real
     engine through the shared composition root.
     """
-    from local_operator.headless_print import run_print_mode
+    from local_operator.exec_session import run_session
+    from local_operator.exec_startup import resolve_startup
 
+    # Worker preflight precedes even the injected session factory. The legacy
+    # selector is called agent_name by the launcher and agent on worker argv.
+    parsed.agent_name = parsed.agent
+    team = resolve_startup(parsed)
     factory = session_factory or (lambda: _default_session_factory(parsed))
 
     async def async_main() -> int:
@@ -177,55 +184,42 @@ def run(
         session_box: list[SessionProtocol] = []
         _install_sigterm_handler(loop, session_box, interrupted)
 
-        source = factory()
-        session: SessionProtocol = await source if inspect.isawaitable(source) else source
-        session_box.append(session)
+        async def execute() -> int:
+            source = factory()
+            session: SessionProtocol = await source if inspect.isawaitable(source) else source
+            session_box.append(session)
+            return await run_session(session, parsed.prompt, parsed, team)
 
-        # Function-local for the same reason as the engine imports above: a
-        # detached worker pays for the runtime stack only when asked for it.
-        from local_operator.session.runtime.exec_control import maybe_start_exec_control
-
-        control = await maybe_start_exec_control(
-            session,
-            enabled=bool(getattr(parsed, "control", False)),
-            cwd=os.getcwd(),
-            yolo=bool(getattr(parsed, "yolo", False)),
-        )
-        if control is not None:
-            # The spawner redirected this process's stderr to the job log, which
-            # is where a supervisor of a detached run looks for the endpoint —
-            # stdout still belongs to the NDJSON stream even here.
-            print(control.endpoint_line, file=sys.stderr, flush=True)
-
-        prompt_task = asyncio.ensure_future(
-            run_print_mode(
-                session,
-                [parsed.prompt],
-                json_mode=parsed.json_mode,
-                before_dispose=(control.aclose if control is not None else None),
-            )
-        )
+        # Race the WHOLE lifetime, not just the first prompt: a worker waiting
+        # on provider discovery must still honour termination and finalize.
+        prompt_task = asyncio.ensure_future(execute())
         interrupt_task = asyncio.ensure_future(interrupted.wait())
         await asyncio.wait({prompt_task, interrupt_task}, return_when=asyncio.FIRST_COMPLETED)
         if interrupted.is_set():
             # Give the turn a bounded window to settle (flush renderer output,
             # dispose the session) before reporting the interrupt.
+            prompt_task.cancel()
             try:
                 await asyncio.wait_for(prompt_task, timeout=5.0)
-            except Exception:  # noqa: BLE001 — interrupt wins regardless
+            except (Exception, asyncio.CancelledError):
+                # The explicit interrupt owns the outcome, including when the
+                # provider was initializing rather than streaming a turn.
                 pass
             return EXIT_INTERRUPTED
         interrupt_task.cancel()
-        return prompt_task.result()
+        try:
+            return prompt_task.result()
+        except asyncio.CancelledError:
+            # A supervisor `stop` cancels the whole lifetime rather than
+            # signalling the process, and ``CancelledError`` is a
+            # BaseException — unhandled it would skip main()'s terminal ledger
+            # write, leaving reconciliation to report a deliberate stop as an
+            # abrupt `interrupted`. Deliberate termination is `cancelled`.
+            return EXIT_INTERRUPTED
 
     try:
         return asyncio.run(async_main())
-    except KeyboardInterrupt:
-        return EXIT_INTERRUPTED
-    except RuntimeError:
-        # Belt (CL-03): loop-level failures (e.g. signal handling races that
-        # surface as RuntimeError) must still read as an interrupt, never as
-        # an uncaught crash in the job log.
+    except (KeyboardInterrupt, asyncio.CancelledError):
         return EXIT_INTERRUPTED
 
 

--- a/local_operator/headless_print.py
+++ b/local_operator/headless_print.py
@@ -312,6 +312,21 @@ class PrintRenderer:
                 self.console.print("[red]aborted[/red]", highlight=False)
 
 
+async def _call_before_dispose(hook: Callable[..., Awaitable[None]], failed: bool) -> None:
+    """Call the teardown hook with the verdict when it wants it.
+
+    Inspected rather than always-passed so the existing zero-argument hooks
+    (and test doubles) are unaffected by a caller that needs the outcome.
+    """
+    import inspect
+
+    try:
+        takes_verdict = bool(inspect.signature(hook).parameters)
+    except (TypeError, ValueError):  # builtins/C callables report no signature
+        takes_verdict = False
+    await (hook(failed) if takes_verdict else hook())
+
+
 def _args_summary(args: dict[str, Any]) -> str:
     """One-line, privacy-minded summary of tool args: first scalar value.
 
@@ -330,7 +345,9 @@ async def run_print_mode(
     session: SessionProtocol,
     messages: list[str],
     json_mode: bool = False,
-    before_dispose: Callable[[], Awaitable[None]] | None = None,
+    before_dispose: Callable[..., Awaitable[None]] | None = None,
+    prompt_handler: Callable[[str], Awaitable[bool | None]] | None = None,
+    continuation: Callable[[], Awaitable[bool]] | None = None,
 ) -> int:
     """One-shot headless run mirroring the print-mode semantics.
 
@@ -339,6 +356,12 @@ async def run_print_mode(
     mode prints the last assistant text to stdout; json mode already emitted
     one line per event. Returns 0 on success, 1 when any turn errored or was
     aborted. Disposes the session before returning (one-shot by contract).
+
+    ``prompt_handler`` replaces the direct ``session.prompt`` call for hosts
+    that own a prompt queue (``exec`` submits through the runtime so a live
+    viewer cannot race it). Returning ``False`` from it marks the run failed;
+    ``None`` (what ``session.prompt`` returns) leaves the verdict to the
+    events, which is where a provider error already reports itself.
 
     ``before_dispose`` is awaited in the teardown, after the last event and
     BEFORE the session is disposed. It exists because the dispose is this
@@ -355,9 +378,19 @@ async def run_print_mode(
     unsubscribe = renderer.attach(session)
     try:
         for message in messages:
-            await session.prompt(message)
+            # A handler may REPORT a failed turn rather than raise, because the
+            # provider's own error arrives as an event the renderer prints. An
+            # explicit False still fails the run, so a turn that died without
+            # emitting an error event cannot be mistaken for success.
+            if await (prompt_handler or session.prompt)(message) is False:
+                renderer.failed = True
             if renderer.failed:
                 break
+        # Keep one subscription and one disposal across initial work and the
+        # owner-local loop: repeated one-shot runs would dispose between turns.
+        if not renderer.failed and continuation is not None:
+            if not await continuation():
+                renderer.failed = True
         if not json_mode and renderer.last_assistant_text:
             sys.stdout.write(renderer.last_assistant_text + "\n")
             sys.stdout.flush()
@@ -366,5 +399,9 @@ async def run_print_mode(
         if callable(unsubscribe):
             unsubscribe()
         if before_dispose is not None:
-            await before_dispose()
+            # Handed the run's own verdict so a teardown that must publish a
+            # terminal outcome (exec's browser scope) uses THIS value rather
+            # than deriving a second, possibly disagreeing, one. Optional-arg
+            # so existing zero-argument hooks keep working.
+            await _call_before_dispose(before_dispose, renderer.failed)
         await session.dispose()

--- a/local_operator/session/frontend_state.py
+++ b/local_operator/session/frontend_state.py
@@ -2920,6 +2920,18 @@ class FrontendStateStore:
                 "epoch": epoch,
                 "sequence": 0,
                 "usage_components": _capped_components(state.usage_components),
+                # The checkpoint describes a previous owner, not a scheduler
+                # to restart. Keep its progress visible without claiming an
+                # iteration still runs (or replaying a possibly costly turn).
+                "loop": (
+                    {
+                        **state.loop,
+                        "status": "interrupted",
+                        "reason": "Owner restarted; iterations were not replayed",
+                    }
+                    if state.loop and state.loop.get("status") in {"running", "judging"}
+                    else state.loop
+                ),
                 **_inherited_identity_fixups(state, session_id),
             }
         )

--- a/local_operator/session/goal_loop.py
+++ b/local_operator/session/goal_loop.py
@@ -20,11 +20,13 @@ class GoalLoop:
         judge: Callable[[str], Awaitable[str]],
         abort: Callable[[], None],
         changed: Callable[[dict[str, Any]], None],
+        checkpoint: Callable[[], Awaitable[None]] | None = None,
     ):
         self.prompt = prompt
         self.judge = judge
         self.abort = abort
         self.changed = changed
+        self.checkpoint = checkpoint
         self.task: asyncio.Task[None] | None = None
         self.state: dict[str, Any] = {"status": "idle", "completed": 0}
 
@@ -43,7 +45,9 @@ class GoalLoop:
             self.abort()
             await asyncio.gather(self.task, return_exceptions=True)
 
-    def start(self, args: str, standing_goal: str) -> dict[str, Any]:
+    def start(
+        self, args: str, standing_goal: str, *, goal_override: str | None = None
+    ) -> dict[str, Any]:
         if self.running:
             raise ValueError("A loop is already running")
         goal = ""
@@ -59,6 +63,10 @@ class GoalLoop:
             # the desktop route's `max_length=200_000`, and an oversized frame
             # is a DROPPED LINE -- a session that simply cannot be attached to.
             goal, count = args[:LOOP_GOAL_CHARS], None
+        # The CLI has distinct count/text flags, so a literal goal such as
+        # '123' must not accidentally become a request for 123 iterations.
+        if goal_override is not None:
+            goal, count = goal_override[:LOOP_GOAL_CHARS], None
         if count is not None and not 1 <= count <= MAX_LOOP_ITERATIONS:
             raise ValueError(f"Iterations must be between 1 and {MAX_LOOP_ITERATIONS}")
         if not goal and not standing_goal:
@@ -72,10 +80,16 @@ class GoalLoop:
         failures = 0
         try:
             while count is None or self.state["completed"] < count:
+                # Persist the boundary BEFORE admitting another turn. A killed
+                # owner exposes its last progress but never replays it on resume.
+                if self.checkpoint is not None:
+                    await self.checkpoint()
                 await self.prompt(LOOP_GOAL_PROMPT.format(goal=goal) if goal else LOOP_PROMPT)
                 self.publish(completed=self.state["completed"] + 1)
                 if goal:
                     self.publish(status="judging")
+                    if self.checkpoint is not None:
+                        await self.checkpoint()
                     try:
                         verdict, reason = _parse_loop_verdict(
                             await self.judge(LOOP_JUDGE_PROMPT.format(goal=goal))
@@ -97,6 +111,11 @@ class GoalLoop:
         except Exception:
             # Provider exception strings may contain private upstream bodies.
             self.publish(status="failed", reason="The loop turn failed")
+        finally:
+            # There may be no next Session turn-end checkpoint (especially in
+            # headless mode), so terminal state must be durable before return.
+            if self.checkpoint is not None:
+                await self.checkpoint()
 
 
 #: Upper bound on the judge's free-text reason, which is the ONLY unbounded

--- a/local_operator/session/runtime/exec_control.py
+++ b/local_operator/session/runtime/exec_control.py
@@ -1,4 +1,4 @@
-"""The opt-in control surface for a headless ``lop exec`` run.
+"""Discovery and optional supervised gates for a headless ``lop exec`` run.
 
 ``exec`` is the harness's machine-driven entry point: a supervisor composes a
 prompt, runs one turn, and parses NDJSON off stdout. Until this module that run
@@ -17,23 +17,12 @@ here is a third ``SessionHandle`` implementation — the whole control vocabular
 ``lop attach`` already speak, so a supervisor written against either drives an
 exec run with no new client.
 
-**Why it is opt-in** (``exec --control``) rather than always on. Every reason
-below is a cost paid by runs that would never use the surface, which is the
-overwhelming majority of them:
-
-- ``lop sessions`` (``cli.sessions_command``) filters on nothing, so every
-  scripted exec and every CI loop would land in the operator's session list and
-  become a ``lop send`` target. A one-shot run is not a peer.
-- the mobile daemon adopts published records, so short-lived exec runs would
-  flicker in and out of the phone's session list.
-- :data:`~local_operator.session.runtime.types.HEARTBEAT_INTERVAL_S` is a 15 s
-  cadence sized for long-lived hosts; most exec runs are shorter than one
-  interval, so the record's whole liveness story would be its publish and its
-  unpublish.
-- the socket, the record and the owned handle pull the asyncio control stack
-  onto a path whose import weight ``tests/unit/test_import_graph.py`` pins,
-  which is why every import into this module is made from inside a function on
-  the CLI path and never at ``exec_mode`` scope.
+Exec now publishes every ordinary session so a background team is discoverable
+and attachable through the same TUI path as a terminal-owned conversation.
+Short-lived records are deliberately ephemeral; durable outcomes belong to the
+exec ledger, not discovery. Publication and gate installation are separate:
+``supervised=False`` leaves the original headless gate untouched. Imports remain
+function-local on the CLI path so parsing/help does not load the runtime stack.
 
 **What ``--control`` changes about the run itself.** The owned handle installs
 its own approval/ask gates (``OwnedSessionHandle._install_gates``), replacing
@@ -137,6 +126,7 @@ async def start_exec_control(
     *,
     cwd: str,
     yolo: bool = False,
+    supervised: bool = True,
 ) -> ExecControl:
     """Publish a record and serve the control socket for ``session``.
 
@@ -170,8 +160,16 @@ async def start_exec_control(
     from local_operator.session.runtime.server import RuntimeServer
 
     loop = asyncio.get_running_loop()
-    handle = OwnedSessionHandle(session, loop, cwd=cwd, auto_approve=yolo, approval_pinned=yolo)
-    attach_gate_config_watch(handle, config_dir())
+    handle = OwnedSessionHandle(
+        session,
+        loop,
+        cwd=cwd,
+        auto_approve=yolo,
+        approval_pinned=yolo,
+        install_gates=supervised,
+    )
+    if supervised:
+        attach_gate_config_watch(handle, config_dir())
     # The ``stop`` control op (and therefore `lop stop`, which can now see this
     # run because it publishes a record) reaches ``request_stop`` -> this hook.
     # Without one the handle falls back to disposing in place, UNDER the prompt

--- a/local_operator/session/runtime/exec_control.py
+++ b/local_operator/session/runtime/exec_control.py
@@ -70,6 +70,11 @@ class ExecControl:
     pid: int
     port: int
     record_path: str
+    #: Whether this run's approval gates were actually replaced by the
+    #: supervisor's (``exec --control``). Discovery is now published for every
+    #: run, so the mode is no longer implied by the surface existing, and
+    #: :attr:`endpoint_line` has to say which one the user is in.
+    supervised: bool = True
 
     @property
     def endpoint_line(self) -> str:
@@ -86,9 +91,19 @@ class ExecControl:
         key is already the owning account. Printing it into a supervisor's log
         would move the credential somewhere the permissions do not reach, so
         the line names the record instead and the supervisor reads it there.
+
+        The NOUN reports the mode, because the two are no longer the same
+        thing. Publication was separated from gate installation, so this line
+        is printed on every run — and printing ``control:`` for a run without
+        ``--control`` tells the user, in the product's own vocabulary (it is
+        the exact name of the flag they did not pass), that the supervised
+        gate is installed. It is not: an unsupervised run keeps the headless
+        deny gate. ``session:`` names what is actually true of every run, and
+        ``control:`` is kept for the gated case a supervisor greps for.
         """
+        label = "control" if self.supervised else "session"
         return (
-            f"lop exec control: session_id={self.session_id} pid={self.pid} "
+            f"lop exec {label}: session_id={self.session_id} pid={self.pid} "
             f"port={self.port} record={self.record_path}"
         )
 
@@ -187,6 +202,7 @@ async def start_exec_control(
         pid=record.pid,
         port=record.control_port,
         record_path=str(registry.record_path(record.pid, config_dir())),
+        supervised=supervised,
     )
 
 

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -1713,8 +1713,14 @@ class OwnedSessionHandle(SessionHandle):
         self._check_loop_thread()
         spec = self._session.model
         if effort not in spec.reasoning_efforts:
-            ladder = ", ".join(spec.reasoning_efforts) or "no rungs"
-            raise ValueError(f"{spec.model_id} accepts {ladder}, not '{effort}'")
+            # Split rather than falling through to one sentence: joining an
+            # EMPTY ladder produced "accepts no rungs, not 'turbo'", a double
+            # negative that reads as though the value were nearly right, and
+            # "rung" is internal vocabulary no user-facing surface uses.
+            if not spec.reasoning_efforts:
+                raise ValueError(f"{spec.model_id} has no reasoning-effort levels; drop --effort")
+            ladder = ", ".join(spec.reasoning_efforts)
+            raise ValueError(f"{spec.model_id} accepts {ladder} \u2014 not '{effort}'")
         self._session.set_model(spec.model_copy(update={"reasoning_effort": effort}))
         self._refresh_state()
         return f"effort: {effort}"

--- a/local_operator/session/runtime/owned.py
+++ b/local_operator/session/runtime/owned.py
@@ -185,6 +185,7 @@ class OwnedSessionHandle(SessionHandle):
         cwd: str,
         auto_approve: bool = False,
         approval_pinned: bool = False,
+        install_gates: bool = True,
     ) -> None:
         self._session = session
         self._goal_loop: Any = None
@@ -340,7 +341,14 @@ class OwnedSessionHandle(SessionHandle):
         # sessions in tests that never grew the attribute keep working.
         if hasattr(session, "on_turn_settled"):
             session.on_turn_settled = self._publish_busy_soon
-        self._install_gates()
+        # Discovery/attachment does not authorize replacing a headless deny
+        # gate with a parked interactive gate. Exec opts into that separately.
+        #: Why the most recent admitted turn failed, for a headless caller that
+        #: has no front end reading the projection. See the drain's handler.
+        self._last_prompt_failure = ""
+        self._gates_installed = install_gates
+        if install_gates:
+            self._install_gates()
 
     # -- gates -----------------------------------------------------------------
 
@@ -1178,11 +1186,64 @@ class OwnedSessionHandle(SessionHandle):
                     store.mutate(loop=state)
                 self._notify()
 
-            self._goal_loop = GoalLoop(prompt, judge, self._cancel_loop_turn, changed)
+            async def checkpoint() -> None:
+                # A headless session need not have a frontend subscriber. Its
+                # loop still owns durable progress, including the terminal
+                # boundary that occurs AFTER the last turn-end checkpoint.
+                store = getattr(self._session, "_frontend_state_store", None)
+                transcript = getattr(self._session, "_transcript", None)
+                if store is not None and transcript is not None:
+                    await store.checkpoint(transcript)
+
+            self._goal_loop = GoalLoop(prompt, judge, self._cancel_loop_turn, changed, checkpoint)
             store = getattr(self._session, "_frontend_state_store", None)
             if store is not None and store.state.loop:
                 self._goal_loop.state = dict(store.state.loop)
         return self._goal_loop
+
+    async def run_headless_prompt(self, text: str) -> bool:
+        """Submit through the owner queue so live viewers cannot race exec.
+
+        Returns whether the turn completed, rather than raising on failure. A
+        provider error arrives as an EVENT, so the renderer already reports the
+        provider's own message and owns the exit code; raising on top of that
+        would replace a real diagnosis with a generic queue message. Returning
+        the outcome still lets the caller fail the run when the turn raised
+        without ever emitting an error event. The goal loop takes the raising
+        path (:meth:`prompt` directly) because it must stop iterating.
+        """
+        self._last_prompt_failure = ""
+        try:
+            await self.prompt(text, command_id=str(uuid.uuid4()), wait_complete=True)
+            return True
+        except RuntimeError:
+            logger.debug("headless turn did not complete", exc_info=True)
+            return False
+
+    @property
+    def last_prompt_failure(self) -> str:
+        """Why the last admitted turn failed, or "" — see the drain's handler."""
+        return self._last_prompt_failure
+
+    async def run_headless_loop(self, *, count: int | None, goal: str | None) -> bool:
+        """Await the same owner-local driver used by /loop, not another runner."""
+        driver = self._loop_driver()
+        driver.start(
+            str(count) if count is not None else "", self._session.goal, goal_override=goal
+        )
+        assert driver.task is not None
+        try:
+            await driver.task
+        finally:
+            if driver.running:
+                await driver.cancel()
+        if driver.state.get("status") == "cancelled":
+            raise asyncio.CancelledError
+        return driver.state.get("status") in {"completed", "achieved"}
+
+    async def cancel_headless_loop(self) -> None:
+        if self._goal_loop is not None:
+            await self._goal_loop.cancel()
 
     def _cancel_loop_turn(self) -> None:
         # Another frontend may have queued a manual turn before this iteration.
@@ -1311,6 +1372,19 @@ class OwnedSessionHandle(SessionHandle):
             command = self._prompt_queue[0]
             self._active_prompt_command_id = command.command_id
             succeeded = False
+            emitted_failure = False
+
+            def observe_end(event: AgentEvent) -> None:
+                nonlocal emitted_failure
+                from local_operator.harness.types import AgentEndEvent
+
+                if isinstance(event, AgentEndEvent) and (event.error or event.aborted):
+                    emitted_failure = True
+
+            # Session.prompt reports provider errors as events, not exceptions.
+            # Queue completion must reflect that terminal result; otherwise a
+            # goal loop submits its next turn after the model already failed.
+            unsubscribe_outcome = self._session.subscribe(observe_end)
             try:
                 parameters = inspect.signature(self._session.prompt).parameters
                 if "message_id" in parameters:
@@ -1328,7 +1402,7 @@ class OwnedSessionHandle(SessionHandle):
                     if not command.admitted.done():
                         command.admitted.set_result(None)
                     await self._session.prompt(command.text, command.images)
-                succeeded = True
+                succeeded = not emitted_failure
             except asyncio.CancelledError:
                 if not command.admitted.done():
                     command.admitted.set_exception(
@@ -1356,6 +1430,10 @@ class OwnedSessionHandle(SessionHandle):
                 self._projection.streaming = self._session.is_streaming
                 self._fold.note_prompt_rejected(str(exc))
                 self._notify()
+                # Kept for a headless caller, which has no front end to read the
+                # projection: a turn that RAISES emits no error event, so this
+                # string is the only description of what went wrong.
+                self._last_prompt_failure = str(exc)
                 logger.exception("mobile prompt failed after admission")
             except BaseException:
                 # KeyboardInterrupt/SystemExit retain their process semantics;
@@ -1363,6 +1441,7 @@ class OwnedSessionHandle(SessionHandle):
                 logger.critical("mobile prompt drain terminated", exc_info=True)
                 raise
             finally:
+                unsubscribe_outcome()
                 if command.completed is not None and not command.completed.done():
                     command.completed.set_result(succeeded)
                 self._active_prompt_command_id = None
@@ -3225,6 +3304,19 @@ class OwnedSessionHandle(SessionHandle):
         sessions, not to a runtime that outlives it.
         """
         argument = (arg or "").strip().lower()
+        if not self._gates_installed:
+            # Publishing an exec owner did not replace its original gate, so
+            # mutating this handle's flag would lie about what tools consult.
+            # Gate routing is a launch decision, never a side effect of attach.
+            return SlashResult(
+                kind="notice",
+                text=(
+                    "exec uses its original headless approval gate"
+                    + (" (--yolo is active)" if self._auto_approve else " (non-TTY requests deny)")
+                    + "; launch with --control for supervisor approval controls"
+                ),
+                style="warning" if argument else "info",
+            )
         if argument == "default" or argument.startswith("default "):
             return SlashResult(
                 kind="notice",

--- a/tests/e2e/test_exec_startup_e2e.py
+++ b/tests/e2e/test_exec_startup_e2e.py
@@ -1,0 +1,609 @@
+"""Installed-style CLI/worker tests against a real loopback provider.
+
+Only the remote model is scripted. CLI parsing, config, session construction,
+team attachment, runtime discovery, transcript writes and worker disposal are
+production code. Every process uses an isolated HOME and no ambient cmux IDs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from local_operator.config import ConfigManager
+from local_operator.teams import TeamEditFields, TeamMember, TeamRegistry
+
+
+@pytest.fixture
+def exec_server(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    root = home / ".local-operator"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(root))
+    for key in list(os.environ):
+        if key.startswith("CMUX_"):
+            monkeypatch.delenv(key)
+    requests: list[dict[str, Any]] = []
+    release = threading.Event()
+    worker_ids: list[str] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, format, *args):
+            pass
+
+        def do_GET(self):
+            body = json.dumps(
+                {"object": "list", "data": [{"id": "exec-fixture", "object": "model"}]}
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_POST(self):
+            body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            requests.append(body)
+            wire = json.dumps(body.get("messages", []))
+            if "FAIL_FIXTURE" in wire:
+                error = json.dumps(
+                    {
+                        "error": {
+                            "message": "fixture invalid request",
+                            "type": "invalid_request_error",
+                        }
+                    }
+                ).encode()
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(error)))
+                self.end_headers()
+                self.wfile.write(error)
+                return
+            if "HOLD_FIXTURE" in wire:
+                release.wait(timeout=45)
+            delta = {"role": "assistant", "content": "Fixture completed"}
+            finish_reason = "stop"
+            called = {
+                call["function"]["name"]
+                for message in body.get("messages", [])
+                for call in message.get("tool_calls", [])
+            }
+            # Request real tools: the dispatcher and delegated child are not mocked.
+            tool = None
+            if "DELEGATE_FIXTURE" in wire and "task" not in called:
+                tool = (
+                    "task",
+                    {
+                        "i": "Delegating fixture work",
+                        "label": "fixture-child",
+                        "prompt": "CHILD_TASK: verify the project brief",
+                        "agent": "coder",
+                    },
+                )
+            elif "DELEGATE_FIXTURE" in wire and "wait" not in called:
+                tool = (
+                    "wait",
+                    {"i": "Awaiting fixture child", "job_id": "fixture-child", "wait_ms": 10000},
+                )
+            elif "WRITE_FIXTURE" in wire and "write" not in called:
+                tool = (
+                    "write",
+                    {
+                        "i": "Writing fixture evidence",
+                        "path": str(tmp_path / "written.txt"),
+                        "content": "side-effect",
+                    },
+                )
+            if tool:
+                delta = {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "call_" + tool[0],
+                            "type": "function",
+                            "function": {"name": tool[0], "arguments": json.dumps(tool[1])},
+                        }
+                    ],
+                }
+                finish_reason = "tool_calls"
+            elif "You are judging" in wire:
+                delta = {"role": "assistant", "content": "VERDICT: ACHIEVED\nFixture verified"}
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.end_headers()
+            for delta, finish in [(delta, None), ({}, finish_reason)]:
+                chunk = {
+                    "id": "fixture",
+                    "object": "chat.completion.chunk",
+                    "created": 1,
+                    "model": "exec-fixture",
+                    "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
+                }
+                self.wfile.write(("data: " + json.dumps(chunk) + "\n\n").encode())
+            self.wfile.write(b"data: [DONE]\n\n")
+            self.wfile.flush()
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    serving = threading.Thread(target=server.serve_forever, daemon=True)
+    serving.start()
+    config = ConfigManager(root)
+    config.update_config(
+        {
+            "hosting": "openai-compatible",
+            "model_name": "exec-fixture",
+            "providers": {
+                "openai-compatible": {
+                    "base_url": f"http://127.0.0.1:{server.server_port}/v1",
+                    "models": {"exec-fixture": {"context_window": 100000, "supports_tools": True}},
+                }
+            },
+        }
+    )
+    TeamRegistry(root).create_team(
+        TeamEditFields(
+            name="release",
+            manager="manager",
+            members=[TeamMember(role="coder")],
+            instructions="COLLABORATION_SENTINEL: review before shipping",
+            project="PROJECT_SENTINEL: verify headless teams",
+        )
+    )
+    env = {k: v for k, v in os.environ.items() if not k.startswith("CMUX_") and k != "NO_COLOR"}
+    env["TERM"] = "xterm-256color"
+
+    def run(*args, stdin=None):
+        result = subprocess.run(
+            [sys.executable, "-m", "local_operator.cli", *args],
+            env=env,
+            input=stdin,
+            text=True,
+            capture_output=True,
+            timeout=60,
+            cwd=tmp_path,
+        )
+        print("COMMAND", "lop", *args, "EXIT", result.returncode)
+        print("STDOUT", result.stdout)
+        print("STDERR", result.stderr)
+        if "Background job " in result.stderr:
+            worker_ids.append(result.stderr.split("Background job ", 1)[1].split(":", 1)[0])
+        return result
+
+    setattr(run, "release", release)
+    setattr(run, "env", env)
+    try:
+        yield run, requests, root
+    finally:
+        import signal
+
+        from local_operator.exec_mode import job_status
+        from local_operator.tools.group_reaper import _owner_is_dead
+
+        release.set()
+        # Assertions may fail while a supervisor gate is parked. Clean only
+        # this fixture's generation-verified workers, never ambient discovery.
+        for job_id in worker_ids:
+            state = job_status(job_id)
+            generation = state.get("process_generation")
+            if (
+                state.get("status") in ("starting", "running")
+                and generation
+                and _owner_is_dead(state["pid"], generation) is False
+            ):
+                os.kill(state["pid"], signal.SIGTERM)
+        server.shutdown()
+        server.server_close()
+        serving.join(timeout=5)
+
+
+def test_exec_team_count_loop_and_resume(exec_server):
+    run, requests, root = exec_server
+    result = run(
+        "exec",
+        "Initial task",
+        "--team",
+        "release",
+        "--profile",
+        "reviewer",
+        "--goal",
+        "Ship safely",
+        "--loop",
+        "2",
+        "--name",
+        "Headless audit",
+        "--json",
+        stdin="",
+    )
+    assert result.returncode == 0
+    assert len(requests) == 3
+    wire = json.dumps(requests[0])
+    for expected in ("COLLABORATION_SENTINEL", "PROJECT_SENTINEL", "manager", "coder", "reviewer"):
+        assert expected in wire
+    rows = [json.loads(line) for line in result.stdout.splitlines()]
+    assert rows
+    session_id = result.stderr.split("session_id=", 1)[1].split()[0]
+    directory = root / "sessions" / session_id
+    assert directory.is_dir()
+    resumed = run(
+        "exec", "Resume without replay", "--resume", session_id, "--clear-goal", "--json", stdin=""
+    )
+    assert resumed.returncode == 0
+    assert len(requests) == 4
+    missing_goal = run("exec", "--resume", session_id, "--loop", "1", stdin="")
+    assert missing_goal.returncode != 0
+    assert len(requests) == 4
+    assert "COLLABORATION_SENTINEL" in json.dumps(requests[-1])
+    persisted = (directory / "transcript.jsonl").read_text()
+    assert "Headless audit" in persisted
+    assert '"status": "completed"' in json.dumps(
+        [json.loads(line) for line in persisted.splitlines()]
+    )
+
+
+def test_exec_unknown_and_goal_only_do_not_call_provider(exec_server):
+    run, requests, _ = exec_server
+    for args in [
+        ("exec", "task", "--team", "missing", "--background"),
+        ("exec", "task", "--profile", "missing"),
+        ("exec", "--goal", "alone"),
+    ]:
+        assert run(*args, stdin="").returncode != 0
+    assert not requests
+
+
+def test_exec_agent_profile_stdin_and_numeric_goal(exec_server):
+    from local_operator.agents import AgentRegistry
+
+    run, requests, root = exec_server
+    legacy = run(
+        "exec", "--agent", "legacy-worker", "--name", "Legacy fixture", stdin="Piped legacy task\n"
+    )
+    assert legacy.returncode == 0
+    agent = AgentRegistry(root).get_agent_by_name("legacy-worker")
+    assert agent is not None
+    by_id = run(
+        "exec", "-", "--agent-id", agent.id, "--name", "Exact fixture", stdin="Exact agent task\n"
+    )
+    assert by_id.returncode == 0
+    goal = run("exec", "--loop-goal", "123", "--name", "Goal fixture", stdin="")
+    assert goal.returncode == 0
+    assert "You are judging" in json.dumps(requests[-1])
+    invalid = run("exec", "No model turn", "--effort", "not-a-level", stdin="")
+    assert invalid.returncode != 0
+    assert len(requests) == 4
+
+
+def test_exec_delegates_actual_team_child(exec_server):
+    run, requests, _ = exec_server
+    result = run(
+        "exec",
+        "DELEGATE_FIXTURE",
+        "--team",
+        "release",
+        "--yolo",
+        "--name",
+        "Delegation fixture",
+        stdin="",
+    )
+    assert result.returncode == 0
+    child_requests = [
+        request
+        for request in requests
+        if "CHILD_TASK" in json.dumps(request) and "DELEGATE_FIXTURE" not in json.dumps(request)
+    ]
+    assert child_requests, "The actual delegated child must reach the provider"
+    child_wire = json.dumps(child_requests[0])
+    assert "COLLABORATION_SENTINEL" in child_wire
+    assert "PROJECT_SENTINEL" in child_wire
+    assert "coder" in child_wire
+
+
+def test_exec_default_non_tty_denies_and_explicit_yolo_writes(exec_server, tmp_path):
+    run, requests, _ = exec_server
+    denied = run("exec", "WRITE_FIXTURE", "--name", "Deny fixture", stdin="")
+    assert denied.returncode == 0
+    assert not (tmp_path / "written.txt").exists()
+    assert "denied" in json.dumps(requests).lower()
+    allowed = run("exec", "WRITE_FIXTURE", "--yolo", "--name", "Allow fixture", stdin="")
+    assert allowed.returncode == 0
+    assert (tmp_path / "written.txt").read_text() == "side-effect"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("team", [None, "release"])
+async def test_exec_live_tui_attachment_and_settled_frames(exec_server, tmp_path, team):
+    import asyncio
+    from argparse import Namespace
+
+    from local_operator.agents import AgentRegistry
+    from local_operator.credentials import CredentialManager
+    from local_operator.exec_mode import ExecArgs, job_status
+    from local_operator.session.remote import RemoteSession
+    from local_operator.session_factory import create_session
+    from local_operator.tui.app import OperatorApp
+    from tests.e2e.harness import wait_for_adoption
+
+    run, requests, root = exec_server
+    options = ["--team", team] if team else []
+    result = run(
+        "exec", "HOLD_FIXTURE", "--background", "--name", "Headless audit", *options, stdin=""
+    )
+    assert result.returncode == 0
+    job_id = result.stderr.split("Background job ", 1)[1].split(":", 1)[0]
+    status = json.loads(run("exec", "--status", job_id, stdin="").stdout)
+    session_id = status["session_id"]
+
+    async def factory():
+        return await create_session(
+            Namespace(**vars(ExecArgs(resume=session_id))),
+            ConfigManager(root),
+            CredentialManager(root),
+            AgentRegistry(root),
+            has_ui=True,
+            cwd=str(tmp_path),
+        )
+
+    app = OperatorApp(factory)
+    try:
+        async with app.run_test(size=(110, 34)) as pilot:
+            await wait_for_adoption(app, pilot)
+            assert isinstance(app._session, RemoteSession)
+            assert app._session.session_id == session_id
+            assert app._session.active_team_name == (team or "")
+            await pilot.pause()
+            destination = os.environ.get("EXEC_EVIDENCE_DIR")
+            if destination:
+                out = Path(destination)
+                out.mkdir(parents=True, exist_ok=True)
+                label = "after-team" if team else "before-no-team"
+                app.save_screenshot(str(out / f"{label}-first.svg"))
+                await pilot.pause()
+                app.save_screenshot(str(out / f"{label}-settled.svg"))
+                geometry = {
+                    widget.id: {
+                        "region": str(widget.region),
+                        "size": str(widget.size),
+                        "virtual_size": str(widget.virtual_size),
+                    }
+                    for widget in app.query("#transcript, #editor, #status-bar")
+                }
+                (out / f"{label}-geometry.json").write_text(json.dumps(geometry, indent=2))
+            # A viewer detaching must leave the exec owner running.
+        assert json.loads(run("exec", "--status", job_id, stdin="").stdout)["status"] == "running"
+    finally:
+        getattr(run, "release").set()
+        for _ in range(100):
+            await asyncio.sleep(0.05)
+            if job_status(job_id)["status"] not in ("starting", "running"):
+                break
+    assert requests
+    assert job_status(job_id)["status"] == "succeeded"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("approve", [False, True])
+async def test_exec_supervisor_approval_ui(exec_server, tmp_path, approve):
+    import asyncio
+    from argparse import Namespace
+
+    from local_operator.agents import AgentRegistry
+    from local_operator.credentials import CredentialManager
+    from local_operator.exec_mode import ExecArgs, job_status
+    from local_operator.session_factory import create_session
+    from local_operator.tui.app import OperatorApp
+    from local_operator.tui.widgets.approval import ApprovalPrompt
+    from tests.e2e.harness import wait_for_adoption
+
+    run, requests, root = exec_server
+    result = run(
+        "exec",
+        "WRITE_FIXTURE",
+        "--control",
+        "--background",
+        "--name",
+        "Supervised fixture",
+        stdin="",
+    )
+    job_id = result.stderr.split("Background job ", 1)[1].split(":", 1)[0]
+    state = job_status(job_id)
+    assert state["status"] == "running"
+    assert not (tmp_path / "written.txt").exists()
+
+    async def factory():
+        return await create_session(
+            Namespace(**vars(ExecArgs(resume=state["session_id"]))),
+            ConfigManager(root),
+            CredentialManager(root),
+            AgentRegistry(root),
+            has_ui=True,
+            cwd=str(tmp_path),
+        )
+
+    app = OperatorApp(factory)
+    async with app.run_test(size=(110, 34)) as pilot:
+        await wait_for_adoption(app, pilot)
+        for _ in range(100):
+            await pilot.pause()
+            if app.query(ApprovalPrompt):
+                break
+        assert app.query(ApprovalPrompt), "An explicit --control run must expose its parked gate"
+        destination = os.environ.get("EXEC_EVIDENCE_DIR")
+        if destination:
+            app.save_screenshot(
+                str(Path(destination) / f"supervised-{'allow' if approve else 'deny'}-pending.svg")
+            )
+        await pilot.press("y" if approve else "n")
+        for _ in range(100):
+            await asyncio.sleep(0.05)
+            await pilot.pause()
+            if job_status(job_id)["status"] not in ("starting", "running"):
+                break
+        assert job_status(job_id)["status"] == "succeeded"
+        if destination:
+            app.save_screenshot(
+                str(Path(destination) / f"supervised-{'allow' if approve else 'deny'}-settled.svg")
+            )
+    assert (tmp_path / "written.txt").exists() is approve
+    assert requests
+
+
+@pytest.mark.parametrize(
+    "termination,expected", [("term", "cancelled"), ("kill", "interrupted"), ("stop", "cancelled")]
+)
+def test_exec_loop_lifecycle_outcomes(exec_server, termination, expected):
+    import signal
+    import time
+
+    from local_operator.exec_mode import job_status
+
+    run, requests, root = exec_server
+    result = run(
+        "exec",
+        "--goal",
+        "HOLD_FIXTURE",
+        "--loop",
+        "2",
+        "--name",
+        "Lifecycle fixture",
+        "--background",
+        stdin="",
+    )
+    assert result.returncode == 0
+    job_id = result.stderr.split("Background job ", 1)[1].split(":", 1)[0]
+    status = job_status(job_id)
+    assert status["status"] == "running"
+    assert status["process_generation"]
+    if termination == "stop":
+        response = run("stop", "--session", status["session_id"], "--yes", stdin="")
+        assert response.returncode == 0
+    else:
+        # Only the worker created by THIS fixture, under its private config,
+        # is signalled. Never target ambient session discovery or cmux state.
+        os.kill(status["pid"], signal.SIGTERM if termination == "term" else signal.SIGKILL)
+    deadline = time.monotonic() + 15
+    while time.monotonic() < deadline:
+        status = job_status(job_id)
+        if status["status"] not in ("starting", "running"):
+            break
+        time.sleep(0.05)
+    assert status["status"] == expected
+    before = len(requests)
+    assert json.loads(run("exec", "--status", job_id, stdin="").stdout)["status"] == expected
+    assert len(requests) == before, "Status/reconciliation must never restart iterations"
+    if termination != "kill":
+        assert not Path(status["runtime_path"]).exists()
+
+
+def test_detached_worker_outliving_its_launcher_stays_running(exec_server):
+    """Launcher exit is NOT evidence about the worker.
+
+    A detached run deliberately survives the process that spawned it (the group
+    reaper excludes exec workers for this reason), so reconciliation must fence
+    on the WORKER's own pid+generation and never infer a terminal state from the
+    launcher being gone. Getting this wrong would close a browser scope out from
+    under live work — the hazard the browser owner asked us to rule out.
+    """
+    import time
+
+    from local_operator.exec_mode import job_status
+    from local_operator.tools.group_reaper import _owner_is_dead
+
+    run, _requests, _root = exec_server
+    # The launcher is `run(...)`: a subprocess that has already exited by the
+    # time it returns, while the worker it spawned keeps holding the model.
+    result = run("exec", "HOLD_FIXTURE", "--background", "--name", "Survivor fixture", stdin="")
+    assert result.returncode == 0
+    job_id = result.stderr.split("Background job ", 1)[1].split(":", 1)[0]
+
+    status = job_status(job_id)
+    assert status["status"] == "running"
+    # The worker's generation is live; the launcher is provably gone.
+    assert _owner_is_dead(status["pid"], status["process_generation"]) is False
+
+    # Reconciliation re-run while the launcher is dead must NOT move it.
+    for _ in range(5):
+        time.sleep(0.05)
+        assert job_status(job_id)["status"] == "running"
+
+    getattr(run, "release").set()
+    deadline = time.monotonic() + 15
+    status = job_status(job_id)
+    while time.monotonic() < deadline and status["status"] in ("starting", "running"):
+        time.sleep(0.05)
+        status = job_status(job_id)
+    assert status["status"] == "succeeded"
+
+
+def test_exec_loop_failure_is_durable_and_stops_iterations(exec_server):
+    import time
+
+    from local_operator.exec_mode import job_status
+
+    run, requests, _ = exec_server
+    result = run(
+        "exec",
+        "--goal",
+        "FAIL_FIXTURE",
+        "--loop",
+        "2",
+        "--name",
+        "Failure fixture",
+        "--background",
+        stdin="",
+    )
+    job_id = result.stderr.split("Background job ", 1)[1].split(":", 1)[0]
+    deadline = time.monotonic() + 15
+    status = job_status(job_id)
+    while time.monotonic() < deadline and status["status"] in ("starting", "running"):
+        time.sleep(0.05)
+        status = job_status(job_id)
+    assert status["status"] == "failed"
+    assert status["exit_code"] == 1
+    assert len(requests) == 1
+    transcript = Path(status["session_directory"]) / "transcript.jsonl"
+    assert '"status": "failed"' in json.dumps(
+        [json.loads(line) for line in transcript.read_text().splitlines()]
+    )
+
+
+def test_exec_background_receipt_and_durable_status(exec_server):
+    import time
+
+    run, requests, root = exec_server
+    result = run(
+        "exec",
+        "Detached task",
+        "--team",
+        "release",
+        "--background",
+        "--name",
+        "Detached fixture",
+        stdin="",
+    )
+    assert result.returncode == 0
+    job_id = result.stderr.split("Background job ", 1)[1].split(":", 1)[0]
+    deadline = time.monotonic() + 30
+    status = {}
+    while time.monotonic() < deadline:
+        response = run("exec", "--status", job_id, stdin="")
+        assert response.returncode == 0
+        status = json.loads(response.stdout)
+        if status["status"] not in ("starting", "running"):
+            break
+    assert status["status"] == "succeeded"
+    assert status["session_id"] != job_id
+    assert status["process_generation"]
+    assert Path(status["log"]).is_file()
+    assert Path(status["session_directory"]).is_dir()
+    assert not Path(status["runtime_path"]).exists()
+    assert len(requests) == 1

--- a/tests/e2e/test_exec_startup_e2e.py
+++ b/tests/e2e/test_exec_startup_e2e.py
@@ -181,6 +181,7 @@ def exec_server(tmp_path, monkeypatch):
 
     setattr(run, "release", release)
     setattr(run, "env", env)
+    setattr(run, "cwd", tmp_path)
     try:
         yield run, requests, root
     finally:
@@ -502,6 +503,134 @@ def test_exec_loop_lifecycle_outcomes(exec_server, termination, expected):
     assert len(requests) == before, "Status/reconciliation must never restart iterations"
     if termination != "kill":
         assert not Path(status["runtime_path"]).exists()
+
+
+def test_dash_leading_values_reach_the_detached_worker(exec_server):
+    """A value starting with ``-`` must survive the launcher/worker argv hop.
+
+    Forwarded as two argv items, ``--name -nightly`` reads as an OPTION to the
+    worker's argparse and dies at ``parse_args`` — before ``--job-id`` is
+    honoured, so no terminal ledger row is written and reconciliation reports
+    ``interrupted``: the word reserved for a worker killed mid-flight, for a
+    run that never started. The values most likely to lead with a dash are the
+    free-text ones this feature adds.
+    """
+    import time
+
+    from local_operator.exec_mode import job_status
+
+    run, _requests, _root = exec_server
+    # The `=` form is what a user must type for a dash-leading value; the
+    # launcher's own argparse rejects the two-token form just as the worker's
+    # does. The bug was that the launcher ACCEPTED this and then re-emitted it
+    # to the worker in the two-token form the worker cannot parse.
+    result = run(
+        "exec", "HOLD_FIXTURE", "--background", "--name=-nightly", "--goal=-- ship it", stdin=""
+    )
+    assert result.returncode == 0
+    job_id = result.stderr.split("Background job ", 1)[1].split(":", 1)[0]
+
+    deadline = time.monotonic() + 20
+    state = job_status(job_id)
+    while time.monotonic() < deadline and state.get("status") == "starting":
+        time.sleep(0.05)
+        state = job_status(job_id)
+    # The worker actually booted, rather than dying at parse_args and being
+    # mislabelled `interrupted` by reconciliation.
+    assert state["status"] == "running", state
+    assert state["session_id"]
+
+    getattr(run, "release").set()
+    deadline = time.monotonic() + 20
+    while time.monotonic() < deadline and state["status"] in ("starting", "running"):
+        time.sleep(0.05)
+        state = job_status(job_id)
+    assert state["status"] == "succeeded", state
+
+
+def test_parked_supervised_run_is_distinguishable_from_working(exec_server):
+    """``--status`` must tell "waiting for you" apart from "working".
+
+    A supervised run parked on an approval sits at ``running`` indefinitely,
+    and that is the one state a user has to notice. ``lop sessions`` already
+    computes it; this asserts ``--status`` reports the same thing rather than
+    collapsing both states into ``running``.
+    """
+    import time
+
+    from local_operator.exec_mode import job_status
+
+    run, _requests, _root = exec_server
+    result = run(
+        "exec", "WRITE_FIXTURE", "--control", "--background", "--name", "Parked fixture", stdin=""
+    )
+    assert result.returncode == 0
+    # The receipt must name the command that shows what a run needs.
+    assert "lop sessions" in result.stderr
+    job_id = result.stderr.split("Background job ", 1)[1].split(":", 1)[0]
+
+    # The gate parks asynchronously; wait for the state rather than sleeping.
+    deadline = time.monotonic() + 30
+    state = job_status(job_id)
+    while time.monotonic() < deadline and not state.get("pending"):
+        time.sleep(0.1)
+        state = job_status(job_id)
+    assert state["status"] == "running"
+    assert state["pending"] == "approval", state
+
+    # Live state only: it must never be frozen into the durable ledger, where
+    # every row is a fact that stays true.
+    persisted = (Path(state["log"]).parent / "exec-jobs.jsonl").read_text()
+    assert '"pending"' not in persisted
+
+
+def test_loop_only_run_does_not_block_on_an_inherited_open_pipe(exec_server):
+    """A loop-only run must not read a stdin that never closes.
+
+    Every other case here passes ``stdin=""`` through ``subprocess.run``, which
+    closes the pipe immediately — so the suite structurally could not see this.
+    A supervisor (CI runner, cmux surface, ``Popen(stdin=PIPE)``) hands its
+    child an inherited pipe and keeps the write end OPEN, so ``sys.stdin.read()``
+    never sees EOF and the documented ``exec --goal X --loop N`` hangs forever
+    with no output. This test therefore opens the pipe and deliberately never
+    writes to or closes it.
+    """
+    import subprocess as sp
+
+    run, _requests, _root = exec_server
+    env = getattr(run, "env")
+    process = sp.Popen(
+        [
+            sys.executable,
+            "-m",
+            "local_operator.cli",
+            "exec",
+            "--goal",
+            "Ship safely",
+            "--loop",
+            "1",
+        ],
+        env=env,
+        text=True,
+        stdin=sp.PIPE,  # held open on purpose; nothing is ever written or closed
+        stdout=sp.PIPE,
+        stderr=sp.PIPE,
+        cwd=getattr(run, "cwd"),
+    )
+    try:
+        # Generous relative to the run itself (the fixture answers instantly),
+        # but finite: before the fix this waited forever.
+        process.wait(timeout=45)
+    except sp.TimeoutExpired:
+        process.kill()
+        process.wait()
+        raise AssertionError("loop-only exec blocked on an inherited open stdin")
+    finally:
+        if process.stdin and not process.stdin.closed:
+            process.stdin.close()
+    stdout = process.stdout.read() if process.stdout else ""
+    stderr = process.stderr.read() if process.stderr else ""
+    assert process.returncode == 0, (stdout, stderr)
 
 
 def test_detached_worker_outliving_its_launcher_stays_running(exec_server):

--- a/tests/unit/test_cli_new.py
+++ b/tests/unit/test_cli_new.py
@@ -1447,6 +1447,16 @@ def test_golden_legacy_parser_surface() -> None:
     golden = json.loads(golden_path.read_text(encoding="utf-8"))
     current = _inventory(build_cli_parser())
 
+    # The ONE deliberate relaxation of the legacy surface, recorded here rather
+    # than edited into the golden data so the reason is visible to a reviewer.
+    # `exec` grew loop-only and piped-stdin forms (`--loop`, `--loop-goal`, `-`,
+    # omitted-with-a-pipe), and argparse cannot express "required unless one of
+    # those" — so the positional is `nargs="?"` and `run_exec` enforces the real
+    # rule, naming the ways to supply a prompt. Relaxing required->optional is
+    # backward compatible: every legacy invocation that passed a prompt still
+    # parses identically. Nothing else may change shape.
+    RELAXED_TO_OPTIONAL = {("exec", "POS:command"): {"required": False, "nargs": "?"}}
+
     problems: list[str] = []
     for command, options in golden.items():
         if command not in current:
@@ -1470,7 +1480,10 @@ def test_golden_legacy_parser_surface() -> None:
                 if removed:
                     problems.append(f"{command}: {key} lost choices: {sorted(removed)}")
                 continue
+            allowed = RELAXED_TO_OPTIONAL.get((command, key), {})
             for field in ("dest", "default", "required", "nargs"):
+                if field in allowed and now[field] == allowed[field]:
+                    continue
                 if now[field] != spec[field]:
                     problems.append(
                         f"{command}: {key} {field} changed: " f"{spec[field]!r} -> {now[field]!r}"
@@ -1535,12 +1548,17 @@ def test_resume_survives_in_front_of_the_subcommand() -> None:
 
     # And the bare form still means "the most recent". It has to come last: with
     # `nargs="?"` a following word IS the id, so `--resume hi` names a session
-    # called `hi` and leaves exec without a prompt. That exits 2 with a usage
-    # message rather than doing something surprising, which is the acceptable end
-    # of an ambiguity argparse cannot resolve for us.
+    # called `hi` and leaves exec without a prompt.
     assert parser.parse_args(["exec", "hi", "--resume"]).resume == cli.RESUME_LATEST
-    with pytest.raises(SystemExit):
-        parser.parse_args(["exec", "--resume", "hi"])
+
+    # That case USED to exit 2, because `command` was a required positional.
+    # `exec` now supports loop-only and piped-stdin runs, so the positional is
+    # optional and argparse can no longer reject it at parse time. The ambiguity
+    # is unchanged and still resolved the same way (`hi` is the session id, not
+    # the prompt); only the layer that reports it moved, to `run_exec`, which
+    # names how to supply a prompt instead of printing a bare usage block.
+    ambiguous = parser.parse_args(["exec", "--resume", "hi"])
+    assert ambiguous.resume == "hi" and ambiguous.command is None
 
 
 def test_a_background_job_carries_the_session_it_was_told_to_resume() -> None:

--- a/tests/unit/test_cli_new.py
+++ b/tests/unit/test_cli_new.py
@@ -1572,8 +1572,9 @@ def test_a_background_job_carries_the_session_it_was_told_to_resume() -> None:
     from local_operator.exec_worker import build_parser
 
     argv = build_worker_argv("hi", ExecArgs(resume="sess-abc123"))
-    assert "--resume" in argv
-    assert argv[argv.index("--resume") + 1] == "sess-abc123"
+    # `--resume=<id>` as one item: every value-carrying option uses the `=`
+    # form so a value beginning with `-` cannot be read as the next option.
+    assert "--resume=sess-abc123" in argv
 
     # And the worker on the other side accepts what was serialized — parsed from
     # the real argv minus the `python [flags] -m <module>` prefix, so the test
@@ -1584,7 +1585,7 @@ def test_a_background_job_carries_the_session_it_was_told_to_resume() -> None:
     assert build_parser().parse_args(argv[argv.index("-m") + 2 :]).resume == "sess-abc123"
 
     # Nothing is emitted when nothing was asked for.
-    assert "--resume" not in build_worker_argv("hi", ExecArgs())
+    assert not any(a.startswith("--resume") for a in build_worker_argv("hi", ExecArgs()))
 
 
 def test_a_bare_resume_classifies_sessions_before_resolving_latest(tmp_path, monkeypatch) -> None:

--- a/tests/unit/test_exec_mode.py
+++ b/tests/unit/test_exec_mode.py
@@ -341,44 +341,31 @@ def test_build_worker_argv_threads_control_to_the_worker() -> None:
 # --- exec_mode foreground -------------------------------------------------------
 
 
-def test_run_exec_starts_no_control_surface_by_default(fake_factory, monkeypatch, capsys) -> None:
-    """The default exec run stays invisible: no record, no socket, no line.
-
-    Opt-in is the whole design (`lop sessions` filters on nothing, so every
-    scripted run would otherwise become a `lop send` target), and this is the
-    pin on it.
-    """
-    started: list[bool] = []
-    monkeypatch.setattr(
-        "local_operator.session.runtime.exec_control.start_exec_control",
-        lambda *a, **k: started.append(True),
-    )
+def test_run_exec_publishes_without_replacing_default_gates(fake_factory, capsys) -> None:
+    """Discovery is universal; installing supervisor gates remains opt-in."""
     session = FakeSession([_success_script()])
+    original = object()
+    session.set_approval_handler(original)
     fake_factory(session)
     assert exec_mode.run_exec("say hello", ExecArgs()) == 0
-    assert started == []
-    assert "lop exec control" not in capsys.readouterr().err
+    assert session.approval_handler is original
+    assert "lop exec control" in capsys.readouterr().err
 
 
 def test_run_exec_control_prints_the_endpoint_on_stderr(fake_factory, monkeypatch, capsys) -> None:
     """stdout is the payload stream; chrome that lands in it corrupts the only
     output the run has."""
 
-    class _Control:
-        endpoint_line = "lop exec control: session_id=x pid=1 port=2 record=/r"
-
-        async def aclose(self) -> None:
-            closed.append(True)
+    from local_operator.session.runtime.exec_control import ExecControl
 
     closed: list[bool] = []
+    original_close = ExecControl.aclose
 
-    async def fake_start(session, *, enabled, cwd, yolo=False):  # noqa: ANN001
-        assert enabled is True
-        return _Control()
+    async def close(control):
+        closed.append(True)
+        await original_close(control)
 
-    monkeypatch.setattr(
-        "local_operator.session.runtime.exec_control.maybe_start_exec_control", fake_start
-    )
+    monkeypatch.setattr(ExecControl, "aclose", close)
     session = FakeSession([_success_script()])
     fake_factory(session)
     assert exec_mode.run_exec("say hello", ExecArgs(control=True)) == 0
@@ -397,18 +384,15 @@ def test_run_exec_control_closes_before_the_session_is_disposed(fake_factory, mo
     """
     order: list[str] = []
 
-    class _Control:
-        endpoint_line = "endpoint"
+    from local_operator.session.runtime.exec_control import ExecControl
 
-        async def aclose(self) -> None:
-            order.append("control-closed")
+    original_close = ExecControl.aclose
 
-    async def fake_start(session, *, enabled, cwd, yolo=False):  # noqa: ANN001
-        return _Control()
+    async def close(control):
+        order.append("control-closed")
+        await original_close(control)
 
-    monkeypatch.setattr(
-        "local_operator.session.runtime.exec_control.maybe_start_exec_control", fake_start
-    )
+    monkeypatch.setattr(ExecControl, "aclose", close)
     session = FakeSession([_success_script()])
     original_dispose = session.dispose
 
@@ -511,6 +495,9 @@ def test_run_exec_prompt_raising_exits_one(fake_factory, capsys) -> None:
     fake_factory(RaisingSession([]))
     code = exec_mode.run_exec("explode", ExecArgs())
     assert code == 1
+    # A RAISING turn emits no error event, so the renderer has nothing to
+    # print: the owner queue's recorded reason is the only diagnosis, and it
+    # must reach stderr rather than being swallowed into a log.
     assert "turn blew up" in capsys.readouterr().err
 
 
@@ -748,6 +735,7 @@ def test_run_exec_background_spawn(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
     popen_mock = MagicMock()
     popen_mock.return_value.pid = 4321
     monkeypatch.setattr("local_operator.exec_mode.subprocess.Popen", popen_mock)
+    monkeypatch.setattr(exec_mode, "_process_generation", lambda pid: None)
 
     code = exec_mode.run_exec(
         "write a long report about penguins",
@@ -792,7 +780,7 @@ def test_run_exec_background_spawn(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
     # STDERR: --json and --background are independent flags, so these two
     # notices must not precede the event stream on stdout.
     out = capsys.readouterr().err
-    assert "Started background job" in out
+    assert "Background job" in out
     log_line = next(line for line in out.splitlines() if line.startswith("Log: "))
     log_path = Path(log_line.removeprefix("Log: "))
     assert log_path == logs_dir / log_path.name
@@ -836,6 +824,7 @@ def test_spawn_background_unconfigured_hosting_returns_one(
     )
     popen_mock = MagicMock()
     monkeypatch.setattr("local_operator.exec_mode.subprocess.Popen", popen_mock)
+    monkeypatch.setattr(exec_mode, "_process_generation", lambda pid: None)
 
     code = exec_mode.run_exec("do a thing", ExecArgs(background=True))
 
@@ -864,6 +853,7 @@ def test_logs_dir_and_log_file_permissions(monkeypatch, tmp_path: Path) -> None:
     popen_mock = MagicMock()
     popen_mock.return_value.pid = 1
     monkeypatch.setattr("local_operator.exec_mode.subprocess.Popen", popen_mock)
+    monkeypatch.setattr(exec_mode, "_process_generation", lambda pid: None)
 
     assert exec_mode.run_exec("perm task", ExecArgs(background=True)) == 0
     assert (logs_dir.stat().st_mode & 0o777) == 0o700
@@ -885,6 +875,7 @@ def test_background_preflight_blocks_spawn(
     monkeypatch.setattr(exec_mode, "resolve_hosting_model_dry", broken)
     popen_mock = MagicMock()
     monkeypatch.setattr("local_operator.exec_mode.subprocess.Popen", popen_mock)
+    monkeypatch.setattr(exec_mode, "_process_generation", lambda pid: None)
 
     code = exec_mode.run_exec("doomed", ExecArgs(background=True))
     assert code != 0
@@ -987,9 +978,10 @@ def test_exec_worker_sigterm_yields_130(tmp_path: Path) -> None:
         "import asyncio\n"
         "import local_operator.exec_worker as ew\n"
         "from local_operator.exec_worker import EXIT_INTERRUPTED\n"
-        "class Slow:\n"
+        "from tests.unit.test_exec_mode import FakeSession\n"
+        "class Slow(FakeSession):\n"
         "    def __init__(self):\n"
-        "        self.disposed = False\n"
+        "        super().__init__([])\n"
         "        self._abort = asyncio.Event()\n"
         "    def subscribe(self, handler):\n"
         "        return lambda: None\n"
@@ -1011,7 +1003,9 @@ def test_exec_worker_sigterm_yields_130(tmp_path: Path) -> None:
         "import sys\n"
         "sys.exit(code)\n"
     )
-    env = dict(_os.environ)
+    env = {key: value for key, value in _os.environ.items() if not key.startswith("CMUX_")}
+    env["HOME"] = str(tmp_path / "home")
+    env["LOCAL_OPERATOR_CONFIG_DIR"] = str(tmp_path / "config")
     env["PYTHONPATH"] = str(repo_root) + _os.pathsep + env.get("PYTHONPATH", "")
     proc = sp.Popen(
         [sys.executable, "-c", script],
@@ -1231,6 +1225,7 @@ def test_background_logs_and_ledger_follow_the_config_dir_override(
     popen_mock = MagicMock()
     popen_mock.return_value.pid = 5150
     monkeypatch.setattr("local_operator.exec_mode.subprocess.Popen", popen_mock)
+    monkeypatch.setattr(exec_mode, "_process_generation", lambda pid: None)
 
     assert exec_mode.run_exec("isolated background task", ExecArgs(background=True)) == 0
 

--- a/tests/unit/test_exec_mode.py
+++ b/tests/unit/test_exec_mode.py
@@ -280,7 +280,12 @@ def test_build_worker_argv_roundtrip() -> None:
     # without it a background exec started inside a checkout of this project
     # runs that checkout (see local_operator.interpreter).
     assert argv[:4] == [sys.executable, "-P", "-m", "local_operator.exec_worker"]
-    assert argv[4:6] == ["--prompt", "do it"]
+    # `--opt=value`, never two argv items: a value that begins with `-` (a name
+    # like `-nightly`, a goal phrased `-- verify everything`) would otherwise
+    # read as the next OPTION and kill the worker at parse_args, before
+    # `--job-id` is honoured — so no terminal ledger row, and reconciliation
+    # mislabels a run that never started as `interrupted`.
+    assert argv[4] == "--prompt=do it"
     # Every set flag serializes; parse it back through the worker parser.
     parsed = exec_worker.build_parser().parse_args(argv[argv.index("-m") + 2 :])
     assert parsed.prompt == "do it"
@@ -349,7 +354,10 @@ def test_run_exec_publishes_without_replacing_default_gates(fake_factory, capsys
     fake_factory(session)
     assert exec_mode.run_exec("say hello", ExecArgs()) == 0
     assert session.approval_handler is original
-    assert "lop exec control" in capsys.readouterr().err
+    # `session:`, not `control:` — discovery is published for every run now, so
+    # the noun has to report the MODE. Printing the name of the flag the user
+    # did not pass told them the supervised gate was installed; it is not.
+    assert "lop exec session" in capsys.readouterr().err
 
 
 def test_run_exec_control_prints_the_endpoint_on_stderr(fake_factory, monkeypatch, capsys) -> None:
@@ -765,14 +773,15 @@ def test_run_exec_background_spawn(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
     # index error rather than naming the cause. Deriving it means another
     # interpreter flag later cannot silently reintroduce that.
     assert argv[1] == SAFE_PATH_FLAG
-    assert argv[argv.index("-m") :][:4] == [
+    assert argv[argv.index("-m") :][:3] == [
         "-m",
         "local_operator.exec_worker",
-        "--prompt",
-        "write a long report about penguins",
+        "--prompt=write a long report about penguins",
     ]
     assert "--json" in argv and "--yolo" in argv
-    assert "--job-id" in argv  # CL-09 terminal-record wiring
+    # `--job-id=<id>`, one item: see build_worker_argv on why every
+    # value-carrying option uses the `=` form.
+    assert any(a.startswith("--job-id=") for a in argv)  # CL-09 terminal-record wiring
     if sys.platform != "win32":
         assert kwargs.get("start_new_session") is True
 

--- a/tests/unit/test_exec_startup.py
+++ b/tests/unit/test_exec_startup.py
@@ -88,16 +88,76 @@ def test_startup_roundtrip_worker_arguments():
         control=True,
     )
     argv = build_worker_argv("literal /team nope", args)
-    parsed = build_parser().parse_args(argv[argv.index("--prompt") :])
+    worker_argv = argv[argv.index("local_operator.exec_worker") + 1 :]
+    parsed = build_parser().parse_args(worker_argv)
     for key in ("team", "profile", "goal", "loop", "name", "effort", "control"):
         assert getattr(parsed, key) == getattr(args, key)
     assert parsed.prompt == "literal /team nope"
+
+
+def test_dash_leading_startup_values_survive_the_worker_argv_hop():
+    """Every value-carrying option must use the ``--opt=value`` form.
+
+    Forwarded as two argv items, a value beginning with ``-`` reads as the next
+    OPTION and the worker dies at ``parse_args`` — before ``--job-id`` is
+    honoured, so no terminal ledger row is written and the run is durably
+    mislabelled ``interrupted``. The free-text options this feature adds are
+    exactly the ones a user is likely to lead with a dash.
+    """
+    from local_operator.exec_worker import build_parser
+
+    args = ExecArgs(
+        team="-team",
+        profile="-role",
+        goal="-- verify every criterion",
+        name="-nightly",
+        effort="-high",
+        agent_name="-agent",
+        agent_id="-id",
+        hosting="-host",
+        model="-model",
+        resume="-sess",
+    )
+    argv = build_worker_argv("-- do the thing", args)
+    worker_argv = argv[argv.index("local_operator.exec_worker") + 1 :]
+    parsed = build_parser().parse_args(worker_argv)
+    assert parsed.prompt == "-- do the thing"
+    assert parsed.goal == "-- verify every criterion"
+    assert parsed.name == "-nightly"
+    assert (parsed.team, parsed.profile, parsed.effort) == ("-team", "-role", "-high")
+    assert (parsed.agent, parsed.agent_id) == ("-agent", "-id")
+    assert (parsed.hosting, parsed.model, parsed.resume) == ("-host", "-model", "-sess")
 
 
 def test_stdin_forms_preserve_literal_text():
     assert resolve_prompt(None, stdin_text="/team literal\n") == "/team literal"
     assert resolve_prompt("-", stdin_text="/team literal\n") == "/team literal"
     assert resolve_prompt("/team literal", stdin_text="ignored") == "/team literal"
+
+
+def test_loop_only_run_never_reads_an_inherited_stdin(monkeypatch):
+    """A loop-only run has DECLARED it has no prompt, so it must not read stdin.
+
+    Without this, an omitted positional fell through to an unbounded
+    ``sys.stdin.read()`` on any non-TTY stdin — and a pipe whose writer stays
+    open never sends EOF, so the documented ``exec --goal X --loop N`` hung
+    forever under any supervisor that hands its child an inherited pipe.
+    """
+    import sys as _sys
+
+    class _NeverEnds:
+        """Any read is the bug: a real inherited pipe would block here."""
+
+        def isatty(self):
+            return False
+
+        def read(self):
+            raise AssertionError("read a stdin that a loop-only run must not touch")
+
+    monkeypatch.setattr(_sys, "stdin", _NeverEnds())
+    assert resolve_prompt(None, has_loop=True) == ""
+    # An explicit `-` is the user ASKING for stdin, so it must still read.
+    assert resolve_prompt("-", stdin_text="piped") == "piped"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_exec_startup.py
+++ b/tests/unit/test_exec_startup.py
@@ -1,0 +1,159 @@
+"""Bounded startup adapters retain actual team/profile and loop semantics."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from local_operator.exec_mode import (
+    ExecArgs,
+    build_worker_argv,
+    job_status,
+    resolve_prompt,
+)
+from local_operator.exec_startup import apply_startup, resolve_startup
+from local_operator.session.goal_loop import GoalLoop
+from local_operator.teams import TeamEditFields, TeamMember, TeamRegistry
+
+
+@pytest.fixture(autouse=True)
+def isolated(tmp_path, monkeypatch):
+    import os
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    for key in list(os.environ):
+        if key.startswith("CMUX_"):
+            monkeypatch.delenv(key)
+
+
+def test_real_team_preflight_and_attachment(tmp_path):
+    team = TeamRegistry(tmp_path / "config").create_team(
+        TeamEditFields(
+            name="release",
+            manager="manager",
+            members=[TeamMember(role="coder")],
+            instructions="review first",
+            project="headless work",
+        )
+    )
+    args = ExecArgs(team="release", profile="reviewer", goal="clear", name="Audit")
+    resolved = resolve_startup(args)
+    assert resolved.id == team.id
+    session = Mock()
+    apply_startup(session, args, resolved)
+    session.attach_team.assert_called_once_with(resolved)
+    session.attach_agent_profile.assert_called_once_with("reviewer")
+    session.set_goal.assert_called_once_with("clear")
+    session.set_conversation_name.assert_called_once_with("Audit")
+
+
+@pytest.mark.parametrize(
+    "args,message",
+    [
+        (ExecArgs(team="missing"), "No team"),
+        (ExecArgs(profile="missing"), "No role"),
+        (ExecArgs(agent_name="a", agent_id="b"), "mutually exclusive"),
+        (ExecArgs(loop=0), "between"),
+        (ExecArgs(loop=26), "between"),
+        (ExecArgs(loop=1, loop_goal="g"), "mutually exclusive"),
+        (ExecArgs(goal="g", clear_goal=True), "mutually exclusive"),
+        (ExecArgs(loop_goal="  "), "must not be empty"),
+    ],
+)
+def test_preflight_invalid(args, message):
+    with pytest.raises(ValueError, match=message):
+        resolve_startup(args)
+
+
+def test_clear_and_resumed_goal_validation():
+    session = SimpleNamespace(goal="", set_goal=Mock())
+    apply_startup(session, ExecArgs(clear_goal=True), None)
+    session.set_goal.assert_called_once_with("")
+    with pytest.raises(ValueError, match="standing goal"):
+        apply_startup(session, ExecArgs(loop=1), None)
+
+
+def test_startup_roundtrip_worker_arguments():
+    from local_operator.exec_worker import build_parser
+
+    args = ExecArgs(
+        team="release",
+        profile="coder",
+        goal="literal",
+        loop=2,
+        name="Night shift",
+        effort="high",
+        control=True,
+    )
+    argv = build_worker_argv("literal /team nope", args)
+    parsed = build_parser().parse_args(argv[argv.index("--prompt") :])
+    for key in ("team", "profile", "goal", "loop", "name", "effort", "control"):
+        assert getattr(parsed, key) == getattr(args, key)
+    assert parsed.prompt == "literal /team nope"
+
+
+def test_stdin_forms_preserve_literal_text():
+    assert resolve_prompt(None, stdin_text="/team literal\n") == "/team literal"
+    assert resolve_prompt("-", stdin_text="/team literal\n") == "/team literal"
+    assert resolve_prompt("/team literal", stdin_text="ignored") == "/team literal"
+
+
+@pytest.mark.asyncio
+async def test_loop_literal_numeric_goal_and_restored_state_do_not_replay():
+    prompts = []
+    states = []
+
+    async def prompt(text):
+        prompts.append(text)
+
+    async def judge(text):
+        return "VERDICT: ACHIEVED\nVerified"
+
+    driver = GoalLoop(prompt, judge, lambda: None, states.append)
+    driver.state = {"status": "running", "completed": 9}
+    await asyncio.sleep(0)
+    assert prompts == []
+    driver.start("", "", goal_override="123")
+    assert driver.task is not None
+    await driver.task
+    assert len(prompts) == 1 and "123" in prompts[0]
+    assert states[-1]["status"] == "achieved"
+
+
+def test_durable_status_does_not_regress_on_late_spawn_row(monkeypatch):
+    from local_operator import exec_mode
+
+    monkeypatch.setattr(
+        exec_mode,
+        "read_job_records",
+        lambda: [
+            {"id": "j", "status": "running", "session_id": "s"},
+            {"id": "j", "status": "succeeded", "exit_code": 0},
+            {"id": "j", "status": "starting", "log_path": "/log", "finished_at": None},
+        ],
+    )
+    status = job_status("j")
+    assert status["status"] == "succeeded"
+    assert status["session_id"] == "s" and status["log_path"] == "/log"
+
+
+def test_generation_reconciliation_marks_interrupted_not_success(monkeypatch):
+    from local_operator import exec_mode
+
+    monkeypatch.setattr(
+        exec_mode,
+        "read_job_records",
+        lambda: [
+            {"id": "j", "status": "running", "pid": 123, "process_generation": "old"},
+        ],
+    )
+    checked = []
+    monkeypatch.setattr(
+        "local_operator.tools.group_reaper._owner_is_dead",
+        lambda pid, generation: checked.append((pid, generation)) or True,
+    )
+    assert job_status("j")["status"] == "interrupted"
+    assert checked == [(123, "old")]
+    assert exec_mode.read_job_records()[0]["status"] == "running"


### PR DESCRIPTION
## Summary of Changes

`lop exec` could only send one prompt to an anonymous run. It now attaches a **saved team** through the real `Session.attach_team` — manager, roster, collaboration and project briefs — so a detached run and the children it delegates to see the same roster a TUI `/team` produces, and the session it owns is an **ordinary persisted session**: visible, attachable while live, and resumable cold.

**Change class: C2, standard/pre-authorized.** Additive CLI surface plus one deliberate, argued relaxation of a parser pin (see below). No dependency changes. **No version bump in this PR.**

### Delivery contract

- `--team NAME` attaches a real saved team via `attach_team`; a prompt is never rewritten into a simulated `/team`. Delegated children inherit the same roster.
- Startup is a **bounded** option set, not forwarded slash strings: `--team`, `--profile`, `--goal`/`--clear-goal`, `--loop N`/`--loop-goal`, `--name`, `--effort`. Team and profile coexist, as the persisted attachment slots already allow.
- Legacy `--agent`/`--agent-id` keep their existing record-selecting behaviour and are documented as distinct from `--profile`.
- Unknown team/profile fails **preflight** — before provider work or a worker spawn — and is re-checked in the worker, because a registry can move between the two.
- `--loop N` runs N continuation iterations after the optional initial prompt, through the existing owner-local `GoalLoop` on the owner's own queue (not a repeated `run_print_mode`, which disposes).
- Discovery is published for every run; installing the **supervisor approval gate** stays opt-in behind `--control`. Non-TTY still denies; `--yolo` remains the only explicit override.
- Execution outcomes are durable in the existing exec ledger, fenced by worker pid **and** process-start generation. `--status JOB_ID` reads it back as JSON.
- Resume shows saved loop progress but **never replays** iterations.

**Non-goals:** browser orphan/recovery (owned by #798), any new runner or ownership registry, arbitrary slash execution, configuration-mutating startup flags.

## Divergence from `/goal`

`/goal <text>` in the TUI (PR #796) sets the objective **and** submits that text as a message, so one Enter starts the work. **`--goal TEXT` deliberately does not** — it only sets the standing goal.

Exec already has a message channel: the positional prompt, `-`, or piped stdin. If `--goal` also submitted its text, `lop exec 'Do the thing' --goal 'Ship safely'` would send two messages for one invocation, and there would be no way to set a goal without spending a turn. So the goal is the objective, the prompt is the message. The `/goal` behaviour in one command is `lop exec 'X' --goal 'X'`.

Documented in three places so a reader who knows the new `/goal` cannot assume otherwise: the flag help, the `exec --help` epilog, and a `Divergence from /goal` section in `docs/EXEC.md`.

**A goal alone never starts model work:**

```
$ lop exec --goal 'Ship safely'
exec failed: no prompt. Pass one as an argument, pipe it on stdin (or '-'), or run a loop with --loop/--loop-goal
# rc=1
```

Structural, not incidental: `resolve_startup` (exec_mode.py:581) and the no-prompt refusal (:592) both precede `_spawn_background` (:598) and any session/model construction. The e2e case asserts **zero provider requests** for this path.

## Golden legacy-parser pin: one deliberate relaxation

This needs a reviewer's judgement rather than inheritance, so it is argued in full.

**(1) What the pin guarantees.** `tests/unit/golden_legacy_parser.json` snapshots every legacy option's `dest`, `default`, `required`, `nargs` and `choices` across the whole CLI. `test_golden_legacy_parser_surface` asserts additive changes are allowed but **removals or shape changes fail**. It is the guard against the rewrite silently changing how an existing invocation parses.

**(2) The allow-listed entry, and why it is a compatible relaxation.** Exactly one entry is allow-listed, recorded in the test itself (not edited into the golden data, so the reason stays visible):

```python
RELAXED_TO_OPTIONAL = {("exec", "POS:command"): {"required": False, "nargs": "?"}}
```

`exec` grew loop-only and piped-stdin forms, and argparse cannot express *"required unless `--loop`/`--loop-goal`/stdin"*. So the positional becomes `nargs="?"` and `run_exec` enforces the real rule. This is a **relaxation, not a break**: every previously-valid invocation still parses to an identical namespace. Evidence — 13 legacy invocations parsed against the baseline parser (`dea525c92`) and this one, comparing all 11 legacy fields:

```
SAME   exec do the thing                     SAME   exec do the thing --agent-id abc123
SAME   exec do the thing --json              SAME   exec do the thing --resume sess-1
SAME   exec do the thing --background        SAME   exec --resume sess-1 do the thing
SAME   exec do the thing --yolo --model gpt-4  SAME exec do the thing --hosting openai
SAME   exec do the thing --agent bob         SAME   exec do the thing --control
SAME   exec do the thing --train             SAME   exec -
SAME   exec --json do the thing

13 legacy invocations checked, 0 differ
```

**(3) What now slips past the pin that previously would not.** The prompt-less `exec` forms — plus, in the other direction, two abbreviations that the new option *names* make ambiguous (see below):

| Invocation | Baseline | This branch | Runtime disposition |
|---|---|---|---|
| `exec` | rejected (exit 2) | accepted, `command=None` | rc=1, names how to supply a prompt |
| `exec --resume hi` | rejected (exit 2) | accepted, `command=None` | rc=1, `no session 'hi' to resume` |
| `exec --goal g` | rejected (exit 2) | accepted, `command=None` | rc=1, no-prompt refusal |
| `exec --loop 2` | rejected (exit 2) | accepted, `command=None` | runs the loop (the feature) |

The cost is that argparse no longer catches a **missing prompt** at parse time for `exec`; `run_exec` does, with a better message. The pin still catches every other shape change on every other option, including all of `exec`'s own flags.

**Correction (R3): the original "precisely this and nothing else" was wrong in the other direction.** The reviewer independently diffed both parsers over 50 invocations and found **zero** silent reinterpretations — no previously-valid invocation now parses to a *different* namespace, which is the dangerous class — so the relaxation is genuinely compatible. But two invocations the baseline **accepted** now exit 2:

```
--c    base -> {'command': 'x', 'control': True}    head -> exit 2
--t    base -> {'command': 'x', 'train': True}      head -> exit 2
```

`allow_abbrev` is on by default, so `--c` uniquely resolved to `--control` and `--t` to `--train`; adding `--clear-goal` and `--team` makes both prefixes ambiguous. Reproduced here: `exec x --c` gives `base=OK(control=True)` / `head=exit2`. **This is caused by the new option NAMES, not by the `nargs` relaxation** — the reviewer isolated it (`nargs='?'` alone keeps both working; new flags alone break both), and it is invisible to the golden pin, which snapshots per-option shape and cannot see cross-option prefix collisions. No code change: the error is loud and self-explanatory (`ambiguous option: --c could match --control, --clear-goal`), a one-letter abbreviation is not a documented interface, and nothing is silently reinterpreted. Recorded so a future reader auditing the pin is not misled into thinking the surface is bit-identical.

### The re-pinned resume-ambiguity case

`test_resume_survives_in_front_of_the_subcommand` asserted `exec --resume hi` raises `SystemExit`. With `nargs="?"` it no longer can.

- **Old rejection layer:** argparse, exit 2, `error: the following arguments are required: command`.
- **New rejection layer:** `run_exec`, exit 1, `no session 'hi' to resume`.
- **The ambiguity is unchanged** and resolved identically — `hi` is still the session id, not the prompt. Only the reporting layer moved, and the user-visible error is *more* specific than the usage block it replaced.

The test now pins the new behaviour explicitly (`ambiguous.resume == "hi" and ambiguous.command is None`) with that reasoning in a comment, rather than being deleted.

## Interfaces

**Browser scope finalizer (inert until #798 merges).** Call site is prepared and commented, with **no import and no stub** referencing the API — it is resolved by `getattr` and does nothing on a build without it.

- **Where:** `exec_session.run_session`'s `close()` teardown hook, which runs after the last event, **before** session disposal, and **before** the worker writes its terminal ledger row — satisfying "await it before publishing that outcome".
- **What:** `scope_id=session.session_id` (canonical durable id naming the session directory), `generation=session.browser_generation` (the browser resource's execution-lease generation, passed verbatim), `outcome=` the ledger's own terminal string.
- **Not** exec's `process_generation`. That is a PID start-token used to prove a recycled PID is not our worker in the exec ledger — a different question from which continuous run owns a browser scope. Settled with the browser owner.
- **All three results are non-fatal by construction**, so a reviewer can see the failure mode was designed for: the caller ignores the return, the function returns `None`, and a bare `except Exception` swallows to a debug log. `closed`, `pending` (no lease/sidecar, or bounded timeout) and `unresolved` (stale generation or scope mismatch) therefore cannot block or alter the terminal publication, which the worker writes regardless.

**Outcome correctness.** The terminal string comes from the run's own authoritative verdict rather than a second guess: `cancelled` is recorded where the `CancelledError` is actually seen, and `failed` is handed in from `run_print_mode`'s `renderer.failed` — the same value that produces the exit code — through an optional-arg `before_dispose` hook, so the browser fence and the exit code cannot disagree. (An earlier cut derived it from a `session.aborted` guess and would have reported `succeeded` for a run that failed via an error *event*; provider errors never raise into that frame.)

## Testing Details

Isolated by construction: every run redirects **both** `HOME` and `LOCAL_OPERATOR_CONFIG_DIR` and scrubs **every** `CMUX_*` variable. Only the remote model is scripted — CLI parsing, config, session construction, team attachment, runtime discovery, transcript writes, the dispatcher, delegated children and worker disposal are all production code.

**15 e2e scenarios** drive the real installed-style CLI as subprocesses against a local HTTP provider:

- Team + profile + goal + `--loop 2` + `--name`: asserts exactly 3 provider calls (1 prompt + 2 continuations), collaboration/project/manager/roster/profile sentinels present in the actual model input, then cold resume of the same transcript with attachments intact and **no iteration replay**.
- **Actual delegated child:** the model requests the real `task` tool; the child's own provider request is asserted to carry the team briefs and roster.
- Unknown team, unknown profile, goal-only: all fail with **zero provider requests**.
- Approvals: default non-TTY **denies** (no file written); `--yolo` writes; `--control` parks a gate that is answered in a **real attached TUI** (`y`/`n`), with the side effect asserted both ways.
- Lifecycle: SIGTERM→`cancelled`, SIGKILL→`interrupted`, `lop stop`→`cancelled`, provider failure→`failed` with iterations halted, each with durable status and no restart.
- **Detached worker outliving its launcher stays `running`** — reconciliation fences on the worker's own pid+generation, never on launcher exit (the "don't close a tab out from under live work" case).
- Live TUI attachment to a detached run (with and without a team), viewer detach leaving the owner running, background receipt → durable status → succeeded.

**Reproduce** (the launcher does the isolation itself):

```sh
# Isolated launcher used for every command below.
python /tmp/headless-team-validate.py pytest tests/e2e/test_exec_startup_e2e.py -m e2e -n0 -q
python /tmp/headless-team-validate.py pytest tests/unit/test_exec_startup.py tests/unit/test_exec_mode.py \
    tests/unit/test_cli_new.py tests/unit/session/runtime/test_exec_control.py -q -n0
# Rendered TUI evidence (SVG + geometry JSON) into a directory:
EXEC_EVIDENCE_DIR=/tmp/headless-team-evidence python /tmp/headless-team-validate.py \
    pytest tests/e2e/test_exec_startup_e2e.py -m e2e -n0 -q
lop exec --help          # every flag, examples, and the precedence epilog
```

### Validation gates (run over the whole tree, exactly as CI)

```
flake8 .                                    OK
black --check .                             1082 files unchanged
isort --check .                             OK
pyright .                                   0 errors, 0 warnings
pytest tests/unit                           16344 passed, 18 skipped (13:47)
pytest tests/e2e -m e2e -n0                 15 passed
```

## Screenshots

Rendered and **viewed** (not just exported), with before/after against the untouched baseline `dea525c92`, captured through the real `OperatorApp` so the stylesheet applies.

- **Baseline vs after, live attachment to a detached run:** the status band gains the `⊞ release` team segment and the `--name` title ("Headless audit" vs the raw prompt) — exactly the visible surface this adds. **Geometry identical** in both (`Region(x=1, y=1, width=108, height=27)`, virtual `106x25`), so nothing reflowed.
- **Consecutive frames** (first vs settled) captured for each case; no motion.
- **Supervised approval gate** parked in the attached TUI for a detached `--control` worker, and the settled frame after answering — the allow and deny paths.

Local artifacts for the design/UX reviewers: `/tmp/headless-team-evidence/{baseline-dea525c92,before-no-team,after-team}-{first,settled}.png`, `supervised-{allow,deny}-{pending,settled}.png`, and `*-geometry.json`. Generated evidence is not committed.

**Attachment limitation:** the browser tooling here exposes no file-upload mechanism and no evidence host was available, so images are referenced by local path rather than embedded. Stated explicitly rather than presenting local paths as if they were uploads.

## Isolation incident (disclosed in full)

While verifying the goal-alone refusal I ran `run_exec` **in-process without redirecting `HOME`/`LOCAL_OPERATOR_CONFIG_DIR`**. The `--goal X` case refused harmlessly, but a second case I should not have included (`--goal X --loop 1`) passed the prompt check and **started a real agent loop against the operator's live configuration** for ~180s until a tool timeout killed it. A reviewer should know this happened while reading the isolation claims above.

**Cost:** provider tokens, plus one stray session in the live config — `~/.local-operator/sessions/85cb2d1d214b` (attachment `{"team":"","agent":"","goal":"X"}`, 72 transcript records). It persists and will appear in the operator's session list. **Left in place deliberately** — it is the operator's data directory and it is evidence; not deleted without him.

**What bounds the damage** — every tool call the runaway loop attempted was **denied**, because there was no TTY to answer, which is the non-TTY deny default this PR preserves: `bash`, `eval`, and an `edit` it tried against `docs/EXEC.md`. That is why the tree is clean. Verified, not assumed: `config.yml` mtime unchanged (00:04, before the window), no exec ledger in the live dir, no surviving process with the worktree as cwd, no file under the repo modified in the window. Read-only tools (`grep`/`glob`/`read`) did execute against the live repo.

**Rule adopted:** all verification goes through the isolation launcher or an explicitly redirected environment. No hand-rolled in-process runs, no exceptions.

## Not addressed

Two pre-existing issues found during this work, deliberately **not** fixed here to avoid expanding scope.

**1. Stale `.execution-lease.recovery` naming a live, recycled PID.** The stray session above left `{"pid":231,...}`, and PID 231 is alive — it is the operator's mobile service, which started hours *before* that file was written. **Investigated and it is not a live hazard**, with proof rather than assertion:

- That pid is **write-only**. `RECOVERY_LOCK_NAME` appears only at its definition (`session_lease.py:21`), its single use as a lock path (`:87`), and a retention test. Nothing parses the file for a pid; authority is the kernel `flock`, which the OS releases on process death (`:113-118`: *"Metadata is diagnostic only… so a surviving file is never mistaken for authority"*).
- The real lease **is** generation-fenced and fails closed: takeover requires the exact `(generation, pid)` pair unchanged **and** the pid provably dead, re-read under the lock (`:224-250`, `:174-188`); uncertainty never permits theft (`:38`).
- Demonstrated with a synthetic recycled-PID collision: `acquire_session_lease` refused (`already open in pid …`), `reap_proven_dead_session_claim` returned `False`, the lease stayed intact, and writing a garbage pid into the recovery file changed nothing.

For **@peer 13068 / #798**: the useful note is that `.execution-lease.recovery` is a **lock, not a state file** — browser ownership must not key off its pid either.

**2. `/private/tmp/link.bak` breaks the eval kernel under a redirected `HOME`, and intermittently aborts subprocess CLI launches (Q1, Q3).** A stray Mach-O binary dated Jul 18 with 380 hard links, which `sys.executable` resolves through; `tests/unit/tools/test_eval_tool.py` then fails with `Library not loaded: @rpath/libpython3.12.dylib`. **Not this diff** — reproduced identically on the untouched baseline with the same redirect, and all 52 pass without it. Left alone: it is a shared-machine artifact that is not mine to delete.

QA independently root-caused the same artifact further: `link.bak` is a **hardlink to the same inode** as the uv interpreter (`st_ino` identical to `realpath(sys.executable)`), so dyld resolves `@executable_path/../lib` to a nonexistent `/private/lib/` and aborts **before any bytecode runs** — measured 26/30 aborts through that name vs 30/30 clean through the venv path. It therefore also produces an intermittent `-6` / `JSONDecodeError` in `tests/e2e` subprocess launches (QA saw `test_exec_live_tui_attachment_and_settled_frames` flake 1-in-4; runs 2–4 passed 15/15), and the two `tests/unit` failures QA saw (`test_guest_deadline`, `test_computer_input`) are the same class — neither file is in the diff, both pass in isolation, and all five CI unit shards are green on this head. Recorded here so the next agent recognises the signature instead of re-diagnosing it.

**3. `cli-sanity` CI flake under provider rate-limiting (Q2).** The job wrote `test.txt` one directory above the checkout alongside two `HTTP 429 … qwen/qwen3.7-flash is temporarily rate-limited upstream`. Both QA and I tested the regression this would imply and disproved it: driving the real CLI with a scripted provider requesting a **relative** write landed the file in the cwd, and `effective_cwd = cwd if cwd is not None else os.getcwd()` in `session_factory.create_session` is byte-identical on baseline and branch. It is the live model choosing an absolute path under rate-limiting — exactly the mode `ci.yml`'s own MODEL CHOICE comment warns about. Re-ran the single job: passes in 34s.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my changes work as intended.
- [x] All new and existing tests pass.
- [x] I have run formatting (black/isort), linting (flake8), and type checks (pyright), and they pass.
- [x] I have updated the documentation when required (`docs/EXEC.md`, README, `--help`).
- [x] Security considerations are addressed — approval gating is unchanged and explicitly preserved; publishing discovery does not weaken it.
- [ ] I have linked all related issues. (No issues created; follow-ups are in "Not addressed" per policy.)

