### PR TITLE
fix(tui): reveal saved conversations independently of runtime sync

### DIFF
--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -521,6 +521,7 @@ class RemoteSession:
         self._history: list[Any] = []
         self._live_history: dict[str, Any] = {}
         self._display_window_requested = False
+        self.saved_preview_partial = False
         self._owner_record: SessionRecord | None = None
         self._display_refresh_lock = asyncio.Lock()
         self._display_refresh_task: asyncio.Task[None] | None = None
@@ -781,6 +782,46 @@ class RemoteSession:
             self._discard_rejected_client()
             raise
         self._finish_sync()
+        return self
+
+    @classmethod
+    async def saved_preview(
+        cls,
+        session_id: str,
+        *,
+        config_dir: Path,
+        cwd: str,
+        takeover_factory: Callable[[], Any],
+    ) -> "RemoteSession":
+        """Expose saved rows without waiting on a runtime or loading its journal.
+
+        This is a display facade, not canonical input readiness. The sidebar
+        keeps mutation gates closed until the usual owner sync finishes. Keep
+        config/auth resolution off this path too: even metadata can block on an
+        external provider. The authenticated snapshot supplies it on binding.
+        """
+        from local_operator.session.frontend_state import FrontendModelSpec
+        from local_operator.session.saved_preview import read_saved_preview
+
+        preview = await asyncio.to_thread(read_saved_preview, config_dir / "sessions" / session_id)
+        self = cls(config_dir=config_dir, session_id=session_id, takeover_factory=takeover_factory)
+        self._cwd = preview.cwd or cwd
+        self.saved_preview_partial = preview.partial
+        self._can_go_cold = True
+        self._display_window_requested = True
+        self._bind_history(preview.messages, None, drop_history_duplicates=True)
+        model = FrontendModelSpec(provider="", model_id="")
+        self._install_frontend(
+            FrontendSessionState(
+                session_id=session_id,
+                epoch=f"cold-{session_id}",
+                cwd=self._cwd,
+                selected_model=model,
+                effective_model=model,
+            )
+        )
+        self._finish_sync()
+        self._owner_ready.set()
         return self
 
     @classmethod

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -801,9 +801,25 @@ class RemoteSession:
         external provider. The authenticated snapshot supplies it on binding.
         """
         from local_operator.session.frontend_state import FrontendModelSpec
-        from local_operator.session.saved_preview import read_saved_preview
+        from local_operator.session.saved_preview import (
+            SavedPreview,
+            read_saved_preview,
+        )
 
-        preview = await asyncio.to_thread(read_saved_preview, config_dir / "sessions" / session_id)
+        try:
+            preview = await asyncio.to_thread(
+                read_saved_preview, config_dir / "sessions" / session_id
+            )
+        except FileNotFoundError:
+            from local_operator.mobile.attach_client import find_owner_record
+
+            # A speculative live owner can deliberately defer creating its
+            # journal until its first write. Only an actual discoverable owner
+            # proves that empty state; a stale catalog row proves nothing.
+            record, owner = await asyncio.to_thread(find_owner_record, config_dir, session_id)
+            if record is None or owner is None:
+                raise FileNotFoundError("This conversation is no longer available") from None
+            preview = SavedPreview([], False, record.cwd or cwd)
         self = cls(config_dir=config_dir, session_id=session_id, takeover_factory=takeover_factory)
         self._cwd = preview.cwd or cwd
         self.saved_preview_partial = preview.partial

--- a/local_operator/session/saved_preview.py
+++ b/local_operator/session/saved_preview.py
@@ -1,0 +1,77 @@
+"""A bounded, explicitly non-canonical journal preview for terminal navigation.
+
+Only complete suffix rows are replayed. Prunes occur after their targets, so
+all prunes affecting these rows are in this same suffix. An incomplete final
+row, malformed row, or unresolved compaction cut makes the preview unavailable:
+we cannot prove that omitted bytes did not retract something we would display.
+No attachment is hydrated and this reader never starts an owner.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from local_operator.session.history_window import DISPLAY_HISTORY_MESSAGES
+from local_operator.session.transcript import TranscriptEntry, replay_entries
+
+PREVIEW_BYTES = 256 * 1024
+
+
+@dataclass(frozen=True)
+class SavedPreview:
+    messages: list[Any]
+    partial: bool
+    cwd: str = ""
+
+
+def read_saved_preview(directory: Path) -> SavedPreview:
+    path = directory / "transcript.jsonl"
+    try:
+        with path.open("rb") as handle:
+            handle.seek(0, 2)
+            size = handle.tell()
+            start = max(0, size - PREVIEW_BYTES)
+            handle.seek(start)
+            data = handle.read(PREVIEW_BYTES)
+    except FileNotFoundError:
+        return SavedPreview([], False)
+    partial = start > 0
+    if partial:
+        _, separator, data = data.partition(b"\n")
+        if not separator:
+            return SavedPreview([], True)
+    if data and not data.endswith(b"\n"):
+        return SavedPreview([], True)
+    entries = []
+    try:
+        for line in data.decode("utf-8").splitlines():
+            if not line.strip():
+                continue
+            entry = TranscriptEntry.from_json(line)
+            if entry is None:
+                return SavedPreview([], True)
+            entries.append(entry)
+    except UnicodeError:
+        return SavedPreview([], True)
+    ids = {entry.id for entry in entries}
+    for entry in reversed(entries):
+        if entry.type == "compaction":
+            kept = entry.payload.get("first_kept_entry_id")
+            if kept is not None and kept not in ids:
+                return SavedPreview([], True)
+            break
+    cwd = next(
+        (str(entry.payload.get("cwd", "")) for entry in entries if entry.type == "session"),
+        "",
+    )
+    messages = replay_entries(entries, None)
+    # The byte ceiling bounds disk/parse work; a separate row ceiling bounds
+    # replay bookkeeping and Textual's preparation of many tiny messages. Apply
+    # prunes/compaction BEFORE slicing, never truncate away their instructions.
+    return SavedPreview(
+        messages[-DISPLAY_HISTORY_MESSAGES:],
+        partial or len(messages) > DISPLAY_HISTORY_MESSAGES,
+        cwd,
+    )

--- a/local_operator/session/saved_preview.py
+++ b/local_operator/session/saved_preview.py
@@ -28,15 +28,15 @@ class SavedPreview:
 
 def read_saved_preview(directory: Path) -> SavedPreview:
     path = directory / "transcript.jsonl"
-    try:
-        with path.open("rb") as handle:
-            handle.seek(0, 2)
-            size = handle.tell()
-            start = max(0, size - PREVIEW_BYTES)
-            handle.seek(start)
-            data = handle.read(PREVIEW_BYTES)
-    except FileNotFoundError:
-        return SavedPreview([], False)
+    # A missing journal is not evidence of an empty conversation. The caller
+    # may separately prove an unmaterialised live owner exists; this reader
+    # never invents that authority from an absent path.
+    with path.open("rb") as handle:
+        handle.seek(0, 2)
+        size = handle.tell()
+        start = max(0, size - PREVIEW_BYTES)
+        handle.seek(start)
+        data = handle.read(PREVIEW_BYTES)
     partial = start > 0
     if partial:
         _, separator, data = data.partition(b"\n")

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -8913,6 +8913,11 @@ class OperatorApp(App[None]):
         A socket object can exist before its canonical sync. Never derive
         permission from that object or queue a user mutation until it binds.
         Local draft clearing, copy and exiting do not require owner authority.
+
+        Scoped to the SOURCE deliberately. ``_session_transition_pending`` is a
+        different state with its own better answers — ``/stop`` says "still
+        starting" there, and ``/reload`` owns the window — so folding it in
+        here would replace those with this method's generic refusal.
         """
         source = source or self._interaction
         return (
@@ -8920,7 +8925,6 @@ class OperatorApp(App[None]):
             and not source.retired
             and not source.display_only
             and not source.command_frame_pending
-            and not self._session_transition_pending
             and not self._sidebar_navigation.requested_id
         )
 

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -4728,6 +4728,7 @@ class OperatorApp(App[None]):
             # A drawer cannot count as a correct visible conversation while it
             # covers the response. Pinned wide sidebars stay open.
             self._set_sidebar_open(False)
+        self._start_resume_fill()
         self._show_sidebar_connection(source)
         if not source.draft.following_tail and source.draft.scroll_anchor_id:
             scroll_revision = source.scroll_revision
@@ -7165,15 +7166,50 @@ class OperatorApp(App[None]):
         duplicate RPC F1 reported, and the cursor it would send is the one the
         first request is already consuming (`history changed while paging`).
         """
-        if not _args or _args[0] is not None:
-            self._interaction.scroll_revision += 1
-        if _args and _args[0] is False:
-            # Explicit End owns its newer-history request and tail handoff.
-            # Re-arming the older-page latch first restores an old top anchor
-            # after End and undoes the user's actual navigation.
-            self._resume_in_zone = False
+        if source.token in self._paging_leases:
+            return None
+        lease = _PagingLease(source_token=source.token)
+        self._paging_leases[source.token] = lease
+        return lease
+
+    def _release_paging_lease(self, lease: _PagingLease | None) -> bool:
+        """Drop ``lease`` only if it is still the holder. Returns whether it was.
+
+        Identity, not source equality: a stale completion arriving after a
+        revisit names the same source as the transaction now in flight, and
+        letting it release on that basis is exactly the bug — the newer fetch
+        loses its gate while it is still running.
+        """
+        if lease is None:
+            return False
+        if self._paging_leases.get(lease.source_token) is not lease:
+            return False
+        del self._paging_leases[lease.source_token]
+        return True
+
+    def _transcript_scrolled(self, *args: Any, continuous: bool = False) -> None:
+        """Coalesce real upward input, never infer demand from layout motion.
+
+        The widget reports True/False for directional input and None for an
+        offset observation. A clamped wheel notch is still input. Observations
+        may complete an animated gesture, but cannot earn another page. One
+        boolean retains at most one additional demand while fetch/mount is
+        busy; a downward gesture cancels that debt.
+        """
+        # A final animation tick may arrive while Textual is unmounting this
+        # surface. Hooks belong to the cached active view; never rediscover a
+        # transcript (or dispatch paging) after that view has been retired.
+        view = self._transcript
+        if view is None or view.parent is None:
             return
-        view = self._transcript_view()
+        upward = args[0] if args else True
+        if upward is not None:
+            # Reader movement, for saved-position ownership, on the same
+            # provenance the paging demand uses: a passive layout correction
+            # must not discard an anchor still being restored.
+            self._interaction.scroll_revision += 1
+            self._resume_fill_active = False
+            self._resume_in_zone = bool(upward)
         if self._resume_pending_tail and view.scroll_y > 0 and view.is_near_bottom():
             self._mount_newer_resume_page()
             return

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3365,7 +3365,7 @@ class OperatorApp(App[None]):
                 ):
                     return
                 source.presentation_revision += 1
