### PR TITLE
fix(tui): recall queued steers by message id, and state an interrupt once

### DIFF
--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -616,6 +616,13 @@ class RemoteSession:
         # optimistic notice through this app-installed callback.
         self._cancel_resolution: Callable[[int], None] | None = None
         self._cancel_task: asyncio.Task[None] | None = None
+        # Esc-recall's twin of the pair above: the synchronous protocol method
+        # answers optimistically from local state and the owner's REJECTION —
+        # the steer was already drained — comes back through this callback, so
+        # the app can warn instead of leaving the user to press Enter on a
+        # composer whose text is still queued (a silent double-send).
+        self._recall_resolution: Callable[[str], None] | None = None
+        self._recall_task: asyncio.Task[None] | None = None
         # Teams and agent profiles are LOCAL CONFIG, not runtime state: they
         # live in `<config_dir>/teams` and `<config_dir>/agents`, the same
         # files `lop team`/`lop agents` read with no session at all. So a
@@ -4631,13 +4638,53 @@ class RemoteSession:
         ]
 
     def recall_steering(self, message: Any) -> bool:
+        """Optimistic unsend: True means the op was ISSUED, not that it landed.
+
+        ``SessionProtocol.recall_steering`` is synchronous — the Esc handler
+        reads its answer inline — but the authoritative queue lives on the
+        owner across a socket, so the real outcome arrives later. The follower
+        answers from the state it holds and reports the owner's verdict through
+        the ``_recall_resolution`` callback the app installs, exactly as
+        ``cancel_subagents`` does for its count.
+
+        The verdict matters because a REJECTION strands the user. By the time
+        the owner answers ``that steering message is no longer queued`` the app
+        has already put the text in the composer and removed the steer's rows,
+        so the message is both still queued on the owner AND sitting in the
+        composer ready for Enter — press it and the same message is delivered
+        twice. That is the double-send this seam exists to report rather than
+        swallow: previously the rejection surfaced only as an unretrieved task
+        exception in the log.
+        """
         ids = {str(item.get("id", "") or "") for item in self.frontend_state.queued_steering}
         if str(getattr(message, "id", "") or "") not in ids:
             return False
         client = self._client
         if client is not None:
-            asyncio.create_task(client.recall_steer(str(message.id)))
+            self._recall_task = asyncio.ensure_future(self._resolve_recall(client, str(message.id)))
         return True
+
+    async def _resolve_recall(self, client: AttachClient, command_id: str) -> None:
+        """Tell the app whether the owner actually unsent the steer."""
+        try:
+            await client.recall_steer(command_id)
+        except Exception:
+            # Every failure shape is the same fact to the user: the composer
+            # holds text the owner may still deliver. A lost socket cannot be
+            # told apart from an explicit rejection here, and guessing wrong
+            # in the quiet direction is what produces a silent double-send.
+            resolver = self._recall_resolution
+            if resolver is not None:
+                resolver(command_id)
+
+    def set_recall_resolution(self, resolver: Callable[[str], None] | None) -> None:
+        """Install the app's handler for a recall the owner did NOT honour.
+
+        Called with the recalled message's command id when the op failed, so
+        the app can warn that the steer may still be delivered. ``None``
+        disarms it.
+        """
+        self._recall_resolution = resolver
 
     def abort(self, reason: str = "interrupted") -> None:
         client = self._client

--- a/local_operator/session/remote.py
+++ b/local_operator/session/remote.py
@@ -108,6 +108,18 @@ logger = logging.getLogger(__name__)
 #: race the gap says the same thing — never the transport's ``not attached``.
 _RECONNECTING_SLASH_NOTICE = "session is reconnecting; try /{command} again in a moment"
 
+#: The id :meth:`RemoteSession.queued_steering` substitutes when a wire item
+#: carries none — an owner too old to put ``id`` on its queued-steer rows.
+#:
+#: EXPORTED rather than inlined because it is not an identity, and consumers
+#: have to be able to say so. The TUI's Esc-recall matches the queue by id
+#: (``OperatorApp._recall_queued_steers``), and this one value names EVERY
+#: id-less entry — so a consumer that cannot tell the placeholder from a real
+#: id could unsend one message while handing the composer another's text. A
+#: hard-coded copy of the string on the far side is one rename away from
+#: silently not matching, which is the same defect with no symptom.
+UNIDENTIFIED_STEER_ID = "remote-steer"
+
 #: How long a VIEWER chases a vanished runtime before unbinding and going cold.
 #: A runtime exits by design when it has nothing left to do, so owner loss is
 #: usually not a crash at all — but a restart after a `kill -9` publishes a new
@@ -622,6 +634,14 @@ class RemoteSession:
         # the app can warn instead of leaving the user to press Enter on a
         # composer whose text is still queued (a silent double-send).
         self._recall_resolution: Callable[[str], None] | None = None
+        #: Held ONLY to keep a strong reference — asyncio does not, and a
+        #: garbage-collected task would drop the refusal the app is waiting
+        #: for. Deliberately not awaited or cancelled in `dispose`, matching
+        #: `_cancel_task` beside it: both are one short request whose whole
+        #: purpose is the callback at its end, and cancelling that at teardown
+        #: would suppress the warning in exactly the disconnect case it exists
+        #: for. The app's own session check is what stops a late refusal
+        #: painting on a conversation that has since been swapped away.
         self._recall_task: asyncio.Task[None] | None = None
         # Teams and agent profiles are LOCAL CONFIG, not runtime state: they
         # live in `<config_dir>/teams` and `<config_dir>/agents`, the same
@@ -4632,7 +4652,7 @@ class RemoteSession:
         return [
             Message.user(
                 str(item.get("text", "") or ""),
-                id=str(item.get("id", "") or "remote-steer"),
+                id=str(item.get("id", "") or UNIDENTIFIED_STEER_ID),
             )
             for item in self.frontend_state.queued_steering
         ]
@@ -4660,8 +4680,20 @@ class RemoteSession:
         if str(getattr(message, "id", "") or "") not in ids:
             return False
         client = self._client
-        if client is not None:
-            self._recall_task = asyncio.ensure_future(self._resolve_recall(client, str(message.id)))
+        if client is None:
+            # NO CLIENT, NO RECALL. ``True`` is what makes the app commit
+            # irreversibly — the composer takes the text and the steer's rows
+            # leave the transcript — so answering it while issuing no op at all
+            # is the exact silent double-send this seam exists to remove,
+            # reached through a different door: the message is still queued on
+            # the owner, the text is in the composer, and the rejection
+            # callback never fires because there is no request to fail.
+            # ``_client`` is None after ``dispose`` and for the whole window
+            # between a dropped socket and a reattach, which is precisely the
+            # disconnect-mid-recall case. Declining leaves the steer queued to
+            # ride the next boundary — what the press would have done anyway.
+            return False
+        self._recall_task = asyncio.ensure_future(self._resolve_recall(client, str(message.id)))
         return True
 
     async def _resolve_recall(self, client: AttachClient, command_id: str) -> None:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -5632,13 +5632,24 @@ class OperatorApp(App[None]):
         if getattr(session, "session_id", ""):
             self._sidebar_sources[session.session_id] = source
         # DISARM THE OUTGOING session's recall resolver before the binding
-        # moves — this is the last moment the old session is reachable. The
-        # incoming one is armed at the foot of this method, so the pair is
-        # symmetric with the cancel resolver above it, which is likewise
-        # cleared on adopt and re-installed per use. `_on_recall_rejected`
-        # also checks the session it was bound to, but that guard only stops
-        # the ROW; releasing the callback here is what stops a retired facade
-        # holding the app alive for the length of its ack timeout.
+        # moves — this is the last moment the old session is reachable from
+        # here. The incoming one is armed at the foot of this method, so the
+        # pair is symmetric with the cancel resolver above it, which is
+        # likewise cleared on adopt and re-installed per use.
+        #
+        # WHAT STOPS THE STALE ROW IS `_on_recall_rejected`'S SESSION CHECK,
+        # not this line, and the distinction matters because this line does
+        # not run everywhere. `_reload_session` and `/resume` null
+        # `self._session` BEFORE calling this, so `outgoing` is None on
+        # exactly those paths and nothing is disarmed there (review round 2,
+        # MINOR-1). That is acceptable rather than a hole: both DISPOSE the
+        # session first, and a pending `_recall_task` retains the facade for
+        # up to `ACK_TIMEOUT_S` regardless of whether its resolver is still
+        # installed — so releasing the callback buys no lifetime those paths
+        # do not already pay. Chasing it into each caller would spread one
+        # rule across three sites to save nothing measurable. The claim is
+        # stated here rather than in the callers so the next reader does not
+        # infer a guarantee this line cannot make on its own.
         outgoing = self._session
         if outgoing is not None and outgoing is not session:
             disarm_recall = getattr(outgoing, "set_recall_resolution", None)
@@ -30978,13 +30989,25 @@ class OperatorApp(App[None]):
         transcript = self._transcript_view()
         for block in (notice, *image_blocks, user_block):
             transcript.remove_block(block)
-        # A decline row from an earlier press advertised exactly this recall
-        # ("clear the composer, esc again"); now that it has happened the row
-        # is an instruction for a state that no longer holds — the same
-        # stale-row class the queued-steer receipts exist to eliminate. Retire
-        # it with the steer's own rows (design round 2, D4).
+        # EITHER Esc-failure row from an earlier press is now stale, and both
+        # go for one reason: each described the state this recall has just
+        # ended. The decline row advertised exactly this recall ("clear the
+        # composer, esc again"), and the ambiguity row asserts a present-tense
+        # fact — "it is still queued" — about a message now sitting in the
+        # composer. Both are the stale-row class the queued-steer receipts
+        # exist to eliminate, so both retire with the steer's own rows (design
+        # round 2 D4; design round 3 D6 / review round 2 MINOR-2).
+        #
+        # The ambiguity row reaches this the way its own docstring says it can:
+        # both routes into it CLEAR ON THEIR OWN — a stale replicated
+        # `frontend_state` that stops doubling an id once the pump catches up,
+        # and an id-less entry draining at a boundary — so the very next press
+        # succeeds while the row it left behind still says the steer is queued.
         stop_notice = self._stop_notice
-        if stop_notice is not None and stop_notice.text() == RECALL_DECLINE_NOTICE:
+        if stop_notice is not None and stop_notice.text() in (
+            RECALL_DECLINE_NOTICE,
+            RECALL_AMBIGUOUS_NOTICE,
+        ):
             transcript.remove_block(stop_notice)
             self._stop_notice = None
         # The steer branch registered a pending echo so the delivery's
@@ -31037,12 +31060,19 @@ class OperatorApp(App[None]):
         round 1, D1).
 
         SCOPED TO THE SESSION THAT ISSUED THE RECALL. The refusal crosses a
