### PR TITLE
chore(release): bump version to 0.51.28

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "local-operator"
-version = "0.51.27"
+version = "0.51.28"
 description = "A team of proactive AI assistants that can work together behind the scenes to help you get mundane tasks done so you can focus on the fun stuff."
 readme = "README.md"
 authors = [{ name = "Damian Tran", email = "damian@gominerva.com" }]


### PR DESCRIPTION
Release window for **v0.51.28**, bump class **PATCH**. Owner session pid 35138.

Last tag v0.51.27. This PR is the lock and the bump: one line in one file (`pyproject.toml`), no code.

Window (both merged):
- [x] #808 `e1f1603c356dc32ba5fa2cb827b9c0dc5da4237c` — Release: patch — a stuck or completed runtime no longer blocks switching: the selected conversation appears from saved state, keeps its draft, and says how to retry.
- [x] #798 `ee146fb73ca31518cff6081765dd13f366ad09f3` — Release: patch — browser tab allocation is exception-safe and ownership is durable, so a failed navigation can no longer strand a tab and exhaust the eight-tab pool.

Bump class argued and independently re-confirmed against the full two-PR window: both are `fix:` on existing subsystems, neither clears the step-function bar alone, and several patches in one window are still one patch. `lop browser tabs/reconcile/cleanup` extend an existing command group rather than adding a surface.

Verified before tagging: `git diff v0.51.27..origin/main -- pyproject.toml` is empty (no merged PR consumed 0.51.28), window re-derived with a plain `git log` (never `--merges`, which drops squash-merged PRs), and all 16 checks green including both `tui-e2e` legs.