### PR TITLE
fix(tui): announce the MCP startup toast once per process, per outcome

### DIFF
--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1581,6 +1581,26 @@ class _ApprovalsFollow(NamedTuple):
     kept: bool
 
 
+class _McpAnnounce(NamedTuple):
+    """An MCP startup announce that was actually put on screen.
+
+    Two fields because "has the user been told this" and "is the card carrying
+    it still the one on screen" are different questions, and the second cannot
+    be answered by the words.
+
+    ``sentence`` is the UNTRUNCATED text, so the comparison is width-independent
+    (review round 2, R2-1/R2-2). ``generation`` is :attr:`Toast.generation` at
+    the moment the card took the slot, and it is what makes an eviction release
+    precise: the same sentence recurs (a server that breaks, recovers and breaks
+    again inside one card), so a queued ``Toast.Evicted`` carrying the text of a
+    long-gone card would otherwise match a record that has come back to those
+    words and release an announce the user is reading right now (R2-3).
+    """
+
+    sentence: str
+    generation: int
+
+
 #: Tag for the toast the COMPOSER's copy raises, so a later edit can withdraw
 #: that card and no other. One `Toast` slot serves every caller, and a receipt
 #: may be SHOWING or HELD behind an actionable notice; the tag rides the card
@@ -1613,6 +1633,20 @@ SPLASH_NOTICE = object()
 #: recognise its own card coming back. Same sentinel idiom and same reason as
 #: `COMPOSER_COPY`: identity is all that is compared.
 MCP_STARTUP_TOAST_OWNER = object()
+
+#: Width budget for the MCP announce's IDENTITY text, as opposed to the card's
+#: DISPLAY text (which is fitted to the terminal). A ceiling rather than a
+#: budget: no real sentence approaches it, so nothing is truncated and the
+#: sentence `format_mcp_startup` returns under it is the complete one, free of
+#: the ellipsis. The announce's "already told them" record keys on that complete
+#: sentence because the truncated one let the terminal width into the identity
+#: in both directions — a resize re-announced news the user had read (review
+#: round 2, R2-1), and two genuinely different failures that ellipsis to the
+#: same characters collapsed, silently swallowing the second (R2-2, UX round 2,
+#: U2-1). `10 ** 6` cells is ~16 km of terminal; it is a sentinel for "do not
+#: truncate", spelled as a width so the existing `format_mcp_startup` path is
+#: reused rather than a second renderer that could drift from it.
+_MCP_ANNOUNCE_KEY_CELLS = 10**6
 
 #: Owner tag for the IN-FLIGHT read card, deliberately distinct from
 #: :data:`COMPOSER_PASTE_NOTICE`.
@@ -2335,33 +2369,54 @@ class OperatorApp(App[None]):
         #: own id or it does not, no swap site has to remember to clear, and a
         #: path added later cannot reintroduce either direction by forgetting.
         self._sessions_that_used_eval: set[str] = set()
-        #: The MCP startup sentence CURRENTLY announced — one string, not a
-        #: ledger of every sentence ever shown. A re-report saying the same
-        #: thing is silent; one saying something else announces and takes this
-        #: slot over. So A→A is silent while A→B→A announces on the return,
-        #: which is what keeps a server that breaks, recovers and breaks AGAIN
-        #: from going quiet forever (UX round 1, U1) — a recurring failure is
-        #: the single most interruption-worthy thing this surface reports, and
-        #: an ever-growing set of retired fingerprints suppressed exactly it.
+        #: What this process has already told the user about MCP startup, in
+        #: two parts, because "have they been told this" has two answers and a
+        #: single global slot cannot give both (QA round 2, Q2-1).
         #:
-        #: Being one slot rather than a set, this is O(1) for the life of the
-        #: process: 126 B measured, whatever the session count. The set it
-        #: replaces held one 642 B fingerprint per distinct outcome and only
-        #: ever grew (review round 1, R1-3; UX round 1, U5).
+        #: PER SESSION: the sentence each session's own last announce carried.
+        #: A re-report for a session whose sentence has not changed since ITS
+        #: last announce is silent, which is what makes a click away and back
+        #: quiet: the sidebar is not cwd-scoped (`load_catalog` scans the whole
+        #: store) while MCP is wired per session cwd, so alternating between a
+        #: repo with `.mcp.json` and one without is ordinary A→B→A→B — and a
+        #: global slot re-announced on every single click, 20 in 20, which is
+        #: the reported defect at full strength.
         #:
-        #: The key is the RENDERED TEXT, which is literally "what the user
-        #: would see": two different server sets that render the same sentence
-        #: are the same news to the person reading it, and keying on the
-        #: structural fingerprint toasted that identical sentence twice (R1-2).
+        #: CURRENT: the sentence the card on screen is carrying, with the
+        #: generation of that card. A session seeing a sentence that another
+        #: session has just put on screen is already looking at it, so it
+        #: inherits that record rather than raising a duplicate — that is what
+        #: keeps four sidebar clicks onto one shared MCP set to one toast even
+        #: though the four sessions have no per-session record between them.
+        #:
+        #: Together they give A→A silent, A→B→A on the SAME session announcing
+        #: (a server that breaks, recovers and breaks again is the most
+        #: interruption-worthy thing here — UX round 1, U1), and A→B→A ACROSS
+        #: sessions silent (nothing changed; the user moved).
+        #:
+        #: The key is the UNTRUNCATED sentence. Keying the width-fitted one let
+        #: the terminal width into the identity in both directions: a resize
+        #: re-announced news already read (R2-1), and worse, two genuinely
+        #: different failures that ellipsis to the same characters collapsed,
+        #: swallowing the second — the one case this surface exists to raise
+        #: (R2-2, U2-1). The card still SHOWS the width-fitted renderable.
+        #:
+        #: Bounded by the sessions ATTACHED in this process, not by attaches
+        #: and not by outcomes: a re-attach and a changed outcome both write
+        #: the same entry. 276 B per entry measured (dict slot 26 B + key
+        #: string 68 B + record 182 B), so a thousand attached sessions cost
+        #: ~270 KiB and a day's sidebar catalogue is kilobytes. No cap is
+        #: warranted and none is imposed (review round 1, R1-3's standard).
         #:
         #: Written when the toast is DISPLAYED, not when `show` is called — the
         #: single slot may evict a 5 s courtesy card, and recording at call
         #: time spent the one announce the user was owed on a card they never
-        #: saw (U2). `on_toast_evicted` clears it back.
+        #: saw (UX round 1, U2). `on_toast_evicted` clears it back.
         #:
         #: Never persisted: an announce that survived a restart would silence
         #: the one launch the user actually wants told about.
-        self._announced_mcp_startup: str | None = None
+        self._announced_mcp_startup: dict[str, _McpAnnounce] = {}
+        self._last_mcp_announce: _McpAnnounce | None = None
         #: MCP failures whose durable notice a session's transcript already
         #: carries, keyed by `(session id, server name, error text)`.
         #:
@@ -10722,33 +10777,42 @@ class OperatorApp(App[None]):
         BOTH surfaces suppress REPEATS, and they are keyed differently because
         they answer different questions.
 
-        The TOAST is keyed by the sentence it would RENDER, and only against
-        the one currently announced. ``session.mcp_startup`` is a frozen BOOT
-        SNAPSHOT, and this method runs on every adoption — boot, ``/new``,
-        ``/resume``, a remote takeover, and every sidebar click, which re-adopts
-        a session and replays a snapshot taken minutes ago (``RemoteSession``
-        even rehydrates the OWNER's round, so attaching to a peer replayed a
-        round this process never ran). MCP servers are process-wide and shared,
-        so re-confirming "12 servers, 425 tools" on each sidebar click is pure
-        noise over the user's work.
+        The TOAST announces when THIS SESSION's sentence differs from what THIS
+        SESSION was last told — one record per session, not one global slot.
+        ``session.mcp_startup`` is a frozen BOOT SNAPSHOT, and this method runs
+        on every adoption — boot, ``/new``, ``/resume``, a remote takeover, and
+        every sidebar click, which re-adopts a session and replays a snapshot
+        taken minutes ago (``RemoteSession`` even rehydrates the OWNER's round,
+        so attaching to a peer replayed a round this process never ran). MCP
+        servers are process-wide and shared, so re-confirming "12 servers, 425
+        tools" on each sidebar click is pure noise over the user's work.
 
-        Why the RENDERED TEXT and not the session id: a per-session key would
-        still toast once per session, which is the reported defect — clicking
-        through five sidebar entries that share one MCP set would raise five
-        identical toasts. Keyed by what the user would read, the first announce
-        covers all of them, while a session in a different cwd with a genuinely
-        different server set announces once because that IS news. It is also
-        the honest test of "has the user been told this": two disjoint server
-        sets that render one identical sentence are one piece of news, and
-        keying the structural outcome showed the same words twice (R1-2).
+        Why PER SESSION rather than one global sentence (QA round 2, Q2-1): the
+        sidebar catalogue is not cwd-scoped (``load_catalog`` scans the whole
+        store) while MCP is wired per session cwd, so two conversations in two
+        repos — one with a ``.mcp.json``, one without — render two different
+        sentences, and clicking between them is A→B→A→B. A single slot cannot
+        tell "the world changed" from "I clicked away and came back": it
+        re-announced on EVERY click, 20 announces in 20, which is the reported
+        defect at full strength. Per session, each side of the alternation is
+        unchanged since its own last announce and stays silent after its first.
 
-        Why only against the CURRENT announce, rather than everything ever
-        shown: a server that dies, recovers, then dies AGAIN is the same
-        sentence as its first death, and a ledger of retired sentences silenced
-        it forever (U1). A recurring failure is precisely what the user needs
-        interrupting for. So the rule is A→A silent, A→B→A announces: four
-        sidebar clicks onto one MCP set are still A→A→A→A and still silent,
-        while a flapping server is announced every time it flaps.
+        Why the sentence at all, and not the structural outcome: two disjoint
+        server sets that render one identical sentence are one piece of news to
+        the person reading it, and keying structurally toasted those identical
+        words twice (R1-2). A session seeing a sentence that another session
+        has CURRENTLY on screen inherits that record rather than raising a
+        duplicate — that is what keeps four sidebar clicks onto one shared MCP
+        set to one toast even though the four sessions had no record of their
+        own.
+
+        Why each session's record holds only its LAST sentence, rather than
+        every sentence it ever showed: a server that dies, recovers, then dies
+        AGAIN is the same sentence as its first death, and a ledger of retired
+        sentences silenced it forever (U1). A recurring failure is precisely
+        what the user needs interrupting for. So A→A on one session is silent,
+        A→B→A on one session announces on the return, and A→B→A across
+        sessions is silent — the world changed back, and the user only moved.
 
         The record is taken when the toast is DISPLAYED, not when ``show`` is
         called. The single slot may evict a courtesy card, and the announce is
@@ -10782,33 +10846,59 @@ class OperatorApp(App[None]):
         if payload is None:
             return
         text, duration_ms = payload
-        # The RENDERABLE is what gets shown — it carries the semantic lamp
-        # colour `format_mcp_startup` derived through the band's own rule — while
-        # its PLAIN form is what gets compared, because "has the user read this
-        # sentence" is a question about words, not styling.
-        sentence = text.plain if isinstance(text, Text) else str(text)
-        if sentence != self._announced_mcp_startup:
-            # Tagged with the app so the eviction notice can be told from every
-            # other card's, and the announce is recorded from what actually took
-            # the slot rather than from the call — a card that yields to an
-            # actionable incumbent is HELD, not shown, and must not count as
-            # told (that is the same U2 mistake in its other form).
-            toast.show(text, duration_ms=duration_ms, owner=MCP_STARTUP_TOAST_OWNER)
-            if toast.message == sentence:
-                self._announced_mcp_startup = sentence
-        if not outcome.failures:
-            return
         # A session with no usable id (a reduced facade, a test double) shares
         # one bucket with every other id-less host, so a second such host loses
         # a notice it was owed. Accepted: no production session reaches here
         # without an id — `SessionProtocol.session_id` returns `str`, `Session`
         # falls back to the transcript directory name and `RemoteSession` takes
         # the id as a constructor argument — and a shared bucket still dedupes
-        # the repeat this method exists to stop (review round 1, R1-4).
+        # the repeat this method exists to stop (review round 1, R1-4). Derived
+        # once and shared with the notice ledger below, so the two surfaces can
+        # never disagree about which session they are talking about.
         try:
             session_key = str(getattr(session, "session_id", "") or "")
         except Exception:  # noqa: BLE001 — a property may raise on a reduced host
             session_key = ""
+        # The comparison text is rendered WITHOUT a width budget while the card
+        # shows the width-fitted one. `max_cells` here is a ceiling no real
+        # sentence approaches, so nothing is truncated and the identity carries
+        # no terminal width — the ellipsis is a display concern, and letting it
+        # into the key both re-announced read news on a resize and, worse,
+        # collapsed two different failures into one and swallowed the second
+        # (review round 2, R2-1/R2-2; UX round 2, U2-1/U2-2).
+        full = format_mcp_startup(outcome, max_cells=_MCP_ANNOUNCE_KEY_CELLS)
+        # Unreachable in practice — `reportable` already said yes above and this
+        # call differs only in width — but `format_mcp_startup` is typed
+        # optional and falling back to the shown text keeps the rule total.
+        key_text = full[0] if full is not None else text
+        sentence = key_text.plain if isinstance(key_text, Text) else str(key_text)
+        told = self._announced_mcp_startup.get(session_key)
+        if told is None or told.sentence != sentence:
+            showing = self._last_mcp_announce
+            if showing is not None and showing.sentence == sentence:
+                # Another session just put these words on screen and they are
+                # still there, so this session is looking at its news already.
+                # It inherits that card's generation, so one eviction releases
+                # every session the card spoke for — otherwise a piggybacking
+                # session would keep a record for a card nobody read.
+                self._announced_mcp_startup[session_key] = showing
+            else:
+                # Tagged with the app so the eviction notice can be told from
+                # every other card's, and the announce is recorded from what
+                # actually took the slot rather than from the call — a card that
+                # yields to an actionable incumbent is HELD, not shown, and must
+                # not count as told (that is the same U2 mistake in its other
+                # form). The RENDERABLE is what gets shown: it carries the
+                # semantic lamp colour `format_mcp_startup` derived through the
+                # band's own rule.
+                before = toast.generation
+                toast.show(text, duration_ms=duration_ms, owner=MCP_STARTUP_TOAST_OWNER)
+                if toast.generation != before and toast.display:
+                    announce = _McpAnnounce(sentence, toast.generation)
+                    self._last_mcp_announce = announce
+                    self._announced_mcp_startup[session_key] = announce
+        if not outcome.failures:
+            return
         # No "server" in the wording: one failure key is ``discovery`` (the
         # config layer itself), and "MCP server discovery failed" would name a
         # server that does not exist. `/mcp` is named because it is the standing
@@ -10831,15 +10921,30 @@ class OperatorApp(App[None]):
         time and therefore spent on a card the user never read, with no second
         chance because the rule is one-shot (UX round 1, U2).
 