-        socket with a 15 s ack timeout (`ACK_TIMEOUT_S`), so `/clear`, `/new`,
-        `/resume`, a sidebar switch or a takeover can all land first — and a
-        row telling the user "that steer was sent" about a conversation that
-        never sent it is worse than silence, because it is the double-send
-        warning aimed at the wrong text. A late ack for a conversation that is
-        no longer on screen is dropped.
+        socket with a 15 s ack timeout (`ACK_TIMEOUT_S`), so `/new`, `/resume`,
+        a sidebar switch or a takeover can all land first — and a row telling
+        the user "that steer was sent" about a conversation that never sent it
+        is worse than silence, because it is the double-send warning aimed at
+        the wrong text. A late ack for a conversation that is no longer
+        current is dropped.
+
+        `/clear` is deliberately NOT in that list, and the guard does not fire
+        there: it empties the SCREEN, leaving the session and its steering
+        queue intact, so the message really may still be delivered and the
+        composer really may still hold the duplicate. The conversation has not
+        changed, so the warning is about the text in front of the user and
+        painting it is correct (review round 2, NIT-1).
         """
         if session is not self._session:
             logger.debug("dropped a recall refusal for a session that is no longer current")

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -494,8 +494,33 @@ RECALL_DECLINE_NOTICE = "queued steer kept — clear the composer, esc again to 
 #: and drafted here. Pressing Enter then sends it twice, which is exactly the
 #: double-send this whole change exists to remove, so the row names the state
 #: rather than letting the user discover it from the agent answering twice.
-#: 56 cells: inside the set's 61-column one-line budget (design round 2, D5).
-RECALL_UNCONFIRMED_NOTICE = "recall did not land — that steer was sent; do not resend"
+#:
+#: It names the RESOLVING ACTION, not a prohibition. "do not resend" (the
+#: round-1 wording) forbids one keystroke and leaves the duplicate sitting in
+#: the composer indefinitely, with no row to say when the ban lifts; clearing
+#: the composer is what actually ends the state, and it is the recovery clause
+#: `RECALL_DECLINE_NOTICE` already uses — so the two Esc-failure rows advise in
+#: one grammar (design round 1, D3).
+#:
+#: Holds ONE LINE FROM 60 COLUMNS, measured on a mounted `NoticeBlock` across
+#: 40-100 columns rather than counted: at 50 characters it is the narrowest row
+#: in this set, where the round-1 string needed 66. Character count is not the
+#: instrument here — `scripts/steer_receipt_candidates.py` says why — and the
+#: "61-column budget" the round-1 comment claimed was true of nothing in the
+#: set, this row included.
+RECALL_UNCONFIRMED_NOTICE = "too late — that steer was sent; clear the composer"
+#: The row an UNNAMEABLE queue prints. Esc matches the queue by message id, and
+#: an id that names two entries — or `UNIDENTIFIED_STEER_ID`, which names every
+#: id-less one — is not an identity, so the newest steer cannot be picked out
+#: and the press recalls nothing (see `_recall_queued_steers`).
+#:
+#: Its own row rather than `RECALL_DECLINE_NOTICE`, which is the other Esc
+#: failure: that one names the COMPOSER as the obstacle and offers "esc again",
+#: and both are false here — the composer is empty and a second press meets the
+#: same queue. A row that advertises a recovery that does not work is worse
+#: than the silence it replaces. What the user needs is that the steer is still
+#: coming, which is also the one piece of good news in the state.
+RECALL_AMBIGUOUS_NOTICE = "could not identify that steer — it is still queued"
 
 
 #: Rows a `.band-slot` spends on itself beyond its content: the rhythm row it
@@ -3681,6 +3706,7 @@ class OperatorApp(App[None]):
             queued_steer_notices=self._queued_steer_notices,
             deferred_steer_notices=self._deferred_steer_notices,
             held_steer_blocks=self._held_steer_blocks,
+            own_interrupt_notice=self._own_interrupt_notice,
             welcome=self._welcome,
             welcome_visible=self._welcome_visible,
         )
@@ -3708,6 +3734,12 @@ class OperatorApp(App[None]):
         self._queued_steer_notices = presentation.queued_steer_notices
         self._deferred_steer_notices = presentation.deferred_steer_notices
         self._held_steer_blocks = presentation.held_steer_blocks
+        # Restored WITH the transcript it names a row in — unlike `_stop_notice`
+        # below, which is cleared because the Esc ladder is a property of the
+        # abandoned viewport. This row is a property of the CONVERSATION: its
+        # outcome anchor is still coming, and an app that forgot it would let
+        # the poller print a second `Interrupted` under the live row on return.
+        self._own_interrupt_notice = presentation.own_interrupt_notice
         self._welcome = presentation.welcome
         self._welcome_visible = None
         # Gesture tasks belong to the abandoned viewport, not its history.
@@ -5599,6 +5631,19 @@ class OperatorApp(App[None]):
         self._set_approve_all(self._approve_all)
         if getattr(session, "session_id", ""):
             self._sidebar_sources[session.session_id] = source
+        # DISARM THE OUTGOING session's recall resolver before the binding
+        # moves — this is the last moment the old session is reachable. The
+        # incoming one is armed at the foot of this method, so the pair is
+        # symmetric with the cancel resolver above it, which is likewise
+        # cleared on adopt and re-installed per use. `_on_recall_rejected`
+        # also checks the session it was bound to, but that guard only stops
+        # the ROW; releasing the callback here is what stops a retired facade
+        # holding the app alive for the length of its ack timeout.
+        outgoing = self._session
+        if outgoing is not None and outgoing is not session:
+            disarm_recall = getattr(outgoing, "set_recall_resolution", None)
+            if callable(disarm_recall):
+                disarm_recall(None)
         self._session = session
         # The id of the session this VIEWER is looking at, kept beside the
         # binding rather than derived from it. `self._session` is dropped by
@@ -5699,9 +5744,18 @@ class OperatorApp(App[None]):
             # already returned — there is no synchronous moment to install it
             # in, and a recall whose warning had nowhere to land would be the
             # silent double-send again.
+            #
+            # BOUND TO THIS SESSION, and the previous one is disarmed on the
+            # line above's own reasoning: the refusal can arrive up to
+            # `ACK_TIMEOUT_S` later, by which time the adopt may already have
+            # put another conversation on screen. Passing the session as an
+            # argument is what lets `_on_recall_rejected` drop a refusal that
+            # is no longer about what the user is looking at — a warning
+            # painted on the wrong conversation is the double-send row aimed
+            # at text that was never sent.
             set_recall_resolution = getattr(session, "set_recall_resolution", None)
             if callable(set_recall_resolution):
-                set_recall_resolution(self._on_recall_rejected)
+                set_recall_resolution(partial(self._on_recall_rejected, session))
         # Before the band is painted below: the freshly built spec carries the
         # MODEL's default effort, and a `/reload` or `/new` that dropped the
         # user's chosen level would repaint the band with a level they did not
@@ -15179,9 +15233,19 @@ class OperatorApp(App[None]):
         block = self._own_interrupt_notice
         if kind != "interrupted" or block is None:
             return False
-        self._own_interrupt_notice = None
         if block not in self._transcript_view().blocks():
+            # NOT consumed. Clearing the reference before this test burnt it on
+            # a failure that is routinely transient: a sidebar switch parks the
+            # row in the other conversation's `TranscriptView`, so this poll
+            # legitimately cannot see it — and dropping it there meant that on
+            # switching back the poller appended its `Interrupted` under the
+            # live `interrupted`, restoring the very duplicate this method
+            # exists to remove. The row is still the announcement of this
+            # outcome; only this view is wrong.
             return False
+        # Consumed only once it has actually been stamped: one outcome, one
+        # adoption, and a later publication must get its own row.
+        self._own_interrupt_notice = None
         block.completion_anchor_id = anchor
         return True
 
@@ -30732,14 +30796,29 @@ class OperatorApp(App[None]):
         the fast path so the in-process session, where the objects genuinely
         are shared, never depends on the id round trip at all.
 
-        Only a NON-EMPTY id may match, and only an id that is UNIQUE in the
-        snapshot. `RemoteSession.queued_steering` substitutes the literal
-        `"remote-steer"` for a wire item carrying no id, so two such entries
-        arrive sharing one id — matching on it would let a recall lift the
-        wrong row's text into the composer while unsending a different
-        message. An ambiguous id is therefore treated as no match at all: the
-        steer stays queued and rides the next boundary, which is what would
-        have happened without the press, and the decline row below says so.
+        An id only counts as an identity when it NAMES ONE ENTRY. Two things
+        break that, and both are the same hazard: a snapshot carrying the id
+        twice, and `UNIDENTIFIED_STEER_ID` — the placeholder
+        `RemoteSession.queued_steering` substitutes for a wire item with no id
+        of its own, which by construction names every id-less entry rather
+        than any one of them. Matching either would let a recall unsend one
+        message while handing the composer another's text, so neither is an
+        identity here and an entry keyed on one is UNRECALLABLE.
+
+        AN UNRECALLABLE NEWEST ENTRY ENDS THE SCAN — it does not fall through
+        to an older one. Skipping to the next entry looks like graceful
+        degradation and is the worst available outcome: the press unsends and
+        lifts a steer the user did not point at, while the one they did stays
+        queued and is delivered. "Only the NEWEST" is the contract above, so
+        an unrecallable newest means NO recall, never a substitute.
+
+        And it SAYS SO, with `RECALL_AMBIGUOUS_NOTICE`. A press that changes
+        nothing on screen is indistinguishable from a dropped keystroke, which
+        is the failure design round 1 (D1) filed the decline row to remove —
+        and that row cannot serve here, because it names the composer as the
+        obstacle and the composer is not the obstacle. The steer stays queued
+        and rides the next boundary either way; the row is what makes that a
+        stated outcome rather than a silence.
 
         A recall that cannot finish — no session, a composer the app has put
         read-only (the subagent view owns it), or a half-typed draft it would
@@ -30749,6 +30828,11 @@ class OperatorApp(App[None]):
         not happened. The message then rides the next boundary, which is the
         behaviour the user had before they pressed Esc.
         """
+        # Function-local like every other `session.remote` import in this file:
+        # the module imports the TUI's own types, so a top-level import here is
+        # a cycle.
+        from local_operator.session.remote import UNIDENTIFIED_STEER_ID
+
         session = self._session
         if session is None or not self._held_steer_blocks:
             return
@@ -30759,20 +30843,53 @@ class OperatorApp(App[None]):
         # press: the membership scan below would otherwise drain-and-rebuild
         # the queue once per held entry on the cancel key's hot path.
         queued_now = session.queued_steering()
-        # Ids that appear MORE THAN ONCE in the snapshot are unusable as a key
-        # — see the docstring on `"remote-steer"`. Counted once per press
-        # rather than per held entry, on the same reasoning as the single
-        # snapshot above: this is the cancel key's hot path.
+        # Ids that name more than one snapshot entry are unusable as a key —
+        # see the docstring. Counted once per press rather than per held
+        # entry, on the same reasoning as the single snapshot above: this is
+        # the cancel key's hot path.
         id_counts: dict[str, int] = {}
         for item in queued_now:
             item_id = str(getattr(item, "id", "") or "")
             if item_id:
                 id_counts[item_id] = id_counts.get(item_id, 0) + 1
