### PR TITLE
fix(osworld): give upstream the proxy pool it reads at import

### DIFF
--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
@@ -417,16 +417,15 @@ class OSWorldV2Adapter:
         # a pure plan (when the task is already known), mints the deterministic
         # cleanup refs, and returns the plan the parent persists BEFORE any
         # side effect exists.
-        enable_proxy = provisioning.resolve_proxy_policy(
-            params.infra_values,
-            task_proxy=bool(self._task.proxy) if self._task is not None else False,
-        )
-        # Validate the proxy-pool config HERE, at the no-cost boundary. Upstream
-        # loads it at import and swallows every failure into a log line, so an
-        # unusable path becomes an empty pool and a crash at reset_start with a
-        # VM already allocated and billed. Failing in prepare converts that paid
-        # crash into a free, self-describing refusal.
-        provisioning.validate_proxy_config_file(params.infra_values, enable_proxy=enable_proxy)
+        provisioning.resolve_proxy_policy(params.infra_values)
+        # A SUPPLIED proxy config is validated here, at the earliest point that
+        # exists. This deliberately does NOT cover the absent-but-needed case:
+        # PrepareParams carries no task_id, so ``self._task`` is still None and
+        # the task's own proxy hint is unknowable at this boundary. Passing
+        # enable_proxy=False states that plainly instead of reading a hint that
+        # is always False and calling it a check. Requiredness is enforced in
+        # reset_start, after the task loads and still before allocation.
+        provisioning.validate_proxy_config_file(params.infra_values, enable_proxy=False)
         self._refs = cleanup_mod.CleanupRefs.mint(params.episode_id)
         self._infra_values = params.infra_values
         vendor_bridge.inject_infra_environment(params.infra_values)
@@ -484,6 +483,21 @@ class OSWorldV2Adapter:
                     f"{missing} were not supplied; OSWorld would return a silent "
                     "0.0, which this adapter refuses to seal"
                 )