-        Only the app's OWN startup card matters here, and only while the
-        evicted text is still the one on record: an announce that was already
-        superseded by a different one is stale, and clearing the record for it
-        would re-announce something the user has since been told.
+        Only the app's OWN startup card matters here, and only the exact CARD
+        that was evicted: matching on the words instead released a live announce
+        whenever the same sentence recurred, because ``Evicted`` is posted and
+        therefore arrives after a flap A→B→A has already brought the record back
+        to A (review round 2, R2-3). The generation is the card's identity and
+        cannot alias, which is the reason :attr:`Toast.generation` exists.
+
+        The release targets the SESSIONS whose announce that card WAS — every
+        session that took its record from it, which is the raising session plus
+        any that piggybacked on the words already being on screen. Sessions told
+        by an earlier card are untouched: they were told by a card that retired
+        normally, and re-arming them would announce news they have read.
         """
         if message.owner is not MCP_STARTUP_TOAST_OWNER:
             return
-        if message.text == self._announced_mcp_startup:
-            self._announced_mcp_startup = None
+        showing = self._last_mcp_announce
+        if showing is None or showing.generation != message.generation:
+            return
+        self._last_mcp_announce = None
+        self._announced_mcp_startup = {
+            key: announce
+            for key, announce in self._announced_mcp_startup.items()
+            if announce.generation != message.generation
+        }
 
     def _report_startup_cleanup(self, *, rechecks_left: float = 0.0) -> None:
         """Announce a startup cleanup pass that removed sessions, once.

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -2327,6 +2327,21 @@ class OperatorApp(App[None]):
         #: own id or it does not, no swap site has to remember to clear, and a
         #: path added later cannot reintroduce either direction by forgetting.
         self._sessions_that_used_eval: set[str] = set()
+        #: MCP startup outcomes this PROCESS has already announced, as the
+        #: fingerprints `_mcp_startup_fingerprint` builds. The toast is a
+        #: per-process interruption, so the ledger lives here rather than on
+        #: the session and is never persisted: a fingerprint that survived a
+        #: restart would silence the one launch the user actually wants told
+        #: about. See `_report_mcp_startup` for why the key is the outcome's
+        #: content and not the session id.
+        self._announced_mcp_startups: set[tuple[Any, ...]] = set()
+        #: Sessions whose transcript already carries the durable MCP failure
+        #: notices, keyed by session id. Deliberately a DIFFERENT key from the
+        #: toast ledger above: a failure record belongs in the transcript of
+        #: the session it describes, so a second session genuinely deserves
+        #: its own copy — it is the repeat on the SAME session (a re-attach)
+        #: that duplicates a notice the user already scrolled past.
+        self._mcp_failure_notice_sessions: set[str] = set()
         #: A show `_set_welcome_visible` withheld during a swap. Applied by
         #: `_reload_session` once the answer is settled, which is what still
         #: puts the splash up for a swap onto a genuinely empty session.
@@ -10663,6 +10678,42 @@ class OperatorApp(App[None]):
         the same failure. So the record goes through :meth:`_system_notice`: it
         lands under the splash, survives the toast, and is there when the
         conversation does begin.
+
+        BOTH surfaces announce AT MOST ONCE, and they are keyed differently
+        because they answer different questions.
+
+        The TOAST is keyed by the outcome's CONTENT, once per app process.
+        ``session.mcp_startup`` is a frozen BOOT SNAPSHOT, and this method runs
+        on every adoption — boot, ``/new``, ``/resume``, a remote takeover, and
+        every sidebar click, which re-adopts a session and replays a snapshot
+        taken minutes ago (``RemoteSession`` even rehydrates the OWNER's round,
+        so attaching to a peer replayed a round this process never ran). MCP
+        servers are process-wide and shared, so re-confirming "12 servers, 425
+        tools" on each sidebar click is pure noise over the user's work.
+
+        Why the CONTENT and not the session id: a per-session key would still
+        toast once per session, which is the reported defect — clicking through
+        five sidebar entries that share one MCP set would raise five identical
+        toasts. Keyed by content, the first announce covers all of them, while
+        a session in a different cwd with a genuinely different server set
+        announces once because that IS news. First loadup is preserved: its
+        fingerprint is new by definition.
+
+        The settle path is unaffected. The 250 ms gate snapshot is ``settling``
+        and therefore unreportable (``format_mcp_startup`` returns ``None``),
+        so nothing is recorded until the settled outcome arrives — and that one
+        carries its own fingerprint and announces.
+
+        Nothing is lost by the suppression: the status band's MCP segment
+        (``_mcp_status``/``_refresh_mcp_status``) is re-read from the LIVE
+        manager on every attach and states the current count unconditionally.
+        That is the surface that legitimately re-states MCP state per attach,
+        and it is precisely what makes silencing the repeat toast safe.
+
+        The NOTICE is keyed per session instead. A durable failure record
+        belongs in the transcript of the session it describes, so a second
+        session deserves its own copy; it is the repeat on the SAME session
+        that duplicates a line the user already has.
         """
         outcome = getattr(session, "mcp_startup", None)
         if outcome is None:
@@ -10671,8 +10722,28 @@ class OperatorApp(App[None]):
         payload = format_mcp_startup(outcome, max_cells=toast.content_cells)
         if payload is None:
             return
-        text, duration_ms = payload
-        toast.show(text, duration_ms=duration_ms)
+        fingerprint = _mcp_startup_fingerprint(outcome)
+        if fingerprint not in self._announced_mcp_startups:
+            self._announced_mcp_startups.add(fingerprint)
+            text, duration_ms = payload
+            toast.show(text, duration_ms=duration_ms)
+        if not outcome.failures:
+            return
+        # Keyed by (session, outcome) rather than by session alone: a session
+        # whose failure set genuinely CHANGED — the settled round naming a
+        # server the gate snapshot could not — owes the transcript that new
+        # record, while the re-attach this method exists to silence replays a
+        # byte-identical outcome and is suppressed. A session with no usable id
+        # (a reduced facade, a test double) degrades to the fingerprint alone,
+        # which keeps a guard rather than losing one.
+        try:
+            session_key = str(getattr(session, "session_id", "") or "")
+        except Exception:  # noqa: BLE001 — a property may raise on a reduced host
+            session_key = ""
+        notice_key = f"{session_key}\x00{fingerprint!r}"
+        if notice_key in self._mcp_failure_notice_sessions:
+            return
+        self._mcp_failure_notice_sessions.add(notice_key)
         # No "server" in the wording: one failure key is ``discovery`` (the
         # config layer itself), and "MCP server discovery failed" would name a
         # server that does not exist.
@@ -31075,6 +31146,37 @@ def slot_rows(slot: Any) -> int:
     # slot, so the larger is the safe one: it can only ever withhold the inset,
     # which costs a blank row, where the smaller costs a scrollable screen.
     return max(measured, predicted, 1)
+
+
+def _mcp_startup_fingerprint(outcome: Any) -> tuple[Any, ...]:
+    """The MATERIAL content of a startup outcome, as a hashable key.
+
+    The identity a re-announce decision needs is "does this say anything the
+    user has not already been told", so the key is what the toast actually
+    renders from: how many servers were configured, which came up, what failed
+    and why, and the tool tally. Two rounds that agree on all four produce the
+    same sentence, and the second one is the noise `_report_mcp_startup`
+    suppresses.
+
+    Object identity is deliberately NOT the key even though ``McpStartupOutcome``
+    is frozen: ``RemoteSession`` rehydrates the owner's outcome into a fresh
+    instance on every attach (``session/remote.py``), so identity — and a plain
+    ``in`` over a list of dataclasses, which would compare equal but for the
+    unhashable ``failures`` dict — either fails to dedupe or cannot be stored.
+
+    ``configured`` and ``connected`` are sorted because they are SETS with an
+    incidental order: the connect order varies run to run (and between the gate
+    snapshot and the settled round), and an order-sensitive key would re-toast
+    an outcome whose content is identical. ``failures`` is flattened to sorted
+    pairs for the same reason and because a dict cannot be hashed.
+    """
+    failures = dict(getattr(outcome, "failures", {}) or {})
+    return (
+        tuple(sorted(getattr(outcome, "configured", ()) or ())),
+        tuple(sorted(getattr(outcome, "connected", ()) or ())),
+        tuple(sorted(failures.items())),
+        int(getattr(outcome, "tool_count", 0) or 0),
+    )
 
 
 def _canonical_frontend(session: Any) -> bool:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1606,6 +1606,14 @@ COMPOSER_PASTE_NOTICE = object()
 # only that session's notice on reload, never an unrelated actionable card.
 SPLASH_NOTICE = object()
 
+#: Tag for the MCP startup announce, so `on_toast_evicted` can tell the app's
+#: own card from every other caller's. That announce is reported AT MOST ONCE
+#: per distinct sentence, and the record of having reported it has to be
+#: released if the card is thrown away unread — which only works if the app can
+#: recognise its own card coming back. Same sentinel idiom and same reason as
+#: `COMPOSER_COPY`: identity is all that is compared.
+MCP_STARTUP_TOAST_OWNER = object()
+
 #: Owner tag for the IN-FLIGHT read card, deliberately distinct from
 #: :data:`COMPOSER_PASTE_NOTICE`.
 #:
@@ -2327,21 +2335,53 @@ class OperatorApp(App[None]):
         #: own id or it does not, no swap site has to remember to clear, and a
         #: path added later cannot reintroduce either direction by forgetting.
         self._sessions_that_used_eval: set[str] = set()
-        #: MCP startup outcomes this PROCESS has already announced, as the
-        #: fingerprints `_mcp_startup_fingerprint` builds. The toast is a
-        #: per-process interruption, so the ledger lives here rather than on
-        #: the session and is never persisted: a fingerprint that survived a
-        #: restart would silence the one launch the user actually wants told
-        #: about. See `_report_mcp_startup` for why the key is the outcome's
-        #: content and not the session id.
-        self._announced_mcp_startups: set[tuple[Any, ...]] = set()
-        #: Sessions whose transcript already carries the durable MCP failure
-        #: notices, keyed by session id. Deliberately a DIFFERENT key from the
-        #: toast ledger above: a failure record belongs in the transcript of
-        #: the session it describes, so a second session genuinely deserves
-        #: its own copy — it is the repeat on the SAME session (a re-attach)
-        #: that duplicates a notice the user already scrolled past.
-        self._mcp_failure_notice_sessions: set[str] = set()
+        #: The MCP startup sentence CURRENTLY announced — one string, not a
+        #: ledger of every sentence ever shown. A re-report saying the same
+        #: thing is silent; one saying something else announces and takes this
+        #: slot over. So A→A is silent while A→B→A announces on the return,
+        #: which is what keeps a server that breaks, recovers and breaks AGAIN
+        #: from going quiet forever (UX round 1, U1) — a recurring failure is
+        #: the single most interruption-worthy thing this surface reports, and
+        #: an ever-growing set of retired fingerprints suppressed exactly it.
+        #:
+        #: Being one slot rather than a set, this is O(1) for the life of the
+        #: process: 126 B measured, whatever the session count. The set it
+        #: replaces held one 642 B fingerprint per distinct outcome and only
+        #: ever grew (review round 1, R1-3; UX round 1, U5).
+        #:
+        #: The key is the RENDERED TEXT, which is literally "what the user
+        #: would see": two different server sets that render the same sentence
+        #: are the same news to the person reading it, and keying on the
+        #: structural fingerprint toasted that identical sentence twice (R1-2).
+        #:
+        #: Written when the toast is DISPLAYED, not when `show` is called — the
+        #: single slot may evict a 5 s courtesy card, and recording at call
+        #: time spent the one announce the user was owed on a card they never
+        #: saw (U2). `on_toast_evicted` clears it back.
+        #:
+        #: Never persisted: an announce that survived a restart would silence
+        #: the one launch the user actually wants told about.
+        self._announced_mcp_startup: str | None = None
+        #: MCP failures whose durable notice a session's transcript already
+        #: carries, keyed by `(session id, server name, error text)`.
+        #:
+        #: Per SESSION because a failure record belongs in the transcript of
+        #: the session it describes, so a second session deserves its own copy;
+        #: it is the repeat on the SAME session (a re-attach) that duplicates a
+        #: line the user already scrolled past.
+        #:
+        #: Per FAILURE rather than per outcome because keying the whole outcome
+        #: made a later round that ADDS a failure re-emit every failure already
+        #: in the transcript — the key changed, so the loop rewrote all of them
+        #: (review round 1, R1-1). Keyed this way each distinct failure lands
+        #: once per session and a new one does not drag its neighbours back.
+        #:
+        #: Grows with DISTINCT failures actually seen, not with attaches — a
+        #: re-attach adds nothing, which is the whole fix. Measured at 246 B
+        #: per key, 1,000 keys total 160 KiB; reaching a megabyte would take
+        #: ~6,500 distinct (session, server, error) triples in one process, so
+        #: no cap is warranted and none is imposed.
+        self._mcp_failure_notices: set[tuple[str, str, str]] = set()
         #: A show `_set_welcome_visible` withheld during a swap. Applied by
         #: `_reload_session` once the answer is settled, which is what still
         #: puts the splash up for a swap onto a genuinely empty session.
@@ -10679,30 +10719,48 @@ class OperatorApp(App[None]):
         lands under the splash, survives the toast, and is there when the
         conversation does begin.
 
-        BOTH surfaces announce AT MOST ONCE, and they are keyed differently
-        because they answer different questions.
+        BOTH surfaces suppress REPEATS, and they are keyed differently because
+        they answer different questions.
 
-        The TOAST is keyed by the outcome's CONTENT, once per app process.
-        ``session.mcp_startup`` is a frozen BOOT SNAPSHOT, and this method runs
-        on every adoption — boot, ``/new``, ``/resume``, a remote takeover, and
-        every sidebar click, which re-adopts a session and replays a snapshot
-        taken minutes ago (``RemoteSession`` even rehydrates the OWNER's round,
-        so attaching to a peer replayed a round this process never ran). MCP
-        servers are process-wide and shared, so re-confirming "12 servers, 425
-        tools" on each sidebar click is pure noise over the user's work.
+        The TOAST is keyed by the sentence it would RENDER, and only against
+        the one currently announced. ``session.mcp_startup`` is a frozen BOOT
+        SNAPSHOT, and this method runs on every adoption — boot, ``/new``,
+        ``/resume``, a remote takeover, and every sidebar click, which re-adopts
+        a session and replays a snapshot taken minutes ago (``RemoteSession``
+        even rehydrates the OWNER's round, so attaching to a peer replayed a
+        round this process never ran). MCP servers are process-wide and shared,
+        so re-confirming "12 servers, 425 tools" on each sidebar click is pure
+        noise over the user's work.
 
-        Why the CONTENT and not the session id: a per-session key would still
-        toast once per session, which is the reported defect — clicking through
-        five sidebar entries that share one MCP set would raise five identical
-        toasts. Keyed by content, the first announce covers all of them, while
-        a session in a different cwd with a genuinely different server set
-        announces once because that IS news. First loadup is preserved: its
-        fingerprint is new by definition.
+        Why the RENDERED TEXT and not the session id: a per-session key would
+        still toast once per session, which is the reported defect — clicking
+        through five sidebar entries that share one MCP set would raise five
+        identical toasts. Keyed by what the user would read, the first announce
+        covers all of them, while a session in a different cwd with a genuinely
+        different server set announces once because that IS news. It is also
+        the honest test of "has the user been told this": two disjoint server
+        sets that render one identical sentence are one piece of news, and
+        keying the structural outcome showed the same words twice (R1-2).
+
+        Why only against the CURRENT announce, rather than everything ever
+        shown: a server that dies, recovers, then dies AGAIN is the same
+        sentence as its first death, and a ledger of retired sentences silenced
+        it forever (U1). A recurring failure is precisely what the user needs
+        interrupting for. So the rule is A→A silent, A→B→A announces: four
+        sidebar clicks onto one MCP set are still A→A→A→A and still silent,
+        while a flapping server is announced every time it flaps.
+
+        The record is taken when the toast is DISPLAYED, not when ``show`` is
+        called. The single slot may evict a courtesy card, and the announce is
+        ``TOAST_DEFAULT_MS`` — below ``yield_to_actionable``'s protection — so
+        recording at call time spent the user's one announce on a card a copy
+        receipt overwrote before they read it (U2). :meth:`on_toast_evicted`
+        clears the record so the next attach re-announces.
 
         The settle path is unaffected. The 250 ms gate snapshot is ``settling``
         and therefore unreportable (``format_mcp_startup`` returns ``None``),
         so nothing is recorded until the settled outcome arrives — and that one
-        carries its own fingerprint and announces.
+        renders its own sentence and announces.
 
         Nothing is lost by the suppression: the status band's MCP segment
         (``_mcp_status``/``_refresh_mcp_status``) is re-read from the LIVE
@@ -10710,10 +10768,11 @@ class OperatorApp(App[None]):
         That is the surface that legitimately re-states MCP state per attach,
         and it is precisely what makes silencing the repeat toast safe.
 
-        The NOTICE is keyed per session instead. A durable failure record
-        belongs in the transcript of the session it describes, so a second
-        session deserves its own copy; it is the repeat on the SAME session
-        that duplicates a line the user already has.
+        The NOTICE is keyed per session and per FAILURE instead — see
+        :attr:`_mcp_failure_notices`. It also names ``/mcp``, because the toast
+        is now one-shot and the standing answer needs signposting at the moment
+        the failure is read (U4); the pointer goes on the durable line, where
+        there is room, and not on the width-budgeted toast.
         """
         outcome = getattr(session, "mcp_startup", None)
         if outcome is None:
