### PR TITLE
fix(ci): serve the live-LLM sanity jobs from a multi-provider model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -511,25 +511,45 @@ jobs:
           #
           # MODEL CHOICE: these live-LLM jobs assert that a small, cheap model
           # can still drive the agent end to end, so the model has to emit real
-          # structured tool calls rather than describe them. The previous pick
-          # (deepseek/deepseek-v4-flash-0731) regressed into printing literal
-          # `<|DSML|>tool_calls` markup as assistant TEXT, so no tool ever ran
-          # and test.txt was never written: measured 0/5 locally against this
-          # exact prompt, and it failed three consecutive CI runs on unrelated
-          # PRs while main (which had run earlier) stayed green.
+          # structured tool calls rather than describe them.
           #
-          # qwen/qwen3.7-flash measured 10/10 on the same harness and also
-          # passes the `exec --json` streaming contract. It is cheaper on input
-          # than the model it replaces ($0.03 vs $0.045 per Mtok).
+          # SERVING CAPACITY IS PART OF THE CHOICE, not just price and
+          # tool-calling. The previous pick (qwen/qwen3.7-flash) tool-called
+          # perfectly and still made this job intermittently red: OpenRouter
+          # lists exactly ONE endpoint for it (Alibaba), so when that single
+          # upstream saturates the job dies with
+          #   HTTP 429 ... Alibaba returned error: qwen/qwen3.7-flash is
+          #   temporarily rate-limited upstream
+          # and test.txt is never written. Observed on runs 34188298919 and
+          # 34184908064 (cli-sanity, main) and 34189747430 attempt 1
+          # (server-sanity, /v1/chat 500s), all of which passed on retry --
+          # which is the signature of upstream capacity, not of a defect in the
+          # PR under test. Retrying is not the fix; a model whose serving is not
+          # one shared bottleneck is.
           #
-          # If this starts failing, FIRST check whether the model is emitting
-          # tool-call markup as text -- that is a model regression, not a bug in
-          # the harness. Re-measure candidates before swapping; a model that
-          # cannot tool-call makes these jobs permanently red and teaches
-          # everyone to ignore them. Any replacement must support `tools` and
-          # be verified against both the --yolo write task and the --json
-          # streaming contract.
-          local-operator --hosting openrouter --model qwen/qwen3.7-flash exec --yolo "create a file called test.txt with the text 'hello world' in it" || exit 1
+          # openai/gpt-oss-20b is served by 14 providers on OpenRouter (9 of
+          # them tool-capable: CoreWeave, DeepInfra, Fireworks, Groq, Parasail,
+          # Darkbloom, ...), so a saturated provider degrades to another one
+          # instead of 429ing the run. Measured locally against these exact
+          # commands: 10/10 on the --yolo write task, 5/5 on the --json
+          # streaming contract, p50 4.0s (vs 7.8s for qwen), and ~$0.00034 per
+          # run at 11.1k prompt / 67 completion tokens -- cheaper per run than
+          # the model it replaces (~$0.00046) at the same $0.030/$0.130 per
+          # Mtok. Rejected: google/gemini-2.5-flash-lite (2/10 -- mid-stream
+          # finish_reason 'error'), amazon/nova-micro-v1 and openai/gpt-5-nano
+          # (both clean but fewer providers and dearer per run).
+          #
+          # If this starts failing, FIRST separate the two failure modes: a
+          # 429/5xx naming one upstream provider is capacity (re-check how many
+          # endpoints OpenRouter still lists for this model), while tool-call
+          # markup appearing as assistant TEXT is a model regression -- the
+          # shape that made deepseek/deepseek-v4-flash-0731 write nothing at
+          # 0/5. Re-measure candidates before swapping; a model that cannot
+          # tool-call makes these jobs permanently red and teaches everyone to
+          # ignore them. Any replacement must support `tools`, be served by
+          # more than one provider, and be verified against both the --yolo
+          # write task and the --json streaming contract.
+          local-operator --hosting openrouter --model openai/gpt-oss-20b exec --yolo "create a file called test.txt with the text 'hello world' in it" || exit 1
 
           # Check if file exists and contains correct text
           if [ ! -f test.txt ]; then