-        for entry in reversed(self._held_steer_blocks):
-            held_id = str(getattr(entry[0], "id", "") or "")
-            if any(item is entry[0] for item in queued_now) or id_counts.get(held_id) == 1:
+        # Whether the queue is carrying entries this app cannot name at all.
+        # An id-less wire item reaches the snapshot as `UNIDENTIFIED_STEER_ID`
+        # while the held message keeps the uuid this app minted, so the two
+        # can never be compared — and any held entry might BE that item. One
+        # such entry therefore makes every by-id match a guess.
+        unnameable = id_counts.get(UNIDENTIFIED_STEER_ID, 0) > 0
+        entry = None
+        ambiguous = False
+        for candidate in reversed(self._held_steer_blocks):
+            held_id = str(getattr(candidate[0], "id", "") or "")
+            # Identity first: on the in-process `Session` the snapshot holds
+            # the very objects this app queued, so that path never depends on
+            # the id round trip, and an id-less sibling cannot spoil it.
+            if any(item is candidate[0] for item in queued_now):
+                entry = candidate
                 break
-        else:
+            if held_id and id_counts.get(held_id) == 1 and not unnameable:
+                entry = candidate
+                break
+            if (held_id and held_id in id_counts) or unnameable:
+                # The entry is in the queue (or may be, as an unnameable one)
+                # but cannot be named uniquely. The scan STOPS here rather
+                # than trying the next-older entry: recalling a message the
+                # user did not point at is the one outcome worse than
+                # declining, and "only the NEWEST" is the contract.
+                ambiguous = True
+                break
+            # Genuinely not in the queue: delivered at a boundary. Skipping is
+            # correct — `on_steering_delivered` removes these when their
+            # receipt lands, so only ones still in flight are seen here.
+        if ambiguous:
+            # Not `RECALL_DECLINE_NOTICE`: that row names the composer as the
+            # obstacle and offers "esc again", neither of which is true here —
+            # a second press hits the same unnameable queue. Its own row says
+            # what actually happened and what the user still has.
+            self._replace_stop_notice(RECALL_AMBIGUOUS_NOTICE, "note")
+            return
+        if entry is None:
             return
         message, user_block, image_blocks, notice, attachments = entry
         editor = self._editor()
@@ -30798,8 +30915,13 @@ class OperatorApp(App[None]):
         # the obstacle. The recovery is one line, replaced on repeat like the
         # ladder's own rows.
         if editor.text.strip():
-            # 59 cells: inside the set's 61-column one-line budget (design
-            # round 2, D5).
+            # 59 characters, and it holds ONE LINE FROM 69 COLUMNS — measured
+            # on a mounted `NoticeBlock`, not counted. The "inside the set's
+            # 61-column budget" this comment used to claim was wrong: at 61
+            # columns this row wraps to two lines, and no row in the set holds
+            # one there. Corrected rather than deleted because the next person
+            # editing the string will look here for the number (design round 1,
+            # D3); `scripts/steer_receipt_candidates.py` is the instrument.
             self._replace_stop_notice(RECALL_DECLINE_NOTICE, "note")
             return
         # The row's text, NOT ``message.text``. For every ordinary steer the
@@ -30831,13 +30953,24 @@ class OperatorApp(App[None]):
         editor.move_cursor(editor._end_of_buffer())
         # Only now is the recall irreversible: the composer holds the text.
         if not session.recall_steering(message):
-            # Defence, not a live race: this handler runs synchronously on the
-            # session's own loop, so nothing drains the queue between the
-            # snapshot above and here. Kept for a future host that runs the
-            # session off this loop; if it ever fires, the composer has the
-            # text and the queue delivered it too — the user sees both and can
-            # delete the draft, and putting the message back would double-send.
-            logger.debug("recall raced a steering delivery; composer keeps the text")
+            # REACHABLE, and no longer merely defensive. That claim held while
+            # the only host was the in-process `Session`, where this handler
+            # runs on the session's own loop and nothing can drain the queue
+            # between the snapshot above and here. A `RemoteSession` reads a
+            # REPLICATED `frontend_state` that the socket pump may have last
+            # written arbitrarily long ago, so a False here is an ordinary
+            # stale-snapshot outcome — and it is also how a viewer with no
+            # client declines rather than claiming a recall it cannot issue.
+            #
+            # The composer keeps the text either way: putting the message back
+            # is not available (it was never taken off the owner's queue) and
+            # discarding the draft is the loss `action_stop` forbids. So this
+            # is the same state the owner's own refusal produces, reached
+            # locally, and it gets the same row — silently removing the steer's
+            # rows here would leave the user holding a duplicate with nothing
+            # on screen having said so.
+            logger.debug("recall did not reach the queue; composer keeps the text")
+            self._append_block(NoticeBlock(RECALL_UNCONFIRMED_NOTICE, "warning"))
         # `entry`, not the list's tail: the tail can be a delivered entry the
         # receipt has not yet removed, and the recall must take exactly the
         # one it loaded into the composer.
@@ -30872,7 +31005,7 @@ class OperatorApp(App[None]):
                 break
         editor.focus()
 
-    def _on_recall_rejected(self, command_id: str) -> None:
+    def _on_recall_rejected(self, session: Any, command_id: str) -> None:
         """The owner did not honour a recall this app already committed.
 
         A follower's recall is optimistic (`RemoteSession.recall_steering`):
@@ -30890,12 +31023,32 @@ class OperatorApp(App[None]):
         `action_stop` forbids. So the honest behaviour is to warn and leave
         the draft under the user's control.
 
-        Through `_replace_stop_notice` because this is the Esc ladder's own
-        row: a press that produced a decline row a moment ago must not stack a
-        second contradicting line under it.
+        APPENDED as its own row, NOT written into the Esc ladder's single slot
+        (`_replace_stop_notice`). That slot holds mutually-exclusive ladder
+        STATES, each describing a settled outcome, and replace-don't-stack is
+        right for them. This row is not one of them: it carries an UNRESOLVED
+        risk — a composer holding text the owner already sent — so it has to
+        outlive the next press. It did not. With two steers queued, a second
+        Esc took the decline path and overwrote this warning with `queued
+        steer kept — clear the composer, esc again to recall`, which invites
+        the user to recall a steer that was already delivered, over a composer
+        whose contents are the duplicate. Pressing Esc again after reading
+        that something went wrong is the reflex, not an edge case (design
+        round 1, D1).
+
+        SCOPED TO THE SESSION THAT ISSUED THE RECALL. The refusal crosses a
+        socket with a 15 s ack timeout (`ACK_TIMEOUT_S`), so `/clear`, `/new`,
+        `/resume`, a sidebar switch or a takeover can all land first — and a
+        row telling the user "that steer was sent" about a conversation that
+        never sent it is worse than silence, because it is the double-send
+        warning aimed at the wrong text. A late ack for a conversation that is
+        no longer on screen is dropped.
         """
+        if session is not self._session:
+            logger.debug("dropped a recall refusal for a session that is no longer current")
+            return
         logger.debug("session owner refused the recall of steer %s", command_id)
