### PR TITLE
chore(release): bump version to 0.51.26

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.25"
+version = "0.51.26"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window claim for v0.51.26. Change class: C0 (single-file version bump).

Window contents: #793 only, merge SHA `fcda02e43951c42567ce52172ab5de08b5041665`.

Release: patch — session history now fills the screen with room to scroll on switch, loads older messages above without shifting what you are reading, and keeps scrolling up without needing a down/up reset.

Scope check: `pyproject.toml` line 7 only, `0.51.25` -> `0.51.26`. No dependency pin, script, or entry point changed beside the bump; no deploy or release pipeline consumes that field as an input.

```
$ git diff origin/main..HEAD
-version = "0.51.25"
+version = "0.51.26"
```