@@ -10722,33 +10781,65 @@ class OperatorApp(App[None]):
         payload = format_mcp_startup(outcome, max_cells=toast.content_cells)
         if payload is None:
             return
-        fingerprint = _mcp_startup_fingerprint(outcome)
-        if fingerprint not in self._announced_mcp_startups:
-            self._announced_mcp_startups.add(fingerprint)
-            text, duration_ms = payload
-            toast.show(text, duration_ms=duration_ms)
+        text, duration_ms = payload
+        # The RENDERABLE is what gets shown — it carries the semantic lamp
+        # colour `format_mcp_startup` derived through the band's own rule — while
+        # its PLAIN form is what gets compared, because "has the user read this
+        # sentence" is a question about words, not styling.
+        sentence = text.plain if isinstance(text, Text) else str(text)
+        if sentence != self._announced_mcp_startup:
+            # Tagged with the app so the eviction notice can be told from every
+            # other card's, and the announce is recorded from what actually took
+            # the slot rather than from the call — a card that yields to an
+            # actionable incumbent is HELD, not shown, and must not count as
+            # told (that is the same U2 mistake in its other form).
+            toast.show(text, duration_ms=duration_ms, owner=MCP_STARTUP_TOAST_OWNER)
+            if toast.message == sentence:
+                self._announced_mcp_startup = sentence
         if not outcome.failures:
             return
-        # Keyed by (session, outcome) rather than by session alone: a session
-        # whose failure set genuinely CHANGED — the settled round naming a
-        # server the gate snapshot could not — owes the transcript that new
-        # record, while the re-attach this method exists to silence replays a
-        # byte-identical outcome and is suppressed. A session with no usable id
-        # (a reduced facade, a test double) degrades to the fingerprint alone,
-        # which keeps a guard rather than losing one.
+        # A session with no usable id (a reduced facade, a test double) shares
+        # one bucket with every other id-less host, so a second such host loses
+        # a notice it was owed. Accepted: no production session reaches here
+        # without an id — `SessionProtocol.session_id` returns `str`, `Session`
+        # falls back to the transcript directory name and `RemoteSession` takes
+        # the id as a constructor argument — and a shared bucket still dedupes
+        # the repeat this method exists to stop (review round 1, R1-4).
         try:
             session_key = str(getattr(session, "session_id", "") or "")
         except Exception:  # noqa: BLE001 — a property may raise on a reduced host
             session_key = ""
-        notice_key = f"{session_key}\x00{fingerprint!r}"
-        if notice_key in self._mcp_failure_notice_sessions:
-            return
-        self._mcp_failure_notice_sessions.add(notice_key)
         # No "server" in the wording: one failure key is ``discovery`` (the
         # config layer itself), and "MCP server discovery failed" would name a
-        # server that does not exist.
+        # server that does not exist. `/mcp` is named because it is the standing
+        # answer and this is the durable surface with room to point at it.
         for name, error in sorted(outcome.failures.items()):
-            self._system_notice(f"MCP {name} failed: {error}", "error")
+            notice_key = (session_key, name, str(error))
+            if notice_key in self._mcp_failure_notices:
+                continue
+            self._mcp_failure_notices.add(notice_key)
+            self._system_notice(f"MCP {name} failed: {error} — /mcp for details", "error")
+
+    def on_toast_evicted(self, message: Toast.Evicted) -> None:
+        """Un-record the MCP announce when its card was thrown away unread.
+
+        The announce is a 5 s courtesy card in a single shared slot, so a
+        routine gesture — the copy receipt is the documented one — can replace
+        it inside those 5 s. ``yield_to_actionable`` does not protect it: that
+        guard only holds for a ``TOAST_FAILURE_MS`` incumbent, and this card is
+        ``TOAST_DEFAULT_MS``. Before this, the announce was recorded at ``show``
+        time and therefore spent on a card the user never read, with no second
+        chance because the rule is one-shot (UX round 1, U2).
+
+        Only the app's OWN startup card matters here, and only while the
+        evicted text is still the one on record: an announce that was already
+        superseded by a different one is stale, and clearing the record for it
+        would re-announce something the user has since been told.
+        """
+        if message.owner is not MCP_STARTUP_TOAST_OWNER:
+            return
+        if message.text == self._announced_mcp_startup:
+            self._announced_mcp_startup = None
 
     def _report_startup_cleanup(self, *, rechecks_left: float = 0.0) -> None:
         """Announce a startup cleanup pass that removed sessions, once.
@@ -31146,37 +31237,6 @@ def slot_rows(slot: Any) -> int:
     # slot, so the larger is the safe one: it can only ever withhold the inset,
     # which costs a blank row, where the smaller costs a scrollable screen.
     return max(measured, predicted, 1)
-
-
-def _mcp_startup_fingerprint(outcome: Any) -> tuple[Any, ...]:
-    """The MATERIAL content of a startup outcome, as a hashable key.
-
-    The identity a re-announce decision needs is "does this say anything the
-    user has not already been told", so the key is what the toast actually
-    renders from: how many servers were configured, which came up, what failed
-    and why, and the tool tally. Two rounds that agree on all four produce the
-    same sentence, and the second one is the noise `_report_mcp_startup`
-    suppresses.
-
-    Object identity is deliberately NOT the key even though ``McpStartupOutcome``
-    is frozen: ``RemoteSession`` rehydrates the owner's outcome into a fresh
-    instance on every attach (``session/remote.py``), so identity — and a plain
-    ``in`` over a list of dataclasses, which would compare equal but for the
-    unhashable ``failures`` dict — either fails to dedupe or cannot be stored.
-
-    ``configured`` and ``connected`` are sorted because they are SETS with an
-    incidental order: the connect order varies run to run (and between the gate
-    snapshot and the settled round), and an order-sensitive key would re-toast
-    an outcome whose content is identical. ``failures`` is flattened to sorted
-    pairs for the same reason and because a dict cannot be hashed.
-    """
-    failures = dict(getattr(outcome, "failures", {}) or {})
-    return (
-        tuple(sorted(getattr(outcome, "configured", ()) or ())),
-        tuple(sorted(getattr(outcome, "connected", ()) or ())),
-        tuple(sorted(failures.items())),
-        int(getattr(outcome, "tool_count", 0) or 0),
-    )
 
 
 def _canonical_frontend(session: Any) -> bool:

--- a/local_operator/tui/app.py
+++ b/local_operator/tui/app.py
@@ -1584,9 +1584,13 @@ class _ApprovalsFollow(NamedTuple):
 class _McpAnnounce(NamedTuple):
     """An MCP startup announce that was actually put on screen.
 
-    Two fields because "has the user been told this" and "is the card carrying
-    it still the one on screen" are different questions, and the second cannot
-    be answered by the words.
+    Two fields because "has the user been told this" and "is this the same
+    CARD that carried it" are different questions, and the second cannot be
+    answered by the words.
+
+    Held as the app's ``_last_mcp_announce`` this is the most recent announce,
+    not the card on screen: only an eviction clears it, so it survives the card
+    being dismissed or timing out (UX round 3, U3-3).
 
     ``sentence`` is the UNTRUNCATED text, so the comparison is width-independent
     (review round 2, R2-1/R2-2). ``generation`` is :attr:`Toast.generation` at
@@ -2382,12 +2386,26 @@ class OperatorApp(App[None]):
         #: global slot re-announced on every single click, 20 in 20, which is
         #: the reported defect at full strength.
         #:
-        #: CURRENT: the sentence the card on screen is carrying, with the
-        #: generation of that card. A session seeing a sentence that another
-        #: session has just put on screen is already looking at it, so it
-        #: inherits that record rather than raising a duplicate — that is what
-        #: keeps four sidebar clicks onto one shared MCP set to one toast even
-        #: though the four sessions have no per-session record between them.
+        #: CURRENT: the sentence the most recent announce carried, with the
+        #: generation of that card, held until that card is EVICTED. A session
+        #: that has never been told anything and whose sentence is the one the
+        #: user was most recently shown inherits that record rather than raising
+        #: a duplicate — that is what keeps four sidebar clicks onto one shared
+        #: MCP set to one toast even though the four sessions have no
+        #: per-session record between them, and it must keep working across the
+        #: card being dismissed between those clicks, which is the honest
+        #: sidebar gesture.
+        #:
+        #: Deliberately NOT "the card on screen": nothing clears this on the
+        #: ordinary retirement (timer expiry, or the user clicking the card
+        #: away), so it outlives the card, and writing the screen invariant here
+        #: promised a guarantee the code does not maintain (UX round 3, U3-3).
+        #: What makes the outliving safe is the `told is None` gate below rather
+        #: than any screen state — a session carrying its own, contradicting
+        #: record can never inherit over the top of it, so retired words cannot
+        #: swallow a genuine new failure (review round 3, R3-1; UX round 3,
+        #: U3-1). What is left is a session with no history reading words the
+        #: user was shown moments ago, which is the shared-set case itself.
         #:
         #: Together they give A→A silent, A→B→A on the SAME session announcing
         #: (a server that breaks, recovers and breaks again is the most
@@ -2403,10 +2421,18 @@ class OperatorApp(App[None]):
         #:
         #: Bounded by the sessions ATTACHED in this process, not by attaches
         #: and not by outcomes: a re-attach and a changed outcome both write
-        #: the same entry. 276 B per entry measured (dict slot 26 B + key
-        #: string 68 B + record 182 B), so a thousand attached sessions cost
-        #: ~270 KiB and a day's sidebar catalogue is kilobytes. No cap is
-        #: warranted and none is imposed (review round 1, R1-3's standard).
+        #: the same entry, so the entry count is the count of distinct sessions
+        #: the user has clicked into since launch, and a day's sidebar
+        #: catalogue is hundreds at the outside. Each entry is a key string
+        #: plus a two-field record — hundreds of bytes, not kilobytes — so no
+        #: cap is warranted and none is imposed (review round 1, R1-3's
+        #: standard). Stated structurally rather than as a byte figure on
+        #: purpose: three rounds measured 194 B, 276 B and 286 B for this
+        #: entry and all three were honest, because the answer depends on
+        #: whether the key string and the shared sentence fall inside the
+        #: measurement window (review round 3, R3-4; QA round 3, Q3-2). The
+        #: session count is the term that decides whether a cap is needed, and
+        #: it is not method-dependent.
         #:
         #: Written when the toast is DISPLAYED, not when `show` is called — the
         #: single slot may evict a 5 s courtesy card, and recording at call
@@ -10847,14 +10873,24 @@ class OperatorApp(App[None]):
             return
         text, duration_ms = payload
         # A session with no usable id (a reduced facade, a test double) shares
-        # one bucket with every other id-less host, so a second such host loses
-        # a notice it was owed. Accepted: no production session reaches here
-        # without an id — `SessionProtocol.session_id` returns `str`, `Session`
-        # falls back to the transcript directory name and `RemoteSession` takes
-        # the id as a constructor argument — and a shared bucket still dedupes
-        # the repeat this method exists to stop (review round 1, R1-4). Derived
-        # once and shared with the notice ledger below, so the two surfaces can
-        # never disagree about which session they are talking about.
+        # one bucket with every other id-less host. Under the per-session record
+        # that degrades further than it did under round 1's global slot, and the
+        # justification written there no longer holds: two id-less hosts with
+        # DIFFERENT outcomes now flip the single `""` entry on every attach, so
+        # alternating between them announces every time — the reported defect at
+        # full strength in this lane, measured at 20 of 20 clicks (review round
+        # 3, R3-3; QA round 3, Q3-1). It is accepted rather than fixed because
+        # no production session reaches here without an id, which QA traced
+        # rather than assumed: all three `_report_mcp_startup` callers are on
+        # the adopted-session path, `SessionProtocol.session_id` returns `str`,
+        # `Session` falls back to the transcript directory name,
+        # `RemoteSession` takes the id as a constructor argument, and the one
+        # `str | None` implementation (`headless_print`) is never adopted by
+        # this app. Keying id-less hosts by `id(session)` would close the lane
+        # but buy nothing reachable, so the honest statement is that a keyless
+        # host announces per attach. Derived once and shared with the notice
+        # ledger below, so the two surfaces can never disagree about which
+        # session they are talking about.
         try:
             session_key = str(getattr(session, "session_id", "") or "")
         except Exception:  # noqa: BLE001 — a property may raise on a reduced host
@@ -10875,12 +10911,27 @@ class OperatorApp(App[None]):
         told = self._announced_mcp_startup.get(session_key)
         if told is None or told.sentence != sentence:
             showing = self._last_mcp_announce
-            if showing is not None and showing.sentence == sentence:
-                # Another session just put these words on screen and they are
-                # still there, so this session is looking at its news already.
-                # It inherits that card's generation, so one eviction releases
-                # every session the card spoke for — otherwise a piggybacking
-                # session would keep a record for a card nobody read.
+            if told is None and showing is not None and showing.sentence == sentence:
+                # A session with NO history of its own, landing on words another
+                # session raised most recently: it is looking at its news
+                # already. It inherits that card's generation, so one eviction
+                # releases every session the card spoke for — otherwise a
+                # piggybacking session would keep a record for a card nobody
+                # read.
+                #
+                # `told is None` is the load-bearing half. `_last_mcp_announce`
+                # is released by eviction only, so after the ORDINARY
+                # retirement — the timer expiring, the user clicking the card
+                # away — it still names words that have left the screen. A
+                # session whose server then genuinely died matched those retired
+                # words and was marked told, so its failure never announced at
+                # all (review round 3, R3-1; UX round 3, U3-1). A session that
+                # was told something else is, by its own record, not looking at
+                # these words — whatever is on screen — so it may never inherit
+                # over the top of that. Gating on `toast.display` instead is the
+                # wrong reading and breaks the case this branch exists for: the
+                # shared-set clicks legitimately inherit across a card the user
+                # already dismissed.
                 self._announced_mcp_startup[session_key] = showing
             else:
                 # Tagged with the app so the eviction notice can be told from
@@ -10933,13 +10984,21 @@ class OperatorApp(App[None]):
         any that piggybacked on the words already being on screen. Sessions told
         by an earlier card are untouched: they were told by a card that retired
         normally, and re-arming them would announce news they have read.