-        self._replace_stop_notice(RECALL_UNCONFIRMED_NOTICE, "warning")
+        self._append_block(NoticeBlock(RECALL_UNCONFIRMED_NOTICE, "warning"))
 
     def _settle_queued_steer_notices_unsent(self) -> None:
         """Retire queued-steer rows the turn that just ended did not deliver.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -487,6 +487,15 @@ DEFERRED_SENT_STEER_NOTICE = "sent — it rode along with that next message"
 #: obstacle and the recovery. Named because the SUCCESSFUL recall retires its
 #: own decline row (design round 2, D4) and must recognise it.
 RECALL_DECLINE_NOTICE = "queued steer kept — clear the composer, esc again to recall"
+#: The row a recall that the SESSION OWNER refused prints. The recall is
+#: optimistic across a socket: the composer has the text and the steer's rows
+#: are gone before the owner answers, so a rejection ("that steering message is
+#: no longer queued" — it drained first) leaves the message both queued there
+#: and drafted here. Pressing Enter then sends it twice, which is exactly the
+#: double-send this whole change exists to remove, so the row names the state
+#: rather than letting the user discover it from the agent answering twice.
+#: 56 cells: inside the set's 61-column one-line budget (design round 2, D5).
+RECALL_UNCONFIRMED_NOTICE = "recall did not land — that steer was sent; do not resend"
 
 
 #: Rows a `.band-slot` spends on itself beyond its content: the rhythm row it
@@ -2448,6 +2457,30 @@ class OperatorApp(App[None]):
         #: The two together are the FIFO the engine drains: these rows were
         #: queued first, so they settle first (see `on_steering_delivered`).
         self._deferred_steer_notices: list[NoticeBlock] = []
+        #: The `interrupted` row THIS app painted for the turn it just retired,
+        #: awaiting the anchor the session publishes for the same outcome.
+        #:
+        #: Two independent producers state one interruption: `_finalize_turn`
+        #: (live, from the turn ending) and `_poll_completion_attention` (a
+        #: tick later, from the durable `AttentionStore`, so a user returning
+        #: to a session learns it stopped while they were away). The poller
+        #: dedupes on `completion_anchor_id`, and the live row has none —
+        #: the anchor is `completion-<token>`, minted by the session when it
+        #: publishes, which is strictly AFTER the row is on screen. So the
+        #: poller could not see the row and appended a second, dimmer
+        #: `Interrupted` under it (the reported defect: `! interrupted` above
+        #: `· Interrupted`).
+        #:
+        #: Holding the row closes that gap without deleting either producer:
+        #: the poll ADOPTS it by stamping the anchor onto it, which both
+        #: suppresses the duplicate and makes the row a real acknowledgement
+        #: target — `_completion_anchor_visible` can now find it, so looking at
+        #: the interruption marks it read exactly as looking at a result does.
+        #:
+        #: Cleared when a NEW turn opens and wherever the transcript is
+        #: dropped, because a row from a conversation the user can no longer
+        #: see must never be stamped with a later outcome's anchor.
+        self._own_interrupt_notice: NoticeBlock | None = None
         #: Controllers that were replaced by a swap which KEPT the transcript,
         #: so a steer receipt still in flight from one of them is about a row
         #: this app is still holding and must still settle it (review round 1,
@@ -5659,6 +5692,16 @@ class OperatorApp(App[None]):
             set_cancel_resolution = getattr(session, "set_cancel_resolution", None)
             if callable(set_cancel_resolution):
                 set_cancel_resolution(None)
+            # Esc-recall is optimistic on a follower for the same reason the
+            # cancel count is: the composer takes the text and the rows go
+            # before the owner has answered. Armed HERE rather than per-press
+            # because the rejection can only be reported after the press has
+            # already returned — there is no synchronous moment to install it
+            # in, and a recall whose warning had nowhere to land would be the
+            # silent double-send again.
+            set_recall_resolution = getattr(session, "set_recall_resolution", None)
+            if callable(set_recall_resolution):
+                set_recall_resolution(self._on_recall_rejected)
         # Before the band is painted below: the freshly built spec carries the
         # MODEL's default effort, and a `/reload` or `/new` that dropped the
         # user's chosen level would repaint the band with a level they did not
@@ -8099,6 +8142,13 @@ class OperatorApp(App[None]):
         # watch the other front end paint it while this one stays silent.
         self._pending_user_echoes.clear()
         self._held_steer_blocks.clear()
+        # And the interrupt row awaiting an anchor: it belonged to the OLD
+        # conversation's turn, so a publication from the replacement session
+        # must never adopt it. `_adopt_own_interrupt_notice` also refuses an
+        # unmounted block, but dropping the reference here states the rule
+        # where the other row references are dropped rather than relying on a
+        # downstream guard to notice.
+        self._own_interrupt_notice = None
         # And the takeover allowance, which only ever protects rows: with the
         # rows gone there is nothing left for a superseded controller's receipt
         # to settle, and an entry outliving them would re-open the very race
@@ -14480,6 +14530,10 @@ class OperatorApp(App[None]):
         self._queued_steer_notices.clear()
         self._deferred_steer_notices.clear()
         self._held_steer_blocks.clear()
+        # The `/clear` removed the interrupt row too, so the anchor it was
+        # waiting for has nothing left to land on. Dropped here for the same
+        # reason as the rows above: a reference outliving its widget.
+        self._own_interrupt_notice = None
         # Same reason as the swap path: the allowance exists only to let a
         # takeover's in-flight receipt reach a row that is still on screen.
         self._superseded_steer_controllers.clear()
@@ -15095,6 +15149,42 @@ class OperatorApp(App[None]):
             logger.debug("notification delivery failed", exc_info=True)
         return False
 
+    def _adopt_own_interrupt_notice(self, kind: str, anchor: str) -> bool:
+        """Stamp a published outcome onto the row this app already painted.
+
+        Returns True when the held `interrupted` row IS the announcement of
+        this outcome, so the caller must not append its own. The row keeps its
+        own wording (`interrupted`, `warning`): it is the live, turn-scoped
+        statement and restating it as the poller's dimmer `Interrupted` would
+        rewrite a row the user has already read for no gain.
+
+        ONLY for `interrupted`. An `error` outcome is a different fact and the
+        live row for it says something else, so a stopped-with-an-error
+        publication must still get its own row rather than silently borrowing
+        the interruption's.
+
+        The row must still be MOUNTED. A `/clear` or a session swap removes it
+        while this reference survives to the next tick, and stamping an anchor
+        onto a detached widget would suppress the poller's row forever while
+        showing the user nothing — a completion the app has quietly agreed to
+        never mention. The membership test is what keeps the suppression tied
+        to something actually on screen.
+
+        The stamp is also what makes the row ACKNOWLEDGEABLE. `unseen` is
+        cleared by `_completion_anchor_visible` finding the anchored block in
+        the viewport, so before this an interruption the user was looking at
+        stayed unread — and the sidebar went on flagging a session whose
+        outcome was on screen the whole time.
+        """
+        block = self._own_interrupt_notice
+        if kind != "interrupted" or block is None:
+            return False
+        self._own_interrupt_notice = None
+        if block not in self._transcript_view().blocks():
+            return False
+        block.completion_anchor_id = anchor
+        return True
+
     def _completion_anchor_visible(self, anchor: str) -> bool:
         from local_operator.tui.widgets.transcript import TranscriptBlock
 
@@ -15671,6 +15761,18 @@ class OperatorApp(App[None]):
                     getattr(block, "completion_anchor_id", "") == anchor
                     for block in transcript.children
                 ):
+                    # This app may have ALREADY said it. `_finalize_turn`
+                    # paints `interrupted` the moment the turn aborts, before
+                    # the session has published the outcome this poll is
+                    # reading — so that row carries no anchor and the dedupe
+                    # above cannot see it. Adopt it instead of appending a
+                    # second row for one interruption (the `! interrupted` /
+                    # `· Interrupted` pair the user reported). The attention
+                    # notice is NOT dropped: the poll still owns the case it
+                    # exists for, a session that stopped while the user was
+                    # away, where no live row was ever painted here.
+                    if self._adopt_own_interrupt_notice(state["kind"], anchor):
+                        return  # Let the committed frame paint before measuring it.
                     block = NoticeBlock(
                         "Stopped with an error" if state["kind"] == "error" else "Interrupted"
                     )
@@ -29228,6 +29330,12 @@ class OperatorApp(App[None]):
         # `_turn_notified` says its ladder has run, and a fresh turn is both
         # live and unannounced.
         self._turn_notified = False
+        # The previous turn's `interrupted` row stops being adoptable here. It
+        # is turn-scoped like the pair above: an anchor published for THIS
+        # turn's outcome must not be stamped onto the row that announced the
+        # last one, which would leave the new outcome with no row at all while
+        # marking an older one read.
+        self._own_interrupt_notice = None
         # A deferred completion belongs to the turn that finished, and a NEW
         # turn supersedes it: the session is working again, so "task complete"
         # would announce a finish while the agent is mid-stream — and the new
@@ -29650,7 +29758,18 @@ class OperatorApp(App[None]):
             # `was_open` because this notice is part of the gated tail: it is an
             # announcement of the turn's OUTCOME, so a turn already retired by
             # the other route has said it once and must not say it twice.
-            self._append_block(NoticeBlock("interrupted", "warning"))
+            interrupted = NoticeBlock("interrupted", "warning")
+            self._append_block(interrupted)
+            # HELD so the attention poller can recognise it as this outcome's
+            # row instead of appending its own. The poller reads the same
+            # interruption back out of the durable `AttentionStore` a tick
+            # later and dedupes ONLY by `completion_anchor_id` — which this row
+            # cannot carry, because the anchor is `completion-<token>` and the
+            # session mints it when it publishes, after this row is painted.
+            # So the two producers announced one fact twice: `! interrupted`
+            # from here and `· Interrupted` from the poll, which is the
+            # reported defect. See `_adopt_own_interrupt_notice`.
+            self._own_interrupt_notice = interrupted
         self._interrupted_cards = 0
         # EVERY turn end reconciles its queued rows, because the invariant is
         # simply stated: a row still held when a turn ends is one this turn did
@@ -30590,8 +30709,37 @@ class OperatorApp(App[None]):
         delivery receipt has settled by then.
 
         Wakes ride the same queue but never appear in `_held_steer_blocks`,
-        so the identity match skips them by construction; a recall can never
-        lift the scheduler's text into the composer.
+        so the match skips them by construction; a recall can never lift the
+        scheduler's text into the composer.
+
+        MATCHED BY MESSAGE ID, not by pointer identity. Pointer identity was a
+        single-process assumption that held only for the in-process `Session`,
+        whose `queued_steering` drains and re-puts the very objects the app
+        queued. `RemoteSession.queued_steering` rebuilds brand-new `Message`
+        objects out of the serialized frontend state on every call, so on any
+        daemon-attached session — which is how a `kind=daemon` runtime is
+        always driven — no snapshot entry could ever BE the held object and
+        this method fell through its `for/else` to a silent `return`. Esc
+        recall was a total no-op there, and silent: the decline path that
+        exists so a refused recall never reads as a dropped keystroke (design
+        round 1, D1) was skipped too.
+
+        The id is the seam's real identity, and it already is everywhere else
+        that crosses the process boundary: `_send_steer_when_ready` sends
+        `command_id=message.id`, `owned.py::recall_steer` finds the queued
+        message by that id, and `RemoteSession.recall_steering` matches on it.
+        The TUI was the one place still reading pointers. Identity is kept as
+        the fast path so the in-process session, where the objects genuinely
+        are shared, never depends on the id round trip at all.
+
+        Only a NON-EMPTY id may match, and only an id that is UNIQUE in the
+        snapshot. `RemoteSession.queued_steering` substitutes the literal
+        `"remote-steer"` for a wire item carrying no id, so two such entries
+        arrive sharing one id — matching on it would let a recall lift the
+        wrong row's text into the composer while unsending a different
+        message. An ambiguous id is therefore treated as no match at all: the
+        steer stays queued and rides the next boundary, which is what would
+        have happened without the press, and the decline row below says so.
 
         A recall that cannot finish — no session, a composer the app has put
         read-only (the subagent view owns it), or a half-typed draft it would
@@ -30611,8 +30759,18 @@ class OperatorApp(App[None]):
         # press: the membership scan below would otherwise drain-and-rebuild
         # the queue once per held entry on the cancel key's hot path.
         queued_now = session.queued_steering()
+        # Ids that appear MORE THAN ONCE in the snapshot are unusable as a key
+        # — see the docstring on `"remote-steer"`. Counted once per press
+        # rather than per held entry, on the same reasoning as the single
+        # snapshot above: this is the cancel key's hot path.
+        id_counts: dict[str, int] = {}
+        for item in queued_now:
+            item_id = str(getattr(item, "id", "") or "")
+            if item_id:
+                id_counts[item_id] = id_counts.get(item_id, 0) + 1
         for entry in reversed(self._held_steer_blocks):
-            if any(item is entry[0] for item in queued_now):
+            held_id = str(getattr(entry[0], "id", "") or "")
+            if any(item is entry[0] for item in queued_now) or id_counts.get(held_id) == 1:
                 break
         else:
             return
@@ -30713,6 +30871,31 @@ class OperatorApp(App[None]):
                 self._deferred_steer_notices.remove(held)
                 break
         editor.focus()
+
+    def _on_recall_rejected(self, command_id: str) -> None:
+        """The owner did not honour a recall this app already committed.
+
+        A follower's recall is optimistic (`RemoteSession.recall_steering`):
+        the composer has the text and the steer's rows have left the
+        transcript before the owner answers. When the answer is a refusal —
+        the drain took the message first — the message really was delivered
+        AND the composer holds it, so an Enter sends the same instruction
+        twice. That is the operator-reported double-send, and it must not be
+        the user's job to notice it from the agent acting on one message
+        twice.
+
+        The row states the fact and nothing else. Putting the message back on
+        the queue is not available (it was never taken off), and clearing the
+        composer would throw away text the user may want to edit — the loss
+        `action_stop` forbids. So the honest behaviour is to warn and leave
+        the draft under the user's control.
+
+        Through `_replace_stop_notice` because this is the Esc ladder's own
+        row: a press that produced a decline row a moment ago must not stack a
+        second contradicting line under it.
+        """
+        logger.debug("session owner refused the recall of steer %s", command_id)
+        self._replace_stop_notice(RECALL_UNCONFIRMED_NOTICE, "warning")
 
     def _settle_queued_steer_notices_unsent(self) -> None:
         """Retire queued-steer rows the turn that just ended did not deliver.

--- a/local_operator/tui/session_presentation.py
+++ b/local_operator/tui/session_presentation.py
@@ -302,6 +302,15 @@ class SessionPresentation:
     queued_steer_notices: list[Any] = field(default_factory=list)
     deferred_steer_notices: list[Any] = field(default_factory=list)
     held_steer_blocks: list[Any] = field(default_factory=list)
