### PR TITLE
chore(release): bump version to 0.51.27

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.26"
+version = "0.51.27"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
## What and why

Release bump for the current window. **Change class C0** — one file, one line, no code.

`pyproject.toml`: `0.51.26` → `0.51.27`.

### Window contents

Re-derived from `git log v0.51.26..main` immediately before opening this PR:

| PR | merge SHA | impact |
|---|---|---|
| #810 | `f914a55c137971927e2cf91dc7481d91d7ef08c9` | Canonical profile, team and session catalogue for the desktop app |

### Bump class: patch

#810 is a substantial feature, so minor is the tempting call. It does not clear the step-function bar the standing rule sets for minor: every endpoint is gated behind `session_catalogue` capability negotiation, an older client observes no change whatsoever, and no existing endpoint, behaviour or data layout is altered. It enables a desktop feature that has not shipped yet — the UI half lives in another repo with its own release — so from this package's perspective it is additive surface no current caller reaches.

Window lock: #813.