+        # The proxy pool, checked HERE rather than in prepare because prepare
+        # has no task: PrepareParams carries no task_id and self._task is first
+        # populated a few lines above, so a prepare-time check reads
+        # task_proxy=False for every task and cannot fire for the very tasks
+        # that need it. This is the same shape as the judge refusal directly
+        # above -- fail AFTER the task is known and BEFORE anything is
+        # allocated, so the refusal is free. Upstream would instead load an
+        # empty pool at import and crash mid-episode with the VM already
+        # billed.
+        provisioning.validate_proxy_config_file(
+            self._infra_values,
+            enable_proxy=provisioning.resolve_proxy_policy(
+                self._infra_values, task_proxy=bool(self._task.proxy)
+            ),
+        )
         if self._provider_factory is None and self._read_provider_config().get("provider") in (
             None,
             "aws",

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
@@ -417,7 +417,16 @@ class OSWorldV2Adapter:
         # a pure plan (when the task is already known), mints the deterministic
         # cleanup refs, and returns the plan the parent persists BEFORE any
         # side effect exists.
-        provisioning.resolve_proxy_policy(params.infra_values)
+        enable_proxy = provisioning.resolve_proxy_policy(
+            params.infra_values,
+            task_proxy=bool(self._task.proxy) if self._task is not None else False,
+        )
+        # Validate the proxy-pool config HERE, at the no-cost boundary. Upstream
+        # loads it at import and swallows every failure into a log line, so an
+        # unusable path becomes an empty pool and a crash at reset_start with a
+        # VM already allocated and billed. Failing in prepare converts that paid
+        # crash into a free, self-describing refusal.
+        provisioning.validate_proxy_config_file(params.infra_values, enable_proxy=enable_proxy)
         self._refs = cleanup_mod.CleanupRefs.mint(params.episode_id)
         self._infra_values = params.infra_values
         vendor_bridge.inject_infra_environment(params.infra_values)

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/adapter.py
@@ -492,12 +492,22 @@ class OSWorldV2Adapter:
         # allocated, so the refusal is free. Upstream would instead load an
         # empty pool at import and crash mid-episode with the VM already
         # billed.
-        provisioning.validate_proxy_config_file(
-            self._infra_values,
-            enable_proxy=provisioning.resolve_proxy_policy(
-                self._infra_values, task_proxy=bool(self._task.proxy)
-            ),
+        # The CONJUNCTION, not the policy alone. ``resolve_proxy_policy``
+        # returns the override verbatim when one is supplied, so gating on it
+        # by itself would refuse every ORDINARY task whenever an operator set
+        # the run-wide OSWORLD_ENABLE_PROXY=true -- for want of a pool that
+        # task never touches. Upstream combines the two the same way
+        # (``desktop_env.py:321``: ``task_use_proxy = task_proxy and
+        # self.enable_proxy``) and so does this package's own requirements
+        # table (``requirements.py``: ``descriptor.proxy and enable_proxy``).
+        # Enforcement that disagrees with the declared requirements is worse
+        # than either rule alone: inspect_requirements would call the input
+        # optional and reset_start would then refuse the episode for missing
+        # it.
+        needs_proxy = bool(self._task.proxy) and provisioning.resolve_proxy_policy(
+            self._infra_values, task_proxy=bool(self._task.proxy)
         )
+        provisioning.validate_proxy_config_file(self._infra_values, enable_proxy=needs_proxy)
         if self._provider_factory is None and self._read_provider_config().get("provider") in (
             None,
             "aws",

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/provisioning.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/provisioning.py
@@ -16,6 +16,8 @@ wrong AMI is a result nobody can reproduce.
 from __future__ import annotations
 
 import hashlib
+import json
+import os
 import re
 from dataclasses import dataclass
 
@@ -65,6 +67,11 @@ DEFAULT_REGION = "us-east-1"
 _DEFAULT_REGION = DEFAULT_REGION
 # The only screen geometry the V2 AMI map and the released IMAGE_ID_MAP carry.
 _SCREEN = (1920, 1080)
+
+# A proxy-pool config is a short JSON list of endpoints; anything larger is a
+# mistyped path (a log, a dataset) and is refused rather than parsed, so a
+# pathological file cannot be read into the worker at prepare time.
+_PROXY_CONFIG_MAX_BYTES = 1 << 20
 
 
 class ProvisioningError(ValueError):
@@ -186,6 +193,67 @@ def resolve_proxy_policy(
             "OSWORLD_ENABLE_PROXY requires benchmark_compute scope and exactly true or false"
         )
     return policies[0].value == "true"
+
+
+def validate_proxy_config_file(
+    infra_values: tuple[ScopedInfraValue, ...], *, enable_proxy: bool = False
+) -> str | None:
+    """Validate the upstream proxy-pool config path, or explain its absence.
+
+    Upstream resolves ``PROXY_CONFIG_FILE`` through ``os.getenv`` with a
+    CWD-RELATIVE default and loads it at module import, swallowing every
+    failure into a log line: a missing or malformed file yields an EMPTY pool
+    and the episode dies at ``reset_start`` with "No proxy available from proxy
+    pool" -- after the VM is allocated and billed. So this validates at
+    ``prepare``, where a failure costs nothing, and requires an ABSOLUTE path:
+    a relative one would be resolved against whatever CWD the ``-I`` worker
+    happens to inherit, which is exactly the bug being fixed.
+
+    Returns the validated path, or None when the input is absent. Absence is
+    only an error when the episode actually needs a proxy; that check belongs
+    to the caller, which knows the task's proxy hint and the policy override.
+    """
+
+    entries = [item for item in infra_values if item.name == "PROXY_CONFIG_FILE"]
+    if not entries:
+        if enable_proxy:
+            raise ProvisioningError(
+                "this task needs a system proxy but PROXY_CONFIG_FILE was not supplied; "
+                "pass an absolute path to an upstream proxy-pool JSON file, or set "
+                "OSWORLD_ENABLE_PROXY=false to select upstream's system-disabled mode"
+            )
+        return None
+    if len({item.value for item in entries}) != 1:
+        raise ProvisioningError("PROXY_CONFIG_FILE was supplied with conflicting values")
+    if any(item.purpose != "benchmark_compute" for item in entries):
+        raise ProvisioningError("PROXY_CONFIG_FILE requires benchmark_compute scope")
+
+    path = entries[0].value
+    if not os.path.isabs(path):
+        # Never echo the value: an operator can mistype a credentialed URL here.
+        raise ProvisioningError("PROXY_CONFIG_FILE must be an absolute path")
+    try:
+        with open(path, "rb") as handle:
+            raw = handle.read(_PROXY_CONFIG_MAX_BYTES + 1)
+    except OSError as exc:
+        raise ProvisioningError(
+            f"PROXY_CONFIG_FILE is not readable ({exc.__class__.__name__})"
+        ) from None
+    if len(raw) > _PROXY_CONFIG_MAX_BYTES:
+        raise ProvisioningError("PROXY_CONFIG_FILE is larger than the supported ceiling")
+    try:
+        parsed = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        raise ProvisioningError("PROXY_CONFIG_FILE is not valid UTF-8 JSON") from None
+    # Mirror ProxyPool.load_proxies_from_file: a list of objects with host+port.
+    # Upstream would accept the file and silently load zero usable proxies; the
+    # whole point of validating here is to refuse what it would swallow.
+    if not isinstance(parsed, list) or not parsed:
+        raise ProvisioningError("PROXY_CONFIG_FILE must be a non-empty JSON list")
+    for entry in parsed:
+        if not isinstance(entry, dict) or "host" not in entry or "port" not in entry:
+            raise ProvisioningError("PROXY_CONFIG_FILE entries need 'host' and 'port'")
+    return path
 
 
 def _has(infra_values: tuple[ScopedInfraValue, ...], name: str) -> bool:

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/provisioning.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/provisioning.py
@@ -19,6 +19,7 @@ import hashlib
 import json
 import os
 import re
+import stat
 from dataclasses import dataclass
 
 from lop_osworld_v2_adapter.taskfile import TaskDescriptor
@@ -244,20 +245,34 @@ def validate_proxy_config_file(
     if not os.path.isabs(path):
         # Never echo the value: an operator can mistype a credentialed URL here.
         raise ProvisioningError("PROXY_CONFIG_FILE must be an absolute path")
-    # Require a regular file BEFORE opening. ``open`` follows symlinks and does
-    # not care about the type, so a path naming a FIFO blocks prepare forever
-    # waiting for a writer -- a hang is a worse failure than a refusal, and
-    # harder to attribute. ``isfile`` resolves symlinks, so a symlink TO a
-    # regular file is still accepted.
-    if not os.path.isfile(path):
-        raise ProvisioningError("PROXY_CONFIG_FILE must name a regular file")
+    # Refuse a non-regular file WITHOUT a TOCTOU window, using the same idiom
+    # as ``ecosystem_instructions._read_instruction_file`` and
+    # ``evidence/store.py`` rather than inventing a second one. A plain
+    # ``isfile`` then ``open`` still races: a regular file swapped for a FIFO
+    # in between reaches the blocking open, and an ``O_RDONLY`` open on a FIFO
+    # blocks in the kernel until a writer appears -- so ``prepare`` hangs with
+    # no timeout above it, which is a strictly worse failure than a refusal and
+    # far harder to attribute. ``O_NONBLOCK`` is load-bearing, not tidiness: it
+    # makes the open return a descriptor immediately so ``S_ISREG`` is
+    # reachable at all. Regular files are unaffected by the flag, and it
+    # follows symlinks, so a symlink TO a regular file still works.
     try:
-        with open(path, "rb") as handle:
-            raw = handle.read(_PROXY_CONFIG_MAX_BYTES + 1)
+        descriptor = os.open(path, os.O_RDONLY | os.O_NONBLOCK)
     except OSError as exc:
         raise ProvisioningError(
             f"PROXY_CONFIG_FILE is not readable ({exc.__class__.__name__})"
         ) from None
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise ProvisioningError("PROXY_CONFIG_FILE must name a regular file")
+        with os.fdopen(descriptor, "rb", closefd=False) as stream:
+            raw = stream.read(_PROXY_CONFIG_MAX_BYTES + 1)
+    except OSError as exc:
+        raise ProvisioningError(
+            f"PROXY_CONFIG_FILE is not readable ({exc.__class__.__name__})"
+        ) from None
+    finally:
+        os.close(descriptor)
     if len(raw) > _PROXY_CONFIG_MAX_BYTES:
         raise ProvisioningError("PROXY_CONFIG_FILE is larger than the supported ceiling")
     try:

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/provisioning.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/provisioning.py
@@ -69,8 +69,11 @@ _DEFAULT_REGION = DEFAULT_REGION
 _SCREEN = (1920, 1080)
 
 # A proxy-pool config is a short JSON list of endpoints; anything larger is a
-# mistyped path (a log, a dataset) and is refused rather than parsed, so a
-# pathological file cannot be read into the worker at prepare time.
+# mistyped path (a log, a dataset) and is refused before it is parsed. This
+# bounds the READ, not the parse: a file just under the ceiling is still handed
+# to json.loads, and deeply nested JSON inside that budget still costs CPU. The
+# path is operator-supplied and parsed on the operator's own machine before any
+# cloud call, so the residual is self-inflicted rather than a exposure.
 _PROXY_CONFIG_MAX_BYTES = 1 << 20
 
 
@@ -204,10 +207,19 @@ def validate_proxy_config_file(
     CWD-RELATIVE default and loads it at module import, swallowing every
     failure into a log line: a missing or malformed file yields an EMPTY pool
     and the episode dies at ``reset_start`` with "No proxy available from proxy
-    pool" -- after the VM is allocated and billed. So this validates at
-    ``prepare``, where a failure costs nothing, and requires an ABSOLUTE path:
+    pool" -- after the VM is allocated and billed. So this validates before
+    allocation, where a failure costs nothing, and requires an ABSOLUTE path:
     a relative one would be resolved against whatever CWD the ``-I`` worker
     happens to inherit, which is exactly the bug being fixed.
+
+    NOT a guarantee about the bytes upstream will load. This checks a PATH, and
+    upstream re-reads that path later, so the file can be replaced, truncated,
+    or chmod-ed in between; upstream also loads a MIXED file partially, leaving
+    a silently degraded pool rather than an empty one. Closing that window
+    would mean passing contents rather than a path, which upstream's
+    import-time ``os.getenv`` read gives us no way to do. What this does buy is
+    that the ordinary failures -- wrong path, unreadable file, wrong shape --
+    stop being discovered after the VM is billed.
 
     Returns the validated path, or None when the input is absent. Absence is
     only an error when the episode actually needs a proxy; that check belongs
@@ -232,6 +244,13 @@ def validate_proxy_config_file(
     if not os.path.isabs(path):
         # Never echo the value: an operator can mistype a credentialed URL here.
         raise ProvisioningError("PROXY_CONFIG_FILE must be an absolute path")
+    # Require a regular file BEFORE opening. ``open`` follows symlinks and does
+    # not care about the type, so a path naming a FIFO blocks prepare forever
+    # waiting for a writer -- a hang is a worse failure than a refusal, and
+    # harder to attribute. ``isfile`` resolves symlinks, so a symlink TO a
+    # regular file is still accepted.
+    if not os.path.isfile(path):
+        raise ProvisioningError("PROXY_CONFIG_FILE must name a regular file")
     try:
         with open(path, "rb") as handle:
             raw = handle.read(_PROXY_CONFIG_MAX_BYTES + 1)

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/requirements.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/requirements.py
@@ -212,11 +212,22 @@ def derive_requirements(
     # --- Conditional on the task -------------------------------------------
 
     if descriptor.proxy and enable_proxy:
-        # Legacy declarations retained for compatibility, NOT working setup:
-        # upstream needs a ProxyPool and these inputs do not construct one.
-        # System-disabled mode must not demand credentials it cannot consume.
-        out.append(_requirement("OSWORLD_PROXY_CREDENTIALS", kind="secret", required=True))
-        out.append(_requirement("OSWORLD_PROXY_ENDPOINT", kind="infra", required=True))
+        # PROXY_CONFIG_FILE is what upstream ACTUALLY consumes: it loads the
+        # pool from this path at import of desktop_env.controllers.setup. It is
+        # required here because an absent pool is not a degraded run, it is a
+        # guaranteed crash at reset_start after the VM is paid for.
+        out.append(_requirement("PROXY_CONFIG_FILE", kind="infra", required=True))
+        # OSWORLD_PROXY_CREDENTIALS and OSWORLD_PROXY_ENDPOINT are NO LONGER
+        # required. They were declared when no working proxy path existed, and
+        # they are consumed by nothing: a grep of this package finds
+        # OSWORLD_PROXY_CREDENTIALS at no call site at all, and
+        # OSWORLD_PROXY_ENDPOINT only in the env-injection allowlist -- upstream
+        # reads neither, because it takes its endpoints from the pool file.
+        # Demanding a secret the apparatus cannot consume trains an operator to
+        # fabricate one, and a fabricated credential that "works" is worse than
+        # a missing one. They stay OPTIONAL so an existing invocation that
+        # supplies them is still accepted unchanged.
+        out.append(_requirement("OSWORLD_PROXY_ENDPOINT", kind="infra", required=False))
 
     if _has_config_type(descriptor, "googledrive", "login"):
         out.append(_requirement("GOOGLE_ACCOUNT_CREDENTIALS", kind="secret", required=True))

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/vendor_bridge.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/vendor_bridge.py
@@ -73,16 +73,25 @@ SECRET_ENV_NAMES = frozenset({JUDGE_KEY_ENV, USER_SIM_KEY_ENV})
 # import succeeds. ``ENABLE_TTL=false`` is set for the same reason: OSWorld's
 # own TTL path is a warning-on-failure one we never rely on, and leaving it
 # enabled would race our own schedule with a second, unnamed one.
-# Names upstream reads at MODULE IMPORT time, so injecting them later than the
-# first ``desktop_env`` import has no effect. PROXY_CONFIG_FILE belongs here and
-# not in ``_ENV_INJECTABLE`` for a reason that cost a paid episode to find:
+# Names upstream reads at MODULE IMPORT time rather than at call time.
+#
+# Both this tuple and ``_ENV_INJECTABLE`` feed the SAME condition below, so
+# membership in either injects the value identically -- the split is
+# documentation of WHEN upstream reads a name, not a mechanism that changes
+# behaviour. It earns its place because the two sets have different failure
+# modes when the adapter is refactored: injecting an import-time name after the
+# first ``desktop_env`` import is a silent no-op, not an error, so a future
+# change that moves injection later breaks these names and nothing else.
+#
+# PROXY_CONFIG_FILE is the case that cost a paid episode:
 # ``desktop_env/controllers/setup.py`` calls ``init_proxy_pool(PROXY_CONFIG_FILE)``
 # at import (module level), reading the name through ``os.getenv`` with a default
 # of the CWD-RELATIVE ``evaluation_examples/settings/proxy/dataimpulse.json``.
 # The adapter worker is spawned with ``-I`` from an arbitrary CWD, so that
-# relative default never resolves, the pool loads zero proxies, and every
-# proxy-declaring task dies at ``reset_start`` with "No proxy available from
-# proxy pool" AFTER the VM is already allocated and paid for.
+# relative default never resolves, ``load_proxies_from_file`` swallows the error
+# into a log line, the pool loads zero proxies, and every proxy-declaring task
+# dies at ``reset_start`` with "No proxy available from proxy pool" AFTER the VM
+# is already allocated and paid for.
 _OSWORLD_IMPORT_ENV = (
     "AWS_REGION",
     "AWS_SUBNET_ID",

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/vendor_bridge.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/vendor_bridge.py
@@ -28,6 +28,7 @@ inherit it. See ``adapter.OSWorldV2Adapter._install_judge_environment``.
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -169,11 +170,31 @@ def instantiate_task(module_path: str, task_id: str) -> Any:
 
     from desktop_env.task_base import BaseTask  # type: ignore[import-not-found]
 
-    spec = importlib.util.spec_from_file_location(f"osworld_task_{task_id}", module_path)
+    module_name = f"osworld_task_{task_id}"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
     if spec is None or spec.loader is None:
         raise ImportError(f"cannot build an import spec for {module_path!r}")
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    # Register BEFORE exec, which is what the import system itself does and
+    # what upstream's loader gets for free by going through ``import``.
+    # Skipping it breaks any task module combining ``from __future__ import
+    # annotations`` with ``@dataclass``: string annotations send dataclasses
+    # into ``_is_type``, which does ``sys.modules.get(cls.__module__)`` and
+    # then reads ``.__dict__`` on the result -- None for an unregistered
+    # module, so the task dies with a bare
+    # ``AttributeError: 'NoneType' object has no attribute '__dict__'``
+    # at reset_start, with the VM already allocated. Reproduced exactly:
+    # unregistered raises, registered imports cleanly.
+    #
+    # Cleaned up in a finally so a failed task import cannot leave a
+    # half-initialised module visible to a later one, and so the process does
+    # not accumulate one entry per episode.
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except BaseException:
+        sys.modules.pop(module_name, None)
+        raise
     get_task = getattr(module, "get_task", None)
     if callable(get_task):
         return get_task()

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/vendor_bridge.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/vendor_bridge.py
@@ -73,7 +73,22 @@ SECRET_ENV_NAMES = frozenset({JUDGE_KEY_ENV, USER_SIM_KEY_ENV})
 # import succeeds. ``ENABLE_TTL=false`` is set for the same reason: OSWorld's
 # own TTL path is a warning-on-failure one we never rely on, and leaving it
 # enabled would race our own schedule with a second, unnamed one.
-_OSWORLD_IMPORT_ENV = ("AWS_REGION", "AWS_SUBNET_ID", "AWS_SECURITY_GROUP_ID")
+# Names upstream reads at MODULE IMPORT time, so injecting them later than the
+# first ``desktop_env`` import has no effect. PROXY_CONFIG_FILE belongs here and
+# not in ``_ENV_INJECTABLE`` for a reason that cost a paid episode to find:
+# ``desktop_env/controllers/setup.py`` calls ``init_proxy_pool(PROXY_CONFIG_FILE)``
+# at import (module level), reading the name through ``os.getenv`` with a default
+# of the CWD-RELATIVE ``evaluation_examples/settings/proxy/dataimpulse.json``.
+# The adapter worker is spawned with ``-I`` from an arbitrary CWD, so that
+# relative default never resolves, the pool loads zero proxies, and every
+# proxy-declaring task dies at ``reset_start`` with "No proxy available from
+# proxy pool" AFTER the VM is already allocated and paid for.
+_OSWORLD_IMPORT_ENV = (
+    "AWS_REGION",
+    "AWS_SUBNET_ID",
+    "AWS_SECURITY_GROUP_ID",
+    "PROXY_CONFIG_FILE",
+)
 
 
 def inject_infra_environment(infra_values: tuple[ScopedInfraValue, ...]) -> None:

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/vendor_bridge.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/vendor_bridge.py
@@ -103,7 +103,11 @@ _OSWORLD_IMPORT_ENV = (
 def inject_infra_environment(infra_values: tuple[ScopedInfraValue, ...]) -> None:
     """Write non-secret infra values into the worker's own process env.
 
-    Called at the START of ``reset_start``, before any ``desktop_env`` import.
+    Called from ``prepare``, which is earlier than the old docstring claimed
+    and still strictly before any ``desktop_env`` import -- the only ordering
+    that matters, since several of these names are read by upstream at import
+    time and a later write would be a silent no-op.
+
     A value not on the closed injectable list is refused, so a secret named
     like an env var cannot leak into the process environment where a child
     process or a crash report would inherit it.

--- a/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/vendor_bridge.py
+++ b/benchmarks/osworld_v2_adapter/src/lop_osworld_v2_adapter/vendor_bridge.py
@@ -186,9 +186,17 @@ def instantiate_task(module_path: str, task_id: str) -> Any:
     # at reset_start, with the VM already allocated. Reproduced exactly:
     # unregistered raises, registered imports cleanly.
     #
-    # Cleaned up in a finally so a failed task import cannot leave a
-    # half-initialised module visible to a later one, and so the process does
-    # not accumulate one entry per episode.
+    # A SUCCESSFUL import stays registered -- that is the fix, not an
+    # oversight, and a module whose annotations are resolved lazily would break
+    # again if it were popped afterwards. Only a FAILED import is removed, so a
+    # half-initialised module is not left visible.
+    #
+    # Note what that removal actually does when the same task_id is imported
+    # twice: the assignment below has already displaced any earlier module
+    # object of this name, so a failed re-import unregisters the previously
+    # good one too. Harmless in the current one-episode-per-worker model (a
+    # live task object holds its own reference), but the pop is not a pure
+    # rollback and should not be read as one.
     sys.modules[module_name] = module
     try:
         spec.loader.exec_module(module)

--- a/docs/benchmarks/osworld_2/README.md
+++ b/docs/benchmarks/osworld_2/README.md
@@ -399,12 +399,44 @@ on; upstream still combines it with the task's proxy hint. Explicit `false`
 sets the switch off regardless of that hint, and post-policy requirements no
 longer demand `OSWORLD_PROXY_CREDENTIALS` or `OSWORLD_PROXY_ENDPOINT`.
 
-**Enabled setup remains incomplete.** The legacy credential/endpoint declarations
-are retained for omission and enabled proxy tasks for compatibility, but are
-insufficient: upstream expects an actual `ProxyPool`; the adapter does not wire
-those `OSWORLD_PROXY_*` inputs into one. Setting `true` or supplying those inputs
-is not proof of a working proxy. A real enabled setup needs a separately reviewed
-follow-up; this change builds no proxy bridge and fabricates no credentials.
+**Enabled setup now works, through `PROXY_CONFIG_FILE`.** This was the
+"separately reviewed follow-up" this section previously called for.
+
+Upstream builds its pool at *module import*: `desktop_env/controllers/setup.py`
+calls `init_proxy_pool(PROXY_CONFIG_FILE)` at the top level, reading that name
+via `os.getenv` with a default of the **CWD-relative**
+`evaluation_examples/settings/proxy/dataimpulse.json`. The adapter worker is
+spawned `-I` from an arbitrary CWD, so that default never resolved, and
+`load_proxies_from_file` swallows the error into a log line — leaving an empty
+pool that only failed later, at `reset_start`, with the VM already billed. Two
+of the ten frozen pilot tasks died that way on every model tried.
+
+Pass an absolute path to an upstream proxy-pool JSON file:
+
+```sh
+--infra PROXY_CONFIG_FILE=/abs/path/to/proxies.json
+```
+
+The file is a JSON list of objects with at least `host` and `port`
+(`username`, `password`, `protocol` optional), exactly as
+`ProxyPool.load_proxies_from_file` parses it. It is validated **before
+allocation** — absolute, a regular file, readable, size-bounded, and shaped the
+way upstream actually accepts — so a bad path is a free refusal naming both
+ways out rather than a paid crash. Because upstream re-reads the path at import,
+validation cannot guarantee the bytes it will load; a file edited in between can
+still yield a degraded pool.
+
+`PROXY_CONFIG_FILE` is **required** for a task whose descriptor sets
+`proxy = True` unless `OSWORLD_ENABLE_PROXY=false` selects system-disabled mode.
+The requirement is enforced in `reset_start` rather than `prepare` because
+`PrepareParams` carries no `task_id`: at `prepare` the task's proxy hint is
+structurally unknowable, so a check there would pass every task it was meant to
+protect.
+
+`OSWORLD_PROXY_CREDENTIALS` is **no longer declared** — nothing in the package
+ever consumed it, and demanding a secret the apparatus cannot use trains an
+operator to fabricate one. `OSWORLD_PROXY_ENDPOINT` remains declared but
+optional, so existing invocations are accepted unchanged.
 
 The requested switch is sealed as `osworld_enable_proxy_override` via the same
 manifest disclosure table as the compute overrides. An older adapter that does

--- a/tests/unit/evaluation/adapters/osworld/test_provisioning.py
+++ b/tests/unit/evaluation/adapters/osworld/test_provisioning.py
@@ -9,6 +9,8 @@ not even a read-only ``describe_images`` is issued.
 
 from __future__ import annotations
 
+import os
+
 import pytest
 from lop_osworld_v2_adapter import provisioning, taskfile
 from lop_osworld_v2_adapter.provisioning import ProvisioningError
@@ -346,13 +348,29 @@ def test_a_relative_proxy_config_path_is_refused(tmp_path) -> None:
         )
 
 
-def test_an_unreadable_proxy_config_is_refused_without_echoing_the_path(tmp_path) -> None:
+def test_an_absent_proxy_config_is_refused_without_echoing_the_path(tmp_path) -> None:
+    # An absent path fails the regular-file check before the open, so it
+    # reports the type rather than the read. Either way it is refused before
+    # allocation and, critically, without repeating the operator's input.
     missing = str(tmp_path / "nope.json")
-    with pytest.raises(ProvisioningError) as excinfo:
+    with pytest.raises(ProvisioningError, match="regular file") as excinfo:
         provisioning.validate_proxy_config_file(_proxy_infra(missing), enable_proxy=True)
-    assert "not readable" in str(excinfo.value)
     # An operator can mistype a credentialed URL into this field; never echo it.
     assert missing not in str(excinfo.value)
+
+
+def test_a_present_but_unreadable_proxy_config_is_refused(tmp_path) -> None:
+    """A regular file we cannot open reaches the read branch and is refused."""
+    path = tmp_path / "locked.json"
+    path.write_text('[{"host": "h.example", "port": 8080}]', encoding="utf-8")
+    path.chmod(0o000)
+    try:
+        with pytest.raises(ProvisioningError) as excinfo:
+            provisioning.validate_proxy_config_file(_proxy_infra(str(path)), enable_proxy=True)
+        assert "not readable" in str(excinfo.value)
+        assert str(path) not in str(excinfo.value)
+    finally:
+        path.chmod(0o600)
 
 
 @pytest.mark.parametrize(
@@ -397,3 +415,33 @@ def test_an_oversized_proxy_config_is_refused_rather_than_parsed(tmp_path) -> No
     path = _proxy_file(tmp_path, "[" + ("0," * 600_000) + "0]")
     with pytest.raises(ProvisioningError, match="ceiling"):
         provisioning.validate_proxy_config_file(_proxy_infra(path), enable_proxy=True)
+
+
+def test_a_proxy_config_naming_a_non_regular_file_is_refused(tmp_path) -> None:
+    """A FIFO must refuse, not hang.
+
+    ``open`` follows symlinks and ignores the file type, so a path naming a
+    FIFO blocks until a writer appears -- with no timeout, at prepare, before
+    anything else runs. A hang is a worse failure than a refusal and much
+    harder to attribute, so the type is checked before the open.
+    """
+    fifo = tmp_path / "fifo"
+    os.mkfifo(fifo)
+    with pytest.raises(ProvisioningError, match="regular file"):
+        provisioning.validate_proxy_config_file(_proxy_infra(str(fifo)), enable_proxy=True)
+
+
+def test_a_proxy_config_symlinked_to_a_regular_file_is_accepted(tmp_path) -> None:
+    """The type check must not break the ordinary symlinked-config case."""
+    real = tmp_path / "real.json"
+    real.write_text('[{"host": "h.example", "port": 8080}]', encoding="utf-8")
+    link = tmp_path / "link.json"
+    link.symlink_to(real)
+    assert provisioning.validate_proxy_config_file(
+        _proxy_infra(str(link)), enable_proxy=True
+    ) == str(link)
+
+
+def test_a_proxy_config_naming_a_directory_is_refused(tmp_path) -> None:
+    with pytest.raises(ProvisioningError, match="regular file"):
+        provisioning.validate_proxy_config_file(_proxy_infra(str(tmp_path)), enable_proxy=True)

--- a/tests/unit/evaluation/adapters/osworld/test_provisioning.py
+++ b/tests/unit/evaluation/adapters/osworld/test_provisioning.py
@@ -10,6 +10,7 @@ not even a read-only ``describe_images`` is issued.
 from __future__ import annotations
 
 import os
+import signal
 
 import pytest
 from lop_osworld_v2_adapter import provisioning, taskfile
@@ -349,11 +350,12 @@ def test_a_relative_proxy_config_path_is_refused(tmp_path) -> None:
 
 
 def test_an_absent_proxy_config_is_refused_without_echoing_the_path(tmp_path) -> None:
-    # An absent path fails the regular-file check before the open, so it
-    # reports the type rather than the read. Either way it is refused before
-    # allocation and, critically, without repeating the operator's input.
+    # An absent path fails at the open itself, so it reports the read rather
+    # than the type -- the race-free check opens first (O_NONBLOCK) and only
+    # then fstats. Either way it is refused before allocation and, critically,
+    # without repeating the operator's input.
     missing = str(tmp_path / "nope.json")
-    with pytest.raises(ProvisioningError, match="regular file") as excinfo:
+    with pytest.raises(ProvisioningError, match="not readable") as excinfo:
         provisioning.validate_proxy_config_file(_proxy_infra(missing), enable_proxy=True)
     # An operator can mistype a credentialed URL into this field; never echo it.
     assert missing not in str(excinfo.value)
@@ -417,18 +419,36 @@ def test_an_oversized_proxy_config_is_refused_rather_than_parsed(tmp_path) -> No
         provisioning.validate_proxy_config_file(_proxy_infra(path), enable_proxy=True)
 
 
+@pytest.mark.skipif(not hasattr(signal, "SIGALRM"), reason="POSIX alarm only")
 def test_a_proxy_config_naming_a_non_regular_file_is_refused(tmp_path) -> None:
     """A FIFO must refuse, not hang.
 
-    ``open`` follows symlinks and ignores the file type, so a path naming a
-    FIFO blocks until a writer appears -- with no timeout, at prepare, before
-    anything else runs. A hang is a worse failure than a refusal and much
-    harder to attribute, so the type is checked before the open.
+    An ``O_RDONLY`` open on a FIFO blocks in the kernel until a writer appears,
+    so without ``O_NONBLOCK`` this path hangs ``prepare`` forever -- there is no
+    timeout above it. A hang is a worse failure than a refusal and much harder
+    to attribute.
+
+    Guarded by ``SIGALRM``, matching
+    ``test_a_fifo_reaching_the_reader_is_refused_instead_of_blocking`` in the
+    ecosystem-instructions suite, for the reason that test states: the
+    regression is an INFINITE BLOCK, so without the alarm dropping the guard
+    would not FAIL this test -- it would hang CI with no report and nothing to
+    read.
     """
     fifo = tmp_path / "fifo"
     os.mkfifo(fifo)
-    with pytest.raises(ProvisioningError, match="regular file"):
-        provisioning.validate_proxy_config_file(_proxy_infra(str(fifo)), enable_proxy=True)
+
+    def _blocked(signum, frame):  # noqa: ANN001 - signal handler signature
+        raise AssertionError("the validator blocked on a fifo instead of refusing it")
+
+    previous = signal.signal(signal.SIGALRM, _blocked)
+    signal.alarm(10)
+    try:
+        with pytest.raises(ProvisioningError, match="regular file"):
+            provisioning.validate_proxy_config_file(_proxy_infra(str(fifo)), enable_proxy=True)
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, previous)
 
 
 def test_a_proxy_config_symlinked_to_a_regular_file_is_accepted(tmp_path) -> None:

--- a/tests/unit/evaluation/adapters/osworld/test_provisioning.py
+++ b/tests/unit/evaluation/adapters/osworld/test_provisioning.py
@@ -13,7 +13,7 @@ import pytest
 from lop_osworld_v2_adapter import provisioning, taskfile
 from lop_osworld_v2_adapter.provisioning import ProvisioningError
 
-from local_operator.evaluation.adapters.api import ScopedInfraValue
+from local_operator.evaluation.adapters.api import InfraPurpose, ScopedInfraValue
 from tests.unit.evaluation.adapters.osworld import fixtures
 
 _INFRA = tuple(
@@ -296,3 +296,104 @@ def test_the_two_infra_overrides_apply_independently() -> None:
     plan = provisioning.resolve(descriptor, episode_id="ep-1", infra_values=infra)
     assert plan.instance_type == "m5.2xlarge"
     assert plan.volume_gb == 150
+
+
+# --- PROXY_CONFIG_FILE ------------------------------------------------------
+#
+# Upstream loads its proxy pool at MODULE IMPORT from a CWD-relative default,
+# and swallows every failure into a log line. An unusable path is therefore not
+# an error upstream -- it is an EMPTY pool, and the episode dies at reset_start
+# with "No proxy available from proxy pool" after the VM is allocated and
+# billed. These tests pin the refusal at prepare, where it is free.
+
+
+def _proxy_file(tmp_path, payload: str) -> str:
+    path = tmp_path / "proxies.json"
+    path.write_text(payload, encoding="utf-8")
+    return str(path)
+
+
+def _proxy_infra(
+    value: str, purpose: InfraPurpose = "benchmark_compute"
+) -> tuple[ScopedInfraValue, ...]:
+    return (ScopedInfraValue(name="PROXY_CONFIG_FILE", purpose=purpose, value=value),)
+
+
+def test_proxy_config_is_optional_when_no_proxy_is_needed() -> None:
+    assert provisioning.validate_proxy_config_file((), enable_proxy=False) is None
+
+
+def test_a_needed_proxy_config_that_is_absent_is_refused_before_allocation() -> None:
+    with pytest.raises(ProvisioningError) as excinfo:
+        provisioning.validate_proxy_config_file((), enable_proxy=True)
+    # The message must name the two ways out, because the operator hitting this
+    # has no other signal: upstream's own failure is a log line and an empty pool.
+    assert "PROXY_CONFIG_FILE" in str(excinfo.value)
+    assert "OSWORLD_ENABLE_PROXY=false" in str(excinfo.value)
+
+
+def test_a_valid_absolute_proxy_config_is_accepted(tmp_path) -> None:
+    path = _proxy_file(tmp_path, '[{"host": "h.example", "port": 8080}]')
+    assert provisioning.validate_proxy_config_file(_proxy_infra(path), enable_proxy=True) == path
+
+
+def test_a_relative_proxy_config_path_is_refused(tmp_path) -> None:
+    # The whole defect: upstream resolves a relative path against whatever CWD
+    # the -I worker inherited, which is never the repo root.
+    with pytest.raises(ProvisioningError, match="absolute path"):
+        provisioning.validate_proxy_config_file(
+            _proxy_infra("evaluation_examples/settings/proxy/x.json"), enable_proxy=True
+        )
+
+
+def test_an_unreadable_proxy_config_is_refused_without_echoing_the_path(tmp_path) -> None:
+    missing = str(tmp_path / "nope.json")
+    with pytest.raises(ProvisioningError) as excinfo:
+        provisioning.validate_proxy_config_file(_proxy_infra(missing), enable_proxy=True)
+    assert "not readable" in str(excinfo.value)
+    # An operator can mistype a credentialed URL into this field; never echo it.
+    assert missing not in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "not json at all",
+        "{}",  # an object, not a list
+        "[]",  # empty: upstream would load zero proxies and crash later
+        '[{"host": "h.example"}]',  # no port
+        '[{"port": 8080}]',  # no host
+        '["just-a-string"]',
+    ],
+)
+def test_a_proxy_config_upstream_would_silently_ignore_is_refused(tmp_path, payload: str) -> None:
+    # Each of these parses (or fails) upstream into an EMPTY pool with only a
+    # log line. Refusing them here is the difference between a free failure and
+    # a paid one.
+    path = _proxy_file(tmp_path, payload)
+    with pytest.raises(ProvisioningError):
+        provisioning.validate_proxy_config_file(_proxy_infra(path), enable_proxy=True)
+
+
+def test_a_proxy_config_in_the_wrong_scope_is_refused(tmp_path) -> None:
+    path = _proxy_file(tmp_path, '[{"host": "h.example", "port": 8080}]')
+    with pytest.raises(ProvisioningError, match="benchmark_compute"):
+        provisioning.validate_proxy_config_file(
+            _proxy_infra(path, "benchmark_user_simulator"), enable_proxy=True
+        )
+
+
+def test_conflicting_proxy_config_values_are_refused(tmp_path) -> None:
+    path = _proxy_file(tmp_path, '[{"host": "h.example", "port": 8080}]')
+    values = (
+        ScopedInfraValue(name="PROXY_CONFIG_FILE", purpose="benchmark_compute", value=path),
+        ScopedInfraValue(name="PROXY_CONFIG_FILE", purpose="benchmark_compute", value="/other"),
+    )
+    with pytest.raises(ProvisioningError, match="conflicting"):
+        provisioning.validate_proxy_config_file(values, enable_proxy=True)
+
+
+def test_an_oversized_proxy_config_is_refused_rather_than_parsed(tmp_path) -> None:
+    path = _proxy_file(tmp_path, "[" + ("0," * 600_000) + "0]")
+    with pytest.raises(ProvisioningError, match="ceiling"):
+        provisioning.validate_proxy_config_file(_proxy_infra(path), enable_proxy=True)

--- a/tests/unit/evaluation/adapters/osworld/test_proxy_policy.py
+++ b/tests/unit/evaluation/adapters/osworld/test_proxy_policy.py
@@ -11,6 +11,7 @@ from local_operator.evaluation.adapters.api import (
     PrepareParams,
     ScopedInfraValue,
 )
+from tests.unit.evaluation.adapters.osworld import fixtures
 from tests.unit.evaluation.adapters.osworld.test_provisioning import _INFRA
 
 
@@ -108,3 +109,94 @@ async def test_post_prepare_requirements_respect_disabled_policy(
     adapter._task = _task(True)
     post = await adapter.inspect_requirements(InspectRequirementsParams())
     assert not any(r.name.startswith("OSWORLD_PROXY_") for r in post.requirements)
+
+
+@pytest.mark.asyncio
+async def test_a_proxy_task_without_a_pool_config_is_refused_before_allocation(
+    tmp_path: Path,
+) -> None:
+    """The refusal must fire for a TASK that needs a proxy, not just an override.
+
+    This is the case the whole fix exists for, and it cannot be checked in
+    ``prepare``: ``PrepareParams`` carries no ``task_id``, so ``self._task`` is
+    still None there and the task's own ``proxy = True`` hint is unknowable.
+    A guard placed in prepare reads ``task_proxy=False`` for every task and
+    silently passes exactly the episodes it was written to protect -- which
+    then allocate a VM and die at upstream's empty pool with the instance
+    billed. So the guard lives in ``reset_start``, after the task loads and
+    before any provider is constructed, and this test pins that placement by
+    failing the moment a provider is built.
+    """
+    from local_operator.evaluation.adapters.api import ResetStartParams
+    from tests.unit.evaluation.adapters.osworld.test_cache_dir import _write_workspace
+
+    def forbidden_provider():
+        pytest.fail("the proxy refusal must precede provider construction")
+
+    workspace = _write_workspace(tmp_path, {"task_proxy": fixtures.PROXY})
+    adapter = OSWorldV2Adapter(provider_factory=forbidden_provider, workspace_root=workspace)
+    artifacts = tmp_path / "run" / "artifacts"
+    artifacts.mkdir(parents=True)
+
+    # No PROXY_CONFIG_FILE anywhere in the infra values.
+    await adapter.prepare(
+        PrepareParams(
+            operation_id="prepare-proxy",
+            episode_id="ep-proxy",
+            secret_refs=(),
+            infra_values=_INFRA,
+        )
+    )
+    with pytest.raises(provisioning.ProvisioningError) as error:
+        await adapter.reset_start(
+            ResetStartParams(
+                operation_id="reset-proxy",
+                task_id="task_proxy",
+                episode_id="ep-proxy",
+                artifact_root=str(artifacts),
+                secrets=(),
+            )
+        )
+    assert "PROXY_CONFIG_FILE" in str(error.value)
+    assert "OSWORLD_ENABLE_PROXY=false" in str(error.value)
+    # Nothing was provisioned: the refusal is free.
+    assert adapter._plan is None
+
+
+@pytest.mark.asyncio
+async def test_a_non_proxy_task_needs_no_pool_config(tmp_path: Path) -> None:
+    """The guard must not become a new required input for ordinary tasks."""
+    from local_operator.evaluation.adapters.api import ResetStartParams
+    from tests.unit.evaluation.adapters.osworld.test_cache_dir import _write_workspace
+
+    built: list[str] = []
+
+    def provider_factory():
+        built.append("yes")
+        raise RuntimeError("stop after the guard, before real work")
+
+    workspace = _write_workspace(tmp_path, {"task_plain": fixtures.PLAIN})
+    adapter = OSWorldV2Adapter(provider_factory=provider_factory, workspace_root=workspace)
+    artifacts = tmp_path / "run" / "artifacts"
+    artifacts.mkdir(parents=True)
+
+    await adapter.prepare(
+        PrepareParams(
+            operation_id="prepare-plain",
+            episode_id="ep-plain",
+            secret_refs=(),
+            infra_values=_INFRA,
+        )
+    )
+    with pytest.raises(RuntimeError, match="stop after the guard"):
+        await adapter.reset_start(
+            ResetStartParams(
+                operation_id="reset-plain",
+                task_id="task_plain",
+                episode_id="ep-plain",
+                artifact_root=str(artifacts),
+                secrets=(),
+            )
+        )
+    # Reaching provider construction proves the proxy guard did not fire.
+    assert built == ["yes"]

--- a/tests/unit/evaluation/adapters/osworld/test_proxy_policy.py
+++ b/tests/unit/evaluation/adapters/osworld/test_proxy_policy.py
@@ -200,3 +200,111 @@ async def test_a_non_proxy_task_needs_no_pool_config(tmp_path: Path) -> None:
         )
     # Reaching provider construction proves the proxy guard did not fire.
     assert built == ["yes"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("override", [None, "false", "true"])
+@pytest.mark.parametrize("hint", [False, True])
+async def test_the_guard_and_the_requirements_table_agree(
+    tmp_path: Path, hint: bool, override: str | None
+) -> None:
+    """Enforcement must demand exactly what ``inspect_requirements`` declares.
+
+    The two drifting apart is worse than either rule being wrong on its own:
+    the adapter would tell an operator ``PROXY_CONFIG_FILE`` is optional for
+    this episode and then refuse the episode for not supplying it, which is
+    unactionable from the outside. That is what happened when the guard gated
+    on the policy override ALONE -- a run-wide ``OSWORLD_ENABLE_PROXY=true``
+    refused every ordinary task for want of a pool it never touches. Upstream
+    combines the two as a conjunction (``desktop_env.py:321``:
+    ``task_use_proxy = task_proxy and self.enable_proxy``), so both sides here
+    must too.
+    """
+    from local_operator.evaluation.adapters.api import ResetStartParams
+    from tests.unit.evaluation.adapters.osworld.test_cache_dir import _write_workspace
+
+    source = fixtures.PROXY if hint else fixtures.PLAIN
+    task_id = "task_proxy" if hint else "task_plain"
+    infra = _INFRA + (() if override is None else (_policy(override),))
+
+    # What the adapter TELLS the operator is required for this episode.
+    descriptor = taskfile.load_static(source.encode(), module_name=f"tasks/{task_id}.py")
+    declared = {
+        req.name
+        for req in requirements.derive_requirements(descriptor, infra_values=infra)
+        if req.required
+    }
+    declares_pool = "PROXY_CONFIG_FILE" in declared
+
+    # What the adapter ENFORCES at the last free moment before allocation.
+    built: list[str] = []
+
+    def provider_factory():
+        built.append("yes")
+        raise RuntimeError("stop after the guard")
+
+    workspace = _write_workspace(tmp_path, {task_id: source})
+    adapter = OSWorldV2Adapter(provider_factory=provider_factory, workspace_root=workspace)
+    artifacts = tmp_path / "run" / "artifacts"
+    artifacts.mkdir(parents=True)
+    await adapter.prepare(
+        PrepareParams(
+            operation_id="prepare-agree",
+            episode_id="ep-agree",
+            secret_refs=(),
+            infra_values=infra,
+        )
+    )
+    with pytest.raises((provisioning.ProvisioningError, RuntimeError)) as error:
+        await adapter.reset_start(
+            ResetStartParams(
+                operation_id="reset-agree",
+                task_id=task_id,
+                episode_id="ep-agree",
+                artifact_root=str(artifacts),
+                secrets=(),
+            )
+        )
+    enforces_pool = isinstance(error.value, provisioning.ProvisioningError)
+
+    assert enforces_pool is declares_pool, (
+        f"hint={hint} override={override}: requirements say "
+        f"{'required' if declares_pool else 'optional'} but the guard "
+        f"{'refused' if enforces_pool else 'allowed'} the episode"
+    )
+    # And the only episodes refused are the ones that truly use a proxy.
+    expected = hint and (hint if override is None else override == "true")
+    assert enforces_pool is expected
+    assert built == ([] if expected else ["yes"])
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_supplied_pool_config_is_refused_at_prepare(tmp_path: Path) -> None:
+    """The prepare-time validation is real work, and this is what pins it.
+
+    ``prepare`` cannot enforce REQUIREDNESS -- it has no task -- so it passes a
+    constant ``enable_proxy=False``. That makes the call look dead to a reader,
+    and deleting it left the whole adapter suite green. It is not dead: a
+    SUPPLIED but unusable path is refused here, before the episode does any
+    work at all, rather than one step later in ``reset_start``. Without this
+    test a future cleanup removes the call and CI agrees.
+    """
+
+    def forbidden_provider():
+        pytest.fail("prepare must not construct a provider")
+
+    adapter = OSWorldV2Adapter(provider_factory=forbidden_provider, workspace_root=tmp_path)
+    relative = ScopedInfraValue.model_validate(
+        {"name": "PROXY_CONFIG_FILE", "purpose": "benchmark_compute", "value": "relative/path.json"}
+    )
+    with pytest.raises(provisioning.ProvisioningError, match="absolute path"):
+        await adapter.prepare(
+            PrepareParams(
+                operation_id="prepare-bad-pool",
+                episode_id="ep-bad-pool",
+                secret_refs=(),
+                infra_values=_INFRA + (relative,),
+            )
+        )
+    # Refused before prepare produced anything at all.
+    assert adapter._refs is None and adapter._plan is None

--- a/tests/unit/evaluation/adapters/osworld/test_proxy_policy.py
+++ b/tests/unit/evaluation/adapters/osworld/test_proxy_policy.py
@@ -36,8 +36,19 @@ def test_policy_plan_and_requirements_agree(hint: bool, value: str | None) -> No
     reqs = {r.name: r for r in requirements.derive_requirements(_task(hint), infra_values=infra)}
     assert reqs["OSWORLD_ENABLE_PROXY"].required is False
     assert reqs["OSWORLD_ENABLE_PROXY"].kind == "infra"
-    for name in ("OSWORLD_PROXY_CREDENTIALS", "OSWORLD_PROXY_ENDPOINT"):
-        assert (name in reqs) is (hint and expected)
+    # PROXY_CONFIG_FILE is the input upstream actually reads, so it appears --
+    # and appears REQUIRED -- exactly when the episode will really use a proxy.
+    needs_proxy = hint and expected
+    assert ("PROXY_CONFIG_FILE" in reqs) is needs_proxy
+    if needs_proxy:
+        assert reqs["PROXY_CONFIG_FILE"].required is True
+    # The legacy pair no longer gates a run: CREDENTIALS is gone entirely
+    # (nothing consumed it) and ENDPOINT survives as optional so an existing
+    # invocation that still supplies it is accepted unchanged.
+    assert "OSWORLD_PROXY_CREDENTIALS" not in reqs
+    assert ("OSWORLD_PROXY_ENDPOINT" in reqs) is needs_proxy
+    if needs_proxy:
+        assert reqs["OSWORLD_PROXY_ENDPOINT"].required is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/evaluation/adapters/osworld/test_requirements.py
+++ b/tests/unit/evaluation/adapters/osworld/test_requirements.py
@@ -53,9 +53,32 @@ def test_plain_task_has_only_the_always_on_set() -> None:
     assert _names(fixtures.PLAIN) == _ALWAYS
 
 
-def test_proxy_task_adds_proxy_requirements() -> None:
-    names = _names(fixtures.PROXY)
-    assert {"OSWORLD_PROXY_CREDENTIALS", "OSWORLD_PROXY_ENDPOINT"} <= names
+def test_proxy_task_requires_the_pool_config_upstream_actually_reads() -> None:
+    """A proxy task must demand PROXY_CONFIG_FILE, and demand it as REQUIRED.
+
+    This is the only proxy input upstream consumes: it loads the pool from that
+    path at import of ``desktop_env.controllers.setup``. An absent pool is not a
+    degraded run, it is a guaranteed crash at ``reset_start`` with the VM
+    already paid for, so 'required' is the honest strength.
+    """
+    fields = _by_name(fixtures.PROXY)
+    assert fields["PROXY_CONFIG_FILE"] == ("infra", True)
+
+
+def test_proxy_task_no_longer_demands_the_credentials_nothing_consumes() -> None:
+    """OSWORLD_PROXY_CREDENTIALS is gone; OSWORLD_PROXY_ENDPOINT is optional.
+
+    Both were declared when no working proxy path existed. Nothing reads
+    CREDENTIALS at any call site, and ENDPOINT only reaches an env allowlist
+    upstream never consults -- upstream takes its endpoints from the pool file.
+    Demanding a secret the apparatus cannot use trains an operator to fabricate
+    one, and a fabricated credential that appears to work is worse than a
+    missing one. ENDPOINT stays declared-but-optional so an existing invocation
+    that still passes it is accepted unchanged.
+    """
+    fields = _by_name(fixtures.PROXY)
+    assert "OSWORLD_PROXY_CREDENTIALS" not in fields
+    assert fields["OSWORLD_PROXY_ENDPOINT"] == ("infra", False)
 
 
 def test_gitlab_task_adds_gitlab_requirements() -> None:

--- a/tests/unit/evaluation/adapters/osworld/test_vendor_bridge.py
+++ b/tests/unit/evaluation/adapters/osworld/test_vendor_bridge.py
@@ -1,0 +1,73 @@
+"""Environment injection into the vendored OSWorld package.
+
+The bridge exists because upstream reads configuration from ``os.environ``, and
+some of it at MODULE IMPORT time rather than at call time. Injecting an
+import-time name after the first ``desktop_env`` import is a silent no-op: the
+value is present, the process looks configured, and upstream has already made
+its decision from the default. These tests pin the distinction.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from lop_osworld_v2_adapter import vendor_bridge
+
+from local_operator.evaluation.adapters.api import ScopedInfraValue
+
+
+def _infra(name: str, value: str) -> ScopedInfraValue:
+    return ScopedInfraValue(name=name, purpose="benchmark_compute", value=value)
+
+
+@pytest.fixture(autouse=True)
+def _restore_environment():
+    """Injection writes to the real process environment; put it back."""
+    names = ("PROXY_CONFIG_FILE", "WEBSITE_HOST_SUFFIX", "AWS_REGION", "NOT_INJECTABLE")
+    saved = {name: os.environ.get(name) for name in names}
+    yield
+    for name, value in saved.items():
+        if value is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = value
+
+
+def test_the_proxy_config_path_reaches_the_process_environment() -> None:
+    """The one property that makes a proxy task runnable at all.
+
+    ``desktop_env.controllers.setup`` calls ``init_proxy_pool(PROXY_CONFIG_FILE)``
+    at import, defaulting to a CWD-relative path that never resolves under the
+    ``-I`` worker. Without this name being injected the pool loads zero proxies
+    and the episode crashes at ``reset_start`` -- after the VM is billed.
+    """
+    os.environ.pop("PROXY_CONFIG_FILE", None)
+    vendor_bridge.inject_infra_environment((_infra("PROXY_CONFIG_FILE", "/abs/proxies.json"),))
+    assert os.environ["PROXY_CONFIG_FILE"] == "/abs/proxies.json"
+
+
+def test_the_proxy_config_path_is_an_import_time_name() -> None:
+    """Placement matters, not just presence.
+
+    ``_OSWORLD_IMPORT_ENV`` is the set the adapter must set before importing
+    ``desktop_env``. If PROXY_CONFIG_FILE ever moves to the call-time list the
+    injection still "works" in a unit test and silently stops working in a real
+    episode, so the membership itself is the assertion.
+    """
+    assert "PROXY_CONFIG_FILE" in vendor_bridge._OSWORLD_IMPORT_ENV
+
+
+def test_a_name_outside_the_allowlist_is_not_injected() -> None:
+    """The allowlist is a containment boundary, not a convenience."""
+    os.environ.pop("NOT_INJECTABLE", None)
+    vendor_bridge.inject_infra_environment((_infra("NOT_INJECTABLE", "secret-shaped-value"),))
+    assert "NOT_INJECTABLE" not in os.environ
+
+
+def test_ordinary_injectable_names_still_reach_the_environment() -> None:
+    vendor_bridge.inject_infra_environment(
+        (_infra("WEBSITE_HOST_SUFFIX", "example.test"), _infra("AWS_REGION", "us-east-1"))
+    )
+    assert os.environ["WEBSITE_HOST_SUFFIX"] == "example.test"
+    assert os.environ["AWS_REGION"] == "us-east-1"

--- a/tests/unit/evaluation/adapters/osworld/test_vendor_bridge.py
+++ b/tests/unit/evaluation/adapters/osworld/test_vendor_bridge.py
@@ -73,7 +73,38 @@ def test_ordinary_injectable_names_still_reach_the_environment() -> None:
     assert os.environ["AWS_REGION"] == "us-east-1"
 
 
-def test_a_task_module_is_registered_before_execution(tmp_path) -> None:
+@pytest.fixture
+def _stub_task_base(monkeypatch):
+    """Make ``instantiate_task`` importable without the upstream package.
+
+    ``instantiate_task`` imports ``desktop_env.task_base`` for the final
+    ``issubclass(BaseTask)`` fallback in its class search. ``desktop_env`` is
+    installed only in the evaluation venv, never in CI -- so guarding these
+    tests with ``importorskip`` meant the whole ``sys.modules`` registration
+    could be deleted with the suite green, which is exactly the regression
+    they exist to catch. Neither probe reaches the fallback (both define
+    ``get_task``), so a two-line stub buys real CI coverage of the fix.
+    """
+    import sys
+    import types
+
+    if "desktop_env.task_base" in sys.modules:  # the evaluation venv: use the real one
+        yield
+        return
+    package = types.ModuleType("desktop_env")
+    package.__path__ = []  # a package, so the submodule import resolves
+    task_base = types.ModuleType("desktop_env.task_base")
+
+    class BaseTask:  # noqa: D401 - stands in for the upstream marker class
+        """Stand-in for the upstream base class used only by an issubclass check."""
+
+    task_base.BaseTask = BaseTask
+    monkeypatch.setitem(sys.modules, "desktop_env", package)
+    monkeypatch.setitem(sys.modules, "desktop_env.task_base", task_base)
+    yield
+
+
+def test_a_task_module_is_registered_before_execution(tmp_path, _stub_task_base) -> None:
     """A task combining future annotations with @dataclass must import.
 
     ``module_from_spec`` does NOT register in ``sys.modules``; the import
@@ -88,9 +119,6 @@ def test_a_task_module_is_registered_before_execution(tmp_path) -> None:
     """
     import sys as _sys
 
-    # instantiate_task imports BaseTask for the class search; the upstream
-    # package is only present in the evaluation venv.
-    pytest.importorskip("desktop_env.task_base")
     from lop_osworld_v2_adapter import vendor_bridge as bridge
 
     module_path = tmp_path / "task_probe.py"
@@ -112,11 +140,12 @@ def test_a_task_module_is_registered_before_execution(tmp_path) -> None:
         _sys.modules.pop("osworld_task_probe", None)
 
 
-def test_a_task_module_that_fails_to_import_is_not_left_registered(tmp_path) -> None:
+def test_a_task_module_that_fails_to_import_is_not_left_registered(
+    tmp_path, _stub_task_base
+) -> None:
     """A half-initialised module must not stay visible to the next episode."""
     import sys as _sys
 
-    pytest.importorskip("desktop_env.task_base")
     from lop_osworld_v2_adapter import vendor_bridge as bridge
 
     module_path = tmp_path / "task_broken.py"

--- a/tests/unit/evaluation/adapters/osworld/test_vendor_bridge.py
+++ b/tests/unit/evaluation/adapters/osworld/test_vendor_bridge.py
@@ -92,13 +92,15 @@ def _stub_task_base(monkeypatch):
         yield
         return
     package = types.ModuleType("desktop_env")
-    package.__path__ = []  # a package, so the submodule import resolves
+    setattr(package, "__path__", [])  # a package, so the submodule import resolves
     task_base = types.ModuleType("desktop_env.task_base")
 
     class BaseTask:  # noqa: D401 - stands in for the upstream marker class
         """Stand-in for the upstream base class used only by an issubclass check."""
 
-    task_base.BaseTask = BaseTask
+    # setattr, not attribute assignment: ModuleType has no declared
+    # 'BaseTask' slot, so pyright rejects the direct form.
+    setattr(task_base, "BaseTask", BaseTask)
     monkeypatch.setitem(sys.modules, "desktop_env", package)
     monkeypatch.setitem(sys.modules, "desktop_env.task_base", task_base)
     yield

--- a/tests/unit/evaluation/adapters/osworld/test_vendor_bridge.py
+++ b/tests/unit/evaluation/adapters/osworld/test_vendor_bridge.py
@@ -71,3 +71,56 @@ def test_ordinary_injectable_names_still_reach_the_environment() -> None:
     )
     assert os.environ["WEBSITE_HOST_SUFFIX"] == "example.test"
     assert os.environ["AWS_REGION"] == "us-east-1"
+
+
+def test_a_task_module_is_registered_before_execution(tmp_path) -> None:
+    """A task combining future annotations with @dataclass must import.
+
+    ``module_from_spec`` does NOT register in ``sys.modules``; the import
+    system does that itself before executing a module, and upstream's loader
+    gets it for free by going through ``import``. Skipping it breaks string
+    annotations: dataclasses resolves them through ``_is_type``, which does
+    ``sys.modules.get(cls.__module__)`` and reads ``.__dict__`` on the result.
+    For an unregistered module that is None, and the task dies at
+    ``reset_start`` -- with the VM already allocated -- with a bare
+    ``AttributeError: 'NoneType' object has no attribute '__dict__'`` that
+    names neither the task nor the cause.
+    """
+    import sys as _sys
+
+    # instantiate_task imports BaseTask for the class search; the upstream
+    # package is only present in the evaluation venv.
+    pytest.importorskip("desktop_env.task_base")
+    from lop_osworld_v2_adapter import vendor_bridge as bridge
+
+    module_path = tmp_path / "task_probe.py"
+    module_path.write_text(
+        "from __future__ import annotations\n"
+        "from dataclasses import dataclass\n"
+        "@dataclass\n"
+        "class _Result:\n"
+        "    ok: bool\n"
+        "    detail: str | None\n"
+        "def get_task():\n"
+        "    return _Result(ok=True, detail=None)\n",
+        encoding="utf-8",
+    )
+    try:
+        task = bridge.instantiate_task(str(module_path), "probe")
+        assert task.ok is True
+    finally:
+        _sys.modules.pop("osworld_task_probe", None)
+
+
+def test_a_task_module_that_fails_to_import_is_not_left_registered(tmp_path) -> None:
+    """A half-initialised module must not stay visible to the next episode."""
+    import sys as _sys
+
+    pytest.importorskip("desktop_env.task_base")
+    from lop_osworld_v2_adapter import vendor_bridge as bridge
+
+    module_path = tmp_path / "task_broken.py"
+    module_path.write_text("raise RuntimeError('boom')\n", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="boom"):
+        bridge.instantiate_task(str(module_path), "broken")
+    assert "osworld_task_broken" not in _sys.modules


### PR DESCRIPTION
## What

Proxy-declaring OSWorld tasks now run. Two of the ten frozen pilot tasks (`task_037`, `task_098`) died at `reset_start` with `No proxy available from proxy pool` — **after the VM was allocated and billed**, on every model tried.

`Release: patch — proxy-declaring benchmark tasks reach the model instead of crashing after the VM is paid for.`

## Why it failed

Not the model, and not the proxy credentials — which exist and are valid.

`desktop_env/controllers/setup.py` calls `init_proxy_pool(PROXY_CONFIG_FILE)` at **module import**, reading that name via `os.getenv` with a default of the **CWD-relative** `evaluation_examples/settings/proxy/dataimpulse.json`. The adapter worker is spawned `-I` from an arbitrary CWD, so the default never resolves. `load_proxies_from_file` then swallows the `FileNotFoundError` into a log line, so the pool loads **zero** proxies and nothing fails until the paid boundary.

Measured on the real installed package:

```
without the env var : Failed to load proxies from evaluation_examples/... [Errno 2]
                      proxies loaded: 0 | get_next_proxy: False
with it             : proxies loaded: 1 | get_next_proxy: True
```

## The fix

`PROXY_CONFIG_FILE` becomes a declared infra input, added to `_OSWORLD_IMPORT_ENV` — **not** `_ENV_INJECTABLE`, because injecting it after the first `desktop_env` import is a silent no-op. It is validated at `prepare` (absolute, readable, bounded, and shaped the way `ProxyPool` actually parses), so an unusable config is a **free refusal** naming both ways out, rather than a paid crash.

Also drops `OSWORLD_PROXY_CREDENTIALS`, which was **required** for these tasks and consumed at no call site in the package. Demanding a secret the apparatus cannot use trains an operator to fabricate one, and a fabricated credential that appears to work is worse than a missing one. `OSWORLD_PROXY_ENDPOINT` stays declared but optional, so existing invocations are accepted unchanged.

This is the "separately reviewed follow-up" the README's proxy section already called for.

## Testing evidence

**End-to-end on a real paid episode**, which is the only proof that counts here:

| | `task_037`, Kimi K3, same apparatus |
|---|---|
| **Before** | `RpcRemoteError: No proxy available from proxy pool` — unscored, VM billed |
| **After** | `status=completed`, `reportability=reportable`, **scored** (binary 0, partial 0), 35 model calls, $1.13, `audit=[]` |

The task now reaches the model and is graded on its merits. Its score is a capability result, not an apparatus failure.

**Unit:** 452 passed, 1 skipped in the OSWorld adapter suite. 14 new tests cover the absolute-path rule, unreadable/oversized/malformed configs, wrong scope, conflicting values, and the six payload shapes upstream would silently load as an empty pool.

**Mutation-tested** rather than assumed — removing `PROXY_CONFIG_FILE` from the import-time list fails two distinct assertions:
```
FAILED ... KeyError: 'PROXY_CONFIG_FILE'
FAILED ... assert 'PROXY_CONFIG_FILE' in ('AWS_REGION', 'AWS_SUBNET_ID', 'AWS_SECURITY_GROUP_ID')
```

**Gates:** flake8, black 26.1.0, isort 5.13.2, pyright — all clean over the whole tree. `pyproject.toml` three-dot diff empty.

## Note on secrets

No credential is printed, logged, or committed. The validator refuses without echoing the path, because an operator can mistype a credentialed URL into that field.