+    #: The `interrupted` row the app painted for this conversation's own turn,
+    #: still waiting for the anchor its session publishes for that outcome.
+    #:
+    #: Carried for the same reason `held_steer_blocks` is: it names a widget in
+    #: THIS presentation's transcript, so it belongs to the conversation rather
+    #: than to the app. Left behind, a switch away and back let the attention
+    #: poller append a second `Interrupted` under the live `interrupted` — the
+    #: duplicate row `OperatorApp._adopt_own_interrupt_notice` exists to remove.
+    own_interrupt_notice: Any = None
     welcome: Any = None
     welcome_visible: bool | None = False
 

--- a/tests/unit/session/test_remote_disconnect.py
+++ b/tests/unit/session/test_remote_disconnect.py
@@ -395,3 +395,41 @@ async def test_a_same_live_turn_rebind_still_seeds_what_the_gap_produced(
     ), f"re-seeding the start clears _started_tools and orphans the card: {types}"
     assert [event for event in received if isinstance(event, AgentEndEvent)] == []
     assert remote.is_streaming is True
+
+
+@pytest.mark.asyncio
+async def test_a_recall_with_no_client_declines_instead_of_claiming_success(
+    tmp_path, monkeypatch
+) -> None:
+    """``True`` is a promise the app commits to irreversibly.
+
+    Round-1 review MAJOR-1. ``recall_steering`` skipped issuing the op when
+    ``_client`` was None but still answered True — and True is what makes the
+    TUI put the text in the composer and remove the steer's rows. So the
+    message stayed queued on the owner, the composer held a copy, and no
+    rejection was ever reported because there was no request to fail: the
+    silent double-send this seam exists to remove, through another door.
+
+    ``_client`` is None after ``dispose`` and for the whole window between a
+    dropped socket and a reattach, which is the disconnect-mid-recall case
+    this file is about.
+    """
+    from types import SimpleNamespace
+
+    from local_operator.harness.types import Message
+
+    remote = _facade(tmp_path, monkeypatch)
+    message = Message.user("use 0.75 for the direct API")
+    # The queue this follower BELIEVES the owner holds — the same replicated
+    # frontend state the real recall reads (`test_remote_refresh.py` stubs the
+    # store the same way).
+    remote._frontend_store = SimpleNamespace(  # type: ignore[assignment]
+        state=SimpleNamespace(queued_steering=[{"id": message.id, "text": message.text}])
+    )
+    refusals: list[str] = []
+    remote.set_recall_resolution(refusals.append)
+    assert remote._client is None, "the premise: this viewer has no socket"
+
+    assert remote.recall_steering(message) is False, "no client means no recall"
+    assert remote._recall_task is None, "and no op was issued"
+    await _cancel_recovery(remote)

--- a/tests/unit/tui/test_attention.py
+++ b/tests/unit/tui/test_attention.py
@@ -357,3 +357,64 @@ async def test_the_adopted_row_can_be_acknowledged(tmp_path, monkeypatch) -> Non
             if not session.store.state(session.identity)["unseen"]:
                 break
         assert not session.store.state(session.identity)["unseen"]
+
+
+@pytest.mark.asyncio
+async def test_a_failed_adoption_does_not_burn_the_held_row(tmp_path) -> None:
+    """A poll that cannot see the row must not consume the reference.
+
+    Round-1 review MAJOR-2. `self._own_interrupt_notice = None` ran BEFORE the
+    mounted-membership test, so a poll that legitimately could not adopt —
+    a sidebar switch parks the row in the other conversation's
+    `TranscriptView` — destroyed the reference anyway. On switching back the
+    poller then appended its `Interrupted` under the live `interrupted`,
+    restoring the duplicate row the adoption exists to remove.
+    """
+    session = InterruptSession(tmp_path / "attention.db")
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _interrupt_a_turn(app, pilot)
+        held = app._own_interrupt_notice
+        assert held is not None
+
+        # The row leaves the CURRENT view — what a sidebar switch does to it,
+        # and what `/clear` does permanently. Either way this poll cannot see
+        # it, and the question is whether the reference survives that.
+        app._transcript_view().remove_block(held)
+        await pilot.pause()
+        session.publish_interrupted()
+        anchor = session.store.state(session.identity)["anchor_id"]
+        assert app._adopt_own_interrupt_notice("interrupted", anchor) is False
+
+        assert app._own_interrupt_notice is held, "the reference survives a failed adoption"
+        assert not held.completion_anchor_id, "and nothing was stamped onto it"
+
+
+@pytest.mark.asyncio
+async def test_the_held_interrupt_row_rides_a_sidebar_switch(tmp_path) -> None:
+    """The row belongs to its conversation, so the presentation carries it.
+
+    Round-1 review MAJOR-2, second half. `SessionPresentation` did not carry
+    `own_interrupt_notice` at all, so a switch away dropped it even once the
+    burn above was fixed.
+    """
+    session = InterruptSession(tmp_path / "attention.db")
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _interrupt_a_turn(app, pilot)
+        held = app._own_interrupt_notice
+        assert held is not None
+
+        captured = app._capture_sidebar_presentation()
+        assert captured.own_interrupt_notice is held, "the switch carries it out"
+
+        # Whatever the app does while away, coming back restores the row.
+        app._own_interrupt_notice = None
+        app._apply_sidebar_presentation(captured)
+        assert app._own_interrupt_notice is held, "and back in"
+
+        # ...and it still adopts, so the duplicate never returns.
+        session.publish_interrupted()
+        await app._poll_completion_attention()
+        await pilot.pause()
+        assert _notice_texts(app) == ["interrupted"]

