### PR TITLE
chore(release): bump version to 0.51.24

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.23"
+version = "0.51.24"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window claimed. Owner session pid: 99348.

Last tag: v0.51.23. Provisional version: v0.51.24, bump class **patch**.

Window (tick as each merges):
- [x] #790 — `cac1155ab410100a7a4cfd27d2f02a0c27ef7ebc` — Release: patch — scheduled wake times now display in local time with AM/PM by default and an explicit timezone label, with a `display.time_format: 24h` opt-in under /settings → Appearance; wake rows also truncate to the screen width so longer timestamps cannot widen the dock in narrow terminals.

If you merge to main while this window is open, reply with PR number, merge SHA and your PR body `Release:` line at merge time. The window will be re-derived immediately before tagging.