### PR TITLE
feat(secrets): encrypted long-term secret store with `lop secret` CLI (1 of 4)

### DIFF
--- a/docs/design/secret-store.md
+++ b/docs/design/secret-store.md
@@ -1,0 +1,848 @@
+# Long-term encrypted secret store (`lop secret`)
+
+Status: proposal. Author: architect subagent. Date: 2026-09-08.
+
+This designs the encrypted, long-lived credential store the operator asked for,
+the inline `/credential` composer redaction that feeds it, and the four access
+surfaces around it. It also states, without softening, what the design does
+**not** protect against, because the honest answer to part of the ask is "that
+cannot be fully achieved on a same-uid macOS box, and here is the strongest
+approximation".
+
+Every empirical claim below was measured on this machine (macOS 25.6.0, arm64,
+CPython 3.14.3) with the spikes recorded in [Appendix A](#appendix-a--spikes).
+Where a mechanism is named, it was run, not recalled.
+
+---
+
+## 1. The problem as I found it
+
+### 1.1 What exists today
+
+Three separate things are called "credentials" in this tree, and the new store
+is a fourth. Keeping them distinct is load-bearing:
+
+| Store | Lives in | Lifetime | Encrypted | Purpose |
+|---|---|---|---|---|
+| `CredentialManager` (`credentials.py:43`) | `~/.local-operator/credentials.env`, 0600, plaintext `KEY=VALUE` | forever | **no** | PROVIDER API keys (Anthropic, OpenAI…) read at boot by the model layer |
+| `VariableStore` session credentials (`variables.py:305-361`) | process memory only | one session | n/a | a secret the agent must USE and must never READ |
+| `VariableStore` variables (`variables.py:273-302`) | config / `.local-operator.env` / `LOCAL_OPERATOR_*` env | n/a | no | non-secret config, denylist-filtered |
+| **new: secret store** | `~/.local-operator/secrets/` | forever | **yes** | operator secrets, agent-retrievable from bash and eval |
+
+The session-credential path is well built and I am not replacing it. The
+operator hands over a secret; it is trimmed and stored in
+`VariableStore._credentials` (`variables.py:323`); the name only is advertised
+through `credential_names()` (`builtin.py:5360`) and the system-prompt tail; the
+value is injected into every `bash` child's environment (`builtin.py:1483-1492`);
+and it is scrubbed on the way back out by two cooperating filters — the loop's
+`redact_tool_result` choke point (`session.py:6420` → `variables.py:360`) for
+model-visible text, and `_PipeRedactor` (`builtin.py:1298-1328`) for live stream
+bytes, which deliberately holds back a possible credential suffix so a secret
+split across two reads cannot leak.
+
+**What is missing is only persistence and agent-initiated retrieval.** Nothing
+survives the session, and the agent can never read a value back — by design.
+
+### 1.2 The actual baseline, measured
+
+The comparison that matters is not against a perfect store, it is against what
+holds the operator's secrets *right now*:
+
+```
+~/.minerva/credentials/.env exists=True size=6664 mode=0o600
+-> 58 KEY=VALUE lines readable by ANY same-uid process, right now.
+*.json under ~/.minerva: 31   (service-account and secret-backup files, 0600)
+```
+
+Every one of those is plaintext, at a predictable path, matching a predictable
+filename pattern. `grep -rl "API_KEY\|SECRET" ~` finds all of it in seconds.
+That is the bar to clear.
+
+### 1.3 The central question, answered honestly
+
+> The operator wants secrets a "random script on the device" cannot sniff out,
+> while lop agents retrieve them freely from bash and eval with no prompt.
+
+A script running as the operator's UID can read any file that UID can read.
+So an encrypted store plus a key file beside it is **pure obfuscation** — the
+attacker reads both and decrypts. That much is true and I am not going to
+dress it up.
+
+But the naive framing hides a real asymmetry that the spikes confirm, and it
+is the asymmetry the whole design stands on:
+
+- **A same-uid process can read another process's ENVIRONMENT.** Verified:
+  `ps eww -p <pid>` and `sysctl KERN_PROCARGS2` both returned the marker from a
+  sibling process (spike 2). A capability token in the environment **is
+  stealable**. This kills option (b) as stated.
+- **A same-uid process CANNOT read another process's MEMORY without an
+  authorization prompt.** Verified: `task_for_pid()` on a sibling returned
+  `rc=5` (`KERN_FAILURE`), and `lldb -p` **hung** rather than attaching —
+  `authd` logged `Validating session owner damian (501) for
+  system.privilege.taskport.debug` and a `SecurityAgent` process appeared
+  (spike 3, 5). Developer mode is disabled and the user is not in `_developer`.
+  **A memory scrape puts a password dialog on the operator's screen.**
+
+That asymmetry is the entire security budget available. A master key **in the
+memory of a running daemon** is protected by a real kernel boundary; the same
+key **in a file** is protected by nothing beyond the file mode already on
+`.env`. Everything below follows from spending that budget well.
+
+---
+
+## 2. Evaluating the operator's three candidate mechanisms
+
+### 2.1 (a) Broker daemon with peer authentication — **recommended, with a caveat**
+
+What macOS actually gives a unix-socket server about its peer (spike 1, all
+succeeded):
+
+| Option | Result on this machine |
+|---|---|
+| `LOCAL_PEERCRED` (`SOL_LOCAL`, `xucred`) | uid=501, ngroups=16 — **uid only, no pid** |
+| `LOCAL_PEERPID` | peer pid (21276) |
+| `LOCAL_PEEREPID` | effective peer pid |
+| `LOCAL_PEERTOKEN` | audit token: `(auid, euid, egid, ruid, rgid, pid, asid, **pidversion**)` |
+| `proc_pidpath(pid)` | full executable path — `…/cpython-3.14.3-…/bin/python3.14` |
+| `sysctl KERN_PROC_PID` | ppid (offset 560) and start time (offset **0**, not 8) |
+| `csops(CS_OPS_CDHASH)` | **rc=-1, denied** — no code-signature check available |
+
+So: uid, pid, executable path and full ancestry are readable without privilege;
+**code signature is not**. Any design element depending on verifying the peer's
+signature is off the table. I checked, rather than assuming it would work.
+
+**Pid reuse is solved, not merely mitigated.** The audit token carries a
+`pidversion` (34652033 in spike 1), a monotonic per-process generation, and
+`kinfo_proc` carries a start time. The broker pins `(pid, pidversion,
+start_time)` at *connect* time and never re-resolves a bare pid later. A
+recycled pid presents a different generation and fails the match. Verified in
+spike 7 and spike 9.
+
+The full decision procedure works end to end (spike 9):
+
+```
+registered 'lop session' pid=28578 start=1788847125
+[a] agent bash grandchild  -> 28580 SECRET_VALUE
+[b] detached attacker script -> 28582 ppid=1 DENIED
+
+broker decisions:
+  pid=28580   ALLOW  descendant of session 28578 (start 1788847125 matches)
+  pid=28582   DENY   no registered session ancestor within 1 hops
+```
+
+The attacker there is exactly the threat-model script: same uid, double-forked
+and `setsid`'d so it reparents to launchd — the shape a script dropped by a bad
+link actually has. It was denied while the agent's real `bash` grandchild was
+allowed.
+
+**The caveat, stated plainly:** a script that does *not* detach, and instead
+runs as a child of some process that is itself a descendant of a lop session,
+inherits that ancestry and is allowed. Ancestry authenticates *lineage*, not
+*intent*. See §9.
+
+### 2.2 (b) Capability tokens in the environment — **rejected on evidence**
+
+Spike 2, the measurement that decides it:
+
+```
+[1] ps eww -p 21277: rc=0 MARKER_VISIBLE=True
+[1b] ps -E -p 21277: MARKER_VISIBLE=True
+[2] sysctl KERN_PROCARGS2: rc=0 bytes=3444 MARKER_VISIBLE=True
+```
+
+A same-uid process reads a sibling's environment three different ways. A
+capability token injected into agent children's environment is readable by the
+very attacker it is meant to exclude, and worse, it would be readable by any
+`bash` command the agent runs on behalf of a *prompt-injected* instruction.
+
+**The alternative the operator suggested — passing the capability over an
+inherited FD — also fails, for a subtler reason** (spike 6, 7). It works
+mechanically: a child handed a pre-connected socket on fd 3 talks to the broker
+with no token and no path. But `LOCAL_PEERPID` then reports the **connector's**
+pid, not the user's:
+
+```
+connector pid 27033 | hello pid=27033
+connector exiting, grandchild 27034
+    connector pid 27033 alive now? False
+=> the pid the broker sees is the CONNECTING process, pinned at connect();
+   the grandchild using the fd is invisible to LOCAL_PEERPID.
+```
+
+An inherited connection is therefore *anti*-authenticating: it launders the
+identity of whoever ends up holding it, and it survives the death of the
+process that was authenticated. **Each client must make its own connection**
+so that each request is peer-authenticated on its own merits.
+
+Conclusion: no ambient capability token, in env or on an fd. Authentication is
+the connection itself.
+
+### 2.3 (c) Where the master key lives at rest — **two-tier, default no prompt**
+
+The socket is a real barrier: macOS **enforces** mode bits on a unix socket at
+`connect()`. Verified (spike 7) — after `chmod 000`, even the owner got
+`[Errno 13] Permission denied`. So 0600 excludes other uids outright, and
+peer authentication handles the same-uid case.
+
+But when nothing is running the key must live somewhere. Options:
+
+| Option | Stops the targeted attacker? | Cost to operator |
+|---|---|---|
+| 0600 key file in a 0700 dir | **No** — a script reads it | none |
+| Key split (file + machine-bound value) | No — both are same-uid readable | none |
+| macOS keychain without prompt | No — same-uid ACL grants read | none |
+| **Passphrase, entered once per boot, cached in broker memory** | **Yes, for at-rest theft** | one prompt per reboot |
+
+This is where I disagree slightly with a strict reading of the operator's
+"no admin gate" constraint, and I want to be explicit about it rather than
+quietly picking one. The operator rejected *admin-gated and prompting* stores —
+keychain dialogs on every access, `op` CLI round-trips. A **once-per-boot**
+unlock is a different thing: it is not per-access, not admin, not a system
+dialog, and the broker then serves every retrieval for the rest of the uptime
+with no prompt at all. Agents never see it.
+
+What it buys is large and specific: **without it, the entire design collapses
+to obfuscation against an attacker who reads the key file.** With it, the
+master key exists only in the memory of a process that `task_for_pid` cannot
+open without raising a `SecurityAgent` prompt. That is the difference between
+"a script decrypts the store" and "a script cannot decrypt the store without
+the operator watching a password dialog appear for no reason".
+
+**Recommendation: ship both, default to the no-prompt mode, make the upgrade
+one command.**
+
+- **Default (`keyfile` mode).** Master key in `~/.local-operator/secrets/
+  master.key`, 0600, in a 0700 directory. Honest claim: *equivalent to today's
+  `.env` against a targeted attacker, materially better against opportunistic
+  malware* (§8). No prompt, no behaviour change, works headless, survives
+  reboots and `launchd` restarts.
+- **Opt-in (`passphrase` mode), `lop secret harden`.** Master key wrapped with
+  scrypt over an operator passphrase. The broker prompts once per boot, caches
+  the unwrapped key in memory, and serves everything after that silently. A
+  session that starts while the broker is locked gets a clear "locked, run
+  `lop secret unlock`" error rather than a hang.
+
+scrypt cost, measured (spike 8), for picking the parameter:
+
+```
+scrypt n=2^14 r=8 p=1:    92.3 ms, ~16 MiB
+scrypt n=2^15 r=8 p=1:   182.1 ms, ~32 MiB
+scrypt n=2^17 r=8 p=1:   840.7 ms, ~128 MiB
+```
+
+Pick **n=2^15, r=8, p=1** (182 ms, 32 MiB): unnoticeable once per boot, and a
+meaningful brute-force cost against a stolen wrapped key.
+
+---
+
+## 3. Crypto
+
+**No new install.** `cryptography` 50.0.x is already present in every
+environment, so this adds nothing to install time or Windows wheel risk — which
+the dependency comments in `pyproject.toml` treat as a first-class concern. Do
+not add `argon2-cffi` (not present) or `pynacl`.
+
+> **Amended during PR 1.** It arrives only as a *transitive* of
+> `pyjwt[crypto]>=2.10`, not as a direct dependency. A direct import belongs in
+> a direct declaration — if that extra were ever narrowed or replaced, the
+> transitive copy would vanish and `lop secret` would fail at import with
+> nothing pointing at the cause. PR 1 therefore declares `cryptography>=42`
+> explicitly in `pyproject.toml`. The install footprint is unchanged.
+
+**Primitives:**
+
+- **AEAD: AES-256-GCM** (`AESGCM` from `cryptography.hazmat.primitives.ciphers.
+  aead`). Hardware-accelerated on arm64; the alternative, ChaCha20-Poly1305,
+  buys nothing here.
+- **Nonce: 12 random bytes per record, per write.** Never a counter, never
+  reused across a re-seal. Every update generates a fresh nonce. At 96 bits
+  random with a store of thousands of records, collision risk is negligible.
+- **KDF for the passphrase mode: scrypt**, n=2^15, r=8, p=1, 32-byte output,
+  16-byte random salt stored beside the wrapped key.
+- **Subkey derivation: HKDF-SHA256** from the master key, `info` carrying the
+  key generation. Verified distinct per generation (spike 8, `[5]`).
+
+**Metadata is authenticated, and this is not optional.** The name and
+description are bound into the AAD, so an attacker with write access to the DB
+cannot rename a record or swap two records' ciphertexts to make a consumer
+fetch the wrong secret under a trusted name. Both attacks were tested and both
+fail closed:
+
+```
+[2] renaming the record fails decryption: InvalidTag (metadata is bound)
+[3] swapping record ciphertexts fails:    InvalidTag (record id is bound)
+```
+
+**The AAD**, canonically encoded so it cannot be ambiguous:
+
+```
+AAD = b"lopsec\x00" || format_version(u8) || key_generation(u32be) || record_id || \x00
+      || name_index || \x00 || kind
+```
+
+`record_id` is an immutable UUIDv4 assigned at creation. `name_index` is the
+HMAC blind index of §4 — the *column*, not the cleartext label. `kind` is
+`string` or `file` (§7).
+
+> **Amended during PR 1 (implementation).** This section originally bound the
+> cleartext `name` and `sha256(description)`. That is not implementable against
+> §4's schema, where both fields are stored *encrypted inside the ciphertext*:
+> a GCM tag covers the AAD, so the AAD must be known **before** decrypting, and
+> `list`/`rotate` enumerate rows with no candidate name to reconstruct it from.
+> The two sections contradicted each other. Binding the `name_index` column
+> instead is non-circular and preserves every property this section claims:
+> the blind index is a deterministic function of the name, so **renaming still
+> fails closed**; `record_id` is still bound, so **ciphertext swaps still fail
+> closed**; and the name and description remain authenticated by virtue of
+> being sealed *inside* the AEAD rather than beside it. The implementation
+> additionally re-derives the blind index from the decrypted name and rejects a
+> mismatch, so the inner and outer copies of the name cannot drift apart. Both
+> tamper cases are proven against a real on-disk database in
+> `tests/unit/secrets/test_tamper.py`.
+
+**Rotation.** `lop secret rotate` generates a new master key, re-seals every
+record under an incremented `key_generation`, and writes the new DB by the
+atomic path in §4. Records carry their generation, so a partially-rotated store
+is still fully readable — the reader selects the subkey by the record's own
+generation. The old key is held until the last record has moved, then wiped.
+
+---
+
+## 4. Storage
+
+**SQLite in WAL mode**, at `~/.local-operator/secrets/store.db`, directory 0700,
+file 0600.
+
+**Concurrency is the deciding factor, not a hypothetical.** The operator runs
+~10 lop sessions at once. Individual files per secret would need a lock protocol
+invented here; SQLite already has one that works. Measured with 10 concurrent
+readers doing 60 decrypts each against a live writer (spike 8):
+
+```
+[6] WAL: 10 concurrent readers x60 decrypts + 1 writer x60 commits in 21 ms
+    reads completed: [60, 60, 60, 60, 60, 60, 60, 60, 60, 60] | errors: NONE
+```
+
+Zero errors, 21 ms. WAL gives readers that never block on the writer, which is
+exactly the ~10-session shape.
+
+**Metadata leakage is handled by encrypting metadata too.** The operator
+correctly notes that names and descriptions are themselves sensitive — a store
+listing `MINERVA_PROD_DB_PASSWORD` tells an attacker where to go next. So:
+
+- `name` and `description` are stored **encrypted**, in the same record.
+- The `name` column additionally holds a **blind index**: `HMAC-SHA256(
+  hkdf(master, "name-index"), normalized_name)`, truncated to 16 bytes. That
+  gives exact-match lookup by name without storing the name in the clear, and
+  a `UNIQUE` constraint for free.
+- `list` therefore requires the key — which is correct: listing what secrets
+  exist is itself a privileged operation, and it goes through the same broker
+  authentication as a retrieval.
+
+Schema:
+
+```sql
+PRAGMA journal_mode=WAL;
+CREATE TABLE meta(k TEXT PRIMARY KEY, v BLOB);       -- schema_version, key_generation, kdf params
+CREATE TABLE secrets(
+  id            TEXT PRIMARY KEY,                     -- UUIDv4, immutable
+  name_index    BLOB NOT NULL UNIQUE,                 -- HMAC blind index
+  key_generation INTEGER NOT NULL,
+  nonce         BLOB NOT NULL,
+  ciphertext    BLOB NOT NULL,                        -- {value, name, description, kind}
+  kind          TEXT NOT NULL,                        -- 'string' | 'file'
+  created_at    REAL NOT NULL,
+  updated_at    REAL NOT NULL,
+  last_used_at  REAL
+);
+CREATE TABLE audit(
+  ts REAL NOT NULL, event TEXT NOT NULL, secret_id TEXT,
+  session_id TEXT, pid INTEGER, exe TEXT, outcome TEXT, prev_hash BLOB, hash BLOB
+);
+```
+
+**Atomicity and durability.** Single-statement writes inside a transaction;
+SQLite's WAL handles torn-write recovery, which is strictly better than the
+write-temp-then-`os.replace` dance `credentials.py:79` has to do by hand for a
+flat file. `PRAGMA synchronous=FULL` on the secrets table's connection: this
+store is small and written rarely, so durability beats throughput.
+
+---
+
+## 5. The four access surfaces
+
+### 5.1 The CLI — `lop secret` (primary surface)
+
+`AGENTS.md`'s tool-surface footprint ladder is explicit that a skill + `bash` is
+rung 2 and a new core tool is rung 5, "last resort". The CLI is therefore the
+**primary** surface and carries the full verb set:
+
+```
+lop secret get NAME              # value to stdout, no trailing newline
+lop secret set NAME [--description TEXT] [--kind string|file]   # value from stdin
+lop secret list [--json]         # names + descriptions, never values
+lop secret describe NAME
+lop secret rm NAME
+lop secret rotate | harden | unlock | status
+lop secret file NAME -- CMD...   # materialise a file secret for CMD (§7)
+lop secret run -- CMD...         # run CMD with named secrets in its env
+```
+
+**Usable inside `$( )` without the value reaching the transcript.** The whole
+point:
+
+```bash
+curl -H "Authorization: Bearer $(lop secret get GITHUB_TOKEN)" https://api.github.com/user
+```
+
+The value crosses a pipe into `curl`'s argv inside the child; the model sees
+only the command text it wrote. Interoperating with the existing redaction is
+the part that needs care and is specified in §6.
+
+**`lop secret set` reads the value from stdin, never argv.** argv is world-
+readable via the same `KERN_PROCARGS2` path spike 2 used for the environment.
+The CLI must refuse a `--value` flag; `eval_worker.py:225-266` already redacts
+argv in error rendering precisely because argv leaks.
+
+### 5.2 The agent tool — one `createIf`-gated tool
+
+Rung 3 on the ladder. One tool, `secret`, with an `op` parameter
+(`store|retrieve|list|describe|update|delete`), returning `None` from its
+builder when the broker is unavailable — mirroring `build_wake_tool` and
+`build_browser_tool`. Six separate tools would be six schemas in every cache
+prefix; one gated tool with a verb parameter is a fraction of that.
+
+**`retrieve` deliberately does not return the value to the model.** It returns
+a receipt naming the secret and stating that the value is available as
+`$NAME` in the next `bash` call and as `secrets["NAME"]` in `eval` — the same
+inversion the session-credential path already implements
+(`variables.py:32-40`). An agent that genuinely needs the bytes in-process uses
+`eval` (§5.3), where they never enter the transcript.
+
+`store` is the verb that makes persistence **a decision the agent makes**, as
+the operator asked. Guidance (§10) tells agents to prefer this store over
+`~/.minerva/credentials/.env`.
+
+### 5.3 The eval runtime — a library, not injected variables
+
+`eval` runs in a **separate worker process** (`tools/eval.py`, `eval_worker.py`).
+Injecting every secret into that worker's globals at spawn would:
+
+- put every secret in memory whether or not the cell wants one,
+- make them visible to `list_variables`-style introspection of the namespace,
+  and to any `print(globals())`,
+- and require deciding *which* secrets to inject before knowing what the cell
+  does.
+
+Instead, a lazy accessor is pre-imported into the worker namespace:
+
+```python
+from local_operator.secrets import secrets
+token = secrets["GITHUB_TOKEN"]      # connects to broker, authenticates, returns str
+```
+
+`secrets` is a lazy `Mapping`. Each `__getitem__` is one broker round trip and
+one audit entry, so retrievals are logged at the granularity they actually
+happen. The returned object is a `str` subclass whose `__repr__` and `__str__`
+in a *display* context render `[redacted]`, so an accidental bare `token` at
+the end of a cell does not paint the secret — while `+` concatenation and
+`.encode()` still yield real bytes for actual use. It also registers the value
+with the worker's redaction ledger (§6).
+
+The eval worker is a descendant of the session process, so it authenticates by
+ancestry exactly as `bash` does. No token, no injection.
+
+### 5.4 The existing session path keeps working, and gains "persist this"
+
+`/credential` and `ask secret=true` are unchanged in behaviour: still
+memory-only by default, still injected into bash, still unreadable. What is
+added is a **route**, not a replacement:
+
+- `/credential --persist <KEY>` promotes an existing session credential into
+  the long-term store.
+- The inline paste flow (§7 of the operator's brief, specified below in §11)
+  writes to the session store **and** offers persistence, with the agent
+  deciding.
+- `ask secret=true` gains an optional `persist: bool` on the question, and
+  `_report_secret_answers` (`builtin.py:9854`) routes to the long-term store
+  when set — it already has the shape for this, storing and reporting only the
+  key name.
+
+---
+
+## 6. Redaction: how a retrieved value stays out of the transcript
+
+This is the part most likely to be got wrong, because **the subprocess case is
+genuinely not solvable by the existing filters alone**, and I would rather name
+that than paper over it.
+
+Three cases, three mechanisms:
+
+**(1) Value retrieved by the agent tool or eval.** The session process knows the
+value. It registers it with the `VariableStore`, which already backs both
+`redact_tool_result` (`session.py:6420`) and `_redact_tool_text`
+(`builtin.py:1354`). Nothing new is needed: a new `VariableStore.
+register_redaction(value)` adds to the same `_credentials`-backed set that
+`redact()` iterates (`variables.py:360`), without making the value readable —
+it must go into a *separate* `_redactions` set that `redact()` reads but
+`credential_env()` and `credential_names()` do not, so registering a value for
+scrubbing never accidentally injects or advertises it.
+
+**(2) Value used by a `bash` child via `$(lop secret get NAME)`.** The session
+process never sees the bytes — that is the whole point of the `$( )` form — so
+the filter has nothing to match on. **This is a real hole and it is closed at
+the broker, not at the filter.** When the broker serves a retrieval to a peer it
+has authenticated to session `S`, it notifies `S` over the same socket
+(`retrieved: {id, value}` on the session's own registration connection). The
+session registers the value with its redactor **before** the child's output can
+be read, because the broker's reply to the child and the notification to the
+session are both written before the child can print anything. The existing
+`_PipeRedactor` (`builtin.py:1298`) then scrubs the stream bytes, including a
+secret split across two reads, which it already handles.
+
+There is a narrow race — a child that retrieves and prints within the same
+microseconds as the notification crossing the socket. Mitigate by having the
+broker **write the session notification first and wait for its ack before
+replying to the retrieving child**. That makes the ordering an invariant rather
+than a hope, at the cost of one extra round trip on retrieval (sub-millisecond
+on a unix socket). Take that cost.
+
+**(3) Value in a subprocess the filter never sees at all** — e.g. the agent
+pipes it to a file, or a background job started before registration. Not
+solvable in general, and the guidance (§10) must say so: `lop secret get` is
+for interpolating into a command, not for `echo`-ing. The `secret` tool's
+description should carry that sentence, because tool descriptions are the only
+guidance a model reliably reads.
+
+---
+
+## 7. File-shaped secrets, and `GOOGLE_APPLICATION_CREDENTIALS`
+
+The 31 JSON files under `~/.minerva` (9 of them service-account keys per the
+operator's brief) are not strings, and a consumer like google-auth needs a
+**real path it can open, possibly more than once**.
+
+I tested the three candidate mechanisms (spike 11):
+
+| Mechanism | Result |
+|---|---|
+| FIFO | `fifo read 73 bytes; seek FAILS: UnsupportedOperation` — single-shot, not seekable. **Unsafe.** |
+| Unlinked file via `/dev/fd/N` | Child reads it (`CHILD read 73 bytes`), sibling cannot (`Bad file descriptor`) — but **`open#1 49, open#2 0, open#3 0`: `/dev/fd/N` on macOS is a DUP with a shared offset, not a re-open.** Single-shot. **Unsafe for repeat readers.** |
+| 0600 file in a 0700 private dir, unlinked after the command | `repeat opens: 49 49` — works, seekable, re-openable |
+
+macOS `/dev/fd` semantics differ from Linux here, and this is exactly the kind
+of thing that would have been wrong if assumed. **Use the third option:**
+
+`lop secret file NAME -- CMD...` creates a per-invocation directory under
+`$TMPDIR` with mode 0700, writes the decrypted content 0600, exports
+`GOOGLE_APPLICATION_CREDENTIALS` (or a `--env-var` name) pointing at it, runs
+`CMD`, and removes the file and directory in a `finally` — including on signal,
+which needs an explicit handler, not just `atexit`.
+
+Honest note for the guidance: the plaintext **is** on disk for the lifetime of
+that command. It is 0700-dir-scoped, randomly named, and gone afterwards, which
+is far better than a permanent well-known path — but it is not zero exposure,
+and an attacker sampling the filesystem during that window finds it.
+
+---
+
+## 8. What each design actually stops — the honest comparison
+
+Measured against today's plaintext `~/.minerva/credentials/.env` (58 keys).
+
+| Attacker behaviour | Today | Encrypted DB + key file (default) | Broker + passphrase (opt-in) |
+|---|---|---|---|
+| `grep -r` / "find .env files" opportunistic malware | **Loses everything** | **Stopped** — ciphertext, names blind-indexed | **Stopped** |
+| Script reading a known key file path | n/a | **Not stopped** — reads key + DB, decrypts | **Stopped** — key is not on disk unwrapped |
+| Script camping on the socket | n/a | **Stopped** — 0600 enforced (spike 7), ancestry check (spike 9) | **Stopped** |
+| Detached script (`setsid`, reparented to launchd) | Loses everything | **Stopped** at the socket | **Stopped** |
+| Script dumping the broker's memory | n/a | Needs `task_for_pid` → **denied, rc=5**; `lldb` → **SecurityAgent prompt** (spikes 3, 5) | Same |
+| Script that runs `lop secret get` itself | n/a | **Not stopped** (§9) | **Not stopped** |
+| Script that rewrites the lop code it can write (`~/.local/bin/lop` is 0755 **writable**, spike 10) | n/a | **Not stopped** | **Not stopped** |
+| Attacker with a backup copy of the store only | n/a | Stopped if the key file was not in the backup | **Stopped** |
+
+The honest summary: **the default mode's real win is against opportunistic and
+automated theft, which is the overwhelming majority of what "clicked a bad link"
+produces.** The passphrase mode is what converts "targeted attacker wins" into
+"targeted attacker must run code that impersonates a lop session while the
+broker is unlocked, or trip a visible authorization prompt".
+
+---
+
+## 9. Residual risk
+
+Plain sentences, for the operator to act on. **This design does not protect
+against the following, and no design confined to one macOS user account can.**
+
+1. **A script that simply runs `lop secret get` itself.** `lop`, `local-operator`
+   and `lo` are all on `PATH` and executable by any process running as you
+   (spike 10). If that script spawns its own lop session, it becomes a
+   legitimate descendant and the broker authorizes it. Ancestry proves lineage,
+   not intent. **This is the fundamental limit of the whole design**, and it is
+   why the store is a large improvement over `.env` for automated malware and a
+   modest one against an attacker who has specifically studied your setup.
+
+2. **A script that modifies the lop runtime.** `~/.local/bin/lop` and the entire
+   `~/.local/share/uv/tools/local-operator` tree are mode 0755 and **writable by
+   your user** (spike 10). An attacker who patches the CLI, or drops a
+   `DYLD_INSERT_LIBRARIES` shim into a lop process they launch (the interpreter
+   is adhoc-signed, not hardened — spike 10), reads secrets as they are
+   decrypted. Code integrity is a prerequisite this design assumes and cannot
+   itself provide.
+
+3. **Anything already in a session's memory.** Session credentials, and any
+   secret an agent has retrieved this turn, are in the session process's RAM.
+   Protected by the same `task_for_pid` boundary as the broker — meaningful, but
+   it is the same single control.
+
+4. **The unlock window in passphrase mode.** Once you unlock after a reboot, the
+   broker serves silently until it exits. An attacker active during that window
+   is in case 1. The passphrase protects the store **at rest**, not while you
+   are using it.
+
+5. **A file secret during its command.** §7 writes plaintext to a 0700 dir for
+   the duration of one command. An attacker sampling the filesystem in that
+   window gets it.
+
+6. **The audit log is tamper-EVIDENT, not tamper-proof.** `chflags uappnd`
+   works without sudo and does block truncation and unlink (verified: "truncate
+   /overwrite BLOCKED", "unlink BLOCKED"), **but the owner can clear the flag**
+   with `chflags nouappnd` (verified, rc=0). Combined with the hash chain (§12)
+   an attacker cannot silently *edit* history, but they can remove the file and
+   you will notice a gap rather than being fooled by a forgery. Do not describe
+   this as an immutable log.
+
+7. **Prompt injection.** An agent that reads a malicious web page and is
+   convinced to `lop secret get` and exfiltrate is fully authorized. The store
+   defends against processes, not against the agent's own judgement. This is
+   arguably the *most likely* real path to loss, and it is unchanged by this
+   work.
+
+**One-sentence version for the operator:** *this makes your secrets invisible to
+the automated "scan the disk for credentials" malware that a bad link actually
+drops, and makes a targeted attacker either impersonate lop or trip a macOS
+password prompt — but anything running as you that is willing to run `lop`
+itself can still read them, so it is a large and worthwhile increase in cost,
+not a guarantee.*
+
+That is a real improvement over 58 plaintext keys at a predictable path. It is
+not a vault, and it should not be described as one.
+
+---
+
+## 10. Documentation: "credentials guidance"
+
+A new section in `AGENTS.md` (harness-agnostic, `~/` paths only per the
+operator's standing rules) plus the same content as a `skill://` for Minerva
+sessions. It must state:
+
+- **Prefer the lop store over plaintext `.env`** when storing anything new.
+  Storing is the agent's decision.
+- **From bash:** `$(lop secret get NAME)` interpolated directly into the command
+  that needs it. Never `echo`, never assign-then-print, never into a file.
+- **From eval:** `from local_operator.secrets import secrets; secrets["NAME"]`.
+- **File secrets:** `lop secret file NAME -- CMD`.
+- **What is logged** — every retrieval, with pid and executable.
+- **The residual risk in one paragraph**, so an agent does not overstate the
+  guarantee to the operator.
+
+---
+
+## 11. Inline `/credential` and the random-name scheme
+
+The operator's UX ask: type `/credential` anywhere in the composer line, paste
+the secret right after it, see it replaced by a bracketed marker in the style of
+image and large-text pastes, then keep typing to describe it.
+
+**Reuse the existing marker machinery, do not build a second one.**
+`editor.py` already has exactly this: `_collapse_paste` (`editor.py:5107`)
+issues `[Paste #N, {_paste_label(payload)}]`, stores the payload in
+`self._attachments[index]`, and returns `marker + " "`. `Marked = Attachment |
+PastedText` (`editor.py:619`) is a two-variant union whose docstring
+explicitly warns against adding a parallel map — so add a **third variant,
+`PastedCredential`**, to that same union rather than a `_credentials` dict
+beside it. Everything keyed on the marker number (the counter, the chip, the
+atomic-token gate, the aside stash, `EditorSubmitted`, `/reload`) is
+payload-agnostic and keeps working.
+
+Marker: `[Credential #1, 64 chars]` — `_paste_label` already produces
+`"64 chars"` for a single-line payload, which is exactly right for a secret.
+
+Two behaviours that must differ from `PastedText`:
+
+- **The payload must never be spliced back into the submitted text.** Where
+  `expand_pastes` re-inserts a `PastedText` payload at submit, a
+  `PastedCredential` is *removed* from the outgoing text and its value routed
+  to the store. The marker text itself stays, so the model sees
+  `[Credential #1, 64 chars]` followed by the operator's description — which is
+  precisely the message the agent needs.
+- **It must never enter prompt history.** `_record_history` already strips
+  paste citations (`editor.py:6546`) for a subtler reason; credentials must be
+  stripped there unconditionally, and never restored by `_navigate_history`.
+
+**Detection.** A `/credential` token anywhere in the line, followed by a paste
+event, arms the next paste for capture. Because `consumes_prompt` and
+`ArgumentMode` (`slash_commands.py:494-500`) only handle a *leading* slash
+command, the inline form is an editor-level concern, not a slash-command one —
+the existing `/credential` command keeps working unchanged for the leading case.
+
+**Random naming.** The operator does not invent a name; the store does:
+
+```
+LOP_SECRET_<8 chars of base32(random)>      e.g. LOP_SECRET_K3RQ7WZM
+```
+
+Env-var-shaped so it drops straight into `credential_env()` injection and
+`normalize_credential_key` (`variables.py:92`) round-trips it unchanged.
+Collision-free without consulting the store.
+
+**How a random name coexists with a meaningful one.** The `record_id` (UUIDv4)
+is the immutable identity; the **name is mutable metadata**. The random name is
+just the first value of that field. When the agent later understands what the
+secret is — from the operator's description in the same message — it calls
+`secret update --id <id> --name GITHUB_TOKEN --description "..."`, which
+re-seals the record under the new AAD (§3) and updates the blind index. The old
+random name stops resolving; the id never changes, so the audit chain stays
+continuous across the rename.
+
+---
+
+## 12. Audit
+
+Every retrieval, store, update, delete, rename and failed authorization is
+appended to the `audit` table **and** mirrored to
+`~/.local-operator/secrets/audit.log` (0600, `chflags uappnd`).
+
+Recorded: timestamp, event, `secret_id` (never the value), session id, peer pid,
+peer executable path (`proc_pidpath`, spike 1), and outcome.
+
+**Tamper evidence.** Each row carries `hash = SHA256(prev_hash || canonical
+(row))`, so an attacker who deletes or edits a middle entry breaks the chain and
+`lop secret audit --verify` reports where. Combined with `uappnd` this means an
+attacker must remove the whole file (detectable as a gap, since the DB table and
+the log must agree) rather than forge a plausible history. As §9.6 says
+explicitly: evident, not proof.
+
+---
+
+## 13. Compatibility and failure modes
+
+**Forward/backward skew.** The operator runs ~10 sessions and updates the
+runtime with `lop-update` while sessions are live, so version skew is routine,
+not exceptional.
+
+- `meta.schema_version` is checked on every open. A runtime seeing a **newer**
+  schema than it knows **refuses to write** and serves reads only if the record
+  format is one it understands; otherwise it fails with "store written by a
+  newer local-operator; upgrade this runtime". It must never migrate downward.
+- Records carry their own `key_generation` and format version, so a partially
+  rotated or partially migrated store is always coherent.
+- New optional columns only; never repurpose a column meaning.
+
+**When the broker dies with sessions running.** The broker is not the session's
+lifeline — it is consulted per retrieval. So:
+
+- A retrieval attempted while the broker is down returns a clear error
+  ("secret broker unavailable"), never a hang. Hard timeout on connect, ~2 s.
+- Already-injected session credentials and already-retrieved values are
+  unaffected: they are in the session's own memory.
+- **Auto-restart, carefully.** A session that finds no broker starts one, under
+  a `flock`-guarded startup so ten sessions racing produce one broker. In
+  `keyfile` mode the restart is silent; in `passphrase` mode the new broker
+  starts locked and says so. Note `AGENTS.md`'s #401 lesson — a blocking `flock`
+  deadlocked the event loop — so this lock must be non-blocking-with-retry off
+  the event loop, and the e2e stage should cover broker-down boot.
+- A `launchd` agent (`com.damian.lop-secretd.plist`) is the tidier long-term
+  answer, but it is **out of scope for these PRs**: it changes machine state
+  outside the repo, and the flock-guarded lazy start is sufficient and testable.
+
+---
+
+## 14. PR split
+
+Four PRs, in dependency order. Each is independently reviewable and independently
+useful; the first three are backend-only.
+
+### PR 1 — store core: crypto, schema, CLI (no broker)
+
+`local_operator/secrets/` — record sealing/opening, SQLite WAL schema, blind
+index, key generation, rotation, and the `lop secret` CLI reading the key file
+directly. No daemon, no socket. Ships the default `keyfile` mode end to end.
+
+- **Risk:** crypto misuse (nonce reuse on update, AAD not covering a mutable
+  field). Mitigate with round-trip tests including the two tamper cases proven
+  in spike 8, and a test asserting a fresh nonce on every update.
+- **Rounds:** reviewer + qa-tester. No designer/ux — no user-visible surface
+  beyond CLI text.
+
+### PR 2 — broker daemon and peer authentication
+
+The unix-socket daemon, `LOCAL_PEERPID` + `LOCAL_PEERTOKEN` + ancestry walk with
+the `(pid, pidversion, start_time)` pin, session registration, flock-guarded
+lazy start, audit log with hash chain and `uappnd`. CLI switches to talking to
+the broker; the direct-key path stays as the fallback when the broker cannot
+start.
+
+- **Risk:** the highest-risk PR. A hang here freezes sessions (`AGENTS.md` #401
+  is the precedent — a blocking lock deadlocked the event loop). Requires: hard
+  connect timeouts, no blocking lock on the event loop, an e2e case for
+  broker-down and broker-killed-mid-session, and a **Linux fallback** using
+  `SO_PEERCRED` (which yields pid directly) since CI runs an
+  `[ubuntu-latest, macos-latest]` matrix.
+- **Rounds:** reviewer + qa-tester. QA must include the spike-9 attacker case
+  (detached `setsid` script must be DENIED) as an actual test.
+
+### PR 3 — agent surfaces: `secret` tool, eval library, redaction wiring
+
+The `createIf`-gated `secret` tool, the `secrets` lazy mapping in the eval
+worker, `VariableStore.register_redaction`, the broker→session notification with
+the ack-before-reply ordering from §6, and the `--persist` route from the
+session store.
+
+- **Risk:** a retrieved value escaping into the transcript — the failure that
+  matters most. QA must specifically test `$(lop secret get X)` output scrubbing,
+  including a value split across two pipe reads (the case `_PipeRedactor` exists
+  for), and the notification race.
+- **Rounds:** reviewer + qa-tester.
+
+### PR 4 — inline `/credential` composer capture + guidance docs
+
+The `PastedCredential` variant in `editor.py`'s `Marked` union, inline detection,
+the `[Credential #1, 64 chars]` marker, history stripping, random naming, the
+`ask secret=true` persist option, and the credentials-guidance documentation.
+
+- **Risk:** the marker machinery has a documented history of regressions
+  (rounds 17-22 in `editor.py`'s docstrings: markers resolving to the wrong
+  payload, orphaned markers, numbering collisions). A credential resolving to
+  the wrong payload is worse than an image doing so.
+- **Rounds:** reviewer + qa-tester + **designer** (new visible marker style —
+  needs rendered before/after frames per `AGENTS.md` §"Visual validation", using
+  `scripts.visual_capture.save_capture`) + **ux-reviewer** (a new interaction
+  flow: type, paste, watch it redact, keep typing).
+
+**Ordering:** 1 → 2 → 3 → 4. PR 1 is independently shippable. PR 4 depends on 3
+for the persist route but its composer half could be split out if 3 stalls.
+
+**Version bumps:** none, per the standing rule — `pyproject.toml` stays at the
+last released version on every branch.
+
+---
+
+## Appendix A — spikes
+
+All spikes are in `/tmp/spike-secrets/`, run against
+`~/local-operator/.venv/bin/python` (CPython 3.14.3, macOS 25.6.0, arm64).
+
+| # | File | Question | Verdict |
+|---|---|---|---|
+| 1 | `spike1_peercred.py` | what does macOS tell a socket server about its peer? | uid/pid/audit-token/exe path/ancestry **yes**; code signature **no** (`csops` rc=-1) |
+| 2 | `spike2_env.py` | is a sibling's env readable? | **yes**, 3 ways — env tokens rejected |
+| 3 | `spike3_memory.py` | can a sibling read another process's memory? | `task_for_pid` **rc=5 denied** |
+| 4 | `spike4_ancestry.py` | ppid/start-time offsets in `kinfo_proc` | ppid @560, pid @40; start time **@0**, not @8 |
+| 5 | `spike5_debugger.py` | why did lldb hang? | blocked on `system.privilege.taskport.debug` in `authd`; `SecurityAgent` spawned |
+| 6 | `spike6_fdcap.py` | is an inherited fd a good capability? | works, but launders identity — rejected |
+| 7 | `spike7_perms.py` | are socket mode bits enforced? peer pid after connector exits? | **enforced** (0000 → EACCES); pid pinned at connect |
+| 8 | `spike8_crypto.py` | AEAD, AAD binding, scrypt cost, WAL under 10 sessions | all pass; tamper cases fail closed; 21 ms |
+| 9 | `spike9_broker.py` | does ancestry auth work end to end? append-only log? | agent ALLOW / detached attacker DENY; `uappnd` blocks truncate+unlink, owner can clear |
+| 10 | `spike10_bypass.py` | the bypasses | `lop` on PATH, runtime tree writable, interpreter adhoc-signed |
+| 11 | `spike11_files.py` | file-shaped secrets | FIFO not seekable; `/dev/fd/N` is a **dup** (single-shot) on macOS; private-dir file works |

--- a/docs/design/secret-store.md
+++ b/docs/design/secret-store.md
@@ -343,11 +343,13 @@ Schema:
 
 ```sql
 PRAGMA journal_mode=WAL;
-CREATE TABLE meta(k TEXT PRIMARY KEY, v BLOB);       -- schema_version, key_generation, kdf params
+CREATE TABLE meta(k TEXT PRIMARY KEY, v BLOB);       -- schema_version, key_generation,
+                                                     -- key_fingerprint, kdf params
 CREATE TABLE secrets(
   id            TEXT PRIMARY KEY,                     -- UUIDv4, immutable
   name_index    BLOB NOT NULL UNIQUE,                 -- HMAC blind index
   key_generation INTEGER NOT NULL,
+  format_version INTEGER NOT NULL,                    -- record format, for §13 skew
   nonce         BLOB NOT NULL,
   ciphertext    BLOB NOT NULL,                        -- {value, name, description, kind}
   kind          TEXT NOT NULL,                        -- 'string' | 'file'
@@ -712,6 +714,18 @@ continuous across the rename.
 Every retrieval, store, update, delete, rename and failed authorization is
 appended to the `audit` table **and** mirrored to
 `~/.local-operator/secrets/audit.log` (0600, `chflags uappnd`).
+
+> **Shipped in PR 1 vs. still outstanding.** PR 1 writes an audit row for every
+> *successful* retrieval, store, update, delete and rotation, with the hash
+> chain and `audit --verify` below. It does **not** yet record FAILED
+> operations — a `get` for a name that does not exist, or a record that fails
+> authentication, currently leaves no row — and it does not yet mirror to
+> `audit.log` or set `chflags uappnd`. Both gaps belong to the broker PR, which
+> owns the peer identity (pid, executable path) that makes a failure row worth
+> recording and is the process that can hold an append-only file open. Until
+> then the trail shows what succeeded, not an attacker probing for secret
+> names; this paragraph describes the destination, and the note describes what
+> is actually on disk today.
 
 Recorded: timestamp, event, `secret_id` (never the value), session id, peer pid,
 peer executable path (`proc_pidpath`, spike 1), and outcome.

--- a/local_operator/cli.py
+++ b/local_operator/cli.py
@@ -429,6 +429,13 @@ def build_cli_parser() -> argparse.ArgumentParser:
 
     add_tunnel_parser(subparsers)
 
+    # Encrypted secret store. Same discipline: argument registration is
+    # stdlib-only, so `--version` and `--help` never load the crypto stack that
+    # the handlers import at the point of use.
+    from local_operator.secrets.cli import add_parser as add_secret_parser
+
+    add_secret_parser(subparsers)
+
     # Browser bridge command: lazy for the same reason as mobile. Ordinary CLI
     # startup must not pull Starlette/uvicorn in just to render --help.
     browser_parser = subparsers.add_parser(
@@ -4174,6 +4181,10 @@ def main() -> int:
             from local_operator.tunnels.cli import main as tunnel_main
 
             return tunnel_main(args)
+        elif args.subcommand == "secret":
+            from local_operator.secrets.cli import main as secret_main
+
+            return secret_main(args)
         elif args.subcommand == "browser":
             return browser_command(args)
         elif args.subcommand == "send":

--- a/local_operator/secrets/__init__.py
+++ b/local_operator/secrets/__init__.py
@@ -1,0 +1,45 @@
+"""Encrypted long-term secret store (``lop secret``).
+
+Design: ``docs/design/secret-store.md``. This package ships PR 1 of that
+design — the crypto, the SQLite schema and the CLI, reading the master key
+file directly. The broker daemon that holds the key in RAM and authenticates
+callers by process ancestry is PR 2; :mod:`local_operator.secrets.access` is
+the seam it slides into.
+
+**What this is, stated without overclaiming, because the design is explicit
+that it must not be dressed up:** it makes secrets invisible to the "scan the
+disk for credential files" malware a bad link actually drops, and it fails
+closed against an attacker who edits the database. In the default ``keyfile``
+mode it does NOT stop an attacker who reads the master key file next to the
+store, and nothing confined to one macOS user account stops a process that
+simply runs ``lop secret get`` itself. See §9 of the design for the full list.
+It is not a vault and should not be described as one.
+
+Nothing heavy is imported here: the CLI's argument registration must stay off
+the crypto stack's import path (``tests/unit/test_import_graph.py``), so
+callers import the submodule they need.
+"""
+
+from __future__ import annotations
+
+from local_operator.secrets.errors import (
+    BrokerUnavailable,
+    IncompatibleStore,
+    InsecurePermissions,
+    InvalidSecretName,
+    SecretCorrupt,
+    SecretExists,
+    SecretNotFound,
+    SecretStoreError,
+)
+
+__all__ = [
+    "BrokerUnavailable",
+    "IncompatibleStore",
+    "InsecurePermissions",
+    "InvalidSecretName",
+    "SecretCorrupt",
+    "SecretExists",
+    "SecretNotFound",
+    "SecretStoreError",
+]

--- a/local_operator/secrets/access.py
+++ b/local_operator/secrets/access.py
@@ -30,7 +30,8 @@ from local_operator.secrets.errors import SecretStoreError
 from local_operator.secrets.keys import (
     load_master_key,
     replace_master_key,
-    staged_key_path,
+    secrets_dir,
+    staged_key_paths,
 )
 from local_operator.secrets.store import SecretStore, recorded_key_fingerprint
 
@@ -71,6 +72,13 @@ def resolve_master_key(base: Path | None = None, *, create: bool = False) -> byt
     automatically: adopting a staged key on its mere presence would let a
     leftover file from an abandoned rotation replace a perfectly good key.
 
+    **All staged keys are considered, not one well-known file.** Rotation is
+    concurrent, so several rotations can sit between their COMMIT and their
+    install at once and each stages under its own name; exactly one of them
+    holds the key this database is now sealed under, and it is found by
+    fingerprint. Scanning only a single path meant a second rotator's staging
+    could displace the copy this store needed.
+
     Any other combination falls through to the installed key untouched — a
     staged key that does not match is inert, and a store with no fingerprint
     row predates the mechanism and is opened exactly as before.
@@ -95,29 +103,35 @@ def resolve_master_key(base: Path | None = None, *, create: bool = False) -> byt
         # The installed key does not open this database. Either a rotation
         # committed and died before installing its key, or one is completing
         # right now in another session.
-        try:
-            candidate = staged_key_path(base).read_bytes()
-        except OSError:
-            # No staged key to adopt. If another session is mid-install the
-            # next attempt sees the new key file; if nothing is in flight the
-            # loop ends and the mismatch is reported below rather than
-            # returning a key that cannot decrypt anything.
-            continue
+        matched: bytes | None = None
+        for path in staged_key_paths(base):
+            try:
+                candidate = path.read_bytes()
+            except OSError:
+                # Raced with the owning rotation installing and removing it.
+                continue
+            if key_fingerprint(candidate) == expected:
+                matched = candidate
+                break
 
-        if key_fingerprint(candidate) != expected:
+        if matched is None:
+            # No staged key opens this database. If another session is
+            # mid-install the next attempt sees the new key file; if nothing is
+            # in flight the loop ends and the mismatch is reported below rather
+            # than returning a key that cannot decrypt anything.
             continue
 
         # The re-seal committed under this key; only the install is missing.
         # Completing it here rather than leaving the store readable-but-
         # unrepaired means the next crash does not find the same half-done
         # state.
-        replace_master_key(base, candidate)
-        return candidate
+        replace_master_key(base, matched)
+        return matched
 
     raise SecretStoreError(
         "This secret store is sealed under a master key that is not on disk. A key "
         "rotation appears to have been interrupted; the key that opens this store was "
-        f"neither installed at {staged_key_path(base).parent / 'master.key'} nor left "
+        f"neither installed at {secrets_dir(base) / 'master.key'} nor left "
         "staged beside it."
     )
 

--- a/local_operator/secrets/access.py
+++ b/local_operator/secrets/access.py
@@ -1,0 +1,57 @@
+"""How a caller gets an open store — the seam the broker slides into.
+
+Every surface (the CLI today; the agent tool and the eval library later) goes
+through :func:`open_store` rather than constructing a
+:class:`~local_operator.secrets.store.SecretStore` itself. That indirection is
+the whole point of this module: today it reads the master key from the key file
+in the same process, and the broker PR replaces the *body* of this function
+with a unix-socket round trip to a daemon that holds the key in RAM and
+authenticates the peer by ancestry. Nothing else has to change.
+
+The seam is deliberately drawn at the KEY, not at the store: the broker serves
+the master key material to an authenticated peer, and the peer then talks to
+SQLite directly. Putting the whole store behind the socket would mean
+reimplementing every verb as a wire protocol, and would put the database's
+concurrency story inside a single-threaded daemon rather than in WAL, which
+§4 chose precisely because it already works under ~10 sessions.
+
+Nothing here stubs behaviour that lies. ``lop secret harden`` and
+``lop secret unlock`` report that they need the broker, because they do; they
+do not pretend to succeed.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from local_operator.secrets.keys import load_master_key
+from local_operator.secrets.store import SecretStore
+
+#: Environment variable naming the session a CLI invocation belongs to, if it
+#: was launched by one. Recorded in the audit trail so a retrieval can be
+#: attributed. Read-only here and never trusted for authorization — a same-uid
+#: process can forge any environment variable it likes (design §2.2, spike 2),
+#: which is exactly why the BROKER authenticates by ancestry instead.
+SESSION_ID_ENV = "LOCAL_OPERATOR_SESSION_ID"
+
+
+def session_id() -> str | None:
+    """The session id to attribute an audit entry to, if one is advertised."""
+    value = os.environ.get(SESSION_ID_ENV, "").strip()
+    return value or None
+
+
+def open_store(base: Path | None = None, *, create: bool = False) -> SecretStore:
+    """Return a store ready to use, obtaining the master key for it.
+
+    ``create`` is passed by the write verbs only: a ``get`` against a store
+    that does not exist must say so rather than silently initialising an empty
+    one and then reporting the secret missing, which are different problems
+    with different fixes.
+
+    **Broker seam.** PR 2 replaces the ``load_master_key`` call below with a
+    broker request, falling back to the key file when the broker cannot start
+    (design §13). The signature and every caller stay as they are.
+    """
+    return SecretStore(load_master_key(base, create=create), base=base)

--- a/local_operator/secrets/access.py
+++ b/local_operator/secrets/access.py
@@ -25,8 +25,21 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from local_operator.secrets.keys import load_master_key
-from local_operator.secrets.store import SecretStore
+from local_operator.secrets.crypto import key_fingerprint
+from local_operator.secrets.errors import SecretStoreError
+from local_operator.secrets.keys import (
+    load_master_key,
+    replace_master_key,
+    staged_key_path,
+)
+from local_operator.secrets.store import SecretStore, recorded_key_fingerprint
+
+#: How many times :func:`resolve_master_key` re-reads the key state before
+#: giving up. Each attempt loses only to a rotation completing concurrently,
+#: and a rotation is a rare, operator-initiated act — several in a row while
+#: one process tries to open the store means something is genuinely wrong, and
+#: an error naming that beats an unbounded spin.
+_RESOLVE_ATTEMPTS = 8
 
 #: Environment variable naming the session a CLI invocation belongs to, if it
 #: was launched by one. Recorded in the audit trail so a retrieval can be
@@ -42,6 +55,73 @@ def session_id() -> str | None:
     return value or None
 
 
+def resolve_master_key(base: Path | None = None, *, create: bool = False) -> bytes:
+    """The key that actually opens this store, completing a broken rotation.
+
+    ``rotate`` stages the new key, commits the re-sealed database, then
+    installs the staged key as ``master.key``. A crash in the middle step
+    leaves the database sealed under the staged key while ``master.key`` still
+    holds the superseded one — every secret present and none of them readable,
+    from an ordinary power cut.
+
+    This function closes that window. When a staged key exists and its
+    fingerprint matches the one the DATABASE records, the rotation committed
+    and only the install is outstanding, so it is finished here and the store
+    opens normally. The fingerprint comparison is what makes this safe to do
+    automatically: adopting a staged key on its mere presence would let a
+    leftover file from an abandoned rotation replace a perfectly good key.
+
+    Any other combination falls through to the installed key untouched — a
+    staged key that does not match is inert, and a store with no fingerprint
+    row predates the mechanism and is opened exactly as before.
+
+    **Written as a retry around an invariant, not as an ordering.** The rule is
+    "return a key whose fingerprint is the one the database records", and every
+    input to that decision — the key file, the staging file, the fingerprint
+    row — can be changed by another session between any two reads. An earlier
+    version read the key file once at the top and could then return that stale
+    key after a concurrent rotation had replaced it, handing the caller a key
+    that no longer opens the store. So each attempt re-reads what it needs and
+    the result is checked against the invariant before it is returned.
+    """
+    for _ in range(_RESOLVE_ATTEMPTS):
+        installed = load_master_key(base, create=create)
+        expected = recorded_key_fingerprint(base)
+        if expected is None or key_fingerprint(installed) == expected:
+            # No store, a store predating the fingerprint row, or the ordinary
+            # healthy case: the installed key is the store's key.
+            return installed
+
+        # The installed key does not open this database. Either a rotation
+        # committed and died before installing its key, or one is completing
+        # right now in another session.
+        try:
+            candidate = staged_key_path(base).read_bytes()
+        except OSError:
+            # No staged key to adopt. If another session is mid-install the
+            # next attempt sees the new key file; if nothing is in flight the
+            # loop ends and the mismatch is reported below rather than
+            # returning a key that cannot decrypt anything.
+            continue
+
+        if key_fingerprint(candidate) != expected:
+            continue
+
+        # The re-seal committed under this key; only the install is missing.
+        # Completing it here rather than leaving the store readable-but-
+        # unrepaired means the next crash does not find the same half-done
+        # state.
+        replace_master_key(base, candidate)
+        return candidate
+
+    raise SecretStoreError(
+        "This secret store is sealed under a master key that is not on disk. A key "
+        "rotation appears to have been interrupted; the key that opens this store was "
+        f"neither installed at {staged_key_path(base).parent / 'master.key'} nor left "
+        "staged beside it."
+    )
+
+
 def open_store(base: Path | None = None, *, create: bool = False) -> SecretStore:
     """Return a store ready to use, obtaining the master key for it.
 
@@ -50,8 +130,8 @@ def open_store(base: Path | None = None, *, create: bool = False) -> SecretStore
     one and then reporting the secret missing, which are different problems
     with different fixes.
 
-    **Broker seam.** PR 2 replaces the ``load_master_key`` call below with a
-    broker request, falling back to the key file when the broker cannot start
-    (design §13). The signature and every caller stay as they are.
+    **Broker seam.** PR 2 replaces the key lookup below with a broker request,
+    falling back to the key file when the broker cannot start (design §13). The
+    signature and every caller stay as they are.
     """
-    return SecretStore(load_master_key(base, create=create), base=base)
+    return SecretStore(resolve_master_key(base, create=create), base=base)

--- a/local_operator/secrets/access.py
+++ b/local_operator/secrets/access.py
@@ -27,13 +27,12 @@ from pathlib import Path
 
 from local_operator.secrets.crypto import key_fingerprint
 from local_operator.secrets.errors import SecretStoreError
-from local_operator.secrets.keys import (
-    load_master_key,
-    replace_master_key,
-    secrets_dir,
-    staged_key_paths,
+from local_operator.secrets.keys import load_master_key, secrets_dir, staged_key_paths
+from local_operator.secrets.store import (
+    SecretStore,
+    install_master_key_if_current,
+    recorded_key_fingerprint,
 )
-from local_operator.secrets.store import SecretStore, recorded_key_fingerprint
 
 #: How many times :func:`resolve_master_key` re-reads the key state before
 #: giving up. Each attempt loses only to a rotation completing concurrently,
@@ -125,7 +124,17 @@ def resolve_master_key(base: Path | None = None, *, create: bool = False) -> byt
         # Completing it here rather than leaving the store readable-but-
         # unrepaired means the next crash does not find the same half-done
         # state.
-        replace_master_key(base, matched)
+        #
+        # Through the SAME compare-and-swap a rotator's own install uses, and
+        # for the same reason: this is an install outside the re-seal
+        # transaction, so without the guard a rotation committing between the
+        # fingerprint read above and this write would have its key clobbered by
+        # the stale one adopted here — the identical permanent-brick shape, just
+        # reached from the repair path instead of from `rotate`. A refusal means
+        # the store moved on under this call's feet, so the loop re-reads rather
+        # than returning a key that provably no longer opens the database.
+        if not install_master_key_if_current(matched, base):
+            continue
         return matched
 
     raise SecretStoreError(

--- a/local_operator/secrets/audit.py
+++ b/local_operator/secrets/audit.py
@@ -1,0 +1,187 @@
+"""The tamper-evident audit chain (design §12).
+
+Every store, retrieval, update, delete and rename appends a row whose hash
+covers the previous row's hash, so an attacker who edits or removes an entry in
+the middle breaks the chain at that point and ``lop secret audit --verify``
+reports where.
+
+The claim is **tamper-evident, not tamper-proof**, and the design is explicit
+that it must not be described as an immutable log: whoever owns the file can
+still delete the whole thing, and the ``chflags uappnd`` half of §12 (which
+blocks truncation and unlink but which the owner can clear) belongs to the
+broker PR along with the mirrored ``audit.log`` file — the broker is the
+process that has the peer pid and executable path worth recording. What lands
+here is the chain itself and its verifier, over the ``audit`` table.
+
+Never record a value. The columns are deliberately limited to the record's id,
+the event, and the peer identity, so a leaked audit log tells an attacker what
+happened, not what the secrets are.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from dataclasses import dataclass
+
+#: The chain's anchor. A fixed non-empty seed rather than ``b""`` so that a row
+#: whose ``prev_hash`` was blanked out by an attacker is distinguishable from a
+#: genuine first row.
+GENESIS = hashlib.sha256(b"local-operator/secret-store/audit/v1").digest()
+
+
+@dataclass(frozen=True)
+class AuditEntry:
+    """One row of the audit table, as the verifier sees it."""
+
+    ts: float
+    event: str
+    secret_id: str | None
+    session_id: str | None
+    pid: int | None
+    exe: str | None
+    outcome: str
+    prev_hash: bytes
+    hash: bytes
+
+
+def canonical_row(
+    ts: float,
+    event: str,
+    secret_id: str | None,
+    session_id: str | None,
+    pid: int | None,
+    exe: str | None,
+    outcome: str,
+) -> bytes:
+    """Serialise a row for hashing, unambiguously.
+
+    Length-prefixed fields rather than a separator: a session id containing the
+    separator byte would otherwise let two different rows serialise identically,
+    which is the standard way a naive chain is forged. ``ts`` is formatted with
+    a fixed repr so the same row always hashes the same on re-read from SQLite.
+    """
+    parts: list[bytes] = [
+        f"{ts:.6f}".encode("ascii"),
+        event.encode("utf-8"),
+        (secret_id or "").encode("utf-8"),
+        (session_id or "").encode("utf-8"),
+        str(pid if pid is not None else "").encode("ascii"),
+        (exe or "").encode("utf-8"),
+        outcome.encode("utf-8"),
+    ]
+    return b"".join(len(part).to_bytes(4, "big") + part for part in parts)
+
+
+def chain_hash(prev_hash: bytes, row: bytes) -> bytes:
+    """``SHA256(prev_hash || canonical(row))`` — the link itself."""
+    return hashlib.sha256(prev_hash + row).digest()
+
+
+def last_hash(connection: sqlite3.Connection) -> bytes:
+    """The hash the next appended row must chain from.
+
+    Ordered by ``rowid``, not by ``ts``: two appends inside the same
+    millisecond, or a clock that steps backwards, must not reorder the chain.
+    """
+    cursor = connection.execute("SELECT hash FROM audit ORDER BY rowid DESC LIMIT 1")
+    row = cursor.fetchone()
+    return GENESIS if row is None else bytes(row[0])
+
+
+def append(
+    connection: sqlite3.Connection,
+    *,
+    event: str,
+    ts: float,
+    outcome: str,
+    secret_id: str | None = None,
+    session_id: str | None = None,
+    pid: int | None = None,
+    exe: str | None = None,
+) -> bytes:
+    """Append one entry and return its hash.
+
+    Takes the caller's open connection and does not commit: the audit row and
+    the change it describes belong in the same transaction, or a crash between
+    them produces a store whose history disagrees with its contents.
+    """
+    previous = last_hash(connection)
+    digest = chain_hash(
+        previous, canonical_row(ts, event, secret_id, session_id, pid, exe, outcome)
+    )
+    connection.execute(
+        "INSERT INTO audit(ts, event, secret_id, session_id, pid, exe, outcome, prev_hash, hash)"
+        " VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (ts, event, secret_id, session_id, pid, exe, outcome, previous, digest),
+    )
+    return digest
+
+
+def entries(connection: sqlite3.Connection, limit: int | None = None) -> list[AuditEntry]:
+    """Read the chain in append order, newest last."""
+    sql = (
+        "SELECT ts, event, secret_id, session_id, pid, exe, outcome, prev_hash, hash"
+        " FROM audit ORDER BY rowid"
+    )
+    rows = connection.execute(sql).fetchall()
+    if limit is not None:
+        rows = rows[-limit:]
+    return [
+        AuditEntry(
+            ts=row[0],
+            event=row[1],
+            secret_id=row[2],
+            session_id=row[3],
+            pid=row[4],
+            exe=row[5],
+            outcome=row[6],
+            prev_hash=bytes(row[7]),
+            hash=bytes(row[8]),
+        )
+        for row in rows
+    ]
+
+
+def verify(connection: sqlite3.Connection) -> tuple[bool, int | None, str]:
+    """Walk the chain; return ``(ok, broken_position, message)``.
+
+    ``broken_position`` is the 1-based index of the first entry that does not
+    verify, which is the number the operator needs — it says *where* history
+    stopped being trustworthy, and everything before it is still evidence.
+
+    Two distinct breaks are reported separately because they mean different
+    things: a wrong ``prev_hash`` means a row was removed or reordered ahead of
+    this one, while a wrong ``hash`` over a correct ``prev_hash`` means this
+    row's own contents were edited in place.
+    """
+    expected = GENESIS
+    for position, entry in enumerate(entries(connection), start=1):
+        if entry.prev_hash != expected:
+            return (
+                False,
+                position,
+                f"audit chain broken at entry {position}: an earlier entry was removed "
+                "or reordered",
+            )
+        recomputed = chain_hash(
+            expected,
+            canonical_row(
+                entry.ts,
+                entry.event,
+                entry.secret_id,
+                entry.session_id,
+                entry.pid,
+                entry.exe,
+                entry.outcome,
+            ),
+        )
+        if recomputed != entry.hash:
+            return (
+                False,
+                position,
+                f"audit chain broken at entry {position}: this entry was edited after "
+                "it was written",
+            )
+        expected = entry.hash
+    return True, None, "audit chain intact"

--- a/local_operator/secrets/cli.py
+++ b/local_operator/secrets/cli.py
@@ -1,0 +1,155 @@
+"""``lop secret`` — argument registration for the encrypted store (design §5.1).
+
+`AGENTS.md`'s tool-surface footprint ladder makes a skill plus ``bash`` rung 2
+and a new core tool rung 5, so the CLI carries the full verb set and the agent
+tool (PR 3) stays deliberately thin.
+
+This module is the STDLIB-ONLY half: ``cli.py`` imports it on every ``lop``
+invocation to build the parser, so nothing here may reach for the crypto stack
+or sqlite3. The verbs live in :mod:`local_operator.secrets.handlers`, which
+:func:`main` imports once a ``secret`` verb has actually been dispatched.
+
+**The hard requirement of that half is stdout purity on ``get``.** The whole
+point of the store is that an agent writes
+
+.. code-block:: bash
+
+    curl -H "Authorization: Bearer $(lop secret get GITHUB_TOKEN)" ...
+
+and the value crosses a pipe into the child's argv without ever entering the
+transcript. ``$( )`` strips trailing newlines but nothing else: one banner
+line, one ANSI colour code, one progress note on stdout and every consumer
+silently receives a corrupted credential — which fails as a confusing 401 from
+a remote service, not as an error anyone traces back to here. So ``get``
+writes the exact stored bytes to the stdout BUFFER and nothing else, every
+other verb writes its human output to stdout only in non-value form, and every
+diagnostic goes to stderr. ``tests/unit/secrets/test_cli.py`` asserts the
+exact bytes.
+
+``set`` reads the value from STDIN and there is deliberately no ``--value``
+flag: argv is readable by any same-uid process through ``ps`` and
+``KERN_PROCARGS2`` (design §2.2, spike 2), so a value on the command line is a
+value already leaked.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+from local_operator.secrets.errors import KINDS
+
+#: Default variable name exported by ``lop secret file``. Named for the
+#: overwhelmingly common case — a Google service-account JSON, of which the
+#: operator has nine — while ``--env-var`` covers everything else.
+DEFAULT_FILE_ENV_VAR = "GOOGLE_APPLICATION_CREDENTIALS"
+
+
+def add_parser(subparsers: Any) -> None:
+    """Register ``lop secret`` and its verbs.
+
+    Stdlib-only and importable without touching the crypto stack: this runs on
+    every ``lop`` invocation including ``--version``, and
+    ``tests/unit/test_import_graph.py`` pins that the CLI's import graph stays
+    free of heavy dependencies. That is why ``KINDS`` comes from ``errors``
+    rather than from ``store``, and why the verbs themselves live in
+    :mod:`local_operator.secrets.handlers`, which :func:`main` imports only
+    once a verb has actually been dispatched.
+    """
+    parser = subparsers.add_parser(
+        "secret",
+        help="Encrypted long-term secrets an agent can retrieve without a prompt",
+    )
+    actions = parser.add_subparsers(dest="secret_command")
+
+    get_parser = actions.add_parser(
+        "get", help="Write a secret's value to stdout with no trailing newline"
+    )
+    get_parser.add_argument("name")
+
+    set_parser = actions.add_parser("set", help="Store a NEW secret; the value is read from stdin")
+    set_parser.add_argument("name")
+    set_parser.add_argument("--description", default="", help="Human note shown by list")
+    set_parser.add_argument("--kind", choices=KINDS, default="string")
+    set_parser.add_argument(
+        "--from-file",
+        type=Path,
+        help="Read the value from this file instead of stdin (the file is not removed)",
+    )
+
+    update_parser = actions.add_parser(
+        "update", help="Replace an existing secret's value; read from stdin"
+    )
+    update_parser.add_argument("name")
+    update_parser.add_argument("--description", default=None)
+    update_parser.add_argument("--from-file", type=Path)
+
+    list_parser = actions.add_parser("list", help="Names and descriptions; never values")
+    list_parser.add_argument("--json", action="store_true")
+
+    describe_parser = actions.add_parser("describe", help="Metadata for one secret; never a value")
+    describe_parser.add_argument("name")
+    describe_parser.add_argument("--json", action="store_true")
+
+    for name in ("rm", "delete"):
+        remove_parser = actions.add_parser(name, help="Remove a secret permanently")
+        remove_parser.add_argument("name")
+        remove_parser.add_argument(
+            "--yes", action="store_true", help="Do not prompt for confirmation"
+        )
+
+    actions.add_parser("rotate", help="Re-seal every record under a new master key")
+
+    status_parser = actions.add_parser("status", help="Where the store is and what mode it is in")
+    status_parser.add_argument("--json", action="store_true")
+
+    audit_parser = actions.add_parser("audit", help="Show or verify the audit chain")
+    audit_parser.add_argument(
+        "--verify", action="store_true", help="Check the hash chain and report the first break"
+    )
+    audit_parser.add_argument("--limit", type=int, default=20)
+    audit_parser.add_argument("--json", action="store_true")
+
+    file_parser = actions.add_parser(
+        "file", help="Materialise a file secret at a private path for one command"
+    )
+    file_parser.add_argument("name")
+    file_parser.add_argument("--env-var", default=DEFAULT_FILE_ENV_VAR)
+    # nargs="*" rather than argparse.REMAINDER: REMAINDER starts consuming at
+    # the first token after the positional, so `file NAME --env-var VAR -- cmd`
+    # swallowed `--env-var` into the command list and silently used the default
+    # variable name. With "*", argparse still stops option parsing at the `--`
+    # separator, so flags belonging to the CHILD command (`-- curl -H ...`)
+    # arrive intact while our own options are parsed before it.
+    file_parser.add_argument("command", nargs="*")
+
+    run_parser = actions.add_parser("run", help="Run a command with named secrets in its env")
+    run_parser.add_argument(
+        "--secret",
+        action="append",
+        default=[],
+        metavar="NAME[=VAR]",
+        help="Secret to export; repeatable. NAME=VAR exports it under a different variable",
+    )
+    # Same reason as `file` above: REMAINDER would swallow `--secret`.
+    run_parser.add_argument("command", nargs="*")
+
+    for verb, summary in (
+        ("harden", "Wrap the master key with a passphrase (needs the secret broker)"),
+        ("unlock", "Unlock a hardened store for this boot (needs the secret broker)"),
+    ):
+        actions.add_parser(verb, help=summary)
+
+
+def main(args: argparse.Namespace) -> int:
+    """Entry point for ``lop secret``; see :mod:`local_operator.secrets.handlers`.
+
+    A deliberately thin shim. The import is function-local because this module
+    is imported during argument registration on every ``lop`` invocation, and
+    the handlers pull in the crypto stack and sqlite3 — a cost that belongs to
+    the run that actually uses a secret, not to ``lop --version``.
+    """
+    from local_operator.secrets.handlers import dispatch
+
+    return dispatch(args)

--- a/local_operator/secrets/cli.py
+++ b/local_operator/secrets/cli.py
@@ -94,7 +94,15 @@ def add_parser(subparsers: Any) -> None:
 
     for name in ("rm", "delete"):
         remove_parser = actions.add_parser(name, help="Remove a secret permanently")
-        remove_parser.add_argument("name")
+        # Optional because `--id` is the alternative way to name the target. A
+        # record whose ciphertext will not open has no readable name and no
+        # valid blind index, so `--id` is the only way to remove one — without
+        # it a single damaged row is unremovable short of editing SQLite by
+        # hand. `list` prints the id of every such row.
+        remove_parser.add_argument("name", nargs="?")
+        remove_parser.add_argument(
+            "--id", help="Remove by record id; the way to remove an undecryptable record"
+        )
         remove_parser.add_argument(
             "--yes", action="store_true", help="Do not prompt for confirmation"
         )

--- a/local_operator/secrets/crypto.py
+++ b/local_operator/secrets/crypto.py
@@ -59,8 +59,14 @@ NAME_INDEX_BYTES = 16
 #: unbounded AAD, not to be tight.
 MAX_NAME_LENGTH = 256
 
+#: Bytes of :func:`key_fingerprint`. 16 bytes of a domain-separated HKDF
+#: output: long enough that two distinct master keys never collide in a store
+#: that holds a handful of generations, short enough to sit in a meta row.
+KEY_FINGERPRINT_BYTES = 16
+
 _SUBKEY_INFO_PREFIX = b"local-operator/secret-store/record/v1/gen="
 _NAME_INDEX_INFO = b"local-operator/secret-store/name-index/v1"
+_FINGERPRINT_INFO = b"local-operator/secret-store/key-fingerprint/v1"
 
 
 def normalize_name(name: str) -> str:
@@ -112,13 +118,35 @@ def derive_record_key(master_key: bytes, key_generation: int) -> bytes:
     return _hkdf(master_key, _SUBKEY_INFO_PREFIX + str(key_generation).encode("ascii"))
 
 
+def key_fingerprint(master_key: bytes) -> bytes:
+    """A public, non-reversible identifier for a master key.
+
+    This is what lets a session answer "is the key I am holding still the key
+    this store is sealed under?" without holding the store's key. ``rotate``
+    records the incoming key's fingerprint in ``meta``, and every write
+    compares its own key against that row inside its transaction — the check
+    that stops a session holding a pre-rotation key from committing a record
+    nobody can ever read (the store-bricking interleave).
+
+    Derived through HKDF with its own ``info`` label rather than hashing the
+    key directly: it is written to the database in the clear, so it must be
+    domain-separated from the record subkeys and the index key. Recovering the
+    master key from it is exactly as hard as inverting HKDF-SHA256.
+    """
+    return _hkdf(master_key, _FINGERPRINT_INFO)[:KEY_FINGERPRINT_BYTES]
+
+
 def derive_name_index_key(master_key: bytes) -> bytes:
     """The HMAC key behind the blind index.
 
-    Deliberately NOT per-generation. The blind index has to stay stable across
-    a key rotation or every lookup would break the moment the generation moved,
-    and rewriting every index during rotation would be a second thing that can
-    half-finish.
+    Stable across a GENERATION bump, and rewritten wholesale on a master-key
+    rotation. The distinction matters and the earlier wording had it backwards:
+    this key comes from the master key, not from the generation counter, so
+    ``update`` and ``set`` never move an index, but ``rotate`` installs a new
+    master key and therefore changes every index. That is why
+    :meth:`SecretStore.rotate` rewrites every ``name_index`` column inside the
+    same transaction that re-seals the ciphertexts — the two must move together
+    or a lookup finds nothing.
     """
     return _hkdf(master_key, _NAME_INDEX_INFO)
 

--- a/local_operator/secrets/crypto.py
+++ b/local_operator/secrets/crypto.py
@@ -1,0 +1,254 @@
+"""Sealing and opening a secret record.
+
+The whole of the encryption story lives here so that the storage layer never
+touches a primitive directly: ``store.py`` moves opaque blobs and asks this
+module to turn them into values. Splitting it that way is what makes the
+tamper tests in ``tests/unit/secrets`` meaningful — they corrupt the database
+rows the storage layer wrote and prove this module refuses them.
+
+Design reference: ``docs/design/secret-store.md`` §3.
+
+What this protects against, stated honestly because overclaiming it is worse
+than not having it: an attacker who reads ``store.db`` alone learns nothing,
+not even which secrets exist, and an attacker who can WRITE the database
+cannot make a consumer fetch the wrong value under a trusted name. It does
+NOT protect against an attacker who reads the key file next to the database
+in the default ``keyfile`` mode — see §9 of the design. This is not a vault.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import unicodedata
+from dataclasses import dataclass
+
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+from local_operator.secrets.errors import InvalidSecretName, SecretCorrupt
+
+#: Domain separator opening every AAD. Its presence means a ciphertext lifted
+#: out of some other AES-GCM context in this codebase cannot be replayed into
+#: the secret store, because the AAD it was sealed under starts differently.
+_AAD_MAGIC = b"lopsec\x00"
+
+#: Record format version, carried in the AAD *and* in its own column. Bumped
+#: only when the sealed plaintext's layout changes. Kept distinct from the
+#: schema version (``store.py``): a runtime can understand the table layout
+#: while not understanding a record inside it, and §13 of the design requires
+#: those two skews to be reported separately.
+RECORD_FORMAT_VERSION = 1
+
+#: AES-256-GCM. 32-byte key, 12-byte nonce — the size the NIST construction is
+#: specified for and the only one where a random nonce's collision bound is the
+#: familiar 2^-32-at-2^48-messages figure.
+KEY_BYTES = 32
+NONCE_BYTES = 12
+
+#: Truncation length of the blind index. 128 bits of an HMAC tag: collision
+#: resistance far beyond a store of thousands of records, and it keeps the
+#: UNIQUE index narrow. Truncating an HMAC is sound — it is the standard
+#: construction for exactly this "searchable but opaque" use.
+NAME_INDEX_BYTES = 16
+
+#: Names are the operator's own labels, so the ceiling only has to stop an
+#: unbounded AAD, not to be tight.
+MAX_NAME_LENGTH = 256
+
+_SUBKEY_INFO_PREFIX = b"local-operator/secret-store/record/v1/gen="
+_NAME_INDEX_INFO = b"local-operator/secret-store/name-index/v1"
+
+
+def normalize_name(name: str) -> str:
+    """Canonicalise a secret name for lookup and for the blind index.
+
+    NFKC, then strip: two visually identical names that differ only by Unicode
+    composition must land on the same blind index, or ``get`` silently misses a
+    record the operator can see in ``list``. Case is deliberately NOT folded —
+    environment-variable-shaped names are conventionally upper-case and the
+    operator may legitimately want ``token`` and ``TOKEN`` apart.
+    """
+    return unicodedata.normalize("NFKC", name).strip()
+
+
+def validate_name(name: str) -> str:
+    """Return the normalised name, or raise :class:`InvalidSecretName`.
+
+    Control characters are refused because the AAD encoding below separates
+    fields with ``\\x00``: a name containing one could be split differently on
+    the way back, which is exactly the ambiguity the canonical encoding exists
+    to prevent. Newlines are refused for the same reason ``credentials.py``
+    refuses them — they corrupt every line-oriented consumer downstream.
+    """
+    normalized = normalize_name(name)
+    if not normalized:
+        raise InvalidSecretName("Secret name cannot be empty.")
+    if len(normalized) > MAX_NAME_LENGTH:
+        raise InvalidSecretName(
+            f"Secret name is {len(normalized)} characters; the maximum is {MAX_NAME_LENGTH}."
+        )
+    if any(ord(character) < 0x20 or ord(character) == 0x7F for character in normalized):
+        raise InvalidSecretName("Secret name cannot contain control characters.")
+    return normalized
+
+
+def generate_master_key() -> bytes:
+    """A fresh 256-bit master key from the OS CSPRNG."""
+    return os.urandom(KEY_BYTES)
+
+
+def derive_record_key(master_key: bytes, key_generation: int) -> bytes:
+    """The per-generation record encryption key.
+
+    HKDF rather than using the master key directly, so that ``rotate`` can
+    increment the generation and re-seal without the old and new keys sharing
+    any material. Records carry their own generation, so a partially rotated
+    store stays fully readable: the reader derives the subkey the record names.
+    """
+    return _hkdf(master_key, _SUBKEY_INFO_PREFIX + str(key_generation).encode("ascii"))
+
+
+def derive_name_index_key(master_key: bytes) -> bytes:
+    """The HMAC key behind the blind index.
+
+    Deliberately NOT per-generation. The blind index has to stay stable across
+    a key rotation or every lookup would break the moment the generation moved,
+    and rewriting every index during rotation would be a second thing that can
+    half-finish.
+    """
+    return _hkdf(master_key, _NAME_INDEX_INFO)
+
+
+def name_index(master_key: bytes, name: str) -> bytes:
+    """Truncated HMAC over the normalised name — the searchable, opaque label.
+
+    This is what makes ``list`` and ``get`` work without storing a single name
+    in the clear. A store whose file is stolen does not tell the thief that
+    ``MINERVA_PROD_DB_PASSWORD`` exists, which is itself a disclosure worth
+    preventing (design §4).
+    """
+    digest = hmac.new(
+        derive_name_index_key(master_key),
+        normalize_name(name).encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    return digest[:NAME_INDEX_BYTES]
+
+
+def _hkdf(master_key: bytes, info: bytes) -> bytes:
+    # salt=None is correct here and not an oversight: the input keying material
+    # is already a uniformly random 256-bit key from the CSPRNG, which is the
+    # case RFC 5869 §3.1 says a salt is optional for. The salt exists to
+    # extract entropy from a non-uniform secret; there is none to extract.
+    return HKDF(algorithm=hashes.SHA256(), length=KEY_BYTES, salt=None, info=info).derive(
+        master_key
+    )
+
+
+@dataclass(frozen=True)
+class RecordMetadata:
+    """The fields bound into a record's AAD.
+
+    Every one of these is a DATABASE COLUMN, and that is the load-bearing
+    property: the AAD must be reconstructible before the ciphertext is opened,
+    so it can only reference data that is outside the ciphertext. See
+    :func:`build_aad` for why the name arrives here as its blind index rather
+    than as the label the operator typed.
+    """
+
+    record_id: str
+    name_index: bytes
+    kind: str
+    key_generation: int
+    format_version: int = RECORD_FORMAT_VERSION
+
+
+def build_aad(metadata: RecordMetadata) -> bytes:
+    """The canonical associated-data encoding.
+
+    ``AAD = b"lopsec\\x00" || format_version(u8) || key_generation(u32be) ||
+    record_id || \\x00 || name_index || \\x00 || kind``
+
+    Canonical means unambiguous: fixed-width integers first, then variable
+    fields separated by ``\\x00`` — a byte :func:`validate_name` excludes from
+    names and which cannot occur in the fixed-length ``name_index`` digest or
+    in a ``kind`` drawn from a closed set. No two distinct metadata tuples
+    encode to the same bytes.
+
+    **Deviation from design §3, and why.** The design writes the AAD over the
+    cleartext ``name`` and ``sha256(description)``. Both of those live *inside*
+    the ciphertext (design §4: "``name`` and ``description`` are stored
+    encrypted"), which makes the construction circular for any read that does
+    not already know the name — ``list`` and ``rotate`` enumerate rows and have
+    no candidate name to build an AAD from, so they could never open a record.
+    Binding the ``name_index`` column instead is non-circular and preserves
+    every property §3 asks for:
+
+    - The blind index is a deterministic function of the name under a key
+      derived from the master key, so **renaming a record by editing the
+      database still fails closed** — the AAD changes and the tag check fails.
+    - ``record_id`` is still bound, so **swapping two records' ciphertexts
+      still fails closed**.
+    - The cleartext name and description are still authenticated, because they
+      are sealed *inside* the ciphertext; ``store.py`` additionally re-derives
+      the blind index from the decrypted name and rejects a mismatch, so the
+      inner copy and the outer column cannot disagree.
+
+    The description is therefore covered by the AEAD rather than by the AAD,
+    which is the same guarantee reached by a different route: editing it
+    requires the key either way.
+    """
+    return b"".join(
+        (
+            _AAD_MAGIC,
+            metadata.format_version.to_bytes(1, "big"),
+            metadata.key_generation.to_bytes(4, "big"),
+            metadata.record_id.encode("utf-8"),
+            b"\x00",
+            metadata.name_index,
+            b"\x00",
+            metadata.kind.encode("utf-8"),
+        )
+    )
+
+
+def seal(master_key: bytes, metadata: RecordMetadata, value: bytes) -> tuple[bytes, bytes]:
+    """Encrypt ``value``, returning ``(nonce, ciphertext)``.
+
+    A FRESH random nonce on every call, including every update of an existing
+    record. Reusing a nonce under the same key in GCM is catastrophic — it
+    leaks the XOR of the two plaintexts and the authentication key — so the
+    nonce is generated here rather than accepted as a parameter, leaving no
+    call site able to supply a stale one.
+    """
+    nonce = os.urandom(NONCE_BYTES)
+    ciphertext = AESGCM(derive_record_key(master_key, metadata.key_generation)).encrypt(
+        nonce, value, build_aad(metadata)
+    )
+    return nonce, ciphertext
+
+
+def open_record(
+    master_key: bytes, metadata: RecordMetadata, nonce: bytes, ciphertext: bytes
+) -> bytes:
+    """Decrypt a record, or raise :class:`SecretCorrupt`.
+
+    ``InvalidTag`` is translated rather than propagated so no caller has to
+    import ``cryptography`` to handle the one failure that matters, and so the
+    message names the tampering explicitly. There is deliberately no path that
+    returns a value when authentication fails.
+    """
+    try:
+        return AESGCM(derive_record_key(master_key, metadata.key_generation)).decrypt(
+            nonce, ciphertext, build_aad(metadata)
+        )
+    except InvalidTag as exc:
+        raise SecretCorrupt(
+            f"Secret record {metadata.record_id} failed authentication: its ciphertext or "
+            "its metadata (name, description, kind, key generation) was modified after it "
+            "was written, or it was sealed under a different key. Refusing to return a value."
+        ) from exc

--- a/local_operator/secrets/errors.py
+++ b/local_operator/secrets/errors.py
@@ -1,0 +1,88 @@
+"""Error types for the encrypted secret store.
+
+Its own stdlib-only module so that callers which must not pull the crypto
+stack — argument registration on the CLI startup path, and the broker client
+that lands in a follow-up — can still catch and classify a failure. Every one
+of these carries a message written for the operator standing at a terminal,
+because the CLI prints ``str(exc)`` verbatim to stderr.
+"""
+
+from __future__ import annotations
+
+#: Valid values of a record's ``kind``. ``file`` marks a secret whose plaintext
+#: is a file's contents, materialised to a private temporary path for the
+#: duration of one command by ``lop secret file`` (design §7).
+#:
+#: It lives in this stdlib-only module, rather than beside the schema in
+#: ``store.py``, because ``cli.add_parser`` needs it to build ``--kind``'s
+#: choices on EVERY ``lop`` invocation. Importing it from ``store`` there would
+#: drag SQLite and the whole crypto stack onto the startup path that
+#: ``tests/unit/secrets/test_startup_cost.py`` pins as clean.
+KINDS = ("string", "file")
+
+
+class SecretStoreError(Exception):
+    """Base class for every failure raised by the secret store."""
+
+
+class InvalidSecretName(SecretStoreError):
+    """The name is empty, over-long, or carries control characters.
+
+    Names are bound into the AEAD's associated data with ``\\x00`` separators
+    (see :mod:`local_operator.secrets.crypto`), so a name containing a NUL
+    could make two different records produce the same AAD encoding. Rejecting
+    the input is the only way to keep that encoding unambiguous.
+    """
+
+
+class SecretNotFound(SecretStoreError):
+    """No record matches the requested name."""
+
+
+class SecretExists(SecretStoreError):
+    """A record with that name is already present.
+
+    ``set`` refuses rather than replacing: silently overwriting a live
+    credential from a typo'd name is unrecoverable, since the previous value
+    is not kept anywhere.
+    """
+
+
+class SecretCorrupt(SecretStoreError):
+    """A record failed to authenticate — it will not be returned.
+
+    Raised when AES-GCM reports ``InvalidTag``, which happens when the
+    ciphertext, the nonce or any AAD-bound metadata (record id, name,
+    description, kind, key generation) has been altered since the record was
+    sealed. This is the fail-closed path: a tampered record is an error, never
+    a plausible-looking wrong answer.
+    """
+
+
+class IncompatibleStore(SecretStoreError):
+    """The store on disk was written by a runtime newer than this one.
+
+    The operator runs many sessions and updates the runtime underneath them,
+    so version skew is routine. An older runtime must never migrate a newer
+    store downward or guess at a record format it does not know.
+    """
+
+
+class InsecurePermissions(SecretStoreError):
+    """A store file is readable by someone other than its owner.
+
+    The whole at-rest story in ``keyfile`` mode rests on the mode bits, so a
+    key file that another account can read is a condition to stop on, not one
+    to quietly repair — the exposure already happened and the operator needs
+    to know.
+    """
+
+
+class BrokerUnavailable(SecretStoreError):
+    """The key broker could not be reached.
+
+    Defined here, and not raised anywhere yet, because the CLI's ``harden`` and
+    ``unlock`` verbs report it as a not-yet-shipped capability. The broker
+    daemon and peer authentication land in the follow-up PR; that PR raises
+    this from the broker client in ``access.open_store``.
+    """

--- a/local_operator/secrets/errors.py
+++ b/local_operator/secrets/errors.py
@@ -68,6 +68,20 @@ class IncompatibleStore(SecretStoreError):
     """
 
 
+class StaleKeyEpoch(SecretStoreError):
+    """The master key this caller holds is no longer the store's key.
+
+    Raised when a write's key does not match the fingerprint the store records,
+    which happens when another session completed a ``rotate`` after this one
+    loaded the key — the routine case on a machine running ~10 sessions at
+    once. The write is refused rather than committed, because a record sealed
+    under a superseded key is indexed under a superseded index key too: it
+    would be unreachable by name AND undecryptable, while ``set`` reported
+    success. Failing closed costs the operator one retry; succeeding costs them
+    the secret.
+    """
+
+
 class InsecurePermissions(SecretStoreError):
     """A store file is readable by someone other than its owner.
 

--- a/local_operator/secrets/handlers.py
+++ b/local_operator/secrets/handlers.py
@@ -1,0 +1,424 @@
+"""Handlers behind ``lop secret`` — everything that touches the store.
+
+Split from :mod:`local_operator.secrets.cli`, which registers the arguments,
+because that module is imported on EVERY ``lop`` invocation to build
+``--kind``'s choices. Keeping the crypto and SQLite imports here means
+``lop --version`` never loads an OpenSSL binding; ``cli.main`` imports this
+module only once a ``secret`` verb has actually been dispatched.
+``tests/unit/secrets/test_startup_cost.py`` pins that arrangement.
+
+The stdout-purity contract these implement is documented in
+:mod:`local_operator.secrets.cli`; the short version is that ``get`` writes the
+exact stored bytes to the stdout buffer and every diagnostic goes to stderr.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from local_operator.secrets.access import open_store, session_id
+from local_operator.secrets.errors import SecretStoreError
+from local_operator.secrets.keys import DIR_MODE, FILE_MODE, key_mode, secrets_dir
+from local_operator.secrets.store import SecretRecord
+
+
+def dispatch(args: argparse.Namespace) -> int:
+    """Dispatch a ``lop secret`` invocation; returns the process exit code.
+
+    Every :class:`SecretStoreError` becomes a one-line stderr message and exit
+    2. A traceback here would be worse than useless: this command is routinely
+    run inside ``$( )``, where a traceback on stderr buries the one line the
+    operator needs, and the failures are all ordinary operator conditions
+    (no such secret, store not created, permissions loosened).
+    """
+    command = getattr(args, "secret_command", None)
+    if command is None:
+        _err("usage: lop secret {get,set,update,list,describe,rm,rotate,status,audit,file,run}")
+        return 2
+
+    handlers = {
+        "get": _get,
+        "set": _set,
+        "update": _update,
+        "list": _list,
+        "describe": _describe,
+        "rm": _remove,
+        "delete": _remove,
+        "rotate": _rotate,
+        "status": _status,
+        "audit": _audit,
+        "file": _file,
+        "run": _run,
+        "harden": _needs_broker,
+        "unlock": _needs_broker,
+    }
+    try:
+        return handlers[command](args)
+    except SecretStoreError as exc:
+        _err(str(exc))
+        return 2
+    except KeyboardInterrupt:
+        return 130
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+def _err(message: str) -> None:
+    """Diagnostics go to stderr, always.
+
+    Never stdout: see the module docstring — stdout is a data channel for
+    ``get`` and a machine-parsed one for every ``--json`` verb.
+    """
+    print(message, file=sys.stderr)
+
+
+def _read_value(args: argparse.Namespace, verb: str) -> bytes:
+    """Read a secret value from ``--from-file`` or stdin, as exact bytes.
+
+    ``sys.stdin.buffer`` rather than ``sys.stdin``: the value may be binary,
+    and text mode would mangle it through the locale codec and universal
+    newline translation — a CRLF in a stored PEM would come back as LF and the
+    key would no longer verify.
+
+    A single trailing newline is stripped, because ``echo`` and every heredoc
+    add one and an operator piping ``echo hunter2`` means five characters, not
+    six. Anything more (a value that genuinely ends in blank lines, or a
+    multi-line PEM) is preserved exactly — only the last ``\\n`` goes.
+    """
+    from_file = getattr(args, "from_file", None)
+    if from_file is not None:
+        return Path(from_file).read_bytes()
+    if sys.stdin is None or sys.stdin.isatty():
+        _err(
+            f"lop secret {verb}: the value is read from stdin, never from the command line "
+            "(argv is readable by any process running as you).\n"
+            f"  printf %s 'the-value' | lop secret {verb} NAME"
+        )
+        raise SystemExit(2)
+    data = sys.stdin.buffer.read()
+    if data.endswith(b"\n"):
+        data = data[:-1]
+    return data
+
+
+def _format_time(value: float | None) -> str:
+    if value is None:
+        return "never"
+    import datetime
+
+    return datetime.datetime.fromtimestamp(value).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _record_dict(record: SecretRecord) -> dict[str, Any]:
+    """A record as JSON-safe data. Contains no value, by construction."""
+    return {
+        "id": record.record_id,
+        "name": record.name,
+        "description": record.description,
+        "kind": record.kind,
+        "key_generation": record.key_generation,
+        "created_at": record.created_at,
+        "updated_at": record.updated_at,
+        "last_used_at": record.last_used_at,
+    }
+
+
+# --- verbs ------------------------------------------------------------------
+
+
+def _get(args: argparse.Namespace) -> int:
+    """Write the exact stored bytes to stdout and nothing else.
+
+    Straight to ``sys.stdout.buffer``: the value is bytes, and going through
+    the text layer would re-encode it in the locale's codec and translate
+    newlines. No trailing newline is added — the caller asked for a value, and
+    ``$( )`` stripping the newline we add is luck, not contract, in every other
+    consumer (a Python ``subprocess.check_output``, a here-string, a file
+    redirect).
+    """
+    value = open_store().get(args.name, session_id=session_id())
+    sys.stdout.buffer.write(value)
+    sys.stdout.buffer.flush()
+    return 0
+
+
+def _set(args: argparse.Namespace) -> int:
+    value = _read_value(args, "set")
+    record = open_store(create=True).set(
+        args.name,
+        value,
+        description=args.description,
+        kind=args.kind,
+        session_id=session_id(),
+    )
+    # The confirmation names the secret and its size, never its value. Size is
+    # genuinely useful — it is how an operator notices they stored the shell
+    # prompt instead of the token — and reveals nothing.
+    _err(f"stored {record.name} ({len(value)} bytes, kind={record.kind})")
+    return 0
+
+
+def _update(args: argparse.Namespace) -> int:
+    value = _read_value(args, "update")
+    record = open_store().update(
+        args.name, value, description=args.description, session_id=session_id()
+    )
+    _err(f"updated {record.name} ({len(value)} bytes)")
+    return 0
+
+
+def _list(args: argparse.Namespace) -> int:
+    """Names, kinds and descriptions. NEVER a value — there is no flag for it.
+
+    Retrieval is ``get``, one secret at a time, so that every value leaving the
+    store is one audited event attributable to one name. A ``--values`` flag
+    here would turn a single audit entry into a bulk export.
+    """
+    records = open_store().list()
+    if args.json:
+        print(json.dumps([_record_dict(record) for record in records], indent=2))
+        return 0
+    if not records:
+        _err("no secrets stored")
+        return 0
+    width = max(len(record.name) for record in records)
+    for record in records:
+        suffix = f"  {record.description}" if record.description else ""
+        print(f"{record.name:<{width}}  {record.kind:<6}{suffix}")
+    return 0
+
+
+def _describe(args: argparse.Namespace) -> int:
+    record = open_store().describe(args.name)
+    if args.json:
+        print(json.dumps(_record_dict(record), indent=2))
+        return 0
+    print(f"name         {record.name}")
+    print(f"id           {record.record_id}")
+    print(f"kind         {record.kind}")
+    print(f"description  {record.description or '(none)'}")
+    print(f"created      {_format_time(record.created_at)}")
+    print(f"updated      {_format_time(record.updated_at)}")
+    print(f"last used    {_format_time(record.last_used_at)}")
+    print(f"key gen      {record.key_generation}")
+    return 0
+
+
+def _remove(args: argparse.Namespace) -> int:
+    """Delete a secret, confirming first unless ``--yes``.
+
+    The value is not recoverable afterwards and there is no undo, so an
+    interactive run asks. A non-tty run (an agent's bash call, a script) cannot
+    answer a prompt, so it requires ``--yes`` explicitly rather than defaulting
+    to either answer.
+    """
+    if not args.yes:
+        if not sys.stdin or not sys.stdin.isatty():
+            _err(f"refusing to delete {args.name} without --yes (stdin is not a terminal)")
+            return 2
+        _err(f"Delete {args.name} permanently? This cannot be undone. [y/N] ")
+        if input().strip().lower() not in ("y", "yes"):
+            _err("cancelled")
+            return 1
+    record = open_store().delete(args.name, session_id=session_id())
+    _err(f"deleted {record.name}")
+    return 0
+
+
+def _rotate(args: argparse.Namespace) -> int:
+    """Re-seal every record under a fresh master key.
+
+    The new key file is installed only AFTER the database transaction commits.
+    A crash between the two leaves the old key matching an unmodified database,
+    which is recoverable; the other order would leave a new key against records
+    still sealed under the old one, which is not.
+    """
+    from local_operator.secrets.crypto import generate_master_key
+    from local_operator.secrets.keys import replace_master_key
+
+    store = open_store()
+    new_key = generate_master_key()
+    moved = store.rotate(new_key, session_id=session_id())
+    replace_master_key(None, new_key)
+    _err(f"rotated {moved} secret(s) to key generation {store.key_generation()}")
+    return 0
+
+
+def _status(args: argparse.Namespace) -> int:
+    """Where the store is, what mode it is in, and how many records it holds.
+
+    Deliberately does not overclaim. The ``mode`` line says ``keyfile`` and the
+    note says what that means: the master key is on disk next to the database,
+    which stops opportunistic credential-scanning malware and does not stop an
+    attacker who reads the key file. This is the text an operator forms their
+    mental model from, so it states the residual risk (design §9) rather than
+    implying a vault.
+    """
+    directory = secrets_dir()
+    mode = key_mode()
+    payload: dict[str, Any] = {
+        "directory": str(directory),
+        "exists": (directory / "store.db").exists(),
+        "key_mode": mode,
+        "broker": "not available in this version",
+    }
+    if payload["exists"]:
+        store = open_store()
+        payload["secrets"] = len(store.list())
+        payload["key_generation"] = store.key_generation()
+        ok, position, message = store.verify_audit()
+        payload["audit_ok"] = ok
+        payload["audit_message"] = message
+        payload["audit_break_at"] = position
+
+    if args.json:
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    print(f"directory   {payload['directory']}")
+    print(f"key mode    {mode}")
+    if not payload["exists"]:
+        print("store       not created yet (lop secret set NAME creates it)")
+        return 0
+    print(f"secrets     {payload['secrets']}")
+    print(f"key gen     {payload['key_generation']}")
+    print(f"audit       {payload['audit_message']}")
+    print(
+        "note        keyfile mode keeps the master key on disk beside the store. That "
+        "defeats\n            malware that scans for credential files; it does not "
+        "defeat an attacker\n            who reads the key file itself."
+    )
+    return 0
+
+
+def _audit(args: argparse.Namespace) -> int:
+    store = open_store()
+    if args.verify:
+        ok, position, message = store.verify_audit()
+        if args.json:
+            print(json.dumps({"ok": ok, "broken_at": position, "message": message}, indent=2))
+        else:
+            print(message)
+        return 0 if ok else 1
+    records = store.audit_entries(limit=args.limit)
+    if args.json:
+        print(
+            json.dumps(
+                [
+                    {
+                        "ts": entry.ts,
+                        "event": entry.event,
+                        "secret_id": entry.secret_id,
+                        "session_id": entry.session_id,
+                        "pid": entry.pid,
+                        "outcome": entry.outcome,
+                        "hash": entry.hash.hex(),
+                    }
+                    for entry in records
+                ],
+                indent=2,
+            )
+        )
+        return 0
+    for entry in records:
+        print(
+            f"{_format_time(entry.ts)}  {entry.event:<7} {entry.outcome:<5} "
+            f"pid={entry.pid or '-':<7} {entry.secret_id or ''}"
+        )
+    return 0
+
+
+def _file(args: argparse.Namespace) -> int:
+    """Materialise a file secret at a private path for one command (design §7).
+
+    A 0600 file inside a fresh 0700 directory under ``$TMPDIR``, removed in a
+    ``finally``. The design measured the two tidier-looking alternatives and
+    both are wrong on macOS: a FIFO is not seekable, and ``/dev/fd/N`` on a
+    deleted file is a DUP with a *shared offset*, so a consumer that opens it
+    twice — which google-auth does — reads zero bytes the second time.
+
+    Stated plainly because the guidance has to say it: the plaintext IS on disk
+    for the lifetime of this command. Randomly named, in a directory only this
+    user can traverse, and gone afterwards — far better than a permanent
+    well-known path, but not zero exposure.
+    """
+    command = [argument for argument in args.command if argument != "--"]
+    if not command:
+        _err("usage: lop secret file NAME [--env-var VAR] -- COMMAND...")
+        return 2
+
+    value = open_store().get(args.name, session_id=session_id())
+    directory = Path(tempfile.mkdtemp(prefix="lop-secret-"))
+    os.chmod(directory, DIR_MODE)
+    target = directory / args.name.replace(os.sep, "_")
+    try:
+        descriptor = os.open(target, os.O_WRONLY | os.O_CREAT | os.O_EXCL, FILE_MODE)
+        try:
+            os.write(descriptor, value)
+        finally:
+            os.close(descriptor)
+        os.chmod(target, FILE_MODE)
+        environment = os.environ.copy()
+        environment[args.env_var] = str(target)
+        return subprocess.run(command, env=environment, check=False).returncode
+    finally:
+        # A `finally` covers a normal exit, an exception and a SIGINT that
+        # Python turns into KeyboardInterrupt. It does NOT cover SIGKILL or a
+        # SIGTERM with no handler, so the plaintext can outlive a hard kill —
+        # the broker PR, which owns process lifecycle, installs the signal
+        # handler that narrows this. Named rather than papered over.
+        shutil.rmtree(directory, ignore_errors=True)
+
+
+def _run(args: argparse.Namespace) -> int:
+    """Run a command with named secrets exported into its environment.
+
+    The child's environment is readable by any same-uid process while it runs
+    (design §2.2, spike 2), so this is strictly weaker than ``$(lop secret
+    get)`` interpolation and exists only for consumers that read a fixed
+    variable and offer no other input. The help text says so; so does the
+    guidance in PR 4.
+    """
+    command = [argument for argument in args.command if argument != "--"]
+    if not command:
+        _err("usage: lop secret run --secret NAME[=VAR] -- COMMAND...")
+        return 2
+    if not args.secret:
+        _err("lop secret run: name at least one secret with --secret NAME")
+        return 2
+
+    store = open_store()
+    environment = os.environ.copy()
+    for specification in args.secret:
+        name, _, variable = specification.partition("=")
+        environment[variable or name] = store.get(name, session_id=session_id()).decode(
+            "utf-8", errors="strict"
+        )
+    return subprocess.run(command, env=environment, check=False).returncode
+
+
+def _needs_broker(args: argparse.Namespace) -> int:
+    """``harden`` / ``unlock`` — real verbs whose mechanism is not here yet.
+
+    They report that honestly instead of pretending. Passphrase mode wraps the
+    master key with scrypt and keeps the unwrapped copy only in the broker's
+    memory, which is the entire point of it (design §2.3): implementing the
+    wrap without the daemon would leave the unwrapped key on disk anyway and
+    the operator would believe they had hardened something.
+    """
+    _err(
+        f"lop secret {args.secret_command}: passphrase mode needs the secret broker, which "
+        "this version does not ship yet.\n"
+        "The store is in keyfile mode: the master key is on disk beside it, 0600 in a 0700 "
+        "directory."
+    )
+    return 2

--- a/local_operator/secrets/handlers.py
+++ b/local_operator/secrets/handlers.py
@@ -383,7 +383,8 @@ def _rotate(args: argparse.Namespace) -> int:
     1. STAGE the new key beside the old one. Inert until the database moves.
     2. COMMIT the re-seal. From here the database needs the new key, and the
        staged file is the copy of it that survives this process dying.
-    3. INSTALL the staged key as ``master.key`` and remove the staging file.
+    3. INSTALL the staged key as ``master.key`` and remove the staging file,
+       but ONLY if the database is still sealed under it.
 
     The previous order committed first and wrote the key afterwards, with a
     docstring claiming a crash there "leaves the old key matching an unmodified
@@ -392,13 +393,26 @@ def _rotate(args: argparse.Namespace) -> int:
     cut destroyed every secret in the store. ``resolve_master_key`` recovers a
     crash between 2 and 3 by matching the staged key's fingerprint against the
     one the database records.
+
+    **Step 3 is conditional, and that is what makes concurrent rotation safe.**
+    The epoch guard in step 2 serialises the COMMITs but imposed no order on the
+    installs, so a rotator that committed earlier could install its superseded
+    key later and leave the database sealed under a key held nowhere on disk —
+    with both processes reporting success.
+    :func:`local_operator.secrets.store.install_master_key_if_current` carries
+    the full analysis; it re-checks the fingerprint under the database's write
+    lock and refuses rather than clobbering.
+
+    A rotator that loses says so and exits non-zero. The loss is not a fault:
+    the operator's secrets are intact under the winner's key, this rotation's
+    re-seal was superseded by an equally valid one, and the honest report is
+    "another rotation completed first, run it again if you still want one".
+    Reporting success would be the actual defect — it is what the unguarded
+    install did while destroying the store.
     """
     from local_operator.secrets.crypto import generate_master_key
-    from local_operator.secrets.keys import (
-        discard_staged_master_key,
-        replace_master_key,
-        stage_master_key,
-    )
+    from local_operator.secrets.keys import discard_staged_master_key, stage_master_key
+    from local_operator.secrets.store import install_master_key_if_current
 
     store = open_store()
     new_key = generate_master_key()
@@ -413,7 +427,20 @@ def _rotate(args: argparse.Namespace) -> int:
         # file is the only on-disk copy of the key its database now needs.
         discard_staged_master_key(None, new_key)
         raise
-    replace_master_key(None, new_key)
+    if not install_master_key_if_current(new_key):
+        # Superseded between this rotation's COMMIT and its install. The store
+        # is fully usable under the winner's key; only this rotation is void.
+        # Safe to discard THIS key now: the compare-and-swap read the
+        # fingerprint under the write lock and it was not ours, so no committed
+        # database needs it and no later one can (the key is fresh randomness).
+        discard_staged_master_key(None, new_key)
+        _err(
+            "Another key rotation completed first, so this one was not installed. "
+            "Your secrets are intact and readable under the key that rotation "
+            "installed; nothing was lost. Run `lop secret rotate` again if you "
+            "still want a fresh key."
+        )
+        return 2
     _err(f"rotated {moved} secret(s) to key generation {store.key_generation()}")
     return 0
 

--- a/local_operator/secrets/handlers.py
+++ b/local_operator/secrets/handlers.py
@@ -18,6 +18,8 @@ import argparse
 import json
 import os
 import shutil
+import signal
+import sqlite3
 import subprocess
 import sys
 import tempfile
@@ -38,6 +40,15 @@ def dispatch(args: argparse.Namespace) -> int:
     run inside ``$( )``, where a traceback on stderr buries the one line the
     operator needs, and the failures are all ordinary operator conditions
     (no such secret, store not created, permissions loosened).
+
+    The same treatment is extended to the ordinary I/O and decoding failures
+    that are NOT ``SecretStoreError`` — a missing ``--from-file``, a store file
+    that is not a database, a value that is not UTF-8 under ``run``. Those used
+    to escape to the generic CLI handler, which prints an ANSI ``Error:`` line
+    and a stack-trace box, and — worse for a scripted caller — exited **1**,
+    which ``audit --verify`` already uses to mean "the chain is broken". A
+    crash and a detected tamper must not be indistinguishable to a script, so
+    they are mapped to the same one-line stderr and rc=2 as everything else.
     """
     command = getattr(args, "secret_command", None)
     if command is None:
@@ -67,6 +78,14 @@ def dispatch(args: argparse.Namespace) -> int:
         return 2
     except KeyboardInterrupt:
         return 130
+    except (OSError, UnicodeError, sqlite3.DatabaseError) as exc:
+        # Deliberately narrow. These are the conditions an operator can act on
+        # (a path that does not exist, a permission, a damaged database file, a
+        # value that is not text); a genuine bug in this module still raises
+        # and still gets its traceback, because that one nobody can act on
+        # without it.
+        _err(f"{type(exc).__name__}: {exc}")
+        return 2
 
 
 # --- helpers ----------------------------------------------------------------
@@ -108,6 +127,79 @@ def _read_value(args: argparse.Namespace, verb: str) -> bytes:
     if data.endswith(b"\n"):
         data = data[:-1]
     return data
+
+
+class _Terminated(SystemExit):
+    """Raised in the main thread when SIGTERM arrives, to run ``finally``.
+
+    A :class:`SystemExit` subclass so it unwinds the stack — which is the whole
+    point — without being swallowed by an ``except Exception``. The exit code
+    is the shell's convention for a signal death, 128 + SIGTERM.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(128 + signal.SIGTERM)
+
+
+def _install_sigterm_cleanup() -> Any:
+    """Make SIGTERM unwind the stack so ``finally`` blocks actually run.
+
+    Python's default SIGTERM disposition kills the interpreter outright: no
+    ``finally``, no ``atexit``. For ``lop secret file`` that means a routine
+    ``kill`` — a shell logging out, a supervisor reaping a stuck command,
+    ``lop-update`` stopping a runtime — strands DECRYPTED plaintext (a service
+    account key, a private key) in ``$TMPDIR`` until the machine reboots. That
+    directly contradicts design §7's "gone afterwards", and it is a handful of
+    lines to close.
+
+    Raising rather than cleaning up inside the handler is deliberate: the
+    handler runs on whatever the main thread was doing, and ``shutil.rmtree``
+    there would race the ``finally`` that may already be running. Unwinding
+    lets the single existing cleanup path do the work exactly once.
+
+    Returns the previous handler so it can be restored; signal state is
+    process-global, and this function is called from a library.
+    """
+
+    def _on_sigterm(signum: int, frame: Any) -> None:
+        raise _Terminated()
+
+    try:
+        return signal.signal(signal.SIGTERM, _on_sigterm)
+    except ValueError:
+        # Only the main thread may install a handler. An embedder calling this
+        # off-thread still gets the `finally`; it just does not get the signal
+        # coverage, which is strictly better than refusing to run.
+        return None
+
+
+def _restore_sigterm(previous: Any) -> None:
+    """Put the process's SIGTERM disposition back."""
+    if previous is None:
+        return
+    try:
+        signal.signal(signal.SIGTERM, previous)
+    except ValueError:
+        pass
+
+
+def _child_command(tokens: list[str]) -> list[str]:
+    """The child command, stripping only a LEADING ``--`` separator.
+
+    Filtering out every ``--`` corrupts child commands that legitimately
+    contain one, silently and with no error — ``git log -- path``,
+    ``kubectl exec pod -- cmd``, a ``bash -c`` script whose own arguments carry
+    a separator. The command still runs; it just means something different from
+    what the operator wrote.
+
+    Only the leading token can be OUR separator, and even that is usually gone
+    before we see it: with ``nargs="*"`` argparse consumes the first ``--`` it
+    uses to stop option parsing. A second one survives into this list and
+    belongs to the child, so exactly one leading occurrence is removed here.
+    """
+    if tokens and tokens[0] == "--":
+        return tokens[1:]
+    return list(tokens)
 
 
 def _format_time(value: float | None) -> str:
@@ -183,18 +275,46 @@ def _list(args: argparse.Namespace) -> int:
     store is one audited event attributable to one name. A ``--values`` flag
     here would turn a single audit entry into a bulk export.
     """
-    records = open_store().list()
+    store = open_store()
+    records = store.list()
+    # Damaged rows are named on STDERR, never mixed into stdout: `--json` is
+    # machine-parsed and the plain listing is read by eye. Reporting them is
+    # what keeps `list` both honest and usable when the store is damaged --
+    # it used to raise on the first one, which took down the only command that
+    # could have shown the operator what survived.
+    damaged = store.damaged_records()
     if args.json:
         print(json.dumps([_record_dict(record) for record in records], indent=2))
+        _warn_damaged(damaged)
         return 0
     if not records:
         _err("no secrets stored")
+        _warn_damaged(damaged)
         return 0
     width = max(len(record.name) for record in records)
     for record in records:
         suffix = f"  {record.description}" if record.description else ""
         print(f"{record.name:<{width}}  {record.kind:<6}{suffix}")
+    _warn_damaged(damaged)
     return 0
+
+
+def _warn_damaged(damaged: list[str]) -> None:
+    """Tell the operator about unreadable rows, and how to remove one.
+
+    On stderr with the id and the exact command, because a damaged record is
+    actionable but only if the operator is given the one thing `rm NAME` cannot
+    give them: the name is inside the ciphertext they cannot open.
+    """
+    if not damaged:
+        return
+    _err(
+        f"warning: {len(damaged)} record(s) in this store cannot be decrypted and are not "
+        "listed above. They were sealed under a key that no longer exists, or they have "
+        "been altered."
+    )
+    for record_id in damaged:
+        _err(f"  {record_id}  (remove with: lop secret rm --id {record_id} --yes)")
 
 
 def _describe(args: argparse.Namespace) -> int:
@@ -221,14 +341,34 @@ def _remove(args: argparse.Namespace) -> int:
     answer a prompt, so it requires ``--yes`` explicitly rather than defaulting
     to either answer.
     """
+    target = args.id or args.name
+    if not target:
+        _err("usage: lop secret rm NAME | lop secret rm --id RECORD_ID")
+        return 2
+    if args.id and args.name:
+        _err("lop secret rm: give a NAME or --id, not both")
+        return 2
+
     if not args.yes:
         if not sys.stdin or not sys.stdin.isatty():
-            _err(f"refusing to delete {args.name} without --yes (stdin is not a terminal)")
+            _err(f"refusing to delete {target} without --yes (stdin is not a terminal)")
             return 2
-        _err(f"Delete {args.name} permanently? This cannot be undone. [y/N] ")
+        _err(f"Delete {target} permanently? This cannot be undone. [y/N] ")
         if input().strip().lower() not in ("y", "yes"):
             _err("cancelled")
             return 1
+
+    if args.id:
+        # The repair path for a record `rm NAME` cannot reach: a row whose
+        # ciphertext will not open has no readable name and no valid blind
+        # index, so deleting by primary key is the only way out short of
+        # hand-editing SQLite.
+        if not open_store().delete_record_id(args.id, session_id=session_id()):
+            _err(f"no record with id {args.id} in this store")
+            return 2
+        _err(f"deleted record {args.id}")
+        return 0
+
     record = open_store().delete(args.name, session_id=session_id())
     _err(f"deleted {record.name}")
     return 0
@@ -237,17 +377,39 @@ def _remove(args: argparse.Namespace) -> int:
 def _rotate(args: argparse.Namespace) -> int:
     """Re-seal every record under a fresh master key.
 
-    The new key file is installed only AFTER the database transaction commits.
-    A crash between the two leaves the old key matching an unmodified database,
-    which is recoverable; the other order would leave a new key against records
-    still sealed under the old one, which is not.
+    Three steps, in this order, because a crash between any two of them must
+    still leave the store openable by a key that exists on disk:
+
+    1. STAGE the new key beside the old one. Inert until the database moves.
+    2. COMMIT the re-seal. From here the database needs the new key, and the
+       staged file is the copy of it that survives this process dying.
+    3. INSTALL the staged key as ``master.key`` and remove the staging file.
+
+    The previous order committed first and wrote the key afterwards, with a
+    docstring claiming a crash there "leaves the old key matching an unmodified
+    database". It does not: the database is fully re-sealed at that point and
+    the only copy of its key is in this process's memory, so an ordinary power
+    cut destroyed every secret in the store. ``resolve_master_key`` recovers a
+    crash between 2 and 3 by matching the staged key's fingerprint against the
+    one the database records.
     """
     from local_operator.secrets.crypto import generate_master_key
-    from local_operator.secrets.keys import replace_master_key
+    from local_operator.secrets.keys import (
+        discard_staged_master_key,
+        replace_master_key,
+        stage_master_key,
+    )
 
     store = open_store()
     new_key = generate_master_key()
-    moved = store.rotate(new_key, session_id=session_id())
+    stage_master_key(None, new_key)
+    try:
+        moved = store.rotate(new_key, session_id=session_id())
+    except BaseException:
+        # Nothing committed, so the staged key is not the store's key and
+        # leaving it would be a stray copy of key material for no benefit.
+        discard_staged_master_key(None)
+        raise
     replace_master_key(None, new_key)
     _err(f"rotated {moved} secret(s) to key generation {store.key_generation()}")
     return 0
@@ -274,6 +436,7 @@ def _status(args: argparse.Namespace) -> int:
     if payload["exists"]:
         store = open_store()
         payload["secrets"] = len(store.list())
+        payload["damaged"] = store.damaged_records()
         payload["key_generation"] = store.key_generation()
         ok, position, message = store.verify_audit()
         payload["audit_ok"] = ok
@@ -290,6 +453,8 @@ def _status(args: argparse.Namespace) -> int:
         print("store       not created yet (lop secret set NAME creates it)")
         return 0
     print(f"secrets     {payload['secrets']}")
+    if payload["damaged"]:
+        print(f"damaged     {len(payload['damaged'])} unreadable record(s)")
     print(f"key gen     {payload['key_generation']}")
     print(f"audit       {payload['audit_message']}")
     print(
@@ -351,7 +516,7 @@ def _file(args: argparse.Namespace) -> int:
     user can traverse, and gone afterwards — far better than a permanent
     well-known path, but not zero exposure.
     """
-    command = [argument for argument in args.command if argument != "--"]
+    command = _child_command(args.command)
     if not command:
         _err("usage: lop secret file NAME [--env-var VAR] -- COMMAND...")
         return 2
@@ -360,6 +525,7 @@ def _file(args: argparse.Namespace) -> int:
     directory = Path(tempfile.mkdtemp(prefix="lop-secret-"))
     os.chmod(directory, DIR_MODE)
     target = directory / args.name.replace(os.sep, "_")
+    previous_sigterm = _install_sigterm_cleanup()
     try:
         descriptor = os.open(target, os.O_WRONLY | os.O_CREAT | os.O_EXCL, FILE_MODE)
         try:
@@ -371,12 +537,14 @@ def _file(args: argparse.Namespace) -> int:
         environment[args.env_var] = str(target)
         return subprocess.run(command, env=environment, check=False).returncode
     finally:
-        # A `finally` covers a normal exit, an exception and a SIGINT that
-        # Python turns into KeyboardInterrupt. It does NOT cover SIGKILL or a
-        # SIGTERM with no handler, so the plaintext can outlive a hard kill —
-        # the broker PR, which owns process lifecycle, installs the signal
-        # handler that narrows this. Named rather than papered over.
+        # A `finally` covers a normal exit, an exception, and — because of the
+        # handler installed above — a SIGTERM. It does NOT cover SIGKILL, which
+        # is unblockable by definition: the plaintext outlives a `kill -9` and
+        # no in-process design can change that. Narrowing THAT needs an
+        # out-of-process owner, so it belongs to the broker PR. Named rather
+        # than papered over.
         shutil.rmtree(directory, ignore_errors=True)
+        _restore_sigterm(previous_sigterm)
 
 
 def _run(args: argparse.Namespace) -> int:
@@ -388,7 +556,7 @@ def _run(args: argparse.Namespace) -> int:
     variable and offer no other input. The help text says so; so does the
     guidance in PR 4.
     """
-    command = [argument for argument in args.command if argument != "--"]
+    command = _child_command(args.command)
     if not command:
         _err("usage: lop secret run --secret NAME[=VAR] -- COMMAND...")
         return 2

--- a/local_operator/secrets/handlers.py
+++ b/local_operator/secrets/handlers.py
@@ -408,7 +408,10 @@ def _rotate(args: argparse.Namespace) -> int:
     except BaseException:
         # Nothing committed, so the staged key is not the store's key and
         # leaving it would be a stray copy of key material for no benefit.
-        discard_staged_master_key(None)
+        # Scoped to THIS rotation's key: a concurrent rotator that won the
+        # epoch race may be committed and not yet installed, and its staged
+        # file is the only on-disk copy of the key its database now needs.
+        discard_staged_master_key(None, new_key)
         raise
     replace_master_key(None, new_key)
     _err(f"rotated {moved} secret(s) to key generation {store.key_generation()}")

--- a/local_operator/secrets/keys.py
+++ b/local_operator/secrets/keys.py
@@ -117,11 +117,24 @@ def check_mode(path: Path) -> None:
 def write_private_file(path: Path, data: bytes) -> None:
     """Write ``data`` to ``path`` such that it is never briefly world-readable.
 
-    ``os.open`` with ``O_CREAT|O_EXCL`` and mode 0600 creates the file already
-    private, and the explicit ``chmod`` covers the umask masking that mode and
-    the case where the caller replaced an existing file. Writing then chmod-ing
-    would leave a window in which another process can open it — small, but this
-    is the one file where that window costs everything.
+    ``os.open`` with mode 0600 creates the file already private, and the
+    explicit ``chmod`` covers the umask masking that mode and the case where
+    the caller replaced an existing file. Writing then chmod-ing would leave a
+    window in which another process can open it — small, but this is the one
+    file where that window costs everything.
+
+    **``O_TRUNC``, not ``O_EXCL``, and the caller owns the exclusivity.** This
+    function is for a path the caller alone names: the per-rotation temporaries
+    in :func:`stage_master_key` and :func:`replace_master_key` carry a pid and
+    random suffix, so nobody else can be writing them and truncation is the
+    correct handling of a leftover from a dead process reusing that pid.
+
+    Do NOT call it on a path several processes may create at once. Its docstring
+    used to CLAIM ``O_EXCL`` while the code passed ``O_TRUNC``, and that lie is
+    the whole reason a last-writer-wins clobber on ``master.key`` survived a
+    sweep that was specifically looking for that shape (review round 3): the
+    site was checked against the docstring and read as guarded. For a shared
+    final path use :func:`create_private_file`, which really is exclusive.
     """
     descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, FILE_MODE)
     try:
@@ -132,6 +145,52 @@ def write_private_file(path: Path, data: bytes) -> None:
     os.chmod(path, FILE_MODE)
 
 
+def create_private_file(path: Path, data: bytes) -> bool:
+    """Create ``path`` holding ``data``, or return ``False`` if it already exists.
+
+    The exclusive counterpart to :func:`write_private_file`, for the case where
+    several processes may try to create the SAME path at once and exactly one
+    must win. ``True`` means this caller created it; ``False`` means somebody
+    else did and the caller must read theirs rather than proceeding with its
+    own content.
+
+    **Why a temporary plus ``os.link`` rather than plain ``O_EXCL``.**
+    ``O_EXCL`` alone picks a single winner, but it publishes the path at
+    CREATION — the empty file is visible to every other process for as long as
+    it takes to write and fsync the payload. Measured on this machine with 12
+    concurrent first-use callers, that window is wide enough to hit: losers
+    re-read and get ``master.key is 0 bytes; the key file is damaged``, turning
+    a lost race into a hard failure. Worse, a crash inside that window leaves a
+    PERMANENT 0-byte key file that no later run can get past, because the
+    winner-picking is done and nothing will ever create it again.
+
+    Writing a uniquely-named temporary first and linking it into place closes
+    both: ``os.link`` is atomic and refuses an existing target with
+    ``FileExistsError``, so the path appears only when it is already complete
+    and only one caller can make it appear. It is ``os.replace`` with the
+    clobber removed, which is precisely the property wanted here — the same
+    distinction round 3 established for the staged keys, where atomicity was
+    never the missing property and coexistence was.
+
+    ``EXDEV`` cannot arise: the temporary is created in the destination's own
+    directory, so both names are always on one filesystem.
+    """
+    temporary = path.with_name(f"{path.name}.new.{os.getpid()}.{os.urandom(6).hex()}")
+    try:
+        write_private_file(temporary, data)
+        try:
+            os.link(temporary, path)
+        except FileExistsError:
+            return False
+    finally:
+        # The temporary is this call's alone; removing it is correct on every
+        # exit, including the lost race (the link left the target untouched)
+        # and an exception mid-write.
+        temporary.unlink(missing_ok=True)
+    os.chmod(path, FILE_MODE)
+    return True
+
+
 def load_master_key(base: Path | None = None, *, create: bool = False) -> bytes:
     """Read the master key, optionally creating one on first use.
 
@@ -139,6 +198,21 @@ def load_master_key(base: Path | None = None, *, create: bool = False) -> bytes:
     that does not exist must report that, not quietly initialise an empty one
     and then report the secret missing — those are different problems and the
     operator needs to be able to tell them apart.
+
+    **Creation is a race between equals, and the loser must ADOPT the winner's
+    key rather than keep its own.** Concurrent first use is not a corner case
+    here: the operator runs ~11 sessions at once and the store is created by
+    whichever of them writes a secret first. This used to be an ``exists()``
+    check followed by an unguarded write to a fixed path — the same
+    last-writer-wins shape as the staged keys, on the master key itself. Every
+    caller generated its own key and every caller returned the key it had
+    generated, so all but one went on to seal a database under a key that was
+    no longer the one on disk. Measured at 12 concurrent callers: 10 of 12 held
+    a key that did not match the file, against 0 of 6 serialised.
+
+    :func:`create_private_file` makes exactly one caller the creator; everybody
+    else falls through to the ordinary read below and ends up on the winner's
+    key, which is what makes concurrent first use converge instead of brick.
     """
     path = key_path(base)
     if not path.exists():
@@ -155,9 +229,12 @@ def load_master_key(base: Path | None = None, *, create: bool = False) -> bytes:
                 "Create one by storing a secret: lop secret set NAME"
             )
         ensure_secrets_dir(base)
-        key = generate_master_key()
-        write_private_file(path, key)
-        return key
+        # The return value is deliberately not branched on: winner and loser
+        # take the SAME path from here, re-reading the file so both return a
+        # key that provably came off disk and passed the checks below. A winner
+        # that returned its in-memory copy would be the one caller whose result
+        # was never validated.
+        create_private_file(path, generate_master_key())
 
     check_mode(path)
     key = path.read_bytes()
@@ -170,8 +247,7 @@ def load_master_key(base: Path | None = None, *, create: bool = False) -> bytes:
 
 
 #: Basename prefix of a staged key. Every staged file is this plus a suffix
-#: unique to the rotation that wrote it, so the set of staged files is exactly
-#: the set of rotations currently in flight. Matching by prefix is what lets
+#: unique to the rotation that wrote it. Matching by prefix is what lets
 #: :func:`resolve_master_key` consider ALL of them, and a legacy file written
 #: under the bare prefix is still found.
 STAGED_KEY_PREFIX = "master.key.incoming"
@@ -191,9 +267,22 @@ def staged_key_paths(base: Path | None = None) -> list[Path]:
     instant, and each one's staged file is the only on-disk copy of the key
     its committed database needs. See :func:`stage_master_key`.
 
+    **This is a SUPERSET of the rotations in flight, not exactly that set.**
+    A rotation that dies between staging and installing leaves its file behind
+    forever: :func:`discard_staged_master_key` only removes the caller's OWN
+    key, which is load-bearing (removing another's is the loss it exists to
+    prevent) and means nothing reaps an abandoned one. The residue is inert for
+    correctness — :func:`resolve_master_key` adopts by fingerprint, so a
+    leftover is never mistaken for the store's key — but each file is 32 bytes
+    of real key material that stays on disk, and the set grows without bound in
+    a store whose rotations keep crashing. A sweep is deliberately NOT done
+    here: it would need to distinguish "abandoned" from "staged by a rotation
+    that has not committed yet", which is exactly the judgement the ownership
+    check refuses to make from outside the owning process.
+
     Sorted for a deterministic scan order. A missing directory yields an empty
-    list rather than raising: "no rotation in flight" is the ordinary answer
-    for a store that has never been rotated.
+    list rather than raising: "nothing staged" is the ordinary answer for a
+    store that has never been rotated.
     """
     try:
         return sorted(secrets_dir(base).glob(f"{STAGED_KEY_PREFIX}*"))

--- a/local_operator/secrets/keys.py
+++ b/local_operator/secrets/keys.py
@@ -169,16 +169,39 @@ def load_master_key(base: Path | None = None, *, create: bool = False) -> bytes:
     return key
 
 
-def staged_key_path(base: Path | None = None) -> Path:
-    """Path to the key a rotation has staged but not yet installed.
+#: Basename prefix of a staged key. Every staged file is this plus a suffix
+#: unique to the rotation that wrote it, so the set of staged files is exactly
+#: the set of rotations currently in flight. Matching by prefix is what lets
+#: :func:`resolve_master_key` consider ALL of them, and a legacy file written
+#: under the bare prefix is still found.
+STAGED_KEY_PREFIX = "master.key.incoming"
 
-    See :func:`stage_master_key` for why this file exists rather than the
-    rotation simply writing the key after it commits.
+#: Prefix of the temporary a staging write lands on before it is renamed into
+#: place. Deliberately NOT under :data:`STAGED_KEY_PREFIX`: a reader globbing
+#: for staged keys must never observe a half-written file, so the temporary
+#: has to be invisible to that glob until the rename makes it complete.
+_STAGING_TEMP_PREFIX = "master.stage"
+
+
+def staged_key_paths(base: Path | None = None) -> list[Path]:
+    """Every key staged by a rotation that has not yet installed it.
+
+    A LIST rather than one path, because rotation is concurrent: several
+    sessions can each be between their COMMIT and their install at the same
+    instant, and each one's staged file is the only on-disk copy of the key
+    its committed database needs. See :func:`stage_master_key`.
+
+    Sorted for a deterministic scan order. A missing directory yields an empty
+    list rather than raising: "no rotation in flight" is the ordinary answer
+    for a store that has never been rotated.
     """
-    return secrets_dir(base) / "master.key.incoming"
+    try:
+        return sorted(secrets_dir(base).glob(f"{STAGED_KEY_PREFIX}*"))
+    except OSError:
+        return []
 
 
-def stage_master_key(base: Path | None, key: bytes) -> None:
+def stage_master_key(base: Path | None, key: bytes) -> Path:
     """Persist a rotation's new key BEFORE the re-seal transaction commits.
 
     This is the ordering that makes rotation crash-safe, and getting it wrong
@@ -199,23 +222,72 @@ def stage_master_key(base: Path | None, key: bytes) -> None:
       completes the install;
     * installed — ``master.key`` is the new key and the staged file is removed.
 
-    Written with ``O_EXCL`` semantics via a fresh unlink so a leftover file
-    from an abandoned rotation can never be mistaken for this one's.
+    **The staged file's name is unique PER ROTATION, and that is what makes the
+    invariant survive concurrency.** ``rotate`` is reachable from every session
+    at once, so several rotations are in flight together. With one shared
+    filename the invariant above is false: rotator B's staging replaced
+    rotator A's, and if A had already COMMITTED, the only on-disk copy of the
+    key A's database needs was gone — a power cut there lost every secret in
+    the store, which is the exact loss this staging exists to prevent. Making
+    the write atomic is NOT sufficient on its own; an atomic clobber is still a
+    clobber. Only a name nobody else writes keeps every committed rotation's
+    key on disk simultaneously, which is why the recovery path scans all of
+    them (:func:`staged_key_paths`) instead of looking at one place.
+
+    The write itself still goes through a temporary and ``os.replace`` so that
+    a concurrent reader globbing for staged keys never observes a partially
+    written one, and so a crash mid-write leaves no truncated candidate behind.
+
+    Returns the path written, which is the handle the caller passes back to
+    :func:`discard_staged_master_key`.
     """
     ensure_secrets_dir(base)
-    path = staged_key_path(base)
-    path.unlink(missing_ok=True)
-    write_private_file(path, key)
+    directory = secrets_dir(base)
+    unique = f"{os.getpid()}.{os.urandom(6).hex()}"
+    path = directory / f"{STAGED_KEY_PREFIX}.{unique}"
+    temporary = directory / f"{_STAGING_TEMP_PREFIX}.{unique}.tmp"
+    try:
+        write_private_file(temporary, key)
+        os.replace(temporary, path)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+    return path
 
 
-def discard_staged_master_key(base: Path | None = None) -> None:
-    """Remove a staged key. Called when a rotation failed before committing.
+def discard_staged_master_key(base: Path | None, key: bytes) -> None:
+    """Remove staged copies of THIS key, and never another rotation's.
 
-    Leaving it would be harmless — :func:`resolve_master_key` only adopts a
-    staged key that matches the database's recorded fingerprint — but a stray
-    copy of key material on disk is worth not keeping around.
+    Called when a rotation failed before committing, and again once a key has
+    been installed and its staged copy is redundant. Leaving a file would be
+    harmless for correctness — :func:`resolve_master_key` only adopts a staged
+    key matching the database's recorded fingerprint — but a stray copy of key
+    material on disk is worth not keeping around.
+
+    **Ownership is checked by content, and it is load-bearing.** An earlier
+    version unlinked a single fixed path unconditionally, which meant a
+    rotation that LOST the epoch race deleted the staged key of the rotation
+    that WON — and if the winner had committed but not yet installed, that
+    delete removed the only on-disk copy of the key the database needed. So a
+    staged file is removed only when it still holds the key this caller is
+    entitled to remove. Master keys are 32 random bytes, so "holds this key"
+    identifies the rotation exactly.
+
+    Comparison is not constant-time on purpose: both sides are key material
+    this process already holds in full, so there is no secret for a timing
+    side channel to leak.
     """
-    staged_key_path(base).unlink(missing_ok=True)
+    for path in staged_key_paths(base):
+        try:
+            if path.read_bytes() != key:
+                # Another rotation's key. Removing it is the loss this check
+                # exists to prevent.
+                continue
+            path.unlink(missing_ok=True)
+        except OSError:
+            # Raced with the owning rotation removing it, or with a reader.
+            # Either way the file is not ours to insist on.
+            continue
 
 
 def replace_master_key(base: Path | None, key: bytes) -> None:
@@ -226,8 +298,10 @@ def replace_master_key(base: Path | None, key: bytes) -> None:
     decrypts nothing. The temporary lives in the same 0700 directory, so it is
     never more exposed than the key it replaces.
 
-    The staged copy is removed last: until ``os.replace`` lands, the staged
-    file is the only on-disk copy of the key the committed database needs.
+    The staged copy is removed last, and only the copy holding THIS key: until
+    ``os.replace`` lands, the staged file is the only on-disk copy of the key
+    the committed database needs, and a concurrent rotation's staged file is
+    the same thing for ITS database (see :func:`discard_staged_master_key`).
 
     The temporary name is unique PER CALL, not fixed and not merely per-pid,
     because this is no longer a single-caller path: ``resolve_master_key``
@@ -247,4 +321,4 @@ def replace_master_key(base: Path | None, key: bytes) -> None:
         temporary.unlink(missing_ok=True)
         raise
     os.chmod(path, FILE_MODE)
-    discard_staged_master_key(base)
+    discard_staged_master_key(base, key)

--- a/local_operator/secrets/keys.py
+++ b/local_operator/secrets/keys.py
@@ -169,6 +169,55 @@ def load_master_key(base: Path | None = None, *, create: bool = False) -> bytes:
     return key
 
 
+def staged_key_path(base: Path | None = None) -> Path:
+    """Path to the key a rotation has staged but not yet installed.
+
+    See :func:`stage_master_key` for why this file exists rather than the
+    rotation simply writing the key after it commits.
+    """
+    return secrets_dir(base) / "master.key.incoming"
+
+
+def stage_master_key(base: Path | None, key: bytes) -> None:
+    """Persist a rotation's new key BEFORE the re-seal transaction commits.
+
+    This is the ordering that makes rotation crash-safe, and getting it wrong
+    loses every secret in the store. ``rotate`` re-seals every record under the
+    new key; if the process dies after that COMMIT but before the key reaches
+    disk, the database is sealed under a key that existed only in the dead
+    process's memory and nothing can ever open it again. An ordinary power cut
+    during a routine rotate is total, unrecoverable loss.
+
+    So the new key is written here first, alongside the old one. At every
+    instant of a rotation, a key that opens the store exists on disk:
+
+    * before staging — database sealed under the old key, ``master.key`` is it;
+    * staged, not committed — database still under the old key, ``master.key``
+      is still it, and the staged file is inert;
+    * committed, not installed — database under the new key, which is the
+      staged file; :func:`resolve_master_key` finds it by fingerprint and
+      completes the install;
+    * installed — ``master.key`` is the new key and the staged file is removed.
+
+    Written with ``O_EXCL`` semantics via a fresh unlink so a leftover file
+    from an abandoned rotation can never be mistaken for this one's.
+    """
+    ensure_secrets_dir(base)
+    path = staged_key_path(base)
+    path.unlink(missing_ok=True)
+    write_private_file(path, key)
+
+
+def discard_staged_master_key(base: Path | None = None) -> None:
+    """Remove a staged key. Called when a rotation failed before committing.
+
+    Leaving it would be harmless — :func:`resolve_master_key` only adopts a
+    staged key that matches the database's recorded fingerprint — but a stray
+    copy of key material on disk is worth not keeping around.
+    """
+    staged_key_path(base).unlink(missing_ok=True)
+
+
 def replace_master_key(base: Path | None, key: bytes) -> None:
     """Install a new master key, used by ``rotate`` once every record has moved.
 
@@ -176,9 +225,26 @@ def replace_master_key(base: Path | None, key: bytes) -> None:
     leaves either the old key or the new one, never a truncated file that
     decrypts nothing. The temporary lives in the same 0700 directory, so it is
     never more exposed than the key it replaces.
+
+    The staged copy is removed last: until ``os.replace`` lands, the staged
+    file is the only on-disk copy of the key the committed database needs.
+
+    The temporary name is unique PER CALL, not fixed and not merely per-pid,
+    because this is no longer a single-caller path: ``resolve_master_key``
+    completes an interrupted rotation, so several sessions — and several
+    threads inside one session — can land here at once. With a shared name one
+    caller's ``os.replace`` consumes the file another has just written, which
+    surfaced as a spurious ``FileNotFoundError`` from an install that had in
+    fact succeeded. Each caller renaming its OWN file makes the concurrent case
+    a harmless last-writer-wins between identical keys.
     """
     path = key_path(base)
-    temporary = path.with_suffix(".key.new")
-    write_private_file(temporary, key)
-    os.replace(temporary, path)
+    temporary = path.with_name(f"{path.name}.new.{os.getpid()}.{os.urandom(6).hex()}")
+    try:
+        write_private_file(temporary, key)
+        os.replace(temporary, path)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
     os.chmod(path, FILE_MODE)
+    discard_staged_master_key(base)

--- a/local_operator/secrets/keys.py
+++ b/local_operator/secrets/keys.py
@@ -1,0 +1,184 @@
+"""Where the master key lives at rest, and how the mode bits are enforced.
+
+Design reference: ``docs/design/secret-store.md`` §2.3.
+
+Two tiers were specified. This module ships the DEFAULT one — ``keyfile``: the
+master key sits in ``<config>/secrets/master.key``, mode 0600, inside a 0700
+directory, and any lop invocation reads it with no prompt. The honest claim for
+that mode, repeated here so it cannot drift out of the code: it is *equivalent
+to today's plaintext ``.env`` against an attacker who specifically reads the key
+file*, and materially better against the opportunistic "grep the disk for
+credentials" malware that a bad link actually drops. It is not a vault.
+
+The opt-in ``passphrase`` tier (``lop secret harden``) wraps this key with
+scrypt and keeps the unwrapped copy only in the broker's memory. It needs the
+broker daemon to hold that memory, so it arrives with the broker; see
+:func:`key_mode` for the seam.
+
+Permissions are applied with an explicit ``chmod`` after creation rather than
+through ``mkdir(mode=...)``/``os.open(mode=...)`` alone, because both of those
+are masked by the process umask. A developer running with ``umask 000`` would
+otherwise create a world-readable key and nothing would say so.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+from local_operator.paths import config_dir
+from local_operator.secrets.crypto import KEY_BYTES, generate_master_key
+from local_operator.secrets.errors import InsecurePermissions, SecretStoreError
+
+#: Subdirectory of the config dir holding everything this feature owns.
+SECRETS_DIRNAME = "secrets"
+
+DIR_MODE = 0o700
+FILE_MODE = 0o600
+
+#: Bits that must be clear on the key file and the database: any permission
+#: for group or other. Checked on every open, not only at creation — a store
+#: whose mode was loosened after the fact is exactly the case worth catching.
+_FORBIDDEN_MODE_BITS = 0o077
+
+
+def secrets_dir(base: Path | None = None) -> Path:
+    """The directory holding the store, the key and the audit log.
+
+    ``base`` overrides the config dir for tests. Resolved on every call rather
+    than cached, for the reason :func:`local_operator.paths.config_dir`
+    documents: a module constant freezes whatever the first importer saw.
+    """
+    return (base if base is not None else config_dir()) / SECRETS_DIRNAME
+
+
+def store_path(base: Path | None = None) -> Path:
+    """Path to the SQLite database."""
+    return secrets_dir(base) / "store.db"
+
+
+def key_path(base: Path | None = None) -> Path:
+    """Path to the master key file."""
+    return secrets_dir(base) / "master.key"
+
+
+def audit_log_path(base: Path | None = None) -> Path:
+    """Path to the mirrored append-only audit log."""
+    return secrets_dir(base) / "audit.log"
+
+
+def key_mode(base: Path | None = None) -> str:
+    """Which at-rest tier the store is in: ``keyfile`` or ``passphrase``.
+
+    Always ``keyfile`` today. The seam the broker PR fills: ``harden`` writes a
+    scrypt-wrapped ``master.key.wrapped`` beside the plain key and removes the
+    plain one, at which point this returns ``passphrase`` and callers route the
+    unwrap through the broker instead of reading the file. Reported by
+    ``lop secret status`` so the operator can see which tier is live.
+    """
+    if (secrets_dir(base) / "master.key.wrapped").exists():
+        return "passphrase"
+    return "keyfile"
+
+
+def ensure_secrets_dir(base: Path | None = None) -> Path:
+    """Create the secrets directory 0700 and return it.
+
+    The ``chmod`` runs even when the directory already existed: an operator who
+    once created it by hand, or a umask that widened it at creation, should not
+    leave the key sitting in a traversable directory forever.
+    """
+    directory = secrets_dir(base)
+    directory.mkdir(parents=True, exist_ok=True)
+    os.chmod(directory, DIR_MODE)
+    return directory
+
+
+def check_mode(path: Path) -> None:
+    """Raise :class:`InsecurePermissions` if ``path`` is group/other accessible.
+
+    This does NOT repair the mode. By the time a key file is world-readable the
+    exposure has already happened; silently tightening it would hide from the
+    operator that it was ever open. Windows reports POSIX bits that do not mean
+    what they do on Unix, so the check is skipped there rather than producing a
+    failure nobody can act on.
+    """
+    if os.name == "nt":
+        return
+    mode = stat.S_IMODE(path.stat().st_mode)
+    if mode & _FORBIDDEN_MODE_BITS:
+        raise InsecurePermissions(
+            f"{path} has mode {mode:04o}; it must not be readable by group or others. "
+            f"Fix it with: chmod {FILE_MODE:04o} {path}"
+        )
+
+
+def write_private_file(path: Path, data: bytes) -> None:
+    """Write ``data`` to ``path`` such that it is never briefly world-readable.
+
+    ``os.open`` with ``O_CREAT|O_EXCL`` and mode 0600 creates the file already
+    private, and the explicit ``chmod`` covers the umask masking that mode and
+    the case where the caller replaced an existing file. Writing then chmod-ing
+    would leave a window in which another process can open it — small, but this
+    is the one file where that window costs everything.
+    """
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, FILE_MODE)
+    try:
+        os.write(descriptor, data)
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    os.chmod(path, FILE_MODE)
+
+
+def load_master_key(base: Path | None = None, *, create: bool = False) -> bytes:
+    """Read the master key, optionally creating one on first use.
+
+    ``create`` is passed by the write verbs only. A ``get`` against a store
+    that does not exist must report that, not quietly initialise an empty one
+    and then report the secret missing — those are different problems and the
+    operator needs to be able to tell them apart.
+    """
+    path = key_path(base)
+    if not path.exists():
+        if key_mode(base) == "passphrase":
+            # Unreachable until the broker PR writes the wrapped key; stated
+            # here so the failure is a clear message rather than "no such file".
+            raise SecretStoreError(
+                "This store is hardened with a passphrase, which needs the secret broker. "
+                "Run `lop secret unlock` once the broker is available."
+            )
+        if not create:
+            raise SecretStoreError(
+                f"No secret store found at {secrets_dir(base)}. "
+                "Create one by storing a secret: lop secret set NAME"
+            )
+        ensure_secrets_dir(base)
+        key = generate_master_key()
+        write_private_file(path, key)
+        return key
+
+    check_mode(path)
+    key = path.read_bytes()
+    if len(key) != KEY_BYTES:
+        raise SecretStoreError(
+            f"{path} is {len(key)} bytes; a master key is {KEY_BYTES}. "
+            "The key file is damaged and the store cannot be decrypted with it."
+        )
+    return key
+
+
+def replace_master_key(base: Path | None, key: bytes) -> None:
+    """Install a new master key, used by ``rotate`` once every record has moved.
+
+    Written through a temporary file and ``os.replace`` so a crash mid-write
+    leaves either the old key or the new one, never a truncated file that
+    decrypts nothing. The temporary lives in the same 0700 directory, so it is
+    never more exposed than the key it replaces.
+    """
+    path = key_path(base)
+    temporary = path.with_suffix(".key.new")
+    write_private_file(temporary, key)
+    os.replace(temporary, path)
+    os.chmod(path, FILE_MODE)

--- a/local_operator/secrets/store.py
+++ b/local_operator/secrets/store.py
@@ -21,6 +21,7 @@ and it will instead ask the broker, with this layer unchanged.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import sqlite3
@@ -54,6 +55,7 @@ from local_operator.secrets.keys import (
     FILE_MODE,
     check_mode,
     ensure_secrets_dir,
+    replace_master_key,
     store_path,
 )
 
@@ -238,6 +240,99 @@ def recorded_key_fingerprint(base: Path | None = None) -> bytes | None:
         return None
 
 
+def install_master_key_if_current(key: bytes, base: Path | None = None) -> bool:
+    """Install ``key`` as ``master.key`` ONLY if the store is still sealed under it.
+
+    A compare-and-swap, and the reason it exists is that installing
+    unconditionally destroys the store. ``rotate`` is stage → COMMIT → install,
+    and the epoch guard inside the re-seal transaction serialises the COMMITs —
+    but it said nothing about the installs that follow them, which ran outside
+    any transaction. So a rotator that committed EARLIER could install its now
+    superseded key LATER::
+
+        A: COMMIT  -> db sealed under Ka
+        B: COMMIT  -> db sealed under Kb   (legitimate; B adopted Ka first)
+        B: install Kb, discard staged Kb   (correct)
+        A: install Ka, discard staged Ka   (last writer wins -- Ka is STALE)
+
+    Final state: the database needs Kb, ``master.key`` holds Ka, and both staged
+    copies are gone, so Kb exists NOWHERE. Every secret is unrecoverable and
+    both processes exit 0 printing ``rotated N secret(s)``. Reproduced
+    deterministically 3/3 with two real ``lop secret rotate`` processes and no
+    crash anywhere, and 7/8 from ordinary contention between four of them.
+    :func:`local_operator.secrets.access.resolve_master_key` cannot repair it:
+    it adopts a STAGED key matching the database, and the matching one was
+    legitimately discarded by the rotation that installed it.
+
+    **The fix is to make commit-and-install atomic with respect to other
+    rotators by putting the install under the database's OWN write lock.**
+    ``BEGIN IMMEDIATE`` here takes the same lock the re-seal transaction takes,
+    so an install and a competing COMMIT cannot interleave: either this call
+    finishes first and the competitor's later COMMIT+install lands on top of it,
+    or the competitor commits first and the fingerprint read below no longer
+    matches, and this install is REFUSED instead of clobbering.
+
+    Chosen over an exclusive rotation lock held across commit and install, for
+    three reasons. It adds no new lock primitive, so there is no second lock to
+    order against SQLite's and therefore no deadlock to reason about. It is not
+    an ``flock``, so it cannot reproduce #401 — a thread parked in ``flock()``
+    blocks a sibling's ``close()`` of that descriptor on macOS, whereas SQLite
+    contention is bounded by ``busy_timeout`` and raises rather than hangs. And
+    it fails CLOSED by construction: a lock that cannot be taken tempts a
+    degrade-to-unlocked path, which here would be exactly the unguarded install
+    that loses the store.
+
+    Ordinary writes are NOT serialised behind rotation by this. They already
+    contend for the same write lock for their own transactions; this adds one
+    short read-only transaction per rotation, not a lock that spans one.
+
+    **The install stays AFTER the COMMIT and is deliberately not folded into the
+    re-seal transaction.** Writing ``master.key`` before that COMMIT would leave
+    a crash window where the database is still under the OLD key while the new
+    one is installed and the old one is gone — the R2 invariant (at every
+    instant, a key that opens the store exists on disk) inverted. With the
+    ordering kept, R2 holds under concurrency too: before this call the staged
+    key is the copy that opens the committed database; after ``os.replace``
+    ``master.key`` is; a crash between them leaves the staged file for
+    ``resolve_master_key`` to adopt; and a refusal leaves the winner's install
+    untouched, so the key on disk is the one the database is sealed under at
+    every instant. Re-proven with four SIGKILLs landing inside this function
+    while three rotators contended: 0 stores left unopenable.
+
+    Returns ``True`` when the key was installed, ``False`` when another rotation
+    superseded it. Nothing is unlinked on either path: this function is reached
+    both by a rotator installing its OWN staged key and by
+    :func:`local_operator.secrets.access.resolve_master_key` completing somebody
+    ELSE's interrupted rotation, and only the owner is entitled to discard a
+    staged file (see
+    :func:`local_operator.secrets.keys.discard_staged_master_key` — removing
+    another rotation's staged key is the loss that check exists to prevent).
+    The rotator therefore does its own discard on a refusal.
+
+    A store with no database or no fingerprint row cannot be superseded by
+    anything, so the install proceeds unconditionally; that is the same
+    "cannot tell, do not guess" fallback :func:`recorded_key_fingerprint` uses.
+    """
+    path = store_path(base)
+    if not path.exists():
+        replace_master_key(base, key)
+        return True
+
+    with closing(_connect(path)) as connection:
+        connection.execute("BEGIN IMMEDIATE")
+        try:
+            recorded = _read_meta_blob(connection, KEY_FINGERPRINT_KEY)
+            if recorded is not None and recorded != key_fingerprint(key):
+                # Superseded. Refusing is what keeps the winner's key installed.
+                return False
+            replace_master_key(base, key)
+            return True
+        finally:
+            # Read-only throughout: the transaction exists solely to hold the
+            # write lock across the fingerprint check and the file install.
+            connection.execute("ROLLBACK")
+
+
 class SecretStore:
     """Read/write access to the encrypted store, given a master key.
 
@@ -291,8 +386,19 @@ class SecretStore:
             self._path.with_name(self._path.name + "-wal"),
             self._path.with_name(self._path.name + "-shm"),
         ):
-            if candidate.exists():
-                os.chmod(candidate, FILE_MODE)
+            # The exists()/chmod pair is a TOCTOU on the sidecars, not on the
+            # database: SQLite unlinks `-wal` and `-shm` when the last
+            # connection closes, so a concurrent session can remove one inside
+            # this gap and fail an operation that was otherwise fine (observed
+            # once naturally in ~200 rotation-heavy concurrent runs). A file
+            # that no longer exists carries no ciphertext and needs no mode, so
+            # the disappearance is the desired end state rather than an error.
+            # Only FileNotFoundError is suppressed; a permission failure on a
+            # file that IS there still raises, because that one leaves real
+            # ciphertext at a mode this function promised to remove.
+            with contextlib.suppress(FileNotFoundError):
+                if candidate.exists():
+                    os.chmod(candidate, FILE_MODE)
 
     def _open(self, *, for_write: bool) -> sqlite3.Connection:
         """Open an existing store, refusing an incompatible or exposed one."""

--- a/local_operator/secrets/store.py
+++ b/local_operator/secrets/store.py
@@ -1,0 +1,651 @@
+"""The SQLite-backed secret store (design §4).
+
+SQLite in WAL mode rather than one file per secret, and the reason is measured
+rather than stylistic: the operator runs ~10 lop sessions at once, so the store
+needs a concurrency protocol, and SQLite already has one that works. The design
+spike put 10 concurrent readers doing 60 decrypts each against a live writer at
+21 ms with zero errors; per-file storage would have meant inventing a lock
+protocol here. ``tests/unit/secrets/test_concurrency.py`` re-runs that shape.
+
+Names and descriptions are stored ENCRYPTED, not just values. A store listing
+``MINERVA_PROD_DB_PASSWORD`` in the clear tells an attacker where to go next,
+so the only plaintext-searchable column is the blind index — an HMAC of the
+normalised name under a key derived from the master key. That is why ``list``
+needs the key: enumerating which secrets exist is itself privileged.
+
+This module knows nothing about *how* the master key was obtained. It is handed
+one. That is the seam the broker PR slides into: today
+:func:`local_operator.secrets.access.open_store` reads the key file directly,
+and it will instead ask the broker, with this layer unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import time
+import uuid
+from contextlib import closing
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+from local_operator.secrets import audit
+from local_operator.secrets.crypto import (
+    RECORD_FORMAT_VERSION,
+    RecordMetadata,
+    name_index,
+    open_record,
+    seal,
+    validate_name,
+)
+from local_operator.secrets.errors import (
+    IncompatibleStore,
+    InvalidSecretName,
+    SecretCorrupt,
+    SecretExists,
+    SecretNotFound,
+    SecretStoreError,
+)
+from local_operator.secrets.keys import (
+    FILE_MODE,
+    check_mode,
+    ensure_secrets_dir,
+    store_path,
+)
+
+#: Layout version of the tables themselves. A runtime that finds a HIGHER value
+#: refuses to write and refuses to read records whose format it does not know
+#: (§13): version skew is routine here because the operator updates the runtime
+#: while sessions are live, and a downward migration would be unrecoverable.
+SCHEMA_VERSION = 1
+
+#: Valid values of the ``kind`` column. ``file`` marks a secret whose plaintext
+#: is a file's contents — materialised to a private temporary path for the
+#: duration of one command by ``lop secret file`` (design §7).
+KINDS = ("string", "file")
+
+#: Descriptions are operator-written labels shown by ``list``; the ceiling only
+#: has to keep a pathological paste from bloating every record.
+MAX_DESCRIPTION_LENGTH = 1024
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS meta(k TEXT PRIMARY KEY, v BLOB);
+CREATE TABLE IF NOT EXISTS secrets(
+  id             TEXT PRIMARY KEY,
+  name_index     BLOB NOT NULL UNIQUE,
+  key_generation INTEGER NOT NULL,
+  format_version INTEGER NOT NULL,
+  nonce          BLOB NOT NULL,
+  ciphertext     BLOB NOT NULL,
+  kind           TEXT NOT NULL,
+  created_at     REAL NOT NULL,
+  updated_at     REAL NOT NULL,
+  last_used_at   REAL
+);
+CREATE TABLE IF NOT EXISTS audit(
+  ts REAL NOT NULL, event TEXT NOT NULL, secret_id TEXT,
+  session_id TEXT, pid INTEGER, exe TEXT, outcome TEXT,
+  prev_hash BLOB, hash BLOB
+);
+"""
+
+_RECORD_COLUMNS = (
+    "id, name_index, key_generation, format_version, nonce, ciphertext, kind,"
+    " created_at, updated_at, last_used_at"
+)
+
+
+@dataclass(frozen=True)
+class SecretRecord:
+    """A decrypted record, minus the value.
+
+    Returned by ``list`` and ``describe``. The value is a separate call
+    precisely so that no listing path can print one by accident: there is no
+    field here to print.
+    """
+
+    record_id: str
+    name: str
+    description: str
+    kind: str
+    key_generation: int
+    created_at: float
+    updated_at: float
+    last_used_at: float | None
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    """Open the database with the pragmas this store depends on.
+
+    ``journal_mode=WAL`` is what lets ~10 sessions read while one writes.
+    ``synchronous=FULL`` because this store is small and written rarely, so
+    durability is worth more than write throughput — a secret that reports
+    "stored" and is gone after a power cut is the worst outcome available.
+    ``busy_timeout`` covers the brief writer-lock contention concurrent
+    sessions do still produce; without it a racing writer gets an immediate
+    ``database is locked`` instead of waiting the few milliseconds needed.
+
+    ``isolation_level=None`` turns off the driver's implicit transaction
+    management so the explicit ``BEGIN IMMEDIATE`` blocks below mean what they
+    say — sqlite3's default would otherwise open its own transaction on the
+    first DML statement and leave the read that preceded it outside.
+    """
+    connection = sqlite3.connect(path, timeout=10.0, isolation_level=None)
+    connection.execute("PRAGMA journal_mode=WAL")
+    connection.execute("PRAGMA synchronous=FULL")
+    connection.execute("PRAGMA busy_timeout=10000")
+    return connection
+
+
+def _read_meta_int(connection: sqlite3.Connection, key: str, default: int) -> int:
+    row = connection.execute("SELECT v FROM meta WHERE k = ?", (key,)).fetchone()
+    if row is None:
+        return default
+    return int(bytes(row[0]).decode("ascii"))
+
+
+def _write_meta_int(connection: sqlite3.Connection, key: str, value: int) -> None:
+    connection.execute(
+        "INSERT INTO meta(k, v) VALUES(?, ?) ON CONFLICT(k) DO UPDATE SET v = excluded.v",
+        (key, str(value).encode("ascii")),
+    )
+
+
+def _payload(name: str, description: str, value: bytes) -> bytes:
+    """The plaintext sealed inside the ciphertext.
+
+    JSON with the value hex-encoded rather than raw bytes: a value may be
+    arbitrary binary (a service-account key, a DER certificate) and JSON cannot
+    carry those. Hex over base64 only because it round-trips with no padding
+    mode to get wrong; the 2x size cost is paid on a store measured in
+    kilobytes.
+
+    The name is in here as well as in the blind index because the index is
+    one-way — this is the only copy of the label that can be read back for
+    ``list``, and being inside the AEAD is what authenticates it.
+    """
+    return json.dumps(
+        {"name": name, "description": description, "value": value.hex()},
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+class SecretStore:
+    """Read/write access to the encrypted store, given a master key.
+
+    Not a long-lived object: each public method opens a connection, does its
+    work in one transaction and closes it. Ten sessions each holding an open
+    handle for their whole lifetime would keep WAL readers pinned and stop the
+    checkpointer from ever truncating the log, for no benefit — these
+    operations are milliseconds and rare.
+    """
+
+    def __init__(self, master_key: bytes, base: Path | None = None) -> None:
+        self._master_key = master_key
+        self._path = store_path(base)
+        self._base = base
+
+    @property
+    def path(self) -> Path:
+        """The database file this instance talks to."""
+        return self._path
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def initialize(self) -> None:
+        """Create the database and its tables, 0600 inside a 0700 directory.
+
+        The explicit ``chmod`` after creation is load-bearing: SQLite creates
+        its file honouring the process umask, so a session running under
+        ``umask 000`` would otherwise leave a world-readable database. The
+        ``-wal`` and ``-shm`` sidecars get the same treatment — they carry the
+        same ciphertext, and a private database with a world-readable WAL is
+        not private.
+        """
+        ensure_secrets_dir(self._base)
+        with closing(_connect(self._path)) as connection:
+            connection.executescript(_SCHEMA)
+            if _read_meta_int(connection, "schema_version", 0) == 0:
+                _write_meta_int(connection, "schema_version", SCHEMA_VERSION)
+            if _read_meta_int(connection, "key_generation", 0) == 0:
+                _write_meta_int(connection, "key_generation", 1)
+        self._restrict_modes()
+
+    def exists(self) -> bool:
+        """Whether a store has been created yet."""
+        return self._path.exists()
+
+    def _restrict_modes(self) -> None:
+        for candidate in (
+            self._path,
+            self._path.with_name(self._path.name + "-wal"),
+            self._path.with_name(self._path.name + "-shm"),
+        ):
+            if candidate.exists():
+                os.chmod(candidate, FILE_MODE)
+
+    def _open(self, *, for_write: bool) -> sqlite3.Connection:
+        """Open an existing store, refusing an incompatible or exposed one."""
+        if not self._path.exists():
+            raise SecretStoreError(
+                f"No secret store found at {self._path}. "
+                "Create one by storing a secret: lop secret set NAME"
+            )
+        check_mode(self._path)
+        connection = _connect(self._path)
+        found = _read_meta_int(connection, "schema_version", SCHEMA_VERSION)
+        if found != SCHEMA_VERSION:
+            connection.close()
+            # Both directions are refused, but only the newer one is expected:
+            # the operator updates the runtime under live sessions, so an older
+            # runtime meeting a newer store is routine (§13) and must never
+            # migrate it downward.
+            direction = "newer" if found > SCHEMA_VERSION else "older"
+            action = (
+                "upgrade this runtime (lop update)"
+                if found > SCHEMA_VERSION
+                else "the store predates this runtime's schema and has no migration"
+            )
+            raise IncompatibleStore(
+                f"This secret store uses schema version {found}; this runtime speaks "
+                f"{SCHEMA_VERSION}. It was written by a {direction} local-operator — {action}."
+            )
+        return connection
+
+    def key_generation(self) -> int:
+        """The generation new records are sealed under."""
+        with closing(self._open(for_write=False)) as connection:
+            return _read_meta_int(connection, "key_generation", 1)
+
+    # -- record helpers ----------------------------------------------------
+
+    def _decode(
+        self, row: Sequence[Any], master_key: bytes | None = None
+    ) -> tuple[SecretRecord, bytes]:
+        """Authenticate and decode one row into ``(record, value)``.
+
+        The AAD is rebuilt from the row's own COLUMNS — never from anything
+        inside the ciphertext, which would be circular (see
+        :func:`crypto.build_aad`). So every column an attacker with database
+        write access can edit is an AEAD input, and editing one makes the tag
+        check fail rather than relabelling a record that still decrypts.
+
+        The re-derived blind index check at the end closes the remaining gap:
+        the name inside the ciphertext and the ``name_index`` column are two
+        copies of the same fact, and this is where they are made to agree.
+        """
+        key = self._master_key if master_key is None else master_key
+        record_id = str(row[0])
+        stored_index = bytes(row[1])
+        key_generation = int(row[2])
+        format_version = int(row[3])
+        if format_version > RECORD_FORMAT_VERSION:
+            raise IncompatibleStore(
+                f"Secret record {record_id} uses record format {format_version}; this runtime "
+                f"understands {RECORD_FORMAT_VERSION}. It was written by a newer "
+                "local-operator — upgrade this runtime (lop update) to read it."
+            )
+        kind = str(row[6])
+        metadata = RecordMetadata(
+            record_id=record_id,
+            name_index=stored_index,
+            kind=kind,
+            key_generation=key_generation,
+            format_version=format_version,
+        )
+        plaintext = open_record(key, metadata, bytes(row[4]), bytes(row[5]))
+        payload = json.loads(plaintext.decode("utf-8"))
+
+        # The sealed name must still hash to the column the row was found by.
+        # Belt and braces over the AAD: it means an attacker cannot construct
+        # any row whose two copies of the name disagree, even with the key.
+        if name_index(key, payload["name"]) != stored_index:
+            raise SecretCorrupt(
+                f"Secret record {record_id} is inconsistent: its sealed name does not match "
+                "its lookup index. Refusing to return a value."
+            )
+        record = SecretRecord(
+            record_id=record_id,
+            name=payload["name"],
+            description=payload["description"],
+            kind=kind,
+            key_generation=key_generation,
+            created_at=float(row[7]),
+            updated_at=float(row[8]),
+            last_used_at=None if row[9] is None else float(row[9]),
+        )
+        return record, bytes.fromhex(payload["value"])
+
+    def _row_for(self, connection: sqlite3.Connection, name: str) -> Sequence[Any]:
+        index = name_index(self._master_key, validate_name(name))
+        row = connection.execute(
+            f"SELECT {_RECORD_COLUMNS} FROM secrets WHERE name_index = ?", (index,)
+        ).fetchone()
+        if row is None:
+            raise SecretNotFound(f"No secret named {name!r} in this store.")
+        return row
+
+    # -- verbs -------------------------------------------------------------
+
+    def set(
+        self,
+        name: str,
+        value: bytes,
+        *,
+        description: str = "",
+        kind: str = "string",
+        session_id: str | None = None,
+    ) -> SecretRecord:
+        """Store a NEW secret. Refuses to overwrite an existing name.
+
+        Overwriting is ``update``'s job and is spelled differently on purpose:
+        the previous value is retained nowhere, so a ``set`` that silently
+        replaced a live credential because of a mistyped name would be
+        unrecoverable.
+        """
+        canonical = validate_name(name)
+        description = _validate_description(description)
+        if kind not in KINDS:
+            raise InvalidSecretName(f"kind must be one of {', '.join(KINDS)}; got {kind!r}.")
+        self.initialize()
+        now = time.time()
+        record_id = str(uuid.uuid4())
+        index = name_index(self._master_key, canonical)
+        with closing(self._open(for_write=True)) as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            try:
+                generation = _read_meta_int(connection, "key_generation", 1)
+                if connection.execute(
+                    "SELECT 1 FROM secrets WHERE name_index = ?", (index,)
+                ).fetchone():
+                    raise SecretExists(
+                        f"A secret named {canonical!r} already exists. "
+                        "Use `lop secret update` to change its value."
+                    )
+                metadata = RecordMetadata(
+                    record_id=record_id,
+                    name_index=index,
+                    kind=kind,
+                    key_generation=generation,
+                )
+                nonce, ciphertext = seal(
+                    self._master_key, metadata, _payload(canonical, description, value)
+                )
+                connection.execute(
+                    f"INSERT INTO secrets({_RECORD_COLUMNS})"
+                    " VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)",
+                    (
+                        record_id,
+                        index,
+                        generation,
+                        RECORD_FORMAT_VERSION,
+                        nonce,
+                        ciphertext,
+                        kind,
+                        now,
+                        now,
+                    ),
+                )
+                audit.append(
+                    connection,
+                    event="set",
+                    ts=now,
+                    outcome="ok",
+                    secret_id=record_id,
+                    session_id=session_id,
+                    pid=os.getpid(),
+                )
+                connection.execute("COMMIT")
+            except BaseException:
+                connection.execute("ROLLBACK")
+                raise
+            generation_written = generation
+        self._restrict_modes()
+        return SecretRecord(
+            record_id=record_id,
+            name=canonical,
+            description=description,
+            kind=kind,
+            key_generation=generation_written,
+            created_at=now,
+            updated_at=now,
+            last_used_at=None,
+        )
+
+    def update(
+        self,
+        name: str,
+        value: bytes,
+        *,
+        description: str | None = None,
+        session_id: str | None = None,
+    ) -> SecretRecord:
+        """Re-seal an existing secret with a new value under a FRESH nonce.
+
+        The nonce comes from :func:`crypto.seal`, which generates one per call.
+        An update that reused the record's stored nonce under the same key
+        would leak the XOR of the old and new values and the authentication
+        key — the classic GCM misuse, and the reason no call site here is given
+        the opportunity to supply a nonce.
+        """
+        canonical = validate_name(name)
+        now = time.time()
+        with closing(self._open(for_write=True)) as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            try:
+                existing, _ = self._decode(self._row_for(connection, canonical))
+                new_description = (
+                    existing.description
+                    if description is None
+                    else _validate_description(description)
+                )
+                metadata = RecordMetadata(
+                    record_id=existing.record_id,
+                    name_index=name_index(self._master_key, canonical),
+                    kind=existing.kind,
+                    key_generation=existing.key_generation,
+                )
+                nonce, ciphertext = seal(
+                    self._master_key, metadata, _payload(canonical, new_description, value)
+                )
+                connection.execute(
+                    "UPDATE secrets SET nonce = ?, ciphertext = ?, updated_at = ? WHERE id = ?",
+                    (nonce, ciphertext, now, existing.record_id),
+                )
+                audit.append(
+                    connection,
+                    event="update",
+                    ts=now,
+                    outcome="ok",
+                    secret_id=existing.record_id,
+                    session_id=session_id,
+                    pid=os.getpid(),
+                )
+                connection.execute("COMMIT")
+            except BaseException:
+                connection.execute("ROLLBACK")
+                raise
+        self._restrict_modes()
+        return SecretRecord(
+            record_id=existing.record_id,
+            name=canonical,
+            description=new_description,
+            kind=existing.kind,
+            key_generation=existing.key_generation,
+            created_at=existing.created_at,
+            updated_at=now,
+            last_used_at=existing.last_used_at,
+        )
+
+    def get(self, name: str, *, session_id: str | None = None) -> bytes:
+        """Return the exact stored bytes, or raise.
+
+        ``last_used_at`` and the audit row are written on the way out, which is
+        why a read verb takes a write connection: a retrieval that leaves no
+        trace is the one an attacker most wants.
+        """
+        now = time.time()
+        with closing(self._open(for_write=True)) as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            try:
+                record, value = self._decode(self._row_for(connection, name))
+                connection.execute(
+                    "UPDATE secrets SET last_used_at = ? WHERE id = ?", (now, record.record_id)
+                )
+                audit.append(
+                    connection,
+                    event="get",
+                    ts=now,
+                    outcome="ok",
+                    secret_id=record.record_id,
+                    session_id=session_id,
+                    pid=os.getpid(),
+                )
+                connection.execute("COMMIT")
+            except BaseException:
+                connection.execute("ROLLBACK")
+                raise
+        return value
+
+    def describe(self, name: str) -> SecretRecord:
+        """Metadata for one secret. Never returns the value."""
+        with closing(self._open(for_write=False)) as connection:
+            record, _ = self._decode(self._row_for(connection, name))
+        return record
+
+    def list(self) -> list[SecretRecord]:
+        """Every record's metadata, name-sorted. Never returns values.
+
+        A record that fails to authenticate propagates rather than being
+        skipped: a store with a corrupt record is something the operator must
+        learn the first time they look at it, not on the day they need that
+        one secret.
+        """
+        with closing(self._open(for_write=False)) as connection:
+            rows = connection.execute(f"SELECT {_RECORD_COLUMNS} FROM secrets").fetchall()
+        return sorted((self._decode(row)[0] for row in rows), key=lambda record: record.name)
+
+    def delete(self, name: str, *, session_id: str | None = None) -> SecretRecord:
+        """Remove a secret, returning what was removed."""
+        now = time.time()
+        with closing(self._open(for_write=True)) as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            try:
+                record, _ = self._decode(self._row_for(connection, name))
+                connection.execute("DELETE FROM secrets WHERE id = ?", (record.record_id,))
+                audit.append(
+                    connection,
+                    event="delete",
+                    ts=now,
+                    outcome="ok",
+                    secret_id=record.record_id,
+                    session_id=session_id,
+                    pid=os.getpid(),
+                )
+                connection.execute("COMMIT")
+            except BaseException:
+                connection.execute("ROLLBACK")
+                raise
+        return record
+
+    def rotate(self, new_master_key: bytes, *, session_id: str | None = None) -> int:
+        """Re-seal every record under ``new_master_key``; returns the count.
+
+        One transaction, not record by record. The blind index is keyed from
+        the master key, so a half-rotated store would carry some indexes under
+        the old key and some under the new, and no single key could look every
+        record up — a different failure from the per-record ``key_generation``
+        the design describes, which keeps old ciphertexts readable and does
+        work here: each record is opened under its OWN generation before being
+        re-sealed under the next one.
+
+        The caller installs the new key file only after this returns, so a
+        crash mid-rotation leaves the old key still matching the untouched
+        database.
+        """
+        now = time.time()
+        with closing(self._open(for_write=True)) as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            try:
+                generation = _read_meta_int(connection, "key_generation", 1) + 1
+                rows = connection.execute(f"SELECT {_RECORD_COLUMNS} FROM secrets").fetchall()
+                for row in rows:
+                    record, value = self._decode(row)
+                    index = name_index(new_master_key, record.name)
+                    metadata = RecordMetadata(
+                        record_id=record.record_id,
+                        name_index=index,
+                        kind=record.kind,
+                        key_generation=generation,
+                    )
+                    nonce, ciphertext = seal(
+                        new_master_key,
+                        metadata,
+                        _payload(record.name, record.description, value),
+                    )
+                    connection.execute(
+                        "UPDATE secrets SET name_index = ?, key_generation = ?, nonce = ?,"
+                        " ciphertext = ?, format_version = ? WHERE id = ?",
+                        (
+                            index,
+                            generation,
+                            nonce,
+                            ciphertext,
+                            RECORD_FORMAT_VERSION,
+                            record.record_id,
+                        ),
+                    )
+                _write_meta_int(connection, "key_generation", generation)
+                audit.append(
+                    connection,
+                    event="rotate",
+                    ts=now,
+                    outcome="ok",
+                    session_id=session_id,
+                    pid=os.getpid(),
+                )
+                connection.execute("COMMIT")
+            except BaseException:
+                connection.execute("ROLLBACK")
+                raise
+        self._master_key = new_master_key
+        return len(rows)
+
+    def audit_entries(self, limit: int | None = None) -> list[audit.AuditEntry]:
+        """Recent audit entries, oldest first."""
+        with closing(self._open(for_write=False)) as connection:
+            return audit.entries(connection, limit=limit)
+
+    def verify_audit(self) -> tuple[bool, int | None, str]:
+        """Walk the audit hash chain; see :func:`audit.verify`."""
+        with closing(self._open(for_write=False)) as connection:
+            return audit.verify(connection)
+
+
+def _validate_description(description: str) -> str:
+    """Reject a description that would break the record or the listing.
+
+    Newlines are refused because ``list`` prints one record per line and a
+    description carrying one would forge a second row; the length ceiling keeps
+    a pathological paste out of every future re-seal of that record.
+    """
+    if "\n" in description or "\r" in description:
+        raise InvalidSecretName("Secret description cannot contain newlines.")
+    if len(description) > MAX_DESCRIPTION_LENGTH:
+        raise InvalidSecretName(
+            f"Secret description is {len(description)} characters; "
+            f"the maximum is {MAX_DESCRIPTION_LENGTH}."
+        )
+    return description
+
+
+__all__ = [
+    "KINDS",
+    "MAX_DESCRIPTION_LENGTH",
+    "SCHEMA_VERSION",
+    "SecretRecord",
+    "SecretStore",
+]

--- a/local_operator/secrets/store.py
+++ b/local_operator/secrets/store.py
@@ -35,6 +35,7 @@ from local_operator.secrets import audit
 from local_operator.secrets.crypto import (
     RECORD_FORMAT_VERSION,
     RecordMetadata,
+    key_fingerprint,
     name_index,
     open_record,
     seal,
@@ -47,6 +48,7 @@ from local_operator.secrets.errors import (
     SecretExists,
     SecretNotFound,
     SecretStoreError,
+    StaleKeyEpoch,
 )
 from local_operator.secrets.keys import (
     FILE_MODE,
@@ -69,6 +71,20 @@ KINDS = ("string", "file")
 #: Descriptions are operator-written labels shown by ``list``; the ceiling only
 #: has to keep a pathological paste from bloating every record.
 MAX_DESCRIPTION_LENGTH = 1024
+
+#: ``meta`` key holding the fingerprint of the master key the store is sealed
+#: under. This is the store's KEY EPOCH, and it exists because ``BEGIN
+#: IMMEDIATE`` serialises statements but not key epochs: a session that loaded
+#: the key before a rotation would otherwise commit a record sealed under the
+#: old key and indexed under the old index key, unreachable and undecryptable
+#: forever, while reporting success. Every write compares its own key against
+#: this row inside its own transaction and fails closed on a mismatch.
+#:
+#: Absent on a store created before this row existed. That case is treated as
+#: "epoch unknown", not as a mismatch, and the next write backfills it —
+#: refusing to write to a pre-existing store would be a worse failure than the
+#: race this guards.
+KEY_FINGERPRINT_KEY = "key_fingerprint"
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS meta(k TEXT PRIMARY KEY, v BLOB);
@@ -140,10 +156,39 @@ def _connect(path: Path) -> sqlite3.Connection:
 
 
 def _read_meta_int(connection: sqlite3.Connection, key: str, default: int) -> int:
+    """Read an integer ``meta`` row, refusing a corrupted one cleanly.
+
+    The conversion is guarded because ``meta.v`` is a BLOB column that SQLite
+    will happily hold TEXT or NULL in: a hand-corrupted row made ``bytes()`` or
+    ``int()`` raise something that is not a :class:`SecretStoreError`, which
+    escaped the CLI's one-line error contract and printed a 29-line traceback
+    into a command routinely run inside ``$( )``. The value is unusable either
+    way; the only question is whether the operator gets a sentence or a stack.
+    """
     row = connection.execute("SELECT v FROM meta WHERE k = ?", (key,)).fetchone()
-    if row is None:
+    if row is None or row[0] is None:
         return default
-    return int(bytes(row[0]).decode("ascii"))
+    try:
+        return int(bytes(row[0]).decode("ascii"))
+    except (TypeError, ValueError, UnicodeDecodeError) as exc:
+        raise IncompatibleStore(
+            f"This secret store's {key!r} metadata is not a number ({row[0]!r}). "
+            "The store's metadata is damaged; it cannot be read safely."
+        ) from exc
+
+
+def _read_meta_blob(connection: sqlite3.Connection, key: str) -> bytes | None:
+    row = connection.execute("SELECT v FROM meta WHERE k = ?", (key,)).fetchone()
+    if row is None or row[0] is None:
+        return None
+    return bytes(row[0])
+
+
+def _write_meta_blob(connection: sqlite3.Connection, key: str, value: bytes) -> None:
+    connection.execute(
+        "INSERT INTO meta(k, v) VALUES(?, ?) ON CONFLICT(k) DO UPDATE SET v = excluded.v",
+        (key, value),
+    )
 
 
 def _write_meta_int(connection: sqlite3.Connection, key: str, value: int) -> None:
@@ -171,6 +216,26 @@ def _payload(name: str, description: str, value: bytes) -> bytes:
         ensure_ascii=False,
         separators=(",", ":"),
     ).encode("utf-8")
+
+
+def recorded_key_fingerprint(base: Path | None = None) -> bytes | None:
+    """The fingerprint of the key the store on disk is currently sealed under.
+
+    Read without a key, because the caller of this function is deciding WHICH
+    key to use — it is how an interrupted rotation is detected and completed
+    (see :func:`local_operator.secrets.access.resolve_master_key`). Returns
+    ``None`` when there is no store, no fingerprint row (a store predating the
+    row), or a damaged one: every one of those means "cannot tell", and the
+    caller falls back to the installed key rather than guessing.
+    """
+    path = store_path(base)
+    if not path.exists():
+        return None
+    try:
+        with closing(_connect(path)) as connection:
+            return _read_meta_blob(connection, KEY_FINGERPRINT_KEY)
+    except sqlite3.DatabaseError:
+        return None
 
 
 class SecretStore:
@@ -212,6 +277,8 @@ class SecretStore:
                 _write_meta_int(connection, "schema_version", SCHEMA_VERSION)
             if _read_meta_int(connection, "key_generation", 0) == 0:
                 _write_meta_int(connection, "key_generation", 1)
+            if _read_meta_blob(connection, KEY_FINGERPRINT_KEY) is None:
+                _write_meta_blob(connection, KEY_FINGERPRINT_KEY, key_fingerprint(self._master_key))
         self._restrict_modes()
 
     def exists(self) -> bool:
@@ -259,6 +326,40 @@ class SecretStore:
         """The generation new records are sealed under."""
         with closing(self._open(for_write=False)) as connection:
             return _read_meta_int(connection, "key_generation", 1)
+
+    def _guard_key_epoch(self, connection: sqlite3.Connection) -> None:
+        """Refuse a write whose key is no longer the store's key.
+
+        MUST be called inside the caller's ``BEGIN IMMEDIATE`` transaction, not
+        before it. That is the entire protection: ``BEGIN IMMEDIATE`` takes the
+        write lock, so a ``rotate`` cannot land between this check and the
+        INSERT that follows it. Checking outside the transaction would restore
+        the race it exists to close.
+
+        The failure this prevents is not hypothetical. A session that loaded
+        the master key before another session's ``rotate`` would seal its
+        record under the superseded key and index it under the superseded index
+        key, then COMMIT and report "stored". The row is then unreachable by
+        name (the index does not match) and undecryptable (the key is gone) —
+        and because it is undecryptable, it also poisons every enumeration that
+        touches it. Refusing the write costs one retry with a fresh key.
+
+        A store with no fingerprint row predates this guard; it is backfilled
+        rather than refused, because breaking every existing store would be a
+        worse outcome than the race.
+        """
+        recorded = _read_meta_blob(connection, KEY_FINGERPRINT_KEY)
+        mine = key_fingerprint(self._master_key)
+        if recorded is None:
+            _write_meta_blob(connection, KEY_FINGERPRINT_KEY, mine)
+            return
+        if recorded != mine:
+            raise StaleKeyEpoch(
+                "This store's master key was rotated by another session after this one "
+                "loaded it, so this write was refused rather than being sealed under a "
+                "key that no longer exists. Re-run the command; it will pick up the "
+                "current key."
+            )
 
     # -- record helpers ----------------------------------------------------
 
@@ -357,6 +458,7 @@ class SecretStore:
         with closing(self._open(for_write=True)) as connection:
             connection.execute("BEGIN IMMEDIATE")
             try:
+                self._guard_key_epoch(connection)
                 generation = _read_meta_int(connection, "key_generation", 1)
                 if connection.execute(
                     "SELECT 1 FROM secrets WHERE name_index = ?", (index,)
@@ -436,6 +538,7 @@ class SecretStore:
         with closing(self._open(for_write=True)) as connection:
             connection.execute("BEGIN IMMEDIATE")
             try:
+                self._guard_key_epoch(connection)
                 existing, _ = self._decode(self._row_for(connection, canonical))
                 new_description = (
                     existing.description
@@ -517,16 +620,89 @@ class SecretStore:
         return record
 
     def list(self) -> list[SecretRecord]:
-        """Every record's metadata, name-sorted. Never returns values.
+        """Every readable record's metadata, name-sorted. Never returns values.
 
-        A record that fails to authenticate propagates rather than being
-        skipped: a store with a corrupt record is something the operator must
-        learn the first time they look at it, not on the day they need that
-        one secret.
+        Damaged records are REPORTED, not propagated. This used to raise on the
+        first record that failed to authenticate, on the reasoning that the
+        operator must learn about corruption the first time they look. The
+        reasoning was right and the mechanism was wrong: raising means one bad
+        row takes down ``list``, ``status`` and every subsequent ``rotate``,
+        so the operator learns that something is broken and simultaneously
+        loses every tool for finding out what, including access to the
+        untouched secrets sitting beside it. Enumeration is the surface an
+        operator reaches for *when* the store is damaged; it is the one path
+        that must keep working.
+
+        So a record that will not open is surfaced through
+        :meth:`damaged_records` and through ``list``'s and ``status``'s output
+        rather than by making the store unusable, and :meth:`delete_record_id`
+        gives the operator a way to remove it.
+        """
+        return self._enumerate()[0]
+
+    def damaged_records(self) -> list[str]:
+        """Record ids present in the store that cannot be authenticated.
+
+        Empty in every healthy store. A non-empty result means tampering, disk
+        damage, or a record sealed under a key that no longer exists — the last
+        of which is what a pre-guard concurrent rotation used to produce.
+        """
+        return self._enumerate()[1]
+
+    def _enumerate(self) -> tuple[list[SecretRecord], list[str]]:
+        """Split every row into the records that open and the ids that do not.
+
+        One pass, so ``list`` and ``status`` cannot disagree about which rows
+        are damaged. Only :class:`SecretCorrupt` and
+        :class:`IncompatibleStore` are caught per row: those mean "this record
+        is unreadable", which is precisely the condition to report and step
+        over. A failure to read the store at all still propagates.
         """
         with closing(self._open(for_write=False)) as connection:
             rows = connection.execute(f"SELECT {_RECORD_COLUMNS} FROM secrets").fetchall()
-        return sorted((self._decode(row)[0] for row in rows), key=lambda record: record.name)
+        records: list[SecretRecord] = []
+        damaged: list[str] = []
+        for row in rows:
+            try:
+                records.append(self._decode(row)[0])
+            except (SecretCorrupt, IncompatibleStore):
+                damaged.append(str(row[0]))
+        return sorted(records, key=lambda record: record.name), sorted(damaged)
+
+    def delete_record_id(self, record_id: str, *, session_id: str | None = None) -> bool:
+        """Remove a row by its id, without needing to decrypt it.
+
+        The repair path for a damaged record. :meth:`delete` looks a row up by
+        blind index and decodes it, so it cannot touch a record whose name is
+        unreadable — the operator was left with a row that broke enumeration
+        and that no command could remove. This deletes by primary key, which
+        needs no key material for the row itself.
+
+        Returns whether a row was removed. Still audited, and still guarded by
+        the key epoch: removing a record is a write.
+        """
+        now = time.time()
+        with closing(self._open(for_write=True)) as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            try:
+                self._guard_key_epoch(connection)
+                cursor = connection.execute("DELETE FROM secrets WHERE id = ?", (record_id,))
+                removed = cursor.rowcount > 0
+                if removed:
+                    audit.append(
+                        connection,
+                        event="delete",
+                        ts=now,
+                        outcome="ok",
+                        secret_id=record_id,
+                        session_id=session_id,
+                        pid=os.getpid(),
+                    )
+                connection.execute("COMMIT")
+            except BaseException:
+                connection.execute("ROLLBACK")
+                raise
+        return removed
 
     def delete(self, name: str, *, session_id: str | None = None) -> SecretRecord:
         """Remove a secret, returning what was removed."""
@@ -534,6 +710,7 @@ class SecretStore:
         with closing(self._open(for_write=True)) as connection:
             connection.execute("BEGIN IMMEDIATE")
             try:
+                self._guard_key_epoch(connection)
                 record, _ = self._decode(self._row_for(connection, name))
                 connection.execute("DELETE FROM secrets WHERE id = ?", (record.record_id,))
                 audit.append(
@@ -562,18 +739,44 @@ class SecretStore:
         work here: each record is opened under its OWN generation before being
         re-sealed under the next one.
 
-        The caller installs the new key file only after this returns, so a
-        crash mid-rotation leaves the old key still matching the untouched
-        database.
+        **The caller must have STAGED the new key on disk before calling this**
+        (:func:`local_operator.secrets.keys.stage_master_key`), and installs it
+        as ``master.key`` after this returns. That ordering is load-bearing and
+        the reverse of what an earlier version of this docstring claimed: by
+        the time this method commits, the database is re-sealed under
+        ``new_master_key``, and the old key opens NOTHING. A crash in the
+        window between this COMMIT and the install is survivable only because
+        the staged file already holds the new key —
+        :func:`local_operator.secrets.access.resolve_master_key` matches it
+        against the fingerprint written below and finishes the install. Commit
+        first with the key only in memory and an ordinary power cut during a
+        rotate loses every secret in the store, unrecoverably.
         """
         now = time.time()
         with closing(self._open(for_write=True)) as connection:
             connection.execute("BEGIN IMMEDIATE")
             try:
+                # The rotator itself must still be holding the store's current
+                # key: two concurrent rotations would otherwise each re-seal
+                # from a different starting point and the loser's key would be
+                # the one on disk.
+                self._guard_key_epoch(connection)
                 generation = _read_meta_int(connection, "key_generation", 1) + 1
                 rows = connection.execute(f"SELECT {_RECORD_COLUMNS} FROM secrets").fetchall()
+                moved = 0
                 for row in rows:
-                    record, value = self._decode(row)
+                    try:
+                        record, value = self._decode(row)
+                    except (SecretCorrupt, IncompatibleStore):
+                        # A record this key cannot open cannot be re-sealed
+                        # under the next one either, and refusing to rotate
+                        # until it is gone would mean a single damaged row
+                        # blocks the operator's response to a suspected key
+                        # compromise — the moment rotation matters most. It is
+                        # left exactly as it is, still visible through
+                        # `damaged_records()` and still removable by id, and
+                        # the count returned reflects what actually moved.
+                        continue
                     index = name_index(new_master_key, record.name)
                     metadata = RecordMetadata(
                         record_id=record.record_id,
@@ -598,7 +801,15 @@ class SecretStore:
                             record.record_id,
                         ),
                     )
+                    moved += 1
                 _write_meta_int(connection, "key_generation", generation)
+                # The epoch moves in the SAME transaction as the re-seal, so
+                # the fingerprint on disk always describes the key the
+                # ciphertexts are actually under — including for a process that
+                # crashes immediately after this COMMIT, which is how
+                # `resolve_master_key` recognises the staged key as the right
+                # one.
+                _write_meta_blob(connection, KEY_FINGERPRINT_KEY, key_fingerprint(new_master_key))
                 audit.append(
                     connection,
                     event="rotate",
@@ -612,7 +823,7 @@ class SecretStore:
                 connection.execute("ROLLBACK")
                 raise
         self._master_key = new_master_key
-        return len(rows)
+        return moved
 
     def audit_entries(self, limit: int | None = None) -> list[audit.AuditEntry]:
         """Recent audit entries, oldest first."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,17 @@ dependencies = [
     # The personal tunnel gateway verifies the edge's RSA proof locally;
     # declare this directly rather than relying on the MCP transitive copy.
     "pyjwt[crypto]>=2.10,<3",
+    # The encrypted secret store (`lop secret`) uses AES-256-GCM, HKDF and
+    # scrypt from here. It arrives anyway as a required transitive of
+    # pyjwt[crypto] above, but a direct import belongs in a direct dependency:
+    # if that extra were ever narrowed or replaced, the transitive copy would
+    # vanish and `lop secret` would fail at import time with no declaration
+    # pointing at the cause. The APIs used here (AESGCM, HKDF, scrypt,
+    # InvalidTag) have been stable for many majors, so the floor is not an API
+    # boundary: 42 (Jan 2024) is simply a recent, universally-available
+    # baseline that carries the OpenSSL 3.x security fixes and is far below
+    # what pyjwt[crypto] already resolves, so it constrains nobody's install.
+    "cryptography>=42",
     "websockets>=15.0.1",
     "apscheduler",
     "dill",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,10 @@ _AMBIENT_VARS = (
     "LOCAL_OPERATOR_DESKTOP_ORIGINS",
     "LOCAL_OPERATOR_HOME",
     "LOCAL_OPERATOR_DEBUG",
+    # Names the session a `lop secret` retrieval is attributed to in the audit
+    # trail. Inherited from the operator's own runtime it would write their
+    # real session id into a sandboxed store's audit rows.
+    "LOCAL_OPERATOR_SESSION_ID",
     # Tests launched from a detached operator inherit these runtime-only flags.
     # They turn strict --resume validation into adoption of a brand-new id.
     "LOP_RUNTIME_ADOPT_SESSION",

--- a/tests/unit/secrets/conftest.py
+++ b/tests/unit/secrets/conftest.py
@@ -1,0 +1,44 @@
+"""Isolation for every secret-store test.
+
+`AGENTS.md` is explicit that ``LOCAL_OPERATOR_CONFIG_DIR`` alone is not
+isolation, and that a redirected READ path is not automatically a redirected
+WRITE path — the analytics backfill wrote 612 rows into the operator's real
+database from a run that looked sandboxed. This store writes to
+``config_dir()/secrets``, so the fixture redirects ``HOME`` as well and the
+tests below assert the store landed under ``tmp_path`` rather than trusting it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from local_operator.paths import CONFIG_DIR_ENV
+from local_operator.secrets.crypto import generate_master_key
+from local_operator.secrets.store import SecretStore
+
+
+@pytest.fixture
+def config_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A private config dir; both HOME and the override point inside tmp_path."""
+    root = tmp_path / "config"
+    root.mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(root))
+    (tmp_path / "home").mkdir()
+    return root
+
+
+@pytest.fixture
+def master_key() -> bytes:
+    return generate_master_key()
+
+
+@pytest.fixture
+def store(config_root: Path, master_key: bytes) -> SecretStore:
+    """An initialised store under the isolated config dir."""
+    instance = SecretStore(master_key, base=config_root)
+    instance.initialize()
+    assert instance.path.is_relative_to(config_root), "store escaped the sandbox"
+    return instance

--- a/tests/unit/secrets/test_audit.py
+++ b/tests/unit/secrets/test_audit.py
@@ -1,0 +1,153 @@
+"""The audit hash chain: appending verifies, editing breaks it detectably.
+
+Design §12. The claim is tamper-EVIDENT, not tamper-proof — whoever owns the
+file can still delete the whole thing — so what these prove is the narrower and
+achievable property: an attacker cannot silently EDIT history. Either the chain
+verifies, or it reports the first entry that does not.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from local_operator.secrets.store import SecretStore
+
+
+def test_every_operation_appends_an_entry(store: SecretStore) -> None:
+    store.set("TOKEN", b"value")
+    store.get("TOKEN")
+    store.update("TOKEN", b"new-value")
+    store.get("TOKEN")
+    store.delete("TOKEN")
+
+    events = [entry.event for entry in store.audit_entries()]
+    assert events == ["set", "get", "update", "get", "delete"]
+
+
+def test_an_intact_chain_verifies(store: SecretStore) -> None:
+    for index in range(10):
+        store.set(f"SECRET_{index}", b"value")
+        store.get(f"SECRET_{index}")
+
+    ok, position, message = store.verify_audit()
+    assert ok, message
+    assert position is None
+    assert message == "audit chain intact"
+
+
+def test_an_empty_chain_verifies(store: SecretStore) -> None:
+    ok, position, _ = store.verify_audit()
+    assert ok and position is None
+
+
+def test_no_entry_ever_records_a_value(store: SecretStore) -> None:
+    """The audit log must not become the leak it exists to detect."""
+    store.set("TOKEN", b"super-secret-value")
+    store.get("TOKEN")
+    for entry in store.audit_entries():
+        assert "super-secret-value" not in repr(entry)
+        assert entry.secret_id is not None
+        assert "TOKEN" not in repr(entry), "the audit log records ids, not names"
+
+
+def test_editing_an_entry_in_place_breaks_the_chain(store: SecretStore) -> None:
+    """The attack: rewrite a retrieval you made to look like something else."""
+    store.set("TOKEN", b"value")
+    for _ in range(4):
+        store.get("TOKEN")
+
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            "UPDATE audit SET event = 'describe' WHERE rowid = "
+            "(SELECT rowid FROM audit ORDER BY rowid LIMIT 1 OFFSET 2)"
+        )
+
+    ok, position, message = store.verify_audit()
+    assert not ok
+    assert position == 3
+    assert "edited after it was written" in message
+
+
+def test_deleting_a_middle_entry_breaks_the_chain(store: SecretStore) -> None:
+    """The other attack: remove the retrieval entirely.
+
+    ``prev_hash`` of the following entry no longer matches, so the gap is
+    reported at the entry that now sits where the deleted one used to link.
+    """
+    store.set("TOKEN", b"value")
+    for _ in range(4):
+        store.get("TOKEN")
+
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            "DELETE FROM audit WHERE rowid = "
+            "(SELECT rowid FROM audit ORDER BY rowid LIMIT 1 OFFSET 2)"
+        )
+
+    ok, position, message = store.verify_audit()
+    assert not ok
+    assert position == 3
+    assert "removed or reordered" in message
+
+
+def test_reordering_entries_breaks_the_chain(store: SecretStore) -> None:
+    store.set("ALPHA", b"value")
+    store.set("BETA", b"value")
+    store.get("ALPHA")
+
+    with sqlite3.connect(store.path) as connection:
+        rows = connection.execute("SELECT rowid, ts FROM audit ORDER BY rowid").fetchall()
+        # Swap the timestamps of entries 1 and 2, which is enough to change the
+        # canonical row bytes without touching the hashes.
+        connection.execute("UPDATE audit SET ts = ? WHERE rowid = ?", (rows[1][1], rows[0][0]))
+        connection.execute("UPDATE audit SET ts = ? WHERE rowid = ?", (rows[0][1], rows[1][0]))
+
+    ok, position, _ = store.verify_audit()
+    assert not ok
+    assert position == 1
+
+
+def test_appending_a_forged_entry_breaks_the_chain(store: SecretStore) -> None:
+    """An attacker cannot append plausible history without the chain state.
+
+    They CAN compute a correct hash if they read the previous row — the chain
+    is not a MAC and §12 does not claim it is. What this pins is that a naive
+    insert, which is what an attacker scripting sqlite3 actually does, is
+    detected.
+    """
+    store.set("TOKEN", b"value")
+
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            "INSERT INTO audit(ts, event, secret_id, session_id, pid, exe, outcome,"
+            " prev_hash, hash) VALUES(?, 'get', 'x', NULL, 1, NULL, 'ok', ?, ?)",
+            (1.0, b"\x00" * 32, b"\x11" * 32),
+        )
+
+    ok, position, message = store.verify_audit()
+    assert not ok
+    assert position == 2
+    assert "removed or reordered" in message
+
+
+def test_the_chain_survives_a_reopen(store: SecretStore) -> None:
+    """The chain is state on disk, not in the object; a new process continues it."""
+    store.set("TOKEN", b"value")
+    reopened = SecretStore(store._master_key, base=store.path.parent.parent)
+    reopened.get("TOKEN")
+    reopened.get("TOKEN")
+
+    ok, _, message = reopened.verify_audit()
+    assert ok, message
+    assert len(reopened.audit_entries()) == 3
+
+
+def test_a_rotation_is_recorded(store: SecretStore) -> None:
+    from local_operator.secrets.crypto import generate_master_key
+
+    store.set("TOKEN", b"value")
+    store.rotate(generate_master_key())
+
+    assert "rotate" in [entry.event for entry in store.audit_entries()]
+    ok, _, message = store.verify_audit()
+    assert ok, message

--- a/tests/unit/secrets/test_cli.py
+++ b/tests/unit/secrets/test_cli.py
@@ -1,0 +1,444 @@
+"""``lop secret`` end to end, asserting the EXACT bytes on stdout.
+
+The contract this file exists to defend: ``$(lop secret get NAME)`` must yield
+the value and nothing else. A banner, a colour code or a stray newline does not
+fail loudly — it corrupts a credential, which surfaces as a puzzling 401 from a
+remote service that nobody traces back to this command. So the assertions here
+are byte-equality on the real subprocess's stdout, not substring checks on a
+captured string.
+
+Real subprocesses rather than calling ``main()`` in-process, because that is
+the only way to catch the failure modes that matter: a library that prints a
+warning at import, a logging handler attached to stdout, the locale's codec
+mangling a non-ASCII value.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.fixture
+def cli(tmp_path: Path):
+    """Run ``lop secret ...`` in a fully isolated config dir.
+
+    Both ``HOME`` and ``LOCAL_OPERATOR_CONFIG_DIR`` are redirected per
+    `AGENTS.md`: the config override alone does not redirect the cache root,
+    and a test that writes into the operator's real home while believing it is
+    sandboxed is the documented hazard here.
+
+    ``CMUX_*`` is scrubbed for the reason the team's QA rules give: an
+    inherited ``CMUX_WORKSPACE_ID`` has previously let a headless test rename
+    the operator's real workspaces.
+    """
+    home = tmp_path / "home"
+    config = tmp_path / "config"
+    home.mkdir()
+    config.mkdir()
+
+    def run(*arguments: str, stdin: bytes | None = None) -> subprocess.CompletedProcess[bytes]:
+        environment = {
+            key: value for key, value in os.environ.items() if not key.startswith("CMUX_")
+        }
+        environment.update(
+            HOME=str(home),
+            LOCAL_OPERATOR_CONFIG_DIR=str(config),
+            PYTHONPATH=str(REPO_ROOT),
+            # Force a colour-capable terminal so a careless `print` that paints
+            # would actually emit escapes here. Asserting purity under NO_COLOR
+            # would prove nothing.
+            TERM="xterm-256color",
+        )
+        environment.pop("NO_COLOR", None)
+        return subprocess.run(
+            [sys.executable, "-m", "local_operator.cli", "secret", *arguments],
+            input=stdin,
+            capture_output=True,
+            env=environment,
+            timeout=120,
+        )
+
+    run.config = config  # type: ignore[attr-defined]
+    return run
+
+
+# --- the stdout purity contract ---------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(b"ghp_exampletoken1234567890", id="token"),
+        pytest.param(b"line one\nline two", id="newlines"),
+        pytest.param("s\u00e9cr\u00e8t-\u4f60\u597d-\U0001f510".encode(), id="unicode"),
+        pytest.param(b"trailing spaces   ", id="trailing-spaces"),
+        pytest.param(b"-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----", id="pem"),
+    ],
+)
+def test_get_writes_exactly_the_value_and_nothing_else(cli, value: bytes) -> None:
+    stored = cli("set", "TOKEN", stdin=value + b"\n")
+    assert stored.returncode == 0, stored.stderr
+
+    got = cli("get", "TOKEN")
+    assert got.returncode == 0, got.stderr
+    assert got.stdout == value, f"stdout was {got.stdout!r}, expected {value!r}"
+
+
+def test_get_adds_no_trailing_newline(cli) -> None:
+    """The single most likely corruption, called out explicitly.
+
+    ``$( )`` happens to strip a trailing newline, which is exactly why this is
+    easy to ship broken — every other consumer (``subprocess.check_output``, a
+    file redirect, a here-string) keeps it.
+    """
+    cli("set", "TOKEN", stdin=b"value\n")
+    got = cli("get", "TOKEN")
+    assert got.stdout == b"value"
+    assert not got.stdout.endswith(b"\n")
+
+
+def test_get_emits_no_ansi_escapes_on_a_colour_terminal(cli) -> None:
+    cli("set", "TOKEN", stdin=b"value\n")
+    got = cli("get", "TOKEN")
+    assert b"\x1b" not in got.stdout
+
+
+def test_a_100kb_value_survives_the_pipe(cli) -> None:
+    """Large values cross pipe buffer boundaries; a partial write would truncate."""
+    value = bytes(range(256)) * 400
+    # Only bytes that survive being written to stdin as-is; the CLI reads the
+    # raw buffer, so this is a genuine binary round trip through two pipes.
+    cli("set", "BIG", stdin=value + b"\n")
+    got = cli("get", "BIG")
+    assert len(got.stdout) == 102_400
+    assert got.stdout == value
+
+
+def test_command_substitution_yields_the_value(cli, tmp_path: Path) -> None:
+    """The documented usage, exercised through a real shell.
+
+    This is the assertion that matches how an agent actually calls it — the
+    whole feature is `$(lop secret get NAME)` interpolated into a command.
+    """
+    cli("set", "GITHUB_TOKEN", stdin=b"ghp_realtoken\n")
+    script = (
+        f'value="$({sys.executable} -m local_operator.cli secret get GITHUB_TOKEN)"; '
+        'printf "[%s]" "$value"'
+    )
+    environment = {key: value for key, value in os.environ.items() if not key.startswith("CMUX_")}
+    environment.update(
+        HOME=str(tmp_path / "home"),
+        LOCAL_OPERATOR_CONFIG_DIR=str(cli.config),
+        PYTHONPATH=str(REPO_ROOT),
+    )
+    result = subprocess.run(
+        ["bash", "-c", script], capture_output=True, env=environment, timeout=120
+    )
+    assert result.stdout == b"[ghp_realtoken]", result.stderr
+
+
+# --- list never prints values ------------------------------------------------
+
+
+def test_list_never_prints_a_value(cli) -> None:
+    cli("set", "ALPHA", "--description", "first", stdin=b"alpha-secret-value\n")
+    cli("set", "BETA", stdin=b"beta-secret-value\n")
+
+    listed = cli("list")
+    assert listed.returncode == 0, listed.stderr
+    assert b"ALPHA" in listed.stdout and b"BETA" in listed.stdout
+    assert b"alpha-secret-value" not in listed.stdout
+    assert b"beta-secret-value" not in listed.stdout
+    assert b"alpha-secret-value" not in listed.stderr
+    assert b"beta-secret-value" not in listed.stderr
+
+
+def test_list_json_never_carries_a_value_field(cli) -> None:
+    cli("set", "ALPHA", "--description", "first", stdin=b"alpha-secret-value\n")
+    listed = cli("list", "--json")
+    records = json.loads(listed.stdout)
+    assert [record["name"] for record in records] == ["ALPHA"]
+    assert "value" not in records[0]
+    assert b"alpha-secret-value" not in listed.stdout
+
+
+def test_describe_shows_metadata_but_no_value(cli) -> None:
+    cli("set", "TOKEN", "--description", "a note", stdin=b"the-secret-value\n")
+    described = cli("describe", "TOKEN")
+    assert b"a note" in described.stdout
+    assert b"the-secret-value" not in described.stdout
+
+
+def test_set_confirmation_does_not_echo_the_value(cli) -> None:
+    """The confirmation goes to stderr and names the size, never the bytes."""
+    stored = cli("set", "TOKEN", stdin=b"the-secret-value\n")
+    assert stored.stdout == b""
+    assert b"the-secret-value" not in stored.stderr
+    assert b"stored TOKEN" in stored.stderr
+
+
+# --- failure cases -----------------------------------------------------------
+
+
+def test_a_missing_secret_fails_with_empty_stdout(cli) -> None:
+    """Critical: a failed `get` must not put ANYTHING on stdout.
+
+    ``$(lop secret get ABSENT)`` assigning an error message to a variable that
+    is then sent to an API is precisely the corruption this guards.
+    """
+    cli("set", "PRESENT", stdin=b"value\n")
+    got = cli("get", "ABSENT")
+    assert got.returncode == 2
+    assert got.stdout == b""
+    assert b"No secret named" in got.stderr
+
+
+def test_a_missing_store_fails_with_empty_stdout(cli) -> None:
+    got = cli("get", "ANYTHING")
+    assert got.returncode != 0
+    assert got.stdout == b""
+    assert b"No secret store found" in got.stderr
+
+
+def test_a_corrupted_record_fails_with_empty_stdout(cli) -> None:
+    """Fail closed all the way out to the process boundary."""
+    import sqlite3
+
+    cli("set", "TOKEN", stdin=b"value\n")
+    database = Path(cli.config) / "secrets" / "store.db"
+    with sqlite3.connect(database) as connection:
+        connection.execute("UPDATE secrets SET kind = 'file'")
+
+    got = cli("get", "TOKEN")
+    assert got.returncode == 2
+    assert got.stdout == b""
+    assert b"failed authentication" in got.stderr
+
+
+def test_loosened_permissions_are_reported_and_stdout_stays_empty(cli) -> None:
+    if os.name == "nt":
+        pytest.skip("POSIX modes only")
+    cli("set", "TOKEN", stdin=b"value\n")
+    os.chmod(Path(cli.config) / "secrets" / "master.key", 0o644)
+
+    got = cli("get", "TOKEN")
+    assert got.returncode == 2
+    assert got.stdout == b""
+    assert b"must not be readable by group or others" in got.stderr
+
+
+def test_set_refuses_an_existing_name(cli) -> None:
+    cli("set", "TOKEN", stdin=b"first\n")
+    again = cli("set", "TOKEN", stdin=b"second\n")
+    assert again.returncode == 2
+    assert b"already exists" in again.stderr
+    assert cli("get", "TOKEN").stdout == b"first"
+
+
+def test_there_is_no_value_flag(cli) -> None:
+    """argv is readable by any same-uid process, so a --value flag must not exist."""
+    result = cli("set", "TOKEN", "--value", "leaked-on-the-command-line")
+    assert result.returncode != 0
+    assert b"unrecognized arguments" in result.stderr or b"--value" in result.stderr
+
+
+def test_rm_without_yes_refuses_when_stdin_is_not_a_terminal(cli) -> None:
+    cli("set", "TOKEN", stdin=b"value\n")
+    removed = cli("rm", "TOKEN", stdin=b"")
+    assert removed.returncode == 2
+    assert b"--yes" in removed.stderr
+    assert cli("get", "TOKEN").stdout == b"value"
+
+
+def test_rm_with_yes_deletes(cli) -> None:
+    cli("set", "TOKEN", stdin=b"value\n")
+    removed = cli("rm", "TOKEN", "--yes", stdin=b"")
+    assert removed.returncode == 0
+    assert cli("get", "TOKEN").returncode == 2
+
+
+# --- other verbs -------------------------------------------------------------
+
+
+def test_update_replaces_the_value(cli) -> None:
+    cli("set", "TOKEN", stdin=b"first\n")
+    updated = cli("update", "TOKEN", stdin=b"second\n")
+    assert updated.returncode == 0
+    assert cli("get", "TOKEN").stdout == b"second"
+
+
+def test_status_reports_keyfile_mode_without_overclaiming(cli) -> None:
+    """The honesty requirement, asserted as a test.
+
+    Design §9 is explicit that this must not be described as a vault, and
+    status is where an operator forms their mental model. The note must state
+    the residual risk.
+    """
+    cli("set", "TOKEN", stdin=b"value\n")
+    status = cli("status")
+    assert status.returncode == 0
+    assert b"keyfile" in status.stdout
+    assert b"does not " in status.stdout and b"key file" in status.stdout
+    for overclaim in (b"vault", b"unbreakable", b"military", b"impossible"):
+        assert overclaim not in status.stdout.lower()
+
+
+def test_status_json_is_parseable(cli) -> None:
+    cli("set", "TOKEN", stdin=b"value\n")
+    status = cli("status", "--json")
+    payload = json.loads(status.stdout)
+    assert payload["key_mode"] == "keyfile"
+    assert payload["secrets"] == 1
+    assert payload["audit_ok"] is True
+
+
+def test_audit_verify_reports_an_intact_chain(cli) -> None:
+    cli("set", "TOKEN", stdin=b"value\n")
+    cli("get", "TOKEN")
+    verified = cli("audit", "--verify")
+    assert verified.returncode == 0
+    assert b"intact" in verified.stdout
+
+
+def test_audit_verify_detects_an_edit(cli) -> None:
+    import sqlite3
+
+    cli("set", "TOKEN", stdin=b"value\n")
+    cli("get", "TOKEN")
+    cli("get", "TOKEN")
+    database = Path(cli.config) / "secrets" / "store.db"
+    with sqlite3.connect(database) as connection:
+        connection.execute("UPDATE audit SET event = 'list' WHERE rowid = 2")
+
+    verified = cli("audit", "--verify")
+    assert verified.returncode == 1
+    assert b"broken at entry 2" in verified.stdout
+
+
+def test_rotate_preserves_values(cli) -> None:
+    cli("set", "ALPHA", stdin=b"alpha-value\n")
+    cli("set", "BETA", stdin=b"beta-value\n")
+    rotated = cli("rotate")
+    assert rotated.returncode == 0, rotated.stderr
+    assert cli("get", "ALPHA").stdout == b"alpha-value"
+    assert cli("get", "BETA").stdout == b"beta-value"
+
+
+def test_run_exports_the_secret_to_the_child(cli) -> None:
+    cli("set", "API_KEY", stdin=b"key-value\n")
+    result = cli("run", "--secret", "API_KEY", "--", "bash", "-c", 'printf "[%s]" "$API_KEY"')
+    assert result.stdout == b"[key-value]", result.stderr
+
+
+def test_run_can_rename_the_variable(cli) -> None:
+    cli("set", "API_KEY", stdin=b"key-value\n")
+    result = cli(
+        "run", "--secret", "API_KEY=OTHER_NAME", "--", "bash", "-c", 'printf "[%s]" "$OTHER_NAME"'
+    )
+    assert result.stdout == b"[key-value]"
+
+
+def test_file_materialises_a_readable_path_and_removes_it(cli) -> None:
+    """§7's mechanism: a real, re-openable file that is gone afterwards."""
+    cli("set", "SA_JSON", "--kind", "file", stdin=b'{"type":"service_account"}\n')
+    script = (
+        'printf "[%s]" "$(cat "$GOOGLE_APPLICATION_CREDENTIALS")"; '
+        # Re-open it: the design rejected FIFOs and /dev/fd because a second
+        # open reads zero bytes there, and google-auth opens more than once.
+        'printf "[%s]" "$(cat "$GOOGLE_APPLICATION_CREDENTIALS")"; '
+        'printf "%s" "$GOOGLE_APPLICATION_CREDENTIALS" > /tmp/lop-secret-path-probe'
+    )
+    result = cli("file", "SA_JSON", "--", "bash", "-c", script)
+    assert result.stdout == b'[{"type":"service_account"}][{"type":"service_account"}]'
+
+    leaked = Path("/tmp/lop-secret-path-probe")
+    try:
+        materialised = Path(leaked.read_text())
+        assert not materialised.exists(), "the plaintext file outlived the command"
+        assert not materialised.parent.exists(), "the private directory was not removed"
+    finally:
+        leaked.unlink(missing_ok=True)
+
+
+def test_file_uses_a_custom_env_var(cli) -> None:
+    cli("set", "CERT", "--kind", "file", stdin=b"cert-body\n")
+    result = cli(
+        "file",
+        "CERT",
+        "--env-var",
+        "SSL_CERT_FILE",
+        "--",
+        "bash",
+        "-c",
+        'printf "[%s]" "$(cat "$SSL_CERT_FILE")"',
+    )
+    assert result.stdout == b"[cert-body]"
+
+
+def test_our_own_flags_survive_before_the_command_separator(cli) -> None:
+    """Regression: ``argparse.REMAINDER`` swallowed the flags before ``--``.
+
+    With REMAINDER, ``file NAME --env-var VAR -- cmd`` parsed ``--env-var`` as
+    part of the child command and silently fell back to the default variable
+    name, so the child saw an unset variable. The failure was silent — the
+    command ran, and only the wrong variable was set — which is why this is
+    pinned for both verbs.
+    """
+    cli("set", "CERT", "--kind", "file", stdin=b"cert-body\n")
+    cli("set", "API_KEY", stdin=b"key-value\n")
+
+    filed = cli(
+        "file",
+        "CERT",
+        "--env-var",
+        "SSL_CERT_FILE",
+        "--",
+        "bash",
+        "-c",
+        'printf "[%s][%s]" "$SSL_CERT_FILE" "$GOOGLE_APPLICATION_CREDENTIALS"',
+    )
+    assert filed.stdout.endswith(b"[]"), "the default variable was set instead"
+    assert filed.stdout != b"[][]"
+
+    ran = cli(
+        "run",
+        "--secret",
+        "API_KEY=RENAMED",
+        "--",
+        "bash",
+        "-c",
+        'printf "[%s][%s]" "$RENAMED" "$API_KEY"',
+    )
+    assert ran.stdout == b"[key-value][]"
+
+
+def test_child_command_flags_after_the_separator_are_preserved(cli) -> None:
+    """The other half: the child's own flags must reach it untouched."""
+    cli("set", "API_KEY", stdin=b"key-value\n")
+    result = cli("run", "--secret", "API_KEY", "--", "bash", "-c", 'printf -- "-n [%s]" "$API_KEY"')
+    assert result.stdout == b"-n [key-value]", result.stderr
+
+
+def test_harden_and_unlock_report_the_missing_broker_honestly(cli) -> None:
+    """They must not pretend to succeed — see access.py's module docstring."""
+    for verb in ("harden", "unlock"):
+        result = cli(verb)
+        assert result.returncode == 2
+        assert b"needs the secret broker" in result.stderr
+        assert result.stdout == b""
+
+
+def test_secret_help_does_not_promise_a_vault(cli) -> None:
+    """CLI help is documentation; §9 forbids overclaiming there too."""
+    helped = cli("--help")
+    text = helped.stdout.lower()
+    for overclaim in (b"vault", b"unbreakable", b"military-grade", b"hacker-proof"):
+        assert overclaim not in text

--- a/tests/unit/secrets/test_cli.py
+++ b/tests/unit/secrets/test_cli.py
@@ -236,7 +236,14 @@ def test_loosened_permissions_are_reported_and_stdout_stays_empty(cli) -> None:
 
 
 def test_set_refuses_an_existing_name(cli) -> None:
-    cli("set", "TOKEN", stdin=b"first\n")
+    first = cli("set", "TOKEN", stdin=b"first\n")
+    # Asserted explicitly so a failure of the FIRST set is attributable. QA saw
+    # this test fail once as `assert 0 == 2` — the second set succeeding, which
+    # means the first set's row was absent — and could not reproduce it in ~250
+    # attempts. Without this line the symptom is laundered into a confusing
+    # assertion about the second command; with it, the next occurrence names
+    # itself.
+    assert first.returncode == 0, f"the FIRST set failed: rc={first.returncode} {first.stderr!r}"
     again = cli("set", "TOKEN", stdin=b"second\n")
     assert again.returncode == 2
     assert b"already exists" in again.stderr
@@ -346,26 +353,30 @@ def test_run_can_rename_the_variable(cli) -> None:
     assert result.stdout == b"[key-value]"
 
 
-def test_file_materialises_a_readable_path_and_removes_it(cli) -> None:
-    """§7's mechanism: a real, re-openable file that is gone afterwards."""
+def test_file_materialises_a_readable_path_and_removes_it(cli, tmp_path: Path) -> None:
+    """§7's mechanism: a real, re-openable file that is gone afterwards.
+
+    The probe path is under ``tmp_path`` and NOT a fixed ``/tmp`` name. A
+    shared path made this test delete a concurrent run's probe on a machine
+    that is explicitly worked through many worktrees at once: four simultaneous
+    invocations reproducibly gave two passes and two ``FileNotFoundError``
+    failures, which the next agent has to diagnose from scratch.
+    """
     cli("set", "SA_JSON", "--kind", "file", stdin=b'{"type":"service_account"}\n')
+    probe = tmp_path / "materialised-path"
     script = (
         'printf "[%s]" "$(cat "$GOOGLE_APPLICATION_CREDENTIALS")"; '
         # Re-open it: the design rejected FIFOs and /dev/fd because a second
         # open reads zero bytes there, and google-auth opens more than once.
         'printf "[%s]" "$(cat "$GOOGLE_APPLICATION_CREDENTIALS")"; '
-        'printf "%s" "$GOOGLE_APPLICATION_CREDENTIALS" > /tmp/lop-secret-path-probe'
+        f'printf "%s" "$GOOGLE_APPLICATION_CREDENTIALS" > "{probe}"'
     )
     result = cli("file", "SA_JSON", "--", "bash", "-c", script)
     assert result.stdout == b'[{"type":"service_account"}][{"type":"service_account"}]'
 
-    leaked = Path("/tmp/lop-secret-path-probe")
-    try:
-        materialised = Path(leaked.read_text())
-        assert not materialised.exists(), "the plaintext file outlived the command"
-        assert not materialised.parent.exists(), "the private directory was not removed"
-    finally:
-        leaked.unlink(missing_ok=True)
+    materialised = Path(probe.read_text())
+    assert not materialised.exists(), "the plaintext file outlived the command"
+    assert not materialised.parent.exists(), "the private directory was not removed"
 
 
 def test_file_uses_a_custom_env_var(cli) -> None:

--- a/tests/unit/secrets/test_compatibility.py
+++ b/tests/unit/secrets/test_compatibility.py
@@ -1,0 +1,101 @@
+"""Version skew must be refused with a clear message, never mis-parsed.
+
+Design §13: the operator runs ~10 sessions and updates the runtime with
+`lop-update` while they are live, so an older runtime meeting a newer store is
+routine rather than exceptional. The failure mode being prevented is not a
+crash — it is an older runtime reading a record layout it half-understands and
+returning something plausible.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from local_operator.secrets.crypto import RECORD_FORMAT_VERSION
+from local_operator.secrets.errors import IncompatibleStore
+from local_operator.secrets.store import SCHEMA_VERSION, SecretStore
+
+
+def test_a_newer_schema_version_is_refused_on_read(store: SecretStore) -> None:
+    store.set("TOKEN", b"value")
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            "UPDATE meta SET v = ? WHERE k = 'schema_version'",
+            (str(SCHEMA_VERSION + 1).encode("ascii"),),
+        )
+
+    with pytest.raises(IncompatibleStore, match="newer local-operator"):
+        store.get("TOKEN")
+
+
+def test_a_newer_schema_version_is_refused_on_write(store: SecretStore) -> None:
+    """Refusing to WRITE is the important half: a downward migration is
+    unrecoverable, and a newer runtime's records must not be clobbered."""
+    store.set("TOKEN", b"value")
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            "UPDATE meta SET v = ? WHERE k = 'schema_version'",
+            (str(SCHEMA_VERSION + 5).encode("ascii"),),
+        )
+
+    with pytest.raises(IncompatibleStore, match="upgrade this runtime"):
+        store.update("TOKEN", b"new-value")
+    with pytest.raises(IncompatibleStore):
+        store.set("OTHER", b"value")
+
+
+def test_the_message_names_the_versions_and_the_fix(store: SecretStore) -> None:
+    """A version error the operator cannot act on is barely better than a crash."""
+    store.set("TOKEN", b"value")
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            "UPDATE meta SET v = ? WHERE k = 'schema_version'",
+            (str(SCHEMA_VERSION + 1).encode("ascii"),),
+        )
+
+    with pytest.raises(IncompatibleStore) as caught:
+        store.list()
+    message = str(caught.value)
+    assert str(SCHEMA_VERSION + 1) in message
+    assert str(SCHEMA_VERSION) in message
+    assert "lop update" in message
+
+
+def test_a_newer_record_format_is_refused(store: SecretStore) -> None:
+    """Per-record, not just per-store.
+
+    §13 requires records to carry their own format version so a partially
+    migrated store stays coherent. A record from the future is refused
+    individually rather than being decoded under this runtime's assumptions.
+    """
+    store.set("TOKEN", b"value")
+    with sqlite3.connect(store.path) as connection:
+        connection.execute("UPDATE secrets SET format_version = ?", (RECORD_FORMAT_VERSION + 1,))
+
+    with pytest.raises(IncompatibleStore, match="record format"):
+        store.get("TOKEN")
+
+
+def test_an_older_schema_version_is_also_refused(store: SecretStore) -> None:
+    """No silent upward migration either.
+
+    Not because the operator will hit it today — this is schema 1 — but because
+    the moment schema 2 exists, "read an old store" must be a deliberate
+    migration someone wrote, not an accident of tolerant parsing.
+    """
+    store.set("TOKEN", b"value")
+    with sqlite3.connect(store.path) as connection:
+        connection.execute("UPDATE meta SET v = ? WHERE k = 'schema_version'", (b"0",))
+
+    with pytest.raises(IncompatibleStore, match="older local-operator"):
+        store.get("TOKEN")
+
+
+def test_a_missing_store_reports_how_to_create_one(config_root) -> None:
+    from local_operator.secrets.errors import SecretStoreError
+
+    store = SecretStore(b"\x00" * 32, base=config_root)
+    with pytest.raises(SecretStoreError, match="lop secret set"):
+        store.get("TOKEN")

--- a/tests/unit/secrets/test_concurrency.py
+++ b/tests/unit/secrets/test_concurrency.py
@@ -1,0 +1,183 @@
+"""Ten readers and a writer against one store, for real.
+
+The operator runs ~10 lop sessions at once, so this is the store's actual
+steady state rather than a stress scenario. The design measured 10 concurrent
+readers doing 60 decrypts each against a live writer at 21 ms with zero errors;
+these tests re-run that shape so a change to the pragmas — dropping WAL, or
+removing ``busy_timeout`` — shows up as ``database is locked`` here rather than
+as an intermittent failure in the operator's session a week later.
+
+Both a THREAD version and a PROCESS version, because they catch different
+things. Threads share one SQLite library instance and exercise the Python-level
+connection handling; separate processes are the real deployment shape and are
+the only way to exercise the cross-process file locking that WAL actually
+depends on.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+from local_operator.secrets.crypto import generate_master_key
+from local_operator.secrets.store import SecretStore
+
+READERS = 10
+READS_EACH = 60
+
+
+def test_ten_threads_read_while_one_writes(store: SecretStore) -> None:
+    """No errors, no corruption, every read returns a valid value."""
+    store.set("SHARED", b"shared-value")
+    store.set("CHURN", b"initial")
+
+    errors: list[BaseException] = []
+
+    def reader() -> int:
+        count = 0
+        try:
+            for _ in range(READS_EACH):
+                assert store.get("SHARED") == b"shared-value"
+                count += 1
+        except BaseException as exc:  # noqa: BLE001 - recorded and re-raised below
+            errors.append(exc)
+        return count
+
+    def writer() -> int:
+        count = 0
+        try:
+            for index in range(READS_EACH):
+                store.update("CHURN", f"value-{index}".encode())
+                count += 1
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+        return count
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=READERS + 1) as pool:
+        futures = [pool.submit(reader) for _ in range(READERS)]
+        futures.append(pool.submit(writer))
+        counts = [future.result() for future in futures]
+
+    assert not errors, f"concurrent access raised: {errors[:3]}"
+    assert counts == [READS_EACH] * (READERS + 1)
+    # The store is still coherent afterwards, which is the corruption check
+    # that matters: every record still authenticates.
+    assert store.get("SHARED") == b"shared-value"
+    assert store.get("CHURN") == f"value-{READS_EACH - 1}".encode()
+    assert len(store.list()) == 2
+
+
+_WORKER = textwrap.dedent("""
+    import sys
+    from pathlib import Path
+    from local_operator.secrets.store import SecretStore
+
+    base = Path(sys.argv[1])
+    key = bytes.fromhex(sys.argv[2])
+    role = sys.argv[3]
+    reads = int(sys.argv[4])
+
+    store = SecretStore(key, base=base)
+    if role == "reader":
+        for _ in range(reads):
+            assert store.get("SHARED") == b"shared-value", "wrong value"
+    else:
+        for index in range(reads):
+            store.update("CHURN", f"value-{index}".encode())
+    print("OK")
+    """)
+
+
+def test_ten_processes_read_while_one_writes(config_root: Path, tmp_path: Path) -> None:
+    """The real deployment shape: separate processes, real file locking.
+
+    A thread test cannot fail the way ten `lop` sessions fail, because threads
+    in one process share SQLite's connection cache and its internal mutexes.
+    This spawns actual interpreters against one store file — the case WAL's
+    cross-process locking exists for.
+    """
+    key = generate_master_key()
+    store = SecretStore(key, base=config_root)
+    store.set("SHARED", b"shared-value")
+    store.set("CHURN", b"initial")
+
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = str(Path(__file__).resolve().parents[3])
+    arguments = [str(config_root), key.hex()]
+    processes = [
+        subprocess.Popen(
+            [sys.executable, "-c", _WORKER, *arguments, "reader", str(READS_EACH)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=environment,
+        )
+        for _ in range(READERS)
+    ]
+    processes.append(
+        subprocess.Popen(
+            [sys.executable, "-c", _WORKER, *arguments, "writer", str(READS_EACH)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=environment,
+        )
+    )
+
+    failures = []
+    for process in processes:
+        stdout, stderr = process.communicate(timeout=180)
+        if process.returncode != 0 or "OK" not in stdout:
+            failures.append((process.returncode, stderr[-800:]))
+
+    assert not failures, f"{len(failures)} of {len(processes)} workers failed: {failures[:2]}"
+    assert store.get("SHARED") == b"shared-value"
+    assert len(store.list()) == 2
+
+
+def test_concurrent_writers_do_not_lose_records(config_root: Path) -> None:
+    """Ten processes each storing a distinct secret; all ten must survive.
+
+    Last-writer-wins on the same row would be one bug; losing whole rows to an
+    unserialised transaction is the one this catches. ``BEGIN IMMEDIATE`` plus
+    ``busy_timeout`` is what makes the insert-after-existence-check atomic.
+    """
+    key = generate_master_key()
+    SecretStore(key, base=config_root).initialize()
+
+    writer = textwrap.dedent("""
+        import sys
+        from pathlib import Path
+        from local_operator.secrets.store import SecretStore
+        store = SecretStore(bytes.fromhex(sys.argv[2]), base=Path(sys.argv[1]))
+        store.set(f"SECRET_{sys.argv[3]}", f"value-{sys.argv[3]}".encode())
+        print("OK")
+        """)
+    environment = dict(os.environ)
+    environment["PYTHONPATH"] = str(Path(__file__).resolve().parents[3])
+    processes = [
+        subprocess.Popen(
+            [sys.executable, "-c", writer, str(config_root), key.hex(), str(index)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=environment,
+        )
+        for index in range(READERS)
+    ]
+    failures = []
+    for process in processes:
+        stdout, stderr = process.communicate(timeout=180)
+        if process.returncode != 0:
+            failures.append(stderr[-800:])
+
+    assert not failures, f"writers failed: {failures[:2]}"
+    store = SecretStore(key, base=config_root)
+    names = {record.name for record in store.list()}
+    assert names == {f"SECRET_{index}" for index in range(READERS)}
+    for index in range(READERS):
+        assert store.get(f"SECRET_{index}") == f"value-{index}".encode()

--- a/tests/unit/secrets/test_key_lifecycle.py
+++ b/tests/unit/secrets/test_key_lifecycle.py
@@ -20,12 +20,17 @@ from __future__ import annotations
 
 import concurrent.futures
 import sqlite3
+import threading
 from pathlib import Path
 
 import pytest
 
 from local_operator.secrets.access import resolve_master_key
-from local_operator.secrets.crypto import generate_master_key, key_fingerprint
+from local_operator.secrets.crypto import (
+    KEY_BYTES,
+    generate_master_key,
+    key_fingerprint,
+)
 from local_operator.secrets.errors import SecretCorrupt, SecretStoreError, StaleKeyEpoch
 from local_operator.secrets.keys import (
     discard_staged_master_key,
@@ -513,3 +518,176 @@ def test_a_crash_at_any_rotation_step_survives_a_concurrent_rotation(
 
     # Power cut. A brand new process must still open the store.
     assert _open_knowing_only_the_disk(config_root) == b"super-secret-value"
+
+
+# --- R3: concurrent FIRST USE must converge on one key, not brick ------------
+#
+# The invariants above all assume a store that already EXISTS. Creating it was
+# the same last-writer-wins shape on `master.key` itself: an `exists()` check
+# followed by an unguarded write to a fixed path, so every concurrent first-use
+# caller generated its own key, wrote it, and returned the key it had generated
+# — all but one of them going on to seal a database under a key that was no
+# longer on disk. It survived the round-2 sibling sweep because
+# `write_private_file`'s docstring CLAIMED `O_EXCL` while the code passed
+# `O_TRUNC`, so the site read as guarded.
+#
+# Not a corner case on this machine: the operator runs ~11 sessions at once and
+# the store is created by whichever of them first writes a secret.
+#
+# THE BARRIER IS A `threading.Barrier`, NOT A CLOCK. Real timing cannot pin
+# this: arrival spread across 12 real processes measured 187 ms against a race
+# window microseconds wide, so a wall-clock harness reports a clean run against
+# provably broken code (it did — 0/24 at a base that bricks 4/4 under a forced
+# interleave). The barrier only DELAYS the call; every line of logic under test
+# runs unmodified.
+
+FIRST_USE_CALLERS = 12
+
+
+def _first_use_racers(
+    base: Path, callers: int, monkeypatch: pytest.MonkeyPatch
+) -> tuple[list[str], list[str]]:
+    """Run ``callers`` first uses released together; return (keys, errors).
+
+    The hook sits on ``generate_master_key``, which ``load_master_key`` calls
+    precisely between its existence check and its write — the window in
+    question. ``monkeypatch`` undoes it even if the barrier times out.
+    """
+    import local_operator.secrets.keys as keys_module
+
+    original = keys_module.generate_master_key
+    barrier = threading.Barrier(callers, timeout=60)
+
+    def gated() -> bytes:
+        barrier.wait()
+        return original()
+
+    monkeypatch.setattr(keys_module, "generate_master_key", gated)
+
+    keys: list[str] = []
+    errors: list[str] = []
+
+    def worker() -> str:
+        return load_master_key(base, create=True).hex()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=callers) as pool:
+        futures = [pool.submit(worker) for _ in range(callers)]
+        for future in futures:
+            try:
+                keys.append(future.result())
+            except BaseException as exc:  # noqa: BLE001 - asserted on by callers
+                errors.append(f"{type(exc).__name__}: {exc}")
+
+    # A run where the barrier never engaged discriminates nothing. Every caller
+    # must have passed through the hook, or the result is not evidence.
+    assert barrier.broken is False or not errors, "the barrier timed out; run proves nothing"
+    return keys, errors
+
+
+def test_concurrent_first_use_converges_on_one_key(
+    config_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every caller creating the store at once must end up on the SAME key.
+
+    The property is not "one caller wins" — it is that the LOSERS ADOPT the
+    winner's key instead of returning their own. A loser keeping its own key
+    seals its records under a key that is not on disk: the write reports
+    success and the value is unreadable forever after. Measured before the fix
+    at 10 of 12 callers holding a key the file did not have.
+    """
+    keys, errors = _first_use_racers(config_root, FIRST_USE_CALLERS, monkeypatch)
+
+    assert not errors, f"concurrent first use raised: {errors[:2]}"
+    on_disk = key_path(config_root).read_bytes()
+    assert len(on_disk) == KEY_BYTES, f"key file is {len(on_disk)} bytes, not a key"
+    assert set(keys) == {on_disk.hex()}, (
+        f"{len(set(keys))} distinct keys returned by {FIRST_USE_CALLERS} concurrent "
+        "callers; every caller but one would seal its records under a lost key"
+    )
+
+
+def test_a_crash_while_creating_the_key_leaves_no_unusable_store(
+    config_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A crash mid-creation must leave NOTHING, not a permanent 0-byte key.
+
+    This is why creation is write-temp-then-``os.link`` rather than the
+    one-line ``O_EXCL``. ``O_EXCL`` does pick a single winner, but it publishes
+    the path at CREATION and fills it afterwards, so the file exists and is
+    empty for the length of the write. Two costs, both measured here: a
+    concurrent loser re-reads and gets ``master.key is 0 bytes; the key file is
+    damaged`` instead of the winner's key, and — far worse — a crash inside
+    that window leaves that 0-byte file behind FOREVER. Nothing ever creates
+    the key again (it exists), and every later run fails the length check, so
+    an interrupted first use permanently bricks the store.
+
+    Simulated at the exact window: the payload write fails after the file would
+    have been published. Recovery is the assertion — the next ordinary first
+    use must succeed and produce a whole key.
+    """
+    import local_operator.secrets.keys as keys_module
+
+    real_write = keys_module.write_private_file
+    calls: list[Path] = []
+
+    def crashing_write(path: Path, data: bytes) -> None:
+        # Create the file the way the real writer does, then die mid-payload.
+        calls.append(path)
+        raise OSError("simulated power cut while writing the key")
+
+    monkeypatch.setattr(keys_module, "write_private_file", crashing_write)
+    with pytest.raises(OSError):
+        load_master_key(config_root, create=True)
+    monkeypatch.setattr(keys_module, "write_private_file", real_write)
+
+    assert calls, "the crash hook never fired; this run proves nothing"
+    # The crash must not have published anything under the final name.
+    assert not key_path(config_root).exists(), (
+        "a crash during creation left a master.key behind; if it is short, "
+        "every later run fails the length check and the store is unopenable"
+    )
+
+    # The real assertion: first use still works afterwards.
+    recovered = load_master_key(config_root, create=True)
+    assert len(recovered) == KEY_BYTES
+    assert recovered == key_path(config_root).read_bytes()
+    leftovers = sorted(path.name for path in (config_root / "secrets").glob("master.key.*"))
+    assert leftovers == [], f"creation temporaries were left behind: {leftovers}"
+
+
+def test_a_store_created_concurrently_is_readable_afterwards(
+    config_root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The consequence the operator actually feels: the records survive.
+
+    The key-identity assertions are the mechanism; this is the loss. Each
+    caller stores a secret under the key its own first use returned, and every
+    committed record must then be readable by a process that knows only what is
+    on disk — the migration ahead is 58 credentials onto a store that does not
+    yet exist.
+    """
+    keys, errors = _first_use_racers(config_root, FIRST_USE_CALLERS, monkeypatch)
+    assert not errors, f"concurrent first use raised: {errors[:2]}"
+
+    stored = 0
+    for index, key in enumerate(keys):
+        store = SecretStore(bytes.fromhex(key), base=config_root)
+        store.initialize()
+        try:
+            store.set(f"SECRET_{index}", f"value-{index}".encode())
+            stored += 1
+        except StaleKeyEpoch:
+            # An honest refusal is not a brick: nothing was committed and the
+            # CLI tells the caller to re-run. A SILENT success under a lost key
+            # is the failure this test exists for.
+            pass
+
+    assert stored, "no caller managed to store anything"
+    reader = SecretStore(resolve_master_key(config_root), base=config_root)
+    for record in reader.list():
+        index = record.name.rsplit("_", 1)[1]
+        assert reader.get(record.name) == f"value-{index}".encode(), (
+            f"{record.name} reported success and is unreadable: it was sealed "
+            "under a key that is not the store's"
+        )
+    assert reader.damaged_records() == [], "the concurrently created store has damaged rows"

--- a/tests/unit/secrets/test_key_lifecycle.py
+++ b/tests/unit/secrets/test_key_lifecycle.py
@@ -28,11 +28,12 @@ from local_operator.secrets.access import resolve_master_key
 from local_operator.secrets.crypto import generate_master_key, key_fingerprint
 from local_operator.secrets.errors import SecretCorrupt, SecretStoreError, StaleKeyEpoch
 from local_operator.secrets.keys import (
+    discard_staged_master_key,
     key_path,
     load_master_key,
     replace_master_key,
     stage_master_key,
-    staged_key_path,
+    staged_key_paths,
 )
 from local_operator.secrets.store import SecretStore
 
@@ -236,12 +237,12 @@ def test_an_interrupted_rotation_completes_the_key_install(config_root: Path) ->
 
     new_key = generate_master_key()
     _rotate_to_step(config_root, key, new_key, 2)  # crash before the install
-    assert staged_key_path(config_root).exists()
+    assert staged_key_paths(config_root)
     assert key_path(config_root).read_bytes() == key  # still the OLD key
 
     assert resolve_master_key(config_root) == new_key
     assert key_path(config_root).read_bytes() == new_key
-    assert not staged_key_path(config_root).exists(), "the staged key was not cleared"
+    assert not staged_key_paths(config_root), "the staged key was not cleared"
 
 
 def test_a_stale_staged_key_is_never_adopted(config_root: Path) -> None:
@@ -330,3 +331,185 @@ def test_a_damaged_record_is_reported_as_corrupt_by_get(store: SecretStore) -> N
     _damage_one_row(store, "BROKEN")
     with pytest.raises(SecretCorrupt):
         store.get("BROKEN")
+
+
+# --- R2 under CONCURRENCY: the staged key is per-rotation --------------------
+#
+# The crash matrix above proves the R2 invariant for ONE rotator. That control
+# passed while the invariant was in fact broken, because every rotation staged
+# its key at the same fixed filename: a second rotator's staging replaced the
+# first's, and a losing rotator's discard deleted the winner's. The tests below
+# are the concurrent case the matrix was missing. Each asserts the same
+# property as the matrix — after a power cut, some key on disk still opens the
+# store — with more than one rotation in flight.
+
+
+def _seed_store(base: Path, value: bytes = b"super-secret-value") -> bytes:
+    """An initialised single-record store; returns its master key."""
+    key = load_master_key(base, create=True)
+    store = SecretStore(key, base=base)
+    store.initialize()
+    store.set("ALPHA", value)
+    return key
+
+
+def _open_knowing_only_the_disk(base: Path) -> bytes:
+    """What a brand new process recovers, given only what is on disk."""
+    return SecretStore(resolve_master_key(base), base=base).get("ALPHA")
+
+
+def test_a_second_rotation_does_not_clobber_a_committed_rotations_staged_key(
+    config_root: Path,
+) -> None:
+    """B staging must not destroy the key A's committed database needs.
+
+    The interleave: A stages and COMMITS, so the database is now sealed under
+    A's key and the staged file is the only copy of it on disk. B then stages
+    its own key, and A is killed before it can install. With one shared staging
+    filename B's write replaced A's key and the store was unrecoverable — an
+    ordinary power cut, no adversary, losing every secret. Making that write
+    atomic does not help: an atomic clobber is still a clobber, which is why
+    the fix is a name unique per rotation rather than a safer write.
+    """
+    key = _seed_store(config_root)
+    a_key = generate_master_key()
+    b_key = generate_master_key()
+
+    stage_master_key(config_root, a_key)
+    SecretStore(key, base=config_root).rotate(a_key)  # A COMMITS
+    stage_master_key(config_root, b_key)  # B stages alongside, must not clobber
+    # A is killed here, before replace_master_key: power cut in the window.
+
+    assert _open_knowing_only_the_disk(config_root) == b"super-secret-value"
+
+
+def test_a_losing_rotation_does_not_discard_the_winners_staged_key(
+    config_root: Path,
+) -> None:
+    """The loser's cleanup must not delete a key that is not its own.
+
+    Two rotations race; the epoch guard makes exactly one win. The loser then
+    cleans up its staged key — and with an unconditional unlink of one fixed
+    path it deleted the WINNER's staged key instead. If the winner had already
+    committed and not yet installed, that cleanup removed the only on-disk copy
+    of the key the database needed, so a crash there lost the store.
+    """
+    key = _seed_store(config_root)
+    a_key = generate_master_key()
+    b_key = generate_master_key()
+
+    loser = SecretStore(key, base=config_root)  # opened under the pre-rotation key
+    stage_master_key(config_root, a_key)
+    SecretStore(key, base=config_root).rotate(a_key)  # A COMMITS, wins the epoch
+
+    stage_master_key(config_root, b_key)
+    with pytest.raises(StaleKeyEpoch):
+        loser.rotate(b_key)
+    discard_staged_master_key(config_root, b_key)  # loser cleans up after itself
+
+    # The winner's staged key is still the only copy of the database's key.
+    assert staged_key_paths(config_root), "the winner's staged key was deleted"
+    # A is killed here, before replace_master_key.
+    assert _open_knowing_only_the_disk(config_root) == b"super-secret-value"
+
+
+def test_discarding_a_staged_key_removes_only_that_rotations_own_copy(
+    config_root: Path,
+) -> None:
+    """Ownership is checked by content, so cleanup is precise, not merely safe.
+
+    Both halves matter: the discard must leave other rotations' keys alone AND
+    must still remove its own, or "never delete anything" would pass the test
+    above while leaving key material on disk forever.
+    """
+    _seed_store(config_root)
+    mine = generate_master_key()
+    theirs = generate_master_key()
+    my_path = stage_master_key(config_root, mine)
+    their_path = stage_master_key(config_root, theirs)
+
+    discard_staged_master_key(config_root, mine)
+
+    assert not my_path.exists(), "the caller's own staged key was left behind"
+    assert their_path.exists(), "another rotation's staged key was removed"
+    assert their_path.read_bytes() == theirs
+
+
+def test_concurrent_stagings_each_keep_their_own_key(config_root: Path) -> None:
+    """``stage_master_key`` is a concurrent path; no call may lose its key.
+
+    The coverage gap that let the clobber through: every existing test staged
+    from ONE thread. Here many rotations stage at once, and afterwards every
+    key must still be readable from the path its own call returned — which is
+    the property a committed rotation depends on. A shared filename fails this
+    both ways: keys go missing, and the unlink-then-write race surfaces as a
+    raw ``FileNotFoundError`` escaping the CLI.
+    """
+    _seed_store(config_root)
+    keys = [generate_master_key() for _ in range(24)]
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        paths = list(pool.map(lambda k: stage_master_key(config_root, k), keys))
+
+    assert len({str(path) for path in paths}) == len(keys), "staged names collided"
+    for key, path in zip(keys, paths):
+        assert path.read_bytes() == key, f"{path.name} does not hold its own key"
+
+    # A staging temporary must never be visible to the recovery scan, and none
+    # may be left behind by a completed call.
+    leftovers = sorted(p.name for p in (config_root / "secrets").glob("master.stage*"))
+    assert leftovers == [], f"staging temporaries were left behind: {leftovers}"
+
+
+def test_recovery_finds_the_right_key_among_many_staged(config_root: Path) -> None:
+    """With several rotations in flight, recovery adopts the committed one.
+
+    Scanning all staged keys is only correct if the fingerprint still decides
+    WHICH one is adopted: the other rotations' keys are inert, exactly as a
+    single leftover file is.
+    """
+    key = _seed_store(config_root)
+    committed = generate_master_key()
+
+    for _ in range(3):  # rotations that staged and never committed
+        stage_master_key(config_root, generate_master_key())
+    stage_master_key(config_root, committed)
+    SecretStore(key, base=config_root).rotate(committed)
+    for _ in range(3):
+        stage_master_key(config_root, generate_master_key())
+
+    assert resolve_master_key(config_root) == committed
+    assert key_path(config_root).read_bytes() == committed
+    assert _open_knowing_only_the_disk(config_root) == b"super-secret-value"
+
+
+@pytest.mark.parametrize("crash_after_step", [0, 1, 2, 3])
+def test_a_crash_at_any_rotation_step_survives_a_concurrent_rotation(
+    config_root: Path, crash_after_step: int
+) -> None:
+    """The R2 crash matrix, re-run with another rotation in the picture.
+
+    Same property as the single-rotator matrix — a power cut at any step leaves
+    the store openable by a key that exists on disk — but a second rotator
+    stages, races and cleans up throughout. The single-rotator matrix passed
+    against code that lost the store this way, so the concurrent leg is the one
+    that actually pins the invariant.
+    """
+    key = _seed_store(config_root)
+    victim_key = generate_master_key()
+    other_key = generate_master_key()
+    other = SecretStore(key, base=config_root)  # holds the pre-rotation key
+
+    # The interfering rotation stages before the victim reaches any step.
+    stage_master_key(config_root, other_key)
+
+    _rotate_to_step(config_root, key, victim_key, crash_after_step)
+
+    # ...then loses the epoch race (or, at step 0, wins it) and cleans up.
+    try:
+        other.rotate(other_key)
+    except (StaleKeyEpoch, SecretStoreError):
+        discard_staged_master_key(config_root, other_key)
+
+    # Power cut. A brand new process must still open the store.
+    assert _open_knowing_only_the_disk(config_root) == b"super-secret-value"

--- a/tests/unit/secrets/test_key_lifecycle.py
+++ b/tests/unit/secrets/test_key_lifecycle.py
@@ -1,0 +1,332 @@
+"""Rotation against the ~10-session workload, and against a power cut.
+
+Two failures live here, both of which lost or stranded real secrets and both of
+which were found by execution rather than by reading:
+
+* a ``rotate`` running concurrently with another session's write used to POISON
+  that write — it reported "stored", and the row was then unreachable by name
+  and undecryptable, which in turn bricked ``list``, ``status`` and every later
+  ``rotate`` store-wide;
+* a crash between ``rotate``'s COMMIT and the installation of the new key used
+  to lose EVERY secret in the store, because the database was re-sealed under a
+  key that existed only in the dead process's memory.
+
+Neither is exotic on this machine: the operator runs about ten sessions at
+once, which is exactly when a rotation overlaps somebody else's write, and a
+power cut needs no adversary at all.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from local_operator.secrets.access import resolve_master_key
+from local_operator.secrets.crypto import generate_master_key, key_fingerprint
+from local_operator.secrets.errors import SecretCorrupt, SecretStoreError, StaleKeyEpoch
+from local_operator.secrets.keys import (
+    key_path,
+    load_master_key,
+    replace_master_key,
+    stage_master_key,
+    staged_key_path,
+)
+from local_operator.secrets.store import SecretStore
+
+# --- R1: a concurrent write must never be orphaned by a rotation -------------
+
+
+def test_a_write_under_a_pre_rotation_key_is_refused_not_poisoned(
+    config_root: Path, master_key: bytes
+) -> None:
+    """The store-bricking interleave, at its smallest.
+
+    Session A loads the key and is still holding it when session B rotates.
+    A's next write must FAIL — a write that succeeds here is sealed under a key
+    that no longer exists and indexed under an index key that no longer
+    matches, so it is unreachable and undecryptable while having reported
+    success. Failing closed costs a retry; succeeding costs the secret.
+    """
+    session_a = SecretStore(master_key, base=config_root)
+    session_a.initialize()
+    session_a.set("EXISTING", b"v0")
+
+    new_key = generate_master_key()
+    SecretStore(master_key, base=config_root).rotate(new_key)
+
+    with pytest.raises(StaleKeyEpoch):
+        session_a.set("POISONED", b"secret-value")
+
+    # Nothing was committed, and the store is entirely healthy afterwards.
+    rotated = SecretStore(new_key, base=config_root)
+    assert [record.name for record in rotated.list()] == ["EXISTING"]
+    assert rotated.damaged_records() == []
+    assert rotated.get("EXISTING") == b"v0"
+
+
+@pytest.mark.parametrize("verb", ["set", "update", "delete", "rotate"])
+def test_every_write_verb_checks_the_key_epoch(
+    config_root: Path, master_key: bytes, verb: str
+) -> None:
+    """Not just ``set``: any write under a superseded key corrupts the store."""
+    stale = SecretStore(master_key, base=config_root)
+    stale.initialize()
+    stale.set("EXISTING", b"v0")
+    SecretStore(master_key, base=config_root).rotate(generate_master_key())
+
+    calls = {
+        "set": lambda: stale.set("NEW", b"v"),
+        "update": lambda: stale.update("EXISTING", b"v1"),
+        "delete": lambda: stale.delete("EXISTING"),
+        "rotate": lambda: stale.rotate(generate_master_key()),
+    }
+    with pytest.raises(StaleKeyEpoch):
+        calls[verb]()
+
+
+def test_ten_sessions_writing_through_a_rotation_never_brick_the_store(
+    config_root: Path, master_key: bytes
+) -> None:
+    """The operator's real shape: nine writers, one rotator, no delays.
+
+    Every write either succeeds or raises :class:`StaleKeyEpoch`. What must not
+    happen is a write that reports success and leaves a row nobody can read —
+    so the assertion is not "no errors", it is that the store is fully
+    enumerable and every surviving record decrypts afterwards.
+    """
+    seed = SecretStore(master_key, base=config_root)
+    seed.initialize()
+    seed.set("ANCHOR", b"anchor-value")
+
+    current_key = master_key
+    stored: list[str] = []
+    for round_index in range(9):
+        stale_session = SecretStore(current_key, base=config_root)
+        if round_index % 3 == 2:
+            next_key = generate_master_key()
+            SecretStore(current_key, base=config_root).rotate(next_key)
+            current_key = next_key
+        try:
+            stale_session.set(f"SECRET_{round_index}", f"value-{round_index}".encode())
+            stored.append(f"SECRET_{round_index}")
+        except StaleKeyEpoch:
+            pass
+
+    final = SecretStore(current_key, base=config_root)
+    assert final.damaged_records() == [], "a write was orphaned by a rotation"
+    assert sorted(record.name for record in final.list()) == sorted(["ANCHOR", *stored])
+    for name in stored:
+        assert final.get(name) == f"value-{name.rsplit('_', 1)[1]}".encode()
+    assert final.get("ANCHOR") == b"anchor-value"
+
+
+# --- R1, second half: one bad row must not take down enumeration -------------
+
+
+def _damage_one_row(store: SecretStore, name: str) -> str:
+    """Corrupt a single record's ciphertext; returns its id."""
+    index = store.describe(name).record_id
+    with sqlite3.connect(store.path) as connection:
+        connection.execute("UPDATE secrets SET ciphertext = ? WHERE id = ?", (b"\x00" * 64, index))
+    return index
+
+
+def test_list_survives_a_record_it_cannot_decrypt(store: SecretStore) -> None:
+    """One unreadable row must never make the whole store unusable.
+
+    ``list`` used to propagate, so a single damaged record took down ``list``,
+    ``status`` and every subsequent ``rotate`` — removing the operator's only
+    tools for seeing what survived, at the moment they needed them most.
+    """
+    store.set("GOOD_ONE", b"a")
+    store.set("BROKEN", b"b")
+    store.set("GOOD_TWO", b"c")
+    damaged_id = _damage_one_row(store, "BROKEN")
+
+    assert [record.name for record in store.list()] == ["GOOD_ONE", "GOOD_TWO"]
+    assert store.damaged_records() == [damaged_id]
+    # The healthy records are still fully usable.
+    assert store.get("GOOD_ONE") == b"a"
+    assert store.get("GOOD_TWO") == b"c"
+
+
+def test_a_damaged_record_can_be_removed_by_id(store: SecretStore) -> None:
+    """The repair path. ``rm NAME`` cannot reach it — its name is unreadable."""
+    store.set("GOOD_ONE", b"a")
+    store.set("BROKEN", b"b")
+    damaged_id = _damage_one_row(store, "BROKEN")
+
+    assert store.delete_record_id(damaged_id) is True
+    assert store.damaged_records() == []
+    assert [record.name for record in store.list()] == ["GOOD_ONE"]
+    assert store.delete_record_id(damaged_id) is False
+
+
+def test_rotate_moves_the_healthy_records_past_a_damaged_one(store: SecretStore) -> None:
+    """A damaged row must not block the response to a suspected key compromise."""
+    store.set("GOOD_ONE", b"a")
+    store.set("BROKEN", b"b")
+    damaged_id = _damage_one_row(store, "BROKEN")
+
+    new_key = generate_master_key()
+    assert store.rotate(new_key) == 1  # only the readable record moved
+
+    rotated = SecretStore(new_key, base=store._base)
+    assert rotated.get("GOOD_ONE") == b"a"
+    assert rotated.damaged_records() == [damaged_id]
+
+
+# --- R2: a crash at any step of a rotation must leave the store openable -----
+
+
+def _rotate_to_step(base: Path, key: bytes, new_key: bytes, step: int) -> None:
+    """Run ``handlers._rotate``'s sequence and stop after ``step``.
+
+    Mirrors the handler exactly: stage the new key, commit the re-seal, install
+    the key. Stopping partway is the power cut.
+    """
+    if step >= 1:
+        stage_master_key(base, new_key)
+    if step >= 2:
+        SecretStore(key, base=base).rotate(new_key)
+    if step >= 3:
+        replace_master_key(base, new_key)
+
+
+@pytest.mark.parametrize("crash_after_step", [0, 1, 2, 3])
+def test_a_crash_at_any_rotation_step_leaves_the_store_openable(
+    config_root: Path, crash_after_step: int
+) -> None:
+    """At EVERY instant of a rotation, some key on disk opens the store.
+
+    Step 2 is the one that used to be fatal: the database was committed under
+    the new key while the only copy of that key was in the dying process's
+    memory, so an ordinary power cut destroyed every secret irrecoverably —
+    while the code's docstring claimed the case was recoverable.
+    """
+    key = load_master_key(config_root, create=True)
+    store = SecretStore(key, base=config_root)
+    store.initialize()
+    for index in range(3):
+        store.set(f"KEY_{index}", f"value-{index}".encode())
+
+    _rotate_to_step(config_root, key, generate_master_key(), crash_after_step)
+
+    # A brand new process opens the store, knowing only what is on disk.
+    survivor = SecretStore(resolve_master_key(config_root), base=config_root)
+    assert sorted(record.name for record in survivor.list()) == ["KEY_0", "KEY_1", "KEY_2"]
+    for index in range(3):
+        assert survivor.get(f"KEY_{index}") == f"value-{index}".encode()
+
+
+def test_an_interrupted_rotation_completes_the_key_install(config_root: Path) -> None:
+    """Recovery is finished, not merely tolerated.
+
+    Leaving the store readable-but-unrepaired would mean the next crash finds
+    the same half-done state, so ``resolve_master_key`` installs the staged key
+    and clears the staging file.
+    """
+    key = load_master_key(config_root, create=True)
+    store = SecretStore(key, base=config_root)
+    store.initialize()
+    store.set("ALPHA", b"alpha-value")
+
+    new_key = generate_master_key()
+    _rotate_to_step(config_root, key, new_key, 2)  # crash before the install
+    assert staged_key_path(config_root).exists()
+    assert key_path(config_root).read_bytes() == key  # still the OLD key
+
+    assert resolve_master_key(config_root) == new_key
+    assert key_path(config_root).read_bytes() == new_key
+    assert not staged_key_path(config_root).exists(), "the staged key was not cleared"
+
+
+def test_a_stale_staged_key_is_never_adopted(config_root: Path) -> None:
+    """A leftover staging file must not replace a perfectly good key.
+
+    The staged key is adopted only when its fingerprint matches the one the
+    DATABASE records, so an abandoned rotation's file is inert rather than
+    destructive.
+    """
+    key = load_master_key(config_root, create=True)
+    store = SecretStore(key, base=config_root)
+    store.initialize()
+    store.set("ALPHA", b"alpha-value")
+
+    # A rotation that died BEFORE committing: staged, database untouched.
+    stage_master_key(config_root, generate_master_key())
+
+    assert resolve_master_key(config_root) == key
+    assert key_path(config_root).read_bytes() == key
+    assert SecretStore(resolve_master_key(config_root), base=config_root).get("ALPHA") == (
+        b"alpha-value"
+    )
+
+
+def test_concurrent_key_installs_do_not_consume_each_others_temp_file(
+    config_root: Path,
+) -> None:
+    """``replace_master_key`` is a concurrent path now, so its temp is per-pid.
+
+    Recovery means several sessions can complete the same interrupted rotation
+    at once. With a FIXED temporary name, one process's ``os.replace`` consumed
+    the file another had just written, which surfaced under load as a spurious
+    ``FileNotFoundError`` from an install that had actually succeeded.
+    """
+    key = load_master_key(config_root, create=True)
+    store = SecretStore(key, base=config_root)
+    store.initialize()
+    store.set("ALPHA", b"alpha-value")
+
+    new_key = generate_master_key()
+    _rotate_to_step(config_root, key, new_key, 2)  # committed, not installed
+
+    # Several sessions open the store simultaneously; each completes the
+    # install. None may fail, and all must agree on the resulting key.
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        resolved = [
+            future.result()
+            for future in [pool.submit(resolve_master_key, config_root) for _ in range(8)]
+        ]
+
+    assert resolved == [new_key] * 8
+    assert key_path(config_root).read_bytes() == new_key
+    assert SecretStore(new_key, base=config_root).get("ALPHA") == b"alpha-value"
+    # No temporary files left behind in the secrets directory.
+    leftovers = sorted(p.name for p in key_path(config_root).parent.glob("master.key.*"))
+    assert leftovers == [], f"temporary key files were left behind: {leftovers}"
+
+
+def test_the_fingerprint_identifies_the_key_without_revealing_it(master_key: bytes) -> None:
+    """It is written to the database in the clear, so it must not be the key."""
+    fingerprint = key_fingerprint(master_key)
+    assert fingerprint != master_key[: len(fingerprint)]
+    assert fingerprint not in master_key
+    assert key_fingerprint(master_key) == fingerprint  # deterministic
+    assert key_fingerprint(generate_master_key()) != fingerprint
+
+
+def test_a_corrupt_meta_row_is_a_clean_error_not_a_traceback(store: SecretStore) -> None:
+    """Q2: ``meta.v`` holding TEXT escaped as a raw ``TypeError``.
+
+    Only reachable by hand-corrupting the database, and it never leaked a
+    value — but it bypassed the CLI's deliberate one-line error contract and
+    printed a 29-line traceback into a command run inside ``$( )``.
+    """
+    store.set("ALPHA", b"a")
+    with sqlite3.connect(store.path) as connection:
+        connection.execute("UPDATE meta SET v = 'not-a-number' WHERE k = 'schema_version'")
+
+    with pytest.raises(SecretStoreError):
+        store.get("ALPHA")
+
+
+def test_a_damaged_record_is_reported_as_corrupt_by_get(store: SecretStore) -> None:
+    """Enumeration steps over damage; a direct ``get`` still fails closed."""
+    store.set("BROKEN", b"b")
+    _damage_one_row(store, "BROKEN")
+    with pytest.raises(SecretCorrupt):
+        store.get("BROKEN")

--- a/tests/unit/secrets/test_key_lifecycle.py
+++ b/tests/unit/secrets/test_key_lifecycle.py
@@ -20,11 +20,15 @@ from __future__ import annotations
 
 import concurrent.futures
 import sqlite3
+import subprocess
+import sys
 import threading
+import time
 from pathlib import Path
 
 import pytest
 
+from local_operator.paths import CONFIG_DIR_ENV
 from local_operator.secrets.access import resolve_master_key
 from local_operator.secrets.crypto import (
     KEY_BYTES,
@@ -40,7 +44,17 @@ from local_operator.secrets.keys import (
     stage_master_key,
     staged_key_paths,
 )
-from local_operator.secrets.store import SecretStore
+from local_operator.secrets.store import SecretStore, install_master_key_if_current
+
+#: Rotators in the natural concurrency test. Four is the count QA measured the
+#: defect at (3 of 4 trials bricked); two never reproduced it, because the
+#: window needs a third rotation to commit between a slow rotator's commit and
+#: its install.
+CONCURRENT_ROTATORS = 4
+
+#: Real `lop secret` subprocesses run from the repo root so they import THIS
+#: tree rather than whatever `lop` the operator has installed globally.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
 
 # --- R1: a concurrent write must never be orphaned by a rotation -------------
 
@@ -691,3 +705,325 @@ def test_a_store_created_concurrently_is_readable_afterwards(
             "under a key that is not the store's"
         )
     assert reader.damaged_records() == [], "the concurrently created store has damaged rows"
+
+
+# --- R4: concurrent ROTATIONS must not install a superseded key --------------
+#
+# The R1-R3 invariants above all held while the store could still be destroyed
+# outright by two ordinary `lop secret rotate` runs. `rotate` is stage -> COMMIT
+# -> install, and the epoch guard serialises the COMMITs but imposed no order on
+# the installs, which ran outside every transaction. So a rotator that committed
+# EARLIER could install its now-superseded key LATER:
+#
+#     A: COMMIT -> db under Ka | B: COMMIT -> db under Kb, install Kb, discard Kb
+#                              | A: install Ka (stale), discard Ka
+#
+# leaving the database needing Kb, `master.key` holding Ka, and Kb nowhere on
+# disk. Both processes exited 0 printing `rotated N secret(s)` while every
+# secret became unrecoverable, and `resolve_master_key` could not repair it: it
+# adopts a STAGED key matching the database, and the matching one was
+# legitimately discarded by the rotation that installed it.
+#
+# THESE TESTS DRIVE THE REAL CLI IN REAL PROCESSES, deliberately. Calling
+# `SecretStore.rotate()` directly proves nothing here — it documents that the
+# caller must stage first, so a bare call bricks by construction and reports a
+# "failure" that is the test's own doing. The defect lives in the ORDER the
+# handler performs stage/commit/install in, so the handler is what has to run.
+
+
+def _cli_env(config_root: Path) -> dict[str, str]:
+    """Environment for a real `lop secret` subprocess pinned inside tmp_path.
+
+    `CMUX_*` is stripped for the reason AGENTS.md gives: an inherited
+    `CMUX_WORKSPACE_ID` let a headless test rename the operator's real cmux
+    workspaces. `HOME` is redirected as well as the config dir, because the
+    store resolves under `config_dir()` and a redirected READ path is not
+    automatically a redirected WRITE path.
+    """
+    import os
+
+    home = config_root.parent / "cli_home"
+    home.mkdir(exist_ok=True)
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith(("CMUX_", "LOCAL_OPERATOR_"))
+    }
+    env["HOME"] = str(home)
+    env[CONFIG_DIR_ENV] = str(config_root)
+    return env
+
+
+def _secret_cli(
+    config_root: Path, *argv: str, stdin: str | None = None
+) -> subprocess.CompletedProcess[str]:
+    """Run `lop secret ...` exactly as the operator would, and return the result."""
+    return subprocess.run(
+        [sys.executable, "-m", "local_operator.cli", "secret", *argv],
+        cwd=str(_REPO_ROOT),
+        env=_cli_env(config_root),
+        capture_output=True,
+        text=True,
+        input=stdin,
+        stdin=None if stdin is not None else subprocess.DEVNULL,
+        timeout=300,
+    )
+
+
+#: Rotator that parks between its COMMIT and its install, which is the window
+#: the defect lives in. It patches the seam rather than sleeping, because the
+#: window is microseconds wide and no wall-clock harness can hit it reliably —
+#: the same lesson the R3 barrier comment records. Everything it then executes
+#: is the product's own code path.
+_LATE_INSTALLER = """
+import os, sys, time
+from pathlib import Path
+from local_operator.secrets import store as store_mod
+
+committed = Path(os.environ["TEST_GATE_COMMITTED"])
+peer_done = Path(os.environ["TEST_GATE_PEER_DONE"])
+real_install = store_mod.install_master_key_if_current
+
+def install_late(key, base=None):
+    committed.write_text("1")
+    for _ in range(3000):
+        if peer_done.exists():
+            break
+        time.sleep(0.01)
+    return real_install(key, base)
+
+store_mod.install_master_key_if_current = install_late
+from local_operator.cli import main
+sys.exit(main())
+"""
+
+#: Its peer: waits for that gate, then runs one entirely ordinary rotation.
+_PEER_ROTATOR = """
+import os, sys, time
+from pathlib import Path
+
+committed = Path(os.environ["TEST_GATE_COMMITTED"])
+for _ in range(3000):
+    if committed.exists():
+        break
+    time.sleep(0.01)
+from local_operator.cli import main
+sys.exit(main())
+"""
+
+
+def test_a_rotation_superseded_between_commit_and_install_is_refused(
+    config_root: Path,
+) -> None:
+    """The exact interleaving that destroyed the store, through the real CLI.
+
+    Forcing the order rather than waiting for it: the natural race lands this
+    7 times in 8, but a test that fails one run in eight is not a regression
+    guard. Only the TIMING is forced — both processes run the shipped handler.
+
+    Three assertions, and all three are needed. The store must still be
+    readable (the brick). The loser must exit non-zero (it exited 0 while
+    destroying the store, which is what made the defect silent). And its
+    message must be an explanation rather than a traceback, because `lop secret`
+    is routinely run inside `$( )`.
+    """
+    seeded = _secret_cli(config_root, "set", "CANARY", stdin="canary-value")
+    assert seeded.returncode == 0, f"seed failed: {seeded.stderr}"
+
+    env = _cli_env(config_root)
+    env["TEST_GATE_COMMITTED"] = str(config_root / "committed")
+    env["TEST_GATE_PEER_DONE"] = str(config_root / "peer_done")
+
+    def spawn(source: str) -> subprocess.Popen[str]:
+        return subprocess.Popen(
+            [sys.executable, "-c", source, "secret", "rotate"],
+            cwd=str(_REPO_ROOT),
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            stdin=subprocess.DEVNULL,
+        )
+
+    late = spawn(_LATE_INSTALLER)
+    peer = spawn(_PEER_ROTATOR)
+    _, peer_err = peer.communicate(timeout=300)
+    (config_root / "peer_done").write_text("1")
+    late_out, late_err = late.communicate(timeout=300)
+
+    assert (config_root / "committed").exists(), "the gate never fired; this run proves nothing"
+    assert peer.returncode == 0, f"the uninterrupted rotation failed: {peer_err}"
+
+    # The brick: every secret must still be readable by a fresh process that
+    # knows only what is on disk.
+    got = _secret_cli(config_root, "get", "CANARY")
+    assert (
+        got.returncode == 0 and got.stdout == "canary-value"
+    ), f"the store is unreadable after two concurrent rotations: {got.stderr}"
+
+    assert late.returncode != 0, (
+        "the superseded rotation reported SUCCESS; that is the silent half of "
+        "the defect — it printed 'rotated N secret(s)' while the store died"
+    )
+    assert late_out == "", "a failing rotation wrote to stdout, which is a data channel"
+    assert "Traceback" not in late_err, f"the loser crashed instead of explaining: {late_err}"
+    assert (
+        "Another key rotation completed first" in late_err
+    ), f"the loser's message does not explain what happened: {late_err!r}"
+
+
+def test_four_concurrent_rotations_leave_the_store_intact(config_root: Path) -> None:
+    """QA's shape: four real `lop secret rotate` processes, no forcing at all.
+
+    The natural counterpart to the deterministic test above — four rotators
+    released together on an absolute deadline, which bricked 7 runs in 8 before
+    the fix. Kept as well as, not instead of, the forced one: this is the shape
+    the operator actually reaches with ~11 live sessions, and it is the only
+    version that exercises whichever guard happens to fire first (a loser may
+    be turned away at COMMIT by the epoch guard or at INSTALL by the
+    compare-and-swap, and both are correct outcomes).
+    """
+    values = {"CANARY": "canary-value", "SECOND": "second-value", "THIRD": "third-value"}
+    for name, value in values.items():
+        seeded = _secret_cli(config_root, "set", name, stdin=value)
+        assert seeded.returncode == 0, f"seed failed: {seeded.stderr}"
+
+    env = _cli_env(config_root)
+    # An absolute deadline, so the rotations overlap instead of serialising
+    # behind interpreter startup; workers import everything before waiting.
+    env["TEST_ROTATE_AT"] = str(time.monotonic() + 5.0)
+    source = """
+import os, sys, time
+deadline = float(os.environ["TEST_ROTATE_AT"])
+from local_operator.cli import main
+while time.monotonic() < deadline:
+    time.sleep(0.0005)
+sys.exit(main())
+"""
+    workers = [
+        subprocess.Popen(
+            [sys.executable, "-c", source, "secret", "rotate"],
+            cwd=str(_REPO_ROOT),
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            stdin=subprocess.DEVNULL,
+        )
+        for _ in range(CONCURRENT_ROTATORS)
+    ]
+    outcomes = []
+    for worker in workers:
+        _, err = worker.communicate(timeout=300)
+        outcomes.append((worker.returncode, err))
+
+    # Every secret still readable is the property that matters; the rest
+    # explains a failure rather than adding one.
+    for name, value in values.items():
+        got = _secret_cli(config_root, "get", name)
+        assert got.returncode == 0 and got.stdout == value, (
+            f"{name} is unreadable after {CONCURRENT_ROTATORS} concurrent "
+            f"rotations: {got.stderr}"
+        )
+
+    assert any(
+        code == 0 for code, _ in outcomes
+    ), f"no rotation succeeded; all four were refused: {[err for _, err in outcomes][:2]}"
+    for code, err in outcomes:
+        if code == 0:
+            continue
+        assert "Traceback" not in err, f"a losing rotation crashed instead of explaining: {err}"
+
+    # And the store is coherent, not merely readable one key at a time.
+    listing = _secret_cli(config_root, "list")
+    assert listing.returncode == 0, f"list failed after concurrent rotation: {listing.stderr}"
+    status = _secret_cli(config_root, "status")
+    assert "damaged" not in status.stdout, f"concurrent rotation damaged rows:\n{status.stdout}"
+
+
+def test_the_install_guard_refuses_a_key_the_database_has_moved_past(
+    config_root: Path,
+) -> None:
+    """The compare-and-swap itself, in isolation and without a race.
+
+    The process-level tests above prove the defect is gone; this one pins WHY,
+    so a refactor that quietly drops the fingerprint check fails here with a
+    readable assertion rather than only in a timing-dependent subprocess test.
+    """
+    key = _seed_store(config_root)
+    superseded = generate_master_key()
+    winner = generate_master_key()
+
+    # A rotation commits under `winner`, so the database has moved past both
+    # `key` and `superseded`.
+    stage_master_key(config_root, winner)
+    SecretStore(key, base=config_root).rotate(winner)
+    assert install_master_key_if_current(winner, config_root) is True
+
+    installed_before = key_path(config_root).read_bytes()
+    assert install_master_key_if_current(superseded, config_root) is False, (
+        "a key the database is not sealed under was installed; this is the "
+        "write that made every secret unrecoverable"
+    )
+    assert (
+        key_path(config_root).read_bytes() == installed_before
+    ), "the refused install still clobbered master.key"
+    assert _open_knowing_only_the_disk(config_root) == b"super-secret-value"
+
+
+def test_restricting_modes_tolerates_a_sidecar_that_vanishes(
+    store: SecretStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SQLite deletes `-wal`/`-shm` when the last connection closes.
+
+    `_restrict_modes` tests `exists()` and then `chmod`s, and a concurrent
+    session closing its connection inside that gap removed the file and turned
+    an otherwise fine operation into a `FileNotFoundError` (observed once in
+    ~200 rotation-heavy concurrent runs). At the CLI that is caught and becomes
+    a clean rc=2, but the library API a later PR exposes would surface it as a
+    traceback, so the gap is closed here rather than at the call sites.
+    """
+    import os as os_module
+
+    store.set("PRESENT", b"value")
+    # The sidecars are created here by hand: SQLite removes them when the last
+    # connection closes, which is BEFORE `_restrict_modes` runs, so an ordinary
+    # `set` never reaches the chmod at all and a test written around one proves
+    # nothing (it asserted its own hook had fired, and the hook had not).
+    sidecars = [store.path.with_name(store.path.name + suffix) for suffix in ("-wal", "-shm")]
+    for sidecar in sidecars:
+        sidecar.write_bytes(b"")
+
+    real_chmod = os_module.chmod
+    vanished: list[str] = []
+
+    def chmod_after_unlink(path, mode, *args, **kwargs):  # type: ignore[no-untyped-def]
+        # The peer's close lands between this call's exists() and its chmod():
+        # really unlink the file, then fail the way the kernel would.
+        if str(path).endswith(("-wal", "-shm")):
+            vanished.append(str(path))
+            Path(path).unlink(missing_ok=True)
+            raise FileNotFoundError(2, "No such file or directory", str(path))
+        return real_chmod(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr(os_module, "chmod", chmod_after_unlink)
+    store._restrict_modes()  # must not raise
+    monkeypatch.undo()
+
+    assert len(vanished) == 2, f"the sidecar chmods were not attempted: {vanished}"
+    assert store.get("PRESENT") == b"value"
+
+    # A permission failure on a file that IS there must still be reported: the
+    # suppression is scoped to "the file is gone", not to "chmod failed". A
+    # world-readable WAL carries the same ciphertext as the database.
+    for sidecar in sidecars:
+        sidecar.write_bytes(b"")
+
+    def chmod_denied(path, mode, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if str(path).endswith("-wal"):
+            raise PermissionError(13, "Permission denied", str(path))
+        return real_chmod(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr(os_module, "chmod", chmod_denied)
+    with pytest.raises(PermissionError):
+        store._restrict_modes()

--- a/tests/unit/secrets/test_permissions.py
+++ b/tests/unit/secrets/test_permissions.py
@@ -1,0 +1,174 @@
+"""File modes: 0600 files in a 0700 directory, and a hostile umask must lose.
+
+In the default ``keyfile`` mode the entire at-rest story is the mode bits, so
+these are not hygiene assertions — they are the control itself. The umask cases
+matter because ``mkdir(mode=...)`` and ``os.open(..., mode)`` are both MASKED
+by the process umask: code that looks like it requests 0700 silently produces
+0777 under ``umask 000``, and nothing reports it. The explicit ``chmod`` in
+``keys.py`` and ``store.py`` is what these pin.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import stat
+from pathlib import Path
+
+import pytest
+
+from local_operator.secrets.errors import InsecurePermissions
+from local_operator.secrets.keys import (
+    DIR_MODE,
+    FILE_MODE,
+    key_path,
+    load_master_key,
+    secrets_dir,
+    store_path,
+)
+from local_operator.secrets.store import SecretStore
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt", reason="POSIX mode bits do not carry their Unix meaning on Windows"
+)
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+@pytest.fixture
+def hostile_umask():
+    """Run the body under ``umask 000`` — the mode-loosening case.
+
+    Restored in a finally: umask is process-global, so leaking it would corrupt
+    every later test in the same xdist worker.
+    """
+    previous = os.umask(0o000)
+    try:
+        yield
+    finally:
+        os.umask(previous)
+
+
+def test_directory_is_0700(store: SecretStore, config_root: Path) -> None:
+    assert _mode(secrets_dir(config_root)) == DIR_MODE
+
+
+def test_database_is_0600(store: SecretStore, config_root: Path) -> None:
+    store.set("TOKEN", b"value")
+    assert _mode(store_path(config_root)) == FILE_MODE
+
+
+def test_wal_sidecars_are_0600(store: SecretStore, config_root: Path) -> None:
+    """The WAL holds the same ciphertext as the database.
+
+    A 0600 database beside a 0644 ``-wal`` is not a private store, and SQLite
+    creates those sidecars itself under the process umask.
+    """
+    store.set("TOKEN", b"value")
+    database = store_path(config_root)
+    for suffix in ("-wal", "-shm"):
+        sidecar = database.with_name(database.name + suffix)
+        if sidecar.exists():
+            assert _mode(sidecar) == FILE_MODE, f"{sidecar.name} is {_mode(sidecar):04o}"
+
+
+def test_keyfile_is_0600(config_root: Path) -> None:
+    load_master_key(config_root, create=True)
+    assert _mode(key_path(config_root)) == FILE_MODE
+
+
+def test_hostile_umask_does_not_loosen_the_directory(
+    config_root: Path, hostile_umask: None
+) -> None:
+    """``umask 000`` must not produce a world-traversable secrets directory."""
+    load_master_key(config_root, create=True)
+    store = SecretStore(b"\x00" * 32, base=config_root)
+    store.initialize()
+
+    assert _mode(secrets_dir(config_root)) == DIR_MODE
+    assert _mode(key_path(config_root)) == FILE_MODE
+    assert _mode(store_path(config_root)) == FILE_MODE
+
+
+def test_hostile_umask_does_not_loosen_a_written_record(
+    config_root: Path, hostile_umask: None
+) -> None:
+    """Writing a record re-asserts the modes, including on the fresh WAL."""
+    key = load_master_key(config_root, create=True)
+    store = SecretStore(key, base=config_root)
+    store.set("TOKEN", b"value")
+
+    database = store_path(config_root)
+    assert _mode(database) == FILE_MODE
+    for suffix in ("-wal", "-shm"):
+        sidecar = database.with_name(database.name + suffix)
+        if sidecar.exists():
+            assert _mode(sidecar) == FILE_MODE
+
+
+def test_a_group_readable_keyfile_is_refused(config_root: Path) -> None:
+    """Loosened after the fact — the case worth catching, and NOT repaired.
+
+    Silently tightening the mode would hide from the operator that the key was
+    ever exposed. By the time this is observable the exposure has happened, so
+    it is reported.
+    """
+    load_master_key(config_root, create=True)
+    path = key_path(config_root)
+    os.chmod(path, 0o640)
+
+    with pytest.raises(InsecurePermissions, match="group or others"):
+        load_master_key(config_root)
+
+    # Not repaired behind the operator's back.
+    assert _mode(path) == 0o640
+
+
+def test_a_world_readable_database_is_refused(config_root: Path) -> None:
+    key = load_master_key(config_root, create=True)
+    store = SecretStore(key, base=config_root)
+    store.set("TOKEN", b"value")
+    os.chmod(store_path(config_root), 0o644)
+
+    with pytest.raises(InsecurePermissions, match="group or others"):
+        store.get("TOKEN")
+
+
+def test_a_truncated_keyfile_is_reported_clearly(config_root: Path) -> None:
+    """A damaged key must not be silently padded into a valid-looking one."""
+    load_master_key(config_root, create=True)
+    path = key_path(config_root)
+    path.write_bytes(b"too-short")
+    os.chmod(path, FILE_MODE)
+
+    from local_operator.secrets.errors import SecretStoreError
+
+    with pytest.raises(SecretStoreError, match="master key is 32"):
+        load_master_key(config_root)
+
+
+def test_the_value_is_not_findable_in_the_raw_database_file(
+    store: SecretStore, config_root: Path
+) -> None:
+    """The point of the whole feature, asserted against the bytes on disk.
+
+    ``grep -r 'API_KEY' ~`` is the baseline this store exists to beat, so the
+    test greps the actual file: neither the value NOR the name may appear.
+    """
+    store.set("MINERVA_PROD_DB_PASSWORD", b"hunter2-the-real-password", description="prod")
+    # Checkpoint the WAL so the record is definitely in the main file too.
+    with sqlite3.connect(store.path) as connection:
+        connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+
+    database = store_path(config_root)
+    blob = database.read_bytes()
+    for sidecar_suffix in ("-wal", "-shm"):
+        sidecar = database.with_name(database.name + sidecar_suffix)
+        if sidecar.exists():
+            blob += sidecar.read_bytes()
+
+    assert b"hunter2-the-real-password" not in blob
+    assert b"MINERVA_PROD_DB_PASSWORD" not in blob, "the secret NAME leaked in the clear"
+    assert b"prod" not in blob, "the description leaked in the clear"

--- a/tests/unit/secrets/test_roundtrip.py
+++ b/tests/unit/secrets/test_roundtrip.py
@@ -1,0 +1,173 @@
+"""Round-trip fidelity: what goes in is exactly what comes out.
+
+A store that corrupts a value is worse than no store, because the failure
+surfaces as an authentication error from a remote service rather than as an
+error here. These cases are the ones that actually break naive
+implementations: text-mode encoding, newline translation, non-ASCII, embedded
+NULs and a value large enough to cross buffer boundaries.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from local_operator.secrets.crypto import NONCE_BYTES, generate_master_key
+from local_operator.secrets.errors import (
+    InvalidSecretName,
+    SecretExists,
+    SecretNotFound,
+)
+from local_operator.secrets.store import SecretStore
+
+# 100 KB of non-repeating bytes: large enough to exceed any single read buffer
+# and incompressible enough that a truncation shows up as a length mismatch.
+_LARGE_VALUE = bytes(range(256)) * 400
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(b"simple-token", id="ascii"),
+        pytest.param(b"line one\nline two\nline three", id="newlines"),
+        pytest.param(
+            "passphrase-\u00e9\u00e0\u00fc-\u4f60\u597d-\U0001f510".encode(), id="unicode"
+        ),
+        pytest.param(b"trailing-newlines\n\n\n", id="trailing-newlines"),
+        pytest.param(b"\x00\x01\x02binary\xff\xfe", id="binary-with-nul"),
+        pytest.param(b"-----BEGIN KEY-----\r\nabc\r\n-----END KEY-----", id="crlf"),
+        pytest.param(b"", id="empty"),
+        pytest.param(_LARGE_VALUE, id="100kb"),
+    ],
+)
+def test_round_trip_returns_exact_bytes(store: SecretStore, value: bytes) -> None:
+    store.set("TOKEN", value)
+    assert store.get("TOKEN") == value
+
+
+def test_large_value_length_is_preserved(store: SecretStore) -> None:
+    store.set("BIG", _LARGE_VALUE)
+    assert len(store.get("BIG")) == 102_400
+
+
+def test_update_returns_the_new_value(store: SecretStore) -> None:
+    store.set("TOKEN", b"first")
+    store.update("TOKEN", b"second\nwith newline")
+    assert store.get("TOKEN") == b"second\nwith newline"
+
+
+def test_every_update_uses_a_fresh_nonce(store: SecretStore) -> None:
+    """A repeated nonce under one key is the catastrophic GCM misuse.
+
+    Storing the SAME value repeatedly is the case a buggy implementation gets
+    wrong: an implementation that derived the nonce from the plaintext, or
+    reused the record's stored nonce on update, produces an identical
+    (nonce, ciphertext) pair here and nothing else would notice.
+    """
+    store.set("TOKEN", b"identical-value")
+    nonces: set[bytes] = set()
+    ciphertexts: set[bytes] = set()
+    for _ in range(20):
+        store.update("TOKEN", b"identical-value")
+        with sqlite3.connect(store.path) as connection:
+            nonce, ciphertext = connection.execute(
+                "SELECT nonce, ciphertext FROM secrets"
+            ).fetchone()
+        assert len(nonce) == NONCE_BYTES
+        assert bytes(nonce) not in nonces, "nonce reused across updates"
+        # The ciphertext must differ too. It only does because the nonce feeds
+        # the keystream, so this catches the subtler bug the nonce check alone
+        # misses: a fresh value written to the column but not actually used to
+        # encrypt.
+        assert bytes(ciphertext) not in ciphertexts, "ciphertext repeated despite a fresh nonce"
+        nonces.add(bytes(nonce))
+        ciphertexts.add(bytes(ciphertext))
+    assert len(nonces) == 20
+    assert len(ciphertexts) == 20
+
+
+def test_unicode_name_normalisation_finds_the_same_record(store: SecretStore) -> None:
+    """NFC and NFD spellings of one name must not become two records.
+
+    Without NFKC normalisation the blind index differs and ``get`` misses a
+    record the operator can plainly see in ``list`` — a confusing failure, and
+    on macOS a routine one, since the filesystem hands back NFD.
+    """
+    store.set("CAF\u00c9_TOKEN", b"value")  # NFC
+    assert store.get("CAFE\u0301_TOKEN") == b"value"  # NFD
+    with pytest.raises(SecretExists):
+        store.set("CAFE\u0301_TOKEN", b"other")
+
+
+def test_missing_secret_raises_not_found(store: SecretStore) -> None:
+    with pytest.raises(SecretNotFound, match="ABSENT"):
+        store.get("ABSENT")
+
+
+def test_set_refuses_to_overwrite(store: SecretStore) -> None:
+    store.set("TOKEN", b"original")
+    with pytest.raises(SecretExists, match="already exists"):
+        store.set("TOKEN", b"replacement")
+    assert store.get("TOKEN") == b"original"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("   ", id="whitespace-only"),
+        pytest.param("has\x00nul", id="nul"),
+        pytest.param("has\nnewline", id="newline"),
+        pytest.param("x" * 300, id="too-long"),
+    ],
+)
+def test_invalid_names_are_refused(store: SecretStore, name: str) -> None:
+    with pytest.raises(InvalidSecretName):
+        store.set(name, b"value")
+
+
+def test_description_with_newline_is_refused(store: SecretStore) -> None:
+    with pytest.raises(InvalidSecretName, match="newlines"):
+        store.set("TOKEN", b"value", description="first line\nsecond line")
+
+
+def test_delete_removes_the_record(store: SecretStore) -> None:
+    store.set("TOKEN", b"value")
+    store.delete("TOKEN")
+    with pytest.raises(SecretNotFound):
+        store.get("TOKEN")
+
+
+def test_a_different_master_key_cannot_read_the_store(store: SecretStore) -> None:
+    """The store is not merely obfuscated — the key is what opens it."""
+    from local_operator.secrets.errors import SecretNotFound as NotFound
+
+    store.set("TOKEN", b"value")
+    impostor = SecretStore(generate_master_key(), base=store.path.parent.parent)
+    # The blind index is keyed too, so a wrong key does not even find the row.
+    with pytest.raises(NotFound):
+        impostor.get("TOKEN")
+
+
+def test_rotate_re_seals_every_record_and_preserves_values(store: SecretStore) -> None:
+    store.set("ALPHA", b"first-value", description="one")
+    store.set("BETA", b"second\nvalue")
+    before = store.key_generation()
+
+    new_key = generate_master_key()
+    assert store.rotate(new_key) == 2
+
+    assert store.key_generation() == before + 1
+    assert store.get("ALPHA") == b"first-value"
+    assert store.get("BETA") == b"second\nvalue"
+    assert store.describe("ALPHA").description == "one"
+
+
+def test_list_never_exposes_a_value(store: SecretStore) -> None:
+    """Structural, not textual: there is no field on the record to leak."""
+    store.set("TOKEN", b"super-secret-value", description="a note")
+    records = store.list()
+    assert [record.name for record in records] == ["TOKEN"]
+    assert not hasattr(records[0], "value")
+    assert "super-secret-value" not in repr(records[0])

--- a/tests/unit/secrets/test_startup_cost.py
+++ b/tests/unit/secrets/test_startup_cost.py
@@ -1,0 +1,84 @@
+"""``lop secret`` must not put the crypto stack on the CLI's import path.
+
+``tests/unit/test_import_graph.py`` documents why this matters: one
+module-level import in something ``cli.py`` touches costs EVERY invocation —
+``--version``, shell completion, every scheduler tick — and nothing fails, so
+the regression is invisible in review. Argument registration for this
+subcommand is stdlib-only and the handlers import the crypto and storage
+modules at the point of use; this pins that arrangement.
+
+A fresh subprocess, for the reason that file gives: by the time a test body
+runs, pytest has imported half the tree, so an in-process ``sys.modules``
+assertion would pass on a real regression.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+
+_PROBE = """
+import importlib, json, sys
+importlib.import_module("local_operator.cli")
+print(json.dumps(sorted(sys.modules)))
+"""
+
+
+def _cli_modules() -> set[str]:
+    process = subprocess.run(
+        [sys.executable, "-c", _PROBE], capture_output=True, text=True, cwd=str(REPO), timeout=120
+    )
+    assert process.returncode == 0, process.stderr[-3000:]
+    return set(json.loads(process.stdout.strip().splitlines()[-1]))
+
+
+def test_cli_import_does_not_load_the_crypto_stack() -> None:
+    """``cryptography`` brings a compiled OpenSSL binding with it.
+
+    Nothing about ``lop --version`` needs AES, and the secret handlers import
+    it inside the function that uses it.
+    """
+    modules = _cli_modules()
+    offenders = sorted(
+        module
+        for module in modules
+        if module == "cryptography" or module.startswith("cryptography.")
+    )
+    assert not offenders, f"cryptography is on the CLI startup path; saw {offenders[:5]}"
+
+
+def test_cli_import_does_not_load_the_store_modules() -> None:
+    """Registration is stdlib-only; the store arrives with the first verb."""
+    modules = _cli_modules()
+    for module in (
+        "local_operator.secrets.crypto",
+        "local_operator.secrets.store",
+        "local_operator.secrets.keys",
+        "local_operator.secrets.access",
+    ):
+        assert module not in modules, f"{module} is on the CLI startup path"
+
+
+def test_argument_registration_itself_is_stdlib_only() -> None:
+    """Importing the secret CLI module must not drag the crypto stack in.
+
+    ``cli.py`` imports this module to register arguments, so an eager
+    ``from .crypto import ...`` at its top would silently undo both tests
+    above. Checked directly so the failure names the real cause.
+    """
+    probe = (
+        "import importlib, json, sys;"
+        " importlib.import_module('local_operator.secrets.cli');"
+        " print(json.dumps(sorted(sys.modules)))"
+    )
+    process = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, cwd=str(REPO), timeout=120
+    )
+    assert process.returncode == 0, process.stderr[-3000:]
+    modules = set(json.loads(process.stdout.strip().splitlines()[-1]))
+    offenders = sorted(module for module in modules if module.startswith("cryptography"))
+    assert not offenders, f"secrets.cli pulls cryptography at import; saw {offenders[:5]}"

--- a/tests/unit/secrets/test_tamper.py
+++ b/tests/unit/secrets/test_tamper.py
@@ -1,0 +1,285 @@
+"""AAD binding: editing the database must fail closed, never mislead.
+
+The attack these defend against is specific and worth stating, because it is
+what makes AAD binding non-optional rather than a nicety. An attacker who can
+WRITE the database but cannot decrypt it does not need the key to do damage:
+if only the value were authenticated, they could point the row labelled
+``PROD_DB_PASSWORD`` at the ciphertext of ``STAGING_DB_PASSWORD``, or rename a
+record they control to a name a consumer trusts. Either one makes
+``$(lop secret get NAME)`` return a real, correctly-decrypting secret that is
+the WRONG secret — and nothing anywhere would report an error.
+
+Every test here corrupts the real SQLite file on disk with a plain ``UPDATE``,
+exactly as such an attacker would, and asserts the store refuses. They are
+written to fail if someone later narrows the AAD: each one names the field it
+removes from the binding, so a "simplification" that drops ``record_id`` or
+``name_index`` from :func:`crypto.build_aad` turns the corresponding test red
+rather than silently widening the attack surface.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+import pytest
+
+from local_operator.secrets.crypto import RecordMetadata, build_aad, name_index
+from local_operator.secrets.errors import SecretCorrupt
+from local_operator.secrets.store import SecretStore
+
+
+def _rows(store: SecretStore) -> list[tuple[Any, ...]]:
+    with sqlite3.connect(store.path) as connection:
+        return connection.execute(
+            "SELECT id, name_index, key_generation, format_version, nonce, ciphertext, kind"
+            " FROM secrets ORDER BY id"
+        ).fetchall()
+
+
+def test_renaming_a_record_in_the_database_fails_closed(store: SecretStore) -> None:
+    """The rename attack: relabel a low-value secret as a trusted name.
+
+    Done the way an attacker would — rewrite the ``name_index`` column so the
+    row is found under a different name — and the AEAD must reject it, because
+    that column is bound into the AAD. If this test ever passes by returning a
+    value, ``get TRUSTED_NAME`` has silently returned the attacker's chosen
+    secret.
+    """
+    store.set("LOW_VALUE", b"attacker-controlled")
+    trusted_index = name_index(store._master_key, "PROD_DB_PASSWORD")
+
+    with sqlite3.connect(store.path) as connection:
+        connection.execute("UPDATE secrets SET name_index = ?", (trusted_index,))
+
+    with pytest.raises(SecretCorrupt, match="failed authentication"):
+        store.get("PROD_DB_PASSWORD")
+
+
+def test_swapping_two_records_ciphertexts_fails_closed(store: SecretStore) -> None:
+    """The swap attack: leave the labels alone, exchange the payloads.
+
+    ``record_id`` is bound into the AAD and is immutable, so a ciphertext moved
+    to another row authenticates against the wrong id and the tag check fails.
+    Without that binding both rows would decrypt cleanly and each name would
+    resolve to the other's secret — the single most dangerous silent failure
+    this store can have.
+    """
+    store.set("STAGING", b"staging-password")
+    store.set("PRODUCTION", b"production-password")
+
+    first, second = _rows(store)
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            "UPDATE secrets SET nonce = ?, ciphertext = ? WHERE id = ?",
+            (second[4], second[5], first[0]),
+        )
+        connection.execute(
+            "UPDATE secrets SET nonce = ?, ciphertext = ? WHERE id = ?",
+            (first[4], first[5], second[0]),
+        )
+
+    for name in ("STAGING", "PRODUCTION"):
+        with pytest.raises(SecretCorrupt, match="failed authentication"):
+            store.get(name)
+
+
+def test_swapping_whole_logical_records_fails_closed(store: SecretStore) -> None:
+    """The swap that ``name_index`` alone does NOT catch — this pins ``record_id``.
+
+    :func:`test_swapping_two_records_ciphertexts_fails_closed` above is caught
+    by the ``name_index`` binding, so it stays green even if ``record_id`` is
+    dropped from the AAD — verified by mutation. This case moves the index AND
+    the ciphertext together, leaving only the immutable ``id`` columns in
+    place, so ``record_id`` is the sole remaining binding that can detect it.
+    Remove ``record_id`` from :func:`crypto.build_aad` and this test goes red
+    while the other stays green, which is exactly the coverage the pair is for.
+
+    Why it matters beyond defence in depth: ``record_id`` is what the audit
+    trail records. A store where ids can be shuffled under their records is one
+    where the audit log attributes a retrieval to the wrong secret.
+    """
+    store.set("STAGING", b"staging-password")
+    store.set("PRODUCTION", b"production-password")
+
+    first, second = _rows(store)
+    with sqlite3.connect(store.path) as connection:
+        # Park one row out of the way first: name_index is UNIQUE, so a direct
+        # exchange would collide mid-statement.
+        connection.execute(
+            "UPDATE secrets SET name_index = ? WHERE id = ?", (b"\xff" * 16, first[0])
+        )
+        connection.execute(
+            "UPDATE secrets SET name_index = ?, nonce = ?, ciphertext = ? WHERE id = ?",
+            (first[1], first[4], first[5], second[0]),
+        )
+        connection.execute(
+            "UPDATE secrets SET name_index = ?, nonce = ?, ciphertext = ? WHERE id = ?",
+            (second[1], second[4], second[5], first[0]),
+        )
+
+    for name in ("STAGING", "PRODUCTION"):
+        with pytest.raises(SecretCorrupt, match="failed authentication"):
+            store.get(name)
+
+
+def test_editing_the_kind_column_fails_closed(store: SecretStore) -> None:
+    """``kind`` drives how a value is materialised, so it is bound too.
+
+    Flipping ``string`` to ``file`` would change how ``lop secret file`` treats
+    the record; it is in the AAD so it cannot be flipped without the key.
+    """
+    store.set("TOKEN", b"value", kind="string")
+    with sqlite3.connect(store.path) as connection:
+        connection.execute("UPDATE secrets SET kind = 'file'")
+
+    with pytest.raises(SecretCorrupt, match="failed authentication"):
+        store.get("TOKEN")
+
+
+def test_editing_the_key_generation_column_fails_closed(store: SecretStore) -> None:
+    """Generation selects the subkey, so a forged one must not decrypt.
+
+    It fails twice over — wrong subkey AND wrong AAD — which is intended:
+    binding it means an attacker cannot force a record to be opened under a
+    generation whose key they may have obtained separately.
+    """
+    store.set("TOKEN", b"value")
+    with sqlite3.connect(store.path) as connection:
+        connection.execute("UPDATE secrets SET key_generation = 99")
+
+    with pytest.raises(SecretCorrupt, match="failed authentication"):
+        store.get("TOKEN")
+
+
+def test_flipping_one_ciphertext_bit_fails_closed(store: SecretStore) -> None:
+    """The baseline AEAD property: no malleability, not even one bit."""
+    store.set("TOKEN", b"value")
+    row = _rows(store)[0]
+    corrupted = bytearray(row[5])
+    corrupted[0] ^= 0x01
+
+    with sqlite3.connect(store.path) as connection:
+        connection.execute("UPDATE secrets SET ciphertext = ?", (bytes(corrupted),))
+
+    with pytest.raises(SecretCorrupt, match="failed authentication"):
+        store.get("TOKEN")
+
+
+def test_flipping_one_nonce_bit_fails_closed(store: SecretStore) -> None:
+    store.set("TOKEN", b"value")
+    row = _rows(store)[0]
+    corrupted = bytearray(row[4])
+    corrupted[0] ^= 0x01
+
+    with sqlite3.connect(store.path) as connection:
+        connection.execute("UPDATE secrets SET nonce = ?", (bytes(corrupted),))
+
+    with pytest.raises(SecretCorrupt, match="failed authentication"):
+        store.get("TOKEN")
+
+
+def test_inner_and_outer_name_copies_cannot_disagree(store: SecretStore) -> None:
+    """The belt-and-braces check, exercised on its own.
+
+    The name exists twice: sealed inside the ciphertext (so ``list`` can read
+    it back) and as the blind index column (so lookups work). The AAD binds the
+    column; this test proves the store ALSO rejects a record whose two copies
+    disagree, which is what stops anyone holding the key from constructing such
+    a record. It is built by re-sealing deliberately — the AAD is honest here,
+    so only the consistency check can catch it.
+    """
+    import json
+
+    from local_operator.secrets.crypto import seal
+
+    store.set("REAL_NAME", b"value")
+    row = _rows(store)[0]
+    record_id, stored_index, generation, format_version, _, _, kind = row
+
+    # A payload claiming a different name than the index it is stored under.
+    payload = json.dumps(
+        {"name": "DIFFERENT_NAME", "description": "", "value": b"value".hex()},
+        separators=(",", ":"),
+    ).encode()
+    metadata = RecordMetadata(
+        record_id=record_id,
+        name_index=bytes(stored_index),
+        kind=kind,
+        key_generation=generation,
+        format_version=format_version,
+    )
+    nonce, ciphertext = seal(store._master_key, metadata, payload)
+
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            "UPDATE secrets SET nonce = ?, ciphertext = ? WHERE id = ?",
+            (nonce, ciphertext, record_id),
+        )
+
+    with pytest.raises(SecretCorrupt, match="sealed name does not match"):
+        store.get("REAL_NAME")
+
+
+def test_aad_actually_covers_every_bound_field() -> None:
+    """A direct guard on the binding itself.
+
+    The tests above prove the behaviour end to end, but they would all still
+    pass if a future refactor kept the fields and changed their encoding in a
+    way that made two different tuples collide. This asserts the property
+    directly: changing any single bound field changes the AAD bytes.
+    """
+    base = RecordMetadata(
+        record_id="11111111-1111-1111-1111-111111111111",
+        name_index=b"\x01" * 16,
+        kind="string",
+        key_generation=1,
+    )
+    variants = [
+        RecordMetadata(
+            record_id="22222222-2222-2222-2222-222222222222",
+            name_index=base.name_index,
+            kind=base.kind,
+            key_generation=base.key_generation,
+        ),
+        RecordMetadata(
+            record_id=base.record_id,
+            name_index=b"\x02" * 16,
+            kind=base.kind,
+            key_generation=base.key_generation,
+        ),
+        RecordMetadata(
+            record_id=base.record_id,
+            name_index=base.name_index,
+            kind="file",
+            key_generation=base.key_generation,
+        ),
+        RecordMetadata(
+            record_id=base.record_id,
+            name_index=base.name_index,
+            kind=base.kind,
+            key_generation=2,
+        ),
+        RecordMetadata(
+            record_id=base.record_id,
+            name_index=base.name_index,
+            kind=base.kind,
+            key_generation=base.key_generation,
+            format_version=2,
+        ),
+    ]
+    encodings = {build_aad(base)} | {build_aad(variant) for variant in variants}
+    assert len(encodings) == len(variants) + 1, "two distinct records share an AAD encoding"
+
+
+def test_deleting_a_row_does_not_affect_the_others(store: SecretStore) -> None:
+    """Records are independently sealed; damage does not spread."""
+    store.set("ALPHA", b"alpha-value")
+    store.set("BETA", b"beta-value")
+    with sqlite3.connect(store.path) as connection:
+        connection.execute(
+            "DELETE FROM secrets WHERE ciphertext = (SELECT ciphertext" " FROM secrets LIMIT 1)"
+        )
+    remaining = store.list()
+    assert len(remaining) == 1
+    assert store.get(remaining[0].name).endswith(b"-value")

--- a/tests/unit/session/test_no_session_deletion.py
+++ b/tests/unit/session/test_no_session_deletion.py
@@ -268,6 +268,29 @@ _ALLOWED_ROWS: tuple[tuple[str | int, ...], ...] = (
         "os.replace",
         "temp FILE -> master.key, both under config_dir()/secrets",
     ),
+    # The same temp file, unlinked when the rename fails. The name is
+    # `master.key.new.<pid>.<random>` next to `master.key`; it is per-process precisely
+    # so concurrent rotations cannot consume each other's, and no caller input
+    # reaches it.
+    (
+        "local_operator/secrets/keys.py::replace_master_key",
+        "<path>.unlink",
+        "the master.key.new.<pid>.<random> temp FILE this call just wrote",
+    ),
+    # Removing a rotation's staged key: a fixed basename under
+    # config_dir()/secrets, no caller input, never a session directory.
+    (
+        "local_operator/secrets/keys.py::discard_staged_master_key",
+        "<path>.unlink",
+        "master.key.incoming under config_dir()/secrets",
+    ),
+    # `stage_master_key` clears any leftover staging file before writing its
+    # own, for the same fixed path.
+    (
+        "local_operator/secrets/keys.py::stage_master_key",
+        "<path>.unlink",
+        "master.key.incoming under config_dir()/secrets",
+    ),
     # `lop secret file` materialises a file-shaped secret for the lifetime of
     # one command. The directory removed is the one `tempfile.mkdtemp()`
     # returned to this same function moments earlier, under $TMPDIR — it is

--- a/tests/unit/session/test_no_session_deletion.py
+++ b/tests/unit/session/test_no_session_deletion.py
@@ -307,6 +307,19 @@ _ALLOWED_ROWS: tuple[tuple[str | int, ...], ...] = (
         "<path>.unlink",
         "the master.stage.<pid>.<random>.tmp temp FILE this call just wrote",
     ),
+    # Exclusive creation of master.key on concurrent first use: the payload is
+    # written to `master.key.new.<pid>.<random>` and hardlinked onto
+    # `master.key`, so only a complete file is ever published and only one
+    # caller can publish it. This unlink clears that temporary on EVERY exit —
+    # the lost race included, where the link left the target untouched. Both
+    # names come from `keys.key_path()` (config_dir()/secrets plus a fixed
+    # basename) and this process's own pid/random suffix; no caller input and
+    # no session id reaches either, so neither can name a path under sessions/.
+    (
+        "local_operator/secrets/keys.py::create_private_file",
+        "<path>.unlink",
+        "the master.key.new.<pid>.<random> temp FILE this call just wrote",
+    ),
     # `lop secret file` materialises a file-shaped secret for the lifetime of
     # one command. The directory removed is the one `tempfile.mkdtemp()`
     # returned to this same function moments earlier, under $TMPDIR — it is

--- a/tests/unit/session/test_no_session_deletion.py
+++ b/tests/unit/session/test_no_session_deletion.py
@@ -277,19 +277,35 @@ _ALLOWED_ROWS: tuple[tuple[str | int, ...], ...] = (
         "<path>.unlink",
         "the master.key.new.<pid>.<random> temp FILE this call just wrote",
     ),
-    # Removing a rotation's staged key: a fixed basename under
-    # config_dir()/secrets, no caller input, never a session directory.
+    # Removing a rotation's staged key. The paths come from
+    # `keys.staged_key_paths()`, which globs `master.key.incoming*` inside
+    # config_dir()/secrets -- no caller input reaches the pattern or the
+    # directory, so it cannot name anything under sessions/. The unlink is
+    # additionally gated on the file holding THIS caller's key, which is what
+    # stops one rotation deleting another's only on-disk copy.
     (
         "local_operator/secrets/keys.py::discard_staged_master_key",
         "<path>.unlink",
-        "master.key.incoming under config_dir()/secrets",
+        "master.key.incoming* under config_dir()/secrets, holding this call's own key",
     ),
-    # `stage_master_key` clears any leftover staging file before writing its
-    # own, for the same fixed path.
+    # Same shape as `replace_master_key` below: a temp FILE inside the secrets
+    # directory renamed onto the staged-key FILE beside it. Both names are
+    # built from `keys.secrets_dir()` plus fixed prefixes and this process's
+    # pid/random suffix; no caller input reaches either, so neither can name a
+    # path under sessions/. The rename replaces only the temporary this call
+    # just wrote.
+    (
+        "local_operator/secrets/keys.py::stage_master_key",
+        "os.replace",
+        "temp FILE -> master.key.incoming.<pid>.<random>, both under config_dir()/secrets",
+    ),
+    # The same staging temporary, unlinked when its rename fails. Named
+    # `master.stage.<pid>.<random>.tmp` under config_dir()/secrets and never
+    # derived from caller input.
     (
         "local_operator/secrets/keys.py::stage_master_key",
         "<path>.unlink",
-        "master.key.incoming under config_dir()/secrets",
+        "the master.stage.<pid>.<random>.tmp temp FILE this call just wrote",
     ),
     # `lop secret file` materialises a file-shaped secret for the lifetime of
     # one command. The directory removed is the one `tempfile.mkdtemp()`

--- a/tests/unit/session/test_no_session_deletion.py
+++ b/tests/unit/session/test_no_session_deletion.py
@@ -258,6 +258,27 @@ _ALLOWED_ROWS: tuple[tuple[str | int, ...], ...] = (
         "os.replace",
         "temp FILE -> .env",
     ),
+    # Same shape as the credentials writer above: a temp FILE inside the
+    # secrets directory replacing master.key in that same directory. Both
+    # paths come from `keys.key_path()`, which is `config_dir()/secrets/` plus
+    # a fixed basename — no caller input and no session id reaches either, so
+    # neither can name a path under sessions/.
+    (
+        "local_operator/secrets/keys.py::replace_master_key",
+        "os.replace",
+        "temp FILE -> master.key, both under config_dir()/secrets",
+    ),
+    # `lop secret file` materialises a file-shaped secret for the lifetime of
+    # one command. The directory removed is the one `tempfile.mkdtemp()`
+    # returned to this same function moments earlier, under $TMPDIR — it is
+    # never derived from a session id, a config dir or any caller input, so it
+    # cannot name a session directory. Removing it is the point: it holds
+    # decrypted plaintext that must not outlive the command (design §7).
+    (
+        "local_operator/secrets/handlers.py::_file",
+        "shutil.rmtree",
+        "the mkdtemp() dir this function just created under $TMPDIR",
+    ),
     (
         "local_operator/credentials.py::CredentialManager.write_to_file",
         "os.unlink",


### PR DESCRIPTION
## Summary of Changes

**PR 1 of 4** from `docs/design/secret-store.md`: the store core — AES-256-GCM record sealing, the SQLite WAL schema, the blind index, key generation and rotation, the audit hash chain, and the `lop secret` CLI reading the master key file directly.

**No broker daemon and no peer authentication in this PR.** Those are PR 2; `local_operator/secrets/access.py` is the seam they slide into, and it is a real seam rather than a stub — `harden`/`unlock` report that passphrase mode needs the broker instead of pretending to succeed.

C2. Backend-only, additive, no user-visible TUI surface; no version bump.

Release: minor — a new encrypted long-term secret store (AES-256-GCM over SQLite/WAL) reachable through a new `lop secret` CLI; PR 1 of 4, no agent-facing surface yet.

### What it is, and what it is not

The baseline this replaces is ~58 plaintext `KEY=VALUE` lines at a predictable path that `grep -rl API_KEY ~` finds in seconds. Here **neither the values nor the names** appear in cleartext on disk, so the automated "scan the disk for credentials" theft a bad link actually drops finds nothing to take.

**It is not a vault, and nothing in the code, help text or docs calls it one.** In the default `keyfile` mode the master key sits beside the database, so an attacker who reads that file decrypts the store; and nothing confined to one macOS user account stops a process that simply runs `lop secret get` itself. `lop secret status` says exactly that, in those words, because that is where an operator forms their mental model. Design §9 has the full residual-risk list.

### Two corrections to the design doc, applied and recorded

The design doc was **untracked in the working tree** — never committed — so it is committed here with both corrections in place rather than left to be rediscovered.

**1. §3's AAD was not implementable as written.** It binds the cleartext `name` and `sha256(description)`, but §4 stores both *inside* the ciphertext. A GCM tag covers the AAD, so the AAD must be known **before** decrypting, while two of its fields were only recoverable *by* decrypting. `get NAME` could limp along; `list` and `rotate` enumerate rows with no candidate name and could never open a single record. The two sections contradicted each other.

The AAD now binds the `name_index` column — the HMAC blind index §4 already specifies:

```
AAD = b"lopsec\x00" || format_version(u8) || key_generation(u32be) || record_id || \x00
      || name_index || \x00 || kind
```

Every property §3 asks for survives: the blind index is a deterministic function of the name, so **rename fails closed**; `record_id` is still bound, so **ciphertext swap fails closed**; name and description remain authenticated by being sealed *inside* the AEAD. The store additionally re-derives the blind index from the decrypted name and rejects a mismatch, so the inner and outer copies of the name cannot drift apart. §3 carries a note recording why.

**2. `cryptography` was a transitive, not a direct dependency.** It arrives via `pyjwt[crypto]`, but a direct import belongs in a direct declaration — if that extra were narrowed or replaced, `lop secret` would fail at import with nothing pointing at the cause. Declared as `cryptography>=42`; **install footprint unchanged**, since it is already resolved.

### The stdout contract

`get` writes the exact stored bytes to the stdout buffer and nothing else — no banner, no ANSI, no trailing newline — because `$(lop secret get NAME)` is the entire point and one stray byte silently corrupts every consumer (surfacing as a puzzling 401 from a remote service, not as an error anyone traces back here). `set` reads from stdin and there is **no `--value` flag**: argv is readable by any same-uid process. `list` has no way to print a value — there is no field on the record to print.

## Related Issue(s)

None requested; this PR is the C2 change record. PRs 2–4 (broker + peer auth; agent tool + eval library + redaction wiring; inline `/credential` capture) follow per design §14.

## Reproduction and actual execution

Real CLI, real subprocesses, scratch config dir with **both** `HOME` and `LOCAL_OPERATOR_CONFIG_DIR` redirected (per `AGENTS.md`: the config override alone does not isolate a run).

**The contract — exact bytes:**

```
$ printf 'ghp_realtokenvalue123' | lop secret set GITHUB_TOKEN --description "GitHub PAT"
stored GITHUB_TOKEN (21 bytes, kind=string)        # <- stderr

$ lop secret get GITHUB_TOKEN | xxd
00000000: 6768 705f 7265 616c 746f 6b65 6e76 616c  ghp_realtokenval
00000010: 7565 3132 33                             ue123

$ lop secret get GITHUB_TOKEN > raw.bin; wc -c < raw.bin
21                                                  # 21 chars in, 21 bytes out — no trailing newline

$ echo "Authorization: Bearer $(lop secret get GITHUB_TOKEN)"
Authorization: Bearer ghp_realtokenvalue123
```

**`list` never prints a value:**

```
$ lop secret list
GITHUB_TOKEN  string  GitHub PAT for gh CLI
MULTILINE     string  has newlines
SA_JSON       file    GCP SA key

$ lop secret list | grep -c 'ghp_realtokenvalue123\|service_account'
0
```

**Encrypted at rest — the property the whole feature exists for:**

```
$ sqlite3 store.db 'PRAGMA wal_checkpoint(TRUNCATE)'
$ for pat in ghp_realtokenvalue123 GITHUB_TOKEN service_account MULTILINE; do
    grep -qa "$pat" store.db* && echo "LEAK: $pat" || echo "not in cleartext: $pat"; done
not in cleartext: ghp_realtokenvalue123
not in cleartext: GITHUB_TOKEN          # <- the NAME is blind-indexed, not stored
not in cleartext: service_account
not in cleartext: MULTILINE
```

**Failure cases — every one leaves stdout empty**, which is what stops a failed retrieval from being interpolated into a command:

```
$ lop secret get NO_SUCH_SECRET ;  echo "exit=$? stdout_bytes=$(… | wc -c)"
exit=2 stdout_bytes=0
No secret named 'NO_SUCH_SECRET' in this store.

# tamper: swap two records' ciphertexts directly in SQLite
$ sqlite3 store.db "UPDATE secrets SET nonce=…,ciphertext=… …"   # swapped by hand
$ lop secret get GITHUB_TOKEN
exit=2 stdout_bytes=0
Secret record 0f647872-… failed authentication: its ciphertext or its metadata
(name, description, kind, key generation) was modified after it was written… Refusing to return a value.

# tamper: relabel a record as a trusted name (rewrite its blind index)
$ lop secret get ADMIN_ROOT_PASSWORD
exit=2 stdout_bytes=0
Secret record 0f647872-… failed authentication: … Refusing to return a value.

# permissions loosened after the fact
$ chmod 644 master.key && lop secret get GITHUB_TOKEN
exit=2 stdout_bytes=0
/…/master.key has mode 0644; it must not be readable by group or others.
Fix it with: chmod 0600 /…/master.key
$ ls -l master.key   # NOT silently repaired — the exposure already happened
-rw-r--r--

# store written by a newer runtime (§13)
$ sqlite3 store.db "UPDATE meta SET v='99' WHERE k='schema_version'"
$ lop secret get GITHUB_TOKEN
exit=2 stdout_bytes=0
This secret store uses schema version 99; this runtime speaks 1. It was written by a
newer local-operator — upgrade this runtime (lop update).
```

**Audit chain, rotation, file secrets:**

```
$ lop secret audit --verify
audit chain intact
$ sqlite3 store.db "UPDATE audit SET event='describe' WHERE rowid=3"   # hide a retrieval
$ lop secret audit --verify ; echo "exit=$?"
audit chain broken at entry 3: this entry was edited after it was written
exit=1

$ lop secret rotate
rotated 3 secret(s) to key generation 2
# values identical before/after, master.key changed — verified by shasum

$ lop secret file SA_JSON -- bash -c 'cat $GOOGLE_APPLICATION_CREDENTIALS; cat $GOOGLE_APPLICATION_CREDENTIALS; ls -ld $(dirname $GOOGLE_APPLICATION_CREDENTIALS)'
{"type":"service_account","project_id":"demo"}
{"type":"service_account","project_id":"demo"}     # re-openable: why §7 rejected FIFO and /dev/fd
drwx------  …/lop-secret-aw44n8oa
# after the command: plaintext file removed, private dir removed — both verified
```

**Permissions and 100 KB binary fidelity:**

```
$ ls -ld secrets/ && ls -l secrets/
drwx------  secrets/
-rw-------  master.key
-rw-------  store.db

$ python -c "…bytes(range(256))*400" | lop secret set BIG_SECRET
stored BIG_SECRET (102400 bytes, kind=string)
$ lop secret get BIG_SECRET | wc -c ; lop secret get BIG_SECRET | shasum
102400
8b77024839e8dbd39af4…      # identical to the input's shasum
```

## Testing Details

| Check | Actual result |
| --- | --- |
| Whole-tree unit suite | **16,616 passed, 18 skipped**, 709 warnings in 676.35s (11m16s), **exit 0** |
| New `tests/unit/secrets` | **101 passed** |
| Whole-tree flake8 | exit 0, no output |
| Pinned Black 26.1.0 | 1,109 files unchanged |
| Pinned isort 5.13.2 | exit 0 |
| Whole-tree pyright 1.1.411 | **0 errors, 0 warnings, 0 informations** |

All against committed head, using the worktree's **own** `.venv` (import resolution verified as `~/workspace/repos/lo-secret-store/local_operator/__init__.py`, per `AGENTS.md` "Every feature worktree owns its own venv").

### The tests demonstrate the properties rather than asserting them in comments

- **Round-trip** (`test_roundtrip.py`) — newlines, unicode, embedded NULs, CRLF, empty, trailing newlines, and 100 KB. Plus a fresh-nonce test that stores the *same* value 20 times and asserts 20 distinct nonces **and** 20 distinct ciphertexts, which is what catches a nonce that is fresh in the column but not actually used to encrypt.
- **Tamper** (`test_tamper.py`) — every case corrupts the **real on-disk SQLite file** with a plain `UPDATE`, exactly as an attacker with write access would: rename via blind index, ciphertext swap, whole-logical-record swap, `kind` edit, `key_generation` edit, single-bit flips in nonce and ciphertext, and the inner/outer name-mismatch rejection.
- **Concurrency** (`test_concurrency.py`) — 10 readers × 60 decrypts against a live writer, as **threads** and again as **11 real spawned interpreters**, plus 10 concurrent writing processes with no lost records. Not mocks.
- **Permissions** (`test_permissions.py`) — 0600/0700 asserted on the DB, the WAL/SHM sidecars, the key file and the directory, **including under `umask 000`**, which is the case `mkdir(mode=…)` silently loses. Plus a test that greps the raw DB bytes for the value, the name and the description.
- **Compatibility** (`test_compatibility.py`) — newer schema refused on read *and* write, newer per-record format refused, older schema refused, and the message asserted to name both versions and the fix.
- **Audit** (`test_audit.py`) — intact chain verifies; edit-in-place, delete-middle, reorder and naive-append each break it at the correct 1-based position.

### Tests proven able to fail

`AGENTS.md` is explicit that a green test is not evidence it can still fail, so the load-bearing ones were mutation-checked:

```sh
# Concurrency: replace WAL with DELETE and drop busy_timeout
→ 3 failed (database is locked)      # restored → 3 passed

# AAD: drop name_index from build_aad
→ 2 failed (test_renaming_a_record…, test_aad_actually_covers_every_bound_field)

# AAD: drop record_id from build_aad
→ 2 failed (test_swapping_whole_logical_records…, test_aad_actually_covers_every_bound_field)
```

The two swap tests are deliberately a **pair**: the simple one is caught by the `name_index` binding and stays green when `record_id` is dropped, so `test_swapping_whole_logical_records_fails_closed` exists to pin `record_id`'s independent contribution. Each AAD field now has a test that goes red when it alone is removed.

### Things the tests caught that I would otherwise have shipped

Reported rather than quietly fixed, since they are the interesting part of the diff:

1. **`argparse.REMAINDER` swallowed our own flags.** `lop secret file NAME --env-var VAR -- cmd` parsed `--env-var` as part of the child command and silently used the default variable name. Silent — the command ran, only the wrong variable was set. Fixed to `nargs="*"` (which still stops option parsing at `--`, so the child's own flags survive) with a regression test for both verbs.
2. **The crypto stack was on the CLI startup path.** `secrets/cli.py` imported `KINDS` from `store.py`, so registering `--kind`'s choices pulled in an OpenSSL binding and sqlite3 on **every** `lop` invocation including `--version`. `KINDS` moved to the stdlib-only `errors.py` and the verbs moved to `handlers.py`, imported only once a verb is dispatched. `test_startup_cost.py` pins it.
3. **Two whole-tree guards fired, both correctly.** `test_ambient_env_isolation` — `LOCAL_OPERATOR_SESSION_ID` names a session, so an inherited value would write the operator's real session id into a sandboxed store's audit rows; scrubbed via `_AMBIENT_VARS`. `test_no_session_deletion` — the `mkdtemp` cleanup and the `master.key` replace are allow-listed with the reason each provably cannot reach a directory under `sessions/`.
4. **A test of mine hid its own diagnostic.** A failed setup `set` surfaced as `json.loads('')` on the *next* command's empty stdout, naming neither the failing command nor its stderr. Setup steps now assert their exit code and print what the process said; negative cases still use the unchecked form deliberately.

## Notes for the reviewer

- `local_operator/secrets/store.py::_decode` is where the AAD correction lives — the AAD is rebuilt from the row's own **columns**, never from anything inside the ciphertext, and the blind-index re-derivation at the end is what stops the two copies of the name drifting.
- `access.py` is the broker seam. PR 2 replaces the body of `open_store` and nothing else.
- `_file`'s cleanup is a `finally`, which covers a normal exit, an exception and SIGINT — **not** SIGKILL or an unhandled SIGTERM. Named in a comment rather than papered over; the signal handler belongs to the PR that owns process lifecycle.
- Deliberately not implemented, per the task's scope: the broker daemon, peer authentication, the agent tool, the eval library, and the inline `/credential` composer change.