--- a/tests/unit/tui/test_attention.py
+++ b/tests/unit/tui/test_attention.py
@@ -182,3 +182,178 @@ async def test_overlay_scrollback_and_blur_do_not_acknowledge(tmp_path, monkeypa
         await pilot.pause()
         await app._poll_completion_attention()
         assert session.store.state("session/sess")["unseen"]
+
+
+class InterruptSession(FakeSession):
+    """An attention-backed fake with nothing published until a test says so.
+
+    ``ReceiptSession`` publishes a COMPLETE outcome in its constructor. The
+    duplicate-row defect needs the opposite order — the app paints its own
+    live row first, and the durable ``interrupted`` outcome is published
+    afterwards, exactly as a real session does (it mints
+    ``completion-<token>`` when it publishes, which is strictly after the turn
+    has ended on screen).
+    """
+
+    def __init__(self, path: Path) -> None:
+        super().__init__()
+        self.store = AttentionStore(path)
+        self.identity = "session/interrupted"
+
+    def publish_interrupted(self) -> str:
+        token = str(uuid.uuid4())
+        self.store.publish(self.identity, token, f"completion-{token}", "interrupted")
+        return token
+
+    async def refresh_attention(self) -> dict[str, Any]:
+        return await asyncio.to_thread(self.store.state, self.identity)
+
+    async def acknowledge_attention(self, token: str) -> dict[str, Any]:
+        return await asyncio.to_thread(self.store.acknowledge, self.identity, token)
+
+
+async def _interrupt_a_turn(app: OperatorApp, pilot: Any) -> None:
+    """Run a turn to the point where the app has painted its own abort row."""
+    from local_operator.tui.events import TurnEnded, TurnStarted
+    from local_operator.tui.widgets.editor import Editor
+
+    for _ in range(200):
+        if app._session is not None:
+            break
+        await pilot.pause()
+        await asyncio.sleep(0.01)
+    editor = app.query_one(Editor)
+    editor.focus()
+    editor.text = "run the long job"
+    await pilot.pause()
+    await pilot.press("enter")
+    await pilot.pause()
+    app.post_message(TurnStarted())
+    await pilot.pause()
+    app.post_message(TurnEnded(True, None))
+    await pilot.pause()
+    await pilot.pause()
+
+
+def _notice_texts(app: OperatorApp) -> list[str]:
+    from local_operator.tui.widgets.transcript import NoticeBlock
+
+    return [
+        block._text for block in app._transcript_view().blocks() if isinstance(block, NoticeBlock)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_one_interruption_is_stated_once(tmp_path) -> None:
+    """Two producers, one outcome, one row.
+
+    ``_finalize_turn`` announces the abort live; the attention poller reads the
+    same interruption back out of the durable store a tick later and appended a
+    SECOND row, because its only dedupe is ``completion_anchor_id`` and the
+    live row cannot carry one (the anchor does not exist until the session
+    publishes). The user saw ``! interrupted`` above ``· Interrupted``.
+    """
+    from local_operator.tui.widgets.transcript import NoticeBlock
+
+    session = InterruptSession(tmp_path / "attention.db")
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _interrupt_a_turn(app, pilot)
+        assert _notice_texts(app) == ["interrupted"], "the turn states its own outcome"
+
+        # Now the session publishes that same interruption durably.
+        token = session.publish_interrupted()
+        await app._poll_completion_attention()
+        await pilot.pause()
+
+        assert _notice_texts(app) == ["interrupted"], "and it is not restated"
+        # The live row ADOPTED the anchor rather than being shadowed by a
+        # second one, which is what lets looking at it mark the outcome read.
+        anchor = session.store.state(session.identity)["anchor_id"]
+        assert [
+            block.completion_anchor_id
+            for block in app._transcript_view().query(NoticeBlock)
+            if block.completion_anchor_id
+        ] == [anchor]
+        assert token
+
+
+@pytest.mark.asyncio
+async def test_an_interruption_this_app_never_painted_still_gets_a_row(tmp_path) -> None:
+    """The poller keeps the case it exists for: a session that stopped away.
+
+    Proves the fix suppresses a DUPLICATE, not the attention notice itself —
+    with no live row to adopt, a user returning to the session must still be
+    told it was interrupted.
+    """
+    session = InterruptSession(tmp_path / "attention.db")
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        for _ in range(200):
+            if app._session is not None:
+                break
+            await pilot.pause()
+            await asyncio.sleep(0.01)
+        # No turn ran in THIS app; the outcome was produced elsewhere.
+        session.publish_interrupted()
+        await app._poll_completion_attention()
+        await pilot.pause()
+
+        assert _notice_texts(app) == ["Interrupted"]
+
+
+@pytest.mark.asyncio
+async def test_a_later_outcome_never_adopts_an_earlier_turns_row(tmp_path) -> None:
+    """The held row is turn-scoped: a new turn makes it unadoptable.
+
+    Otherwise a second interruption would stamp its anchor onto the FIRST
+    turn's row — marking an old outcome read while the new one gets no row at
+    all.
+    """
+    from local_operator.tui.events import TurnStarted
+
+    session = InterruptSession(tmp_path / "attention.db")
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _interrupt_a_turn(app, pilot)
+        assert _notice_texts(app) == ["interrupted"]
+
+        # A NEW turn opens, and only then does an outcome get published.
+        app.post_message(TurnStarted())
+        await pilot.pause()
+        session.publish_interrupted()
+        await app._poll_completion_attention()
+        await pilot.pause()
+
+        assert _notice_texts(app) == ["interrupted", "Interrupted"]
+
+
+@pytest.mark.asyncio
+async def test_the_adopted_row_can_be_acknowledged(tmp_path, monkeypatch) -> None:
+    """Adoption stamps a real anchor, so looking at the row marks it read.
+
+    Not incidental to the duplicate fix but the other half of it. The receipt
+    is cleared by `_completion_anchor_visible` finding the ANCHORED block in
+    the viewport; suppressing the poller's row without stamping the live one
+    would leave an interruption the user is looking at permanently unseen, and
+    the sidebar flagging a session whose outcome is on screen.
+    """
+    monkeypatch.setattr("local_operator.tui.attention.terminal_is_foreground", lambda: True)
+    session = InterruptSession(tmp_path / "attention.db")
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await _interrupt_a_turn(app, pilot)
+        session.publish_interrupted()
+        app.on_app_focus(AppFocus())
+        await app._poll_completion_attention()
+        await pilot.pause()
+
+        anchor = session.store.state(session.identity)["anchor_id"]
+        assert app._completion_anchor_visible(anchor), "the adopted row is the anchor"
+        # Wait on the acknowledgement the poll publishes, not on a clock.
+        for _ in range(20):
+            await app._poll_completion_attention()
+            await pilot.pause()
+            if not session.store.state(session.identity)["unseen"]:
+                break
+        assert not session.store.state(session.identity)["unseen"]

--- a/tests/unit/tui/test_esc_recall.py
+++ b/tests/unit/tui/test_esc_recall.py
@@ -8,10 +8,14 @@ the engine's steering queue, its rows (the user row, its images, the queued
 receipt) leave the transcript, and the composer holds the text ready for an
 immediate edit-and-resend.
 
-The pairing is by IDENTITY: the app hands the session the very ``Message`` it
-queued (``steer_message``), so a recall can name exactly the object the
-composer is about to hold — equal-but-distinct messages, older steers, and
-wake deliveries that ride the same queue are never what a recall removes.
+The pairing is by MESSAGE ID, with object identity kept as a fast path. The
+app hands the session the very ``Message`` it queued (``steer_message``), and
+the in-process ``Session`` gives that object back — but a ``RemoteSession``
+rebuilds its queue snapshot out of serialized frontend state, so on every
+daemon-attached session the objects differ and only the id survives. The id is
+what the recall already crosses the process boundary on (``command_id``), so
+it is the seam's real identity; older steers and wake deliveries that ride the
+same queue are still never what a recall removes.
 """
 
 from __future__ import annotations
@@ -28,6 +32,7 @@ from local_operator.session.transcript import Transcript
 from local_operator.tui.app import (
     DEFERRED_STEER_NOTICE,
     QUEUED_STEER_NOTICE,
+    RECALL_UNCONFIRMED_NOTICE,
     SENT_STEER_NOTICE,
     OperatorApp,
 )
@@ -398,3 +403,139 @@ async def test_the_session_recall_is_identity_scoped(tmp_path: Path) -> None:
     session.steer_message(first)
     drained = await session._drain_steering()
     assert [getattr(m, "text", "") for m in drained] == ["same text"]
+
+
+class _RemoteLikeStreaming(_Streaming):
+    """A mid-turn fake with ``RemoteSession``'s queued_steering semantics.
+
+    The in-process ``Session`` drains and re-puts the very objects it was
+    handed, so a snapshot's entries ARE the app's messages.
+    ``RemoteSession.queued_steering`` cannot do that: the queue lives in
+    another process and reaches this one as serialized frontend state, so it
+    rebuilds a fresh ``Message`` per item on every call. Equal ids, never the
+    same object — which is what the TUI's pointer-identity match silently
+    failed on for every daemon-attached session.
+
+    Modelled rather than driven through a real socket because the property
+    under test is the app's matching rule, not the transport: what a fake can
+    get wrong here is only whether it rebuilds, and it does.
+    """
+
+    def steer_message(self, message: Any) -> None:
+        # Stored as the WIRE shape (a dict), so no Message object survives in
+        # this fake for the app to accidentally match by identity.
+        self._steering_queue.append({"id": message.id, "text": message.text})
+
+    def queued_steering(self) -> list[Any]:
+        return [Message.user(item["text"], id=item["id"]) for item in self._steering_queue]
+
+    def recall_steering(self, message: Any) -> bool:
+        wanted = str(getattr(message, "id", "") or "")
+        for index, item in enumerate(self._steering_queue):
+            if item["id"] == wanted:
+                del self._steering_queue[index]
+                return True
+        return False
+
+
+@pytest.mark.asyncio
+async def test_esc_recalls_a_steer_from_a_session_that_rebuilds_its_queue() -> None:
+    """The daemon case: equal-but-distinct messages must still be recallable.
+
+    Pointer identity was a single-process assumption. Every session attached
+    to a ``kind=daemon`` runtime goes through ``RemoteSession``, whose
+    ``queued_steering`` rebuilds its entries, so the match found nothing and
+    Esc-recall was a total, SILENT no-op there — the message stayed queued and
+    was delivered anyway, while the user believed they had taken it back.
+    """
+    session = _RemoteLikeStreaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        await _submit(pilot, editor, "Ok after you did that, it seems to work now")
+        assert len(session.queued_steering()) == 1
+        # The premise of the test: nothing in the snapshot IS the held object.
+        held = app._held_steer_blocks[-1][0]
+        snapshot = session.queued_steering()
+        assert not any(item is held for item in snapshot), "the fake must rebuild"
+        assert snapshot[0].id == held.id, "...while preserving the id"
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+        # Unsent: the message left the queue, so it cannot ride a later
+        # boundary and be delivered a second time.
+        assert session.queued_steering() == []
+        assert editor.text == "Ok after you did that, it seems to work now"
+        assert QUEUED_STEER_NOTICE not in _notice_texts(app)
+        assert _user_texts(app) == []
+
+
+@pytest.mark.asyncio
+async def test_an_ambiguous_queue_id_declines_instead_of_guessing() -> None:
+    """An id that names two queue entries is not an identity, so it must not match.
+
+    ``RemoteSession.queued_steering`` substitutes the literal ``remote-steer``
+    for a wire item carrying no id, and any wire that repeats an id has the
+    same shape: one key, several messages. Matching on it would unsend one
+    message while handing the composer another one's text. The recall declines
+    instead — the steers stay queued and ride the next boundary, exactly as if
+    Esc had not been pressed, which is the same "cost the user nothing" rule
+    the read-only and half-typed-draft declines follow.
+
+    The app's OWN ids are minted per submit and therefore unique, so this
+    guards the queue the app is told about rather than one it can produce; a
+    duplicated id is modelled here directly because that is the only way the
+    condition is reachable from outside.
+    """
+    session = _RemoteLikeStreaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        await _submit(pilot, editor, "older steer")
+        await _submit(pilot, editor, "newer steer")
+        # The wire reports the newest steer's id TWICE — one key, two messages.
+        newest_id = app._held_steer_blocks[-1][0].id
+        for item in session._steering_queue:
+            item["id"] = newest_id
+        assert [m.id for m in session.queued_steering()] == [newest_id, newest_id]
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+        # Nothing lifted and nothing unsent: an ambiguous match is no match.
+        assert editor.text == ""
+        assert [m.text for m in session.queued_steering()] == ["older steer", "newer steer"]
+        assert _user_texts(app) == ["older steer", "newer steer"]
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_remote_recall_warns_instead_of_double_sending() -> None:
+    """The owner refused: the composer holds text the session already sent.
+
+    A follower's recall is optimistic — the composer takes the text and the
+    rows go before the owner answers. When the drain won the race the owner
+    answers ``that steering message is no longer queued``, and the message is
+    both delivered AND drafted here. Pressing Enter would send it twice, which
+    is the reported double-send, so the app says so rather than leaving the
+    user to infer it from the agent acting on one instruction twice.
+    """
+    session = _RemoteLikeStreaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        await _submit(pilot, editor, "use 0.75 for the direct API")
+        message_id = app._held_steer_blocks[-1][0].id
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert editor.text == "use 0.75 for the direct API"
+
+        # The owner's rejection arrives after the press has already returned.
+        app._on_recall_rejected(message_id)
+        await pilot.pause()
+
+        assert RECALL_UNCONFIRMED_NOTICE in _notice_texts(app)
+        # The draft is NOT thrown away: discarding what the user may want to
+        # edit is the loss `action_stop` forbids. The row warns; the user decides.
+        assert editor.text == "use 0.75 for the direct API"

--- a/tests/unit/tui/test_esc_recall.py
+++ b/tests/unit/tui/test_esc_recall.py
@@ -32,6 +32,8 @@ from local_operator.session.transcript import Transcript
 from local_operator.tui.app import (
     DEFERRED_STEER_NOTICE,
     QUEUED_STEER_NOTICE,
+    RECALL_AMBIGUOUS_NOTICE,
+    RECALL_DECLINE_NOTICE,
     RECALL_UNCONFIRMED_NOTICE,
     SENT_STEER_NOTICE,
     OperatorApp,
@@ -438,6 +440,34 @@ class _RemoteLikeStreaming(_Streaming):
         return False
 
 
+class _IdLessStreaming(_Streaming):
+    """A follower whose OWNER is too old to put ``id`` on its queued-steer rows.
+
+    ``RemoteSession.queued_steering`` substitutes ``UNIDENTIFIED_STEER_ID`` for
+    such an item, so every id-less entry arrives under one key. Modelled with
+    the real substitution rather than a hand-written literal, so a rename of
+    the constant moves this fake with it.
+    """
+
+    def steer_message(self, message: Any) -> None:
+        self._steering_queue.append({"text": message.text})  # no id on the wire
+
+    def queued_steering(self) -> list[Any]:
+        from local_operator.session.remote import UNIDENTIFIED_STEER_ID
+
+        return [
+            Message.user(
+                str(item.get("text", "") or ""),
+                id=str(item.get("id", "") or UNIDENTIFIED_STEER_ID),
+            )
+            for item in self._steering_queue
+        ]
+
+    def recall_steering(self, message: Any) -> bool:
+        ids = {str(item.get("id", "") or "") for item in self._steering_queue}
+        return str(getattr(message, "id", "") or "") in ids
+
+
 @pytest.mark.asyncio
 async def test_esc_recalls_a_steer_from_a_session_that_rebuilds_its_queue() -> None:
     """The daemon case: equal-but-distinct messages must still be recallable.
@@ -507,6 +537,11 @@ async def test_an_ambiguous_queue_id_declines_instead_of_guessing() -> None:
         assert editor.text == ""
         assert [m.text for m in session.queued_steering()] == ["older steer", "newer steer"]
         assert _user_texts(app) == ["older steer", "newer steer"]
+        # ...and it SAYS so. A press that changes nothing on screen is the
+        # dropped-keystroke reading D1 filed the decline row against; this case
+        # needs its own row because the composer is not the obstacle.
+        assert RECALL_AMBIGUOUS_NOTICE in _notice_texts(app)
+        assert RECALL_DECLINE_NOTICE not in _notice_texts(app)
 
 
 @pytest.mark.asyncio
@@ -532,10 +567,145 @@ async def test_a_rejected_remote_recall_warns_instead_of_double_sending() -> Non
         assert editor.text == "use 0.75 for the direct API"
 
         # The owner's rejection arrives after the press has already returned.
-        app._on_recall_rejected(message_id)
+        app._on_recall_rejected(session, message_id)
         await pilot.pause()
 
         assert RECALL_UNCONFIRMED_NOTICE in _notice_texts(app)
         # The draft is NOT thrown away: discarding what the user may want to
         # edit is the loss `action_stop` forbids. The row warns; the user decides.
+        assert editor.text == "use 0.75 for the direct API"
+
+
+@pytest.mark.asyncio
+async def test_an_unrecallable_newest_steer_never_falls_back_to_an_older_one() -> None:
+    """The scan STOPS at an unnameable newest entry; it does not substitute.
+
+    Round-1 review BLOCKER-1. The guard refused the ambiguous newest candidate
+    but let the `for` keep walking backwards, so the next-older entry — whose
+    id happened to be unique — was recalled instead: the press unsent and
+    lifted a message the user never pointed at, while the one they did mean to
+    take back stayed queued and was delivered. That is strictly worse than the
+    silent no-op it replaced, and it is the precise harm the guard was written
+    to prevent, one entry over.
+    """
+    session = _RemoteLikeStreaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        await _submit(pilot, editor, "OLD: use the staging bucket")
+        await _submit(pilot, editor, "NEW: actually stop and revert")
+        # A third queue entry duplicates the NEWEST id, so the newest held
+        # entry is unnameable while the OLDER one is still perfectly unique.
+        newest_id = app._held_steer_blocks[-1][0].id
+        session._steering_queue.append({"id": newest_id, "text": "wake delivery"})
+        older_id = app._held_steer_blocks[0][0].id
+        assert [m.id for m in session.queued_steering()].count(older_id) == 1
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+        # The OLDER steer is what a fallback would have taken. It must not.
+        assert editor.text == "", "no message may be lifted when the newest is unnameable"
+        assert [m.text for m in session.queued_steering()] == [
+            "OLD: use the staging bucket",
+            "NEW: actually stop and revert",
+            "wake delivery",
+        ], "nothing may be unsent"
+        assert _user_texts(app) == ["OLD: use the staging bucket", "NEW: actually stop and revert"]
+        assert RECALL_AMBIGUOUS_NOTICE in _notice_texts(app)
+
+
+@pytest.mark.asyncio
+async def test_an_id_less_queue_entry_is_answered_rather_than_ignored() -> None:
+    """`UNIDENTIFIED_STEER_ID` names every id-less entry, so it names none.
+
+    Round-1 review MAJOR-3. The guard keyed on the HELD id — always an
+    app-minted uuid4 — which can never equal the placeholder a `RemoteSession`
+    substitutes for a wire item with no id. So the case the guard's own
+    docstring was written around never reached it, and the press was a silent
+    dropped keystroke: exactly the D1 failure the PR claimed to have closed.
+    """
+    session = _IdLessStreaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        await _submit(pilot, editor, "please stop")
+        from local_operator.session.remote import UNIDENTIFIED_STEER_ID
+
+        assert [m.id for m in session.queued_steering()] == [UNIDENTIFIED_STEER_ID]
+        assert app._held_steer_blocks[-1][0].id != UNIDENTIFIED_STEER_ID, "ids cannot be compared"
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+        # Declining is right; being SILENT about it is the defect.
+        assert editor.text == ""
+        assert [m.text for m in session.queued_steering()] == ["please stop"]
+        assert RECALL_AMBIGUOUS_NOTICE in _notice_texts(app)
+
+
+@pytest.mark.asyncio
+async def test_a_stale_recall_refusal_never_paints_on_another_conversation() -> None:
+    """A late ack belongs to the conversation that issued it, or to nothing.
+
+    Round-1 review BLOCKER-2. The refusal crosses a socket with a 15 s ack
+    timeout, so `/clear`, `/new`, `/resume`, a sidebar switch or a takeover can
+    all land first. A row reading "that steer was sent" on a conversation that
+    never sent it is worse than silence: it is the double-send warning aimed at
+    text the user never queued.
+    """
+    first = _RemoteLikeStreaming()
+    app = OperatorApp(lambda: _factory(first))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        await _submit(pilot, editor, "use 0.75 for the direct API")
+        message_id = app._held_steer_blocks[-1][0].id
+        await pilot.press("escape")
+        await pilot.pause()
+
+        # The user moves to a DIFFERENT conversation before the owner answers.
+        second = _RemoteLikeStreaming()
+        app._adopt_session(second, replay_history=False)
+        await pilot.pause()
+        assert app._session is second
+
+        # The first conversation's refusal finally arrives.
+        app._on_recall_rejected(first, message_id)
+        await pilot.pause()
+
+        assert RECALL_UNCONFIRMED_NOTICE not in _notice_texts(app)
+
+
+@pytest.mark.asyncio
+async def test_the_double_send_warning_survives_the_next_escape() -> None:
+    """The warning outlives the reflex press, because its risk is unresolved.
+
+    Design round 1, D1. Written through the Esc ladder's single slot, the
+    warning was replaced by the NEXT press's decline row — and that row invites
+    the exact wrong action ("esc again to recall") over a composer holding the
+    duplicate. Pressing Esc again after reading that something went wrong is
+    the reflex; the row has to be a transcript fact, not a ladder state.
+    """
+    session = _RemoteLikeStreaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        # TWO steers: with only one queued the second press finds nothing and
+        # returns before touching the slot, which is why this hid in testing.
+        await _submit(pilot, editor, "first steer")
+        await _submit(pilot, editor, "use 0.75 for the direct API")
+        message_id = app._held_steer_blocks[-1][0].id
+
+        await pilot.press("escape")
+        await pilot.pause()
+        app._on_recall_rejected(session, message_id)
+        await pilot.pause()
+        assert RECALL_UNCONFIRMED_NOTICE in _notice_texts(app)
+
+        # The reflex press. The composer is dirty, so this is the DECLINE path.
+        await pilot.press("escape")
+        await pilot.pause()
+
+        assert RECALL_DECLINE_NOTICE in _notice_texts(app), "the decline still speaks"
+        assert RECALL_UNCONFIRMED_NOTICE in _notice_texts(app), "and the warning survives it"
         assert editor.text == "use 0.75 for the direct API"

--- a/tests/unit/tui/test_esc_recall.py
+++ b/tests/unit/tui/test_esc_recall.py
@@ -709,3 +709,50 @@ async def test_the_double_send_warning_survives_the_next_escape() -> None:
         assert RECALL_DECLINE_NOTICE in _notice_texts(app), "the decline still speaks"
         assert RECALL_UNCONFIRMED_NOTICE in _notice_texts(app), "and the warning survives it"
         assert editor.text == "use 0.75 for the direct API"
+
+
+@pytest.mark.asyncio
+async def test_a_successful_recall_retires_the_ambiguity_row() -> None:
+    """`it is still queued` must not outlive the recall that unsends the steer.
+
+    Design round 3 D6 / review round 2 MINOR-2. The ambiguity row asserts a
+    PRESENT-TENSE fact and lives in the Esc ladder's single slot, but the
+    successful-recall path retired that slot only when it held the decline
+    row. Both routes into ambiguity clear on their own — a stale replicated
+    ``frontend_state`` that stops doubling an id once the socket pump catches
+    up, and an id-less entry draining at a boundary — so the very next press
+    succeeds and leaves a row standing that says the steer is queued while it
+    is sitting in the composer.
+
+    That is the same stale-row class the decline row is retired for, on a
+    surface whose whole argument is that stale promises get retired.
+    """
+    session = _RemoteLikeStreaming()
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        editor = await _boot(pilot, app)
+        await _submit(pilot, editor, "use 0.75 for the direct API")
+        # A stale snapshot doubles the id, so this press cannot name the steer.
+        held_id = app._held_steer_blocks[-1][0].id
+        session._steering_queue.append({"id": held_id, "text": "a stale duplicate"})
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert RECALL_AMBIGUOUS_NOTICE in _notice_texts(app)
+        assert editor.text == "", "nothing was recalled while the id was ambiguous"
+
+        # The pump catches up: the duplicate is gone and the id names one entry.
+        session._steering_queue = [
+            item for item in session._steering_queue if item["text"] != "a stale duplicate"
+        ]
+        await pilot.press("escape")
+        await pilot.pause()
+
+        # The recall worked...
+        assert editor.text == "use 0.75 for the direct API"
+        assert session.queued_steering() == []
+        # ...so the row claiming it is still queued must be gone with it.
+        remaining = _notice_texts(app)
+        assert (
+            RECALL_AMBIGUOUS_NOTICE not in remaining
+        ), f"the ambiguity row outlived the recall that made it false: {remaining}"


### PR DESCRIPTION
## What and why

Pressing **Esc** to take back a mid-turn steer showed `interrupted` **twice** and did **not** recall the message — the row said `sent — it rode along with that next message` and the message was delivered anyway. The user's words were sent twice.

That single symptom is two independent defects. Evidence session `caccd7ff6769` has the user text at transcript index **51 and 56 with two different message ids** (`a2ad1a1d…`, `7d9558a3…`), so it was genuinely sent twice — not a render artifact. The recall unsent nothing.

**Change class: C1 — bug fix on an existing seam.** No new surface, no data migration, no security-posture change.

### Defect 1 — Esc-recall was dead on every daemon-attached session

`_recall_queued_steers` selected the entry to recall by **object identity**:

```python
queued_now = session.queued_steering()
for entry in reversed(self._held_steer_blocks):
    if any(item is entry[0] for item in queued_now):   # identity
        break
else:
    return                                              # silent no-op
```

That contract holds only for the in-process `Session`, which drains and re-puts **the same objects**. `RemoteSession.queued_steering` rebuilds brand-new `Message` objects from the serialized frontend state on every call:

```python
return [Message.user(str(item.get("text","") or ""), id=str(item.get("id","") or "remote-steer"))
        for item in self.frontend_state.queued_steering]
```

Measured on this tree:

```
ids equal: True
IDENTITY equal (what the TUI matched on): False
```

So the `for/else` **always** fell through to `return`. Esc-recall was a **total, silent no-op for every session attached to a daemon runtime** — which is how every session in `lop sessions` runs. Not a race: 100% reproducible. The silent `return` also skipped `RECALL_DECLINE_NOTICE`, so the user got no feedback at all — precisely the "dropped keystroke" failure that notice was added (design round 1, D1) to eliminate.

**Fix:** match on **message id**, with identity kept as the fast path. The id is already the seam's cross-process identity — `_send_steer_when_ready` sends `command_id=message.id`, `owned.py::recall_steer` matches on it, `RemoteSession.recall_steering` matches on it. The TUI was the one place still reading pointers.

An id only counts as an identity when it **names one entry**. Two things break that: a snapshot carrying the id twice, and `UNIDENTIFIED_STEER_ID` — the placeholder `RemoteSession` substitutes for a wire item with no id, which by construction names *every* id-less entry rather than any one of them. Matching either would unsend one message while handing the composer another one's text, so an entry keyed on one is unrecallable.

**An unrecallable newest entry ends the scan**; it never falls back to an older one. Recalling a steer the user did not point at is the one outcome worse than declining. The steer stays queued and rides the next boundary, and `RECALL_AMBIGUOUS_NOTICE` says so — a press that changes nothing on screen is the dropped-keystroke reading D1 was filed against, and the decline row cannot serve here because it names the composer as the obstacle.

> **Corrected after review round 1.** The first version of this paragraph was true of the queue but **false of the feedback**: the ambiguous path returned with no row at all. It was also false of the `remote-steer` case it was written around — the guard keyed on the *held* id, always an app-minted uuid4, which can never equal that placeholder, so id-less entries stayed a silent no-op. Both are fixed in `60d4bd481`; see the remediation comment for the reproductions.

**And the rejection path, which is the other half of the double-send.** `RemoteSession.recall_steering` was fire-and-forget (`asyncio.create_task(client.recall_steer(...))`). When the owner refuses (`ValueError("that steering message is no longer queued")` — the drain won the race) the app has **already** put the text in the composer and removed the rows, so the message is both delivered **and** drafted: one Enter from a genuine double-send. Previously that surfaced only as an unretrieved task exception in the log. It now reports the verdict through a `_recall_resolution` callback — mirroring the existing `cancel_subagents`/`_cancel_resolution` seam — and the app warns. The draft is **not** discarded: throwing away text the user may want to edit is the loss `action_stop` forbids, so the row states the fact and the user decides.

### Defect 2 — two producers stated one interruption

1. `_finalize_turn` appends `NoticeBlock("interrupted", "warning")` when the turn aborts.
2. `_poll_completion_attention` appends `NoticeBlock("Interrupted")` from the durable `AttentionStore`, deduped **only** by `completion_anchor_id`.

The live row **cannot** carry that anchor: it is `completion-<token>`, minted by the session when it publishes, strictly **after** the row is on screen. So the poller could not see it and appended a second, dimmer row. Confirmed in the evidence transcript — a `completion_attention` row with `"kind": "interrupted"` at index 49, right after the turn's own interrupt.

**The attention notice is not deleted** — it exists for a real reason (a user returning to a session learns it stopped while they were away). The poll now **adopts** the live row by stamping the anchor onto it. Neither producer is removed; a session that stopped with no live row still gets its own. The stamp also makes the row **acknowledgeable** (`_completion_anchor_visible` can now find it), so looking at an interruption marks it read — before this it stayed permanently unseen and the sidebar went on flagging a session whose outcome was on screen.

## Evidence — real execution, not a green suite

### The real path: a genuine `RemoteSession` over a real socket

Owned runtime + `RuntimeServer` + `RemoteSession.connect`, driving the real `OperatorApp` headlessly, reading the **owner's** queue directly. Same script, both trees:

**`origin/main` (46b6dfc7f):**
```
attached: is_remote=True streaming=True
owner queue BEFORE esc: ['Ok after you did that, it seems to work now']
  remote snapshot rebuilds? True
  ids match?                True
owner queue AFTER esc:  ['Ok after you did that, it seems to work now']
composer:               ''
notice rows:            ['still queued — sends with that next message', 'interrupted', 'Interrupted']
user rows:              ['Ok after you did that, it seems to work now']

RESULT: FAIL — unsent on the owner, text in composer
```

**This head:**
```
attached: is_remote=True streaming=True
owner queue BEFORE esc: ['Ok after you did that, it seems to work now']
  remote snapshot rebuilds? True
  ids match?                True
owner queue AFTER esc:  []
composer:               'Ok after you did that, it seems to work now'
notice rows:            ['interrupted']
user rows:              []

RESULT: PASS — unsent on the owner, text in composer
```

The message really left the **owner's** queue — it cannot ride a later boundary and be delivered a second time.

**Owner rejection, on the same real socket** (owner drains first, follower's snapshot is stale, recall issued against it):

```
owner queue: ['use 0.75 for the direct API']
owner drained first: ['use 0.75 for the direct API']
follower issued the recall optimistically: True
composer after esc: 'use 0.75 for the direct API'
notice rows: ['sent — the agent has it now', 'too late — that steer was sent; clear the composer']

RESULT: PASS — rejection warned, draft kept
```

### Failing-then-passing regression tests

Both new tests were run against `origin/main` (worktree at 46b6dfc7f) before the fix.

**On `origin/main`:**
```
FAILED tests/unit/tui/test_esc_recall.py::test_esc_recalls_a_steer_from_a_session_that_rebuilds_its_queue
        assert session.queued_steering() == []
E       AssertionError: assert [Message(role...cb3bacc67e3')] == []
FAILED tests/unit/tui/test_esc_recall.py::test_a_rejected_remote_recall_warns_instead_of_double_sending
E       AssertionError: assert '' == 'use 0.75 for the direct API'
2 failed, 11 passed

FAILED tests/unit/tui/test_attention.py::test_one_interruption_is_stated_once - AssertionError: and it is not restated
  assert ['interrupted', 'Interrupted'] == ['interrupted']
  Full diff:
    [
        'interrupted',
  +     'Interrupted',
    ]
1 failed, 8 passed
```

**On this head:** `23 passed` across both files.

### The tests were proven able to fail, not merely to pass

Per AGENTS.md ("Prove the test can still fail"), each guard was mutated in place:

| Mutation | Result |
|---|---|
| Ambiguity guard weakened to `held_id in id_counts` | `FAILED test_an_ambiguous_queue_id_declines_instead_of_guessing` — `assert 'newer steer' == ''` (it lifted the wrong row) |
| Adoption disabled (`if False and ...`) | `FAILED test_one_interruption_is_stated_once` |
| Adoption suppresses **without** stamping the anchor | `FAILED test_one_interruption_is_stated_once`, `FAILED test_the_adopted_row_can_be_acknowledged` |

**One test was discarded for being vacuous.** A first draft asserted the `remote-steer` collision directly — but the app's held id is always an app-minted uuid, so it can never equal `remote-steer`: the strict and loose guards agreed (both declined) and the test proved nothing. It passed against the weakened guard. Replaced with the reachable form — a wire that reports one real id for two entries — which does fail when the guard is weakened.

> **Round 1 caught what that replacement gave up.** Dropping the vacuous test also dropped the only coverage of the id-less case, and the *code* never handled it either — `UNIDENTIFIED_STEER_ID` now makes the guard genuinely cover it, with `test_an_id_less_queue_entry_is_answered_rather_than_ignored` pinning it.

### Rendered frames

Captured with `scripts.visual_capture.save_capture` and viewed, isolated `HOME`/config, all `CMUX_*` scrubbed and synthetic ids.

| | before (`origin/main`) | after (this head) |
|---|---|---|
| Esc-recall, remote semantics | queued row + user row still up, composer empty | transcript rows gone, composer holds the text, cursor at end |
| Interrupted turn | `! interrupted` **and** `· Interrupted` | one `! interrupted` |
| Real socket, `origin/main` | `still queued` + `! interrupted` + `· Interrupted`, user row surviving — **the operator's reported frame reproduced** | — |
| Owner rejection | — | `✓ sent — the agent has it now` above `! too late — that steer was sent; clear the composer`, draft intact |

### Acknowledgement, measured

```
unseen after adopt-poll:                True
anchor visible on the adopted row:      True
unseen after looking at it:             False
```

## Review round 1 — what changed since `a440bddaa`

Reviewer (2 blocker, 4 major, 2 minor) and designer (1 major, 2 minor, 2 nits) both found real defects, all in the **safety layer** around the id-match core rather than in the diagnosis; QA passed with no findings. One remediation commit, `60d4bd481`:

| Finding | Fix |
|---|---|
| BLOCKER-1 — ambiguous newest id recalled the older steer | the scan now **terminates** on an unrecallable newest entry |
| BLOCKER-2 — resolver armed at adopt, never disarmed | bound to its session, disarmed in `_adopt_session`, session-checked on arrival |
| MAJOR-1 — `recall_steering` returned True with no client | declines; the local decline path prints the same warning |
| MAJOR-2 — failed adoption burnt the held row | consumed only once stamped; `SessionPresentation` carries it across a sidebar switch |
| MAJOR-3 — guard could not engage on the id-less case | `UNIDENTIFIED_STEER_ID` exported and treated as unnameable |
| MAJOR-4 / D2 — ambiguous path was silent | `RECALL_AMBIGUOUS_NOTICE` |
| D1 — warning erased by the next Esc | appended as its own row, not into the ladder's single slot |
| D3 — `do not resend` named the wrong recovery; width comments false | designer's `c2`; widths re-measured on a mounted `NoticeBlock` |

Eight new/updated tests, each **reproduced failing on `a440bddaa`** first — including BLOCKER-1 lifting `'OLD: use the staging bucket'` and BLOCKER-2 painting on a conversation that never sent the steer. Full output in the remediation comment.

D4 (two spellings of "interrupted") is **deferred**: capitalised `Interrupted` is shared vocabulary across `notify.py`, `catalog.py` and `mobile/daemon.py`, so unifying it is a cross-surface copy change, not a nit inside this diff.

## Gates

`flake8`, `black --check` (pinned 26.1.0), `isort --check`, `pyright` — **all clean over the whole tree**.

Full unit suite on this head: **16703 passed, 18 skipped, 9 failed, 1 error** (22:01).

**Every failure is pre-existing and unrelated**, verified rather than assumed:

- **9 × `tests/unit/tui/test_ask_picker.py`** — the picker's footer, which this diff does not touch. They are **sensitive to the length of the cwd**: the assertion prints the worktree path where it expects the footer's key hints. Controlled for directly — `origin/main` checked out at a *short* path passes `122 passed`; the **same `origin/main` commit** checked out at `~/workspace/repos/lo-esc-recall-BASECHECK` (a path the same length as this worktree's) produces the **identical 9 failures**. Pre-existing, environmental, not this change.
- **1 × `tests/unit/evaluation/.../test_episode_subprocess.py`** — `dyld: Library not loaded: @rpath/libpython3.12.dylib ... Referenced from: /private/tmp/link.bak`, a stray artifact from another worktree in the shared temp dir. Environmental.

`tests/e2e` (the assembled-application stage): **93 passed, 7 skipped**.

## Not addressed

- The `test_ask_picker.py` cwd-length sensitivity is **recorded, not fixed** — it is outside this diff and root-causing it (the footer's width budget vs. the rendered cwd) is its own change.
- `RemoteSession._resolve_recall` cannot distinguish an explicit owner rejection from a lost socket; both are reported as "did not land". That is deliberate and commented — they are the same fact to the user, and guessing in the quiet direction is what produces a silent double-send.

