### PR TITLE
feat(tui): capture pasted credentials inline in the composer

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -211,6 +211,7 @@ from local_operator.tui.widgets.editor import (
     SHELL_PLACEHOLDER,
     ArgumentHighlightChanged,
     ArgumentQueryOpened,
+    CredentialArmChanged,
     Editor,
     EditorCopied,
     EditorCopyStale,
@@ -326,6 +327,7 @@ if TYPE_CHECKING:  # keeps the provider graph off the TUI's runtime import path
         SessionDiagnostics,
         SessionScreen,
     )
+    from local_operator.variables import CredentialStoreFailure
 
 
 #: Lead of the `/model` footer clause for a provider whose live refresh FAILED
@@ -1390,6 +1392,40 @@ PROMPT_CHEVRON = "❯"
 #: mode; using it as the marker would make the frame look like the bang
 #: was inserted into the buffer (it is consumed, not typed).
 SHELL_CHEVRON = "$"
+
+#: The composer's prompt marker while an inline credential capture is ARMED.
+#: One cell, so it fits the same 2-cell box and shifts nothing.
+#:
+#: The MASK CHARACTER, which this app already uses to stand in for one hidden
+#: character of a secret (``key_prompt.MASK_CHAR``). Reusing it is what makes
+#: the mark legible without a legend: the marker says "what you type or paste
+#: here is masked", which is exactly the state. A key glyph (``⚿``) was the
+#: first choice and was rejected on rendered evidence — it is tofu in the
+#: terminal font stack, and a mode marker that renders as a replacement box is
+#: worse than no marker at all.
+#:
+#: Shape AND colour, the same pairing bang-mode uses and for the same #385
+#: reason: hue alone is invisible under ``NO_COLOR``, on a monochrome terminal
+#: and to a colourblind reader. The bar is higher here than for bang-mode —
+#: this mode changes what a PASTE means, and a misread puts a plaintext secret
+#: in scrollback that no keystroke can recall (design round 1, D2).
+CREDENTIAL_CHEVRON = "•"
+
+#: Class the input dock carries while a capture is armed. Reads as the
+#: ``warning`` amber, one step off both the resting chevron and bang-mode's
+#: green, so three composer modes are three distinct marks.
+COMPOSER_CREDENTIAL_CLASS = "-composer-credential"
+
+#: The composer's placeholder while armed. States what the next paste will do
+#: and how to leave, in the same voice and shape as
+#: :data:`~local_operator.tui.widgets.editor.SHELL_PLACEHOLDER`.
+CREDENTIAL_PLACEHOLDER = "Paste the secret… — it is captured, not shown"
+
+#: Shown where ``/credential``'s argument rows would be while a capture is
+#: armed. The rows are suppressed there (see ``_credential_choices``), and a
+#: list that simply vanished would read as the gesture having been dropped —
+#: so the row says what the composer is waiting for instead.
+CREDENTIAL_ARMED_NOTICE = "armed — paste the secret; it is captured, never shown"
 
 #: How long after a terminal resize the floating overlay cards re-measure
 #: themselves. They are hosted in `width: auto` containers, so Textual sends
@@ -10823,6 +10859,21 @@ class OperatorApp(App[None]):
             # reasoning as the branch above, and it keeps the two causes the
             # branch can honestly name without asserting which one applies.
             text = "Couldn't attach that file. Too large, or not an image."
+        elif message.reason == "credential-blank":
+            # A paste while ARMED that carried no value. States the outcome and
+            # the one fact the operator cannot read off the screen: the arm
+            # SURVIVED, so the next paste is still captured. Without that, the
+            # frame is neither "captured" nor "failed" and the natural repair —
+            # re-typing the gesture — is a move they do not need (design round
+            # 1, D3).
+            text = "Nothing to capture — still armed for the next paste."
+        elif message.reason == "credential-sealed":
+            # ctrl+r on a credential chip. The refusal is the security property
+            # working, but a bare no-op reads as a missed keystroke because
+            # every other marker kind answers this key — so the sentence states
+            # the property and names the gesture that DOES work (design round
+            # 1, D6).
+            text = "A credential can't be expanded — backspace forgets it."
         elif message.reason == "too_large":
             # Names the payload, not the clipboard. The bound is deliberate -
             # truncating a paste is invisible damage - so the honest report is
@@ -12473,7 +12524,103 @@ class OperatorApp(App[None]):
         except NoMatches:
             return
         dock.set_class(message.active, COMPOSER_SHELL_CLASS)
-        chevron.update(SHELL_CHEVRON if message.active else PROMPT_CHEVRON)
+        # Leaving bang-mode RESTORES the armed marker rather than the resting
+        # one when a capture is still armed. The two modes are independently
+        # reachable (`!` then `/credential`, or the reverse), and a state that
+        # silently lost its glyph on the way out of another mode is the exact
+        # invisibility D2 is about — the arm would still be live and nothing
+        # would say so.
+        armed = self._editor().credential_armed()
+        if message.active:
+            chevron.update(SHELL_CHEVRON)
+        else:
+            chevron.update(CREDENTIAL_CHEVRON if armed else PROMPT_CHEVRON)
+
+    def on_credential_arm_changed(self, message: CredentialArmChanged) -> None:
+        """Follow the composer's ARMED state onto the dock class, glyph and copy.
+
+        The same three-channel treatment bang-mode gets, for a state whose
+        misread is worse: the class is the colour cue, the glyph is the
+        colour-independent one, and the placeholder says it in words for the
+        empty composer. All three flip on one message so they cannot drift.
+
+        Bang-mode's class is left to outrank this one in the stylesheet — the
+        two are mutually reachable (``!`` then ``/credential``) and Enter
+        running a command is the louder claim about the key the operator is
+        about to press.
+
+        A disarm the operator DID NOT ASK FOR gets a word. ``captured`` needs
+        none (the marker in the buffer is the receipt) and ``gone`` was them
+        deleting the token, but ``argument`` is the case where they kept typing
+        and the mode changed underneath: they typed a flag, which means they are
+        addressing the command rather than arming, and the next paste would land
+        in plaintext. That is the false negative D2 names as unrecoverable, so
+        it is the one that must never be silent.
+        """
+        try:
+            dock = self.query_one("#input-dock")
+            chevron = self.query_one("#prompt-chevron", Chrome)
+        except NoMatches:
+            return
+        editor = self._editor()
+        dock.set_class(message.active, COMPOSER_CREDENTIAL_CLASS)
+        if editor.shell_mode:
+            # Bang-mode owns the glyph while it is on; the class above still
+            # goes on so the state is not lost when the mode is left.
+            pass
+        elif message.active:
+            chevron.update(CREDENTIAL_CHEVRON)
+        else:
+            chevron.update(PROMPT_CHEVRON)
+        # The placeholder is a SHARED channel — bang-mode, the aside and the
+        # read-only subagent page each own it in their own mode — so this only
+        # writes it where the resting copy is what would otherwise be showing,
+        # and only restores what it replaced. Restoring `resting_placeholder`
+        # unconditionally would have overwritten "Ask the aside…" with
+        # "Message Local Operator…" for anyone who armed a capture inside the
+        # aside, silently relabelling a surface this change has no business
+        # touching.
+        if not editor.shell_mode:
+            if message.active and editor.placeholder == editor.resting_placeholder:
+                editor.placeholder = CREDENTIAL_PLACEHOLDER
+            elif not message.active and editor.placeholder == CREDENTIAL_PLACEHOLDER:
+                editor.placeholder = editor.resting_placeholder
+        if not message.active and message.reason == "argument":
+            self._notice(
+                "credential capture disarmed — that is an argument to "
+                "/credential, so the next paste is NOT captured",
+                "warning",
+            )
+
+    def session_credential_names(self) -> tuple[str, ...]:
+        """Names the session store already holds, for the composer's key guard.
+
+        The composer generates a name for an inline capture and must avoid one
+        already in use — a collision SILENTLY REPLACES a live credential, and
+        its own map resets on every submit, so it cannot see a credential the
+        operator handed over earlier in the session (review round 1, R3). This
+        is the read that closes that gap.
+
+        Names only, never values: a viewer or a store that cannot answer yields
+        an empty tuple, which degrades the guard to probability rather than
+        failing a capture whose secret is already out of the buffer.
+        """
+        store = getattr(self._session, "variables", None) if self._session is not None else None
+        names = getattr(store, "credential_names", None)
+        if not callable(names):
+            return ()
+        try:
+            # The store is reached duck-typed (a viewer has no `variables` at
+            # all), so the call's return is untyped here: narrowed rather than
+            # trusted, because a double returning something unexpected must
+            # degrade the guard, not raise on the submit seam.
+            reported = names()
+            if not isinstance(reported, (list, tuple, set, frozenset)):
+                return ()
+            return tuple(str(name) for name in reported)
+        except Exception:  # noqa: BLE001 — an unreadable store is an empty set
+            logger.debug("could not read stored credential names", exc_info=True)
+            return ()
 
     def on_interrupt_requested(self, message: InterruptRequested) -> None:
         """Ctrl+C from the composer — the NORMAL path, since it holds focus.
@@ -25821,8 +25968,10 @@ class OperatorApp(App[None]):
             picker.set_notice("")
             return
         if message.command in ("credential", "cred"):
-            picker.set_choices(self._credential_choices())
-            picker.set_notice("")
+            picker.set_choices(self._credential_choices(armed=editor.credential_armed()))
+            picker.set_notice(
+                CREDENTIAL_ARMED_NOTICE if editor.credential_armed() else "",
+            )
             return
         if message.command in ("team", "teams", "agent", "agents"):
             # Rows and the render-time name snapshot are one fill operation. The
@@ -25920,14 +26069,38 @@ class OperatorApp(App[None]):
             # opened. Reuse the opening fill so rows and snapshots stay paired.
             self._fill_name_argument_list(editor, message.command)
 
-    def _credential_choices(self) -> list[ArgumentChoice]:
+    def _credential_choices(self, *, armed: bool = False) -> list[ArgumentChoice]:
         """The verbs ``/credential`` offers, plus each stored key to forget.
 
         Verbs first so a user who opened the list to store something is not
         looking at a forget row. Stored keys are offered as ``--forget KEY``
         rather than the bare name: completing a stored key into the buffer
         would re-open the paste prompt for a key that is already held.
+
+        EMPTY WHILE A CAPTURE IS ARMED, which is the fix for the destructive
+        default row (design round 1, D1). The two intents are mutually
+        exclusive — "I am about to hand you a secret" and "forget the secrets I
+        already handed you" — and offering the second while the operator is
+        mid-way through the first parked them on a preselected, unconfirmed
+        ``--forget-all`` with a ghost under the caret. Two proven consequences
+        on the real app: Enter+Enter completed and ran the highlighted row and
+        wiped a live store with no confirm and no undo; Tab accepted the ghost,
+        which consumed the arming token, so the very next paste landed the
+        secret IN PLAINTEXT on screen.
+
+        Suppressing the ROWS closes both, because both keys act on a highlighted
+        row and there is now no row to act on. The notice takes their place, so
+        the list still says something rather than vanishing.
+
+        Deliberately NOT a redesign of ``--forget-all``'s own confirmation. That
+        row and this picker predate this PR and the same wipe reproduces on
+        ``main`` without any of this — the defect owned here is that a new happy
+        path routes the operator through that state, so the fix is scoped to the
+        armed state and the destructive verb is reached exactly as before by
+        typing it (``CREDENTIAL_ARGUMENT`` disarms on the leading ``-``).
         """
+        if armed:
+            return []
         choices = [
             ArgumentChoice(
                 "--forget-all",
@@ -26523,6 +26696,22 @@ class OperatorApp(App[None]):
         too — to an explicit "not stored" phrase — so the model is never handed
         a name it cannot use, which is the silent failure the viewer split in
         ``_FRONTEND_LOCAL_SLASHES`` exists to prevent.
+
+        PER CREDENTIAL, not per submit. That invariant is only true if each
+        citation reflects ITS OWN payload's outcome, and an aggregate guard
+        cannot deliver it: guarding on "did anything store" rewrote every
+        citation to the confident form whenever ONE payload landed, so a
+        message carrying a refused credential beside a stored one advertised
+        ``$LOP_SECRET_…`` for a key ``credential_env()`` does not contain
+        (review round 1 R1, QA round 1 Q1 — two independent derivations of the
+        same defect).
+
+        That mixed case is REACHABLE through shipped components: a draft spilled
+        to the sidebar's temp JSON comes back with ``value=""`` by design (the
+        encoder deliberately does not persist secrets), ``store_credential``
+        refuses a blank, and one restored credential beside one freshly pasted
+        one is exactly the shape. The docstring above asserted the invariant
+        twice while the code held it only in the all-or-nothing case.
         """
         payloads = credential_payloads(text, attachments)
         if not payloads:
@@ -26547,9 +26736,19 @@ class OperatorApp(App[None]):
             )
             return self._mark_credentials_unstored(text, attachments)
         stored: list[str] = []
+        # Keyed by the payload's OWN key, so the citation rewrite below can ask
+        # about each credential individually. A list of successes is not enough:
+        # the rewrite has to be able to say "this one did not land" for a
+        # specific marker, which is the whole of R1/Q1.
+        refused: dict[str, CredentialStoreFailure] = {}
         for payload in payloads:
             result = store.store_credential(payload.key, payload.value, "command")
             if not result.ok or result.credential is None:
+                # `empty-value` is the reachable one (a restored spilled draft
+                # carries no bytes); `empty-key` cannot happen for a generated
+                # name, but the reason is carried through rather than assumed so
+                # the model is told what actually refused.
+                refused[payload.key] = result.reason or "empty-value"
                 continue
             stored.append(result.credential.key)
             # Journalled exactly as the masked-paste flow journals, so a
@@ -26557,17 +26756,53 @@ class OperatorApp(App[None]):
             # a resume. The record names the KEY only; `journal_credential_
             # change` never sees the value.
             self._journal_credential_change(result.credential.key, replaced=bool(result.replaced))
+        if refused:
+            # THE OPERATOR HEARS IT TOO, on every refusal and not only the
+            # all-failed one. The composer has already cleared and the marker is
+            # gone, so silence here left them believing they had handed over a
+            # credential that the store refused and the model was told was
+            # missing — the one belief this feature must never create (QA round
+            # 1, Q2). Warning rather than info: it reports a gesture that did
+            # not do what it looked like it did.
+            noun = "credential" if len(refused) == 1 else "credentials"
+            self._system_notice(
+                f"{len(refused)} {noun} could not be stored "
+                f"({', '.join(sorted(refused))}); the agent has been told so. "
+                "Paste the value again after /credential to retry.",
+                "warning",
+            )
         if not stored:
-            return self._mark_credentials_unstored(text, attachments)
-        substituted = substitute_credentials(text, attachments)
+            return self._mark_credentials_unstored(text, attachments, refused)
+        substituted = substitute_credentials(text, attachments, refused)
         # SCRUB THE MAP once the store owns the value. The same attachments map
         # rides on past this point into `SessionDraft` (the accepted-draft and
         # `/reload` hand-back), the compaction hold and the aside stash — all
         # in-memory, none of which needs the bytes now that
         # `VariableStore._credentials` holds them. Emptying the payload here
         # means those seams are safe BY CONSTRUCTION rather than by an argument
-        # about which of them re-expands, and it bounds how long a secret sits
-        # in a widget's memory to the one turn it was pasted in.
+        # about which of them re-expands.
+        #
+        # WHAT THIS SCRUB DOES NOT REACH, stated exactly, because an earlier
+        # version of this comment claimed it bounded a secret's lifetime to the
+        # one turn it was pasted in and that is FALSE (review round 1, R2). It
+        # reaches every holder that shares this map OBJECT. It cannot reach a
+        # copy taken before it ran, and `Editor._navigate_history` takes one:
+        # pressing Up with an unsubmitted credential does
+        # `_draft_attachments = dict(self._attachments)`, and `PastedCredential`
+        # is frozen, so replacing the entry here cannot reach that copy. A
+        # parked session therefore holds the plaintext in
+        # `SessionDraft.history_stash_attachments` for as long as the draft is
+        # parked, across sidebar switches.
+        #
+        # That retention is DELIBERATE and it is not a leak — verified: the
+        # field is absent from `_encode_draft`'s list (`session_drafts.py`), so
+        # it never reaches disk, and nothing re-expands it into a prompt. It is
+        # the operator's own unsubmitted draft, and scrubbing it would hand them
+        # back a credential marker with no value behind it, which
+        # `store_credential` then refuses — destroying unsubmitted work to
+        # shorten the lifetime of a secret that never leaves memory. The
+        # narrower claim is the true one: this bounds what the SUBMITTED turn's
+        # downstream holders carry, not what a parked draft retains.
         #
         # The key and marker stay so a restored draft still paints its receipt.
         # A restore that re-submits finds an empty value, which
@@ -26585,15 +26820,27 @@ class OperatorApp(App[None]):
         )
         return substituted
 
-    def _mark_credentials_unstored(self, text: str, attachments: Mapping[int, Marked]) -> str:
+    def _mark_credentials_unstored(
+        self,
+        text: str,
+        attachments: Mapping[int, Marked],
+        refused: Mapping[str, CredentialStoreFailure] | None = None,
+    ) -> str:
         """Rewrite credential citations to say the value did NOT land.
 
         The honest form of the degraded path. Stripping the citation instead
         would send the operator's description of a secret with no mention that
         the secret is missing, and the agent would go looking for an env var
         nobody set.
+
+        ``refused`` names why each key was refused, when a store was present and
+        said no. Without it the phrase is the viewer case — there is no store on
+        this side at all. The distinction is the whole of QA finding Q3: the
+        sentence used to hard-code "no session store available" for both, so a
+        store that WAS present and refused an empty value told the model the
+        store was unavailable, pointing any diagnosis at the wrong subsystem.
         """
-        from local_operator.tui.widgets.editor import cite
+        from local_operator.tui.widgets.editor import cite, describe_unstored
 
         spans = [
             (span, payload)
@@ -26601,10 +26848,9 @@ class OperatorApp(App[None]):
             if isinstance(payload, PastedCredential)
             and (span := cite(text, index, payload)) is not None
         ]
-        for (start, end), _payload in sorted(spans, reverse=True):
-            text = (
-                text[:start] + "[credential NOT stored — no session store available]" + text[end:]
-            )
+        for (start, end), payload in sorted(spans, reverse=True):
+            reason = (refused or {}).get(payload.key)
+            text = text[:start] + describe_unstored(reason) + text[end:]
         return text
 
     async def _credential_store_flow(self, store: object, key: str) -> None:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -30,7 +30,7 @@ import sys
 import threading
 import time
 import uuid
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping, MutableMapping, Sequence
 from dataclasses import dataclass, replace
 from functools import partial
 from typing import (
@@ -223,13 +223,16 @@ from local_operator.tui.widgets.editor import (
     InterruptRequested,
     Marked,
     ModelQueryOpened,
+    PastedCredential,
     RecallState,
     RefreshArgumentChoices,
     ShellModeChanged,
     SkillQueryOpened,
     StopRequested,
+    credential_payloads,
     expand_pastes,
     resolve_markers,
+    substitute_credentials,
 )
 from local_operator.tui.widgets.image_block import ImageBlock
 from local_operator.tui.widgets.model_picker import ModelRow
@@ -11978,6 +11981,18 @@ class OperatorApp(App[None]):
         # screenshot pasted with no words still submits, carrying its marker.
         if not text and not message.shell:
             return
+        # INLINE CREDENTIALS, before every exit below. This is the one seam
+        # where the secret leaves the composer's map for the session store, and
+        # it has to run ahead of the aside/shell/slash branches because each of
+        # them returns: a credential captured into a draft that was then sent
+        # to `/btw` would otherwise be silently dropped, and the marker naming
+        # it would reach the model as a promise of a key nothing stored.
+        #
+        # It rewrites `text` in place, so from here down NOTHING carries a
+        # credential citation any further than the name — the transcript row,
+        # the history entry, the journal and the model all read the substituted
+        # form, and the value exists only in the store.
+        text = self._capture_inline_credentials(text, message.attachments)
         # The aside owns the composer while it is up. EVERYTHING goes to it,
         # slash-shaped lines included: the card is a MODE, its footer says so
         # (`esc close · enter ask again`) and its placeholder says so, and a
@@ -26489,6 +26504,108 @@ class OperatorApp(App[None]):
             f"{verb} {stored_key}. Injected into every bash command "
             "as an environment variable; the agent cannot read the value."
         )
+
+    def _capture_inline_credentials(self, text: str, attachments: Mapping[int, Marked]) -> str:
+        """Store every credential ``text`` cites; return the text to send on.
+
+        The submit-side half of the inline ``/credential`` gesture. The
+        composer took the secret OUT of the buffer at paste time and left a
+        ``[Credential #N, <len> chars]`` receipt; this is where the value goes
+        into the session store under its generated name and the receipt is
+        rewritten to NAME that credential for the model.
+
+        Returns ``text`` unchanged when nothing was captured, which is the
+        overwhelmingly common case and costs one dict scan.
+
+        WHY THE SUBSTITUTION HAPPENS EVEN WHEN THE STORE REFUSES: a marker left
+        in the outgoing text would tell the model a credential exists that
+        nothing holds. Every failure path below therefore rewrites the citation
+        too — to an explicit "not stored" phrase — so the model is never handed
+        a name it cannot use, which is the silent failure the viewer split in
+        ``_FRONTEND_LOCAL_SLASHES`` exists to prevent.
+        """
+        payloads = credential_payloads(text, attachments)
+        if not payloads:
+            return text
+        session = self._session
+        store = getattr(session, "variables", None)
+        if store is None or not hasattr(store, "store_credential"):
+            # A VIEWER (or a session still starting). The store that matters is
+            # the OWNER's — `credential_env()` is read by the `bash` tool in
+            # the owner's process — and this path is synchronous, on the submit
+            # seam, with no place to await the remote op. Rather than store
+            # locally (a key no tool could read: the exact leak
+            # `_FRONTEND_LOCAL_SLASHES` documents) the capture DEGRADES
+            # LOUDLY: the secret is dropped here, the operator is told, and the
+            # model is told nothing was stored. `/credential <KEY>` still
+            # routes to the owner over the dedicated op and remains the
+            # supported way to hand a secret over from a viewer.
+            self._system_notice(
+                "inline /credential needs the session that runs the tools; "
+                "use /credential <KEY> here and the secret is stored on the owner",
+                "warning",
+            )
+            return self._mark_credentials_unstored(text, attachments)
+        stored: list[str] = []
+        for payload in payloads:
+            result = store.store_credential(payload.key, payload.value, "command")
+            if not result.ok or result.credential is None:
+                continue
+            stored.append(result.credential.key)
+            # Journalled exactly as the masked-paste flow journals, so a
+            # credential handed over inline is visible to the next turn and to
+            # a resume. The record names the KEY only; `journal_credential_
+            # change` never sees the value.
+            self._journal_credential_change(result.credential.key, replaced=bool(result.replaced))
+        if not stored:
+            return self._mark_credentials_unstored(text, attachments)
+        substituted = substitute_credentials(text, attachments)
+        # SCRUB THE MAP once the store owns the value. The same attachments map
+        # rides on past this point into `SessionDraft` (the accepted-draft and
+        # `/reload` hand-back), the compaction hold and the aside stash — all
+        # in-memory, none of which needs the bytes now that
+        # `VariableStore._credentials` holds them. Emptying the payload here
+        # means those seams are safe BY CONSTRUCTION rather than by an argument
+        # about which of them re-expands, and it bounds how long a secret sits
+        # in a widget's memory to the one turn it was pasted in.
+        #
+        # The key and marker stay so a restored draft still paints its receipt.
+        # A restore that re-submits finds an empty value, which
+        # `store_credential` refuses, and the operator is told it was not
+        # stored rather than the model being promised a key twice.
+        if isinstance(attachments, MutableMapping):
+            for index, payload in list(attachments.items()):
+                if isinstance(payload, PastedCredential):
+                    attachments[index] = PastedCredential("", payload.key, payload.marker)
+        # The receipt names what the agent can now use. Plural-safe because two
+        # pastes while armed capture two credentials (see `_capture_credential`).
+        self._notice(
+            f"Stored {', '.join(stored)}. Injected into every bash command "
+            "as an environment variable; the agent cannot read the value."
+        )
+        return substituted
+
+    def _mark_credentials_unstored(self, text: str, attachments: Mapping[int, Marked]) -> str:
+        """Rewrite credential citations to say the value did NOT land.
+
+        The honest form of the degraded path. Stripping the citation instead
+        would send the operator's description of a secret with no mention that
+        the secret is missing, and the agent would go looking for an env var
+        nobody set.
+        """
+        from local_operator.tui.widgets.editor import cite
+
+        spans = [
+            (span, payload)
+            for index, payload in attachments.items()
+            if isinstance(payload, PastedCredential)
+            and (span := cite(text, index, payload)) is not None
+        ]
+        for (start, end), _payload in sorted(spans, reverse=True):
+            text = (
+                text[:start] + "[credential NOT stored — no session store available]" + text[end:]
+            )
+        return text
 
     async def _credential_store_flow(self, store: object, key: str) -> None:
         """Masked paste for ``/credential <KEY>``, then store what arrived."""

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1416,9 +1416,28 @@ CREDENTIAL_CHEVRON = "•"
 #: green, so three composer modes are three distinct marks.
 COMPOSER_CREDENTIAL_CLASS = "-composer-credential"
 