@@ -555,7 +575,7 @@ jobs:
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: |
-          local-operator --hosting openrouter --model qwen/qwen3.7-flash \
+          local-operator --hosting openrouter --model openai/gpt-oss-20b \
             --yolo exec --json "create a file called contract.txt containing ok" \
             > run.jsonl 2> run.err || exit 1
           python scripts/check_streaming_contract.py run.jsonl || {
@@ -569,7 +589,7 @@ jobs:
         run: |
           set +e
           env -u OPENROUTER_API_KEY local-operator --hosting openrouter \
-            --model qwen/qwen3.7-flash exec --json "hi" > err_out.jsonl 2> err_err.txt
+            --model openai/gpt-oss-20b exec --json "hi" > err_out.jsonl 2> err_err.txt
           set -e
           if [ -s err_out.jsonl ]; then
             # `|| [ -n "$line" ]`: bash read returns non-zero at EOF on an
@@ -749,7 +769,7 @@ jobs:
             -d '{
               "prompt": "create a file called test.txt with the text '\''hello world'\'' in it",
               "hosting": "openrouter",
-              "model": "qwen/qwen3.7-flash",
+              "model": "openai/gpt-oss-20b",
               "context": [],
               "options": {
                 "temperature": 0.7,


### PR DESCRIPTION
## Summary of changes

The `cli-sanity` and `server-sanity` jobs drive a real model end to end. They have been intermittently red because `qwen/qwen3.7-flash` is served by **exactly one** OpenRouter endpoint (Alibaba): when that single upstream saturates, the run dies with HTTP 429 and `test.txt` is never written — which reads like a defect in whatever PR happens to be under test. This swaps the four call sites to `openai/gpt-oss-20b`, which OpenRouter serves from **14 providers (9 tool-capable)**, so a busy provider degrades to another instead of 429ing the job.

**Change class: C1, standard/pre-authorized.** CI workflow only — no application code, no wire/API, configuration, dependency or authorization change. **Release: patch — stop the live-LLM CI sanity jobs failing on a single saturated upstream provider.** No version bump in this PR.

### Delivery contract

- All four `qwen/qwen3.7-flash` call sites move to `openai/gpt-oss-20b`: cli-sanity `--yolo` write task, `Run Streaming Contract Check` (`exec --json`), `Assert Error Paths Keep stdout Clean` (key unset), and the server-sanity `/v1/chat` POST body.
- The replacement supports `tools` and passes both gates the workflow's own rule requires: the `--yolo` write task and the `--json` streaming contract.
- The `MODEL CHOICE` comment states the operative rationale (upstream 429 saturation) instead of the superseded deepseek tool-markup story, and now requires any future replacement to be multi-provider as well as tool-capable.

**Non-goals:** retry/backoff logic in the workflow, changes to `scripts/check_streaming_contract.py`, the provider failover code paths, or the model used anywhere outside these two jobs.

## The failure being fixed

Verbatim from the job logs — the same message in all three:

```
rate limit or quota exceeded (HTTP 429): Alibaba returned error:
qwen/qwen3.7-flash is temporarily rate-limited upstream. Please retry shortly,
or add your own key to accumulate your rate limits
```

| Run | Job | Surface | Symptom |
|-----|-----|---------|---------|
| [34188298919](https://github.com/damianvtran/local-operator/actions/runs/34188298919) | `cli-sanity` (id 101943389344) | `--yolo` write task | 429 → `test.txt was not created` |
| [34184908064](https://github.com/damianvtran/local-operator/actions/runs/34184908064) | `cli-sanity` (id 101933144332) | `--yolo` write task | 429 → `test.txt was not created` |
| [34189747430](https://github.com/damianvtran/local-operator/actions/runs/34189747430) attempt 1 | `server-sanity` (id 101947674568) | `POST /v1/chat` | 429 → `RuntimeError: Agent turn failed` → `500 Internal Server Error` |

All three passed on retry with no code change, which is the signature of upstream capacity rather than a defect in the PR under test. Note for the record: the sanity jobs on run `34186963876` were **skipped**, not failed — the two real `cli-sanity` failures are the runs above.

The root cause is structural, and measurable from the OpenRouter endpoints API rather than inferred:

```sh
curl -s https://openrouter.ai/api/v1/models/qwen/qwen3.7-flash/endpoints \
  -H "Authorization: Bearer $OPENROUTER_API_KEY" | jq '[.data.endpoints[].provider_name]'
# ["Alibaba"]        <- one endpoint, so saturation has nowhere to fall back to
```

## Measurement protocol

The workflow's own rule ("Re-measure candidates before swapping … Any replacement must support `tools` and be verified against both the `--yolo` write task and the `--json` streaming contract") is binding, so every candidate was run through **the exact commands from `ci.yml`**, not a paraphrase.

Harness conditions: a throwaway cwd per run with isolated `HOME` **and** `LOCAL_OPERATOR_CONFIG_DIR` (a redirected config dir alone still reads/writes the real `~/.local-operator/cache`), every `CMUX_*` variable stripped, and the worktree's own `.venv` (verified to resolve `local_operator` from this worktree, not the parent). The key was sourced from the credential store and never placed on a command line.

```sh
# write task, 10x per candidate — ci.yml "Run CLI Sanity Test"
local-operator --hosting openrouter --model "$MODEL" \
  exec --yolo "create a file called test.txt with the text 'hello world' in it"

# streaming contract, 5x per candidate — ci.yml "Run Streaming Contract Check"
local-operator --hosting openrouter --model "$MODEL" \
  --yolo exec --json "create a file called contract.txt containing ok" > run.jsonl
python scripts/check_streaming_contract.py run.jsonl
```

### Candidate results

Candidates were re-pulled from the OpenRouter models API (428 models, 343 tool-capable and priced) rather than taken from a shortlist, then filtered for tool support and ranked by provider count as well as price.

| Model | write | contract | providers | tool-capable eps | p50 write | $/Mtok in/out | $/run |
|---|---|---|---|---|---|---|---|
| **openai/gpt-oss-20b** ✅ | **10/10** | **5/5** | **14** | **9** | **4.0s** | 0.030/0.130 | **$0.00034** |
| qwen/qwen3.7-flash (current) | 10/10 | 5/5 | 1 | 1 | 7.8s | 0.030/0.130 | $0.00045 |
| amazon/nova-micro-v1 | 10/10 | 5/5 | 2 | 2 | 4.8s | 0.035/0.140 | $0.00053 |
| openai/gpt-5-nano | 10/10 | 5/5 | 4 | 4 | 8.8s | 0.050/0.400 | $0.00075 |
| google/gemini-2.5-flash-lite | **2/10** ❌ | 3/5 ❌ | 5 | 5 | 6.8s | 0.050/0.200 | $0.00093 |

Cost is measured, not estimated: token counts come from the `usage` on `turn_end`/`agent_end` in the captured `--json` streams (SC-6), averaged over 5 runs — gpt-oss-20b at 11,140 prompt / 67 completion tokens, qwen at 14,815 / 80.

The incumbent is **not** broken on capability — it measured 10/10 and 5/5 here, exactly as when it was picked. What it cannot do is survive its single upstream being busy, and that is what the swap addresses. `google/gemini-2.5-flash-lite` was eliminated on evidence: it fails mid-stream with `provider reported a mid-stream failure (finish_reason 'error')`, unrelated to rate limits. `nova-micro-v1` and `gpt-5-nano` both pass cleanly but have fewer providers and cost more per run.

### The other two steps, on the winning candidate

`Assert Error Paths Keep stdout Clean` — run with the key unset, as CI does:

```
exec rc=1 (non-zero expected)
stdout EMPTY: PASS
stderr carries a diagnostic: PASS
  "...R_API_KEY is required for hosting platform 'openrouter' but is not configured..."
```

`server-sanity` — a real `local-operator serve` on a free port, health-polled, then the workflow's verbatim `/v1/chat` POST body, run 3 consecutive times:

```
server healthy after 2s
POST /v1/chat http=200
test.txt created with expected text: PASS      (3/3)
```

One earlier server-sanity attempt returned 500; that was diagnosed to my harness leaking a port (`[Errno 48] address already in use` — the health check hit the previous run's server), not to the model, and fixed by picking a free port per run. Recording it because the 500 shape is the same one the 429 produces, and it would be easy to misread.

## Gates

Run over the whole tree from the worktree venv, exactly as CI spells them:

| Gate | Result |
|---|---|
| `python -m flake8 .` | clean, rc=0 |
| `black --check .` (26.1.0, via uvx) | `1085 files would be left unchanged` |
| `isort --check .` (5.13.2, via uvx) | clean |
| `python -m pyright --pythonpath .venv/bin/python .` | `0 errors, 0 warnings, 0 informations` |
| `pytest tests/unit -q -n 2` | `1 failed, 16470 passed, 18 skipped` |

The single failure is `tests/unit/tui/test_logger_silence.py::test_a_failing_mcp_server_still_says_why_in_the_log`, and it is **not** from this diff, which changes one file (`.github/workflows/ci.yml`) and no Python. It passes in isolation on this branch (`5 passed`), and its assertion text shows a host artifact — a stale `/private/tmp/link.bak` and a missing `libpython3.12.dylib` — swallowing the expected message while a sibling worktree ran its own suite on a host at load ~90-168. Flagging it rather than writing it off: it is worth an independent look, but it is not attributable to this change. YAML validity was re-parsed after the edit (11 jobs, both sanity jobs present).

## Risk

Low and self-revealing. If `openai/gpt-oss-20b` were wrong for these jobs, the jobs go red immediately and visibly on the next run rather than degrading silently. The rewritten comment tells the next reader how to tell the two failure modes apart — a 429 naming one provider is capacity, tool-call markup as assistant text is a model regression — so the diagnosis does not have to be rediscovered.