+
+        That per-session filter is the ONLY release, and it always runs. The
+        global slot is a separate, weaker fact — the card showing most recently
+        — and short-circuiting on it dropped exactly the case this PR is about:
+        two quick sidebar clicks, where session ``b``'s card displaces ``a``'s
+        unread, moves the slot to ``b``'s generation, and left ``a`` marked told
+        for a card nobody saw (review round 3, R3-2). The filter needs no such
+        guard because it is already scoped to the evicted card's generation, so
+        it can only ever release the sessions that card spoke for.
         """
         if message.owner is not MCP_STARTUP_TOAST_OWNER:
             return
         showing = self._last_mcp_announce
-        if showing is None or showing.generation != message.generation:
-            return
-        self._last_mcp_announce = None
+        if showing is not None and showing.generation == message.generation:
+            self._last_mcp_announce = None
         self._announced_mcp_startup = {
             key: announce
             for key, announce in self._announced_mcp_startup.items()

--- a/local_operator/tui/widgets/toast.py
+++ b/local_operator/tui/widgets/toast.py
@@ -226,16 +226,24 @@ class Toast(Static):
         evicts it (UX round 1, U2) — this is how its owner learns to announce
         again rather than treating the news as delivered.
 
-        Carries the card's TEXT as well as its owner: an owner that raises a
-        second card legitimately evicts its own first one, and the text is what
-        lets it tell "my stale card was dropped" from "my current card is the
-        one that dropped it".
+        Carries the card's GENERATION as well as its owner, and the text for
+        the reader's convenience only. The generation is the identity: an owner
+        that raises a second card legitimately evicts its own first one, and
+        matching on TEXT cannot tell "my stale card was dropped" from "my
+        current card is the one that dropped it" whenever the same words recur.
+        That is not hypothetical — a server that breaks, recovers and breaks
+        again inside one card's 5 s produces A→B→A, so the queued
+        ``Evicted(text=A)`` matches a record that has since come back to A and
+        releases an announce the user is reading right now (review round 2,
+        R2-3). :attr:`Toast.generation` exists for exactly this and says so:
+        "two notices can word themselves identically".
         """
 
-        def __init__(self, owner: object, text: str) -> None:
+        def __init__(self, owner: object, text: str, generation: int) -> None:
             super().__init__()
             self.owner = owner
             self.text = text
+            self.generation = generation
 
     def __init__(self) -> None:
         super().__init__("")
@@ -339,8 +347,17 @@ class Toast(Static):
         # is owed the news that the interruption it asked for never landed. See
         # :class:`Evicted`. Only OWNED cards are reported: an unowned card has
         # nobody to tell, and posting for one is traffic with no reader.
-        if self.display and self._owner is not None:
-            self.post_message(self.Evicted(self._owner, self._message))
+        #
+        # Captured BEFORE the state below is overwritten, but posted AFTER every
+        # guard that can still decline the slot, so the notice is true by
+        # construction rather than by the current guard ordering: any early
+        # return added between here and the replacement would otherwise announce
+        # an eviction that never happened (review round 2, R2-4).
+        evicted = (
+            self.Evicted(self._owner, self._message, self._generation)
+            if self.display and self._owner is not None
+            else None
+        )
         self._deferred = None
         self._stop_timer()
         self._generation += 1
@@ -360,6 +377,8 @@ class Toast(Static):
         self.display = True
         self._refit()
         self._timer = self.set_timer(duration_ms / 1000, self.dismiss_toast)
+        if evicted is not None:
+            self.post_message(evicted)
 
     def withdraw(self, owner: object) -> None:
         """Retire ``owner``'s card, whether it is SHOWING or still held.

--- a/local_operator/tui/widgets/toast.py
+++ b/local_operator/tui/widgets/toast.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 from rich.cells import cell_len
 from rich.style import Style
 from rich.text import Text
+from textual.message import Message
 from textual.screen import Screen
 from textual.widgets import Static
 
@@ -209,6 +210,33 @@ class Toast(Static):
     window in which two cards exist at once.
     """
 
+    class Evicted(Message):
+        """An owned card was REPLACED while it was still showing.
+
+        The distinction this carries is "thrown away" versus "retired": a card
+        that ran its timer out, or that the user clicked away, was delivered —
+        they had their chance to read it. A card overwritten mid-display was
+        not, and a caller that announces something ONCE needs to know the
+        difference, because its record of "already told them" is otherwise
+        spent on a card nobody saw.
+
+        Concretely, the single slot is shared and ``yield_to_actionable`` only
+        protects an incumbent that is :data:`TOAST_FAILURE_MS`-long. The MCP
+        startup announce is a 5 s courtesy card, so a routine copy receipt
+        evicts it (UX round 1, U2) — this is how its owner learns to announce
+        again rather than treating the news as delivered.
+
+        Carries the card's TEXT as well as its owner: an owner that raises a
+        second card legitimately evicts its own first one, and the text is what
+        lets it tell "my stale card was dropped" from "my current card is the
+        one that dropped it".
+        """
+
+        def __init__(self, owner: object, text: str) -> None:
+            super().__init__()
+            self.owner = owner
+            self.text = text
+
     def __init__(self) -> None:
         super().__init__("")
         # Hidden means ``display: none`` — zero rows, so an empty slot cannot
@@ -307,6 +335,12 @@ class Toast(Static):
             # the stacking this widget exists to avoid.
             self._deferred = (text, duration_ms, owner)
             return
+        # A SHOWING card is being thrown away rather than retired, so its owner
+        # is owed the news that the interruption it asked for never landed. See
+        # :class:`Evicted`. Only OWNED cards are reported: an unowned card has
+        # nobody to tell, and posting for one is traffic with no reader.
+        if self.display and self._owner is not None:
+            self.post_message(self.Evicted(self._owner, self._message))
         self._deferred = None
         self._stop_timer()
         self._generation += 1

--- a/scripts/mcp_toast_attach_shot.py
+++ b/scripts/mcp_toast_attach_shot.py
@@ -1,0 +1,146 @@
+"""Capture the frame a SIDEBAR ATTACH leaves behind, for the MCP startup toast.
+
+Run from the worktree root:
+
+    env -u NO_COLOR TERM=xterm-256color .venv/bin/python \
+        scripts/mcp_toast_attach_shot.py OUT.svg [COLSxROWS]
+
+The reported defect is a frame, not a log line: "MCP ready: 12 servers, 425
+tools" painted over the user's transcript on EVERY session attach, including
+every click in the session sidebar. So the evidence for the fix has to be the
+frame after an attach — the toast present on the pre-fix tree, absent on the
+fixed one — which is what this script renders.
+
+WHAT IT DOES, and why in this order. It boots the app on a session carrying a
+startup outcome, lets the boot toast appear, DISMISSES it (the boot announce is
+wanted and is not what is under test), then adopts a SECOND session carrying an
+outcome with identical content — which is what a sidebar click does, since MCP
+servers are process-wide and every session in the list shares one set. The
+frame captured is the one the user is looking at a beat after that click.
+
+The transcript is seeded first so the toast has something to paint OVER: an
+overlay against an empty splash understates the interruption the report is
+about. The status band is in frame deliberately — it carries the live
+``⊙ 3 MCP`` segment on both trees, and that segment continuing to re-state MCP
+state on every attach is precisely what makes silencing the repeat toast safe.
+
+Set ``LO_MCP_TOAST_SHOT_STAGE=boot`` to capture the FIRST loadup instead, which
+is the half of the rule that must not change: the fix suppresses the repeat, not
+the announce. A before/after pair of the attach frame alone cannot show that,
+since both trees are expected to differ there — the boot pair proves the two
+trees still agree where they should.
+
+Deterministic: the outcome is fixed, the toast's own dismissal timer is far
+longer than the capture, and nothing here animates.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.visual_capture import isolate_capture, save_capture  # noqa: E402
+
+isolate_capture()
+
+from local_operator.session.mcp_status import McpStartupOutcome  # noqa: E402
+from local_operator.tui.app import OperatorApp  # noqa: E402
+from local_operator.tui.widgets.assistant import AssistantBlock  # noqa: E402
+from local_operator.tui.widgets.toast import Toast  # noqa: E402
+from local_operator.tui.widgets.transcript import UserBlock  # noqa: E402
+from tests.unit.tui.test_app_pilot import (  # noqa: E402
+    FakeMcpManager,
+    McpSession,
+    _band,
+    _factory,
+)
+
+#: The reported shape, shrunk to fit a 100-column frame: several servers up and
+#: a four-figure tool tally, exactly the sentence the operator saw repeated.
+OUTCOME = McpStartupOutcome(
+    configured=("github", "linear", "slack"),
+    connected=("github", "linear", "slack"),
+    tool_count=425,
+)
+
+
+class _IdentifiedMcpSession(McpSession):
+    """``McpSession`` with a distinct id, so the two sessions are not one."""
+
+    def __init__(self, session_id: str) -> None:
+        super().__init__(
+            FakeMcpManager(list(OUTCOME.configured), list(OUTCOME.connected)),
+            OUTCOME,
+        )
+        self._session_id = session_id
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+
+async def main() -> None:
+    out = sys.argv[1]
+    size = (100, 30)
+    if len(sys.argv) > 2:
+        cols, rows = sys.argv[2].split("x")
+        size = (int(cols), int(rows))
+
+    first = _IdentifiedMcpSession("aaaaaaaaaaa1")
+    second = _IdentifiedMcpSession("aaaaaaaaaaa2")
+
+    app = OperatorApp(lambda: _factory(first))
+    async with app.run_test(size=size) as pilot:
+        for _ in range(6):
+            await pilot.pause()
+
+        toast = app.query_one(Toast)
+        assert toast.display is True, "the BOOT announce is expected on both trees"
+        boot_message = toast.message
+
+        if os.environ.get("LO_MCP_TOAST_SHOT_STAGE") == "boot":
+            # First loadup, over the splash the user actually sees on launch —
+            # no seeded transcript, because that is not the state a boot is in.
+            save_capture(app, out)
+            print(
+                f"terminal={size[0]}x{size[1]} stage=boot "
+                f"toast_display={toast.display} toast_message={boot_message!r}"
+            )
+            return
+
+        toast.dismiss_toast()
+        await pilot.pause()
+
+        for turn in range(1, 6):
+            app._append_block(UserBlock(f"Turn {turn}: can you check the release window?"))
+            prose = AssistantBlock()
+            prose.update_text(
+                f"Answer {turn}: the merge queue is clear, so the window is open. "
+                "Nothing else is waiting on a tag right now."
+            )
+            app._append_block(prose)
+        await pilot.pause()
+
+        # THE ATTACH under test: a sidebar click onto a sibling session that
+        # shares this process's MCP servers.
+        app._adopt_session(second, replay_history=False)
+        for _ in range(6):
+            await pilot.pause()
+
+        save_capture(app, out)
+        band = _band(app)
+        print(
+            f"terminal={size[0]}x{size[1]} "
+            f"boot_toast={boot_message!r} "
+            f"toast_after_attach_display={toast.display} "
+            f"toast_after_attach_message={toast.message!r} "
+            f"band_has_mcp={'MCP' in band} "
+            f"band={band.strip()!r}"
+        )
+
+
+asyncio.run(main())

--- a/scripts/mcp_toast_attach_shot.py
+++ b/scripts/mcp_toast_attach_shot.py
@@ -32,6 +32,12 @@ trees still agree where they should.
 
 Deterministic: the outcome is fixed, the toast's own dismissal timer is far
 longer than the capture, and nothing here animates.
+
+Every wait here POLLS for the condition rather than spending a fixed number of
+ticks. A fixed budget raced the boot announce and tripped this script's own
+assertion in 2 of 11 runs on an idle machine (UX round 1, U6) — the app is fine,
+but the next person re-capturing evidence reads a script flake as a product
+regression. AGENTS.md's timing section: wait on the event, never on the clock.
 """
 
 from __future__ import annotations
@@ -83,6 +89,20 @@ class _IdentifiedMcpSession(McpSession):
         return self._session_id
 
 
+async def _until(pilot, predicate) -> bool:  # type: ignore[no-untyped-def]
+    """Pause until ``predicate()`` holds, or the budget runs out.
+
+    Returns whether it held, so a caller asserting the NEGATIVE — a toast that
+    must stay absent — can still spend the full budget looking for it instead
+    of concluding from a frame that had not settled yet.
+    """
+    for _ in range(200):
+        await pilot.pause()
+        if predicate():
+            return True
+    return False
+
+
 async def main() -> None:
     out = sys.argv[1]
     size = (100, 30)
@@ -95,11 +115,10 @@ async def main() -> None:
 
     app = OperatorApp(lambda: _factory(first))
     async with app.run_test(size=size) as pilot:
-        for _ in range(6):
-            await pilot.pause()
-
         toast = app.query_one(Toast)
-        assert toast.display is True, "the BOOT announce is expected on both trees"
+        assert await _until(
+            pilot, lambda: toast.display
+        ), "the BOOT announce is expected on both trees"
         boot_message = toast.message
 
         if os.environ.get("LO_MCP_TOAST_SHOT_STAGE") == "boot":
@@ -128,8 +147,12 @@ async def main() -> None:
         # THE ATTACH under test: a sidebar click onto a sibling session that
         # shares this process's MCP servers.
         app._adopt_session(second, replay_history=False)
-        for _ in range(6):
-            await pilot.pause()
+        # The expected outcome here is ABSENCE, which no condition can confirm
+        # early — so this one spends the whole budget on purpose, and captures
+        # whatever the toast is doing by the end of it. On the pre-fix tree the
+        # poll trips as soon as the re-announce lands, which is the frame that
+        # script exists to capture.
+        await _until(pilot, lambda: toast.display)
 
         save_capture(app, out)
         band = _band(app)

--- a/tests/unit/tui/test_mcp_startup_announce.py
+++ b/tests/unit/tui/test_mcp_startup_announce.py
@@ -7,11 +7,14 @@ sidebar switch re-announced a round that happened minutes ago — and, through
 ``RemoteSession``'s rehydration of the owner's outcome, sometimes a round this
 process never ran at all.
 