-#: The composer's placeholder while armed. States what the next paste will do
-#: and how to leave, in the same voice and shape as
+#: The composer's placeholder while armed, in the same voice and shape as
 #: :data:`~local_operator.tui.widgets.editor.SHELL_PLACEHOLDER`.
+#:
+#: IT DOES NOT RENDER, and cannot: ``Editor`` paints a placeholder only on an
+#: EMPTY buffer, while arming requires the ``/credential`` token to be IN the
+#: buffer — mutually exclusive conditions. Bang-mode's placeholder works
+#: because ``!`` is consumed out of the buffer; ``/credential`` is not, and
+#: every armed intermediate state (``/cred``, ``/credential``) is non-empty
+#: (design round 2, D8; QA round 2 measured the same).
+#:
+#: Kept, rather than deleted, because the armed STATE is what it belongs to and
+#: the swap is what keeps that state consistent with bang-mode's — including
+#: restoring whatever placeholder it replaced, which is load-bearing for the
+#: aside (see ``on_credential_arm_changed``). It would begin rendering the day
+#: an arming form leaves the buffer empty, and until then it is a state field,
+#: NOT a signalling channel.
+#:
+#: So the armed state has TWO channels an operator can actually see, not the
+#: three an earlier remediation claimed: the ``⚿`` chevron (colour-independent)
+#: and the amber ink on the token itself, plus the picker's own notice row
+#: while its list is open. Anything counting channels here must count what
+#: PAINTS — the attribute being set correctly is not the same claim.
 CREDENTIAL_PLACEHOLDER = "Paste the secret… — it is captured, not shown"
 
 #: Shown where ``/credential``'s argument rows would be while a capture is
@@ -12539,10 +12558,16 @@ class OperatorApp(App[None]):
     def on_credential_arm_changed(self, message: CredentialArmChanged) -> None:
         """Follow the composer's ARMED state onto the dock class, glyph and copy.
 
-        The same three-channel treatment bang-mode gets, for a state whose
-        misread is worse: the class is the colour cue, the glyph is the
-        colour-independent one, and the placeholder says it in words for the
-        empty composer. All three flip on one message so they cannot drift.
+        The same treatment bang-mode gets, for a state whose misread is worse:
+        the class is the colour cue, the glyph the colour-independent one, and
+        the picker's notice row says it in words while its list is open. They
+        flip on one message so they cannot drift.
+
+        The placeholder is written too, but it does NOT paint here — a
+        placeholder needs an empty buffer and arming needs the token in it (see
+        :data:`CREDENTIAL_PLACEHOLDER`, design round 2, D8). It is kept in sync
+        as state, and the restore branch below is load-bearing for the aside
+        regardless of whether anything is drawn.
 
         Bang-mode's class is left to outrank this one in the stylesheet — the
         two are mutually reachable (``!`` then ``/credential``) and Enter
@@ -12585,6 +12610,22 @@ class OperatorApp(App[None]):
                 editor.placeholder = CREDENTIAL_PLACEHOLDER
             elif not message.active and editor.placeholder == CREDENTIAL_PLACEHOLDER:
                 editor.placeholder = editor.resting_placeholder
+        # THE PICKER'S OWN ROW, when the list is open. `CREDENTIAL_ARMED_NOTICE`
+        # is written on `ArgumentQueryOpened`, which fires when the list OPENS —
+        # so a disarm that happens while it is already open never revised it,
+        # and the row went on promising "armed — paste the secret; it is
+        # captured, never shown" after the state had ended. The flag disarm is
+        # the reachable case: deleting the token closes the list and a capture
+        # replaces the buffer, but typing `-` leaves the list open, and it is
+        # exactly the disarm the operator is least likely to expect (design
+        # round 2, D7).
+        #
+        # Worse than a stale hint: it sat NEARER the caret than the transcript
+        # notice below, so the two channels contradicted each other and the row
+        # the operator was looking at was the false one — a promise that the
+        # next paste is never shown, immediately above the plaintext paste.
+        if editor.argument_command in ("credential", "cred"):
+            editor.picker.set_notice(CREDENTIAL_ARMED_NOTICE if message.active else "")
         if not message.active and message.reason == "argument":
             self._notice(
                 "credential capture disarmed — that is an argument to "

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1446,6 +1446,24 @@ CREDENTIAL_PLACEHOLDER = "Paste the secret… — it is captured, not shown"
 #: so the row says what the composer is waiting for instead.
 CREDENTIAL_ARMED_NOTICE = "armed — paste the secret; it is captured, never shown"
 
+#: Shown where those same rows would be once a capture has LANDED and the
+#: buffer still cites it (design round 3, D9). The armed notice cannot be
+#: reused: it says "paste the secret", and by this point the operator already
+#: did — a row promising the next paste is captured, next to a chip saying one
+#: already was, is the stale-hint defect D7 removed one state earlier.
+#:
+#: It names the reason the rows are gone rather than merely stating a fact, so
+#: the operator can act on it: the destructive verbs are still reachable in the
+#: same keystrokes they always were, by typing the flag.
+#:
+#: LENGTH IS A CONSTRAINT, not a preference. The picker's notice row ellipsizes
+#: at the panel width, and the measured budget at a 120-column terminal is ~82
+#: cells — a longer line drops its own TAIL, which is exactly the half that says
+#: how to reach the verbs, leaving a row that states a restriction and hides the
+#: way out of it. Kept comfortably inside that budget, and pinned by the test
+#: that asserts the whole string paints rather than a prefix of it.
+CREDENTIAL_HELD_NOTICE = "a credential is in this draft — type --forget-all to forget"
+
 #: How long after a terminal resize the floating overlay cards re-measure
 #: themselves. They are hosted in `width: auto` containers, so Textual sends
 #: them no resize event, and the dock's re-arrange lands AFTER the refresh
@@ -12624,8 +12642,22 @@ class OperatorApp(App[None]):
         # notice below, so the two channels contradicted each other and the row
         # the operator was looking at was the false one — a promise that the
         # next paste is never shown, immediately above the plaintext paste.
+        #
+        # The disarm branch falls back to the HELD notice rather than to blank
+        # (design round 3, D9): a capture disarms, and if the list is still open
+        # over a buffer that now cites the chip, the rows are suppressed for the
+        # citation instead. Blanking the row there would leave the list looking
+        # empty for no stated reason — the same "vanished, so the gesture must
+        # have been dropped" reading `CREDENTIAL_ARMED_NOTICE` exists to
+        # prevent. Rows are deliberately NOT refilled on this path: this handler
+        # only ever narrows what the list offers, so no disarm can hand back a
+        # destructive row the fill above withheld.
         if editor.argument_command in ("credential", "cred"):
-            editor.picker.set_notice(CREDENTIAL_ARMED_NOTICE if message.active else "")
+            editor.picker.set_notice(
+                CREDENTIAL_ARMED_NOTICE
+                if message.active
+                else (CREDENTIAL_HELD_NOTICE if editor.credential_cited() else "")
+            )
         if not message.active and message.reason == "argument":
             self._notice(
                 "credential capture disarmed — that is an argument to "
@@ -26009,9 +26041,16 @@ class OperatorApp(App[None]):
             picker.set_notice("")
             return
         if message.command in ("credential", "cred"):
-            picker.set_choices(self._credential_choices(armed=editor.credential_armed()))
+            # Both suppression reasons are read here, and the notice follows
+            # whichever applies. ARMED wins the notice when both are true (a
+            # second gesture armed while an earlier chip is still in the
+            # draft): the operator is mid-gesture, so what the NEXT paste does
+            # is the more urgent of the two things to say.
+            armed = editor.credential_armed()
+            cited = editor.credential_cited()
+            picker.set_choices(self._credential_choices(armed=armed, cited=cited))
             picker.set_notice(
-                CREDENTIAL_ARMED_NOTICE if editor.credential_armed() else "",
+                CREDENTIAL_ARMED_NOTICE if armed else (CREDENTIAL_HELD_NOTICE if cited else "")
             )
             return
         if message.command in ("team", "teams", "agent", "agents"):
@@ -26110,7 +26149,9 @@ class OperatorApp(App[None]):
             # opened. Reuse the opening fill so rows and snapshots stay paired.
             self._fill_name_argument_list(editor, message.command)
 
-    def _credential_choices(self, *, armed: bool = False) -> list[ArgumentChoice]:
+    def _credential_choices(
+        self, *, armed: bool = False, cited: bool = False
+    ) -> list[ArgumentChoice]:
         """The verbs ``/credential`` offers, plus each stored key to forget.
 
         Verbs first so a user who opened the list to store something is not
@@ -26129,18 +26170,40 @@ class OperatorApp(App[None]):
         which consumed the arming token, so the very next paste landed the
         secret IN PLAINTEXT on screen.
 
-        Suppressing the ROWS closes both, because both keys act on a highlighted
-        row and there is now no row to act on. The notice takes their place, so
-        the list still says something rather than vanishing.
+        EMPTY ALSO WHILE THE BUFFER CITES A CAPTURE (design round 3, D9), which
+        is the same defect one step later in the same gesture. ``armed`` covers
+        only the window BEFORE the secret arrives, and the capture itself ends
+        it — so a draft that mentions the command twice (``fix the /credential
+        command`` typed before the real gesture, which is an ordinary sentence)
+        keeps a second, now-UNARMED token in the buffer once the marker splices
+        at the first. Its argument slot is empty, so every row came back with
+        ``--forget-all`` preselected, and pure keystrokes out of the feature's
+        own post-capture output — ``end,enter,enter`` — wiped the whole store
+        INCLUDING the credential just captured, while its chip was still sitting
+        in the buffer citing it. That last part is the load-bearing half: the
+        frame then showed a chip promising a credential the store no longer
+        held, which is two rows of one screen contradicting each other.
 