-                if not self._is_current(source):
+                if not self._is_current(source) or source.display_only:
                     self._reduce_hidden_session_event(source, message)
                     return
         if (
@@ -3704,14 +3704,23 @@ class OperatorApp(App[None]):
             source.preparations += 1
             return source
         directory = config_dir()
-        record, owner = await asyncio.to_thread(find_owner_record, directory, session_id)
 
         async def no_takeover() -> Any:
             # Match the CLI viewer policy: discovery/preparation must never
             # turn this TUI into an owner or recursively create a cold facade.
             raise RuntimeError("a sidebar viewer never takes over a session")
 
-        if record is not None and owner is not None:
+        if not speculative:
+            remote = await RemoteSession.saved_preview(
+                session_id,
+                config_dir=directory,
+                cwd=str(getattr(self._session, "cwd", "")),
+                takeover_factory=no_takeover,
+            )
+        else:
+            record, owner = await asyncio.to_thread(find_owner_record, directory, session_id)
+            if record is None or owner is None:
+                raise RuntimeError("The prepared owner is no longer active")
             remote = await RemoteSession.connect(
                 record,
                 session_id,
@@ -3719,18 +3728,13 @@ class OperatorApp(App[None]):
                 takeover_factory=no_takeover,
                 display_window=True,
             )
-        else:
-            if speculative:
-                raise RuntimeError("The prepared owner is no longer active")
-            if self._resume_factory is None:
-                raise RuntimeError("This launcher cannot reopen an inactive conversation")
-            remote = await self._resume_factory(session_id)
         if not isinstance(remote, RemoteSession):
             raise RuntimeError("Sidebar navigation requires an owner-backed session")
         try:
             if remote.session_id != session_id:
                 raise RuntimeError("The launcher returned a different conversation")
             source = SessionInteraction(remote)
+            source.display_only = remote.is_cold
             source.draft = await self._sidebar_drafts.get(session_id)
             if source.draft.approve_all is None:
                 source.draft.approve_all = self._approvals_default_auto
@@ -3763,16 +3767,16 @@ class OperatorApp(App[None]):
             self._sidebar_prior_workers.discard(worker)
 
     async def _prepare_sidebar_session(
-        self, session_id: str, *, speculative: bool = False
+        self, session_id: str, *, speculative: bool = False, refresh: bool = False
     ) -> tuple[SessionInteraction, SessionPresentation]:
         from local_operator.session.remote import RemoteSession
         from local_operator.tui.session_catalog import session_directory_name
 
         if not session_directory_name(session_id):
             raise ValueError("The conversation identifier is not valid")
-        if self._session is not None and self._session.session_id == session_id:
+        if not refresh and self._session is not None and self._session.session_id == session_id:
             return self._interaction, self._capture_sidebar_presentation()
-        if not speculative:
+        if not speculative and not refresh:
             await self._drain_sidebar_prior_transitions()
         source = await self._lease_sidebar_source(session_id, speculative=speculative)
         replay: PreparedReplay | None = None
@@ -3781,41 +3785,25 @@ class OperatorApp(App[None]):
             session = source.session
             if not isinstance(session, RemoteSession):
                 raise RuntimeError("Sidebar navigation requires an owner-backed session")
-            if session.is_cold:
-                if speculative:
-                    raise RuntimeError("The prepared owner is no longer ready")
-                # NO outer wall clock. The removed `wait_for(..., 15)` was not
-                # redundant with anything — it was DESTRUCTIVE: it replaced
-                # `_ensure_bound`'s `ConnectionError`, which carries a sentence
-                # worth showing, with a bare `TimeoutError` whose `str()` is the
-                # empty string, so the sidebar's "Could not open conversation:
-                # {error}" rendered with nothing after the colon. It was also
-                # the last bare wall clock left on this seam, which is the shape
-                # this change exists to replace (review round 2, MINOR-1).
-                #
-                # BUT it was the only thing bounding this call at 15 s, so be
-                # precise about what does bound it now (review round 3, M3-2).
-                # `_FOREGROUND_BIND_BUDGET_S` (15 s) covers only the retry/sync
-                # half: that deadline is computed AFTER `engage_runtime` has
-                # returned, and the foreground engage passes no `deadline_s`, so
-                # it takes `DEFAULT_DEADLINE_S` (30 s) first. Worst case here is
-                # therefore ~45 s, not 15 s — measured 30.00 s in the engage
-                # alone against a stalling owner. That is a deliberate trade,
-                # not an oversight: capping the foreground engage would halve
-                # the spawn/discovery window on a cold start, which is the path
-                # this change exists to make more reliable, and the wait is
-                # cancellable and reports progress rather than being silent.
-                # Do not re-add an outer `wait_for` to "restore" the 15 s; bound
-                # the engage itself if that worst case ever needs shortening.
-                await session._ensure_bound()
-            if session.is_cold:
-                raise RuntimeError("The conversation has not finished connecting")
-            await session.ensure_display_current()
-            gate = session.frontend_state.pending_gate
+            # Canonical synchronization belongs to the source connection task,
+            # never to a click waiting for its first useful viewport.
+            if speculative and session.is_cold:
+                raise RuntimeError("The prepared owner is no longer ready")
+            if speculative or refresh:
+                await session.ensure_display_current()
+            if not refresh:
+                source.display_only = session.is_cold or not session.display_history_current
+            gate = (
+                None if source.display_only and not refresh else session.frontend_state.pending_gate
+            )
             if gate is not None and gate.kind not in {"ask", "approval"}:
                 raise RuntimeError("This viewer does not support the conversation's pending input")
             cached = self._sidebar_presentations.get(session_id)
-            if cached is not None and self._sidebar_presentation_current(cached, source, gate):
+            if (
+                not refresh
+                and cached is not None
+                and self._sidebar_presentation_current(cached, source, gate)
+            ):
                 # Reinsert so dict order is recency: eviction pops the OLDEST
                 # key, and a hit must count as a use or a hot pair of sessions
                 # would evict each other the moment a third is visited.
@@ -3832,8 +3820,12 @@ class OperatorApp(App[None]):
             replay = PreparedReplay()
             welcome: WelcomeView | None = None
             revision = source.presentation_revision
-            if not source.draft.following_tail and source.draft.scroll_anchor_id:
-                if not await session.ensure_display_anchor(source.draft.scroll_anchor_id):
+            if refresh and not source.draft.following_tail and source.draft.scroll_anchor_id:
+                scroll_revision = source.scroll_revision
+                if (
+                    not await session.ensure_display_anchor(source.draft.scroll_anchor_id)
+                    and scroll_revision == source.scroll_revision
+                ):
                     # A canonical compaction can remove an old anchor. The owner
                     # explicitly reset that seek; never pretend another row is it.
                     source.draft.following_tail = True
@@ -3846,6 +3838,17 @@ class OperatorApp(App[None]):
                 bound=max(12, self.size.height // 2),
                 anchor_id=source.draft.scroll_anchor_id if not source.draft.following_tail else "",
             )
+            preview_unavailable = (
+                not replay.blocks
+                and source.display_only
+                and getattr(session, "saved_preview_partial", False)
+            )
+            if preview_unavailable:
+                replay.blocks.append(
+                    NoticeBlock(
+                        "Saved preview unavailable. Connect to load the conversation.", "note"
+                    )
+                )
             self._mark_pending_tool_rows(replay.blocks, session)
             replay.view.styles.layer = "session-cache"
             # visibility:hidden removes the compositor map and makes size=0.
@@ -3866,7 +3869,7 @@ class OperatorApp(App[None]):
             # tests of "is this conversation empty" on the two halves of one
             # switch would eventually disagree, and the visible failure is a
             # target that arrives with no empty state and no way to grow one.
-            if not conversation_started(replay.blocks):
+            if not preview_unavailable and not conversation_started(replay.blocks):
                 welcome = WelcomeView(
                     lambda: session_welcome_info(
                         session,
@@ -3882,12 +3885,20 @@ class OperatorApp(App[None]):
                 for block in replay.blocks:
                     replay.view.append_block(block)
             replay.view.follow_tail()
-            # Preparation waits for layout, not for a guessed sleep. The commit
-            # can then reveal already measured rows without replaying history.
-            laid_out = asyncio.Event()
-            self.call_after_refresh(laid_out.set)
-            await laid_out.wait()
-            if not source.draft.following_tail and source.draft.scroll_anchor_id:
+            # Retained/canonical views benefit from a measured parked layout.
+            # A first saved view has no existing geometry to preserve: painting
+            # it offscreen first adds a whole extra layout/frame before useful
+            # content appears. Reveal those real rows immediately; the commit's
+            # compositor-map gate still waits for their actual visible paint.
+            if not source.display_only or refresh:
+                laid_out = asyncio.Event()
+                self.call_after_refresh(laid_out.set)
+                await laid_out.wait()
+            if (
+                (not source.display_only or refresh)
+                and not source.draft.following_tail
+                and source.draft.scroll_anchor_id
+            ):
                 replay.view.restore_navigation_anchor(
                     source.draft.scroll_anchor_id,
                     source.draft.scroll_anchor_part,
@@ -3907,7 +3918,10 @@ class OperatorApp(App[None]):
             )
         except BaseException:
             if replay is not None and replay.view.parent is not None:
-                await replay.view.remove()
+                # AwaitRemove joins Textual's own message-pump tasks. A
+                # second navigation/shutdown cancellation must not travel
+                # through that gather and cancel the widget pumps themselves.
+                await asyncio.shield(replay.view.remove())
             raise
         finally:
             source.preparations -= 1
@@ -3997,10 +4011,12 @@ class OperatorApp(App[None]):
             )
 
     def _sidebar_gate_surface_ready(self, source: SessionInteraction) -> bool:
-        if (
-            not self._is_current(source)
-            or getattr(source.session, "is_cold", False)
-            or not getattr(source.session, "display_history_current", True)
+        if not self._is_current(source) or (
+            not source.display_only
+            and (
+                getattr(source.session, "is_cold", False)
+                or not getattr(source.session, "display_history_current", True)
+            )
         ):
             return False
         view = self._transcript_view()
@@ -4069,6 +4085,8 @@ class OperatorApp(App[None]):
         # the entire state (jobs, usage, trajectories) on every display, which
         # profiling measured as the largest single cost of the cold frame. A
         # reduced facade without the narrow accessor still falls back below.
+        if source.display_only:
+            return self._ask_screen is None and self._approval is None
         session = source.session
         gate = getattr(session, "pending_gate", None)
         if gate is None and not hasattr(session, "pending_gate"):
@@ -4171,7 +4189,7 @@ class OperatorApp(App[None]):
         if isinstance(current, RemoteSession):
             if session_id:
                 self._suspend_sidebar_gates(self._interaction)
-            else:
+            elif not self._interaction.display_only:
                 current.resume_viewer_gates()
         if session_id:
             self._begin_sidebar_transition()
@@ -4421,7 +4439,7 @@ class OperatorApp(App[None]):
         ):
             return
         if presentation.replay.view.is_mounted:
-            await presentation.replay.view.remove()
+            await asyncio.shield(presentation.replay.view.remove())
         await self._release_sidebar_source(source)
 
     def _park_sidebar_aside(self, source: SessionInteraction) -> None:
@@ -4475,11 +4493,11 @@ class OperatorApp(App[None]):
         session = source.session
         if session is None or session.session_id != session_id:
             raise RuntimeError("The prepared conversation identity changed")
-        if source is self._interaction:
+        if source is self._interaction and incoming.replay.view is self._transcript_view():
             return
-        if not isinstance(session, RemoteSession) or session.is_cold:
-            raise RuntimeError("The conversation is not ready for input")
-        if (
+        if not isinstance(session, RemoteSession):
+            raise RuntimeError("The conversation is not owner-backed")
+        if not source.display_only and (
             not session.display_history_current
             or incoming.replay_revision != session.display_history_revision
         ):
@@ -4487,12 +4505,15 @@ class OperatorApp(App[None]):
 
             raise PreparationInvalidated("canonical replay changed during preparation")
         outgoing = self._interaction
+        refreshing = outgoing is source
+        focused_before_refresh = self.focused if refreshing else None
         previous = outgoing.session
         if previous is not None and not isinstance(previous, RemoteSession):
             raise RuntimeError("Sidebar navigation requires an owner-backed current session")
-        self._close_subagent_view()
-        self._close_org_chart_view()
-        self._close_settings_view()
+        if not refreshing:
+            self._close_subagent_view()
+            self._close_org_chart_view()
+            self._close_settings_view()
         editor = self._editor()
         if self._sidebar_transition_from is outgoing:
             # The outgoing draft was frozen at ``pending``; the editor holds
@@ -4512,27 +4533,16 @@ class OperatorApp(App[None]):
             outgoing.draft.history_stash = recall.stash
             outgoing.draft.history_stash_attachments = dict(recall.stash_attachments)
         self._sidebar_transition_from = None
-        old_view = self._transcript_view()
-        outgoing.draft.following_tail = old_view.is_following_tail
-        if not outgoing.draft.following_tail:
-            top = old_view.content_region.y
-            anchor = next(
-                (
-                    block
-                    for block in old_view.blocks()
-                    if block.navigation_anchor_id and block.display and block.region.bottom > top
-                ),
-                None,
-            )
-            if anchor is not None:
-                outgoing.draft.scroll_anchor_id = anchor.navigation_anchor_id
-                outgoing.draft.scroll_anchor_part = anchor.navigation_anchor_part
-                outgoing.draft.scroll_offset = top - anchor.region.y
+        if (not refreshing or source.scroll_revision != source.preview_scroll_revision) and (
+            not outgoing.display_only
+            or outgoing.scroll_revision != outgoing.preview_scroll_revision
+        ):
+            self._capture_sidebar_scroll(outgoing)
         outgoing_presentation = None
         if previous is not None:
             self._sidebar_sources[previous.session_id] = outgoing
             outgoing_presentation = self._capture_sidebar_presentation()
-            if self._admit_sidebar_presentation(
+            if outgoing is not source and self._admit_sidebar_presentation(
                 previous.session_id, outgoing, outgoing_presentation
             ):
                 self._sidebar_presentations[previous.session_id] = outgoing_presentation
@@ -4670,11 +4680,17 @@ class OperatorApp(App[None]):
             for text, kind in source.notices:
                 self._system_notice(text, kind)
             source.notices.clear()
-            self._submit_boot_prompt(session)
-            session.resume_viewer_gates()
+            if not source.display_only:
+                self._submit_boot_prompt(session)
+                session.resume_viewer_gates()
             self._session_sidebar.current_id = session_id
             self._session_sidebar.refresh()
-            if source.draft.focus_id == "@transcript":
+            if refreshing and focused_before_refresh is not None:
+                if focused_before_refresh is old_view:
+                    incoming.replay.view.focus()
+                elif focused_before_refresh.is_mounted:
+                    focused_before_refresh.focus()
+            elif source.draft.focus_id == "@transcript":
                 incoming.replay.view.focus()
             else:
                 editor.focus()
@@ -4703,16 +4719,152 @@ class OperatorApp(App[None]):
             self.run_worker(
                 self._release_sidebar_preparation((self._sidebar_sources[evicted_id], evicted))
             )
-        if self.query_one("#session-workspace").has_class("sidebar-overlay"):
+        if not refreshing and self.query_one("#session-workspace").has_class("sidebar-overlay"):
             # A drawer cannot count as a correct visible conversation while it
             # covers the response. Pinned wide sidebars stay open.
             self._set_sidebar_open(False)
-        self._start_resume_fill()
-        return self._await_sidebar_frame(source, generation)
+        self._show_sidebar_connection(source)
+        ready = self._await_sidebar_frame(source, generation)
+        if source.display_only:
+            source.preview_scroll_revision = source.scroll_revision
+
+            # Even background socket work can receive a large synchronous
+            # projection in this same event loop. Start it AFTER the measured
+            # useful frame, not just after swapping the presentation fields.
+            def connect_after_paint(frame: asyncio.Future[None]) -> None:
+                if not frame.cancelled() and not source.retired:
+                    self._start_sidebar_connection(source)
+
+            ready.add_done_callback(connect_after_paint)
+        return ready
+
+    def _capture_sidebar_scroll(self, source: SessionInteraction) -> None:
+        old_view = self._transcript_view()
+        source.draft.following_tail = old_view.is_following_tail
+        if not source.draft.following_tail:
+            top = old_view.content_region.y
+            anchor = next(
+                (
+                    block
+                    for block in old_view.blocks()
+                    if block.navigation_anchor_id and block.display and block.region.bottom > top
+                ),
+                None,
+            )
+            if anchor is not None:
+                source.draft.scroll_anchor_id = anchor.navigation_anchor_id
+                source.draft.scroll_anchor_part = anchor.navigation_anchor_part
+                source.draft.scroll_offset = top - anchor.region.y
+
+    def _show_sidebar_connection(self, source: SessionInteraction) -> None:
+        if not self._is_current(source):
+            return
+        status = ""
+        if source.display_only:
+            saved = (
+                "Saved excerpt"
+                if getattr(source.session, "saved_preview_partial", False)
+                else "Saved"
+            )
+            status = (
+                f"{saved} · Connection unavailable"
+                if source.connection_error
+                else f"{saved} · Connecting…"
+            )
+        if self._status is not None:
+            self._status.update(connection=status)
+        self._editor().placeholder = "Draft a message…" if status else "Message Local Operator…"
+
+    def _start_sidebar_connection(self, source: SessionInteraction) -> None:
+        if source.connection_task is not None and not source.connection_task.done():
+            return
+        source.connection_error = ""
+        source.connection_task = asyncio.create_task(self._connect_sidebar_source(source))
+
+        def settled(task: asyncio.Task[None]) -> None:
+            if task.cancelled():
+                return
+            if task.exception() is not None:
+                logger.error("sidebar connection cleanup failed", exc_info=task.exception())
+            # An evicted hidden source can have been held solely by this task.
+            # Recheck after it settles, when retained_for_local_work no longer
+            # counts the connection; otherwise that viewer never gets released.
+            if self.is_running and not source.retired and not self._is_current(source):
+                self.run_worker(self._release_sidebar_source(source))
+
+        source.connection_task.add_done_callback(settled)
+
+    async def _connect_sidebar_source(self, source: SessionInteraction) -> None:
+        """Reconcile a saved view without holding the navigation coordinator.
+
+        A source owns its socket task. Hidden completion must not select itself,
+        and a cancellation-resistant attach cannot hold the latest-wins lock.
+        Reuse prepared widgets and the final generation fence for canonical
+        replacement, rather than inventing a second replay/event reducer.
+        """
+        from local_operator.session.remote import RemoteSession
+        from local_operator.tui.session_navigation import PreparationInvalidated
+
+        prepared = None
+        retry = False
+        try:
+            session = source.session
+            if not isinstance(session, RemoteSession):
+                return
+            await session._ensure_bound()
+            await session.ensure_display_current()
+            if source.retired or not self._is_current(source):
+                return
+            if self._sidebar_navigation.requested_id:
+                navigation = self._sidebar_navigation._task
+                if navigation is not None:
+                    await asyncio.shield(navigation)
+            if source.retired or not self._is_current(source):
+                return
+            generation = self._sidebar_navigation.generation
+            if source.scroll_revision != source.preview_scroll_revision:
+                self._capture_sidebar_scroll(source)
+            scroll_revision = source.scroll_revision
+            prepared = await self._prepare_sidebar_session(session.session_id, refresh=True)
+            if source.scroll_revision != scroll_revision:
+                retry = True
+                return
+            if (
+                source.retired
+                or not self._is_current(source)
+                or generation != self._sidebar_navigation.generation
+                or self._sidebar_navigation.requested_id
+            ):
+                return
+            source.display_only = False
+            source.command_frame_pending = True
+            ready = self._commit_sidebar_session(session.session_id, prepared, generation)
+            prepared = None
+            if ready is not None:
+                await ready
+        except asyncio.CancelledError:
+            raise
+        except PreparationInvalidated:
+            source.display_only = True
+            retry = True
+        except Exception as error:
+            source.display_only = True
+            source.connection_error = str(error) or "Connection unavailable"
+        finally:
+            if prepared is not None:
+                await self._release_sidebar_preparation(prepared)
+            source.command_frame_pending = False
+            if not source.retired:
+                self._show_sidebar_connection(source)
+                if retry and self._is_current(source):
+                    asyncio.get_running_loop().call_soon(self._start_sidebar_connection, source)
 
     def on_session_sidebar_selected(self, message: SessionSidebar.Selected) -> None:
         message.stop()
         if self._session is not None and self._session.session_id == message.session_id:
+            if self._interaction.display_only:
+                self._start_sidebar_connection(self._interaction)
+                self._show_sidebar_connection(self._interaction)
             if self._sidebar_navigation.requested_id:
                 self._sidebar_navigation.cancel()
             # Selecting the attached session is a no-op navigation, so nothing
@@ -5637,6 +5789,8 @@ class OperatorApp(App[None]):
         # back (review round 2, F6). An update arrives only after adoption has
         # finished, so by then a spec with the dial off means someone turned
         # it off — the user, or `Session._on_fast_refused`.
+        if self._interaction.display_only:
+            return
         self._reconcile_fast_choice(state)
         self._apply_frontend_state(state)
 
@@ -6966,46 +7120,8 @@ class OperatorApp(App[None]):
         duplicate RPC F1 reported, and the cursor it would send is the one the
         first request is already consuming (`history changed while paging`).
         """
-        if source.token in self._paging_leases:
-            return None
-        lease = _PagingLease(source_token=source.token)
-        self._paging_leases[source.token] = lease
-        return lease
-
-    def _release_paging_lease(self, lease: _PagingLease | None) -> bool:
-        """Drop ``lease`` only if it is still the holder. Returns whether it was.
-
-        Identity, not source equality: a stale completion arriving after a
-        revisit names the same source as the transaction now in flight, and
-        letting it release on that basis is exactly the bug — the newer fetch
-        loses its gate while it is still running.
-        """
-        if lease is None:
-            return False
-        if self._paging_leases.get(lease.source_token) is not lease:
-            return False
-        del self._paging_leases[lease.source_token]
-        return True
-
-    def _transcript_scrolled(self, *args: Any, continuous: bool = False) -> None:
-        """Coalesce real upward input, never infer demand from layout motion.
-
-        The widget reports True/False for directional input and None for an
-        offset observation. A clamped wheel notch is still input. Observations
-        may complete an animated gesture, but cannot earn another page. One
-        boolean retains at most one additional demand while fetch/mount is
-        busy; a downward gesture cancels that debt.
-        """
-        # A final animation tick may arrive while Textual is unmounting this
-        # surface. Hooks belong to the cached active view; never rediscover a
-        # transcript (or dispatch paging) after that view has been retired.
-        view = self._transcript
-        if view is None or view.parent is None:
-            return
-        upward = args[0] if args else True
-        if upward is not None:
-            self._resume_fill_active = False
-            self._resume_in_zone = bool(upward)
+        self._interaction.scroll_revision += 1
+        view = self._transcript_view()
         if self._resume_pending_tail and view.scroll_y > 0 and view.is_near_bottom():
             self._mount_newer_resume_page()
             return
@@ -8009,6 +8125,7 @@ class OperatorApp(App[None]):
         # would report a number for history no longer on screen — until the new
         # session's first turn happened to end.
         self._status.update(
+            connection="",
             model_label=MODEL_PENDING,
             # Cleared with the label it describes: a name left standing beside
             # `MODEL_PENDING` would be the dead session's model.
@@ -8736,9 +8853,18 @@ class OperatorApp(App[None]):
                 if editor.argument_command in ("team", "teams", "agent", "agents"):
                     self._fill_name_argument_list(editor, editor.argument_command)
 
+    def composer_submission_refused(self) -> None:
+        if self._interaction.display_only:
+            self._notice("Send unavailable until connected", "warning")
+
     def composer_submission_blocked(self) -> bool:
         """Whether Editor must retain rather than submit its current draft."""
-        return self._session_transition_pending or self._model_activation_pending is not None
+        return (
+            self._session_transition_pending
+            or self._interaction.display_only
+            or self._interaction.command_frame_pending
+            or self._model_activation_pending is not None
+        )
 
     async def _attach_or_refuse(self, config_root, concrete: str, owner: int) -> None:
         """Build a RemoteSession and adopt it like any ordinary resume.
@@ -12834,6 +12960,9 @@ class OperatorApp(App[None]):
         # to close and leaving is the right answer.
         if self._close_settings_view():
             return
+        if self._interaction.display_only or self._interaction.command_frame_pending:
+            self.composer_submission_refused()
+            return
         # A live `ask` picker takes Escape as "leave this question unanswered",
         # which is what its own footer advertises (`esc skip`) and what its
         # binding does when the card holds focus.
@@ -14839,6 +14968,7 @@ class OperatorApp(App[None]):
             len(self.screen_stack) != 1
             or not self.app_focus
             or self._session_transition_pending
+            or self._interaction.display_only
             or self._sidebar_frame_pending
         ):
             return False
@@ -16135,6 +16265,15 @@ class OperatorApp(App[None]):
                 pass
             except WorkerFailed:
                 logger.debug("sidebar prewarm failed during shutdown", exc_info=True)
+        connections = [
+            source.connection_task
+            for source in self._interactions.values()
+            if source.connection_task is not None and not source.connection_task.done()
+        ]
+        for connection in connections:
+            connection.cancel()
+        if connections:
+            await asyncio.gather(*connections, return_exceptions=True)
         await self._sidebar_navigation.close()
         await self._sidebar_drafts.close()
         if self._sidebar_timer is not None:
@@ -20340,7 +20479,11 @@ class OperatorApp(App[None]):
         parts = text.split(maxsplit=1)
         entry = slash_command_for(text)
         command = f"/{entry.name}" if entry is not None else parts[0].lower()
-        if self._sidebar_navigation.requested_id and command not in (
+        if (
+            self._sidebar_navigation.requested_id
+            or self._interaction.display_only
+            or self._interaction.command_frame_pending
+        ) and command not in (
             "/sidebar",
             "/help",
             "/settings",

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -3792,7 +3792,12 @@ class OperatorApp(App[None]):
             if speculative or refresh:
                 await session.ensure_display_current()
             if not refresh:
-                source.display_only = session.is_cold or not session.display_history_current
+                # A successful hidden bind is not a committed canonical view:
+                # its saved anchor and live projection still need reconciliation
+                # on return. Only that source's canonical commit clears this.
+                source.display_only = (
+                    source.display_only or session.is_cold or not session.display_history_current
+                )
             gate = (
                 None if source.display_only and not refresh else session.frontend_state.pending_gate
             )
@@ -4724,6 +4729,30 @@ class OperatorApp(App[None]):
             # covers the response. Pinned wide sidebars stay open.
             self._set_sidebar_open(False)
         self._show_sidebar_connection(source)
+        if not source.draft.following_tail and source.draft.scroll_anchor_id:
+            scroll_revision = source.scroll_revision
+            view = incoming.replay.view
+
+            def restore_revealed_anchor() -> None:
+                if (
+                    not self._is_current(source)
+                    or generation != self._sidebar_navigation.generation
+                    or self._transcript_view() is not view
+                ):
+                    return
+                if source.scroll_revision != scroll_revision:
+                    self._capture_sidebar_scroll(source)
+                    return
+                # Offscreen measurement is not final visible geometry for a
+                # wrapped viewport. Re-anchor after reveal, and let the normal
+                # painted-map gate verify the resulting frame, not a timer.
+                view.restore_navigation_anchor(
+                    source.draft.scroll_anchor_id,
+                    source.draft.scroll_anchor_part,
+                    source.draft.scroll_offset,
+                )
+
+            self.call_after_refresh(restore_revealed_anchor)
         ready = self._await_sidebar_frame(source, generation)
         if source.display_only:
             source.preview_scroll_revision = source.scroll_revision
@@ -4767,13 +4796,21 @@ class OperatorApp(App[None]):
                 else "Saved"
             )
             status = (
-                f"{saved} · Connection unavailable"
+                f"{saved} · Connection unavailable · Reselect to retry"
                 if source.connection_error
                 else f"{saved} · Connecting…"
             )
         if self._status is not None:
             self._status.update(connection=status)
-        self._editor().placeholder = "Draft a message…" if status else "Message Local Operator…"
+        editor = self._editor()
+        if editor.read_only:
+            editor.placeholder = READ_ONLY_PLACEHOLDER
+        elif self._aside_is_open():
+            editor.placeholder = ASIDE_PLACEHOLDER
+        elif editor.shell_mode:
+            editor.placeholder = SHELL_PLACEHOLDER
+        else:
+            editor.placeholder = "Draft a message…" if status else editor.resting_placeholder
 
     def _start_sidebar_connection(self, source: SessionInteraction) -> None:
         if source.connection_task is not None and not source.connection_task.done():
@@ -4807,6 +4844,7 @@ class OperatorApp(App[None]):
 
         prepared = None
         retry = False
+        cancelled = False
         try:
             session = source.session
             if not isinstance(session, RemoteSession):
@@ -4843,6 +4881,7 @@ class OperatorApp(App[None]):
             if ready is not None:
                 await ready
         except asyncio.CancelledError:
+            cancelled = True
             raise
         except PreparationInvalidated:
             source.display_only = True
@@ -4854,7 +4893,7 @@ class OperatorApp(App[None]):
             if prepared is not None:
                 await self._release_sidebar_preparation(prepared)
             source.command_frame_pending = False
-            if not source.retired:
+            if not source.retired and not cancelled:
                 self._show_sidebar_connection(source)
                 if retry and self._is_current(source):
                     asyncio.get_running_loop().call_soon(self._start_sidebar_connection, source)
@@ -6401,7 +6440,13 @@ class OperatorApp(App[None]):
         would tell the naming errand this conversation is already named and
         retire the one call that could give it a real one.
         """
-        if self._status is None or session.conversation_name or self._provisional_name:
+        if self._status is None or session.conversation_name:
+            return
+        if self._provisional_name:
+            # The source retains its provisional name across a park, while the
+            # shared footer was cleared for the other conversation. Restore the
+            # retained identity without running another naming operation.
+            self._status.update(conversation_name=self._provisional_name)
             return
         opener = getattr(session, "history_opener_text", None)
         if isinstance(opener, str):
@@ -7120,7 +7165,14 @@ class OperatorApp(App[None]):
         duplicate RPC F1 reported, and the cursor it would send is the one the
         first request is already consuming (`history changed while paging`).
         """
-        self._interaction.scroll_revision += 1
+        if not _args or _args[0] is not None:
+            self._interaction.scroll_revision += 1
+        if _args and _args[0] is False:
+            # Explicit End owns its newer-history request and tail handoff.
+            # Re-arming the older-page latch first restores an old top anchor
+            # after End and undoes the user's actual navigation.
+            self._resume_in_zone = False
+            return
         view = self._transcript_view()
         if self._resume_pending_tail and view.scroll_y > 0 and view.is_near_bottom():
             self._mount_newer_resume_page()
@@ -8853,18 +8905,58 @@ class OperatorApp(App[None]):
                 if editor.argument_command in ("team", "teams", "agent", "agents"):
                     self._fill_name_argument_list(editor, editor.argument_command)
 
-    def composer_submission_refused(self) -> None:
-        if self._interaction.display_only:
-            self._notice("Send unavailable until connected", "warning")
+    _SAVED_LOCAL_COMMANDS = frozenset({"/copy", "/sidebar", "/help", "/settings"})
 
-    def composer_submission_blocked(self) -> bool:
-        """Whether Editor must retain rather than submit its current draft."""
+    def _source_commands_ready(self, source: SessionInteraction | None = None) -> bool:
+        """One authority boundary for Enter, shortcuts and async continuations.
+
+        A socket object can exist before its canonical sync. Never derive
+        permission from that object or queue a user mutation until it binds.
+        Local draft clearing, copy and exiting do not require owner authority.
+        """
+        source = source or self._interaction
         return (
-            self._session_transition_pending
-            or self._interaction.display_only
-            or self._interaction.command_frame_pending
-            or self._model_activation_pending is not None
+            self._is_current(source)
+            and not source.retired
+            and not source.display_only
+            and not source.command_frame_pending
+            and not self._session_transition_pending
+            and not self._sidebar_navigation.requested_id
         )
+
+    def _allow_source_command(self, source: SessionInteraction | None = None) -> bool:
+        if self._source_commands_ready(source):
+            return True
+        if source is None or self._is_current(source):
+            hint = (
+                " Select this session again to retry." if self._interaction.connection_error else ""
+            )
+            self._notice(f"Commands unavailable until connected.{hint}", "warning")
+        return False
+
+    def composer_submission_refused(self) -> None:
+        if self._interaction.display_only or self._interaction.command_frame_pending:
+            hint = (
+                " Select this session again to retry." if self._interaction.connection_error else ""
+            )
+            self._notice(f"Send unavailable until connected.{hint}", "warning")
+
+    def composer_submission_blocked(
+        self, text: str | None = None, *, shell: bool | None = None
+    ) -> bool:
+        """Check the draft, or the immutable payload after Editor clears it."""
+        if self._session_transition_pending or self._model_activation_pending is not None:
+            return True
+        if self._source_commands_ready():
+            return False
+        try:
+            editor = self._editor()
+        except NoMatches:
+            return True
+        if (editor.shell_mode if shell is None else shell) or self._aside_is_open():
+            return True
+        entry = slash_command_for(editor.text if text is None else text)
+        return entry is None or f"/{entry.name}" not in self._SAVED_LOCAL_COMMANDS
 
     async def _attach_or_refuse(self, config_root, concrete: str, owner: int) -> None:
         """Build a RemoteSession and adopt it like any ordinary resume.
@@ -12070,7 +12162,7 @@ class OperatorApp(App[None]):
 
     def on_editor_submitted(self, message: EditorSubmitted) -> None:
         """Slash commands run synchronously BEFORE any prompt is sent."""
-        if self.composer_submission_blocked():
+        if self.composer_submission_blocked(message.text, shell=message.shell):
             # Enter is normally intercepted inside Editor before it clears. Keep
             # this second boundary for mouse/programmatic submits: the event may
             # already have been posted, so return the draft rather than routing
@@ -12853,6 +12945,9 @@ class OperatorApp(App[None]):
         loop would immediately submit the next — the user would have to press
         Ctrl+C once per remaining iteration to actually stop.
         """
+        if not self._allow_source_command():
+            self._abort_shell_command()
+            return
         if self._loop_running:
             self._loop_cancelled = True
         # A turn parked on an approval cannot see the abort signal until the
@@ -12960,8 +13055,7 @@ class OperatorApp(App[None]):
         # to close and leaving is the right answer.
         if self._close_settings_view():
             return
-        if self._interaction.display_only or self._interaction.command_frame_pending:
-            self.composer_submission_refused()
+        if not self._allow_source_command():
             return
         # A live `ask` picker takes Escape as "leave this question unanswered",
         # which is what its own footer advertises (`esc skip`) and what its
@@ -20479,18 +20573,8 @@ class OperatorApp(App[None]):
         parts = text.split(maxsplit=1)
         entry = slash_command_for(text)
         command = f"/{entry.name}" if entry is not None else parts[0].lower()
-        if (
-            self._sidebar_navigation.requested_id
-            or self._interaction.display_only
-            or self._interaction.command_frame_pending
-        ) and command not in (
-            "/sidebar",
-            "/help",
-            "/settings",
-        ):
-            self._system_notice(
-                "Wait for the conversation to open before sending a command", "warning"
-            )
+        if not self._source_commands_ready() and command not in self._SAVED_LOCAL_COMMANDS:
+            self._allow_source_command()
             return
         arg = parts[1].strip() if len(parts) > 1 else ""
         # The argument of a ``consumes_prompt`` command with its collapsed
@@ -21599,6 +21683,8 @@ class OperatorApp(App[None]):
         on screen says the next launch comes back on the old one — so the command
         that fixes that was reachable only by already knowing it existed.
         """
+        if arg and not self._allow_source_command():
+            return
         session = self._session
         if not arg:
             # The persist-hint notice is NOT printed here: reopening the list
@@ -21808,6 +21894,11 @@ class OperatorApp(App[None]):
         persist_default: bool,
         notice: NoticeFn,
     ) -> None:
+        # Resolution can yield across a view switch. Recheck the captured
+        # session, then the shared readiness boundary, immediately before any
+        # setter or cold-bind task can be created.
+        if session is not self._session or not self._allow_source_command():
+            return
         old_label = session.model_label
         # The DESTINATION is derived from the spec this command resolved, never
         # re-read from ``session.model_label`` after ``set_model``. On a local
@@ -22403,6 +22494,8 @@ class OperatorApp(App[None]):
         spec (the embedders and pilot fakes this module degrades for) would
         otherwise get a line announcing a level nothing is running.
         """
+        if not self._allow_source_command():
+            return False
         session = self._session
         spec = _model_spec(session)
         if session is None or spec is None or not hasattr(session, "set_model"):
@@ -22436,6 +22529,8 @@ class OperatorApp(App[None]):
         REPLACED under a running app, and READ BACK rather than trusted so a
         receipt is never printed for a state the session is not carrying.
         """
+        if not self._allow_source_command():
+            return False
         session = self._session
         spec = _model_spec(session)
         if session is None or spec is None or not hasattr(session, "set_model"):
@@ -23772,6 +23867,8 @@ class OperatorApp(App[None]):
         useful response is to begin the login, not to refuse and make them retype
         the provider name into a different command.
         """
+        if not self._allow_source_command():
+            return
         notice = self._notice
         if not row.connected:
             notice(f"{row.provider} needs a login first — starting it now", "warning")
@@ -25796,6 +25893,9 @@ class OperatorApp(App[None]):
                 "warning",
             )
             return
+        if not self._source_commands_ready():
+            panel.set_notice("Connect before adding this aside to the conversation")
+            return
         pairs = panel.fork_messages()
         if not pairs:
             panel.set_notice("ask something first — there is nothing to fork")
@@ -25824,6 +25924,8 @@ class OperatorApp(App[None]):
         user asked to keep is what they are left looking at, rather than a
         popup over it.
         """
+        if session is not self._session or not self._source_commands_ready():
+            return
         messages: list[Message] = []
         for question, answer in pairs:
             messages.append(Message.user(question))
@@ -25831,7 +25933,10 @@ class OperatorApp(App[None]):
         try:
             await session.adopt_aside(messages)
         except Exception as error:  # noqa: BLE001 — surfaced, never swallowed
-            self._system_notice(f"could not fork the aside: {error}", "warning")
+            if session is self._session:
+                self._system_notice(f"could not fork the aside: {error}", "warning")
+            return
+        if session is not self._session:
             return
         self._close_aside()
         for question, answer in pairs:

--- a/local_operator/tui/session_interaction.py
+++ b/local_operator/tui/session_interaction.py
@@ -128,6 +128,14 @@ class SessionInteraction:
     aside_open: bool = False
     aside_generation: int = 0
     preparations: int = 0
+    # Reading a saved viewport never grants authority to submit. The bind task
+    # belongs to this source, not to whichever navigation happens to be current.
+    display_only: bool = False
+    command_frame_pending: bool = False
+    connection_task: asyncio.Task[None] | None = field(default=None, repr=False)
+    connection_error: str = ""
+    scroll_revision: int = 0
+    preview_scroll_revision: int = 0
     # A gate draft can contain a secret. It stays only in this live context,
     # never in the general draft spill or diagnostic repr.
     gate_draft: tuple[tuple[Any, ...], Any] | None = field(default=None, repr=False)
@@ -155,6 +163,7 @@ class SessionInteraction:
         """
         return bool(
             self.active_workers
+            or (self.connection_task is not None and not self.connection_task.done())
             or self.loop.running
             or self.shell.worker is not None
             or self.compaction.held_prompt

--- a/local_operator/tui/widgets/editor.py
+++ b/local_operator/tui/widgets/editor.py
@@ -2946,6 +2946,9 @@ class Editor(TextArea):
         # explicit user decisions without introducing a visible transition mode.
         blocked = getattr(self.app, "composer_submission_blocked", None)
         if callable(blocked) and blocked():
+            refused = getattr(self.app, "composer_submission_refused", None)
+            if callable(refused):
+                refused()
             return
         text = self.text
         # Bang-mode is a MODE, but a recalled `! ls` is TEXT that still means

--- a/local_operator/tui/widgets/status_line.py
+++ b/local_operator/tui/widgets/status_line.py
@@ -1252,6 +1252,7 @@ class StatusLine:
     def update(
         self,
         *,
+        connection: str | None = None,
         model_label: str | None = None,
         model_name: str | None = None,
         effort: str | None = None,
@@ -1275,6 +1276,8 @@ class StatusLine:
         approvals_always: bool | None = None,
     ) -> None:
         """Update any subset of segments and repaint the band."""
+        if connection is not None:
+            self._connection = connection
         if model_label is not None:
             self._model_label = model_label
         if model_name is not None:
@@ -1560,6 +1563,16 @@ class StatusLine:
         seam = Style(color=theme_mod.semantic_color("faint"))
         accent = Style(color=theme_mod.semantic_color("accent"))
 
+        connection = getattr(self, "_connection", "")
+        if connection:
+            # Connection authority outranks live cost/model details from a saved
+            # checkpoint. Reuse the existing row so reconnect never moves the
+            # transcript or steals the reader's scroll anchor.
+            left = Text(connection, style=muted)
+            left.truncate(max(0, width), overflow="ellipsis")
+            right = Text(self._conversation_name, style=dim)
+            right.truncate(max(0, width - left.cell_len - 3), overflow="ellipsis")
+            return self._compose(left, right, width, dim)
         fitted = self._fit(width, dim, muted, seam, accent)
         if fitted is not None:
             dropped, left, right = fitted

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -3706,8 +3706,16 @@ class TranscriptView(ScrollableContainer):
             # gate open — see `OperatorApp._check_resume_page`), so the many
             # firings of one animated gesture collapse into ONE page (M1/U1).
             if self._on_user_scroll is not None:
-                # Observation can complete motion already requested by input,
-                # but must never arm demand by itself (including layout clamps).
+                # NOT the re-arm: the watch reports OFFSET MOTION, which is
+                # travel evidence rather than a gesture, and it fires for the
+                # clamped 1->0 step of a wheel already pinned at the top.
+                # Passing continuous=True keeps the page-back latch's re-arm
+                # rule intact (a clamped notch earns nothing) while still
+                # scheduling the at-rest check that lands the gesture.
+                # None marks passive offset observation, not user input.
+                # Consumers still need the paging check, but must not treat a
+                # layout/anchor compensation as permission to discard a saved
+                # reading position being restored asynchronously.
                 self._on_user_scroll(None, continuous=True)
 
     def _resync_tail_anchor(self) -> None:
@@ -3941,7 +3949,11 @@ class TranscriptView(ScrollableContainer):
         top of it un-acquires that anchor a frame later (U2). See
         :meth:`_report_scroll_input`.
         """
-        self._report_scroll_input(False)
+        # End is explicit DOWNWARD intent even when already at the tail. It
+        # must invalidate saved-position restoration, but must not re-arm an
+        # older-page request at the top before its own tail handoff runs.
+        if self._on_user_scroll is not None:
+            self._on_user_scroll(False, continuous=False)
         if self._on_tail_requested is not None:
             self._on_tail_requested()
         self.follow_tail()

--- a/local_operator/tui/widgets/transcript.py
+++ b/local_operator/tui/widgets/transcript.py
@@ -3706,16 +3706,8 @@ class TranscriptView(ScrollableContainer):
             # gate open — see `OperatorApp._check_resume_page`), so the many
             # firings of one animated gesture collapse into ONE page (M1/U1).
             if self._on_user_scroll is not None:
-                # NOT the re-arm: the watch reports OFFSET MOTION, which is
-                # travel evidence rather than a gesture, and it fires for the
-                # clamped 1->0 step of a wheel already pinned at the top.
-                # Passing continuous=True keeps the page-back latch's re-arm
-                # rule intact (a clamped notch earns nothing) while still
-                # scheduling the at-rest check that lands the gesture.
-                # None marks passive offset observation, not user input.
-                # Consumers still need the paging check, but must not treat a
-                # layout/anchor compensation as permission to discard a saved
-                # reading position being restored asynchronously.
+                # Observation can complete motion already requested by input,
+                # but must never arm demand by itself (including layout clamps).
                 self._on_user_scroll(None, continuous=True)
 
     def _resync_tail_anchor(self) -> None:
@@ -3949,11 +3941,7 @@ class TranscriptView(ScrollableContainer):
         top of it un-acquires that anchor a frame later (U2). See
         :meth:`_report_scroll_input`.
         """
-        # End is explicit DOWNWARD intent even when already at the tail. It
-        # must invalidate saved-position restoration, but must not re-arm an
-        # older-page request at the top before its own tail handoff runs.
-        if self._on_user_scroll is not None:
-            self._on_user_scroll(False, continuous=False)
+        self._report_scroll_input(False)
         if self._on_tail_requested is not None:
             self._on_tail_requested()
         self.follow_tail()

--- a/tests/e2e/test_sidebar_display_e2e.py
+++ b/tests/e2e/test_sidebar_display_e2e.py
@@ -1,0 +1,195 @@
+"""A responsive viewport is independent of the runtime's canonical sync.
+
+Use real authenticated owner sockets and real OperatorApp composition. The
+held subscribe event is the assertion: display must finish before it is ever
+released, rather than winning a race against an arbitrary latency threshold.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from local_operator.session.remote import RemoteSession
+from local_operator.session.runtime.owned import OwnedSessionHandle
+from local_operator.session.runtime.server import RuntimeServer
+from local_operator.tui.app import OperatorApp, ToolCard
+from local_operator.tui.session_interaction import SessionDraft
+from tests.e2e.harness import (
+    ScriptedStream,
+    assistant_message,
+    build_session,
+    seed_transcript,
+    user_message,
+    wait_for_adoption,
+)
+from tests.unit.tui.test_app_pilot import _renderable_plain
+
+
+def visible_text(app: OperatorApp) -> str:
+    return "\n".join(
+        _renderable_plain(getattr(block, "renderable", ""))
+        for block in app._transcript_view().blocks()
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "switch_away, fail_sync, restore_anchor",
+    [(False, False, False), (True, False, False), (False, True, False), (False, False, True)],
+)
+async def test_saved_view_switches_while_authenticated_owner_sync_is_held(
+    headless_tui_env: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    switch_away: bool,
+    fail_sync: bool,
+    restore_anchor: bool,
+):
+    config = headless_tui_env
+    servers = {}
+    released = asyncio.Event()
+    entered = asyncio.Event()
+    anchor_id = ""
+    original_await = RemoteSession._await_frontend
+
+    async def await_frontend(remote, future, *, timeout, preempt=None):
+        # Expire an AUTHENTICATED, deliberately held sync deterministically.
+        # No healthy work competes against this test clock: release is closed.
+        if remote.session_id == "waiting" and fail_sync:
+            await entered.wait()
+            timeout = 0
+        return await original_await(remote, future, timeout=timeout, preempt=preempt)
+
+    monkeypatch.setattr(RemoteSession, "_await_frontend", await_frontend)
+    try:
+        for sid in ("origin", "waiting", "neighbour"):
+            directory = config / "sessions" / sid
+            messages = [user_message(sid + " question"), assistant_message(sid + " saved answer")]
+            if sid == "waiting" and restore_anchor:
+                anchor = user_message("waiting historical anchor")
+                anchor_id = anchor.id
+                messages = (
+                    [anchor]
+                    + [assistant_message(f"Historical row {i}") for i in range(200)]
+                    + messages
+                )
+            await seed_transcript(directory, messages)
+            owner = build_session(directory, ScriptedStream([]), cwd=config)
+            handle = OwnedSessionHandle(owner, asyncio.get_running_loop(), cwd=str(config))
+            if sid == "waiting":
+                original = handle.subscribe_frontend
+
+                async def held_subscribe(*args, **kwargs):
+                    entered.set()
+                    await released.wait()
+                    return await original(*args, **kwargs)
+
+                monkeypatch.setattr(handle, "subscribe_frontend", held_subscribe)
+            server = RuntimeServer(handle, kind="daemon")
+            await server.start_in_process()
+            servers[sid] = server
+
+        def find(_directory, sid):
+            server = servers.get(sid)
+            return (server._record, server._record.pid) if server else (None, None)
+
+        async def never():
+            raise AssertionError("view navigation must never take execution ownership")
+
+        async def resume(sid):
+            return await RemoteSession.connect(
+                servers[sid]._record,
+                sid,
+                config_dir=config,
+                takeover_factory=never,
+                display_window=True,
+            )
+
+        app = OperatorApp(lambda: resume("origin"), resume_factory=resume)
+        with (
+            patch("local_operator.mobile.attach_client.find_owner_record", find),
+            patch.object(OperatorApp, "_check_for_update", lambda self: None),
+        ):
+            async with app.run_test(size=(120, 36)) as pilot:
+                await wait_for_adoption(app, pilot)
+                # A provider placeholder may be adopted by tool NAME, but only
+                # inside its own presentation. An outgoing bash row must never
+                # become the incoming conversation's bash call.
+                outgoing_card = ToolCard("pending-origin", "bash", {}, "Origin command")
+                app._composing_cards["pending-origin"] = outgoing_card
+                app._append_block(outgoing_card)
+                if restore_anchor:
+                    await app._sidebar_drafts.put(
+                        "waiting", SessionDraft(following_tail=False, scroll_anchor_id=anchor_id)
+                    )
+                task = app._sidebar_navigation.select("waiting")
+                await asyncio.wait_for(task, 10)
+                await asyncio.wait_for(entered.wait(), 10)
+                source = app._interaction
+                assert not released.is_set()
+                assert isinstance(app._session, RemoteSession)
+                assert app._session.session_id == "waiting"
+                assert "waiting saved answer" in visible_text(app)
+                assert app._sidebar_gate_surface_ready(source)
+                assert app._adopt_composing_card("new-call", "bash") is None
+                assert outgoing_card not in app._transcript_view().blocks()
+                assert source.display_only and app.composer_submission_blocked()
+                assert app._status is not None
+                assert "Saved" in app._status.render_text(120).plain
+                editor = app._editor()
+                editor.text = "Keep this unsent draft"
+                await pilot.press("enter")
+                assert editor.text == "Keep this unsent draft"
+                assert not app._session.frontend_state.streaming
+
+                saved_view = app._transcript_view()
+                connection = source.connection_task
+                # A slow source does not serialize the next local selection.
+                if switch_away:
+                    await asyncio.wait_for(app._sidebar_navigation.select("neighbour"), 10)
+                    assert "neighbour saved answer" in visible_text(app)
+                    assert source.draft.text == "Keep this unsent draft"
+                    await asyncio.wait_for(app._sidebar_navigation.select("waiting"), 10)
+                    assert app._transcript_view() is saved_view
+                    assert source.connection_task is connection
+                    assert not released.is_set()
+                    assert "waiting saved answer" in visible_text(app)
+                    await asyncio.wait_for(app._sidebar_navigation.select("neighbour"), 10)
+                if fail_sync:
+                    assert source.connection_task is not None
+                    await asyncio.wait_for(asyncio.shield(source.connection_task), 10)
+                    assert source.connection_error == "the runtime is not responding"
+                    assert source.display_only and app.composer_submission_blocked()
+                    assert "waiting saved answer" in visible_text(app)
+                    assert editor.text == "Keep this unsent draft"
+                    assert "Connection unavailable" in app._status.render_text(120).plain
+                    fail_sync = False
+                    released.set()
+                    app._start_sidebar_connection(source)
+                else:
+                    released.set()
+                assert source.connection_task is not None
+                await asyncio.wait_for(asyncio.shield(source.connection_task), 10)
+                if switch_away:
+                    assert isinstance(app._session, RemoteSession)
+                    assert app._session.session_id == "neighbour"
+                    assert "waiting saved answer" not in visible_text(app)
+                    # Returning uses its own canonical state and controller.
+                    await asyncio.wait_for(app._sidebar_navigation.select("waiting"), 10)
+                assert app._interaction is source
+                assert editor.text == "Keep this unsent draft"
+                assert not source.display_only
+                if restore_anchor:
+                    assert "waiting historical anchor" in visible_text(app)
+                    assert not source.draft.following_tail
+                    assert source.draft.scroll_anchor_id == anchor_id
+                else:
+                    assert "waiting saved answer" in visible_text(app)
+                assert not app.composer_submission_blocked()
+    finally:
+        released.set()
+        for server in servers.values():
+            await server.aclose()

--- a/tests/e2e/test_sidebar_display_e2e.py
+++ b/tests/e2e/test_sidebar_display_e2e.py
@@ -16,8 +16,9 @@ import pytest
 from local_operator.session.remote import RemoteSession
 from local_operator.session.runtime.owned import OwnedSessionHandle
 from local_operator.session.runtime.server import RuntimeServer
-from local_operator.tui.app import OperatorApp, ToolCard
+from local_operator.tui.app import ASIDE_PLACEHOLDER, OperatorApp, ToolCard
 from local_operator.tui.session_interaction import SessionDraft
+from local_operator.tui.widgets.copy_picker import CopyPickerScreen
 from tests.e2e.harness import (
     ScriptedStream,
     assistant_message,
@@ -26,7 +27,7 @@ from tests.e2e.harness import (
     user_message,
     wait_for_adoption,
 )
-from tests.unit.tui.test_app_pilot import _renderable_plain
+from tests.unit.tui.test_app_pilot import _renderable_plain, _set_editor_line
 
 
 def visible_text(app: OperatorApp) -> str:
@@ -38,8 +39,16 @@ def visible_text(app: OperatorApp) -> str:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "switch_away, fail_sync, restore_anchor",
-    [(False, False, False), (True, False, False), (False, True, False), (False, False, True)],
+    "switch_away, fail_sync, restore_anchor, wrapped, move_reader",
+    [
+        (False, False, False, False, False),
+        (True, False, False, False, False),
+        (False, True, False, False, False),
+        (False, False, True, False, False),
+        (True, False, True, False, False),
+        (False, False, True, True, False),
+        (False, False, True, False, True),
+    ],
 )
 async def test_saved_view_switches_while_authenticated_owner_sync_is_held(
     headless_tui_env: Path,
@@ -47,12 +56,17 @@ async def test_saved_view_switches_while_authenticated_owner_sync_is_held(
     switch_away: bool,
     fail_sync: bool,
     restore_anchor: bool,
+    wrapped: bool,
+    move_reader: bool,
 ):
     config = headless_tui_env
     servers = {}
     released = asyncio.Event()
     entered = asyncio.Event()
     anchor_id = ""
+    aborts = []
+    initial_content = "waiting historical anchor" if wrapped else "waiting saved answer"
+    local_modes = not (switch_away or fail_sync or restore_anchor)
     original_await = RemoteSession._await_frontend
 
     async def await_frontend(remote, future, *, timeout, preempt=None):
@@ -73,13 +87,25 @@ async def test_saved_view_switches_while_authenticated_owner_sync_is_held(
                 anchor_id = anchor.id
                 messages = (
                     [anchor]
-                    + [assistant_message(f"Historical row {i}") for i in range(200)]
+                    + [
+                        assistant_message(
+                            f"Historical row {i} " + ("wrapped content " * 35 if wrapped else "")
+                        )
+                        for i in range(20 if wrapped else 200)
+                    ]
                     + messages
                 )
             await seed_transcript(directory, messages)
             owner = build_session(directory, ScriptedStream([]), cwd=config)
             handle = OwnedSessionHandle(owner, asyncio.get_running_loop(), cwd=str(config))
             if sid == "waiting":
+                original_abort = owner.abort
+
+                def record_abort(*args, **kwargs):
+                    aborts.append(args)
+                    return original_abort(*args, **kwargs)
+
+                monkeypatch.setattr(owner, "abort", record_abort)
                 original = handle.subscribe_frontend
 
                 async def held_subscribe(*args, **kwargs):
@@ -132,7 +158,7 @@ async def test_saved_view_switches_while_authenticated_owner_sync_is_held(
                 assert not released.is_set()
                 assert isinstance(app._session, RemoteSession)
                 assert app._session.session_id == "waiting"
-                assert "waiting saved answer" in visible_text(app)
+                assert initial_content in visible_text(app)
                 assert app._sidebar_gate_surface_ready(source)
                 assert app._adopt_composing_card("new-call", "bash") is None
                 assert outgoing_card not in app._transcript_view().blocks()
@@ -140,12 +166,26 @@ async def test_saved_view_switches_while_authenticated_owner_sync_is_held(
                 assert app._status is not None
                 assert "Saved" in app._status.render_text(120).plain
                 editor = app._editor()
+                await pilot.press("ctrl+c")
                 editor.text = "Keep this unsent draft"
                 await pilot.press("enter")
                 assert editor.text == "Keep this unsent draft"
                 assert not app._session.frontend_state.streaming
 
+                if local_modes:
+                    _set_editor_line(editor, "/copy")
+                    await pilot.press("escape", "enter")
+                    assert isinstance(app.screen, CopyPickerScreen)
+                    await pilot.press("escape")
+                    editor.text = "Keep this unsent draft"
+                    await pilot.press("f8")
+                    assert app._aside_is_open()
+                    assert editor.placeholder == ASIDE_PLACEHOLDER
+                if move_reader:
+                    await pilot.press("ctrl+end")
+                    await pilot.pause()
                 saved_view = app._transcript_view()
+                saved_name = app._status.render_text(120).plain
                 connection = source.connection_task
                 # A slow source does not serialize the next local selection.
                 if switch_away:
@@ -155,17 +195,19 @@ async def test_saved_view_switches_while_authenticated_owner_sync_is_held(
                     await asyncio.wait_for(app._sidebar_navigation.select("waiting"), 10)
                     assert app._transcript_view() is saved_view
                     assert source.connection_task is connection
+                    assert app._status.render_text(120).plain == saved_name
                     assert not released.is_set()
-                    assert "waiting saved answer" in visible_text(app)
+                    assert initial_content in visible_text(app)
                     await asyncio.wait_for(app._sidebar_navigation.select("neighbour"), 10)
                 if fail_sync:
                     assert source.connection_task is not None
                     await asyncio.wait_for(asyncio.shield(source.connection_task), 10)
                     assert source.connection_error == "the runtime is not responding"
                     assert source.display_only and app.composer_submission_blocked()
-                    assert "waiting saved answer" in visible_text(app)
+                    assert initial_content in visible_text(app)
                     assert editor.text == "Keep this unsent draft"
-                    assert "Connection unavailable" in app._status.render_text(120).plain
+                    assert "Connection unavailable" in app._status.render_text(80).plain
+                    assert "retry" in app._status.render_text(80).plain
                     fail_sync = False
                     released.set()
                     app._start_sidebar_connection(source)
@@ -179,16 +221,37 @@ async def test_saved_view_switches_while_authenticated_owner_sync_is_held(
                     assert "waiting saved answer" not in visible_text(app)
                     # Returning uses its own canonical state and controller.
                     await asyncio.wait_for(app._sidebar_navigation.select("waiting"), 10)
+                    await pilot.pause()
+                    if source.connection_task is not None:
+                        await asyncio.wait_for(asyncio.shield(source.connection_task), 10)
+                if local_modes:
+                    assert app._aside_is_open()
+                    assert editor.placeholder == ASIDE_PLACEHOLDER
+                    await pilot.press("escape")
                 assert app._interaction is source
                 assert editor.text == "Keep this unsent draft"
                 assert not source.display_only
-                if restore_anchor:
+                if restore_anchor and not move_reader:
                     assert "waiting historical anchor" in visible_text(app)
                     assert not source.draft.following_tail
                     assert source.draft.scroll_anchor_id == anchor_id
-                else:
+                elif move_reader:
                     assert "waiting saved answer" in visible_text(app)
+                    assert source.draft.following_tail
+                else:
+                    assert initial_content in visible_text(app)
                 assert not app.composer_submission_blocked()
+                await pilot.pause()
+                assert aborts == [], "an offline shortcut queued a delayed owner abort"
+                if local_modes:
+                    missing = config / "sessions" / "deleted-target"
+                    assert not missing.exists()
+                    await asyncio.wait_for(app._sidebar_navigation.select("deleted-target"), 10)
+                    assert app._interaction is source
+                    assert editor.text == "Keep this unsent draft"
+                    assert "waiting saved answer" in visible_text(app)
+                    assert "no longer available" in visible_text(app)
+                    assert not missing.exists()
     finally:
         released.set()
         for server in servers.values():

--- a/tests/unit/session/test_saved_preview.py
+++ b/tests/unit/session/test_saved_preview.py
@@ -1,0 +1,96 @@
+"""Saved display must be bounded without inventing a canonical replay cut."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from local_operator.harness.types import Message
+from local_operator.session.saved_preview import PREVIEW_BYTES, read_saved_preview
+from local_operator.session.transcript import TranscriptEntry, encode_message_payload
+
+
+def message(identifier: str, text: str) -> TranscriptEntry:
+    return TranscriptEntry(identifier, 0, "message", encode_message_payload(Message.user(text)))
+
+
+def journal(path: Path, entries: list[TranscriptEntry]) -> None:
+    (path / "transcript.jsonl").write_text(
+        "".join(entry.to_json() + "\n" for entry in entries), encoding="utf-8"
+    )
+
+
+def test_preview_replays_correct_session_and_prunes(tmp_path):
+    journal(
+        tmp_path,
+        [
+            message("old", "original tool output"),
+            message("new", "Useful saved answer"),
+            TranscriptEntry("prune", 0, "prune", {"target": "old", "notice": "Removed"}),
+        ],
+    )
+    result = read_saved_preview(tmp_path)
+    assert not result.partial
+    assert result.messages[-1].text == "Useful saved answer"
+    assert "original tool output" not in result.messages[0].text
+
+
+def test_preview_reads_only_bounded_suffix(tmp_path, monkeypatch):
+    journal(tmp_path, [message("huge", "x" * (PREVIEW_BYTES * 16)), message("tail", "Useful tail")])
+    original = Path.open
+    reads = []
+
+    class BoundedRead:
+        def __init__(self, handle):
+            self.handle = handle
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            self.handle.close()
+
+        def seek(self, *args):
+            return self.handle.seek(*args)
+
+        def tell(self):
+            return self.handle.tell()
+
+        def read(self, count=-1):
+            reads.append(count)
+            assert 0 <= count <= PREVIEW_BYTES
+            return self.handle.read(count)
+
+    monkeypatch.setattr(Path, "open", lambda path, *a, **kw: BoundedRead(original(path, *a, **kw)))
+    result = read_saved_preview(tmp_path)
+    assert result.partial
+    assert [row.text for row in result.messages] == ["Useful tail"]
+    assert reads == [PREVIEW_BYTES]
+
+
+@pytest.mark.parametrize("suffix", [b'{"type":"prune"', b"not json\n"])
+def test_incomplete_or_corrupt_tail_cannot_resurrect_content(tmp_path, suffix):
+    journal(tmp_path, [message("saved", "May have been retracted")])
+    with (tmp_path / "transcript.jsonl").open("ab") as handle:
+        handle.write(suffix)
+    result = read_saved_preview(tmp_path)
+    assert result.partial and result.messages == []
+
+
+def test_unresolved_compaction_cut_does_not_use_full_history_fallback(tmp_path):
+    journal(
+        tmp_path,
+        [
+            message("saved", "Do not resurrect"),
+            TranscriptEntry("compact", 0, "compaction", {"first_kept_entry_id": "missing"}),
+        ],
+    )
+    result = read_saved_preview(tmp_path)
+    assert result.partial and result.messages == []
+
+
+def test_oversized_last_row_reports_unavailable_instead_of_fake_content(tmp_path):
+    journal(tmp_path, [message("huge", "x" * (PREVIEW_BYTES * 2))])
+    result = read_saved_preview(tmp_path)
+    assert result.partial and result.messages == []

--- a/tests/unit/session/test_saved_preview.py
+++ b/tests/unit/session/test_saved_preview.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -19,6 +20,62 @@ def journal(path: Path, entries: list[TranscriptEntry]) -> None:
     (path / "transcript.jsonl").write_text(
         "".join(entry.to_json() + "\n" for entry in entries), encoding="utf-8"
     )
+
+
+def test_missing_journal_is_not_a_complete_empty_saved_conversation(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        read_saved_preview(tmp_path / "missing")
+    with pytest.raises(FileNotFoundError):
+        read_saved_preview(tmp_path)
+    assert not (tmp_path / "missing").exists()
+
+
+def test_existing_empty_journal_is_a_valid_empty_preview(tmp_path):
+    (tmp_path / "transcript.jsonl").touch()
+    result = read_saved_preview(tmp_path)
+    assert result.messages == [] and not result.partial
+
+
+@pytest.mark.asyncio
+async def test_unmaterialized_empty_view_requires_a_discoverable_owner(tmp_path, monkeypatch):
+    from local_operator.session.remote import RemoteSession
+
+    record = SimpleNamespace(cwd="/synthetic-owner")
+    monkeypatch.setattr(
+        "local_operator.mobile.attach_client.find_owner_record", lambda *args: (record, 12345)
+    )
+
+    async def no_takeover():
+        raise AssertionError("a preview must not become an execution owner")
+
+    remote = await RemoteSession.saved_preview(
+        "unstarted", config_dir=tmp_path, cwd="/other", takeover_factory=no_takeover
+    )
+    try:
+        assert remote.is_cold
+        assert remote.frontend_state.cwd == "/synthetic-owner"
+        assert remote.display_history_window() == []
+        assert not (tmp_path / "sessions" / "unstarted").exists()
+    finally:
+        await remote.dispose()
+
+
+@pytest.mark.asyncio
+async def test_absent_owner_and_journal_refuse_before_building_facade(tmp_path, monkeypatch):
+    from local_operator.session.remote import RemoteSession
+
+    monkeypatch.setattr(
+        "local_operator.mobile.attach_client.find_owner_record", lambda *args: (None, None)
+    )
+
+    async def no_takeover():
+        raise AssertionError("a missing target must not launch an owner")
+
+    with pytest.raises(FileNotFoundError, match="no longer available"):
+        await RemoteSession.saved_preview(
+            "deleted", config_dir=tmp_path, cwd="/other", takeover_factory=no_takeover
+        )
+    assert not (tmp_path / "sessions" / "deleted").exists()
 
 
 def test_preview_replays_correct_session_and_prunes(tmp_path):

--- a/tests/unit/tui/test_sidebar_command_readiness.py
+++ b/tests/unit/tui/test_sidebar_command_readiness.py
@@ -1,0 +1,89 @@
+"""Every human owner mutation shares the saved-view readiness boundary."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from local_operator.harness.types import ModelSpec
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.session_interaction import SessionInteraction
+from tests.unit.tui.test_app_pilot import FakeSession, _factory
+
+
+class MutationAttempt(AssertionError):
+    pass
+
+
+class ControlSession(FakeSession):
+    @property
+    def model(self):
+        return ModelSpec(provider="test", model_id="model", reasoning_effort="low")
+
+    def abort(self, reason="interrupted"):
+        raise MutationAttempt("unready abort reached the owner facade")
+
+    def set_model(self, model, *, explicit=False):
+        raise MutationAttempt("unready model mutation reached the owner facade")
+
+
+@pytest.mark.parametrize("boundary", ["display_only", "command_frame_pending"])
+@pytest.mark.parametrize("operation", ["interrupt", "effort", "fast", "model"])
+def test_direct_owner_controls_refuse_both_readiness_boundaries(monkeypatch, boundary, operation):
+    session = ControlSession()
+    app = OperatorApp(lambda: _factory(session))
+    app._session = session
+    source = SessionInteraction(session)
+    app._interaction = source
+    app._interactions[id(session)] = source
+    setattr(source, boundary, True)
+    monkeypatch.setattr(app, "_notice", Mock())
+    if operation == "interrupt":
+        app._interrupt()
+    elif operation == "effort":
+        assert not app._apply_effort("high")
+    elif operation == "fast":
+        assert not app._apply_fast_mode(True)
+    else:
+        app._activate_resolved_model(session, "test", "other", session.model, False, app._notice)
+
+
+def test_model_activation_rechecks_captured_source_after_selection_changed(monkeypatch):
+    previous = ControlSession()
+    current = FakeSession()
+    app = OperatorApp(lambda: _factory(current))
+    app._session = current
+    app._interaction = SessionInteraction(current)
+    app._interactions[id(previous)] = SessionInteraction(previous)
+    monkeypatch.setattr(app, "_notice", Mock())
+    app._activate_resolved_model(previous, "test", "other", previous.model, False, app._notice)
+
+
+@pytest.mark.parametrize("boundary", ["display_only", "command_frame_pending"])
+def test_aside_fork_does_not_schedule_unready_owner_work(monkeypatch, boundary):
+    session = ControlSession()
+    app = OperatorApp(lambda: _factory(session))
+    app._session = session
+    app._interaction = SessionInteraction(session)
+    setattr(app._interaction, boundary, True)
+    panel = SimpleNamespace(
+        is_open=True, fork_messages=lambda: [("Question", "Answer")], set_notice=Mock()
+    )
+    monkeypatch.setattr(app, "_aside_panel", lambda: panel)
+    scheduled = Mock(side_effect=lambda coroutine, **kwargs: coroutine.close())
+    monkeypatch.setattr(app, "run_worker", scheduled)
+    app.action_fork_aside()
+    scheduled.assert_not_called()
+    assert "Connect" in panel.set_notice.call_args.args[0]
+
+
+def test_ready_control_can_reach_the_instrumented_owner(monkeypatch):
+    session = ControlSession()
+    app = OperatorApp(lambda: _factory(session))
+    app._session = session
+    app._interaction = SessionInteraction(session)
+    monkeypatch.setattr(app, "_notice", Mock())
+    with pytest.raises(MutationAttempt, match="model mutation"):
+        app._apply_effort("high")


### PR DESCRIPTION
## Summary

Selecting a conversation now reveals its retained or bounded saved transcript without first waiting for that conversation's runtime. Previously, an authenticated socket that never delivered canonical sync kept the **old** conversation on screen for 15 seconds and then reported `the runtime is not responding` — the requested session was never painted at all. A runtime that is stuck, gone, or slow no longer blocks switching to it.

**Release: patch — a stuck or completed runtime no longer blocks switching: the selected conversation appears from saved state, keeps its draft, and says how to retry.**

**Change class: C2, standard/pre-authorized.** No version bump; `pyproject.toml` stays at the last released version.

Opened as a **draft**: round-2 convergence review and QA round 2 over the remediation delta are still owed. It will be marked ready once those are clean, per this repo's guidance on opening drafts while remediation rounds are expected.

## Delivery contract

- Latest-wins sidebar/keyboard navigation displays actual correct-session content independently of owner synchronization. A sidebar highlight, spinner or placeholder does not count as a useful render.
- Saved display and command readiness are separate. Drafting, selecting/copying text (including `/copy`) and local scrolling stay usable. Submission preserves its draft and names the retry.
- **Every** owner mutation shares one readiness boundary — Enter, Ctrl+C, `shift+tab` effort, fast mode, model activation and dispatch, aside fork — rechecked after each await, so a resolution that yields across a switch cannot land on the wrong conversation. Unready controls **refuse**; they never queue. Local-only acts (clearing a draft, exiting, copying) keep working. The boundary is scoped to the *source*: a `/reload` transition keeps its own, better answers.
- A conversation whose journal **and** owner are both absent is refused, leaving the previous view, its draft and its transcript intact, and creating nothing on disk. A live owner that has deliberately not materialised its journal still opens as a genuine empty conversation.
- The retained conversation name, the active composer mode's placeholder, and the reader's scroll position survive a park and a canonical handover. Passive layout compensation is not treated as reader input; explicit input always wins over a pending restore.
- Timeout leaves the target selected showing `Saved · Connection unavailable · Reselect to retry` rather than rolling back. Reselecting the current row retries without submitting the draft.
- Existing execution ownership, the owner protocol, gate identity, presentation payload/LRU limits and runtime lifecycle remain authoritative. Nothing here embeds tmux or adds a service.

### Scope / non-goals

Owner-side replay/cache/daemon contention is coordinated parallel work, not this PR. Ordinary historical paging and viewport-fill are also owned elsewhere; this change only moves saved-anchor hydration off the selection path and adds a source-scoped reader-movement fence.

The saved preview reads at most 256 KiB and retains at most the existing 120-message display bound, applying prune/compaction semantics **before** slicing. Incomplete or malformed suffixes and unresolved compaction cuts fail closed; an oversized final record without a safe suffix shows an explicit unavailable-preview state and is **not** counted as a successful useful-content sample. Full canonical history still comes from the owner.

## Performance: what is established and what is not

**The reported failure is eliminated.** With canonical sync deliberately withheld, the target conversation paints its actual saved content — independent QA measured **78.109 ms** to useful paint *before* the held subscribe was released, and the 15-second timeout no longer removes it from screen. On the pinned base the same fixture painted the target **never**: `await frontend` ran the full `15000.52 ms` and the original conversation stayed up.

**A universal `<100 ms` guarantee is NOT established, and this PR does not claim one.** Measured, with the conditions attached:

| Run | Conditions | Result |
|---|---|---|
| Held-sync lifecycle probe | held socket | 78.109 ms useful paint (QA), 87.695 / 40.791 ms on my two state probes |
| Warm retained switches | 14-core host, load avg 33-59 | p50 32-39 ms, p95 63-98 ms, max 85-109 ms |
| First (cold) large views | same run | 145-163 ms |
| QA round-1 acceptance run | **load avg 175-198** on 14 cores | first small 187 ms, large 602-869 ms |
| QA matched-pressure **base** | same period, same pressure | first 101 / 192 / 460 ms — **the base misses the threshold by the same margin** |

The round-1 samples that missed 100 ms were taken while the host was at load average 175-198 on 14 cores, and the pinned base measured at the same time missed it by the same margin. Those numbers measure host contention, not this diff — and equally, they must not be waived. One profiled first-large sample was 224 ms wall against 69 ms loop CPU, which is scheduling, not work.

**Open item: a clean-host re-measure is outstanding.** QA's Q1 stands as an acknowledged acceptance gap, not a silent omission. Instrumented spans (overlapping, not additive) put the saved-source lease at ~4-10 ms, preparation including its layout wait at 25-45 ms, and the synchronous commit at 8-12 ms; the remainder is Textual layout/paint plus host scheduling. No timeout was widened and no spinner was added to disguise latency.

## Real execution evidence

Fixtures use real `RuntimeServer` / `OwnedSessionHandle` authenticated in-process sockets and the real `OperatorApp` with its stylesheet, holding the runtime's canonical subscription after socket authentication. HOME/config are isolated and every `CMUX_*` variable is removed before app imports. No personal session or live daemon was touched.

- [Round-1 evidence: before/after SVGs, geometry, runnable socket fixture, measured output](https://gist.github.com/damianvtran/374650b3bc7079e6b375f578c55871ea)
- [Remediation-round evidence (`state4_*`, captured on `68f00681`)](https://gist.github.com/damianvtran/239307a63fac38f37040858954444830)

```sh
LO_SOURCE_ROOT="$PWD" .venv/bin/python /path/to/gist/states.py
```

### Rendered frames

Faithful terminal SVGs with geometry sidecars; PNG rasterizations were inspected locally. **No browser PNG attachment is claimed.** Before and after use independent synthetic conversations reproducing the same held-sync boundary.

| State | Capture |
|---|---|
| Before: requested target never displayed | [SVG](https://gist.githubusercontent.com/damianvtran/374650b3bc7079e6b375f578c55871ea/raw/90fea74bffba11501e77f93b34342dae189fd35b/before_qa_stall_pending.svg) |
| Before: timeout leaves the old conversation | [SVG](https://gist.githubusercontent.com/damianvtran/374650b3bc7079e6b375f578c55871ea/raw/7aec836958305448df9929996fe234b155aff2ec/before_qa_stall_final.svg) |
| After: actual selected saved transcript, sidebar and draft | [SVG](https://gist.githubusercontent.com/damianvtran/374650b3bc7079e6b375f578c55871ea/raw/3782a7329df965d41ffc847cbf7c52e9df72fb3e/state3_connecting_wide.svg) |
| After: canonical recovery | [SVG](https://gist.githubusercontent.com/damianvtran/374650b3bc7079e6b375f578c55871ea/raw/e6084961bf149a2e5677189c32c5b82ed788a50c/state3_live_narrow.svg) |
| Aside open while connecting | [SVG](https://gist.githubusercontent.com/damianvtran/239307a63fac38f37040858954444830/raw/14b1e9d15e2b52bddcf1f28c568b21459faa92ae/state4_aside_before.svg) |
| Aside after canonical handover — still `Ask the aside…` (U5) | [SVG](https://gist.githubusercontent.com/damianvtran/239307a63fac38f37040858954444830/raw/d722ced1ff9ee4f4b4fb230205565d29afa77542/state4_aside_after.svg) |
| Return while still connecting — name retained (D1) | [SVG](https://gist.githubusercontent.com/damianvtran/239307a63fac38f37040858954444830/raw/3782a7329df965d41ffc847cbf7c52e9df72fb3e/state4_returned_connecting_wide.svg) |
| Unavailable, with the retry named (U3) | [SVG](https://gist.githubusercontent.com/damianvtran/239307a63fac38f37040858954444830/raw/7274d399863bf0f97bab3d13f008f35018c24646/state4_timeout_narrow.svg) |
| Deleted target refused, draft and transcript intact (F4) | [SVG](https://gist.githubusercontent.com/damianvtran/239307a63fac38f37040858954444830/raw/bb0bdf6790f17bbc7e86fe63980d8718a0bda007/state4_missing_narrow.svg) |

Actual probe output (`actual-states4.jsonl`):

```json
{"state":"returned","name":"Saved · Connecting…    Target investigation","selected":"target"}
{"state":"timeout","selected":"target","blocked":true,"error":"the runtime is not responding","draft":"Keep this draft until the connection is ready"}
{"state":"aside_recovered","open":true,"placeholder":"Ask the aside…"}
{"state":"live","selected":"target","blocked":false,"error":"","draft":"Keep this draft until the connection is ready"}
{"state":"missing","selected":"target","draft":"Keep this draft until the connection is ready","path_exists":false}
```

Consecutive connecting and recovered frames are byte-identical to their settled captures (no reflow). Narrow screen content `[78,28]` equals virtual size, with no screen scrollbar.

## Regression evidence

```text
Round-1 findings reproduced on the pre-fix product:  16 failed, 8 passed in 7.33s
Same matrix after remediation:                       30 passed in 9.02s
Focused + neighbour matrix on head:                 322 passed in 195.88s
Assembled e2e stage on head:                         56 passed in 67.25s
Whole-tree unit suite on head:      1 failed, 16210 passed, 18 skipped in 2982.90s
```

The 16 pre-fix failures are the round-1 findings reproduced **through the real application**, not restatements of them: a delayed owner abort arriving after the user switched away (F1), direct effort/fast-mode/model setters reaching an unbound facade (F1), a hidden bind skipping anchor reconciliation (F2), a wrapped-viewport anchor discarded by passive layout (F3), a fabricated empty conversation for a deleted target (F4), and a lost saved conversation name (D1).

The new matrix covers selected-visible and hidden completion, revisiting an already-retained stuck-owner view without a second connection, preserving unsent drafts, timeout/read-only/retry, a distant persisted scroll anchor, explicit End superseding a pending restore, offline `/copy` and aside mode, missing-target refusal, and name-based composing-card adoption not borrowing a card from another conversation.

**The neighbour run earned its place.** Routing End through the generic user-scroll hook re-armed the older-page latch and undid End's own tail jump (`test_resume_render::test_the_composer_pages_the_transcript_by_keyboard`, 257 passed / 1 failed). End now publishes explicit *downward* intent, which invalidates a pending restore without re-arming paging. That fix landed inside the same round, not after it.

### Unit-suite failure attribution

The first full run reported **5 failed**. Each was checked against the unmodified base `4433b7e8b` in a throwaway worktree:

| Failure | Attributable? | Root cause |
|---|---|---|
| `test_stop_command::test_an_ordinary_reload_does_not_take_the_unbound_branch` | **Yes — fixed** | My readiness predicate folded in `_session_transition_pending`, so a `/reload` window answered with the generic refusal instead of that path's own "still starting". Narrowed to source binding (`4ef7d901`); the file is now 35 passed. |
| 3 × `test_app_pilot` terminal-title tests | No | **My test runner**, not either tree: it exported `LOCAL_OPERATOR_NO_TERMINAL_TITLE=1`, and those tests assert the title wiring. They fail identically on base and pass with the variable removed. Same hazard class as the `CMUX_*` rule — an over-eager isolation variable manufacturing failures. |
| `test_computer_input` clipboard/X11 case | No | Environment-dependent; passes on rerun and on base. |

The re-run on head with the corrected runner reports **1 failed, 16210 passed**: `test_visual_gallery::test_gallery_inventory_lists_and_rejects_unknown_case`, which aborts (`-6`) inside a launched subprocess with `dyld: /private/lib/libpython3.12.dylib (no such file)`. That is an interpreter-resolution failure in a forked process under contention, untouched by this diff; the file passes `-n0` and `-n2` in isolation (10 passed).

## Quality gates (whole tree, exactly as CI)

| Gate | Result |
|---|---|
| `python -m flake8 .` | clean |
| `black --check .` (26.1.0) | 1075 files unchanged |
| `isort --check .` (5.13.2) | clean |
| `pyright --pythonpath .venv/bin/python .` | **0 errors, 0 warnings** |
| `pytest tests/unit` | 16210 passed, 1 unattributable failure (above) |
| `pytest tests/e2e -m e2e -n0` | 56 passed |

Every test command runs through an isolated HOME/config with `CMUX_*` scrubbed before imports, `TERM=xterm-256color`, `NO_COLOR` removed. The worktree owns its own real editable Python 3.12 environment; import provenance was verified from outside the repo.

## Coordination

If the parallel `TranscriptView` input-provenance change lands first, the later branch must count only explicit input (`args` absent, or `args[0] is not None`) toward `source.scroll_revision`, and must preserve End as explicit downward intent. This is a merge-convergence obligation, not licence to ignore a semantic conflict.

## Rollback

Revert these commits to restore the prior sidebar preparation path. No storage schema, owner protocol, version, or external runtime migration is involved.

🤖 Authored by an agent; see the review rounds on this PR.
