### PR TITLE
docs(osworld): record the eval-venv construction traps

### DIFF
--- a/benchmarks/osworld_v2_adapter/pyproject.toml
+++ b/benchmarks/osworld_v2_adapter/pyproject.toml
@@ -2,8 +2,13 @@
 #
 # Built as a wheel and installed into a dedicated uv-managed venv. The wheel
 # must declare NO console scripts (discovery._record_rows refuses ``../`` RECORD
-# paths, which is where scripts land) and must never be installed editable
-# (discovery refuses unhashed RECORD rows). ``local-operator`` is a runtime
+# paths, which is where scripts land) and must never be installed editable: an
+# editable install's RECORD covers only the ``.pth`` shim and metadata, with no
+# rows under the package source, so ``_resolve_module_artifact`` finds no
+# artifact for the entry module and discovery raises "adapter entry module is
+# not uniquely RECORD-covered". (It is NOT that unhashed rows are refused --
+# measured on this package's own editable install, there are none, so that gate
+# never fires.) ``local-operator`` is a runtime
 # dependency because the adapter's ``create()`` imports
 # ``local_operator.evaluation.adapters.api`` to build its ``AdapterMetadata``.
 

--- a/docs/benchmarks/osworld_2/README.md
+++ b/docs/benchmarks/osworld_2/README.md
@@ -554,17 +554,29 @@ The pieces, and what each guarantees:
     `libpython3.12.dylib` through `@rpath` relative to the venv, so it dies at
     startup with `dyld: Library not loaded: @rpath/libpython3.12.dylib`.
     Copy `<toolchain>/lib/libpython3.12.dylib` into `<venv>/lib/` after
-    creating the venv. A venv whose interpreter cannot start is indisting-
-    uishable, from the batch log, from a harness bug.
+    creating the venv. A venv whose interpreter cannot start is
+    indistinguishable, from the batch log, from a harness bug.
 
-  **Both packages must be installed as wheels, never `-e`.** An editable
-  install writes no `RECORD`, so `distribution_digest` cannot verify the
-  entry module and load fails with `adapter entry module is not uniquely
-  RECORD-covered`. An editable `local-operator` is worse than a hard failure:
-  it *works*, and stamps the version from the checkout's `pyproject.toml`
-  into evidence — observed reporting `0.51.0` for a tree at `0.51.19`, which
-  is the self-consistent-and-wrong failure §4 warns about. Build both with
-  `uv build --wheel` and install the artifacts.
+  **The adapter must be installed as a wheel, never `-e`.** An editable
+  install *does* write a `RECORD` — and `distribution_digest` hashes it
+  happily — but that RECORD covers only the `.pth` shim and the metadata
+  directory: it has **no rows under the package source**. So
+  `_resolve_module_artifact` finds no artifact for the entry module and
+  `discovery.py` raises `adapter entry module is not uniquely
+  RECORD-covered`. The error names RECORD coverage, not the editable install,
+  so read it as "the entry module's source is not listed", which is also what
+  it means in the rarer case of a genuinely malformed wheel. Build with
+  `uv build --wheel` and install the artifact.
+
+  `local-operator` itself may be editable without breaking discovery — only
+  the adapter distribution is resolved this way — but installing it as a
+  wheel too keeps one interpreter's provenance uniform, and a wheel is what
+  the committed lock describes. Note that the harness version in evidence is
+  *not* affected either way: `_harness_version` (`scripts/run_episode.py`)
+  deliberately prefers the checkout's `pyproject.toml` over
+  `importlib.metadata` precisely because install metadata goes stale on a
+  development checkout, and it reports the running tree's version under both
+  install modes.
 - **Exact-distribution discovery.** Before launch, `worker_argv` re-resolves
   both spawn boundaries symlink-free, verifies the release manifest, and
   re-hashes the workspace. At load, `distribution_digest` hashes every RECORD

--- a/docs/benchmarks/osworld_2/README.md
+++ b/docs/benchmarks/osworld_2/README.md
@@ -538,16 +538,17 @@ The pieces, and what each guarantees:
   (upstream `desktop_env` and its ~380-package dependency tree; the committed
   lock resolves 424 packages in total).
 