-These tests pin the rule the fix implements: announce at most once per app
-process per DISTINCT outcome (content, not session identity), with the durable
-failure notice deduped per session instead. The status band is asserted
-alongside, because the suppression is only safe while the band keeps
-re-stating live MCP state on every attach.
+These tests pin the rule the fix implements: the toast announces only what
+differs from the sentence CURRENTLY announced, so a re-attach saying the same
+thing is silent (A→A) while a server that breaks, recovers and breaks again is
+announced every time (A→B→A). The record is taken when the card is DISPLAYED,
+not when ``show`` is called, so an announce evicted unread is not spent. The
+durable failure notice is deduped per session AND per failure instead. The
+status band is asserted alongside, because the suppression is only safe while
+the band keeps re-stating live MCP state on every attach.
 """
 
 from __future__ import annotations
@@ -81,15 +84,43 @@ def _session(outcome: McpStartupOutcome, *, session_id: str) -> _IdentifiedMcpSe
     return _IdentifiedMcpSession(manager, outcome, session_id)
 
 
+#: The reported failure, as a whole outcome: slack down, the other two up.
+_SLACK_DOWN = dict(
+    connected=("github", "linear"),
+    failures={"slack": "command not found: slack-mcp"},
+    tool_count=310,
+)
+
+
+async def _until(pilot, predicate) -> bool:  # type: ignore[no-untyped-def]
+    """Pause until ``predicate()`` holds, or the budget runs out.
+
+    Polled rather than a fixed tick count: a wall-clock-shaped wait is what
+    made the evidence script flake ~18% of the time under load (UX round 1,
+    U6), and AGENTS.md's timing section says to wait on the event, not the
+    clock. Returns whether it held, so a caller asserting the NEGATIVE (a toast
+    that must stay silent) can still spend the full budget looking for it.
+    """
+    for _ in range(200):
+        await pilot.pause()
+        if predicate():
+            return True
+    return False
+
+
+async def _quiet(pilot) -> None:  # type: ignore[no-untyped-def]
+    """Give a toast that must NOT appear every chance to appear anyway."""
+    for _ in range(20):
+        await pilot.pause()
+
+
 @pytest.mark.asyncio
 async def test_boot_announces_the_startup_outcome() -> None:
     """First loadup is exactly what the operator wants announced."""
     app = OperatorApp(lambda: _factory(_session(_outcome(), session_id="a")))
     async with app.run_test(size=(100, 24)) as pilot:
-        for _ in range(6):
-            await pilot.pause()
         toast = app.query_one(Toast)
-        assert toast.display is True
+        assert await _until(pilot, lambda: toast.display)
         assert "MCP ready: 3 servers, 425 tools" in toast.message
 
 
@@ -102,19 +133,50 @@ async def test_attaching_a_second_session_with_the_same_outcome_stays_silent() -
     second = _session(_outcome(), session_id="b")
     app = OperatorApp(lambda: _factory(first))
     async with app.run_test(size=(100, 24)) as pilot:
-        for _ in range(6):
-            await pilot.pause()
         toast = app.query_one(Toast)
-        assert toast.display is True
+        assert await _until(pilot, lambda: toast.display)
         toast.dismiss_toast()
         await pilot.pause()
 
         app._adopt_session(second, replay_history=False)
-        for _ in range(6):
-            await pilot.pause()
+        await _quiet(pilot)
         assert toast.display is False, "a re-attach re-announced a boot snapshot"
         # The surface that legitimately re-states MCP state per attach.
-        assert "⊙ 3 MCP" in _band(app)
+        assert "\u2299 3 MCP" in _band(app)
+
+
+@pytest.mark.asyncio
+async def test_four_sidebar_clicks_onto_one_mcp_set_announce_once() -> None:
+    """The operator's actual complaint, at the count they reported it at.
+
+    A\u2192A\u2192A\u2192A\u2192A: the sentence never changes, so only the first announces.
+    Pinned at four attaches rather than one because "only the CURRENT announce
+    is compared" would still be satisfied by a rule that alternated, and this
+    is the case that must not regress while U1 is being fixed.
+    """
+    sessions = [_session(_outcome(), session_id=f"s{i}") for i in range(5)]
+    shown: list[str] = []
+    app = OperatorApp(lambda: _factory(sessions[0]))
+    async with app.run_test(size=(100, 24)) as pilot:
+        toast = app.query_one(Toast)
+        original = toast.show
+
+        def _spy(text, **kwargs):  # type: ignore[no-untyped-def]
+            shown.append(text.plain if hasattr(text, "plain") else str(text))
+            return original(text, **kwargs)
+
+        assert await _until(pilot, lambda: toast.display)
+        assert toast.message.startswith("\u2299 MCP ready")
+        toast.show = _spy  # type: ignore[method-assign]
+
+        for session in sessions[1:]:
+            toast.dismiss_toast()
+            await pilot.pause()
+            app._adopt_session(session, replay_history=False)
+            await _quiet(pilot)
+            assert toast.display is False
+
+        assert shown == [], f"a re-attach re-announced: {shown}"
 
 
 @pytest.mark.asyncio
@@ -124,21 +186,19 @@ async def test_re_adopting_the_same_session_stays_silent() -> None:
     session = _session(_outcome(), session_id="a")
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 24)) as pilot:
-        for _ in range(6):
-            await pilot.pause()
         toast = app.query_one(Toast)
+        assert await _until(pilot, lambda: toast.display)
         toast.dismiss_toast()
         await pilot.pause()
         app._adopt_session(session, replay_history=False)
-        for _ in range(6):
-            await pilot.pause()
+        await _quiet(pilot)
         assert toast.display is False
 
 
 @pytest.mark.asyncio
 async def test_a_changed_tally_announces_again() -> None:
     """A session in another cwd with a genuinely different server set IS news,
