### PR TITLE
fix(agents): stop an empty legacy nested dir from bricking profile launch and team attach

### DIFF
--- a/local_operator/agents.py
+++ b/local_operator/agents.py
@@ -249,6 +249,7 @@ class AgentRegistry:
     _agents: Dict[str, AgentData]
     _last_refresh_time: float
     _refresh_interval: float
+    _incomplete_agent_dirs: List[Path]
 
     def __init__(self, config_dir: Path, refresh_interval: float = 5.0) -> None:
         """
@@ -271,6 +272,10 @@ class AgentRegistry:
 
         self._agents: Dict[str, AgentData] = {}
         self._metadata_complete = True
+        # Concrete directories whose agent.yml could not be read/parsed/validated.
+        # Kept so the strict path can name what to repair: the user-facing error
+        # otherwise says "repair unreadable definitions" while naming none of them.
+        self._incomplete_agent_dirs: List[Path] = []
         self._last_refresh_time = time.time()
         self._refresh_interval = refresh_interval
 
@@ -281,6 +286,68 @@ class AgentRegistry:
         # Load agent metadata
         self._load_agents_metadata()
 
+    def _scan_agents_metadata(self) -> Tuple[Dict[str, AgentData], List[Path]]:
+        """Read every agent definition under ``agents_dir``.
+
+        Returns the agents read and the directories that held an ``agent.yml``
+        which could not be read, parsed or validated.
+
+        Completeness means "every agent definition I could see, I read
+        successfully" -- NOT "every directory here looks like an agent". A
+        subdirectory with no ``agent.yml`` is not a failed read of an agent, it
+        is not an agent at all, so it is skipped without touching completeness.
+        Counting it as incomplete permanently bricked profile launch and team
+        attach on any machine carrying the empty legacy ``agents/agents/``
+        directory that ``migrate_agents_dir`` used to leave behind: the strict
+        path raised forever, and the advice it gave ("repair unreadable agent
+        definitions") named nothing the user could act on because every real
+        definition was in fact fine.
+
+        A directory that HAS an ``agent.yml`` which fails to load still counts
+        as incomplete. That is a genuine unreadable definition, and the strict
+        path must keep failing loudly for it -- silently skipping an edited
+        installed role would let ``resolve_profile`` fall through to the
+        packaged role of the same name and run something the user did not
+        choose (see :meth:`require_complete_metadata`).
+
+        Both this scan's callers go through here so the rule cannot drift
+        between the initial load and the periodic refresh; it previously
+        existed as two copies, and the bug above was present in both.
+        """
+        agents: Dict[str, AgentData] = {}
+        incomplete: List[Path] = []
+
+        if not self.agents_dir.exists():
+            return agents, incomplete
+
+        for agent_dir in self.agents_dir.iterdir():
+            if not agent_dir.is_dir():
+                continue
+
+            agent_config_file = agent_dir / "agent.yml"
+            if not agent_config_file.exists():
+                # Not an agent directory: a stray temp dir, an editor artifact,
+                # or the drained legacy nested dir. Debug rather than warning --
+                # it is discoverable when someone goes looking, but it is not a
+                # fault and must not be reported to the user as one.
+                logging.debug(
+                    "Skipping non-agent directory in agents dir (no agent.yml): %s",
+                    agent_dir,
+                )
+                continue
+
+            try:
+                with agent_config_file.open("r", encoding="utf-8") as f:
+                    agent_data = yaml.safe_load(f)
+
+                agent = AgentData.model_validate(agent_data)
+                agents[agent.id] = agent
+            except Exception as e:
+                incomplete.append(agent_dir)
+                logging.error(f"Invalid agent metadata in {agent_dir.name}: {str(e)}")
+
+        return agents, incomplete
+
     def _load_agents_metadata(self) -> None:
         """
         Load agents' metadata from agent.yml files in the agents directory.
@@ -289,29 +356,8 @@ class AgentRegistry:
         Raises:
             Exception: If there is an error loading or parsing the agent metadata files
         """
-        # Clear existing agents
-        self._agents = {}
-        self._metadata_complete = True
-
-        # Iterate through all directories in the agents directory
-        for agent_dir in self.agents_dir.iterdir():
-            if not agent_dir.is_dir():
-                continue
-
-            agent_config_file = agent_dir / "agent.yml"
-            if not agent_config_file.exists():
-                self._metadata_complete = False
-                continue
-
-            try:
-                with agent_config_file.open("r", encoding="utf-8") as f:
-                    agent_data = yaml.safe_load(f)
-
-                agent = AgentData.model_validate(agent_data)
-                self._agents[agent.id] = agent
-            except Exception as e:
-                self._metadata_complete = False
-                logging.error(f"Invalid agent metadata in {agent_dir.name}: {str(e)}")
+        self._agents, self._incomplete_agent_dirs = self._scan_agents_metadata()
+        self._metadata_complete = not self._incomplete_agent_dirs
 
     def create_agent(self, agent_edit_metadata: AgentEditFields) -> AgentData:
         """
@@ -662,7 +708,19 @@ class AgentRegistry:
         except OSError:
             raise ProfileRegistryUnavailable() from None
         if not self._metadata_complete:
-            raise ProfileRegistryUnavailable()
+            # The full paths go to the local log only. This error crosses the
+            # attach/HTTP transport boundary, where ``session/errors.py``
+            # admits an enumerated CATEGORY rather than owner-supplied prose --
+            # a filesystem path names the operator's home and their agents, so
+            # it must not ride along. Basenames are agent UUIDs (or a
+            # user-chosen directory name) and are equally not worth leaking, so
+            # only the COUNT is carried, which is enough for the user to know
+            # how many definitions to look for and for the log to name them.
+            logging.warning(
+                "Agent registry incomplete; unreadable agent definitions at: %s",
+                ", ".join(str(path) for path in self._incomplete_agent_dirs),
+            )
+            raise ProfileRegistryUnavailable(count=len(self._incomplete_agent_dirs))
 
     def _refresh_if_needed(self) -> None:
         """
@@ -678,37 +736,12 @@ class AgentRegistry:
         Reload agents' metadata from agent.yml files in the agents directory.
         This is used to refresh the in-memory state with changes made by other processes.
         """
-        # Clear existing agents
-        refreshed_agents = {}
-        self._metadata_complete = True
-
-        # First try to load from agent.yml files in the agents directory
-        if self.agents_dir.exists():
-            # Iterate through all directories in the agents directory
-            for agent_dir in self.agents_dir.iterdir():
-                if not agent_dir.is_dir():
-                    continue
-
-                agent_config_file = agent_dir / "agent.yml"
-                if not agent_config_file.exists():
-                    self._metadata_complete = False
-                    continue
-
-                try:
-                    with agent_config_file.open("r", encoding="utf-8") as f:
-                        agent_data = yaml.safe_load(f)
-
-                    agent = AgentData.model_validate(agent_data)
-                    refreshed_agents[agent.id] = agent
-                except Exception as e:
-                    self._metadata_complete = False
-                    # Log the error but continue processing other agents
-                    logging.error(
-                        f"Error refreshing agent metadata from {agent_dir.name}: {str(e)}"
-                    )
+        refreshed_agents, incomplete = self._scan_agents_metadata()
 
         # Update the in-memory agents dictionary
         self._agents = refreshed_agents
+        self._incomplete_agent_dirs = incomplete
+        self._metadata_complete = not incomplete
 
     def get_agent(self, agent_id: str) -> AgentData:
         """
@@ -1223,6 +1256,14 @@ class AgentRegistry:
 
         This method checks for agents in a nested 'agents/agents' directory structure
         and moves them to the correct location in the agents directory.
+
+        The drained ``nested_dir`` is removed afterwards. Leaving it behind is
+        what created the litter this migration is now also responsible for
+        cleaning up: an empty ``agents/agents/`` survived indefinitely, and the
+        metadata scan used to count it as an unreadable agent (see
+        :meth:`_scan_agents_metadata`). Because ``__init__`` runs this
+        migration, an upgraded machine heals itself on the next start rather
+        than needing the user to find and delete the directory.
         """
         nested_dir = self.agents_dir / "agents"
         if not nested_dir.exists():
@@ -1251,6 +1292,24 @@ class AgentRegistry:
                     logging.info(f"Migrated agent {agent_id} from nested directory")
                 except Exception as e:
                     logging.error(f"Failed to migrate agent {agent_id}: {str(e)}")
+
+        try:
+            # ``rmdir``, never ``rmtree``: it refuses a non-empty directory, so
+            # anything that did NOT migrate (a copy that raised, or a child
+            # whose target already existed) keeps its data AND keeps the
+            # directory visible for a human to resolve. Silently deleting
+            # unmigrated agent data would be far worse than the litter this
+            # removal exists to prevent, so the emptiness check is the
+            # filesystem's own and not a pre-flight listing that could race.
+            nested_dir.rmdir()
+            logging.info("Removed drained legacy nested agents directory")
+        except OSError:
+            # Non-empty (agents remain to migrate) or not removable. Both are
+            # states to leave alone: the next start retries the migration.
+            logging.debug(
+                "Legacy nested agents directory retained (not empty or not removable): %s",
+                nested_dir,
+            )
 
     def migrate_legacy_agents(self) -> List[str]:
         """

--- a/local_operator/agents.py
+++ b/local_operator/agents.py
@@ -286,27 +286,93 @@ class AgentRegistry:
         # Load agent metadata
         self._load_agents_metadata()
 
+    #: Files ``save_agent`` creates alongside ``agent.yml``. Their presence is
+    #: what distinguishes "an agent whose definition vanished" from "a
+    #: directory that was never an agent" -- see :meth:`_claims_to_be_an_agent`.
+    _AGENT_DATA_NAMES = (
+        "conversation.jsonl",
+        "execution_history.jsonl",
+        "learnings.jsonl",
+        "schedules.jsonl",
+        "context.pkl",
+        "current_plan.txt",
+        "instruction_details.txt",
+        "system_prompt.md",
+    )
+
+    @classmethod
+    def _claims_to_be_an_agent(cls, agent_dir: Path) -> bool:
+        """Does this directory assert that an agent lives here?
+
+        The predicate behind the completeness rule, and it must answer
+        "cannot prove otherwise" as YES. Asking ``Path.exists()`` instead was a
+        silent-substitution hole: it follows symlinks and swallows ``OSError``,
+        so a directory that unambiguously holds an agent took the "not an agent
+        at all" branch whenever the target failed to resolve -- a dangling
+        ``agent.yml`` symlink, a symlink loop, or an unreadable parent. The
+        strict path then reported a clean registry, ``resolve_profile`` found no
+        row, and the operator silently ran the PACKAGED role of the same name
+        with none of their edits. ``os.path.lexists`` alone is not enough
+        either: it is ``False`` for both of the ``agent.yml``-genuinely-absent
+        cases below and, being ``lstat``-with-``except OSError``, it reports a
+        ``chmod 000`` parent as "no agent here".
+
+        Two independent signals, either of which means "agent":
+
+        1. **The ``agent.yml`` NAME is taken.** ``lstat`` does not follow the
+           link, so a dangling symlink and a loop both answer yes and land in
+           the unreadable bucket rather than the skip bucket. Only ``ENOENT``
+           proves the name free; any other ``OSError`` (``EACCES`` on the
+           parent, ``ENOTDIR``) means we cannot prove absence, and guessing
+           "absent" is the unsafe guess.
+        2. **Agent data files remain.** ``agent.yml`` can be genuinely gone
+           while the agent's history is still on disk -- an interrupted
+           ``migrate_agents_dir`` copy, or a user who deleted the wrong file.
+           That is a definition that failed to read, not an empty directory,
+           and it must keep raising exactly as it did before this rule existed.
+
+        A directory that answers no to both is not an agent: the drained legacy
+        ``agents/agents/``, a stray temp dir, a ``.DS_Store``.
+        """
+        try:
+            os.lstat(agent_dir / "agent.yml")
+            return True
+        except FileNotFoundError:
+            pass  # Name is genuinely free; fall through to the data-file probe.
+        except OSError:
+            return True
+
+        for name in cls._AGENT_DATA_NAMES:
+            try:
+                os.lstat(agent_dir / name)
+                return True
+            except FileNotFoundError:
+                continue
+            except OSError:
+                return True
+        return False
+
     def _scan_agents_metadata(self) -> Tuple[Dict[str, AgentData], List[Path]]:
         """Read every agent definition under ``agents_dir``.
 
-        Returns the agents read and the directories that held an ``agent.yml``
-        which could not be read, parsed or validated.
+        Returns the agents read and the directories that hold an agent which
+        could not be read, parsed or validated.
 
         Completeness means "every agent definition I could see, I read
         successfully" -- NOT "every directory here looks like an agent". A
-        subdirectory with no ``agent.yml`` is not a failed read of an agent, it
-        is not an agent at all, so it is skipped without touching completeness.
-        Counting it as incomplete permanently bricked profile launch and team
-        attach on any machine carrying the empty legacy ``agents/agents/``
-        directory that ``migrate_agents_dir`` used to leave behind: the strict
-        path raised forever, and the advice it gave ("repair unreadable agent
-        definitions") named nothing the user could act on because every real
-        definition was in fact fine.
+        subdirectory that does not claim to be an agent at all (see
+        :meth:`_claims_to_be_an_agent`) is not a failed read, so it is skipped
+        without touching completeness. Counting it as incomplete permanently
+        bricked profile launch and team attach on any machine carrying the
+        empty legacy ``agents/agents/`` directory that ``migrate_agents_dir``
+        used to leave behind: the strict path raised forever, and the advice it
+        gave ("repair unreadable agent definitions") named nothing the user
+        could act on because every real definition was in fact fine.
 
-        A directory that HAS an ``agent.yml`` which fails to load still counts
-        as incomplete. That is a genuine unreadable definition, and the strict
-        path must keep failing loudly for it -- silently skipping an edited
-        installed role would let ``resolve_profile`` fall through to the
+        A directory that DOES claim to be an agent and fails to load still
+        counts as incomplete. That is a genuine unreadable definition, and the
+        strict path must keep failing loudly for it -- silently skipping an
+        edited installed role would let ``resolve_profile`` fall through to the
         packaged role of the same name and run something the user did not
         choose (see :meth:`require_complete_metadata`).
 
@@ -317,6 +383,11 @@ class AgentRegistry:
         agents: Dict[str, AgentData] = {}
         incomplete: List[Path] = []
 
+        # A vanished agents_dir yields an empty scan here rather than an error:
+        # this is also the TOLERANT path (``list_agents`` and friends), which
+        # has always answered "no agents" instead of raising. The strict path
+        # does not accept that answer and checks the directory itself -- see
+        # :meth:`require_complete_metadata`.
         if not self.agents_dir.exists():
             return agents, incomplete
 
@@ -325,7 +396,7 @@ class AgentRegistry:
                 continue
 
             agent_config_file = agent_dir / "agent.yml"
-            if not agent_config_file.exists():
+            if not self._claims_to_be_an_agent(agent_dir):
                 # Not an agent directory: a stray temp dir, an editor artifact,
                 # or the drained legacy nested dir. Debug rather than warning --
                 # it is discoverable when someone goes looking, but it is not a
@@ -698,6 +769,11 @@ class AgentRegistry:
         because skipping an edited installed role could select a packaged role
         of the same name. Recheck a failed snapshot so repair is immediately
         retryable without replacing the session or waiting for cache expiry.
+
+        A snapshot that SUCCEEDS is still cached for ``refresh_interval``, so a
+        registry that breaks again is not noticed until the interval elapses.
+        That asymmetry is deliberate -- the recheck exists to make repair
+        retryable, not to re-stat the tree on every profile launch.
         """
         from local_operator.session.errors import ProfileRegistryUnavailable
 
@@ -706,7 +782,23 @@ class AgentRegistry:
             if not self._metadata_complete:
                 self._refresh_agents_metadata()
         except OSError:
+            # Deliberately COUNTLESS: the scan died before it could attribute
+            # the failure to specific directories, so there is no number to
+            # report. ``errors.py`` allows the bare form for exactly this and
+            # for the far side of the transport.
             raise ProfileRegistryUnavailable() from None
+
+        # "The agents directory is gone" is an unreadable registry, not an
+        # empty one. The tolerant scan answers zero agents for it (the callers
+        # there predate this rule and must keep working), but for the strict
+        # path zero-because-vanished is indistinguishable from zero-because-
+        # empty, and every role would then resolve to a packaged seed with no
+        # warning. ``__init__`` creates the directory, so this is only
+        # reachable when something removes it under a live registry.
+        if not self.agents_dir.exists():
+            logging.warning("Agent registry incomplete; agents dir is missing: %s", self.agents_dir)
+            raise ProfileRegistryUnavailable() from None
+
         if not self._metadata_complete:
             # The full paths go to the local log only. This error crosses the
             # attach/HTTP transport boundary, where ``session/errors.py``
@@ -1278,12 +1370,24 @@ class AgentRegistry:
                 if target_dir.exists():
                     continue
 
+                created_target = False
                 try:
-                    # Create the target directory
-                    target_dir.mkdir(parents=True, exist_ok=True)
+                    # ``exist_ok`` is deliberately OFF: it is what makes the
+                    # rollback below provably safe. The check above already
+                    # skipped a pre-existing target, so reaching a
+                    # ``FileExistsError`` means another process created it in
+                    # the meantime -- and then it is not ours to remove.
+                    target_dir.mkdir(parents=True)
+                    created_target = True
 
-                    # Move all files from nested directory to the target directory
-                    for file_path in agent_dir.glob("*"):
+                    # ``agent.yml`` is copied LAST so a copy that dies partway
+                    # cannot leave a target that looks like a healthy agent
+                    # while its history is missing. Combined with the rollback
+                    # below, a torn migration is either fully undone or fully
+                    # visible -- never a definition-less directory that the
+                    # scan has to classify.
+                    sources = sorted(agent_dir.glob("*"), key=lambda path: path.name == "agent.yml")
+                    for file_path in sources:
                         target_file = target_dir / file_path.name
                         shutil.copy2(file_path, target_file)
 
@@ -1292,6 +1396,28 @@ class AgentRegistry:
                     logging.info(f"Migrated agent {agent_id} from nested directory")
                 except Exception as e:
                     logging.error(f"Failed to migrate agent {agent_id}: {str(e)}")
+                    # Roll the half-written target back so the next start
+                    # retries this agent from scratch. Without it the partial
+                    # directory is skipped forever by the ``target_dir.exists()``
+                    # check above, stranding the agent in the nested dir.
+                    #
+                    # This ``rmtree`` is safe where the one removing
+                    # ``nested_dir`` would not be, on two counts: every file
+                    # here is a COPY whose source is still intact (``agent_dir``
+                    # is only removed after the loop completes), and
+                    # ``created_target`` proves this directory was created by
+                    # this attempt, so no pre-existing agent data can be inside
+                    # it.
+                    if created_target:
+                        try:
+                            shutil.rmtree(target_dir)
+                        except OSError as cleanup_error:
+                            logging.error(
+                                "Failed to roll back partial migration of agent %s at %s: %s",
+                                agent_id,
+                                target_dir,
+                                cleanup_error,
+                            )
 
         try:
             # ``rmdir``, never ``rmtree``: it refuses a non-empty directory, so

--- a/local_operator/mobile/attach_client.py
+++ b/local_operator/mobile/attach_client.py
@@ -455,7 +455,7 @@ class AttachClient:
         if reply.get("op") == "error":
             from local_operator.session.errors import admission_error
 
-            known = admission_error(str(reply.get("error_code", "")))
+            known = admission_error(str(reply.get("error_code", "")), reply.get("error_count"))
             if known is not None:
                 raise known
             raise RuntimeError(str(reply.get("message", "request failed")))
@@ -476,7 +476,7 @@ class AttachClient:
         if reply.get("op") == "error":
             from local_operator.session.errors import admission_error
 
-            known = admission_error(str(reply.get("error_code", "")))
+            known = admission_error(str(reply.get("error_code", "")), reply.get("error_count"))
             if known is not None:
                 raise known
             raise RuntimeError(str(reply.get("message", "request failed")))
@@ -531,7 +531,7 @@ class AttachClient:
         if reply.get("op") == "error":
             from local_operator.session.errors import admission_error
 
-            known = admission_error(str(reply.get("error_code", "")))
+            known = admission_error(str(reply.get("error_code", "")), reply.get("error_count"))
             if known is not None:
                 raise known
             raise RuntimeError(str(reply.get("message", "request failed")))

--- a/local_operator/session/errors.py
+++ b/local_operator/session/errors.py
@@ -31,10 +31,13 @@ class ProfileRegistryUnavailable(ValueError):
         which is what the original wording could not do when the true cause was
         a directory that is not an agent at all.
 
-        ``count`` is optional because :func:`admission_error` reconstructs this
-        error from a bare code on the far side of the transport, where no
-        detail is available.
+        ``count`` is optional because the raising site does not always have a
+        number: a scan that died on an ``OSError`` never attributed the failure
+        to specific directories, and an older peer sends no count at all.
         """
+        # Kept so the transport can forward the integer itself rather than
+        # re-parsing it out of the rendered sentence.
+        self.count = count
         detail = ""
         if count is not None:
             noun = "definition" if count == 1 else "definitions"
@@ -46,10 +49,24 @@ class ProfileRegistryUnavailable(ValueError):
         )
 
 
-def admission_error(code: str) -> ValueError | None:
-    """Decode only an enumerated category, never owner-supplied message text."""
+def admission_error(code: str, count: int | None = None) -> ValueError | None:
+    """Decode only an enumerated category, never owner-supplied message text.
+
+    ``count`` is carried as its own integer field rather than being recovered
+    from the peer's message, which is the whole point: the wording is rebuilt
+    locally from the category, so the only thing crossing the transport is a
+    number. An integer cannot name a path, a socket address or another
+    conversation's identity, so it does not widen what the module docstring
+    admits -- unlike ``str(exc)``, which is why that is still never trusted.
+
+    Anything that is not a plain non-negative ``int`` is dropped rather than
+    rendered: the far side is untrusted input, and a caller that omits the
+    field (an older runtime) must degrade to the countless wording, not raise.
+    """
     if code == AttachmentUnavailable.code:
         return AttachmentUnavailable()
     if code == ProfileRegistryUnavailable.code:
-        return ProfileRegistryUnavailable()
+        if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+            count = None
+        return ProfileRegistryUnavailable(count=count)
     return None

--- a/local_operator/session/errors.py
+++ b/local_operator/session/errors.py
@@ -19,9 +19,28 @@ class AttachmentUnavailable(ValueError):
 class ProfileRegistryUnavailable(ValueError):
     code = "profile_registry_unavailable"
 
-    def __init__(self) -> None:
+    def __init__(self, count: int | None = None) -> None:
+        """Report HOW MANY definitions are unreadable, never WHICH.
+
+        The offending paths are logged at warning by the raising site. They are
+        deliberately not interpolated here: this message crosses the transport
+        boundary (see the module docstring), and a path names the operator's
+        home directory, while a basename is an agent id. A count is
+        content-free but still actionable -- it tells the user whether to look
+        for one bad definition or several, and confirms the number is not zero,
+        which is what the original wording could not do when the true cause was
+        a directory that is not an agent at all.
+
+        ``count`` is optional because :func:`admission_error` reconstructs this
+        error from a bare code on the far side of the transport, where no
+        detail is available.
+        """
+        detail = ""
+        if count is not None:
+            noun = "definition" if count == 1 else "definitions"
+            detail = f" {count} agent {noun} could not be read."
         super().__init__(
-            "The agent registry could not be read completely. "
+            "The agent registry could not be read completely." + detail + " "
             "Repair unreadable or invalid agent definitions, then retry. "
             "No packaged profile was substituted."
         )

--- a/local_operator/session/runtime/server.py
+++ b/local_operator/session/runtime/server.py
@@ -1739,6 +1739,16 @@ class RuntimeServer:
                 # Category, not arbitrary prose, certifies this as a repairable
                 # admission rejection to older/newer attach clients alike.
                 frame["error_code"] = exc.code
+            if isinstance(exc, ProfileRegistryUnavailable) and exc.count is not None:
+                # The count rides as its own INTEGER field so the attach client
+                # can rebuild the actionable wording locally. Without it the
+                # client reconstructs from the bare code and renders the
+                # countless sentence, which is the unactionable message this
+                # detail exists to replace -- and ``/team`` attach is one of
+                # the two surfaces that motivated it. An integer carries no
+                # path, host or identity, so it does not widen what
+                # ``session/errors.py`` admits across this boundary.
+                frame["error_count"] = exc.count
             await self._send_to(conn, frame)
             await self._push()
 

--- a/tests/unit/session/runtime/test_server_registry_error_count.py
+++ b/tests/unit/session/runtime/test_server_registry_error_count.py
@@ -1,0 +1,102 @@
+"""The unreadable-agent COUNT across the attach transport.
+
+``ProfileRegistryUnavailable`` gained a count so the message tells the operator
+how many definitions to go and repair. That detail only helps if it reaches the
+surface that motivated it: ``/team <name>`` over an attach client renders the
+error the client RECONSTRUCTS from the frame, not the owner's string, so a
+count that stops at the socket leaves that surface showing the original
+unactionable sentence.
+
+The integer travels in its own ``error_count`` field rather than inside the
+message. ``session/errors.py`` admits an enumerated category across this
+boundary precisely because arbitrary prose may carry paths, socket addresses or
+another conversation's identity; an integer carries none of those, so the
+wording is still rebuilt locally from the code.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, cast
+
+import pytest
+
+from local_operator.session.errors import (
+    AttachmentUnavailable,
+    ProfileRegistryUnavailable,
+    admission_error,
+)
+from local_operator.session.runtime.server import RuntimeServer, _ClientConn
+from tests.unit.session.runtime.test_server import FakeHandle
+
+
+def _rig(exc: Exception) -> tuple[RuntimeServer, list[dict[str, Any]], _ClientConn]:
+    """A server whose dispatch raises ``exc``, with its socket writes captured."""
+    server = RuntimeServer(FakeHandle(), kind="tui")
+    sent: list[dict[str, Any]] = []
+
+    async def capture(target, frame):  # noqa: ANN001
+        sent.append(frame)
+
+    async def failing_dispatch(op, frame):  # noqa: ANN001
+        raise exc
+
+    server._send_to = capture  # type: ignore[assignment]
+    server._dispatch = failing_dispatch  # type: ignore[assignment]
+    conn = _ClientConn(writer=cast(Any, object()), kind=cast(Any, "attach"))
+    server._clients[id(conn.writer)] = conn
+    return server, sent, conn
+
+
+async def _error_frame(exc: Exception) -> dict[str, Any]:
+    server, sent, conn = _rig(exc)
+    await server._on_request({"op": "prompt", "req": 1}, conn)
+    errors = [f for f in sent if f.get("op") == "error"]
+    assert errors, f"expected an error frame, got {sent}"
+    # Round-trip through JSON: the frame really goes over a socket.
+    return cast(dict[str, Any], json.loads(json.dumps(errors[0])))
+
+
+@pytest.mark.asyncio
+async def test_registry_error_count_reaches_the_attach_client() -> None:
+    """End to end: raise on the owner, decode on the client, keep the count."""
+    frame = await _error_frame(ProfileRegistryUnavailable(count=3))
+
+    assert frame["error_code"] == ProfileRegistryUnavailable.code
+    assert frame["error_count"] == 3
+
+    # Exactly what attach_client.py does with the reply.
+    known = admission_error(str(frame.get("error_code", "")), frame.get("error_count"))
+    assert isinstance(known, ProfileRegistryUnavailable)
+    assert "3 agent definitions could not be read" in str(known)
+
+
+@pytest.mark.asyncio
+async def test_countless_registry_error_sends_no_count_field() -> None:
+    """A scan that died on OSError has no number, and must not invent one."""
+    frame = await _error_frame(ProfileRegistryUnavailable())
+
+    assert frame["error_code"] == ProfileRegistryUnavailable.code
+    assert "error_count" not in frame
+
+    known = admission_error(str(frame.get("error_code", "")), frame.get("error_count"))
+    assert "could not be read." not in str(known)
+
+
+@pytest.mark.asyncio
+async def test_other_admission_categories_carry_no_count() -> None:
+    """``error_count`` belongs to one category, not to error frames generally."""
+    frame = await _error_frame(AttachmentUnavailable())
+
+    assert frame["error_code"] == AttachmentUnavailable.code
+    assert "error_count" not in frame
+
+
+@pytest.mark.asyncio
+async def test_registry_error_frame_leaks_no_path() -> None:
+    """The offending paths stay in the local log; only the integer crosses."""
+    frame = await _error_frame(ProfileRegistryUnavailable(count=2))
+
+    wire = json.dumps(frame)
+    for token in ("/Users", "/private", "/tmp", ".yml", "agents/"):
+        assert token not in wire, f"{token} crossed the transport boundary"

--- a/tests/unit/session/test_no_session_deletion.py
+++ b/tests/unit/session/test_no_session_deletion.py
@@ -191,7 +191,13 @@ _ALLOWED_ROWS: tuple[tuple[str | int, ...], ...] = (
     (
         "local_operator/agents.py::AgentRegistry.migrate_agents_dir",
         "shutil.rmtree",
-        "legacy agents/ layout",
+        "Two calls, both confined to agents/: (1) the drained source under the "
+        "legacy agents/agents/ layout, removed only after every file was copied "
+        "out; (2) rollback of a target this same attempt created, guarded by "
+        "created_target so a pre-existing agent directory is never reachable -- "
+        "mkdir() without exist_ok is what proves ownership. Without the rollback "
+        "a torn copy strands the agent behind the target_dir.exists() skip",
+        2,
     ),
     (
         "local_operator/agents.py::AgentRegistry.migrate_agents_dir",

--- a/tests/unit/session/test_no_session_deletion.py
+++ b/tests/unit/session/test_no_session_deletion.py
@@ -194,6 +194,14 @@ _ALLOWED_ROWS: tuple[tuple[str | int, ...], ...] = (
         "legacy agents/ layout",
     ),
     (
+        "local_operator/agents.py::AgentRegistry.migrate_agents_dir",
+        "<path>.rmdir",
+        "The drained legacy agents/agents/ directory itself, and only when the "
+        "filesystem confirms it is empty -- rmdir refuses a non-empty directory, "
+        "so no agent data (and nothing under sessions/, which is a sibling of "
+        "agents/ and never reachable from this fixed path) can be removed",
+    ),
+    (
         "local_operator/agents.py::AgentRegistry.export_agent_archive",
         "shutil.rmtree",
         "mkdtemp staging dir",

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -2267,3 +2267,178 @@ def test_migrate_agents_dir_error_handling(temp_agents_dir: Path, monkeypatch):
     target_dir = temp_agents_dir / "agents" / test_agent_id
     assert target_dir.exists()
     assert not (target_dir / "agent.yml").exists()
+
+
+def _valid_agent_yaml(agent_id: str, name: str) -> str:
+    """Minimal agent.yml that ``AgentData`` accepts, for filesystem fixtures."""
+    return yaml.safe_dump(
+        {
+            "id": agent_id,
+            "name": name,
+            "created_date": datetime.now(timezone.utc).isoformat(),
+            "version": "1.0.0",
+        }
+    )
+
+
+def test_empty_legacy_nested_dir_does_not_break_strict_reads(temp_agents_dir: Path):
+    """An empty ``agents/agents/`` must not brick profile launch or team attach.
+
+    The operator-facing regression: the old migration left this directory
+    behind forever, the metadata scan counted it as an unreadable agent, and
+    ``require_complete_metadata`` therefore raised on every profile launch and
+    ``/team`` attach with advice that named nothing repairable.
+    """
+    registry = AgentRegistry(temp_agents_dir)
+    registry.create_agent(
+        AgentEditFields(
+            name="Real Agent",
+            security_prompt=None,
+            hosting=None,
+            model=None,
+            description=None,
+            tags=None,
+            categories=None,
+            last_message=None,
+            temperature=None,
+            top_p=None,
+            top_k=None,
+            max_tokens=None,
+            stop=None,
+            frequency_penalty=None,
+            presence_penalty=None,
+            seed=None,
+            current_working_directory=None,
+        )
+    )
+
+    nested_dir = temp_agents_dir / "agents" / "agents"
+    nested_dir.mkdir(parents=True, exist_ok=True)
+
+    # Scan directly: the leftover must not clear completeness even before the
+    # migration has had a chance to remove it.
+    registry._refresh_agents_metadata()
+    registry.require_complete_metadata()
+    assert len(registry.list_agents()) == 1
+
+    # And a fresh registry heals the machine, because __init__ migrates.
+    healed = AgentRegistry(temp_agents_dir)
+    healed.require_complete_metadata()
+    assert not nested_dir.exists()
+
+
+def test_non_agent_directories_are_tolerated(temp_agents_dir: Path):
+    """A stray directory is not an agent, so it is not a failed agent read."""
+    registry = AgentRegistry(temp_agents_dir)
+    agent_dir = temp_agents_dir / "agents" / "good-agent"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    (agent_dir / "agent.yml").write_text(_valid_agent_yaml("good-agent", "Good"))
+
+    (temp_agents_dir / "agents" / ".DS_Store").mkdir()
+    (temp_agents_dir / "agents" / "tmp-scratch").mkdir()
+    (temp_agents_dir / "agents" / "notes.txt").write_text("not a directory")
+
+    registry._refresh_agents_metadata()
+    registry.require_complete_metadata()
+    assert "good-agent" in {agent.id for agent in registry.list_agents()}
+
+
+def test_malformed_agent_yml_still_fails_strict_reads(temp_agents_dir: Path):
+    """The safety check must survive the tolerance added above.
+
+    A directory that HAS an ``agent.yml`` which cannot be parsed is a genuine
+    unreadable definition. Skipping it would let profile resolution fall
+    through to the packaged role of the same name, so it must still raise.
+    """
+    from local_operator.session.errors import ProfileRegistryUnavailable
+
+    registry = AgentRegistry(temp_agents_dir)
+    broken_dir = temp_agents_dir / "agents" / "broken-agent"
+    broken_dir.mkdir(parents=True, exist_ok=True)
+    (broken_dir / "agent.yml").write_text("name: [unclosed\n:::not yaml")
+
+    registry._refresh_agents_metadata()
+    assert registry._metadata_complete is False
+    with pytest.raises(ProfileRegistryUnavailable) as excinfo:
+        registry.require_complete_metadata()
+
+    # The count is actionable; the path must NOT cross the transport boundary.
+    assert "1 agent definition could not be read" in str(excinfo.value)
+    assert str(broken_dir) not in str(excinfo.value)
+    assert registry._incomplete_agent_dirs == [broken_dir]
+
+
+def test_agent_yml_failing_validation_still_fails_strict_reads(temp_agents_dir: Path):
+    """Parseable YAML that is not a valid ``AgentData`` is also incomplete."""
+    from local_operator.session.errors import ProfileRegistryUnavailable
+
+    registry = AgentRegistry(temp_agents_dir)
+    invalid_dir = temp_agents_dir / "agents" / "invalid-agent"
+    invalid_dir.mkdir(parents=True, exist_ok=True)
+    (invalid_dir / "agent.yml").write_text("id: invalid-agent\nname: Missing Fields\n")
+
+    registry._refresh_agents_metadata()
+    with pytest.raises(ProfileRegistryUnavailable):
+        registry.require_complete_metadata()
+
+
+def test_migrate_agents_dir_removes_drained_nested_dir(temp_agents_dir: Path):
+    """Once drained, the legacy nested directory itself is removed."""
+    registry = AgentRegistry(temp_agents_dir)
+
+    nested_dir = temp_agents_dir / "agents" / "agents"
+    agent_dir = nested_dir / "migrated-agent"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    (agent_dir / "agent.yml").write_text(_valid_agent_yaml("migrated-agent", "Moved"))
+    (agent_dir / "conversation.jsonl").write_text('{"role": "user"}\n')
+
+    registry.migrate_agents_dir()
+
+    target_dir = temp_agents_dir / "agents" / "migrated-agent"
+    assert (target_dir / "agent.yml").exists()
+    assert (target_dir / "conversation.jsonl").read_text() == '{"role": "user"}\n'
+    assert not nested_dir.exists()
+
+
+def test_migrate_agents_dir_keeps_nested_dir_when_child_fails(temp_agents_dir: Path, monkeypatch):
+    """A child that failed to migrate keeps its data AND keeps the directory.
+
+    Removal is ``rmdir``-style precisely so a real migration failure stays
+    visible instead of being silently deleted with the agent's data.
+    """
+    registry = AgentRegistry(temp_agents_dir)
+
+    nested_dir = temp_agents_dir / "agents" / "agents"
+    agent_dir = nested_dir / "stuck-agent"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    (agent_dir / "agent.yml").write_text("name: Stuck Agent")
+
+    def mock_copy2_error(src, dst):
+        raise IOError("Simulated copy error")
+
+    monkeypatch.setattr(shutil, "copy2", mock_copy2_error)
+
+    registry.migrate_agents_dir()
+
+    assert nested_dir.exists()
+    assert (agent_dir / "agent.yml").read_text() == "name: Stuck Agent"
+
+
+def test_migrate_agents_dir_keeps_nested_dir_when_target_exists(temp_agents_dir: Path):
+    """A child skipped because its target exists also keeps the nested dir."""
+    registry = AgentRegistry(temp_agents_dir)
+
+    nested_dir = temp_agents_dir / "agents" / "agents"
+    agent_dir = nested_dir / "dup-agent"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    (agent_dir / "agent.yml").write_text("name: Nested Agent")
+
+    target_dir = temp_agents_dir / "agents" / "dup-agent"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    (target_dir / "agent.yml").write_text("name: Existing Agent")
+
+    registry.migrate_agents_dir()
+
+    assert nested_dir.exists()
+    assert (agent_dir / "agent.yml").read_text() == "name: Nested Agent"
+    assert (target_dir / "agent.yml").read_text() == "name: Existing Agent"

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -2263,10 +2263,12 @@ def test_migrate_agents_dir_error_handling(temp_agents_dir: Path, monkeypatch):
     # The nested directory should still exist since migration failed
     assert (nested_dir / test_agent_id).exists()
 
-    # Target directory should be created but empty
+    # The half-written target is now rolled back rather than left behind. It
+    # previously survived as an empty directory, which the ``target_dir.exists()``
+    # skip then treated as "already migrated" on every later start, stranding
+    # the agent in the nested dir forever while the registry reported it absent.
     target_dir = temp_agents_dir / "agents" / test_agent_id
-    assert target_dir.exists()
-    assert not (target_dir / "agent.yml").exists()
+    assert not target_dir.exists()
 
 
 def _valid_agent_yaml(agent_id: str, name: str) -> str:
@@ -2442,3 +2444,303 @@ def test_migrate_agents_dir_keeps_nested_dir_when_target_exists(temp_agents_dir:
     assert nested_dir.exists()
     assert (agent_dir / "agent.yml").read_text() == "name: Nested Agent"
     assert (target_dir / "agent.yml").read_text() == "name: Existing Agent"
+
+
+def _seed_valid_agent(agents_root: Path, agent_id: str = "good-agent") -> Path:
+    """A healthy agent beside the broken one, so a raise cannot be vacuous."""
+    agent_dir = agents_root / agent_id
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    (agent_dir / "agent.yml").write_text(_valid_agent_yaml(agent_id, "Good"))
+    return agent_dir
+
+
+def test_agent_yml_dangling_symlink_still_fails_strict_reads(temp_agents_dir: Path):
+    """A dangling ``agent.yml`` symlink is a broken agent, not a stray directory.
+
+    ``Path.exists()`` follows symlinks, so the target failing to resolve made
+    this look like "no agent.yml here" and took the tolerant skip branch. The
+    strict path then reported a clean registry and ``resolve_profile`` fell
+    through to the packaged role of the same name -- the exact silent
+    substitution the completeness rule exists to prevent.
+    """
+    from local_operator.session.errors import ProfileRegistryUnavailable
+
+    registry = AgentRegistry(temp_agents_dir)
+    agents_root = temp_agents_dir / "agents"
+    _seed_valid_agent(agents_root)
+
+    broken_dir = agents_root / "broken-agent"
+    broken_dir.mkdir(parents=True, exist_ok=True)
+    os.symlink(agents_root / "nowhere.yml", broken_dir / "agent.yml")
+
+    registry._refresh_agents_metadata()
+    assert registry._metadata_complete is False
+    assert registry._incomplete_agent_dirs == [broken_dir]
+    with pytest.raises(ProfileRegistryUnavailable):
+        registry.require_complete_metadata()
+
+
+def test_agent_yml_symlink_loop_still_fails_strict_reads(temp_agents_dir: Path):
+    """A self-referential ``agent.yml`` symlink is unreadable, not absent."""
+    from local_operator.session.errors import ProfileRegistryUnavailable
+
+    registry = AgentRegistry(temp_agents_dir)
+    agents_root = temp_agents_dir / "agents"
+    _seed_valid_agent(agents_root)
+
+    broken_dir = agents_root / "looped-agent"
+    broken_dir.mkdir(parents=True, exist_ok=True)
+    os.symlink(broken_dir / "agent.yml", broken_dir / "agent.yml")
+
+    registry._refresh_agents_metadata()
+    assert registry._incomplete_agent_dirs == [broken_dir]
+    with pytest.raises(ProfileRegistryUnavailable):
+        registry.require_complete_metadata()
+
+
+def test_missing_agent_yml_with_data_files_still_fails_strict_reads(temp_agents_dir: Path):
+    """A deleted ``agent.yml`` beside surviving history is a BROKEN agent.
+
+    The distinction the rule turns on: an empty directory is not an agent, but
+    a directory still holding ``conversation.jsonl`` plainly was one, so its
+    missing definition is a failed read and must keep raising.
+    """
+    from local_operator.session.errors import ProfileRegistryUnavailable
+
+    registry = AgentRegistry(temp_agents_dir)
+    agents_root = temp_agents_dir / "agents"
+    _seed_valid_agent(agents_root)
+
+    broken_dir = agents_root / "gutted-agent"
+    broken_dir.mkdir(parents=True, exist_ok=True)
+    (broken_dir / "conversation.jsonl").write_text('{"role": "user"}\n')
+    (broken_dir / "execution_history.jsonl").write_text("")
+
+    registry._refresh_agents_metadata()
+    assert registry._incomplete_agent_dirs == [broken_dir]
+    with pytest.raises(ProfileRegistryUnavailable):
+        registry.require_complete_metadata()
+
+
+def test_torn_migration_target_still_fails_strict_reads(temp_agents_dir: Path):
+    """The shape a half-finished ``migrate_agents_dir`` leaves behind.
+
+    Reachable with no symlinks at all: a copy that dies before ``agent.yml``
+    leaves a target holding history and no definition. Reported complete, that
+    is a durable silent substitution on every later start.
+    """
+    from local_operator.session.errors import ProfileRegistryUnavailable
+
+    registry = AgentRegistry(temp_agents_dir)
+    agents_root = temp_agents_dir / "agents"
+    _seed_valid_agent(agents_root)
+
+    torn_dir = agents_root / "torn-agent"
+    torn_dir.mkdir(parents=True, exist_ok=True)
+    (torn_dir / "conversation.jsonl").write_text('{"role": "user"}\n')
+
+    registry._refresh_agents_metadata()
+    assert registry._incomplete_agent_dirs == [torn_dir]
+    with pytest.raises(ProfileRegistryUnavailable):
+        registry.require_complete_metadata()
+
+
+def test_unreadable_agent_dir_still_fails_strict_reads(temp_agents_dir: Path):
+    """An agent directory we cannot stat into must not read as "not an agent".
+
+    ``os.path.lexists`` answers False on ``EACCES`` just as ``exists`` does, so
+    the predicate treats any non-``ENOENT`` error as "cannot prove absence" and
+    keeps the directory in the strict bucket.
+    """
+    from local_operator.session.errors import ProfileRegistryUnavailable
+
+    registry = AgentRegistry(temp_agents_dir)
+    agents_root = temp_agents_dir / "agents"
+    _seed_valid_agent(agents_root)
+
+    locked_dir = agents_root / "locked-agent"
+    locked_dir.mkdir(parents=True, exist_ok=True)
+    (locked_dir / "agent.yml").write_text(_valid_agent_yaml("locked-agent", "Locked"))
+    os.chmod(locked_dir, 0o000)
+    try:
+        registry._refresh_agents_metadata()
+        assert registry._incomplete_agent_dirs == [locked_dir]
+        with pytest.raises(ProfileRegistryUnavailable):
+            registry.require_complete_metadata()
+    finally:
+        # Restore access so tmp_path teardown can remove the tree.
+        os.chmod(locked_dir, 0o755)
+
+
+def test_vanished_agents_dir_fails_strict_reads(temp_agents_dir: Path):
+    """A registry whose directory disappeared is unreadable, not empty.
+
+    Zero-because-vanished and zero-because-empty are indistinguishable to the
+    strict path, and treating the first as success resolves every role to a
+    packaged seed with no warning.
+    """
+    from local_operator.session.errors import ProfileRegistryUnavailable
+
+    registry = AgentRegistry(temp_agents_dir)
+    _seed_valid_agent(temp_agents_dir / "agents")
+    registry._refresh_agents_metadata()
+    registry.require_complete_metadata()
+
+    shutil.rmtree(temp_agents_dir / "agents")
+    registry._refresh_agents_metadata()
+
+    with pytest.raises(ProfileRegistryUnavailable):
+        registry.require_complete_metadata()
+
+    # The tolerant readers keep their long-standing "no agents" answer.
+    assert registry.list_agents() == []
+
+
+def test_torn_migration_rolls_back_and_next_start_recovers(temp_agents_dir: Path, monkeypatch):
+    """A failed copy must not strand the agent in the nested directory.
+
+    Without the rollback the half-written target satisfies the
+    ``target_dir.exists()`` skip on every later start, so the definition stays
+    in ``agents/agents/`` forever while the registry reports it absent.
+    """
+    registry = AgentRegistry(temp_agents_dir)
+    agents_root = temp_agents_dir / "agents"
+
+    nested_dir = agents_root / "agents"
+    source_dir = nested_dir / "torn-agent"
+    source_dir.mkdir(parents=True, exist_ok=True)
+    (source_dir / "agent.yml").write_text(_valid_agent_yaml("torn-agent", "Torn"))
+    (source_dir / "conversation.jsonl").write_text('{"role": "user"}\n')
+
+    real_copy2 = shutil.copy2
+
+    def copy2_failing_on_agent_yml(src, dst):
+        if Path(src).name == "agent.yml":
+            raise OSError(28, "No space left on device")
+        return real_copy2(src, dst)
+
+    monkeypatch.setattr(shutil, "copy2", copy2_failing_on_agent_yml)
+    registry.migrate_agents_dir()
+    monkeypatch.undo()
+
+    # Rolled back: no definition-less target, and the source is untouched.
+    assert not (agents_root / "torn-agent").exists()
+    assert (source_dir / "agent.yml").exists()
+    assert (source_dir / "conversation.jsonl").exists()
+
+    # The next start completes the migration instead of skipping it forever.
+    recovered = AgentRegistry(temp_agents_dir)
+    recovered.require_complete_metadata()
+    assert "torn-agent" in {agent.id for agent in recovered.list_agents()}
+    assert (agents_root / "torn-agent" / "conversation.jsonl").exists()
+    assert not nested_dir.exists()
+
+
+def test_migrate_agents_dir_copies_agent_yml_last(temp_agents_dir: Path, monkeypatch):
+    """Ordering is load-bearing, so it is asserted rather than assumed.
+
+    ``agent.yml`` last means an interrupted copy can never leave a target that
+    looks like a healthy agent while its history is missing.
+    """
+    registry = AgentRegistry(temp_agents_dir)
+
+    nested_dir = temp_agents_dir / "agents" / "agents"
+    source_dir = nested_dir / "ordered-agent"
+    source_dir.mkdir(parents=True, exist_ok=True)
+    (source_dir / "agent.yml").write_text(_valid_agent_yaml("ordered-agent", "Ordered"))
+    (source_dir / "conversation.jsonl").write_text("")
+    (source_dir / "learnings.jsonl").write_text("")
+
+    copied: list[str] = []
+    real_copy2 = shutil.copy2
+
+    def recording_copy2(src, dst):
+        copied.append(Path(src).name)
+        return real_copy2(src, dst)
+
+    monkeypatch.setattr(shutil, "copy2", recording_copy2)
+    registry.migrate_agents_dir()
+
+    assert copied[-1] == "agent.yml"
+    assert set(copied) == {"agent.yml", "conversation.jsonl", "learnings.jsonl"}
+
+
+def test_preexisting_target_is_never_removed_by_rollback(temp_agents_dir: Path, monkeypatch):
+    """The rollback must only ever delete a directory this attempt created.
+
+    Data safety is the whole reason the nested dir uses ``rmdir``; the rollback
+    would undo that guarantee if it could reach an operator's real agent.
+    """
+    registry = AgentRegistry(temp_agents_dir)
+    agents_root = temp_agents_dir / "agents"
+
+    nested_dir = agents_root / "agents"
+    source_dir = nested_dir / "dup-agent"
+    source_dir.mkdir(parents=True, exist_ok=True)
+    (source_dir / "agent.yml").write_text(_valid_agent_yaml("dup-agent", "Nested"))
+
+    target_dir = agents_root / "dup-agent"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    (target_dir / "agent.yml").write_text(_valid_agent_yaml("dup-agent", "Existing"))
+    (target_dir / "conversation.jsonl").write_text('{"role": "user"}\n')
+
+    def always_failing_copy2(src, dst):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(shutil, "copy2", always_failing_copy2)
+    registry.migrate_agents_dir()
+
+    # Both copies of the data survive: the pre-existing target took the skip
+    # branch, so the rollback never applies to it.
+    assert (target_dir / "conversation.jsonl").exists()
+    assert "Existing" in (target_dir / "agent.yml").read_text()
+    assert (source_dir / "agent.yml").read_text().count("Nested") == 1
+    assert nested_dir.exists()
+
+
+def test_profile_registry_unavailable_count_survives_attach_transport():
+    """major-1: the count must reach the attach client, which rebuilds wording.
+
+    ``/team`` attach renders from the reconstructed error, so a count that
+    stops at the transport leaves that surface showing the unactionable
+    sentence this detail was added to replace.
+    """
+    from local_operator.session.errors import (
+        ProfileRegistryUnavailable,
+        admission_error,
+    )
+
+    exc = ProfileRegistryUnavailable(count=3)
+    assert exc.count == 3
+
+    # The frame the runtime server puts on the wire, JSON round-tripped.
+    frame = json.loads(json.dumps({"error_code": exc.code, "error_count": exc.count}))
+    known = admission_error(str(frame.get("error_code", "")), frame.get("error_count"))
+
+    assert isinstance(known, ProfileRegistryUnavailable)
+    assert "3 agent definitions could not be read" in str(known)
+    assert "1 agent definition could not be read" in str(
+        admission_error(ProfileRegistryUnavailable.code, 1)
+    )
+
+
+def test_admission_error_rejects_untrusted_count_values():
+    """Only a plain non-negative int renders; the far side is untrusted input.
+
+    An older runtime sends no count at all and must degrade to the countless
+    wording rather than raising, so the parameter stays optional.
+    """
+    from local_operator.session.errors import (
+        ProfileRegistryUnavailable,
+        admission_error,
+    )
+
+    countless = str(ProfileRegistryUnavailable())
+    for bad in ["7; rm -rf /", {"a": 1}, [1], True, -4, 3.9, "3", None]:
+        rebuilt = admission_error(ProfileRegistryUnavailable.code, bad)  # type: ignore[arg-type]
+        assert str(rebuilt) == countless
+
+    # And no path-like token ever rides along with a well-formed count.
+    populated = str(admission_error(ProfileRegistryUnavailable.code, 2))
+    for token in ("/Users", "/private", "/tmp", ".yml"):
+        assert token not in populated


### PR DESCRIPTION
## Summary

An **empty** leftover `agents/agents/` directory permanently bricked profile
launch and team attach. The operator hit this twice, in two different sessions:

```
The agent registry could not be read completely. Repair unreadable or invalid
agent definitions, then retry. No packaged profile was substituted.

could not attach team 'lopdev': The agent registry could not be read completely. ...
```

All 20 of the operator's agent definitions were valid YAML. The sole offender was
an empty directory dated Aug 6 that nothing could clear, and the message named no
path — so there was nothing actionable to repair.

**The chain.** `migrate_agents_dir()` drains the legacy nested `agents/agents/`
directory but `rmtree`s only each migrated *child*, never `nested_dir` itself. The
metadata scan then counted any subdirectory without an `agent.yml` as an
unreadable agent, clearing `_metadata_complete` on **every** refresh, and
`require_complete_metadata()` — the strict path behind profile launch, the desktop
catalogue and team attach — raised `ProfileRegistryUnavailable` unconditionally.
Forever.

No version bump: `pyproject.toml` stays at `0.51.28`.

## The completeness rule, and why

> Completeness means **"every agent definition I could see, I read successfully"**
> — not "every directory here looks like an agent".

A subdirectory that does not **claim to be an agent at all** is not a failed read.
It is skipped without clearing the flag, and logged at `debug` so a stray directory
stays discoverable without being reported to the user as a fault.

"Claims to be an agent" is decided by `_claims_to_be_an_agent()`, and it answers
**"cannot prove otherwise" as YES**. Two independent signals, either of which is
enough:

1. **The `agent.yml` name is taken** — probed with `os.lstat`, which does not
   follow symlinks. Only `ENOENT` proves the name free; any other `OSError`
   (`EACCES` on the parent, `ENOTDIR`) means absence cannot be proven, and
   guessing "absent" is the unsafe guess.
2. **Agent data files remain** (`conversation.jsonl` and friends). `agent.yml`
   can be genuinely gone while the agent's history is still on disk — an
   interrupted migration, or a deleted file — and that is a definition that
   failed to read, not an empty directory.

A directory that answers yes and then fails to read, parse or validate still
clears the flag. That distinction is the whole point: the strict path exists
because `resolve_profile` is deliberately *tolerant* and falls through to the
packaged seed when a role row is absent, so an incomplete snapshot makes "absent"
and "unreadable" indistinguishable — a corrupt installed role would be silently
stamped as the packaged role of the same name and executed as the user's profile.
Loosening that check wholesale would have "fixed" the bug by removing the safety
property. There is a dedicated test asserting a malformed `agent.yml` still raises.

## What changed

**1. The scan (`local_operator/agents.py`).** The rule above, applied to
directories with no `agent.yml`. The scan existed as **two copies** — in
`_load_agents_metadata` and `_refresh_agents_metadata` — and the bug was present in
both; they are now one `_scan_agents_metadata()` so the rule cannot drift between
initial load and periodic refresh.

**2. The migration.** `migrate_agents_dir()` now removes the drained `nested_dir`
with **`rmdir`, never `rmtree`**. `rmdir` refuses a non-empty directory, so a child
that failed to migrate (a copy that raised, or one whose target already existed)
keeps its data *and* keeps the directory visible for a human to resolve. Silently
deleting unmigrated agent data would be far worse than the litter being cleaned up,
so the emptiness check is the filesystem's own rather than a pre-flight listing
that could race.

**3. The error is actionable (`local_operator/session/errors.py`).** The offending
paths are logged at `warning` by the raising site; the raised error carries only a
**count**:

```
The agent registry could not be read completely. 1 agent definition could not be
read. Repair unreadable or invalid agent definitions, then retry. ...
```

The count rides in its own **integer** `error_count` frame field so the attach
client (`/team`) can rebuild the actionable wording locally, rather than
reconstructing from the bare code and rendering the countless sentence. An
integer names no path, host or identity, so the enumerated-category rule holds;
anything that is not a plain non-negative `int` is dropped rather than rendered,
and an older peer that omits the field degrades to the countless wording.

Paths deliberately do **not** ride along. That module's docstring restricts what
crosses the transport boundary to enumerated categories, warning that arbitrary
text "may contain socket addresses, credentials or another conversation's
identity". A path names the operator's home directory and a basename is an agent
id, so neither is safe to interpolate into a string that crosses a socket. A count
is content-free but still actionable — it tells the user whether to look for one
bad definition or several. `count` is optional because `admission_error()`
reconstructs this error from a bare code on the far side, where no detail exists.

**4. Deletion-guard allow-list.** `tests/unit/session/test_no_session_deletion.py`
caught the new `rmdir` and required a justification, which is recorded there:
`rmdir` cannot remove a non-empty directory, and the path is fixed at
`agents/agents/` — `sessions/` is a sibling of `agents/` and unreachable from it.

## Self-heal

`migrate_agents_dir()` is called from `AgentRegistry.__init__`, so an affected
machine repairs itself on the next start; no user action, and no need to find and
delete the directory by hand. Verified below.

## Testing evidence

### The repro, before the fix

Isolated config dir (`HOME` redirected too, per AGENTS.md), one real agent plus an
empty `agents/agents/`:

```
REPRO RESULT: RAISED ProfileRegistryUnavailable -> The agent registry could not be
read completely. Repair unreadable or invalid agent definitions, then retry. No
packaged profile was substituted.
AFTER REMOVING EMPTY DIR: passed, agents=1
```

### The same repro, after the fix

```
1 PASS: no raise; agents=1; nested removed by __init__=True
2 PASS: stray dirs tolerated; agents=1
3 PASS: raised -> ... 1 agent definition could not be read. ...
4 PASS: nested gone=True; migrated file=True
```

### Both operator-facing symptoms, end to end

The two strict consumers driven directly, with the operator's exact litter shape
present:

```
desktop catalogue profile_detail('coder'): OK, name='coder'
team attach resolver: kind=seed resolved=coder
litter self-healed by __init__: True
```

### Transport boundary still intact

```
reconstructed: ProfileRegistryUnavailable
msg: The agent registry could not be read completely. Repair unreadable ...
code preserved: profile_registry_unavailable
plural: ... 3 agent definitions could not be read. ...
```

### New tests fail on unfixed code

The new tests copied onto a pristine `origin/main` worktree and run with this
branch's venv:

```
FAILED test_migrate_agents_dir_removes_drained_nested_dir - AssertionError: assert not True
FAILED test_malformed_agent_yml_still_fails_strict_reads - AssertionError: assert
  '1 agent definition could not be read' in 'The agent registry could not be read completely. ...'
FAILED test_non_agent_directories_are_tolerated - ProfileRegistryUnavailable: ...
FAILED test_empty_legacy_nested_dir_does_not_break_strict_reads - ProfileRegistryUnavailable: ...
4 failed, 3 passed
```

The 4 that fail are the bug tests. The 3 that pass on both trees are the guard
tests — they assert behaviour that must **not** change (a failed child keeps the
nested dir, an existing target keeps it, invalid `AgentData` still raises).

### Gates, whole tree, exactly as CI

```
.venv/bin/python -m flake8 .                                  -> clean
uvx --from black==26.1.0 black --check .                      -> 1123 files unchanged
uvx isort==5.13.2 --check .                                   -> clean
.venv/bin/python -m pyright --pythonpath .venv/bin/python .   -> 0 errors, 0 warnings
.venv/bin/python -m pytest tests/unit -q  -> 16712 passed, 18 skipped
```

Two unrelated failures appeared in the final suite run and are **environmental, not
from this diff**: a sibling agent on this machine hardlinked the shared uv
interpreter into `/private/tmp/link.bak` (confirmed same inode as
`~/.local/share/uv/python/cpython-3.12-*/bin/python3.12`), and dyld resolves
`@rpath/libpython3.12.dylib` through that path and aborts any subprocess-spawning
test. They are in `tests/unit/tui/test_logger_silence.py` and
`tests/unit/evaluation/runner/test_episode_subprocess.py` — files this diff does not
touch — and **all 10 pass in isolation**:

```
10 passed, 2 warnings in 47.88s
```

Nothing in this repository creates `link.bak` (grepped), and CI has no such `/tmp`.

## Not done

- The operator's live `~/.local-operator` registry was not touched. Their copy of
  the litter remains quarantined at `/tmp/lop-agents-quarantine/agents` (confirmed
  empty, matching the diagnosis); once this ships, `__init__` would have removed it
  on its own.
- `_load_agents_metadata`'s docstring still advertises `Raises: Exception`, which it
  does not do and did not do before. Left alone as out of scope.


---

## Round 1 remediation (`c64e1ad9b`)

The completeness rule's **predicate** changed in round 1; the rule's intent is
unchanged. Where the scan previously asked `Path.exists()` — which follows
symlinks and swallows `OSError` — it now asks `_claims_to_be_an_agent()`,
documented above. Three additional shapes consequently raise again (dangling
`agent.yml` symlink, symlink loop, deleted `agent.yml` with data remaining),
restoring parity with `origin/main` on those, plus two the base never handled
(a torn-migration target, an unreadable agent directory).

`migrate_agents_dir` also copies `agent.yml` **last** and rolls a failed target
back, so a torn migration cannot leave a definition-less directory at all. The
rollback is guarded by `created_target` — `mkdir()` without `exist_ok` is what
proves the directory is ours — and is declared in the deletion allow-list, whose
count guard caught the new call and required this justification.

Full detail and evidence in the remediation comment.