-        Deliberately NOT a redesign of ``--forget-all``'s own confirmation. That
-        row and this picker predate this PR and the same wipe reproduces on
-        ``main`` without any of this — the defect owned here is that a new happy
-        path routes the operator through that state, so the fix is scoped to the
-        armed state and the destructive verb is reached exactly as before by
-        typing it (``CREDENTIAL_ARGUMENT`` disarms on the leading ``-``).
+        Why the citation and not the leftover token: splicing the marker at the
+        caret's token instead cannot fix this, because with two mentions a
+        capture consumes exactly one and the other is stray either way — it only
+        changes WHICH one is left. Moving the ARM to the caret's token was the
+        other candidate and it is worse than a no-op: ``CREDENTIAL_ARM``
+        transiently matches an earlier ``/cred`` while that sentence is still
+        being typed, so re-latching per sync migrates the arm onto a token the
+        operator never armed — exactly the R6b/R6c leak this PR closed in round
+        2. The condition that actually tracks the hazard is "this composer is
+        holding a secret the operator can see", which is what a citation means.
+
+        Still NOT a redesign of ``--forget-all``'s own confirmation. That row
+        and this picker predate this PR and the same wipe reproduces on ``main``
+        without any of this — the defect owned here is that a new happy path
+        routes the operator through that state, so the fix stays scoped to the
+        states this feature creates, and the destructive verb is reached exactly
+        as before by typing it (``CREDENTIAL_ARGUMENT`` disarms on a leading
+        ``-``, and a typed flag is the explicit act the rows are not).
         """
-        if armed:
+        if armed or cited:
             return []
         choices = [
             ArgumentChoice(

--- a/local_operator/tui/local_operator.tcss
+++ b/local_operator/tui/local_operator.tcss
@@ -551,6 +551,34 @@ ToolCard:focus, WakeBlock:focus, PeerMessageBlock:focus, .interactive-notice:foc
  * Outranks the focus brightness: the mode is the louder fact, and a
  * focused shell-mode marker that went `fg` would look identical to a
  * focused prompt on a colour-capable terminal. */
+/* An ARMED inline credential capture recolors the marker AND swaps the glyph
+ * (`❯` → `⚿`; see `OperatorApp.on_credential_arm_changed`), on exactly the
+ * reasoning the bang-mode rule above states: the glyph is the cue that survives
+ * `NO_COLOR`, a monochrome terminal and red-green colour vision deficiency, and
+ * colour is the redundant one.
+ *
+ * The bar is HIGHER here than for bang-mode, which is why the state gets a mark
+ * at all. Bang-mode's worst misread runs a command the operator can see and
+ * undo; a misread arm puts a plaintext secret on screen and in scrollback,
+ * where no keystroke can recall it. Before this rule the composer was
+ * byte-identical armed and disarmed once the picker was dismissed, so the only
+ * feedback that arming had worked was the paste itself — by which point a
+ * misread has already leaked (design round 1, D2).
+ *
+ * `warning` amber: a third distinct hue from the resting `fg`/`dim` and
+ * bang-mode's `string` green, so the three composer modes are three marks
+ * rather than two-and-a-shade. Measured on this panel's `surface`: 8.64:1 dark
+ * and 5.04:1 light, both clear of AA for the one-cell glyph.
+ *
+ * Bang-mode OUTRANKS it — declared after, same specificity — for the same
+ * reason bang-mode outranks the focus brightness: the two modes are
+ * independently reachable and "Enter runs a command" is the louder claim about
+ * the key the operator is about to press. The armed glyph is restored on the
+ * way out of bang-mode; see `on_shell_mode_changed`. */
+#input-dock.-composer-credential #prompt-chevron {
+    color: $lo-warning;
+}
+
 #input-dock.-composer-shell #prompt-chevron {
     color: $lo-string;
 }
@@ -678,6 +706,28 @@ Editor .text-area--slash-argument {
  * into an alarm colour. */
 Editor .text-area--slash-unknown {
     color: $lo-dim;
+}
+
+/* The `/credential` token that has ARMED the next paste.
+ *
+ * `warning` amber and BOLD, matching the armed chevron, so the mode states
+ * itself at both ends of the composer in one colour — the same "one mode, one
+ * hue, said twice" the focus rule uses for `fg`.
+ *
+ * Deliberately NOT `slash-command`, which is what this token used to get on a
+ * leading arm and what it must not keep getting. That class means "a recognized
+ * command that will run", and an armed token is precisely the one that will
+ * NOT run: it is consumed by the capture. Painting the two states identically
+ * is the false-negative direction of D2 — the operator reads "recognized" and
+ * still cannot tell whether the next paste is captured or lands in plaintext.
+ *
+ * It is also the only run this file paints that is NOT a leading-command rule.
+ * A MID-LINE `/credential` — the headline of the gesture — got no ink at all
+ * under `_compute_slash_runs`'s leading-command parse, leaving the one form the
+ * feature is built around as the one form with zero visual state. */
+Editor .text-area--credential-armed {
+    color: $lo-warning;
+    text-style: bold;
 }
 
 /* ── startup toast ───────────────────────────────────────────────────────

--- a/local_operator/tui/session_drafts.py
+++ b/local_operator/tui/session_drafts.py
@@ -44,12 +44,18 @@ class SessionDraftStore:
 
     @staticmethod
     def _size(draft: SessionDraft) -> int:
-        from local_operator.tui.widgets.editor import Attachment, PastedText
+        from local_operator.tui.widgets.editor import (
+            Attachment,
+            PastedCredential,
+            PastedText,
+        )
 
         size = len(draft.text.encode("utf-8")) + len((draft.aside_main_text or "").encode("utf-8"))
         for attachment in (*draft.attachments.values(), *draft.aside_main_images.values()):
             if isinstance(attachment, Attachment):
                 size += len(attachment.image.data)
+            elif isinstance(attachment, PastedCredential):
+                size += len(attachment.value.encode("utf-8"))
             elif isinstance(attachment, PastedText):
                 size += len(attachment.text.encode("utf-8"))
         if draft.aside is not None:
@@ -108,7 +114,11 @@ class SessionDraftStore:
 
     @staticmethod
     def _encode_attachments(values: dict[int, Any]) -> dict[str, Any]:
-        from local_operator.tui.widgets.editor import Attachment, PastedText
+        from local_operator.tui.widgets.editor import (
+            Attachment,
+            PastedCredential,
+            PastedText,
+        )
 
         attachments: dict[str, Any] = {}
         for index, attachment in values.items():
@@ -116,6 +126,27 @@ class SessionDraftStore:
                 attachments[str(index)] = {
                     "kind": "image",
                     "image": attachment.image.model_dump(),
+                    "marker": attachment.marker,
+                }
+            elif isinstance(attachment, PastedCredential):
+                # THE VALUE IS DELIBERATELY NOT WRITTEN. This encoder spills an
+                # unsubmitted draft to a temp JSON file when the sidebar's RAM
+                # budget is exceeded, and a session credential is
+                # memory-only-for-one-session by construction (see
+                # `VariableStore.store_credential`) — persisting it here would
+                # put a plaintext secret on disk through a caching side door
+                # that nothing about the gesture suggests.
+                #
+                # The KEY and LENGTH are kept so the restored draft still
+                # paints its marker and the operator can see what was there.
+                # The empty value is what makes the loss honest rather than
+                # silent: on submit `store_credential` refuses a blank, and
+                # `_mark_credentials_unstored` tells the model the credential
+                # was NOT stored, so the operator re-pastes instead of the
+                # agent hunting an env var nobody set.
+                attachments[str(index)] = {
+                    "kind": "credential",
+                    "key": attachment.key,
                     "marker": attachment.marker,
                 }
             elif isinstance(attachment, PastedText):
@@ -168,15 +199,23 @@ class SessionDraftStore:
 
     @staticmethod
     def _decode_attachments(values: dict[str, Any]) -> dict[int, Any]:
-        from local_operator.tui.widgets.editor import Attachment, PastedText
+        from local_operator.tui.widgets.editor import (
+            Attachment,
+            PastedCredential,
+            PastedText,
+        )
 
         attachments = {}
         for index, item in values.items():
-            attachments[int(index)] = (
-                Attachment(ImageContent.model_validate(item["image"]), item["marker"])
-                if item["kind"] == "image"
-                else PastedText(item["text"], item["marker"])
-            )
+            if item["kind"] == "image":
+                attachments[int(index)] = Attachment(
+                    ImageContent.model_validate(item["image"]), item["marker"]
+                )
+            elif item["kind"] == "credential":
+                # Value intentionally absent from the file — see the encoder.
+                attachments[int(index)] = PastedCredential("", item["key"], item["marker"])
+            else:
+                attachments[int(index)] = PastedText(item["text"], item["marker"])
         return attachments
 
     def _decode_draft(self, data: dict[str, Any]) -> SessionDraft:

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -109,6 +109,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import re
+import secrets
 import shlex
 import time
 from bisect import bisect_right
@@ -262,7 +263,17 @@ MIN_PASTE_ROWS = COMPOSER_ROWS // 2
 #: alternation would have silently made it mean "the kind" at all of them - a
 #: rewrite with no type error and no failing test until an index came back as
 #: ``'Image'``. Naming the groups makes the conversion mechanical instead.
-ATTACHMENT_MARKER = re.compile(r"\[(?P<kind>Image|Paste) #(?P<index>[1-9]\d*)(?:,[^\]\n\[]*)?\]")
+#: ``Credential`` joins the alternation rather than getting a grammar of its
+#: own: the number space is SHARED (see :func:`_marker_indices`), so a parser
+#: that could not see ``[Credential #1, 64 chars]`` would hand out ``#1`` again
+#: to the next image and bind two payloads to one citation. Everything that
+#: keys on the NUMBER — the chip, the atomic-token gate, the release rule — is
+#: payload-agnostic and therefore correct for a credential for free; the places
+#: that must differ discriminate on the PAYLOAD TYPE
+#: (:class:`PastedCredential`), never on this ``kind`` group.
+ATTACHMENT_MARKER = re.compile(
+    r"\[(?P<kind>Image|Paste|Credential) #(?P<index>[1-9]\d*)(?:,[^\]\n\[]*)?\]"
+)
 
 
 #: The IMAGE half of the grammar, for the one consumer that must keep counting
@@ -509,6 +520,112 @@ def _paste_label(payload: str) -> str:
     return f"{len(payload)} chars"
 
 
+#: The arming token, matched case-insensitively at a word boundary anywhere in
+#: the line. The ALIAS is included because ``/cred`` completes to ``credential``
+#: in the picker but a user who typed the alias and pasted without completing
+#: never went through the picker at all — and the gesture must not depend on
+#: having accepted a completion.
+#: Lookbehind rather than a consuming ``\s`` so the match STARTS at the ``/``:
+#: the span is spliced out of the buffer, and eating the separating space with
+#: it would glue the marker onto the previous word.
+CREDENTIAL_ARM = re.compile(r"(?:^|(?<=\s))/(?:credential|cred)[ \t]*$", re.IGNORECASE)
+
+#: Random-name alphabet: Crockford-ish base32 WITHOUT the letters that read as
+#: digits. The name is quoted back to the operator in a notice and may be typed
+#: into a shell by hand, so ``0/O`` and ``1/I/L`` confusions are worth the two
+#: bits of entropy they cost. 8 chars over this 32-symbol alphabet is 40 bits.
+_KEY_ALPHABET = "ABCDEFGHJKMNPQRSTVWXYZ23456789"
+
+#: Prefix from ``docs/design/secret-store.md`` §11. Env-var-shaped so the name
+#: drops straight into ``credential_env()`` injection and round-trips through
+#: ``normalize_credential_key`` unchanged — verified by test, because a name the
+#: store renormalises would advertise one key to the model and hold another.
+CREDENTIAL_KEY_PREFIX = "LOP_SECRET_"
+
+
+def generate_credential_key(taken: Iterable[str] = ()) -> str:
+    """A fresh ``LOP_SECRET_XXXXXXXX`` name, avoiding ``taken``.
+
+    The operator does not invent a name for an inline capture — that is the
+    point of the gesture — so the store does. 40 bits makes a collision
+    negligible, but ``taken`` is still consulted rather than trusted to
+    probability: a collision would SILENTLY REPLACE a live credential
+    (``store_credential`` overwrites), and a secret the operator handed over
+    ten minutes ago disappearing is not a failure mode worth a birthday-paradox
+    argument. Bounded retries, then a widened name, so this can never spin.
+
+    ``secrets`` rather than ``random``: this names a credential, and a
+    predictable name lets anything that can read the model's context guess the
+    env var to look for.
+    """
+    used = set(taken)
+    for _ in range(16):
+        candidate = CREDENTIAL_KEY_PREFIX + "".join(secrets.choice(_KEY_ALPHABET) for _ in range(8))
+        if candidate not in used:
+            return candidate
+    # Unreachable in practice (it needs 16 collisions against a set the
+    # operator would have had to fill by hand); widening rather than raising
+    # keeps a capture that has already taken the secret out of the composer
+    # from failing at the naming step.
+    return CREDENTIAL_KEY_PREFIX + "".join(secrets.choice(_KEY_ALPHABET) for _ in range(16))
+
+
+def credential_payloads(text: str, attachments: Mapping[int, Marked]) -> list[PastedCredential]:
+    """The credentials ``text`` still cites, in citation order.
+
+    The submit-side counterpart of :func:`resolve_markers`: one walk, keyed on
+    the payload type and on :func:`cite`, so "what is chipped is what is
+    stored" is the same predicate the composer paints. A marker the user
+    backspaced away is not cited, so its secret is never stored — which is the
+    same rule that drops an uncited image.
+    """
+    cited = [
+        (span[0], payload)
+        for index, payload in attachments.items()
+        if isinstance(payload, PastedCredential)
+        and (span := cite(text, index, payload)) is not None
+    ]
+    return [payload for _, payload in sorted(cited, key=lambda item: item[0])]
+
+
+def substitute_credentials(text: str, attachments: Mapping[int, Marked]) -> str:
+    """``text`` with each credential citation rewritten to NAME the credential.
+
+    The one transformation a credential marker gets on its way to the model,
+    and it is a substitution rather than an expansion: the VALUE is replaced by
+    the store key, never by the secret. ``[Credential #1, 64 chars]`` becomes
+    ``[credential LOP_SECRET_K3RQ7WZM (64 chars) — available to bash and eval as
+    $LOP_SECRET_K3RQ7WZM; its value cannot be read]``.
+
+    Why the marker is rewritten at all, when §11 of the design doc has the
+    marker text pass through unchanged: ``#1`` is a COMPOSER-local label that
+    resets every submit, so a model told only ``[Credential #1]`` learns that a
+    secret exists and has no way to USE it — it cannot name the env var, which
+    is the entire point of the session credential store. Substituting the key
+    turns the marker into the three facts the agent needs (it exists, what it
+    is called, how to reach it) while keeping the operator's own description,
+    typed around the marker, exactly where they typed it.
+
+    Spliced by :func:`cite`'s span and DESCENDING, for the same two reasons
+    :func:`expand_pastes` documents: only the app's OWN citation is rewritten
+    (a hand-typed lookalike is prose), and an ascending walk would invalidate
+    every later offset.
+    """
+    spans = [
+        (span, payload)
+        for index, payload in attachments.items()
+        if isinstance(payload, PastedCredential)
+        and (span := cite(text, index, payload)) is not None
+    ]
+    for (start, end), payload in sorted(spans, reverse=True):
+        named = (
+            f"[credential {payload.key} ({_paste_label(payload.value)}) — available to "
+            f"bash and eval as ${payload.key}; its value cannot be read]"
+        )
+        text = text[:start] + named + text[end:]
+    return text
+
+
 def strip_paste_citations(text: str, attachments: Mapping[int, Marked]) -> str:
     """``text`` with the app's own citations of collapsed pastes REMOVED.
 
@@ -525,11 +642,26 @@ def strip_paste_citations(text: str, attachments: Mapping[int, Marked]) -> str:
     Takes the trailing space the marker was issued with, so
     ``[Paste #1, 240 lines] why does this fail?`` records as
     ``why does this fail?`` rather than with a leading gap.
+
+    A CREDENTIAL citation is stripped by the same walk, and for a stronger
+    reason than the paste it shares the rule with. A recalled
+    ``[Credential #1, 64 chars]`` resolves to nothing (the map is cleared on
+    submit), so Up-arrow-Enter would send a chip-shaped string claiming a
+    secret that is not attached — the operator believes they re-sent the
+    credential and the agent is told nothing exists. Removing the citation at
+    the record seam means the recalled line reads as the description alone,
+    which is true, visible BEFORE Enter, and re-armable by typing
+    ``/credential`` and pasting again. This is the deliberate answer to the
+    "marker recalled from history" edge case: strip rather than refuse, because
+    a refusal at submit could not tell the app's own recalled marker from the
+    operator writing ABOUT one (at that seam the map is empty and the two are
+    byte-identical), and would silently eat the sentence.
     """
     spans = [
         span
         for index, pasted in attachments.items()
-        if isinstance(pasted, PastedText) and (span := cite(text, index, pasted)) is not None
+        if isinstance(pasted, (PastedText, PastedCredential))
+        and (span := cite(text, index, pasted)) is not None
     ]
     for start, end in sorted(spans, reverse=True):
         if text[end : end + 1] == " ":
@@ -605,10 +737,42 @@ class PastedText:
     marker: str
 
 
-#: One map, two payload shapes. Everything that keys on the marker NUMBER - the
-#: counter, the chip, the atomic-token gate, the release rule, the aside stash,
-#: the compaction hold, ``EditorSubmitted``, ``/reload`` - is unchanged and
-#: payload-agnostic.
+@dataclass(frozen=True)
+class PastedCredential:
+    """A SECRET captured out of the composer, and the marker citing it.
+
+    The third variant of :data:`Marked`, and deliberately a sibling of
+    :class:`PastedText` rather than a flag on it. The two differ in the one
+    property that matters most here: a ``PastedText`` payload is spliced BACK
+    into the outgoing prompt at submit, and a ``PastedCredential`` payload must
+    never be. Making that a boolean field on one dataclass would put "expand
+    me" and "never expand me" in the same type, so every seam would need a
+    predicate that reads a flag instead of a type — and a seam that forgot the
+    flag would leak the secret rather than merely mislabel a paste. As distinct
+    types the existing ``isinstance(..., PastedText)`` filters at every
+    expansion seam exclude a credential BY CONSTRUCTION.
+
+    ``key`` is the randomly generated env-var-shaped name the value is stored
+    under (see :func:`generate_credential_key`). It is not a secret — it is
+    exactly what the model is told, so it rides in the message like any other
+    marker metadata. ``value`` is the secret and must reach only
+    ``VariableStore.store_credential``.
+    """
+
+    #: The secret, verbatim. NEVER put this in a transcript row, a history
+    #: entry, a journal record, a notice, or anything the model receives.
+    value: str
+    #: The generated store key, e.g. ``LOP_SECRET_K3RQ7WZM``. Model-visible.
+    key: str
+    #: Exactly the text issued at :meth:`Editor._capture_credential`, e.g.
+    #: ``[Credential #1, 64 chars]``.
+    marker: str
+
+
+#: One map, three payload shapes. Everything that keys on the marker NUMBER -
+#: the counter, the chip, the atomic-token gate, the release rule, the aside
+#: stash, the compaction hold, ``EditorSubmitted``, ``/reload`` - is unchanged
+#: and payload-agnostic.
 #:
 #: A SECOND MAP (``_pastes: dict[int, str]``) is the trap this feature has
 #: fallen into three times over (see :class:`Attachment`, and rounds 18/19):
@@ -616,7 +780,9 @@ class PastedText:
 #: ``adopt_attachments``, the aside stash, the compaction hold and
 #: ``EditorSubmitted.attachments`` would each need a second parameter threaded
 #: through, and every one of those is a round trip an earlier round broke.
-Marked = Attachment | PastedText
+#: :class:`PastedCredential` was added HERE for the same reason, and it buys
+#: the release rule (backspacing the marker forgets the secret) at no cost.
+Marked = Attachment | PastedText | PastedCredential
 
 
 def cite(text: str, index: int, attachment: Marked) -> tuple[int, int] | None:
@@ -4393,7 +4559,47 @@ class Editor(TextArea):
         base handler cannot start while this one is suspended. The same
         sequencing is why two fast pastes cannot interleave: the pump dispatches
         one message at a time, so marker issuance stays in paste order.
+
+        THE CREDENTIAL GATE COMES FIRST, ahead of every branch below including
+        the whitespace one. It is a MODE question ("did the operator just type
+        ``/credential`` here?"), not a question about the payload, and the size
+        thresholds the other branches ask cannot answer it: a one-line API key
+        is nowhere near ``COLLAPSE_ROWS``/``MIN_PASTE_ROWS``, so asking the
+        size question first would insert the secret into the buffer verbatim
+        and the redaction would never happen at all.
+
+        No :class:`EditorPasteAttached` or :class:`EditorPasteEmpty` is posted
+        on this route. Those toasts describe IMAGE attachment ("attached" /
+        "nothing on the clipboard to attach"), and a credential capture is
+        neither; the receipt the operator needs is the marker itself, which is
+        already in the buffer where they are looking.
         """
+        arm = self._credential_arm_span()
+        if arm is not None:
+            captured = self._capture_credential(event.text)
+            if captured is not None:
+                event.prevent_default()
+                event.stop()
+                # The arming token is selected and REPLACED by the marker, so
+                # one edit does both halves of the gesture: the command word
+                # disappears and the receipt takes its place, leaving the caret
+                # past the trailing space ready for the description. Going
+                # through `replace` (not `_replace_selection`) keeps this a
+                # single undoable edit rather than a delete the operator could
+                # undo into a buffer holding the secret — which the buffer never
+                # held in the first place.
+                start, end = arm
+                self.replace(
+                    captured,
+                    self._offset_to_location(start),
+                    self._offset_to_location(end),
+                    maintain_selection_offset=False,
+                )
+                self.move_cursor(self._offset_to_location(start + len(captured)))
+                return
+            # Empty/whitespace-only while armed: fall through, so the operator
+            # gets the characters they actually copied rather than a
+            # zero-length credential. See :meth:`_capture_credential`.
         if not event.text.strip():
             # A payload with no text in it is the clipboard-image signal. The
             # clipboard is consulted, but the event is consumed ONLY if that
@@ -4803,6 +5009,13 @@ class Editor(TextArea):
         if not isinstance(pasted, PastedText):
             # An image marker, or a number that resolves to nothing. There is
             # no text to put back, and expanding an image is not a thing.
+            #
+            # A CREDENTIAL is refused by this same predicate, and that is a
+            # SECURITY property rather than a missing feature: this key is the
+            # one gesture that puts a stashed payload back into the visible
+            # buffer, and the whole point of the capture is that the secret is
+            # out of the buffer. The escape hatch for a credential pasted by
+            # mistake is backspace, which forgets it (`_release_uncited`).
             raise SkipAction()
         # Dropped BEFORE the edit. `edit()` runs `_release_uncited` over the
         # attachments this removal touches, and the entry is gone by then
@@ -4847,6 +5060,97 @@ class Editor(TextArea):
         result = self._replace_via_keyboard(pasted, *self.selection)
         if result is not None:
             self.move_cursor(result.end_location)
+
+    def _credential_arm_span(self) -> tuple[int, int] | None:
+        """Buffer offsets of the ``/credential`` token arming the next paste.
+
+        The MODE GATE for the next paste. Anchored at the caret and at the end
+        of the token, so it answers "is the operator pasting a secret RIGHT
+        HERE" rather than "does this draft mention the command anywhere" — a
+        draft that says ``fix the /credential command`` and then pastes a log
+        four words later must collapse that log as an ordinary paste.
+
+        Deliberately NOT routed through ``slash_command_for`` /
+        ``consumes_prompt``. ``consumes_prompt=True`` (``/team``, ``/agent``)
+        HOISTS the draft to the front of the line, which is the exact opposite
+        of "keep typing in place" that this gesture is specified as; and
+        ``ArgumentMode`` handles a LEADING slash command, while this token is
+        inline by construction. Per ``docs/design/secret-store.md`` §11 the
+        inline form is an editor-level concern, and the existing leading
+        ``/credential KEYNAME`` masked-paste command is untouched by it.
+
+        Trailing spaces and tabs are allowed but a newline is not: the token
+        must be on the caret's own line, otherwise a ``/credential`` used three
+        lines up would arm a paste the operator is making somewhere else
+        entirely.
+
+        A SPAN rather than a boolean because the token is CONSUMED by the
+        capture, exactly as the pasted secret is. Two reasons, and the second is
+        a correctness bug rather than a preference:
+
+        - It is an arming GESTURE, not prose. Leaving it behind would send
+          ``deploy with /credential [credential LOP_SECRET_…]`` to the model,
+          where an image paste — the style this marker is specified to match —
+          leaves no command word behind.
+        - A capture armed at the START of the line would otherwise leave the
+          submitted text beginning with ``/credential``, which
+          ``_dispatchable_slash`` routes to the masked-paste command with the
+          marker as its KEY argument. Consuming the token means the leading and
+          the mid-line gestures behave identically, and bare
+          ``/credential <KEY>`` (no paste, so no capture) still dispatches
+          exactly as it always has.
+        """
+        offset = self._caret_offset()
+        before = self.text[:offset]
+        line_start = len(before) - len(before.rpartition("\n")[2])
+        match = CREDENTIAL_ARM.search(before[line_start:])
+        if match is None:
+            return None
+        return line_start + match.start(), offset
+
+    def _capture_credential(self, pasted: str) -> str | None:
+        """Stash ``pasted`` as a secret; return the marker to put in its place.
+
+        ``None`` when there is nothing to capture, which the caller treats as
+        "not a credential paste" and lets fall through to the ordinary
+        branches. That is the answer for an EMPTY OR WHITESPACE-ONLY paste
+        while armed: ``store_credential`` refuses a blank value anyway (a blank
+        env var is how a tool silently falls back to another credential), so
+        minting a zero-length ``[Credential #1, 0 chars]`` would advertise a key
+        to the model that can never hold anything. Falling through inserts the
+        whitespace the operator actually had on their clipboard, exactly as an
+        unarmed paste would.
+
+        A SECOND paste while still armed captures a SECOND credential, with its
+        own number and its own key. It is not a replacement: the first marker is
+        still in the buffer and still cited, so replacing its payload would make
+        a visible receipt point at bytes the operator never put behind it. Two
+        markers is also the honest reading of two pastes — the operator handing
+        over a key and a secret is an ordinary thing to do, and both reach the
+        agent named and described.
+        """
+        value = pasted.strip()
+        if not value:
+            return None
+        self._sync_next_marker()
+        index = self._next_marker
+        self._next_marker += 1
+        # `_paste_label` unchanged, so a one-line secret reads `64 chars` in the
+        # same vocabulary an image reads `1568x200` and a paste reads `240
+        # lines`. The LENGTH is the whole receipt: it is what lets the operator
+        # see the paste landed intact without seeing the value.
+        marker = f"[Credential #{index}, {_paste_label(value)}]"
+        key = generate_credential_key(
+            payload.key
+            for payload in self._attachments.values()
+            if isinstance(payload, PastedCredential)
+        )
+        self._attachments[index] = PastedCredential(value, key, marker)
+        # The trailing space is load-bearing exactly as it is for the other two
+        # marker kinds (`_delete_marker_past_spaces`, `action_expand_paste`),
+        # and here it is also what leaves the caret ready for the description
+        # the operator keeps typing inline.
+        return marker + " "
 
     async def _attach_pasted_images(self, pasted: str) -> str | None:
         """Load every path in ``pasted`` as an attachment; return the markers.

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -520,6 +520,26 @@ def _paste_label(payload: str) -> str:
     return f"{len(payload)} chars"
 
 
+def _credential_label(value: str) -> str:
+    """A credential's receipt tail: ALWAYS ``<n> chars``, never ``<n> lines``.
+
+    Deliberately NOT :func:`_paste_label`, which is the only place this feature
+    departs from the paste vocabulary, and the departure is the point. The two
+    labels answer different questions. A paste's label describes what the user
+    watched scroll off the field, and a line count is the right unit for that.
+    A credential's label is an INTEGRITY CHECK: with the value gone from the
+    buffer and ``ctrl+r`` refusing to put it back, the length is the operator's
+    only opportunity to notice that what got captured is not what they meant to
+    capture (a truncated token, the wrong clipboard).
+
+    A line count is a much weaker check than a character count for exactly the
+    payloads where truncation is hardest to spot — a PEM block or a multi-line
+    service-account key read ``27 lines`` whether or not the tail arrived, while
+    the character count moves for every lost byte (agent review round 1, R5).
+    """
+    return f"{len(value)} chars"
+
+
 #: The arming token, matched case-insensitively at a word boundary anywhere in
 #: the line. The ALIAS is included because ``/cred`` completes to ``credential``
 #: in the picker but a user who typed the alias and pasted without completing
@@ -530,10 +550,43 @@ def _paste_label(payload: str) -> str:
 #: it would glue the marker onto the previous word.
 CREDENTIAL_ARM = re.compile(r"(?:^|(?<=\s))/(?:credential|cred)[ \t]*$", re.IGNORECASE)
 
+#: The same token WITHOUT the end-of-line anchor, used to RE-LOCATE a token
+#: that has already armed. Arming itself still asks :data:`CREDENTIAL_ARM`, so
+#: ``fix the /credential command`` typed as prose never arms; this one only
+#: answers "where did the token I already armed on move to" after the operator
+#: kept typing (design round 1, D2).
+#:
+#: The negative lookahead is the same partition ``CREDENTIAL_ARM``'s ``[ \t]*$``
+#: draws: ``/credential`` and ``/cred`` are the token, ``/credentials`` is not.
+CREDENTIAL_TOKEN = re.compile(r"(?:^|(?<=\s))/(?:credential|cred)(?!\S)", re.IGNORECASE)
+
+#: What DISARMS a latched capture: a flag-shaped argument on the token's own
+#: line. Nothing else does — see :meth:`Editor._sync_credential_arm`.
+#:
+#: The arm has to survive ordinary typing, because the failure it prevents is
+#: ASYMMETRIC: a false negative ("I thought I was armed") puts the secret on
+#: screen and in scrollback and cannot be undone, while a false positive costs
+#: one backspace. Under the original end-of-line rule a newline or one more
+#: typed word silently disarmed and the next paste landed in plaintext, with
+#: nothing on screen having changed (design round 1, D2 — reproduced on the
+#: real app in both forms).
+#:
+#: A LEADING ``-`` is the one continuation that is unambiguously the COMMAND
+#: rather than a description, and it is unambiguous by construction: the
+#: credential verbs are flag-shaped (``--forget``, ``--forget-all``) precisely
+#: so they can never collide with a key, because keys normalize to
+#: ``[A-Z0-9_]`` and cannot begin with ``-`` (see ``variables.py``). So the
+#: operator who wants the destructive verb still reaches it by typing it, and
+#: the operator writing ``deploy with /credential the prod key`` stays armed.
+CREDENTIAL_ARGUMENT = re.compile(r"[ \t]+-", re.IGNORECASE)
+
 #: Random-name alphabet: Crockford-ish base32 WITHOUT the letters that read as
 #: digits. The name is quoted back to the operator in a notice and may be typed
-#: into a shell by hand, so ``0/O`` and ``1/I/L`` confusions are worth the two
-#: bits of entropy they cost. 8 chars over this 32-symbol alphabet is 40 bits.
+#: into a shell by hand, so ``0/O`` and ``1/I/L`` confusions are worth the
+#: entropy they cost. THIRTY symbols, not 32 — the exclusions are ``O``, ``I``,
+#: ``L``, ``U``, ``0`` and ``1`` against base32's own 32 — so 8 characters is
+#: **39.3 bits**, not the 40 an earlier comment claimed by counting the
+#: alphabet it described rather than the one it defines (review round 1, R3).
 _KEY_ALPHABET = "ABCDEFGHJKMNPQRSTVWXYZ23456789"
 
 #: Prefix from ``docs/design/secret-store.md`` §11. Env-var-shaped so the name
@@ -547,12 +600,21 @@ def generate_credential_key(taken: Iterable[str] = ()) -> str:
     """A fresh ``LOP_SECRET_XXXXXXXX`` name, avoiding ``taken``.
 
     The operator does not invent a name for an inline capture — that is the
-    point of the gesture — so the store does. 40 bits makes a collision
+    point of the gesture — so the store does. 39.3 bits makes a collision
     negligible, but ``taken`` is still consulted rather than trusted to
     probability: a collision would SILENTLY REPLACE a live credential
     (``store_credential`` overwrites), and a secret the operator handed over
     ten minutes ago disappearing is not a failure mode worth a birthday-paradox
     argument. Bounded retries, then a widened name, so this can never spin.
+
+    ``taken`` MUST include the credentials the session store already holds, not
+    only the ones this composer is carrying. The composer's map resets on every
+    submit (:meth:`Editor.clear_content`), so a set drawn from it alone cannot
+    see the credential the operator handed over ten minutes ago — which is
+    precisely the live credential this guard exists to protect. Passing only
+    the composer's own keys made the guard narrower than the argument above,
+    reducing it to the probability bet the argument declines to make (review
+    round 1, R3). :meth:`Editor._capture_credential` unions both sets.
 
     ``secrets`` rather than ``random``: this names a credential, and a
     predictable name lets anything that can read the model's context guess the
@@ -588,7 +650,42 @@ def credential_payloads(text: str, attachments: Mapping[int, Marked]) -> list[Pa
     return [payload for _, payload in sorted(cited, key=lambda item: item[0])]
 
 
-def substitute_credentials(text: str, attachments: Mapping[int, Marked]) -> str:
+def describe_unstored(reason: str | None) -> str:
+    """The citation a credential gets when its value did NOT reach the store.
+
+    ONE authority for the phrase, because two paths write it — the whole-message
+    degrade (:meth:`OperatorApp._mark_credentials_unstored`) and the
+    per-credential rewrite below — and a model reading two different sentences
+    for one outcome would have to guess whether they mean different things.
+
+    ``reason`` is ``None`` when there is no store on this side at all (a viewer,
+    or a session still starting) and a
+    :data:`~local_operator.variables.CredentialStoreFailure` when a store was
+    present and refused the write. Naming which is not cosmetic: the phrase used
+    to hard-code "no session store available" for both, so a present store
+    refusing an empty value told the model the store was unavailable and sent
+    any diagnosis after the wrong subsystem (QA round 1, Q3).
+
+    In every form the sentence states the OUTCOME the agent must act on — there
+    is no usable credential here — before it explains the cause, because an
+    agent that reads only the first clause must still not go hunting an env var
+    nobody set.
+    """
+    if reason is None:
+        return "[credential NOT stored — no session store available]"
+    if reason == "empty-key":
+        return "[credential NOT stored — the store rejected its name]"
+    # `empty-value`, the reachable one: a draft that spilled to disk comes back
+    # without its bytes by design, and the store refuses a blank rather than
+    # holding an empty env var a tool would silently fall back from.
+    return "[credential NOT stored — its value did not survive; ask the operator to paste it again]"
+
+
+def substitute_credentials(
+    text: str,
+    attachments: Mapping[int, Marked],
+    refused: Mapping[str, str] | None = None,
+) -> str:
     """``text`` with each credential citation rewritten to NAME the credential.
 
     The one transformation a credential marker gets on its way to the model,
@@ -610,6 +707,19 @@ def substitute_credentials(text: str, attachments: Mapping[int, Marked]) -> str:
     :func:`expand_pastes` documents: only the app's OWN citation is rewritten
     (a hand-typed lookalike is prose), and an ascending walk would invalidate
     every later offset.
+
+    ``refused`` maps a key to why the store would not take it. EVERY citation is
+    rewritten either way — leaving one alone would send a composer-local
+    ``[Credential #1, 52 chars]`` the model cannot use — but a refused one gets
+    :func:`describe_unstored` instead of the confident form. Taking the outcome
+    PER PAYLOAD is the fix for the defect two independent review streams found:
+    the caller used to decide once for the whole message, so one refusal among
+    several successes still advertised ``$LOP_SECRET_…`` for a key nothing held
+    (review round 1 R1, QA round 1 Q1).
+
+    Defaulted to ``None`` so the pure-success call site and every existing test
+    read unchanged — an empty map means every citation stored, which is the
+    overwhelmingly common case.
     """
     spans = [
         (span, payload)
@@ -618,10 +728,14 @@ def substitute_credentials(text: str, attachments: Mapping[int, Marked]) -> str:
         and (span := cite(text, index, payload)) is not None
     ]
     for (start, end), payload in sorted(spans, reverse=True):
-        named = (
-            f"[credential {payload.key} ({_paste_label(payload.value)}) — available to "
-            f"bash and eval as ${payload.key}; its value cannot be read]"
-        )
+        reason = (refused or {}).get(payload.key)
+        if reason is not None:
+            named = describe_unstored(reason)
+        else:
+            named = (
+                f"[credential {payload.key} ({_credential_label(payload.value)}) — available to "
+                f"bash and eval as ${payload.key}; its value cannot be read]"
+            )
         text = text[:start] + named + text[end:]
     return text
 
@@ -1132,6 +1246,18 @@ class EditorPasteEmpty(Message):
       user cannot see until they read back what they sent; named rather than
       collapsed into ``"nothing"``, because the clipboard was not empty (code
       round 2, F7).
+    * ``"credential-blank"`` — a paste made while a capture was ARMED carried
+      no value. The one reason on this message that is not about the clipboard
+      being unreadable: the payload arrived and was declined, because a
+      zero-length credential would advertise a key that can never hold
+      anything. It rides here because it is the same shape as every other
+      reason — a gesture the operator performed that produces no visible
+      response — and the notice must also say the arm SURVIVED (design round 1,
+      D3).
+    * ``"credential-sealed"`` — ``ctrl+r`` was pressed on a credential chip.
+      The refusal is a security property (that key is the one gesture that puts
+      a payload back in the visible buffer), but a silent refusal reads as a
+      missed keystroke, so it is stated (design round 1, D6).
     * ``"timeout"`` — the clipboard did not answer inside
       :data:`~local_operator.clipboard.CLIPBOARD_TIMEOUT_S`. Also not a
       statement about what was on it. Split out of ``"nothing"`` because the
@@ -1214,6 +1340,32 @@ class StopRequested(Message):
 
     def __init__(self) -> None:
         super().__init__()
+
+
+class CredentialArmChanged(Message):
+    """Posted when the composer arms (or disarms) an inline credential capture.
+
+    The armed state changes what the next PASTE means, so it owes the operator
+    the same legibility bang-mode owes them for what the next ENTER means — and
+    for a sharper reason: bang-mode's worst misread runs a command the user can
+    see, while a misread arm puts a plaintext secret in scrollback that no
+    keystroke can recall (design round 1, D2).
+
+    The editor owns the STATE (it alone sees the paste and the token) and the
+    app owns the VOICE, the same split :class:`EditorPasteEmpty` and
+    :class:`ShellModeChanged` already draw.
+
+    ``reason`` is why the arm ENDED, and is empty on the arming edge. The app
+    speaks only for a disarm the operator might not expect: ``"captured"``
+    needs no words (the marker is the receipt) and ``"gone"`` was the operator
+    deleting the token, but ``"argument"`` is the one where they typed on and
+    the mode changed under them.
+    """
+
+    def __init__(self, active: bool, *, reason: str = "") -> None:
+        super().__init__()
+        self.active = active
+        self.reason = reason
 
 
 class ShellModeChanged(Message):
@@ -1693,6 +1845,7 @@ class Editor(TextArea):
         "text-area--slash-command",  # recognized /command word
         "text-area--slash-argument",  # recognized team/agent NAME
         "text-area--slash-unknown",  # a leading /word that is NOT a command
+        "text-area--credential-armed",  # a /credential token arming a capture
     }
 
     def __init__(
@@ -1909,6 +2062,15 @@ class Editor(TextArea):
         #: the start of a question. Default on; the main chat is the only
         #: surface that runs commands.
         self._allows_shell = True
+        #: Buffer offsets of the ``/credential`` token that has ARMED the next
+        #: paste, or ``None``. Latched (see :meth:`_arm_credential`) rather
+        #: than re-derived at paste time, because an invisible rule that
+        #: silently stops matching is a safety property that silently stops
+        #: holding: under the derive-per-paste version a newline or one more
+        #: typed word disarmed with the frame unchanged, and the next paste put
+        #: the secret on screen (design round 1, D2). The app follows via
+        #: :class:`CredentialArmChanged`, exactly as it follows bang-mode.
+        self._credential_arm: tuple[int, int] | None = None
         self.set_commands(commands or [])
 
     def render_line(self, y: int) -> Strip:
@@ -2390,6 +2552,12 @@ class Editor(TextArea):
         self._attachments.clear()
         self._draft_attachments.clear()
         self._next_marker = 1
+        # The arm belongs to the text that armed it. A submit or a `/clear`
+        # takes that text away, so leaving the latch set would carry "the next
+        # paste is a secret" into a buffer the operator never typed a gesture
+        # into — the false POSITIVE direction, which costs a backspace rather
+        # than a leak, but is still a mode nothing on screen would explain.
+        self._disarm_credential("gone")
 
     def begin_model_query(self) -> None:
         """Put the buffer into the state that shows the model list.
@@ -3656,6 +3824,11 @@ class Editor(TextArea):
             self._picker.mode,
             self._picker.is_open(),
             self._picker.is_pending(),
+            # The armed span is an input to the runs now (see
+            # `_compute_slash_runs`), and it is the one input that can change
+            # while the buffer does not — so it has to be in the key or the
+            # armed ink would lag its own state by a keystroke.
+            self._credential_arm,
         )
         cached = self._slash_runs_cache
         if cached is not None and cached[0] == key:
@@ -3675,6 +3848,29 @@ class Editor(TextArea):
         be sent — EXCEPT while the command picker is still choosing (``/te``),
         where the word is a prefix in progress, not yet a typo.
         """
+        # THE ARMED TOKEN FIRST, and returned on its own, because it is not a
+        # leading-command rule and every rule below is. `/credential` typed
+        # mid-line is the headline of this gesture and got NO ink at all: the
+        # composer looked identical armed and disarmed, which is exactly what
+        # made a silent disarm unreadable (design round 1, D2).
+        #
+        # It also OUTRANKS the leading-command highlight for the same token,
+        # which is a correction rather than a preference. `text-area--slash-
+        # command` says "this is a recognized command that will run", and an
+        # ARMED token is precisely what will NOT run — it is consumed by the
+        # capture (see `_credential_arm_span`). Painting the two states
+        # identically is the false-negative direction: the operator reads
+        # "command recognized" and cannot tell whether the next paste is
+        # captured or lands in plaintext.
+        if self._credential_arm is not None:
+            start, end = self._credential_arm
+            before = self.text[:start]
+            line_index = before.count("\n")
+            line_start = len(before) - len(before.rpartition("\n")[2])
+            return (
+                line_index,
+                [(start - line_start, end - line_start, "text-area--credential-armed")],
+            )
         lines = self.text.split("\n")
         first = next((i for i, line in enumerate(lines) if line.strip()), None)
         if first is None:
@@ -4574,7 +4770,7 @@ class Editor(TextArea):
         neither; the receipt the operator needs is the marker itself, which is
         already in the buffer where they are looking.
         """
-        arm = self._credential_arm_span()
+        arm = self._credential_arm
         if arm is not None:
             captured = self._capture_credential(event.text)
             if captured is not None:
@@ -4600,6 +4796,14 @@ class Editor(TextArea):
             # Empty/whitespace-only while armed: fall through, so the operator
             # gets the characters they actually copied rather than a
             # zero-length credential. See :meth:`_capture_credential`.
+            #
+            # Falling through is still the right DECISION, but it used to be a
+            # SILENT one: the operator who fumbled the copy (took the trailing
+            # selection, not the token) saw a frame that was neither "captured"
+            # nor "failed", and nothing said the arm had survived (design round
+            # 1, D3). Posted before the fall-through so the notice describes the
+            # gesture they made rather than the whitespace that lands.
+            self.post_message(EditorPasteEmpty(reason="credential-blank"))
         if not event.text.strip():
             # A payload with no text in it is the clipboard-image signal. The
             # clipboard is consulted, but the event is consumed ONLY if that
@@ -5016,6 +5220,18 @@ class Editor(TextArea):
             # buffer, and the whole point of the capture is that the secret is
             # out of the buffer. The escape hatch for a credential pasted by
             # mistake is backspace, which forgets it (`_release_uncited`).
+            #
+            # SAID OUT LOUD, unlike the other two refusals this branch serves.
+            # A bare SkipAction leaves the frame byte-unchanged, and every other
+            # marker kind answers this key — so the operator's read is "the
+            # keystroke missed" and the natural next move is to press it again
+            # or hunt the marker with the mouse (design round 1, D6). One
+            # sentence turns a dead key into a statement of the security
+            # property AND advertises the recovery gesture. An image marker
+            # keeps the silent refusal: nothing was ever hidden there, so there
+            # is no property to state and no recovery to point at.
+            if isinstance(pasted, PastedCredential):
+                self.post_message(EditorPasteEmpty(reason="credential-sealed"))
             raise SkipAction()
         # Dropped BEFORE the edit. `edit()` runs `_release_uncited` over the
         # attachments this removal touches, and the entry is gone by then
@@ -5060,6 +5276,150 @@ class Editor(TextArea):
         result = self._replace_via_keyboard(pasted, *self.selection)
         if result is not None:
             self.move_cursor(result.end_location)
+
+    def credential_armed(self) -> bool:
+        """True while the next paste will be captured as a secret.
+
+        The PUBLIC read of the armed state, for the app (which paints the
+        chevron and the placeholder from it) and for tests. A property of the
+        composer, exactly as :attr:`shell_mode` is, and for the same reason:
+        it changes what the next gesture MEANS, so it must be legible without
+        the picker — which Esc dismisses (design round 1, D2).
+        """
+        return self._credential_arm is not None
+
+    def _credential_names_taken(self) -> frozenset[str]:
+        """Every credential name a fresh key must avoid.
+
+        The union of this composer's own captures and the names the SESSION
+        STORE already holds. The composer's map resets on every submit, so it
+        alone cannot see the credential the operator handed over ten minutes
+        ago — the exact live credential a collision would silently replace
+        (review round 1, R3).
+
+        Reached through the app by ``getattr`` rather than an import: this
+        widget is imported BY the app, so it cannot import it back, and the
+        same duck-typed reach is how :meth:`_submit` asks about submission
+        blocking. Any failure degrades to the composer-local set, which is the
+        behaviour before this guard existed — a name generator must never be
+        the thing that fails a capture whose secret is already out of the
+        buffer.
+        """
+        taken = {
+            payload.key
+            for payload in self._attachments.values()
+            if isinstance(payload, PastedCredential)
+        }
+        names = getattr(self.app, "session_credential_names", None)
+        if callable(names):
+            try:
+                # Untyped by construction — the host may be any App (the
+                # widget's own test host has no such method), so the result is
+                # narrowed here rather than trusted.
+                reported = names()
+                if isinstance(reported, (list, tuple, set, frozenset)):
+                    taken.update(str(name) for name in reported)
+            except Exception:  # noqa: BLE001 — an unreadable store is an empty set
+                # Not logged here: the app-side helper already logs the store
+                # read it owns, and this widget has no logger of its own. A
+                # second record of one failure is noise, and the degraded
+                # behaviour (a composer-local `taken` set) is the documented
+                # fallback rather than an error.
+                pass
+        return frozenset(taken)
+
+    def _arm_credential(self, span: tuple[int, int]) -> None:
+        """LATCH the armed state onto the token at ``span``.
+
+        Latched rather than re-derived per paste because the whole defect D2
+        names is that the derivation is invisible: the operator cannot read
+        an end-of-line anchor off the screen, so a rule that quietly stops
+        matching is a rule that quietly drops the safety property. Once
+        latched, only :meth:`_disarm_credential` ends it, and every route
+        through it is either the capture itself or something the operator can
+        see.
+        """
+        if self._credential_arm == span:
+            return
+        self._credential_arm = span
+        self._invalidate_slash_runs()
+        self.post_message(CredentialArmChanged(True))
+
+    def _disarm_credential(self, reason: str) -> None:
+        """End the armed state, saying WHY so the app can speak for it.
+
+        ``reason`` is ``"captured"`` (the secret landed — the marker is the
+        receipt, so nothing more is said), ``"argument"`` (the operator typed a
+        flag, so they are addressing the command rather than arming), or
+        ``"gone"`` (the token itself was deleted). The app decides which of
+        those is worth a word; the editor only reports the transition, the same
+        split :class:`EditorPasteEmpty` draws.
+        """
+        if self._credential_arm is None:
+            return
+        self._credential_arm = None
+        self._invalidate_slash_runs()
+        self.post_message(CredentialArmChanged(False, reason=reason))
+
+    def _invalidate_slash_runs(self) -> None:
+        """Drop the per-render memo so the armed ink repaints this frame.
+
+        :meth:`_slash_runs` keys its cache on every input the computation
+        reads, and the armed state is now one of them — but it is set from
+        outside the buffer edit that would otherwise change the key, so a
+        latch or a disarm on an UNCHANGED buffer (Esc, a completed argument)
+        would repaint from the stale entry and the ink would lag a keystroke.
+        """
+        self._slash_runs_cache = None
+        self.refresh()
+
+    def _sync_credential_arm(self) -> None:
+        """Re-derive the latched arm after a buffer mutation.
+
+        Runs on the same funnel the picker syncs on, so the arm can never be
+        one keystroke behind the text it describes.
+
+        Three questions, in the order that makes each one cheap:
+
+        1. Nothing latched? Ask :data:`CREDENTIAL_ARM` at the caret — the
+           original, unchanged arming rule. This is the ONLY way to arm.
+        2. Latched, but the token is gone from the buffer? Disarm: the
+           operator deleted the gesture, which is the visible way to withdraw
+           it.
+        3. Latched, token still there, and a flag-shaped argument now follows
+           it? Disarm: ``/credential --forget-all`` is the operator addressing
+           the COMMAND, not arming a capture, and the two intents are mutually
+           exclusive (design round 1, D1).
+
+        Everything else KEEPS the arm — a newline, a typed word, a caret move,
+        an Esc that closes the picker. That is the whole point: those are the
+        edits that used to disarm silently and land the secret in plaintext.
+        """
+        if self._credential_arm is None:
+            span = self._credential_arm_span()
+            if span is not None:
+                self._arm_credential(span)
+            return
+        match = CREDENTIAL_TOKEN.search(self.text)
+        if match is None:
+            self._disarm_credential("gone")
+            return
+        # Re-anchored on every sync: the token slides as the operator edits
+        # text before it, and a stale span would splice the wrong range out of
+        # the buffer at capture time.
+        start, end = match.span()
+        line_end = self.text.find("\n", end)
+        tail = self.text[end : line_end if line_end != -1 else len(self.text)]
+        if CREDENTIAL_ARGUMENT.match(tail):
+            self._disarm_credential("argument")
+            return
+        # The span CONSUMES the token's trailing spaces, which is what the
+        # caret-anchored version got for free by ending at the caret. The
+        # marker replaces the whole span and carries its own trailing space, so
+        # stopping at the token would leave the operator's space behind and the
+        # buffer would read `[Credential #1, 64 chars]  ` — two spaces, one of
+        # them theirs and now meaningless.
+        self._credential_arm = (start, end + (len(tail) - len(tail.lstrip(" \t"))))
 
     def _credential_arm_span(self) -> tuple[int, int] | None:
         """Buffer offsets of the ``/credential`` token arming the next paste.
@@ -5132,19 +5492,17 @@ class Editor(TextArea):
         value = pasted.strip()
         if not value:
             return None
+        self._disarm_credential("captured")
         self._sync_next_marker()
         index = self._next_marker
         self._next_marker += 1
-        # `_paste_label` unchanged, so a one-line secret reads `64 chars` in the
-        # same vocabulary an image reads `1568x200` and a paste reads `240
-        # lines`. The LENGTH is the whole receipt: it is what lets the operator
-        # see the paste landed intact without seeing the value.
-        marker = f"[Credential #{index}, {_paste_label(value)}]"
-        key = generate_credential_key(
-            payload.key
-            for payload in self._attachments.values()
-            if isinstance(payload, PastedCredential)
-        )
+        # `_credential_label`, NOT `_paste_label`: always characters. The
+        # LENGTH is the whole receipt — it is what lets the operator see the
+        # paste landed intact without seeing the value — and a line count is
+        # the weakest form of that check exactly where truncation hides best
+        # (R5; see the function's own docstring).
+        marker = f"[Credential #{index}, {_credential_label(value)}]"
+        key = generate_credential_key(self._credential_names_taken())
         self._attachments[index] = PastedCredential(value, key, marker)
         # The trailing space is load-bearing exactly as it is for the other two
         # marker kinds (`_delete_marker_past_spaces`, `action_expand_paste`),
@@ -5496,6 +5854,11 @@ class Editor(TextArea):
             # cue to start a runtime while the user is still typing.
             self.post_message(EditorDraftStarted())
         self._sync_picker()
+        # AFTER the picker, on the same funnel and for the same reason: the arm
+        # is derived from the buffer, so deriving it anywhere but here would
+        # leave it a message-loop tick behind the text — and that tick is the
+        # one in which a paste decides whether it is a secret.
+        self._sync_credential_arm()
         if touched:
             self._release_uncited(touched)
         return result
@@ -5626,6 +5989,14 @@ class Editor(TextArea):
         # the right place is both correct and cheaper.
         if not self._suspend_picker_sync:
             self._sync_picker()
+        # Unconditional, unlike the picker sync above: the suspend flag exists
+        # so ONE sync happens at the final caret position, and the arm is not
+        # caret-anchored once latched (:meth:`_sync_credential_arm` searches the
+        # whole buffer), so there is no second position to wait for. Skipping it
+        # here would carry a stale arm across a whole-buffer replacement —
+        # a history recall, a `/reload` hand-back, a sidebar session switch —
+        # which is the one direction that must not be left to a later keystroke.
+        self._sync_credential_arm()
 
     def _caret_offset(self) -> int:
         """The caret as a whole-buffer offset, for the slash parsers.

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -557,12 +557,14 @@ CREDENTIAL_ARM = re.compile(r"(?:^|(?<=\s))/(?:credential|cred)[ \t]*$", re.IGNO
 #: I already armed on move to" after the operator kept typing (design round 1,
 #: D2).
 #:
-#: It is matched against a WINDOW around the latched offset rather than the
-#: whole buffer (see :meth:`Editor._sync_credential_arm`). A whole-buffer
+#: It is matched NEAREST the latched offset rather than by a whole-buffer
+#: ``search`` (see :meth:`Editor._sync_credential_arm`). A whole-buffer
 #: ``search`` returns the FIRST token in the text, which is unrelated to the
 #: one that armed: a buffer replaced while armed re-anchored the latch onto a
 #: token the operator never typed, and the next ordinary paste was swallowed as
-#: a secret (review round 2, R6b/R6c; QA round 2, Q4).
+#: a secret (review round 2, R6b/R6c; QA round 2, Q4). Nearest is a TIE-BREAK
+#: among tokens, never a distance test — see ``_relocate_armed_token`` for why
+#: bounding it by a distance re-opened the leak (review round 3, R7; QA Q5).
 #:
 #: NOTE the token typed as prose — ``fix the /credential command`` — DOES arm,
 #: and deliberately so: it passes through ``/credential`` at end-of-line while
@@ -595,20 +597,6 @@ CREDENTIAL_TOKEN = re.compile(r"(?:^|(?<=\s))/(?:credential|cred)(?!\S)", re.IGN
 #: operator who wants the destructive verb still reaches it by typing it, and
 #: the operator writing ``deploy with /credential the prod key`` stays armed.
 CREDENTIAL_ARGUMENT = re.compile(r"[ \t]+-", re.IGNORECASE)
-
-#: How far the latched token may have MOVED between two syncs and still be
-#: recognised as the same occurrence (:meth:`Editor._relocate_armed_token`).
-#:
-#: Every buffer edit re-syncs, so ordinary typing before the token moves it by
-#: one character; the slack is for the edits that move it further in one step
-#: (a completion, a pasted word, a deleted line). It is a DRIFT tolerance, not
-#: a search radius: its job is only to separate "the token I armed on, nudged"
-#: from "a different token in a buffer that was wholly replaced", and a
-#: replacement moves the token by much more than this or puts it in text that
-#: has none. Erring generous is the safe direction — too tight disarms
-#: mid-typing and lands the secret in plaintext (design round 1, D2), which is
-#: unrecoverable, while too loose costs a swallowed paste (review round 2, R6).
-_ARM_DRIFT = 64
 
 #: Random-name alphabet: Crockford-ish base32 WITHOUT the letters that read as
 #: digits. The name is quoted back to the operator in a notice and may be typed
@@ -5432,10 +5420,15 @@ class Editor(TextArea):
         MIGRATED the arm onto a token the operator never typed, and the next
         ordinary paste was swallowed as a secret: unrecoverable, because
         ``ctrl+o`` refuses to expand a credential and a submit stores the blob
-        (review round 2, R6b/R6c; QA round 2, Q4). Matching within a window
-        around the latched offset keeps the "token slides as you type before
-        it" case working while making an arriving token unable to inherit the
-        arm.
+        (review round 2, R6b/R6c; QA round 2, Q4). Matching nearest the latched
+        offset keeps the "token slides as you type before it" case working
+        while making an arriving token unable to inherit the arm.
+
+        "Gone" here means GONE FROM THE BUFFER, not "moved further than some
+        window". :meth:`_relocate_armed_token` answers by identity and never by
+        distance, so this branch cannot fire on a token the operator can still
+        see — which it did, silently, while a distance bound stood there
+        (review round 3, R7; QA round 3, Q5).
         """
         if self._credential_arm is None:
             span = self._credential_arm_span()
@@ -5479,25 +5472,49 @@ class Editor(TextArea):
         token the operator never typed, and the next ordinary paste was
         swallowed as a secret with no way to get it back.
 
-        The window is deliberately generous rather than exact. A single edit
-        can legitimately move the token by more than one character (an
-        autocomplete before it, a pasted word, a deleted line), and being too
-        strict fails the SAFE way only for the migration case — in the ordinary
-        case it would disarm mid-typing and put the secret in plaintext, which
-        is the unrecoverable direction D2 exists to prevent. So it admits any
-        match whose start is within :data:`_ARM_DRIFT` of where the latch left
-        it, and rejects the wholesale replacements that move a token much
-        further or introduce one in unrelated prose.
+        Nearest is a TIE-BREAK among the tokens present, NOT a distance test.
+        There used to be an ``_ARM_DRIFT = 64`` window here, and a distance
+        bound of any size is unsafe in this direction: a SINGLE edit can move
+        the token arbitrarily far while it is still plainly in the buffer —
+        ``shift+home`` over a long line above it, ``ctrl+x`` of a block,
+        ``ctrl+u``, ``delete_line``, an ordinary paste of context before it —
+        and past the bound this returned ``None``, which
+        :meth:`_sync_credential_arm` reads as "the operator deleted the
+        gesture" and disarms. SILENTLY: ``reason="gone"`` has no notice branch.
+        The next paste then landed in the composer, in scrollback and in the
+        prompt SENT TO THE MODEL in plaintext — measured at exactly N=64 on the
+        line above, N=63 still capturing (review round 3, R7; QA round 3, Q5).
+        Every finite window has that cliff, and the cliff fails in the one
+        direction D2 calls unrecoverable, so there is no window to tune.
+
+        WHEN THE BUFFER HOLDS EXACTLY ONE MATCH THERE IS NO AMBIGUITY: it is
+        the token that armed, however far the text before it moved, so it is
+        returned regardless of distance. That single case is what the drift
+        window was breaking, and it is the overwhelmingly common one.
+
+        With two or more, the arm is genuinely ambiguous — the operator typed a
+        second mention — and nearest-to-the-latch is the right reading, because
+        the token slides only as text before it is edited while an added
+        mention appears somewhere else entirely. That is the property
+        ``test_the_arm_stays_on_its_own_token_when_an_earlier_one_is_typed_in``
+        pins. Ambiguity still resolves to STAYING ARMED rather than to
+        ``None``: a wrong-but-armed token costs a swallowed paste the operator
+        can see and redo, while disarming costs a disclosure that no keystroke
+        undoes. The arriving-text routes that a window was defending against
+        are already closed upstream and by construction — :meth:`load_text`
+        DISARMS rather than re-syncing, so a recalled prompt, a restored draft
+        or a completion never reaches this function with a live arm at all
+        (review round 2, R6b/R6c).
         """
         anchor = self._credential_arm[0] if self._credential_arm is not None else 0
         nearest: tuple[int, int] | None = None
-        best = _ARM_DRIFT + 1
+        best = -1
         for match in CREDENTIAL_TOKEN.finditer(self.text):
             distance = abs(match.start() - anchor)
-            if distance < best:
+            if nearest is None or distance < best:
                 best = distance
                 nearest = match.span()
-            elif nearest is not None:
+            else:
                 # `finditer` walks left to right, so once the distance stops
                 # shrinking every later match is further away still.
                 break
@@ -5508,9 +5525,20 @@ class Editor(TextArea):
 
         The MODE GATE for the next paste. Anchored at the caret and at the end
         of the token, so it answers "is the operator pasting a secret RIGHT
-        HERE" rather than "does this draft mention the command anywhere" — a
-        draft that says ``fix the /credential command`` and then pastes a log
-        four words later must collapse that log as an ordinary paste.
+        HERE" rather than "does this draft mention the command anywhere".
+
+        It is the ONLY way to arm, but it is not the only thing that decides
+        whether an arm is live: once it latches, the arm survives the words
+        typed after the token (:meth:`_arm_credential`). So a draft that says
+        ``fix the /credential command`` and then pastes a log four words later
+        DOES capture that log — the prose passes through ``/credential`` at
+        end-of-line as it is typed, which is exactly the arming gesture, and it
+        is the same keystroke shape as ``deploy with /credential the prod key``,
+        which must stay armed (design round 1, D2). No rule keyed on the buffer
+        separates the two, so this docstring no longer promises that it does
+        (review round 2, R6a; corrected review round 3, R8). See
+        ``CREDENTIAL_TOKEN`` and :meth:`_sync_credential_arm` for the same note
+        at the two other places the rule is written down.
 
         Deliberately NOT routed through ``slash_command_for`` /
         ``consumes_prompt``. ``consumes_prompt=True`` (``/team``, ``/agent``)

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -552,9 +552,25 @@ CREDENTIAL_ARM = re.compile(r"(?:^|(?<=\s))/(?:credential|cred)[ \t]*$", re.IGNO
 
 #: The same token WITHOUT the end-of-line anchor, used to RE-LOCATE a token
 #: that has already armed. Arming itself still asks :data:`CREDENTIAL_ARM`, so
-#: ``fix the /credential command`` typed as prose never arms; this one only
-#: answers "where did the token I already armed on move to" after the operator
-#: kept typing (design round 1, D2).
+#: a token that merely ARRIVES in the buffer — a recalled prompt, a restored
+#: draft, a completion — never arms; this one only answers "where did the token
+#: I already armed on move to" after the operator kept typing (design round 1,
+#: D2).
+#:
+#: It is matched against a WINDOW around the latched offset rather than the
+#: whole buffer (see :meth:`Editor._sync_credential_arm`). A whole-buffer
+#: ``search`` returns the FIRST token in the text, which is unrelated to the
+#: one that armed: a buffer replaced while armed re-anchored the latch onto a
+#: token the operator never typed, and the next ordinary paste was swallowed as
+#: a secret (review round 2, R6b/R6c; QA round 2, Q4).
+#:
+#: NOTE the token typed as prose — ``fix the /credential command`` — DOES arm,
+#: and deliberately so: it passes through ``/credential`` at end-of-line while
+#: being typed, which is the arming gesture, and the latch is what makes the
+#: arm survive the words typed after it. That is the same keystroke shape as
+#: ``deploy with /credential the prod key``, which MUST stay armed (design
+#: round 1, D2), so no rule keyed on the buffer can separate the two. See
+#: :meth:`Editor._sync_credential_arm` for why the latch is kept anyway.
 #:
 #: The negative lookahead is the same partition ``CREDENTIAL_ARM``'s ``[ \t]*$``
 #: draws: ``/credential`` and ``/cred`` are the token, ``/credentials`` is not.
@@ -579,6 +595,20 @@ CREDENTIAL_TOKEN = re.compile(r"(?:^|(?<=\s))/(?:credential|cred)(?!\S)", re.IGN
 #: operator who wants the destructive verb still reaches it by typing it, and
 #: the operator writing ``deploy with /credential the prod key`` stays armed.
 CREDENTIAL_ARGUMENT = re.compile(r"[ \t]+-", re.IGNORECASE)
+
+#: How far the latched token may have MOVED between two syncs and still be
+#: recognised as the same occurrence (:meth:`Editor._relocate_armed_token`).
+#:
+#: Every buffer edit re-syncs, so ordinary typing before the token moves it by
+#: one character; the slack is for the edits that move it further in one step
+#: (a completion, a pasted word, a deleted line). It is a DRIFT tolerance, not
+#: a search radius: its job is only to separate "the token I armed on, nudged"
+#: from "a different token in a buffer that was wholly replaced", and a
+#: replacement moves the token by much more than this or puts it in text that
+#: has none. Erring generous is the safe direction — too tight disarms
+#: mid-typing and lands the secret in plaintext (design round 1, D2), which is
+#: unrecoverable, while too loose costs a swallowed paste (review round 2, R6).
+_ARM_DRIFT = 64
 
 #: Random-name alphabet: Crockford-ish base32 WITHOUT the letters that read as
 #: digits. The name is quoted back to the operator in a notice and may be typed
@@ -5394,20 +5424,32 @@ class Editor(TextArea):
         Everything else KEEPS the arm — a newline, a typed word, a caret move,
         an Esc that closes the picker. That is the whole point: those are the
         edits that used to disarm silently and land the secret in plaintext.
+
+        Question 2 asks about THE TOKEN THAT ARMED, not about any token. The
+        re-anchor used to be ``CREDENTIAL_TOKEN.search(self.text)`` — the first
+        match in the whole buffer, which has no relation to the latched one. A
+        buffer replaced while armed (a recalled prompt, a restored draft) then
+        MIGRATED the arm onto a token the operator never typed, and the next
+        ordinary paste was swallowed as a secret: unrecoverable, because
+        ``ctrl+o`` refuses to expand a credential and a submit stores the blob
+        (review round 2, R6b/R6c; QA round 2, Q4). Matching within a window
+        around the latched offset keeps the "token slides as you type before
+        it" case working while making an arriving token unable to inherit the
+        arm.
         """
         if self._credential_arm is None:
             span = self._credential_arm_span()
             if span is not None:
                 self._arm_credential(span)
             return
-        match = CREDENTIAL_TOKEN.search(self.text)
+        match = self._relocate_armed_token()
         if match is None:
             self._disarm_credential("gone")
             return
         # Re-anchored on every sync: the token slides as the operator edits
         # text before it, and a stale span would splice the wrong range out of
         # the buffer at capture time.
-        start, end = match.span()
+        start, end = match
         line_end = self.text.find("\n", end)
         tail = self.text[end : line_end if line_end != -1 else len(self.text)]
         if CREDENTIAL_ARGUMENT.match(tail):
@@ -5420,6 +5462,46 @@ class Editor(TextArea):
         # buffer would read `[Credential #1, 64 chars]  ` — two spaces, one of
         # them theirs and now meaningless.
         self._credential_arm = (start, end + (len(tail) - len(tail.lstrip(" \t"))))
+
+    def _relocate_armed_token(self) -> tuple[int, int] | None:
+        """Where the LATCHED token is now, or ``None`` if it is gone.
+
+        The identity the arm owns. ``_credential_arm`` holds the span the token
+        occupied at the last sync, and the token moves only as the operator
+        edits the text BEFORE it — one keystroke at a time, since every edit
+        re-syncs. So the token that armed is the ``CREDENTIAL_TOKEN`` match
+        nearest the latched offset, and a match far from it is a DIFFERENT
+        token that happens to share the spelling.
+
+        That distinction is the fix for R6b/R6c (QA Q4): the old whole-buffer
+        ``search`` took the first token in the text, so replacing the buffer
+        while armed — history recall, a restored draft — handed the arm to a
+        token the operator never typed, and the next ordinary paste was
+        swallowed as a secret with no way to get it back.
+
+        The window is deliberately generous rather than exact. A single edit
+        can legitimately move the token by more than one character (an
+        autocomplete before it, a pasted word, a deleted line), and being too
+        strict fails the SAFE way only for the migration case — in the ordinary
+        case it would disarm mid-typing and put the secret in plaintext, which
+        is the unrecoverable direction D2 exists to prevent. So it admits any
+        match whose start is within :data:`_ARM_DRIFT` of where the latch left
+        it, and rejects the wholesale replacements that move a token much
+        further or introduce one in unrelated prose.
+        """
+        anchor = self._credential_arm[0] if self._credential_arm is not None else 0
+        nearest: tuple[int, int] | None = None
+        best = _ARM_DRIFT + 1
+        for match in CREDENTIAL_TOKEN.finditer(self.text):
+            distance = abs(match.start() - anchor)
+            if distance < best:
+                best = distance
+                nearest = match.span()
+            elif nearest is not None:
+                # `finditer` walks left to right, so once the distance stops
+                # shrinking every later match is further away still.
+                break
+        return nearest
 
     def _credential_arm_span(self) -> tuple[int, int] | None:
         """Buffer offsets of the ``/credential`` token arming the next paste.
@@ -5989,14 +6071,27 @@ class Editor(TextArea):
         # the right place is both correct and cheaper.
         if not self._suspend_picker_sync:
             self._sync_picker()
-        # Unconditional, unlike the picker sync above: the suspend flag exists
-        # so ONE sync happens at the final caret position, and the arm is not
-        # caret-anchored once latched (:meth:`_sync_credential_arm` searches the
-        # whole buffer), so there is no second position to wait for. Skipping it
-        # here would carry a stale arm across a whole-buffer replacement —
-        # a history recall, a `/reload` hand-back, a sidebar session switch —
-        # which is the one direction that must not be left to a later keystroke.
-        self._sync_credential_arm()
+        # A whole-buffer replacement ENDS an arm, it never carries or moves
+        # one. This funnel is precisely "text that did not come from the
+        # operator's keystrokes" — a history recall, a restored draft, a
+        # `/reload` hand-back, a sidebar session switch — and the arming
+        # gesture is something the operator TYPES. Re-syncing here instead let
+        # a latched arm re-anchor onto whatever `/credential` the arriving text
+        # happened to contain, so a recalled prompt that merely MENTIONED the
+        # command swallowed the next ordinary paste as a secret, unrecoverably
+        # (review round 2, R6b/R6c; QA round 2, Q4).
+        #
+        # Disarming rather than syncing is also the conservative half of the
+        # pair: it fails toward "not armed", where a paste lands as ordinary
+        # text the operator can see and re-do. `clear_content` already draws
+        # this exact line for submit and `/clear`, and the reason is the same —
+        # the arm belongs to the text that armed it.
+        #
+        # `_set_text_and_caret` is NOT exempted. It funnels the completions,
+        # which replace the buffer for `/team`, `/model` and friends; a
+        # completion is not the arming gesture either, and letting one preserve
+        # an arm would reopen the migration route through a second door.
+        self._disarm_credential("gone")
 
     def _caret_offset(self) -> int:
         """The caret as a whole-buffer offset, for the slash parsers.

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -5306,6 +5306,26 @@ class Editor(TextArea):
         """
         return self._credential_arm is not None
 
+    def credential_cited(self) -> bool:
+        """True while the buffer still CITES a credential this composer holds.
+
+        The second public read of credential state, and the counterpart to
+        :meth:`credential_armed`: "armed" is *before* the secret arrives, this
+        is *after*. Both change what a destructive verb would MEAN, so both
+        gate the same rows (design round 3, D9).
+
+        Asked through :func:`credential_payloads` rather than by scanning
+        ``_attachments`` directly, because the two answer different questions.
+        The map keeps a payload until the edit funnel releases it, so a marker
+        the operator has already backspaced away can still be IN the map — and
+        a capture the buffer no longer cites is one the operator has visibly
+        withdrawn, which must not keep the verbs suppressed. Citation is also
+        the predicate submit uses to decide what is stored, so "what is
+        chipped" is exactly what this reports and the guard cannot outlive the
+        chip that justifies it.
+        """
+        return bool(credential_payloads(self.text, self._attachments))
+
     def _credential_names_taken(self) -> frozenset[str]:
         """Every credential name a fresh key must avoid.
 

--- a/scripts/credential_armed_shot.py
+++ b/scripts/credential_armed_shot.py
@@ -1,0 +1,188 @@
+"""Capture the inline ``/credential`` ARMED states after the D1/D2 remediation.
+
+Usage: python scripts/credential_armed_shot.py OUTDIR [120x36]
+
+Re-shoots the four frames the design round asked for by name — ``03-armed``,
+``17-armed-tab-accepted``, ``24-tab-then-paste-PLAINTEXT``,
+``40-forget-all-destroyed-it`` — plus the new frame of the armed affordance that
+answers D2, at both the leading and the mid-line arm, and the two silent
+disarms D2 reproduced (a newline and a typed word).
+
+The three keystroke sequences that USED to be destructive are driven exactly as
+the designer drove them, so a frame that still showed the old behaviour would
+show it here: arm then Enter twice (which wiped a seeded store), arm then Tab
+(which accepted the ``--forget-all`` ghost and consumed the arming token), and
+arm-Tab-paste (which landed the secret in plaintext). Each capture prints the
+state assertions beside the frame it writes, because the frame proves what is
+on screen and the numbers prove what is in the store and the buffer.
+
+No provider request, live session or operator config is used: ``CMUX_*`` is
+cleared before any application import and ``probe_isolation`` sandboxes HOME,
+so a headless run cannot touch the operator's real sessions or workspaces.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Clear every multiplexer identifier BEFORE any application import: a headless
+# pilot must not rename the operator's real workspace through inherited CMUX IDs.
+for _key in tuple(os.environ):
+    if _key.startswith("CMUX_"):
+        os.environ.pop(_key)
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import asyncio  # noqa: E402
+
+from textual import events  # noqa: E402
+
+import scripts.probe_isolation  # noqa: E402, F401
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from scripts.visual_capture import save_capture  # noqa: E402
+from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
+from tests.unit.tui.test_slash_echo import _boot  # noqa: E402
+
+#: A realistic 64-character token. Never printed, only length-checked and
+#: searched for in the rendered frames — a frame containing it is a leak.
+SECRET = "ghp_A1b2C3d4E5f6G7h8J9k0L1m2N3p4Q5r6S7t8U9v0WxYz1234567890abcd"
+
+#: Seeded before the destructive sequences so a wipe is VISIBLE in the store
+#: readout rather than being a no-op on an empty store.
+LIVE_KEY = "LOP_SECRET_FSD7W3NK"
+
+
+def painted(app) -> str:
+    return "\n".join(strip.text for strip in app.screen._compositor.render_strips())
+
+
+async def type_text(pilot, text: str) -> None:
+    for char in text:
+        await pilot.press(char)
+    for _ in range(3):
+        await pilot.pause()
+
+
+async def shoot(outdir: Path, size: tuple[int, int], name: str, drive) -> None:
+    """Boot a fresh app, run ``drive``, and save the frame plus its assertions."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=size) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        session.variables.store_credential(LIVE_KEY, "seeded-live-value", "command")
+        notes = await drive(pilot, app, editor, session)
+        for _ in range(3):
+            await pilot.pause()
+        frame = painted(app)
+        save_capture(app, outdir / f"{name}.svg")
+        leaked = SECRET in frame
+        print(f"\n=== {name} ===")
+        print(f"  store:        {session.variables.credential_names()}")
+        print(f"  armed:        {editor.credential_armed()}")
+        print(f"  buffer:       {editor.text!r}")
+        print(f"  SECRET on screen: {leaked}   <-- must be False")
+        for note in notes or []:
+            print(f"  {note}")
+        assert not leaked, f"{name} put the secret on screen"
+
+
+async def main() -> None:
+    outdir = Path(sys.argv[1] if len(sys.argv) > 1 else "/tmp/cred-frames")
+    dims = sys.argv[2] if len(sys.argv) > 2 else "120x36"
+    width, height = (int(part) for part in dims.split("x"))
+    size = (width, height)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    async def armed(pilot, app, editor, session):
+        """03-armed: the leading arm, which used to preselect --forget-all."""
+        await type_text(pilot, "/credential ")
+        return [
+            f"picker highlighted row: {editor.picker.highlighted_name()!r} (was '--forget-all')"
+        ]
+
+    async def armed_midline(pilot, app, editor, session):
+        """The D2 answer at the form that had NO ink at all before."""
+        await type_text(pilot, "deploy staging with /credential ")
+        runs = editor._slash_runs()
+        return [f"slash runs (was None mid-line): {runs}"]
+
+    async def tab_accepted(pilot, app, editor, session):
+        """17: Tab used to accept the --forget-all ghost and consume the arm."""
+        await type_text(pilot, "deploy with /credential ")
+        await pilot.press("tab")
+        for _ in range(4):
+            await pilot.pause()
+        return ["'--forget-all' in buffer: " + str("--forget-all" in editor.text)]
+
+    async def tab_then_paste(pilot, app, editor, session):
+        """24: the leak — Tab disarmed, so the next paste landed in plaintext."""
+        await type_text(pilot, "deploy with /credential ")
+        await pilot.press("tab")
+        for _ in range(4):
+            await pilot.pause()
+        app.post_message(events.Paste(SECRET))
+        for _ in range(4):
+            await pilot.pause()
+        return ["SECRET in buffer: " + str(SECRET in editor.text)]
+
+    async def forget_all(pilot, app, editor, session):
+        """40: arm + Enter + Enter wiped the store with no confirm and no undo."""
+        await type_text(pilot, "/credential ")
+        await pilot.press("enter")
+        await pilot.press("enter")
+        for _ in range(8):
+            await pilot.pause()
+        return [f"live credential survived: {LIVE_KEY in session.variables.credential_names()}"]
+
+    async def disarm_newline(pilot, app, editor, session):
+        """D2: shift+Enter after the arm used to disarm silently."""
+        await type_text(pilot, "deploy with /credential ")
+        await pilot.press("shift+enter")
+        for _ in range(3):
+            await pilot.pause()
+        return ["armed after a newline (was False): " + str(editor.credential_armed())]
+
+    async def disarm_word(pilot, app, editor, session):
+        """D2: one more typed word used to disarm silently."""
+        await type_text(pilot, "deploy with /credential ")
+        await type_text(pilot, "the prod key ")
+        return ["armed after a typed word (was False): " + str(editor.credential_armed())]
+
+    async def captured(pilot, app, editor, session):
+        """The happy path end state: chip in place, arm released, secret gone."""
+        await type_text(pilot, "deploy with /credential ")
+        app.post_message(events.Paste(SECRET))
+        for _ in range(4):
+            await pilot.pause()
+        await type_text(pilot, "this is the staging deploy key")
+        return [f"chip: {'[Credential #1' in editor.text}"]
+
+    async def blank_paste(pilot, app, editor, session):
+        """D3: a whitespace paste while armed used to be a silent no-op."""
+        await type_text(pilot, "deploy with /credential ")
+        app.post_message(events.Paste("   \n  "))
+        for _ in range(6):
+            await pilot.pause()
+        return ["still armed: " + str(editor.credential_armed())]
+
+    frames = [
+        ("03-armed", armed),
+        ("03b-armed-midline", armed_midline),
+        ("17-armed-tab-accepted", tab_accepted),
+        ("24-tab-then-paste-PLAINTEXT", tab_then_paste),
+        ("40-forget-all-destroyed-it", forget_all),
+        ("50-armed-affordance-newline", disarm_newline),
+        ("51-armed-affordance-typed-word", disarm_word),
+        ("52-captured", captured),
+        ("53-blank-paste-while-armed", blank_paste),
+    ]
+    for name, drive in frames:
+        await shoot(outdir, size, name, drive)
+    print(f"\nwrote {len(frames)} frames to {outdir}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/credential_armed_shot.py
+++ b/scripts/credential_armed_shot.py
@@ -39,7 +39,7 @@ import asyncio  # noqa: E402
 from textual import events  # noqa: E402
 
 import scripts.probe_isolation  # noqa: E402, F401
-from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.app import CREDENTIAL_HELD_NOTICE, OperatorApp  # noqa: E402
 from scripts.visual_capture import save_capture  # noqa: E402
 from tests.unit.tui.test_app_pilot import FakeSession, _factory  # noqa: E402
 from tests.unit.tui.test_slash_echo import _boot  # noqa: E402
@@ -198,6 +198,65 @@ async def main() -> None:
             f"chip in buffer (was the raw secret):   {'[Credential #1' in editor.text}",
         ]
 
+    async def two_token_leftover(pilot, app, editor, session):
+        """D9: the post-capture state that leaves a SECOND token behind.
+
+        The draft mentions the command in prose before the real gesture, so the
+        latch sits on the EARLIER token and the marker splices there — leaving
+        the token the operator typed at the caret in the buffer, unarmed, with
+        an empty argument slot. This frame is the state itself.
+        """
+        await type_text(pilot, "fix the /credential command /credential ")
+        app.post_message(events.Paste(SECRET))
+        for _ in range(4):
+            await pilot.pause()
+        return [
+            f"leftover token in buffer: {'/credential' in editor.text}",
+            f"cites a held credential: {editor.credential_cited()}",
+        ]
+
+    async def two_token_leftover_rows(pilot, app, editor, session):
+        """D9: the load-bearing frame — the leftover's argument list, OPEN.
+
+        This is where ``--forget-all`` used to sit preselected under the caret,
+        two keystrokes from destroying the store INCLUDING the credential the
+        chip beside it cites. The rows must be empty and the row must say why.
+        """
+        await type_text(pilot, "fix the /credential command /credential ")
+        app.post_message(events.Paste(SECRET))
+        for _ in range(4):
+            await pilot.pause()
+        await pilot.press("end")
+        for _ in range(6):
+            await pilot.pause()
+        return [
+            f"highlighted row (was '--forget-all'): {editor.picker.highlighted_name()!r}",
+            f"rows offered (was 2): {len(editor.picker._choices)}",
+            f"notice painted: {CREDENTIAL_HELD_NOTICE in painted(app)}",
+        ]
+
+    async def two_token_leftover_after_enter(pilot, app, editor, session):
+        """D9: the exact destructive drive — ``end,enter,enter`` — after the fix.
+
+        The store readout beside this frame is the proof: the seeded credential
+        survives, and the captured one is now IN the store rather than having
+        been wiped alongside it while its chip was still on screen.
+        """
+        await type_text(pilot, "fix the /credential command /credential ")
+        app.post_message(events.Paste(SECRET))
+        for _ in range(4):
+            await pilot.pause()
+        await pilot.press("end")
+        await pilot.press("enter")
+        await pilot.press("enter")
+        for _ in range(10):
+            await pilot.pause()
+        names = session.variables.credential_names()
+        return [
+            f"seeded credential survived (was wiped): {LIVE_KEY in names}",
+            f"captured credential reached the store:  {len(names) > 1}",
+        ]
+
     frames = [
         ("03-armed", armed),
         ("03b-armed-midline", armed_midline),
@@ -209,6 +268,9 @@ async def main() -> None:
         ("52-captured", captured),
         ("53-blank-paste-while-armed", blank_paste),
         ("54-big-edit-then-capture", big_edit_then_capture),
+        ("55-two-token-leftover", two_token_leftover),
+        ("56-two-token-leftover-rows", two_token_leftover_rows),
+        ("57-two-token-leftover-after-enter-enter", two_token_leftover_after_enter),
     ]
     for name, drive in frames:
         await shoot(outdir, size, name, drive)

--- a/scripts/credential_armed_shot.py
+++ b/scripts/credential_armed_shot.py
@@ -168,6 +168,36 @@ async def main() -> None:
             await pilot.pause()
         return ["still armed: " + str(editor.credential_armed())]
 
+    async def big_edit_then_capture(pilot, app, editor, session):
+        """R7/QA Q5: ONE large edit above the token, then a capture.
+
+        The frame that has to show a MARKER CHIP rather than ``ghp_…``. Under
+        the old ``_ARM_DRIFT = 64`` window this single ``delete_line`` moved
+        the token past the bound, ``_relocate_armed_token`` returned ``None``,
+        and the arm was dropped SILENTLY while the token was still in the
+        buffer — so this same paste painted the secret here in plaintext.
+        """
+        await type_text(pilot, "x" * 120)
+        await pilot.press("shift+enter")
+        await type_text(pilot, "deploy /credential ")
+        armed_before = editor.credential_armed()
+        editor.move_cursor((0, 120))
+        await pilot.pause()
+        await pilot.press("ctrl+shift+k")
+        for _ in range(3):
+            await pilot.pause()
+        armed_after = editor.credential_armed()
+        editor.move_cursor(editor._end_of_buffer())
+        app.post_message(events.Paste(SECRET))
+        for _ in range(6):
+            await pilot.pause()
+        await type_text(pilot, " the staging deploy key")
+        return [
+            f"armed before the 121-char delete_line: {armed_before}",
+            f"armed after it (was False, the leak):  {armed_after}",
+            f"chip in buffer (was the raw secret):   {'[Credential #1' in editor.text}",
+        ]
+
     frames = [
         ("03-armed", armed),
         ("03b-armed-midline", armed_midline),
@@ -178,6 +208,7 @@ async def main() -> None:
         ("51-armed-affordance-typed-word", disarm_word),
         ("52-captured", captured),
         ("53-blank-paste-while-armed", blank_paste),
+        ("54-big-edit-then-capture", big_edit_then_capture),
     ]
     for name, drive in frames:
         await shoot(outdir, size, name, drive)

--- a/tests/unit/tui/test_inline_credential.py
+++ b/tests/unit/tui/test_inline_credential.py
@@ -24,7 +24,11 @@ from textual import events
 from textual.actions import SkipAction
 from textual.app import App, ComposeResult
 
-from local_operator.tui.app import CREDENTIAL_PLACEHOLDER, OperatorApp
+from local_operator.tui.app import (
+    CREDENTIAL_ARMED_NOTICE,
+    CREDENTIAL_PLACEHOLDER,
+    OperatorApp,
+)
 from local_operator.tui.widgets.editor import (
     ASIDE_PLACEHOLDER,
     ATTACHMENT_MARKER,
@@ -170,8 +174,11 @@ async def test_an_unarmed_paste_of_the_same_secret_is_left_alone() -> None:
         assert not editor._attachments
 
 
+@pytest.mark.parametrize("start_armed", [False, True], ids=["cold", "armed"])
 @pytest.mark.asyncio
-async def test_a_mention_of_the_command_in_text_never_typed_through_the_arm_does_not_arm() -> None:
+async def test_a_mention_of_the_command_in_text_never_typed_through_the_arm_does_not_arm(
+    start_armed: bool,
+) -> None:
     """A draft that ARRIVES holding the word never passed through the gesture.
 
     Recalled history, a restored draft and a pasted paragraph all land through
@@ -179,11 +186,24 @@ async def test_a_mention_of_the_command_in_text_never_typed_through_the_arm_does
     Arming is still :data:`CREDENTIAL_ARM` at the caret and nothing else — what
     changed in design round 1 (D2) is how long an arm SURVIVES once taken, not
     how one is taken.
+
+    PARAMETERISED OVER BOTH STARTING STATES because the single cold case could
+    not fail. ``_sync_credential_arm`` has two branches and the cold editor only
+    ever reaches the first ("should this arm?"); every way this property has
+    actually broken lives in the second ("where did the armed token go?"), where
+    a latched arm re-anchored onto a token in text that merely ARRIVED. The test
+    asserted the right property against the one path that could not violate it
+    (review round 2, R6; QA round 2, Q4).
     """
     app = Host()
     async with app.run_test(size=(100, 30)) as pilot:
         editor = app.query_one(Editor)
         editor.focus()
+        if start_armed:
+            for char in "/credential ":
+                await pilot.press(char)
+            await pilot.pause()
+            assert editor.credential_armed(), "precondition: the gesture armed"
         editor.load_text("fix the /credential command please ")
         editor.move_cursor(editor._end_of_buffer())
         await pilot.pause()
@@ -195,6 +215,168 @@ async def test_a_mention_of_the_command_in_text_never_typed_through_the_arm_does
         assert not any(
             isinstance(value, PastedCredential) for value in editor._attachments.values()
         )
+
+
+@pytest.mark.asyncio
+async def test_an_arm_does_not_migrate_to_another_token_when_the_buffer_is_replaced() -> None:
+    """R6b: the latch tracks THE token that armed, not the first one in the text.
+
+    The re-anchor used to be a whole-buffer ``search``, so replacing the buffer
+    while armed handed the arm to whatever ``/credential`` the new text happened
+    to contain — and the operator's next ordinary paste was swallowed as a
+    secret they can neither expand nor recover (review round 2, R6b).
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        for char in "/credential ":
+            await pilot.press(char)
+        await pilot.pause()
+        assert editor.credential_armed()
+        editor.load_text("unrelated draft that says /cred somewhere in it")
+        editor.move_cursor(editor._end_of_buffer())
+        await pilot.pause()
+        assert not editor.credential_armed(), "the arm did not survive onto another token"
+        app.post_message(events.Paste("ordinary pasted text"))
+        await pilot.pause()
+        await pilot.pause()
+        assert editor.text.endswith("ordinary pasted text"), "the paste is visible, not stashed"
+        assert not editor._attachments
+
+
+@pytest.mark.asyncio
+async def test_an_arm_is_not_inherited_across_history_recall() -> None:
+    """R6c: recalling a prompt that MENTIONS the command must not stay armed.
+
+    The route an operator reaches without doing anything unusual: arm, press Up
+    to check what they sent last time, paste. The recalled text arrives through
+    ``load_text`` and is not a gesture, so the arm ends with it.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        editor._history.append("how do I use /cred to store a token")
+        for char in "/credential ":
+            await pilot.press(char)
+        await pilot.pause()
+        assert editor.credential_armed()
+        await pilot.press("up")
+        await pilot.pause()
+        assert editor.text == "how do I use /cred to store a token"
+        assert not editor.credential_armed(), "the recalled prompt did not inherit the arm"
+        app.post_message(events.Paste("ordinary pasted text"))
+        await pilot.pause()
+        await pilot.pause()
+        assert editor.text.endswith("ordinary pasted text")
+        assert not any(
+            isinstance(value, PastedCredential) for value in editor._attachments.values()
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_restored_draft_does_not_inherit_a_live_arm() -> None:
+    """R6c/Q4: parking a draft over an armed composer must not carry the arm.
+
+    ``_load_editor_draft`` restores a parked draft straight into the composer
+    with no empty-buffer guard, so this is reachable in the product rather than
+    only through the widget — and a draft that merely mentions the command
+    would otherwise swallow the operator's next paste.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        for char in "deploy with /credential ":
+            await pilot.press(char)
+        await pilot.pause()
+        assert editor.credential_armed()
+        # Exactly what `_load_editor_draft` does with a parked draft.
+        editor.load_text("ask about /credential rotation before the release")
+        await pilot.pause()
+        assert not editor.credential_armed()
+        app.post_message(events.Paste("a 200-line deploy log"))
+        await pilot.pause()
+        await pilot.pause()
+        assert "a 200-line deploy log" in editor.text
+        assert not any(
+            isinstance(value, PastedCredential) for value in editor._attachments.values()
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_arm_stays_on_its_own_token_when_an_earlier_one_is_typed_in() -> None:
+    """R6b by TYPING — the route ``load_text`` disarming does not cover.
+
+    The operator arms mid-line, then goes back to the front of the draft and
+    types a sentence that also mentions the command. Under a whole-buffer
+    ``search`` the arm jumped to that EARLIER token, and the capture then spliced
+    the marker into the wrong half of the sentence — rewriting the operator's
+    words where they were not pasting, while the token they actually armed sat
+    untouched. This is the case that makes the re-anchor an identity question
+    rather than a text-arrival question (review round 2, R6b).
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        for char in "deploy /credential ":
+            await pilot.press(char)
+        await pilot.pause()
+        armed_at = editor._credential_arm
+        assert armed_at is not None
+        editor.move_cursor((0, 0))
+        for char in "ask about /cred later ":
+            await pilot.press(char)
+        await pilot.pause()
+        assert editor.text == "ask about /cred later deploy /credential "
+        assert editor._credential_arm is not None
+        # The span carries the token's trailing whitespace too (see
+        # `_arm_credential`), which is what the capture splices out.
+        armed_text = editor.text[slice(*editor._credential_arm)]
+        assert armed_text.strip() == "/credential", f"arm stayed on its token: {armed_text!r}"
+        assert editor._credential_arm[0] == editor.text.index("deploy ") + len("deploy ")
+
+        editor.move_cursor(editor._end_of_buffer())
+        app.post_message(events.Paste(SECRET))
+        await pilot.pause()
+        await pilot.pause()
+        assert SECRET not in editor.text
+        # The marker replaced the ARMED token; the earlier mention is untouched.
+        assert editor.text.startswith("ask about /cred later deploy [Credential #1,")
+
+
+@pytest.mark.asyncio
+async def test_the_armed_token_is_still_tracked_while_text_before_it_is_edited() -> None:
+    """The case the whole-buffer search was written for still works.
+
+    Anchoring to the armed occurrence must not break the reason the re-anchor
+    exists: the token SLIDES as the operator edits text before it, and a stale
+    span would splice the wrong range out of the buffer at capture time.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        for char in "deploy /credential ":
+            await pilot.press(char)
+        await pilot.pause()
+        armed_at = editor._credential_arm
+        assert armed_at is not None
+        editor.move_cursor((0, 0))
+        for char in "please ":
+            await pilot.press(char)
+        await pilot.pause()
+        assert editor.credential_armed(), "typing before the token keeps the arm"
+        assert editor._credential_arm is not None
+        assert editor._credential_arm[0] == armed_at[0] + len("please "), "it tracked the slide"
+        editor.move_cursor(editor._end_of_buffer())
+        app.post_message(events.Paste(SECRET))
+        await pilot.pause()
+        await pilot.pause()
+        assert SECRET not in editor.text, "still captures at the tracked span"
+        assert editor.text.startswith("please deploy [Credential #1,")
 
 
 # -- the edge cases the gesture has to decide ---------------------------------
@@ -967,3 +1149,71 @@ async def test_arming_does_not_relabel_a_composer_another_mode_owns() -> None:
         for _ in range(4):
             await pilot.pause()
         assert editor.placeholder == CREDENTIAL_PLACEHOLDER, "a resting composer does say it"
+
+
+@pytest.mark.asyncio
+async def test_the_armed_placeholder_is_state_only_and_never_paints() -> None:
+    """D8: the placeholder cannot render, so nothing may count it as a channel.
+
+    A placeholder needs an EMPTY buffer and arming needs the token IN it, so the
+    two conditions are mutually exclusive. The old assertion checked the
+    ATTRIBUTE — which is set correctly — and so passed while the channel was
+    invisible. This pins what is PAINTED, in both arming forms, so the comment
+    claiming two live channels cannot silently become false.
+    """
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        for form in ("/credential ", "deploy with /credential "):
+            editor.load_text("")
+            editor.placeholder = editor.resting_placeholder
+            await pilot.pause()
+            for char in form:
+                await pilot.press(char)
+            for _ in range(4):
+                await pilot.pause()
+            assert editor.credential_armed(), f"{form!r} arms"
+            assert editor.placeholder == CREDENTIAL_PLACEHOLDER, "the state is set"
+            assert CREDENTIAL_PLACEHOLDER not in _painted(app), "but it does not paint"
+            assert editor.text, "because an armed buffer is never empty"
+
+
+@pytest.mark.asyncio
+async def test_a_flag_disarm_clears_the_pickers_armed_notice() -> None:
+    """D7: the row promising capture must not outlive the capture.
+
+    ``CREDENTIAL_ARMED_NOTICE`` was written only when the argument list OPENED,
+    so a disarm while it was already open left it on screen. The flag disarm is
+    the reachable case — deleting the token closes the list, a capture replaces
+    the buffer — and it is the disarm the operator is least likely to expect.
+    The stale row then sat NEARER the caret than the transcript's warning and
+    contradicted it, promising "never shown" directly above a plaintext paste.
+    """
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        for char in "deploy with /credential ":
+            await pilot.press(char)
+        for _ in range(4):
+            await pilot.pause()
+        assert editor.credential_armed()
+        assert CREDENTIAL_ARMED_NOTICE in _painted(app), "precondition: the row is up"
+
+        await pilot.press("-")
+        for _ in range(8):
+            await pilot.pause()
+        assert not editor.credential_armed()
+        assert CREDENTIAL_ARMED_NOTICE not in _painted(app), "the promise went with the state"
+
+        # And it STAYS cleared: the operator pastes into the disarmed composer,
+        # which is the moment the stale row would have lied about.
+        app.post_message(events.Paste("an ordinary paste"))
+        for _ in range(4):
+            await pilot.pause()
+        assert CREDENTIAL_ARMED_NOTICE not in _painted(app)

--- a/tests/unit/tui/test_inline_credential.py
+++ b/tests/unit/tui/test_inline_credential.py
@@ -1,0 +1,595 @@
+"""Inline ``/credential``: capture a secret out of the composer, never leak it.
+
+The gesture: type ``/credential`` ANYWHERE in the composer, paste the secret,
+watch it become ``[Credential #N, <len> chars]``, keep typing a description, and
+send. The value goes to the session credential store under a generated name; the
+model learns the NAME, the LENGTH and the operator's description, and never the
+bytes.
+
+The bulk of this file is the SAFETY property, because it is the one no other
+marker type has. Every existing marker exists to be re-expanded into the prompt
+at submit; a credential marker must be skipped at every seam where that happens.
+There are six such seams, each pinned by a test below under "the six expansion
+seams" — a regression at any one of them puts a plaintext secret somewhere it
+can never be recalled from.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from textual import events
+from textual.actions import SkipAction
+from textual.app import App, ComposeResult
+
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.editor import (
+    ATTACHMENT_MARKER,
+    CREDENTIAL_KEY_PREFIX,
+    Attachment,
+    Editor,
+    Marked,
+    PastedCredential,
+    PastedText,
+    credential_payloads,
+    expand_pastes,
+    generate_credential_key,
+    resolve_markers,
+    strip_paste_citations,
+    substitute_credentials,
+)
+from local_operator.variables import VariableStore, normalize_credential_key
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+from tests.unit.tui.test_slash_echo import _boot
+
+#: A realistic 64-character token. Length matters: it is what the marker label
+#: reports, and it is far below every size threshold the ordinary collapse uses
+#: (COLLAPSE_ROWS=20, MIN_PASTE_ROWS=4) — which is exactly why the credential
+#: mode gate has to be asked BEFORE the size question.
+SECRET = "ghp_" + "x" * 56 + "TAIL"
+
+
+class Host(App[None]):
+    def compose(self) -> ComposeResult:
+        yield Editor()
+
+
+async def _armed_capture(pilot, editor: Editor, prefix: str, secret: str = SECRET) -> None:
+    """Type ``prefix``, arm with ``/credential``, and paste ``secret``."""
+    for char in f"{prefix}/credential ":
+        await pilot.press(char)
+    await pilot.pause()
+    editor.app.post_message(events.Paste(secret))
+    await pilot.pause()
+    await pilot.pause()
+
+
+def _painted(app: App[None]) -> str:
+    return "\n".join(strip.text for strip in app.screen._compositor.render_strips())
+
+
+# -- the gesture --------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_paste_while_armed_is_replaced_by_a_marker_naming_its_length() -> None:
+    """The reported ask: the secret never appears in the composer at all."""
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _armed_capture(pilot, editor, "deploy with ")
+        assert editor.text == "deploy with [Credential #1, 64 chars] "
+        assert SECRET not in editor.text
+        assert SECRET not in _painted(app)
+
+
+@pytest.mark.asyncio
+async def test_the_caret_lands_after_the_marker_so_typing_continues_inline() -> None:
+    """ "Keep typing a description in the same message" is the whole gesture."""
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _armed_capture(pilot, editor, "deploy with ")
+        for char in " for staging":
+            await pilot.press(char)
+        await pilot.pause()
+        assert editor.text == "deploy with [Credential #1, 64 chars]  for staging"
+
+
+@pytest.mark.asyncio
+async def test_arming_works_mid_line_not_only_at_the_start() -> None:
+    """``/credential`` ANYWHERE in the line, per the operator's request."""
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _armed_capture(pilot, editor, "here is the key we use in CI, ")
+        assert editor.text.startswith("here is the key we use in CI, [Credential #1,")
+        assert SECRET not in editor.text
+
+
+@pytest.mark.asyncio
+async def test_the_mid_line_command_picker_opens_and_highlights_credential() -> None:
+    """The picker's mid-line predicate, pinned against the REAL app.
+
+    Scope note: the picker already supported an inline slash token, so this
+    asserts rather than adds. It is pinned because the whole gesture is
+    discoverable only through this list.
+    """
+    app = OperatorApp(lambda: _factory(FakeSession()))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        for char in "check this /cred":
+            await pilot.press(char)
+        await pilot.pause()
+        assert editor._picker.is_open()
+        assert editor._picker_query() == "cred"
+        assert editor._picker.highlighted_name() == "cred"
+
+
+@pytest.mark.asyncio
+async def test_a_short_secret_is_captured_though_it_is_far_below_the_collapse_size() -> None:
+    """The mode gate must precede the size question.
+
+    A one-line secret is nowhere near ``MIN_PASTE_ROWS``; if the size branch
+    were asked first the value would be inserted verbatim and never redacted.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _armed_capture(pilot, editor, "", secret="short-key")
+        assert editor.text == "[Credential #1, 9 chars] "
+
+
+@pytest.mark.asyncio
+async def test_an_unarmed_paste_of_the_same_secret_is_left_alone() -> None:
+    """The gate is the ARMING TOKEN, not the payload: no paste is special."""
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        for char in "just some text ":
+            await pilot.press(char)
+        app.post_message(events.Paste("short-key"))
+        await pilot.pause()
+        await pilot.pause()
+        assert editor.text == "just some text short-key"
+        assert not editor._attachments
+
+
+@pytest.mark.asyncio
+async def test_a_mention_of_the_command_earlier_in_the_draft_does_not_arm() -> None:
+    """``/credential`` must be at the CARET, or an ordinary paste is captured."""
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        for char in "fix the /credential command please ":
+            await pilot.press(char)
+        app.post_message(events.Paste("an ordinary paste"))
+        await pilot.pause()
+        await pilot.pause()
+        assert editor.text.endswith("an ordinary paste")
+        assert not any(
+            isinstance(value, PastedCredential) for value in editor._attachments.values()
+        )
+
+
+# -- the edge cases the gesture has to decide ---------------------------------
+@pytest.mark.asyncio
+async def test_an_empty_paste_while_armed_creates_no_zero_length_credential() -> None:
+    """A blank value is refused by the store anyway; advertising it would lie."""
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        for char in "/credential ":
+            await pilot.press(char)
+        app.post_message(events.Paste("   \n  "))
+        await pilot.pause()
+        await pilot.pause()
+        assert not editor._attachments
+        assert "Credential #" not in editor.text
+
+
+@pytest.mark.asyncio
+async def test_pasting_twice_while_armed_captures_two_distinct_credentials() -> None:
+    """Two pastes are two secrets: the first marker keeps its own payload."""
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _armed_capture(pilot, editor, "", secret="first-secret")
+        for char in "/credential ":
+            await pilot.press(char)
+        app.post_message(events.Paste("second-secret"))
+        await pilot.pause()
+        await pilot.pause()
+        payloads = credential_payloads(editor.text, editor._attachments)
+        assert [payload.value for payload in payloads] == ["first-secret", "second-secret"]
+        assert len({payload.key for payload in payloads}) == 2
+
+
+@pytest.mark.asyncio
+async def test_backspacing_the_marker_forgets_the_stashed_secret() -> None:
+    """No orphaned secret survives in memory after the marker is deleted."""
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _armed_capture(pilot, editor, "")
+        assert any(isinstance(value, PastedCredential) for value in editor._attachments.values())
+        # Backspace over the trailing space, then over the marker itself, which
+        # deletes atomically as one token.
+        await pilot.press("backspace")
+        await pilot.press("backspace")
+        await pilot.pause()
+        assert "Credential #" not in editor.text
+        assert not editor._attachments
+
+
+@pytest.mark.asyncio
+async def test_ctrl_r_refuses_to_expand_a_credential_back_into_the_buffer() -> None:
+    """The escape hatch for a paste must not become a way to reveal a secret."""
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _armed_capture(pilot, editor, "")
+        # SkipAction is the refusal: the key falls through the binding chain
+        # rather than silently doing nothing, exactly as it does on an image.
+        with pytest.raises(SkipAction):
+            editor.action_expand_paste()
+        await pilot.pause()
+        assert SECRET not in editor.text
+        assert "[Credential #1, 64 chars]" in editor.text
+
+
+# -- the random name ----------------------------------------------------------
+def test_a_generated_key_round_trips_through_normalize_credential_key() -> None:
+    """A name the store would renormalise would advertise the wrong key."""
+    for _ in range(200):
+        key = generate_credential_key()
+        assert key.startswith(CREDENTIAL_KEY_PREFIX)
+        assert normalize_credential_key(key) == key
+
+
+def test_a_generated_key_avoids_names_already_taken() -> None:
+    """A collision would SILENTLY REPLACE a live credential."""
+    taken = {generate_credential_key() for _ in range(50)}
+    for _ in range(50):
+        assert generate_credential_key(taken) not in taken
+
+
+def test_generated_keys_are_not_all_the_same() -> None:
+    assert len({generate_credential_key() for _ in range(100)}) > 90
+
+
+# -- the six expansion seams --------------------------------------------------
+# Each existing marker type is designed to be re-expanded into the prompt at
+# submit. A credential must be skipped at EVERY seam where that happens, and
+# these six are all of them. They are listed individually rather than in a loop
+# so a failure names the seam that leaked.
+def _mixed() -> tuple[str, dict[int, Marked]]:
+    """A draft citing a credential, a collapsed paste and an image at once."""
+    from local_operator.harness.types import ImageContent
+
+    text = (
+        "look at [Paste #1, 9 lines] and [Credential #2, 64 chars] "
+        "and [Image #3, 10x20] together"
+    )
+    attachments: dict[int, Marked] = {
+        1: PastedText("PAYLOAD-TEXT", "[Paste #1, 9 lines]"),
+        2: PastedCredential(SECRET, "LOP_SECRET_ABCD2345", "[Credential #2, 64 chars]"),
+        3: Attachment(
+            ImageContent(data="AAAA", mime_type="image/png"),
+            "[Image #3, 10x20]",
+        ),
+    }
+    return text, attachments
+
+
+def test_seam_1_expand_pastes_does_not_splice_a_credential_value() -> None:
+    """``expand_pastes`` is THE prompt-side expansion: /goal, /team, $skill…"""
+    text, attachments = _mixed()
+    expanded = expand_pastes(text, attachments)
+    assert SECRET not in expanded
+    assert "PAYLOAD-TEXT" in expanded, "the ordinary paste must still expand"
+    assert "[Credential #2, 64 chars]" in expanded
+
+
+def test_seam_2_resolve_markers_does_not_resolve_a_credential_to_an_image() -> None:
+    text, attachments = _mixed()
+    images = resolve_markers(text, attachments)
+    assert len(images) == 1, "only the real image resolves"
+
+
+def test_seam_3_strip_paste_citations_removes_the_credential_from_history() -> None:
+    """History cannot carry the payload, so it must not carry the citation."""
+    text, attachments = _mixed()
+    stripped = strip_paste_citations(text, attachments)
+    assert SECRET not in stripped
+    assert "Credential #2" not in stripped
+    assert "Paste #1" not in stripped
+    assert "[Image #3, 10x20]" in stripped, "images are deliberately left alone"
+
+
+def test_seam_4_substitute_credentials_emits_the_name_and_never_the_value() -> None:
+    """The one rewrite a credential marker gets: name + length, no bytes."""
+    text, attachments = _mixed()
+    substituted = substitute_credentials(text, attachments)
+    assert SECRET not in substituted
+    assert "LOP_SECRET_ABCD2345" in substituted
+    assert "64 chars" in substituted
+
+
+def test_seam_5_the_draft_store_never_writes_a_secret_to_disk(tmp_path: Path) -> None:
+    """The sidebar spills unsubmitted drafts to a temp JSON file."""
+    from local_operator.tui.session_drafts import SessionDraftStore
+    from local_operator.tui.session_interaction import SessionDraft
+
+    text, attachments = _mixed()
+    store = SessionDraftStore()
+    payload = store._encode_draft(SessionDraft(text=text, attachments=dict(attachments)))
+    encoded = json.dumps(payload)
+    assert SECRET not in encoded
+    assert "LOP_SECRET_ABCD2345" in encoded, "the key is kept so the marker still paints"
+    assert "PAYLOAD-TEXT" in encoded, "an ordinary paste is still spilled"
+    # And it survives the round trip as a valued-less credential.
+    restored = store._decode_attachments(payload["attachments"])
+    assert isinstance(restored[2], PastedCredential)
+    assert restored[2].value == ""
+    assert restored[2].key == "LOP_SECRET_ABCD2345"
+
+
+def test_seam_6_the_marker_grammar_keeps_its_groups_named() -> None:
+    """A positional group here silently makes ``index`` mean ``'Credential'``."""
+    match = ATTACHMENT_MARKER.search("x [Credential #7, 64 chars] y")
+    assert match is not None
+    assert match.group("kind") == "Credential"
+    assert match.group("index") == "7"
+
+
+# -- the submit path, end to end ----------------------------------------------
+@pytest.mark.asyncio
+async def test_submitting_stores_the_secret_and_sends_only_its_name() -> None:
+    """The whole property, on the real app: value to the store, name to the model."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        await _armed_capture(pilot, editor, "deploy with ")
+        for char in " use this for staging":
+            await pilot.press(char)
+        await pilot.press("enter")
+        for _ in range(10):
+            await pilot.pause()
+
+        keys = session.variables.credential_names()
+        assert len(keys) == 1
+        assert keys[0].startswith(CREDENTIAL_KEY_PREFIX)
+        assert session.variables.credential_env()[keys[0]] == SECRET
+
+        sent = " ".join(str(prompt) for prompt in session.prompts)
+        assert SECRET not in sent
+        assert keys[0] in sent, "the model must learn the NAME"
+        assert "64 chars" in sent, "…and the length"
+        assert "use this for staging" in sent, "…and the operator's description"
+        assert SECRET not in _painted(app)
+
+
+@pytest.mark.asyncio
+async def test_the_arming_token_is_consumed_so_a_leading_gesture_is_not_dispatched() -> None:
+    """A leading ``/credential`` + paste must SEND, not run the slash command.
+
+    Without consuming the token the submitted line would start with
+    ``/credential`` and ``_dispatchable_slash`` would route it to the masked
+    prompt with the marker as its KEY.
+    """
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        await _armed_capture(pilot, editor, "")
+        for char in " the staging deploy key":
+            await pilot.press(char)
+        await pilot.press("enter")
+        for _ in range(10):
+            await pilot.pause()
+        assert session.variables.credential_names(), "the secret was stored"
+        sent = " ".join(str(prompt) for prompt in session.prompts)
+        assert "the staging deploy key" in sent, "the message was SENT, not dispatched"
+        assert SECRET not in sent
+
+
+@pytest.mark.asyncio
+async def test_the_secret_never_reaches_the_prompt_history() -> None:
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        await _armed_capture(pilot, editor, "deploy with ")
+        for char in " for staging":
+            await pilot.press(char)
+        await pilot.press("enter")
+        for _ in range(10):
+            await pilot.pause()
+        assert editor._history
+        assert not any(SECRET in entry for entry in editor._history)
+        assert not any("Credential #" in entry for entry in editor._history)
+
+
+@pytest.mark.asyncio
+async def test_a_credential_inside_a_goal_argument_is_not_expanded() -> None:
+    """``prompt_arg`` is flag-derived; a credential must not ride into /goal."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        for char in "/goal ship it with /credential ":
+            await pilot.press(char)
+        await pilot.pause()
+        app.post_message(events.Paste(SECRET))
+        await pilot.pause()
+        await pilot.pause()
+        assert SECRET not in editor.text
+        await pilot.press("enter")
+        for _ in range(10):
+            await pilot.pause()
+        goal = getattr(session, "goal", "") or ""
+        assert SECRET not in goal
+        assert SECRET not in _painted(app)
+
+
+@pytest.mark.asyncio
+async def test_the_secret_never_reaches_the_session_journal() -> None:
+    """The journal records the KEY; a resume must not replay the value."""
+    session = FakeSession()
+    recorded: list[tuple[str, str]] = []
+
+    def _journal(key: str, *, action: str = "stored", replaced: bool = False) -> None:
+        recorded.append((key, action))
+
+    session.journal_credential_change = _journal  # type: ignore[attr-defined]
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        await _armed_capture(pilot, editor, "deploy with ")
+        await pilot.press("enter")
+        for _ in range(10):
+            await pilot.pause()
+    assert recorded, "the capture must be announced to the model"
+    assert all(key.startswith(CREDENTIAL_KEY_PREFIX) for key, _ in recorded)
+    assert not any(SECRET in key for key, _ in recorded)
+
+
+@pytest.mark.asyncio
+async def test_arming_from_inside_another_commands_argument_slot_still_captures() -> None:
+    """No existing command combines an argument list with a modal paste state.
+
+    The scout flagged this as genuinely unknown behaviour, so it is pinned
+    rather than reasoned about: with the caret sitting in ``/model``'s argument
+    slot, an inline ``/credential`` still arms and the paste is still captured.
+    The gate is a caret-anchored text predicate, so it does not care which list
+    the picker happens to be showing — which is the property that makes the
+    combination safe.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        await _armed_capture(pilot, editor, "/model gpt ")
+        assert editor.text == "/model gpt [Credential #1, 64 chars] "
+        assert SECRET not in editor.text
+
+
+@pytest.mark.asyncio
+async def test_a_credential_captured_while_the_aside_is_open_does_not_leak_into_it() -> None:
+    """The ``/btw`` exit returns early, so the capture must precede it."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        for char in "/btw ":
+            await pilot.press(char)
+        await pilot.press("enter")
+        for _ in range(10):
+            await pilot.pause()
+        if not app._aside_is_open():
+            pytest.skip("the aside did not open in this configuration")
+        editor = app._editor()
+        editor.focus()
+        await _armed_capture(pilot, editor, "what is ")
+        await pilot.press("enter")
+        for _ in range(10):
+            await pilot.pause()
+        assert SECRET not in _painted(app)
+        asked = " ".join(str(question) for question in getattr(session, "aside_questions", []))
+        assert SECRET not in asked
+
+
+@pytest.mark.asyncio
+async def test_the_secret_never_reaches_a_shell_command() -> None:
+    """Bang-mode runs the submitted line as a command — so it must not hold bytes.
+
+    The capture runs ahead of the shell branch, so what reaches
+    ``_run_shell_command`` (and therefore the operator's shell history) is the
+    substituted name, never the value.
+    """
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    ran: list[str] = []
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        app._run_shell_command = lambda command: ran.append(command)  # type: ignore[assignment]
+        editor = app._editor()
+        editor.focus()
+        editor.set_shell_mode(True)
+        await pilot.pause()
+        await _armed_capture(pilot, editor, "echo ")
+        await pilot.press("enter")
+        for _ in range(10):
+            await pilot.pause()
+    assert not any(SECRET in command for command in ran), ran
+
+
+# -- degraded paths -----------------------------------------------------------
+def test_the_store_key_is_usable_by_a_real_variable_store() -> None:
+    """The generated name must actually work in the store it is destined for."""
+    store = VariableStore()
+    key = generate_credential_key()
+    result = store.store_credential(key, SECRET, "command")
+    assert result.ok
+    assert result.credential is not None
+    assert result.credential.key == key
+    assert store.credential_env()[key] == SECRET
+    assert store.credential_names() == [key]
+
+
+class _ViewerSession(FakeSession):
+    """A follower: no local variable store, exactly as a real viewer has none.
+
+    A SUBCLASS rather than a patched attribute on the shared double, so the
+    viewer shape cannot leak into any other test in the suite.
+    """
+
+    @property
+    def variables(self):  # type: ignore[override]
+        return None
+
+
+@pytest.mark.asyncio
+async def test_a_session_without_a_store_says_so_instead_of_silently_dropping() -> None:
+    """A viewer must never advertise a key ``bash`` cannot read."""
+    session = _ViewerSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        await _armed_capture(pilot, editor, "deploy with ")
+        await pilot.press("enter")
+        for _ in range(10):
+            await pilot.pause()
+        painted = _painted(app)
+        assert SECRET not in painted
+        sent = " ".join(str(prompt) for prompt in session.prompts)
+        assert SECRET not in sent
+        assert "NOT stored" in sent, "the model must not be promised a key nothing holds"

--- a/tests/unit/tui/test_inline_credential.py
+++ b/tests/unit/tui/test_inline_credential.py
@@ -26,6 +26,7 @@ from textual.app import App, ComposeResult
 
 from local_operator.tui.app import (
     CREDENTIAL_ARMED_NOTICE,
+    CREDENTIAL_HELD_NOTICE,
     CREDENTIAL_PLACEHOLDER,
     OperatorApp,
 )
@@ -1384,3 +1385,239 @@ async def test_a_flag_disarm_clears_the_pickers_armed_notice() -> None:
         for _ in range(4):
             await pilot.pause()
         assert CREDENTIAL_ARMED_NOTICE not in _painted(app)
+
+
+# -- D9: a leftover token is a live destroy-everything control ----------------
+async def _capture_leaving_a_leftover_token(pilot, app, editor) -> None:
+    """Post-capture state that leaves a SECOND, unarmed ``/credential`` behind.
+
+    The draft mentions the command in prose before the operator makes the real
+    gesture — ``fix the /credential command`` is an ordinary sentence, and it
+    ARMS, because it passes through ``/credential`` at end-of-line while being
+    typed (that is the same keystroke shape as ``deploy with /credential the
+    prod key``, which must stay armed; see ``CREDENTIAL_TOKEN``). The latch
+    therefore sits on the EARLIER token, the marker splices there, and the
+    token the operator typed at the caret is left in the buffer, unarmed and
+    with an empty argument slot.
+    """
+    for char in "fix the /credential command /credential ":
+        await pilot.press(char)
+    for _ in range(4):
+        await pilot.pause()
+    app.post_message(events.Paste(SECRET))
+    for _ in range(4):
+        await pilot.pause()
+    assert "/credential" in editor.text, "precondition: a leftover token remains"
+    assert not editor.credential_armed(), "precondition: the capture ended the arm"
+
+
+@pytest.mark.parametrize(
+    ("label", "keys"),
+    [
+        ("end", ["end", "enter", "enter"]),
+        ("right-walk", ["right"] * 30 + ["enter", "enter"]),
+    ],
+)
+@pytest.mark.asyncio
+async def test_the_post_capture_leftover_token_cannot_wipe_the_store(
+    label: str, keys: list[str]
+) -> None:
+    """D9: pure keystrokes out of the feature's own output wiped everything.
+
+    The leftover token is not a cosmetic blemish, it is a live, PRESELECTED,
+    unconfirmed ``--forget-all``. Its argument slot is empty, so the picker
+    offered every row with the destructive one highlighted, and ``end`` then
+    Enter twice — or an equivalent walk to end-of-line — completed and RAN it
+    against a live store, with no confirmation and no undo.
+
+    D1's guard does not cover this: it keys on ARMED, and the capture itself
+    disarms, so by this frame the arm is already gone. The condition that
+    tracks the hazard is that the composer is HOLDING a secret the operator can
+    see, which is what a citation means.
+    """
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        # A live credential from BEFORE this draft: the one a wipe destroys
+        # that the operator never consented to lose.
+        session.variables.store_credential("LOP_SECRET_LIVEKEY1", "kept", "command")
+        await _capture_leaving_a_leftover_token(pilot, app, editor)
+
+        for key in keys:
+            await pilot.press(key)
+            await pilot.pause()
+        for _ in range(8):
+            await pilot.pause()
+
+        assert (
+            "LOP_SECRET_LIVEKEY1" in session.variables.credential_names()
+        ), f"the pre-existing credential survives {label},enter,enter"
+
+
+@pytest.mark.asyncio
+async def test_the_chip_and_the_store_never_contradict_each_other() -> None:
+    """D9's load-bearing half: the wipe took the credential the chip cites.
+
+    The marker is a RECEIPT. Destroying what it points at while it is still on
+    screen put two rows of one frame in contradiction — a chip promising a
+    credential beside "No credentials stored for this session" — which is the
+    same defect class as the stale armed row (D7). So the property is not only
+    "the store survives" but "what is chipped is what is held".
+    """
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        await _capture_leaving_a_leftover_token(pilot, app, editor)
+        cited = [payload.key for payload in credential_payloads(editor.text, editor._attachments)]
+        assert len(cited) == 1, "precondition: the draft cites exactly one capture"
+
+        await pilot.press("end")
+        await pilot.press("enter")
+        await pilot.press("enter")
+        for _ in range(10):
+            await pilot.pause()
+
+        # The draft submitted, so its citation was honoured: the captured
+        # credential is IN the store rather than having been wiped alongside it.
+        assert (
+            cited[0] in session.variables.credential_names()
+        ), "the credential the chip cited reached the store"
+        assert SECRET not in _painted(app), "and the value itself never painted"
+
+
+@pytest.mark.asyncio
+async def test_a_held_credential_suppresses_the_destructive_rows_and_says_why() -> None:
+    """The mechanism behind D9, and the notice that keeps the list legible.
+
+    A list that simply emptied would read as the gesture having been dropped,
+    which is why the armed state has a notice; the held state needs its own,
+    because the armed one says "paste the secret" and by this point the
+    operator already has.
+    """
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        session.variables.store_credential("LOP_SECRET_LIVEKEY1", "kept", "command")
+        await _capture_leaving_a_leftover_token(pilot, app, editor)
+        assert editor.credential_cited(), "the buffer still cites the capture"
+
+        await pilot.press("end")
+        for _ in range(6):
+            await pilot.pause()
+        assert editor.picker.highlighted_name() is None, "no row is preselected"
+        assert CREDENTIAL_HELD_NOTICE in _painted(app), "the row says why it is empty"
+        assert CREDENTIAL_ARMED_NOTICE not in _painted(
+            app
+        ), "and does not promise a capture that already happened"
+
+
+@pytest.mark.asyncio
+async def test_the_forget_verbs_stay_reachable_by_typing_while_a_chip_is_held() -> None:
+    """The guard withholds ROWS, never the command.
+
+    Suppression that made the destructive verb unreachable would be a
+    regression dressed as a fix. The operator who means it still types it, and
+    typing the flag is the explicit act the preselected row was not.
+    """
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        session.variables.store_credential("LOP_SECRET_LIVEKEY1", "kept", "command")
+        await _capture_leaving_a_leftover_token(pilot, app, editor)
+
+        # Clear the draft, then ask for the destructive verb deliberately.
+        editor.text = ""
+        editor.move_cursor(editor._end_of_buffer())
+        for _ in range(4):
+            await pilot.pause()
+        for char in "/credential --forget-all":
+            await pilot.press(char)
+        for _ in range(4):
+            await pilot.pause()
+        await pilot.press("enter")
+        for _ in range(10):
+            await pilot.pause()
+
+        assert (
+            session.variables.credential_names() == []
+        ), "an explicitly typed --forget-all still wipes"
+
+
+@pytest.mark.asyncio
+async def test_the_guard_lifts_once_the_chip_is_gone() -> None:
+    """The suppression is scoped to the citation, not sticky for the session.
+
+    A capture the operator backspaced away is one they visibly withdrew, and
+    the map can still hold its payload until the edit funnel releases it — so
+    the guard asks about the CITATION, which tracks what is on screen.
+    """
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        session.variables.store_credential("LOP_SECRET_LIVEKEY1", "kept", "command")
+        await _capture_leaving_a_leftover_token(pilot, app, editor)
+        assert editor.credential_cited()
+
+        # The operator clears the draft: nothing is chipped any more.
+        editor.text = ""
+        editor.move_cursor(editor._end_of_buffer())
+        for _ in range(4):
+            await pilot.pause()
+        assert not editor.credential_cited(), "no chip, no reason to withhold the rows"
+        assert app._credential_choices(armed=False, cited=False), "the rows come back"
+
+
+@pytest.mark.asyncio
+async def test_a_second_capture_still_arms_while_the_first_chip_is_held() -> None:
+    """The two guards compose: holding a chip must not block a further capture.
+
+    Suppressing the destructive ROWS while a credential is cited must not touch
+    the gesture itself — handing over a key and then a secret is an ordinary
+    thing to do, and it is the case ``_capture_credential`` documents. The
+    ARMED notice takes precedence over the HELD one here because the operator
+    is mid-gesture, so what the NEXT paste does is the more urgent thing to say.
+    """
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        for char in "deploy with /credential ":
+            await pilot.press(char)
+        for _ in range(4):
+            await pilot.pause()
+        app.post_message(events.Paste(SECRET))
+        for _ in range(4):
+            await pilot.pause()
+        assert editor.credential_cited() and not editor.credential_armed()
+
+        for char in "and /credential ":
+            await pilot.press(char)
+        for _ in range(6):
+            await pilot.pause()
+        assert editor.credential_armed(), "the second gesture still arms"
+        painted = _painted(app)
+        assert CREDENTIAL_ARMED_NOTICE in painted, "mid-gesture, the armed notice wins"
+        assert CREDENTIAL_HELD_NOTICE not in painted, "and the two do not both show"
+
+        app.post_message(events.Paste("second-secret-value"))
+        for _ in range(4):
+            await pilot.pause()
+        assert editor.text.count("[Credential #") == 2, "both captures are chipped"
+        assert "second-secret-value" not in _painted(app)

--- a/tests/unit/tui/test_inline_credential.py
+++ b/tests/unit/tui/test_inline_credential.py
@@ -379,6 +379,173 @@ async def test_the_armed_token_is_still_tracked_while_text_before_it_is_edited()
         assert editor.text.startswith("please deploy [Credential #1,")
 
 
+#: Single edits that move the armed token FAR in one step, each a keystroke an
+#: operator reaches without doing anything unusual. The parameter is what the
+#: token slides by, and the values straddle the ``_ARM_DRIFT = 64`` boundary
+#: that used to sit in ``_relocate_armed_token``: 63 captured and 64 leaked.
+_ONE_BIG_EDIT = (
+    ("shift+home", ("shift+home", "backspace")),
+    ("delete_line", ("ctrl+shift+k",)),
+    ("kill_to_start", ("ctrl+u",)),
+    ("cut_block", ("shift+home", "ctrl+x")),
+)
+
+
+@pytest.mark.parametrize("name,keys", _ONE_BIG_EDIT, ids=[case[0] for case in _ONE_BIG_EDIT])
+@pytest.mark.parametrize("pad", (63, 64, 70, 120))
+@pytest.mark.asyncio
+async def test_one_large_edit_before_the_token_cannot_disarm_it(
+    pad: int, name: str, keys: tuple[str, ...]
+) -> None:
+    """R7 / QA Q5: a SINGLE edit may move the token ANY distance and stay armed.
+
+    ``_relocate_armed_token`` used to bound the move by ``_ARM_DRIFT = 64`` and
+    return ``None`` past it, which ``_sync_credential_arm`` reads as "the
+    operator deleted the gesture" — so it disarmed while the token was STILL
+    PLAINLY IN THE BUFFER, and silently, because ``reason="gone"`` has no
+    notice branch. The next paste landed as ordinary text: in the composer, in
+    scrollback, and in the prompt sent to the model in plaintext.
+
+    Measured at exactly that boundary: 63 characters above the token captured,
+    64 leaked. That is why this is parameterised over the distance rather than
+    asserting one case — a window of any size has the same cliff one character
+    further along, which is why the fix removes the distance test rather than
+    widening it.
+
+    The delta's own drift test could not catch this: it types seven characters
+    ONE KEYSTROKE AT A TIME, so the token never moves more than one character
+    per sync and no single edit ever crosses the window.
+    """
+    app = Host()
+    # Wide enough that the padding line is ONE visual row for every `pad` here:
+    # `home` moves to the start of the WRAPPED row, so a narrower composer would
+    # select only part of the line and the token would move less than `pad`.
+    async with app.run_test(size=(200, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        # Context ABOVE the token, then the gesture — all typed, because the
+        # arm is only reachable by keystrokes (`load_text` disarms).
+        for char in "x" * pad:
+            await pilot.press(char)
+        await pilot.press("shift+enter")
+        for char in "deploy /credential ":
+            await pilot.press(char)
+        await pilot.pause()
+        assert editor.credential_armed(), "precondition: the gesture armed"
+
+        # ONE edit, removing the whole line above and moving the token by pad+1.
+        editor.move_cursor((0, pad))
+        await pilot.pause()
+        for key in keys:
+            await pilot.press(key)
+        await pilot.pause()
+        assert editor.credential_armed(), f"{name} moved the token {pad} chars; it is still there"
+
+        editor.move_cursor(editor._end_of_buffer())
+        app.post_message(events.Paste(SECRET))
+        await pilot.pause()
+        await pilot.pause()
+        assert SECRET not in editor.text, "the paste was CAPTURED, not left in plaintext"
+        assert "[Credential #1, 64 chars]" in editor.text
+        assert SECRET not in _painted(app), "and nothing painted the secret"
+
+
+@pytest.mark.asyncio
+async def test_typing_over_a_large_selection_before_the_token_does_not_disarm_it() -> None:
+    """The same cliff reached by REPLACING a block rather than deleting it.
+
+    One keystroke over a wide selection is a single edit that both removes and
+    inserts, so the token's net move is the block's length. It is the route
+    that looks least like an edit to the token — the operator is retyping a
+    sentence somewhere else entirely — and under the drift window it disarmed
+    just as silently.
+    """
+    app = Host()
+    # Wide enough that the 150-character line is ONE visual row: `home` moves to
+    # the start of the WRAPPED row, so a narrower composer would select only
+    # part of it and measure a shorter move than the test claims.
+    async with app.run_test(size=(200, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        for char in "z" * 150:
+            await pilot.press(char)
+        await pilot.press("shift+enter")
+        for char in "deploy /credential ":
+            await pilot.press(char)
+        await pilot.pause()
+        assert editor.credential_armed()
+
+        # Select the whole 150-character line above and type ONE character over
+        # it: a single edit that moves the token by 149.
+        editor.move_cursor((0, 150))
+        await pilot.pause()
+        await pilot.press("shift+home")
+        await pilot.press("q")
+        await pilot.pause()
+        assert editor.text.startswith("q\n"), "precondition: the block really was replaced"
+        assert editor.credential_armed(), "replacing a block before the token keeps the arm"
+
+        editor.move_cursor(editor._end_of_buffer())
+        app.post_message(events.Paste(SECRET))
+        await pilot.pause()
+        await pilot.pause()
+        assert SECRET not in editor.text, "the secret was captured, not left in plaintext"
+        assert "[Credential #1, 64 chars]" in editor.text
+        assert SECRET not in _painted(app)
+
+
+@pytest.mark.asyncio
+async def test_a_large_edit_then_submit_never_discloses_the_secret() -> None:
+    """R7/Q5 as the DISCLOSURE property, on the real app and through submit.
+
+    ``credential_armed() is True`` is the mechanism; this is the thing that
+    actually matters and the thing that regressed — the secret must not reach
+    the model's prompt, the transcript, or the painted screen. Asserted end to
+    end because every one of those is a separate seam from the latch.
+    """
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        for char in "x" * 120:
+            await pilot.press(char)
+        await pilot.press("shift+enter")
+        for char in "deploy /credential ":
+            await pilot.press(char)
+        await pilot.pause()
+        assert editor.credential_armed()
+
+        # ONE edit, moving the token by 121. `delete_line` rather than
+        # `shift+home`: it takes the whole LOGICAL line, so the move does not
+        # depend on where the composer soft-wraps it at this width.
+        editor.move_cursor((0, 120))
+        await pilot.pause()
+        await pilot.press("ctrl+shift+k")
+        await pilot.pause()
+        assert editor.text.startswith("deploy /credential"), "precondition: the line above is gone"
+
+        editor.move_cursor(editor._end_of_buffer())
+        app.post_message(events.Paste(SECRET))
+        await pilot.pause()
+        await pilot.pause()
+        for char in " the staging key":
+            await pilot.press(char)
+        await pilot.press("enter")
+        for _ in range(12):
+            await pilot.pause()
+
+        sent = " ".join(str(prompt) for prompt in session.prompts)
+        assert SECRET not in sent, "the secret must NEVER reach the model"
+        assert "the staging key" in sent, "precondition: the message really was sent"
+        keys = session.variables.credential_names()
+        assert len(keys) == 1, "it went to the store instead"
+        assert session.variables.credential_env()[keys[0]] == SECRET
+        assert keys[0] in sent, "the model learns the NAME"
+        assert SECRET not in _painted(app), "and it is not on screen"
+
+
 # -- the edge cases the gesture has to decide ---------------------------------
 @pytest.mark.asyncio
 async def test_an_empty_paste_while_armed_creates_no_zero_length_credential() -> None:

--- a/tests/unit/tui/test_inline_credential.py
+++ b/tests/unit/tui/test_inline_credential.py
@@ -24,8 +24,9 @@ from textual import events
 from textual.actions import SkipAction
 from textual.app import App, ComposeResult
 
-from local_operator.tui.app import OperatorApp
+from local_operator.tui.app import CREDENTIAL_PLACEHOLDER, OperatorApp
 from local_operator.tui.widgets.editor import (
+    ASIDE_PLACEHOLDER,
     ATTACHMENT_MARKER,
     CREDENTIAL_KEY_PREFIX,
     Attachment,
@@ -33,14 +34,21 @@ from local_operator.tui.widgets.editor import (
     Marked,
     PastedCredential,
     PastedText,
+    _credential_label,
+    _paste_label,
     credential_payloads,
+    describe_unstored,
     expand_pastes,
     generate_credential_key,
     resolve_markers,
     strip_paste_citations,
     substitute_credentials,
 )
-from local_operator.variables import VariableStore, normalize_credential_key
+from local_operator.variables import (
+    CredentialStoreResult,
+    VariableStore,
+    normalize_credential_key,
+)
 from tests.unit.tui.test_app_pilot import FakeSession, _factory
 from tests.unit.tui.test_slash_echo import _boot
 
@@ -163,14 +171,23 @@ async def test_an_unarmed_paste_of_the_same_secret_is_left_alone() -> None:
 
 
 @pytest.mark.asyncio
-async def test_a_mention_of_the_command_earlier_in_the_draft_does_not_arm() -> None:
-    """``/credential`` must be at the CARET, or an ordinary paste is captured."""
+async def test_a_mention_of_the_command_in_text_never_typed_through_the_arm_does_not_arm() -> None:
+    """A draft that ARRIVES holding the word never passed through the gesture.
+
+    Recalled history, a restored draft and a pasted paragraph all land through
+    ``load_text``, and none of them is the operator typing the arming gesture.
+    Arming is still :data:`CREDENTIAL_ARM` at the caret and nothing else — what
+    changed in design round 1 (D2) is how long an arm SURVIVES once taken, not
+    how one is taken.
+    """
     app = Host()
     async with app.run_test(size=(100, 30)) as pilot:
         editor = app.query_one(Editor)
         editor.focus()
-        for char in "fix the /credential command please ":
-            await pilot.press(char)
+        editor.load_text("fix the /credential command please ")
+        editor.move_cursor(editor._end_of_buffer())
+        await pilot.pause()
+        assert not editor.credential_armed()
         app.post_message(events.Paste("an ordinary paste"))
         await pilot.pause()
         await pilot.pause()
@@ -593,3 +610,360 @@ async def test_a_session_without_a_store_says_so_instead_of_silently_dropping() 
         sent = " ".join(str(prompt) for prompt in session.prompts)
         assert SECRET not in sent
         assert "NOT stored" in sent, "the model must not be promised a key nothing holds"
+
+
+# -- the degraded store paths (review round 1 R1/R2, QA round 1 Q1-Q3) --------
+class _RefusingStore(VariableStore):
+    """A store that refuses named keys, so a PARTIAL store is reachable in test.
+
+    The shape this doubles is not hypothetical: a draft that spilled to the
+    sidebar's temp JSON comes back with ``value=""`` by design and the real
+    ``store_credential`` refuses a blank. This double reaches the same branch
+    without depending on the spill machinery, so the test pins the CITATION
+    rule rather than one route to it.
+    """
+
+    def __init__(self, *args, refuse: set[str] | None = None, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.refuse = refuse or set()
+
+    def store_credential(self, raw_key, value, source="command"):  # type: ignore[override]
+        if raw_key in self.refuse:
+            return CredentialStoreResult(ok=False, reason="empty-value")
+        return super().store_credential(raw_key, value, source)
+
+
+@pytest.mark.asyncio
+async def test_a_partial_store_never_advertises_the_key_that_did_not_land() -> None:
+    """THE regression test: some stored, some refused, each citation its own truth.
+
+    Two independent review streams found this one defect (review round 1 R1,
+    QA round 1 Q1): the guard was ``if not stored`` — the ALL-failed case — so a
+    single success rewrote EVERY citation to the confident "available to bash as
+    $KEY" form, including credentials the store had refused. The model was told
+    a secret was usable that ``credential_env()`` does not contain, and would
+    then debug an auth failure with no cause in the world it can see.
+
+    Asserted per citation, not in aggregate, because an aggregate assertion is
+    exactly the mistake the code made.
+    """
+    session = FakeSession()
+    # Seeded through the double's own lazy slot rather than the read-only
+    # property, so the refusing store IS the session's store everywhere.
+    session._variables = _RefusingStore(cwd="/tmp", env={})
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        await _armed_capture(pilot, editor, "client id ", secret="A" * 45)
+        # The FIRST capture is the one that will be refused, so the test also
+        # pins that the two citations are told apart by identity rather than by
+        # position — the failure mode a "first one wins" fix would still have.
+        first_key = next(
+            payload.key
+            for payload in editor._attachments.values()
+            if isinstance(payload, PastedCredential)
+        )
+        session.variables.refuse = {first_key}
+        for char in " and secret /credential ":
+            await pilot.press(char)
+        app.post_message(events.Paste("B" * 44))
+        await pilot.pause()
+        await pilot.pause()
+        for char in " for the oauth app":
+            await pilot.press(char)
+        await pilot.press("enter")
+        for _ in range(10):
+            await pilot.pause()
+
+        stored = session.variables.credential_names()
+        assert len(stored) == 1, "exactly one landed"
+        second_key = stored[0]
+        assert second_key != first_key
+
+        sent = " ".join(str(prompt) for prompt in session.prompts)
+        # The one that LANDED is advertised, with the env var the agent can use.
+        assert f"available to bash and eval as ${second_key}" in sent
+        # The one that did NOT is named as unstored, and its key is never
+        # offered to the agent in the confident form.
+        assert f"available to bash and eval as ${first_key}" not in sent
+        assert "NOT stored" in sent
+        # And the phantom key is not promised anywhere in the outgoing prompt.
+        assert first_key not in sent
+        assert "A" * 45 not in sent
+        assert "B" * 44 not in sent
+        # The operator's own words survive between the two citations.
+        assert "for the oauth app" in sent
+
+
+@pytest.mark.asyncio
+async def test_a_store_refusal_is_reported_to_the_operator_not_only_the_model() -> None:
+    """Q2: the composer clears and the marker vanishes — silence is not an option.
+
+    The viewer branch already emitted a notice; the refusal branch emitted
+    nothing, so an operator whose store said no was left believing they had
+    handed over a credential.
+    """
+    session = FakeSession()
+    # Seeded through the double's own lazy slot rather than the read-only
+    # property, so the refusing store IS the session's store everywhere.
+    session._variables = _RefusingStore(cwd="/tmp", env={})
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        await _armed_capture(pilot, editor, "deploy with ")
+        key = next(
+            payload.key
+            for payload in editor._attachments.values()
+            if isinstance(payload, PastedCredential)
+        )
+        session.variables.refuse = {key}
+        await pilot.press("enter")
+        for _ in range(10):
+            await pilot.pause()
+        painted = _painted(app)
+        assert "could not be stored" in painted, "the OPERATOR is told, not just the model"
+        assert key in painted, "…and which credential it was"
+        assert SECRET not in painted
+
+
+def test_the_refusal_phrase_names_the_cause_that_actually_applied() -> None:
+    """Q3: "no session store available" is false when a store refused the write."""
+    assert "no session store available" in describe_unstored(None)
+    # A present store that refused must not blame an absent one.
+    refused = describe_unstored("empty-value")
+    assert "no session store available" not in refused
+    assert "NOT stored" in refused, "the outcome leads, whatever the cause"
+
+
+# -- the armed state is legible and cannot be disarmed by accident (D1/D2) ----
+@pytest.mark.asyncio
+async def test_the_arm_survives_a_newline_and_a_typed_word() -> None:
+    """D2: the two ordinary edits that used to disarm SILENTLY into a plaintext paste.
+
+    The failure is asymmetric — a false negative puts the secret on screen and
+    in scrollback where nothing can recall it, while a false positive costs one
+    backspace — so the arm survives ordinary typing and only a flag ends it.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        for char in "deploy with /credential ":
+            await pilot.press(char)
+        assert editor.credential_armed()
+        await pilot.press("shift+enter")
+        assert editor.credential_armed(), "a newline must not disarm"
+        for char in "the prod key ":
+            await pilot.press(char)
+        assert editor.credential_armed(), "typing a description must not disarm"
+        app.post_message(events.Paste(SECRET))
+        await pilot.pause()
+        await pilot.pause()
+        assert SECRET not in editor.text, "the secret must NOT be in the buffer"
+        assert "[Credential #1, 64 chars]" in editor.text
+
+
+@pytest.mark.asyncio
+async def test_a_flag_argument_disarms_so_the_command_verbs_stay_reachable() -> None:
+    """The one continuation that is unambiguously the COMMAND, not a description.
+
+    Credential verbs are flag-shaped precisely so they cannot collide with a
+    key (keys normalize to ``[A-Z0-9_]`` and cannot begin with ``-``), so a
+    leading ``-`` is a safe partition.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        for char in "/credential ":
+            await pilot.press(char)
+        assert editor.credential_armed()
+        await pilot.press("-")
+        assert not editor.credential_armed(), "an argument is the command, not an arm"
+
+
+@pytest.mark.asyncio
+async def test_the_armed_token_is_painted_even_mid_line() -> None:
+    """D2: mid-line arming is the headline of the gesture and had NO ink at all.
+
+    ``_compute_slash_runs`` is a leading-command rule, so a mid-line
+    ``/credential`` returned ``None`` and the composer was byte-identical armed
+    and disarmed.
+    """
+    app = Host()
+    async with app.run_test(size=(100, 30)) as pilot:
+        editor = app.query_one(Editor)
+        editor.focus()
+        for char in "deploy with /credential ":
+            await pilot.press(char)
+        runs = editor._slash_runs()
+        assert runs is not None, "a mid-line arm must paint"
+        line, spans = runs
+        assert line == 0
+        assert [component for _, _, component in spans] == ["text-area--credential-armed"]
+        start, end, _ = spans[0]
+        assert editor.text[start:end].startswith("/credential")
+
+
+@pytest.mark.asyncio
+async def test_arming_suppresses_the_destructive_argument_rows() -> None:
+    """D1: arm + Enter + Enter used to complete and RUN ``--forget-all``.
+
+    The row was preselected with a ghost under the caret, no confirmation and
+    no undo, and Tab on the same row consumed the arming token so the next
+    paste landed in plaintext. Both keys act on a highlighted row, so removing
+    the rows while armed closes both.
+    """
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        # Seed a live credential so a wipe would be visible.
+        session.variables.store_credential("LOP_SECRET_LIVEKEY1", "kept", "command")
+        for char in "/credential ":
+            await pilot.press(char)
+        for _ in range(4):
+            await pilot.pause()
+        assert editor.credential_armed()
+        assert editor.picker.highlighted_name() is None, "no row is preselected while armed"
+        await pilot.press("enter")
+        await pilot.press("enter")
+        for _ in range(6):
+            await pilot.pause()
+        assert session.variables.credential_names() == [
+            "LOP_SECRET_LIVEKEY1"
+        ], "the live credential survives the reflex double-Enter"
+
+
+@pytest.mark.asyncio
+async def test_tab_while_armed_cannot_consume_the_token_into_a_plaintext_paste() -> None:
+    """D1(b): Tab accepted the ghost, which disarmed, and the next paste leaked."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        for char in "deploy with /credential ":
+            await pilot.press(char)
+        for _ in range(4):
+            await pilot.pause()
+        await pilot.press("tab")
+        for _ in range(4):
+            await pilot.pause()
+        assert "--forget-all" not in editor.text, "no ghost to accept"
+        assert editor.credential_armed(), "Tab must not silently disarm"
+        app.post_message(events.Paste(SECRET))
+        await pilot.pause()
+        await pilot.pause()
+        assert SECRET not in editor.text
+        assert SECRET not in _painted(app)
+
+
+# -- the small ones (R3, R5, D3, D6) ------------------------------------------
+def test_a_generated_key_avoids_names_the_session_store_already_holds() -> None:
+    """R3: the composer's own map resets each submit, so it cannot be the whole set."""
+    taken = {f"{CREDENTIAL_KEY_PREFIX}{'A' * 8}"}
+    for _ in range(50):
+        assert generate_credential_key(taken) not in taken
+
+
+def test_a_multi_line_secret_reports_characters_not_lines() -> None:
+    """R5: a line count is the weakest integrity check exactly where it matters.
+
+    A PEM block reads ``27 lines`` whether or not its tail arrived; the
+    character count moves for every lost byte, and the length is the operator's
+    only channel for noticing a wrong or truncated capture.
+    """
+    pem = "-----BEGIN KEY-----\n" + "\n".join("x" * 40 for _ in range(6)) + "\n-----END KEY-----"
+    assert "lines" not in _credential_label(pem)
+    assert _credential_label(pem) == f"{len(pem)} chars"
+    # The paste vocabulary is deliberately unchanged for ordinary pastes.
+    assert _paste_label(pem).endswith("lines")
+
+
+@pytest.mark.asyncio
+async def test_a_blank_paste_while_armed_says_so_and_stays_armed() -> None:
+    """D3: the operator who fumbled the copy saw neither "captured" nor "failed"."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        for char in "/credential ":
+            await pilot.press(char)
+        app.post_message(events.Paste("   \n  "))
+        for _ in range(6):
+            await pilot.pause()
+        assert not editor._attachments
+        assert editor.credential_armed(), "the arm survives, and the notice says so"
+        assert "still armed" in _painted(app)
+
+
+@pytest.mark.asyncio
+async def test_ctrl_r_on_a_credential_says_why_instead_of_doing_nothing() -> None:
+    """D6: a bare SkipAction left a byte-identical frame, read as a missed key."""
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        await _armed_capture(pilot, editor, "deploy with ")
+        editor.move_cursor(editor._offset_to_location(editor.text.index("[Credential") + 2))
+        # The ACTION, as its sibling test drives it: `pilot.press("ctrl+r")`
+        # does not reach the binding under this host, and the refusal (a
+        # SkipAction that falls through the binding chain) is the behaviour
+        # being asserted around.
+        with pytest.raises(SkipAction):
+            editor.action_expand_paste()
+        for _ in range(8):
+            await pilot.pause()
+        painted = _painted(app)
+        assert SECRET not in editor.text, "the refusal still holds"
+        assert SECRET not in painted
+        assert "can't be expanded" in painted
+
+
+@pytest.mark.asyncio
+async def test_arming_does_not_relabel_a_composer_another_mode_owns() -> None:
+    """The placeholder is a SHARED channel; the armed copy only borrows it.
+
+    Bang-mode, the aside and the read-only subagent page each own the
+    placeholder in their own mode, so restoring the RESTING copy on disarm
+    would silently relabel a surface this feature has no business touching.
+    """
+    session = FakeSession()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _boot(pilot, app)
+        editor = app._editor()
+        editor.focus()
+        editor.placeholder = ASIDE_PLACEHOLDER
+        for char in "/credential ":
+            await pilot.press(char)
+        for _ in range(4):
+            await pilot.pause()
+        assert editor.credential_armed()
+        assert editor.placeholder == ASIDE_PLACEHOLDER, "the aside keeps its own voice"
+        await pilot.press("-")
+        for _ in range(4):
+            await pilot.pause()
+        assert not editor.credential_armed()
+        assert editor.placeholder == ASIDE_PLACEHOLDER, "…and keeps it on the way out"
+
+        editor.load_text("")
+        editor.placeholder = editor.resting_placeholder
+        await pilot.pause()
+        for char in "/credential ":
+            await pilot.press(char)
+        for _ in range(4):
+            await pilot.pause()
+        assert editor.placeholder == CREDENTIAL_PLACEHOLDER, "a resting composer does say it"


### PR DESCRIPTION
## Summary of Changes

Typing `/credential` **anywhere** in the composer line now arms the next paste for capture. The secret is stashed **out of the buffer** and replaced in place by a bracketed marker in the same style as an image or large-text paste, showing its length — `[Credential #1, 64 chars]` — with the caret left past it so the operator keeps typing a description in the same message. On submit the value goes into the session credential store under a **randomly generated** name; the model receives the credential's NAME, its LENGTH and the operator's description, and never the bytes.

C2 additive feature. PR 4 of the credential-store series, but independent of PRs 1–3: it works against the existing session store (`variables.py` `store_credential`) today and leaves a clean seam for "persist this to the long-term store" later.

Release: minor — a new composer gesture; the paste path, the marker grammar and the draft spill format all gained a payload type.

`/credential KEYNAME` (the existing masked-prompt flow) is **unchanged**; `tests/unit/tui/test_credential_command.py` passes untouched. No version bump in this PR.

## Related Issue(s)

None requested; this PR is the C2 change record. Design context: `docs/design/secret-store.md` §11.

## Delivery contract

- `/credential` arms mid-line as well as leading. The command picker's inline predicate already supported this; it is now **pinned by test** against the real app rather than assumed.
- The captured marker uses `_paste_label`'s existing vocabulary (`64 chars` / `N lines`), the exact bracket style, and the **load-bearing trailing space** the other two marker kinds are issued with.
- The credential is named `LOP_SECRET_XXXXXXXX` (§11), env-var-shaped, generated with `secrets`, checked against names already taken, and asserted to round-trip `normalize_credential_key` unchanged.
- Deleting the marker forgets the secret — no orphaned value retained after a backspace.
- `ctrl+r` (`action_expand_paste`) **refuses** a credential. It is the one gesture that puts a stashed payload back into the visible buffer, so refusing is a security property, not a gap.
- The arming token is **consumed** with the paste, so a leading gesture sends as a message instead of dispatching the masked-prompt command with the marker as its KEY.
- Viewer/remote degrades **loudly**: the frontend has no local store (`credential_env()` is read by `bash` in the owner's process), so the capture is refused with a notice pointing at `/credential <KEY>`, and the model is told the credential was NOT stored. No silent no-op advertising a key the agent cannot read. Desktop is untouched — the inline gesture never routes through `native_action`, so `desktop_sessions.py:277`'s refusal is unaffected.

Non-goals: no long-term encrypted store, no `secret` CLI, no changes to redaction or `credential_env()` injection, no layout or theme changes.

## Implementation: one map, a third payload type

`PastedCredential` is a **third variant of the `Marked` union**, not a parallel map — `editor.py:608-618` documents that a second dict is the trap this feature has fallen into three times. Everything keyed on the marker number (the counter, the chip, the atomic-token gate, the release rule, the aside stash, the compaction hold, `EditorSubmitted`, `/reload`) is payload-agnostic and correct for free.

It is a **sibling of `PastedText` rather than a flag on it**, deliberately: the two differ in whether the payload is spliced back into the outgoing prompt, and as distinct types the existing `isinstance(..., PastedText)` filters exclude a credential **by construction** rather than by a flag a seam could forget.

`ATTACHMENT_MARKER` gained `Credential` in its alternation with **named groups preserved** — the number space is shared, so a parser blind to the new marker would hand `#1` out twice.

## The safety property: all six expansion seams

Every existing marker exists to be re-expanded at submit. A credential must be skipped at each seam, and each is proven by a test in `tests/unit/tui/test_inline_credential.py`:

| # | Seam | What it would have leaked | Test |
| --- | --- | --- | --- |
| 1 | `expand_pastes` | the prompt-side splice: `/goal`, `/team`, `/agent`, `$skill`, the aside | `test_seam_1_…` |
| 2 | `resolve_markers` | image resolution binding a credential as an attachment | `test_seam_2_…` |
| 3 | `strip_paste_citations` | the prompt **history**, recalled with Up-arrow | `test_seam_3_…` |
| 4 | `substitute_credentials` | the model-facing rewrite — emits the NAME, never the value | `test_seam_4_…` |
| 5 | `SessionDraftStore` | the sidebar spills unsubmitted drafts to a **temp JSON file** | `test_seam_5_…` |
| 6 | `ATTACHMENT_MARKER` | a positional group makes `index` silently return `'Credential'` | `test_seam_6_…` |

Seam 5 is the one not visible from the paste path: the draft store now writes the **key and marker but never the value**, so a session credential — memory-only for one session by construction — cannot reach disk through a caching side door.

Beyond the six, the value is **scrubbed from the attachments map** once the store owns it, so the `SessionDraft` hand-back, the compaction hold and the aside stash are safe by construction rather than by an argument about which of them re-expands.

**Both guards were mutation-tested.** Reverting seam 3's filter to `isinstance(pasted, PastedText)` fails 2 tests; adding `"value"` back to the seam-5 encoder fails 1. The tests can genuinely fail.

## Reproduction and actual execution

Driven through the **real `OperatorApp`** (real editor, real submit handler, real `VariableStore`), scripted provider only. Full gesture, 64-char token:

```text
1. COMPOSER AFTER PASTE : 'deploy with [Credential #1, 64 chars] '
   secret in composer?  : False
   caret               : (0, 38) len= 38
2. COMPOSER + DESCRIPTION: 'deploy with [Credential #1, 64 chars]  use this for the staging deploy'
   PAINTED has secret?  : False
3. STORE KEYS           : ['LOP_SECRET_XRQG9D43']
   value matches paste? : True
   key round-trips?     : True
4. PROMPTS SENT TO MODEL:
      'deploy with [credential LOP_SECRET_XRQG9D43 (64 chars) — available to bash and
       eval as $LOP_SECRET_XRQG9D43; its value cannot be read]  use this for the staging deploy'
   secret in prompts?   : False
5. secret in TRANSCRIPT?: False
   history entries      : ["'deploy with  use this for the staging deploy'"]
   secret in history?   : False
   attachments after    : {}
```

**Point at the absence:** line 4 is the entire message the model receives — the name, the length, how to use it, and the operator's own description, with no bytes. Line 5 shows the transcript, the prompt history and the composer's attachment map all clean after the turn. The store (line 3) holds the exact pasted value under a name that round-trips `normalize_credential_key`.

Edge cases, driven the same way:

| Case | Actual result |
| --- | --- |
| Mid-line arming, `check this /cred` | picker **open**, mode `COMMAND`, query `cred`, highlighted `cred` |
| Caret in **another command's argument slot** (`/model gpt /credential ` + paste) | `'/model gpt [Credential #1, 64 chars] '` — captured, no leak. The scout flagged this combination as genuinely unknown; the gate is a caret-anchored text predicate, so it does not care which list is showing |
| **History recall** after a capture | `'note  the deploy key'` — no secret, no orphaned marker. Stripped at the record seam (where the map is still live and `cite()` can tell the app's own citation from prose) rather than refused at submit, where the two are byte-identical |
| Credential inside a **`/goal`** argument | `prompt_arg` is flag-derived; the goal text and the painted frame are both free of the value |
| **Empty/whitespace** paste while armed | no marker, no zero-length credential; the whitespace the operator actually copied is inserted, since `store_credential` refuses a blank anyway |
| **Two pastes** while armed | two markers, two distinct keys, both payloads intact — the first receipt is never repointed at bytes the operator did not put behind it |
| **Bang-mode** submit | the substituted name reaches `_run_shell_command`, so the value cannot enter shell history |
| **Aside (`/btw`)** open | capture runs ahead of that early return; neither the painted frame nor the aside question holds the value |
| `EditorPasteAttached` / `EditorPasteEmpty` | neither fires on a credential paste — they describe image attachment, and the marker is its own receipt |

## Before / after frames

Captured with `scripts.visual_capture.save_capture` against the **real `OperatorApp` with its production stylesheet**, rasterized and actually viewed. Evidence is [on this gist](https://gist.github.com/damianvtran/9db0dac199afd91f0ffd249f38329a78), not in the repository.

Same state in both: the operator typed `deploy with /credential `, pasted a token, then typed ` use this for the staging deploy`.

- [before.svg](https://gist.githubusercontent.com/damianvtran/9db0dac199afd91f0ffd249f38329a78/raw/pr4-before.svg) — the raw secret sits in the composer across three wrapped rows, in plain text, on screen.
- [after.svg](https://gist.githubusercontent.com/damianvtran/9db0dac199afd91f0ffd249f38329a78/raw/pr4-after.svg) — `[Credential #1, 60 chars]` painted as a marker chip, the description continuing inline after it, no secret anywhere on the frame.

**Numbers behind the frames** (geometry JSON in the gist): grid unchanged at `110×26` in both. The composer shrinks from 3 rows to 2 — `Editor` size `[69,3]` → `[69,2]`, `input-row` `[73,3]` → `[73,2]`, `input-dock` `[108,10]` → `[108,8]` — because the marker is shorter than the token it replaced, so the transcript above gains 2 rows (`TranscriptView` `[107,13]` → `[107,15]`). That is the redaction visible as layout, and it is the intended direction: the draft got shorter and more legible, which is the whole point of collapsing a payload to a receipt. No scrollbars appear in either frame.

## Testing Details

| Check | Actual result |
| --- | --- |
| Whole-tree unit suite (`tests/unit`, as CI) | **16,539 passed, 18 skipped, 1 error** in 1109.22s (18m29s) — the error classified below |
| New suite `tests/unit/tui/test_inline_credential.py` | **31 passed** |
| Focused regression (credential, paste-collapse, marker-chip, paste-images, drafts, composer-seam) | **281 passed** in 27.33s |
| Assembled `tests/e2e -m e2e -n0` | **50 passed** in 62.80s |
| Whole-tree flake8 | exit 0 |
| Pinned Black 26.1.0 | `1091 files would be left unchanged` |
| Pinned isort 5.13.2 | exit 0 |
| Whole-tree pyright 1.1.411 | **0 errors, 0 warnings, 0 informations** |
| Mutation check, seam 3 | reverting the filter → **2 failed**, guard is load-bearing |
| Mutation check, seam 5 | re-adding `"value"` to the encoder → **1 failed**, guard is load-bearing |

**The one error is host contention, not this change.** `tests/unit/evaluation/runner/test_episode_subprocess.py::test_real_worker_completes_a_scored_episode` errored under xdist with `dyld: Library not loaded: @rpath/libpython3.12.dylib` while copying an interpreter into a temp venv — the machine was at **load average 175** from sibling worktrees running their own suites. Re-run in isolation on this same branch: **30 passed in 191.39s**. The test imports nothing from `tui/`, `editor` or `session_drafts`, and the failure mode is a missing shared library in a temp venv, not an assertion.

TUI runs used `env -u NO_COLOR TERM=xterm-256color`. The worktree owns its own venv, verified resolving to `lo-pr4-credential/local_operator/__init__.py`.