-    and the fingerprint is content — so it announces once of its own."""
+    and the key is the rendered sentence — so it announces once of its own."""
     first = _session(_outcome(), session_id="a")
     second = _session(
         _outcome(
@@ -150,24 +210,21 @@ async def test_a_changed_tally_announces_again() -> None:
     )
     app = OperatorApp(lambda: _factory(first))
     async with app.run_test(size=(100, 24)) as pilot:
-        for _ in range(6):
-            await pilot.pause()
         toast = app.query_one(Toast)
+        assert await _until(pilot, lambda: toast.display)
         toast.dismiss_toast()
         await pilot.pause()
 
         app._adopt_session(second, replay_history=False)
-        for _ in range(6):
-            await pilot.pause()
-        assert toast.display is True
+        assert await _until(pilot, lambda: toast.display)
         assert "MCP ready: 4 servers, 511 tools" in toast.message
 
 
 @pytest.mark.asyncio
 async def test_connect_order_alone_does_not_re_announce() -> None:
-    """``connected`` is a set with an incidental order — the connect race
+    """``connected`` is a set with an incidental order \u2014 the connect race
     reorders it run to run. An order-sensitive key would re-toast an outcome
-    whose content is identical, which is why the fingerprint sorts."""
+    whose content is identical; the rendered sentence is inherently immune."""
     first = _session(_outcome(), session_id="a")
     second = _session(
         _outcome(connected=("slack", "github", "linear")),
@@ -175,22 +232,175 @@ async def test_connect_order_alone_does_not_re_announce() -> None:
     )
     app = OperatorApp(lambda: _factory(first))
     async with app.run_test(size=(100, 24)) as pilot:
-        for _ in range(6):
-            await pilot.pause()
         toast = app.query_one(Toast)
+        assert await _until(pilot, lambda: toast.display)
         toast.dismiss_toast()
         await pilot.pause()
         app._adopt_session(second, replay_history=False)
-        for _ in range(6):
-            await pilot.pause()
+        await _quiet(pilot)
         assert toast.display is False
+
+
+@pytest.mark.asyncio
+async def test_the_same_failure_recurring_after_a_recovery_announces_again() -> None:
+    """UX round 1, U1 \u2014 the regression the ever-growing ledger introduced.
+
+    A ``lop`` window lives for days, so a server that dies, recovers and dies
+    AGAIN is the operator's normal shape. Keyed by "every sentence ever shown",
+    the second death was silent forever because its sentence had been retired
+    hours earlier \u2014 suppressing a RECURRING FAILURE, which is the single most
+    interruption-worthy thing this surface reports and the exact opposite of
+    the intent. Keyed against the CURRENT announce only, A\u2192B\u2192A announces on
+    the return, and it keeps announcing however often the server flaps.
+    """
+    session = _session(_outcome(), session_id="a")
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        toast = app.query_one(Toast)
+        assert await _until(pilot, lambda: toast.display)
+        assert "MCP ready: 3 servers" in toast.message
+
+        for round_number in range(1, 4):
+            # It breaks.
+            toast.dismiss_toast()
+            await pilot.pause()
+            session.mcp_startup = _outcome(**_SLACK_DOWN)
+            app._report_mcp_startup(session)
+            assert await _until(pilot, lambda: toast.display), (
+                f"breakage {round_number} was silent \u2014 a recurring failure "
+                "must always announce"
+            )
+            assert "2 of 3 servers up" in toast.message
+            assert "slack" in toast.message
+
+            # It recovers. Also news: pre-fix this announced too.
+            toast.dismiss_toast()
+            await pilot.pause()
+            session.mcp_startup = _outcome()
+            app._report_mcp_startup(session)
+            assert await _until(pilot, lambda: toast.display), f"recovery {round_number} was silent"
+            assert "MCP ready: 3 servers" in toast.message
+
+
+@pytest.mark.asyncio
+async def test_an_announce_evicted_before_it_is_read_is_not_spent() -> None:
+    """UX round 1, U2 \u2014 the announce is consumed on being SEEN, not on being
+    shown.
+
+    The single toast slot is shared, and ``yield_to_actionable`` only protects
+    an incumbent whose duration is ``TOAST_FAILURE_MS``. The healthy announce is
+    ``TOAST_DEFAULT_MS``, so a routine copy receipt inside those 5 s replaces
+    it. Recording at ``show`` time spent the user's ONE announce on a card they
+    never read, with no second chance now the rule is one-shot.
+    """
+    first = _session(_outcome(), session_id="a")
+    second = _session(_outcome(), session_id="b")
+    app = OperatorApp(lambda: _factory(first))
+    async with app.run_test(size=(100, 24)) as pilot:
+        toast = app.query_one(Toast)
+        assert await _until(pilot, lambda: toast.display)
+        assert "MCP ready: 3 servers" in toast.message
+
+        # The documented eviction: a routine copy receipt, which asks to yield
+        # but is not made to, because the announce is not actionable.
+        toast.show("copied 12 lines to clipboard", yield_to_actionable=True)
+        assert await _until(pilot, lambda: toast.message.startswith("copied"))
+        assert "MCP" not in toast.message, "the announce really was evicted"
+
+        # The next attach owes the user the announce they never got to read.
+        toast.dismiss_toast()
+        await pilot.pause()
+        app._adopt_session(second, replay_history=False)
+        assert await _until(
+            pilot, lambda: toast.display
+        ), "an evicted announce was still counted as told"
+        assert "MCP ready: 3 servers, 425 tools" in toast.message
+
+
+@pytest.mark.asyncio
+async def test_an_announce_the_user_actually_saw_is_not_re_announced() -> None:
+    """The other half of U2: eviction is not the same as expiry.
+
+    A card that ran its timer out, or that the user clicked away, WAS delivered
+    \u2014 they had their chance to read it. Only a card thrown away mid-display
+    releases the record. Without this, `on_toast_evicted` would re-arm on every
+    normal dismissal and the reported defect would return.
+    """
+    first = _session(_outcome(), session_id="a")
+    second = _session(_outcome(), session_id="b")
+    app = OperatorApp(lambda: _factory(first))
+    async with app.run_test(size=(100, 24)) as pilot:
+        toast = app.query_one(Toast)
+        assert await _until(pilot, lambda: toast.display)
+        toast.dismiss_toast()  # read and dismissed, the ordinary path
+        await pilot.pause()
+        app._adopt_session(second, replay_history=False)
+        await _quiet(pilot)
+        assert toast.display is False
+
+
+@pytest.mark.asyncio
+async def test_an_actionable_failure_announce_is_held_not_evicted() -> None:
+    """The failure announce is ``TOAST_FAILURE_MS`` and therefore actionable, so
+    a courtesy receipt defers to it rather than evicting it. It must stay
+    recorded: nothing was thrown away, so a re-attach is still a repeat."""
+    session = _session(_outcome(**_SLACK_DOWN), session_id="a")
+    other = _session(_outcome(**_SLACK_DOWN), session_id="b")
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        toast = app.query_one(Toast)
+        assert await _until(pilot, lambda: toast.display)
+        assert "2 of 3 servers up" in toast.message
+
+        toast.show("copied 12 lines to clipboard", yield_to_actionable=True)
+        await _quiet(pilot)
+        assert (
+            "2 of 3 servers up" in toast.message
+        ), "the actionable announce should have held the slot"
+
+        toast.dismiss_toast()
+        await _until(pilot, lambda: toast.message.startswith("copied"))
+        toast.dismiss_toast()
+        await pilot.pause()
+        app._adopt_session(other, replay_history=False)
+        await _quiet(pilot)
+        assert toast.display is False, "a held announce was never lost, so it is a repeat"
+
+
+@pytest.mark.asyncio
+async def test_two_server_sets_rendering_one_sentence_announce_once() -> None:
+    """Review round 1, R1-2 \u2014 the key is what the user would READ.
+
+    Two disjoint server sets of the same size and tool tally render a
+    byte-identical sentence. Keyed structurally, the user saw the same words
+    twice for no reason; keyed on the sentence, it is one piece of news.
+    """
+    first = _session(_outcome(), session_id="a")
+    second = _session(
+        _outcome(
+            configured=("notion", "sentry", "stripe"),
+            connected=("notion", "sentry", "stripe"),
+        ),
+        session_id="b",
+    )
+    app = OperatorApp(lambda: _factory(first))
+    async with app.run_test(size=(100, 24)) as pilot:
+        toast = app.query_one(Toast)
+        assert await _until(pilot, lambda: toast.display)
+        sentence = toast.message
+        toast.dismiss_toast()
+        await pilot.pause()
+
+        app._adopt_session(second, replay_history=False)
+        await _quiet(pilot)
+        assert toast.display is False, f"the same sentence {sentence!r} was announced twice"
 
 
 @pytest.mark.asyncio
 async def test_the_settled_outcome_still_announces_after_a_silent_gate() -> None:
     """The 250 ms gate snapshot is ``settling`` and unreportable, so it records
-    nothing; the settled round that follows carries its own fingerprint and is
-    the one the user actually sees. The fix must not consume the gate pass."""
+    nothing; the settled round that follows renders its own sentence and is the
+    one the user actually sees. The fix must not consume the gate pass."""
     settling = McpStartupOutcome(
         configured=("github", "linear", "slack"),
         settling=True,
@@ -198,52 +408,201 @@ async def test_the_settled_outcome_still_announces_after_a_silent_gate() -> None
     session = _session(settling, session_id="a")
     app = OperatorApp(lambda: _factory(session))
     async with app.run_test(size=(100, 24)) as pilot:
-        for _ in range(6):
-            await pilot.pause()
         toast = app.query_one(Toast)
+        await _quiet(pilot)
         assert toast.display is False, "a settling snapshot must stay quiet"
 
         # What the manager's settle callback does: the factory rebuilds
         # ``session.mcp_startup`` with the final tally, then the app re-reports.
         session.mcp_startup = _outcome()
         app._report_mcp_startup(session)
-        await pilot.pause()
-        assert toast.display is True
+        assert await _until(pilot, lambda: toast.display)
         assert "MCP ready: 3 servers, 425 tools" in toast.message
 
 
 @pytest.mark.asyncio
 async def test_a_failure_notice_is_written_once_per_session() -> None:
     """A durable failure record belongs in the transcript of the session it
-    describes — so a SECOND session gets its own copy — but the repeat on the
+    describes \u2014 so a SECOND session gets its own copy \u2014 but the repeat on the
     same session is the duplicate the re-attach used to append."""
-    outcome = _outcome(
-        connected=("github", "linear"),
-        failures={"slack": "command not found: slack-mcp"},
-        tool_count=310,
-    )
-    first = _session(outcome, session_id="a")
-    second = _session(outcome, session_id="b")
+    first = _session(_outcome(**_SLACK_DOWN), session_id="a")
+    second = _session(_outcome(**_SLACK_DOWN), session_id="b")
     app = OperatorApp(lambda: _factory(first))
     async with app.run_test(size=(100, 24)) as pilot:
-        for _ in range(6):
-            await pilot.pause()
-        assert _transcript_text(app).count("MCP slack failed") == 1
+        assert await _until(pilot, lambda: _transcript_text(app).count("MCP slack failed") == 1)
 
         # Same session again: the transcript already carries the record.
         app._adopt_session(first, replay_history=False)
-        for _ in range(6):
-            await pilot.pause()
+        await _quiet(pilot)
         assert _transcript_text(app).count("MCP slack failed") == 1
 
         # A different session with the same failure: its own transcript has
-        # never carried it, so it gets the record even though the toast — a
-        # process-wide interruption — stays silent.
+        # never carried it, so it gets the record even though the toast \u2014 a
+        # process-wide interruption \u2014 stays silent.
         toast = app.query_one(Toast)
         toast.dismiss_toast()
         await pilot.pause()
         app._adopt_session(second, replay_history=False)
-        for _ in range(6):
-            await pilot.pause()
-        assert _transcript_text(app).count("MCP slack failed") == 2
+        assert await _until(pilot, lambda: _transcript_text(app).count("MCP slack failed") == 2)
         assert toast.display is False
+
+
+@pytest.mark.asyncio
+async def test_a_new_failure_does_not_drag_its_neighbours_back() -> None:
+    """Review round 1, R1-1 \u2014 reproduced there as ``slack=2, github=1``.
+
+    Keyed by ``(session, whole outcome)``, a later round that ADDS a failure
+    changed the key, so the loop re-emitted EVERY failure in the outcome \u2014
+    including ones already in the transcript. Reachable via ``/mcp reload``,
+    which re-enters ``_connect_round`` and re-arms the settle. Keyed per
+    ``(session, server, error)``, each distinct failure lands once per session
+    and the new one arrives alone.
+    """
+    session = _session(_outcome(**_SLACK_DOWN), session_id="a")
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        assert await _until(pilot, lambda: _transcript_text(app).count("MCP slack failed") == 1)
+
+        # A reload round: github breaks too, slack is still broken.
+        session.mcp_startup = _outcome(
+            connected=("linear",),
+            failures={
+                "slack": "command not found: slack-mcp",
+                "github": "command not found: gh",
+            },
+            tool_count=120,
+        )
+        app._report_mcp_startup(session)
+        assert await _until(pilot, lambda: _transcript_text(app).count("MCP github failed") == 1)
+        transcript = _transcript_text(app)
+        assert (
+            transcript.count("MCP slack failed") == 1
+        ), "the already-recorded failure was re-emitted alongside the new one"
+
+
+@pytest.mark.asyncio
+async def test_a_failure_whose_error_changes_is_recorded_again() -> None:
+    """The error text is part of the key because it is the actionable half.
+
+    ``slack: command not found`` and ``slack: connection refused`` are different
+    problems with different fixes, and a key on the server name alone would
+    swallow the second."""
+    session = _session(_outcome(**_SLACK_DOWN), session_id="a")
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        assert await _until(pilot, lambda: "command not found: slack-mcp" in _transcript_text(app))
+        session.mcp_startup = _outcome(
+            connected=("github", "linear"),
+            failures={"slack": "connection refused"},
+            tool_count=310,
+        )
+        app._report_mcp_startup(session)
+        assert await _until(pilot, lambda: "connection refused" in _transcript_text(app))
+        assert _transcript_text(app).count("MCP slack failed") == 2
+
+
+@pytest.mark.asyncio
+async def test_the_failure_notice_points_at_the_standing_answer() -> None:
+    """UX round 1, U4 \u2014 ``/mcp`` is the standing answer and it was named
+    nowhere.
+
+    It matters more now the announce is one-shot: "I'll read it next time" no
+    longer works. The pointer goes on the DURABLE notice, where there is room,
+    and not on the toast, whose width budget is already tight enough to
+    truncate.
+    """
+    session = _session(_outcome(**_SLACK_DOWN), session_id="a")
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        assert await _until(pilot, lambda: "MCP slack failed" in _transcript_text(app))
+        assert "/mcp for details" in _transcript_text(app)
+        # NOT on the toast: it is width-budgeted and already two lines.
+        assert "/mcp" not in app.query_one(Toast).message
+
+
+@pytest.mark.asyncio
+async def test_the_announce_keeps_its_semantic_lamp() -> None:
+    """Comparing the plain text must not cost the toast its colour.
+
+    ``format_mcp_startup`` returns a ``Text`` carrying the lamp tint derived
+    through the band's own rule, precisely so the two surfaces cannot disagree.
+    The dedupe compares ``.plain`` — words, not styling — but what is SHOWN has
+    to stay the renderable, or a failure announce paints in the healthy colour.
+    """
+    from textual.geometry import Region
+
+    from local_operator.tui import theme as theme_mod
+
+    session = _session(_outcome(**_SLACK_DOWN), session_id="a")
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        toast = app.query_one(Toast)
+        assert await _until(pilot, lambda: toast.display)
+        # The PAINTED cells, which is the only place the lamp is observable:
+        # `Toast` stores the renderable through Textual's internal content
+        # accessor, so the frame is what a caller is entitled to inspect.
+        painted = {
+            segment.style.color.triplet.hex.lower()
+            for strip in toast.render_lines(Region(0, 0, toast.size.width, toast.size.height))
+            for segment in strip
+            if segment.style is not None
+            and segment.style.color is not None
+            and segment.style.color.triplet is not None
+        }
+        assert theme_mod.semantic_color("danger").lower() in painted, (
+            "the failure announce lost its danger lamp — it was shown as a "
+            f"bare string. painted: {sorted(painted)}"
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("columns", [100, 80, 70, 60, 50, 44, 40])
+async def test_the_notice_pointer_wraps_rather_than_truncating(columns: int) -> None:
+    """The pointer is only worth adding if the user can actually read it.
+
+    The toast was excluded from U4 precisely because it truncates; the notice
+    was chosen because it WRAPS. That distinction is the whole justification
+    for where the text went, so it is asserted against the painted cell grid
+    at the widths the band was driven at \u2014 the rendered frame, not the block's
+    source string, because only the frame shows what wrapping did to it.
+    """
+    session = _session(_outcome(**_SLACK_DOWN), session_id="a")
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(columns, 24)) as pilot:
+
+        def _grid() -> str:
+            return "\n".join(
+                "".join(segment.text for segment in strip).rstrip()
+                for strip in app.screen._compositor.render_strips()
+            )
+
+        assert await _until(pilot, lambda: "MCP slack" in _grid())
+        lines = [line.strip() for line in _grid().splitlines() if line.strip()]
+        start = next(index for index, line in enumerate(lines) if "MCP slack" in line)
+        # Three rows is the deepest this wraps at 40 columns, the narrowest
+        # width the status band itself was driven at.
+        painted = " ".join(lines[start : start + 3])
+        assert "/mcp for details" in painted, f"the pointer was clipped at {columns}"
+
+
+@pytest.mark.asyncio
+async def test_the_announce_record_is_one_slot_not_a_ledger() -> None:
+    """UX round 1, U5 \u2014 the toast ledger grew for the life of the process.
+
+    Forty distinct outcomes left 41 entries behind. Holding only the CURRENT
+    sentence there is no growth to bound: this asserts the shape, so a future
+    change back to a set fails here rather than in a memory profile.
+    """
+    session = _session(_outcome(), session_id="a")
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        toast = app.query_one(Toast)
+        assert await _until(pilot, lambda: toast.display)
+        for index in range(40):
+            toast.dismiss_toast()
+            await pilot.pause()
+            session.mcp_startup = _outcome(tool_count=100 + index)
+            app._report_mcp_startup(session)
+            assert await _until(pilot, lambda: toast.display)
+        assert isinstance(app._announced_mcp_startup, str)
+        assert f"{100 + 39} tools" in app._announced_mcp_startup

--- a/tests/unit/tui/test_mcp_startup_announce.py
+++ b/tests/unit/tui/test_mcp_startup_announce.py
@@ -500,6 +500,94 @@ async def test_an_eviction_releases_every_session_the_card_spoke_for() -> None:
 
 
 @pytest.mark.asyncio
+async def test_a_sibling_card_displacing_an_announce_does_not_spend_it() -> None:
+    """Review round 3, R3-2 — the evictor is another SESSION's MCP card.
+
+    Two sidebar clicks in quick succession is the gesture this whole PR is
+    about, and inside the first card's 5 s the second session's DIFFERENT
+    sentence takes the slot. The first card was thrown away unread, so its
+    session is owed the announce back exactly as it would be after a copy
+    receipt — the evictor being another MCP card changes nothing about what
+    the user did or did not read.
+
+    The round-3 head returned early here: ``_last_mcp_announce`` had already
+    moved to the evicting card's generation, so the guard fired before the
+    per-session release ever ran and ``a`` stayed marked as told for a card
+    nobody saw. That is U2 reopened for the cross-session case.
+    """
+    first = _session(_outcome(), session_id="a")
+    second = _session(_outcome(**_SLACK_DOWN), session_id="b")
+    app = OperatorApp(lambda: _factory(first))
+    async with app.run_test(size=(100, 24)) as pilot:
+        toast = app.query_one(Toast)
+        assert await _until(pilot, lambda: toast.display)
+        assert "MCP ready: 3 servers" in toast.message
+
+        # No dismissal: b's card displaces a's while a's is still showing.
+        app._adopt_session(second, replay_history=False)
+        assert await _until(pilot, lambda: "failed: slack" in toast.message)
+
+        toast.dismiss_toast()
+        await pilot.pause()
+        app._adopt_session(first, replay_history=False)
+        assert await _until(
+            pilot, lambda: toast.display
+        ), "a sibling session's card spent an announce its own session never read"
+        assert "MCP ready: 3 servers, 425 tools" in toast.message
+
+
+@pytest.mark.asyncio
+async def test_a_retired_card_does_not_lend_its_words_to_a_new_failure() -> None:
+    """Review round 3, R3-1 / UX round 3, U3-1 — inheritance needs a card on
+    screen, and only a session with no record of its own may take one.
+
+    ``_last_mcp_announce`` is cleared by eviction alone, so after the ordinary
+    retirement — a timer expiring, or the user clicking the card away — it
+    still names a card that left the screen. A session whose server then
+    genuinely dies matched those retired words and inherited them, and its
+    failure was never announced at all: the worst outcome this surface has,
+    and the exact thing the inheritance branch claims to be safe from because
+    "the user is looking at it already".
+
+    Gating on the session having NO record of its own is what makes that claim
+    true: a session that has been told something else is not looking at these
+    words, whatever is or is not on screen. It cannot cost the shared-set case,
+    which is precisely the sessions that have no record yet.
+    """
+    healthy = _session(_outcome(), session_id="a")
+    broken = _session(_outcome(**_SLACK_DOWN), session_id="b")
+    app = OperatorApp(lambda: _factory(healthy))
+    async with app.run_test(size=(100, 24)) as pilot:
+        toast = app.query_one(Toast)
+        assert await _until(pilot, lambda: toast.display)
+        toast.dismiss_toast()  # read and dismissed — the ordinary path
+        await pilot.pause()
+
+        app._adopt_session(broken, replay_history=False)
+        assert await _until(pilot, lambda: "failed: slack" in toast.message)
+        toast.dismiss_toast()  # read and dismissed too; the screen is now empty
+        await pilot.pause()
+        assert toast.display is False
+
+        # a's own slack now dies. Its record says "healthy", so this is news a
+        # was never told, and the words b left behind are not on screen.
+        healthy.mcp_startup = _outcome(**_SLACK_DOWN)
+        app._adopt_session(healthy, replay_history=False)
+        assert await _until(
+            pilot, lambda: toast.display
+        ), "a genuine new failure inherited a card that had already retired"
+        assert "failed: slack" in toast.message
+
+        # And it stays announced: the record now holds the failure, so the
+        # repeat is silent for the right reason rather than the wrong one.
+        toast.dismiss_toast()
+        await pilot.pause()
+        app._adopt_session(healthy, replay_history=False)
+        await _quiet(pilot)
+        assert toast.display is False
+
+
+@pytest.mark.asyncio
 async def test_an_announce_the_user_actually_saw_is_not_re_announced() -> None:
     """The other half of U2: eviction is not the same as expiry.
 
@@ -897,7 +985,9 @@ async def test_the_announce_record_is_bounded_by_sessions_not_outcomes() -> None
     entries behind, for the life of the process. The record is now one entry
     per ATTACHED session \u2014 outcome churn on one session rewrites that
     session's entry, and a re-attach adds nothing \u2014 so the bound is the
-    session count (276 B measured per entry), not the outcome count. This
+    session count, not the outcome count — which is the term that decides
+    whether a cap is needed, and unlike a byte figure it is not
+    measurement-method dependent (review round 3, R3-4). This
     asserts the shape, so a future change back to per-outcome growth fails
     here rather than in a memory profile.
     """

--- a/tests/unit/tui/test_mcp_startup_announce.py
+++ b/tests/unit/tui/test_mcp_startup_announce.py
@@ -1,0 +1,249 @@
+"""The MCP startup toast announces once per process, per distinct outcome.
+
+Reported: "MCP ready: 12 servers, 425 tools" fired on EVERY session attach,
+including every click in the session sidebar. ``session.mcp_startup`` is a
+frozen BOOT SNAPSHOT and ``_report_mcp_startup`` runs on every adoption, so a
+sidebar switch re-announced a round that happened minutes ago — and, through
+``RemoteSession``'s rehydration of the owner's outcome, sometimes a round this
+process never ran at all.
+
+These tests pin the rule the fix implements: announce at most once per app
+process per DISTINCT outcome (content, not session identity), with the durable
+failure notice deduped per session instead. The status band is asserted
+alongside, because the suppression is only safe while the band keeps
+re-stating live MCP state on every attach.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from local_operator.session.mcp_status import McpStartupOutcome
+from local_operator.tui.app import OperatorApp
+from local_operator.tui.widgets.toast import Toast
+from tests.unit.tui.test_app_pilot import (
+    FakeMcpManager,
+    McpSession,
+    _band,
+    _factory,
+    _transcript_text,
+)
+
+
+@pytest.fixture(autouse=True)
+def isolate_sources(tmp_path, monkeypatch):
+    # A headless pilot that inherits the operator's CMUX_* variables can rename
+    # their real cmux workspaces; HOME is redirected too because the config dir
+    # alone leaves the cache pointed at the real home (AGENTS.md, "Isolating a
+    # run").
+    for key in tuple(os.environ):
+        if key.startswith("CMUX_"):
+            monkeypatch.delenv(key)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LOCAL_OPERATOR_CONFIG_DIR", str(tmp_path / "config"))
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_NOTIFICATIONS", "1")
+    monkeypatch.setenv("LOCAL_OPERATOR_NO_TERMINAL_TITLE", "1")
+    monkeypatch.setattr(OperatorApp, "_check_for_update", lambda self: None)
+
+
+def _outcome(**overrides) -> McpStartupOutcome:
+    """The reported shape, shrunk: several servers up, a tool tally, no failure."""
+    fields = {
+        "configured": ("github", "linear", "slack"),
+        "connected": ("github", "linear", "slack"),
+        "tool_count": 425,
+    }
+    fields.update(overrides)
+    return McpStartupOutcome(**fields)  # type: ignore[arg-type]
+
+
+class _IdentifiedMcpSession(McpSession):
+    """``McpSession`` with a settable id.
+
+    ``FakeSession.session_id`` is a fixed property returning ``"sess"``, so two
+    fakes are indistinguishable to the per-session notice key — which is
+    exactly the distinction these tests are about.
+    """
+
+    def __init__(self, manager, startup, session_id: str) -> None:
+        super().__init__(manager, startup)
+        self._session_id = session_id
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+
+def _session(outcome: McpStartupOutcome, *, session_id: str) -> _IdentifiedMcpSession:
+    manager = FakeMcpManager(list(outcome.configured), list(outcome.connected))
+    return _IdentifiedMcpSession(manager, outcome, session_id)
+
+
+@pytest.mark.asyncio
+async def test_boot_announces_the_startup_outcome() -> None:
+    """First loadup is exactly what the operator wants announced."""
+    app = OperatorApp(lambda: _factory(_session(_outcome(), session_id="a")))
+    async with app.run_test(size=(100, 24)) as pilot:
+        for _ in range(6):
+            await pilot.pause()
+        toast = app.query_one(Toast)
+        assert toast.display is True
+        assert "MCP ready: 3 servers, 425 tools" in toast.message
+
+
+@pytest.mark.asyncio
+async def test_attaching_a_second_session_with_the_same_outcome_stays_silent() -> None:
+    """THE REPORTED DEFECT. MCP servers are process-wide and shared, so every
+    sidebar click re-announced a tally the user was already told. The band still
+    carries the live count, which is what makes the silence safe."""
+    first = _session(_outcome(), session_id="a")
+    second = _session(_outcome(), session_id="b")
+    app = OperatorApp(lambda: _factory(first))
+    async with app.run_test(size=(100, 24)) as pilot:
+        for _ in range(6):
+            await pilot.pause()
+        toast = app.query_one(Toast)
+        assert toast.display is True
+        toast.dismiss_toast()
+        await pilot.pause()
+
+        app._adopt_session(second, replay_history=False)
+        for _ in range(6):
+            await pilot.pause()
+        assert toast.display is False, "a re-attach re-announced a boot snapshot"
+        # The surface that legitimately re-states MCP state per attach.
+        assert "⊙ 3 MCP" in _band(app)
+
+
+@pytest.mark.asyncio
+async def test_re_adopting_the_same_session_stays_silent() -> None:
+    """A sidebar click back onto the session already attached is the same
+    snapshot a second time; nothing about it is news."""
+    session = _session(_outcome(), session_id="a")
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        for _ in range(6):
+            await pilot.pause()
+        toast = app.query_one(Toast)
+        toast.dismiss_toast()
+        await pilot.pause()
+        app._adopt_session(session, replay_history=False)
+        for _ in range(6):
+            await pilot.pause()
+        assert toast.display is False
+
+
+@pytest.mark.asyncio
+async def test_a_changed_tally_announces_again() -> None:
+    """A session in another cwd with a genuinely different server set IS news,
+    and the fingerprint is content — so it announces once of its own."""
+    first = _session(_outcome(), session_id="a")
+    second = _session(
+        _outcome(
+            configured=("github", "linear", "slack", "notion"),
+            connected=("github", "linear", "slack", "notion"),
+            tool_count=511,
+        ),
+        session_id="b",
+    )
+    app = OperatorApp(lambda: _factory(first))
+    async with app.run_test(size=(100, 24)) as pilot:
+        for _ in range(6):
+            await pilot.pause()
+        toast = app.query_one(Toast)
+        toast.dismiss_toast()
+        await pilot.pause()
+
+        app._adopt_session(second, replay_history=False)
+        for _ in range(6):
+            await pilot.pause()
+        assert toast.display is True
+        assert "MCP ready: 4 servers, 511 tools" in toast.message
+
+
+@pytest.mark.asyncio
+async def test_connect_order_alone_does_not_re_announce() -> None:
+    """``connected`` is a set with an incidental order — the connect race
+    reorders it run to run. An order-sensitive key would re-toast an outcome
+    whose content is identical, which is why the fingerprint sorts."""
+    first = _session(_outcome(), session_id="a")
+    second = _session(
+        _outcome(connected=("slack", "github", "linear")),
+        session_id="b",
+    )
+    app = OperatorApp(lambda: _factory(first))
+    async with app.run_test(size=(100, 24)) as pilot:
+        for _ in range(6):
+            await pilot.pause()
+        toast = app.query_one(Toast)
+        toast.dismiss_toast()
+        await pilot.pause()
+        app._adopt_session(second, replay_history=False)
+        for _ in range(6):
+            await pilot.pause()
+        assert toast.display is False
+
+
+@pytest.mark.asyncio
+async def test_the_settled_outcome_still_announces_after_a_silent_gate() -> None:
+    """The 250 ms gate snapshot is ``settling`` and unreportable, so it records
+    nothing; the settled round that follows carries its own fingerprint and is
+    the one the user actually sees. The fix must not consume the gate pass."""
+    settling = McpStartupOutcome(
+        configured=("github", "linear", "slack"),
+        settling=True,
+    )
+    session = _session(settling, session_id="a")
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        for _ in range(6):
+            await pilot.pause()
+        toast = app.query_one(Toast)
+        assert toast.display is False, "a settling snapshot must stay quiet"
+
+        # What the manager's settle callback does: the factory rebuilds
+        # ``session.mcp_startup`` with the final tally, then the app re-reports.
+        session.mcp_startup = _outcome()
+        app._report_mcp_startup(session)
+        await pilot.pause()
+        assert toast.display is True
+        assert "MCP ready: 3 servers, 425 tools" in toast.message
+
+
+@pytest.mark.asyncio
+async def test_a_failure_notice_is_written_once_per_session() -> None:
+    """A durable failure record belongs in the transcript of the session it
+    describes — so a SECOND session gets its own copy — but the repeat on the
+    same session is the duplicate the re-attach used to append."""
+    outcome = _outcome(
+        connected=("github", "linear"),
+        failures={"slack": "command not found: slack-mcp"},
+        tool_count=310,
+    )
+    first = _session(outcome, session_id="a")
+    second = _session(outcome, session_id="b")
+    app = OperatorApp(lambda: _factory(first))
+    async with app.run_test(size=(100, 24)) as pilot:
+        for _ in range(6):
+            await pilot.pause()
+        assert _transcript_text(app).count("MCP slack failed") == 1
+
+        # Same session again: the transcript already carries the record.
+        app._adopt_session(first, replay_history=False)
+        for _ in range(6):
+            await pilot.pause()
+        assert _transcript_text(app).count("MCP slack failed") == 1
+
+        # A different session with the same failure: its own transcript has
+        # never carried it, so it gets the record even though the toast — a
+        # process-wide interruption — stays silent.
+        toast = app.query_one(Toast)
+        toast.dismiss_toast()
+        await pilot.pause()
+        app._adopt_session(second, replay_history=False)
+        for _ in range(6):
+            await pilot.pause()
+        assert _transcript_text(app).count("MCP slack failed") == 2
+        assert toast.display is False

--- a/tests/unit/tui/test_mcp_startup_announce.py
+++ b/tests/unit/tui/test_mcp_startup_announce.py
@@ -1,4 +1,4 @@
-"""The MCP startup toast announces once per process, per distinct outcome.
+"""The MCP startup toast announces once per session, per distinct outcome.
 
 Reported: "MCP ready: 12 servers, 425 tools" fired on EVERY session attach,
 including every click in the session sidebar. ``session.mcp_startup`` is a
@@ -7,14 +7,19 @@ sidebar switch re-announced a round that happened minutes ago — and, through
 ``RemoteSession``'s rehydration of the owner's outcome, sometimes a round this
 process never ran at all.
 
-These tests pin the rule the fix implements: the toast announces only what
-differs from the sentence CURRENTLY announced, so a re-attach saying the same
-thing is silent (A→A) while a server that breaks, recovers and breaks again is
-announced every time (A→B→A). The record is taken when the card is DISPLAYED,
-not when ``show`` is called, so an announce evicted unread is not spent. The
-durable failure notice is deduped per session AND per failure instead. The
-status band is asserted alongside, because the suppression is only safe while
-the band keeps re-stating live MCP state on every attach.
+These tests pin the rule the fix implements: each SESSION remembers the last
+sentence it was told and stays silent while its own outcome is unchanged, so
+clicking away and back is quiet (A→B→A→B across sessions) while a server that
+breaks, recovers and breaks again is announced every time (A→B→A on one
+session). A session seeing a sentence that is CURRENTLY on screen inherits
+that record, which is what keeps one shared MCP set to one toast. The identity
+is the UNTRUNCATED sentence — the card still shows the width-fitted one — so
+terminal width cannot re-arm or swallow an announce. The record is taken when
+the card is DISPLAYED, not when ``show`` is called, and is released by
+eviction for every session that card spoke for. The durable failure notice is
+deduped per session AND per failure instead. The status band is asserted
+alongside, because the suppression is only safe while the band keeps
+re-stating live MCP state on every attach.
 """
 
 from __future__ import annotations
@@ -91,6 +96,18 @@ _SLACK_DOWN = dict(
     tool_count=310,
 )
 
+#: Two errors whose FULL sentences differ but whose 50-column renders are
+#: byte-identical (both ellipsize to ``failed: slack — command not found:
+#: slack-…``). The pair review and UX both measured collapsing into one
+#: announce on the round-2 head, swallowing the second failure (R2-2, U2-1).
+_TRUNCATION_COLLISION_A = "command not found: slack-mcp-stdio-bridge"
+_TRUNCATION_COLLISION_B = "command not found: slack-mcp-oauth-refresh-expired"
+
+#: An error long enough to fit the 100-column card WHOLE but truncate at 46,
+#: so a resize between attaches changed the round-2 head's key for an
+#: unchanged outcome (R2-1).
+_RESIZE_SENSITIVE_ERROR = "command not found: slack-mcp-stdio-bridge-v2-bin"
+
 
 async def _until(pilot, predicate) -> bool:  # type: ignore[no-untyped-def]
     """Pause until ``predicate()`` holds, or the budget runs out.
@@ -100,6 +117,14 @@ async def _until(pilot, predicate) -> bool:  # type: ignore[no-untyped-def]
     U6), and AGENTS.md's timing section says to wait on the event, not the
     clock. Returns whether it held, so a caller asserting the NEGATIVE (a toast
     that must stay silent) can still spend the full budget looking for it.
