### PR TITLE
chore(release): bump version to 0.51.25

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.24"
+version = "0.51.25"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window bump. Owner session pid **85528**.

Bumps `pyproject.toml` from 0.51.24 to **0.51.25**. One line, no dependency, script or entry-point changes beside it.

**Bump class: patch.** Both PRs in this window are behavioural fixes to existing surfaces. Neither introduces a new capability or clears the step-function bar for a minor.

Window contents (re-derived immediately before tagging, `31b17fa91..origin/main`):

- [x] #800 `44de3b3886fef2759eba419cc1fd16a76c2e7a87` — sidebar and mobile session lists hold a stable category and creation order instead of reshuffling on activity
- [x] #805 `bbab46284c743d8b0883b5fad199088d0dd32565` — CI: live-LLM sanity jobs served from a multi-provider model