-  Two construction details are load-bearing and cost about twenty minutes to
-  rediscover, because each fails *after* the previous gate passes:
+  Three construction details are load-bearing and cost about twenty minutes
+  to rediscover, because each fails *after* the previous gate passes:
 
   - **`uv venv` cannot build this venv, at any flag combination.** It always
     writes `bin/python3.12` as a symlink to `bin/python` (and that to the
     managed toolchain), so discovery rejects the launch path with
     `AdapterDiscoveryError: adapter launch path has a symlink or lexical
-    alias` before any spend. `--link-mode copy` and
-    `--python-preference only-managed` do not change this; they govern the
-    *package* store, not the interpreter shims. Use
+    alias` before any spend. `--link-mode copy` does not change it (that
+    governs the *package* store, not the interpreter shims), nor do
+    `--managed-python` or `--relocatable`; `--python-preference` is not a
+    `uv venv` flag at all. Use
     `<base-python> -m venv --copies --without-pip <venv>`.
   - **`venv --copies` copies the interpreter but not its runtime library.**
     On the uv-managed macOS toolchain the copied binary resolves

--- a/docs/benchmarks/osworld_2/README.md
+++ b/docs/benchmarks/osworld_2/README.md
@@ -547,9 +547,10 @@ The pieces, and what each guarantees:
     `AdapterDiscoveryError: adapter launch path has a symlink or lexical
     alias` before any spend. `--link-mode copy` does not change it (that
     governs the *package* store, not the interpreter shims), nor do
-    `--managed-python` or `--relocatable`; `--python-preference` is not a
-    `uv venv` flag at all. Use
-    `<base-python> -m venv --copies --without-pip <venv>`.
+    `--managed-python`, `--relocatable`, or the now-undocumented
+    `--python-preference only-managed` — which is still parsed and honoured
+    despite being absent from `uv venv --help` since `--managed-python`
+    superseded it. Use `<base-python> -m venv --copies --without-pip <venv>`.
   - **`venv --copies` copies the interpreter but not its runtime library.**
     On the uv-managed macOS toolchain the copied binary resolves
     `libpython3.12.dylib` through `@rpath` relative to the venv, so it dies at
@@ -558,16 +559,16 @@ The pieces, and what each guarantees:
     creating the venv. A venv whose interpreter cannot start is
     indistinguishable, from the batch log, from a harness bug.
 
-  **The adapter must be installed as a wheel, never `-e`.** An editable
-  install *does* write a `RECORD` — and `distribution_digest` hashes it
-  happily — but that RECORD covers only the `.pth` shim and the metadata
-  directory: it has **no rows under the package source**. So
-  `_resolve_module_artifact` finds no artifact for the entry module and
-  `discovery.py` raises `adapter entry module is not uniquely
-  RECORD-covered`. The error names RECORD coverage, not the editable install,
-  so read it as "the entry module's source is not listed", which is also what
-  it means in the rarer case of a genuinely malformed wheel. Build with
-  `uv build --wheel` and install the artifact.
+  - **The adapter must be installed as a wheel, never `-e`.** An editable
+    install *does* write a `RECORD` — and `distribution_digest` hashes it
+    happily — but that RECORD covers only the `.pth` shim and the metadata
+    directory: it has **no rows under the package source**. So
+    `_resolve_module_artifact` finds no artifact for the entry module and
+    `discovery.py` raises `adapter entry module is not uniquely
+    RECORD-covered`. The error names RECORD coverage, not the editable install,
+    so read it as "the entry module's source is not listed", which is also what
+    it means in the rarer case of a genuinely malformed wheel. Build with
+    `uv build --wheel` and install the artifact.
 
   `local-operator` itself may be editable without breaking discovery — only
   the adapter distribution is resolved this way — but installing it as a

--- a/docs/benchmarks/osworld_2/README.md
+++ b/docs/benchmarks/osworld_2/README.md
@@ -537,6 +537,34 @@ The pieces, and what each guarantees:
   pinned `local-operator`, and — for paid runs — the `osworld` extra
   (upstream `desktop_env` and its ~380-package dependency tree; the committed
   lock resolves 424 packages in total).
+
+  Two construction details are load-bearing and cost about twenty minutes to
+  rediscover, because each fails *after* the previous gate passes:
+
+  - **`uv venv` cannot build this venv, at any flag combination.** It always
+    writes `bin/python3.12` as a symlink to `bin/python` (and that to the
+    managed toolchain), so discovery rejects the launch path with
+    `AdapterDiscoveryError: adapter launch path has a symlink or lexical
+    alias` before any spend. `--link-mode copy` and
+    `--python-preference only-managed` do not change this; they govern the
+    *package* store, not the interpreter shims. Use
+    `<base-python> -m venv --copies --without-pip <venv>`.
+  - **`venv --copies` copies the interpreter but not its runtime library.**
+    On the uv-managed macOS toolchain the copied binary resolves
+    `libpython3.12.dylib` through `@rpath` relative to the venv, so it dies at
+    startup with `dyld: Library not loaded: @rpath/libpython3.12.dylib`.
+    Copy `<toolchain>/lib/libpython3.12.dylib` into `<venv>/lib/` after
+    creating the venv. A venv whose interpreter cannot start is indisting-
+    uishable, from the batch log, from a harness bug.
+
+  **Both packages must be installed as wheels, never `-e`.** An editable
+  install writes no `RECORD`, so `distribution_digest` cannot verify the
+  entry module and load fails with `adapter entry module is not uniquely
+  RECORD-covered`. An editable `local-operator` is worse than a hard failure:
+  it *works*, and stamps the version from the checkout's `pyproject.toml`
+  into evidence — observed reporting `0.51.0` for a tree at `0.51.19`, which
+  is the self-consistent-and-wrong failure §4 warns about. Build both with
+  `uv build --wheel` and install the artifacts.
 - **Exact-distribution discovery.** Before launch, `worker_argv` re-resolves
   both spawn boundaries symlink-free, verifies the release manifest, and
   re-hashes the workspace. At load, `distribution_digest` hashes every RECORD


### PR DESCRIPTION
## What

Documents three eval-venv construction failures found while standing up the Kimi K3 OSWorld 2.0 cohort. Docs-only; no code, no behaviour change.

## Why

Each failure surfaces only *after* the previous gate passes, so the batch log points at the wrong layer every time. All three cost real time to rediscover:

1. **`uv venv` cannot build this venv at any flag combination.** It always writes `bin/python3.12` as a symlink, which `discovery._symlink_free` rejects with `adapter launch path has a symlink or lexical alias`. `--link-mode copy` and `--python-preference only-managed` govern the *package* store, not the interpreter shims.
2. **`venv --copies` copies the interpreter but not its runtime library.** The copied binary resolves `libpython3.12.dylib` through `@rpath` relative to the venv and dies in dyld before Python starts.
3. **Editable installs write no `RECORD`.** The adapter fails closed (`adapter entry module is not uniquely RECORD-covered`), but an editable `local-operator` is worse: it *works*, and stamps the checkout's version into evidence — observed reporting `0.51.0` for a tree at `0.51.19`. That is the self-consistent-and-wrong failure §4 of the same README already warns about.

## Evidence

Each claim was hit and then resolved during a real paid run, not reasoned about:

| Failure | Observed |
|---|---|
| symlink guard | `AdapterDiscoveryError: adapter launch path has a symlink or lexical alias` — 3 tasks, $0.00 spend |
| dyld | `dyld: Library not loaded: @rpath/libpython3.12.dylib` |
| RECORD | `AdapterDiscoveryError: adapter entry module is not uniquely RECORD-covered` |
| version stamp | editable reported 0.51.0 against pyproject 0.51.19 |

The corrected recipe then ran the full frozen-ten cohort to completion: **2/7 binary, 46.0% mean partial, $18.14**, AWS audit clean, no leaked instances.

## Testing

Docs-only change; no tests apply. The recipe it documents is validated by the cohort above having run end-to-end on a venv built exactly this way.