+
+    The budget is 200 ``pause()`` calls, not seconds: a pause is one event-loop
+    tick, and the observed settle for this surface is single-digit ticks (the
+    announce is synchronous in ``show``; only the posted ``Toast.Evicted`` ever
+    needs a drain). 200 is roughly two orders of magnitude above that need
+    while still costing milliseconds — tight enough that a genuine hang fails
+    the test quickly, loose enough that CI under load cannot turn a pass into
+    a flake (review round 2, R2-5).
     """
     for _ in range(200):
         await pilot.pause()
@@ -177,6 +202,59 @@ async def test_four_sidebar_clicks_onto_one_mcp_set_announce_once() -> None:
             assert toast.display is False
 
         assert shown == [], f"a re-attach re-announced: {shown}"
+
+
+@pytest.mark.asyncio
+async def test_alternating_clicks_between_two_mcp_sets_announce_once_each() -> None:
+    """QA round 2, Q2-1 — the reported defect had returned at full strength.
+
+    The sidebar catalogue is not cwd-scoped (``load_catalog`` scans the whole
+    store) while MCP is wired per session cwd, so alternating between a repo
+    with a ``.mcp.json`` and one without is ordinary A→B→A→B. One global
+    sentence slot cannot tell "the world changed" from "I clicked elsewhere
+    and came back": every single click re-announced — 20 announces in 20
+    clicks, identical to the unfixed tree. Per session, each side of the
+    alternation is unchanged since its own last announce, so only the first
+    click per distinct outcome speaks.
+
+    QA's own shape: the real ``_adopt_session``, the card dismissed between
+    clicks so eviction is not the variable, and announces counted at the real
+    ``Toast.show``. The boot session carries a third outcome so neither click
+    target has been told yet — the expected count is then exactly one per
+    distinct session outcome.
+    """
+    boot = _session(
+        _outcome(
+            configured=("github", "linear"),
+            connected=("github", "linear"),
+            tool_count=180,
+        ),
+        session_id="boot",
+    )
+    repo = _session(_outcome(), session_id="repo")
+    plain = _session(
+        _outcome(configured=("github",), connected=("github",), tool_count=40),
+        session_id="plain",
+    )
+    app = OperatorApp(lambda: _factory(boot))
+    async with app.run_test(size=(100, 24)) as pilot:
+        toast = app.query_one(Toast)
+        assert await _until(pilot, lambda: toast.display)
+        toast.dismiss_toast()
+        await pilot.pause()
+
+        announced = 0
+        for index in range(20):
+            app._adopt_session(repo if index % 2 == 0 else plain, replay_history=False)
+            await _quiet(pilot)
+            if toast.display:
+                announced += 1
+                toast.dismiss_toast()
+                await pilot.pause()
+        assert announced == 2, (
+            f"{announced} announces in 20 alternating clicks between two MCP "
+            "sets — expected exactly one per distinct session outcome"
+        )
 
 
 @pytest.mark.asyncio
@@ -283,6 +361,70 @@ async def test_the_same_failure_recurring_after_a_recovery_announces_again() -> 
 
 
 @pytest.mark.asyncio
+async def test_a_flap_on_one_session_announces_through_sibling_clicks() -> None:
+    """U1 and Q2-1 together — the two shapes UX walked in one flow.
+
+    The sibling clicks must stay silent (nothing changed for either session)
+    while the break→recover→break on ONE session announces every transition:
+    per-session records are what let both hold at once, where the single
+    global slot could only ever trade one for the other.
+    """
+    # The sibling carries a THIRD sentence, distinct from both of a's states:
+    # the point is that a's transitions announce on their own merits, not that
+    # they coincide with words the user just read on the sibling's card.
+    broken = _session(_outcome(**_SLACK_DOWN), session_id="a")
+    sibling = _session(
+        _outcome(
+            configured=("notion", "sentry", "stripe"),
+            connected=("notion", "sentry", "stripe"),
+            tool_count=512,
+        ),
+        session_id="b",
+    )
+    app = OperatorApp(lambda: _factory(broken))
+    async with app.run_test(size=(100, 24)) as pilot:
+        toast = app.query_one(Toast)
+        assert await _until(pilot, lambda: toast.display)
+        assert "2 of 3 servers up" in toast.message  # a breaks (announce 1)
+
+        toast.dismiss_toast()
+        await pilot.pause()
+        app._adopt_session(sibling, replay_history=False)
+        assert await _until(pilot, lambda: toast.display)  # b's first (2)
+        assert "3 servers" in toast.message and "512 tools" in toast.message
+
+        toast.dismiss_toast()
+        await pilot.pause()
+        app._adopt_session(broken, replay_history=False)
+        await _quiet(pilot)
+        assert toast.display is False, "clicking back to an unchanged outcome re-announced"
+
+        toast.dismiss_toast()
+        await pilot.pause()
+        app._adopt_session(sibling, replay_history=False)
+        await _quiet(pilot)
+        assert toast.display is False, "the sibling's unchanged outcome re-announced"
+
+        broken.mcp_startup = _outcome()  # a recovers (announce 3)
+        app._report_mcp_startup(broken)
+        assert await _until(pilot, lambda: toast.display)
+        assert "MCP ready: 3 servers" in toast.message
+
+        toast.dismiss_toast()
+        await pilot.pause()
+        app._adopt_session(sibling, replay_history=False)
+        await _quiet(pilot)
+        assert toast.display is False
+
+        broken.mcp_startup = _outcome(**_SLACK_DOWN)  # a breaks AGAIN (4)
+        app._report_mcp_startup(broken)
+        assert await _until(
+            pilot, lambda: toast.display
+        ), "a recurring failure after a recovery went silent — U1 must stay closed"
+        assert "2 of 3 servers up" in toast.message
+
+
+@pytest.mark.asyncio
 async def test_an_announce_evicted_before_it_is_read_is_not_spent() -> None:
     """UX round 1, U2 \u2014 the announce is consumed on being SEEN, not on being
     shown.
@@ -318,6 +460,46 @@ async def test_an_announce_evicted_before_it_is_read_is_not_spent() -> None:
 
 
 @pytest.mark.asyncio
+async def test_an_eviction_releases_every_session_the_card_spoke_for() -> None:
+    """U2's release, per session now — the evicted card spoke for more than
+    its raiser.
+
+    A session that stayed silent because the words were ALREADY on screen
+    inherited its record from that card, so the card being thrown away unread
+    owes that session its announce back too. A session told by an earlier,
+    delivered card keeps its record: it was told by a card that retired
+    normally. Pins the per-session release; passes on the round-2 head as
+    well, where the single slot coincided with this behaviour.
+    """
+    first = _session(_outcome(), session_id="a")
+    second = _session(_outcome(), session_id="b")
+    third = _session(_outcome(), session_id="c")
+    app = OperatorApp(lambda: _factory(first))
+    async with app.run_test(size=(100, 24)) as pilot:
+        toast = app.query_one(Toast)
+        assert await _until(pilot, lambda: toast.display)
+
+        # b and c inherit the LIVE card's record: same words, on screen now.
+        app._adopt_session(second, replay_history=False)
+        await _quiet(pilot)
+        app._adopt_session(third, replay_history=False)
+        await _quiet(pilot)
+        assert toast.display, "the boot card is still showing"
+
+        # A routine copy receipt throws that card away unread. Everyone it
+        # spoke for — its raiser and its inheritors — is owed the announce.
+        toast.show("copied 12 lines to clipboard", yield_to_actionable=True)
+        assert await _until(pilot, lambda: toast.message.startswith("copied"))
+
+        toast.dismiss_toast()
+        await pilot.pause()
+        app._adopt_session(third, replay_history=False)
+        assert await _until(
+            pilot, lambda: toast.display
+        ), "an inheritor's record survived the eviction of the card that spoke for it"
+
+
+@pytest.mark.asyncio
 async def test_an_announce_the_user_actually_saw_is_not_re_announced() -> None:
     """The other half of U2: eviction is not the same as expiry.
 
@@ -337,6 +519,47 @@ async def test_an_announce_the_user_actually_saw_is_not_re_announced() -> None:
         app._adopt_session(second, replay_history=False)
         await _quiet(pilot)
         assert toast.display is False
+
+
+@pytest.mark.asyncio
+async def test_a_flap_inside_one_card_does_not_release_the_live_announce() -> None:
+    """Review round 2, R2-3 — a stale ``Evicted`` released a live announce.
+
+    ``Evicted`` is posted, so it arrives after further reports have run. A
+    flap A→B→A inside one card's lifetime queues ``Evicted(text=A)`` from the
+    FIRST card; matching the release on the WORDS made it clear a record that
+    had since come back to A, re-arming the announce for a sentence the user
+    was reading right then. The release matches the card's GENERATION, which
+    cannot alias. Sentences here are short so truncation is not the variable.
+    """
+    session = _session(_outcome(), session_id="a")
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        toast = app.query_one(Toast)
+        assert await _until(pilot, lambda: toast.display)
+        assert "MCP ready: 3 servers" in toast.message  # A takes the slot
+
+        # No dismissal: each report evicts the previous card, queueing its
+        # Evicted behind the pump.
+        session.mcp_startup = _outcome(**_SLACK_DOWN)
+        app._report_mcp_startup(session)  # B evicts A
+        session.mcp_startup = _outcome()
+        app._report_mcp_startup(session)  # A evicts B — the flap closes
+
+        # The queued Evicted(text=A) is delivered here and must not release
+        # the record: the card on screen IS A, and the user is reading it.
+        await pilot.pause()
+        await _quiet(pilot)
+        assert toast.display, "the live announce card vanished"
+        assert "MCP ready: 3 servers" in toast.message
+
+        toast.dismiss_toast()
+        await pilot.pause()
+        app._report_mcp_startup(session)
+        await _quiet(pilot)
+        assert (
+            toast.display is False
+        ), "the A→B→A flap re-armed the announce for a sentence already on screen"
 
 
 @pytest.mark.asyncio
@@ -394,6 +617,86 @@ async def test_two_server_sets_rendering_one_sentence_announce_once() -> None:
         app._adopt_session(second, replay_history=False)
         await _quiet(pilot)
         assert toast.display is False, f"the same sentence {sentence!r} was announced twice"
+
+
+@pytest.mark.asyncio
+async def test_a_terminal_resize_does_not_re_announce_news_the_user_read() -> None:
+    """Review round 2, R2-1 / UX round 2, U2-2 — width leaked into identity.
+
+    The round-2 head keyed the TRUNCATED sentence, so the same outcome keyed
+    differently at two widths: announce at 100 columns, narrow the pane,
+    re-attach, and the identical outcome announced again. The key is now the
+    untruncated sentence; the card still shows the width-fitted renderable.
+    This error fits a 100-column card whole but truncates at 46, so the two
+    keys genuinely differed on the round-2 head.
+    """
+    session = _session(
+        _outcome(
+            connected=("github", "linear"),
+            failures={"slack": _RESIZE_SENSITIVE_ERROR},
+            tool_count=310,
+        ),
+        session_id="a",
+    )
+    app = OperatorApp(lambda: _factory(session))
+    async with app.run_test(size=(100, 24)) as pilot:
+        toast = app.query_one(Toast)
+        assert await _until(pilot, lambda: toast.display)
+        # The card truncates at BOTH widths — differently, which is the point:
+        # the round-2 head keyed this rendered text, so the resize changed the
+        # key for an unchanged outcome.
+        at_wide = toast.message
+        assert "slack" in at_wide
+        toast.dismiss_toast()
+        await pilot.pause()
+
+        await pilot.resize_terminal(46, 24)
+        await pilot.pause()
+        app._report_mcp_startup(session)
+        await _quiet(pilot)
+        assert toast.display is False, "a resize re-announced an unchanged outcome"
+
+
+@pytest.mark.asyncio
+async def test_two_failures_that_truncate_identically_both_announce() -> None:
+    """Review round 2, R2-2 / UX round 2, U2-1 — the serious half.
+
+    Truncation is lossy, so two genuinely different failures whose 50-column
+    renders are byte-identical collapsed into one key on the round-2 head and
+    the SECOND failure was silently swallowed — the one case this surface
+    exists to raise. Keying the untruncated sentence, both announce. The card
+    may still SHOW the same ellipsized text; what matters is that it is raised.
+    """
+    first = _session(
+        _outcome(
+            connected=("github", "linear"),
+            failures={"slack": _TRUNCATION_COLLISION_A},
+            tool_count=310,
+        ),
+        session_id="a",
+    )
+    second = _session(
+        _outcome(
+            connected=("github", "linear"),
+            failures={"slack": _TRUNCATION_COLLISION_B},
+            tool_count=310,
+        ),
+        session_id="b",
+    )
+    app = OperatorApp(lambda: _factory(first))
+    async with app.run_test(size=(50, 24)) as pilot:
+        toast = app.query_one(Toast)
+        assert await _until(pilot, lambda: toast.display)
+        assert "slack-" in toast.message  # truncated, but raised
+        rendered = toast.message
+        toast.dismiss_toast()
+        await pilot.pause()
+
+        app._adopt_session(second, replay_history=False)
+        assert await _until(pilot, lambda: toast.display), (
+            "a genuinely different failure was swallowed because it truncates "
+            f"identically to the last one ({rendered!r})"
+        )
 
 
 @pytest.mark.asyncio
@@ -586,12 +889,17 @@ async def test_the_notice_pointer_wraps_rather_than_truncating(columns: int) -> 
 
 
 @pytest.mark.asyncio
-async def test_the_announce_record_is_one_slot_not_a_ledger() -> None:
-    """UX round 1, U5 \u2014 the toast ledger grew for the life of the process.
+async def test_the_announce_record_is_bounded_by_sessions_not_outcomes() -> None:
+    """UX round 1, U5 / review round 1, R1-3 \u2014 the record's growth, re-stated
+    for the per-session shape.
 
-    Forty distinct outcomes left 41 entries behind. Holding only the CURRENT
-    sentence there is no growth to bound: this asserts the shape, so a future
-    change back to a set fails here rather than in a memory profile.
+    The round-1 ledger grew per distinct OUTCOME: forty outcomes left forty
+    entries behind, for the life of the process. The record is now one entry
+    per ATTACHED session \u2014 outcome churn on one session rewrites that
+    session's entry, and a re-attach adds nothing \u2014 so the bound is the
+    session count (276 B measured per entry), not the outcome count. This
+    asserts the shape, so a future change back to per-outcome growth fails
+    here rather than in a memory profile.
     """
     session = _session(_outcome(), session_id="a")
     app = OperatorApp(lambda: _factory(session))
@@ -604,5 +912,22 @@ async def test_the_announce_record_is_one_slot_not_a_ledger() -> None:
             session.mcp_startup = _outcome(tool_count=100 + index)
             app._report_mcp_startup(session)
             assert await _until(pilot, lambda: toast.display)
-        assert isinstance(app._announced_mcp_startup, str)
-        assert f"{100 + 39} tools" in app._announced_mcp_startup
+        assert list(app._announced_mcp_startup) == ["a"], (
+            "forty distinct outcomes on one session left more than that " "session's entry behind"
+        )
+        assert f"{100 + 39} tools" in app._announced_mcp_startup["a"].sentence
+
+        # The other direction of the bound: sessions grow the record, attaches
+        # do not. Five sessions is five entries; re-adopting all of them again
+        # is still five.
+        others = [_session(_outcome(), session_id=f"s{i}") for i in range(4)]
+        for other in others:
+            toast.dismiss_toast()
+            await pilot.pause()
+            app._adopt_session(other, replay_history=False)
+            await _quiet(pilot)
+        assert sorted(app._announced_mcp_startup) == ["a", "s0", "s1", "s2", "s3"]
+        for again in [session, *others]:
+            app._adopt_session(again, replay_history=False)
+        await _quiet(pilot)
+        assert sorted(app._announced_mcp_startup) == ["a", "s0", "s1", "s2", "s3"]


### PR DESCRIPTION
## Summary

The MCP startup toast — `⊙ MCP ready: 12 servers, 425 tools` — fired on **every session attach**, including every click in the session sidebar. The operator wants it on session creation / first loadup only.

`session.mcp_startup` is a frozen **boot snapshot**, and `_report_mcp_startup` runs on every adoption: boot, `/new`, `/resume`, `_commit_sidebar_session`, and remote takeover. So a sidebar switch re-announced a round that happened minutes ago — and through `RemoteSession`'s rehydration of the owner's outcome (`session/remote.py:3092`), sometimes a round this process never ran at all.

**Change class: C1 — standard/pre-authorized bug fix.** No version bump, no release, no tracker requested. `pyproject.toml` is untouched.

`Release: patch — the boot MCP toast stops re-firing on every sidebar click.`

## The rule

**Announce at most once per app process, per distinct outcome.** A set of fingerprints lives on the App instance; a fingerprint is the outcome's material content — sorted `configured`, sorted `connected`, the `failures` mapping, and `tool_count`.

- Boot announces: its fingerprint is new by definition, so "first loadup" is preserved.
- Every re-attach of the same MCP state is silent — the reported complaint.
- Sidebar-switching between sessions that share one MCP set is silent after the first, because the fingerprint is **shared**. A per-session key would still toast once per session and would **not** fix the reported problem — that is why the key is content, not identity.
- A session in a different cwd with a genuinely different server set announces once, because that IS news.
- The settle path is unchanged: the 250 ms gate snapshot is `settling` and therefore unreportable, so nothing is recorded until the settled outcome arrives carrying its own fingerprint. `McpStartupOutcome.reportable` is not weakened.

`configured`/`connected` are **sorted** into the key because they are sets with an incidental order — the connect race reorders them run to run, and an order-sensitive key would re-toast identical content. Object identity is not the key even though the outcome is frozen, precisely because `RemoteSession` rebuilds a fresh instance per attach.

Neither ledger is persisted and neither lives on the session: the toast is a per-process interruption, and a fingerprint that survived a restart would silence the one launch the user actually wants announced.

**The status band is deliberately untouched.** `_mcp_status`/`_refresh_mcp_status` re-read the **live** manager on every attach and re-state the count unconditionally. That is the surface which legitimately restates MCP state per attach, and it is exactly what makes suppressing the repeat toast safe rather than a loss of information. The reasoning above is in the code comments, not only here.

## Sibling spam fixed with it

`_report_mcp_startup` appended a `_system_notice` **per failure on every call**, so a re-attach duplicated failure records into the transcript. Deduped **per session** (session id + outcome), not per process: a durable failure record belongs in the transcript of the session it describes, so a second session genuinely deserves its own copy — it is the repeat on the *same* session that is the defect. Including the outcome in that key keeps a settled round that names a *new* failure landing in the transcript.

## Reproduced before fixing

The five new guards were run against the **immutable pre-fix tree** (`git show HEAD:local_operator/tui/app.py`) before the fix was written:

```
4 failed, 3 passed
FAILED test_attaching_a_second_session_with_the_same_outcome_stays_silent - AssertionError: a re-attach re-announced a boot snapshot
FAILED test_re_adopting_the_same_session_stays_silent - assert True is False
FAILED test_connect_order_alone_does_not_re_announce - assert True is False
FAILED test_a_failure_notice_is_written_once_per_session - assert 2 == 1
  where '✗ MCP slack failed: command not found: slack-mcp\n  ✗ MCP slack failed: command not found: slack-mcp'
```

The 3 that pass on both trees are the preserved-behaviour half (boot announces, a changed tally re-announces, the settled outcome announces after a silent gate) — they are there to catch the fix over-suppressing, so they *must* pass pre-fix. All 7 pass on the fix.

## Real-path evidence

A headless Textual pilot drives the **real** `OperatorApp` (loads `local_operator.tcss`), isolated `HOME`/config dir, every `CMUX_*` variable scrubbed, synthetic session ids. No operator session was touched.

`scripts/mcp_toast_attach_shot.py` boots on a session carrying an outcome, dismisses the wanted boot toast, seeds a transcript for the overlay to paint over, then adopts a **second** session whose outcome has identical content — which is what a sidebar click does.

| Tree | boot toast | toast after attach | band |
|---|---|---|---|
| Pre-fix `46b6dfc7f` | `⊙ MCP ready: 3 servers, 425 tools` | **`display=True`**, `'⊙ MCP ready: 3 servers, 425 tools'` | `⊙ 3 MCP` |
| Fixed | `⊙ MCP ready: 3 servers, 425 tools` | **`display=False`**, `''` | `⊙ 3 MCP` |

The band is identical on both trees — the live count survives the silence.

### Before / after frames

Native 100×30 captures via `scripts.visual_capture.save_capture` (8×17px cells, system monospace, `.geometry.json` alongside). Rasterized and **actually inspected**. [Evidence bundle](https://gist.github.com/damianvtran/066066dbbc22e853cc92df2052fd8581) — all four raw URLs verified HTTP 200 `image/svg+xml`.

| Before: the attach re-announces over the transcript | After: the attach is silent |
|---|---|
| ![Before](https://gist.githubusercontent.com/damianvtran/066066dbbc22e853cc92df2052fd8581/raw/cb60d094a6afad224cab0670eba8ff7ba1531cda/before.svg) | ![After](https://gist.githubusercontent.com/damianvtran/066066dbbc22e853cc92df2052fd8581/raw/cafc20322f8773d26dbc6115336d9622eb7f175b/after.svg) |

**The numbers behind the frames**, from the paired `.geometry.json` — the stills show the symptom, these show the cause. Exactly one widget differs; every other region is byte-identical:

| Widget | Before | After |
|---|---|---|
| `#toast-host` region | `[64, 1, 35, 1]` | **absent** |
| `Toast` region | `[64, 1, 35, 1]` | **absent** |
| screen size / virtual_size / scrollbars | `98×28` / `98×28` / none | `98×28` / `98×28` / none |
| widget count | 21 | 19 |

**First loadup is unchanged, proven rather than asserted.** Captured with `LO_MCP_TOAST_SHOT_STAGE=boot` on both trees, the boot frames are **byte-identical** (`cmp` reports no difference) — the fix suppresses the repeat, not the announce. A before/after pair of the attach frame alone cannot show that, since the two trees are *expected* to differ there.

| Boot on the fixed tree — the announce the operator wants |
|---|
| ![Boot](https://gist.githubusercontent.com/damianvtran/066066dbbc22e853cc92df2052fd8581/raw/768348f401dbef54b04cd7abe3f5fac017077afb/boot_after.svg) |

## Gates

Run over the **whole tree**, exactly as CI:

| Gate | Result |
|---|---|
| `.venv/bin/python -m flake8 .` | clean |
| `uvx --from black==26.1.0 black --check .` | 1125 files unchanged |
| `uvx isort==5.13.2 --check .` | clean |
| `.venv/bin/python -m pyright --pythonpath .venv/bin/python .` | **0 errors**, 0 warnings |
| `env -u NO_COLOR TERM=xterm-256color .venv/bin/python -m pytest tests/unit -q` | **16713 passed, 18 skipped** in 982s |

Fresh worktree cut from `origin/main` with its **own** venv (`import local_operator` resolves to this worktree, verified — never a symlink).

## Not in scope

- The status band's live MCP segment is untouched, by design.
- `McpStartupOutcome.reportable` and the `settling` guard are unchanged.
- No change to `_wire_mcp_status`, the settle callback, or `on_auth_required` (a mid-session OAuth prompt is a live event, not a boot snapshot, and still toasts every time).
